### PR TITLE
GVT-1519: Update react-select to 5.7.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,7 +27,7 @@
                 "react-i18next": "^11.18.6",
                 "react-redux": "^8.0.4",
                 "react-router-dom": "^6.4.2",
-                "react-select": "^5.6.1",
+                "react-select": "^5.7.0",
                 "react-toastify": "^9.0.8",
                 "redux": "^4.2.0",
                 "redux-persist": "^6.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -65,7 +65,7 @@
         "react-i18next": "^11.18.6",
         "react-redux": "^8.0.4",
         "react-router-dom": "^6.4.2",
-        "react-select": "^5.6.1",
+        "react-select": "^5.7.0",
         "react-toastify": "^9.0.8",
         "redux": "^4.2.0",
         "redux-persist": "^6.0.0",


### PR DESCRIPTION
Täällä oli tarkoituksena tutkia vieläkö uusin react-select käyttää inline-tyylejä. Uusia CSP:n kannalta kivempia tyylittelymahdollisuuksia on tullut uusimman version myötä, mutta react-select käyttää silti myös inline-stylejä, joten päädyin lopulta pelkästämään päivittämään komponentin sen kummemmin tyyleihin koskematta.