### PR TITLE
GVT-1439: Slight changes to how track numbers are displayed on top of alignments

### DIFF
--- a/ui/src/map/layers/alignment-layer.ts
+++ b/ui/src/map/layers/alignment-layer.ts
@@ -28,7 +28,11 @@ import {
     SegmentDataHolder,
 } from 'map/layers/layer-utils';
 import { OlLayerAdapter, SearchItemsOptions } from 'map/layers/layer-model';
-import { createTrackNumberFeature, DisplayMode, TrackNumberPoint } from 'map/layers/track-number';
+import {
+    createMapAlignmentBadgeFeature,
+    DisplayMode,
+    MapAlignmentBadgePoint,
+} from 'map/layers/track-number';
 import * as Limits from 'map/layers/layer-visibility-limits';
 import {
     getTrackNumberDrawDistance,
@@ -137,7 +141,7 @@ function createFeatures(
         trackNumberDisplayMode !== DisplayMode.NONE &&
         segmentHasTrackNumberLabel
     ) {
-        const trackNumberPoints: TrackNumberPoint[] = [];
+        const badgePoints: MapAlignmentBadgePoint[] = [];
         let length = segment.start % drawDistance;
         const pointLength = segment.length / segment.points.length;
         segment.points.forEach((point, index) => {
@@ -145,7 +149,7 @@ function createFeatures(
                 (length % drawDistance == 0.0 || length >= drawDistance) &&
                 index < segment.points.length - 1
             ) {
-                trackNumberPoints.push({
+                badgePoints.push({
                     point: point,
                     nextPoint: segment.points[index + 1],
                 });
@@ -156,14 +160,14 @@ function createFeatures(
             length += pointLength;
         });
 
-        const trackNumberFeatures: Feature<Point>[] = createTrackNumberFeature(
+        const alignmentBadgeFeatures: Feature<Point>[] = createMapAlignmentBadgeFeature(
             alignment,
-            trackNumberPoints,
+            badgePoints,
             trackNumber,
             selected || highlighted,
             trackNumberDisplayMode,
         );
-        features.push(...trackNumberFeatures);
+        features.push(...alignmentBadgeFeatures);
     }
 
     segmentFeature.set('segment-data', dataHolder);
@@ -299,9 +303,7 @@ function createFeaturesCached(
                           data,
                           !!(selected || isLinking),
                           highlighted,
-                          isReference && trackNumberDisplayMode === DisplayMode.NUMBER
-                              ? DisplayMode.NONE // No need to repeat the track number on all lines
-                              : trackNumberDisplayMode,
+                          trackNumberDisplayMode,
                           trackNumberDrawDistance,
                       );
             featureCache.set(key, features);

--- a/ui/src/map/map.module.scss
+++ b/ui/src/map/map.module.scss
@@ -44,17 +44,17 @@ $font-family: 'Open Sans';
     alignmentHighlightColor: $color-geoviite-blue;
 }
 
-// Track number styling
+// Alignment badge styling
 :export {
-    tracknumber: {
+    alignment-badge: {
         @include typography-body-strong;
     }
-    trackNumber-background: $color-black-default;
-    trackNumber-background-near: $color-white-default;
-    trackNumber-background-selected: $color-geoviite-blue;
-    trackNumber-background-border: $color-black-lighter;
-    trackNumber-color: $color-white-default;
-    trackNumber-color-near: $color-black-default;
+    alignment-badge-background: $color-black-default;
+    alignment-badge-background-near: $color-white-default;
+    alignment-badge-background-selected: $color-geoviite-blue;
+    alignment-badge-background-border: $color-black-lighter;
+    alignment-badge-color: $color-white-default;
+    alignment-badge-color-near: $color-black-default;
 }
 
 // Km post styling


### PR DESCRIPTION
Pientä hienosääntöä kuinka ratanumeroa näytetään kartalla:

Kartta zoomattuna todella kauas:
Pituusmittauslinjat pelkästään

Kartta zoomattuna kauas:
Pituusmittauslinjat ratanumerolaatikoineen

Kartta zoomattuna lähelle:
Pituusmittauslinjat ratanumerolaatikoineen ja 
sijaintiraiteet ratanumerolaatioineen, joissa on myös sijaintiraiteen nimi