### PR TITLE
GVT-1551: PublicationTablen refaktorointia

### DIFF
--- a/ui/src/preview/change-table-entry-mapping.ts
+++ b/ui/src/preview/change-table-entry-mapping.ts
@@ -1,0 +1,133 @@
+import {
+    KmPostPublishCandidate,
+    LocationTrackPublishCandidate,
+    Operation,
+    PublishCandidates,
+    ReferenceLinePublishCandidate,
+    SwitchPublishCandidate,
+    TrackNumberPublishCandidate,
+} from 'publication/publication-model';
+import { TimeStamp } from 'common/common-model';
+import { SelectedPublishChange } from 'track-layout/track-layout-store';
+import {
+    LayoutKmPostId,
+    LayoutSwitchId,
+    LayoutTrackNumber,
+    LayoutTrackNumberId,
+    LocationTrackId,
+    ReferenceLineId,
+} from 'track-layout/track-layout-model';
+
+export type ChangeTableProps = {
+    previewChanges: PublishCandidates;
+    showRatkoPushDate?: boolean;
+    showStatus?: boolean;
+    showActions?: boolean;
+    ratkoPushDate?: TimeStamp;
+    onPreviewSelect?: (selectedChanges: SelectedPublishChange) => void;
+    publish?: boolean;
+};
+
+type PublicationId =
+    | LayoutTrackNumberId
+    | ReferenceLineId
+    | LocationTrackId
+    | LayoutSwitchId
+    | LayoutKmPostId;
+
+export type ChangeTableEntry = {
+    id: PublicationId;
+    name: string;
+    uiName: string;
+    trackNumber: string;
+    changeTime: string;
+    userName: string;
+    operation: Operation;
+};
+
+type TranslationFunc = (tKey: string) => string;
+
+export const trackNumberToChangeTableEntry = (
+    trackNumber: TrackNumberPublishCandidate,
+    t: TranslationFunc,
+) => ({
+    id: trackNumber.id,
+    uiName: `${t('publication-table.track-number-long')} ${trackNumber.number}`,
+    name: trackNumber.number,
+    userName: trackNumber.userName,
+    trackNumber: trackNumber.number,
+    changeTime: trackNumber.draftChangeTime,
+    operation: trackNumber.operation,
+});
+
+export const referenceLineToChangeTableEntry = (
+    referenceLine: ReferenceLinePublishCandidate,
+    trackNumbers: LayoutTrackNumber[],
+    t: TranslationFunc,
+) => {
+    const trackNumber = trackNumbers.find((tn) => tn.id === referenceLine.trackNumberId);
+    return {
+        id: referenceLine.id,
+        uiName: `${t('publication-table.reference-line')} ${referenceLine.name}`,
+        name: referenceLine.name,
+        userName: referenceLine.userName,
+        trackNumber: trackNumber ? trackNumber.number : '',
+        changeTime: referenceLine.draftChangeTime,
+        operation: referenceLine.operation,
+    };
+};
+
+export const locationTrackToChangeTableEntry = (
+    locationTrack: LocationTrackPublishCandidate,
+    trackNumbers: LayoutTrackNumber[],
+    t: TranslationFunc,
+) => {
+    const trackNumber = trackNumbers.find((tn) => tn.id === locationTrack.trackNumberId);
+    return {
+        id: locationTrack.id,
+        uiName: `${t('publication-table.location-track')} ${locationTrack.name}`,
+        name: locationTrack.name,
+        userName: locationTrack.userName,
+        trackNumber: trackNumber ? trackNumber.number : '',
+        changeTime: locationTrack.draftChangeTime,
+        operation: locationTrack.operation,
+    };
+};
+
+export const switchToChangeTableEntry = (
+    layoutSwitch: SwitchPublishCandidate,
+    trackNumbers: LayoutTrackNumber[],
+    t: TranslationFunc,
+) => {
+    const trackNumber = trackNumbers
+        .filter((tn) => layoutSwitch.trackNumberIds.some((lstn) => lstn == tn.id))
+        .sort()
+        .map((tn) => tn.number)
+        .join(', ');
+    return {
+        id: layoutSwitch.id,
+        uiName: `${t('publication-table.switch')} ${layoutSwitch.name}`,
+        name: layoutSwitch.name,
+        userName: layoutSwitch.userName,
+        trackNumber,
+        changeTime: layoutSwitch.draftChangeTime,
+        operation: layoutSwitch.operation,
+    };
+};
+
+export const kmPostChangeTableEntry = (
+    kmPost: KmPostPublishCandidate,
+    trackNumbers: LayoutTrackNumber[],
+    t: TranslationFunc,
+) => {
+    const trackNumber = trackNumbers.find((tn) => tn.id === kmPost.trackNumberId);
+    return {
+        id: kmPost.id,
+        uiName: `${t('publication-table.km-post')} ${kmPost.kmNumber}`,
+        name: kmPost.kmNumber,
+        userName: kmPost.userName,
+        trackNumber: trackNumber ? trackNumber.number : '',
+        changeTime: kmPost.draftChangeTime,
+        operation: kmPost.operation,
+    };
+};

--- a/ui/src/preview/change-table-entry-mapping.ts
+++ b/ui/src/preview/change-table-entry-mapping.ts
@@ -2,13 +2,10 @@ import {
     KmPostPublishCandidate,
     LocationTrackPublishCandidate,
     Operation,
-    PublishCandidates,
     ReferenceLinePublishCandidate,
     SwitchPublishCandidate,
     TrackNumberPublishCandidate,
 } from 'publication/publication-model';
