### PR TITLE
GVT-1527: Muutoksen hylkääminen

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
@@ -57,10 +57,10 @@ class PublicationController @Autowired constructor(
 
     @PreAuthorize(AUTH_ALL_WRITE)
     @DeleteMapping("/candidates")
-    fun revertPublishCandidates(): PublishResult {
+    fun revertPublishCandidates(@RequestBody toDelete: PublishRequest): PublishResult {
         logger.apiCall("revertPublishCandidates")
         return lockDao.runWithLock(PUBLICATION, publicationMaxDuration) {
-            publishService.revertPublishCandidates()
+            publishService.revertPublishCandidates(toDelete)
         } ?: throw PublicationFailureException(
             message = "Could not reserve publication lock",
             localizedMessageKey = "lock-obtain-failed",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
@@ -155,14 +155,14 @@ class PublishService @Autowired constructor(
     }
 
     @Transactional
-    fun revertPublishCandidates(): PublishResult {
+    fun revertPublishCandidates(toDelete: PublishRequest): PublishResult {
         logger.serviceCall("revertPublishCandidates")
-        val locationTrackCount = locationTrackService.deleteDrafts().size
-        val referenceLineCount = referenceLineService.deleteDrafts().size
+        val locationTrackCount = toDelete.locationTracks.map { id -> locationTrackService.revertDraft(id) }.size
+        val referenceLineCount = toDelete.referenceLines.map { id -> referenceLineService.revertDraft(id) }.size
         alignmentDao.deleteOrphanedAlignments()
-        val switchCount = switchService.deleteDrafts().size
-        val kmPostCount = kmPostService.deleteDrafts().size
-        val trackNumberCount = trackNumberService.deleteDrafts().size
+        val switchCount = toDelete.switches.map { id -> switchService.revertDraft(id) }.size
+        val kmPostCount = toDelete.kmPosts.map { id -> kmPostService.revertDraft(id) }.size
+        val trackNumberCount = toDelete.trackNumbers.map { id -> trackNumberService.revertDraft(id) }.size
 
         return PublishResult(
             publishId = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
@@ -157,12 +157,12 @@ class PublishService @Autowired constructor(
     @Transactional
     fun revertPublishCandidates(toDelete: PublishRequest): PublishResult {
         logger.serviceCall("revertPublishCandidates")
-        val locationTrackCount = toDelete.locationTracks.map { id -> locationTrackService.revertDraft(id) }.size
-        val referenceLineCount = toDelete.referenceLines.map { id -> referenceLineService.revertDraft(id) }.size
+        val locationTrackCount = toDelete.locationTracks.map { id -> locationTrackService.deleteDraft(id) }.size
+        val referenceLineCount = toDelete.referenceLines.map { id -> referenceLineService.deleteDraft(id) }.size
         alignmentDao.deleteOrphanedAlignments()
-        val switchCount = toDelete.switches.map { id -> switchService.revertDraft(id) }.size
-        val kmPostCount = toDelete.kmPosts.map { id -> kmPostService.revertDraft(id) }.size
-        val trackNumberCount = toDelete.trackNumbers.map { id -> trackNumberService.revertDraft(id) }.size
+        val switchCount = toDelete.switches.map { id -> switchService.deleteDraft(id) }.size
+        val kmPostCount = toDelete.kmPosts.map { id -> kmPostService.deleteUnpublishedDraft(id) }.size
+        val trackNumberCount = toDelete.trackNumbers.map { id -> trackNumberService.deleteDraft(id) }.size
 
         return PublishResult(
             publishId = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
@@ -91,19 +91,20 @@ abstract class DraftableObjectService<ObjectType: Draftable<ObjectType>, DaoType
         }
     }
 
-    fun deleteDrafts(): List<Pair<IntId<ObjectType>, IntId<ObjectType>?>> {
+    @Deprecated("Should only be used for cleaning up before/after tests")
+    fun deleteAllDrafts(): List<Pair<IntId<ObjectType>, IntId<ObjectType>?>> {
         logger.serviceCall("deleteDrafts")
         return dao.deleteDrafts()
+    }
+
+    fun deleteDraft(id: IntId<ObjectType>): List<Pair<IntId<ObjectType>, IntId<ObjectType>?>> {
+        logger.serviceCall("deleteDraft")
+        return dao.deleteDrafts(id)
     }
 
     open fun deleteUnpublishedDraft(id: IntId<ObjectType>): RowVersion<ObjectType> {
         logger.serviceCall("deleteUnpublishedDraft", "id" to id)
         return dao.deleteUnpublishedDraft(id)
-    }
-
-    fun revertDraft(id: IntId<ObjectType>): List<Pair<IntId<ObjectType>, IntId<ObjectType>?>> {
-        logger.serviceCall("revertDraft")
-        return dao.deleteDrafts(id)
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
@@ -101,6 +101,11 @@ abstract class DraftableObjectService<ObjectType: Draftable<ObjectType>, DaoType
         return dao.deleteUnpublishedDraft(id)
     }
 
+    fun revertDraft(id: IntId<ObjectType>): List<Pair<IntId<ObjectType>, IntId<ObjectType>?>> {
+        logger.serviceCall("revertDraft")
+        return dao.deleteDrafts(id)
+    }
+
     @Transactional
     open fun publish(id: IntId<ObjectType>): RowVersion<ObjectType> {
         logger.serviceCall("Publish", "id" to id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -101,6 +101,6 @@ class LayoutKmPostController(private val kmPostService: LayoutKmPostService) {
     @DeleteMapping("/draft/{id}")
     fun deleteDraftKmPost(@PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>): IntId<TrackLayoutKmPost> {
         logger.apiCall("deleteDraftKmPost", "kmPostId" to kmPostId)
-        return kmPostService.deleteDraft(kmPostId)
+        return kmPostService.deleteUnpublishedDraftById(kmPostId)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -99,7 +99,7 @@ class LayoutKmPostService(dao: LayoutKmPostDao) : DraftableObjectService<TrackLa
     }
 
     @Transactional
-    fun deleteDraft(kmPostId: IntId<TrackLayoutKmPost>): IntId<TrackLayoutKmPost> {
+    fun deleteUnpublishedDraftById(kmPostId: IntId<TrackLayoutKmPost>): IntId<TrackLayoutKmPost> {
         logger.serviceCall("deleteDraftKmPost", "kmPostId" to kmPostId)
         return dao.deleteUnpublishedDraft(kmPostId).id
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
@@ -115,7 +115,7 @@ class GeocodingDaoIT @Autowired constructor(
         val kmPostDraft =
             kmPostService.insertKmPost(TrackLayoutKmPostSaveRequest(KmNumber(1), LayoutState.IN_USE, trackNumberId))
         assertChangeTimeProceedsWhen(trackNumberId, PublishType.DRAFT) {
-            kmPostService.deleteDraft(kmPostDraft)
+            kmPostService.deleteUnpublishedDraft(kmPostDraft)
         }
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -111,7 +111,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
 
         assertEquals(1, kmPostService.list(DRAFT, { k -> k == draftFromDb }).size)
 
-        kmPostService.deleteDraft(draftId)
+        kmPostService.deleteUnpublishedDraft(draftId)
 
         assertEquals(0, kmPostService.list(DRAFT, { k -> k == draftFromDb }).size)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -32,9 +32,9 @@ class LocationTrackServiceIT @Autowired constructor(
 
     @BeforeEach
     fun setup() {
-        locationTrackService.deleteDrafts()
+        locationTrackService.deleteAllDrafts()
         alignmentDao.deleteOrphanedAlignments()
-        switchService.deleteDrafts()
+        switchService.deleteAllDrafts()
     }
 
     @Test

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,6 +21,7 @@
                 "ol": "~6.14.1",
                 "proj4": "^2.8.0",
                 "react": "^18.2.0",
+                "react-contexify": "^5.0.0",
                 "react-dom": "^18.2.0",
                 "react-i18next": "^11.18.6",
                 "react-redux": "^8.0.4",
@@ -7939,6 +7940,21 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-contexify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/react-contexify/-/react-contexify-5.0.0.tgz",
+            "integrity": "sha512-2FIp7lxJ6dtfGr8EZ4uVV5p5TQjd0n2h/JU7PrejNIMiCeZWvSVPFh4lj1ZvjXosglBvP7q5JQQ8yUCdSaMSaw==",
+            "dependencies": {
+                "clsx": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": ">=16",
+                "react-dom": ">=16"
             }
         },
         "node_modules/react-dom": {
@@ -16101,6 +16117,14 @@
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
             "requires": {
                 "loose-envify": "^1.1.0"
+            }
+        },
+        "react-contexify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/react-contexify/-/react-contexify-5.0.0.tgz",
+            "integrity": "sha512-2FIp7lxJ6dtfGr8EZ4uVV5p5TQjd0n2h/JU7PrejNIMiCeZWvSVPFh4lj1ZvjXosglBvP7q5JQQ8yUCdSaMSaw==",
+            "requires": {
+                "clsx": "^1.1.1"
             }
         },
         "react-dom": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -57,6 +57,7 @@
         "ol": "~6.14.1",
         "proj4": "^2.8.0",
         "react": "^18.2.0",
+        "react-contexify": "^5.0.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^11.18.6",
         "react-redux": "^8.0.4",

--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -1,17 +1,11 @@
 import * as React from 'react';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
-import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Switch } from 'vayla-design-lib/switch/switch';
 import { useTranslation } from 'react-i18next';
 import styles from './preview-view.scss';
 import dialogStyles from '../vayla-design-lib/dialog/dialog.scss';
-import {
-    publishCandidates,
-    PublishRequest,
-    PublishResult,
-    revertCandidates,
-} from 'publication/publication-api';
+import { publishCandidates, PublishRequest, PublishResult } from 'publication/publication-api';
 import { filterNotEmpty } from 'utils/array-utils';
 import {
     updateKmPostChangeTime,
@@ -24,7 +18,6 @@ import { Dialog, DialogVariant } from 'vayla-design-lib/dialog/dialog';
 import { PublishType } from 'common/common-model';
 import { PublishCandidates, PublishValidationError } from 'publication/publication-model';
 import { OnSelectFunction } from 'selection/selection-model';
-import { createEmptyItemCollections } from 'selection/selection-store';
 import { PreviewCandidates } from 'preview/preview-view';
 
 type PreviewFooterProps = {
@@ -77,12 +70,9 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
     };
 
     const { t } = useTranslation();
-
-    const [revertConfirmVisible, setRevertConfirmVisible] = React.useState(false);
     const [publishConfirmVisible, setPublishConfirmVisible] = React.useState(false);
 
     const [isPublishing, setPublishing] = React.useState(false);
-    const [isReverting, setReverting] = React.useState(false);
 
     const emptyRequest =
         props.request.trackNumbers.length == 0 &&
@@ -97,25 +87,6 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
         props.previewChanges.locationTracks.some((lt) => lt.pendingValidation) ||
         props.previewChanges.switches.some((sw) => sw.pendingValidation) ||
         props.previewChanges.kmPosts.some((km) => km.pendingValidation);
-
-    const revert = () => {
-        setReverting(true);
-        revertCandidates()
-            .then((r) => {
-                if (r.isOk()) {
-                    const result = r.unwrapOr(null);
-                    Snackbar.success(t('publish.revert-success'), describeResult(result));
-                    updateChangeTimes(result);
-                    props.onClosePreview();
-                }
-            })
-            .finally(() => {
-                props.onSelect(createEmptyItemCollections());
-                props.onPublishPreviewRevert();
-                setRevertConfirmVisible(false);
-                setReverting(false);
-            });
-    };
 
     const publish = () => {
         setPublishing(true);
@@ -138,19 +109,10 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
         <footer className={styles['preview-footer']}>
             <div className={styles['preview-footer__action-buttons']}>
                 <Button
-                    onClick={() => setRevertConfirmVisible(true)}
-                    variant={ButtonVariant.WARNING}
-                    icon={Icons.Delete}
-                    disabled={emptyRequest || revertConfirmVisible || publishConfirmVisible}>
-                    {t('preview-footer.reject-changes')}
-                </Button>
-
-                <Button
                     onClick={() => setPublishConfirmVisible(true)}
                     variant={ButtonVariant.PRIMARY}
                     disabled={
                         emptyRequest ||
-                        revertConfirmVisible ||
                         publishConfirmVisible ||
                         validationPending ||
                         (allPublishErrors && allPublishErrors?.length > 0)
@@ -175,12 +137,12 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
                         <React.Fragment>
                             <Button
                                 onClick={() => setPublishConfirmVisible(false)}
-                                disabled={emptyRequest || isReverting || isPublishing}
+                                disabled={emptyRequest || isPublishing}
                                 variant={ButtonVariant.SECONDARY}>
                                 {t('publish.publish-confirm.cancel')}
                             </Button>
                             <Button
-                                disabled={isReverting || isPublishing}
+                                disabled={isPublishing}
                                 isProcessing={isPublishing}
                                 onClick={publish}>
                                 {t('publish.publish-confirm.confirm')}
@@ -188,33 +150,6 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
                         </React.Fragment>
                     }>
                     <div>{t('publish.publish-confirm.description')}</div>
-                </Dialog>
-            )}
-            {revertConfirmVisible && (
-                <Dialog
-                    title={t('publish.revert-confirm.title')}
-                    variant={DialogVariant.LIGHT}
-                    allowClose={false}
-                    className={dialogStyles['dialog--normal']}
-                    footerContent={
-                        <React.Fragment>
-                            <Button
-                                onClick={() => setRevertConfirmVisible(false)}
-                                disabled={emptyRequest || isReverting || isPublishing}
-                                variant={ButtonVariant.SECONDARY}>
-                                {t('publish.revert-confirm.cancel')}
-                            </Button>
-                            <Button
-                                icon={Icons.Delete}
-                                disabled={isReverting || isPublishing}
-                                isProcessing={isReverting}
-                                variant={ButtonVariant.WARNING}
-                                onClick={revert}>
-                                {t('publish.revert-confirm.confirm')}
-                            </Button>
-                        </React.Fragment>
-                    }>
-                    <div>{t('publish.revert-confirm.description')}</div>
                 </Dialog>
             )}
         </footer>

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -7,6 +7,8 @@ import { useTranslation } from 'react-i18next';
 import { Operation, PublishValidationError } from 'publication/publication-model';
 import { createClassName } from 'vayla-design-lib/utils';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Menu } from 'vayla-design-lib/menu/menu';
 
 export type PreviewTableItemProps = {
     itemName: string;
@@ -17,6 +19,7 @@ export type PreviewTableItemProps = {
     userName: string;
     pendingValidation: boolean;
     onPublishItemSelect?: () => void;
+    onRevert: () => void;
     publish?: boolean;
 };
 
@@ -29,6 +32,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     userName,
     pendingValidation,
     onPublishItemSelect,
+    onRevert,
     publish = false,
 }) => {
     const { t } = useTranslation();
@@ -37,6 +41,13 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     const errorsToStrings = (list: PublishValidationError[], type: 'ERROR' | 'WARNING') => {
         const filtered = list.filter((e) => e.type === type);
         return filtered.map((error) => t(error.localizationKey, error.params));
+    };
+    const [menuVisible, setMenuVisible] = React.useState(false);
+
+    const menuItems = [{ value: 'revert', name: t('publish.revert-change') }];
+    const handleMenuItemSelection = (item: string) => {
+        if (item == 'revert') onRevert();
+        setMenuVisible(false);
     };
 
     const errorTexts = errorsToStrings(errors, 'ERROR');
@@ -81,21 +92,41 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                         )}
                     </td>
                 )}
-                <td
-                    className={'preview-table-item preview-table-item__actions--cell'}
-                    onClick={() => {
-                        onPublishItemSelect && onPublishItemSelect();
-                    }}>
-                    {publish ? (
-                        <Icons.Ascending size={IconSize.SMALL} />
-                    ) : (
-                        <Icons.Descending size={IconSize.SMALL} />
-                    )}
+                <td className={'preview-table-item preview-table-item__actions--cell'}>
+                    <div>
+                        <div>
+                            <Button
+                                variant={ButtonVariant.GHOST}
+                                onClick={() => {
+                                    onPublishItemSelect && onPublishItemSelect();
+                                }}
+                                icon={publish ? Icons.Ascending : Icons.Descending}
+                            />
+                        </div>
+                        <div>
+                            <Button
+                                variant={ButtonVariant.GHOST}
+                                onClick={() => {
+                                    setMenuVisible(!menuVisible);
+                                }}
+                                icon={Icons.More}
+                            />
+                            {menuVisible && (
+                                <div className={styles['preview-table-item__title-menu']}>
+                                    <Menu
+                                        items={menuItems}
+                                        onChange={(item) =>
+                                            item && handleMenuItemSelection(item)
+                                        }></Menu>
+                                </div>
+                            )}
+                        </div>
+                    </div>
                 </td>
             </tr>
             {isErrorRowExpanded && hasErrors && (
                 <tr className={'preview-table-item preview-table-item--error'}>
-                    <td colSpan={4}>
+                    <td colSpan={6}>
                         {errorTexts.length > 0 && (
                             <div className="preview-table-item__msg-group preview-table-item__msg-group--errors">
                                 <div className="preview-table-item__group-title">

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -4,13 +4,17 @@ import styles from 'publication/publication-table-item.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { formatDateFull } from 'utils/date-utils';
 import { useTranslation } from 'react-i18next';
-import { Operation, PublishValidationError } from 'publication/publication-model';
+import { Operation, PublicationId, PublishValidationError } from 'publication/publication-model';
 import { createClassName } from 'vayla-design-lib/utils';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { Menu, Item, useContextMenu } from 'react-contexify';
+import 'react-contexify/dist/ReactContexify.css';
+import { PreviewSelectType } from 'preview/preview-table';
 
 export type PreviewTableItemProps = {
+    id: PublicationId;
+    type: PreviewSelectType;
     itemName: string;
     trackNumber?: string;
     errors: PublishValidationError[];
@@ -24,6 +28,8 @@ export type PreviewTableItemProps = {
 };
 
 export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
+    id,
+    type,
     itemName,
     trackNumber,
     errors,
@@ -42,13 +48,10 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         const filtered = list.filter((e) => e.type === type);
         return filtered.map((error) => t(error.localizationKey, error.params));
     };
-    const [menuVisible, setMenuVisible] = React.useState(false);
-
-    const menuItems = [{ value: 'revert', name: t('publish.revert-change') }];
-    const handleMenuItemSelection = (item: string) => {
-        if (item == 'revert') onRevert();
-        setMenuVisible(false);
-    };
+    const menuId = () => `contextmenu_${id}_${type}`;
+    const { show } = useContextMenu({
+        id: menuId(),
+    });
 
     const errorTexts = errorsToStrings(errors, 'ERROR');
     const warningTexts = errorsToStrings(errors, 'WARNING');
@@ -106,20 +109,18 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                         <div>
                             <Button
                                 variant={ButtonVariant.GHOST}
-                                onClick={() => {
-                                    setMenuVisible(!menuVisible);
-                                }}
                                 icon={Icons.More}
+                                onClick={(event: React.MouseEvent) => {
+                                    show(event, {});
+                                }}
                             />
-                            {menuVisible && (
-                                <div className={styles['preview-table-item__title-menu']}>
-                                    <Menu
-                                        items={menuItems}
-                                        onChange={(item) =>
-                                            item && handleMenuItemSelection(item)
-                                        }></Menu>
-                                </div>
-                            )}
+                            <div className={styles['preview-table-item__title-menu']}>
+                                <Menu animation={false} id={menuId()}>
+                                    <Item id="1" onClick={() => onRevert()}>
+                                        {t('publish.revert-change')}
+                                    </Item>
+                                </Menu>
+                            </div>
                         </div>
                     </div>
                 </td>

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -127,7 +127,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
             </tr>
             {isErrorRowExpanded && hasErrors && (
                 <tr className={'preview-table-item preview-table-item--error'}>
-                    <td colSpan={6}>
+                    <td colSpan={7}>
                         {errorTexts.length > 0 && (
                             <div className="preview-table-item__msg-group preview-table-item__msg-group--errors">
                                 <div className="preview-table-item__group-title">

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -9,7 +9,6 @@ import { createClassName } from 'vayla-design-lib/utils';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Menu, Item, useContextMenu } from 'react-contexify';
-import 'react-contexify/dist/ReactContexify.css';
 import { PreviewSelectType } from 'preview/preview-table';
 
 export type PreviewTableItemProps = {
@@ -114,7 +113,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                                     show(event, {});
                                 }}
                             />
-                            <div className={styles['preview-table-item__title-menu']}>
+                            <div>
                                 <Menu animation={false} id={menuId()}>
                                     <Item id="1" onClick={() => onRevert()}>
                                         {t('publish.revert-change')}

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -33,7 +33,7 @@ import { PreviewTableItem } from 'preview/preview-table-item';
 import { PublishValidationError } from 'publication/publication-model';
 import { PreviewCandidates } from 'preview/preview-view';
 
-type PublicationId =
+export type PublicationId =
     | LayoutTrackNumberId
     | ReferenceLineId
     | LocationTrackId
@@ -201,6 +201,8 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
                                     onPublishItemSelect={() =>
                                         handlePreviewSelect(entry.id, entry.type)
                                     }
+                                    id={entry.id}
+                                    type={entry.type}
                                     onRevert={() => onRevert(entry)}
                                     itemName={entry.uiName}
                                     trackNumber={entry.trackNumber}

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -40,13 +40,13 @@ type PublicationId =
     | LayoutSwitchId
     | LayoutKmPostId;
 
-type PreviewTableEntry = {
+export type PreviewTableEntry = {
     type: PreviewSelectType;
     errors: PublishValidationError[];
     pendingValidation: boolean;
 } & ChangeTableEntry;
 
-enum PreviewSelectType {
+export enum PreviewSelectType {
     trackNumber = 'trackNumber',
     referenceLine = 'referenceLine',
     locationTrack = 'locationTrack',
@@ -57,10 +57,16 @@ enum PreviewSelectType {
 type PreviewTableProps = {
     previewChanges: PreviewCandidates;
     onPreviewSelect: (selectedChanges: SelectedPublishChange) => void;
+    onRevert: (entry: PreviewTableEntry) => void;
     staged: boolean;
 };
 
-const PreviewTable: React.FC<PreviewTableProps> = ({ previewChanges, onPreviewSelect, staged }) => {
+const PreviewTable: React.FC<PreviewTableProps> = ({
+    previewChanges,
+    onPreviewSelect,
+    onRevert,
+    staged,
+}) => {
     const { t } = useTranslation();
     const [trackNumbers, setTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
     React.useEffect(() => {
@@ -195,6 +201,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({ previewChanges, onPreviewSe
                                     onPublishItemSelect={() =>
                                         handlePreviewSelect(entry.id, entry.type)
                                     }
+                                    onRevert={() => onRevert(entry)}
                                     itemName={entry.uiName}
                                     trackNumber={entry.trackNumber}
                                     errors={entry.errors}

--- a/ui/src/preview/preview-view.scss
+++ b/ui/src/preview/preview-view.scss
@@ -81,7 +81,3 @@
         align-items: center;
     }
 }
-
-:root {
-    --contexify-menu-radius: 4px;
-}

--- a/ui/src/preview/preview-view.scss
+++ b/ui/src/preview/preview-view.scss
@@ -81,3 +81,7 @@
         align-items: center;
     }
 }
+
+:root {
+    --contexify-menu-radius: 4px;
+}

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -6,6 +6,7 @@ import {
     getCalculatedChanges,
     getPublishCandidates,
     PublishRequest,
+    revertCandidates,
     validatePublishCandidates,
 } from 'publication/publication-api';
 
@@ -27,6 +28,7 @@ import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import {
     KmPostPublishCandidate,
     LocationTrackPublishCandidate,
+    PublicationId,
     PublishCandidate,
     PublishCandidates,
     ReferenceLinePublishCandidate,
@@ -40,7 +42,12 @@ import {
     LocationTrackId,
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
-import PreviewTable from 'preview/preview-table';
+import PreviewTable, { PreviewSelectType, PreviewTableEntry } from 'preview/preview-table';
+import { updateAllChangeTimes } from 'common/change-time-api';
+import { Dialog, DialogVariant } from 'vayla-design-lib/dialog/dialog';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+import dialogStyles from '../vayla-design-lib/dialog/dialog.scss';
 
 type CandidateId =
     | LocationTrackId
@@ -236,9 +243,27 @@ const pendingCandidate = <T extends PublishCandidate>(candidate: T) => ({
     pendingValidation: true,
 });
 
+const typeTranslationKey = (type: PreviewSelectType | undefined) => {
+    switch (type) {
+        case PreviewSelectType.trackNumber:
+            return 'track-number';
+        case PreviewSelectType.referenceLine:
+            return 'reference-line';
+        case PreviewSelectType.locationTrack:
+            return 'location-track';
+        case PreviewSelectType.switch:
+            return 'switch';
+        case PreviewSelectType.kmPost:
+            return 'km-post';
+        default:
+            return '';
+    }
+};
+
 export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const { t } = useTranslation();
-    const entireChangeset = useLoader(() => getPublishCandidates(), []);
+
+    const entireChangeset = useLoader(() => getPublishCandidates(), [props.changeTimes]);
     const entireChangesetValidation = useLoader(
         () =>
             validatePublishCandidates(
@@ -287,6 +312,24 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
         [props.selectedPublishCandidateIds],
     );
     const [mapMode, setMapMode] = React.useState<PublishType>('DRAFT');
+    const [isReverting, setIsReverting] = React.useState(false);
+    const [revertConfirmVisible, setRevertConfirmVisible] = React.useState(false);
+    const [entryBeingReverted, setEntryBeingReverted] = React.useState<PreviewTableEntry>();
+
+    const onRevertRow = (id: PublicationId, type: PreviewSelectType) => {
+        const request = {
+            trackNumbers: type === PreviewSelectType.trackNumber ? [id] : [],
+            referenceLines: type === PreviewSelectType.referenceLine ? [id] : [],
+            locationTracks: type === PreviewSelectType.locationTrack ? [id] : [],
+            switches: type === PreviewSelectType.switch ? [id] : [],
+            kmPosts: type === PreviewSelectType.kmPost ? [id] : [],
+        };
+        revertCandidates(request).finally(() => {
+            setRevertConfirmVisible(false);
+            setIsReverting(false);
+            updateAllChangeTimes();
+        });
+    };
 
     return (
         <React.Fragment>
@@ -301,6 +344,10 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 </div>
                                 <PreviewTable
                                     onPreviewSelect={props.onPreviewSelect}
+                                    onRevert={(entry) => {
+                                        setEntryBeingReverted(entry);
+                                        setRevertConfirmVisible(true);
+                                    }}
                                     previewChanges={unstagedPreviewChanges}
                                     staged={false}
                                 />
@@ -312,6 +359,10 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 </div>
                                 <PreviewTable
                                     onPreviewSelect={props.onPublishPreviewRemove}
+                                    onRevert={(entry) => {
+                                        setEntryBeingReverted(entry);
+                                        setRevertConfirmVisible(true);
+                                    }}
                                     previewChanges={stagedPreviewChanges}
                                     staged={true}
                                 />
@@ -354,6 +405,40 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                     onPublishPreviewRevert={props.onPublishPreviewRevert}
                 />
             </div>
+            {revertConfirmVisible && (
+                <Dialog
+                    title={t('publish.revert-confirm.title')}
+                    variant={DialogVariant.LIGHT}
+                    allowClose={false}
+                    className={dialogStyles['dialog--wide']}
+                    footerContent={
+                        <React.Fragment>
+                            <Button
+                                onClick={() => setRevertConfirmVisible(false)}
+                                disabled={isReverting}
+                                variant={ButtonVariant.SECONDARY}>
+                                {t('publish.revert-confirm.cancel')}
+                            </Button>
+                            <Button
+                                icon={Icons.Delete}
+                                disabled={isReverting}
+                                isProcessing={isReverting}
+                                variant={ButtonVariant.WARNING}
+                                onClick={() => {
+                                    if (entryBeingReverted) {
+                                        setIsReverting(true);
+                                        onRevertRow(entryBeingReverted.id, entryBeingReverted.type);
+                                    }
+                                }}>
+                                {t('publish.revert-confirm.confirm')}
+                            </Button>
+                        </React.Fragment>
+                    }>
+                    <div>{`${t('publish.revert-confirm.description')} ${t(
+                        `publish.revert-confirm.${typeTranslationKey(entryBeingReverted?.type)}`,
+                    )} ${entryBeingReverted?.name}?`}</div>
+                </Dialog>
+            )}
         </React.Fragment>
     );
 };

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -273,7 +273,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     );
     const stagedValidation = useLoader(
         () => validatePublishCandidates(props.selectedPublishCandidateIds),
-        [props.selectedPublishCandidateIds],
+        [props.selectedPublishCandidateIds, props.changeTimes],
     );
     const unstagedChanges = entireChangesetValidation
         ? getUnstagedChanges(
@@ -317,6 +317,13 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const [entryBeingReverted, setEntryBeingReverted] = React.useState<PreviewTableEntry>();
 
     const onRevertRow = (id: PublicationId, type: PreviewSelectType) => {
+        const selectedChange = {
+            trackNumber: type === PreviewSelectType.trackNumber ? id : undefined,
+            referenceLine: type === PreviewSelectType.referenceLine ? id : undefined,
+            locationTrack: type === PreviewSelectType.locationTrack ? id : undefined,
+            switch: type === PreviewSelectType.switch ? id : undefined,
+            kmPost: type === PreviewSelectType.kmPost ? id : undefined,
+        };
         const request = {
             trackNumbers: type === PreviewSelectType.trackNumber ? [id] : [],
             referenceLines: type === PreviewSelectType.referenceLine ? [id] : [],
@@ -324,11 +331,13 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
             switches: type === PreviewSelectType.switch ? [id] : [],
             kmPosts: type === PreviewSelectType.kmPost ? [id] : [],
         };
-        revertCandidates(request).finally(() => {
-            setRevertConfirmVisible(false);
-            setIsReverting(false);
-            updateAllChangeTimes();
-        });
+        revertCandidates(request)
+            .then(() => props.onPublishPreviewRemove(selectedChange))
+            .finally(() => {
+                setRevertConfirmVisible(false);
+                setIsReverting(false);
+                updateAllChangeTimes();
+            });
     };
 
     return (

--- a/ui/src/preview/translations.fi.json
+++ b/ui/src/preview/translations.fi.json
@@ -28,11 +28,17 @@
             "confirm": "Julkaise"
         },
         "revert-confirm": {
-            "title": "Hylkää muutokset?",
-            "description": "Haluatko varmasti hylätä kaikki luonnostilassa tehdyt muutokset?",
+            "title": "Muutoksen hylkääminen",
+            "description": "Haluatko hylätä muutoksen",
             "cancel": "Peruuta",
-            "confirm": "Hylkää kaikki"
+            "confirm": "Hylkää",
+            "location-track": "sijaintiraiteeseen",
+            "track-number": "ratanumeroon",
+            "reference-line": "pituusmittauslinjaan",
+            "switch": "vaihteeseen",
+            "km-post": "tasakilometripisteeseen"
         },
+        "revert-change": "Hylkää muutos",
         "publish-success": "Muutokset julkaistu paikannuspohjaan",
         "revert-success": "Luonnosmuutokset peruttu",
         "track-numbers": "Ratanumeroita",

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -78,10 +78,10 @@ export const getPublishCandidates = () =>
     getIgnoreError<PublishCandidates>(`${PUBLISH_URI}/candidates`);
 
 export const validatePublishCandidates = (request: PublishRequest) =>
-    postIgnoreError<PublishRequest, ValidatedPublishCandidates>(`${PUBLISH_URI}/validate`, request)
+    postIgnoreError<PublishRequest, ValidatedPublishCandidates>(`${PUBLISH_URI}/validate`, request);
 
-export const revertCandidates = () =>
-    deleteAdt<null, PublishResult>(`${PUBLISH_URI}/candidates`, null, true);
+export const revertCandidates = (request: PublishRequest) =>
+    deleteAdt<PublishRequest, PublishResult>(`${PUBLISH_URI}/candidates`, request, true);
 
 export const publishCandidates = (request: PublishRequest) => {
     return postAdt<PublishRequest, PublishResult>(`${PUBLISH_URI}`, request, true);

--- a/ui/src/publication/publication-table-item.scss
+++ b/ui/src/publication/publication-table-item.scss
@@ -64,21 +64,8 @@ $color-warning: #9f6700;
 }
 
 .table .preview-table-item--error td {
-    //position: relative;
     padding: 5px 30px;
 }
-
-// If there is need to show an "expanded" status line at left :
-//.preview-table-item--error td::before {
-//  position: absolute;
-//  top: 0;
-//  bottom: 0;
-//  left: 0;
-//  width: 4px;
-//  background: $color-red-dark;
-//  font-size: 0;
-//  content: ' ';
-//}
 
 .preview-table-item__msg-group {
     margin-top: 10px;

--- a/ui/src/publication/publication-table-item.scss
+++ b/ui/src/publication/publication-table-item.scss
@@ -1,4 +1,5 @@
 @import '../vayla-design-lib/colors';
+@import '../vayla-design-lib/shadows';
 @import '../vayla-design-lib/typography';
 
 $color-ok: $color-green-dark;
@@ -87,12 +88,4 @@ $color-warning: #9f6700;
 
 .preview-table-item__msg {
     margin: 10px 0;
-}
-
-.preview-table-item__title-menu {
-    .menu {
-        position: absolute;
-        margin-top: 5px;
-        z-index: 10;
-    }
 }

--- a/ui/src/publication/publication-table-item.scss
+++ b/ui/src/publication/publication-table-item.scss
@@ -52,7 +52,11 @@ $color-warning: #9f6700;
 }
 
 .preview-table-item__actions--cell {
-    cursor: pointer;
+    display: contents;
+
+    > div {
+        display: inline-block;
+    }
 }
 
 .preview-table-item--error {
@@ -60,7 +64,7 @@ $color-warning: #9f6700;
 }
 
 .table .preview-table-item--error td {
-    position: relative;
+    //position: relative;
     padding: 5px 30px;
 }
 
@@ -96,4 +100,12 @@ $color-warning: #9f6700;
 
 .preview-table-item__msg {
     margin: 10px 0;
+}
+
+.preview-table-item__title-menu {
+    .menu {
+        position: absolute;
+        margin-top: 5px;
+        z-index: 10;
+    }
 }

--- a/ui/src/publication/publication-table-item.scss
+++ b/ui/src/publication/publication-table-item.scss
@@ -55,7 +55,7 @@ $color-warning: #9f6700;
     display: contents;
 
     > div {
-        display: inline-block;
+        display: inline-flex;
     }
 }
 

--- a/ui/src/publication/publication-table.scss
+++ b/ui/src/publication/publication-table.scss
@@ -1,9 +1,10 @@
 .publication-table__container {
-  overflow-y: auto;
-  height: 100%;
+    overflow-y: auto;
+    height: 100%;
 }
 
 .publication-table__header {
-  position: sticky;
-  top: 0;
+    position: sticky;
+    top: 0;
+    z-index: 1;
 }

--- a/ui/src/vayla-design-lib/menu/menu.scss
+++ b/ui/src/vayla-design-lib/menu/menu.scss
@@ -3,14 +3,16 @@
 @import '../typography';
 @import '../transitions';
 
-.menu {
+.menu,
+.react-contexify {
     @include typography-body;
     @include shadow-8dp;
     background: $color-white-default;
     border-radius: 4px;
 }
 
-.menu__item {
+.menu__item,
+.react-contexify__item {
     height: 36px;
     color: $color-black-default;
     fill: $color-white-default;
@@ -26,6 +28,12 @@
     &:hover {
         background: $color-blue-lighter;
     }
+}
+
+.react-contexify {
+    position: absolute;
+    margin-top: 5px;
+    z-index: 10;
 }
 
 .menu__item--selected {

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -1,12 +1,14 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-require('dotenv').config();
+const dotenv = require('dotenv');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ESLintWebpackPlugin = require('eslint-webpack-plugin');
 const LicensePlugin = require('webpack-license-plugin');
 const CspHtmlWebpackPlugin = require('csp-html-webpack-plugin');
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+dotenv.config();
 
 // If non-allowed licenses are found, you may have added a dependency with a new license type.
 // First, ensure it's licensing conditions are compatible with EUPL and our use.
@@ -47,7 +49,7 @@ module.exports = (env) => {
                 '/api': {
                     target: 'http://localhost:8080',
                     logLevel: 'debug',
-                    pathRewrite: {'^/api': ''},
+                    pathRewrite: { '^/api': '' },
                 },
                 '/map': {
                     target: 'http://localhost:8081/geoserver/Geoviite/wms',
@@ -58,7 +60,7 @@ module.exports = (env) => {
                     '/location-map/': {
                         target: process.env.MML_MAP_URL,
                         logLevel: 'debug',
-                        pathRewrite: {'^/location-map': ''},
+                        pathRewrite: { '^/location-map': '' },
                         changeOrigin: true,
                         headers: {
                             'X-API-Key': process.env.MML_MAP_API_KEY,
@@ -121,34 +123,36 @@ module.exports = (env) => {
                 {
                     test: /\.css$/i,
                     include: /node_modules/,
-                    use: [MiniCssExtractPlugin.loader, "css-loader"],
+                    use: [MiniCssExtractPlugin.loader, 'css-loader'],
                 },
-
             ],
         },
         plugins: [
             new HtmlWebpackPlugin({
                 template: './src/index.html',
             }),
-            new MiniCssExtractPlugin({insert: ":last-child(meta)"}),
+            new MiniCssExtractPlugin({ insert: ':last-child(meta)' }),
             // NOTE: According to this post this plugin is bad and headers should be used instead
             // https://towardsdatascience.com/content-security-policy-how-to-create-an-iron-clad-nonce-based-csp3-policy-with-webpack-and-nginx-ce5a4605db90
-            new CspHtmlWebpackPlugin({
-                'base-uri': "'self'",
-                'object-src': "'none'",
-                'img-src': "data: http: https:", // http: is for running locally
-                // Remove explicit style-src and favor nonces when react-select can be made to use non-inline styles
-                'style-src': "'unsafe-inline' http: https:",
-                'default-src': "'self'"
-            }, {
-                enabled: true,
-                hashingMethod: 'sha256',
-                nonceEnabled: {
-                    'script-src': true,
-                    // Enable nonce for style-src when react-select can be made to use non-inline styles
-                    'style-src': false,
-                }
-            }),
+            new CspHtmlWebpackPlugin(
+                {
+                    'base-uri': "'self'",
+                    'object-src': "'none'",
+                    'img-src': 'data: http: https:', // http: is for running locally
+                    // Remove explicit style-src and favor nonces when react-select can be made to use non-inline styles
+                    'style-src': "'unsafe-inline' http: https:",
+                    'default-src': "'self'",
+                },
+                {
+                    enabled: true,
+                    hashingMethod: 'sha256',
+                    nonceEnabled: {
+                        'script-src': true,
+                        // Enable nonce for style-src when react-select can be made to use non-inline styles
+                        'style-src': false,
+                    },
+                },
+            ),
             new ESLintWebpackPlugin({
                 extensions: ['js', 'jsx', 'ts', 'tsx'],
             }),
@@ -158,6 +162,9 @@ module.exports = (env) => {
                 unacceptableLicenseTest: (licenseIdentifier) => {
                     return !acceptedLicenses.includes(licenseIdentifier);
                 },
+            }),
+            new webpack.DefinePlugin({
+                'process.env': JSON.stringify(dotenv.config().parsed),
             }),
         ],
     };


### PR DESCRIPTION
Täällä tehty sekä bäkkäri- että fronttipuoli muutosten yksittäisestä hylkäämisestä. Summa summarum:
- Bäkkäripuolella muutettu `revertPublishCandidates()` ottamaan `PublishRequest`-tyyppisen olion, joka sisältää id:t siitä mitä revertataan (`PublishRequest`in nimen muuttamista voisi ehkä harkita jossain kohtaa)
- Fronttipuolella lisätty joka riville menu, jonka kautta pystyy reverttaamaan vain ka. riviin liittyvän muutoksen. Menut tehdään `react-contexify`-paketilla
- Esikatselunäkymän footerista poistettu Hylkää muutokset -nappi

Tätä tehdessä tuli vastaan juttuja, joita EI tehty vielä tällä tiketillä. Teen näistä omat lippulappunsa Jiraan:
- Revert ei indikoidu operaattorille välitömästi, vaan rivi poistuu taulukosta vasta kun bäkkäri on saanut poistettua draftin ja validoitua kaiken uudestaan
- TrackNumberin ja ReferenceLinen revertissä pitäisi myös revertata aina ka. reference lineä vastaava track number ja toisin päin. 