### PR TITLE
GVT-1723: KKJ-kolmioverkkomuunnoksen optimointi

### DIFF
--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
     implementation("net.postgis:postgis-jdbc:2021.1.0")
     implementation("jakarta.activation:jakarta.activation-api:2.1.0")
     implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
-    implementation("org.apache.commons:commons-csv:1.9.0")
+    implementation("com.github.davidmoten:rtree2:0.9.3")
     compileOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.sun.xml.bind:jaxb-impl:4.0.1")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvParsing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvParsing.kt
@@ -1,5 +1,7 @@
 package fi.fta.geoviite.infra.dataImport
 
+import com.github.davidmoten.rtree2.RTree
+import com.github.davidmoten.rtree2.geometry.Rectangle
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.geography.*
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
@@ -118,7 +120,7 @@ fun createReferenceLinesFromCsv(
     file: CsvFile<ReferenceLineColumns>,
     metadataMap: Map<Oid<ReferenceLine>, List<AlignmentCsvMetaData<ReferenceLine>>>,
     trackNumbers: Map<Oid<TrackLayoutTrackNumber>, IntId<TrackLayoutTrackNumber>>,
-    kkjToEtrsTriangulationTriangles: List<KKJtoETRSTriangle>
+    kkjToEtrsTriangulationTriangles: RTree<KKJtoETRSTriangle, Rectangle>,
 ): Sequence<CsvReferenceLine> {
     return file.parseLinesStreaming { line ->
         val resolution = line.getInt(ReferenceLineColumns.RESOLUTION)
@@ -229,7 +231,7 @@ fun createLocationTracksFromCsv(
     metadataMap: Map<Oid<LocationTrack>, List<AlignmentCsvMetaData<LocationTrack>>>,
     switchLinksMap: Map<Oid<LocationTrack>, List<AlignmentSwitchLink>>,
     trackNumbers: Map<Oid<TrackLayoutTrackNumber>, IntId<TrackLayoutTrackNumber>>,
-    kkjToEtrsTriangulationTriangles: List<KKJtoETRSTriangle>
+    kkjToEtrsTriangulationTriangles: RTree<KKJtoETRSTriangle, Rectangle>
 ): Sequence<CsvLocationTrack> {
     return alignmentsFile.parseLinesStreaming { line ->
         val resolution = line.getInt(LocationTrackColumns.RESOLUTION)
@@ -666,7 +668,7 @@ fun <T> combineMetadataToSegments(
     switchLinks: List<AlignmentSwitchLink> = listOf(),
     alignmentMetadata: List<AlignmentCsvMetaData<T>> = listOf(),
     points: List<AddressPoint>,
-    kkjToEtrsTriangulationTriangles: List<KKJtoETRSTriangle>,
+    kkjToEtrsTriangulationTriangles: RTree<KKJtoETRSTriangle, Rectangle>,
 ): List<SegmentCsvMetaDataRange<T>> {
     val adjustedAlignmentMetadata = validateAndAdjustAlignmentCsvMetaData(
         points.first().trackMeter,
@@ -1000,7 +1002,7 @@ fun <T> noElementsCsvMetadata(alignmentMetaData: AlignmentCsvMetaData<T>) = Elem
 fun <T> getGeometryElementRanges(
     allPoints: List<AddressPoint>,
     alignment: AlignmentCsvMetaData<T>,
-    kkjToEtrsTriangulationTriangles: List<KKJtoETRSTriangle>
+    kkjToEtrsTriangulationTriangles: RTree<KKJtoETRSTriangle, Rectangle>,
 ): List<ElementCsvMetadata<T>> {
     val planSrid = alignment.geometry?.coordinateSystemSrid
     val elements = alignment.geometry?.elements ?: return listOf(noElementsCsvMetadata(alignment))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationService.kt
@@ -32,7 +32,7 @@ data class Transformation private constructor(
     }
 
     init {
-        require(triangulationNetwork != null || !isKKJ(sourceSrid) || targetSrid != LAYOUT_SRID) {
+        require((triangulationNetwork != null && !triangulationNetwork.isEmpty) || !isKKJ(sourceSrid) || targetSrid != LAYOUT_SRID) {
             "Trying to convert from KKJx (${sourceSrid}) to ${targetSrid} without triangulation network"
         }
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/dataImport/CsvImportIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/dataImport/CsvImportIT.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.dataImport
 
+import com.github.davidmoten.rtree2.RTree
 import fi.fta.geoviite.infra.ITTestBase
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
@@ -67,7 +68,7 @@ class CsvImportIT @Autowired constructor(
                 mapOf(),
                 mapOf(),
                 trackIdMap,
-                emptyList()
+                RTree.create()
             ).toList()
 
             assertEquals(15, locationTracks.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geography/KkjToEtrsTriangulationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geography/KkjToEtrsTriangulationDaoIT.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.geography
 
+import com.github.davidmoten.rtree2.geometry.Geometries
 import fi.fta.geoviite.infra.ITTestBase
 import fi.fta.geoviite.infra.math.Point
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -21,7 +22,7 @@ class KkjToEtrsTriangulationDaoIT @Autowired constructor(
         // Point is in Hervanta, Tampere
         val triangles = kkJtoETRSTriangulationDao.fetchTriangulationNetwork()
         val point = toJtsPoint(Point(3332494.083, 6819936.144), YKJ_CRS)
-        val triangle = triangles.find { it.intersects(point) }
+        val triangle = triangles.search(Geometries.point(point.x, point.y)).find { it.value().intersects(point) }
         assertNotNull(triangle)
     }
 
@@ -30,7 +31,7 @@ class KkjToEtrsTriangulationDaoIT @Autowired constructor(
         // Point is in a triangulation network corner point
         val triangles = kkJtoETRSTriangulationDao.fetchTriangulationNetwork()
         val point = toJtsPoint(Point(3199159.097, 6747800.979), YKJ_CRS)
-        val triangle = triangles.find { it.intersects(point) }
+        val triangle = triangles.search(Geometries.point(point.x, point.y)).find { it.value().intersects(point) }
         assertNotNull(triangle)
     }
 
@@ -39,7 +40,7 @@ class KkjToEtrsTriangulationDaoIT @Autowired constructor(
         // Point is in Norway
         val triangles = kkJtoETRSTriangulationDao.fetchTriangulationNetwork()
         val point = toJtsPoint(Point(2916839.212, 7227390.743), YKJ_CRS)
-        val triangle = triangles.find { it.intersects(point) }
+        val triangle = triangles.search(Geometries.point(point.x, point.y)).find { it.value().intersects(point) }
         assertNull(triangle)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TransformationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TransformationTest.kt
@@ -1,5 +1,7 @@
 package fi.fta.geoviite.infra.geometry
 
+import com.github.davidmoten.rtree2.RTree
+import com.github.davidmoten.rtree2.geometry.Rectangle
 import fi.fta.geoviite.infra.common.RotationDirection.CCW
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
 import fi.fta.geoviite.infra.dataImport.RATKO_SRID
@@ -15,19 +17,7 @@ import org.junit.jupiter.api.assertThrows
 import java.lang.IllegalArgumentException
 import kotlin.test.assertEquals
 
-val DummyTriangulationNetwork = listOf(
-    KKJtoETRSTriangle(
-        Point(0.0, 0.0),
-        Point(1.0, 1.0),
-        Point(0.0, 1.0),
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0
-    )
-)
+val DummyTriangulationNetwork = RTree.create<KKJtoETRSTriangle, Rectangle>()
 
 class TransformationTest {
 
@@ -79,13 +69,6 @@ class TransformationTest {
             ),
             toPointList(curve, 1),
         )
-    }
-
-    @Test
-    fun `Creating KKJ to TM35 transformation with empty triangulation network throws`() {
-        assertThrows<IllegalArgumentException> {
-            Transformation.possiblyKKJToETRSTransform(KKJ2, LAYOUT_SRID, emptyList())
-        }
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -1,5 +1,7 @@
 package fi.fta.geoviite.infra.ui.testdata
 
+import com.github.davidmoten.rtree2.RTree
+import com.github.davidmoten.rtree2.geometry.Rectangle
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.geography.KKJtoETRSTriangle
 import fi.fta.geoviite.infra.geography.Transformation
@@ -187,7 +189,7 @@ fun pointsFromIncrementList(basePoint: Point, incrementPoints: List<Point>) =
 fun locationTrackAndAlignmentForGeometryAlignment(
     trackNumberId: IntId<TrackLayoutTrackNumber>,
     geometryAlignment: GeometryAlignment,
-    triangulationNetwork: List<KKJtoETRSTriangle>,
+    triangulationNetwork: RTree<KKJtoETRSTriangle, Rectangle>,
     planSrid: Srid = LAYOUT_SRID,
 ): Pair<LocationTrack, LayoutAlignment> {
     val transformation = Transformation.possiblyKKJToETRSTransform(planSrid, LAYOUT_SRID, triangulationNetwork)


### PR DESCRIPTION
Täällä otettu käyttöön R*-puu KKJx->TM35FIN-muunnoksen kolmioverkon kolmiohaun nopeuttamiseksi. Mitään sen kummempia perffitestejä en ajanut, mutta tämän luul_isi_ ainakin nopeuttavan kolmioiden etsimistä merkittävästi