### PR TITLE
GVT-1409: Ratko-viennissä kuuluisi näyttää aina uusin virhe

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDao.kt
@@ -188,7 +188,7 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                 on ratko_push.id = ratko_push_error.ratko_push_id
               inner join integrations.ratko_push_content using(ratko_push_id)
             where ratko_push_content.publication_id = :id
-            order by ratko_push.end_time desc
+            order by ratko_push_error.id desc
             limit 1;
         """.trimIndent()
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -159,12 +159,20 @@ internal class RatkoPushDaoIT @Autowired constructor(
     }
 
     @Test
-    fun shouldFindPushErrorByPublicationId() {
+    fun shouldFindLatestPushErrorByPublicationId() {
         val ratkoPushId = ratkoPushDao.startPushing(getCurrentUserName(), listOf(layoutPublishId))
         ratkoPushDao.insertRatkoPushError(
             ratkoPushId,
             RatkoPushErrorType.PROPERTIES,
             RatkoOperation.UPDATE,
+            RatkoAssetType.LOCATION_TRACK,
+            locationTrackId,
+            "Response body"
+        )
+        ratkoPushDao.insertRatkoPushError(
+            ratkoPushId,
+            RatkoPushErrorType.PROPERTIES,
+            RatkoOperation.CREATE,
             RatkoAssetType.TRACK_NUMBER,
             trackNumberId,
             "Response body"
@@ -174,6 +182,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
         assertNotNull(ratkoPushError)
         assertEquals(trackNumberId, ratkoPushError.assetId)
+        assertEquals(RatkoOperation.CREATE, ratkoPushError.operation)
     }
 
     fun insertAndPublishLocationTrack() = locationTrackAndAlignment(trackNumberId).let { (track, alignment) ->


### PR DESCRIPTION
En saanut tätä toistumaan muuten kuin että tein samaan ratkopuskuun useamman virheen (tilanne, jonka luulin alunperin olevan mahdoton.) Tällöin näytettiin jokin satunnainen virhe, sillä erroreita ei varsinaisesti oltu järjestetty ollenkaan. Korjattu nyt niin, että varmasti tulee aina uusin virhe.