### PR TITLE
GVT-1469 Update SecurityConfiguration to not use deprecated features

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/SecurityConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/SecurityConfiguration.kt
@@ -3,37 +3,36 @@ package fi.fta.geoviite.infra.configuration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.config.http.SessionCreationPolicy.STATELESS
+import org.springframework.security.web.SecurityFilterChain
+
 
 @ConditionalOnWebApplication
 @EnableWebSecurity
 @Configuration
-class SecurityConfiguration : WebSecurityConfigurerAdapter(true) {
-
+class SecurityConfiguration {
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    override fun configure(auth: AuthenticationManagerBuilder) {
-        logger.info("Configuring authentication manager")
-        auth.inMemoryAuthentication() // No users
-    }
-
-    override fun configure(http: HttpSecurity) {
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
         logger.info("Configuring HTTP Security")
-        val httpConfig = http
+        return http
             .httpBasic().disable()
             // Disable CORS: Not sharing anything with other domains
             .cors().disable()
             // Disable CSRF: JWT is stored in ALB -> session not configured here
             .csrf().disable()
+            // Disable SecurityContextPersistenceFilter which by default would replace the security context set up in
+            // RequestFilter with an empty one
+            .securityContext().disable()
             // Set session management to stateless
             .sessionManagement().sessionCreationPolicy(STATELESS).and()
-
-        // Set permissions on endpoints
-        httpConfig.authorizeRequests().anyRequest().authenticated().and()
+            // Set permissions on endpoints
+            .authorizeHttpRequests().anyRequest().authenticated().and()
+            .build()
     }
 }


### PR DESCRIPTION
Pääjuoni tuo securityContext().disable(). Vanhalla tavalla konffatessa `springSecurityFilterChain`iin ei ilmesty `SecurityContextPersistenceFilter`iä oletuksena lainkaan, mutta uudella ilmestyy: Ja sekös asiat rikkoo, koska oletuksena se yrittää ladata persistoidun SecurityContextin, paitsi että oletuspersistointitapa on vain luoda uusi konteksti, ja sinne sitten katoaa meidän `RequestFilter`in luoma autentikointi.

Toinen vaihtoehto olisi ollut siirtää `RequestFilter` itse `springSecurityFilterChain`iin, kätevästi käsillä olevalla `HttpSecurity`n `addFilterAfter`-metodilla juuri tuon `SecurityContextPersistenceFilter`in jälkeen, jolloin se ei enää saisi kadotettua meidän autentikointia. Siinä vaan on oma rumuutensa, kun luokkaan olisi pitänyt viitata suoremmin, ja se pentele on vieläpä itsekin deprekoitu.