### PR TITLE
GVT-1696: Elementit haetaan vaikka rataosoite on virheellinen

### DIFF
--- a/ui/src/data-products/element-list/continuous-geometry-search.tsx
+++ b/ui/src/data-products/element-list/continuous-geometry-search.tsx
@@ -91,8 +91,11 @@ const ContinuousGeometrySearch = ({
 
     useLoader(() => {
         return (
-            !state.searchParameters.locationTrack || hasErrors('searchGeometries')
-                ? Promise.resolve([])
+            !state.searchParameters.locationTrack ||
+            hasErrors('searchGeometries') ||
+            hasErrors('startTrackMeter') ||
+            hasErrors('endTrackMeter')
+                ? Promise.resolve(state.elements)
                 : getLocationTrackElements(
                       state.searchParameters.locationTrack.id,
                       selectedElementTypes(state.searchParameters.searchGeometries),

--- a/ui/src/data-products/element-list/element-list-store.ts
+++ b/ui/src/data-products/element-list/element-list-store.ts
@@ -171,6 +171,13 @@ const continuousGeometrySearchSlice = createSlice({
             { payload: propEdit }: PayloadAction<PropEdit<ContinuousSearchParameters, TKey>>,
         ) {
             state.searchFields[propEdit.key] = propEdit.value;
+            if (propEdit.key === 'locationTrack') {
+                state.searchParameters['startTrackMeter'] = '';
+                state.searchParameters['endTrackMeter'] = '';
+                state.searchFields['startTrackMeter'] = '';
+                state.searchFields['endTrackMeter'] = '';
+            }
+
             state.validationErrors = validateContinuousGeometry(state);
             if (isPropEditFieldCommitted(propEdit, state.committedFields, state.validationErrors)) {
                 // Valid value entered for a field, mark that field as committed


### PR DESCRIPTION
Täällä toteutettu (vähän speksin ulkopuolelta) myös alku- ja loppuarvojen nollaaminen silloin kun sijaintiraidetta vaihdetaan. Jos tätä ei halutakaan, voidaan tehdä jotain muuta tilalle.