### PR TITLE
GVT-1285 Fix reference line selection going out of sync

### DIFF
--- a/ui/src/geoviite-design-lib/track-number/track-number-link.tsx
+++ b/ui/src/geoviite-design-lib/track-number/track-number-link.tsx
@@ -1,5 +1,5 @@
-import { LayoutTrackNumberId, ReferenceLineId } from 'track-layout/track-layout-model';
-import { useTrackNumber, useTrackNumberReferenceLine } from 'track-layout/track-layout-react-utils';
+import { LayoutTrackNumberId } from 'track-layout/track-layout-model';
+import { useTrackNumber } from 'track-layout/track-layout-react-utils';
 import { PublishType } from 'common/common-model';
 import { Link } from 'vayla-design-lib/link/link';
 import React from 'react';
@@ -11,29 +11,24 @@ import { createEmptyItemCollections } from 'selection/selection-store';
 export type TrackNumberLinkProps = {
     trackNumberId?: LayoutTrackNumberId;
     publishType: PublishType;
-    onClick?: (
-        trackNumberId: LayoutTrackNumberId,
-        referenceLineId: ReferenceLineId | undefined,
-    ) => void;
+    onClick?: (trackNumberId: LayoutTrackNumberId) => void;
 };
 
 function createSelectAction() {
     const dispatch = useTrackLayoutAppDispatch();
     const delegates = createDelegates(dispatch, TrackLayoutActions);
-    return (trackNumberId: LayoutTrackNumberId, referenceLineId: ReferenceLineId | undefined) =>
+    return (trackNumberId: LayoutTrackNumberId) =>
         delegates.onSelect({
             ...createEmptyItemCollections(),
             trackNumbers: [trackNumberId],
-            referenceLines: referenceLineId ? [referenceLineId] : [],
         });
 }
 
 export const TrackNumberLink: React.FC<TrackNumberLinkProps> = (props: TrackNumberLinkProps) => {
     const trackNumber = useTrackNumber(props.publishType, props.trackNumberId);
-    const referenceLine = useTrackNumberReferenceLine(props.trackNumberId, props.publishType);
     const clickAction = props.onClick || createSelectAction();
     return (
-        <Link onClick={() => trackNumber && clickAction(trackNumber.id, referenceLine?.id)}>
+        <Link onClick={() => trackNumber && clickAction(trackNumber.id)}>
             {trackNumber?.number || ''}
         </Link>
     );

--- a/ui/src/map/layers/alignment-layer.ts
+++ b/ui/src/map/layers/alignment-layer.ts
@@ -473,9 +473,8 @@ adapterInfoRegister.add('alignment', {
         const selectionSearchFunction = (hitArea: Polygon, options: SearchItemsOptions) => {
             const found = shownItemsSearchFunction(hitArea, options);
             return {
-                ...found,
                 locationTracks: found.locationTracks.map((t) => t.id),
-                referenceLines: found.referenceLines.map((l) => l.id),
+                trackNumbers: found.referenceLines.map((l) => l.trackNumberId),
             };
         };
 

--- a/ui/src/map/layers/layer-utils.ts
+++ b/ui/src/map/layers/layer-utils.ts
@@ -452,7 +452,6 @@ export function mergePartialItemSearchResults(
     return searchResults.reduce<OptionalItemCollections>((merged, searchResult) => {
         return {
             locationTracks: mergeOptionalArrays(merged.locationTracks, searchResult.locationTracks),
-            referenceLines: mergeOptionalArrays(merged.referenceLines, searchResult.referenceLines),
             segments: mergeOptionalArrays(merged.segments, searchResult.segments),
             kmPosts: mergeOptionalArrays(merged.kmPosts, searchResult.kmPosts),
             geometryKmPosts: mergeOptionalArrays(

--- a/ui/src/map/location-holder/location-holder-view.tsx
+++ b/ui/src/map/location-holder/location-holder-view.tsx
@@ -3,18 +3,14 @@ import styles from './location-holder-view.scss';
 import { formatToTM35FINString } from 'utils/geography-utils';
 import { trackLayoutStore } from 'store/store';
 import { Point } from 'model/geometry';
-import {
-    LayoutTrackNumberId,
-    LocationTrackId,
-    ReferenceLineId,
-} from 'track-layout/track-layout-model';
+import { LayoutTrackNumberId, LocationTrackId } from 'track-layout/track-layout-model';
 import { PublishType, TrackMeter as TrackMeterModel } from 'common/common-model';
 import { useDebouncedState, useLoader } from 'utils/react-utils';
 import { getAddress } from 'common/geocoding-api';
 import TrackMeter from 'geoviite-design-lib/track-meter/track-meter';
 import { getLocationTrack } from 'track-layout/layout-location-track-api';
 import { getTrackNumberById } from 'track-layout/layout-track-number-api';
-import { getReferenceLine } from 'track-layout/layout-reference-line-api';
+import { getTrackNumberReferenceLine } from 'track-layout/layout-reference-line-api';
 
 type LocationHolderProps = {
     hoveredCoordinate: Point | null;
@@ -37,11 +33,11 @@ export async function getLocationTrackHoverLocation(
 }
 
 export async function getReferenceLineHoverLocation(
-    referenceLineId: ReferenceLineId,
+    trackNumberId: LayoutTrackNumberId,
     publishType: PublishType,
     coordinate: Point,
 ): Promise<HoverLocation> {
-    return getReferenceLine(referenceLineId, publishType).then((line) => {
+    return getTrackNumberReferenceLine(trackNumberId, publishType).then((line) => {
         if (!line) {
             return emptyHoveredLocation(coordinate);
         } else {
@@ -74,13 +70,13 @@ export async function getHoverLocation(
 }
 
 async function getHoverLocationBySelection(coordinate: Point | null): Promise<HoverLocation> {
-    const referenceLines =
-        trackLayoutStore.getState().trackLayout.selection.selectedItems.referenceLines;
+    const trackNumberIds =
+        trackLayoutStore.getState().trackLayout.selection.selectedItems.trackNumbers;
     const locationTracks =
         trackLayoutStore.getState().trackLayout.selection.selectedItems.locationTracks;
     const publishType = trackLayoutStore.getState().trackLayout.publishType;
-    if (referenceLines.length == 1 && coordinate != null) {
-        return getReferenceLineHoverLocation(referenceLines[0], publishType, coordinate);
+    if (trackNumberIds.length == 1 && coordinate != null) {
+        return getReferenceLineHoverLocation(trackNumberIds[0], publishType, coordinate);
     } else if (locationTracks.length == 1 && coordinate != null) {
         return getLocationTrackHoverLocation(locationTracks[0], publishType, coordinate);
     } else {

--- a/ui/src/selection-panel/alignment-panel/reference-lines-panel.tsx
+++ b/ui/src/selection-panel/alignment-panel/reference-lines-panel.tsx
@@ -23,7 +23,7 @@ type ReferenceLinesPanelProps = {
         trackNumberId: LayoutTrackNumberId,
         referenceLine: ReferenceLineId,
     ) => void;
-    selectedReferenceLines?: ReferenceLineId[];
+    selectedTrackNumbers?: LayoutTrackNumberId[];
     canSelectReferenceLine: boolean;
     max?: number;
 };
@@ -33,10 +33,11 @@ const ReferenceLinesPanel: React.FC<ReferenceLinesPanelProps> = ({
     trackNumberChangeTime,
     referenceLines,
     onToggleReferenceLineSelection,
-    selectedReferenceLines,
+    selectedTrackNumbers,
     canSelectReferenceLine,
     max = 16,
 }: ReferenceLinesPanelProps) => {
+    console.log('Selection-Panel bind', selectedTrackNumbers);
     const { t } = useTranslation();
     const [linesCount, setLinesCount] = React.useState(0);
     const [visibleLines, setVisibleLines] = React.useState<LayoutReferenceLine[]>([]);
@@ -61,13 +62,13 @@ const ReferenceLinesPanel: React.FC<ReferenceLinesPanelProps> = ({
                 className={styles['reference-lines-panel__reference-lines']}
                 qa-id="reference-lines-list">
                 {visibleLines.map((line) => {
-                    const isSelected = selectedReferenceLines?.some(
-                        (selectedId) => selectedId == line.id,
+                    const isSelected = selectedTrackNumbers?.some(
+                        (selectedId) => selectedId == line.trackNumberId,
                     );
                     const itemClassName = createClassName(
                         'reference-lines-panel__reference-line',
                         canSelectReferenceLine &&
-                            'reference-lines-panel__reference-line--can-select',
+                        'reference-lines-panel__reference-line--can-select',
                     );
                     const trackNumber = trackNumbers?.find((tn) => tn.id == line.trackNumberId);
                     return (

--- a/ui/src/selection-panel/alignment-panel/reference-lines-panel.tsx
+++ b/ui/src/selection-panel/alignment-panel/reference-lines-panel.tsx
@@ -37,7 +37,6 @@ const ReferenceLinesPanel: React.FC<ReferenceLinesPanelProps> = ({
     canSelectReferenceLine,
     max = 16,
 }: ReferenceLinesPanelProps) => {
-    console.log('Selection-Panel bind', selectedTrackNumbers);
     const { t } = useTranslation();
     const [linesCount, setLinesCount] = React.useState(0);
     const [visibleLines, setVisibleLines] = React.useState<LayoutReferenceLine[]>([]);

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -129,11 +129,10 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
     );
 
     const onToggleReferenceLineSelection = React.useCallback(
-        (trackNumber: string, referenceLine: string) =>
+        (trackNumber: string) =>
             onSelect({
                 ...createEmptyItemCollections(),
                 trackNumbers: [trackNumber],
-                referenceLines: [referenceLine],
                 isToggle: true,
             }),
         [],
@@ -197,9 +196,8 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
             {planHeaders && (
                 <section>
                     <h3 className={styles['selection-panel__title']}>
-                        {`${t('selection-panel.geometries-title')} (${
-                            planHeaders.length
-                        }/${planHeaderCount})`}
+                        {`${t('selection-panel.geometries-title')} (${planHeaders.length
+                            }/${planHeaderCount})`}
                     </h3>
                     <div
                         className={createClassName(
@@ -305,17 +303,16 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
             </section>
             <section>
                 <h3 className={styles['selection-panel__title']}>
-                    {`${t('selection-panel.reference-lines-title')}  (${
-                        filteredReferenceLines.length
-                    })`}
+                    {`${t('selection-panel.reference-lines-title')}  (${filteredReferenceLines.length
+                        })`}
                 </h3>
                 <div className={styles['selection-panel__content']}>
                     <ReferenceLinesPanel
                         publishType={publishType}
                         referenceLines={filteredReferenceLines}
                         trackNumberChangeTime={changeTimes.layoutTrackNumber}
-                        selectedReferenceLines={selectedItems?.referenceLines}
-                        canSelectReferenceLine={selectableItemTypes.includes('referenceLines')}
+                        selectedTrackNumbers={selectedItems?.trackNumbers}
+                        canSelectReferenceLine={selectableItemTypes.includes('trackNumbers')}
                         onToggleReferenceLineSelection={onToggleReferenceLineSelection}
                     />
                 </div>

--- a/ui/src/selection/selection-model.ts
+++ b/ui/src/selection/selection-model.ts
@@ -29,7 +29,7 @@ export type SelectionMode = 'alignment' | 'segment' | 'point' | 'switch' | 'trac
 export type ItemCollections = {
     segments: MapSegment[];
     locationTracks: LocationTrackId[];
-    referenceLines: ReferenceLineId[];
+    // referenceLines: ReferenceLineId[];
     kmPosts: LayoutKmPost[];
     geometryKmPosts: SelectedGeometryItem<LayoutKmPost>[];
     switches: LayoutSwitch[];

--- a/ui/src/selection/selection-model.ts
+++ b/ui/src/selection/selection-model.ts
@@ -29,7 +29,6 @@ export type SelectionMode = 'alignment' | 'segment' | 'point' | 'switch' | 'trac
 export type ItemCollections = {
     segments: MapSegment[];
     locationTracks: LocationTrackId[];
-    // referenceLines: ReferenceLineId[];
     kmPosts: LayoutKmPost[];
     geometryKmPosts: SelectedGeometryItem<LayoutKmPost>[];
     switches: LayoutSwitch[];
@@ -75,7 +74,6 @@ export type SelectableItemType = keyof ItemCollections;
 export const allSelectableItemTypes: SelectableItemType[] = ensureAllKeys<SelectableItemType>()([
     'segments',
     'locationTracks',
-    'referenceLines',
     'kmPosts',
     'geometryKmPosts',
     'switches',

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -62,7 +62,6 @@ function getNewIdCollection<TId extends string>(
     // The isExactSelection flag being set is a special case. Empty selections should be respected then
     if (newIds == undefined) return ids;
 
-    // Define "new items" collection
     if (flags.isIncremental) {
         return deduplicate([...newIds, ...ids]);
     } else if (flags.isToggle) {
@@ -136,7 +135,6 @@ function getNewItemCollectionUsingCustomId<TEntity, TId>(
         return items;
     }
 
-    // Define "new items" collection
     if (flags.isIncremental) {
         return [...newItems, ...items].filter(filterUniqueById(getId));
     } else if (flags.isToggle) {

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -27,7 +27,7 @@ export function createEmptyItemCollections(): ItemCollections {
     return {
         segments: [],
         locationTracks: [],
-        referenceLines: [],
+        // referenceLines: [],
         kmPosts: [],
         geometryKmPosts: [],
         switches: [],
@@ -66,7 +66,9 @@ function getNewIdCollection<TId extends string>(
     if (flags.isIncremental) {
         return deduplicate([...newIds, ...ids]);
     } else if (flags.isToggle) {
-        return deduplicate(newIds.filter((newId) => !ids.includes(newId)));
+        const filtered = deduplicate(newIds.filter((newId) => !ids.includes(newId)));
+        console.log('Toggling ids:', 'old', ids, 'new', ids, 'filtered', filtered);
+        return filtered;
     } else {
         return deduplicate(newIds);
     }
@@ -138,19 +140,16 @@ function getNewItemCollectionUsingCustomId<TEntity, TId>(
 
     // Define "new items" collection
     if (flags.isIncremental) {
-        newItems = [...newItems, ...items].filter(filterUniqueById(getId));
+        return [...newItems, ...items].filter(filterUniqueById(getId));
     } else if (flags.isToggle) {
-        newItems = newItems.filter(
+        const filtered = newItems.filter(
             (newItem) => !items.find((item) => getId(item) == getId(newItem)),
         );
+        console.log('Toggling item:', 'old', items, 'new', newItems, 'filtered', filtered);
+        return filtered;
+    } else {
+        return newItems;
     }
-
-    // FIXME: this doesn't work because the ID doesn't change always when the object changes. If these were ids only (no data in selection), this would be fine.
-    // Return "new items" only if it differs from original
-    // if (!itemsEqual(items, newItems, (item1, item2) => getId(item1) == getId(item2))) {
-    return newItems;
-    // }
-    // return items;
 }
 
 function updateItemCollectionsByOptions(

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -156,6 +156,7 @@ function updateItemCollectionsByOptions(
     itemCollections: ItemCollections,
     options: OnSelectOptions,
 ) {
+    console.log('updateItemCollectionsByOptions', options);
     // Repetitive code, but seems that there is no way do make typescript to accept this in a loop
     const flags = options as OnSelectFlags;
     itemCollections['segments'] = getNewItemCollection(
@@ -166,11 +167,6 @@ function updateItemCollectionsByOptions(
     itemCollections['locationTracks'] = getNewIdCollection(
         itemCollections['locationTracks'],
         options['locationTracks'],
-        flags,
-    );
-    itemCollections['referenceLines'] = getNewIdCollection(
-        itemCollections['referenceLines'],
-        options['referenceLines'],
         flags,
     );
     itemCollections['kmPosts'] = getNewItemCollection(
@@ -251,10 +247,6 @@ function updateItemCollectionsByUnselecting(
     itemCollections['locationTracks'] = filterIdCollection(
         itemCollections['locationTracks'],
         unselectItemCollections['locationTracks'],
-    );
-    itemCollections['referenceLines'] = filterIdCollection(
-        itemCollections['referenceLines'],
-        unselectItemCollections['referenceLines'],
     );
     itemCollections['kmPosts'] = filterItemCollection(
         itemCollections['kmPosts'],

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -66,9 +66,7 @@ function getNewIdCollection<TId extends string>(
     if (flags.isIncremental) {
         return deduplicate([...newIds, ...ids]);
     } else if (flags.isToggle) {
-        const filtered = deduplicate(newIds.filter((newId) => !ids.includes(newId)));
-        console.log('Toggling ids:', 'old', ids, 'new', ids, 'filtered', filtered);
-        return filtered;
+        return deduplicate(newIds.filter((newId) => !ids.includes(newId)));
     } else {
         return deduplicate(newIds);
     }
@@ -142,11 +140,7 @@ function getNewItemCollectionUsingCustomId<TEntity, TId>(
     if (flags.isIncremental) {
         return [...newItems, ...items].filter(filterUniqueById(getId));
     } else if (flags.isToggle) {
-        const filtered = newItems.filter(
-            (newItem) => !items.find((item) => getId(item) == getId(newItem)),
-        );
-        console.log('Toggling item:', 'old', items, 'new', newItems, 'filtered', filtered);
-        return filtered;
+        return newItems.filter((newItem) => !items.find((item) => getId(item) == getId(newItem)));
     } else {
         return newItems;
     }
@@ -156,7 +150,6 @@ function updateItemCollectionsByOptions(
     itemCollections: ItemCollections,
     options: OnSelectOptions,
 ) {
-    console.log('updateItemCollectionsByOptions', options);
     // Repetitive code, but seems that there is no way do make typescript to accept this in a loop
     const flags = options as OnSelectFlags;
     itemCollections['segments'] = getNewItemCollection(

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-container.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-container.tsx
@@ -57,10 +57,7 @@ const GeometryAlignmentLinkingContainer: React.FC<GeometryAlignmentLinkingContai
 
     return (
         <GeometryAlignmentInfobox
-            onSelect={(a) => {
-                console.log('a', a);
-                delegates.onSelect(a);
-            }}
+            onSelect={delegates.onSelect}
             geometryAlignment={geometryAlignment}
             layoutLocationTrack={selectedLocationTrackId ? locationTrack : undefined}
             layoutReferenceLine={selectedLocationTrackId ? undefined : referenceLine}

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-container.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-container.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { useTrackLayoutAppDispatch, useTrackLayoutAppSelector } from 'store/hooks';
 import {
+    LayoutTrackNumberId,
     LocationTrackId,
     MapAlignment,
     MapSegment,
-    ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import { LinkingState } from 'linking/linking-model';
 import { createDelegates } from 'store/store-utils';
@@ -12,14 +12,17 @@ import { actionCreators as TrackLayoutActions } from 'track-layout/track-layout-
 import { GeometryPlanId } from 'geometry/geometry-model';
 import { PublishType } from 'common/common-model';
 import GeometryAlignmentInfobox from 'tool-panel/geometry-alignment/geometry-alignment-infobox';
-import { useLocationTrack, useReferenceLine } from 'track-layout/track-layout-react-utils';
+import {
+    useLocationTrack,
+    useTrackNumberReferenceLine,
+} from 'track-layout/track-layout-react-utils';
 import { getMaxTimestamp } from 'utils/date-utils';
 
 type GeometryAlignmentLinkingContainerProps = {
     geometryAlignment: MapAlignment;
     segment?: MapSegment;
     selectedLocationTrackId?: LocationTrackId;
-    selectedReferenceLineId?: ReferenceLineId;
+    selectedTrackNumberId?: LayoutTrackNumberId;
     planId: GeometryPlanId;
     linkingState?: LinkingState;
     publishType: PublishType;
@@ -29,7 +32,7 @@ const GeometryAlignmentLinkingContainer: React.FC<GeometryAlignmentLinkingContai
     geometryAlignment,
     segment,
     selectedLocationTrackId,
-    selectedReferenceLineId,
+    selectedTrackNumberId,
     planId,
     linkingState,
     publishType,
@@ -46,18 +49,21 @@ const GeometryAlignmentLinkingContainer: React.FC<GeometryAlignmentLinkingContai
         publishType,
         changeTimes.layoutLocationTrack,
     );
-    const referenceLine = useReferenceLine(
-        selectedReferenceLineId,
+    const referenceLine = useTrackNumberReferenceLine(
+        selectedTrackNumberId,
         publishType,
-        changeTimes.layoutReferenceLine,
+        changeTimes.layoutTrackNumber,
     );
 
     return (
         <GeometryAlignmentInfobox
-            onSelect={delegates.onSelect}
+            onSelect={(a) => {
+                console.log('a', a);
+                delegates.onSelect(a);
+            }}
             geometryAlignment={geometryAlignment}
             layoutLocationTrack={selectedLocationTrackId ? locationTrack : undefined}
-            layoutReferenceLine={selectedReferenceLineId ? referenceLine : undefined}
+            layoutReferenceLine={selectedLocationTrackId ? undefined : referenceLine}
             segment={segment}
             planId={planId}
             alignmentChangeTime={getMaxTimestamp(

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -28,7 +28,6 @@ import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import InfoboxText from 'tool-panel/infobox/infobox-text';
 import { LocationTrackEditDialog } from 'tool-panel/location-track/dialog/location-track-edit-dialog';
 import {
-    getLocationTrack,
     getLocationTracks,
     getLocationTracksNear,
     getNonLinkedLocationTracks,
@@ -135,9 +134,9 @@ type GeometryAlignmentLinkingInfoboxProps = {
     alignmentChangeTime: TimeStamp;
     trackNumberChangeTime: TimeStamp;
     linkingState?:
-        | LinkingGeometryWithAlignment
-        | LinkingGeometryWithEmptyAlignment
-        | PreliminaryLinkingGeometry;
+    | LinkingGeometryWithAlignment
+    | LinkingGeometryWithEmptyAlignment
+    | PreliminaryLinkingGeometry;
     onLockAlignment: (lockParameters: GeometryLinkingAlignmentLockParameters) => void;
     onLinkingStart: (startParams: GeometryPreliminaryLinkingParameters) => void;
     onStopLinking: () => void;
@@ -212,9 +211,6 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
     const [alignmentRefs, setAlignmentRefs] = React.useState<AlignmentRefs>({});
     const [locationTracks, setLocationTracks] = React.useState<LayoutLocationTrack[]>([]);
     const [referenceLines, setReferenceLines] = React.useState<LayoutReferenceLine[]>([]);
-    const [chosenTrackNumberId, setChosenTrackNumberId] = React.useState<
-        LayoutTrackNumberId | undefined
-    >(undefined);
     const linkingInProgress = linkingState?.state === 'setup' || linkingState?.state === 'allSet';
     const isLinked =
         geometryAlignment.sourceId && linkedAlignmentIds.includes(geometryAlignment.sourceId);
@@ -252,17 +248,17 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
         return !!(key && alignmentRefs[key]);
     };
 
-    const onReferenceLineSelect = (rl: LayoutReferenceLine) =>
+    const onReferenceLineSelect = (rl: LayoutReferenceLine) => {
+        console.log('Select', rl, rl.trackNumberId);
         onSelect({
             trackNumbers: rl.trackNumberId ? [rl.trackNumberId] : [],
-            referenceLines: [rl.id],
             locationTracks: [],
         });
+    };
 
     const onLocationTrackSelect = (lt: LayoutLocationTrack) =>
         onSelect({
             trackNumbers: lt.trackNumberId ? [lt.trackNumberId] : [],
-            referenceLines: [],
             locationTracks: [lt.id],
         });
 
@@ -330,26 +326,12 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
         }
     }, [geometryAlignment.boundingBox, alignmentChangeTime]);
 
-    React.useEffect(() => {
-        const line = referenceLines.find((line) => line.trackNumberId === chosenTrackNumberId);
-        updateReferenceLineChangeTime().then(() =>
-            updateTrackNumberChangeTime().then(() => line && onReferenceLineSelect(line)),
-        );
-    }, [referenceLines]);
-
-    function handleLocationTrackInsert(id: LocationTrackId) {
-        updateLocationTrackChangeTime().then((ts) => {
-            getLocationTrack(id, publishType, ts).then((locationTrack) => {
-                if (locationTrack) onLocationTrackSelect(locationTrack);
-            });
-            setShowAddLocationTrackDialog(false);
-        });
+    function handleLocationTrackInsert(_id: LocationTrackId) {
+        updateLocationTrackChangeTime();
     }
 
-    function handleTrackNumberSave(id: LayoutTrackNumberId) {
-        updateReferenceLineChangeTime().then(() =>
-            updateTrackNumberChangeTime().then(() => setChosenTrackNumberId(id)),
-        );
+    function handleTrackNumberSave(_id: LayoutTrackNumberId) {
+        updateReferenceLineChangeTime().then(() => updateTrackNumberChangeTime());
     }
 
     function lockAlignment() {
@@ -476,8 +458,8 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                         const selection = key ? alignmentRefs[key] : undefined;
                                         const trackNumber = trackNumbers
                                             ? trackNumbers.find(
-                                                  (tn) => tn.id === line.trackNumberId,
-                                              )
+                                                (tn) => tn.id === line.trackNumberId,
+                                            )
                                             : undefined;
                                         if (!selection || !trackNumber) return '';
                                         return (
@@ -588,8 +570,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                         <InfoboxButtons>
                             <Button size={ButtonSize.SMALL} onClick={startLinking}>
                                 {t(
-                                    `tool-panel.alignment.geometry.${
-                                        isLinked ? 'add-linking' : 'start-setup'
+                                    `tool-panel.alignment.geometry.${isLinked ? 'add-linking' : 'start-setup'
                                     }`,
                                 )}
                             </Button>

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -249,16 +249,15 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
     };
 
     const onReferenceLineSelect = (rl: LayoutReferenceLine) => {
-        console.log('Select', rl, rl.trackNumberId);
         onSelect({
-            trackNumbers: rl.trackNumberId ? [rl.trackNumberId] : [],
+            trackNumbers: [rl.trackNumberId],
             locationTracks: [],
         });
     };
 
     const onLocationTrackSelect = (lt: LayoutLocationTrack) =>
         onSelect({
-            trackNumbers: lt.trackNumberId ? [lt.trackNumberId] : [],
+            trackNumbers: [],
             locationTracks: [lt.id],
         });
 

--- a/ui/src/tool-panel/geometry-alignment/reference-line-names.tsx
+++ b/ui/src/tool-panel/geometry-alignment/reference-line-names.tsx
@@ -2,11 +2,7 @@ import * as React from 'react';
 import styles from './linked-items-list.scss';
 import { useTranslation } from 'react-i18next';
 
-import {
-    LayoutReferenceLine,
-    LayoutTrackNumberId,
-    ReferenceLineId,
-} from 'track-layout/track-layout-model';
+import { LayoutReferenceLine, LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import { ReferenceLineBadge } from 'geoviite-design-lib/alignment/reference-line-badge';
 import { getTrackNumbers } from 'track-layout/layout-track-number-api';
 import { PublishType, TimeStamp } from 'common/common-model';
@@ -26,11 +22,10 @@ type ReferenceLineNamesProps = {
 function createSelectAction() {
     const dispatch = useTrackLayoutAppDispatch();
     const delegates = createDelegates(dispatch, TrackLayoutActions);
-    return (trackNumberId: LayoutTrackNumberId, referenceLineId: ReferenceLineId | undefined) =>
+    return (trackNumberId: LayoutTrackNumberId) =>
         delegates.onSelect({
             ...createEmptyItemCollections(),
             trackNumbers: [trackNumberId],
-            referenceLines: referenceLineId ? [referenceLineId] : [],
         });
 }
 
@@ -90,8 +85,7 @@ const ReferenceLineNames: React.FC<ReferenceLineNamesProps> = ({
                                         <ReferenceLineBadge
                                             trackNumber={trackNumber}
                                             onClick={() =>
-                                                trackNumber &&
-                                                clickAction(trackNumber.id, referenceLine.id)
+                                                trackNumber && clickAction(trackNumber.id)
                                             }
                                         />
                                     </div>

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -154,6 +154,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                 stateActions.onSaveSucceed(locationTrackId);
                                 props.onInsert && props.onInsert(locationTrackId);
                                 Snackbar.success(t('location-track-dialog.created-successfully'));
+                                props.onClose && props.onClose();
                             })
                             .mapErr((_err) => {
                                 stateActions.onSaveFailed();
@@ -174,6 +175,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                         ? t('location-track-dialog.deleted-successfully')
                                         : t('location-track-dialog.modified-successfully');
                                 Snackbar.success(successMessage);
+                                props.onClose && props.onClose();
                             })
                             .mapErr((_err) => {
                                 stateActions.onSaveFailed();
@@ -200,8 +202,8 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     function getVisibleErrorsByProp(prop: keyof LocationTrackSaveRequest) {
         return state.allFieldsCommitted || state.committedFields.includes(prop)
             ? state.validationErrors
-                  .filter((error) => error.field == prop)
-                  .map((error) => t(`location-track-dialog.${error.reason}`))
+                .filter((error) => error.field == prop)
+                .map((error) => t(`location-track-dialog.${error.reason}`))
             : [];
     }
 

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -27,7 +27,10 @@ const ToolPanelContainer: React.FC = () => {
         [store.selection.selectedItems.switches],
     );
 
-    const startSwitchLinking = React.useCallback(function (suggestedSwitch: SuggestedSwitch, layoutSwitch: LayoutSwitch) {
+    const startSwitchLinking = React.useCallback(function(
+        suggestedSwitch: SuggestedSwitch,
+        layoutSwitch: LayoutSwitch,
+    ) {
         delegates.onSelect({
             suggestedSwitches: [suggestedSwitch],
         });
@@ -35,23 +38,25 @@ const ToolPanelContainer: React.FC = () => {
         delegates.onSelect({
             switches: [layoutSwitch],
         });
-    }, []);
+    },
+        []);
 
-    const startSwitchPlacing = React.useCallback(function (layoutSwitch: LayoutSwitch) {
+    const startSwitchPlacing = React.useCallback(function(layoutSwitch: LayoutSwitch) {
         delegates.startSwitchPlacing(layoutSwitch);
     }, []);
 
     React.useEffect(() => {
         const linkingState = store.linkingState;
-        if (linkingState?.type == LinkingType.PlacingSwitch &&
-            linkingState.location) {
-            getSuggestedSwitchByPoint(linkingState.location, linkingState.layoutSwitch.switchStructureId)
-                .then((suggestedSwitches) => {
-                    delegates.stopLinking();
-                    if (suggestedSwitches.length) {
-                        startSwitchLinking(suggestedSwitches[0], linkingState.layoutSwitch);
-                    }
-                });
+        if (linkingState?.type == LinkingType.PlacingSwitch && linkingState.location) {
+            getSuggestedSwitchByPoint(
+                linkingState.location,
+                linkingState.layoutSwitch.switchStructureId,
+            ).then((suggestedSwitches) => {
+                delegates.stopLinking();
+                if (suggestedSwitches.length) {
+                    startSwitchLinking(suggestedSwitches[0], linkingState.layoutSwitch);
+                }
+            });
         }
     }, [store.linkingState]);
 
@@ -64,7 +69,6 @@ const ToolPanelContainer: React.FC = () => {
             switchIds={switchIds}
             geometrySwitches={store.selection.selectedItems.geometrySwitches}
             locationTrackIds={store.selection.selectedItems.locationTracks}
-            referenceLineIds={store.selection.selectedItems.referenceLines}
             geometryAlignments={store.selection.selectedItems.geometryAlignments}
             geometrySegments={store.selection.selectedItems.geometrySegments}
             linkingState={store.linkingState}

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -87,8 +87,6 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     setSelectedTabId,
     startSwitchPlacing,
 }: ToolPanelProps) => {
-    console.log('Tool-Panel bind', 'trackNumbers', trackNumberIds, 'referenceLines');
-
     const [previousTabs, setPreviousTabs] = React.useState<ToolPanelTab[]>([]);
     const [tabs, setTabs] = React.useState<ToolPanelTab[]>([]);
 
@@ -102,9 +100,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     }, []);
 
     const onUnSelectSwitches = React.useCallback((switchId: LayoutSwitchId) => {
-        onUnselect({
-            switches: [switchId],
-        });
+        onUnselect({ switches: [switchId] });
     }, []);
 
     const tracksSwitchesKmPosts = useLoader(() => {

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -45,7 +45,6 @@ type ToolPanelProps = {
     switchIds: LayoutSwitchId[];
     geometrySwitches: SelectedGeometryItem<LayoutSwitch>[];
     locationTrackIds: LocationTrackId[];
-    // referenceLineIds: ReferenceLineId[];
     geometryAlignments: SelectedGeometryItem<MapAlignment>[];
     geometrySegments: SelectedGeometryItem<MapSegment>[];
     suggestedSwitches: SuggestedSwitch[];

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -89,6 +89,14 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     setSelectedTabId,
     startSwitchPlacing,
 }: ToolPanelProps) => {
+    console.log(
+        'Tool-Panel bind',
+        'trackNumbers',
+        trackNumberIds,
+        'referenceLines',
+        referenceLineIds,
+    );
+
     const [previousTabs, setPreviousTabs] = React.useState<ToolPanelTab[]>([]);
     const [tabs, setTabs] = React.useState<ToolPanelTab[]>([]);
 

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -13,7 +13,6 @@ import {
     LocationTrackId,
     MapAlignment,
     MapSegment,
-    ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import KmPostInfobox from 'tool-panel/km-post/km-post-infobox';
 import SwitchInfobox from 'tool-panel/switch/switch-infobox';
@@ -46,7 +45,7 @@ type ToolPanelProps = {
     switchIds: LayoutSwitchId[];
     geometrySwitches: SelectedGeometryItem<LayoutSwitch>[];
     locationTrackIds: LocationTrackId[];
-    referenceLineIds: ReferenceLineId[];
+    // referenceLineIds: ReferenceLineId[];
     geometryAlignments: SelectedGeometryItem<MapAlignment>[];
     geometrySegments: SelectedGeometryItem<MapSegment>[];
     suggestedSwitches: SuggestedSwitch[];
@@ -75,7 +74,6 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     switchIds,
     geometrySwitches,
     locationTrackIds,
-    referenceLineIds,
     geometryAlignments,
     geometrySegments,
     suggestedSwitches,
@@ -89,13 +87,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     setSelectedTabId,
     startSwitchPlacing,
 }: ToolPanelProps) => {
-    console.log(
-        'Tool-Panel bind',
-        'trackNumbers',
-        trackNumberIds,
-        'referenceLines',
-        referenceLineIds,
-    );
+    console.log('Tool-Panel bind', 'trackNumbers', trackNumberIds, 'referenceLines');
 
     const [previousTabs, setPreviousTabs] = React.useState<ToolPanelTab[]>([]);
     const [tabs, setTabs] = React.useState<ToolPanelTab[]>([]);
@@ -306,7 +298,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                     <GeometryAlignmentLinkingContainer
                         geometryAlignment={a.geometryItem}
                         selectedLocationTrackId={locationTrackIds[0]}
-                        selectedReferenceLineId={referenceLineIds[0]}
+                        selectedTrackNumberId={trackNumberIds[0]}
                         segment={geometrySegments[0]?.geometryItem}
                         planId={a.planId}
                         linkingState={linkingState}

--- a/ui/src/track-layout/track-layout-store.ts
+++ b/ui/src/track-layout/track-layout-store.ts
@@ -96,7 +96,7 @@ export function getSelectableItemTypes(
 ): SelectableItemType[] {
     switch (linkingState?.type) {
         case LinkingType.UnknownAlignment:
-            return ['locationTracks', 'referenceLines'];
+            return ['locationTracks', 'trackNumbers'];
         case LinkingType.LinkingGeometryWithAlignment:
             return ['layoutLinkPoints', 'geometryLinkPoints', 'clusterPoints'];
         case LinkingType.LinkingGeometryWithEmptyAlignment:
@@ -160,7 +160,7 @@ const trackLayoutSlice = createSlice({
         },
 
         // Intercept select/highlight reducers to modify options
-        onSelect: function (state: TrackLayoutState, action: PayloadAction<OnSelectOptions>): void {
+        onSelect: function(state: TrackLayoutState, action: PayloadAction<OnSelectOptions>): void {
             // Handle selection
             const options = filterItemSelectOptions(state, action.payload);
             selectionReducers.onSelect(state.selection, {
@@ -204,7 +204,7 @@ const trackLayoutSlice = createSlice({
                 }
             }
         },
-        onPreviewSelect: function (
+        onPreviewSelect: function(
             state: TrackLayoutState,
             action: PayloadAction<SelectedPublishChange>,
         ): void {
@@ -213,15 +213,15 @@ const trackLayoutSlice = createSlice({
                 : [...state.selectedPublishCandidateIds.trackNumbers];
             const referenceLines = action.payload.referenceLine
                 ? [
-                      ...state.selectedPublishCandidateIds.referenceLines,
-                      action.payload.referenceLine,
-                  ]
+                    ...state.selectedPublishCandidateIds.referenceLines,
+                    action.payload.referenceLine,
+                ]
                 : [...state.selectedPublishCandidateIds.referenceLines];
             const locationTracks = action.payload.locationTrack
                 ? [
-                      ...state.selectedPublishCandidateIds.locationTracks,
-                      action.payload.locationTrack,
-                  ]
+                    ...state.selectedPublishCandidateIds.locationTracks,
+                    action.payload.locationTrack,
+                ]
                 : [...state.selectedPublishCandidateIds.locationTracks];
             const switches = action.payload.switch
                 ? [...state.selectedPublishCandidateIds.switches, action.payload.switch]
@@ -238,39 +238,39 @@ const trackLayoutSlice = createSlice({
                 kmPosts: kmPosts,
             };
         },
-        onPublishPreviewRemove: function (
+        onPublishPreviewRemove: function(
             state: TrackLayoutState,
             action: PayloadAction<SelectedPublishChange>,
         ): void {
             const trackNumbers = action.payload.trackNumber
                 ? removeFromPublishCandidates(
-                      [...state.selectedPublishCandidateIds.trackNumbers],
-                      action.payload.trackNumber,
-                  )
+                    [...state.selectedPublishCandidateIds.trackNumbers],
+                    action.payload.trackNumber,
+                )
                 : [...state.selectedPublishCandidateIds.trackNumbers];
             const referenceLines = action.payload.referenceLine
                 ? removeFromPublishCandidates(
-                      [...state.selectedPublishCandidateIds.referenceLines],
-                      action.payload.referenceLine,
-                  )
+                    [...state.selectedPublishCandidateIds.referenceLines],
+                    action.payload.referenceLine,
+                )
                 : [...state.selectedPublishCandidateIds.referenceLines];
             const locationTracks = action.payload.locationTrack
                 ? removeFromPublishCandidates(
-                      [...state.selectedPublishCandidateIds.locationTracks],
-                      action.payload.locationTrack,
-                  )
+                    [...state.selectedPublishCandidateIds.locationTracks],
+                    action.payload.locationTrack,
+                )
                 : [...state.selectedPublishCandidateIds.locationTracks];
             const switches = action.payload.switch
                 ? removeFromPublishCandidates(
-                      [...state.selectedPublishCandidateIds.switches],
-                      action.payload.switch,
-                  )
+                    [...state.selectedPublishCandidateIds.switches],
+                    action.payload.switch,
+                )
                 : [...state.selectedPublishCandidateIds.switches];
             const kmPosts = action.payload.kmPost
                 ? removeFromPublishCandidates(
-                      [...state.selectedPublishCandidateIds.kmPosts],
-                      action.payload.kmPost,
-                  )
+                    [...state.selectedPublishCandidateIds.kmPosts],
+                    action.payload.kmPost,
+                )
                 : [...state.selectedPublishCandidateIds.kmPosts];
 
             state.selectedPublishCandidateIds = {
@@ -282,7 +282,7 @@ const trackLayoutSlice = createSlice({
             };
         },
         // TODO when Hylkää muutokset -button is removed from Preview-view, this reducer will become obsolete
-        onPublishPreviewRevert: function (state: TrackLayoutState): void {
+        onPublishPreviewRevert: function(state: TrackLayoutState): void {
             state.selectedPublishCandidateIds = {
                 trackNumbers: [],
                 referenceLines: [],
@@ -291,7 +291,7 @@ const trackLayoutSlice = createSlice({
                 kmPosts: [],
             };
         },
-        onHighlightItems: function (
+        onHighlightItems: function(
             state: TrackLayoutState,
             action: PayloadAction<OnSelectOptions>,
         ): void {
@@ -308,7 +308,7 @@ const trackLayoutSlice = createSlice({
                 selectionReducers.togglePlanVisibility(state.selection, action);
             }
         },
-        setChangeTimes: function (
+        setChangeTimes: function(
             { changeTimes }: TrackLayoutState,
             { payload }: PayloadAction<ChangeTimes>,
         ) {
@@ -331,42 +331,42 @@ const trackLayoutSlice = createSlice({
                 changeTimes.geometryPlan = payload.geometryPlan;
             }
         },
-        setLayoutTrackNumberChangeTime: function (
+        setLayoutTrackNumberChangeTime: function(
             { changeTimes }: TrackLayoutState,
             { payload }: PayloadAction<TimeStamp>,
         ) {
             if (toDate(changeTimes.layoutTrackNumber) < toDate(payload))
                 changeTimes.layoutTrackNumber = payload;
         },
-        setLayoutLocationTrackChangeTime: function (
+        setLayoutLocationTrackChangeTime: function(
             { changeTimes }: TrackLayoutState,
             { payload }: PayloadAction<TimeStamp>,
         ) {
             if (toDate(changeTimes.layoutLocationTrack) < toDate(payload))
                 changeTimes.layoutLocationTrack = payload;
         },
-        setLayoutReferenceLineChangeTime: function (
+        setLayoutReferenceLineChangeTime: function(
             { changeTimes }: TrackLayoutState,
             { payload }: PayloadAction<TimeStamp>,
         ) {
             if (toDate(changeTimes.layoutReferenceLine) < toDate(payload))
                 changeTimes.layoutReferenceLine = payload;
         },
-        setLayoutSwitchChangeTime: function (
+        setLayoutSwitchChangeTime: function(
             { changeTimes }: TrackLayoutState,
             { payload }: PayloadAction<TimeStamp>,
         ) {
             if (toDate(changeTimes.layoutSwitch) < toDate(payload))
                 changeTimes.layoutSwitch = payload;
         },
-        setLayoutKmPostChangeTime: function (
+        setLayoutKmPostChangeTime: function(
             { changeTimes }: TrackLayoutState,
             { payload }: PayloadAction<TimeStamp>,
         ) {
             if (toDate(changeTimes.layoutKmPost) < toDate(payload))
                 changeTimes.layoutKmPost = payload;
         },
-        setGeometryPlanChangeTime: function (
+        setGeometryPlanChangeTime: function(
             { changeTimes }: TrackLayoutState,
             { payload }: PayloadAction<TimeStamp>,
         ) {


### PR DESCRIPTION
Tämä aiheutui ratanumeron valinnan ja pituusmittauslinjan valinnan epäsynkasta koska osa komponenteista valitsi ne aina yhtäaikaisesti käyttäen togglea ja osa valitsi vain pituusmittauslinjan. Oikeassa järjestyksessä klikaten ne menivät ristiin. Koko leikki on sinällään turhaa että pituusmittauslinja on 1=1 ratanumeron kanssa joten poistin pituusmittauslinjan valittavista käsitteistä - ratanumeron valinta on sama asia. 