### PR TITLE
GVT-1476 Fixes to duplicate track handling

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishValidation.kt
@@ -185,7 +185,10 @@ fun validateDuplicateOfState(
                 duplicateOfLocationTrack.name.value
             )
         },
-    )
+        validateWithParams(duplicateOfLocationTrack.duplicateOf == null) {
+            "$VALIDATION_LOCATION_TRACK.duplicate-of.duplicate" to listOf(duplicateOfLocationTrack.name.value)
+        }
+   )
 
 fun validateDraftReferenceLineFields(referenceLine: ReferenceLine): List<PublishValidationError> =
     listOfNotNull(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublishValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublishValidationTest.kt
@@ -610,6 +610,15 @@ class PublishValidationTest {
         )
     }
 
+    @Test
+    fun validationCatchesLoopyDuplicate() {
+        val lt = locationTrack(IntId(0)).copy(duplicateOf = IntId(0))
+        assertContainsError(
+            true, validateDuplicateOfState(lt, lt, listOf(IntId(0))),
+            "$VALIDATION_LOCATION_TRACK.duplicate-of.duplicate"
+        )
+    }
+
     private fun editSegment(segmentSwitch: SegmentSwitch, edit: (segment: LayoutSegment) -> LayoutSegment) =
         segmentSwitch.copy(
             segments = segmentSwitch.segments.map(edit),

--- a/ui/src/preview/translations.fi.json
+++ b/ui/src/preview/translations.fi.json
@@ -99,7 +99,8 @@
                         "DELETED": "Raiteen duplikaatti {{0}} on poistettu. Duplikaattitietoa ei enää tarvita."
                     },
                     "not-official": "Raide viittaa duplikaattiraiteen {{0}} luonnosriviin",
