### PR TITLE
GVT-1512 User shouldn't need to know that some switch names have double empty space in db

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -125,7 +125,7 @@ class LayoutSwitchService @Autowired constructor(
         switch.externalId.toString() == term || switch.id.toString() == term
 
     private fun contentMatches(term: String, switch: TrackLayoutSwitch) =
-        switch.exists && switch.name.contains(term, true)
+        switch.exists && switch.name.toString().replace("  ", " ").contains(term, true)
 
     fun pageSwitches(
         switches: List<TrackLayoutSwitch>,


### PR DESCRIPTION
[https://extranet.vayla.fi/jira/browse/GVT-1512](https://extranet.vayla.fi/jira/browse/GVT-1512)