### PR TITLE
GVT-1490 Fix publish validation not giving error when post km is the same as reference line start km

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -113,7 +113,9 @@ data class GeocodingContext(
                 referenceLineGeometry = referenceLineGeometry,
                 referencePoints = referencePoints,
                 rejectedKmPosts = kmPosts.filterNot { post ->
-                    referencePoints.any { reference -> reference.kmNumber == post.kmNumber }
+                    referencePoints.any { reference ->
+                        reference.kmNumber == post.kmNumber && reference.meters == BigDecimal.ZERO
+                    }
                 },
             )
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
@@ -302,7 +302,7 @@ fun getCauseForRejection(kmPost: TrackLayoutKmPost, geocodingContext: GeocodingC
 
     return if (kmPost.location == null) {
         PublishValidationError(ERROR, "$VALIDATION_GEOCODING.km-post-no-location", params)
-    } else if (TrackMeter(kmPost.kmNumber, 0) < geocodingContext.referenceLine.startAddress) {
+    } else if (TrackMeter(kmPost.kmNumber, 0) <= geocodingContext.referenceLine.startAddress) {
         PublishValidationError(ERROR, "$VALIDATION_GEOCODING.km-post-smaller-than-track-number-start", params)
     } else {
         val intersectType = geocodingContext.referenceLineGeometry.getLengthUntil(kmPost.location)?.second
@@ -318,7 +318,7 @@ fun getCauseForRejection(kmPost: TrackLayoutKmPost, geocodingContext: GeocodingC
 
 fun validateGeocodingContext(
     context: GeocodingContext?,
-    validationTargetLocalizationPrefix: String
+    validationTargetLocalizationPrefix: String,
 ): List<PublishValidationError> =
     if (context == null) listOf(
         PublishValidationError(ERROR, "$validationTargetLocalizationPrefix.no-context", listOf())


### PR DESCRIPTION
Pieni lisäkorjaus km-pylväiden validointivirhe-tikettiin. Huomasin että jos pylvään km-arvo on sama kuin pituusmittauslinjan alku-km, se ei päädy rejectediin (vaikka ei ole käytössäkään) ja siksi siitä ei tule validointivirhettä.