### PR TITLE
GVT-1525: Muutokset-taulun toimintamuutokset

### DIFF
--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -28,7 +28,7 @@ import { createEmptyItemCollections } from 'selection/selection-store';
 
 type PreviewFooterProps = {
     onSelect: OnSelectFunction;
-    request: PublishRequest;
+    request: PublishRequest | undefined;
     onClosePreview: () => void;
     mapMode: PublishType;
     onChangeMapMode: (type: PublishType) => void;
@@ -83,12 +83,13 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
     const [isPublishing, setPublishing] = React.useState(false);
     const [isReverting, setReverting] = React.useState(false);
 
-    const emptyRequest =
-        props.request.trackNumbers.length == 0 &&
-        props.request.kmPosts.length == 0 &&
-        props.request.referenceLines.length == 0 &&
-        props.request.locationTracks.length == 0 &&
-        props.request.switches.length == 0;
+    const emptyRequest = props.request
+        ? props.request.trackNumbers.length == 0 &&
+          props.request.kmPosts.length == 0 &&
+          props.request.referenceLines.length == 0 &&
+          props.request.locationTracks.length == 0 &&
+          props.request.switches.length == 0
+        : true;
 
     const revert = () => {
         setReverting(true);
@@ -110,20 +111,22 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
     };
 
     const publish = () => {
-        setPublishing(true);
-        publishCandidates(props.request)
-            .then((r) => {
-                if (r.isOk()) {
-                    const result = r.unwrapOr(null);
-                    Snackbar.success(t('publish.publish-success'), describeResult(result));
-                    updateChangeTimes(result);
-                    props.onClosePreview();
-                }
-            })
-            .finally(() => {
-                setPublishConfirmVisible(false);
-                setPublishing(false);
-            });
+        if (props.request) {
+            setPublishing(true);
+            publishCandidates(props.request)
+                .then((r) => {
+                    if (r.isOk()) {
+                        const result = r.unwrapOr(null);
+                        Snackbar.success(t('publish.publish-success'), describeResult(result));
+                        updateChangeTimes(result);
+                        props.onClosePreview();
+                    }
+                })
+                .finally(() => {
+                    setPublishConfirmVisible(false);
+                    setPublishing(false);
+                });
+        }
     };
 
     return (

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -6,6 +6,7 @@ import { formatDateFull } from 'utils/date-utils';
 import { useTranslation } from 'react-i18next';
 import { Operation, PublishValidationError } from 'publication/publication-model';
 import { createClassName } from 'vayla-design-lib/utils';
+import { Spinner } from 'vayla-design-lib/spinner/spinner';
 
 export type PreviewTableItemProps = {
     itemName: string;
@@ -14,6 +15,7 @@ export type PreviewTableItemProps = {
     changeTime: TimeStamp;
     operation: Operation | null;
     userName: string;
+    pendingValidation: boolean;
     onPublishItemSelect?: () => void;
     publish?: boolean;
 };
@@ -25,6 +27,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     changeTime,
     operation,
     userName,
+    pendingValidation,
     onPublishItemSelect,
     publish = false,
 }) => {
@@ -53,25 +56,31 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                 <td>{operation ? t(`enum.publish-operation.${operation}`) : ''}</td>
                 <td>{formatDateFull(changeTime)}</td>
                 <td>{userName}</td>
-                <td
-                    className={statusCellClassName}
-                    onClick={() => setIsErrorRowExpanded(!isErrorRowExpanded)}>
-                    {!hasErrors && (
-                        <span className={styles['preview-table-item__ok-status']}>
-                            <Icons.Tick color={IconColor.INHERIT} size={IconSize.SMALL} />
-                        </span>
-                    )}
-                    {errorTexts.length > 0 && (
-                        <span className={styles['preview-table-item__error-status']}>
-                            {t('publication-table.errors-status-text', [errorTexts.length])}
-                        </span>
-                    )}
-                    {warningTexts.length > 0 && (
-                        <span className={styles['preview-table-item__warning-status']}>
-                            {t('publication-table.warnings-status-text', [warningTexts.length])}
-                        </span>
-                    )}
-                </td>
+                {pendingValidation ? (
+                    <td>
+                        <Spinner />
+                    </td>
+                ) : (
+                    <td
+                        className={statusCellClassName}
+                        onClick={() => setIsErrorRowExpanded(!isErrorRowExpanded)}>
+                        {!hasErrors && (
+                            <span className={styles['preview-table-item__ok-status']}>
+                                <Icons.Tick color={IconColor.INHERIT} size={IconSize.SMALL} />
+                            </span>
+                        )}
+                        {errorTexts.length > 0 && (
+                            <span className={styles['preview-table-item__error-status']}>
+                                {t('publication-table.errors-status-text', [errorTexts.length])}
+                            </span>
+                        )}
+                        {warningTexts.length > 0 && (
+                            <span className={styles['preview-table-item__warning-status']}>
+                                {t('publication-table.warnings-status-text', [warningTexts.length])}
+                            </span>
+                        )}
+                    </td>
+                )}
                 <td
                     onClick={() => {
                         onPublishItemSelect && onPublishItemSelect();

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -30,7 +30,8 @@ import {
     trackNumberToChangeTableEntry,
 } from 'preview/change-table-entry-mapping';
 import { PreviewTableItem } from 'preview/preview-table-item';
-import { PublishCandidates, PublishValidationError } from 'publication/publication-model';
+import { PublishValidationError } from 'publication/publication-model';
+import { PreviewCandidates } from 'preview/preview-view';
 
 type PublicationId =
     | LayoutTrackNumberId
@@ -42,6 +43,7 @@ type PublicationId =
 type PreviewTableEntry = {
     type: PreviewSelectType;
     errors: PublishValidationError[];
+    pendingValidation: boolean;
 } & ChangeTableEntry;
 
 enum PreviewSelectType {
@@ -53,7 +55,7 @@ enum PreviewSelectType {
 }
 
 type PreviewTableProps = {
-    previewChanges: PublishCandidates;
+    previewChanges: PreviewCandidates;
     onPreviewSelect: (selectedChanges: SelectedPublishChange) => void;
     staged: boolean;
 };
@@ -100,18 +102,20 @@ const PreviewTable: React.FC<PreviewTableProps> = ({ previewChanges, onPreviewSe
         }
     }
 
-    const changesToPublicationEntries = (previewChanges: PublishCandidates): PreviewTableEntry[] =>
+    const changesToPublicationEntries = (previewChanges: PreviewCandidates): PreviewTableEntry[] =>
         previewChanges.trackNumbers
             .map((trackNumberCandidate) => ({
                 ...trackNumberToChangeTableEntry(trackNumberCandidate, t),
                 errors: trackNumberCandidate.errors,
                 type: PreviewSelectType.trackNumber,
+                pendingValidation: trackNumberCandidate.pendingValidation,
             }))
             .concat(
                 previewChanges.referenceLines.map((referenceLineCandidate) => ({
                     ...referenceLineToChangeTableEntry(referenceLineCandidate, trackNumbers, t),
                     errors: referenceLineCandidate.errors,
                     type: PreviewSelectType.referenceLine,
+                    pendingValidation: referenceLineCandidate.pendingValidation,
                 })),
             )
             .concat(
@@ -119,6 +123,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({ previewChanges, onPreviewSe
                     ...locationTrackToChangeTableEntry(locationTrackCandidate, trackNumbers, t),
                     errors: locationTrackCandidate.errors,
                     type: PreviewSelectType.locationTrack,
+                    pendingValidation: locationTrackCandidate.pendingValidation,
                 })),
             )
             .concat(
@@ -126,6 +131,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({ previewChanges, onPreviewSe
                     ...switchToChangeTableEntry(switchCandidate, trackNumbers, t),
                     errors: switchCandidate.errors,
                     type: PreviewSelectType.switch,
+                    pendingValidation: switchCandidate.pendingValidation,
                 })),
             )
             .concat(
@@ -133,6 +139,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({ previewChanges, onPreviewSe
                     ...kmPostChangeTableEntry(kmPostCandidate, trackNumbers, t),
                     errors: kmPostCandidate.errors,
                     type: PreviewSelectType.kmPost,
+                    pendingValidation: kmPostCandidate.pendingValidation,
                 })),
             );
 
@@ -193,6 +200,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({ previewChanges, onPreviewSe
                                     errors={entry.errors}
                                     changeTime={entry.changeTime}
                                     userName={entry.userName}
+                                    pendingValidation={entry.pendingValidation}
                                     operation={entry.operation}
                                     publish={staged}
                                 />

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -24,7 +24,15 @@ import { ChangeTimes, SelectedPublishChange } from 'track-layout/track-layout-st
 import { PublishType } from 'common/common-model';
 import { CalculatedChangesView } from './calculated-changes-view';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
-import { PublishCandidates, ValidatedPublishCandidates } from 'publication/publication-model';
+import {
+    KmPostPublishCandidate,
+    LocationTrackPublishCandidate,
+    PublishCandidate,
+    PublishCandidates,
+    ReferenceLinePublishCandidate,
+    SwitchPublishCandidate,
+    TrackNumberPublishCandidate,
+} from 'publication/publication-model';
 import {
     LayoutKmPostId,
     LayoutSwitchId,
@@ -52,6 +60,18 @@ export type SelectedChanges = {
     kmPosts: LayoutKmPostId[];
 };
 
+type PendingValidation = {
+    pendingValidation: boolean;
+};
+
+export type PreviewCandidates = {
+    trackNumbers: (TrackNumberPublishCandidate & PendingValidation)[];
+    referenceLines: (ReferenceLinePublishCandidate & PendingValidation)[];
+    locationTracks: (LocationTrackPublishCandidate & PendingValidation)[];
+    switches: (SwitchPublishCandidate & PendingValidation)[];
+    kmPosts: (KmPostPublishCandidate & PendingValidation)[];
+};
+
 type PreviewProps = {
     map: Map;
     selection: Selection;
@@ -77,7 +97,7 @@ const publishCandidateIds = (candidates: PublishCandidates): PublishRequest => (
     kmPosts: candidates.kmPosts.map((s) => s.id),
 });
 
-const initialCandidates = {
+const emptyChanges = {
     trackNumbers: [],
     locationTracks: [],
     referenceLines: [],
@@ -103,11 +123,11 @@ const getStagedChanges = (
     switches: publishCandidates.switches.filter((layoutSwitch) =>
         filterStaged(stagedChangeIds.switches, layoutSwitch),
     ),
-    kmPosts: publishCandidates.kmPosts.filter((trackNumber) =>
-        filterStaged(stagedChangeIds.kmPosts, trackNumber),
+    kmPosts: publishCandidates.kmPosts.filter((kmPost) =>
+        filterStaged(stagedChangeIds.kmPosts, kmPost),
     ),
-    referenceLines: publishCandidates.referenceLines.filter((trackNumber) =>
-        filterStaged(stagedChangeIds.referenceLines, trackNumber),
+    referenceLines: publishCandidates.referenceLines.filter((referenceLine) =>
+        filterStaged(stagedChangeIds.referenceLines, referenceLine),
     ),
 });
 
@@ -124,57 +144,147 @@ const getUnstagedChanges = (
     switches: publishCandidates.switches.filter((layoutSwitch) =>
         filterUnstaged(stagedChangeIds.switches, layoutSwitch),
     ),
-    kmPosts: publishCandidates.kmPosts.filter((trackNumber) =>
-        filterUnstaged(stagedChangeIds.kmPosts, trackNumber),
+    kmPosts: publishCandidates.kmPosts.filter((kmPost) =>
+        filterUnstaged(stagedChangeIds.kmPosts, kmPost),
     ),
-    referenceLines: publishCandidates.referenceLines.filter((trackNumber) =>
-        filterUnstaged(stagedChangeIds.referenceLines, trackNumber),
+    referenceLines: publishCandidates.referenceLines.filter((referenceLine) =>
+        filterUnstaged(stagedChangeIds.referenceLines, referenceLine),
     ),
+});
+
+// Validating the change set takes time. After a change is staged, it should be regarded as staged, but pending
+// validation until validation is complete
+const pendingValidation = (
+    allStaged: CandidateId[],
+    allValidated: CandidateId[],
+    id: CandidateId,
+) => allStaged.includes(id) && !allValidated.includes(id);
+
+const previewChanges = (
+    stagedValidatedChanges: PublishCandidates,
+    allSelectedChanges: PublishRequest,
+    entireChangeset: PublishCandidates,
+) => {
+    const validatedIds = publishCandidateIds(stagedValidatedChanges);
+
+    return {
+        trackNumbers: [
+            ...stagedValidatedChanges.trackNumbers.map(nonPendingCandidate),
+            ...entireChangeset.trackNumbers
+                .filter((change) =>
+                    pendingValidation(
+                        allSelectedChanges.trackNumbers,
+                        validatedIds.trackNumbers,
+                        change.id,
+                    ),
+                )
+                .map(pendingCandidate),
+        ],
+        referenceLines: [
+            ...stagedValidatedChanges.referenceLines.map(nonPendingCandidate),
+            ...entireChangeset.referenceLines
+                .filter((change) =>
+                    pendingValidation(
+                        allSelectedChanges.referenceLines,
+                        validatedIds.referenceLines,
+                        change.id,
+                    ),
+                )
+                .map(pendingCandidate),
+        ],
+        locationTracks: [
+            ...stagedValidatedChanges.locationTracks.map(nonPendingCandidate),
+            ...entireChangeset.locationTracks
+                .filter((change) =>
+                    pendingValidation(
+                        allSelectedChanges.locationTracks,
+                        validatedIds.locationTracks,
+                        change.id,
+                    ),
+                )
+                .map(pendingCandidate),
+        ],
+        switches: [
+            ...stagedValidatedChanges.switches.map(nonPendingCandidate),
+            ...entireChangeset.switches
+                .filter((change) =>
+                    pendingValidation(
+                        allSelectedChanges.switches,
+                        validatedIds.switches,
+                        change.id,
+                    ),
+                )
+                .map(pendingCandidate),
+        ],
+        kmPosts: [
+            ...stagedValidatedChanges.kmPosts.map(nonPendingCandidate),
+            ...entireChangeset.kmPosts
+                .filter((change) =>
+                    pendingValidation(allSelectedChanges.kmPosts, validatedIds.kmPosts, change.id),
+                )
+                .map(pendingCandidate),
+        ],
+    };
+};
+
+const nonPendingCandidate = <T extends PublishCandidate>(candidate: T) => ({
+    ...candidate,
+    pendingValidation: false,
+});
+const pendingCandidate = <T extends PublishCandidate>(candidate: T) => ({
+    ...candidate,
+    pendingValidation: true,
 });
 
 export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const { t } = useTranslation();
-    const allChanges = useLoader(() => getPublishCandidates(), []);
-    const allValidatedPublishCandidates: ValidatedPublishCandidates | null | undefined = useLoader(
+    const entireChangeset = useLoader(() => getPublishCandidates(), []);
+    const entireChangesetValidation = useLoader(
         () =>
-            (allChanges && validatePublishCandidates(publishCandidateIds(allChanges))) ?? undefined,
-        [allChanges],
+            validatePublishCandidates(
+                publishCandidateIds(entireChangeset ? entireChangeset : emptyChanges),
+            ),
+        [entireChangeset],
     );
-    // GVT-1510 currently all changes are fetched above and hence all validated as a single publication unit
-    const publishCandidates: PublishCandidates | undefined =
-        allValidatedPublishCandidates?.validatedAsPublicationUnit;
-    const unstagedChanges = publishCandidates
-        ? getUnstagedChanges(publishCandidates, props.selectedPublishCandidateIds)
-        : initialCandidates;
-    const stagedChanges = publishCandidates
-        ? getStagedChanges(publishCandidates, props.selectedPublishCandidateIds)
-        : initialCandidates;
+    const stagedValidation = useLoader(
+        () => validatePublishCandidates(props.selectedPublishCandidateIds),
+        [props.selectedPublishCandidateIds],
+    );
+    const unstagedChanges = entireChangesetValidation
+        ? getUnstagedChanges(
+              entireChangesetValidation?.validatedAsPublicationUnit,
+              props.selectedPublishCandidateIds,
+          )
+        : undefined;
+    const stagedChangesValidated = stagedValidation
+        ? getStagedChanges(
+              stagedValidation.validatedAsPublicationUnit,
+              props.selectedPublishCandidateIds,
+          )
+        : undefined;
 
-    const [selectedChanges, setSelectedChanges] = React.useState<SelectedChanges>({
-        trackNumbers: [],
-        referenceLines: [],
-        locationTracks: [],
-        switches: [],
-        kmPosts: [],
-    });
-    React.useEffect(() => {
-        setSelectedChanges({
-            trackNumbers: publishCandidates
-                ? publishCandidates.trackNumbers.map((tn) => tn.id)
-                : [],
-            referenceLines: publishCandidates
-                ? publishCandidates.referenceLines.map((a) => a.id)
-                : [],
-            locationTracks: publishCandidates
-                ? publishCandidates.locationTracks.map((a) => a.id)
-                : [],
-            switches: publishCandidates ? publishCandidates.switches.map((s) => s.id) : [],
-            kmPosts: publishCandidates ? publishCandidates.kmPosts.map((kmp) => kmp.id) : [],
-        });
-    }, [publishCandidates]);
+    const unstagedPreviewChanges: PreviewCandidates = unstagedChanges
+        ? {
+              trackNumbers: unstagedChanges.trackNumbers.map(nonPendingCandidate),
+              referenceLines: unstagedChanges.referenceLines.map(nonPendingCandidate),
+              locationTracks: unstagedChanges.locationTracks.map(nonPendingCandidate),
+              switches: unstagedChanges.switches.map(nonPendingCandidate),
+              kmPosts: unstagedChanges.kmPosts.map(nonPendingCandidate),
+          }
+        : emptyChanges;
+
+    const stagedPreviewChanges: PreviewCandidates =
+        stagedChangesValidated && entireChangeset
+            ? previewChanges(
+                  stagedChangesValidated,
+                  props.selectedPublishCandidateIds,
+                  entireChangeset,
+              )
+            : emptyChanges;
+
     const calculatedChanges = useLoader(
-        () => getCalculatedChanges(selectedChanges),
-        [selectedChanges],
+        () => getCalculatedChanges(props.selectedPublishCandidateIds),
+        [props.selectedPublishCandidateIds],
     );
     const [mapMode, setMapMode] = React.useState<PublishType>('DRAFT');
 
@@ -183,7 +293,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
             <div className={styles['preview-view']} qa-id="preview-content">
                 <PreviewToolBar onClosePreview={props.onClosePreview} />
                 <div className={styles['preview-view__changes']}>
-                    {(unstagedChanges && stagedChanges && (
+                    {(unstagedChanges && stagedChangesValidated && (
                         <>
                             <section className={styles['preview-section']}>
                                 <div className={styles['preview-view__changes-title']}>
@@ -191,7 +301,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 </div>
                                 <PreviewTable
                                     onPreviewSelect={props.onPreviewSelect}
-                                    previewChanges={unstagedChanges}
+                                    previewChanges={unstagedPreviewChanges}
                                     staged={false}
                                 />
                             </section>
@@ -202,7 +312,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 </div>
                                 <PreviewTable
                                     onPreviewSelect={props.onPublishPreviewRemove}
-                                    previewChanges={stagedChanges}
+                                    previewChanges={stagedPreviewChanges}
                                     staged={true}
                                 />
                             </section>
@@ -232,11 +342,15 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
 
                 <PreviewFooter
                     onSelect={props.onSelect}
-                    request={selectedChanges}
+                    request={
+                        stagedChangesValidated
+                            ? publishCandidateIds(stagedChangesValidated)
+                            : undefined
+                    }
                     onClosePreview={props.onClosePreview}
                     mapMode={mapMode}
                     onChangeMapMode={setMapMode}
-                    previewChanges={unstagedChanges == null ? undefined : unstagedChanges}
+                    previewChanges={stagedChangesValidated ? stagedChangesValidated : undefined}
                     onPublishPreviewRevert={props.onPublishPreviewRevert}
                 />
             </div>

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -345,12 +345,12 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                     request={
                         stagedChangesValidated
                             ? publishCandidateIds(stagedChangesValidated)
-                            : undefined
+                            : emptyChanges
                     }
                     onClosePreview={props.onClosePreview}
                     mapMode={mapMode}
                     onChangeMapMode={setMapMode}
-                    previewChanges={stagedChangesValidated ? stagedChangesValidated : undefined}
+                    previewChanges={stagedPreviewChanges ? stagedPreviewChanges : emptyChanges}
                     onPublishPreviewRevert={props.onPublishPreviewRevert}
                 />
             </div>


### PR DESCRIPTION
Suurin pihvi täälä on validointi osissa. Huomioita tästä:

Julkaistavien muutosten taulukko validoi vain sen muutosjoukon, jotka on valittu ka. taulukkoon, mutta ylempi taulukko validoi nyt speksistä poiketen aivan koko julkaisemattoman tilan. Tämä johtuu siitä, että muutosten validointi erillisinä voi piilottaa virheitä siten, että ne tulevat näkyviin vasta kun ka. muutokset stagetaan. Esimerkki tällaisesta virheestä on jos tasakilometripiste sijaitsee ennen radan alkua tai sen lopun jälkeen.

Muutoksen stageaminen siirtää ka. muutoksen välittömästä julkaistavien muutosten listaan käyttökokemuksen parantamiseksi. Koska validoinnissa voi kestää, tilacolumnissa näytetään siirretyillä riveillä spinneri siihen saakka kunnes validointi on valmistunut.