### PR TITLE
GVT-712: Pysty- ja vaakageometrioiden infoboksi silloin kun segmenttiä ei ole valittu

### DIFF
--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-infobox.tsx
@@ -25,6 +25,7 @@ import { OnSelectOptions } from 'selection/selection-model';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
 import { BoundingBox } from 'model/geometry';
+import InfoboxText from 'tool-panel/infobox/infobox-text';
 
 type GeometryAlignmentInfoboxProps = {
     onSelect: (options: OnSelectOptions) => void;
@@ -115,9 +116,20 @@ const GeometryAlignmentInfobox: React.FC<GeometryAlignmentInfoboxProps> = ({
             )}
 
             {planHeader && <GeometryPlanInfobox planHeader={planHeader} />}
-            {segment && planHeader && (
-                <GeometrySegmentInfobox chosenSegment={segment} planHeader={planHeader} />
-            )}
+            {planHeader &&
+                (segment ? (
+                    <GeometrySegmentInfobox chosenSegment={segment} planHeader={planHeader} />
+                ) : (
+                    <Infobox title={t('tool-panel.alignment.geometry-segment.title')}>
+                        <InfoboxContent>
+                            <InfoboxText
+                                value={t(
+                                    'tool-panel.alignment.geometry-segment.no-segment-selected',
+                                )}
+                            />
+                        </InfoboxContent>
+                    </Infobox>
+                ))}
         </React.Fragment>
     );
 };

--- a/ui/src/tool-panel/geometry-plan-infobox.tsx
+++ b/ui/src/tool-panel/geometry-plan-infobox.tsx
@@ -14,7 +14,6 @@ import { differenceInYears } from 'date-fns';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { useAppNavigate } from 'common/navigate';
-import { Link } from 'vayla-design-lib/link/link';
 import { INFRAMODEL_URI } from 'infra-model/infra-model-api';
 import { Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { getCoordinateSystem } from 'common/common-api';
@@ -162,14 +161,16 @@ const GeometryPlanInfobox: React.FC<GeometryPlanInfoboxProps> = ({
                         {t('tool-panel.geometry-plan.open-inframodel')}
                     </Button>
                     {planHeader.source !== 'PAIKANNUSPALVELU' && (
-                        <Link
+                        <Button
+                            size={ButtonSize.SMALL}
+                            variant={ButtonVariant.SECONDARY}
                             className={styles['geometry-plan-tool-panel__download-link']}
-                            href={`${INFRAMODEL_URI}/${planHeader.id}/file`}>
-                            <Button size={ButtonSize.SMALL} variant={ButtonVariant.SECONDARY}>
-                                <Icons.Download size={IconSize.SMALL} />{' '}
-                                {t('tool-panel.geometry-plan.download-file')}
-                            </Button>
-                        </Link>
+                            onClick={() =>
+                                (location.href = `${INFRAMODEL_URI}/${planHeader.id}/file`)
+                            }>
+                            <Icons.Download size={IconSize.SMALL} />{' '}
+                            {t('tool-panel.geometry-plan.download-file')}
+                        </Button>
                     )}
                 </InfoboxButtons>
             </InfoboxContent>

--- a/ui/src/tool-panel/translations.fi.json
+++ b/ui/src/tool-panel/translations.fi.json
@@ -9,7 +9,6 @@
             "file": "Tiedosto",
             "created": "Luotu",
             "source": "Lähde",
-            "measurement-method": "Laatu",
             "phase": "Vaihe",
             "decision": "Vaiheen tarkennus",
             "track-number": "Ratanumero",
@@ -171,6 +170,7 @@
             "geometry-segment": {
                 "title": "Vaaka- ja pystygeometriat",
                 "no-geometry-information": "Ei geometriatietoja valitulle segmentille.",
+                "no-segment-selected": "Valitse segmentti kartalta nähdäksesi sen geometriatiedot.",
                 "horizontal": "Vaakageometriat",
                 "vertical": "Pystygeometriat",
                 "chosen-segment": "Valittu kohta",


### PR DESCRIPTION
Näissä tilanteissa infoboksia ei näkynyt ollenkaan, joten operaattorin piti Tietää^TM, että segmentin valittua siitä näkyy tarkemmat myös pysty- ja vaakageometriaelementtitiedot. Tässä toteutettu infoboksin tynkä, jossa operaattorille ilmoitetaan asiasta.