### PR TITLE
GVT-1635: Uuden kilometripylvään nimeäminen väärin aiheuttaa bäkkärivirheitä

### DIFF
--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -13,6 +13,7 @@ import {
     actions,
     canSaveKmPost,
     initialKmPostEditState,
+    kmNumberMatchesRegExp,
     reducer,
 } from 'tool-panel/km-post/dialog/km-post-edit-store';
 import { KmPostSaveRequest } from 'linking/linking-model';
@@ -109,7 +110,8 @@ export const KmPostEditDialog: React.FC<KmPostDialogProps> = (props: KmPostDialo
             state.kmPost?.trackNumberId &&
             !isNullOrBlank(state.kmPost.kmNumber) &&
             (state.kmPost.kmNumber != state.baselineKmNumber ||
-                state.kmPost.trackNumberId != state.baselineTrackNumberId)
+                state.kmPost.trackNumberId != state.baselineTrackNumberId) &&
+            kmNumberMatchesRegExp(state.kmPost.kmNumber)
         ) {
             getKmPostByNumber('DRAFT', state.kmPost.trackNumberId, state.kmPost.kmNumber).then(
                 (found) => {

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
@@ -75,21 +75,12 @@ function validateLinkingKmPost(kmPost: KmPostSaveRequest): ValidationError<KmPos
     ];
 
     if (kmPost.kmNumber.length > 0) {
-        if (!kmNumberMatchesRegExp(kmPost)) {
+        if (!kmNumberMatchesRegExp(kmPost.kmNumber)) {
             return [...errors, ...getKmNumberDoesntMatchRegExpError()];
         }
     }
 
     return errors;
-}
-
-function kmNumberMatchesRegExp(kmPost: KmPostSaveRequest): boolean {
-    if (kmPost.kmNumber.length <= 4) {
-        return /^\d{4}$/.test(kmPost.kmNumber);
-    } else if (kmPost.kmNumber.length <= 6) {
-        return /^\d{4}[A-Z]{1,2}$/.test(kmPost.kmNumber);
-    }
-    return false;
 }
 
 function getKmNumberDoesntMatchRegExpError(): ValidationError<KmPostSaveRequest>[] {
@@ -208,6 +199,15 @@ const kmPostEditSlice = createSlice({
 
 export function canSaveKmPost(state: KmPostEditState): boolean {
     return !!(state.kmPost && !state.validationErrors.length && !state.isSaving);
+}
+
+export function kmNumberMatchesRegExp(kmNumber: string): boolean {
+    if (kmNumber.length <= 4) {
+        return /^\d{4}$/.test(kmNumber);
+    } else if (kmNumber.length <= 6) {
+        return /^\d{4}[A-Z]{1,2}$/.test(kmNumber);
+    }
+    return false;
 }
 
 export const reducer = kmPostEditSlice.reducer;


### PR DESCRIPTION
Tässä ongelmana ei ollutkaan varsinainen fronttipään validointi, vaan bäkkärikysely jolla kyseltiin onko ka. numerolla olemassa jo kilometripistettä. Tämä vaikutti fiksuimmalta korjata frontin päässä. Lisäsin ka. kyselyyn tarkastuksen, että kysellään kilometripisteen olemassaolevuutta vain jos kyseessä ylipäätään on järkevä kmnumber-arvo.