### PR TITLE
GVT-1688: Elementtiluettelon CSV vastaamaan taulukkoa UI:ssa + refaktorointia

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
@@ -1,33 +1,53 @@
 package fi.fta.geoviite.infra.geometry
 
 val ELEMENT_LISTING = "Elementtilistaus"
-private val ELEMENT_LISTING_COMMON_CSV_HEADERS = listOf(
-    "Suunnitelman raide",
-    "Elementin tyyppi",
-    "Rataosoite alussa",
-    "Rataosoite lopussa",
-    "Sijainti alussa E",
-    "Sijainti alussa N",
-    "Sijainti lopussa E",
-    "Sijainti lopussa N",
-    "Pituus (m)",
-    "Kaarresäde alussa",
-    "Kaarresäde lopussa",
-    "Kallistus alussa",
-    "Kallistus lopussa",
-    "Suuntakulma alussa (grad)",
-    "Suuntakulma lopussa (grad)",
-    "Suunnitelma",
-    "Lähde",
-    "Koordinaatisto"
-)
 
-val CONTINUOUS_ELEMENT_LISTING_CSV_HEADERS = listOf(
-    "Ratanumero",
-    "Sijaintiraide"
-) + ELEMENT_LISTING_COMMON_CSV_HEADERS
+enum class ElementListingHeader {
+    TRACK_NUMBER,
+    LOCATION_TRACK,
+    PLAN_TRACK,
+    ELEMENT_TYPE,
+    TRACK_ADDRESS_START,
+    TRACK_ADDRESS_END,
+    LOCATION_START_E,
+    LOCATION_START_N,
+    LOCATION_END_E,
+    LOCATION_END_N,
+    LENGTH,
+    RADIUS_START,
+    RADIUS_END,
+    CANT_START,
+    CANT_END,
+    DIRECTION_START,
+    DIRECTION_END,
+    PLAN_NAME,
+    PLAN_SOURCE,
+    CRS
+}
 
-val PLAN_ELEMENT_LISTING_CSV_HEADERS = listOf("Ratanumero") + ELEMENT_LISTING_COMMON_CSV_HEADERS
+fun translateElementListingHeader(header: ElementListingHeader) =
+    when (header) {
+        ElementListingHeader.TRACK_NUMBER -> "Ratanumero"
+        ElementListingHeader.LOCATION_TRACK -> "Sijaintiraide"
+        ElementListingHeader.PLAN_TRACK -> "Suunnitelman raide"
+        ElementListingHeader.ELEMENT_TYPE -> "Elementin tyyppi"
+        ElementListingHeader.TRACK_ADDRESS_START -> "Rataosoite alussa"
+        ElementListingHeader.TRACK_ADDRESS_END -> "Rataosoite lopussa"
+        ElementListingHeader.LOCATION_START_E -> "Sijainti alussa E"
+        ElementListingHeader.LOCATION_START_N -> "Sijainti alussa N"
+        ElementListingHeader.LOCATION_END_E -> "Sijainti lopussa E"
+        ElementListingHeader.LOCATION_END_N -> "Sijainti lopussa N"
+        ElementListingHeader.LENGTH -> "Pituus (m)"
+        ElementListingHeader.RADIUS_START -> "Kaarresäde alussa"
+        ElementListingHeader.RADIUS_END -> "Kaarresäde lopussa"
+        ElementListingHeader.CANT_START -> "Kallistus alussa"
+        ElementListingHeader.CANT_END -> "Kallistus lopussa"
+        ElementListingHeader.DIRECTION_START -> "Suuntakulma alussa (gooni)"
+        ElementListingHeader.DIRECTION_END -> "Suuntakulma lopussa (gooni)"
+        ElementListingHeader.PLAN_NAME -> "Suunnitelma"
+        ElementListingHeader.PLAN_SOURCE -> "Lähde"
+        ElementListingHeader.CRS -> "Koordinaatisto"
+    }
 
 
 fun translateTrackGeometryElementType(type: TrackGeometryElementType) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/CSVPrintingUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/CSVPrintingUtils.kt
@@ -1,0 +1,25 @@
+package fi.fta.geoviite.infra.util
+
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVPrinter
+
+data class CsvEntry<T>(
+    val header: String,
+    val getValue: (data: T) -> Any?,
+)
+
+fun <T>printCsv(columns: List<CsvEntry<T>>, data: List<T>): ByteArray {
+    val csvBuilder = StringBuilder()
+    CSVPrinter(csvBuilder, CSVFormat.RFC4180).let { csvPrinter ->
+        try {
+            csvPrinter.printRecord(columns.map { it.header })
+            data.forEach { dataRow ->
+                columns.map { column -> csvPrinter.print(column.getValue(dataRow)) }
+                csvPrinter.println()
+            }
+        } finally {
+            csvPrinter.close()
+        }
+    }
+    return csvBuilder.toString().toByteArray()
+}


### PR DESCRIPTION
Wanha malli CSV-generointiin oli vähän... kehno ja ei-skaalautuva. Tein nyt CSVEntry-dataclassin, joka yhdistää datan ja sen otsikon. Nyt columnien reorder menee käytännössä sillä, että vaan järjestellään uudelleen printattavat CSVEntryt