### PR TITLE
GVT-1643: Stagetetun muutoksen hylkääminen siirtää muutoksen hetkeksi ylempään muutostaulukkoon

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Publication.kt
@@ -83,7 +83,7 @@ enum class Operation {
 
 data class ValidatedPublishCandidates(
     val validatedAsPublicationUnit: PublishCandidates,
-    val validatedSeparately: PublishCandidates,
+    val allChangesValidated: PublishCandidates,
 )
 
 data class PublishCandidates(
@@ -93,19 +93,13 @@ data class PublishCandidates(
     val switches: List<SwitchPublishCandidate>,
     val kmPosts: List<KmPostPublishCandidate>,
 ) {
-    fun splitByRequest(versions: PublicationVersions) =
+    fun candidatesInRequest(versions: PublicationVersions) =
         PublishCandidates(
             trackNumbers.filter { candidate -> versions.containsTrackNumber(candidate.id) },
             locationTracks.filter { candidate -> versions.containsLocationTrack(candidate.id) },
             referenceLines.filter { candidate -> versions.containsReferenceLine(candidate.id) },
             switches.filter { candidate -> versions.containsSwitch(candidate.id) },
             kmPosts.filter { candidate -> versions.containsKmPost(candidate.id) },
-        ) to PublishCandidates(
-            trackNumbers.filterNot { candidate -> versions.containsTrackNumber(candidate.id) },
-            locationTracks.filterNot { candidate -> versions.containsLocationTrack(candidate.id) },
-            referenceLines.filterNot { candidate -> versions.containsReferenceLine(candidate.id) },
-            switches.filterNot { candidate -> versions.containsSwitch(candidate.id) },
-            kmPosts.filterNot { candidate -> versions.containsKmPost(candidate.id) },
         )
 
     fun ids(): PublishRequest = PublishRequest(
@@ -140,9 +134,6 @@ data class PublicationVersions(
 
     fun findTrackNumber(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.find { it.officialId == id }
     fun findLocationTrack(id: IntId<LocationTrack>) = locationTracks.find { it.officialId == id }
-    fun findReferenceLine(id: IntId<ReferenceLine>) = referenceLines.find { it.officialId == id }
-    fun findSwitch(id: IntId<TrackLayoutSwitch>) = switches.find { it.officialId == id }
-    fun findKmPost(id: IntId<TrackLayoutKmPost>) = kmPosts.find { it.officialId == id }
 }
 
 data class PublicationVersion<T>(val officialId: IntId<T>, val draftVersion: RowVersion<T>)

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -79,7 +79,7 @@ export type PublishCandidates = {
 
 export type ValidatedPublishCandidates = {
     validatedAsPublicationUnit: PublishCandidates;
-    validatedSeparately: PublishCandidates;
+    allChangesValidated: PublishCandidates;
 };
 
 export type PublicationDetails = {


### PR DESCRIPTION
Täällä tarvi myös refaktoroida bäkkäripuolta jonkin verran. Nyt koko validaatiotulos (sekä koko setti että stagetetut) tulee yhdessä kutsussa. Lisäksi fronttiin tehty hyvin ikävä redraw-kontrollihärpäke. Näiden yhteispelillä sai bugin korjattua, mutta tarvitsee molempia.