### PR TITLE
GVT-1617: "Aloita linkitys" -nappi ei tule aina näkyviin vaihteelle

### DIFF
--- a/ui/src/linking/linking-status.tsx
+++ b/ui/src/linking/linking-status.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import InfoboxField from 'tool-panel/infobox/infobox-field';
+import styles from 'tool-panel/switch/switch-infobox.scss';
+import { useTranslation } from 'react-i18next';
+import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
+import { getPlanLinkStatus } from 'linking/linking-api';
+import { GeometryPlanId } from 'geometry/geometry-model';
+import { PublishType, TimeStamp } from 'common/common-model';
+import { LayoutSwitchId } from 'track-layout/track-layout-model';
+import { Spinner } from 'vayla-design-lib/spinner/spinner';
+
+type LinkingStatusProps = {
+    switchId: LayoutSwitchId;
+    planId: GeometryPlanId;
+    publishType: PublishType;
+    switchChangeTime: TimeStamp;
+    locationTrackChangeTime: TimeStamp;
+};
+
+export const LinkingStatus: React.FC<LinkingStatusProps> = ({
+    switchId,
+    planId,
+    publishType,
+    switchChangeTime,
+    locationTrackChangeTime,
+}) => {
+    const { t } = useTranslation();
+    const [planStatus, planStatusFetchStatus] = useLoaderWithStatus(
+        () => (planId ? getPlanLinkStatus(planId, publishType) : undefined),
+        [planId, publishType, switchChangeTime, locationTrackChangeTime],
+    );
+
+    const isLinked = planStatus?.switches.find((s) => s.id === switchId)?.isLinked;
+
+    return (
+        <InfoboxField
+            label={t('tool-panel.switch.geometry.is-linked')}
+            className={styles['geometry-switch-infobox__linked-status']}
+            value={
+                planStatusFetchStatus === LoaderStatus.Ready ? (
+                    isLinked ? (
+                        <span className={styles['geometry-switch-infobox__linked-text']}>
+                            {t('yes')}
+                        </span>
+                    ) : (
+                        <span className={styles['geometry-switch-infobox__not-linked-text']}>
+                            {t('no')}
+                        </span>
+                    )
+                ) : (
+                    <Spinner />
+                )
+            }
+        />
+    );
+};

--- a/ui/src/linking/linking-utils.ts
+++ b/ui/src/linking/linking-utils.ts
@@ -8,6 +8,12 @@ import {
 } from 'track-layout/track-layout-model';
 import { getLocationTrack } from 'track-layout/layout-location-track-api';
 
