### PR TITLE
GVT-1570 Revert dependencies along with requested object to revert

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
@@ -63,6 +63,13 @@ class PublicationController @Autowired constructor(
         )
     }
 
+    @PreAuthorize(AUTH_ALL_READ)
+    @PostMapping("/candidates/revert-request-dependencies")
+    fun getRevertRequestDependencies(@RequestBody toDelete: PublishRequest): PublishRequest {
+        logger.apiCall("getRevertRequestDependencies")
+        return publishService.getRevertRequestDependencies(toDelete)
+    }
+
     @PreAuthorize(AUTH_ALL_WRITE)
     @PostMapping
     fun publishChanges(@RequestBody request: PublishRequest): PublishResult {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationServiceIT.kt
@@ -469,6 +469,81 @@ class PublicationServiceIT @Autowired constructor(
         assertDoesNotThrow { switchService.getDraft(switch2) }
     }
 
+    @Test
+    fun transitiveSearchForDraftSwitchAndLocationTrackChanges() {
+        val trackNumber = insertOfficialTrackNumber()
+
+        val switch1 = switchService.saveDraft(switch(123)).id
+        val switch2 = switchService.saveDraft(switch(234)).id
+        val switch3 = switchService.saveDraft(switch(345)).id
+        val distantSwitch = switchService.saveDraft(switch(456)).id
+
+        val track1BetweenSwitch1and2 = locationTrackAndAlignment(
+            trackNumber,
+            segment(Point(0.0, 0.0), Point(1.0, 1.0)).copy(
+                startJointNumber = JointNumber(1), switchId = switch1
+            ),
+            segment(Point(1.0, 1.0), Point(2.0, 2.0)).copy(
+                endJointNumber = JointNumber(1), switchId = switch2
+            ),
+        )
+        val locationTrack1Id =
+            locationTrackService.saveDraft(track1BetweenSwitch1and2.first, track1BetweenSwitch1and2.second).id
+
+        val track2BetweenSwitch2and3 = locationTrackAndAlignment(
+            trackNumber,
+            segment(Point(2.0, 2.0), Point(3.0, 3.0)).copy(
+                endJointNumber = JointNumber(1), switchId = switch3
+            )
+        )
+        val locationTrack2Id = locationTrackService.saveDraft(
+            track2BetweenSwitch2and3.first.copy(
+                topologyStartSwitch =
+                TopologyLocationTrackSwitch(switch2, JointNumber(1))
+            ), track2BetweenSwitch2and3.second
+        ).id
+
+        val officialTrackBetweenSwitch3AndDistantSwitch = locationTrackAndAlignment(
+            trackNumber,
+            segment(Point(3.0, 3.0), Point(4.0, 4.0)).copy(
+                startJointNumber = JointNumber(1), switchId = switch3
+            ),
+            segment(Point(4.0, 4.0), Point(5.0, 5.0)).copy(
+                endJointNumber = JointNumber(1), switchId = distantSwitch
+            )
+        )
+        locationTrackDao.insert(
+            officialTrackBetweenSwitch3AndDistantSwitch.first.copy(
+                alignmentVersion =
+                alignmentDao.insert(officialTrackBetweenSwitch3AndDistantSwitch.second)
+            )
+        ).id
+        val dependencies = publicationService.getRevertRequestDependencies(
+            publishRequest(switches = listOf(switch1))
+        )
+        assertEquals(
+            publishRequest(
+                locationTracks = listOf(locationTrack1Id, locationTrack2Id),
+                switches = listOf(switch1, switch2, switch3),
+            ), dependencies
+        )
+    }
+
+    @Test
+    fun trackNumberAndReferenceLineChangesDependOnEachOther() {
+        val trackNumber = insertDraftTrackNumber()
+        val referenceLine = referenceLineService.saveDraft(referenceLine(trackNumber)).id
+        val publishBoth = publishRequest(trackNumbers = listOf(trackNumber), referenceLines = listOf(referenceLine))
+        assertEquals(
+            publishBoth,
+            publicationService.getRevertRequestDependencies(publishRequest(trackNumbers = listOf(trackNumber)))
+        )
+        assertEquals(
+            publishBoth,
+            publicationService.getRevertRequestDependencies(publishRequest(referenceLines = listOf(referenceLine)))
+        )
+    }
+
     private fun someTrackNumber() = trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).id
 
     private fun getCalculatedChangesInRequest(versions: PublicationVersions): CalculatedChanges =

