### PR TITLE
GVT-1596: Suunnitelmien importissa KKJ-muunnoksiin tulee heittoa

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvParsing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvParsing.kt
@@ -25,7 +25,7 @@ val LOG: Logger = LoggerFactory.getLogger(CsvFile::class.java)
 val RATKO_SRID = Srid(4326)
 
 // Prepare math-transform, rather than recreating on every conversion
-val RATKO_TO_LAYOUT_TRANSFORM = Transformation(RATKO_SRID, LAYOUT_SRID)
+val RATKO_TO_LAYOUT_TRANSFORM = Transformation.nonKKJToETRSTransform(RATKO_SRID, LAYOUT_SRID)
 const val MIN_ANGLE_DIFFERENCE_TO_DETECT_CONNECTION_SEGMENT = PI/32
 const val MAX_SUM_ANGLE_DIFFERENCE_TO_DETECT_CONNECTION_SEGMENT = PI/32
 const val LAYOUT_METER_LENGTH_WARNING_THRESHOLD = 5.0
@@ -810,7 +810,7 @@ fun <T> createLayoutSegment(
     val srid = metadata.metadata?.geometrySrid
     val sourceElement = if (srid != null) metadata.metadata.geometryElement else null
     val sourceStart = if (srid != null && sourceElement != null) {
-        sourceElement.getLengthUntil(transformCoordinate(LAYOUT_SRID, srid, segmentPoints.first()))
+        sourceElement.getLengthUntil(transformNonKKJCoordinate(LAYOUT_SRID, srid, segmentPoints.first()))
     } else null
     return LayoutSegment(
         points = toLayoutPoints(segmentPoints),
@@ -1014,7 +1014,7 @@ fun <T> getGeometryElementRanges(
                 "alignment=${alignment.alignmentOid} " +
                 "geom=${alignment.geometry.id}"
         )
-        val transform = Transformation(sourceSrid, LAYOUT_SRID, kkjToEtrsTriangulationTriangles)
+        val transform = Transformation.possiblyKKJToETRSTransform(sourceSrid, LAYOUT_SRID, kkjToEtrsTriangulationTriangles)
         val firstElementPoint = transform.transform(elements.first().start)
         val lastElementPoint = transform.transform(elements.last().end)
         val dirElements = directionBetweenPoints(firstElementPoint, lastElementPoint)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
@@ -122,7 +122,9 @@ data class Transformation(
 
     private constructor(sourceSrid: Srid, targetSrid: Srid) :
             this(crs(sourceSrid), crs(targetSrid)) {
-                require(!isKKJ(sourceRef) || targetRef != LAYOUT_CRS) { "MOI ${sourceSrid} ${targetSrid}" }
+                require(!isKKJ(sourceRef) || targetRef != LAYOUT_CRS) {
+                    "Trying to convert from KKJx (${sourceSrid}) to ${targetSrid} without triangulation network"
+                }
             }
 
     fun transform(point: IPoint): Point {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
@@ -1,7 +1,6 @@
 package fi.fta.geoviite.infra.geography
 
 import fi.fta.geoviite.infra.common.Srid
-import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_CRS
@@ -18,28 +17,8 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem
 import org.opengis.referencing.operation.MathTransform
 import java.util.concurrent.ConcurrentHashMap
 
-fun pointInPolygon(polygonPoints: List<IPoint>, point: IPoint, ref: CoordinateReferenceSystem): Boolean {
-    return toJtsPolygon(polygonPoints, ref)?.intersects(toJtsPoint(point, ref)) ?: false
-}
-
-fun transformBoundingBox(sourceSrid: Srid, targetSrid: Srid, bbox: BoundingBox, buffer: Double = 0.0): BoundingBox? {
-    val bufferAdjustment = Point(
-        x = buffer * (bbox.x.max - bbox.x.min),
-        y = buffer * (bbox.y.max - bbox.y.min),
-    )
-    return try {
-        val transform = Transformation(sourceSrid, targetSrid)
-        BoundingBox(
-            min = transform.transform(bbox.min) - bufferAdjustment,
-            max = transform.transform(bbox.max) + bufferAdjustment,
-        )
-    } catch (e: CoordinateTransformationException) {
-        null
-    }
-}
-
-fun transformCoordinate(sourceSrid: Srid, targetSrid: Srid, point: IPoint): Point {
-    return Transformation(sourceSrid, targetSrid).transform(point)
+fun transformNonKKJCoordinate(sourceSrid: Srid, targetSrid: Srid, point: IPoint): Point {
+    return Transformation.nonKKJToETRSTransform(sourceSrid, targetSrid).transform(point)
 }
 
 fun calculateDistance(points: List<IPoint>, srid: Srid): Double = calculateDistance(points, crs(srid))
@@ -121,20 +100,35 @@ class CoordinateTransformationException(message: String, cause: Throwable? = nul
             this("Cannot determine coordinate axis order x=$x y=$y crs=$crs order=$order")
 }
 
+fun isKKJ(sourceRef: CoordinateReferenceSystem) = listOf(KKJ0, KKJ1, KKJ2, KKJ3_YKJ, KKJ4, KKJ5).contains(sourceRef)
+
 data class Transformation(
     val sourceRef: CoordinateReferenceSystem,
     val targetRef: CoordinateReferenceSystem,
     val math: MathTransform = CRS.findMathTransform(sourceRef, targetRef),
     val triangles: List<KKJtoETRSTriangle> = emptyList(),
 ) {
-    constructor(sourceSrid: Srid, targetSrid: Srid, triangles: List<KKJtoETRSTriangle> = emptyList()) :
-            this(crs(sourceSrid), crs(targetSrid), triangles = triangles)
+    companion object {
+        fun possiblyKKJToETRSTransform(sourceSrid: Srid, targetSrid: Srid, triangles: List<KKJtoETRSTriangle>) =
+            Transformation(sourceSrid, targetSrid, triangles)
+
+        fun nonKKJToETRSTransform(sourceSrid: Srid, targetSrid: Srid) =
+            Transformation(sourceSrid, targetSrid)
+    }
+    private constructor(sourceSrid: Srid, targetSrid: Srid, triangles: List<KKJtoETRSTriangle>) :
+            this(crs(sourceSrid), crs(targetSrid), triangles = triangles) {
+                require(triangles.isNotEmpty()) { "Triangulation network was not provided" }
+            }
+
+    private constructor(sourceSrid: Srid, targetSrid: Srid) :
+            this(crs(sourceSrid), crs(targetSrid)) {
+                require(!isKKJ(sourceRef) || targetRef != LAYOUT_CRS) { "MOI ${sourceSrid} ${targetSrid}" }
+            }
 
     fun transform(point: IPoint): Point {
         try {
-            val sourceIsKkj = listOf(KKJ0, KKJ1, KKJ2, KKJ3_YKJ, KKJ4, KKJ5).contains(sourceRef)
             // Intercept transforms from KKJx to ETRS
-            return if (triangles.any() && sourceIsKkj && targetRef == LAYOUT_CRS) {
+            return if (triangles.any() && isKKJ(sourceRef) && targetRef == LAYOUT_CRS) {
                 val ykjPoint = transformKkjToYkjAndNormalizeAxes(point)
                 val triangle = triangles.find { it.intersects(ykjPoint) }
                 requireNotNull(triangle) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/BoundingPolygon.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/BoundingPolygon.kt
@@ -29,6 +29,6 @@ fun createBoundingPolygonPoints(
     triangulationTriangles: List<KKJtoETRSTriangle>,
 ): List<Point> {
     val bounds = boundingPolygonPointsByConvexHull(points, srid)
-    val transformation = Transformation(srid, LAYOUT_SRID, triangulationTriangles)
+    val transformation = Transformation.possiblyKKJToETRSTransform(srid, LAYOUT_SRID, triangulationTriangles)
     return bounds.map { p -> transformation.transform(p) }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.error.LinkingFailureException
+import fi.fta.geoviite.infra.geography.KKJtoETRSTriangulationDao
 import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
@@ -73,6 +74,7 @@ class LinkingService @Autowired constructor(
     private val locationTrackService: LocationTrackService,
     private val layoutKmPostService: LayoutKmPostService,
     private val linkingDao: LinkingDao,
+    private val kkJtoETRSTriangulationDao: KKJtoETRSTriangulationDao
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -325,7 +327,7 @@ class LinkingService @Autowired constructor(
             ?: throw IllegalArgumentException("Cannot link a geometry km post with an unknown coordinate system!")
         requireNotNull(geometryKmPost.location) { "Cannot link a geometry km post without a location!" }
 
-        val transformation = Transformation(kmPostSrid, LAYOUT_SRID)
+        val transformation = Transformation.possiblyKKJToETRSTransform(kmPostSrid, LAYOUT_SRID, kkJtoETRSTriangulationDao.fetchTriangulationNetwork())
 
         val layoutKmPost = layoutKmPostService.getDraft(kmPostLinkingParameters.layoutKmPostId)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
@@ -2,6 +2,8 @@ package fi.fta.geoviite.infra.linking
 
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.common.PublishType.DRAFT
+import fi.fta.geoviite.infra.geography.KKJtoETRSTriangle
+import fi.fta.geoviite.infra.geography.KKJtoETRSTriangulationDao
 import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.geometry.GeometryPlan
@@ -27,8 +29,9 @@ fun calculateLayoutSwitchJoints(
     geomSwitch: GeometrySwitch,
     switchStructure: SwitchStructure,
     planSrid: Srid,
+    kkJtoETRSTriangulationNetwork: List<KKJtoETRSTriangle>
 ): List<SwitchJoint>? {
-    val fromPlanToLayoutTransformation = Transformation(planSrid, LAYOUT_SRID)
+    val fromPlanToLayoutTransformation = Transformation.possiblyKKJToETRSTransform(planSrid, LAYOUT_SRID, kkJtoETRSTriangulationNetwork)
 
     val layoutJointPoints = geomSwitch.joints.map { geomJoint ->
         SwitchJoint(
@@ -1049,6 +1052,7 @@ class SwitchLinkingService @Autowired constructor(
     private val linkingDao: LinkingDao,
     private val geometryDao: GeometryDao,
     private val switchLibraryService: SwitchLibraryService,
+    private val kkJtoETRSTriangulationDao: KKJtoETRSTriangulationDao
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -1062,7 +1066,12 @@ class SwitchLinkingService @Autowired constructor(
             val structure = geomSwitch.switchStructureId?.let(switchLibraryService::getSwitchStructure)
             // TODO: There is a missing switch here, but current logic doesn't support non-typed suggestions
             if (structure == null) null
-            else calculateLayoutSwitchJoints(geomSwitch, structure, missingLayoutSwitchLinking.planSrid)
+            else calculateLayoutSwitchJoints(
+                geomSwitch,
+                structure,
+                missingLayoutSwitchLinking.planSrid,
+                kkJtoETRSTriangulationDao.fetchTriangulationNetwork()
+            )
                 ?.let { calculatedJoints ->
                     val switchBoundingBox = boundingBoxAroundPoints(calculatedJoints.map { it.location }) * 1.5
                     val nearAlignmentIds = locationTrackDao.fetchVersionsNear(DRAFT, switchBoundingBox)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.dataImport.RATKO_SRID
-import fi.fta.geoviite.infra.geography.transformCoordinate
+import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
@@ -100,7 +100,7 @@ class RatkoTrackMeter private constructor(
 class RatkoGeometry(val type: RatkoGeometryType, coordinates: List<Double>, crs: RatkoCrs) {
     val coordinates: List<Double> =
         if (crs.properties.name != RATKO_SRID)
-            transformCoordinate(crs.properties.name, RATKO_SRID, Point(coordinates[0], coordinates[1]))
+            transformNonKKJCoordinate(crs.properties.name, RATKO_SRID, Point(coordinates[0], coordinates[1]))
                 .let { listOf(it.x, it.y) }
         else coordinates
 
@@ -108,7 +108,7 @@ class RatkoGeometry(val type: RatkoGeometryType, coordinates: List<Double>, crs:
 
     constructor(point: IPoint) : this(
         type = RatkoGeometryType.POINT,
-        coordinates = transformCoordinate(LAYOUT_SRID, RATKO_SRID, Point(point.x, point.y)).let { listOf(it.x, it.y) },
+        coordinates = transformNonKKJCoordinate(LAYOUT_SRID, RATKO_SRID, Point(point.x, point.y)).let { listOf(it.x, it.y) },
         crs = RatkoCrs()
     )
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Transformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Transformation.kt
@@ -25,7 +25,7 @@ fun toTrackLayout(
     pointListStepLength: Int,
     includeGeometryData: Boolean,
 ): GeometryPlanLayout {
-    val transformation = Transformation(planSrid, LAYOUT_SRID, kkjToEtrsTriangles)
+    val transformation = Transformation.possiblyKKJToETRSTransform(planSrid, LAYOUT_SRID, kkjToEtrsTriangles)
 
     val switches = toTrackLayoutSwitches(geometryPlan.switches, transformation)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/dataImport/CsvImportIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/dataImport/CsvImportIT.kt
@@ -2,7 +2,7 @@ package fi.fta.geoviite.infra.dataImport
 
 import fi.fta.geoviite.infra.ITTestBase
 import fi.fta.geoviite.infra.common.*
-import fi.fta.geoviite.infra.geography.transformCoordinate
+import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
 import fi.fta.geoviite.infra.switchLibrary.SwitchBaseType.YV
@@ -50,7 +50,7 @@ class CsvImportIT @Autowired constructor(
         assertEquals(IN_USE, trackLayoutKmPosts[0].state)
         assertEquals(trackIdMap[Oid("1.2.246.578.3.10001.188907")], trackLayoutKmPosts[0].trackNumberId)
         assertApproximatelyEquals(
-            transformCoordinate(RATKO_SRID, LAYOUT_SRID, Point(24.835685172734934, 60.218980868897404)),
+            transformNonKKJCoordinate(RATKO_SRID, LAYOUT_SRID, Point(24.835685172734934, 60.218980868897404)),
             trackLayoutKmPosts[0].location!!,
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/dataImport/CsvParsingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/dataImport/CsvParsingTest.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.dataImport
 
 import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.geometry.DummyTriangulationNetwork
 import fi.fta.geoviite.infra.geometry.line
 import fi.fta.geoviite.infra.getSomeOid
 import fi.fta.geoviite.infra.math.IPoint
@@ -208,7 +209,7 @@ class CsvParsingTest {
             listOf(sl1),
             listOf(md1),
             points,
-            listOf(),
+            DummyTriangulationNetwork,
         )
         val expected = listOf(
             SegmentCsvMetaDataRange(TrackMeter("0001+000.5")..TrackMeter("0001+002.0"), expandedMd1, sl1),
@@ -355,7 +356,7 @@ class CsvParsingTest {
             listOf(sl1, sl2),
             listOf(md1),
             points,
-            listOf(),
+            DummyTriangulationNetwork,
         )
         val expected = listOf(
             SegmentCsvMetaDataRange(TrackMeter("0001+000.5")..TrackMeter("0001+002.0"), expandedMd1, sl1),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TransformationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TransformationTest.kt
@@ -1,15 +1,37 @@
 package fi.fta.geoviite.infra.geometry
 
 import fi.fta.geoviite.infra.common.RotationDirection.CCW
+import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
+import fi.fta.geoviite.infra.dataImport.RATKO_SRID
 import fi.fta.geoviite.infra.geography.HeightTriangle
+import fi.fta.geoviite.infra.geography.KKJtoETRSTriangle
+import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.geography.transformHeightValue
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Point3DM
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.lengthPoints
 import fi.fta.geoviite.infra.tracklayout.toPointList
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalArgumentException
 import kotlin.test.assertEquals
+
+val DummyTriangulationNetwork = listOf(
+    KKJtoETRSTriangle(
+        Point(0.0, 0.0),
+        Point(1.0, 1.0),
+        Point(0.0, 1.0),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    )
+)
 
 class TransformationTest {
 
@@ -61,6 +83,34 @@ class TransformationTest {
             ),
             toPointList(curve, 1),
         )
+    }
+
+    @Test
+    fun `Creating KKJ to TM35 transformation with empty triangulation network throws`() {
+        assertThrows<IllegalArgumentException> {
+            Transformation.possiblyKKJToETRSTransform(Srid(2392) /* KKJ2 */, LAYOUT_SRID, emptyList())
+        }
+    }
+
+    @Test
+    fun `Creating KKJ to TM35 transformation using non-KKJ transform throws`() {
+        assertThrows<IllegalArgumentException> {
+            Transformation.nonKKJToETRSTransform(Srid(2392) /* KKJ2 */, LAYOUT_SRID)
+        }
+    }
+
+    @Test
+    fun `Creating LAYOUT_SRID to RATKO_SRID transformation works without triangulation network`() {
+        assertDoesNotThrow {
+            Transformation.nonKKJToETRSTransform(LAYOUT_SRID, RATKO_SRID)
+        }
+    }
+
+    @Test
+    fun `Creating KKJ to TM35 transform works with triangulation network`() {
+        assertDoesNotThrow {
+            Transformation.possiblyKKJToETRSTransform(LAYOUT_SRID, RATKO_SRID, DummyTriangulationNetwork)
+        }
     }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingTest.kt
@@ -3,7 +3,7 @@ package fi.fta.geoviite.infra.linking
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.Srid
-import fi.fta.geoviite.infra.geography.transformCoordinate
+import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Point3DZ
 import fi.fta.geoviite.infra.tracklayout.*
@@ -629,7 +629,7 @@ fun createGeometrySegments(): List<LayoutSegment> {
         segment10, segment11, segment12, segment13, segment14, segment15, segment16).map { segment ->
         //temporary solution
         val newPoints = segment.points.map { p ->
-            val transformedPoint = transformCoordinate(Srid(3857), LAYOUT_SRID, Point(p.x, p.y))
+            val transformedPoint = transformNonKKJCoordinate(Srid(3857), LAYOUT_SRID, Point(p.x, p.y))
             LayoutPoint(transformedPoint.x, transformedPoint.y, p.z, p.m, p.cant)
         }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.linking
 
 import fi.fta.geoviite.infra.ITTestBase
 import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.geography.KKJtoETRSTriangulationDao
 import fi.fta.geoviite.infra.geometry.*
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
@@ -30,6 +31,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
     private val locationTrackService: LocationTrackService,
     private val geometryDao: GeometryDao,
     private val switchStructureDao: SwitchStructureDao,
+    private val kkJtoETRSTriangulationDao: KKJtoETRSTriangulationDao
     ) : ITTestBase() {
 
     lateinit var switchStructure: SwitchStructure
@@ -267,7 +269,10 @@ class SwitchLinkingServiceIT @Autowired constructor(
 
         val trackNumberIds =
             (plan1.alignments + plan2.alignments).map { a ->
-                val (locationTrack, alignment) = locationTrackAndAlignmentForGeometryAlignment(trackNumberId, a)
+                val (locationTrack, alignment) = locationTrackAndAlignmentForGeometryAlignment(
+                    trackNumberId,
+                    a,
+                    kkJtoETRSTriangulationDao.fetchTriangulationNetwork())
                 locationTrackService.saveDraft(locationTrack, alignment)
             }
         val mainLocationTrackId = trackNumberIds[0].id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/GeographyTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/GeographyTest.kt
@@ -3,8 +3,7 @@ package fi.fta.geoviite.infra.math
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.geography.boundingPolygonPointsByConvexHull
 import fi.fta.geoviite.infra.geography.calculateDistance
-import fi.fta.geoviite.infra.geography.transformBoundingBox
-import fi.fta.geoviite.infra.geography.transformCoordinate
+import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -42,7 +41,7 @@ class GeographyTest {
         val point3067 = Point(410380.415197, 6695143.038955)
         val point3857 = Point(2824659.40, 8485448.86)
 
-        val transformed3857 = transformCoordinate(Srid(3067), Srid(3857), point3067)
+        val transformed3857 = transformNonKKJCoordinate(Srid(3067), Srid(3857), point3067)
         assertApproximatelyEquals(point3857, transformed3857, 0.01)
     }
 
@@ -51,7 +50,7 @@ class GeographyTest {
         val point2392 = Point(2545821.01, 6679696.72)
         val point3857 = Point(2763351.44, 8450266.36)
 
-        val transformed3857 = transformCoordinate(Srid(2392), Srid(3857), point2392)
+        val transformed3857 = transformNonKKJCoordinate(Srid(2392), Srid(3857), point2392)
         assertApproximatelyEquals(point3857, transformed3857, 0.01)
     }
 
@@ -60,7 +59,7 @@ class GeographyTest {
         val point2392 = Point(2493105.32, 7472870.07)
         val point3857 = Point(2653350.403813375, 10254765.780128963)
 
-        val transformed3857 = transformCoordinate(Srid(2392), Srid(3857), point2392)
+        val transformed3857 = transformNonKKJCoordinate(Srid(2392), Srid(3857), point2392)
         assertApproximatelyEquals(point3857, transformed3857, 0.01)
     }
 
@@ -69,7 +68,7 @@ class GeographyTest {
         val point3857 = Point(2763351.44, 8450266.36)
         val point2392 = Point(2545821.01, 6679696.72)
 
-        val transformed2392 = transformCoordinate(Srid(3857), Srid(2392), point3857)
+        val transformed2392 = transformNonKKJCoordinate(Srid(3857), Srid(2392), point3857)
         assertApproximatelyEquals(point2392, transformed2392, 0.01)
     }
 
@@ -78,7 +77,7 @@ class GeographyTest {
         val point3857 = Point(2778638.852223, 8546271.258509)
         val point3879 = Point(25497863.32, 6726678.57)
 
-        val transformed3879 = transformCoordinate(Srid(3857), Srid(3879), point3857)
+        val transformed3879 = transformNonKKJCoordinate(Srid(3857), Srid(3879), point3857)
         assertApproximatelyEquals(point3879, transformed3879, 0.01)
     }
 
@@ -87,26 +86,8 @@ class GeographyTest {
         val point3857 = Point(2778638.852223, 8546271.258509)
         val point3879 = Point(25497863.32, 6726678.57)
 
-        val transformed3857 = transformCoordinate(Srid(3879), Srid(3857), point3879)
+        val transformed3857 = transformNonKKJCoordinate(Srid(3879), Srid(3857), point3879)
         assertApproximatelyEquals(point3857, transformed3857, 0.01)
-    }
-
-    @Test
-    fun boundingBoxTranformEpsg3879To3067Works() {
-        val bbox3879 = BoundingBox(25492893.85..25496016.7, 6669815.35..6672923.65)
-        val bbox3067 = BoundingBox(381830.86..385045.68, 6669043.92..6672055.54)
-
-        val transformed3857 = transformBoundingBox(Srid(3879), Srid(3067), bbox3879)!!
-        assertBoundingBoxApproximatelyEquals(bbox3067, transformed3857, 0.2)
-    }
-
-    @Test
-    fun boundingBoxTranformEpsg3067To3879Works() {
-        val bbox3067 = BoundingBox(381830.89..385045.70, 6669043.93..6672055.53)
-        val bbox3879 = BoundingBox(25492893.88..25496016.77, 6669815.36..6672923.64)
-
-        val transformed3879 = transformBoundingBox(Srid(3067), Srid(3879), bbox3067)!!
-        assertBoundingBoxApproximatelyEquals(bbox3879, transformed3879, 0.2)
     }
 
     @Test
@@ -138,15 +119,10 @@ class GeographyTest {
     @Test
     fun pointConversion3067to4326AndBackIsAccurateEnough() {
         val p3067 = Point(509099.11577, 6711823.23316)
-        val p4326 = transformCoordinate(Srid(3067), Srid(4326), p3067)
-        val p3067v2 = transformCoordinate(Srid(4326), Srid(3067), p4326)
+        val p4326 = transformNonKKJCoordinate(Srid(3067), Srid(4326), p3067)
+        val p3067v2 = transformNonKKJCoordinate(Srid(4326), Srid(3067), p4326)
         assertApproximatelyEquals(Point(x=27.165853988, y=60.542330292), p4326, 0.000000001)
         assertApproximatelyEquals(p3067, p3067v2, 0.01)
     }
 
-}
-
-fun assertBoundingBoxApproximatelyEquals(bbox1: BoundingBox, bbox2: BoundingBox, accuracy: Double) {
-    assertApproximatelyEquals(bbox1.min, bbox2.min, accuracy)
-    assertApproximatelyEquals(bbox1.max, bbox2.max, accuracy)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.ui.testdata
 
 import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.geography.KKJtoETRSTriangle
 import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.geometry.*
@@ -186,9 +187,10 @@ fun pointsFromIncrementList(basePoint: Point, incrementPoints: List<Point>) =
 fun locationTrackAndAlignmentForGeometryAlignment(
     trackNumberId: IntId<TrackLayoutTrackNumber>,
     geometryAlignment: GeometryAlignment,
-    planSrid: Srid = LAYOUT_SRID
+    triangulationNetwork: List<KKJtoETRSTriangle>,
+    planSrid: Srid = LAYOUT_SRID,
 ): Pair<LocationTrack, LayoutAlignment> {
-    val transformation = Transformation(planSrid, LAYOUT_SRID)
+    val transformation = Transformation.possiblyKKJToETRSTransform(planSrid, LAYOUT_SRID, triangulationNetwork)
     return locationTrackAndAlignment(
         trackNumberId,
         geometryAlignment.elements.map { element ->


### PR DESCRIPTION
Täällä toteutettu parempi erottelu Transformation-luokkaan kolmiointiverkon vaativien KKJx->ETRS-TM35FIN -muunnosten ja muiden välille. Nyt Transformation-olioiden luonnille on selkeästi eriytetyt funktiot, ja väärän käyttäminen heittää poikkeuksen. Samalla lisätty kolmioverkon välittämistä kohtiin, jossa on aiemmin ollut mahdollista tehdä transformeja KKJ-koordinaatistoista TM35:een ilman kolmioverkkoa.