### PR TITLE
GVT-1682 Allow closing publish confirmation dialog

### DIFF
--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -158,7 +158,8 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
                 <Dialog
                     title={t('publish.publish-confirm.title')}
                     variant={DialogVariant.LIGHT}
-                    allowClose={false}
+                    allowClose={!isPublishing}
+                    onClose={() => setPublishConfirmVisible(false)}
                     className={dialogStyles['dialog--wide']}
                     footerContent={
                         <React.Fragment>


### PR DESCRIPTION
Edellinen osui väärään dialogiin, mutta sielläkin toki tarvittiin sulkeminen. Nyt myös itse julkaisun confirm-dialogissa.