### PR TITLE
GVT-1428 Cache mass-fetches on frontend

### DIFF
--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -180,3 +180,7 @@ export function removeIfExists<T>(originalCollection: T[], valueToRemove: T | un
 export function addIfExists<T>(originalCollection: T[], newValue: T | undefined): T[] {
     return newValue ? [...originalCollection, newValue] : [...originalCollection];
 }
+
+export function indexIntoMap<Id, Obj extends { id: Id }>(objs: Obj[]): Map<Id, Obj> {
+    return objs.reduce((map, obj) => map.set(obj.id, obj), new Map());
+}


### PR DESCRIPTION
AsyncCachella pysyy yhä se ominaisuus, että sen sisältö ja changeTime vastaavat toisiaan (sikäli kuin tehdään muutosajallisia hakuja); tämä vaikuttaa toteutukseen niin, että getMany()ssä ei pysty ensiksi odottamaan haun tulosta ja vasta sitten lyömään tuloksia cacheen, koska jos näin tehtäisiin, niin tulokset olisivat voineet haun aikana vanhentua.

(Tosin en vielä tässä ottanut muutosaikoja mukaan näihin getMany()-kutsuihin, kun olisi pitänyt tehdä vastaavia säätöjä niitä käyttäviin komponentteihin; kaikki aikanaan)