### PR TITLE
Improve InframodelIT tests

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.inframodel
 import assertPlansMatch
 import fi.fta.geoviite.infra.ITTestBase
 import fi.fta.geoviite.infra.geometry.GeometryDao
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -16,6 +17,11 @@ class InfraModelServiceIT @Autowired constructor(
     val infraModelService: InfraModelService,
     val geometryDao: GeometryDao,
 ): ITTestBase() {
+
+    @BeforeEach
+    fun clearPlanFiles() {
+        jdbc.execute("delete from geometry.plan_file") { it.execute() }
+    }
 
     @Test
     fun simpleFileIsWrittenAndReadCorrectly() {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
@@ -3,7 +3,6 @@ package fi.fta.geoviite.infra.inframodel
 import assertPlansMatch
 import fi.fta.geoviite.infra.ITTestBase
 import fi.fta.geoviite.infra.geometry.GeometryDao
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -15,7 +14,6 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest
 class InfraModelServiceIT @Autowired constructor(
     val infraModelService: InfraModelService,
-    val trackNumberService: LayoutTrackNumberService,
     val geometryDao: GeometryDao,
 ): ITTestBase() {
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
@@ -2,9 +2,12 @@ package fi.fta.geoviite.infra.inframodel
 
 import assertPlansMatch
 import fi.fta.geoviite.infra.ITTestBase
+import fi.fta.geoviite.infra.error.InframodelParsingException
 import fi.fta.geoviite.infra.geometry.GeometryDao
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
@@ -41,6 +44,17 @@ class InfraModelServiceIT @Autowired constructor(
         val planId = infraModelService.saveInfraModel(file, null, null)
 
         assertPlansMatch(parsedPlan, geometryDao.fetchPlan(planId))
+    }
+
+    @Test
+    fun duplicatePlanCausesParsingException() {
+        val file = getMockedMultipartFile(TESTFILE_CLOTHOID_AND_PARABOLA)
+
+        infraModelService.saveInfraModel(file, null, null)
+        val exception = assertThrows<InframodelParsingException> {
+            infraModelService.saveInfraModel(file, null, null)
+        }
+        assertTrue(exception.message?.contains("InfraModel file exists already") ?: false)
     }
 
     fun getMockedMultipartFile(fileLocation: String): MockMultipartFile = MockMultipartFile(


### PR DESCRIPTION
Pääjuttuna tuo clearPlanFiles jotta testit saa ajettua peräkkäin putsaamatta välissä koko tietokantaa, lisäsin samalla uuden testin kun sattui nuo duplikaattivirheet olemaan mielessä.