### PR TITLE
GVT-1487 fix publish details automatic update

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
@@ -36,7 +36,7 @@ data class Publication(
     val ratkoPushTime: Instant?,
 )
 
-data class PublicationStatusTime(
+data class PublicationTime(
     val publishTime: Instant,
     val status: RatkoPushStatus?,
     val ratkoPushTime: Instant?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
@@ -31,7 +31,15 @@ data class Publication(
     val referenceLines: List<ReferenceLinePublishCandidate>,
     val locationTracks: List<LocationTrackPublishCandidate>,
     val switches: List<SwitchPublishCandidate>,
-    val kmPosts: List<KmPostPublishCandidate>
+    val kmPosts: List<KmPostPublishCandidate>,
+    val status: RatkoPushStatus?,
+    val ratkoPushTime: Instant?,
+)
+
+data class PublicationStatusTime(
+    val publishTime: Instant,
+    val status: RatkoPushStatus?,
+    val ratkoPushTime: Instant?,
 )
 
 enum class DraftChangeType {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishDao.kt
@@ -12,7 +12,6 @@ import fi.fta.geoviite.infra.util.*
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 @Service
 class PublishDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTemplateParam) {
@@ -290,7 +289,7 @@ class PublishDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
         }
     }
 
-    fun fetchPublishStatusTime(publicationId: IntId<Publication>): PublicationStatusTime {
+    fun fetchPublishTime(publicationId: IntId<Publication>): PublicationTime {
         val sql = """
             select
               publication.publication_time,
@@ -302,12 +301,12 @@ class PublishDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
               left join integrations.ratko_push
                 on ratko_push.id = ratko_push_content.ratko_push_id
             where publication.id = :id
-            order by ratko_push.id desc
+            order by ratko_push.end_time desc
             limit 1
         """.trimIndent()
         return getOne(publicationId,
             jdbcTemplate.query(sql, mapOf("id" to publicationId.intValue)) { rs, _ ->
-                PublicationStatusTime(
+                PublicationTime(
                     publishTime = rs.getInstant("publication_time"),
                     status = rs.getEnumOrNull<RatkoPushStatus>("status"),
                     ratkoPushTime = rs.getInstantOrNull("ratko_push_time")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
@@ -363,7 +363,7 @@ class PublishService @Autowired constructor(
         publishDao.fetchRatkoPublicationListing()
 
     fun getPublication(id: IntId<Publication>): Publication {
-        val (publishTime, status, pushTime) = publishDao.fetchPublishStatusTime(id)
+        val (publishTime, status, pushTime) = publishDao.fetchPublishTime(id)
         val locationTracks = locationTrackDao.fetchPublicationInformation(id)
         val referenceLines = referenceLineDao.fetchPublicationInformation(id)
         val kmPosts = kmPostDao.fetchPublicationInformation(id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
@@ -363,7 +363,7 @@ class PublishService @Autowired constructor(
         publishDao.fetchRatkoPublicationListing()
 
     fun getPublication(id: IntId<Publication>): Publication {
-        val publishTime = publishDao.fetchPublishTime(id)
+        val (publishTime, status, pushTime) = publishDao.fetchPublishStatusTime(id)
         val locationTracks = locationTrackDao.fetchPublicationInformation(id)
         val referenceLines = referenceLineDao.fetchPublicationInformation(id)
         val kmPosts = kmPostDao.fetchPublicationInformation(id)
@@ -378,6 +378,8 @@ class PublishService @Autowired constructor(
             locationTracks,
             switches,
             kmPosts,
+            status,
+            pushTime,
         )
     }
 

--- a/ui/src/publication/publication-details.tsx
+++ b/ui/src/publication/publication-details.tsx
@@ -28,8 +28,9 @@ const PublicationDetails: React.FC<PublicationDetailsProps> = ({
 }) => {
 
     const [publicationDetails, setPublicationDetails] = React.useState<PublicationDetails | null >();
+    const [waitingAfterFail, setWaitingAfterFail] = React.useState<boolean>();
     const { t } = useTranslation();
-    const waitingAfterFail = publication.status === null && anyFailed;
+
 
     React.useEffect(() => {
         let cancel = false;
@@ -42,7 +43,8 @@ const PublicationDetails: React.FC<PublicationDetailsProps> = ({
         }
 
         fetchPublications();
-        const intervalTimer = setInterval(fetchPublications, 30000)
+        const intervalTimer = setInterval(fetchPublications, 30000);
+        setWaitingAfterFail(publication.status === null && anyFailed);
 
         return () => {
             cancel = true;
@@ -69,7 +71,7 @@ const PublicationDetails: React.FC<PublicationDetailsProps> = ({
                         previewChanges={publicationDetails}
                         ratkoPushDate={
                             publicationDetails.status === RatkoPushStatus.SUCCESSFUL
-                                ? publicationDetails.ratkoPushTime
+                                ? publicationDetails.ratkoPushTime || undefined
                                 : undefined
                         }
                         showRatkoPushDate={true}

--- a/ui/src/publication/publication-details.tsx
+++ b/ui/src/publication/publication-details.tsx
@@ -27,7 +27,7 @@ const PublicationDetails: React.FC<PublicationDetailsProps> = ({
     anyFailed,
 }) => {
 
-    const [publishCandidates, setPublishCandidates] = React.useState<PublicationDetails | null >();
+    const [publicationDetails, setPublicationDetails] = React.useState<PublicationDetails | null >();
     const { t } = useTranslation();
     const waitingAfterFail = publication.status === null && anyFailed;
 
@@ -36,7 +36,7 @@ const PublicationDetails: React.FC<PublicationDetailsProps> = ({
         function fetchPublications () {
             getPublication(publication.id).then(result => {
                 if (!cancel) {
-                    setPublishCandidates(result)
+                    setPublicationDetails(result)
                 }
             });
         }
@@ -60,16 +60,16 @@ const PublicationDetails: React.FC<PublicationDetailsProps> = ({
                     {t('frontpage.frontpage-link')}
                 </Link>
                 <span style={{ whiteSpace: 'pre' }}>
-                    {publishCandidates && ' > ' + formatDateFull(publishCandidates.publishTime)}
+                    {publicationDetails && ' > ' + formatDateFull(publicationDetails.publishTime)}
                 </span>
             </div>
             <div className={styles['publication-details__content']}>
-                {publishCandidates && (
+                {publicationDetails && (
                     <PublicationTable
-                        previewChanges={publishCandidates}
+                        previewChanges={publicationDetails}
                         ratkoPushDate={
-                            publishCandidates.status === RatkoPushStatus.SUCCESSFUL
-                                ? publishCandidates.ratkoPushTime
+                            publicationDetails.status === RatkoPushStatus.SUCCESSFUL
+                                ? publicationDetails.ratkoPushTime
                                 : undefined
                         }
                         showRatkoPushDate={true}

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -108,7 +108,7 @@ export type PublicationDetails = {
     switches: SwitchPublishCandidate[];
     kmPosts: KmPostPublishCandidate[];
     status: RatkoPushStatus | null;
-    ratkoPushTime?: TimeStamp;
+    ratkoPushTime?: TimeStamp | null;
 };
 
 export type RatkoPushError = {

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -107,6 +107,8 @@ export type PublicationDetails = {
     locationTracks: LocationTrackPublishCandidate[];
     switches: SwitchPublishCandidate[];
     kmPosts: KmPostPublishCandidate[];
+    status: RatkoPushStatus | null;
+    ratkoPushTime?: TimeStamp;
 };
 
 export type RatkoPushError = {


### PR DESCRIPTION
Etusivun julkaisujen tarkempi näkymä ei päivittynyt automaattisesti. 
Lisätty:
- ajastettu pollaus komponentin sisälle
- status ja ratko push timestamp details-hakuun (API-kutsu ja tietokantahaku)