### PR TITLE
GVT-1500 Consistentify segment-based and topological switch link display

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
@@ -1087,7 +1087,6 @@ class SwitchLinkingService @Autowired constructor(
     private val linkingDao: LinkingDao,
     private val geometryDao: GeometryDao,
     private val switchLibraryService: SwitchLibraryService,
-    private val addressPointService: AddressPointService
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -1212,40 +1211,48 @@ class SwitchLinkingService @Autowired constructor(
             }
     }
 
-    fun getTopologySwitchTrackMeters(
+    fun getSwitchJointConnections(
+        publishType: PublishType,
+        switchId: IntId<TrackLayoutSwitch>
+    ): List<TrackLayoutSwitchJointConnection> {
+        logger.serviceCall(
+            "getSwitchJointConnections",
+            "publishType" to publishType,
+            "switchId" to switchId
+        )
+        val segment = switchService.getSegmentSwitchJointConnections(publishType, switchId)
+        val topological = getTopologySwitchJointConnections(publishType, switchId)
+        return (segment + topological)
+            .groupBy { joint -> joint.number }
+            .values.map { jointConnections ->
+                jointConnections.reduceRight(TrackLayoutSwitchJointConnection::merge)
+            }
+    }
+
+    fun getTopologySwitchJointConnections(
         publicationState: PublishType,
         layoutSwitchId: IntId<TrackLayoutSwitch>
-    ): List<LocationTrackMeter> {
+    ): List<TrackLayoutSwitchJointConnection> {
         val layoutSwitch = switchService.get(publicationState, layoutSwitchId)
             ?: return listOf()
-        val switchStructure = switchLibraryService.getSwitchStructure(layoutSwitch.switchStructureId)
         return getLocationTracksLinkedToSwitch(publicationState, layoutSwitchId)
             .flatMap { (locationTrack, layoutAlignment) ->
-                val geocodingContext by lazy {
-                    addressPointService.getTrackGeocodingData(
-                        publicationState, locationTrack.id as IntId
-                    )?.context
-                }
-
-                val topologySwitchAndPointPairs = listOf(
+                listOf(
                     locationTrack.topologyStartSwitch to layoutAlignment.start,
                     locationTrack.topologyEndSwitch to layoutAlignment.end
                 )
-
-                topologySwitchAndPointPairs.mapNotNull { (topologySwitch, point) ->
-                    if (point != null &&
-                        topologySwitch?.switchId == layoutSwitchId &&
-                        topologySwitch.jointNumber == switchStructure.presentationJointNumber
-                    )
-                        geocodingContext?.getAddress(point)?.let { (trackMeter, _) ->
-                            LocationTrackMeter(
-                                locationTrackId = locationTrack.id as IntId,
-                                trackMeter = trackMeter
-                            )
+                    .mapNotNull { (connection, point) ->
+                        if (connection == null || point == null || connection.switchId != layoutSwitchId) null else {
+                            layoutSwitch.getJoint(connection.jointNumber)?.let { joint ->
+                                TrackLayoutSwitchJointConnection(
+                                    connection.jointNumber,
+                                    listOf(TrackLayoutSwitchJointMatch(locationTrack.id as IntId, point.toPoint())),
+                                    listOf(),
+                                    joint.locationAccuracy
+                                )
+                            }
                         }
-                    else null
-
-                }
+                    }
             }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -25,7 +25,7 @@ class LayoutSwitchDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
     DraftableDaoBase<TrackLayoutSwitch>(jdbcTemplateParam, LAYOUT_SWITCH) {
 
     @Transactional
-    fun fetchSwitchJointConnections(
+    fun fetchSegmentSwitchJointConnections(
         publishType: PublishType,
         switchId: IntId<TrackLayoutSwitch>
     ): List<TrackLayoutSwitchJointConnection> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -19,16 +19,16 @@ class LayoutSwitchService @Autowired constructor(
     private val switchLibraryService: SwitchLibraryService,
 ) : DraftableObjectService<TrackLayoutSwitch, LayoutSwitchDao>(dao) {
 
-    fun getSwitchJointConnections(
+    fun getSegmentSwitchJointConnections(
         publishType: PublishType,
         switchId: IntId<TrackLayoutSwitch>,
     ): List<TrackLayoutSwitchJointConnection> {
         logger.serviceCall(
-            "getSwitchJointConnections",
+            "getSegmentSwitchJointConnections",
             "publishType" to publishType,
             "switchId" to switchId
         )
-        return dao.fetchSwitchJointConnections(publishType, switchId)
+        return dao.fetchSegmentSwitchJointConnections(publishType, switchId)
     }
 
     fun getPresentationJoint(switch: TrackLayoutSwitch): TrackLayoutSwitchJoint? {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -108,9 +108,6 @@ data class TopologyLocationTrackSwitch(
     val jointNumber: JointNumber,
 )
 
-data class LocationTrackMeter(val locationTrackId: IntId<LocationTrack>, val trackMeter: TrackMeter)
-
-
 data class LocationTrack(
     val name: AlignmentName,
     val description: FreeText,
@@ -206,4 +203,17 @@ data class TrackLayoutSwitchJointConnection(
         }
     }
 
+    fun merge(other: TrackLayoutSwitchJointConnection): TrackLayoutSwitchJointConnection {
+        check(number == other.number) { "expected $number == $other.number in TrackLayoutSwitchJointConnection#merge" }
+        // location accuracy comes from the joint and hence can't differ
+        check(locationAccuracy == other.locationAccuracy) {
+            "expected $locationAccuracy == ${other.locationAccuracy} in TrackLayoutSwitchJointConnection#merge"
+        }
+        return TrackLayoutSwitchJointConnection(
+            number,
+            accurateMatches + other.accurateMatches,
+            fallbackMatches + other.fallbackMatches,
+            locationAccuracy,
+        )
+    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutController.kt
@@ -383,17 +383,6 @@ class TrackLayoutController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{publishType}/switches/{id}/topology-track-meters")
-    fun getTrackLayoutSwitchTrackMeters(
-        @PathVariable("publishType") publishType: PublishType,
-        @PathVariable("id") id: IntId<TrackLayoutSwitch>,
-    ): ResponseEntity<List<LocationTrackMeter>> {
-        logger.apiCall("getTrackLayoutSwitchTrackMeters", "id" to id, "publishType" to publishType)
-        return ResponseEntity(switchLinkingService.getTopologySwitchTrackMeters(publishType, id), HttpStatus.OK)
-    }
-
-
-    @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{publishType}/switches", params = ["ids"])
     fun getTrackLayoutSwitches(
         @PathVariable("publishType") publishType: PublishType,
@@ -410,7 +399,7 @@ class TrackLayoutController(
         @PathVariable("id") id: IntId<TrackLayoutSwitch>,
     ): List<TrackLayoutSwitchJointConnection> {
         logger.apiCall("getSwitchJointConnections", "switchId" to id, "publishType" to publishType)
-        return switchService.getSwitchJointConnections(publishType, id)
+        return switchLinkingService.getSwitchJointConnections(publishType, id)
 
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -260,7 +260,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
 
         Assertions.assertEquals(
             listOf(TrackLayoutSwitchJointMatch(locationTrackVersion.id, joint1Point)),
-            connections[0].accurateMatches
+            connections.first { connection -> connection.number == JointNumber(1) }.accurateMatches
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -21,7 +21,6 @@ import kotlin.random.Random
 @ActiveProfiles("dev", "test")
 @SpringBootTest
 class LayoutSwitchServiceIT @Autowired constructor(
-    private val locationTrackService: LocationTrackService,
     private val switchService: LayoutSwitchService,
     private val switchLibraryService: SwitchLibraryService,
     private val switchDao: LayoutSwitchDao,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -21,6 +21,7 @@ import kotlin.random.Random
 @ActiveProfiles("dev", "test")
 @SpringBootTest
 class LayoutSwitchServiceIT @Autowired constructor(
+    private val locationTrackService: LocationTrackService,
     private val switchService: LayoutSwitchService,
     private val switchLibraryService: SwitchLibraryService,
     private val switchDao: LayoutSwitchDao,

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -27,7 +27,6 @@ import {
     getLocationTrack,
     getSwitch,
     getSwitchJointConnections,
-    getTopologySwitchTrackMeters,
     getTrackAddress,
 } from 'track-layout/track-layout-api';
 import { PublishType, SwitchOwnerId, SwitchStructure, TrackMeter } from 'common/common-model';
@@ -112,36 +111,13 @@ const getSwitchTrackMeters = (
             ? accurateMatches.map((match) => match.locationTrackId)
             : presentationJointConnection?.fallbackMatches ?? [];
 
-    const switchTrackMeters = presentationJoint?.location ?
+    return presentationJoint?.location ?
         Promise.all(
             locationTrackIds.map((id) =>
                 getSwitchTrackMeter(id, publishType, changeTimes, presentationJoint),
             ),
         ).then(result => result.filter(filterNotEmpty))
         : Promise.resolve([]);
-
-    const topologySwitchTrackMeters = layoutSwitch != undefined ?
-        getTopologySwitchTrackMeters(publishType, layoutSwitch.id)
-            .then(switchTrackMeters =>
-                Promise.all(
-                    switchTrackMeters.map(switchTrackMeter =>
-                        getLocationTrack(switchTrackMeter.locationTrackId, publishType)
-                            .then(locationTrack => {
-                                const switchTrackMeterWithName: SwitchTrackMeter = {
-                                    ...switchTrackMeter,
-                                    name: locationTrack.name,
-                                };
-                                return switchTrackMeterWithName;
-                            }),
-                    )),
-            ) : Promise.resolve([]);
-
-    return Promise.all(
-        [
-            switchTrackMeters,
-            topologySwitchTrackMeters,
-        ],
-    ).then(result => result.flatMap(trackMeters => trackMeters));
 };
 
 const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({

--- a/ui/src/track-layout/track-layout-api.ts
+++ b/ui/src/track-layout/track-layout-api.ts
@@ -21,12 +21,10 @@ import {
     MapSegment,
     ReferenceLineId,
     ReferenceLineStartAndEndPoints,
-    SwitchTrackMeter,
 } from './track-layout-model';
 import {
     API_URI,
     deleteAdt,
-    getIgnoreError,
     getThrowError,
     getWithDefault,
     postIgnoreError,
@@ -403,16 +401,6 @@ export async function getSwitches(
     return switchIds.length > 0
         ? getThrowError<LayoutSwitch[]>(`${layoutUri(publishType)}/switches?ids=${switchIds}`)
         : Promise.resolve([]);
-}
-
-export async function getTopologySwitchTrackMeters(
-    publishType: PublishType,
-    switchId: LayoutSwitchId,
-): Promise<SwitchTrackMeter[]> {
-    const result = await getIgnoreError<SwitchTrackMeter[]>(
-        `${layoutUri(publishType)}/switches/${switchId}/topology-track-meters`,
-    );
-    return result || [];
 }
 
 export async function getKmPost(


### PR DESCRIPTION
Kommittiviestin mukaisesti: Sekä segmentille linkitetyt että topologisesti linkitetyt vaihdepisteet tulevat nyt saman vanhan getSwitchJointConnections-API:n kautta, ja frontti käyttää nyt molempien kanssa rataosoitteiden näyttämiseen samaa logiikkaa.

Varsinainen alkuperäinen taski oli tuoda topologiset linkit mukaan "Vaihteen sijaintitiedot"-boksiin niin, että siinä näkyvät myös vaihteelle päätyvät raiteet. Tätä varten ei tarvinnut minkäänlaista muutosta SwitchJointInfoboksin omaan logiikaan, vaan se osaa päätellä yhteyslistasta jo topologiset yhteydet valmiiksi, nyt kun ne tulevat listassa mukana.