### PR TITLE
GVT-1463 Handle Ratko being offline in getRatkoOnlineStatus

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -39,9 +39,7 @@ class RatkoClient @Autowired constructor(private val client: WebClient) {
         jsonMapper { addModule(kotlinModule { configure(KotlinFeature.NullIsSameAsDefault, true) }) }
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
-    data class RatkoStatus(val statusCode: HttpStatus) {
-        val isOnline = statusCode == HttpStatus.OK
-    }
+    data class RatkoStatus(val isOnline: Boolean)
 
     fun getRatkoOnlineStatus(): RatkoStatus {
         return client
@@ -49,10 +47,8 @@ class RatkoClient @Autowired constructor(private val client: WebClient) {
             .uri("/api/versions/v1.0/version")
             .retrieve()
             .toBodilessEntity()
-            .thenReturn(RatkoStatus(HttpStatus.OK))
-            .onErrorResume(WebClientResponseException::class.java) {
-                Mono.just(RatkoStatus(it.statusCode))
-            }
+            .map { response -> RatkoStatus(response.statusCode == HttpStatus.OK) }
+            .onErrorReturn(RatkoStatus(false))
             .block(defaultBlockTimeout)!!
     }
 


### PR DESCRIPTION
Getting no HTTP response at all gets reported as WebClientRequestException, not WebClientResponseException, and the original implementation would just throw that all the way up to the controller if Ratko in fact was offline.