### PR TITLE
GVT-1600 Fix validation for switches with topology links

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
@@ -323,12 +323,12 @@ class PublicationService @Autowired constructor(
         val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
         val linkedTracksAndAlignments = getLinkedTracksAndAlignments(version.officialId, publicationVersions)
         val fieldErrors = validateDraftSwitchFields(switch)
-        val referenceErrors = validateSwitchSegmentReferences(
+        val referenceErrors = validateSwitchLocationTrackLinkReferences(
             switch,
             linkedTracksAndAlignments.map(Pair<LocationTrack,*>::first),
             publicationVersions.locationTracks.map { it.officialId },
         )
-        val structureErrors = validateSwitchSegmentStructure(switch, structure, linkedTracksAndAlignments)
+        val structureErrors = validateSwitchLocationTrackLinkStructure(switch, structure, linkedTracksAndAlignments)
         return fieldErrors + referenceErrors + structureErrors
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
@@ -587,10 +587,12 @@ private fun collectTopologyEndLinks(
         track to listOfNotNull(
             track.topologyStartSwitch?.let { topologySwitch ->
                 if (topologySwitch.switchId == switch.id)
-                    alignment.start?.let { p -> TopologyEndLink(topologySwitch, p) } else null
+                    alignment.start?.let { p -> TopologyEndLink(topologySwitch, p) }
+                else null
             }, track.topologyEndSwitch?.let { topologySwitch ->
                 if (topologySwitch.switchId == switch.id)
-                    alignment.end?.let { p -> TopologyEndLink(topologySwitch, p) } else null
+                    alignment.end?.let { p -> TopologyEndLink(topologySwitch, p) }
+                else null
             }
         )
     }.filter { (_, ends) -> ends.isNotEmpty() }


### PR DESCRIPTION
Lisäsin puhtaasti yhdenmukaisuusmielessä samassa syssyssä validaation, että vaihdepisteen sijaintia verrataan topologialinkillisen raiteen päätepisteen sijaintiin, ja tämä ei sinällään mitään riko, koska validaatio on varoitustasoinen; mutta en ole varma, onko oikeasti oikein validoida näin.