### PR TITLE
GVT-1670: Selvennä vahvistusviestiä joka näytetään muutosta hylättäessa

### DIFF
--- a/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
+++ b/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
@@ -52,7 +52,9 @@ const onlyDependencies = (changesBeingReverted: ChangesBeingReverted): PublishRe
         trackNumbers: allChanges.trackNumbers.filter(
             (tn) => reqType != PreviewSelectType.trackNumber || tn !== reqId,
         ),
-        kmPosts: allChanges.kmPosts,
+        kmPosts: allChanges.kmPosts.filter(
+            (kmPost) => reqType != PreviewSelectType.kmPost || kmPost !== reqId,
+        ),
         referenceLines: allChanges.referenceLines.filter(
             (rl) => reqType != PreviewSelectType.referenceLine || rl !== reqId,
         ),


### PR DESCRIPTION
Kyseessä olikin bugi kilometripylväiden revertissä. Riippuvia kilometripylväitä ei näytetä koskaan hylkäysvahvistusdialogissa (oletettavasti koska niitä ei pitäisi koskaan olla.) Samalla kilometripylväille ei tehty samanlaista filtteröintiä kuin muille tyypeille, jolloin kilometripylväs itsensä näkyi itsensä dependencynä.