### PR TITLE
GVT-1671 Remove switch existence assumption

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -264,7 +264,7 @@ class CalculatedChangesService(
                 locationTrack = newLocationTrack,
                 alignment = newAlignment,
                 geocodingContext = context,
-                fetchSwitch = changeContext.switches::getAfter,
+                fetchSwitch = changeContext.switches::getAfterIfExists,
                 fetchStructure = switchLibraryService::getSwitchStructure,
             )
         } ?: emptyList()


### PR DESCRIPTION
The called code was already prepared for nulls, and if the switch is in fact new and not selected to be published, it indeed doesn't exist.