### PR TITLE
GVT-1552 Update reference line list when track number filter changes

### DIFF
--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -177,7 +177,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
     );
     const filteredReferenceLines = React.useMemo(() => {
         return referenceLines.filter((l) => filterByTrackNumberId(l.trackNumberId));
-    }, [referenceLines]);
+    }, [referenceLines, trackNumberFilter]);
 
     const filteredKmPosts = kmPosts.filter((km) => filterByTrackNumberId(km.trackNumberId));
     return (


### PR DESCRIPTION
Periaatteessa selkeämpää voisi kai olla pyöräyttää filterByTrackNumberId useCallback()in sisään, ja sitten passata tämä callback itsessään filteredReferenceLinesin riippuvuudeksi, mutta tässä tapauksessa se ei näyttänyt oikein tähdelliseltä.