### PR TITLE
GVT-1554 Improve fetching switch track number links for publication change list

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
@@ -114,7 +114,7 @@ class PublicationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
             draft_switch.change_time,
             draft_switch.change_user,
             (select array_agg(sltn)
-             from layout.switch_linked_track_numbers(coalesce(official_switch.row_id, draft_switch.row_id)) sltn)
+             from layout.switch_linked_track_numbers(coalesce(official_switch.row_id, draft_switch.row_id), :publication_state) sltn)
               as track_numbers,
             layout.infer_operation_from_state_category_transition(
               official_switch.state_category, 
@@ -126,7 +126,9 @@ class PublicationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
                   and 'OFFICIAL' = any(official_switch.publication_states)
             where draft_switch.draft = true
         """.trimIndent()
-        val candidates = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
+        val candidates = jdbcTemplate.query(sql, mapOf<String, Any>(
+            "publication_state" to PublishType.DRAFT.name,
+        )) { rs, _ ->
             SwitchPublishCandidate(
                 id = rs.getIntId("official_id"),
                 name = SwitchName(rs.getString("name")),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
@@ -113,10 +113,9 @@ class PublicationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
             draft_switch.name, 
             draft_switch.change_time,
             draft_switch.change_user,
-            (select array_agg(distinct track_number_id)
-              from layout.segment
-                join layout.location_track using(alignment_id)
-              where coalesce(official_switch.draft_id, draft_switch.row_id) = segment.switch_id) as track_numbers,
+            (select array_agg(sltn)
+             from layout.switch_linked_track_numbers(coalesce(official_switch.row_id, draft_switch.row_id)) sltn)
+              as track_numbers,
             layout.infer_operation_from_state_category_transition(
               official_switch.state_category, 
               draft_switch.state_category

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -405,10 +405,9 @@ class LayoutSwitchDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
               switch_change_view.version,
               switch_change_view.change_user,
               layout.infer_operation_from_state_category_transition(switch_change_view.old_state_category, switch_change_view.state_category) operation,
-              (select array_agg(distinct track_number_id)
-               from layout.segment_version
-                 join layout.location_track_version using(alignment_id, alignment_version)
-               where switch_change_view.id = segment_version.switch_id) as track_numbers
+              (select array_agg(sltn)
+                from layout.switch_linked_track_numbers(switch_change_view.id) sltn)
+               as track_numbers
             from publication.switch published_switch
               left join layout.switch_change_view
                 on published_switch.switch_id = switch_change_view.id

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -406,7 +406,7 @@ class LayoutSwitchDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
               switch_change_view.change_user,
               layout.infer_operation_from_state_category_transition(switch_change_view.old_state_category, switch_change_view.state_category) operation,
               (select array_agg(sltn)
-                from layout.switch_linked_track_numbers(switch_change_view.id) sltn)
+                from layout.switch_linked_track_numbers(switch_change_view.id, :publication_state) sltn)
                as track_numbers
             from publication.switch published_switch
               left join layout.switch_change_view
@@ -417,7 +417,8 @@ class LayoutSwitchDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
         return jdbcTemplate.query(
             sql,
             mapOf(
-                "id" to publicationId.intValue
+                "id" to publicationId.intValue,
+                "publication_state" to PublishType.OFFICIAL.name,
             )
         ) { rs, _ ->
             SwitchPublishCandidate(

--- a/infra/src/main/resources/db/migration/repeatable/R__05.01_layout_functions.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__05.01_layout_functions.sql
@@ -26,7 +26,7 @@ end
 $$ language plpgsql called on null input
                     immutable;
 
-create or replace function layout.switch_linked_track_numbers(switch_id_in integer)
+create or replace function layout.switch_linked_track_numbers(switch_id_in integer, publication_state text)
   returns setof integer as
 $$
 select distinct track_number_id
@@ -34,15 +34,16 @@ select distinct track_number_id
     (
       select track_number_id
         from layout.segment
-          join layout.location_track using (alignment_id)
-        where switch_id_in = segment.switch_id
+          join layout.location_track_publication_view location_track using (alignment_id)
+        where switch_id_in = segment.switch_id and publication_state = any(location_track.publication_states)
     )
     union all
     (
       select track_number_id
-        from layout.location_track
-        where switch_id_in = location_track.topology_start_switch_id
-           or switch_id_in = location_track.topology_end_switch_id
+        from layout.location_track_publication_view location_track
+        where (switch_id_in = location_track.topology_start_switch_id
+           or switch_id_in = location_track.topology_end_switch_id)
+          and publication_state = any(location_track.publication_states)
     )
   ) tns
-$$ language sql immutable;
+$$ language sql stable;

--- a/infra/src/main/resources/db/migration/repeatable/R__05.01_layout_functions.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__05.01_layout_functions.sql
@@ -25,3 +25,24 @@ begin
 end
 $$ language plpgsql called on null input
                     immutable;
+
+create or replace function layout.switch_linked_track_numbers(switch_id_in integer)
+  returns setof integer as
+$$
+select distinct track_number_id
+  from (
+    (
+      select track_number_id
+        from layout.segment
+          join layout.location_track using (alignment_id)
+        where switch_id_in = segment.switch_id
+    )
+    union all
+    (
+      select track_number_id
+        from layout.location_track
+        where switch_id_in = location_track.topology_start_switch_id
+           or switch_id_in = location_track.topology_end_switch_id
+    )
+  ) tns
+$$ language sql immutable;


### PR DESCRIPTION
Rikki oli ratanumeroiden hakeminen topologialinkin kautta (tämä oli jäänyt alkuperäisestä toteutuksesta minulta vaan kokonaan pois) ja näkyminen julkaisulistassa (tämä taisi olla regressio, tai toivottavasti oli kun kyllä se minun mielestä minun jäljiltä toimi); lähinnä jälkimmäisen takia lisätty testit.