+export enum SwitchTypeMatch {
+    Exact,
+    Similar,
+    Invalid,
+}
+
 type LocationTracksEndingAtJoint = {
     jointNumber: JointNumber;
     locationTrackIds: LocationTrackId[];

--- a/ui/src/tool-panel/switch/geometry-switch-linking-candidates.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-candidates.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { LayoutSwitch, LayoutSwitchId } from 'track-layout/track-layout-model';
+import styles from 'tool-panel/switch/switch-infobox.scss';
+import { SwitchBadge, SwitchBadgeStatus } from 'geoviite-design-lib/switch/switch-badge';
+import { useLoader } from 'utils/react-utils';
+import { getSwitchesByBoundingBox } from 'track-layout/layout-switch-api';
+import { SuggestedSwitch } from 'linking/linking-model';
+import { TimeStamp } from 'common/common-model';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+
+type GeometrySwitchLinkingCandidateListingProps = {
+    suggestedSwitch: SuggestedSwitch | null | undefined;
+    selectedSwitchId: LayoutSwitchId | undefined;
+    onSelectSwitch: (selectedSwitch: LayoutSwitch) => void;
+    switchChangeTime: TimeStamp;
+    onShowAddSwitchDialog: () => void;
+};
+
+export const GeometrySwitchLinkingCandidates: React.FC<
+    GeometrySwitchLinkingCandidateListingProps
+> = ({
+    suggestedSwitch,
+    selectedSwitchId,
+    onSelectSwitch,
+    switchChangeTime,
+    onShowAddSwitchDialog,
+}) => {
+    const switches = useLoader(() => {
+        const point = suggestedSwitch?.joints.find((joint) => joint.location)?.location;
+        if (point) {
+            // This is a simple way to select nearby layout switches,
+            // can be fine tuned later
+            const bboxSize = 100;
+            const bbox = {
+                x: { min: point.x - bboxSize, max: point.x + bboxSize },
+                y: { min: point.y - bboxSize, max: point.y + bboxSize },
+            };
+
+            return getSwitchesByBoundingBox(bbox, 'DRAFT', point, true);
+        } else {
+            return undefined;
+        }
+    }, [suggestedSwitch, switchChangeTime]);
+
+    return (
+        <React.Fragment>
+            <div className={styles['geometry-switch-infobox__search-container']}>
+                <Button
+                    variant={ButtonVariant.GHOST}
+                    size={ButtonSize.SMALL}
+                    icon={Icons.Append}
+                    onClick={onShowAddSwitchDialog}
+                    qa-id=""
+                />
+            </div>
+            <ul className={styles['geometry-switch-infobox__switches-container']}>
+                {switches?.map((s) => {
+                    return (
+                        <li
+                            key={s.id}
+                            className={styles['geometry-switch-infobox__switch']}
+                            onClick={() => onSelectSwitch(s)}>
+                            <SwitchBadge
+                                switchItem={s}
+                                status={
+                                    selectedSwitchId === s.id
+                                        ? SwitchBadgeStatus.SELECTED
+                                        : SwitchBadgeStatus.DEFAULT
+                                }
+                            />
+                        </li>
+                    );
+                })}
+            </ul>
+        </React.Fragment>
+    );
+};

--- a/ui/src/tool-panel/switch/geometry-switch-linking-errors.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-errors.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import styles from 'tool-panel/switch/switch-infobox.scss';
+import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
+import { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
+import { useTranslation } from 'react-i18next';
+import { SuggestedSwitch } from 'linking/linking-model';
+import { SwitchStructure } from 'common/common-model';
+
+export enum SwitchTypeMatch {
+    Exact,
+    Similar,
+    Invalid,
+}
+
+type GeometrySwitchLinkingErrorsProps = {
+    selectedLayoutSwitchStructure: SwitchStructure | undefined;
+    switchTypeMatch: SwitchTypeMatch;
+    suggestedSwitch: SuggestedSwitch;
+    onConfirmChanged: (confirmed: boolean) => void;
+};
+
+export const GeometrySwitchLinkingErrors: React.FC<GeometrySwitchLinkingErrorsProps> = ({
+    selectedLayoutSwitchStructure,
+    suggestedSwitch,
+    switchTypeMatch,
+    onConfirmChanged,
+}) => {
+    const { t } = useTranslation();
+    const [typeDifferenceConfirmed, setTypeDifferenceConfirmed] = React.useState(false);
+
+    return (
+        <InfoboxContentSpread>
+            <MessageBox
+                pop={
+                    selectedLayoutSwitchStructure != undefined &&
+                    switchTypeMatch == SwitchTypeMatch.Invalid
+                }>
+                <div className={styles['geometry-switch-infobox__switch-type-warning-msg']}>
+                    {t('tool-panel.switch.geometry.cannot-link-invalid-switch-type', [
+                        suggestedSwitch?.switchStructure.type,
+                        selectedLayoutSwitchStructure?.type,
+                    ])}
+                </div>
+            </MessageBox>
+            <MessageBox
+                pop={
+                    selectedLayoutSwitchStructure != undefined &&
+                    switchTypeMatch == SwitchTypeMatch.Similar
+                }>
+                <div className={styles['geometry-switch-infobox__switch-type-warning-msg']}>
+                    {t('tool-panel.switch.geometry.switch-type-differs-warning', [
+                        suggestedSwitch?.switchStructure.type,
+                        selectedLayoutSwitchStructure?.type,
+                    ])}
+                </div>
+                <div className={styles['geometry-switch-infobox__switch-type-confirm']}>
+                    <Checkbox
+                        checked={typeDifferenceConfirmed}
+                        onChange={(e) => {
+                            setTypeDifferenceConfirmed(e.target.checked);
+                            onConfirmChanged(e.target.checked);
+                        }}>
+                        {t('tool-panel.switch.geometry.switch-type-confirm-msg')}
+                    </Checkbox>
+                </div>
+            </MessageBox>
+        </InfoboxContentSpread>
+    );
+};

--- a/ui/src/tool-panel/switch/geometry-switch-linking-errors.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-errors.tsx
@@ -6,12 +6,7 @@ import { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
 import { useTranslation } from 'react-i18next';
 import { SuggestedSwitch } from 'linking/linking-model';
 import { SwitchStructure } from 'common/common-model';
-
-export enum SwitchTypeMatch {
-    Exact,
-    Similar,
-    Invalid,
-}
+import { SwitchTypeMatch } from 'linking/linking-utils';
 
 type GeometrySwitchLinkingErrorsProps = {
     selectedLayoutSwitchStructure: SwitchStructure | undefined;

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -25,10 +25,8 @@ import { LinkingStatus } from 'linking/linking-status';
 import { GeometrySwitchLinkingStartButton } from 'tool-panel/switch/geometry-switch-linking-start-button';
 import { GeometrySwitchLinkingCandidates } from 'tool-panel/switch/geometry-switch-linking-candidates';
 import { SwitchJointInfoboxContainer } from 'tool-panel/switch/switch-joint-infobox-container';
-import {
-    GeometrySwitchLinkingErrors,
-    SwitchTypeMatch,
-} from 'tool-panel/switch/geometry-switch-linking-errors';
+import { GeometrySwitchLinkingErrors } from 'tool-panel/switch/geometry-switch-linking-errors';
+import { SwitchTypeMatch } from 'linking/linking-utils';
 
 type GeometrySwitchLinkingInfoboxProps = {
     geometrySwitchId?: GeometrySwitchId;

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Infobox from 'tool-panel/infobox/infobox';
-import InfoboxContent, { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
+import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import { useTranslation } from 'react-i18next';
 import styles from './switch-infobox.scss';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
@@ -25,14 +25,10 @@ import { LinkingStatus } from 'linking/linking-status';
 import { GeometrySwitchLinkingStartButton } from 'tool-panel/switch/geometry-switch-linking-start-button';
 import { GeometrySwitchLinkingCandidates } from 'tool-panel/switch/geometry-switch-linking-candidates';
 import { SwitchJointInfoboxContainer } from 'tool-panel/switch/switch-joint-infobox-container';
-import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
-import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
-
-enum SwitchTypeMatch {
-    Exact,
-    Similar,
-    Invalid,
-}
+import {
+    GeometrySwitchLinkingErrors,
+    SwitchTypeMatch,
+} from 'tool-panel/switch/geometry-switch-linking-errors';
 
 type GeometrySwitchLinkingInfoboxProps = {
     geometrySwitchId?: GeometrySwitchId;
@@ -231,62 +227,16 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
                                     {t('tool-panel.switch.geometry.zoom-closer')}
                                 </div>
                             )}
-                            <InfoboxContentSpread>
-                                <MessageBox
-                                    pop={
-                                        selectedLayoutSwitch != undefined &&
-                                        switchTypeMatch == SwitchTypeMatch.Invalid
-                                    }>
-                                    <div
-                                        className={
-                                            styles[
-                                                'geometry-switch-infobox__switch-type-warning-msg'
-                                            ]
-                                        }>
-                                        {t(
-                                            'tool-panel.switch.geometry.cannot-link-invalid-switch-type',
-                                            [
-                                                suggestedSwitch?.switchStructure.type,
-                                                selectedLayoutSwitchStructure?.type,
-                                            ],
-                                        )}
-                                    </div>
-                                </MessageBox>
-                                <MessageBox
-                                    pop={
-                                        selectedLayoutSwitch != undefined &&
-                                        switchTypeMatch == SwitchTypeMatch.Similar
-                                    }>
-                                    <div
-                                        className={
-                                            styles[
-                                                'geometry-switch-infobox__switch-type-warning-msg'
-                                            ]
-                                        }>
-                                        {t(
-                                            'tool-panel.switch.geometry.switch-type-differs-warning',
-                                            [
-                                                suggestedSwitch?.switchStructure.type,
-                                                selectedLayoutSwitchStructure?.type,
-                                            ],
-                                        )}
-                                    </div>
-                                    <div
-                                        className={
-                                            styles['geometry-switch-infobox__switch-type-confirm']
-                                        }>
-                                        <Checkbox
-                                            checked={switchTypeDifferenceIsConfirmed}
-                                            onChange={(e) =>
-                                                setSwitchTypeDifferenceIsConfirmed(e.target.checked)
-                                            }>
-                                            {t(
-                                                'tool-panel.switch.geometry.switch-type-confirm-msg',
-                                            )}
-                                        </Checkbox>
-                                    </div>
-                                </MessageBox>
-                            </InfoboxContentSpread>
+                            {suggestedSwitch && (
+                                <GeometrySwitchLinkingErrors
+                                    selectedLayoutSwitchStructure={selectedLayoutSwitchStructure}
+                                    suggestedSwitch={suggestedSwitch}
+                                    switchTypeMatch={switchTypeMatch}
+                                    onConfirmChanged={(confirmed) =>
+                                        setSwitchTypeDifferenceIsConfirmed(confirmed)
+                                    }
+                                />
+                            )}
                             <InfoboxButtons>
                                 <Button
                                     size={ButtonSize.SMALL}

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -1,34 +1,30 @@
 import * as React from 'react';
-import InfoboxField from 'tool-panel/infobox/infobox-field';
 import Infobox from 'tool-panel/infobox/infobox';
 import InfoboxContent, { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
 import { useTranslation } from 'react-i18next';
 import styles from './switch-infobox.scss';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
-import { LinkingSwitch, SuggestedSwitch } from 'linking/linking-model';
-import { TextField, TextFieldVariant } from 'vayla-design-lib/text-field/text-field';
+import { LinkingState, LinkingSwitch, SuggestedSwitch } from 'linking/linking-model';
 import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
-import { SwitchBadge, SwitchBadgeStatus } from 'geoviite-design-lib/switch/switch-badge';
 import { SwitchEditDialog } from './dialog/switch-edit-dialog';
-import {
-    LayoutSwitch,
-    LayoutSwitchId,
-    LayoutSwitchJointConnection,
-} from 'track-layout/track-layout-model';
-import { getSwitch, getSwitchesByBoundingBox } from 'track-layout/layout-switch-api';
-import { useDebouncedState, useLoader } from 'utils/react-utils';
+import { LayoutSwitch, LayoutSwitchId } from 'track-layout/track-layout-model';
+import { getSwitch } from 'track-layout/layout-switch-api';
+import { LoaderStatus, useLoader, useLoaderWithStatus } from 'utils/react-utils';
 import { PublishType, TimeStamp } from 'common/common-model';
 import { SWITCH_SHOW } from 'map/layers/layer-visibility-limits';
-import { getPlanLinkStatus, getSuggestedSwitchesByTile, linkSwitch } from 'linking/linking-api';
+import { getSuggestedSwitchesByTile, linkSwitch } from 'linking/linking-api';
 import * as SnackBar from 'geoviite-design-lib/snackbar/snackbar';
 import GeometrySwitchLinkingSuggestedInfobox from 'tool-panel/switch/geometry-switch-linking-suggested-infobox';
 import { GeometryPlanId, GeometrySwitchId } from 'geometry/geometry-model';
 import { getGeometrySwitch, getGeometrySwitchLayout } from 'geometry/geometry-api';
 import { boundingBoxAroundPoints, expandBoundingBox } from 'model/geometry';
-import SwitchJointInfobox from 'tool-panel/switch/switch-joint-infobox';
-import { asTrackLayoutSwitchJointConnection } from 'linking/linking-utils';
 import { useSwitch, useSwitchStructure } from 'track-layout/track-layout-react-utils';
+import { Spinner } from 'vayla-design-lib/spinner/spinner';
+import { LinkingStatus } from 'linking/linking-status';
+import { GeometrySwitchLinkingStartButton } from 'tool-panel/switch/geometry-switch-linking-start-button';
+import { GeometrySwitchLinkingCandidates } from 'tool-panel/switch/geometry-switch-linking-candidates';
+import { SwitchJointInfoboxContainer } from 'tool-panel/switch/switch-joint-infobox-container';
 import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
 import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
 
@@ -55,6 +51,9 @@ type GeometrySwitchLinkingInfoboxProps = {
     publishType: PublishType;
 };
 
+const isLinkingStarted = (linkingState: LinkingState) =>
+    linkingState.state === 'setup' || linkingState.state === 'allSet';
+
 const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> = ({
     geometrySwitchId,
     linkingState,
@@ -80,7 +79,7 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
         () => (geometrySwitchId ? getGeometrySwitchLayout(geometrySwitchId) : undefined),
         [geometrySwitchId],
     );
-    const suggestedSwitch = useLoader(() => {
+    const [suggestedSwitch, suggestedSwitchFetchStatus] = useLoaderWithStatus(() => {
         if (selectedSuggestedSwitch) {
             return Promise.resolve(selectedSuggestedSwitch);
         } else if (geometrySwitch && geometrySwitchLayout) {
@@ -102,39 +101,9 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
         }
         return undefined;
     }, [geometrySwitchId, selectedSuggestedSwitch, geometrySwitchLayout]);
-    const showAlignmentNotLinkedMsg = suggestedSwitch === null;
-    const [searchTerm, setSearchTerm] = React.useState('');
-    const debouncedSearchTerm = useDebouncedState(searchTerm, 200);
     const [showAddSwitchDialog, setShowAddSwitchDialog] = React.useState(false);
-    const planStatus = useLoader(
-        () => (planId ? getPlanLinkStatus(planId, publishType) : undefined),
-        [planId, publishType, switchChangeTime, locationTrackChangeTime],
-    );
-    const switches = useLoader(() => {
-        const point = selectedSuggestedSwitch?.joints.find((joint) => joint.location)?.location;
-        if (point) {
-            // This is a simple way to select nearby layout switches,
-            // can be fine tuned later
-            const bboxSize = 100;
-            const bbox = {
-                x: { min: point.x - bboxSize, max: point.x + bboxSize },
-                y: { min: point.y - bboxSize, max: point.y + bboxSize },
-            };
-
-            return getSwitchesByBoundingBox(bbox, 'DRAFT', debouncedSearchTerm, point, true);
-        } else {
-            return undefined;
-        }
-    }, [selectedSuggestedSwitch, debouncedSearchTerm, switchChangeTime]);
-    const switchJointConnections: LayoutSwitchJointConnection[] | undefined = suggestedSwitch
-        ? suggestedSwitch.joints.map((joint) => asTrackLayoutSwitchJointConnection(joint))
-        : undefined;
-    const isGeometrySwitchLinking = !!switchId;
-    const isSwitchLinked = planStatus?.switches.find((s) => s.id === switchId)?.isLinked;
-    const linkingIsStarted = linkingState?.state === 'setup' || linkingState?.state === 'allSet';
     const [linkingCallInProgress, setLinkingCallInProgress] = React.useState(false);
     const selectedLayoutSwitch = useSwitch(linkingState?.layoutSwitchId, publishType);
-    const isLayoutSwitchSelected = selectedLayoutSwitch != undefined;
     const selectedLayoutSwitchStructure = useSwitchStructure(
         selectedLayoutSwitch?.switchStructureId,
     );
@@ -154,18 +123,14 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
         React.useState(false);
     const isValidLayoutSwitch =
         suggestedSwitch != undefined &&
-        selectedLayoutSwitch != undefined &&
+        selectedLayoutSwitch &&
         (switchTypeMatch == SwitchTypeMatch.Exact ||
             (switchTypeMatch == SwitchTypeMatch.Similar && switchTypeDifferenceIsConfirmed));
     const canLink =
-        isLayoutSwitchSelected &&
+        selectedLayoutSwitch &&
         isValidLayoutSwitch &&
         linkingState?.state === 'allSet' &&
         !linkingCallInProgress;
-    const showInvalidSwitchTypeError =
-        isLayoutSwitchSelected && switchTypeMatch == SwitchTypeMatch.Invalid;
-    const showSwitchTypeDiffersWarning =
-        isLayoutSwitchSelected && switchTypeMatch == SwitchTypeMatch.Similar;
 
     React.useEffect(() => setSwitchTypeDifferenceIsConfirmed(false), [selectedLayoutSwitch]);
 
@@ -220,116 +185,57 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
                 title={t('tool-panel.switch.geometry.linking-header')}
                 qa-id="geometry-switch-linking-infobox">
                 <InfoboxContent>
-                    {isGeometrySwitchLinking && (
+                    {switchId && planId && (
                         <React.Fragment>
-                            <InfoboxField
-                                label={t('tool-panel.switch.geometry.is-linked')}
-                                className={styles['geometry-switch-infobox__linked-status']}
-                                value={
-                                    isSwitchLinked ? (
-                                        <span
-                                            className={
-                                                styles['geometry-switch-infobox__linked-text']
-                                            }>
-                                            {t('yes')}
-                                        </span>
-                                    ) : (
-                                        <span
-                                            className={
-                                                styles['geometry-switch-infobox__not-linked-text']
-                                            }>
-                                            {t('no')}
-                                        </span>
-                                    )
-                                }
+                            <LinkingStatus
+                                switchId={switchId}
+                                planId={planId}
+                                publishType={publishType}
+                                switchChangeTime={switchChangeTime}
+                                locationTrackChangeTime={locationTrackChangeTime}
                             />
-                            {!isSwitchLinked && (
-                                <React.Fragment>
-                                    {showAlignmentNotLinkedMsg && (
-                                        <InfoboxContentSpread>
-                                            <MessageBox>
-                                                {t(
-                                                    'tool-panel.switch.geometry.cannot-start-switch-linking-related-tracks-not-linked-msg',
-                                                )}
-                                            </MessageBox>
-                                        </InfoboxContentSpread>
-                                    )}
-                                </React.Fragment>
+                            {suggestedSwitchFetchStatus !== LoaderStatus.Loading ? (
+                                <GeometrySwitchLinkingStartButton
+                                    onStartLinking={startLinking}
+                                    hasSuggestedSwitch={suggestedSwitch !== null}
+                                    linkingState={linkingState}
+                                />
+                            ) : (
+                                <Spinner />
                             )}
                         </React.Fragment>
                     )}
                     {linkingState && (
-                        <div className={styles['geometry-switch-infobox__linking-container']}>
-                            <span className={styles['geometry-switch-infobox__info-text']}>
-                                {t('tool-panel.switch.geometry.select-switch-msg')}
-                            </span>
-                            <div className={styles['geometry-switch-infobox__search-container']}>
-                                <div className={styles['geometry-switch-infobox__search-input']}>
-                                    <TextField
-                                        variant={TextFieldVariant.NO_BORDER}
-                                        Icon={Icons.Search}
-                                        wide
-                                        value={searchTerm}
-                                        onChange={(e) => {
-                                            setSearchTerm(e.target.value);
-                                        }}
-                                    />
-                                </div>
-                                <Button
-                                    variant={ButtonVariant.GHOST}
-                                    size={ButtonSize.SMALL}
-                                    icon={Icons.Append}
-                                    onClick={() => setShowAddSwitchDialog(true)}
-                                    qa-id=""
-                                />
-                            </div>
-                            <ul className={styles['geometry-switch-infobox__switches-container']}>
-                                {switches?.map((s) => {
-                                    return (
-                                        <li
-                                            key={s.id}
-                                            className={styles['geometry-switch-infobox__switch']}
-                                            onClick={() => onSwitchSelect(s)}>
-                                            <SwitchBadge
-                                                switchItem={s}
-                                                status={
-                                                    layoutSwitch?.id === s.id
-                                                        ? SwitchBadgeStatus.SELECTED
-                                                        : SwitchBadgeStatus.DEFAULT
-                                                }
-                                            />
-                                        </li>
-                                    );
-                                })}
-                            </ul>
-                            {suggestedSwitch && switchJointConnections && (
-                                <SwitchJointInfobox
-                                    switchAlignments={suggestedSwitch.switchStructure.alignments}
-                                    jointConnections={switchJointConnections}
-                                    publishType={publishType}
-                                />
-                            )}
-                        </div>
-                    )}
-                    {linkingIsStarted && resolution > SWITCH_SHOW && (
-                        <div className={styles['geometry-switch-infobox__zoom-warning']}>
-                            <Icons.Info color={IconColor.INHERIT} />
-                            {t('tool-panel.switch.geometry.zoom-closer')}
-                        </div>
-                    )}
-                    {suggestedSwitch && linkingState === undefined && (
-                        <InfoboxButtons>
-                            <Button size={ButtonSize.SMALL} onClick={startLinking}>
-                                {t('tool-panel.switch.geometry.start-setup')}
-                            </Button>
-                        </InfoboxButtons>
-                    )}
-                    {linkingState && (
                         <React.Fragment>
+                            <div className={styles['geometry-switch-infobox__linking-container']}>
+                                <span className={styles['geometry-switch-infobox__info-text']}>
+                                    {t('tool-panel.switch.geometry.select-switch-msg')}
+                                </span>
+                                <GeometrySwitchLinkingCandidates
+                                    onSelectSwitch={onSwitchSelect}
+                                    selectedSwitchId={layoutSwitch?.id}
+                                    switchChangeTime={switchChangeTime}
+                                    suggestedSwitch={suggestedSwitch}
+                                    onShowAddSwitchDialog={() => setShowAddSwitchDialog(true)}
+                                />
+                                {suggestedSwitch && (
+                                    <SwitchJointInfoboxContainer
+                                        suggestedSwitch={suggestedSwitch}
+                                        publishType={publishType}
+                                    />
+                                )}
+                            </div>
+                            {isLinkingStarted(linkingState) && resolution > SWITCH_SHOW && (
+                                <div className={styles['geometry-switch-infobox__zoom-warning']}>
+                                    <Icons.Info color={IconColor.INHERIT} />
+                                    {t('tool-panel.switch.geometry.zoom-closer')}
+                                </div>
+                            )}
                             <InfoboxContentSpread>
                                 <MessageBox
                                     pop={
-                                        showInvalidSwitchTypeError || showSwitchTypeDiffersWarning
+                                        selectedLayoutSwitch != undefined &&
+                                        switchTypeMatch == SwitchTypeMatch.Invalid
                                     }>
                                     <div
                                         className={
@@ -337,43 +243,48 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
                                                 'geometry-switch-infobox__switch-type-warning-msg'
                                             ]
                                         }>
-                                        {showInvalidSwitchTypeError &&
-                                            t(
-                                                'tool-panel.switch.geometry.cannot-link-invalid-switch-type',
-                                                [
-                                                    suggestedSwitch?.switchStructure.type,
-                                                    selectedLayoutSwitchStructure?.type,
-                                                ],
-                                            )}
-                                        {showSwitchTypeDiffersWarning &&
-                                            t(
-                                                'tool-panel.switch.geometry.switch-type-differs-warning',
-                                                [
-                                                    suggestedSwitch?.switchStructure.type,
-                                                    selectedLayoutSwitchStructure?.type,
-                                                ],
-                                            )}
+                                        {t(
+                                            'tool-panel.switch.geometry.cannot-link-invalid-switch-type',
+                                            [
+                                                suggestedSwitch?.switchStructure.type,
+                                                selectedLayoutSwitchStructure?.type,
+                                            ],
+                                        )}
                                     </div>
-                                    {showSwitchTypeDiffersWarning && (
-                                        <div
-                                            className={
-                                                styles[
-                                                    'geometry-switch-infobox__switch-type-confirm'
-                                                ]
+                                </MessageBox>
+                                <MessageBox
+                                    pop={
+                                        selectedLayoutSwitch != undefined &&
+                                        switchTypeMatch == SwitchTypeMatch.Similar
+                                    }>
+                                    <div
+                                        className={
+                                            styles[
+                                                'geometry-switch-infobox__switch-type-warning-msg'
+                                            ]
+                                        }>
+                                        {t(
+                                            'tool-panel.switch.geometry.switch-type-differs-warning',
+                                            [
+                                                suggestedSwitch?.switchStructure.type,
+                                                selectedLayoutSwitchStructure?.type,
+                                            ],
+                                        )}
+                                    </div>
+                                    <div
+                                        className={
+                                            styles['geometry-switch-infobox__switch-type-confirm']
+                                        }>
+                                        <Checkbox
+                                            checked={switchTypeDifferenceIsConfirmed}
+                                            onChange={(e) =>
+                                                setSwitchTypeDifferenceIsConfirmed(e.target.checked)
                                             }>
-                                            <Checkbox
-                                                checked={switchTypeDifferenceIsConfirmed}
-                                                onChange={(e) =>
-                                                    setSwitchTypeDifferenceIsConfirmed(
-                                                        e.target.checked,
-                                                    )
-                                                }>
-                                                {t(
-                                                    'tool-panel.switch.geometry.switch-type-confirm-msg',
-                                                )}
-                                            </Checkbox>
-                                        </div>
-                                    )}
+                                            {t(
+                                                'tool-panel.switch.geometry.switch-type-confirm-msg',
+                                            )}
+                                        </Checkbox>
+                                    </div>
                                 </MessageBox>
                             </InfoboxContentSpread>
                             <InfoboxButtons>

--- a/ui/src/tool-panel/switch/geometry-switch-linking-start-button.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-start-button.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
+import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
+import { Button, ButtonSize } from 'vayla-design-lib/button/button';
+import { LinkingState } from 'linking/linking-model';
+
+type LinkingStatusProps = {
+    linkingState: LinkingState | undefined;
+    hasSuggestedSwitch: boolean;
+    onStartLinking: () => void;
+};
+
+export const GeometrySwitchLinkingStartButton: React.FC<LinkingStatusProps> = ({
+    linkingState,
+    hasSuggestedSwitch,
+    onStartLinking,
+}) => {
+    const { t } = useTranslation();
+    return (
+        <React.Fragment>
+            {linkingState === undefined && (
+                <React.Fragment>
+                    {hasSuggestedSwitch ? (
+                        <InfoboxButtons>
+                            <Button size={ButtonSize.SMALL} onClick={onStartLinking}>
+                                {t('tool-panel.switch.geometry.start-setup')}
+                            </Button>
+                        </InfoboxButtons>
+                    ) : (
+                        <InfoboxContentSpread>
+                            <MessageBox>
+                                {t(
+                                    'tool-panel.switch.geometry.cannot-start-switch-linking-related-tracks-not-linked-msg',
+                                )}
+                            </MessageBox>
+                        </InfoboxContentSpread>
+                    )}
+                </React.Fragment>
+            )}
+        </React.Fragment>
+    );
+};

--- a/ui/src/tool-panel/switch/switch-infobox.scss
+++ b/ui/src/tool-panel/switch/switch-infobox.scss
@@ -2,157 +2,156 @@
 @import '../../vayla-design-lib/colors';
 
 .geometry-switch-infobox {
-  &__linked-status .infobox__field-label {
-    line-height: 24px;
-  }
-
-  &__not-linked-text,
-  &__linked-text {
-    padding: 4px 8px;
-  }
-
-  &__not-linked-text {
-    background-color: $color-red-lighter;
-  }
-
-  &__linked-text {
-    background-color: $color-green-lighter;
-  }
-
-  &__linking-container {
-    padding: 8px 0 8px 4px;
-  }
-
-  &__info-text {
-    @include typography-caption;
-
-    padding: 10px 0;
-  }
-
-  &__search-container {
-    display: flex;
-    align-items: center;
-  }
-
-  &__search-input {
-    flex: 1;
-  }
-
-  &__switches-container {
-    border: 1px solid $color-white-darker;
-    border-radius: 4px;
-    padding: 10px 20px 10px 12px;
-
-    max-height: 200px;
-    overflow: auto;
-    list-style: none;
-    margin: 0;
-  }
-
-  &__switch {
-    display: flex;
-    align-items: center;
-    padding: 4px 0;
-    cursor: pointer;
-
-    .switch-badge {
-      margin-right: 8px;
+    &__linked-status .infobox__field-label {
+        line-height: 24px;
     }
 
-    .icon {
-      fill: $color-black-light;
+    &__not-linked-text,
+    &__linked-text {
+        padding: 4px 8px;
     }
-  }
 
-  &__zoom-warning {
-    display: flex;
-    align-items: center;
-    background-color: $color-lemon-light;
-    padding: 10px 16px 10px 26px;
-    margin: 0 -16px 0 -20px;
-    font-size: 12px;
-
-    .icon {
-      fill: $color-black-lighter;
-      margin-right: 12px;
+    &__not-linked-text {
+        background-color: $color-red-lighter;
     }
-  }
+
+    &__linked-text {
+        background-color: $color-green-lighter;
+    }
+
+    &__linking-container {
+        padding: 8px 0 8px 4px;
+    }
+
+    &__info-text {
+        @include typography-caption;
+
+        padding: 10px 0;
+    }
+
+    &__search-container {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+    }
+
+    &__search-input {
+        flex: 1;
+    }
+
+    &__switches-container {
+        border: 1px solid $color-white-darker;
+        border-radius: 4px;
+        padding: 10px 20px 10px 12px;
+
+        max-height: 200px;
+        overflow: auto;
+        list-style: none;
+        margin: 0;
+    }
+
+    &__switch {
+        display: flex;
+        align-items: center;
+        padding: 4px 0;
+        cursor: pointer;
+
+        .switch-badge {
+            margin-right: 8px;
+        }
+
+        .icon {
+            fill: $color-black-light;
+        }
+    }
+
+    &__zoom-warning {
+        display: flex;
+        align-items: center;
+        background-color: $color-lemon-light;
+        padding: 10px 16px 10px 26px;
+        margin: 0 -16px 0 -20px;
+        font-size: 12px;
+
+        .icon {
+            fill: $color-black-lighter;
+            margin-right: 12px;
+        }
+    }
 }
 
 .geometry-switch-infobox__switch-type-warning-msg {
-  white-space: pre-line;
+    white-space: pre-line;
 }
 
 .geometry-switch-infobox__switch-type-confirm {
-  margin-top: 20px;
+    margin-top: 20px;
 }
 
 .switch-edit-dialog__delete-button {
-  position: absolute;
+    position: absolute;
 }
 
 .switch-edit-dialog__confirmation-list {
-  margin: 0;
-  padding: 0;
-  list-style: inside;
+    margin: 0;
+    padding: 0;
+    list-style: inside;
 }
 
 .switch-infobox-track-meters {
+    &__track-meters {
+        list-style-type: none; /* Remove bullets */
+        padding: 0; /* Remove padding */
+        margin: 0; /* Remove margins */
+    }
 
-  &__track-meters {
-  list-style-type: none; /* Remove bullets */
-  padding: 0; /* Remove padding */
-  margin: 0; /* Remove margins */
-  }
+    &__track-meter {
+        margin-bottom: 4px;
+    }
 
-  &__track-meter {
-    margin-bottom: 4px;
-  }
+    &__joint-number {
+        @include typography-caption;
+        color: $color-black-light;
 
-  &__joint-number {
-    @include typography-caption;
-    color: $color-black-light;
+        display: inline-block;
+        margin: 6px 0 2px 0;
+    }
 
-    display: inline-block;
-    margin: 6px 0 2px 0;
-  }
-
-  &__show-more {
-    margin-top: 8px;
-  }
-
+    &__show-more {
+        margin-top: 8px;
+    }
 }
 
 .switch-joint-infobox {
-  &__joints-container {
-    display: grid;
-    grid-template-columns: 120px 1fr;
-    margin: 12px 0 16px 0;
+    &__joints-container {
+        display: grid;
+        grid-template-columns: 120px 1fr;
+        margin: 12px 0 16px 0;
 
-    dd {
-      margin-left: 0;
+        dd {
+            margin-left: 0;
+        }
     }
-  }
 
-  &__joint-title {
-    @include typography-caption-strong;
+    &__joint-title {
+        @include typography-caption-strong;
 
-    color: $color-black-light;
-    padding: 4px 0;
-  }
-
-  &__joint-alignments-title,
-  &__joint-points-title {
-    @include typography-caption;
-    padding: 6px 0;
-    line-height: 20px;
-  }
-
-  &__location-tracks {
-    padding: 6px 0;
-
-    .alignment-badge {
-      margin: 0 4px 4px 0;
+        color: $color-black-light;
+        padding: 4px 0;
     }
-  }
+
+    &__joint-alignments-title,
+    &__joint-points-title {
+        @include typography-caption;
+        padding: 6px 0;
+        line-height: 20px;
+    }
+
+    &__location-tracks {
+        padding: 6px 0;
+
+        .alignment-badge {
+            margin: 0 4px 4px 0;
+        }
+    }
 }

--- a/ui/src/tool-panel/switch/switch-joint-infobox-container.tsx
+++ b/ui/src/tool-panel/switch/switch-joint-infobox-container.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import SwitchJointInfobox from 'tool-panel/switch/switch-joint-infobox';
+import { asTrackLayoutSwitchJointConnection } from 'linking/linking-utils';
+import { SuggestedSwitch } from 'linking/linking-model';
+import { PublishType } from 'common/common-model';
+
+type SwitchJointInfoboxContainerProps = {
+    suggestedSwitch: SuggestedSwitch;
+    publishType: PublishType;
+};
+
+export const SwitchJointInfoboxContainer: React.FC<SwitchJointInfoboxContainerProps> = ({
+    suggestedSwitch,
+    publishType,
+}) => {
+    const jointConnections = suggestedSwitch
+        ? suggestedSwitch.joints.map((joint) => asTrackLayoutSwitchJointConnection(joint))
+        : undefined;
+    const switchAlignments = suggestedSwitch.switchStructure.alignments;
+
+    return jointConnections ? (
+        <SwitchJointInfobox
+            switchAlignments={switchAlignments}
+            jointConnections={jointConnections}
+            publishType={publishType}
+        />
+    ) : (
+        <React.Fragment />
+    );
+};

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -27,7 +27,6 @@ const switchGroupsCache = asyncCache<string, LayoutSwitch[]>();
 export async function getSwitchesByBoundingBox(
     bbox: BoundingBox,
     publishType: PublishType,
-    _searchTerm?: string,
     comparisonPoint?: Point,
     includeSwitchesWithNoJoints = false,
 ): Promise<LayoutSwitch[]> {


### PR DESCRIPTION
Olipas työmaa, ja pahoittelut jo etukäteen siitä minkälainen samanlainen tämän reviewin lukeminen tulee olemaan. Lopulta en oikeastaan tainnut edes tehdä varsinaisesti mitään sille, että nappi tulisi näkyviin yhtään aiempaa paremmin. Nappi ja virheilmoitus ovat molemmat sellaisia, että ennen kuin ne voidaan näyttää, useamman eri bäkkärihaun pitää mennä kunnialla läpi. Jos operaattori kliksuttelee ympäriinsä paljon, on ihan täysin luonnollista, että selain tai bäkkäri voi mennä tarpeeksi tukkoon että joku requesti kestää pitkään tai hukkuu jonnekin. Nyt näytetään spinneri napin/virheilmon sijasta silloin kun sitä ladataan, joka ainakin omasta mielestäni on sentään fiksumpi tapa ilmaista tuo odottelu.

Päädyin tässä tekemään aika ekstensiivistä refakkia tuolle infoboksille, sillä wanha infoboksi oli jotakuinkin 420 riviä spagettia. Pilkoin sitä osiin sikäli kun näin aiheelliseksi ja jaoin alihakuja niistä vastaaviin omiin komponentteihinsa. Nyt (toivottavasti) tuosta infoboksista saa paremmin tolkkua