### PR TITLE
GVT-1701: Elementtiluettelo: Jatkuvalle geometrialle ja suunnitelmatilaiselle geometrialle saatesanat / selitys / kuvaavammat termit

### DIFF
--- a/ui/src/data-products/element-list/continuous-geometry-search.tsx
+++ b/ui/src/data-products/element-list/continuous-geometry-search.tsx
@@ -100,6 +100,9 @@ const ContinuousGeometrySearch = ({
 
     return (
         <React.Fragment>
+            <p className={styles['element-list__geometry-search-legend']}>
+                {t('data-products.element-list.location-track-legend')}
+            </p>
             <div className={styles['element-list__geometry-search']}>
                 <FieldLayout
                     label={t('data-products.element-list.search.location-track')}

--- a/ui/src/data-products/element-list/element-list-view.scss
+++ b/ui/src/data-products/element-list/element-list-view.scss
@@ -44,6 +44,10 @@
     }
 }
 
+.element-list__geometry-search-legend {
+    max-width: 800px;
+}
+
 .element-list__geometry-search {
     display: flex;
 

--- a/ui/src/data-products/element-list/element-list-view.tsx
+++ b/ui/src/data-products/element-list/element-list-view.tsx
@@ -47,7 +47,7 @@ const ElementListView = () => {
                     <div>
                         <span className={styles['element-list-view__radio-layout']}>
                             <Radio onChange={handleRadioClick} checked={continuousGeometrySelected}>
-                                {t('data-products.element-list.continuous-geometry')}
+                                {t('data-products.element-list.location-track-geometry')}
                             </Radio>
                             <Radio
                                 onChange={handleRadioClick}

--- a/ui/src/data-products/element-list/plan-geometry-search.tsx
+++ b/ui/src/data-products/element-list/plan-geometry-search.tsx
@@ -85,8 +85,8 @@ const PlanGeometrySearch = ({
     function getVisibleErrorsByProp(prop: keyof PlanGeometrySearchState) {
         return state.committedFields.includes(prop)
             ? state.validationErrors
-                .filter((error) => error.field == prop)
-                .map((error) => t(`data-products.element-list.search.${error.reason}`))
+                  .filter((error) => error.field == prop)
+                  .map((error) => t(`data-products.element-list.search.${error.reason}`))
             : [];
     }
 
@@ -104,6 +104,9 @@ const PlanGeometrySearch = ({
 
     return (
         <React.Fragment>
+            <p className={styles['element-list__geometry-search-legend']}>
+                {t('data-products.element-list.plan-legend')}
+            </p>
             <div className={styles['element-list__geometry-search']}>
                 <div className={styles['element-list__plan-search-dropdown']}>
                     <FieldLayout

--- a/ui/src/data-products/translations.fi.json
+++ b/ui/src/data-products/translations.fi.json
@@ -17,8 +17,10 @@
                 "download-csv": "Lataa CSV"
             },
             "element-list-title": "Elementtiluettelo",
-            "continuous-geometry": "Jatkuva geometria",
+            "location-track-geometry": "Raiteen geometria",
+            "location-track-legend": "Raiteen geometria näyttää luettelossa paikannuspohjan raiteeseen liityvät geometriaelementit. Tämä elementtiluettelo ei täysin vastaa sitä suunnitelmakokonaisuutta, jonka mukaan raide on rakennettu, joten luettelon tietoja on syytä pitää  epäluotettavina. Luettelon tietoja voi käyttää esim. kokonaiskuvan hahmottamiseen tai ongelmien selvittämiseen, mutta niitä ei pidä käyttää esim. tukemiskoneen työn lähtötietona.",
             "plan-geometry": "Suunnitelman geometria",
+            "plan-legend": "Suunnitelman geometria näyttää luettelossa suunnitelman sisältämät geometriaelementit. Rataosoiteet on laskettu paikannuspohjan pituusmittauksen mukaan, joten rataosoitteiden tarkkuutta on syytä pitää epäluotettavana. Myös  paikannuspalvelun suunnitelmien elementtien tietoja on syytä pitää epäluotettavina, joten niitä ei pidä käyttää esim. tukemiskoneen työn lähtötietona.",
             "geometry-elements": "Geometriaelementit ({{amount}} kpl)",
             "pcs": "kpl",
             "element-list-table": {


### PR DESCRIPTION
Samalla muutin termin "Jatkuva geometria" figmassa olleen "Raiteen geometria" mukaiseksi