### PR TITLE
General: Add missing XML parsing error localization string

### DIFF
--- a/ui/src/i18n/fi/fi.json
+++ b/ui/src/i18n/fi/fi.json
@@ -39,6 +39,7 @@
             "request-failed": "Pyyntö taustapalvelimelle epäonnistui",
             "parsing": {
                 "generic": "Tiedoston jäsentäminen epäonnistui",
+                "xml-invalid": "Tiedoston rakenne on virheellinen. Varmista että merkistö (XML:n alkutagin encoding-kenttä) on oikein.",
                 "missing-section": {
                     "coordinate-system": "Koordinaattijärjestelmän tiedot (CoordinateSystem-elementti) puuttuu",
                     "units": "Yksikkötiedot (Units-elementti) puuttuu",


### PR DESCRIPTION
Huomattu v1 kättöönottopalaverissa. Erillinen tiketti merkistöongelmien tarkemmasta käsittelystä:
https://extranet.vayla.fi/jira/browse/GVT-1493