### PR TITLE
GVT-1581 Add indexes for remaining tables used in geocoding context key query

### DIFF
--- a/infra/src/main/resources/db/migration/repeatable/R__03.17.layout_reference_line_version_track_number_id_change_time_index.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.17.layout_reference_line_version_track_number_id_change_time_index.sql
@@ -1,0 +1,1 @@
+create index reference_line_version_track_number_id_change_time_ix on layout.reference_line_version (track_number_id, change_time desc);

--- a/infra/src/main/resources/db/migration/repeatable/R__03.18.layout_track_number_version_change_time_index.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.18.layout_track_number_version_change_time_index.sql
@@ -1,0 +1,1 @@
+create index track_number_track_number_id_change_time_ix on layout.track_number_version (id, change_time desc);


### PR DESCRIPTION
Yhtäältä nämä taulut on todella pieniä eivätkä tule kasvamaan nopeasti, mutta toisaalta getGeocodingContextCacheKey()tä kutsutaan kyllä melko paljon, eli kokonaisuutena lienee parempi, että nämä indeksit on systemaattisesti olemassa.