-                    "not-published": "Raide viittaa julkaisemattomaan duplikaattiraiteeseen {{0}}"
+                    "not-published": "Raide viittaa julkaisemattomaan duplikaattiraiteeseen {{0}}",
+                    "duplicate": "Raide on merkitty duplikaatiksi raiteelle {{0}}, joka itse on myös duplikaatti"
                 },
                 "empty-segments": "Sijaintiraiteella ei ole geometriaa",
                 "points": {

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -382,7 +382,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                             errors={getVisibleErrorsByProp('description')}
                         />
 
-                        {props.duplicatesExist || (
+                        {props.duplicatesExist || props.publishType === undefined || (
                             <FieldLayout
                                 label={`${t('location-track-dialog.duplicate-of')}`}
                                 value={

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -58,7 +58,9 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
             : undefined;
     const firstInputRef = React.useRef<HTMLInputElement>(null);
     const [state, dispatcher] = React.useReducer(reducer, initialLocationTrackEditState);
-    const [selectedDuplicateTrackName, setSelectedDuplicateTrackName] = React.useState<string | undefined>(props.existingDuplicateTrack?.name);
+    const [selectedDuplicateTrack, setSelectedDuplicateTrack] = React.useState<
+        LayoutLocationTrack | undefined
+    >(props.existingDuplicateTrack);
     const [nonDraftDeleteConfirmationVisible, setNonDraftDeleteConfirmationVisible] =
         React.useState<boolean>(state.locationTrack?.state == 'DELETED');
     const [draftDeleteConfirmationVisible, setDraftDeleteConfirmationVisible] =
@@ -225,19 +227,9 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     // Use memoized function to make debouncing functionality to work when re-rendering
     const memoizedDebouncedGetOptions = React.useCallback(debouncedGetOptions, []);
 
-    function onDuplicateTrackNameSelected(duplicateTrackName: SearchItemValue | undefined) {
-        if (duplicateTrackName) {
-            switch (duplicateTrackName?.type) {
-                case 'locationTrackSearchItem':
-                    duplicateTrackName.locationTrack.id &&
-                    updateProp('duplicateOf', duplicateTrackName.locationTrack.id);
-                    setSelectedDuplicateTrackName(duplicateTrackName.locationTrack.name);
-                    break;
-            }
-        } else {
-            updateProp('duplicateOf', null);
-            setSelectedDuplicateTrackName(undefined);
-        }
+    function onDuplicateTrackSelected(duplicateTrack: SearchItemValue | undefined) {
+        updateProp('duplicateOf', duplicateTrack?.locationTrack?.id ?? null);
+        setSelectedDuplicateTrack(duplicateTrack?.locationTrack ?? undefined);
     }
 
     return (
@@ -387,14 +379,15 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                 label={`${t('location-track-dialog.duplicate-of')}`}
                                 value={
                                     <Dropdown
-                                        placeholder={
-                                            selectedDuplicateTrackName
-                                                ? selectedDuplicateTrackName
-                                                : `${t('location-track-dialog.search')}`
-                                        }
+                                        value={selectedDuplicateTrack && ({
+                                            type: 'locationTrackSearchItem',
+                                            locationTrack: selectedDuplicateTrack
+                                        })}
+                                        getName={(item) => item.locationTrack.name}
+                                        placeholder={t('location-track-dialog.search')}
                                         options={memoizedDebouncedGetOptions}
                                         searchable
-                                        onChange={onDuplicateTrackNameSelected}
+                                        onChange={onDuplicateTrackSelected}
                                         onBlur={() => stateActions.onCommitField('duplicateOf')}
                                         canUnselect={true}
                                         wideList

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -41,6 +41,7 @@ export type LocationTrackDialogProps = {
     onUnselect?: () => void;
     locationTrackChangeTime: TimeStamp;
     existingDuplicateTrack?: LayoutLocationTrack | undefined;
+    duplicatesExist?: boolean
 };
 
 export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
@@ -381,7 +382,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                             errors={getVisibleErrorsByProp('description')}
                         />
 
-                        {selectedDuplicateTrackName && (
+                        {props.duplicatesExist || (
                             <FieldLayout
                                 label={`${t('location-track-dialog.duplicate-of')}`}
                                 value={

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -390,6 +390,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                         onChange={onDuplicateTrackSelected}
                                         onBlur={() => stateActions.onCommitField('duplicateOf')}
                                         canUnselect={true}
+                                        unselectText={t('location-track-dialog.not-a-duplicate')}
                                         wideList
                                         wide
                                     />

--- a/ui/src/tool-panel/location-track/dialog/translations.fi.json
+++ b/ui/src/tool-panel/location-track/dialog/translations.fi.json
@@ -22,6 +22,7 @@
         "invalid-description": "Kuvauksen tulee olla 4-256 merkkiä pitkä",
         "invalid-name": "Virheellinen sijaintiraidetunnus",
         "duplicate-of": "Duplikaatti raiteelle",
+        "not-a-duplicate": "Ei duplikaatti",
         "search": "Hae...",
         "topological-connectivity": "Topologinen kytkeytyminen"
     },

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -154,9 +154,6 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
 
     const existingDuplicate = existingDuplicateOfList && existingDuplicateOfList[0];
     const duplicatesOfLocationTrack = useLocationTrackDuplicates(locationTrack.id, publishType);
-    const showDuplicates =
-        existingDuplicate != undefined ||
-        (duplicatesOfLocationTrack && duplicatesOfLocationTrack.length > 0);
 
     return (
         <React.Fragment>
@@ -207,12 +204,14 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     />
                     <InfoboxText value={trackNumber?.description} />
 
-                    {showDuplicates && (
+                    {duplicatesOfLocationTrack !== undefined &&
                         <InfoboxField
                             label={
-                                existingDuplicate
-                                    ? t('tool-panel.location-track.duplicate-of')
-                                    : t('tool-panel.location-track.has-duplicates')
+                                duplicatesOfLocationTrack.length > 0
+                                    ? t('tool-panel.location-track.has-duplicates')
+                                    : existingDuplicate ?
+                                        t('tool-panel.location-track.duplicate-of') :
+                                        t('tool-panel.location-track.not-a-duplicate')
                             }
                             value={
                                 <LocationTrackInfoboxDuplicateOf
@@ -220,10 +219,10 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                     duplicatesOfLocationTrack={duplicatesOfLocationTrack}
                                 />
                             }
-                            onEdit={existingDuplicate && openEditLocationTrackDialog}
-                            iconDisabled={existingDuplicate && isOfficial()}
-                        />
-                    )}
+                            onEdit={duplicatesOfLocationTrack.length > 0 ? undefined : openEditLocationTrackDialog}
+                            iconDisabled={isOfficial()}
+                        />}
+
                     <InfoboxField
                         label={t('tool-panel.location-track.topological-connectivity')}
                         value={
@@ -373,6 +372,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     locationTrackChangeTime={locationTrackChangeTime}
                     onUnselect={() => onUnselect(locationTrack)}
                     existingDuplicateTrack={existingDuplicate}
+                    duplicatesExist={duplicatesOfLocationTrack !== undefined && duplicatesOfLocationTrack.length > 0}
                 />
             )}
         </React.Fragment>

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import styles from './location-track-infobox.scss';
 import Infobox from 'tool-panel/infobox/infobox';
-import { LAYOUT_SRID, LayoutLocationTrack, MapAlignment } from 'track-layout/track-layout-model';
+import {
+    LAYOUT_SRID,
+    LayoutLocationTrack,
+    LayoutLocationTrackDuplicate,
+    MapAlignment,
+} from 'track-layout/track-layout-model';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
 import {
@@ -153,7 +158,14 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     }, [locationTrack]);
 
     const existingDuplicate = existingDuplicateOfList && existingDuplicateOfList[0];
-    const duplicatesOfLocationTrack = useLocationTrackDuplicates(locationTrack.id, publishType);
+    const allDuplicatesOfLocationTrack = useLocationTrackDuplicates(locationTrack.id, publishType);
+    // useLocationTrackDuplicates will return both the official and draft versions of a track duplicating us, if both
+    // exist; so we deduplicate our duplicates
+    const duplicatesOfLocationTrack = allDuplicatesOfLocationTrack &&
+        Array.from(allDuplicatesOfLocationTrack
+            .reduce((acc, v) => acc.set(v.id, v),
+                new Map() as Map<string, LayoutLocationTrackDuplicate>)
+            .values());
 
     return (
         <React.Fragment>

--- a/ui/src/tool-panel/translations.fi.json
+++ b/ui/src/tool-panel/translations.fi.json
@@ -176,6 +176,7 @@
             "track-number": "Ratanumero",
             "duplicate-of": "Duplikaatti raiteelle",
             "has-duplicates": "Duplikaattiraiteet",
+            "not-a-duplicate": "Ei duplikaatti",
             "change-info-heading": "Lokitiedot",
             "created": "Luotu",
             "changed": "Muokattu",


### PR DESCRIPTION
Hyvin pieneltä logiikkamuutokselta näyttävän taskin takaa löytyi lopulta paljon näprättävää.

Nyt pitäisi kälin toimia yhdenmukaisesti niin, että duplikaatit ovat 1:n-suhde, jossa jos duplikaatteja on lainkaan, niin keskellä on yksi kanoninen raide, johon on sitten linkitetty (ainoastaan suoraan) mahdollisia muita raiteita; mutta muuten duplikaattien linkittelyä voi tehdä vapaasti ja käsitellä ihan kuin mitä vaan dataa.