### PR TITLE
GVT-1677 Add common eye button to geometry plan panel

### DIFF
--- a/ui/src/geoviite-design-lib/accordion/accordion.scss
+++ b/ui/src/geoviite-design-lib/accordion/accordion.scss
@@ -33,17 +33,4 @@
     &__body {
         padding-left: 16px;
     }
-
-    &__visibility {
-        cursor: pointer;
-        margin-left: auto;
-        transition: fill 150ms;
-        fill: $color-white-darker;
-        height: 20px;
-        padding-left: 4px;
-
-        &--visible {
-            fill: $color-blue-default;
-        }
-    }
 }

--- a/ui/src/geoviite-design-lib/accordion/accordion.tsx
+++ b/ui/src/geoviite-design-lib/accordion/accordion.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 import styles from './accordion.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 import { AccordionToggle } from 'vayla-design-lib/accordion-toggle/accordion-toggle';
-import CircularProgress from 'vayla-design-lib/progress/circular-progress';
+import { Eye } from 'geoviite-design-lib/eye/eye';
 
 type AccordionProps = {
     open: boolean;
@@ -45,7 +44,11 @@ export const Accordion: React.FC<AccordionProps> = ({
     return (
         <div className="accordion">
             <h4 className={accordionClasses}>
-                <AccordionToggle onToggle={disabled ? undefined : onToggle} open={open} disabled={disabled} />
+                <AccordionToggle
+                    onToggle={disabled ? undefined : onToggle}
+                    open={open}
+                    disabled={disabled}
+                />
                 <span
                     className={titleClasses}
                     title={header}
@@ -54,17 +57,11 @@ export const Accordion: React.FC<AccordionProps> = ({
                     {subheader && <div className="accordion__subheader">{subheader}</div>}
                 </span>
                 {onVisibilityToggle && (
-                    <span
-                        className={`${styles['accordion__visibility']} ${
-                            visibility ? styles['accordion__visibility--visible'] : ''
-                        }`}
-                        onClick={onVisibilityToggle}>
-                        {fetchingContent ? (
-                            <CircularProgress />
-                        ) : (
-                            <Icons.Eye color={IconColor.INHERIT} />
-                        )}
-                    </span>
+                    <Eye
+                        onVisibilityToggle={onVisibilityToggle}
+                        visibility={visibility}
+                        fetchingContent={fetchingContent}
+                    />
                 )}
             </h4>
             {open && <div className={styles['accordion__body']}>{children}</div>}

--- a/ui/src/geoviite-design-lib/eye/eye.scss
+++ b/ui/src/geoviite-design-lib/eye/eye.scss
@@ -1,0 +1,14 @@
+@import '../../vayla-design-lib/colors';
+@import '../../vayla-design-lib/typography';
+
+.eye {
+    cursor: pointer;
+    margin-left: auto;
+    transition: fill 150ms;
+    fill: $color-white-darker;
+    padding-left: 4px;
+
+    &--visible {
+        fill: $color-blue-default;
+    }
+}

--- a/ui/src/geoviite-design-lib/eye/eye.tsx
+++ b/ui/src/geoviite-design-lib/eye/eye.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import styles from './eye.scss';
+import CircularProgress from 'vayla-design-lib/progress/circular-progress';
+import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
+
+type EyeProps = {
+    visibility?: boolean;
+    fetchingContent?: boolean;
+    onVisibilityToggle: React.MouseEventHandler;
+};
+export const Eye: React.FC<EyeProps> = ({ visibility, fetchingContent, onVisibilityToggle }) => {
+    return (
+        <span
+            className={`${styles['eye']} ${visibility ? styles['eye--visible'] : ''}`}
+            onClick={onVisibilityToggle}>
+            {fetchingContent ? <CircularProgress /> : <Icons.Eye color={IconColor.INHERIT} />}
+        </span>
+    );
+};

--- a/ui/src/selection-panel/selection-panel-geometry-section.tsx
+++ b/ui/src/selection-panel/selection-panel-geometry-section.tsx
@@ -1,0 +1,249 @@
+import styles from 'selection-panel/selection-panel.scss';
+import { Eye } from 'geoviite-design-lib/eye/eye';
+import { createClassName } from 'vayla-design-lib/utils';
+import { GeometryPlanPanel } from 'selection-panel/geometry-plan-panel/geometry-plan-panel';
+import {
+    createEmptyItemCollections,
+    ToggleAccordionOpenPayload,
+    ToggleAlignmentPayload,
+    ToggleKmPostPayload,
+    TogglePlanWithSubItemsOpenPayload,
+    ToggleSwitchPayload,
+} from 'selection/selection-store';
+import * as React from 'react';
+import {
+    GeometryPlanHeader,
+    GeometryPlanId,
+    SortByValue,
+    SortOrderValue,
+} from 'geometry/geometry-model';
+import { useTranslation } from 'react-i18next';
+import { useMapState, useSetState } from 'utils/react-utils';
+import { getGeometryPlanHeaders, getTrackLayoutPlan } from 'geometry/geometry-api';
+import { GeometryPlanLayout, LayoutTrackNumber } from 'track-layout/track-layout-model';
+import { GeometryPlanLinkStatus } from 'linking/linking-model';
+import { getPlanLinkStatus } from 'linking/linking-api';
+import { MapViewport } from 'map/map-model';
+import {
+    OnSelectOptions,
+    OpenedPlanLayout,
+    OptionalItemCollections,
+} from 'selection/selection-model';
+import { ChangeTimes } from 'track-layout/track-layout-store';
+import { PublishType } from 'common/common-model';
+
+type GeometryPlansPanelProps = {
+    changeTimes: ChangeTimes;
+    publishType: PublishType;
+    selectedItems?: OptionalItemCollections;
+    viewport: MapViewport;
+    selectedPlanLayouts?: GeometryPlanLayout[];
+    trackNumberFilter: LayoutTrackNumber[];
+    onTogglePlanVisibility: (payload: GeometryPlanLayout | null) => void;
+    onToggleAlignmentVisibility: (payload: ToggleAlignmentPayload) => void;
+    onToggleSwitchVisibility: (payload: ToggleSwitchPayload) => void;
+    onToggleKmPostVisibility: (payload: ToggleKmPostPayload) => void;
+    togglePlanOpen: (payload: TogglePlanWithSubItemsOpenPayload) => void;
+    openedPlanLayouts: OpenedPlanLayout[];
+    togglePlanKmPostsOpen: (payload: ToggleAccordionOpenPayload) => void;
+    togglePlanAlignmentsOpen: (payload: ToggleAccordionOpenPayload) => void;
+    togglePlanSwitchesOpen: (payload: ToggleAccordionOpenPayload) => void;
+    onSelect: (options: OnSelectOptions) => void;
+};
+const MAX_PLAN_HEADERS = 50;
+
+type LoadedGeometryPlan = {
+    planLayout: GeometryPlanLayout;
+    linkStatus: GeometryPlanLinkStatus;
+};
+
+const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
+    changeTimes,
+    publishType,
+    selectedItems,
+    viewport,
+    selectedPlanLayouts,
+    trackNumberFilter,
+    onTogglePlanVisibility,
+    onToggleAlignmentVisibility,
+    onToggleSwitchVisibility,
+    onToggleKmPostVisibility,
+    togglePlanOpen,
+    openedPlanLayouts,
+    togglePlanKmPostsOpen,
+    togglePlanAlignmentsOpen,
+    togglePlanSwitchesOpen,
+    onSelect,
+}) => {
+    const { t } = useTranslation();
+    const [planHeadersInView, setPlanHeadersInView] = React.useState<GeometryPlanHeader[]>([]);
+    const [planHeaderCount, setPlanHeaderCount] = React.useState<number>(0);
+    const [loadedPlans, setLoadedPlan] = useMapState<GeometryPlanId, LoadedGeometryPlan>();
+    const [plansBeingLoaded, startLoadingPlan, finishLoadingPlan] = useSetState<GeometryPlanId>();
+
+    React.useEffect(() => {
+        getGeometryPlanHeaders(
+            MAX_PLAN_HEADERS,
+            0,
+            viewport.area,
+            ['GEOVIITE', 'GEOMETRIAPALVELU', 'PAIKANNUSPALVELU'],
+            trackNumberFilter.map((tn) => tn.id),
+            undefined,
+            SortByValue.UPLOADED_AT,
+            SortOrderValue.ASCENDING,
+        ).then((page) => {
+            setPlanHeadersInView(page.items);
+            setPlanHeaderCount(page.totalCount);
+        });
+    }, [viewport.area, changeTimes.geometryPlan, trackNumberFilter]);
+
+    React.useEffect(
+        () => [...loadedPlans.keys()].forEach(loadPlanLayout),
+        [
+            publishType,
+            changeTimes.geometryPlan,
+            changeTimes.layoutReferenceLine,
+            changeTimes.layoutLocationTrack,
+            changeTimes.layoutSwitch,
+            changeTimes.layoutKmPost,
+        ],
+    );
+
+    const loadPlanLayout = (id: GeometryPlanId) => {
+        startLoadingPlan(id);
+        const rv = Promise.all([
+            getTrackLayoutPlan(id, changeTimes.geometryPlan, false),
+            getPlanLinkStatus(id, publishType),
+        ]).then(([planLayout, linkStatus]) => {
+            if (planLayout) {
+                setLoadedPlan(id, { planLayout, linkStatus });
+            }
+            return planLayout;
+        });
+        rv.finally(() => finishLoadingPlan(id));
+        return rv;
+    };
+
+    const planHeaderIdsInView = planHeadersInView
+        .map((plan) => plan.id)
+        .reduce((set, id) => set.add(id), new Set());
+    const selectedPlansInView = (selectedPlanLayouts ?? []).filter((plan) =>
+        planHeaderIdsInView.has(plan.planId),
+    );
+
+    const toggleAllPlanVisibilities = () => {
+        if (selectedPlansInView.length > 0) {
+            selectedPlansInView.forEach(onTogglePlanVisibility);
+        } else {
+            planHeadersInView.forEach((ph) => {
+                loadPlanLayout(ph.id).then((loadedPlan) => {
+                    onTogglePlanVisibility(loadedPlan);
+                });
+            });
+        }
+    };
+
+    return (
+        <section>
+            <h3 className={styles['selection-panel__title']}>
+                {`${t('selection-panel.geometries-title')} (${
+                    planHeadersInView.length
+                }/${planHeaderCount})`}{' '}
+                {planHeadersInView.length > 1 && planHeadersInView.length === planHeaderCount && (
+                    <Eye
+                        onVisibilityToggle={toggleAllPlanVisibilities}
+                        visibility={selectedPlansInView.length > 0}
+                    />
+                )}
+            </h3>
+            <div
+                className={createClassName(
+                    styles['selection-panel__content'],
+                    styles['selection-panel__content--unpadded'],
+                )}>
+                {planHeadersInView.length == planHeaderCount &&
+                    planHeadersInView.map((h) => {
+                        return (
+                            <GeometryPlanPanel
+                                key={h.id}
+                                planHeader={h}
+                                onPlanHeaderSelection={(header) =>
+                                    onSelect({
+                                        ...createEmptyItemCollections(),
+                                        geometryPlans: [header],
+                                        isToggle: true,
+                                    })
+                                }
+                                publishType={publishType}
+                                changeTimes={changeTimes}
+                                onTogglePlanVisibility={onTogglePlanVisibility}
+                                onToggleAlignmentVisibility={onToggleAlignmentVisibility}
+                                onToggleAlignmentSelection={(alignment) =>
+                                    onSelect({
+                                        ...createEmptyItemCollections(),
+                                        geometryAlignments: [
+                                            {
+                                                geometryItem: alignment,
+                                                planId: h.id,
+                                            },
+                                        ],
+                                        isToggle: true,
+                                    })
+                                }
+                                onToggleSwitchVisibility={onToggleSwitchVisibility}
+                                onToggleSwitchSelection={(switchItem) =>
+                                    onSelect({
+                                        ...createEmptyItemCollections(),
+                                        geometrySwitches: [
+                                            {
+                                                geometryItem: switchItem,
+                                                planId: h.id,
+                                            },
+                                        ],
+                                        isToggle: true,
+                                    })
+                                }
+                                onToggleKmPostVisibility={onToggleKmPostVisibility}
+                                onToggleKmPostSelection={(kmPost) =>
+                                    onSelect({
+                                        ...createEmptyItemCollections(),
+                                        geometryKmPosts: [
+                                            {
+                                                geometryItem: kmPost,
+                                                planId: h.id,
+                                            },
+                                        ],
+                                        isToggle: true,
+                                    })
+                                }
+                                selectedItems={selectedItems}
+                                selectedPlanLayouts={selectedPlanLayouts}
+                                togglePlanOpen={togglePlanOpen}
+                                openedPlanLayouts={openedPlanLayouts}
+                                togglePlanKmPostsOpen={togglePlanKmPostsOpen}
+                                togglePlanAlignmentsOpen={togglePlanAlignmentsOpen}
+                                togglePlanSwitchesOpen={togglePlanSwitchesOpen}
+                                planLayout={loadedPlans.get(h.id)?.planLayout ?? null}
+                                linkStatus={loadedPlans.get(h.id)?.linkStatus ?? null}
+                                planBeingLoaded={plansBeingLoaded.has(h.id)}
+                                loadPlanLayout={() => loadPlanLayout(h.id)}
+                            />
+                        );
+                    })}
+                {planHeadersInView.length < planHeaderCount && (
+                    <span className={styles['selection-panel__subtitle']}>{`${t(
+                        'selection-panel.zoom-closer',
+                    )}`}</span>
+                )}
+
+                {planHeadersInView.length === 0 && (
+                    <span className={styles['selection-panel__subtitle']}>
+                        {`${t('selection-panel.no-results')}`}{' '}
+                    </span>
+                )}
+            </div>
+        </section>
+    );
+};
+
+export default SelectionPanelGeometrySection;

--- a/ui/src/selection-panel/selection-panel.scss
+++ b/ui/src/selection-panel/selection-panel.scss
@@ -12,10 +12,13 @@
         @include typography-sub-heading;
         box-shadow: 0 1px 1px rgba($color-black-default, 0.12);
 
-        padding: 12px 0 8px 20px;
+        padding: 12px 20px 8px 20px;
         background-color: $color-white-dark;
         color: $color-black-default;
         margin: 0 0 12px 0;
+
+        display: flex;
+        flex-direction: row;
     }
 
     &__subtitle {

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -16,13 +16,18 @@ import {
     OptionalItemCollections,
     SelectableItemType,
 } from 'selection/selection-model';
-import { GeometryPlanHeader, SortByValue, SortOrderValue } from 'geometry/geometry-model';
+import {
+    GeometryPlanHeader,
+    GeometryPlanId,
+    SortByValue,
+    SortOrderValue,
+} from 'geometry/geometry-model';
 import { createClassName } from 'vayla-design-lib/utils';
 import { KmPostsPanel } from 'selection-panel/km-posts-panel/km-posts-panel';
 import SwitchPanel from 'selection-panel/switch-panel/switch-panel';
 import { getTrackNumbers } from 'track-layout/layout-track-number-api';
 import TrackNumberPanel from 'selection-panel/track-number-panel/track-number-panel';
-import { getGeometryPlanHeaders } from 'geometry/geometry-api';
+import { getGeometryPlanHeaders, getTrackLayoutPlan } from 'geometry/geometry-api';
 import { MapViewport } from 'map/map-model';
 import {
     createEmptyItemCollections,
@@ -37,6 +42,10 @@ import { PublishType } from 'common/common-model';
 import { useTranslation } from 'react-i18next';
 import { LocationTracksPanel } from 'selection-panel/alignment-panel/location-tracks-panel';
 import ReferenceLinesPanel from 'selection-panel/alignment-panel/reference-lines-panel';
+import { Eye } from 'geoviite-design-lib/eye/eye';
+import { GeometryPlanLinkStatus } from 'linking/linking-model';
+import { getPlanLinkStatus } from 'linking/linking-api';
+import { useMapState, useSetState } from 'utils/react-utils';
 
 type SelectionPanelProps = {
     changeTimes: ChangeTimes;
@@ -62,6 +71,11 @@ type SelectionPanelProps = {
 };
 
 const MAX_PLAN_HEADERS = 50;
+
+type LoadedGeometryPlan = {
+    planLayout: GeometryPlanLayout;
+    linkStatus: GeometryPlanLinkStatus;
+};
 
 const SelectionPanel: React.FC<SelectionPanelProps> = ({
     publishType,
@@ -89,6 +103,8 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
     const [visibleTrackNumbers, setVisibleTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
     const [trackNumberFilter, setTrackNumberFilter] = React.useState<LayoutTrackNumber[]>([]);
     const [planHeaders, setPlanHeaders] = React.useState<GeometryPlanHeader[]>([]);
+    const [loadedPlans, setLoadedPlan] = useMapState<GeometryPlanId, LoadedGeometryPlan>();
+    const [plansBeingLoaded, startLoadingPlan, finishLoadingPlan] = useSetState<GeometryPlanId>();
     const [planHeaderCount, setPlanHeaderCount] = React.useState<number>(0);
 
     React.useEffect(() => {
@@ -106,6 +122,18 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
             setPlanHeaderCount(page.totalCount);
         });
     }, [viewport.area, changeTimes.geometryPlan, trackNumberFilter]);
+
+    React.useEffect(
+        () => [...loadedPlans.keys()].forEach(loadPlanLayout),
+        [
+            publishType,
+            changeTimes.geometryPlan,
+            changeTimes.layoutReferenceLine,
+            changeTimes.layoutLocationTrack,
+            changeTimes.layoutSwitch,
+            changeTimes.layoutKmPost,
+        ],
+    );
 
     const toggleTrackNumberFilter = React.useCallback(
         (tn: LayoutTrackNumber) => {
@@ -179,6 +207,41 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
     }, [referenceLines, trackNumberFilter]);
 
     const filteredKmPosts = kmPosts.filter((km) => filterByTrackNumberId(km.trackNumberId));
+    const planHeaderIds = planHeaders
+        .map((plan) => plan.id)
+        .reduce((set, id) => set.add(id), new Set());
+    const visibleSelectedPlans = (selectedPlanLayouts ?? []).filter((plan) =>
+        planHeaderIds.has(plan.planId),
+    );
+    const anyPlansVisible = visibleSelectedPlans.length > 0;
+
+    const loadPlanLayout = (id: GeometryPlanId) => {
+        startLoadingPlan(id);
+        const rv = Promise.all([
+            getTrackLayoutPlan(id, changeTimes.geometryPlan, false),
+            getPlanLinkStatus(id, publishType),
+        ]).then(([planLayout, linkStatus]) => {
+            if (planLayout) {
+                setLoadedPlan(id, { planLayout, linkStatus });
+            }
+            return planLayout;
+        });
+        rv.finally(() => finishLoadingPlan(id));
+        return rv;
+    };
+
+    const toggleAllPlanVisibilities = () => {
+        if (anyPlansVisible) {
+            visibleSelectedPlans.forEach(onTogglePlanVisibility);
+        } else {
+            planHeaders.forEach((ph) => {
+                loadPlanLayout(ph.id).then((loadedPlan) => {
+                    onTogglePlanVisibility(loadedPlan);
+                });
+            });
+        }
+    };
+
     return (
         <div className={styles['selection-panel']}>
             <section>
@@ -198,7 +261,13 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                     <h3 className={styles['selection-panel__title']}>
                         {`${t('selection-panel.geometries-title')} (${
                             planHeaders.length
-                        }/${planHeaderCount})`}
+                        }/${planHeaderCount})`}{' '}
+                        {planHeaders.length > 1 && planHeaders.length === planHeaderCount && (
+                            <Eye
+                                onVisibilityToggle={toggleAllPlanVisibilities}
+                                visibility={anyPlansVisible}
+                            />
+                        )}
                     </h3>
                     <div
                         className={createClassName(
@@ -267,6 +336,10 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                                         togglePlanKmPostsOpen={togglePlanKmPostsOpen}
                                         togglePlanAlignmentsOpen={togglePlanAlignmentsOpen}
                                         togglePlanSwitchesOpen={togglePlanSwitchesOpen}
+                                        planLayout={loadedPlans.get(h.id)?.planLayout ?? null}
+                                        linkStatus={loadedPlans.get(h.id)?.linkStatus ?? null}
+                                        planBeingLoaded={plansBeingLoaded.has(h.id)}
+                                        loadPlanLayout={() => loadPlanLayout(h.id)}
                                     />
                                 );
                             })}

--- a/ui/src/utils/react-utils.tsx
+++ b/ui/src/utils/react-utils.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { ForwardedRef, useEffect, useRef, useState } from 'react';
 import { debounce } from 'ts-debounce';
-import { ForwardedRef, useEffect, useRef } from 'react';
 
 /**
  * To load/get something asynchronously and to set that into state
@@ -145,4 +145,41 @@ export function useCloneRef<T>(
         }
     }, [ref]);
     return localRef;
+}
+
+export function useMapState<K, V>(
+    initial?: Map<K, V> | (() => Map<K, V>),
+): [
+    map: Map<K, V>,
+    setValue: (key: K, value: V) => void,
+    removeKey: (key: K) => void,
+    setMap: React.Dispatch<React.SetStateAction<Map<K, V>>>,
+] {
+    const [map, setMap] = useState<Map<K, V>>(initial ?? (() => new Map()));
+    const setValue = (key: K, value: V) => setMap((prevMap) => new Map(prevMap).set(key, value));
+    const removeKey = (key: K) =>
+        setMap((prevMap) => {
+            const copy = new Map(prevMap);
+            copy.delete(key);
+            return copy;
+        });
+    return [map, setValue, removeKey, setMap];
+}
+export function useSetState<T>(
+    initial?: Set<T> | (() => Set<T>),
+): [
+    set: Set<T>,
+    addToSet: (member: T) => void,
+    deleteFromSet: (member: T) => void,
+    setSet: React.Dispatch<React.SetStateAction<Set<T>>>,
+] {
+    const [set, setSet] = useState<Set<T>>(initial ?? (() => new Set()));
+    const addToSet = (member: T) => setSet((prevSet) => new Set(prevSet).add(member));
+    const deleteFromSet = (member: T) =>
+        setSet((prevSet) => {
+            const copy = new Set(prevSet);
+            copy.delete(member);
+            return copy;
+        });
+    return [set, addToSet, deleteFromSet, setSet];
 }


### PR DESCRIPTION
Isohko pullari, koska aiemmin GeometryPlanPanel piti itse huolta yksittäisten suunnitelmien lataamisesta, mutta nyt kun halutaan pystyä lataamaan iso joukko suunnitelmia kerralla, Reactimaisesti korrekti tapa oli vetää tila ylempään komponenttiin; päädyin erottamaan sen omaksi SelectionPanelGeometrySection-komponentikseen, jotta ihan kaikki suunnitelmien lataamiseen liittyvä koodi ei olisi sekaisin muiden SelectionPanel-juttujen kanssa.

Muutin tämän siirron yhteydessä vielä muutaman muuttujan nimen hieman selkeämmäksi, niin että SelectionPanelGeometrySectionissa näkyy vähän selkeämmin, mitkä asiat riippuvat vaan siitä, mitkä suunnitelmat ovat kartalla juuri sillä hetkellä näkyvillä.