### PR TITLE
GVT-1558 Calculate spiral directions from PI-point rather than use the declared values

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -1169,8 +1169,8 @@ class GeometryDao @Autowired constructor(
 
     private fun getSpiralData(rs: ResultSet, units: GeometryUnits): SpiralData = SpiralData(
         rotation = rs.getEnum("rotation"),
-        directionStart = toAngle(rs.getBigDecimal("spiral_dir_start"), units.directionUnit),
-        directionEnd = toAngle(rs.getBigDecimal("spiral_dir_end"), units.directionUnit),
+        directionStart = rs.getBigDecimal("spiral_dir_start")?.let { bd -> toAngle(bd, units.directionUnit) },
+        directionEnd = rs.getBigDecimal("spiral_dir_end")?.let { bd -> toAngle(bd, units.directionUnit) },
         radiusStart = rs.getBigDecimal("spiral_radius_start"),
         radiusEnd = rs.getBigDecimal("spiral_radius_end"),
         pi = rs.getPoint("spiral_pi_x", "spiral_pi_y"),
@@ -1306,8 +1306,8 @@ class GeometryDao @Autowired constructor(
                     .plus(getPointSqlParams("curve_center_point", element.center))
                 is GeometrySpiral -> mapOf(
                     "rotation" to element.rotation.name,
-                    "spiral_dir_start" to element.directionStart.original,
-                    "spiral_dir_end" to element.directionEnd.original,
+                    "spiral_dir_start" to element.directionStart?.original,
+                    "spiral_dir_end" to element.directionEnd?.original,
                     "spiral_radius_start" to element.radiusStart,
                     "spiral_radius_end" to element.radiusEnd,
                 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
@@ -86,6 +86,7 @@ class InfraModelController @Autowired constructor(
             infraModelService.saveInfraModel(file, overrideParameters, extraInfoParameters).id)
     }
 
+    @PreAuthorize(AUTH_ALL_READ)
     @PostMapping("/validate")
     fun validateFile(
         @RequestPart(value = "file") file: MultipartFile,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
@@ -269,8 +269,8 @@ fun toGvtGeometryElement(
             val endAngle = angle("$name end direction", element.dirEnd ?: "", units.directionUnit)
             val spiralData = SpiralData(
                 rotation = parseEnum("$name spiral curvature direction", element.rot),
-                directionStart = startAngle ?: angleBetween(start, pi, units.directionUnit),
-                directionEnd = endAngle ?: angleBetween(pi, end, units.directionUnit),
+                directionStart = startAngle,
+                directionEnd = endAngle,
                 radiusStart = spiralRadius(element.radiusStart),
                 radiusEnd = spiralRadius(element.radiusEnd),
                 pi = pi,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryAssertions.kt
@@ -1,0 +1,91 @@
+import fi.fta.geoviite.infra.geometry.*
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+
+fun assertPlansMatch(original: GeometryPlan, planFromDb: GeometryPlan) {
+    assertMatches(original.project, planFromDb.project)
+    assertMatches(original.author, planFromDb.author)
+    assertMatches(original.application, planFromDb.application)
+    assertEquals(original.units, planFromDb.units)
+    assertEquals(original.fileName, planFromDb.fileName)
+
+    assertEquals(original.trackNumberId, planFromDb.trackNumberId)
+    assertEquals(original.trackNumberDescription, planFromDb.trackNumberDescription)
+
+    assertEquals(original.alignments.size, planFromDb.alignments.size)
+    original.alignments.forEachIndexed { index, convertedAlignment ->
+        assertMatches(convertedAlignment, planFromDb.alignments[index])
+    }
+
+    assertEquals(original.switches.size, planFromDb.switches.size)
+    original.switches.forEachIndexed { index, convertedSwitch ->
+        assertMatches(convertedSwitch, planFromDb.switches[index])
+    }
+
+    assertEquals(original.kmPosts.size, planFromDb.kmPosts.size)
+    original.kmPosts.forEachIndexed { index, convertedKmPost ->
+        assertMatches(convertedKmPost, planFromDb.kmPosts[index])
+    }
+    assertEquals(original.bounds, planFromDb.bounds)
+}
+
+fun assertMatches(original: Project, fromDb: Project) {
+    assertEquals(original.name, fromDb.name)
+    assertEquals(original.description, fromDb.description)
+}
+
+fun assertMatches(original: Author?, fromDb: Author?) {
+    assertEquals(original == null, fromDb == null)
+    assertEquals(original?.companyName, fromDb?.companyName)
+}
+
+fun assertMatches(original: Application, fromDb: Application) {
+    assertEquals(original.name, fromDb.name)
+    assertEquals(original.manufacturer, fromDb.manufacturer)
+    assertEquals(original.version, fromDb.version)
+}
+
+fun assertMatches(original: GeometryKmPost, fromDb: GeometryKmPost) {
+    assertEquals(original.staBack, fromDb.staBack)
+    assertEquals(original.staAhead, fromDb.staAhead)
+    assertEquals(original.staInternal, fromDb.staInternal)
+    assertEquals(original.kmNumber, fromDb.kmNumber)
+    assertEquals(original.description, fromDb.description)
+    assertEquals(original.location, fromDb.location)
+    assertEquals(original.state, fromDb.state)
+}
+
+fun assertMatches(original: GeometrySwitch, fromDb: GeometrySwitch) {
+    assertEquals(original.name, fromDb.name)
+    assertEquals(original.switchStructureId, fromDb.switchStructureId)
+    assertEquals(original.typeName, fromDb.typeName)
+    assertEquals(original.state, fromDb.state)
+    assertEquals(original.joints, fromDb.joints)
+}
+
+fun assertMatches(original: TrackLayoutTrackNumber?, fromDb: TrackLayoutTrackNumber?) {
+    if (original != null || fromDb != null) {
+        assertEquals(original?.number, fromDb?.number)
+        assertEquals(original?.description, fromDb?.description)
+        assertEquals(original?.state, fromDb?.state)
+    }
+}
+
+fun assertMatches(original: GeometryAlignment, fromDb: GeometryAlignment) {
+    assertEquals(original.name, fromDb.name)
+    assertEquals(original.description, fromDb.description)
+    assertEquals(original.staStart, fromDb.staStart)
+    assertEquals(original.featureTypeCode, fromDb.featureTypeCode)
+    assertEquals(original.profile, fromDb.profile)
+    assertEquals(original.cant, fromDb.cant)
+
+    assertEquals(original.elements.size, fromDb.elements.size)
+    original.elements.forEachIndexed { index, convertedElement ->
+        val elementFromDb = fromDb.elements[index]
+        assertTrue(
+            convertedElement.contentEquals(elementFromDb),
+            "Contents should be equal: \n\texpect=$convertedElement. \n\tactual=$elementFromDb"
+        )
+    }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
@@ -1,13 +1,9 @@
 package fi.fta.geoviite.infra.inframodel
 
+import assertPlansMatch
 import fi.fta.geoviite.infra.ITTestBase
-import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.TrackNumber
-import fi.fta.geoviite.infra.geometry.*
+import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
-import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -30,7 +26,7 @@ class InfraModelServiceIT @Autowired constructor(
         val (parsedPlan, _) = infraModelService.validateInputFileAndParseInfraModel(file)
         val planId = infraModelService.saveInfraModel(file, null, null)
 
-        assertResultsMatch(parsedPlan, geometryDao.fetchPlan(planId))
+        assertPlansMatch(parsedPlan, geometryDao.fetchPlan(planId))
     }
 
     @Test
@@ -40,109 +36,7 @@ class InfraModelServiceIT @Autowired constructor(
         val (parsedPlan, _) = infraModelService.validateInputFileAndParseInfraModel(file)
         val planId = infraModelService.saveInfraModel(file, null, null)
 
-        assertResultsMatch(parsedPlan, geometryDao.fetchPlan(planId))
-    }
-
-    @Test
-    fun insertPlanWorks() {
-        val trackNumber = getOrCreateTrackNumber(TrackNumber("654"))
-        if (trackNumber.draft != null) trackNumberService.publish(trackNumber.id as IntId)
-        val plan = plan(trackNumber.id as IntId)
-        val fileContent = "<a></a>"
-        val id = geometryDao.insertPlan(plan, InfraModelFile(plan.fileName, fileContent))
-        val fetchedPlan = geometryDao.fetchPlan(id)
-        val file = geometryDao.getPlanFile(id.id)
-        assertResultsMatch(plan, fetchedPlan)
-        assertEquals(fileContent, file.content)
-        assertEquals(plan.fileName, file.name)
-    }
-
-
-    fun assertResultsMatch(original: GeometryPlan, planFromDb: GeometryPlan) {
-        assertMatches(original.project, planFromDb.project)
-        assertMatches(original.author, planFromDb.author)
-        assertMatches(original.application, planFromDb.application)
-        assertEquals(original.units, planFromDb.units)
-        assertEquals(original.fileName, planFromDb.fileName)
-
-        assertEquals(original.trackNumberId, planFromDb.trackNumberId)
-        assertEquals(original.trackNumberDescription, planFromDb.trackNumberDescription)
-
-        assertEquals(original.alignments.size, planFromDb.alignments.size)
-        original.alignments.forEachIndexed { index, convertedAlignment ->
-            assertMatches(convertedAlignment, planFromDb.alignments[index])
-        }
-
-        assertEquals(original.switches.size, planFromDb.switches.size)
-        original.switches.forEachIndexed { index, convertedSwitch ->
-            assertMatches(convertedSwitch, planFromDb.switches[index])
-        }
-
-        assertEquals(original.kmPosts.size, planFromDb.kmPosts.size)
-        original.kmPosts.forEachIndexed { index, convertedKmPost ->
-            assertMatches(convertedKmPost, planFromDb.kmPosts[index])
-        }
-        assertEquals(original.bounds, planFromDb.bounds)
-    }
-
-    fun assertMatches(original: Project, fromDb: Project) {
-        assertEquals(original.name, fromDb.name)
-        assertEquals(original.description, fromDb.description)
-    }
-
-    fun assertMatches(original: Author?, fromDb: Author?) {
-        assertEquals(original == null, fromDb == null)
-        assertEquals(original?.companyName, fromDb?.companyName)
-    }
-
-    fun assertMatches(original: Application, fromDb: Application) {
-        assertEquals(original.name, fromDb.name)
-        assertEquals(original.manufacturer, fromDb.manufacturer)
-        assertEquals(original.version, fromDb.version)
-    }
-
-    fun assertMatches(original: GeometryKmPost, fromDb: GeometryKmPost) {
-        assertEquals(original.staBack, fromDb.staBack)
-        assertEquals(original.staAhead, fromDb.staAhead)
-        assertEquals(original.staInternal, fromDb.staInternal)
-        assertEquals(original.kmNumber, fromDb.kmNumber)
-        assertEquals(original.description, fromDb.description)
-        assertEquals(original.location, fromDb.location)
-        assertEquals(original.state, fromDb.state)
-    }
-
-    fun assertMatches(original: GeometrySwitch, fromDb: GeometrySwitch) {
-        assertEquals(original.name, fromDb.name)
-        assertEquals(original.switchStructureId, fromDb.switchStructureId)
-        assertEquals(original.typeName, fromDb.typeName)
-        assertEquals(original.state, fromDb.state)
-        assertEquals(original.joints, fromDb.joints)
-    }
-
-    fun assertMatches(original: TrackLayoutTrackNumber?, fromDb: TrackLayoutTrackNumber?) {
-        if (original != null || fromDb != null) {
-            assertEquals(original?.number, fromDb?.number)
-            assertEquals(original?.description, fromDb?.description)
-            assertEquals(original?.state, fromDb?.state)
-        }
-    }
-
-    fun assertMatches(original: GeometryAlignment, fromDb: GeometryAlignment) {
-        assertEquals(original.name, fromDb.name)
-        assertEquals(original.description, fromDb.description)
-        assertEquals(original.staStart, fromDb.staStart)
-        assertEquals(original.featureTypeCode, fromDb.featureTypeCode)
-        assertEquals(original.profile, fromDb.profile)
-        assertEquals(original.cant, fromDb.cant)
-
-        assertEquals(original.elements.size, fromDb.elements.size)
-        original.elements.forEachIndexed { index, convertedElement ->
-            val elementFromDb = fromDb.elements[index]
-            Assertions.assertTrue(
-                convertedElement.contentEquals(elementFromDb),
-                "Contents should be equal: \n\texpect=$convertedElement. \n\tactual=$elementFromDb"
-            )
-        }
+        assertPlansMatch(parsedPlan, geometryDao.fetchPlan(planId))
     }
 
     fun getMockedMultipartFile(fileLocation: String): MockMultipartFile = MockMultipartFile(


### PR DESCRIPTION
3DWin tuottaa suuntakulmat IM:ään myötäkelloon laskettuna, kun ne pitäisi olla vastakelloon. Toisaalta, ilmoitettuja suuntakulmia ei kannattaisi käyttää muutenkaan.

Taustaa: IM:ssä on paljon ylimääriteltyjä arvoja, mm elementtien suuntakulmat (myös pituus, kaaren chord, jne), jotka ovat myös laskettavissa muusta datasta. Ne ovat kuitenkin speksin mukaan pakollisia. Geoviite ei enimmäkseen käytä näitä lisätietoja, mutta siirtymäkaarten (spiral) tapauksessa se käytti alku/loppu suuntia geometrian laskennassa. Tässä pullarissa muutetaan tuo laskenta käyttämään PI-pistettä (Point of Intersection = alku- ja lopputangenttien kohtauspiste), jolloin ilmoitetuista dir-arvoista ei välitetä tuossakaan tapauksessa ja myös 3DWin:in tuottamat tiedostot näkyvät oikein.