### PR TITLE
GVT-1669: Raidetiedon selkeytys elementtiluettelossa + muita refaktorointeja

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
@@ -1,9 +1,8 @@
 package fi.fta.geoviite.infra.geometry
 
 val ELEMENT_LISTING = "Elementtilistaus"
-val ELEMENT_LISTING_CSV_HEADERS = listOf(
-    "Ratanumero",
-    "Raide",
+private val ELEMENT_LISTING_COMMON_CSV_HEADERS = listOf(
+    "Suunnitelman raide",
     "Elementin tyyppi",
     "Rataosoite alussa",
     "Rataosoite lopussa",
@@ -22,6 +21,14 @@ val ELEMENT_LISTING_CSV_HEADERS = listOf(
     "Lähde",
     "Koordinaatisto"
 )
+
+val CONTINUOUS_ELEMENT_LISTING_CSV_HEADERS = listOf(
+    "Ratanumero",
+    "Sijaintiraide"
+) + ELEMENT_LISTING_COMMON_CSV_HEADERS
+
+val PLAN_ELEMENT_LISTING_CSV_HEADERS = listOf("Ratanumero") + ELEMENT_LISTING_COMMON_CSV_HEADERS
+
 
 fun translateTrackGeometryElementType(type: TrackGeometryElementType) =
     when (type) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
@@ -12,6 +12,8 @@ import fi.fta.geoviite.infra.math.radsToGrads
 import fi.fta.geoviite.infra.math.round
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.FileName
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVPrinter
 import java.math.BigDecimal
 
 const val COORDINATE_DECIMALS = 3
@@ -32,6 +34,8 @@ data class ElementListing(
 
     val alignmentId: DomainId<GeometryAlignment>?,
     val alignmentName: AlignmentName?,
+
+    val locationTrackName: AlignmentName?,
 
     val elementId: DomainId<GeometryElement>?,
     val elementType: TrackGeometryElementType,
@@ -82,7 +86,7 @@ fun toElementListing(
     val headersAndAlignments = linkedAlignmentIds.associateWith { id -> getPlanHeaderAndAlignment(id) }
     return linkedElementIds.mapNotNull { (segment, elementId) ->
         if (elementId == null) {
-            if (elementTypes.contains(MISSING_SECTION)) toMissingElementListing(context, track.trackNumberId, segment)
+            if (elementTypes.contains(MISSING_SECTION)) toMissingElementListing(context, track.trackNumberId, segment, track)
             else null
         }
         else {
@@ -115,6 +119,7 @@ private fun toMissingElementListing(
     context: GeocodingContext?,
     trackNumberId: IntId<TrackLayoutTrackNumber>,
     segment: LayoutSegment,
+    locationTrack: LocationTrack
 ) = ElementListing(
     planId = null,
     planSource = null,
@@ -130,6 +135,7 @@ private fun toMissingElementListing(
     lengthMeters = round(segment.length, LENGTH_DECIMALS),
     start = getLocation(context, segment.points.first(), segment.startDirection()),
     end = getLocation(context, segment.points.last(), segment.endDirection()),
+    locationTrackName = locationTrack.name
 )
 
 private fun toElementListing(
@@ -150,6 +156,7 @@ private fun toElementListing(
     trackNumberDescription = null,
     alignment = alignment,
     element = element,
+    locationTrack = locationTrack
 )
 
 private fun toElementListing(
@@ -169,7 +176,88 @@ private fun toElementListing(
     trackNumberDescription = plan.trackNumberDescription,
     alignment = alignment,
     element = element,
+    locationTrack = null,
 )
+
+fun planElementListingToCsv(
+    trackNumbers: List<TrackLayoutTrackNumber>,
+    elementListing: List<ElementListing>,
+): ByteArray {
+    val csvBuilder = StringBuilder()
+    CSVPrinter(csvBuilder, CSVFormat.RFC4180).let { csvPrinter ->
+        try {
+            csvPrinter.printRecord(PLAN_ELEMENT_LISTING_CSV_HEADERS)
+
+            elementListing.forEach {
+                csvPrinter.printRecord(
+                    it.trackNumberId.let { locationTrackTrackNumber -> trackNumbers.find { tn -> tn.id == locationTrackTrackNumber }?.number },
+                    it.alignmentName,
+                    it.elementType.let(::translateTrackGeometryElementType),
+                    it.start.address?.let { address -> formatTrackMeter(address.kmNumber, address.meters) },
+                    it.end.address?.let { address -> formatTrackMeter(address.kmNumber, address.meters) },
+                    it.start.coordinate.x,
+                    it.start.coordinate.y,
+                    it.end.coordinate.x,
+                    it.end.coordinate.y,
+                    it.lengthMeters,
+                    it.start.radiusMeters,
+                    it.end.radiusMeters,
+                    it.start.cant,
+                    it.end.cant,
+                    it.start.directionGrads,
+                    it.end.directionGrads,
+                    it.fileName,
+                    it.planSource,
+                    it.coordinateSystemSrid ?: it.coordinateSystemName
+                )
+
+            }
+        } finally {
+            csvPrinter.close()
+        }
+    }
+    return csvBuilder.toString().toByteArray()
+}
+
+fun locationTrackElementListingToCsv(
+    trackNumbers: List<TrackLayoutTrackNumber>,
+    elementListing: List<ElementListing>,
+): ByteArray {
+    val csvBuilder = StringBuilder()
+    CSVPrinter(csvBuilder, CSVFormat.RFC4180).let { csvPrinter ->
+        try {
+            csvPrinter.printRecord(CONTINUOUS_ELEMENT_LISTING_CSV_HEADERS)
+
+            elementListing.forEach {
+                csvPrinter.printRecord(
+                    it.trackNumberId.let { locationTrackTrackNumber -> trackNumbers.find { tn -> tn.id == locationTrackTrackNumber }?.number },
+                    it.locationTrackName,
+                    it.alignmentName,
+                    it.elementType.let(::translateTrackGeometryElementType),
+                    it.start.address?.let { address -> formatTrackMeter(address.kmNumber, address.meters) },
+                    it.end.address?.let { address -> formatTrackMeter(address.kmNumber, address.meters) },
+                    it.start.coordinate.x,
+                    it.start.coordinate.y,
+                    it.end.coordinate.x,
+                    it.end.coordinate.y,
+                    it.lengthMeters,
+                    it.start.radiusMeters,
+                    it.end.radiusMeters,
+                    it.start.cant,
+                    it.end.cant,
+                    it.start.directionGrads,
+                    it.end.directionGrads,
+                    it.fileName,
+                    it.planSource,
+                    it.coordinateSystemSrid ?: it.coordinateSystemName
+                )
+            }
+        } finally {
+            csvPrinter.close()
+        }
+    }
+    return csvBuilder.toString().toByteArray()
+}
 
 private fun elementListing(
     context: GeocodingContext?,
@@ -181,6 +269,7 @@ private fun elementListing(
     trackNumberId: IntId<TrackLayoutTrackNumber>?,
     trackNumberDescription: PlanElementName?,
     alignment: GeometryAlignment,
+    locationTrack: LocationTrack?,
     element: GeometryElement,
 ) = units.coordinateSystemSrid?.let(getTransformation).let { transformation ->
     ElementListing(
@@ -193,6 +282,7 @@ private fun elementListing(
         trackNumberDescription = trackNumberDescription,
         alignmentId = alignment.id,
         alignmentName = alignment.name,
+        locationTrackName = locationTrack?.name,
         elementId = element.id,
         elementType = TrackGeometryElementType.of(element.type),
         lengthMeters = round(element.calculatedLength, LENGTH_DECIMALS),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -17,9 +17,6 @@ import fi.fta.geoviite.infra.util.SortOrder.ASCENDING
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.ContentDisposition
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
@@ -161,13 +158,7 @@ class GeometryController @Autowired constructor(private val geometryService: Geo
     ): ResponseEntity<ByteArray> {
         log.apiCall("getPlanElementList", "id" to id, "elementTypes" to elementTypes)
         val (filename, content) = geometryService.getElementListingCsv(id, elementTypes)
-
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_OCTET_STREAM
-        headers.set(
-            HttpHeaders.CONTENT_DISPOSITION,
-            ContentDisposition.attachment().filename("${filename}.csv").build().toString())
-        return ResponseEntity.ok().headers(headers).body(content)
+        return toFileDownloadResponse("${filename}.csv", content)
     }
 
     @PreAuthorize(AUTH_ALL_READ)
@@ -197,12 +188,6 @@ class GeometryController @Autowired constructor(private val geometryService: Geo
             "endAddress" to endAddress)
         val (filename, content) = geometryService
             .getElementListingCsv(id, elementTypes, startAddress, endAddress)
-
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_OCTET_STREAM
-        headers.set(
-            HttpHeaders.CONTENT_DISPOSITION,
-            ContentDisposition.attachment().filename("${filename}.csv").build().toString())
-        return ResponseEntity.ok().headers(headers).body(content)
+        return toFileDownloadResponse("${filename}.csv", content)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -16,8 +16,6 @@ import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.LocalizationKey
 import fi.fta.geoviite.infra.util.SortOrder
-import org.apache.commons.csv.CSVFormat
-import org.apache.commons.csv.CSVPrinter
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -222,16 +220,13 @@ class GeometryService @Autowired constructor(
         return toElementListing(context, coordinateTransformationService::getLayoutTransformation, plan, elementTypes)
     }
 
-    fun getElementListingCsv(planId: IntId<GeometryPlan>, elementTypes: List<GeometryElementType>): Pair<String, ByteArray> {
+    fun getElementListingCsv(planId: IntId<GeometryPlan>, elementTypes: List<GeometryElementType>): Pair<FileName, ByteArray> {
         logger.serviceCall("getElementListing", "planId" to planId, "elementTypes" to elementTypes)
-        val plan = geometryDao.fetchPlan(geometryDao.fetchPlanVersion(planId))
-        val context = plan.trackNumberId?.let { tnId ->
-            geocodingService.getGeocodingContext(OFFICIAL, tnId)
-        }
-        val elementListing = toElementListing(context, coordinateTransformationService::getLayoutTransformation, plan, elementTypes)
+        val plan = getPlanHeader(planId)
+        val elementListing = getElementListing(planId, elementTypes)
 
-        val csvFileContent = elementListingToCsv(elementListing)
-        return "${ELEMENT_LISTING} ${plan.fileName}" to csvFileContent
+        val csvFileContent = planElementListingToCsv(trackNumberService.list(OFFICIAL), elementListing)
+        return FileName("${ELEMENT_LISTING} ${plan.fileName}") to csvFileContent
     }
 
     fun getElementListing(
@@ -262,65 +257,15 @@ class GeometryService @Autowired constructor(
         elementTypes: List<TrackGeometryElementType>,
         startAddress: TrackMeter?,
         endAddress: TrackMeter?,
-    ): Pair<String, ByteArray> {
+    ): Pair<FileName, ByteArray> {
         logger.serviceCall("getElementListing",
             "trackId" to trackId, "elementTypes" to elementTypes,
             "startAddress" to startAddress, "endAdress" to endAddress,
         )
-        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(OFFICIAL, trackId)
-        val elementListing = toElementListing(
-            geocodingService.getGeocodingContext(OFFICIAL, track.trackNumberId),
-            coordinateTransformationService::getLayoutTransformation,
-            track,
-            alignment,
-            elementTypes,
-            startAddress,
-            endAddress,
-            ::getHeaderAndAlignment,
-        )
-
-        val csvFileContent = elementListingToCsv(elementListing)
-        return "${ELEMENT_LISTING} ${track.name}" to csvFileContent
-    }
-
-    private fun elementListingToCsv(
-        elementListing: List<ElementListing>,
-    ): ByteArray {
-        val trackNumbers = trackNumberService.list(OFFICIAL)
-
-        val csvBuilder = StringBuilder()
-        CSVPrinter(csvBuilder, CSVFormat.RFC4180).let { csvPrinter ->
-            try {
-                csvPrinter.printRecord(ELEMENT_LISTING_CSV_HEADERS)
-
-                elementListing.forEach {
-                    csvPrinter.printRecord(
-                        it.trackNumberId.let { locationTrackTrackNumber -> trackNumbers.find { tn -> tn.id == locationTrackTrackNumber }?.number },
-                        it.alignmentName,
-                        it.elementType.let(::translateTrackGeometryElementType),
-                        it.start.address?.let { address -> formatTrackMeter(address.kmNumber, address.meters) },
-                        it.end.address?.let { address -> formatTrackMeter(address.kmNumber, address.meters) },
-                        it.start.coordinate.x,
-                        it.start.coordinate.y,
-                        it.end.coordinate.x,
-                        it.end.coordinate.y,
-                        it.lengthMeters,
-                        it.start.radiusMeters,
-                        it.end.radiusMeters,
-                        it.start.cant,
-                        it.end.cant,
-                        it.start.directionGrads,
-                        it.end.directionGrads,
-                        it.fileName,
-                        it.planSource,
-                        it.coordinateSystemSrid ?: it.coordinateSystemName
-                    )
-                }
-            } finally {
-                csvPrinter.close()
-            }
-        }
-        return csvBuilder.toString().toByteArray()
+        val track = locationTrackService.getOrThrow(OFFICIAL, trackId)
+        val elementListing = getElementListing(trackId, elementTypes, startAddress, endAddress)
+        val csvFileContent = locationTrackElementListingToCsv(trackNumberService.list(OFFICIAL), elementListing)
+        return FileName("${ELEMENT_LISTING} ${track.name}") to csvFileContent
     }
 
     private fun getHeaderAndAlignment(id: IntId<GeometryAlignment>): Pair<GeometryPlanHeader, GeometryAlignment> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
@@ -9,11 +9,10 @@ import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
+import fi.fta.geoviite.infra.util.toFileDownloadResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.ContentDisposition
-import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -141,12 +140,8 @@ class InfraModelController @Autowired constructor(
     @GetMapping("{id}/file", MediaType.APPLICATION_OCTET_STREAM_VALUE)
     fun downloadFile(@PathVariable("id") id: IntId<GeometryPlan>): ResponseEntity<ByteArray> {
         logger.apiCall("downloadFile", "id" to id)
-        val headers = HttpHeaders()
         val infraModelFile: InfraModelFile = geometryService.getPlanFile(id)
-        headers.contentType = MediaType.APPLICATION_OCTET_STREAM
-        headers.set(HttpHeaders.CONTENT_DISPOSITION,
-            ContentDisposition.attachment().filename(fileNameWithSuffix(infraModelFile.name)).build().toString())
-        return ResponseEntity.ok().headers(headers).body(infraModelFile.content.toByteArray())
+        return toFileDownloadResponse(fileNameWithSuffix(infraModelFile.name), infraModelFile.content.toByteArray())
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResponseEntity.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResponseEntity.kt
@@ -1,7 +1,19 @@
 package fi.fta.geoviite.infra.util
 
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.HttpStatus.OK
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 
 fun <T> toResponse(value: T?) = value?.let { v -> ResponseEntity(v, OK) } ?: ResponseEntity(NO_CONTENT)
+
+fun toFileDownloadResponse(fileName: String, content: ByteArray): ResponseEntity<ByteArray> {
+    val headers = HttpHeaders()
+    headers.contentType = MediaType.APPLICATION_OCTET_STREAM
+    headers.set(
+        HttpHeaders.CONTENT_DISPOSITION,
+        ContentDisposition.attachment().filename(fileName).build().toString())
+    return ResponseEntity.ok().headers(headers).body(content)
+}

--- a/ui/src/data-products/element-list/element-list-store.ts
+++ b/ui/src/data-products/element-list/element-list-store.ts
@@ -7,8 +7,9 @@ import {
     ValidationErrorType,
 } from 'utils/validation-utils';
 import { filterNotEmpty } from 'utils/array-utils';
-import { GeometryPlanHeader, GeometryType } from 'geometry/geometry-model';
+import { ElementItem, GeometryPlanHeader, GeometryType } from 'geometry/geometry-model';
 import { trackMeterIsValid } from 'common/common-model';
+import { LayoutLocationTrack } from 'track-layout/track-layout-model';
 
 type SearchGeometries = {
     searchLines: boolean;
@@ -21,6 +22,7 @@ export type PlanGeometrySearchState = {
     plan: GeometryPlanHeader | undefined;
     searchGeometries: SearchGeometries;
 
+    elements: ElementItem[];
     validationErrors: ValidationError<PlanGeometrySearchState>[];
     committedFields: (keyof PlanGeometrySearchState)[];
 };
@@ -40,11 +42,13 @@ export const initialPlanGeometrySearchState: PlanGeometrySearchState = {
         searchMissingGeometry: false,
     },
 
+    elements: [],
     validationErrors: [],
     committedFields: [],
 };
 
 export type ContinuousSearchParameters = {
+    locationTrack: LayoutLocationTrack | undefined;
     startTrackMeter: string;
     endTrackMeter: string;
     searchGeometries: SearchGeometries;
@@ -54,12 +58,14 @@ export type ElementListContinuousGeometrySearchState = {
     searchFields: ContinuousSearchParameters;
     searchParameters: ContinuousSearchParameters;
 
+    elements: ElementItem[];
     validationErrors: ValidationError<ContinuousSearchParameters>[];
     committedFields: (keyof ContinuousSearchParameters)[];
 };
 
 export const initialContinuousSearchState: ElementListContinuousGeometrySearchState = {
     searchFields: {
+        locationTrack: undefined,
         startTrackMeter: '',
         endTrackMeter: '',
         searchGeometries: {
@@ -71,6 +77,7 @@ export const initialContinuousSearchState: ElementListContinuousGeometrySearchSt
     },
 
     searchParameters: {
+        locationTrack: undefined,
         startTrackMeter: '',
         endTrackMeter: '',
         searchGeometries: {
@@ -81,6 +88,7 @@ export const initialContinuousSearchState: ElementListContinuousGeometrySearchSt
         },
     },
 
+    elements: [],
     validationErrors: [],
     committedFields: [],
 };
@@ -166,6 +174,12 @@ const continuousGeometrySearchSlice = createSlice({
         ) {
             state.committedFields = [...state.committedFields, key];
         },
+        onSetElements: function (
+            state: ElementListContinuousGeometrySearchState,
+            { payload: elements }: PayloadAction<ElementItem[]>,
+        ) {
+            state.elements = elements;
+        },
     },
 });
 
@@ -189,6 +203,12 @@ const planSearchSlice = createSlice({
                 // Valid value entered for a field, mark that field as committed
                 state.committedFields = [...state.committedFields, propEdit.key];
             }
+        },
+        onSetElements: function (
+            state: PlanGeometrySearchState,
+            { payload: elements }: PayloadAction<ElementItem[]>,
+        ) {
+            state.elements = elements;
         },
     },
 });

--- a/ui/src/data-products/element-list/element-list-view.scss
+++ b/ui/src/data-products/element-list/element-list-view.scss
@@ -1,7 +1,6 @@
 @import '../../vayla-design-lib/radio/radio';
 
 .element-list-view {
-    padding-left: 32px;
     width: 100%;
 
     &__radio-layout > .radio {
@@ -17,8 +16,12 @@
     }
 
     &__table-container {
-        width: 1865px;
         overflow-x: auto;
+        padding-left: 32px;
+    }
+
+    &__header-container {
+        padding-left: 32px;
     }
 }
 

--- a/ui/src/data-products/element-list/element-list-view.scss
+++ b/ui/src/data-products/element-list/element-list-view.scss
@@ -23,6 +23,10 @@
     &__header-container {
         padding-left: 32px;
     }
+
+    &__table-heading th {
+        min-width: 100px;
+    }
 }
 
 .element-list__geometry-search {

--- a/ui/src/data-products/element-list/element-list-view.tsx
+++ b/ui/src/data-products/element-list/element-list-view.tsx
@@ -14,6 +14,7 @@ import {
 } from 'data-products/element-list/element-list-store';
 import { createDelegates } from 'store/store-utils';
 import PlanGeometrySearch from 'data-products/element-list/plan-geometry-search';
+import { ElementTable } from 'data-products/element-list/element-table';
 
 const ElementListView = () => {
     const { t } = useTranslation();
@@ -41,29 +42,43 @@ const ElementListView = () => {
     return (
         <EnvRestricted restrictTo={'dev'}>
             <div className={styles['element-list-view']}>
-                <h2>{t('data-products.element-list.element-list-title')}</h2>
-                <div>
-                    <span className={styles['element-list-view__radio-layout']}>
-                        <Radio onChange={handleRadioClick} checked={continuousGeometrySelected}>
-                            {t('data-products.element-list.continuous-geometry')}
-                        </Radio>
-                        <Radio onChange={handleRadioClick} checked={!continuousGeometrySelected}>
-                            {t('data-products.element-list.plan-geometry')}
-                        </Radio>
-                    </span>
+                <div className={styles['element-list-view__header-container']}>
+                    <h2>{t('data-products.element-list.element-list-title')}</h2>
+                    <div>
+                        <span className={styles['element-list-view__radio-layout']}>
+                            <Radio onChange={handleRadioClick} checked={continuousGeometrySelected}>
+                                {t('data-products.element-list.continuous-geometry')}
+                            </Radio>
+                            <Radio
+                                onChange={handleRadioClick}
+                                checked={!continuousGeometrySelected}>
+                                {t('data-products.element-list.plan-geometry')}
+                            </Radio>
+                        </span>
+                    </div>
+                    {continuousGeometrySelected ? (
+                        <ContinuousGeometrySearch
+                            state={continuousSearchState}
+                            onUpdateProp={continuousSearchStateActions.onUpdateProp}
+                            onCommitField={continuousSearchStateActions.onCommitField}
+                            setElements={continuousSearchStateActions.onSetElements}
+                        />
+                    ) : (
+                        <PlanGeometrySearch
+                            state={planSearchState}
+                            onUpdateProp={planSearchStateActions.onUpdateProp}
+                            setElements={planSearchStateActions.onSetElements}
+                        />
+                    )}
                 </div>
-                {continuousGeometrySelected ? (
-                    <ContinuousGeometrySearch
-                        state={continuousSearchState}
-                        onUpdateProp={continuousSearchStateActions.onUpdateProp}
-                        onCommitField={continuousSearchStateActions.onCommitField}
-                    />
-                ) : (
-                    <PlanGeometrySearch
-                        state={planSearchState}
-                        onUpdateProp={planSearchStateActions.onUpdateProp}
-                    />
-                )}
+                <ElementTable
+                    elements={
+                        continuousGeometrySelected
+                            ? continuousSearchState.elements
+                            : planSearchState.elements
+                    }
+                    showLocationTrackName={true}
+                />
             </div>
         </EnvRestricted>
     );

--- a/ui/src/data-products/element-list/element-list-view.tsx
+++ b/ui/src/data-products/element-list/element-list-view.tsx
@@ -77,7 +77,7 @@ const ElementListView = () => {
                             ? continuousSearchState.elements
                             : planSearchState.elements
                     }
-                    showLocationTrackName={true}
+                    showLocationTrackName={continuousGeometrySelected}
                 />
             </div>
         </EnvRestricted>

--- a/ui/src/data-products/element-list/element-table-item.tsx
+++ b/ui/src/data-products/element-list/element-table-item.tsx
@@ -6,8 +6,9 @@ import { TrackMeter } from 'common/common-model';
 export type ElementTableItemProps = {
     id: string;
     trackNumber: string | undefined;
-    track: string;
+    geometryAlignmentName: string;
     type: string;
+    locationTrackName: string;
     trackAddressStart: TrackMeter | undefined;
     trackAddressEnd: TrackMeter | undefined;
     locationStartE: number;
@@ -24,11 +25,14 @@ export type ElementTableItemProps = {
     plan: string;
     source: string;
     coordinateSystem: string;
+
+    showLocationTrackName: boolean;
 };
 
 export const ElementTableItem: React.FC<ElementTableItemProps> = ({
     trackNumber,
-    track,
+    geometryAlignmentName,
+    locationTrackName,
     type,
     trackAddressStart,
     trackAddressEnd,
@@ -45,12 +49,14 @@ export const ElementTableItem: React.FC<ElementTableItemProps> = ({
     angleEnd,
     plan,
     source,
+    showLocationTrackName,
 }) => {
     return (
         <React.Fragment>
             <tr>
                 <td>{trackNumber}</td>
-                <td>{track}</td>
+                {showLocationTrackName && <td>{locationTrackName}</td>}
+                <td>{geometryAlignmentName}</td>
                 <td>{type}</td>
                 <td>{trackAddressStart && formatTrackMeter(trackAddressStart)}</td>
                 <td>{trackAddressEnd && formatTrackMeter(trackAddressEnd)}</td>

--- a/ui/src/data-products/element-list/element-table.tsx
+++ b/ui/src/data-products/element-list/element-table.tsx
@@ -7,17 +7,20 @@ import { ElementItem } from 'geometry/geometry-model';
 import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
 
 type ElementTableProps = {
-    plans: ElementItem[];
+    elements: ElementItem[];
+    showLocationTrackName: boolean;
 };
 
-export const ElementTable = ({ plans }: ElementTableProps) => {
+export const ElementTable = ({ elements, showLocationTrackName }: ElementTableProps) => {
     const { t } = useTranslation();
     const trackNumbers = useTrackNumbers('OFFICIAL');
-    const amount = plans.length;
+    const amount = elements.length;
 
     return (
         <div>
-            <p>{t(`data-products.element-list.geometry-elements`, { amount })}</p>
+            <p className={styles['element-list-view__table-container']}>
+                {t(`data-products.element-list.geometry-elements`, { amount })}
+            </p>
             <div className={styles['element-list-view__table-container']}>
                 <Table wide>
                     <thead>
@@ -25,6 +28,13 @@ export const ElementTable = ({ plans }: ElementTableProps) => {
                             <th>
                                 {t('data-products.element-list.element-list-table.track-number')}
                             </th>
+                            {showLocationTrackName && (
+                                <th>
+                                    {t(
+                                        'data-products.element-list.element-list-table.location-track',
+                                    )}
+                                </th>
+                            )}
                             <th>{t('data-products.element-list.element-list-table.alignment')}</th>
                             <th>
                                 {t('data-products.element-list.element-list-table.element-type')}
@@ -82,7 +92,7 @@ export const ElementTable = ({ plans }: ElementTableProps) => {
                         </tr>
                     </thead>
                     <tbody>
-                        {plans.map((item, index) => (
+                        {elements.map((item, index) => (
                             // Element list can contain the same element multiple times -> use index in list as key
                             <React.Fragment key={`${index}`}>
                                 <ElementTableItem
@@ -91,7 +101,8 @@ export const ElementTable = ({ plans }: ElementTableProps) => {
                                         trackNumbers?.find((tn) => tn.id === item.trackNumberId)
                                             ?.number
                                     }
-                                    track={item.alignmentName}
+                                    geometryAlignmentName={item.alignmentName}
+                                    locationTrackName={item.locationTrackName}
                                     type={t(
                                         `data-products.element-list.element-list-table.${item.elementType}`,
                                     )}
@@ -113,6 +124,7 @@ export const ElementTable = ({ plans }: ElementTableProps) => {
                                     angleEnd={item.end.directionGrads}
                                     plan={item.fileName}
                                     source={item.planSource}
+                                    showLocationTrackName={showLocationTrackName}
                                 />
                             </React.Fragment>
                         ))}

--- a/ui/src/data-products/element-list/element-table.tsx
+++ b/ui/src/data-products/element-list/element-table.tsx
@@ -23,7 +23,7 @@ export const ElementTable = ({ elements, showLocationTrackName }: ElementTablePr
             </p>
             <div className={styles['element-list-view__table-container']}>
                 <Table wide>
-                    <thead>
+                    <thead className={styles['element-list-view__table-heading']}>
                         <tr>
                             <th>
                                 {t('data-products.element-list.element-list-table.track-number')}

--- a/ui/src/data-products/translations.fi.json
+++ b/ui/src/data-products/translations.fi.json
@@ -21,8 +21,9 @@
             "geometry-elements": "Geometriaelementit ({{amount}} kpl)",
             "pcs": "kpl",
             "element-list-table": {
+                "location-track": "Sijaintiraide",
                 "track-number": "Ratanumero",
-                "alignment": "Raide",
+                "alignment": "Suunnitelman raide",
                 "element-type": "Elementin tyyppi",
                 "track-address-start": "Rataosoite alussa",
                 "track-address-end": "Rataosoite lopussa",

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -105,6 +105,11 @@ export async function getGeometryPlanElements(
     return getIgnoreError(`${GEOMETRY_URI}/plans/${planId}/element-listing${params}`);
 }
 
+export const getGeometryPlanElementsCsv = (
+    planId: GeometryPlanId,
+    elementTypes: GeometryTypeIncludingMissing[],
+) => `${GEOMETRY_URI}/plans/${planId}/element-listing/file${queryParams({ elementTypes })}`;
+
 export async function getLocationTrackElements(
     id: LocationTrackId,
     elementTypes: GeometryTypeIncludingMissing[],
@@ -118,6 +123,20 @@ export async function getLocationTrackElements(
     });
     return getIgnoreError(`${GEOMETRY_URI}/layout/location-tracks/${id}/element-listing${params}`);
 }
+
+export const getLocationTrackElementsCsv = (
+    locationTrackId: LocationTrackId,
+    elementTypes: GeometryTypeIncludingMissing[],
+    startAddress: string | undefined,
+    endAddress: string | undefined,
+) => {
+    const searchQueryParameters = queryParams({
+        elementTypes,
+        startAddress,
+        endAddress,
+    });
+    return `${GEOMETRY_URI}/layout/location-tracks/${locationTrackId}/element-listing/file${searchQueryParameters}`;
+};
 
 export async function getGeometryPlan(
     planId: GeometryPlanId,

--- a/ui/src/geometry/geometry-model.ts
+++ b/ui/src/geometry/geometry-model.ts
@@ -260,6 +260,7 @@ export type GeometryElement =
 export type ElementItem = {
     alignmentId: LocationTrackId;
     alignmentName: string;
+    locationTrackName: string;
     elementId: GeometryElementId;
     elementType: GeometryTypeIncludingMissing;
     start: ElementLocation;

--- a/ui/src/vayla-design-lib/table/table.scss
+++ b/ui/src/vayla-design-lib/table/table.scss
@@ -19,7 +19,7 @@ $table-cell-padding: 10px 16px;
             background: $color-white-dark;
             padding: $table-cell-padding;
             text-align: left;
-            white-space: nowrap;
+            white-space: break-spaces;
 
             &.table__th--clickable {
                 cursor: pointer;

--- a/ui/src/vayla-design-lib/table/table.tsx
+++ b/ui/src/vayla-design-lib/table/table.tsx
@@ -9,7 +9,11 @@ export type TableProps = {
 } & React.HTMLProps<HTMLTableElement>;
 
 export const Table: React.FC<TableProps> = (props: TableProps) => {
-    const className = createClassName(styles.table, props.wide && styles['table--wide']);
+    const className = createClassName(
+        props.className,
+        styles.table,
+        props.wide && styles['table--wide'],
+    );
     return <table className={className}>{props.children}</table>;
 };
 


### PR DESCRIPTION
Tämä lähti vähän käsistä. Päädyin refakkaamaan koko elementtilistauksen komponenttirakenteen yhden frontin tyylijutun takia. Toisaalta sikäli uusi malli on parempi, että vaihtaessa listaustyyppiä vanhat hakuparametrit ja -tulokset säilyvät nyt.

Samalla tehty alkuperäiselle reviewille mainittuja review-korjauksia.