--- a/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
+++ b/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
@@ -82,7 +82,7 @@ const TrackNumberItem: React.FC<{ trackNumberId: LayoutTrackNumberId; changeTime
         <li />
     ) : (
         <li>
-            {t('publish.revert-confirm.track-number')} {trackNumber.number}
+            {t('publish.revert-confirm.dependency-list.track-number')} {trackNumber.number}
         </li>
     );
 };
@@ -106,7 +106,7 @@ const ReferenceLineItem: React.FC<{
         <li />
     ) : (
         <li>
-            {t('publish.revert-confirm.reference-line')} {trackNumber.number}
+            {t('publish.revert-confirm.dependency-list.reference-line')} {trackNumber.number}
         </li>
     );
 };
@@ -120,7 +120,7 @@ const LocationTrackItem: React.FC<{ locationTrackId: LocationTrackId; changeTime
         <li />
     ) : (
         <li>
-            {t('publish.revert-confirm.location-track')} {locationTrack.name}
+            {t('publish.revert-confirm.dependency-list.location-track')} {locationTrack.name}
         </li>
     );
 };
@@ -132,7 +132,7 @@ const SwitchItem: React.FC<{ switchId: LayoutSwitchId }> = ({ switchId }) => {
         <li />
     ) : (
         <li>
-            {t('publish.revert-confirm.switch')} {switchObj.name}
+            {t('publish.revert-confirm.dependency-list.switch')} {switchObj.name}
         </li>
     );
 };