-import { TimeStamp } from 'common/common-model';
-import { SelectedPublishChange } from 'track-layout/track-layout-store';
 import {
     LayoutKmPostId,
     LayoutSwitchId,
@@ -17,16 +14,6 @@ import {
     LocationTrackId,
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
-
-export type ChangeTableProps = {
-    previewChanges: PublishCandidates;
-    showRatkoPushDate?: boolean;
-    showStatus?: boolean;
-    showActions?: boolean;
-    ratkoPushDate?: TimeStamp;
-    onPreviewSelect?: (selectedChanges: SelectedPublishChange) => void;
-    publish?: boolean;
-};
 
 type PublicationId =
     | LayoutTrackNumberId

--- a/ui/src/preview/change-table-sorting.ts
+++ b/ui/src/preview/change-table-sorting.ts
@@ -1,5 +1,6 @@
 import { Operation, PublishValidationError } from 'publication/publication-model';
 import { fieldComparator } from 'utils/array-utils';
+import { Icons } from 'vayla-design-lib/icon/Icon';
 
 export enum SortProps {
     NAME = 'NAME',
@@ -85,3 +86,10 @@ export const getSortInfoForProp = (
             : SortDirection.ASCENDING,
     function: sortFunctionsByPropName[newSortPropName],
 });
+
+export const sortDirectionIcon = (direction: SortDirection) =>
+    direction === SortDirection.ASCENDING
+        ? Icons.Ascending
+        : direction === SortDirection.DESCENDING
+        ? Icons.Descending
+        : undefined;

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { TimeStamp } from 'common/common-model';
+import styles from 'publication/publication-table-item.scss';
+import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { formatDateFull } from 'utils/date-utils';
+import { useTranslation } from 'react-i18next';
+import { Operation, PublishValidationError } from 'publication/publication-model';
+import { createClassName } from 'vayla-design-lib/utils';
+
+export type PreviewTableItemProps = {
+    itemName: string;
+    trackNumber?: string;
+    errors: PublishValidationError[];
+    changeTime: TimeStamp;
+    operation: Operation | null;
+    userName: string;
+    onPublishItemSelect?: () => void;
+    publish?: boolean;
+};
+
+export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
+    itemName,
+    trackNumber,
+    errors,
+    changeTime,
+    operation,
+    userName,
+    onPublishItemSelect,
+    publish = false,
+}) => {
+    const { t } = useTranslation();
+    const [isErrorRowExpanded, setIsErrorRowExpanded] = React.useState(false);
+
+    const errorsToStrings = (list: PublishValidationError[], type: 'ERROR' | 'WARNING') => {
+        const filtered = list.filter((e) => e.type === type);
+        return filtered.map((error) => t(error.localizationKey, error.params));
+    };
+
+    const errorTexts = errorsToStrings(errors, 'ERROR');
+    const warningTexts = errorsToStrings(errors, 'WARNING');
+    const hasErrors = errors.length > 0;
+
+    const statusCellClassName = createClassName(
+        styles['preview-table-item__status-cell'],
+        hasErrors && styles['preview-table-item__status-cell--expandable'],
+    );
+
+    return (
+        <React.Fragment>
+            <tr className={'preview-table-item'}>
+                <td>{itemName}</td>
+                <td>{trackNumber ? trackNumber : ''}</td>
+                <td>{operation ? t(`enum.publish-operation.${operation}`) : ''}</td>
+                <td>{formatDateFull(changeTime)}</td>
+                <td>{userName}</td>
+                <td
+                    className={statusCellClassName}
+                    onClick={() => setIsErrorRowExpanded(!isErrorRowExpanded)}>
+                    {!hasErrors && (
+                        <span className={styles['preview-table-item__ok-status']}>
+                            <Icons.Tick color={IconColor.INHERIT} size={IconSize.SMALL} />
+                        </span>
+                    )}
+                    {errorTexts.length > 0 && (
+                        <span className={styles['preview-table-item__error-status']}>
+                            {t('publication-table.errors-status-text', [errorTexts.length])}
+                        </span>
+                    )}
+                    {warningTexts.length > 0 && (
+                        <span className={styles['preview-table-item__warning-status']}>
+                            {t('publication-table.warnings-status-text', [warningTexts.length])}
+                        </span>
+                    )}
+                </td>
+                <td
+                    onClick={() => {
+                        onPublishItemSelect && onPublishItemSelect();
+                    }}>
+                    {publish ? (
+                        <Icons.Ascending size={IconSize.SMALL} />
+                    ) : (
+                        <Icons.Descending size={IconSize.SMALL} />
+                    )}
+                </td>
+            </tr>
+            {isErrorRowExpanded && hasErrors && (
+                <tr className={'preview-table-item preview-table-item--error'}>
+                    <td colSpan={4}>
+                        {errorTexts.length > 0 && (
+                            <div className="preview-table-item__msg-group preview-table-item__msg-group--errors">
+                                <div className="preview-table-item__group-title">
+                                    {t('publication-table.errors-group-title')}
+                                </div>
+                                {errorTexts.map((errorText, index) => (
+                                    <div key={index} className="preview-table-item__msg">
+                                        {errorText}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                        {warningTexts.length > 0 && (
+                            <div className="preview-table-item__msg-group preview-table-item__msg-group--warnings">
+                                <div className="preview-table-item__group-title">
+                                    {t('publication-table.warnings-group-title')}
+                                </div>
+                                {warningTexts?.map((warningText, index) => (
+                                    <div key={index} className="preview-table-item__msg">
+                                        {warningText}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </td>
+                </tr>
+            )}
+        </React.Fragment>
+    );
+};

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -1,0 +1,242 @@
+import { Table, Th } from 'vayla-design-lib/table/table';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+    LayoutKmPostId,
+    LayoutSwitchId,
+    LayoutTrackNumber,
+    LayoutTrackNumberId,
+    LocationTrackId,
+    ReferenceLineId,
+} from 'track-layout/track-layout-model';
+import { getTrackNumbers } from 'track-layout/layout-track-number-api';
+import styles from '../publication/publication-table.scss';
+import { SelectedPublishChange } from 'track-layout/track-layout-store';
+import { negComparator } from 'utils/array-utils';
+import {
+    getSortInfoForProp,
+    InitiallyUnsorted,
+    SortDirection,
+    sortDirectionIcon,
+    SortInformation,
+    SortProps,
+} from 'preview/change-table-sorting';
+import {
+    ChangeTableEntry,
+    ChangeTableProps,
+    kmPostChangeTableEntry,
+    locationTrackToChangeTableEntry,
+    referenceLineToChangeTableEntry,
+    switchToChangeTableEntry,
+    trackNumberToChangeTableEntry,
+} from 'preview/change-table-entry-mapping';
+import { PreviewTableItem } from 'preview/preview-table-item';
+import { PublishCandidates, PublishValidationError } from 'publication/publication-model';
+
+type PublicationId =
+    | LayoutTrackNumberId
+    | ReferenceLineId
+    | LocationTrackId
+    | LayoutSwitchId
+    | LayoutKmPostId;
+
+type PreviewTableEntry = {
+    type: PreviewSelectType;
+    errors: PublishValidationError[];
+} & ChangeTableEntry;
+
+enum PreviewSelectType {
+    trackNumber = 'trackNumber',
+    referenceLine = 'referenceLine',
+    locationTrack = 'locationTrack',
+    switch = 'switch',
+    kmPost = 'kmPost',
+}
+
+const PreviewTable: React.FC<ChangeTableProps> = ({
+    previewChanges,
+    onPreviewSelect = undefined,
+    publish = false,
+}) => {
+    const { t } = useTranslation();
+    const [trackNumbers, setTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
+    React.useEffect(() => {
+        getTrackNumbers('DRAFT').then((trackNumbers) => setTrackNumbers(trackNumbers));
+    }, []);
+
+    const [sortInfo, setSortInfo] = React.useState<SortInformation>(InitiallyUnsorted);
+
+    const defaultSelectedPublishChange: SelectedPublishChange = {
+        trackNumber: undefined,
+        referenceLine: undefined,
+        locationTrack: undefined,
+        switch: undefined,
+        kmPost: undefined,
+    };
+
+    function handlePreviewSelect<T>(id: PublicationId, type: T) {
+        switch (type) {
+            case PreviewSelectType.trackNumber:
+                onPreviewSelect &&
+                    onPreviewSelect({ ...defaultSelectedPublishChange, trackNumber: id });
+                break;
+            case PreviewSelectType.referenceLine:
+                onPreviewSelect &&
+                    onPreviewSelect({ ...defaultSelectedPublishChange, referenceLine: id });
+                break;
+            case PreviewSelectType.locationTrack:
+                onPreviewSelect &&
+                    onPreviewSelect({ ...defaultSelectedPublishChange, locationTrack: id });
+                break;
+            case PreviewSelectType.switch:
+                onPreviewSelect && onPreviewSelect({ ...defaultSelectedPublishChange, switch: id });
+                break;
+            case PreviewSelectType.kmPost:
+                onPreviewSelect && onPreviewSelect({ ...defaultSelectedPublishChange, kmPost: id });
+                break;
+            default:
+                onPreviewSelect && onPreviewSelect(defaultSelectedPublishChange);
+        }
+    }
+
+    const changesToPublicationEntries = (previewChanges: PublishCandidates): PreviewTableEntry[] =>
+        previewChanges.trackNumbers
+            .map((trackNumberCandidate) => ({
+                ...trackNumberToChangeTableEntry(trackNumberCandidate, t),
+                errors: trackNumberCandidate.errors,
+                type: PreviewSelectType.trackNumber,
+            }))
+            .concat(
+                previewChanges.referenceLines.map((referenceLineCandidate) => ({
+                    ...referenceLineToChangeTableEntry(referenceLineCandidate, trackNumbers, t),
+                    errors: referenceLineCandidate.errors,
+                    type: PreviewSelectType.referenceLine,
+                })),
+            )
+            .concat(
+                previewChanges.locationTracks.map((locationTrackCandidate) => ({
+                    ...locationTrackToChangeTableEntry(locationTrackCandidate, trackNumbers, t),
+                    errors: locationTrackCandidate.errors,
+                    type: PreviewSelectType.locationTrack,
+                })),
+            )
+            .concat(
+                previewChanges.switches.map((switchCandidate) => ({
+                    ...switchToChangeTableEntry(switchCandidate, trackNumbers, t),
+                    errors: switchCandidate.errors,
+                    type: PreviewSelectType.switch,
+                })),
+            )
+            .concat(
+                previewChanges.kmPosts.map((kmPostCandidate) => ({
+                    ...kmPostChangeTableEntry(kmPostCandidate, trackNumbers, t),
+                    errors: kmPostCandidate.errors,
+                    type: PreviewSelectType.kmPost,
+                })),
+            );
+
+    const publicationEntries = changesToPublicationEntries(previewChanges);
+
+    const sortedPublicationEntries =
+        sortInfo && sortInfo.direction !== SortDirection.UNSORTED
+            ? [...publicationEntries].sort(
+                  sortInfo.direction == SortDirection.ASCENDING
+                      ? sortInfo.function
+                      : negComparator(sortInfo.function),
+              )
+            : [...publicationEntries];
+
+    const sortByProp = (propName: SortProps) => {
+        const newSortInfo = getSortInfoForProp(sortInfo.direction, sortInfo.propName, propName);
+        setSortInfo(newSortInfo);
+    };
+
+    return (
+        <div className={styles['publication-table__container']}>
+            <Table wide>
+                <thead className={styles['publication-table__header']}>
+                    <tr>
+                        <Th
+                            onClick={() => sortByProp(SortProps.NAME)}
+                            icon={
+                                sortInfo.propName === SortProps.NAME
+                                    ? sortDirectionIcon(sortInfo.direction)
+                                    : undefined
+                            }>
+                            {t('publication-table.change-target')}
+                        </Th>
+                        <Th
+                            onClick={() => sortByProp(SortProps.TRACK_NUMBER)}
+                            icon={
+                                sortInfo.propName === SortProps.TRACK_NUMBER
+                                    ? sortDirectionIcon(sortInfo.direction)
+                                    : undefined
+                            }>
+                            {t('publication-table.track-number-short')}
+                        </Th>
+                        <Th
+                            onClick={() => sortByProp(SortProps.OPERATION)}
+                            icon={
+                                sortInfo.propName === SortProps.OPERATION
+                                    ? sortDirectionIcon(sortInfo.direction)
+                                    : undefined
+                            }>
+                            {t('publication-table.change-type')}
+                        </Th>
+                        <Th
+                            onClick={() => sortByProp(SortProps.CHANGE_TIME)}
+                            icon={
+                                sortInfo.propName === SortProps.CHANGE_TIME
+                                    ? sortDirectionIcon(sortInfo.direction)
+                                    : undefined
+                            }>
+                            {t('publication-table.modified-moment')}
+                        </Th>
+                        <Th
+                            onClick={() => sortByProp(SortProps.USER_NAME)}
+                            icon={
+                                sortInfo.propName === SortProps.USER_NAME
+                                    ? sortDirectionIcon(sortInfo.direction)
+                                    : undefined
+                            }>
+                            {t('publication-table.user')}
+                        </Th>
+                        <Th
+                            onClick={() => sortByProp(SortProps.ERRORS)}
+                            icon={
+                                sortInfo.propName === SortProps.ERRORS
+                                    ? sortDirectionIcon(sortInfo.direction)
+                                    : undefined
+                            }>
+                            {t('publication-table.status')}
+                        </Th>
+
+                        <Th>{t('publication-table.actions')}</Th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {sortedPublicationEntries.map((entry) => (
+                        <React.Fragment key={entry.id}>
+                            {
+                                <PreviewTableItem
+                                    onPublishItemSelect={() =>
+                                        handlePreviewSelect(entry.id, entry.type)
+                                    }
+                                    itemName={entry.uiName}
+                                    trackNumber={entry.trackNumber}
+                                    errors={entry.errors}
+                                    changeTime={entry.changeTime}
+                                    userName={entry.userName}
+                                    operation={entry.operation}
+                                    publish={publish}
+                                />
+                            }
+                        </React.Fragment>
+                    ))}
+                </tbody>
+            </Table>
+        </div>
+    );
+};
+
+export default PreviewTable;

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -23,7 +23,6 @@ import {
 } from 'preview/change-table-sorting';
 import {
     ChangeTableEntry,
-    ChangeTableProps,
     kmPostChangeTableEntry,
     locationTrackToChangeTableEntry,
     referenceLineToChangeTableEntry,
@@ -53,11 +52,13 @@ enum PreviewSelectType {
     kmPost = 'kmPost',
 }
 
-const PreviewTable: React.FC<ChangeTableProps> = ({
-    previewChanges,
-    onPreviewSelect = undefined,
-    publish = false,
-}) => {
+type PreviewTableProps = {
+    previewChanges: PublishCandidates;
+    onPreviewSelect: (selectedChanges: SelectedPublishChange) => void;
+    staged: boolean;
+};
+
+const PreviewTable: React.FC<PreviewTableProps> = ({ previewChanges, onPreviewSelect, staged }) => {
     const { t } = useTranslation();
     const [trackNumbers, setTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
     React.useEffect(() => {
@@ -228,7 +229,7 @@ const PreviewTable: React.FC<ChangeTableProps> = ({
                                     changeTime={entry.changeTime}
                                     userName={entry.userName}
                                     operation={entry.operation}
-                                    publish={publish}
+                                    publish={staged}
                                 />
                             }
                         </React.Fragment>

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -192,6 +192,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 <PreviewTable
                                     onPreviewSelect={props.onPreviewSelect}
                                     previewChanges={unstagedChanges}
+                                    staged={false}
                                 />
                             </section>
 
@@ -202,7 +203,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 <PreviewTable
                                     onPreviewSelect={props.onPublishPreviewRemove}
                                     previewChanges={stagedChanges}
-                                    publish={true}
+                                    staged={true}
                                 />
                             </section>
 

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -22,7 +22,6 @@ import {
 } from 'selection/selection-model';
 import { ChangeTimes, SelectedPublishChange } from 'track-layout/track-layout-store';
 import { PublishType } from 'common/common-model';
-import PublicationTable from 'publication/publication-table';
 import { CalculatedChangesView } from './calculated-changes-view';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { PublishCandidates, ValidatedPublishCandidates } from 'publication/publication-model';
@@ -33,6 +32,7 @@ import {
     LocationTrackId,
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
+import PreviewTable from 'preview/preview-table';
 
 type CandidateId =
     | LocationTrackId
@@ -189,11 +189,9 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 <div className={styles['preview-view__changes-title']}>
                                     <h3>{t('preview-view.other-changes-title')}</h3>
                                 </div>
-                                <PublicationTable
+                                <PreviewTable
                                     onPreviewSelect={props.onPreviewSelect}
                                     previewChanges={unstagedChanges}
-                                    showActions={true}
-                                    showStatus={true}
                                 />
                             </section>
 
@@ -201,12 +199,10 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 <div className={styles['preview-view__changes-title']}>
                                     <h3>{t('preview-view.publish-candidates-title')}</h3>
                                 </div>
-                                <PublicationTable
+                                <PreviewTable
                                     onPreviewSelect={props.onPublishPreviewRemove}
                                     previewChanges={stagedChanges}
                                     publish={true}
-                                    showActions={true}
-                                    showStatus={true}
                                 />
                             </section>
 

--- a/ui/src/publication/publication-details.tsx
+++ b/ui/src/publication/publication-details.tsx
@@ -22,10 +22,9 @@ const PublicationDetails: React.FC<PublicationDetailsProps> = ({
     onPublicationUnselected,
     anyFailed,
 }) => {
-
     const [publicationDetails, setPublicationDetails] = React.useState<PublicationDetails | null>();
     const [waitingAfterFail, setWaitingAfterFail] = React.useState<boolean>();
-    const {t} = useTranslation();
+    const { t } = useTranslation();
 
     function setPublicationDetailsAndWaitingAfterFail(details?: PublicationDetails) {
         setPublicationDetails(details);
@@ -55,13 +54,12 @@ const PublicationDetails: React.FC<PublicationDetailsProps> = ({
             <div className={styles['publication-details__content']}>
                 {publicationDetails && (
                     <PublicationTable
-                        previewChanges={publicationDetails}
+                        publicationChanges={publicationDetails}
                         ratkoPushDate={
                             publicationDetails.status === RatkoPushStatus.SUCCESSFUL
                                 ? publicationDetails.ratkoPushTime || undefined
                                 : undefined
                         }
-                        showRatkoPushDate={true}
                     />
                 )}
             </div>
@@ -102,7 +100,7 @@ const PublicationDetails: React.FC<PublicationDetailsProps> = ({
                             </span>
                         </div>
                     )}
-                    <RatkoPublishButton/>
+                    <RatkoPublishButton />
                 </footer>
             )}
         </div>

--- a/ui/src/publication/publication-table-item.tsx
+++ b/ui/src/publication/publication-table-item.tsx
@@ -1,57 +1,27 @@
 import * as React from 'react';
 import { TimeStamp } from 'common/common-model';
-import styles from 'publication/publication-table-item.scss';
-import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { formatDateFull } from 'utils/date-utils';
 import { useTranslation } from 'react-i18next';
-import { Operation, PublishValidationError } from 'publication/publication-model';
-import { createClassName } from 'vayla-design-lib/utils';
+import { Operation } from 'publication/publication-model';
 
 export type PreviewTableItemProps = {
     itemName: string;
     trackNumber?: string;
-    errors: PublishValidationError[];
     changeTime: TimeStamp;
-    showRatkoPushDate: boolean;
-    showStatus: boolean;
-    showActions: boolean;
     ratkoPushDate?: TimeStamp;
     operation: Operation | null;
     userName: string;
-    onPublishItemSelect?: () => void;
-    publish?: boolean;
 };
 
 export const PublicationTableItem: React.FC<PreviewTableItemProps> = ({
     itemName,
     trackNumber,
-    errors,
     changeTime,
-    showRatkoPushDate,
-    showStatus,
-    showActions,
     ratkoPushDate,
     operation,
     userName,
-    onPublishItemSelect,
-    publish = false,
 }) => {
     const { t } = useTranslation();
-    const [isErrorRowExpanded, setIsErrorRowExpanded] = React.useState(false);
-
-    const errorsToStrings = (list: PublishValidationError[], type: 'ERROR' | 'WARNING') => {
-        const filtered = list.filter((e) => e.type === type);
-        return filtered.map((error) => t(error.localizationKey, error.params));
-    };
-
-    const errorTexts = errorsToStrings(errors, 'ERROR');
-    const warningTexts = errorsToStrings(errors, 'WARNING');
-    const hasErrors = errors.length > 0;
-
-    const statusCellClassName = createClassName(
-        styles['preview-table-item__status-cell'],
-        hasErrors && styles['preview-table-item__status-cell--expandable'],
-    );
 
     return (
         <React.Fragment>
@@ -61,73 +31,8 @@ export const PublicationTableItem: React.FC<PreviewTableItemProps> = ({
                 <td>{operation ? t(`enum.publish-operation.${operation}`) : ''}</td>
                 <td>{formatDateFull(changeTime)}</td>
                 <td>{userName}</td>
-                {showStatus && (
-                    <td
-                        className={statusCellClassName}
-                        onClick={() => setIsErrorRowExpanded(!isErrorRowExpanded)}>
-                        {!hasErrors && (
-                            <span className={styles['preview-table-item__ok-status']}>
-                                <Icons.Tick color={IconColor.INHERIT} size={IconSize.SMALL} />
-                            </span>
-                        )}
-                        {errorTexts.length > 0 && (
-                            <span className={styles['preview-table-item__error-status']}>
-                                {t('publication-table.errors-status-text', [errorTexts.length])}
-                            </span>
-                        )}
-                        {warningTexts.length > 0 && (
-                            <span className={styles['preview-table-item__warning-status']}>
-                                {t('publication-table.warnings-status-text', [warningTexts.length])}
-                            </span>
-                        )}
-                    </td>
-                )}
-                {showRatkoPushDate && (
-                    <td>{ratkoPushDate ? formatDateFull(ratkoPushDate) : t('no')}</td>
-                )}
-                {showActions && (
-                    <td
-                        onClick={() => {
-                            onPublishItemSelect && onPublishItemSelect();
-                        }}>
-                        {publish ? (
-                            <Icons.Ascending size={IconSize.SMALL} />
-                        ) : (
-                            <Icons.Descending size={IconSize.SMALL} />
-                        )}
-                    </td>
-                )}
+                <td>{ratkoPushDate ? formatDateFull(ratkoPushDate) : t('no')}</td>
             </tr>
-            {isErrorRowExpanded && hasErrors && (
-                <tr className={'preview-table-item preview-table-item--error'}>
-                    <td colSpan={4}>
-                        {errorTexts.length > 0 && (
-                            <div className="preview-table-item__msg-group preview-table-item__msg-group--errors">
-                                <div className="preview-table-item__group-title">
-                                    {t('publication-table.errors-group-title')}
-                                </div>
-                                {errorTexts.map((errorText, index) => (
-                                    <div key={index} className="preview-table-item__msg">
-                                        {errorText}
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-                        {warningTexts.length > 0 && (
-                            <div className="preview-table-item__msg-group preview-table-item__msg-group--warnings">
-                                <div className="preview-table-item__group-title">
-                                    {t('publication-table.warnings-group-title')}
-                                </div>
-                                {warningTexts?.map((warningText, index) => (
-                                    <div key={index} className="preview-table-item__msg">
-                                        {warningText}
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-                    </td>
-                </tr>
-            )}
         </React.Fragment>
     );
 };

--- a/ui/src/publication/publication-table.tsx
+++ b/ui/src/publication/publication-table.tsx
@@ -15,7 +15,6 @@ import {
     SortProps,
 } from 'preview/change-table-sorting';
 import {
-    ChangeTableProps,
     trackNumberToChangeTableEntry,
     referenceLineToChangeTableEntry,
     locationTrackToChangeTableEntry,
@@ -23,10 +22,16 @@ import {
     kmPostChangeTableEntry,
 } from 'preview/change-table-entry-mapping';
 import { PublishCandidates } from 'publication/publication-model';
+import { TimeStamp } from 'common/common-model';
 
-const PublicationTable: React.FC<ChangeTableProps> = ({
-    previewChanges,
-    ratkoPushDate = undefined,
+export type PublicationTableProps = {
+    publicationChanges: PublishCandidates;
+    ratkoPushDate: TimeStamp | undefined;
+};
+
+const PublicationTable: React.FC<PublicationTableProps> = ({
+    publicationChanges: changesInPublication,
+    ratkoPushDate,
 }) => {
     const { t } = useTranslation();
     const [trackNumbers, setTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
@@ -60,7 +65,7 @@ const PublicationTable: React.FC<ChangeTableProps> = ({
 
     const [sortInfo, setSortInfo] = React.useState<SortInformation>(InitiallyUnsorted);
 
-    const publicationEntries = changesToPublicationEntries(previewChanges);
+    const publicationEntries = changesToPublicationEntries(changesInPublication);
 
     const sortedPublicationEntries =
         sortInfo && sortInfo.direction !== SortDirection.UNSORTED

--- a/ui/src/publication/publication-table.tsx
+++ b/ui/src/publication/publication-table.tsx
@@ -1,214 +1,66 @@
 import { Table, Th } from 'vayla-design-lib/table/table';
 import { PublicationTableItem } from 'publication/publication-table-item';
 import * as React from 'react';
-import {
-    KmPostPublishCandidate,
-    LocationTrackPublishCandidate,
-    Operation,
-    PublishCandidates,
-    PublishValidationError,
-    ReferenceLinePublishCandidate,
-    SwitchPublishCandidate,
-    TrackNumberPublishCandidate,
-} from 'publication/publication-model';
 import { useTranslation } from 'react-i18next';
-import {
-    LayoutKmPostId,
-    LayoutSwitchId,
-    LayoutTrackNumber,
-    LayoutTrackNumberId,
-    LocationTrackId,
-    ReferenceLineId,
-} from 'track-layout/track-layout-model';
+import { LayoutTrackNumber } from 'track-layout/track-layout-model';
 import { getTrackNumbers } from 'track-layout/layout-track-number-api';
-import { TimeStamp } from 'common/common-model';
 import styles from './publication-table.scss';
-import { SelectedPublishChange } from 'track-layout/track-layout-store';
 import { negComparator } from 'utils/array-utils';
-import { Icons } from 'vayla-design-lib/icon/Icon';
 import {
     getSortInfoForProp,
     InitiallyUnsorted,
     SortDirection,
+    sortDirectionIcon,
     SortInformation,
     SortProps,
-} from 'publication/publication-table-sorting';
+} from 'preview/change-table-sorting';
+import {
+    ChangeTableProps,
+    trackNumberToChangeTableEntry,
+    referenceLineToChangeTableEntry,
+    locationTrackToChangeTableEntry,
+    switchToChangeTableEntry,
+    kmPostChangeTableEntry,
+} from 'preview/change-table-entry-mapping';
+import { PublishCandidates } from 'publication/publication-model';
 
-type PublicationTableProps = {
-    previewChanges: PublishCandidates;
-    showRatkoPushDate?: boolean;
-    showStatus?: boolean;
-    showActions?: boolean;
-    ratkoPushDate?: TimeStamp;
-    onPreviewSelect?: (selectedChanges: SelectedPublishChange) => void;
-    publish?: boolean;
-};
-
-enum PreviewSelectType {
-    trackNumber = 'trackNumber',
-    referenceLine = 'referenceLine',
-    locationTrack = 'locationTrack',
-    switch = 'switch',
-    kmPost = 'kmPost',
-}
-
-type PublicationId =
-    | LayoutTrackNumberId
-    | ReferenceLineId
-    | LocationTrackId
-    | LayoutSwitchId
-    | LayoutKmPostId;
-
-type PublicationEntry = {
-    id: LayoutTrackNumberId | LocationTrackId | LayoutSwitchId | ReferenceLineId | LayoutKmPostId;
-    type: PreviewSelectType;
-    name: string;
-    uiName: string;
-    errors: PublishValidationError[];
-    trackNumber: string;
-    changeTime: string;
-    userName: string;
-    operation: Operation;
-};
-
-export const sortDirectionIcon = (direction: SortDirection) =>
-    direction === SortDirection.ASCENDING
-        ? Icons.Ascending
-        : direction === SortDirection.DESCENDING
-        ? Icons.Descending
-        : undefined;
-
-const PublicationTable: React.FC<PublicationTableProps> = ({
+const PublicationTable: React.FC<ChangeTableProps> = ({
     previewChanges,
-    showRatkoPushDate = false,
-    showStatus = false,
-    showActions = false,
     ratkoPushDate = undefined,
-    onPreviewSelect = undefined,
-    publish = false,
 }) => {
     const { t } = useTranslation();
     const [trackNumbers, setTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
     React.useEffect(() => {
-        getTrackNumbers('DRAFT').then((trackNumbers) => setTrackNumbers(trackNumbers));
+        getTrackNumbers('OFFICIAL').then((trackNumbers) => setTrackNumbers(trackNumbers));
     }, []);
+
+    const changesToPublicationEntries = (previewChanges: PublishCandidates) =>
+        previewChanges.trackNumbers
+            .map((trackNumberCandidate) => trackNumberToChangeTableEntry(trackNumberCandidate, t))
+            .concat(
+                previewChanges.referenceLines.map((referenceLineCandidate) =>
+                    referenceLineToChangeTableEntry(referenceLineCandidate, trackNumbers, t),
+                ),
+            )
+            .concat(
+                previewChanges.locationTracks.map((locationTrackCandidate) =>
+                    locationTrackToChangeTableEntry(locationTrackCandidate, trackNumbers, t),
+                ),
+            )
+            .concat(
+                previewChanges.switches.map((switchCandidate) =>
+                    switchToChangeTableEntry(switchCandidate, trackNumbers, t),
+                ),
+            )
+            .concat(
+                previewChanges.kmPosts.map((kmPostCandidate) =>
+                    kmPostChangeTableEntry(kmPostCandidate, trackNumbers, t),
+                ),
+            );
 
     const [sortInfo, setSortInfo] = React.useState<SortInformation>(InitiallyUnsorted);
 
-    const defaultSelectedPublishChange: SelectedPublishChange = {
-        trackNumber: undefined,
-        referenceLine: undefined,
-        locationTrack: undefined,
-        switch: undefined,
-        kmPost: undefined,
-    };
-
-    function handlePreviewSelect<T>(id: PublicationId, type: T) {
-        switch (type) {
-            case PreviewSelectType.trackNumber:
-                onPreviewSelect &&
-                    onPreviewSelect({ ...defaultSelectedPublishChange, trackNumber: id });
-                break;
-            case PreviewSelectType.referenceLine:
-                onPreviewSelect &&
-                    onPreviewSelect({ ...defaultSelectedPublishChange, referenceLine: id });
-                break;
-            case PreviewSelectType.locationTrack:
-                onPreviewSelect &&
-                    onPreviewSelect({ ...defaultSelectedPublishChange, locationTrack: id });
-                break;
-            case PreviewSelectType.switch:
-                onPreviewSelect &&
-                    onPreviewSelect({ ...defaultSelectedPublishChange, locationTrack: id });
-                break;
-            case PreviewSelectType.kmPost:
-                onPreviewSelect &&
-                    onPreviewSelect({ ...defaultSelectedPublishChange, locationTrack: id });
-                break;
-            default:
-                onPreviewSelect && onPreviewSelect(defaultSelectedPublishChange);
-        }
-    }
-
-    const trackNumberToPublicationEntry = (trackNumber: TrackNumberPublishCandidate) => ({
-        id: trackNumber.id,
-        type: PreviewSelectType.trackNumber,
-        uiName: `${t('publication-table.track-number-long')} ${trackNumber.number}`,
-        name: trackNumber.number,
-        userName: trackNumber.userName,
-        trackNumber: trackNumber.number,
-        changeTime: trackNumber.draftChangeTime,
-        errors: trackNumber.errors,
-        operation: trackNumber.operation,
-    });
-    const referenceLineToPublicationEntry = (referenceLine: ReferenceLinePublishCandidate) => {
-        const trackNumber = trackNumbers.find((tn) => tn.id === referenceLine.trackNumberId);
-        return {
-            id: referenceLine.id,
-            type: PreviewSelectType.referenceLine,
-            uiName: `${t('publication-table.reference-line')} ${referenceLine.name}`,
-            name: referenceLine.name,
-            userName: referenceLine.userName,
-            trackNumber: trackNumber ? trackNumber.number : '',
-            changeTime: referenceLine.draftChangeTime,
-            errors: referenceLine.errors,
-            operation: referenceLine.operation,
-        };
-    };
-    const locationTrackToPublicationEntry = (locationTrack: LocationTrackPublishCandidate) => {
-        const trackNumber = trackNumbers.find((tn) => tn.id === locationTrack.trackNumberId);
-        return {
-            id: locationTrack.id,
-            type: PreviewSelectType.locationTrack,
-            uiName: `${t('publication-table.location-track')} ${locationTrack.name}`,
-            name: locationTrack.name,
-            userName: locationTrack.userName,
-            trackNumber: trackNumber ? trackNumber.number : '',
-            changeTime: locationTrack.draftChangeTime,
-            errors: locationTrack.errors,
-            operation: locationTrack.operation,
-        };
-    };
-    const switchToPublicationEntry = (layoutSwitch: SwitchPublishCandidate) => {
-        const trackNumber = trackNumbers
-            .filter((tn) => layoutSwitch.trackNumberIds.some((lstn) => lstn == tn.id))
-            .sort()
-            .map((tn) => tn.number)
-            .join(', ');
-        return {
-            id: layoutSwitch.id,
-            type: PreviewSelectType.switch,
-            uiName: `${t('publication-table.switch')} ${layoutSwitch.name}`,
-            name: layoutSwitch.name,
-            userName: layoutSwitch.userName,
-            trackNumber,
-            changeTime: layoutSwitch.draftChangeTime,
-            errors: layoutSwitch.errors,
-            operation: layoutSwitch.operation,
-        };
-    };
-    const kmPostPublicationEntry = (kmPost: KmPostPublishCandidate) => {
-        const trackNumber = trackNumbers.find((tn) => tn.id === kmPost.trackNumberId);
-        return {
-            id: kmPost.id,
-            type: PreviewSelectType.kmPost,
-            uiName: `${t('publication-table.km-post')} ${kmPost.kmNumber}`,
-            name: kmPost.kmNumber,
-            userName: kmPost.userName,
-            trackNumber: trackNumber ? trackNumber.number : '',
-            changeTime: kmPost.draftChangeTime,
-            errors: kmPost.errors,
-            operation: kmPost.operation,
-        };
-    };
-
-    const publicationEntries: PublicationEntry[] =
-        previewChanges.trackNumbers
-            .map(trackNumberToPublicationEntry)
-            .concat(previewChanges.referenceLines.map(referenceLineToPublicationEntry))
-            .concat(previewChanges.locationTracks.map(locationTrackToPublicationEntry))
-            .concat(previewChanges.switches.map(switchToPublicationEntry))
-            .concat(previewChanges.kmPosts.map(kmPostPublicationEntry)) || [];
+    const publicationEntries = changesToPublicationEntries(previewChanges);
 
     const sortedPublicationEntries =
         sortInfo && sortInfo.direction !== SortDirection.UNSORTED
@@ -274,19 +126,7 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
                             }>
                             {t('publication-table.user')}
                         </Th>
-                        {showStatus && (
-                            <Th
-                                onClick={() => sortByProp(SortProps.ERRORS)}
-                                icon={
-                                    sortInfo.propName === SortProps.ERRORS
-                                        ? sortDirectionIcon(sortInfo.direction)
-                                        : undefined
-                                }>
-                                {t('publication-table.status')}
-                            </Th>
-                        )}
-                        {showRatkoPushDate && <Th>{t('publication-table.exported-to-ratko')}</Th>}
-                        {showActions && <Th>{t('publication-table.actions')}</Th>}
+                        <Th>{t('publication-table.exported-to-ratko')}</Th>
                     </tr>
                 </thead>
                 <tbody>
@@ -294,20 +134,12 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
                         <React.Fragment key={entry.id}>
                             {
                                 <PublicationTableItem
-                                    onPublishItemSelect={() =>
-                                        handlePreviewSelect(entry.id, entry.type)
-                                    }
                                     itemName={entry.uiName}
                                     trackNumber={entry.trackNumber}
-                                    errors={entry.errors}
                                     changeTime={entry.changeTime}
                                     ratkoPushDate={ratkoPushDate}
-                                    showRatkoPushDate={showRatkoPushDate}
-                                    showStatus={showStatus}
-                                    showActions={showActions}
                                     userName={entry.userName}
                                     operation={entry.operation}
-                                    publish={publish}
                                 />
                             }
                         </React.Fragment>


### PR DESCRIPTION
Täällä eriytetty PublicationTable kahdeksi eriliseksi taulukoksi, sillä ne alkoivat eriytymään toisistaan aika merkittävästi. Jotain yhteisiä osia (sorttaus, yhteisten tietojen mäppäys rivi-informaatio-olioksi) lötyy `change-table`-nimen alta