### PR TITLE
GVT-1510 Separate out a publication candidate validation API

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
@@ -55,13 +55,41 @@ data class PublicationChanges(
     val calculatedChanges: CalculatedChanges,
 )
 
+data class ValidatedPublishCandidates(
+    val validatedAsPublicationUnit: PublishCandidates,
+    val validatedSeparately: PublishCandidates,
+)
+
 data class PublishCandidates(
     val trackNumbers: List<TrackNumberPublishCandidate>,
     val locationTracks: List<LocationTrackPublishCandidate>,
     val referenceLines: List<ReferenceLinePublishCandidate>,
     val switches: List<SwitchPublishCandidate>,
     val kmPosts: List<KmPostPublishCandidate>,
-)
+) {
+    fun filteredToRequest(publishRequest: PublishRequest): PublishCandidates {
+        val trackNumberIds = publishRequest.trackNumbers.toSet()
+        val locationTrackIds = publishRequest.locationTracks.toSet()
+        val referenceLineIds = publishRequest.referenceLines.toSet()
+        val switchIds = publishRequest.switches.toSet()
+        val kmPostIds = publishRequest.kmPosts.toSet()
+        return PublishCandidates(
+            trackNumbers.filter { candidate -> trackNumberIds.contains(candidate.id) },
+            locationTracks.filter { candidate -> locationTrackIds.contains(candidate.id) },
+            referenceLines.filter { candidate -> referenceLineIds.contains(candidate.id) },
+            switches.filter { candidate -> switchIds.contains(candidate.id) },
+            kmPosts.filter { candidate -> kmPostIds.contains(candidate.id) },
+        )
+    }
+
+    fun ids(): PublishRequest = PublishRequest(
+        trackNumbers.map { candidate -> candidate.id },
+        locationTracks.map { candidate -> candidate.id },
+        referenceLines.map { candidate -> candidate.id },
+        switches.map { candidate -> candidate.id },
+        kmPosts.map { candidate -> candidate.id },
+    )
+}
 
 data class PublishRequest(
     val trackNumbers: List<IntId<TrackLayoutTrackNumber>>,
@@ -69,7 +97,16 @@ data class PublishRequest(
     val referenceLines: List<IntId<ReferenceLine>>,
     val switches: List<IntId<TrackLayoutSwitch>>,
     val kmPosts: List<IntId<TrackLayoutKmPost>>,
-)
+) {
+    operator fun minus(other: PublishRequest) =
+        PublishRequest(
+            trackNumbers - other.trackNumbers.toSet(),
+            locationTracks - other.locationTracks.toSet(),
+            referenceLines - other.referenceLines.toSet(),
+            switches - other.switches.toSet(),
+            kmPosts - other.kmPosts.toSet(),
+        )
+}
 
 data class PublishResult(
     val publishId: IntId<Publication>?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishController.kt
@@ -32,7 +32,14 @@ class PublishController @Autowired constructor(
     @GetMapping("/candidates")
     fun getPublishCandidates(): PublishCandidates {
         logger.apiCall("getPublishCandidates")
-        return publishService.validatePublishCandidates(publishService.collectPublishCandidates())
+        return publishService.getPublishCandidates()
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @PostMapping("/validate")
+    fun validatePublishCandidates(@RequestBody publishRequest: PublishRequest): ValidatedPublishCandidates {
+        logger.apiCall("validatePublishCandidates")
+        return publishService.validatePublishCandidates(publishRequest)
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
@@ -79,39 +79,19 @@ class PublishService @Autowired constructor(
     fun validateSeparately(publishCandidates: PublishCandidates) =
         PublishCandidates(
             trackNumbers = publishCandidates.trackNumbers.map { candidate ->
-                candidate.copy(
-                    errors = validateTrackNumberOwnInformation(
-                        candidate.id
-                    )
-                )
+                candidate.copy(errors = validateTrackNumberOwnInformation(candidate.id))
             },
             locationTracks = publishCandidates.locationTracks.map { candidate ->
-                candidate.copy(
-                    errors = validateLocationTrackOwnInformation(
-                        candidate.id
-                    )
-                )
+                candidate.copy(errors = validateLocationTrackOwnInformation(candidate.id))
             },
             referenceLines = publishCandidates.referenceLines.map { candidate ->
-                candidate.copy(
-                    errors = validateReferenceLineOwnInformation(
-                        candidate.id
-                    )
-                )
+                candidate.copy(errors = validateReferenceLineOwnInformation(candidate.id))
             },
             switches = publishCandidates.switches.map { candidate ->
-                candidate.copy(
-                    errors = validateSwitchOwnInformation(
-                        candidate.id
-                    )
-                )
+                candidate.copy(errors = validateSwitchOwnInformation(candidate.id))
             },
             kmPosts = publishCandidates.kmPosts.map { candidate ->
-                candidate.copy(
-                    errors = validateKmPostOwnInformation(
-                        candidate.id
-                    )
-                )
+                candidate.copy(errors = validateKmPostOwnInformation(candidate.id))
             },
         )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
@@ -58,8 +58,64 @@ class PublishService @Autowired constructor(
         )
     }
 
-    fun validatePublishCandidates(publishCandidates: PublishCandidates): PublishCandidates {
+    fun getPublishCandidates(): PublishCandidates {
+        logger.serviceCall("getPublishCandidates")
+        return collectPublishCandidates()
+    }
+
+    fun validatePublishCandidates(publishRequest: PublishRequest): ValidatedPublishCandidates {
         logger.serviceCall("validatePublishCandidates")
+        val allPublishCandidates = collectPublishCandidates()
+        val candidatesInPublicationRequest = allPublishCandidates.filteredToRequest(publishRequest)
+        val candidatesNotInPublicationRequest =
+            allPublishCandidates.filteredToRequest(allPublishCandidates.ids() - publishRequest)
+
+        return ValidatedPublishCandidates(
+            validatedAsPublicationUnit = validateAsPublicationUnit(candidatesInPublicationRequest),
+            validatedSeparately = validateSeparately(candidatesNotInPublicationRequest),
+        )
+    }
+
+    fun validateSeparately(publishCandidates: PublishCandidates) =
+        PublishCandidates(
+            trackNumbers = publishCandidates.trackNumbers.map { candidate ->
+                candidate.copy(
+                    errors = validateTrackNumberOwnInformation(
+                        candidate.id
+                    )
+                )
+            },
+            locationTracks = publishCandidates.locationTracks.map { candidate ->
+                candidate.copy(
+                    errors = validateLocationTrackOwnInformation(
+                        candidate.id
+                    )
+                )
+            },
+            referenceLines = publishCandidates.referenceLines.map { candidate ->
+                candidate.copy(
+                    errors = validateReferenceLineOwnInformation(
+                        candidate.id
+                    )
+                )
+            },
+            switches = publishCandidates.switches.map { candidate ->
+                candidate.copy(
+                    errors = validateSwitchOwnInformation(
+                        candidate.id
+                    )
+                )
+            },
+            kmPosts = publishCandidates.kmPosts.map { candidate ->
+                candidate.copy(
+                    errors = validateKmPostOwnInformation(
+                        candidate.id
+                    )
+                )
+            },
+        )
+
+    fun validateAsPublicationUnit(publishCandidates: PublishCandidates): PublishCandidates {
         val publishSwitchIds = publishCandidates.switches.map(SwitchPublishCandidate::id)
         val publishKmPostIds = publishCandidates.kmPosts.map(KmPostPublishCandidate::id)
         val publishReferenceLineIds = publishCandidates.referenceLines.map(ReferenceLinePublishCandidate::id)
@@ -249,14 +305,17 @@ class PublishService @Autowired constructor(
         )
     }
 
+    fun validateTrackNumberOwnInformation(id: IntId<TrackLayoutTrackNumber>): List<PublishValidationError> {
+        return validateDraftTrackNumberFields(getDraftTrackNumberWithOfficialId(id))
+    }
+
     fun validateTrackNumber(
         id: IntId<TrackLayoutTrackNumber>,
         publishKmPostIds: List<IntId<TrackLayoutKmPost>>,
         publishReferenceLineIds: List<IntId<ReferenceLine>>,
         publishLocationTrackIds: List<IntId<LocationTrack>>,
     ): List<PublishValidationError> {
-        val trackNumber = trackNumberService.getDraft(id)
-        require(trackNumber.id == id) { "Attempting to publish track number via draft ID" }
+        val trackNumber = getDraftTrackNumberWithOfficialId(id)
         val kmPosts = kmPostService.list(DRAFT, id)
         val locationTracks = publishDao.fetchTrackNumberLocationTrackRows(id).map(locationTrackDao::fetch)
         return validateDraftTrackNumberFields(trackNumber) +
@@ -285,12 +344,15 @@ class PublishService @Autowired constructor(
         }
     }
 
+    fun validateKmPostOwnInformation(id: IntId<TrackLayoutKmPost>): List<PublishValidationError> {
+        return validateDraftKmPostFields(getDraftKmPostWithOfficialId(id))
+    }
+
     fun validateKmPost(
         id: IntId<TrackLayoutKmPost>,
         publishTrackNumberIds: List<IntId<TrackLayoutTrackNumber>>,
     ): List<PublishValidationError> {
-        val kmPost = kmPostService.getDraft(id)
-        require(kmPost.id == id) { "Attempting to publish km-post via draft ID" }
+        val kmPost = getDraftKmPostWithOfficialId(id)
         val trackNumber = kmPost.trackNumberId?.let { tnId ->
             trackNumberService.getDraft(tnId as IntId)
         }
@@ -301,12 +363,15 @@ class PublishService @Autowired constructor(
                 } else listOf()
     }
 
+    fun validateSwitchOwnInformation(id: IntId<TrackLayoutSwitch>): List<PublishValidationError> {
+        return validateDraftSwitchFields(getDraftSwitchWithOfficialId(id))
+    }
+
     fun validateSwitch(
         id: IntId<TrackLayoutSwitch>,
         publishLocationTrackIds: List<IntId<LocationTrack>>,
     ): List<PublishValidationError> {
-        val switch = switchDao.fetch(switchDao.fetchDraftVersionOrThrow(id))
-        require(switch.id == id) { "Attempting to publish switch via draft ID" }
+        val switch = getDraftSwitchWithOfficialId(id)
         val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
         val locationTracksAndAlignments = publishDao.fetchLinkedAlignmentRows(id)
             .map { (trackVersion, alignmentVersion) ->
@@ -320,14 +385,21 @@ class PublishService @Autowired constructor(
                 validateSwitchSegmentStructure(switch, structure, locationTracksAndAlignments)
     }
 
+    fun validateReferenceLineOwnInformation(id: IntId<ReferenceLine>): List<PublishValidationError> {
+        val (referenceLine, alignment) = getDraftReferenceLineAndAlignmentWithOfficialId(id)
+        val trackNumber = trackNumberService.getDraft(referenceLine.trackNumberId)
+        return validateDraftReferenceLineFields(referenceLine) +
+                if (trackNumber.exists) {
+                    validateReferenceLineAlignment(alignment)
+                } else listOf()
+
+    }
+
     fun validateReferenceLine(
         id: IntId<ReferenceLine>,
         publishTrackNumberIds: List<IntId<TrackLayoutTrackNumber>>,
     ): List<PublishValidationError> {
-        val (referenceLine, alignment) = requireNotNull(referenceLineService.getWithAlignment(DRAFT, id)) {
-            "Cannot find draft reference line: $id"
-        }
-        require(referenceLine.id == id) { "Attempting to publish validate ReferenceLine via draft ID" }
+        val (referenceLine, alignment) = getDraftReferenceLineAndAlignmentWithOfficialId(id)
         val trackNumber = trackNumberService.getDraft(referenceLine.trackNumberId)
         return validateDraftReferenceLineFields(referenceLine) +
                 validateReferenceLineReference(referenceLine, trackNumber, publishTrackNumberIds) +
@@ -338,16 +410,21 @@ class PublishService @Autowired constructor(
                 } else listOf()
     }
 
+    fun validateLocationTrackOwnInformation(id: IntId<LocationTrack>): List<PublishValidationError> {
+        val (locationTrack, alignment) = getDraftLocationTrackAndAlignmentWithOfficialId(id)
+        return validateDraftLocationTrackFields(locationTrack) +
+                if (locationTrack.exists) {
+                    validateLocationTrackAlignment(alignment)
+                } else listOf()
+    }
+
     fun validateLocationTrack(
         id: IntId<LocationTrack>,
         publishTrackNumberIds: List<IntId<TrackLayoutTrackNumber>>,
         publishSwitchIds: List<IntId<TrackLayoutSwitch>>,
         publishLocationTrackIds: List<IntId<LocationTrack>>,
     ): List<PublishValidationError> {
-        val (locationTrack, alignment) = requireNotNull(locationTrackService.getWithAlignment(DRAFT, id)) {
-            "Cannot find draft location track: $id"
-        }
-        require(locationTrack.id == id) { "Attempting to publish LocationTrack via draft ID" }
+        val (locationTrack, alignment) = getDraftLocationTrackAndAlignmentWithOfficialId(id)
         val trackNumber = trackNumberService.getDraft(locationTrack.trackNumberId)
         val duplicateOfLocationTrack = locationTrack.duplicateOf?.let { duplicateId ->
             locationTrackService.getOrThrow(DRAFT, duplicateId)
@@ -406,5 +483,39 @@ class PublishService @Autowired constructor(
                 segments = segments,
             )
         }
+    }
+
+    private fun getDraftKmPostWithOfficialId(id: IntId<TrackLayoutKmPost>): TrackLayoutKmPost {
+        val kmPost = kmPostService.getDraft(id)
+        require(kmPost.id == id) { "Attempting to publish km-post via draft ID" }
+        return kmPost
+    }
+
+    private fun getDraftSwitchWithOfficialId(id: IntId<TrackLayoutSwitch>): TrackLayoutSwitch {
+        val switch = switchDao.fetch(switchDao.fetchDraftVersionOrThrow(id))
+        require(switch.id == id) { "Attempting to publish switch via draft ID" }
+        return switch
+    }
+
+    private fun getDraftTrackNumberWithOfficialId(id: IntId<TrackLayoutTrackNumber>): TrackLayoutTrackNumber {
+        val trackNumber = trackNumberService.getDraft(id)
+        require(trackNumber.id == id) { "Attempting to publish track number via draft ID" }
+        return trackNumber
+    }
+
+    private fun getDraftReferenceLineAndAlignmentWithOfficialId(id: IntId<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment> {
+        val (referenceLine, alignment) = requireNotNull(referenceLineService.getWithAlignment(DRAFT, id)) {
+            "Cannot find draft reference line: $id"
+        }
+        require(referenceLine.id == id) { "Attempting to publish ReferenceLine via draft ID" }
+        return referenceLine to alignment
+    }
+
+    private fun getDraftLocationTrackAndAlignmentWithOfficialId(id: IntId<LocationTrack>): Pair<LocationTrack, LayoutAlignment> {
+        val (locationTrack, alignment) = requireNotNull(locationTrackService.getWithAlignment(DRAFT, id)) {
+            "Cannot find draft location track: $id"
+        }
+        require(locationTrack.id == id) { "Attempting to publish LocationTrack via draft ID" }
+        return locationTrack to alignment
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
@@ -465,33 +465,23 @@ class PublishService @Autowired constructor(
         }
     }
 
-    private fun getDraftKmPostWithOfficialId(id: IntId<TrackLayoutKmPost>): TrackLayoutKmPost {
-        val kmPost = kmPostService.getDraft(id)
-        require(kmPost.id == id) { "Attempting to publish km-post via draft ID" }
-        return kmPost
-    }
+    private fun getDraftKmPostWithOfficialId(id: IntId<TrackLayoutKmPost>): TrackLayoutKmPost =
+        kmPostService.getDraft(id)
+            .also { kmPost -> require(kmPost.id == id) { "Attempting to publish km-post via draft ID" } }
 
-    private fun getDraftSwitchWithOfficialId(id: IntId<TrackLayoutSwitch>): TrackLayoutSwitch {
-        val switch = switchDao.fetch(switchDao.fetchDraftVersionOrThrow(id))
-        require(switch.id == id) { "Attempting to publish switch via draft ID" }
-        return switch
-    }
+    private fun getDraftSwitchWithOfficialId(id: IntId<TrackLayoutSwitch>): TrackLayoutSwitch =
+        switchDao.fetch(switchDao.fetchDraftVersionOrThrow(id))
+            .also { switch -> require(switch.id == id) { "Attempting to publish switch via draft ID" } }
 
-    private fun getDraftTrackNumberWithOfficialId(id: IntId<TrackLayoutTrackNumber>): TrackLayoutTrackNumber {
-        val trackNumber = trackNumberService.getDraft(id)
-        require(trackNumber.id == id) { "Attempting to publish track number via draft ID" }
-        return trackNumber
-    }
+    private fun getDraftTrackNumberWithOfficialId(id: IntId<TrackLayoutTrackNumber>): TrackLayoutTrackNumber =
+        trackNumberService.getDraft(id)
+            .also { trackNumber -> require(trackNumber.id == id) { "Attempting to publish track number via draft ID" } }
 
-    private fun getDraftReferenceLineAndAlignmentWithOfficialId(id: IntId<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment> {
-        val (referenceLine, alignment) = referenceLineService.getWithAlignmentOrThrow(DRAFT, id)
-        require(referenceLine.id == id) { "Attempting to publish ReferenceLine via draft ID" }
-        return referenceLine to alignment
-    }
+    private fun getDraftReferenceLineAndAlignmentWithOfficialId(id: IntId<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment> =
+        referenceLineService.getWithAlignmentOrThrow(DRAFT, id)
+            .also { (referenceLine, _) -> require(referenceLine.id == id) { "Attempting to publish ReferenceLine via draft ID" } }
 
-    private fun getDraftLocationTrackAndAlignmentWithOfficialId(id: IntId<LocationTrack>): Pair<LocationTrack, LayoutAlignment> {
-        val (locationTrack, alignment) = locationTrackService.getWithAlignmentOrThrow(DRAFT, id)
-        require(locationTrack.id == id) { "Attempting to publish LocationTrack via draft ID" }
-        return locationTrack to alignment
-    }
+    private fun getDraftLocationTrackAndAlignmentWithOfficialId(id: IntId<LocationTrack>): Pair<LocationTrack, LayoutAlignment> =
+        locationTrackService.getWithAlignmentOrThrow(DRAFT, id)
+            .also { (locationTrack, _) -> require(locationTrack.id == id) { "Attempting to publish LocationTrack via draft ID" } }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublishService.kt
@@ -484,17 +484,13 @@ class PublishService @Autowired constructor(
     }
 
     private fun getDraftReferenceLineAndAlignmentWithOfficialId(id: IntId<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment> {
-        val (referenceLine, alignment) = requireNotNull(referenceLineService.getWithAlignment(DRAFT, id)) {
-            "Cannot find draft reference line: $id"
-        }
+        val (referenceLine, alignment) = referenceLineService.getWithAlignmentOrThrow(DRAFT, id)
         require(referenceLine.id == id) { "Attempting to publish ReferenceLine via draft ID" }
         return referenceLine to alignment
     }
 
     private fun getDraftLocationTrackAndAlignmentWithOfficialId(id: IntId<LocationTrack>): Pair<LocationTrack, LayoutAlignment> {
-        val (locationTrack, alignment) = requireNotNull(locationTrackService.getWithAlignment(DRAFT, id)) {
-            "Cannot find draft location track: $id"
-        }
+        val (locationTrack, alignment) = locationTrackService.getWithAlignmentOrThrow(DRAFT, id)
         require(locationTrack.id == id) { "Attempting to publish LocationTrack via draft ID" }
         return locationTrack to alignment
     }

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -69,8 +69,16 @@ export interface CalculatedChanges {
     switchChanges: SwitchChange[];
 }
 
+export interface ValidatedPublishCandidates {
+    validatedAsPublicationUnit: PublishCandidates;
+    validatedSeparately: PublishCandidates;
+}
+
 export const getPublishCandidates = () =>
     getIgnoreError<PublishCandidates>(`${PUBLISH_URI}/candidates`);
+
+export const validatePublishCandidates = (request: PublishRequest) =>
+    postIgnoreError<PublishRequest, ValidatedPublishCandidates>(`${PUBLISH_URI}/validate`, request)
 
 export const revertCandidates = () =>
     deleteAdt<null, PublishResult>(`${PUBLISH_URI}/candidates`, null, true);

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -70,6 +70,11 @@ export type PublishCandidates = {
     kmPosts: KmPostPublishCandidate[];
 };
 
+export type ValidatedPublishCandidates = {
+    validatedAsPublicationUnit: PublishCandidates;
+    validatedSeparately: PublishCandidates;
+}
+
 export type PublicationListingItem = {
     id: PublicationId;
     publishTime: TimeStamp;


### PR DESCRIPTION
Frontti hakee nyt ensiksi kaikki julkaisuehdokkaat yhden API:n kautta, ja sitten validointi-API:n kautta vielä erikseen niille validointivirheet. Tässä siis back-end tekee periaatteessa vähän ylimääräistä työtä, koska varsinaisen validoinnin yhteydessä se hakee julkaisuehdokkaat uusiksi saadakseen listattua sekä julkaisuyksikköön liittyvät että "loput" muutetut oliot, mutta aikaa siihen ei juuri vaikuta menevän.