@@ -175,7 +175,7 @@ export const PreviewConfirmRevertChangesDialog: React.FC<PreviewRejectConfirmDia
                 </React.Fragment>
             }>
             <div>{`${t('publish.revert-confirm.description')} ${t(
-                `publish.revert-confirm.${typeTranslationKey(
+                `publish.revert-confirm.revert-target.${typeTranslationKey(
                     changesBeingReverted.requestedRevertChange.type,
                 )}`,
             )} ${changesBeingReverted.requestedRevertChange.name}?`}</div>

--- a/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
+++ b/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
@@ -1,0 +1,216 @@
+import { ChangeTimes } from 'track-layout/track-layout-store';
+import { PublishRequest } from 'publication/publication-api';
+import { Dialog, DialogVariant } from 'vayla-design-lib/dialog/dialog';
+import dialogStyles from 'vayla-design-lib/dialog/dialog.scss';
+import * as React from 'react';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+import { useTranslation } from 'react-i18next';
+import { PreviewSelectType } from 'preview/preview-table';
+import {
+    LayoutSwitchId,
+    LayoutTrackNumberId,
+    LocationTrackId,
+    ReferenceLineId,
+} from 'track-layout/track-layout-model';
+import { ChangesBeingReverted } from 'preview/preview-view';
+import {
+    useLocationTrack,
+    useReferenceLine,
+    useSwitch,
+    useTrackNumbers,
+} from 'track-layout/track-layout-react-utils';
+import { TimeStamp } from 'common/common-model';
+
+export interface PreviewRejectConfirmDialogProps {
+    changesBeingReverted: ChangesBeingReverted;
+    changeTimes: ChangeTimes;
+    confirmRevertChanges: () => void;
+    cancelRevertChanges: () => void;
+}
+
+const typeTranslationKey = (type: PreviewSelectType) => {
+    switch (type) {
+        case 'trackNumber':
+            return 'track-number';
+        case 'referenceLine':
+            return 'reference-line';
+        case 'locationTrack':
+            return 'location-track';
+        case 'switch':
+            return 'switch';
+        case 'kmPost':
+            return 'km-post';
+    }
+};
+
+const onlyDependencies = (changesBeingReverted: ChangesBeingReverted): PublishRequest => {
+    const allChanges = changesBeingReverted.changeIncludingDependencies;
+    const reqType = changesBeingReverted.requestedRevertChange.type;
+    const reqId = changesBeingReverted.requestedRevertChange.id;
+    return {
+        trackNumbers: allChanges.trackNumbers.filter(
+            (tn) => reqType != PreviewSelectType.trackNumber || tn !== reqId,
+        ),
+        kmPosts: allChanges.kmPosts,
+        referenceLines: allChanges.referenceLines.filter(
+            (rl) => reqType != PreviewSelectType.referenceLine || rl !== reqId,
+        ),
+        switches: allChanges.switches.filter(
+            (sw) => reqType != PreviewSelectType.switch || sw !== reqId,
+        ),
+        locationTracks: allChanges.locationTracks.filter(
+            (lt) => reqType != PreviewSelectType.locationTrack || lt !== reqId,
+        ),
+    };
+};
+
+const publicationRequestSize = (req: PublishRequest): number =>
+    req.switches.length +
+    req.trackNumbers.length +
+    req.locationTracks.length +
+    req.referenceLines.length +
+    req.kmPosts.length;
+
+const TrackNumberItem: React.FC<{ trackNumberId: LayoutTrackNumberId; changeTime: TimeStamp }> = (
+    props,
+) => {
+    const { t } = useTranslation();
+    const trackNumbers = useTrackNumbers('DRAFT', props.changeTime);
+    const trackNumber = trackNumbers && trackNumbers.find((tn) => tn.id === props.trackNumberId);
+    return trackNumber === undefined ? (
+        <li />
+    ) : (
+        <li>
+            {t('publish.revert-confirm.track-number')} {trackNumber.number}
+        </li>
+    );
+};
+
+const ReferenceLineItem: React.FC<{
+    referenceLineId: ReferenceLineId;
+    changeTimes: ChangeTimes;
+}> = (props) => {
+    const { t } = useTranslation();
+    const trackNumbers = useTrackNumbers('DRAFT', props.changeTimes.layoutTrackNumber);
+    const referenceLine = useReferenceLine(
+        props.referenceLineId,
+        'DRAFT',
+        props.changeTimes.layoutReferenceLine,
+    );
+    if (referenceLine === undefined || trackNumbers === undefined) {
+        return <li />;
+    }
+    const trackNumber = trackNumbers.find((tn) => tn.id === referenceLine.trackNumberId);
+    return trackNumber === undefined ? (
+        <li />
+    ) : (
+        <li>
+            {t('publish.revert-confirm.reference-line')} {trackNumber.number}
+        </li>
+    );
+};
+
+const LocationTrackItem: React.FC<{ locationTrackId: LocationTrackId; changeTime: TimeStamp }> = (
+    props,
+) => {
+    const { t } = useTranslation();
+    const locationTrack = useLocationTrack(props.locationTrackId, 'DRAFT', props.changeTime);
+    return locationTrack === undefined ? (
+        <li />
+    ) : (
+        <li>
+            {t('publish.revert-confirm.location-track')} {locationTrack.name}
+        </li>
+    );
+};
+
+const SwitchItem: React.FC<{ switchId: LayoutSwitchId }> = ({ switchId }) => {
+    const { t } = useTranslation();
+    const switchObj = useSwitch(switchId, 'DRAFT');
+    return switchObj === undefined ? (
+        <li />
+    ) : (
+        <li>
+            {t('publish.revert-confirm.switch')} {switchObj.name}
+        </li>
+    );
+};
+
+export const PreviewConfirmRevertChangesDialog: React.FC<PreviewRejectConfirmDialogProps> = ({
+    changesBeingReverted,
+    changeTimes,
+    cancelRevertChanges,
+    confirmRevertChanges,
+}) => {
+    const { t } = useTranslation();
+    const [isReverting, setIsReverting] = React.useState(false);
+    const dependencies = onlyDependencies(changesBeingReverted);
+
+    return (
+        <Dialog
+            title={t('publish.revert-confirm.title')}
+            variant={DialogVariant.LIGHT}
+            allowClose={false}
+            className={dialogStyles['dialog--wide']}
+            footerContent={
+                <React.Fragment>
+                    <Button
+                        onClick={cancelRevertChanges}
+                        disabled={isReverting}
+                        variant={ButtonVariant.SECONDARY}>
+                        {t('publish.revert-confirm.cancel')}
+                    </Button>
+                    <Button
+                        icon={Icons.Delete}
+                        disabled={isReverting}
+                        isProcessing={isReverting}
+                        variant={ButtonVariant.WARNING}
+                        onClick={() => {
+                            setIsReverting(true);
+                            confirmRevertChanges();
+                        }}>
+                        {t('publish.revert-confirm.confirm')}
+                    </Button>
+                </React.Fragment>
+            }>
+            <div>{`${t('publish.revert-confirm.description')} ${t(
+                `publish.revert-confirm.${typeTranslationKey(
+                    changesBeingReverted.requestedRevertChange.type,
+                )}`,
+            )} ${changesBeingReverted.requestedRevertChange.name}?`}</div>
+            {publicationRequestSize(dependencies) > 0 && (
+                <>
+                    <div>{t(`publish.revert-confirm.dependencies`)}</div>
+                    <ul>
+                        {dependencies.trackNumbers.map((tn) => (
+                            <TrackNumberItem
+                                trackNumberId={tn}
+                                changeTime={changeTimes.layoutTrackNumber}
+                                key={tn}
+                            />
+                        ))}
+
+                        {dependencies.referenceLines.map((rl) => (
+                            <ReferenceLineItem
+                                referenceLineId={rl}
+                                changeTimes={changeTimes}
+                                key={rl}
+                            />
+                        ))}
+                        {dependencies.locationTracks.map((lt) => (
+                            <LocationTrackItem
+                                locationTrackId={lt}
+                                changeTime={changeTimes.layoutLocationTrack}
+                                key={lt}
+                            />
+                        ))}
+                        {dependencies.switches.map((sw) => (
+                            <SwitchItem switchId={sw} key={sw} />
+                        ))}
+                    </ul>
+                </>
+            )}
+        </Dialog>
+    );
+};

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -262,11 +262,11 @@ const singleRowPublishRequestOfPreviewTableEntry = (
 const singleRowPublishRequestOfSelectedPublishChange = (
     change: SelectedPublishChange,
 ): PublishRequest => ({
-    trackNumbers: change.trackNumber === undefined ? [] : [change.trackNumber],
-    referenceLines: change.referenceLine === undefined ? [] : [change.referenceLine],
-    locationTracks: change.locationTrack === undefined ? [] : [change.locationTrack],
-    switches: change.switch === undefined ? [] : [change.switch],
-    kmPosts: change.kmPost === undefined ? [] : [change.kmPost],
+    trackNumbers: change.trackNumber ? [change.trackNumber] : [],
+    referenceLines: change.referenceLine ? [change.referenceLine] : [],
+    locationTracks: change.locationTrack ? [change.locationTrack] : [],
+    switches: change.switch ? [change.switch] : [],
+    kmPosts: change.kmPost ? [change.kmPost] : [],
 });
 
 export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -5,6 +5,7 @@ import { useLoader } from 'utils/react-utils';
 import {
     getCalculatedChanges,
     getPublishCandidates,
+    getRevertRequestDependencies,
     PublishRequest,
     revertCandidates,
     validatePublishCandidates,
@@ -44,11 +45,8 @@ import {
 } from 'track-layout/track-layout-model';
 import PreviewTable, { PreviewSelectType, PreviewTableEntry } from 'preview/preview-table';
 import { updateAllChangeTimes } from 'common/change-time-api';
-import { Dialog, DialogVariant } from 'vayla-design-lib/dialog/dialog';
-import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
-import { Icons } from 'vayla-design-lib/icon/Icon';
-import dialogStyles from '../vayla-design-lib/dialog/dialog.scss';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
+import { PreviewConfirmRevertChangesDialog } from 'preview/preview-confirm-revert-changes-dialog';
 
 type CandidateId =
     | LocationTrackId
@@ -80,6 +78,11 @@ export type PreviewCandidates = {
     kmPosts: (KmPostPublishCandidate & PendingValidation)[];
 };
 
+export type ChangesBeingReverted = {
+    requestedRevertChange: PreviewTableEntry;
+    changeIncludingDependencies: PublishRequest;
+};
+
 type PreviewProps = {
     map: Map;
     selection: Selection;
@@ -94,7 +97,7 @@ type PreviewProps = {
     onPublish: () => void;
     onClosePreview: () => void;
     onPreviewSelect: (selectedChange: SelectedPublishChange) => void;
-    onPublishPreviewRemove: (selectedChange: SelectedPublishChange) => void;
+    onPublishPreviewRemove: (selectedChangesWithDependencies: PublishRequest) => void;
     onPublishPreviewRevert: () => void;
 };
 
@@ -245,22 +248,13 @@ const pendingCandidate = <T extends PublishCandidate>(candidate: T) => ({
     pendingValidation: true,
 });
 
-const typeTranslationKey = (type: PreviewSelectType | undefined) => {
-    switch (type) {
-        case PreviewSelectType.trackNumber:
-            return 'track-number';
-        case PreviewSelectType.referenceLine:
-            return 'reference-line';
-        case PreviewSelectType.locationTrack:
-            return 'location-track';
-        case PreviewSelectType.switch:
-            return 'switch';
-        case PreviewSelectType.kmPost:
-            return 'km-post';
-        default:
-            return '';
-    }
-};
+const singleRowPublishRequest = (id: PublicationId, type: PreviewSelectType): PublishRequest => ({
+    trackNumbers: type === 'trackNumber' ? [id] : [],
+    referenceLines: type === 'referenceLine' ? [id] : [],
+    locationTracks: type === 'locationTrack' ? [id] : [],
+    switches: type === 'switch' ? [id] : [],
+    kmPosts: type === 'kmPost' ? [id] : [],
+});
 
 export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const { t } = useTranslation();
@@ -314,36 +308,35 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
         [props.selectedPublishCandidateIds],
     );
     const [mapMode, setMapMode] = React.useState<PublishType>('DRAFT');
-    const [isReverting, setIsReverting] = React.useState(false);
-    const [revertConfirmVisible, setRevertConfirmVisible] = React.useState(false);
-    const [entryBeingReverted, setEntryBeingReverted] = React.useState<PreviewTableEntry>();
+    const [changesBeingReverted, setChangesBeingReverted] = React.useState<ChangesBeingReverted>();
 
-    const onRevertRow = (id: PublicationId, type: PreviewSelectType) => {
-        const selectedChange = {
-            trackNumber: type === PreviewSelectType.trackNumber ? id : undefined,
-            referenceLine: type === PreviewSelectType.referenceLine ? id : undefined,
-            locationTrack: type === PreviewSelectType.locationTrack ? id : undefined,
-            switch: type === PreviewSelectType.switch ? id : undefined,
-            kmPost: type === PreviewSelectType.kmPost ? id : undefined,
-        };
-        const request = {
-            trackNumbers: type === PreviewSelectType.trackNumber ? [id] : [],
-            referenceLines: type === PreviewSelectType.referenceLine ? [id] : [],
-            locationTracks: type === PreviewSelectType.locationTrack ? [id] : [],
-            switches: type === PreviewSelectType.switch ? [id] : [],
-            kmPosts: type === PreviewSelectType.kmPost ? [id] : [],
-        };
-        revertCandidates(request)
+    const onRequestRevert = (requestedRevertChange: PreviewTableEntry) => {
+        getRevertRequestDependencies(
+            singleRowPublishRequest(requestedRevertChange.id, requestedRevertChange.type),
+        ).then((changeIncludingDependencies) => {
+            if (changeIncludingDependencies != null) {
+                setChangesBeingReverted({
+                    requestedRevertChange,
+                    changeIncludingDependencies,
+                });
+            }
+        });
+    };
+
+    const onConfirmRevert = () => {
+        if (changesBeingReverted === undefined) {
+            return;
+        }
+        revertCandidates(changesBeingReverted.changeIncludingDependencies)
             .then((r) => {
                 if (r.isOk()) {
                     Snackbar.success(t('publish.revert-success'));
-                    props.onPublishPreviewRemove(selectedChange);
+                    props.onPublishPreviewRemove(changesBeingReverted.changeIncludingDependencies);
                 }
             })
             .finally(() => {
-                setRevertConfirmVisible(false);
-                setIsReverting(false);
-                updateAllChangeTimes();
+                setChangesBeingReverted(undefined);
+                void updateAllChangeTimes();
             });
     };
 
@@ -362,10 +355,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 </div>
                                 <PreviewTable
                                     onPreviewSelect={props.onPreviewSelect}
-                                    onRevert={(entry) => {
-                                        setEntryBeingReverted(entry);
-                                        setRevertConfirmVisible(true);
-                                    }}
+                                    onRevert={onRequestRevert}
                                     previewChanges={unstagedPreviewChanges}
                                     staged={false}
                                 />
@@ -376,11 +366,8 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                     <h3>{t('preview-view.staged-changes-title')}</h3>
                                 </div>
                                 <PreviewTable
-                                    onPreviewSelect={props.onPublishPreviewRemove}
-                                    onRevert={(entry) => {
-                                        setEntryBeingReverted(entry);
-                                        setRevertConfirmVisible(true);
-                                    }}
+                                    onPreviewSelect={props.onPreviewSelect}
+                                    onRevert={onRequestRevert}
                                     previewChanges={stagedPreviewChanges}
                                     staged={true}
                                 />
@@ -423,39 +410,15 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                     onPublishPreviewRevert={props.onPublishPreviewRevert}
                 />
             </div>
-            {revertConfirmVisible && (
-                <Dialog
-                    title={t('publish.revert-confirm.title')}
-                    variant={DialogVariant.LIGHT}
-                    allowClose={false}
-                    className={dialogStyles['dialog--wide']}
-                    footerContent={
-                        <React.Fragment>
-                            <Button
-                                onClick={() => setRevertConfirmVisible(false)}
-                                disabled={isReverting}
-                                variant={ButtonVariant.SECONDARY}>
-                                {t('publish.revert-confirm.cancel')}
-                            </Button>
-                            <Button
-                                icon={Icons.Delete}
-                                disabled={isReverting}
-                                isProcessing={isReverting}
-                                variant={ButtonVariant.WARNING}
-                                onClick={() => {
-                                    if (entryBeingReverted) {
-                                        setIsReverting(true);
-                                        onRevertRow(entryBeingReverted.id, entryBeingReverted.type);
-                                    }
-                                }}>
-                                {t('publish.revert-confirm.confirm')}
-                            </Button>
-                        </React.Fragment>
-                    }>
-                    <div>{`${t('publish.revert-confirm.description')} ${t(
-                        `publish.revert-confirm.${typeTranslationKey(entryBeingReverted?.type)}`,
-                    )} ${entryBeingReverted?.name}?`}</div>
-                </Dialog>
+            {changesBeingReverted !== undefined && (
+                <PreviewConfirmRevertChangesDialog
+                    changeTimes={props.changeTimes}
+                    changesBeingReverted={changesBeingReverted}
+                    cancelRevertChanges={() => {
+                        setChangesBeingReverted(undefined);
+                    }}
+                    confirmRevertChanges={onConfirmRevert}
+                />
             )}
         </React.Fragment>
     );

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -248,12 +248,25 @@ const pendingCandidate = <T extends PublishCandidate>(candidate: T) => ({
     pendingValidation: true,
 });
 
-const singleRowPublishRequest = (id: PublicationId, type: PreviewSelectType): PublishRequest => ({
+const singleRowPublishRequestOfPreviewTableEntry = (
+    id: PublicationId,
+    type: PreviewSelectType,
+): PublishRequest => ({
     trackNumbers: type === 'trackNumber' ? [id] : [],
     referenceLines: type === 'referenceLine' ? [id] : [],
     locationTracks: type === 'locationTrack' ? [id] : [],
     switches: type === 'switch' ? [id] : [],
     kmPosts: type === 'kmPost' ? [id] : [],
+});
+
+const singleRowPublishRequestOfSelectedPublishChange = (
+    change: SelectedPublishChange,
+): PublishRequest => ({
+    trackNumbers: change.trackNumber === undefined ? [] : [change.trackNumber],
+    referenceLines: change.referenceLine === undefined ? [] : [change.referenceLine],
+    locationTracks: change.locationTrack === undefined ? [] : [change.locationTrack],
+    switches: change.switch === undefined ? [] : [change.switch],
+    kmPosts: change.kmPost === undefined ? [] : [change.kmPost],
 });
 
 export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
@@ -312,7 +325,10 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
 
     const onRequestRevert = (requestedRevertChange: PreviewTableEntry) => {
         getRevertRequestDependencies(
-            singleRowPublishRequest(requestedRevertChange.id, requestedRevertChange.type),
+            singleRowPublishRequestOfPreviewTableEntry(
+                requestedRevertChange.id,
+                requestedRevertChange.type,
+            ),
         ).then((changeIncludingDependencies) => {
             if (changeIncludingDependencies != null) {
                 setChangesBeingReverted({
@@ -338,6 +354,12 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                 setChangesBeingReverted(undefined);
                 void updateAllChangeTimes();
             });
+    };
+
+    const onPublishPreviewRemove = (selectedChange: SelectedPublishChange): void => {
+        props.onPublishPreviewRemove(
+            singleRowPublishRequestOfSelectedPublishChange(selectedChange),
+        );
     };
 
     return (
@@ -366,7 +388,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                     <h3>{t('preview-view.staged-changes-title')}</h3>
                                 </div>
                                 <PreviewTable
-                                    onPreviewSelect={props.onPreviewSelect}
+                                    onPreviewSelect={onPublishPreviewRemove}
                                     onRevert={onRequestRevert}
                                     previewChanges={stagedPreviewChanges}
                                     staged={true}

--- a/ui/src/preview/translations.fi.json
+++ b/ui/src/preview/translations.fi.json
@@ -30,13 +30,14 @@
         "revert-confirm": {
             "title": "Muutoksen hylkääminen",
             "description": "Haluatko hylätä muutoksen",
+            "dependencies": "Tämän muutoksen hylkääminen aiheuttaa myös seuraavien riippuvien muutosten hylkäämisen:",
             "cancel": "Peruuta",
             "confirm": "Hylkää",
-            "location-track": "sijaintiraiteeseen",
-            "track-number": "ratanumeroon",
-            "reference-line": "pituusmittauslinjaan",
-            "switch": "vaihteeseen",
-            "km-post": "tasakilometripisteeseen"
+            "location-track": "Sijaintiraide",
+            "track-number": "Ratanumero",
+            "reference-line": "Pituusmittauslinja",
+            "switch": "Vaihde",
+            "km-post": "Tasakilometripiste"
         },
         "revert-change": "Hylkää muutos",
         "publish-success": "Muutokset julkaistu paikannuspohjaan",

--- a/ui/src/preview/translations.fi.json
+++ b/ui/src/preview/translations.fi.json
@@ -33,11 +33,20 @@
             "dependencies": "Tämän muutoksen hylkääminen aiheuttaa myös seuraavien riippuvien muutosten hylkäämisen:",
             "cancel": "Peruuta",
             "confirm": "Hylkää",
-            "location-track": "Sijaintiraide",
-            "track-number": "Ratanumero",
-            "reference-line": "Pituusmittauslinja",
-            "switch": "Vaihde",
-            "km-post": "Tasakilometripiste"
+            "revert-target": {
+                "location-track": "sijaintiraiteeseen",
+                "track-number": "ratanumeroon",
+                "reference-line": "pituusmittauslinjaan",
+                "switch": "vaihteeseen",
+                "km-post": "tasakilometripisteeseen"
+           },
+            "dependency-list": {
+                "location-track": "Sijaintiraide",
+                "track-number": "Ratanumero",
+                "reference-line": "Pituusmittauslinja",
+                "switch": "Vaihde",
+                "km-post": "Tasakilometripiste"
+            }
         },
         "revert-change": "Hylkää muutos",
         "publish-success": "Muutokset julkaistu paikannuspohjaan",

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -97,3 +97,9 @@ export const getCalculatedChanges = (request: PublishRequest) =>
         `${PUBLISH_URI}/calculated-changes`,
         request,
     );
+
+export const getRevertRequestDependencies = (request: PublishRequest) =>
+    postIgnoreError<PublishRequest, PublishRequest>(
+        `${PUBLISH_URI}/candidates/revert-request-dependencies`,
+        request,
+    );

--- a/ui/src/track-layout/track-layout-store.ts
+++ b/ui/src/track-layout/track-layout-store.ts
@@ -22,7 +22,8 @@ import {
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import { Point } from 'model/geometry';
-import { addIfExists, removeIfExists } from 'utils/array-utils';
+import { addIfExists, subtract } from 'utils/array-utils';
+import { PublishRequest } from 'publication/publication-api';
 
 export type SelectedPublishChanges = {
     trackNumbers: LayoutTrackNumberId[];
@@ -234,39 +235,33 @@ const trackLayoutSlice = createSlice({
                 kmPosts: kmPosts,
             };
         },
+
         onPublishPreviewRemove: function (
             state: TrackLayoutState,
-            action: PayloadAction<SelectedPublishChange>,
+            action: PayloadAction<PublishRequest>,
         ): void {
-            const trackNumbers = removeIfExists(
-                [...state.selectedPublishCandidateIds.trackNumbers],
-                action.payload.trackNumber,
+            const stateCandidates = state.selectedPublishCandidateIds;
+            const toRemove = action.payload;
+            const trackNumbers = subtract(stateCandidates.trackNumbers, toRemove.trackNumbers);
+            const referenceLines = subtract(
+                stateCandidates.referenceLines,
+                toRemove.referenceLines,
             );
-            const referenceLines = removeIfExists(
-                [...state.selectedPublishCandidateIds.referenceLines],
-                action.payload.referenceLine,
+            const locationTracks = subtract(
+                stateCandidates.locationTracks,
+                toRemove.locationTracks,
             );
-            const locationTracks = removeIfExists(
-                [...state.selectedPublishCandidateIds.locationTracks],
-                action.payload.locationTrack,
-            );
-            const switches = removeIfExists(
-                [...state.selectedPublishCandidateIds.switches],
-                action.payload.switch,
-            );
-            const kmPosts = removeIfExists(
-                [...state.selectedPublishCandidateIds.kmPosts],
-                action.payload.kmPost,
-            );
-
+            const switches = subtract(stateCandidates.switches, toRemove.switches);
+            const kmPosts = subtract(stateCandidates.kmPosts, toRemove.kmPosts);
             state.selectedPublishCandidateIds = {
-                trackNumbers: trackNumbers,
-                referenceLines: referenceLines,
-                locationTracks: locationTracks,
-                switches: switches,
-                kmPosts: kmPosts,
+                trackNumbers,
+                referenceLines,
+                locationTracks,
+                switches,
+                kmPosts,
             };
         },
+
         // TODO when Hylkää muutokset -button is removed from Preview-view, this reducer will become obsolete
         onPublishPreviewRevert: function (state: TrackLayoutState): void {
             state.selectedPublishCandidateIds = {

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -140,6 +140,14 @@ export function last<T>(array: T[]): T {
     return array[array.length - 1];
 }
 
+export function subtract<T>(originalCollection: T[], valuesToRemove: T[]): T[] {
+    if (valuesToRemove.length === 0) {
+        return originalCollection;
+    }
+    const setToRemove = new Set(valuesToRemove);
+    return originalCollection.filter((x) => !setToRemove.has(x));
+}
+
 export function removeIfExists<T>(originalCollection: T[], valueToRemove: T | undefined) {
     return valueToRemove
         ? originalCollection.filter((changeId) => changeId != valueToRemove)


### PR DESCRIPTION
Lisätty API, joka hakee julkaistavan asian hylkäämisen riippuvuudet (sekä GVT-1570:n varsinainen juttu eli ratanumeroiden ja pituusmittauslinjojen riippuminen toisistaan, että GVT-1527:ltä jäänyt rekursiivinen sijaintiraiteiden ja vaihteiden haku), ja siirretty hylkäämisen vahvistusdialogi omaksi komponentikseen, joka sitten näyttää riippuvuuslistan.