### PR TITLE
GVT-1534 Publication+validation with fixed versions

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
@@ -92,10 +92,10 @@ data class TrackMeter @JsonCreator(mode = DISABLED) constructor(override val kmN
 
     init {
         require(meters in metersValidRange) {
-            "Track address meters outside valid range: value=$meters"
+            "Track address meters outside valid range: km=$kmNumber value=$meters"
         }
         require(meters.scale() in metersDecimalsValidRange) {
-            "Track address meters have too many decimals: value=$meters"
+            "Track address meters have too many decimals: km=$kmNumber value=$meters"
         }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
@@ -2,10 +2,8 @@ package fi.fta.geoviite.infra.geocoding
 
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType
-import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.configuration.CACHE_ADDRESS_POINTS
-import fi.fta.geoviite.infra.linking.PublicationVersions
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
@@ -18,7 +16,6 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 data class AddressPointCacheKey(
-    val locationTrackVersion: RowVersion<LocationTrack>,
     val alignmentVersion: RowVersion<LayoutAlignment>,
     val geocodingContextCacheKey: GeocodingContextCacheKey,
 )
@@ -40,25 +37,7 @@ class AddressPointsCache(
             val track = locationTrackDao.fetch(trackVersion)
             val contextCacheKey = geocodingDao.getGeocodingContextCacheKey(publishType, track.trackNumberId)
             if (track.alignmentVersion != null && contextCacheKey != null) {
-                AddressPointCacheKey(trackVersion, track.alignmentVersion, contextCacheKey)
-            } else {
-                null
-            }
-        }
-    }
-
-    @Transactional(readOnly = true)
-    fun getAddressPointCacheKey(
-        locationTrackId: IntId<LocationTrack>,
-        publicationVersions: PublicationVersions,
-    ): AddressPointCacheKey? {
-        val locationTrackVersion = publicationVersions.findLocationTrack(locationTrackId)?.draftVersion
-            ?: locationTrackDao.fetchVersion(locationTrackId, OFFICIAL)
-        return locationTrackVersion?.let { trackVersion ->
-            val track = locationTrackDao.fetch(trackVersion)
-            val contextCacheKey = geocodingDao.getGeocodingContextCacheKey(track.trackNumberId, publicationVersions)
-            if (track.alignmentVersion != null && contextCacheKey != null) {
-                AddressPointCacheKey(trackVersion, track.alignmentVersion, contextCacheKey)
+                AddressPointCacheKey(track.alignmentVersion, contextCacheKey)
             } else {
                 null
             }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
@@ -2,10 +2,15 @@ package fi.fta.geoviite.infra.geocoding
 
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType
+import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.configuration.CACHE_ADDRESS_POINTS
+import fi.fta.geoviite.infra.linking.PublicationVersions
 import fi.fta.geoviite.infra.logging.serviceCall
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.Cacheable
@@ -30,12 +35,28 @@ class AddressPointsCache(
     fun getAddressPointCacheKey(
         publishType: PublishType,
         locationTrackId: IntId<LocationTrack>,
-        kmPostIdsToPublish: List<IntId<TrackLayoutKmPost>>? = null,
     ): AddressPointCacheKey? {
         return locationTrackDao.fetchVersion(locationTrackId, publishType)?.let { trackVersion ->
             val track = locationTrackDao.fetch(trackVersion)
-            val contextCacheKey =
-                geocodingDao.getGeocodingContextCacheKey(publishType, track.trackNumberId, kmPostIdsToPublish)
+            val contextCacheKey = geocodingDao.getGeocodingContextCacheKey(publishType, track.trackNumberId)
+            if (track.alignmentVersion != null && contextCacheKey != null) {
+                AddressPointCacheKey(trackVersion, track.alignmentVersion, contextCacheKey)
+            } else {
+                null
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun getAddressPointCacheKey(
+        locationTrackId: IntId<LocationTrack>,
+        publicationVersions: PublicationVersions,
+    ): AddressPointCacheKey? {
+        val locationTrackVersion = publicationVersions.findLocationTrack(locationTrackId)?.draftVersion
+            ?: locationTrackDao.fetchVersion(locationTrackId, OFFICIAL)
+        return locationTrackVersion?.let { trackVersion ->
+            val track = locationTrackDao.fetch(trackVersion)
+            val contextCacheKey = geocodingDao.getGeocodingContextCacheKey(track.trackNumberId, publicationVersions)
             if (track.alignmentVersion != null && contextCacheKey != null) {
                 AddressPointCacheKey(trackVersion, track.alignmentVersion, contextCacheKey)
             } else {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
@@ -16,32 +16,33 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
-interface GeocodingContextCacheKey {
-    val trackNumberId: IntId<TrackLayoutTrackNumber>;
-    val changeTime: Instant;
-    val publishType: PublishType
+data class GeocodingContextCacheKey (
+    val trackNumberVersion: RowVersion<TrackLayoutTrackNumber>,
+    val referenceLineVersion: RowVersion<ReferenceLine>,
+    val kmPostVersions: RowVersion<TrackLayoutKmPost>,
+//    val changeTime: Instant
+//    val publishType: PublishType
+//    fun fetchVersions(kmPostDao: LayoutKmPostDao): List<RowVersion<TrackLayoutKmPost>>
+ )
 
-    fun fetchVersions(kmPostDao: LayoutKmPostDao): List<RowVersion<TrackLayoutKmPost>>
-}
-
-data class OrdinaryGeocodingContextCacheKey(
-    override val publishType: PublishType,
-    override val trackNumberId: IntId<TrackLayoutTrackNumber>,
-    override val changeTime: Instant,
-) : GeocodingContextCacheKey {
-    override fun fetchVersions(kmPostDao: LayoutKmPostDao): List<RowVersion<TrackLayoutKmPost>> =
-        kmPostDao.fetchVersions(publishType, false, trackNumberId, null)
-}
-
-data class PublicationGeocodingContextCacheKey(
-    override val trackNumberId: IntId<TrackLayoutTrackNumber>,
-    override val changeTime: Instant,
-    val kmPostIdsToPublish: List<IntId<TrackLayoutKmPost>>,
-) : GeocodingContextCacheKey {
-    override val publishType = PublishType.DRAFT
-    override fun fetchVersions(kmPostDao: LayoutKmPostDao): List<RowVersion<TrackLayoutKmPost>> =
-        kmPostDao.fetchVersionsForPublication(trackNumberId, kmPostIdsToPublish)
-}
+//data class OrdinaryGeocodingContextCacheKey(
+//    override val publishType: PublishType,
+//    override val trackNumberId: IntId<TrackLayoutTrackNumber>,
+//    override val changeTime: Instant,
+//) : GeocodingContextCacheKey {
+//    override fun fetchVersions(kmPostDao: LayoutKmPostDao): List<RowVersion<TrackLayoutKmPost>> =
+//        kmPostDao.fetchVersions(publishType, false, trackNumberId, null)
+//}
+//
+//data class PublicationGeocodingContextCacheKey(
+//    override val trackNumberId: IntId<TrackLayoutTrackNumber>,
+//    override val changeTime: Instant,
+//    val kmPostIdsToPublish: List<IntId<TrackLayoutKmPost>>,
+//) : GeocodingContextCacheKey {
+//    override val publishType = PublishType.DRAFT
+//    override fun fetchVersions(kmPostDao: LayoutKmPostDao): List<RowVersion<TrackLayoutKmPost>> =
+////        kmPostDao.fetchVersionsForPublication(trackNumberId, kmPostIdsToPublish)
+//}
 
 @Transactional(readOnly = true)
 @Component

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
@@ -5,47 +5,21 @@ import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.configuration.CACHE_GEOCODING_CONTEXTS
-import fi.fta.geoviite.infra.linking.PublicationVersion
 import fi.fta.geoviite.infra.linking.PublicationVersions
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.DaoBase
-import fi.fta.geoviite.infra.util.getInstantOrNull
-import fi.fta.geoviite.infra.util.queryOptional
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 data class GeocodingContextCacheKey (
     val trackNumberVersion: RowVersion<TrackLayoutTrackNumber>,
     val referenceLineVersion: RowVersion<ReferenceLine>,
     val kmPostVersions: List<RowVersion<TrackLayoutKmPost>>,
-//    val changeTime: Instant
-//    val publishType: PublishType
-//    fun fetchVersions(kmPostDao: LayoutKmPostDao): List<RowVersion<TrackLayoutKmPost>>
  )
-
-//data class OrdinaryGeocodingContextCacheKey(
-//    override val publishType: PublishType,
-//    override val trackNumberId: IntId<TrackLayoutTrackNumber>,
-//    override val changeTime: Instant,
-//) : GeocodingContextCacheKey {
-//    override fun fetchVersions(kmPostDao: LayoutKmPostDao): List<RowVersion<TrackLayoutKmPost>> =
-//        kmPostDao.fetchVersions(publishType, false, trackNumberId, null)
-//}
-//
-//data class PublicationGeocodingContextCacheKey(
-//    override val trackNumberId: IntId<TrackLayoutTrackNumber>,
-//    override val changeTime: Instant,
-//    val kmPostIdsToPublish: List<IntId<TrackLayoutKmPost>>,
-//) : GeocodingContextCacheKey {
-//    override val publishType = PublishType.DRAFT
-//    override fun fetchVersions(kmPostDao: LayoutKmPostDao): List<RowVersion<TrackLayoutKmPost>> =
-////        kmPostDao.fetchVersionsForPublication(trackNumberId, kmPostIdsToPublish)
-//}
 
 @Transactional(readOnly = true)
 @Component
@@ -61,131 +35,37 @@ class GeocodingDao(
     fun getGeocodingContextCacheKey(
         publishType: PublishType,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
-    ) = GeocodingContextCacheKey(
-        trackNumberVersion = trackNumberDao.fetchVersionOrThrow(trackNumberId, publishType),
-        referenceLineVersion = referenceLineDao.fetchVersionOrThrow(publishType, trackNumberId),
-        kmPostVersions = kmPostDao.fetchVersions(publishType, true, trackNumberId)
-            .sortedBy { p -> p.id.intValue },
-    )
+    ): GeocodingContextCacheKey? {
+        val trackNumberVersion = trackNumberDao.fetchVersion(trackNumberId, publishType)
+        val referenceLineVersion = referenceLineDao.fetchVersion(publishType, trackNumberId)
+        return if (trackNumberVersion != null && referenceLineVersion != null) {
+            val kmPostVersions = kmPostDao.fetchVersions(publishType, false, trackNumberId)
+                .sortedBy { p -> p.id.intValue }
+            GeocodingContextCacheKey(trackNumberVersion, referenceLineVersion, kmPostVersions)
+        } else null
+    }
+
 
     fun getGeocodingContextCacheKey(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         publicationVersions: PublicationVersions,
-    ) = getGeocodingContextCacheKey(OFFICIAL, trackNumberId).let { official ->
-        val publicationTrackNumber = publicationVersions.find(official.trackNumberVersion.id)?.rowVersion
-            ?: official.trackNumberVersion
-        val publicationReferenceLine = publicationVersions.find(official.referenceLineVersion.id)?.rowVersion
-            ?: official.referenceLineVersion
-        val officialKmPosts = official.kmPostVersions.filter { kmPostVersion ->
-            !publicationVersions.contains(kmPostVersion.id)
-        }
-        val draftKmPosts = publicationVersions.kmPosts.filter { draftPost ->
-            kmPostDao.fetch(draftPost.rowVersion).trackNumberId == trackNumberId
-        }.map(PublicationVersion<TrackLayoutKmPost>::rowVersion)
-        val publicationKmPosts = (officialKmPosts + draftKmPosts).sortedBy { p -> p.id.intValue }
-        GeocodingContextCacheKey(publicationTrackNumber, publicationReferenceLine, publicationKmPosts)
-    }
-
-    fun getGeocodingContextCacheKey(
-        publishType: PublishType,
-        trackNumberId: IntId<TrackLayoutTrackNumber>,
-        kmPostIdsToPublish: List<IntId<TrackLayoutKmPost>>? = null,
     ): GeocodingContextCacheKey? {
-        assert(!(publishType == OFFICIAL && kmPostIdsToPublish != null)) {
-            "Trying to get geocoding context cache key for in OFFICIAL mode but intending to publish km post ids"
-        }
-        // if the track has been saved at all, it will have a change time, and if not, it can't have any km posts
-        // referencing it -> early exit is correct
-        val maxChangeTimeOnTrack = getTrackNumberOrReferenceLineChangeTime(publishType, trackNumberId)
-            ?: return null
-        return if (kmPostIdsToPublish != null) {
-            publicationGeocodingContextCacheKey(trackNumberId, kmPostIdsToPublish, maxChangeTimeOnTrack)
-        } else {
-            ordinaryGeocodingContextCacheKey(trackNumberId, publishType, maxChangeTimeOnTrack)
-        }
-    }
-
-    private fun ordinaryGeocodingContextCacheKey(
-        trackNumberId: IntId<TrackLayoutTrackNumber>,
-        publishType: PublishType,
-        maxChangeTimeOnTrack: Instant
-    ): OrdinaryGeocodingContextCacheKey {
-        val sql = """
-            select max(km_post.change_time) as change_time
-            from layout.km_post_version km_post
-            where km_post.track_number_id = :track_number_id
-              and ((km_post.draft and :publication_type = 'DRAFT')
-                    or (not km_post.draft and :publication_type = 'OFFICIAL'))
-            """.trimIndent()
-        val maxChangeTimeOnKmPosts = jdbcTemplate.queryOptional(
-            sql, mapOf(
-                "track_number_id" to trackNumberId.intValue,
-                "publication_type" to publishType.name
-            )
-        ) { rs, _ ->
-            rs.getInstantOrNull("change_time")
-        }
-        return OrdinaryGeocodingContextCacheKey(
-            publishType,
-            trackNumberId,
-            maxOfOneNotNull(maxChangeTimeOnTrack, maxChangeTimeOnKmPosts)
-        )
-    }
-
-    private fun publicationGeocodingContextCacheKey(
-        trackNumberId: IntId<TrackLayoutTrackNumber>,
-        kmPostIdsToPublish: List<IntId<TrackLayoutKmPost>>,
-        maxChangeTimeOnTrackOrReferenceLine: Instant
-    ): PublicationGeocodingContextCacheKey {
-        val sql = """
-            select max(km_post.change_time) as change_time
-            from layout.km_post_version km_post
-            where km_post.track_number_id = :track_number_id
-              and ((km_post.draft and coalesce(km_post.draft_of_km_post_id, km_post.id) in (:km_post_ids_to_publish))
-                   or (not km_post.draft and (km_post.id in (:km_post_ids_to_publish)) is distinct from true))
-            """.trimIndent()
-        val maxChangeTimeOnKmPosts = jdbcTemplate.queryOptional(sql, mapOf(
-            "track_number_id" to trackNumberId.intValue,
-            // listOf(null) to indicate an empty list due to SQL syntax limitations; the "is distinct from true" checks
-            // explicitly for false or null, since "foo in (null)" in SQL is null
-            "km_post_ids_to_publish" to (kmPostIdsToPublish.map { id -> id.intValue }.ifEmpty { listOf(null) })
-        )
-        ) { rs, _ ->
-            rs.getInstantOrNull("change_time")
-        }
-        return PublicationGeocodingContextCacheKey(
-            trackNumberId,
-            maxOfOneNotNull(maxChangeTimeOnTrackOrReferenceLine, maxChangeTimeOnKmPosts),
-            kmPostIdsToPublish
-        )
-    }
-
-    private fun <T: Comparable<T>> maxOfOneNotNull(a: T, b: T?): T =
-        b?.let { listOf(a, b).max() } ?: a
-
-    fun getTrackNumberOrReferenceLineChangeTime(
-        publishType: PublishType,
-        trackNumberId: IntId<TrackLayoutTrackNumber>
-    ): Instant? {
-        val sql = """
-            select greatest(
-              (select max(track_number.change_time)
-                 from layout.track_number_publication_view track_number
-                 where track_number.official_id = :track_number_id
-                   and :publication_state = any(track_number.publication_states)
-              ),
-              (select max(reference_line.change_time)
-                 from layout.reference_line_publication_view reference_line
-                 where reference_line.track_number_id = :track_number_id
-                   and :publication_state = any(reference_line.publication_states)
-              )
-            ) as max_change_time
-              """
-        val params = mapOf(
-            "track_number_id" to trackNumberId.intValue,
-            "publication_state" to publishType.name,
-        )
-        return jdbcTemplate.queryOptional(sql, params) { rs, _ -> rs.getInstantOrNull("max_change_time") }
+        val trackNumberVersion = publicationVersions.findTrackNumber(trackNumberId)?.draftVersion
+            ?: trackNumberDao.fetchVersion(trackNumberId, OFFICIAL)
+        // We have to fetch the actual objects (reference line & km-post) here to check references
+        // However, when this is done, the objects are needed elsewhere as well -> they should always be in cache
+        val referenceLineVersion = publicationVersions.referenceLines
+            .find { v -> referenceLineDao.fetch(v.draftVersion).trackNumberId == trackNumberId }?.draftVersion
+            ?: referenceLineDao.fetchVersion(OFFICIAL, trackNumberId)
+        return if (trackNumberVersion != null && referenceLineVersion != null) {
+            val officialKmPosts = kmPostDao.fetchVersions(OFFICIAL, false, trackNumberId)
+                .filter { version -> !publicationVersions.containsKmPost(version.id) }
+            val draftKmPosts = publicationVersions.kmPosts.filter { draftPost ->
+                kmPostDao.fetch(draftPost.draftVersion).trackNumberId == trackNumberId
+            }.map { v -> v.draftVersion }
+            val kmPostVersions = (officialKmPosts + draftKmPosts).sortedBy { p -> p.id.intValue }
+            GeocodingContextCacheKey(trackNumberVersion, referenceLineVersion, kmPostVersions)
+        } else null
     }
 
     @Cacheable(CACHE_GEOCODING_CONTEXTS, sync = true)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -1,9 +1,6 @@
 package fi.fta.geoviite.infra.geocoding
 
-import fi.fta.geoviite.infra.common.DomainId
-import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.PublishType
-import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.linking.PublicationVersions
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.IPoint
@@ -33,16 +30,15 @@ class GeocodingService(
             ?.let(addressPointsCache::getAddressPoints)
     }
 
-    fun getAddressPointsForPublication(
-        locationTrackId: IntId<LocationTrack>,
-        publicationVersions: PublicationVersions,
+    fun getAddressPoints(
+        contextKey: GeocodingContextCacheKey,
+        alignmentVersion: RowVersion<LayoutAlignment>,
     ): AlignmentAddresses? {
         logger.serviceCall(
             "getAddressPointsForPublication",
-            "locationTrackId" to locationTrackId, "publicationVersions" to publicationVersions
+            "alignmentVersion" to alignmentVersion, "contextKey" to contextKey
         )
-        return addressPointsCache.getAddressPointCacheKey(locationTrackId, publicationVersions)
-            ?.let(addressPointsCache::getAddressPoints)
+        return addressPointsCache.getAddressPoints(AddressPointCacheKey(alignmentVersion, contextKey))
     }
 
     fun getAddress(
@@ -118,10 +114,10 @@ class GeocodingService(
     ) = geocodingDao.getGeocodingContextCacheKey(publicationState, trackNumberId)
         ?.let(geocodingDao::getGeocodingContext)
 
-    fun getGeocodingContext(
+    fun getGeocodingContextCacheKey(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         publicationVersions: PublicationVersions,
     ) = geocodingDao.getGeocodingContextCacheKey(trackNumberId, publicationVersions)
-        ?.let(geocodingDao::getGeocodingContext)
+
 
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.linking.PublicationVersions
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType
@@ -23,75 +24,73 @@ class GeocodingService(
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    fun getAddressPoints(locationTrackId: DomainId<LocationTrack>, publishType: PublishType): AlignmentAddresses? {
-        check(locationTrackId is IntId) { "Location track must be stored in DB before calculating address points" }
+    fun getAddressPoints(locationTrackId: IntId<LocationTrack>, publicationState: PublishType): AlignmentAddresses? {
         logger.serviceCall(
             "getAddressPoints",
-            "locationTrackId" to locationTrackId, "publishType" to publishType
+            "locationTrackId" to locationTrackId, "publicationState" to publicationState
         )
-        return addressPointsCache.getAddressPointCacheKey(publishType, locationTrackId)
+        return addressPointsCache.getAddressPointCacheKey(publicationState, locationTrackId)
             ?.let(addressPointsCache::getAddressPoints)
     }
 
     fun getAddressPointsForPublication(
-        locationTrackId: DomainId<LocationTrack>,
-        kmPostIdsToPublish: List<IntId<TrackLayoutKmPost>>
+        locationTrackId: IntId<LocationTrack>,
+        publicationVersions: PublicationVersions,
     ): AlignmentAddresses? {
-        check(locationTrackId is IntId) { "Location track must be stored in DB before calculating address points" }
         logger.serviceCall(
             "getAddressPointsForPublication",
-            "locationTrackId" to locationTrackId, "kmPostIdsToPublish" to kmPostIdsToPublish
+            "locationTrackId" to locationTrackId, "publicationVersions" to publicationVersions
         )
-        return addressPointsCache.getAddressPointCacheKey(PublishType.DRAFT, locationTrackId, kmPostIdsToPublish)
+        return addressPointsCache.getAddressPointCacheKey(locationTrackId, publicationVersions)
             ?.let(addressPointsCache::getAddressPoints)
     }
 
     fun getAddress(
-        publishType: PublishType,
+        publicationState: PublishType,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         location: IPoint,
     ): Pair<TrackMeter, IntersectType>? {
         logger.serviceCall(
             "getAddress",
-            "trackNumberId" to trackNumberId, "location" to location, "publishType" to publishType
+            "trackNumberId" to trackNumberId, "location" to location, "publicationState" to publicationState
         )
-        return getGeocodingContext(publishType, trackNumberId)?.getAddress(location)
+        return getGeocodingContext(publicationState, trackNumberId)?.getAddress(location)
     }
 
     fun getAddressIfWithin(
-        publishType: PublishType,
+        publicationState: PublishType,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         location: IPoint,
     ): TrackMeter? {
         logger.serviceCall(
             "getAddressIfWithin",
-            "trackNumberId" to trackNumberId, "location" to location, "publishType" to publishType
+            "trackNumberId" to trackNumberId, "location" to location, "publicationState" to publicationState
         )
-        return getGeocodingContext(publishType, trackNumberId)?.getAddress(location)
+        return getGeocodingContext(publicationState, trackNumberId)?.getAddress(location)
             ?.let { (address, intersect) -> if (intersect != WITHIN) null else address }
     }
 
     fun getLocationTrackStartAndEnd(
-        publishType: PublishType,
+        publicationState: PublishType,
         locationTrackId: IntId<LocationTrack>,
     ): AlignmentStartAndEnd? {
         logger.serviceCall(
             "getLocationTrackStartAndEnd",
-            "publishType" to publishType, "locationTrackId" to locationTrackId)
-        return locationTrackService.getWithAlignment(publishType, locationTrackId)?.let { (track, alignment) ->
-            val geocodingContext = getGeocodingContext(publishType, track.trackNumberId)
+            "publicationState" to publicationState, "locationTrackId" to locationTrackId)
+        return locationTrackService.getWithAlignment(publicationState, locationTrackId)?.let { (track, alignment) ->
+            val geocodingContext = getGeocodingContext(publicationState, track.trackNumberId)
             geocodingContext?.getStartAndEnd(alignment)
         }
     }
 
     fun getReferenceLineStartAndEnd(
-        publishType: PublishType,
+        publicationState: PublishType,
         referenceLineId: IntId<ReferenceLine>,
     ): AlignmentStartAndEnd? {
         logger.serviceCall("getReferenceLineStartAndEnd",
-            "publishType" to publishType, "referenceLineId" to referenceLineId)
-        return referenceLineService.getWithAlignment(publishType, referenceLineId)?.let { (line, alignment) ->
-            val geocodingContext = getGeocodingContext(publishType, line.trackNumberId)
+            "publicationState" to publicationState, "referenceLineId" to referenceLineId)
+        return referenceLineService.getWithAlignment(publicationState, referenceLineId)?.let { (line, alignment) ->
+            val geocodingContext = getGeocodingContext(publicationState, line.trackNumberId)
             geocodingContext?.getStartAndEnd(alignment)
         }
     }
@@ -99,25 +98,30 @@ class GeocodingService(
     fun getTrackLocation(
         locationTrackId: IntId<LocationTrack>,
         address: TrackMeter,
-        publishType: PublishType,
+        publicationState: PublishType,
     ): AddressPoint? {
         logger.serviceCall("getTrackLocation",
-            "locationTrackId" to locationTrackId, "address" to address, "publishType" to publishType)
-        return locationTrackService.getWithAlignment(publishType, locationTrackId)?.let { (track, alignment) ->
-            getGeocodingContext(publishType, track.trackNumberId)?.getTrackLocation(alignment, address)
+            "locationTrackId" to locationTrackId, "address" to address, "publicationState" to publicationState)
+        return locationTrackService.getWithAlignment(publicationState, locationTrackId)?.let { (track, alignment) ->
+            getGeocodingContext(publicationState, track.trackNumberId)?.getTrackLocation(alignment, address)
         }
     }
 
     fun getGeocodingContext(
-        publishType: PublishType,
+        publicationState: PublishType,
         trackNumberId: DomainId<TrackLayoutTrackNumber>?,
-        publishKmPostIds: List<IntId<TrackLayoutKmPost>>? = null
-    ) =
-        if (trackNumberId is IntId) {
-            geocodingDao.getGeocodingContextCacheKey(publishType, trackNumberId, publishKmPostIds)
-                ?.let(geocodingDao::getGeocodingContext)
-        } else {
-            logger.warn("Cannot get geocoding context for track number: $trackNumberId")
-            null
-        }
+    ) = if (trackNumberId is IntId) getGeocodingContext(publicationState, trackNumberId) else null
+
+    fun getGeocodingContext(
+        publicationState: PublishType,
+        trackNumberId: IntId<TrackLayoutTrackNumber>,
+    ) = geocodingDao.getGeocodingContextCacheKey(publicationState, trackNumberId)
+        ?.let(geocodingDao::getGeocodingContext)
+
+    fun getGeocodingContext(
+        trackNumberId: IntId<TrackLayoutTrackNumber>,
+        publicationVersions: PublicationVersions,
+    ) = geocodingDao.getGeocodingContextCacheKey(trackNumberId, publicationVersions)
+        ?.let(geocodingDao::getGeocodingContext)
+
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -118,6 +118,4 @@ class GeocodingService(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         publicationVersions: PublicationVersions,
     ) = geocodingDao.getGeocodingContextCacheKey(trackNumberId, publicationVersions)
-
-
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingTransformation.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.linking
 
 import fi.fta.geoviite.infra.common.DomainId
+import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.error.LinkingFailureException
 import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
@@ -303,3 +304,8 @@ fun getSegmentsWithoutSwitchInformation(segments: List<MapSegment>): List<Layout
         )
     }
 }
+
+fun isLinkedToSwitch(locationTrack: LocationTrack, alignment: LayoutAlignment, switchId: IntId<TrackLayoutSwitch>) =
+    locationTrack.topologyStartSwitch?.switchId == switchId ||
+            locationTrack.topologyEndSwitch?.switchId == switchId ||
+            alignment.segments.any { seg -> seg.switchId == switchId }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
@@ -93,6 +93,14 @@ data class PublishCandidates(
     )
 }
 
+data class PublicationVersions(
+    val trackNumbers: List<RowVersion<TrackLayoutTrackNumber>>,
+    val locationTracks: List<RowVersion<LocationTrack>>,
+    val referenceLines: List<RowVersion<ReferenceLine>>,
+    val switches: List<RowVersion<TrackLayoutSwitch>>,
+    val kmPosts: List<RowVersion<TrackLayoutKmPost>>,
+)
+
 data class PublishRequest(
     val trackNumbers: List<IntId<TrackLayoutTrackNumber>>,
     val locationTracks: List<IntId<LocationTrack>>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
@@ -109,13 +109,6 @@ data class PublicationVersions(
     val switches: List<PublicationVersion<TrackLayoutSwitch>>,
     val kmPosts: List<PublicationVersion<TrackLayoutKmPost>>,
 ) {
-//    // TODO: switch the structures for maps?
-//    private val trackNumberMap by lazy { trackNumbers.associateBy { it.officialId } }
-//    private val locationTrackMap by lazy { locationTracks.associateBy { it.officialId } }
-//    private val referenceLineMap by lazy { referenceLines.associateBy { it.officialId } }
-//    private val switchMap by lazy { switches.associateBy { it.officialId } }
-//    private val kmPostsMap by lazy { kmPosts.associateBy { it.officialId } }
-
     fun containsTrackNumber(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.any { it.officialId == id }
     fun containsLocationTrack(id: IntId<LocationTrack>) = locationTracks.any { it.officialId == id }
     fun containsReferenceLine(id: IntId<ReferenceLine>) = referenceLines.any { it.officialId == id }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
@@ -72,17 +72,17 @@ data class PublishCandidates(
 ) {
     fun splitByRequest(versions: PublicationVersions) =
         PublishCandidates(
-            trackNumbers.filter { candidate -> versions.contains(candidate.id) },
-            locationTracks.filter { candidate -> versions.contains(candidate.id) },
-            referenceLines.filter { candidate -> versions.contains(candidate.id) },
-            switches.filter { candidate -> versions.contains(candidate.id) },
-            kmPosts.filter { candidate -> versions.contains(candidate.id) },
+            trackNumbers.filter { candidate -> versions.containsTrackNumber(candidate.id) },
+            locationTracks.filter { candidate -> versions.containsLocationTrack(candidate.id) },
+            referenceLines.filter { candidate -> versions.containsReferenceLine(candidate.id) },
+            switches.filter { candidate -> versions.containsSwitch(candidate.id) },
+            kmPosts.filter { candidate -> versions.containsKmPost(candidate.id) },
         ) to PublishCandidates(
-            trackNumbers.filterNot { candidate -> versions.contains(candidate.id) },
-            locationTracks.filterNot { candidate -> versions.contains(candidate.id) },
-            referenceLines.filterNot { candidate -> versions.contains(candidate.id) },
-            switches.filterNot { candidate -> versions.contains(candidate.id) },
-            kmPosts.filterNot { candidate -> versions.contains(candidate.id) },
+            trackNumbers.filterNot { candidate -> versions.containsTrackNumber(candidate.id) },
+            locationTracks.filterNot { candidate -> versions.containsLocationTrack(candidate.id) },
+            referenceLines.filterNot { candidate -> versions.containsReferenceLine(candidate.id) },
+            switches.filterNot { candidate -> versions.containsSwitch(candidate.id) },
+            kmPosts.filterNot { candidate -> versions.containsKmPost(candidate.id) },
         )
 
     fun ids(): PublishRequest = PublishRequest(
@@ -103,27 +103,33 @@ private inline fun <reified T, reified S: PublishCandidate<T>> getOrThrow(all: L
     all.find { c -> c.id == id } ?: throw NoSuchEntityException(S::class, id)
 
 data class PublicationVersions(
-    // TODO: switch the structures for maps
     val trackNumbers: List<PublicationVersion<TrackLayoutTrackNumber>>,
     val locationTracks: List<PublicationVersion<LocationTrack>>,
     val referenceLines: List<PublicationVersion<ReferenceLine>>,
     val switches: List<PublicationVersion<TrackLayoutSwitch>>,
     val kmPosts: List<PublicationVersion<TrackLayoutKmPost>>,
 ) {
-    fun contains(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.any { it.officialId == id }
-    fun contains(id: IntId<LocationTrack>) = locationTracks.any { it.officialId == id }
-    fun contains(id: IntId<ReferenceLine>) = referenceLines.any { it.officialId == id }
-    fun contains(id: IntId<TrackLayoutSwitch>) = switches.any { it.officialId == id }
-    fun contains(id: IntId<TrackLayoutKmPost>) = kmPosts.any { it.officialId == id }
+//    // TODO: switch the structures for maps?
+//    private val trackNumberMap by lazy { trackNumbers.associateBy { it.officialId } }
+//    private val locationTrackMap by lazy { locationTracks.associateBy { it.officialId } }
+//    private val referenceLineMap by lazy { referenceLines.associateBy { it.officialId } }
+//    private val switchMap by lazy { switches.associateBy { it.officialId } }
+//    private val kmPostsMap by lazy { kmPosts.associateBy { it.officialId } }
 
-    fun find(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.find { it.officialId == id }
-    fun find(id: IntId<LocationTrack>) = locationTracks.find { it.officialId == id }
-    fun find(id: IntId<ReferenceLine>) = referenceLines.find { it.officialId == id }
-    fun find(id: IntId<TrackLayoutSwitch>) = switches.find { it.officialId == id }
-    fun find(id: IntId<TrackLayoutKmPost>) = kmPosts.find { it.officialId == id }
+    fun containsTrackNumber(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.any { it.officialId == id }
+    fun containsLocationTrack(id: IntId<LocationTrack>) = locationTracks.any { it.officialId == id }
+    fun containsReferenceLine(id: IntId<ReferenceLine>) = referenceLines.any { it.officialId == id }
+    fun containsSwitch(id: IntId<TrackLayoutSwitch>) = switches.any { it.officialId == id }
+    fun containsKmPost(id: IntId<TrackLayoutKmPost>) = kmPosts.any { it.officialId == id }
+
+    fun findTrackNumber(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.find { it.officialId == id }
+    fun findLocationTrack(id: IntId<LocationTrack>) = locationTracks.find { it.officialId == id }
+    fun findReferenceLine(id: IntId<ReferenceLine>) = referenceLines.find { it.officialId == id }
+    fun findSwitch(id: IntId<TrackLayoutSwitch>) = switches.find { it.officialId == id }
+    fun findKmPost(id: IntId<TrackLayoutKmPost>) = kmPosts.find { it.officialId == id }
 }
 
-data class PublicationVersion<T>(val officialId: IntId<T>, val rowVersion: RowVersion<T>)
+data class PublicationVersion<T>(val officialId: IntId<T>, val draftVersion: RowVersion<T>)
 
 data class PublishRequest(
     val trackNumbers: List<IntId<TrackLayoutTrackNumber>>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
@@ -94,12 +94,14 @@ data class PublishCandidates(
 }
 
 data class PublicationVersions(
-    val trackNumbers: List<RowVersion<TrackLayoutTrackNumber>>,
-    val locationTracks: List<RowVersion<LocationTrack>>,
-    val referenceLines: List<RowVersion<ReferenceLine>>,
-    val switches: List<RowVersion<TrackLayoutSwitch>>,
-    val kmPosts: List<RowVersion<TrackLayoutKmPost>>,
+    val trackNumbers: List<PublicationVersion<TrackLayoutTrackNumber>>,
+    val locationTracks: List<PublicationVersion<LocationTrack>>,
+    val referenceLines: List<PublicationVersion<ReferenceLine>>,
+    val switches: List<PublicationVersion<TrackLayoutSwitch>>,
+    val kmPosts: List<PublicationVersion<TrackLayoutKmPost>>,
 )
+
+data class PublicationVersion<T>(val officialId: IntId<T>, val rowVersion: RowVersion<T>)
 
 data class PublishRequest(
     val trackNumbers: List<IntId<TrackLayoutTrackNumber>>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
@@ -115,6 +115,12 @@ data class PublicationVersions(
     fun contains(id: IntId<ReferenceLine>) = referenceLines.any { it.officialId == id }
     fun contains(id: IntId<TrackLayoutSwitch>) = switches.any { it.officialId == id }
     fun contains(id: IntId<TrackLayoutKmPost>) = kmPosts.any { it.officialId == id }
+
+    fun find(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.find { it.officialId == id }
+    fun find(id: IntId<LocationTrack>) = locationTracks.find { it.officialId == id }
+    fun find(id: IntId<ReferenceLine>) = referenceLines.find { it.officialId == id }
+    fun find(id: IntId<TrackLayoutSwitch>) = switches.find { it.officialId == id }
+    fun find(id: IntId<TrackLayoutKmPost>) = kmPosts.find { it.officialId == id }
 }
 
 data class PublicationVersion<T>(val officialId: IntId<T>, val rowVersion: RowVersion<T>)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
@@ -75,7 +75,6 @@ class PublicationController @Autowired constructor(
             publishService.updateExternalId(request)
             val versions = publishService.getPublicationVersions(request)
             publishService.validatePublishRequest(versions)
-//            publishService.validatePublishRequest(request)
             publishService.publishChanges(versions)
         } ?: throw PublicationFailureException(
             message = "Could not reserve publication lock",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
@@ -39,7 +39,7 @@ class PublicationController @Autowired constructor(
     @PostMapping("/validate")
     fun validatePublishCandidates(@RequestBody publishRequest: PublishRequest): ValidatedPublishCandidates {
         logger.apiCall("validatePublishCandidates")
-        return publishService.validatePublishCandidates(publishRequest)
+        return publishService.validatePublishCandidates(publishService.getPublicationVersions(publishRequest))
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
@@ -72,9 +72,11 @@ class PublicationController @Autowired constructor(
     fun publishChanges(@RequestBody request: PublishRequest): PublishResult {
         logger.apiCall("publishChanges", "request" to request)
         return lockDao.runWithLock(PUBLICATION, publicationMaxDuration) {
-            publishService.validatePublishRequest(request)
             publishService.updateExternalId(request)
-            publishService.publishChanges(request)
+            val versions = publishService.getPublicationVersions(request)
+            publishService.validatePublishRequest(versions)
+//            publishService.validatePublishRequest(request)
+            publishService.publishChanges(versions)
         } ?: throw PublicationFailureException(
             message = "Could not reserve publication lock",
             localizedMessageKey = "lock-obtain-failed",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
@@ -297,7 +297,7 @@ class PublicationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
     fun fetchLinkedLocationTracks(
         switchId: IntId<TrackLayoutSwitch>,
         publicationStatus: PublishType,
-    ): List<PublicationVersion<LocationTrack>> {
+    ): List<RowVersion<LocationTrack>> {
         val sql = """
             select 
               location_track.official_id,
@@ -325,23 +325,6 @@ class PublicationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
             "switch_id" to switchId.intValue,
             "publication_status" to publicationStatus.name,
         )
-        return jdbcTemplate.query(sql, params) { rs, _ -> PublicationVersion(
-            officialId = rs.getIntId("official_id"),
-            rowVersion = rs.getRowVersion("row_id", "row_version"),
-        ) }
-    }
-
-    fun fetchTrackNumberLocationTrackRows(
-        trackNumberId: IntId<TrackLayoutTrackNumber>
-    ): List<RowVersion<LocationTrack>> {
-        val sql = """
-            select row_id, row_version 
-            from layout.location_track_publication_view location_track
-            where location_track.track_number_id = :track_number_id 
-              and 'DRAFT' = any(location_track.publication_states)
-              and location_track.state != 'DELETED'
-        """.trimIndent()
-        val params = mapOf("track_number_id" to trackNumberId.intValue)
         return jdbcTemplate.query(sql, params) { rs, _ ->
             rs.getRowVersion("row_id", "row_version")
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
@@ -294,32 +294,41 @@ class PublicationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
             )
         }.toTypedArray()
 
-    fun fetchLinkedAlignmentRows(
+    fun fetchLinkedLocationTracks(
         switchId: IntId<TrackLayoutSwitch>,
-    ): List<Pair<RowVersion<LocationTrack>, RowVersion<LayoutAlignment>>> {
+        publicationStatus: PublishType,
+    ): List<PublicationVersion<LocationTrack>> {
         val sql = """
             select 
-                location_track.row_id,
-                location_track.row_version,
-                location_track.alignment_id,
-                location_track.alignment_version 
+              location_track.official_id,
+              location_track.row_id,
+              location_track.row_version,
+              location_track.alignment_id,
+              location_track.alignment_version 
             from layout.location_track_publication_view location_track
-                left join layout.segment on segment.alignment_id = location_track.alignment_id
-            where segment.switch_id = :switch_id 
-              and 'DRAFT' = any(location_track.publication_states)
+              left join layout.segment on segment.alignment_id = location_track.alignment_id
+            where :publication_status = any(location_track.publication_states)
               and location_track.state != 'DELETED'
+              and (
+                location_track.topology_start_switch_id = :switch_id or
+                location_track.topology_end_switch_id = :switch_id or
+                segment.switch_id = :switch_id 
+              )
             group by 
-                location_track.row_id,
-                location_track.row_version, 
-                location_track.alignment_id, 
-                location_track.alignment_version 
+              location_track.official_id,
+              location_track.row_id,
+              location_track.row_version, 
+              location_track.alignment_id, 
+              location_track.alignment_version 
         """.trimIndent()
-        val params = mapOf("switch_id" to switchId.intValue)
-        return jdbcTemplate.query(sql, params) { rs, _ ->
-            val trackVersion = rs.getRowVersion<LocationTrack>("row_id", "row_version")
-            val alignmentVersion = rs.getRowVersion<LayoutAlignment>("alignment_id", "alignment_version")
-            trackVersion to alignmentVersion
-        }
+        val params = mapOf(
+            "switch_id" to switchId.intValue,
+            "publication_status" to publicationStatus.name,
+        )
+        return jdbcTemplate.query(sql, params) { rs, _ -> PublicationVersion(
+            officialId = rs.getIntId("official_id"),
+            rowVersion = rs.getRowVersion("row_id", "row_version"),
+        ) }
     }
 
     fun fetchTrackNumberLocationTrackRows(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
@@ -200,6 +200,15 @@ class PublishService @Autowired constructor(
         }
     }
 
+    @Transactional(readOnly = true)
+    fun getPublicationVersions(request: PublishRequest) = PublicationVersions(
+        trackNumbers = trackNumberDao.fetchVersions(DRAFT, false).filter { v -> request.trackNumbers.contains(v.id) },
+        referenceLines = referenceLineDao.fetchVersions(DRAFT, false).filter { v -> request.referenceLines.contains(v.id) },
+        kmPosts = kmPostDao.fetchVersions(DRAFT, false).filter { v -> request.kmPosts.contains(v.id) },
+        locationTracks = locationTrackDao.fetchVersions(DRAFT, false).filter { v -> request.locationTracks.contains(v.id) },
+        switches = switchDao.fetchVersions(DRAFT, false).filter { v -> request.switches.contains(v.id) },
+    )
+
     private fun updateExternalIdForLocationTrack(locationTrackId: IntId<LocationTrack>) {
         val locationTrackOid = ratkoService?.let { s ->
             s.getNewLocationTrackOid() ?: throw IllegalStateException("No OID received from RATKO")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
@@ -359,7 +359,8 @@ fun isOrderOk(previous: GeocodingReferencePoint?, next: GeocodingReferencePoint?
     if (previous == null || next == null) true
     else previous.distance < next.distance
 
-fun validateAddressPoints(
+// TODO
+fun validateAddressPointsNOTFIXED(
     trackNumber: TrackLayoutTrackNumber,
     locationTrack: LocationTrack,
     validationTargetLocalizationPrefix: String,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
@@ -359,26 +359,20 @@ fun isOrderOk(previous: GeocodingReferencePoint?, next: GeocodingReferencePoint?
     if (previous == null || next == null) true
     else previous.distance < next.distance
 
-// TODO
-fun validateAddressPointsNOTFIXED(
+fun validateAddressPoints(
     trackNumber: TrackLayoutTrackNumber,
     locationTrack: LocationTrack,
     validationTargetLocalizationPrefix: String,
     geocode: () -> AlignmentAddresses?,
 ): List<PublishValidationError> =
     try {
-        val addresses = geocode()
-        if (addresses == null) {
-            listOf(
-                PublishValidationError(
-                    ERROR,
-                    "$validationTargetLocalizationPrefix.no-context",
-                    listOf(trackNumber.number.toString())
-                )
-            )
-        } else {
+        geocode()?.let { addresses ->
             validateAddressPoints(trackNumber, locationTrack, addresses)
-        }
+        } ?: listOf(PublishValidationError(
+            ERROR,
+            "$validationTargetLocalizationPrefix.no-context",
+            listOf(trackNumber.number.toString())
+        ))
     } catch (e: ClientException) {
         listOf(PublishValidationError(ERROR, e.localizedMessageKey))
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -79,7 +79,7 @@ class RatkoLocationTrackService @Autowired constructor(
     private fun createLocationTrack(layoutLocationTrack: LocationTrack) {
         logger.serviceCall("createRatkoLocationTrack", "layoutLocationTrack" to layoutLocationTrack)
 
-        val addresses = geocodingService.getAddressPoints(layoutLocationTrack.id, PublishType.OFFICIAL)
+        val addresses = geocodingService.getAddressPoints(layoutLocationTrack.id as IntId, PublishType.OFFICIAL)
         checkNotNull(addresses) {
             "Cannot update location track without location track address points $layoutLocationTrack"
         }
@@ -145,13 +145,13 @@ class RatkoLocationTrackService @Autowired constructor(
                 val startTrackMeter = geocodingService.getAddress(
                     trackNumberId = layoutLocationTrack.trackNumberId,
                     location = metadata.startPoint,
-                    publishType = PublishType.OFFICIAL
+                    publicationState = PublishType.OFFICIAL
                 )?.first
 
                 val endTrackMeter = geocodingService.getAddress(
                     trackNumberId = layoutLocationTrack.trackNumberId,
                     location = metadata.endPoint,
-                    publishType = PublishType.OFFICIAL
+                    publicationState = PublishType.OFFICIAL
                 )?.first
 
                 if (startTrackMeter != null
@@ -186,7 +186,7 @@ class RatkoLocationTrackService @Autowired constructor(
         logger.serviceCall("deleteLocationTrack", "layoutLocationTrack" to layoutLocationTrack)
         requireNotNull(layoutLocationTrack.externalId) { "Cannot delete location track without oid $layoutLocationTrack" }
 
-        val addresses = geocodingService.getAddressPoints(layoutLocationTrack.id, PublishType.OFFICIAL)
+        val addresses = geocodingService.getAddressPoints(layoutLocationTrack.id as IntId, PublishType.OFFICIAL)
         checkNotNull(addresses) {
             "Cannot delete location track without location track address points $layoutLocationTrack"
         }
@@ -218,7 +218,7 @@ class RatkoLocationTrackService @Autowired constructor(
         requireNotNull(layoutLocationTrack.externalId) { "Cannot update location track without oid $layoutLocationTrack" }
         val locationTrackOid = RatkoOid<RatkoLocationTrack>(layoutLocationTrack.externalId)
 
-        val addresses = geocodingService.getAddressPoints(layoutLocationTrack.id, PublishType.OFFICIAL)
+        val addresses = geocodingService.getAddressPoints(layoutLocationTrack.id as IntId, PublishType.OFFICIAL)
         checkNotNull(addresses) {
             "Cannot update location track without location track address points $layoutLocationTrack"
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -87,7 +87,7 @@ jdbcTemplateParam: NamedParameterJdbcTemplate?,
               id as row_id, 
               version as row_version
             from ${table.fullName} 
-            where official_id in (:ids)
+            where coalesce(${table.draftLink}, id) in (:ids)
               and draft = true
         """.trimIndent()
         val params = mapOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -61,7 +61,7 @@ interface IDraftableObjectDao<T : Draftable<T>> : IDraftableObjectReader<T>, IDr
 
 @Transactional(readOnly = true)
 abstract class DraftableDaoBase<T : Draftable<T>>(
-jdbcTemplateParam: NamedParameterJdbcTemplate?,
+    jdbcTemplateParam: NamedParameterJdbcTemplate?,
     private val table: DbTable,
 ): DaoBase(jdbcTemplateParam), IDraftableObjectDao<T> {
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.linking.PublicationVersion
 import fi.fta.geoviite.infra.logging.serviceCall
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -102,9 +103,9 @@ abstract class DraftableObjectService<ObjectType: Draftable<ObjectType>, DaoType
     }
 
     @Transactional
-    open fun publish(id: IntId<ObjectType>): RowVersion<ObjectType> {
-        logger.serviceCall("Publish", "id" to id)
-        return publishInternal(dao.fetchVersionPair(id))
+    open fun publish(version: PublicationVersion<ObjectType>): RowVersion<ObjectType> {
+        logger.serviceCall("Publish", "version" to version)
+        return publishInternal(VersionPair(dao.fetchOfficialVersion(version.officialId), version.draftVersion))
     }
 
     protected fun publishInternal(versions: VersionPair<ObjectType>): RowVersion<ObjectType> {
@@ -114,7 +115,7 @@ abstract class DraftableObjectService<ObjectType: Draftable<ObjectType>, DaoType
         val published = createPublished(draft)
         if (published.draft != null) throw IllegalStateException("Published object is still a draft")
 
-        val publishedVersion = dao.update(published)
+        val publishedVersion = dao.updateAndVerifyVersion(versions.official ?: versions.draft, published)
         if (versions.official != null && versions.draft.id != versions.official.id) {
             // Draft data is saved on official id -> delete the draft row
             dao.deleteDrafts(versions.draft.id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -29,8 +29,8 @@ class LayoutKmPostDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
     fun fetchVersions(
         publicationState: PublishType,
         includeDeleted: Boolean,
-        trackNumberId: IntId<TrackLayoutTrackNumber>?,
-        bbox: BoundingBox?,
+        trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
+        bbox: BoundingBox? = null,
     ): List<RowVersion<TrackLayoutKmPost>> {
         val sql = """
             select km_post.row_id, km_post.row_version 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -7,7 +7,6 @@ import fi.fta.geoviite.infra.geometry.GeometryKmPost
 import fi.fta.geoviite.infra.geometry.create2DPolygonString
 import fi.fta.geoviite.infra.linking.KmPostPublishCandidate
 import fi.fta.geoviite.infra.linking.Publication
-import fi.fta.geoviite.infra.linking.PublicationVersion
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.BoundingBox
@@ -54,22 +53,6 @@ class LayoutKmPostDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
         )) { rs, _ ->
             rs.getRowVersion("row_id", "row_version")
         }
-    }
-
-    fun fetchPublicationVersions(
-        publicationState: PublishType,
-        trackNumberId: IntId<TrackLayoutTrackNumber>,
-    ): List<PublicationVersion<TrackLayoutKmPost>> {
-        val sql = """
-            select official_id, row_id, row_version
-            from layout.km_post_publication_view
-            where :publication_state = any(publication_states)
-              and :track_number_id = track_number_id
-        """.trimIndent()
-        return jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ -> PublicationVersion(
-            rs.getIntId("official_id"),
-            rs.getRowVersion("row_id", "row_version"),
-        ) }
     }
 
     fun fetchVersionsForPublication(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -7,6 +7,7 @@ import fi.fta.geoviite.infra.geometry.GeometryKmPost
 import fi.fta.geoviite.infra.geometry.create2DPolygonString
 import fi.fta.geoviite.infra.linking.KmPostPublishCandidate
 import fi.fta.geoviite.infra.linking.Publication
+import fi.fta.geoviite.infra.linking.PublicationVersion
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.BoundingBox
@@ -53,6 +54,22 @@ class LayoutKmPostDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
         )) { rs, _ ->
             rs.getRowVersion("row_id", "row_version")
         }
+    }
+
+    fun fetchPublicationVersions(
+        publicationState: PublishType,
+        trackNumberId: IntId<TrackLayoutTrackNumber>,
+    ): List<PublicationVersion<TrackLayoutKmPost>> {
+        val sql = """
+            select official_id, row_id, row_version
+            from layout.km_post_publication_view
+            where :publication_state = any(publication_states)
+              and :track_number_id = track_number_id
+        """.trimIndent()
+        return jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ -> PublicationVersion(
+            rs.getIntId("official_id"),
+            rs.getRowVersion("row_id", "row_version"),
+        ) }
     }
 
     fun fetchVersionsForPublication(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -40,7 +40,7 @@ class LayoutTrackNumberController(private val trackNumberService: LayoutTrackNum
     @PostMapping("/draft")
     fun insertTrackNumber(@RequestBody saveRequest: TrackNumberSaveRequest): IntId<TrackLayoutTrackNumber> {
         logger.apiCall("insertTrackNumber", "trackNumber" to saveRequest)
-        return trackNumberService.insert(saveRequest)
+        return trackNumberService.insert(saveRequest).id
     }
 
     @PreAuthorize(AUTH_ALL_WRITE)
@@ -50,7 +50,8 @@ class LayoutTrackNumberController(private val trackNumberService: LayoutTrackNum
         @RequestBody saveRequest: TrackNumberSaveRequest,
     ): IntId<TrackLayoutTrackNumber> {
         logger.apiCall("updateTrackNumber", "id" to id, "trackNumber" to saveRequest)
-        return trackNumberService.update(id, saveRequest)
+        trackNumberService.update(id, saveRequest)
+        return id
     }
 
     @PreAuthorize(AUTH_ALL_WRITE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -62,9 +62,7 @@ class LayoutTrackNumberService(
     }
 
     @Transactional
-    fun deleteDraftOnlyTrackNumberAndReferenceLine(
-        id: IntId<TrackLayoutTrackNumber>,
-    ): IntId<TrackLayoutTrackNumber> {
+    fun deleteDraftOnlyTrackNumberAndReferenceLine(id: IntId<TrackLayoutTrackNumber>): IntId<TrackLayoutTrackNumber> {
         val trackNumber = getDraft(id)
         val referenceLine = referenceLineService.getByTrackNumber(DRAFT, id)
             ?: throw IllegalStateException("Found Track Number without Reference Line $id")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -15,40 +15,43 @@ class LayoutTrackNumberService(
 ) : DraftableObjectService<TrackLayoutTrackNumber, LayoutTrackNumberDao>(dao) {
 
     @Transactional
-    fun insert(saveRequest: TrackNumberSaveRequest): IntId<TrackLayoutTrackNumber> {
+    fun insert(saveRequest: TrackNumberSaveRequest): RowVersion<TrackLayoutTrackNumber> {
         logger.serviceCall("insert", "trackNumber" to saveRequest.number)
-        val trackNumberId = saveDraftInternal(
+        val trackNumberVersion = saveDraftInternal(
             TrackLayoutTrackNumber(
                 number = saveRequest.number,
                 description = saveRequest.description,
                 state = saveRequest.state,
                 externalId = null,
             )
-        ).id
-        referenceLineService.addTrackNumberReferenceLine(trackNumberId, saveRequest.startAddress)
-        return trackNumberId
+        )
+        referenceLineService.addTrackNumberReferenceLine(trackNumberVersion.id, saveRequest.startAddress)
+        return trackNumberVersion
     }
 
     @Transactional
-    fun update(id: IntId<TrackLayoutTrackNumber>, saveRequest: TrackNumberSaveRequest): IntId<TrackLayoutTrackNumber> {
+    fun update(
+        id: IntId<TrackLayoutTrackNumber>,
+        saveRequest: TrackNumberSaveRequest,
+    ): RowVersion<TrackLayoutTrackNumber> {
         logger.serviceCall("update", "trackNumber" to saveRequest.number)
         val original = getInternalOrThrow(DRAFT, id)
-        val trackNumberId = saveDraftInternal(
+        val trackNumberVersion = saveDraftInternal(
             original.copy(
                 number = saveRequest.number,
                 description = saveRequest.description,
                 state = saveRequest.state,
             )
-        ).id
+        )
         referenceLineService.updateTrackNumberReferenceLine(id, saveRequest.startAddress)
-        return trackNumberId
+        return trackNumberVersion
     }
 
 
     @Transactional
     fun updateExternalId(
         id: IntId<TrackLayoutTrackNumber>,
-        oid: Oid<TrackLayoutTrackNumber>
+        oid: Oid<TrackLayoutTrackNumber>,
     ): RowVersion<TrackLayoutTrackNumber> {
         logger.serviceCall("updateExternalIdForTrackNumber", "id" to id, "oid" to oid)
 
@@ -59,8 +62,9 @@ class LayoutTrackNumberService(
     }
 
     @Transactional
-    fun deleteDraftOnlyTrackNumberAndReferenceLine(id: IntId<TrackLayoutTrackNumber>):
-            IntId<TrackLayoutTrackNumber> {
+    fun deleteDraftOnlyTrackNumberAndReferenceLine(
+        id: IntId<TrackLayoutTrackNumber>,
+    ): IntId<TrackLayoutTrackNumber> {
         val trackNumber = getDraft(id)
         val referenceLine = referenceLineService.getByTrackNumber(DRAFT, id)
             ?: throw IllegalStateException("Found Track Number without Reference Line $id")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.configuration.CACHE_LAYOUT_LOCATION_TRACK
 import fi.fta.geoviite.infra.linking.LocationTrackPublishCandidate
 import fi.fta.geoviite.infra.linking.Publication
+import fi.fta.geoviite.infra.linking.PublicationVersion
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.BoundingBox
@@ -19,6 +20,23 @@ import org.springframework.transaction.annotation.Transactional
 @Component
 class LocationTrackDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
     : DraftableDaoBase<LocationTrack>(jdbcTemplateParam, LAYOUT_LOCATION_TRACK) {
+
+    fun fetchPublicationVersions(publicationState: PublishType, trackNumberId: IntId<TrackLayoutTrackNumber>): List<PublicationVersion<LocationTrack>> {
+        val sql = """
+            select official_id, row_id, row_version
+            from layout.location_track_publication_view
+            where :publication_state = any(publication_states)
+              and :track_number_id = track_number_id
+        """.trimIndent()
+        val params = mapOf(
+            "publication_state" to publicationState.name,
+            "track_number_id" to trackNumberId.intValue,
+        )
+        return jdbcTemplate.query(sql, params) { rs, _ -> PublicationVersion(
+            rs.getIntId("official_id"),
+            rs.getRowVersion("row_id", "row_version"),
+        ) }
+    }
 
     fun fetchDuplicates(id: IntId<LocationTrack>, publicationState: PublishType): List<LocationTrackDuplicate> {
         val sql = """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -5,7 +5,6 @@ import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.configuration.CACHE_LAYOUT_LOCATION_TRACK
 import fi.fta.geoviite.infra.linking.LocationTrackPublishCandidate
 import fi.fta.geoviite.infra.linking.Publication
-import fi.fta.geoviite.infra.linking.PublicationVersion
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.BoundingBox
@@ -20,23 +19,6 @@ import org.springframework.transaction.annotation.Transactional
 @Component
 class LocationTrackDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
     : DraftableDaoBase<LocationTrack>(jdbcTemplateParam, LAYOUT_LOCATION_TRACK) {
-
-    fun fetchPublicationVersions(publicationState: PublishType, trackNumberId: IntId<TrackLayoutTrackNumber>): List<PublicationVersion<LocationTrack>> {
-        val sql = """
-            select official_id, row_id, row_version
-            from layout.location_track_publication_view
-            where :publication_state = any(publication_states)
-              and :track_number_id = track_number_id
-        """.trimIndent()
-        val params = mapOf(
-            "publication_state" to publicationState.name,
-            "track_number_id" to trackNumberId.intValue,
-        )
-        return jdbcTemplate.query(sql, params) { rs, _ -> PublicationVersion(
-            rs.getIntId("official_id"),
-            rs.getRowVersion("row_id", "row_version"),
-        ) }
-    }
 
     fun fetchDuplicates(id: IntId<LocationTrack>, publicationState: PublishType): List<LocationTrackDuplicate> {
         val sql = """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.configuration.CACHE_LAYOUT_REFERENCE_LINE
+import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.linking.Publication
 import fi.fta.geoviite.infra.linking.ReferenceLinePublishCandidate
 import fi.fta.geoviite.infra.logging.AccessType
@@ -138,6 +139,10 @@ class ReferenceLineDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
         logger.daoAccess(AccessType.UPDATE, ReferenceLine::class, rowId)
         return result
     }
+
+    fun fetchVersionOrThrow(publicationState: PublishType, trackNumberId: IntId<TrackLayoutTrackNumber>) =
+        fetchVersion(publicationState, trackNumberId)
+            ?: throw NoSuchEntityException(ReferenceLine::class, trackNumberId)
 
     fun fetchVersion(
         publicationState: PublishType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -30,6 +30,7 @@ enum class DbTable(schema: String, table: String, sortColumns: List<String> = li
     val fullName: String = "$schema.$table"
     val versionTable = "$schema.${table}_version"
     val draftLink: String = "draft_of_${table}_id"
+    val publicationView: String = "$schema.${table}_publication_view"
     val orderBy: String = sortColumns.joinToString(",")
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -30,7 +30,6 @@ enum class DbTable(schema: String, table: String, sortColumns: List<String> = li
     val fullName: String = "$schema.$table"
     val versionTable = "$schema.${table}_version"
     val draftLink: String = "draft_of_${table}_id"
-    val publicationView: String = "$schema.${table}_publication_view"
     val orderBy: String = sortColumns.joinToString(",")
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -196,7 +196,7 @@ inline fun <reified T> ResultSet.getListOrNull(name: String): List<T>? {
     return if (arrayObj is Array<*>) {
         (arrayObj as Array<out Any?>).toList().mapNotNull { o ->
             if (o is T) o
-            else throw IllegalStateException("Array contains value of unexpected type")
+            else throw IllegalStateException("Array contains value of unexpected type: expectedType=${T::class.simpleName} found=$o")
         }
     } else {
         null

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
@@ -5,7 +5,6 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.common.TrackMeter
-import fi.fta.geoviite.infra.linking.PublishRequest
 import fi.fta.geoviite.infra.linking.PublishService
 import fi.fta.geoviite.infra.linking.TrackLayoutKmPostSaveRequest
 import fi.fta.geoviite.infra.math.Point
@@ -16,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import publish
 import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -68,15 +68,7 @@ class GeocodingDaoIT @Autowired constructor(
             )
         }
         assertChangeTimeProceedsWhen(trackNumberId, PublishType.OFFICIAL) {
-            publishService.publishChanges(
-                PublishRequest(
-                    listOf(),
-                    listOf(),
-                    listOf(),
-                    listOf(),
-                    listOf(kmPostVersion.id)
-                )
-            )
+            publish(publishService, kmPosts = listOf(kmPostVersion.id))
         }
     }
 
@@ -119,10 +111,15 @@ class GeocodingDaoIT @Autowired constructor(
         }
     }
 
-    fun assertChangeTimeProceedsWhen(trackNumberId: IntId<TrackLayoutTrackNumber>, publishType: PublishType, block: () -> Unit) {
+    fun <T> assertChangeTimeProceedsWhen(
+        trackNumberId: IntId<TrackLayoutTrackNumber>,
+        publishType: PublishType,
+        block: () -> T,
+    ): T {
         val before = geocodingDao.getGeocodingContextCacheKey(publishType, trackNumberId)!!.changeTime
-        block()
+        val result = block()
         val after = geocodingDao.getGeocodingContextCacheKey(publishType, trackNumberId)!!.changeTime
         assertTrue(before.isBefore(after), "on track number $trackNumberId, expected $before before $after")
+        return result
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoAddressPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoAddressPointServiceIT.kt
@@ -7,6 +7,7 @@ import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
+import fi.fta.geoviite.infra.linking.PublicationVersion
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType
 import fi.fta.geoviite.infra.math.Point
@@ -612,13 +613,8 @@ class RatkoAddressPointServiceIT @Autowired constructor(
         locationTrack: LocationTrack,
         alignment: LayoutAlignment
     ) {
-        val version = locationTrackService.saveDraft(
-            locationTrack,
-            alignment.copy(
-                segments = listOf()
-            )
-        )
-        locationTrackService.publish(version.id)
+        val version = locationTrackService.saveDraft(locationTrack, alignment.copy(segments = listOf()))
+        locationTrackService.publish(PublicationVersion(version.id, version))
     }
 
 
@@ -643,7 +639,7 @@ class RatkoAddressPointServiceIT @Autowired constructor(
                 }
             )
         )
-        locationTrackService.publish(version.id)
+        locationTrackService.publish(PublicationVersion(version.id, version))
     }
 
     fun moveReferenceLineGeometryPointsAndUpdate(
@@ -667,7 +663,7 @@ class RatkoAddressPointServiceIT @Autowired constructor(
                 }
             )
         )
-        referenceLineService.publish(version.id)
+        referenceLineService.publish(PublicationVersion(version.id, version))
     }
 
     fun moveKmPostAndUpdate(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -176,6 +176,6 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
     fun insertAndPublishLocationTrack() = locationTrackAndAlignment(trackNumberId).let { (track, alignment) ->
         val draftVersion = locationTrackService.saveDraft(track, alignment)
-        locationTrackService.publish(PublicationVersion(track.id as IntId, draftVersion))
+        locationTrackService.publish(PublicationVersion(draftVersion.id, draftVersion))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -1,7 +1,6 @@
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.linking.PublishRequest
-import fi.fta.geoviite.infra.linking.PublishResult
-import fi.fta.geoviite.infra.linking.PublishService
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.linking.*
 import fi.fta.geoviite.infra.tracklayout.*
 
 fun publishRequest(
@@ -16,6 +15,20 @@ fun publishRequest(
     switches = switches,
     referenceLines = referenceLines,
     locationTracks = locationTracks,
+)
+
+fun publicationVersions(
+    trackNumbers: List<Pair<IntId<TrackLayoutTrackNumber>, RowVersion<TrackLayoutTrackNumber>>> = listOf(),
+    referenceLines: List<Pair<IntId<ReferenceLine>, RowVersion<ReferenceLine>>> = listOf(),
+    kmPosts: List<Pair<IntId<TrackLayoutKmPost>, RowVersion<TrackLayoutKmPost>>> = listOf(),
+    locationTracks: List<Pair<IntId<LocationTrack>, RowVersion<LocationTrack>>> = listOf(),
+    switches: List<Pair<IntId<TrackLayoutSwitch>, RowVersion<TrackLayoutSwitch>>> = listOf(),
+) = PublicationVersions(
+    trackNumbers = trackNumbers.map { (id,version) -> PublicationVersion(id, version) },
+    referenceLines = referenceLines.map { (id,version) -> PublicationVersion(id, version) },
+    kmPosts = kmPosts.map { (id,version) -> PublicationVersion(id, version) },
+    locationTracks = locationTracks.map { (id,version) -> PublicationVersion(id, version) },
+    switches = switches.map { (id,version) -> PublicationVersion(id, version) },
 )
 
 fun publish(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -1,0 +1,31 @@
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.linking.PublishRequest
+import fi.fta.geoviite.infra.linking.PublishResult
+import fi.fta.geoviite.infra.linking.PublishService
+import fi.fta.geoviite.infra.tracklayout.*
+
+fun publishRequest(
+    trackNumbers: List<IntId<TrackLayoutTrackNumber>> = listOf(),
+    kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
+    switches: List<IntId<TrackLayoutSwitch>> = listOf(),
+    referenceLines: List<IntId<ReferenceLine>> = listOf(),
+    locationTracks: List<IntId<LocationTrack>> = listOf(),
+) = PublishRequest(
+    trackNumbers = trackNumbers,
+    kmPosts = kmPosts,
+    switches = switches,
+    referenceLines = referenceLines,
+    locationTracks = locationTracks,
+)
+
+fun publish(
+    publicationService: PublishService,
+    trackNumbers: List<IntId<TrackLayoutTrackNumber>> = listOf(),
+    kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
+    switches: List<IntId<TrackLayoutSwitch>> = listOf(),
+    referenceLines: List<IntId<ReferenceLine>> = listOf(),
+    locationTracks: List<IntId<LocationTrack>> = listOf(),
+) = publish(publicationService, publishRequest(trackNumbers, kmPosts, switches, referenceLines, locationTracks))
+
+fun publish(publicationService: PublishService, request: PublishRequest): PublishResult =
+    publicationService.publishChanges(publicationService.getPublicationVersions(request))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -77,8 +77,9 @@ class LinkingServiceIT @Autowired constructor(
         )
 
         val (locationTrack, alignment) = locationTrackAndAlignment(insertOfficialTrackNumber(), segment1, segment2, segment3)
-        val locationTrackId = locationTrackService.saveDraft(locationTrack, alignment).id
-        locationTrackService.publish(locationTrackId)
+        val locationTrackVersion = locationTrackService.saveDraft(locationTrack, alignment)
+        val locationTrackId = locationTrackVersion.id
+        locationTrackService.publish(PublicationVersion(locationTrackId, locationTrackVersion))
 
         val (officialTrack, officialAlignment) = locationTrackService.getWithAlignmentOrThrow(OFFICIAL, locationTrackId)
         assertMatches(officialTrack to officialAlignment, locationTrackService.getWithAlignmentOrThrow(DRAFT, locationTrackId))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationDaoIT.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.ITTestBase
 import fi.fta.geoviite.infra.TEST_USER
 import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.integration.*
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.*
@@ -19,9 +20,13 @@ import kotlin.test.assertTrue
 @SpringBootTest
 class PublicationDaoIT @Autowired constructor(
     val publicationDao: PublicationDao,
+    val switchService: LayoutSwitchService,
     val switchDao: LayoutSwitchDao,
+    val trackNumberService: LayoutTrackNumberService,
     val trackNumberDao: LayoutTrackNumberDao,
+    val kmPostService: LayoutKmPostService,
     val kmPostDao: LayoutKmPostDao,
+    val referenceLineService: ReferenceLineService,
     val referenceLineDao: ReferenceLineDao,
     val locationTrackService: LocationTrackService,
     val locationTrackDao: LocationTrackDao,
@@ -49,9 +54,11 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun referenceLinePublishCandidatesAreFound() {
-        val trackNumberId = insertAndCheck(trackNumber(getUnusedTrackNumber())).id as IntId
-        val line = insertAndCheck(referenceLine(trackNumberId))
-        val draft = insertAndCheck(draft(line).copy(startAddress = TrackMeter("0123", 658.321, 3)))
+        val trackNumberId = insertAndCheck(trackNumber(getUnusedTrackNumber())).first.id
+        val (_, line) = insertAndCheck(referenceLine(trackNumberId))
+        val (_, draft) = insertAndCheck(draft(line).copy(
+            startAddress = TrackMeter("0123", 658.321, 3),
+        ))
         val candidates = publicationDao.fetchReferenceLinePublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(line.id, candidates.first().id)
@@ -62,8 +69,10 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun locationTrackPublishCandidatesAreFound() {
-        val track = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
-        val draft = insertAndCheck(draft(track).copy(name = AlignmentName("${track.name} DRAFT")))
+        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
+        val (_, draft) = insertAndCheck(draft(track).copy(
+            name = AlignmentName("${track.name} DRAFT"),
+        ))
         val candidates = publicationDao.fetchLocationTrackPublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -75,8 +84,8 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun switchPublishCandidatesAreFound() {
-        val switch = insertAndCheck(switch(987))
-        val draft = insertAndCheck(draft(switch).copy(name = SwitchName("${switch.name} DRAFT")))
+        val (_, switch) = insertAndCheck(switch(987))
+        val (_, draft) = insertAndCheck(draft(switch).copy(name = SwitchName("${switch.name} DRAFT")))
         val candidates = publicationDao.fetchSwitchPublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(switch.id, candidates.first().id)
@@ -87,7 +96,7 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun createOperationIsInferredCorrectly() {
-        val track = insertAndCheck(draft(locationTrack(insertOfficialTrackNumber())))
+        val (_, track) = insertAndCheck(draft(locationTrack(insertOfficialTrackNumber())))
         val candidates = publicationDao.fetchLocationTrackPublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -96,10 +105,14 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun modifyOperationIsInferredCorrectly() {
-        val track = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
-        val draft = insertAndCheck(draft(track).copy(name = AlignmentName("${track.name} DRAFT")))
-        locationTrackService.publish(draft.id as IntId)
-        locationTrackService.saveDraft(draft(locationTrackService.getOrThrow(PublishType.OFFICIAL, draft.id as IntId).let { lt -> lt.copy(name = AlignmentName("${lt.name} TEST")) }))
+        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
+        val (version, draft) = insertAndCheck(draft(track).copy(name = AlignmentName("${track.name} DRAFT")))
+        publishAndCheck(version)
+        locationTrackService.saveDraft(
+            draft(locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId)).let { lt -> lt.copy(
+                name = AlignmentName("${lt.name} TEST"),
+            ) }
+        )
         val candidates = publicationDao.fetchLocationTrackPublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -108,10 +121,14 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun deleteOperationIsInferredCorrectly() {
-        val track = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
-        val draft = insertAndCheck(draft(track).copy(name = AlignmentName("${track.name} DRAFT")))
-        locationTrackService.publish(draft.id as IntId)
-        locationTrackService.saveDraft(draft(locationTrackService.getOrThrow(PublishType.OFFICIAL, draft.id as IntId).copy(state = LayoutState.DELETED)))
+        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
+        val (version, draft) = insertAndCheck(draft(track).copy(name = AlignmentName("${track.name} DRAFT")))
+        publishAndCheck(version)
+        locationTrackService.saveDraft(
+            draft(locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId)).copy(
+                state = LayoutState.DELETED,
+            )
+        )
         val candidates = publicationDao.fetchLocationTrackPublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -120,10 +137,15 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun restoreOperationIsInferredCorrectly() {
-        val track = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
-        val draft = insertAndCheck(draft(track).copy(name = AlignmentName("${track.name} DRAFT"), state = LayoutState.DELETED))
-        locationTrackService.publish(draft.id as IntId)
-        locationTrackService.saveDraft(draft(locationTrackService.getOrThrow(PublishType.OFFICIAL, draft.id as IntId).copy(state = LayoutState.IN_USE)))
+        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
+        val (version, draft) = insertAndCheck(draft(track).copy(
+            name = AlignmentName("${track.name} DRAFT"),
+            state = LayoutState.DELETED,
+        ))
+        publishAndCheck(version)
+        locationTrackService.saveDraft(draft(locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId).copy(
+            state = LayoutState.IN_USE,
+        )))
         val candidates = publicationDao.fetchLocationTrackPublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -133,8 +155,8 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun allCalculatedChangesAreRecorded() {
         val trackNumberId = insertOfficialTrackNumber()
-        val locationTrackId = insertAndCheck(locationTrack(trackNumberId)).id as IntId<LocationTrack>
-        val switchId = insertAndCheck(switch(234)).id as IntId<TrackLayoutSwitch>
+        val locationTrackId = insertAndCheck(locationTrack(trackNumberId)).first.id
+        val switchId = insertAndCheck(switch(234)).first.id
 
         val switchJointChange = SwitchJointChange(
             JointNumber(1),
@@ -209,37 +231,44 @@ class PublicationDaoIT @Autowired constructor(
         assertEquals(editedCandidate.trackNumberIds, listOf(trackNumberId))
     }
 
-    private fun insertAndCheck(trackNumber: TrackLayoutTrackNumber): TrackLayoutTrackNumber {
-        val dbVersion = trackNumberDao.insert(trackNumber)
-        val fromDb = trackNumberDao.fetch(dbVersion)
+    private fun insertAndCheck(trackNumber: TrackLayoutTrackNumber): Pair<RowVersion<TrackLayoutTrackNumber>, TrackLayoutTrackNumber> {
+        val rowVersion = trackNumberDao.insert(trackNumber)
+        val fromDb = trackNumberDao.fetch(rowVersion)
         assertMatches(trackNumber, fromDb)
         assertTrue { fromDb.id is IntId }
-        return fromDb
+        return rowVersion to fromDb
     }
 
-    private fun insertAndCheck(switch: TrackLayoutSwitch): TrackLayoutSwitch {
-        val fromDb = switchDao.fetch(switchDao.insert(switch))
+    private fun insertAndCheck(switch: TrackLayoutSwitch): Pair<RowVersion<TrackLayoutSwitch>, TrackLayoutSwitch> {
+        val rowVersion = switchDao.insert(switch)
+        val fromDb = switchDao.fetch(rowVersion)
         assertMatches(switch, fromDb)
         assertTrue(fromDb.id is IntId)
-        return fromDb
+        return rowVersion to fromDb
     }
 
-    private fun insertAndCheck(referenceLine: ReferenceLine): ReferenceLine {
+    private fun insertAndCheck(referenceLine: ReferenceLine): Pair<RowVersion<ReferenceLine>, ReferenceLine> {
         val dbAlignmentVersion = alignmentDao.insert(alignment())
         val lineWithAlignment = referenceLine.copy(alignmentVersion = dbAlignmentVersion)
-        val fromDb = referenceLineDao.fetch(referenceLineDao.insert(lineWithAlignment))
+        val rowVersion = referenceLineDao.insert(lineWithAlignment)
+        val fromDb = referenceLineDao.fetch(rowVersion)
         assertMatches(lineWithAlignment, fromDb)
         assertTrue(fromDb.id is IntId)
-        return fromDb
+        return rowVersion to fromDb
     }
 
-    private fun insertAndCheck(locationTrack: LocationTrack): LocationTrack {
+    private fun insertAndCheck(locationTrack: LocationTrack): Pair<RowVersion<LocationTrack>, LocationTrack> {
         val dbAlignmentVersion = alignmentDao.insert(alignment())
         val trackWithAlignment = locationTrack.copy(alignmentVersion = dbAlignmentVersion)
-        val fromDb = locationTrackDao.fetch(locationTrackDao.insert(trackWithAlignment))
+        val rowVersion = locationTrackDao.insert(trackWithAlignment)
+        val fromDb = locationTrackDao.fetch(rowVersion)
         assertMatches(trackWithAlignment, fromDb)
         assertTrue(fromDb.id is IntId)
-        return fromDb
+        return rowVersion to fromDb
+    }
+
+    private fun publishAndCheck(rowVersion: RowVersion<LocationTrack>) {
+        publishAndCheck(rowVersion, locationTrackDao, locationTrackService)
     }
 
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationDaoIT.kt
@@ -197,7 +197,7 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun fetchOfficialSwitchTrackNumbers() {
         val trackNumberId = insertOfficialTrackNumber()
-        val switch = insertAndCheck(switch(234, name = "Foo"))
+        val (_, switch) = insertAndCheck(switch(234, name = "Foo"))
         val switchId = switch.id as IntId
         insertAndCheck(
             locationTrack(trackNumberId).copy(
@@ -214,7 +214,7 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun fetchDraftOnlySwitchTrackNumbers() {
         val trackNumberId = insertOfficialTrackNumber()
-        val switch = insertAndCheck(draft(switch(345, name = "Foo")))
+        val (_, switch) = insertAndCheck(draft(switch(345, name = "Foo")))
         val switchId = switch.id as IntId
         insertAndCheck(
             draft(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationValidationTest.kt
@@ -558,7 +558,7 @@ class PublicationValidationTest {
                         kmPost(IntId(1), KmNumber(1), Point(12.0, 0.0)),
                         kmPost(IntId(1), KmNumber(2), Point(18.0, 0.0)),
                     ),
-                ), ""
+                )
             ),
             error,
         )
@@ -572,7 +572,7 @@ class PublicationValidationTest {
                         kmPost(IntId(1), KmNumber(2), Point(18.0, 0.0)),
                         kmPost(IntId(1), KmNumber(1), Point(12.0, 0.0)),
                     ),
-                ), ""
+                )
             ),
             error,
         )
@@ -589,7 +589,7 @@ class PublicationValidationTest {
                 geocodingContext(
                     toTrackLayoutPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
                     listOf(kmPost(IntId(1), KmNumber(1), Point(15.0, 0.0))),
-                ), ""
+                )
             ),
             error,
         )
@@ -599,7 +599,7 @@ class PublicationValidationTest {
                 geocodingContext(
                     toTrackLayoutPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
                     listOf(kmPost(IntId(1), KmNumber(1), Point(5.0, 0.0))),
-                ), ""
+                )
             ),
             kmPostsOutsideLineErrorBefore,
         )
@@ -609,7 +609,7 @@ class PublicationValidationTest {
                 geocodingContext(
                     toTrackLayoutPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
                     listOf(kmPost(IntId(1), KmNumber(1), Point(25.0, 0.0))),
-                ), ""
+                )
             ),
             kmPostsOutsideLineErrorAfter,
         )
@@ -734,7 +734,7 @@ class PublicationValidationTest {
         hasError: Boolean,
         context: GeocodingContext,
         error: String,
-    ) = assertContainsError(hasError, validateGeocodingContext(context, ""), error)
+    ) = assertContainsError(hasError, validateGeocodingContext(context), error)
 
     private fun assertSegmentSwitchError(
         hasError: Boolean,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
@@ -3,9 +3,9 @@ package fi.fta.geoviite.infra.ratko
 import fi.fta.geoviite.infra.ITTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType
+import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.ratko.model.*
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
-import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
@@ -64,7 +64,7 @@ class RatkoClientIT @Autowired constructor(
     @Test
     fun shouldAddNewTrackAlignment() {
         val track = locationTrackService.getOrThrow(PublishType.OFFICIAL, IntId(997))
-        val addresses = geocodingService.getAddressPoints(track.id, PublishType.OFFICIAL)
+        val addresses = geocodingService.getAddressPoints(track.id as IntId, PublishType.OFFICIAL)
             ?: throw IllegalStateException("Cannot calculate addresses for location track ${track.id}")
         val ratkoNodes = convertToRatkoNodeCollection(addresses)
         val ratkoAlignment =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -26,6 +26,7 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest
 class LocationTrackServiceIT @Autowired constructor(
     private val locationTrackService: LocationTrackService,
+    private val locationTrackDao: LocationTrackDao,
     private val alignmentDao: LayoutAlignmentDao,
     private val switchService: LayoutSwitchService,
 ): ITTestBase() {
@@ -53,7 +54,7 @@ class LocationTrackServiceIT @Autowired constructor(
     fun deletingOfficialLocationTrackThrowsException() {
         val (track, alignment) = locationTrackAndAlignment(insertOfficialTrackNumber(), someSegment())
         val version = locationTrackService.saveDraft(track, alignment)
-        locationTrackService.publish(version.id)
+        publish(version.id)
         assertThrows<NoSuchEntityException> { locationTrackService.deleteUnpublishedDraft(version.id) }
     }
 
@@ -398,12 +399,12 @@ class LocationTrackServiceIT @Autowired constructor(
     fun fetchDuplicatesIsVersioned() {
         val trackNumberId = getUnusedTrackNumberId()
         val originalLocationTrackId = locationTrackService.insert(saveRequest(trackNumberId, 1)).id
-        locationTrackService.publish(originalLocationTrackId)
+        publish(originalLocationTrackId)
         val officialCopy = insertAndFetch(
             locationTrack(getUnusedTrackNumberId()).copy(duplicateOf = originalLocationTrackId),
             alignment()
         )
-        locationTrackService.publish(officialCopy.first.id as IntId<LocationTrack>)
+        publish(officialCopy.first.id as IntId<LocationTrack>)
 
         val draftCopyVersion = locationTrackService.update(
             officialCopy.first.id as IntId,
@@ -454,7 +455,7 @@ class LocationTrackServiceIT @Autowired constructor(
         val (draft, draftAlignment) = locationTrackService.getWithAlignmentOrThrow(DRAFT, locationTrackId)
         assertNotNull(draft.draft)
 
-        val publishedVersion = locationTrackService.publish(draft.id as IntId)
+        val publishedVersion = publish(draft.id as IntId)
         val (published, publishedAlignment) = locationTrackService.getWithAlignmentOrThrow(OFFICIAL, publishedVersion.id)
         assertNull(published.draft)
         assertEquals(draft.id, published.id)
@@ -508,4 +509,9 @@ class LocationTrackServiceIT @Autowired constructor(
         duplicateOf = null,
         topologicalConnectivity = TopologicalConnectivityType.START_AND_END
     )
+
+    private fun publish(id: IntId<LocationTrack>) =
+        locationTrackDao.fetchPublicationVersions(listOf(id))
+            .first()
+            .let { version -> locationTrackService.publish(version) }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.PublishType
+import fi.fta.geoviite.infra.linking.PublicationVersion
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import java.time.Instant
@@ -17,7 +18,7 @@ fun moveLocationTrackGeometryPointsAndUpdate(
         locationTrack,
         moveAlignmentPoints(alignment, moveFunc)
     )
-    locationTrackService.publish(version.id)
+    locationTrackService.publish(PublicationVersion(locationTrack.id as IntId, version))
     return locationTrackService.getChangeTime()
 }
 
@@ -37,7 +38,7 @@ fun addTopologyEndSwitchIntoLocationTrackAndUpdate(
         ),
         alignment
     )
-    locationTrackService.publish(version.id)
+    locationTrackService.publish(PublicationVersion(locationTrack.id as IntId, version))
     return locationTrackService.getChangeTime()
 }
 
@@ -53,7 +54,7 @@ fun removeTopologySwitchesFromLocationTrackAndUpdate(
         ),
         alignment
     )
-    locationTrackService.publish(version.id)
+    locationTrackService.publish(PublicationVersion(locationTrack.id as IntId, version))
     return locationTrackService.getChangeTime()
 }
 
@@ -74,7 +75,7 @@ fun addTopologyStartSwitchIntoLocationTrackAndUpdate(
         ),
         alignment
     )
-    locationTrackService.publish(version.id)
+    locationTrackService.publish(PublicationVersion(locationTrack.id as IntId, version))
     return locationTrackService.getChangeTime()
 }
 
@@ -89,7 +90,7 @@ fun moveReferenceLineGeometryPointsAndUpdate(
         referenceLine,
         moveAlignmentPoints(alignment, moveFunc)
     )
-    referenceLineService.publish(version.id)
+    referenceLineService.publish(PublicationVersion(referenceLine.id as IntId, version))
     return referenceLineService.getChangeTime()
 }
 
@@ -118,14 +119,9 @@ fun moveSwitchPoints(
     moveFunc: (point: IPoint) -> IPoint,
     switchService: LayoutSwitchService,
 ): Pair<TrackLayoutSwitch, Instant> {
-    val updatedSwitch = switchService.getOrThrow(
-        PublishType.OFFICIAL,
-        switchService.publish(
-            switchService.saveDraft(
-                moveSwitchPoints(switch, moveFunc)
-            ).id
-        ).id
-    )
+    val draftVersion = switchService.saveDraft(moveSwitchPoints(switch, moveFunc))
+    val publishedVersion = switchService.publish(PublicationVersion(switch.id as IntId, draftVersion))
+    val updatedSwitch = switchService.getOrThrow(PublishType.OFFICIAL, publishedVersion.id)
     return updatedSwitch to switchService.getChangeTime()
 }
 


### PR DESCRIPTION
Julkaisuvalidointi + julkaisu muutettu versioiduksi:
- Haetaan julkaistavien käsitteiden rowversiot prosessin aluksi
  - Vain mukaan tulevat draftit - loput poimitaan lennossa official-puolelta
  - Vain julkaisu muokkaa official-puolta ja julkaisuja on vain 1 kerrallaan, joten voidaan luottaa että se ei muutu kesken julkaisun
- Suoritetaan validoinnit kiinnitetyillä versioilla
  - Myös geokoodaus: kontekstin cache-avain muutettu käyttämään versioita aikaleiman sijaan
  - Optimointi: Koska versiot on jo kiinnitetty, validoinnissa tarvitsee tehdä vähemmän kantaan meneviä hakuja
- Julkaisussa tehdään julkaisu version mukaisella datalla - jos draftiin on tullut joku muu muutos kesken prosessin, se ylikirjoittuu eikä pääse julkaisuun mukaan (koska sitä ei ole validoitu)

Muutoslaskentaa ei vielä muutettu versioiduksi. Tuosta oma tiketti: https://extranet.vayla.fi/jira/browse/GVT-1568