### PR TITLE
GVT-1691 Refactor and optimize segment data structure & saving

### DIFF
--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -7,7 +7,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "2.7.6"
+    id("org.springframework.boot") version "2.7.9"
     id("io.spring.dependency-management") version "1.0.15.RELEASE"
     id("com.github.jk1.dependency-license-report") version "2.0"
     kotlin("jvm") version "1.7.20"
@@ -35,7 +35,7 @@ dependencies {
 
     // For gt-epsg-hsql
     implementation("org.hsqldb", "hsqldb").version {
-        strictly("[2.7.1,)")
+        strictly("[2.7.1,2.8.0)")
     }
     // For spring-boot-starter-actuator & aws-java-sdk-cloudfront
     implementation("org.yaml", "snakeyaml").version {
@@ -43,7 +43,7 @@ dependencies {
     }
 
     // Actual deps
-    implementation("com.amazonaws:aws-java-sdk-cloudfront:1.12.347")
+    implementation("com.amazonaws:aws-java-sdk-cloudfront:1.12.415")
     implementation("org.bouncycastle:bcpkix-jdk15on:1.70")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
@@ -58,7 +58,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     implementation("com.zaxxer:HikariCP")
     implementation("org.flywaydb:flyway-core")
-    implementation("com.github.ben-manes.caffeine:caffeine:3.1.1")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.1.4")
     implementation("org.geotools:gt-main:$geotoolsVersion") {
         // Excluded as the license (JDL or JRL) compatibility is unconfirmed. We don't need this.
         exclude("javax.media", "jai_core")
@@ -71,23 +71,22 @@ dependencies {
         // jgridshift doesn't provide licensing information. We don't need it.
         exclude("it.geosolutions.jgridshift", "jgridshift-core")
     }
-    implementation("org.apache.commons:commons-csv:1.9.0")
+    implementation("org.apache.commons:commons-csv:1.10.0")
     implementation("commons-io:commons-io:2.11.0")
-    implementation("com.auth0:jwks-rsa:0.21.2")
-    implementation("com.auth0:java-jwt:4.2.1")
-    implementation("io.netty:netty-resolver-dns-native-macos:4.1.85.Final:osx-aarch_64")
-    implementation("org.postgresql:postgresql:42.5.0")
+    implementation("com.auth0:jwks-rsa:0.22.0")
+    implementation("com.auth0:java-jwt:4.3.0")
+    implementation("io.netty:netty-resolver-dns-native-macos:4.1.89.Final:osx-aarch_64")
+    implementation("org.postgresql:postgresql:42.5.4")
     implementation("net.postgis:postgis-jdbc:2021.1.0")
-    implementation("jakarta.activation:jakarta.activation-api:2.1.0")
+    implementation("jakarta.activation:jakarta.activation-api:2.1.1")
     implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
-    implementation("org.apache.commons:commons-csv:1.9.0")
     compileOnly("org.springframework.boot:spring-boot-devtools")
-    runtimeOnly("com.sun.xml.bind:jaxb-impl:4.0.1")
+    runtimeOnly("com.sun.xml.bind:jaxb-impl:4.0.2")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.7.20")
-    testImplementation("org.seleniumhq.selenium:selenium-java:4.6.0")
-    testImplementation("io.github.bonigarcia:webdrivermanager:5.3.1")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.8.10")
+    testImplementation("org.seleniumhq.selenium:selenium-java:4.8.1")
+    testImplementation("io.github.bonigarcia:webdrivermanager:5.3.2")
     testImplementation("org.mock-server:mockserver-netty-no-dependencies:5.14.0")
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvParsing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvParsing.kt
@@ -815,10 +815,12 @@ fun <T> createLayoutSegment(
         null
     }
     return LayoutSegment(
-        points = toLayoutPoints(segmentPoints),
+        geometry = SegmentGeometry(
+            resolution = resolution,
+            points = toLayoutPoints(segmentPoints),
+        ),
         sourceId = metadata.metadata?.geometryElement?.id,
         sourceStart = sourceStart,
-        resolution = resolution,
         switchId = metadata.switchLink?.switchId,
         startJointNumber = metadata.switchLink?.getJointNumber(metadata.meters.start),
         endJointNumber = metadata.switchLink?.getJointNumber(metadata.meters.endInclusive),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -430,8 +430,8 @@ fun getIntersection(projection: Line, edges: List<PolyLineEdge>): Pair<PolyLineE
 private fun getPolyLineEdges(alignment: LayoutAlignment): List<PolyLineEdge> {
     return alignment.segments.flatMapIndexed { index: Int, segment: LayoutSegment -> getPolyLineEdges(
         segment,
-        alignment.segments.getOrNull(index-1)?.endDirection(),
-        alignment.segments.getOrNull(index+1)?.startDirection(),
+        alignment.segments.getOrNull(index-1)?.endDirection,
+        alignment.segments.getOrNull(index+1)?.startDirection,
     ) }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
@@ -132,8 +132,8 @@ private fun toMissingElementListing(
     elementId = null,
     elementType = MISSING_SECTION,
     lengthMeters = round(segment.length, LENGTH_DECIMALS),
-    start = getLocation(context, segment.points.first(), segment.startDirection()),
-    end = getLocation(context, segment.points.last(), segment.endDirection()),
+    start = getLocation(context, segment.points.first(), segment.startDirection),
+    end = getLocation(context, segment.points.last(), segment.endDirection),
     locationTrackName = locationTrack.name
 )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -217,7 +217,7 @@ class LinkingService @Autowired constructor(
         }
         segments.forEachIndexed { index, segment ->
             segments.getOrNull(index - 1)?.let { previous ->
-                val diff = angleDiffRads(previous.endDirection(), segment.startDirection())
+                val diff = angleDiffRads(previous.endDirection, segment.startDirection)
                 if (diff > PI / 2) throw LinkingFailureException(
                     message = "Linked geometry has over 90 degree angles between segments: " +
                             "segment=${segment.id} angle=${radsToDegrees(diff)}",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -14,7 +14,6 @@ import fi.fta.geoviite.infra.geometry.GeometryService
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.tracklayout.*
-import fi.fta.geoviite.infra.util.measureAndCollect
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -98,18 +97,16 @@ class LinkingService @Autowired constructor(
                     "referenceLineId=$referenceLineId"
         )
 
-        val (referenceLine, layoutAlignment) = measureAndCollect("fetch-current") {
-            referenceLineService.getWithAlignmentOrThrow(DRAFT, referenceLineId)
-        }
+        val (referenceLine, layoutAlignment) = referenceLineService.getWithAlignmentOrThrow(DRAFT, referenceLineId)
 
-        val segments = measureAndCollect("create-segments") { createLinkedSegments(
+        val segments = createLinkedSegments(
             linkingParameters.geometryPlanId,
             linkingParameters.geometryInterval,
             layoutAlignment,
             linkingParameters.layoutInterval,
-        ) }
-        val alignment = measureAndCollect("create-alignment") { tryCreateLinkedAlignment(layoutAlignment, segments) }
-        return measureAndCollect("save-draft") { referenceLineService.saveDraft(referenceLine, alignment).id }
+        )
+        val alignment = tryCreateLinkedAlignment(layoutAlignment, segments)
+        return referenceLineService.saveDraft(referenceLine, alignment).id
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -14,6 +14,7 @@ import fi.fta.geoviite.infra.geometry.GeometryService
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.util.measureAndCollect
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -97,16 +98,18 @@ class LinkingService @Autowired constructor(
                     "referenceLineId=$referenceLineId"
         )
 
-        val (referenceLine, layoutAlignment) = referenceLineService.getWithAlignmentOrThrow(DRAFT, referenceLineId)
+        val (referenceLine, layoutAlignment) = measureAndCollect("fetch-current") {
+            referenceLineService.getWithAlignmentOrThrow(DRAFT, referenceLineId)
+        }
 
-        val segments = createLinkedSegments(
+        val segments = measureAndCollect("create-segments") { createLinkedSegments(
             linkingParameters.geometryPlanId,
             linkingParameters.geometryInterval,
             layoutAlignment,
             linkingParameters.layoutInterval,
-        )
-        val alignment = tryCreateLinkedAlignment(layoutAlignment, segments)
-        return referenceLineService.saveDraft(referenceLine, alignment).id
+        ) }
+        val alignment = measureAndCollect("create-alignment") { tryCreateLinkedAlignment(layoutAlignment, segments) }
+        return measureAndCollect("save-draft") { referenceLineService.saveDraft(referenceLine, alignment).id }
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -242,7 +242,7 @@ class LinkingService @Autowired constructor(
         return getSegmentsBetweenPoints(
             geometryIndexRange.start,
             geometryIndexRange.endInclusive,
-            getSegmentsWithoutSwitchInformation(geometryAlignment.segments),
+            transformGeometryToLayoutSegments(geometryAlignment.segments),
             fromGeometryPoint,
             toGeometryPoint,
             0.0,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingTransformation.kt
@@ -48,7 +48,7 @@ fun <T> replaceTrackLayoutGeometry(
     val geometrySegments = getSegmentsBetweenPoints(
         geometryIndexRange.start,
         geometryIndexRange.endInclusive,
-        getSegmentsWithoutSwitchInformation(geometryAlignment.segments),
+        transformGeometryToLayoutSegments(geometryAlignment.segments),
         fromGeometryPoint,
         toGeometryPoint,
         endLength(startLayoutSegments),
@@ -85,7 +85,7 @@ fun extendAlignmentWithGeometry(
         val geometrySegments = getSegmentsBetweenPoints(
             geometryIndexRange.start,
             geometryIndexRange.endInclusive,
-            getSegmentsWithoutSwitchInformation(geometryAlignment.segments),
+            transformGeometryToLayoutSegments(geometryAlignment.segments),
             fromGeometryPoint,
             toGeometryPoint,
             0.0,
@@ -107,7 +107,7 @@ fun extendAlignmentWithGeometry(
         val geometrySegments = getSegmentsBetweenPoints(
             geometryIndexRange.start,
             geometryIndexRange.endInclusive,
-            getSegmentsWithoutSwitchInformation(geometryAlignment.segments),
+            transformGeometryToLayoutSegments(geometryAlignment.segments),
             fromGeometryPoint,
             toGeometryPoint,
             endLength(listOfNotNull(gapSegment))
@@ -236,13 +236,15 @@ fun cutSegmentBetweenStartAndEndPoints(
 fun createGapConnectionSegment(start: Point, end: Point, startLength: Double): LayoutSegment? {
     val length = calculateDistance(LAYOUT_SRID, start, end)
     return if (length > 0) LayoutSegment(
-        points = listOf(
-            LayoutPoint(start.x, start.y, null, 0.0, null),
-            LayoutPoint(end.x, end.y, null, length, null)
+        geometry = SegmentGeometry(
+            resolution = max(length.toInt(), 1),
+            points = listOf(
+                LayoutPoint(start.x, start.y, null, 0.0, null),
+                LayoutPoint(end.x, end.y, null, length, null)
+            ),
         ),
         sourceId = null,
         sourceStart = null,
-        resolution = max(length.toInt(), 1),
         switchId = null,
         startJointNumber = null,
         endJointNumber = null,
@@ -289,13 +291,15 @@ fun getSegmentsInRange(
     }
 }
 
-fun getSegmentsWithoutSwitchInformation(segments: List<MapSegment>): List<LayoutSegment> {
+fun transformGeometryToLayoutSegments(segments: List<MapSegment>): List<LayoutSegment> {
     return segments.map { segment ->
         LayoutSegment(
-            points = segment.points,
+            geometry = SegmentGeometry(
+                resolution = segment.resolution,
+                points = segment.points,
+            ),
             sourceId = segment.sourceId,
             sourceStart = segment.sourceStart,
-            resolution = segment.resolution,
             switchId = null,
             startJointNumber = null,
             endJointNumber = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
@@ -266,13 +266,14 @@ class PublicationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
               location_track.alignment_id,
               location_track.alignment_version 
             from layout.location_track_publication_view location_track
-              left join layout.segment on segment.alignment_id = location_track.alignment_id
+              left join layout.segment_version on segment_version.alignment_id = location_track.alignment_id
+                and segment_version.alignment_version = location_track.alignment_version
             where :publication_status = any(location_track.publication_states)
               and location_track.state != 'DELETED'
               and (
                 location_track.topology_start_switch_id = :switch_id or
                 location_track.topology_end_switch_id = :switch_id or
-                segment.switch_id = :switch_id 
+                segment_version.switch_id = :switch_id 
               )
             group by 
               location_track.official_id,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/BoundingBox.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/BoundingBox.kt
@@ -106,7 +106,7 @@ fun boundingBoxAroundPoints(point1: Point, vararg rest: Point): BoundingBox =
 fun boundingBoxAroundPoints(points: List<Point>, buffer: Double = DEFAULT_BUFFER) =
     boundingBoxAroundPointsOrNull(points, buffer) ?: throw IllegalStateException("Failed to create bounding box")
 
-fun boundingBoxAroundPointsOrNull(points: List<Point>, buffer: Double = DEFAULT_BUFFER) =
+fun <T : IPoint> boundingBoxAroundPointsOrNull(points: List<T>, buffer: Double = DEFAULT_BUFFER) =
     if (points.isEmpty()) null
     else BoundingBox(minPoint(points) - Point(buffer, buffer), maxPoint(points) + Point(buffer, buffer))
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Point.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Point.kt
@@ -127,10 +127,10 @@ data class RoundedPoint(val roundedX: BigDecimal, val roundedY: BigDecimal): IPo
     }
 }
 
-fun minPoint(points: List<Point>): Point =
+fun minPoint(points: List<IPoint>): IPoint =
     points.reduceRight { acc, point -> Point(min(acc.x, point.x), min(acc.y, point.y)) }
 
-fun maxPoint(points: List<Point>): Point =
+fun maxPoint(points: List<IPoint>): IPoint =
     points.reduceRight { acc, point -> Point(max(acc.x, point.x), max(acc.y, point.y)) }
 
 fun parsePointPair(value: String): Pair<Double, Double> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -133,7 +133,7 @@ class RatkoLocationTrackService @Autowired constructor(
         }
         requireNotNull(layoutLocationTrack.alignmentVersion)
 
-        layoutAlignmentDao.fetchMetadata(layoutLocationTrack.alignmentVersion.id)
+        layoutAlignmentDao.fetchMetadata(layoutLocationTrack.alignmentVersion)
             .fold(mutableListOf<LayoutSegmentMetadata>()) { acc, metadata ->
                 val previousMetadata = acc.lastOrNull()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -84,7 +84,7 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
         val id: RowVersion<LayoutAlignment> =
             jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
                 ?: throw IllegalStateException("Failed to generate ID for new Track Layout Alignment")
-        upsertSegments(id, alignment.segments)
+        measureAndCollect("save-insert-upsert-segments") { upsertSegments(id, alignment.segments) }
         logger.daoAccess(AccessType.INSERT, LayoutAlignment::class, id)
         return id
     }
@@ -115,7 +115,7 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
             rs.getRowVersion("id", "version")
         } ?: throw IllegalStateException("Failed to get new version for Track Layout Alignment")
         logger.daoAccess(AccessType.UPDATE, LayoutAlignment::class, result.id)
-        upsertSegments(result, alignment.segments)
+        measureAndCollect("save-update-upsert-segments") { upsertSegments(result, alignment.segments) }
         return result
     }
 
@@ -303,20 +303,22 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
         return result
     }
 
+    // TODO: No IT Test runs this
     fun fetchMetadata(alignmentId: IntId<LayoutAlignment>): List<LayoutSegmentMetadata> {
         //language=SQL
         val sql = """
             select
-              postgis.st_x(postgis.st_startpoint(segment.geometry)) as start_point_x,
-              postgis.st_y(postgis.st_startpoint(segment.geometry)) as start_point_y,
-              postgis.st_x(postgis.st_endpoint(segment.geometry)) as end_point_x,
-              postgis.st_y(postgis.st_endpoint(segment.geometry)) as end_point_y,
+              postgis.st_x(postgis.st_startpoint(segment_geometry.geometry)) as start_point_x,
+              postgis.st_y(postgis.st_startpoint(segment_geometry.geometry)) as start_point_y,
+              postgis.st_x(postgis.st_endpoint(segment_geometry.geometry)) as end_point_x,
+              postgis.st_y(postgis.st_endpoint(segment_geometry.geometry)) as end_point_y,
               alignment.name as alignment_name,
               plan.plan_time,
               plan.measurement_method,
               plan.srid,
               plan_file.name as file_name
             from layout.segment
+              inner join layout.segment_geometry on segment.geometry_id = segment_geometry.id
               left join geometry.alignment on alignment.id = segment.geometry_alignment_id
               left join geometry.plan on alignment.plan_id = plan.id
               left join geometry.plan_file on plan_file.plan_id = plan.id
@@ -343,7 +345,7 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
 
     private fun upsertSegments(alignmentId: RowVersion<LayoutAlignment>, segments: List<LayoutSegment>) {
         if (segments.isNotEmpty()) {
-            val withGeometriesStored = saveSegmentGeometries(segments)
+            val geometryIds = measureAndCollect("save-segment-geometries") { saveSegmentGeometries(segments) }
             val sql = """
               insert into layout.segment(
                 alignment_id,
@@ -389,7 +391,7 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                 source = excluded.source,
                 geometry_id = excluded.geometry_id
               """.trimIndent()
-            val params = withGeometriesStored.mapIndexed { i, s ->
+            val params = segments.mapIndexed { i, s ->
                 mapOf(
                     "alignment_id" to alignmentId.id.intValue,
                     "alignment_version" to alignmentId.version,
@@ -403,10 +405,13 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                     "length" to s.length,
                     "source_start" to s.sourceStart,
                     "source" to s.source.name,
-                    "geometry_id" to (s.geometry.id as IntId).intValue,
+                    "geometry_id" to (
+                        if (s.geometry.id is IntId) s.geometry.id
+                        else requireNotNull(geometryIds[s.geometry.id]) { "SegmentGeometry not stored: id=${s.id}" }
+                    ).intValue,
                 )
             }.toTypedArray()
-            jdbcTemplate.batchUpdate(sql, params)
+            measureAndCollect("batch-update-segments") { jdbcTemplate.batchUpdate(sql, params) }
         }
 
         if (alignmentId.version > 1) {
@@ -420,37 +425,50 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                 "alignment_id" to alignmentId.id.intValue,
                 "alignment_version" to alignmentId.version,
             )
-            jdbcTemplate.update(sqlDelete, paramsDelete)
+            measureAndCollect("delete-redundant-segments") { jdbcTemplate.update(sqlDelete, paramsDelete) }
         }
     }
 
-    private fun saveSegmentGeometries(segments: List<LayoutSegment>): List<LayoutSegment> {
+    private fun saveSegmentGeometries(
+        segments: List<LayoutSegment>
+    ): Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>> {
         val unsaved = segments.mapNotNull { s -> if (s.geometry.id is StringId) s.geometry else null }
-        val insertedIds = insertSegmentGeometries(unsaved)
-        val newGeometries: MutableMap<IntId<SegmentGeometry>, SegmentGeometry> =
-            segmentGeometryCache.getAll(insertedIds.values) { dbIds ->
-                require(dbIds.all { insertedIds.containsValue(it) }) {
-                    "Insert cache population tried to fetch extra ids: inserted=$insertedIds requested=$dbIds"
-                }
-                insertedIds.entries.mapNotNull { (tempId, dbId) ->
-                    if (dbIds.contains(dbId)) {
-                        val savedObject = unsaved.find { geometry -> geometry.id == tempId }
-                            ?: throw IllegalStateException("Insert result incorrect: tempId=$tempId dbId=$dbId")
-                        logger.debug("Mapped temp geometry to DB: temp=$tempId db=$dbId")
-                        dbId to savedObject.copy(id = dbId)
-                    } else null
-                }.associate { it }
-            }
-        return segments.map { s -> when (s.geometry.id) {
-            is IntId -> s
-            is StringId -> {
-                val geometry = newGeometries[insertedIds[s.geometry.id]]
-                    ?: throw IllegalStateException("Saving new geometry failed: segment=${s.id}")
-                require(geometry.id is IntId) { "Saving new geometry failed: segment=${s.id}" }
-                s.copy(geometry = geometry)
-            }
-            else -> throw IllegalStateException("Segment geometry with invalid ID: ${s.geometry.id}")
-        } }
+        logger.warn("Storing segment geometries: segments=${segments.size} unsavedGeoms=${unsaved.size}")
+        return measureAndCollect("save-alignment-insert-geom") { insertSegmentGeometries(unsaved) }
+//        val newGeometries: MutableMap<IntId<SegmentGeometry>, SegmentGeometry> =
+//            measureAndCollect("save-alignment-fetch-geoms") {
+//            segmentGeometryCache.getAll(insertedIds.values) { dbIds ->
+//                require(dbIds.all { insertedIds.containsValue(it) }) {
+//                    "Insert cache population tried to fetch extra ids: inserted=$insertedIds requested=$dbIds"
+//                }
+//                val inserted = insertedIds.entries.mapNotNull { (tempId, dbId) ->
+//                    if (dbIds.contains(dbId)) {
+//                        val savedObject = unsaved.find { geometry -> geometry.id == tempId }
+//                            ?: throw IllegalStateException("Insert result incorrect: tempId=$tempId dbId=$dbId")
+//                        logger.debug("Mapped temp geometry to DB: temp=$tempId db=$dbId")
+//                        dbId to savedObject.copy(id = dbId)
+//                    } else null
+//                }.associate { it }
+//                val directFromDb = fetchSegmentGeometriesInternal(dbIds)
+//                require(inserted.mapValues { v -> v. } == directFromDb) {
+//                    "Mismatch: generated=$inserted fromDb=$directFromDb"
+//                }
+//
+//                inserted
+//            }
+//        }
+//        unsaved.forEach { unsavedGeom ->
+//            val savedGeom = requireNotNull(newGeometries[insertedIds[unsavedGeom.id]])
+//            require(savedGeom.points == unsavedGeom.points)
+//            require(savedGeom.resolution == unsavedGeom.resolution)
+//            require(savedGeom.boundingBox == unsavedGeom.boundingBox)
+//            require(savedGeom.length == unsavedGeom.length)
+//        }
+//        return segments.associate { s -> s.id to when (s.geometry.id) {
+//            is IntId -> s.geometry.id
+//            is StringId -> requireNotNull(insertedIds[s.geometry.id]) { "Saving new geometry failed: segment=${s.id}" }
+//            else -> throw IllegalStateException("Segment geometry with invalid ID: ${s.geometry.id}")
+//        } }
     }
 
     // TODO: GVT-1691 batching this is a little tricky due to difficulty in mapping generated ids:
@@ -458,11 +476,11 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
     //  If we could calculate the hash prior to saving we could use that to identify the mapping
     private fun insertSegmentGeometries(
         geometries: List<SegmentGeometry>,
-    ): Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>> = geometries.map { geometry ->
+    ): Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>> = geometries.associate { geometry ->
         jdbcTemplate.query(segmentGeometryInsertSql, segmentGeometryParams(geometry)) { rs, _ ->
             geometry.id as StringId to rs.getIntId<SegmentGeometry>("id")
         }.first()
-    }.associate { it }
+    }
 
     //language=SQL
     private val segmentGeometryInsertSql = """
@@ -495,9 +513,14 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
     private fun fetchSegmentGeometries(
         ids: List<IntId<SegmentGeometry>>,
     ): Map<IntId<SegmentGeometry>, SegmentGeometry> {
-        return segmentGeometryCache.getAll(ids) { fetchIds ->
-            if (fetchIds.isNotEmpty()) {
-                val sql = """
+        return segmentGeometryCache.getAll(ids) { fetchIds -> fetchSegmentGeometriesInternal(fetchIds) }
+    }
+
+    private fun fetchSegmentGeometriesInternal(
+        ids: Set<IntId<SegmentGeometry>>,
+    ): Map<IntId<SegmentGeometry>, SegmentGeometry> {
+        return if (ids.isNotEmpty()) {
+            val sql = """
                   select 
                     id,
                     postgis.st_astext(geometry) as geometry_wkt,
@@ -513,17 +536,16 @@ class LayoutAlignmentDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                   from layout.segment_geometry
                   where id in (:ids)
                 """.trimIndent()
-                val params = mapOf("ids" to ids.map(IntId<SegmentGeometry>::intValue))
-                jdbcTemplate.query(sql, params) { rs, _ ->
-                    val id = rs.getIntId<SegmentGeometry>("id")
-                    id to SegmentGeometry(
-                        id = id,
-                        points = getSegmentPoints(rs, "geometry_wkt", "height_values", "cant_values"),
-                        resolution = rs.getInt("resolution"),
-                    )
-                }.associate { it }
-            } else mapOf()
-        }
+            val params = mapOf("ids" to ids.map(IntId<SegmentGeometry>::intValue))
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                val id = rs.getIntId<SegmentGeometry>("id")
+                id to SegmentGeometry(
+                    id = id,
+                    points = getSegmentPoints(rs, "geometry_wkt", "height_values", "cant_values"),
+                    resolution = rs.getInt("resolution"),
+                )
+            }.associate { it }
+        } else mapOf()
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
@@ -27,10 +27,9 @@ class LayoutAlignmentService(
     fun duplicate(alignmentVersion: RowVersion<LayoutAlignment>): RowVersion<LayoutAlignment> =
         save(asNew(dao.fetch(alignmentVersion)))
 
-    fun save(alignment: LayoutAlignment): RowVersion<LayoutAlignment> {
-        return if (alignment.dataType == DataType.STORED) dao.update(alignment)
+    fun save(alignment: LayoutAlignment): RowVersion<LayoutAlignment> =
+        if (alignment.dataType == DataType.STORED) dao.update(alignment)
         else dao.insert(alignment)
-    }
 
     fun newEmpty(): Pair<LayoutAlignment, RowVersion<LayoutAlignment>> {
         val alignment = emptyAlignment()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -275,17 +275,11 @@ data class LayoutSegment(
         if (fromIndex >= toIndex) null
         else withPoints(points.slice(fromIndex..toIndex), newStart)
 
-    fun withPoints(points: List<LayoutPoint>, newStart: Double = start): LayoutSegment {
-        val mOffset = points.first().m
-        val newPoints =
-            if (mOffset == 0.0) points
-            else points.map { p -> p.copy(m = max(0.0, p.m - mOffset)) }
-        return copy(
-            geometry = geometry.withPoints(newPoints),
-            sourceStart = sourceStart?.plus(mOffset),
-            start = newStart,
-        )
-    }
+    fun withPoints(points: List<LayoutPoint>, newStart: Double = start): LayoutSegment = copy(
+        geometry = geometry.withPoints(points),
+        sourceStart = sourceStart?.plus(points.first().m),
+        start = newStart,
+    )
 
     fun splitAtM(m: Double, tolerance: Double): Pair<LayoutSegment, LayoutSegment?> =
         if (m <= points.first().m || m >= points.last().m) this to null
@@ -349,9 +343,7 @@ data class LayoutSegment(
                 // Found target between the points
                 interpolatedM to WITHIN
             }.also { (length, _) ->
-                require(length.isFinite()) {
-                    "Invalid length value: length=$length target=$target"
-                }
+                require(length.isFinite()) { "Invalid length value: length=$length target=$target" }
             }
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -53,10 +53,11 @@ class LayoutSwitchDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
                 location_track.alignment_id,
                 segment.segment_index,
                 segment.switch_id,
-                segment.geometry,
+                segment_geometry.geometry,
                 segment.switch_start_joint_number,
                 segment.switch_end_joint_number
               from layout.segment
+                inner join layout.segment_geometry on segment.geometry_id = segment_geometry.id
                 inner join layout.alignment on alignment.id = segment.alignment_id
                 inner join layout.location_track_publication_view location_track
                   on location_track.alignment_id = alignment.id

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -51,16 +51,16 @@ class LayoutSwitchDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
               select
                 location_track.official_id,
                 location_track.alignment_id,
-                segment.segment_index,
-                segment.switch_id,
+                segment_version.segment_index,
+                segment_version.switch_id,
                 segment_geometry.geometry,
-                segment.switch_start_joint_number,
-                segment.switch_end_joint_number
-              from layout.segment
-                inner join layout.segment_geometry on segment.geometry_id = segment_geometry.id
-                inner join layout.alignment on alignment.id = segment.alignment_id
+                segment_version.switch_start_joint_number,
+                segment_version.switch_end_joint_number
+              from layout.segment_version
+                inner join layout.segment_geometry on segment_version.geometry_id = segment_geometry.id
                 inner join layout.location_track_publication_view location_track
-                  on location_track.alignment_id = alignment.id
+                  on location_track.alignment_id = segment_version.alignment_id
+                    and location_track.alignment_version = segment_version.alignment_version
                     and location_track.state != 'DELETED'
                     and :publication_state = any (location_track.publication_states)
             )
@@ -400,12 +400,13 @@ class LayoutSwitchDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
               location_track.row_id,
               location_track.row_version,
               location_track.external_id
-            from layout.segment
+            from layout.segment_version
             inner join layout.location_track_publication_view location_track 
-                         on location_track.alignment_id = segment.alignment_id
+              on location_track.alignment_id = segment_version.alignment_id
+                and location_track.alignment_version = segment_version.alignment_version
             where :publication_state = any(publication_states)
              and (
-               segment.switch_id = :switch_id
+               segment_version.switch_id = :switch_id
                  or (
                   location_track.topology_start_switch_id = :switch_id 
                   and (

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -294,7 +294,8 @@ class LocationTrackDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
             select
               distinct lt.row_id, lt.row_version
             from layout.location_track_publication_view lt
-            inner join layout.segment s on lt.alignment_id = s.alignment_id
+            inner join layout.segment_version s on lt.alignment_id = s.alignment_id 
+              and lt.alignment_version = s.alignment_version
             inner join layout.segment_geometry sg on s.geometry_id = sg.id
               and postgis.st_intersects(
                 postgis.st_makeenvelope (

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -295,13 +295,14 @@ class LocationTrackDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
               distinct lt.row_id, lt.row_version
             from layout.location_track_publication_view lt
             inner join layout.segment s on lt.alignment_id = s.alignment_id
+            inner join layout.segment_geometry sg on s.geometry_id = sg.id
               and postgis.st_intersects(
                 postgis.st_makeenvelope (
                   :x_min, :y_min,
                   :x_max, :y_max,
                   :layout_srid
                 ),
-                s.bounding_box
+                sg.bounding_box
               )
             where :publication_state = any(lt.publication_states) 
               and lt.state != 'DELETED'

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -185,6 +185,7 @@ class ReferenceLineDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
         }
     }
 
+    // TODO: No IT test runs this
     fun fetchVersionsNear(
         publicationState: PublishType,
         bbox: BoundingBox,
@@ -195,9 +196,10 @@ class ReferenceLineDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
               rl.row_version
               from layout.reference_line_publication_view rl
                 inner join layout.segment s on rl.alignment_id = s.alignment_id
+                inner join layout.segment_geometry sg on s.geometry_id = sg.id
                   and postgis.st_intersects(
                     postgis.st_makeenvelope(:x_min, :y_min, :x_max, :y_max, :layout_srid),
-                    s.bounding_box
+                    sg.bounding_box
                   )
                 left join layout.track_number_publication_view tn
                   on rl.track_number_id = tn.official_id and :publication_state = any(tn.publication_states)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -195,7 +195,8 @@ class ReferenceLineDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
               rl.row_id, 
               rl.row_version
               from layout.reference_line_publication_view rl
-                inner join layout.segment s on rl.alignment_id = s.alignment_id
+                inner join layout.segment_version s on rl.alignment_id = s.alignment_id 
+                  and rl.alignment_version = s.alignment_version
                 inner join layout.segment_geometry sg on s.geometry_id = sg.id
                   and postgis.st_intersects(
                     postgis.st_makeenvelope(:x_min, :y_min, :x_max, :y_max, :layout_srid),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -12,7 +12,6 @@ import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.linking.ValidationVersion
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.BoundingBox
-import fi.fta.geoviite.infra.util.measureAndCollect
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -74,17 +73,15 @@ class ReferenceLineService(
         val alignmentVersion =
             // If we're creating a new row or starting a draft, we duplicate the alignment to not edit any original
             if (draft.dataType == TEMP || draft.draft == null) {
-                measureAndCollect("save-duplicate-alignment") { alignmentService.saveAsNew(alignment) }
+                alignmentService.saveAsNew(alignment)
             }
             // Ensure that we update the correct one.
             else if (draft.getAlignmentVersionOrThrow().id != alignment.id) {
-                measureAndCollect("save-update-draft-alignment") {
-                    alignmentService.save(alignment.copy(id = draft.getAlignmentVersionOrThrow().id, dataType = STORED))
-                }
+                alignmentService.save(alignment.copy(id = draft.getAlignmentVersionOrThrow().id, dataType = STORED))
             } else {
-                measureAndCollect("save-as-new-alignment") { alignmentService.save(alignment) }
+                alignmentService.save(alignment)
             }
-        return measureAndCollect("save-reference-line-draft") { saveDraftInternal(draft.copy(alignmentVersion = alignmentVersion)) }
+        return saveDraftInternal(draft.copy(alignmentVersion = alignmentVersion))
     }
 
     private fun updatedAlignmentVersion(line: ReferenceLine) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -12,6 +12,7 @@ import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.linking.ValidationVersion
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.BoundingBox
+import fi.fta.geoviite.infra.util.measureAndCollect
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -73,15 +74,17 @@ class ReferenceLineService(
         val alignmentVersion =
             // If we're creating a new row or starting a draft, we duplicate the alignment to not edit any original
             if (draft.dataType == TEMP || draft.draft == null) {
-                alignmentService.saveAsNew(alignment)
+                measureAndCollect("save-duplicate-alignment") { alignmentService.saveAsNew(alignment) }
             }
             // Ensure that we update the correct one.
             else if (draft.getAlignmentVersionOrThrow().id != alignment.id) {
-                alignmentService.save(alignment.copy(id = draft.getAlignmentVersionOrThrow().id, dataType = STORED))
+                measureAndCollect("save-update-draft-alignment") {
+                    alignmentService.save(alignment.copy(id = draft.getAlignmentVersionOrThrow().id, dataType = STORED))
+                }
             } else {
-                alignmentService.save(alignment)
+                measureAndCollect("save-as-new-alignment") { alignmentService.save(alignment) }
             }
-        return saveDraftInternal(draft.copy(alignmentVersion = alignmentVersion))
+        return measureAndCollect("save-reference-line-draft") { saveDraftInternal(draft.copy(alignmentVersion = alignmentVersion)) }
     }
 
     private fun updatedAlignmentVersion(line: ReferenceLine) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Transformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Transformation.kt
@@ -173,7 +173,7 @@ private fun toMapSegments(
             }
 
             MapSegment(
-                id = StringId(),
+                id = deriveFromSourceId("AS", element.id),
                 points = segmentPoints,
                 sourceId = element.id,
                 sourceStart = 0.0,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Transformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Transformation.kt
@@ -24,7 +24,6 @@ fun toTrackLayout(
 
     val alignments: List<MapAlignment<GeometryAlignment>> = toTrackLayoutAlignments(
         geometryPlan.alignments,
-//        switches.mapValues { s -> s.value.id },
         planToLayout,
         pointListStepLength,
         heightTriangles,
@@ -93,7 +92,6 @@ fun toTrackLayoutSwitches(
 
 fun toTrackLayoutAlignments(
     geometryAlignments: List<GeometryAlignment>,
-//    switchIds: Map<DomainId<GeometrySwitch>, DomainId<TrackLayoutSwitch>>,
     planToLayout: Transformation,
     pointListStepLength: Int,
     heightTriangles: List<HeightTriangle>,
@@ -104,7 +102,6 @@ fun toTrackLayoutAlignments(
         .map { alignment ->
             val mapSegments = toMapSegments(
                 alignment = alignment,
-//                switchIds = switchIds,
                 planToLayoutTransformation = planToLayout,
                 pointListStepLength = pointListStepLength,
                 heightTriangles = heightTriangles,
@@ -140,7 +137,6 @@ fun toTrackLayoutAlignments(
 
 private fun toMapSegments(
     alignment: GeometryAlignment,
-//    switchIds: Map<DomainId<GeometrySwitch>, DomainId<TrackLayoutSwitch>>,
     planToLayoutTransformation: Transformation,
     pointListStepLength: Int,
     heightTriangles: List<HeightTriangle>,
@@ -178,9 +174,6 @@ private fun toMapSegments(
                 sourceId = element.id,
                 sourceStart = 0.0,
                 resolution = pointListStepLength,
-//                switchId = switchIds[element.switchId],
-//                startJointNumber = element.startJointNumber,
-//                endJointNumber = element.endJointNumber,
                 start = segmentStartLength,
                 source = GeometrySource.PLAN,
                 length = segmentPoints.last().m,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Transformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Transformation.kt
@@ -6,10 +6,7 @@ import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.geography.transformHeightValue
 import fi.fta.geoviite.infra.geometry.*
 import fi.fta.geoviite.infra.geometry.PlanState.*
-import fi.fta.geoviite.infra.math.BoundingBox
-import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.math.Point3DM
-import fi.fta.geoviite.infra.math.boundingBoxAroundPoints
+import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.tracklayout.LayoutState.*
 import kotlin.math.max
 
@@ -27,7 +24,7 @@ fun toTrackLayout(
 
     val alignments: List<MapAlignment<GeometryAlignment>> = toTrackLayoutAlignments(
         geometryPlan.alignments,
-        switches.mapValues { s -> s.value.id },
+//        switches.mapValues { s -> s.value.id },
         planToLayout,
         pointListStepLength,
         heightTriangles,
@@ -96,7 +93,7 @@ fun toTrackLayoutSwitches(
 
 fun toTrackLayoutAlignments(
     geometryAlignments: List<GeometryAlignment>,
-    switchIds: Map<DomainId<GeometrySwitch>, DomainId<TrackLayoutSwitch>>,
+//    switchIds: Map<DomainId<GeometrySwitch>, DomainId<TrackLayoutSwitch>>,
     planToLayout: Transformation,
     pointListStepLength: Int,
     heightTriangles: List<HeightTriangle>,
@@ -105,9 +102,9 @@ fun toTrackLayoutAlignments(
 ): List<MapAlignment<GeometryAlignment>> {
     return geometryAlignments
         .map { alignment ->
-            val layoutSegments = toLayoutSegments(
+            val mapSegments = toMapSegments(
                 alignment = alignment,
-                switchIds = switchIds,
+//                switchIds = switchIds,
                 planToLayoutTransformation = planToLayout,
                 pointListStepLength = pointListStepLength,
                 heightTriangles = heightTriangles,
@@ -128,7 +125,7 @@ fun toTrackLayoutAlignments(
                 alignmentType = getAlignmentType(alignment.featureTypeCode),
                 type = null,
                 state = state,
-                segments = layoutSegments.map(::toMapSegment),
+                segments = mapSegments,
                 trackNumberId = alignment.trackNumberId,
                 sourceId = alignment.id,
                 id = alignment.id,
@@ -141,15 +138,15 @@ fun toTrackLayoutAlignments(
         }
 }
 
-fun toLayoutSegments(
+private fun toMapSegments(
     alignment: GeometryAlignment,
-    switchIds: Map<DomainId<GeometrySwitch>, DomainId<TrackLayoutSwitch>>,
+//    switchIds: Map<DomainId<GeometrySwitch>, DomainId<TrackLayoutSwitch>>,
     planToLayoutTransformation: Transformation,
     pointListStepLength: Int,
     heightTriangles: List<HeightTriangle>,
     verticalCoordinateSystem: VerticalCoordinateSystem?,
     includeGeometryData: Boolean = true,
-): List<LayoutSegment> {
+): List<MapSegment> {
     val alignmentStationStart = alignment.staStart.toDouble()
     var segmentStartLength = 0.0
     val elements = alignment.elements
@@ -162,7 +159,6 @@ fun toLayoutSegments(
     val segments =
         if (!includeGeometryData) listOf()
         else elements.map { (element, segmentStartLength) ->
-
             val segmentPoints = toPointList(element, pointListStepLength).map { p ->
                 toTrackLayoutPoint(
                     planToLayoutTransformation.transform(p),
@@ -176,16 +172,20 @@ fun toLayoutSegments(
                 )
             }
 
-            LayoutSegment(
+            MapSegment(
+                id = StringId(),
                 points = segmentPoints,
                 sourceId = element.id,
                 sourceStart = 0.0,
                 resolution = pointListStepLength,
-                switchId = switchIds[element.switchId],
-                startJointNumber = element.startJointNumber,
-                endJointNumber = element.endJointNumber,
+//                switchId = switchIds[element.switchId],
+//                startJointNumber = element.startJointNumber,
+//                endJointNumber = element.endJointNumber,
                 start = segmentStartLength,
                 source = GeometrySource.PLAN,
+                length = segmentPoints.last().m,
+                pointCount = segmentPoints.size,
+                boundingBox = boundingBoxAroundPointsOrNull(segmentPoints),
             )
         }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/NamedParameterJdbcTemplateExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/NamedParameterJdbcTemplateExternal.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.util
 import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.authorization.getCurrentUserName
 import fi.fta.geoviite.infra.error.NoSuchEntityException
+import org.springframework.jdbc.core.ParameterizedPreparedStatementSetter
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.sql.ResultSet
 
@@ -29,3 +30,15 @@ fun NamedParameterJdbcTemplate.setUser(userName: UserName) {
     // set doesn't work with parameters, but it's validated in UserName constructor
     update("set local geoviite.edit_user = '$userName';", mapOf<String, Any>())
 }
+
+fun <T> NamedParameterJdbcTemplate.batchUpdateIndexed(
+    sql: String,
+    items: List<T>,
+    paramSetter: ParameterizedPreparedStatementSetter<Pair<Int, T>>,
+) = batchUpdate(sql, items.mapIndexed { index, item -> index to item }, paramSetter)
+
+fun <T> NamedParameterJdbcTemplate.batchUpdate(
+    sql: String,
+    items: List<T>,
+    paramSetter: ParameterizedPreparedStatementSetter<T>,
+) = jdbcTemplate.batchUpdate(sql, items, items.size, paramSetter)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/PreparedStatementExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/PreparedStatementExternal.kt
@@ -1,0 +1,24 @@
+package fi.fta.geoviite.infra.util
+
+import java.sql.JDBCType
+import java.sql.PreparedStatement
+
+fun PreparedStatement.setNullInt(index: Int) =
+    setNull(index, JDBCType.INTEGER.vendorTypeNumber)
+
+fun PreparedStatement.setNullDouble(index: Int) =
+    setNull(index, JDBCType.DOUBLE.vendorTypeNumber)
+
+fun PreparedStatement.setNullableInt(index: Int, getter: () -> Int?) =
+    setNullableInt(index, getter())
+
+fun PreparedStatement.setNullableDouble(index: Int, getter: () -> Double?) =
+    setNullableDouble(index, getter())
+
+fun PreparedStatement.setNullableInt(index: Int, value: Int?) =
+    if (value != null) setInt(index, value)
+    else setNullInt(index)
+
+fun PreparedStatement.setNullableDouble(index: Int, value: Double?) =
+    if (value != null) setDouble(index, value)
+    else setNullDouble(index)

--- a/infra/src/main/resources/db/migration/prod/V27__separate_segment_geometry.sql
+++ b/infra/src/main/resources/db/migration/prod/V27__separate_segment_geometry.sql
@@ -28,13 +28,15 @@ create table layout.segment_geometry
 drop table layout.segment;
 delete from layout.segment_version where deleted = true;
 alter table layout.segment_version
+  drop constraint segment_version_pkey, -- Remove old primary key
   drop column change_time, -- Metadata is on alignment, which changes as a whole -> this is duplicate info
   drop column change_user, -- Metadata is on alignment, which changes as a whole -> this is duplicate info
   drop column version, -- Alignment versioning is sufficient as segments don't change independently
   drop column deleted, -- Deleted rows: the new alignment version just doesn't have a segment for the index
   drop column length, -- This is currently the m-value of the last point -> no separate column needed
   drop column start, -- This is the sum of lengths by-index -> no separate column needed
-  add column geometry_id int null -- Reference to the new geometry table
+  add column geometry_id int null, -- Reference to the new geometry table
+  add primary key (alignment_id, alignment_version, segment_index) -- Add new primary key
 ;
 
 -- Copy all known geometries to the new table, preserving the the ids

--- a/infra/src/main/resources/db/migration/prod/V27__separate_segment_geometry.sql
+++ b/infra/src/main/resources/db/migration/prod/V27__separate_segment_geometry.sql
@@ -1,0 +1,89 @@
+-- Immutable helper function for generating hashes on geometry data
+create or replace function layout.calculate_geometry_hash(
+  resolution int,
+  geometry postgis.geometry,
+  height_values numeric[],
+  cant_values numeric[]
+) returns uuid language sql as $$
+  select md5(row(resolution, geometry, height_values, cant_values)::text)::uuid
+$$ immutable;
+
+-- Create new un-versioned table for separately stored geometries
+create table layout.segment_geometry
+(
+  id            int primary key generated always as identity,
+  resolution    int                                 not null,
+  geometry      postgis.geometry(linestringm, 3067) not null,
+  height_values decimal(10, 6)[]                    null,
+  cant_values   decimal(10, 6)[]                    null,
+  bounding_box  postgis.geometry                    not null
+    generated always as (postgis.st_envelope(geometry)) stored,
+  hash          uuid                                not null unique
+    generated always as (
+      layout.calculate_geometry_hash(resolution, geometry, height_values, cant_values)
+    ) stored
+);
+
+alter table layout.segment_version add column geometry_id int null;
+
+-- Copy all known geometries to the new table, preserving the the ids
+insert into layout.segment_geometry(resolution, geometry, height_values, cant_values)
+select resolution, geometry, height_values, cant_values
+  from layout.segment_version
+on conflict(hash) do nothing;
+
+-- Update new geometry ids to version table
+update layout.segment_version sv
+set geometry_id = segment_geometry.id
+from layout.segment_geometry
+where segment_geometry.hash = layout.calculate_geometry_hash(
+  sv.resolution,
+  sv.geometry,
+  sv.height_values,
+  sv.cant_values
+  );
+
+-- Update segment_version to use new table's data instead of own
+alter table layout.segment_version
+  drop column resolution,
+  drop column geometry,
+  drop column height_values,
+  drop column cant_values,
+  drop column bounding_box,
+  alter column geometry_id set not null;
+
+-- Disable versioning triggers on the main table so the following edits don't create version rows
+alter table layout.segment disable trigger version_row_trigger;
+alter table layout.segment disable trigger version_update_trigger;
+
+-- Remove indexes relying on old columns (new indices will be added in a repeatable migration)
+drop index if exists layout.layout_segment_bounding_box_index;
+
+-- Swap geometry data for gemetry table id in the main table (null for now)
+alter table layout.segment
+  drop column resolution,
+  drop column geometry,
+  drop column height_values,
+  drop column cant_values,
+  add column geometry_id int null;
+
+-- Collect all geometry table references from the current version rows
+update layout.segment
+set geometry_id = sv.geometry_id
+  from layout.segment_version sv
+  where sv.alignment_id = segment.alignment_id
+    and sv.segment_index = segment.segment_index
+    and sv.version = segment.version;
+
+-- Set geometry id as mandatory + add foreign key reference
+alter table layout.segment
+  alter column geometry_id set not null,
+  add constraint segment_segment_geometry_id_fkey foreign key (geometry_id) references layout.segment_geometry (id);
+
+-- Re-enable versioning triggers
+alter table layout.segment enable trigger version_update_trigger;
+alter table layout.segment enable trigger version_row_trigger;
+
+-- Full vacuum analyse for perf & storage space, as the tables have changed drastically
+vacuum full analyse layout.segment_version;
+vacuum full analyse layout.segment;

--- a/infra/src/main/resources/db/migration/prod/V27__separate_segment_geometry.sql
+++ b/infra/src/main/resources/db/migration/prod/V27__separate_segment_geometry.sql
@@ -23,6 +23,7 @@ create table layout.segment_geometry
       layout.calculate_geometry_hash(resolution, geometry, height_values, cant_values)
     ) stored
 );
+comment on table layout.segment_geometry is 'Layout segment geometry: a polyline with height and cant values.';
 
 -- Update segment table structure
 drop table layout.segment;
@@ -41,8 +42,7 @@ alter table layout.segment_version
 
 -- Copy all known geometries to the new table, preserving the the ids
 insert into layout.segment_geometry(resolution, geometry, height_values, cant_values)
-select resolution, geometry, height_values, cant_values
-  from layout.segment_version
+select resolution, geometry, height_values, cant_values from layout.segment_version
 on conflict(hash) do nothing;
 
 -- Update new geometry ids to version table
@@ -55,6 +55,7 @@ where segment_geometry.hash = layout.calculate_geometry_hash(
   sv.height_values,
   sv.cant_values
   );
+comment on table layout.segment_version is 'Layout segment version: segment metadata, versioned by alignment version.';
 
 -- Remove the transferred from the segment table
 alter table layout.segment_version
@@ -71,8 +72,6 @@ alter table layout.segment_version
     foreign key (geometry_id) references layout.segment_geometry (id),
   add constraint segment_version_alignment_version_fkey
     foreign key(alignment_id, alignment_version) references layout.alignment_version(id, version),
---   add constraint segment_version_switch_version_fkey
---     foreign key (switch_id, switch_version) references layout.switch_version (id, version),
   add constraint segment_version_geometry_alignment_fkey
     foreign key (geometry_alignment_id) references geometry.alignment (id),
   add constraint segment_version_geometry_element_fkey

--- a/infra/src/main/resources/db/migration/prod/V27__separate_segment_geometry.sql
+++ b/infra/src/main/resources/db/migration/prod/V27__separate_segment_geometry.sql
@@ -59,7 +59,7 @@ alter table layout.segment disable trigger version_update_trigger;
 -- Remove indexes relying on old columns (new indices will be added in a repeatable migration)
 drop index if exists layout.layout_segment_bounding_box_index;
 
--- Swap geometry data for gemetry table id in the main table (null for now)
+-- Swap geometry data for geometry table id in the main table (null for now)
 alter table layout.segment
   drop column resolution,
   drop column geometry,
@@ -83,7 +83,3 @@ alter table layout.segment
 -- Re-enable versioning triggers
 alter table layout.segment enable trigger version_update_trigger;
 alter table layout.segment enable trigger version_row_trigger;
-
--- Full vacuum analyse for perf & storage space, as the tables have changed drastically
-vacuum full analyse layout.segment_version;
-vacuum full analyse layout.segment;

--- a/infra/src/main/resources/db/migration/prod/V28__vacuum_analyze_segments.sql
+++ b/infra/src/main/resources/db/migration/prod/V28__vacuum_analyze_segments.sql
@@ -1,2 +1,3 @@
 -- Full vacuum analyse for perf & storage space, as the tables have changed drastically
 vacuum full analyse layout.segment_version;
+vacuum full analyse layout.segment_geometry;

--- a/infra/src/main/resources/db/migration/prod/V28__vacuum_analyze_segments.sql
+++ b/infra/src/main/resources/db/migration/prod/V28__vacuum_analyze_segments.sql
@@ -1,3 +1,2 @@
 -- Full vacuum analyse for perf & storage space, as the tables have changed drastically
 vacuum full analyse layout.segment_version;
-vacuum full analyse layout.segment;

--- a/infra/src/main/resources/db/migration/prod/V28__vacuum_analyze_segments.sql
+++ b/infra/src/main/resources/db/migration/prod/V28__vacuum_analyze_segments.sql
@@ -1,0 +1,3 @@
+-- Full vacuum analyse for perf & storage space, as the tables have changed drastically
+vacuum full analyse layout.segment_version;
+vacuum full analyse layout.segment;

--- a/infra/src/main/resources/db/migration/repeatable/R__03.04_layout_segment_index.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.04_layout_segment_index.sql
@@ -4,5 +4,11 @@ create index layout_segment_switch on layout.segment(switch_id);
 drop index if exists layout.layout_segment_geometry_element;
 create index layout_segment_geometry_element on layout.segment(geometry_alignment_id, geometry_element_index);
 
+-- Deprecated index, drop if it still exists
 drop index if exists layout.layout_segment_bounding_box_index;
-create index layout_segment_bounding_box_index on layout.segment using gist (bounding_box);
+
+drop index if exists layout.layout_segment_segment_geometry;
+create index layout_segment_segment_geometry on layout.segment(geometry_id);
+
+drop index if exists layout.layout_segment_geometry_bounding_box_index;
+create index layout_segment_geometry_bounding_box_index on layout.segment_geometry using gist (bounding_box);

--- a/infra/src/main/resources/db/migration/repeatable/R__03.04_layout_segment_index.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.04_layout_segment_index.sql
@@ -1,14 +1,16 @@
 drop index if exists layout.layout_segment_switch;
-create index layout_segment_switch on layout.segment(switch_id);
+drop index if exists layout.layout_segment_version_switch;
+create index layout_segment_version_switch on layout.segment_version(switch_id);
 
 drop index if exists layout.layout_segment_geometry_element;
-create index layout_segment_geometry_element on layout.segment(geometry_alignment_id, geometry_element_index);
+drop index if exists layout.layout_segment_version_geometry_element;
+create index layout_segment_version_geometry_element on layout.segment_version(geometry_alignment_id, geometry_element_index);
 
 -- Deprecated index, drop if it still exists
 drop index if exists layout.layout_segment_bounding_box_index;
 
-drop index if exists layout.layout_segment_segment_geometry;
-create index layout_segment_segment_geometry on layout.segment(geometry_id);
+drop index if exists layout.layout_segment_version_segment_geometry;
+create index layout_segment_version_segment_geometry on layout.segment_version(geometry_id);
 
 drop index if exists layout.layout_segment_geometry_bounding_box_index;
 create index layout_segment_geometry_bounding_box_index on layout.segment_geometry using gist (bounding_box);

--- a/infra/src/main/resources/db/migration/repeatable/R__03.04_layout_segment_index.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.04_layout_segment_index.sql
@@ -6,11 +6,6 @@ drop index if exists layout.layout_segment_geometry_element;
 drop index if exists layout.layout_segment_version_geometry_element;
 create index layout_segment_version_geometry_element on layout.segment_version(geometry_alignment_id, geometry_element_index);
 
--- Deprecated index, drop if it still exists
 drop index if exists layout.layout_segment_bounding_box_index;
-
 drop index if exists layout.layout_segment_version_segment_geometry;
 create index layout_segment_version_segment_geometry on layout.segment_version(geometry_id);
-
-drop index if exists layout.layout_segment_geometry_bounding_box_index;
-create index layout_segment_geometry_bounding_box_index on layout.segment_geometry using gist (bounding_box);

--- a/infra/src/main/resources/db/migration/repeatable/R__03.06_layout_segment_version_alignment_version_index.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.06_layout_segment_version_alignment_version_index.sql
@@ -1,3 +1,2 @@
+-- Old redundant index
 drop index if exists layout.layout_segment_version_alignment_version_index;
-create index layout_segment_version_alignment_version_index
-  on layout.segment_version(alignment_id, alignment_version);

--- a/infra/src/main/resources/db/migration/repeatable/R__03.06_layout_segment_version_alignment_version_index.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.06_layout_segment_version_alignment_version_index.sql
@@ -1,3 +1,3 @@
 drop index if exists layout.layout_segment_version_alignment_version_index;
 create index layout_segment_version_alignment_version_index
-  on layout.segment_version(alignment_id, alignment_version, deleted);
+  on layout.segment_version(alignment_id, alignment_version);

--- a/infra/src/main/resources/db/migration/repeatable/R__03.12.layout_segment_version_geometry_alignment_version_index.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.12.layout_segment_version_geometry_alignment_version_index.sql
@@ -1,2 +1,2 @@
 drop index if exists layout.segment_version_geometry_alignment_version_ix;
-create index segment_version_geometry_alignment_version_ix on layout.segment_version (geometry_alignment_id, version);
+create index segment_version_geometry_alignment_version_ix on layout.segment_version (geometry_alignment_id, alignment_version);

--- a/infra/src/main/resources/db/migration/repeatable/R__03.19_layout_segment_geometry_index.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.19_layout_segment_geometry_index.sql
@@ -1,0 +1,2 @@
+drop index if exists layout.layout_segment_geometry_bounding_box_index;
+create index layout_segment_geometry_bounding_box_index on layout.segment_geometry using gist (bounding_box);

--- a/infra/src/main/resources/db/migration/repeatable/R__05.01_layout_functions.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__05.01_layout_functions.sql
@@ -33,9 +33,9 @@ select distinct track_number_id
   from (
     (
       select track_number_id
-        from layout.segment
-          join layout.location_track_publication_view location_track using (alignment_id)
-        where switch_id_in = segment.switch_id and publication_state = any(location_track.publication_states)
+        from layout.segment_version
+          inner join layout.location_track_publication_view location_track using (alignment_id, alignment_version)
+        where switch_id_in = segment_version.switch_id and publication_state = any(location_track.publication_states)
     )
     union all
     (

--- a/infra/src/main/resources/db/migration/repeatable/R__06.01_add_segment_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__06.01_add_segment_view.sql
@@ -1,0 +1,9 @@
+drop view if exists layout.segment;
+create view layout.segment as
+(
+  select segment_version.*
+  from layout.segment_version
+  inner join layout.alignment
+    on segment_version.alignment_id = alignment.id
+      and segment_version.alignment_version = alignment.version
+);

--- a/infra/src/main/resources/db/migration/repeatable/R__06.01_add_segment_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__06.01_add_segment_view.sql
@@ -1,9 +1,0 @@
-drop view if exists layout.segment;
-create view layout.segment as
-(
-  select segment_version.*
-  from layout.segment_version
-  inner join layout.alignment
-    on segment_version.alignment_id = alignment.id
-      and segment_version.alignment_version = alignment.version
-);

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -27,7 +27,7 @@ val segment1 = segment(
     Point(x = 385273.0397969192, y = 6675558.0948048225),
     Point(x = 385216.6663371209, y = 6675701.1816949705),
     Point(x = 385081.84688330034, y = 6675970.204397376),
-    startLength = 0.0,
+    start = 0.0,
 )
 val segment2 = segment(
     Point(x = 385081.84688330034, y = 6675970.204397376),
@@ -44,7 +44,7 @@ val segment2 = segment(
     Point(x = 382900.3670653631, y = 6677856.032651512),
     Point(x = 382761.2176702685, y = 6677923.467526838),
     Point(x = 382711.47467736073, y = 6677942.28533952),
-    startLength = segment1.start + segment1.length
+    start = segment1.start + segment1.length
 )
 val segment3 = segment(
     Point(x = 382711.47467736073, y = 6677942.28533952),
@@ -60,7 +60,7 @@ val segment3 = segment(
     Point(x = 380075.3780522702, y = 6677812.131510135),
     Point(x = 379546.59970029286, y = 6677795.661380321),
     Point(x = 379109.7436289962, y = 6677820.218810541),
-    startLength = segment2.start + segment2.length
+    start = segment2.start + segment2.length
 )
 val alignment = alignment(segment1, segment2, segment3)
 val startAddress = TrackMeter(KmNumber(2), 150)
@@ -216,19 +216,19 @@ class GeocodingTest {
             Point(-0.7, 0.0),
             Point(1.0, 2.0),
             Point(3.0, 4.0),
-            startLength = 10.0,
+            start = 10.0,
             source = PLAN,
         )
         val connectSegment = segment(
             Point(3.0,4.0),
             Point(3.0,6.0),
-            startLength = startSegment.start + startSegment.length,
+            start = startSegment.start + startSegment.length,
             source = GENERATED,
         )
         val endSegment = segment(
             Point(3.0,6.0),
             Point(7.0,10.0),
-            startLength = connectSegment.start + connectSegment.length,
+            start = connectSegment.start + connectSegment.length,
             source = PLAN,
         )
         val startAddress = TrackMeter(KmNumber(2), 100)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
@@ -143,8 +143,8 @@ class AddressChangesServiceIT @Autowired constructor(
         // Move start-point a bit
         updateAndPublish(initialLocationTrack, setupData.locationTrackGeometry.copy(
             segments = setupData.locationTrackGeometry.segments.mapIndexed { index, segment ->
-                if (index == 0) segment.copy(
-                    points = listOf(movePoint(segment.points.first(), -1.0)) + segment.points.drop(1)
+                if (index == 0) segment.withPoints(
+                    points = listOf(movePoint(segment.points.first(), -1.0)) + segment.points.drop(1),
                 ) else segment
             }
         ))
@@ -690,31 +690,6 @@ class AddressChangesServiceIT @Autowired constructor(
         locationTrackService.publish(ValidationVersion(version.id, version.rowVersion))
     }
 
-
-    fun moveLocationTrackGeometryPointsAndUpdate(
-        locationTrack: LocationTrack,
-        alignment: LayoutAlignment,
-        moveFunc: (point: IPoint) -> IPoint,
-    ) {
-        val version = locationTrackService.saveDraft(
-            locationTrack,
-            alignment.copy(
-                segments = alignment.segments.map { segment ->
-                    segment.copy(
-                        points = segment.points.map { point ->
-                            val newPoint = moveFunc(point)
-                            point.copy(
-                                x = newPoint.x,
-                                y = newPoint.y
-                            )
-                        }
-                    )
-                }
-            )
-        )
-        locationTrackService.publish(ValidationVersion(version.id, version.rowVersion))
-    }
-
     fun moveReferenceLineGeometryPointsAndUpdate(
         referenceLine: ReferenceLine,
         alignment: LayoutAlignment,
@@ -725,7 +700,7 @@ class AddressChangesServiceIT @Autowired constructor(
             referenceLine,
             alignment.copy(
                 segments = fixSegmentStarts(alignment.segments.map { segment ->
-                    segment.copy(
+                    segment.withPoints(
                         points = fixMValues(segment.points.mapIndexed { inSegmentIndex, point ->
                             val newPoint = moveFunc(index, point)
                             if (inSegmentIndex < segment.points.lastIndex) index++
@@ -733,7 +708,7 @@ class AddressChangesServiceIT @Autowired constructor(
                                 x = newPoint.x,
                                 y = newPoint.y
                             )
-                        } )
+                        } ),
                     )
                 } )
             )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -65,15 +65,15 @@ class LinkingServiceIT @Autowired constructor(
         val start = geometryStart - Point(1.0, 1.5)
         val segment1 = segment(
             start, start + 1.0, start + 2.0, start + 3.0, start + 4.0,
-            startLength = 0.0,
+            start = 0.0,
         )
         val segment2 = segment(
             start + 4.0, start + 5.0, start + 6.0, start + 7.0, start + 8.0, start + 9.0,
-            startLength = segment1.length,
+            start = segment1.length,
         )
         val segment3 = segment(
             start + 9.0, start + 10.0, start + 11.0,
-            startLength = segment2.length,
+            start = segment2.length,
         )
 
         val (locationTrack, alignment) = locationTrackAndAlignment(insertOfficialTrackNumber(), segment1, segment2, segment3)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/PublicationValidationTest.kt
@@ -384,20 +384,16 @@ class PublicationValidationTest {
         )
         assertSegmentSwitchError(
             true,
-            editSegment(segmentSwitch) { segment ->
-                segment.copy(
-                    points = toTrackLayoutPoints(segment.points.first(), segment.points.last() + Point(0.0, 1.0))
-                )
-            },
+            editSegment(segmentSwitch) { segment -> segment.withPoints(
+                points = toTrackLayoutPoints(segment.points.first(), segment.points.last() + Point(0.0, 1.0)),
+            ) },
             "$VALIDATION_LOCATION_TRACK.switch.joint-location-mismatch",
         )
         assertSegmentSwitchError(
             true,
-            editSegment(segmentSwitch) { segment ->
-                segment.copy(
-                    points = toTrackLayoutPoints(segment.points.first() + Point(0.0, 1.0), segment.points.last())
-                )
-            },
+            editSegment(segmentSwitch) { segment -> segment.withPoints(
+                points = toTrackLayoutPoints(segment.points.first() + Point(0.0, 1.0), segment.points.last()),
+            ) },
             "$VALIDATION_LOCATION_TRACK.switch.joint-location-mismatch",
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SuggestedSwitchTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SuggestedSwitchTest.kt
@@ -11,12 +11,12 @@ import kotlin.test.assertEquals
 import kotlin.test.fail
 
 class SuggestedSwitchTest {
-    val switchStructure = switchStructureYV60_300_1_9()
-    val switchAlignment_1_5_2 =
-        switchStructure.alignments.find { alignment -> alignment.jointNumbers.contains(JointNumber(5)) }
-            ?: throw IllegalStateException("Invalid switch structure")
+    private val switchStructure = switchStructureYV60_300_1_9()
+    private val switchAlignment_1_5_2 = switchStructure.alignments.find { alignment ->
+        alignment.jointNumbers.contains(JointNumber(5))
+    } ?: throw IllegalStateException("Invalid switch structure")
 
-    fun transformPoint(
+    private fun transformPoint(
         point: IPoint,
         translation: IPoint = Point(2000.0, 3000.0),
         rotation: Double = degreesToRads(45.0),
@@ -24,7 +24,7 @@ class SuggestedSwitchTest {
         return rotateAroundOrigin(rotation, point) + translation
     }
 
-    fun createAlignmentBySwitchAlignment(
+    private fun createAlignmentBySwitchAlignment(
         switchAlignment: SwitchAlignment,
         translation: Point,
         rotation: Double,
@@ -111,24 +111,17 @@ class SuggestedSwitchTest {
         val reverseSegments = fixStartDistances(alignment.segments.reversed().map { segment ->
             val reversedPoints = segment.points.reversed()
             var cumulativeM = 0.0
-            segment.copy(points = reversedPoints.mapIndexed { index, point ->
-                cumulativeM += if (index == 0) 0.0 else lineLength(reversedPoints[index - 1], point)
-                point.copy(m = cumulativeM)
-            })
+            segment.withPoints(
+                reversedPoints.mapIndexed { index, point ->
+                    cumulativeM += if (index == 0) 0.0 else lineLength(reversedPoints[index - 1], point)
+                    point.copy(m = cumulativeM)
+                }
+            )
         })
         return alignment.copy(segments = reverseSegments)
     }
 
-    private enum class SegmentEndPoint {
-        start,
-        end
-    }
-
-    private data class MatchToCheck(
-        val alignmentId: IntId<LocationTrack>,
-        val segmentIndex: Int,
-        val endPoint: SegmentEndPoint,
-    )
+    private enum class SegmentEndPoint { START, END }
 
     private fun assertSuggestedSwitchContainsMatch(
         suggestedSwitch: SuggestedSwitch,
@@ -187,7 +180,7 @@ class SuggestedSwitchTest {
                 JointNumber(1),
                 alignmentId = IntId(1),
                 segmentIndex = 1,
-                SegmentEndPoint.start
+                SegmentEndPoint.START
             )
 
             assertSuggestedSwitchContainsMatch(
@@ -195,7 +188,7 @@ class SuggestedSwitchTest {
                 JointNumber(5),
                 alignmentId = IntId(1),
                 segmentIndex = 1,
-                SegmentEndPoint.end
+                SegmentEndPoint.END
             )
 
             assertSuggestedSwitchContainsMatch(
@@ -203,7 +196,7 @@ class SuggestedSwitchTest {
                 JointNumber(2),
                 alignmentId = IntId(1),
                 segmentIndex = 2,
-                SegmentEndPoint.end
+                SegmentEndPoint.END
             )
         } else {
             fail("Should be able to create suggested switch")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -100,7 +100,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val segments = (1..5).map { num ->
             val start = (num - 1).toDouble() * 10.0
             val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startLength = startLength)
+            segment(Point(start, start), Point(end, end), start = startLength)
                 .also { s -> startLength += s.length }
         }
 
@@ -175,7 +175,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val segments = (1..5).map { num ->
             val start = (num - 1).toDouble() * 10.0
             val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startLength = startLength)
+            segment(Point(start, start), Point(end, end), start = startLength)
                 .also { s -> startLength += s.length }
         }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
@@ -39,7 +39,7 @@ class SwitchLinkingTest {
         val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..5).map { num ->
             val start = (num - 1).toDouble() * 10.0
             val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startLength = startLength)
+            segment(Point(start, start), Point(end, end), start = startLength)
                 .also { s -> startLength += s.length }
         }, locationTrackId)
 
@@ -111,7 +111,7 @@ class SwitchLinkingTest {
         val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..5).map { num ->
             val start = (num - 1).toDouble() * 10.0
             val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startLength = startLength)
+            segment(Point(start, start), Point(end, end), start = startLength)
                 .also { s -> startLength += s.length }
         }, locationTrackId)
 
@@ -183,7 +183,7 @@ class SwitchLinkingTest {
         val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..5).map { num ->
             val start = (num - 1).toDouble() * 10.0
             val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startLength = startLength)
+            segment(Point(start, start), Point(end, end), start = startLength)
                 .also { s -> startLength += s.length }
         }, locationTrackId)
 
@@ -236,7 +236,7 @@ class SwitchLinkingTest {
         val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..5).map { num ->
             val start = (num - 1).toDouble() * 10.0
             val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startLength = startLength)
+            segment(Point(start, start), Point(end, end), start = startLength)
                 .also { s -> startLength += s.length }
         }, locationTrackId)
 
@@ -289,7 +289,7 @@ class SwitchLinkingTest {
         val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..5).map { num ->
             val start = (num - 1).toDouble() * 10.0
             val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startLength = startLength)
+            segment(Point(start, start), Point(end, end), start = startLength)
                 .also { s -> startLength += s.length }
         }, locationTrackId)
 
@@ -352,7 +352,7 @@ class SwitchLinkingTest {
         val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..3).map { num ->
             val start = (num - 1).toDouble() * 10.0
             val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startLength = startLength)
+            segment(Point(start, start), Point(end, end), start = startLength)
                 .also { s -> startLength += s.length }
         }, locationTrackId)
 
@@ -569,19 +569,19 @@ class SwitchLinkingTest {
                     Point(5.0, 0.0),
                     Point(7.5, 0.0),
                     Point(10.0, 0.0),
-                    startLength = 5.0
+                    start = 5.0
                 ),
                 segment(
                     Point(10.0, 0.0),
                     Point(12.5, 0.0),
                     Point(15.0, 0.0),
-                    startLength = 10.0
+                    start = 10.0
                 ),
                 segment(
                     Point(15.0, 0.0),
                     Point(17.5, 0.0),
                     Point(20.0, 0.0),
-                    startLength = 15.0
+                    start = 15.0
                 )
             ),
             sourceId = null
@@ -633,19 +633,19 @@ class SwitchLinkingTest {
                     Point(5.0, 0.0),
                     Point(7.5, 0.0),
                     Point(10.0, 0.0),
-                    startLength = 5.0
+                    start = 5.0
                 ),
                 segment(
                     Point(10.0, 0.0),
                     Point(12.5, 0.0),
                     Point(15.0, 0.0),
-                    startLength = 10.0
+                    start = 10.0
                 ),
                 segment(
                     Point(15.0, 0.0),
                     Point(17.5, 0.0),
                     Point(20.0, 0.0),
-                    startLength = 15.0
+                    start = 15.0
                 )
             ),
             sourceId = null
@@ -697,18 +697,18 @@ class SwitchLinkingTest {
                     Point(0.5, 0.0),
                     Point(0.6, 0.0),
                     Point(10.0, 0.0),
-                    startLength = 0.5
+                    start = 0.5
                 ),
                 segment(
                     Point(10.0, 0.0),
                     Point(10.6, 0.0),
                     Point(11.0, 0.0),
-                    startLength = 10.0
+                    start = 10.0
                 ),
                 segment(
                     Point(11.0, 0.0),
                     Point(20.0, 0.0),
-                    startLength = 11.0
+                    start = 11.0
                 )
             ),
             sourceId = null
@@ -760,7 +760,7 @@ class SwitchLinkingTest {
                     Point(1.0, 0.0),
                     Point(9.5, 0.0),
                     Point(10.0, 0.0),
-                    startLength = 1.0
+                    start = 1.0
                 ),
             ),
             sourceId = null
@@ -811,7 +811,7 @@ class SwitchLinkingTest {
                 segment(
                     Point(5.0, 0.0),
                     Point(10.0, 0.0),
-                    startLength = 4.999
+                    start = 4.999
                 ),
             ),
             sourceId = null
@@ -857,13 +857,13 @@ class SwitchLinkingTest {
                 segment(
                     Point(5.0, 0.0),
                     Point(10.0, 0.0),
-                    startLength = 5.0
+                    start = 5.0
                 ),
                 segment(
                     Point(10.0009, 0.0),
                     Point(15.0, 0.0),
                     Point(20.0, 0.0),
-                    startLength = 10.0
+                    start = 10.0
                 )
             ),
             sourceId = null
@@ -908,32 +908,32 @@ class SwitchLinkingTest {
                 segment(
                     Point(4.0, 0.0),
                     Point(8.0, 0.0),
-                    startLength = 4.0
+                    start = 4.0
                 ),
                 segment(
                     Point(8.0, 0.0),
                     Point(10.0, 0.0),
-                    startLength = 8.0
+                    start = 8.0
                 ),
                 segment(
                     Point(10.0, 0.0),
                     Point(12.0, 0.0),
-                    startLength = 10.0
+                    start = 10.0
                 ),
                 segment(
                     Point(12.0, 0.0),
                     Point(15.0, 0.0),
-                    startLength = 12.0
+                    start = 12.0
                 ),
                 segment(
                     Point(15.0, 0.0),
                     Point(16.0, 0.0),
-                    startLength = 15.0
+                    start = 15.0
                 ),
                 segment(
                     Point(16.0, 0.0),
                     Point(20.0, 0.0),
-                    startLength = 16.0
+                    start = 16.0
                 )
             ),
             sourceId = null
@@ -954,14 +954,14 @@ class SwitchLinkingTest {
                     Point(15.0, 0.0),
                     Point(14.0, 0.0),
                     Point(13.0, 0.0),
-                    startLength = 5.0
+                    start = 5.0
                 ),
                 segment(
                     Point(13.0, 0.0),
                     Point(12.0, 0.0),
                     Point(11.0, 0.0),
                     Point(10.0, 0.0),
-                    startLength = 7.0
+                    start = 7.0
                 ),
                 segment(
                     Point(10.0, 0.0),
@@ -970,7 +970,7 @@ class SwitchLinkingTest {
                     Point(7.0, 0.0),
                     Point(6.0, 0.0),
                     Point(5.0, 0.0),
-                    startLength = 10.0
+                    start = 10.0
                 ),
                 segment(
                     Point(5.0, 0.0),
@@ -979,7 +979,7 @@ class SwitchLinkingTest {
                     Point(2.0, 0.0),
                     Point(1.0, 0.0),
                     Point(0.0, 0.0),
-                    startLength = 15.0
+                    start = 15.0
                 ),
             ),
             sourceId = null
@@ -1036,12 +1036,12 @@ class SwitchLinkingTest {
                     Point(10.0, 0.0),
                     Point(12.5, 0.0),
                     Point(15.0, 0.0),
-                    startLength = 5.0
+                    start = 5.0
                 ),
                 segment(
                     Point(15.0, 0.0),
                     Point(20.0, 0.0),
-                    startLength = 15.0
+                    start = 15.0
                 )
             ),
             sourceId = null
@@ -1088,12 +1088,12 @@ class SwitchLinkingTest {
                     Point(5.0, 0.0),
                     Point(10.0, 0.0),
                     Point(15.0, 0.0),
-                    startLength = 5.0
+                    start = 5.0
                 ),
                 segment(
                     Point(15.0, 0.0),
                     Point(20.0, 0.0),
-                    startLength = 15.0
+                    start = 15.0
                 )
             ),
             sourceId = null

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientTestData.kt
@@ -1,41 +1,23 @@
 package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.math.Point3DM
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.FreeText
 
 fun getUpdateLayoutAlignment(): Pair<LocationTrack, LayoutAlignment> {
-    val alignment = LayoutAlignment(
+    val alignment = alignment(
         listOf(
-            LayoutSegment(
-                points = listOf(
-                    LayoutPoint(
-                        x = 288037.36665503116,
-                        y = 7067239.269061557,
-                        z = null,
-                        m = 0.0,
-                        cant = null
-                    ),
-                    LayoutPoint(
-                        x = 288052.17096940894,
-                        y = 7067276.688420034,
-                        z = null,
-                        m = 40.23542958800948,
-                        cant = null
-                    )
+            segment(
+                points = toTrackLayoutPoints(
+                    Point3DM(x = 288037.36665503116, y = 7067239.269061557, m = 0.0),
+                    Point3DM(x = 288052.17096940894, y = 7067276.688420034, m = 40.23542958800948),
                 ),
-                sourceId = null,
-                sourceStart = null,
                 resolution = 100,
-                switchId = null,
-                startJointNumber = null,
-                endJointNumber = null,
                 start = 0.0,
-                id = IndexedId(257, 0),
                 source = GeometrySource.PLAN,
-            ),
+            ).copy(id = IndexedId(257, 0)),
         ),
-        sourceId = null,
     )
     return LocationTrack(
         name = AlignmentName("PTS 102"),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
@@ -211,14 +211,14 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         fixStartDistances((0..count).map { seed -> segmentWithoutZAndCant(alignmentSeed + seed) })
 
     private fun segmentWithoutZAndCant(segmentSeed: Int) =
-        segment(segmentSeed, points(
+        createSegment(segmentSeed, points(
             count = 10,
             x = (segmentSeed*10).toDouble()..(segmentSeed*10 + 10.0),
             y = (segmentSeed*10).toDouble()..(segmentSeed*10 + 10.0),
         ))
 
     private fun segmentWithZAndCant(segmentSeed: Int) =
-        segment(segmentSeed, points(
+        createSegment(segmentSeed, points(
             count = 20,
             x = (segmentSeed*10).toDouble()..(segmentSeed*10 + 10.0),
             y = (segmentSeed*10).toDouble()..(segmentSeed*10 + 10.0),
@@ -226,15 +226,9 @@ class LayoutAlignmentDaoIT @Autowired constructor(
             cant = segmentSeed.toDouble()..segmentSeed + 20.0,
         ))
 
-    private fun segment(segmentSeed: Int, points: List<LayoutPoint>) = LayoutSegment(
+    private fun createSegment(segmentSeed: Int, points: List<LayoutPoint>) = segment(
         points = points,
-        sourceId = null,
-        sourceStart = null,
-        resolution = 1,
         start = segmentSeed * 0.1,
-        switchId = null,
-        startJointNumber = null,
-        endJointNumber = null,
         source = GeometrySource.PLAN,
     )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
@@ -251,7 +251,12 @@ class LayoutAlignmentDaoIT @Autowired constructor(
 
     fun getDbSegmentCount(alignmentId: IntId<LayoutAlignment>): Int =
         jdbc.queryForObject(
-            "select count(*) from layout.segment where alignment_id = :id",
+            """
+                select count(*) 
+                from layout.alignment inner join layout.segment_version 
+                  on alignment.id = segment_version.alignment_id and alignment.version = segment_version.alignment_version
+                where alignment_id = :id
+                """,
             mapOf("id" to alignmentId.intValue),
         ) { rs, _ -> rs.getInt("count") } ?: 0
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
@@ -88,7 +88,7 @@ fun assertMatches(expected: LayoutAlignment, actual: LayoutAlignment, idMatch: B
 }
 
 fun assertMatches(expected: LayoutSegment, actual: LayoutSegment, idMatch: Boolean = false) {
-    val expectedWithSameFloats = expected.copy(points = actual.points, start = actual.start)
+    val expectedWithSameFloats = expected.copy(geometry = actual.geometry, start = actual.start)
     if (idMatch) {
         assertEquals(expectedWithSameFloats, actual)
     } else {
@@ -98,6 +98,7 @@ fun assertMatches(expected: LayoutSegment, actual: LayoutSegment, idMatch: Boole
     assertEquals(expected.start, actual.start, LENGTH_DELTA)
     assertEquals(expected.length, actual.length, LENGTH_DELTA)
     assertEquals(expected.points.size, actual.points.size)
+    assertEquals(expected.resolution, actual.resolution)
     expected.points.forEachIndexed { index, point -> assertMatches(point, actual.points[index]) }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometryTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometryTest.kt
@@ -52,13 +52,15 @@ class LayoutGeometryTest {
     @Test
     fun splitSegmentMetadataShouldBeCorrect() {
         val segment = LayoutSegment(
-            points = listOf(
-                point(10.0, 10.0, 0.0),
-                point(20.0, 20.0, hypot(10.0, 10.0)),
+            geometry = SegmentGeometry(
+                points = listOf(
+                    point(10.0, 10.0, 0.0),
+                    point(20.0, 20.0, hypot(10.0, 10.0)),
+                ),
+                resolution = 2,
             ),
             sourceId = StringId(),
             sourceStart = 15.0,
-            resolution = 2,
             switchId = StringId(),
             startJointNumber = JointNumber(2),
             endJointNumber = JointNumber(2),
@@ -263,15 +265,17 @@ class LayoutGeometryTest {
     fun sliceWorks() {
         val pointInterval = hypot(10.0, 10.0)
         val original = LayoutSegment(
-            points = listOf(
-                point(10.0, 10.0, 0.0),
-                point(20.0, 20.0, pointInterval),
-                point(30.0, 30.0, 2*pointInterval),
-                point(40.0, 40.0, 3*pointInterval),
+            geometry = SegmentGeometry(
+                points = listOf(
+                    point(10.0, 10.0, 0.0),
+                    point(20.0, 20.0, pointInterval),
+                    point(30.0, 30.0, 2*pointInterval),
+                    point(40.0, 40.0, 3*pointInterval),
+                ),
+                resolution = 2,
             ),
             sourceId = StringId(),
             sourceStart = 15.0,
-            resolution = 2,
             switchId = StringId(),
             startJointNumber = JointNumber(2),
             endJointNumber = JointNumber(2),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
@@ -188,8 +188,8 @@ class LocationTrackDaoIT @Autowired constructor(
             locationTrackDao.fetchVersions(OFFICIAL, false, tnId).toSet(),
         )
         assertEquals(
-            listOf(officialTrackVersion1, officialTrackVersion2, draftTrackVersion),
-            locationTrackDao.fetchVersions(DRAFT, false, tnId),
+            listOf(officialTrackVersion1, officialTrackVersion2, draftTrackVersion).toSet(),
+            locationTrackDao.fetchVersions(DRAFT, false, tnId).toSet(),
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -65,7 +65,7 @@ class LocationTrackServiceIT @Autowired constructor(
             segment(
                 Point(x = 0.0, y = 0.0),
                 Point(x = 5.0, y = 0.0),
-                startLength = 5.0,
+                start = 5.0,
             )
         )
         val (trackOutside, alignmentOutside) = locationTrackAndAlignment(
@@ -73,7 +73,7 @@ class LocationTrackServiceIT @Autowired constructor(
             segment(
                 Point(x = 20.0, y = 20.0),
                 Point(x = 30.0, y = 20.0),
-                startLength = 10.0,
+                start = 10.0,
             )
         )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
@@ -99,7 +99,7 @@ fun moveAlignmentPoints(
 ): LayoutAlignment {
     return alignment.copy(
         segments = alignment.segments.map { segment ->
-            segment.copy(
+            segment.withPoints(
                 points = segment.points.map { point ->
                     val length = segment.start + point.m
                     val newPoint = moveFunc(point, length)
@@ -107,7 +107,7 @@ fun moveAlignmentPoints(
                         x = newPoint.x,
                         y = newPoint.y
                     )
-                }
+                },
             )
         }
     )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutTest.kt
@@ -134,20 +134,4 @@ class TrackLayoutTest {
             )
         }
     }
-
-
-    private fun segment(points: Int, minX: Double, maxX: Double, minY: Double, maxY: Double): LayoutSegment {
-        return LayoutSegment(
-            points = points(points, minX, maxX, minY, maxY),
-            sourceId = null,
-            sourceStart = null,
-            resolution = 1,
-            start = 0.0,
-            switchId = null,
-            startJointNumber = null,
-            endJointNumber = null,
-            source = GeometrySource.PLAN,
-        )
-    }
-
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/SeleniumTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/SeleniumTest.kt
@@ -12,7 +12,7 @@ import org.openqa.selenium.SessionNotCreatedException
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeOptions
-import org.openqa.selenium.devtools.v106.emulation.Emulation
+import org.openqa.selenium.devtools.v110.emulation.Emulation
 import org.openqa.selenium.firefox.FirefoxDriver
 import org.openqa.selenium.firefox.FirefoxOptions
 import org.openqa.selenium.logging.LogEntries

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -197,11 +197,13 @@ fun locationTrackAndAlignmentForGeometryAlignment(
             val start = transformation.transform(element.start)
             val end = transformation.transform(element.end)
             LayoutSegment(
-                points = listOf(
-                    LayoutPoint(start.x, start.y, 0.0, 0.0, 0.0),
-                    LayoutPoint(end.x, end.y, 0.0, element.calculatedLength, 0.0)
+                geometry = SegmentGeometry(
+                    points = listOf(
+                        LayoutPoint(start.x, start.y, 0.0, 0.0, 0.0),
+                        LayoutPoint(end.x, end.y, 0.0, element.calculatedLength, 0.0)
+                    ),
+                    resolution = 100,
                 ),
-                resolution = 100,
                 startJointNumber = element.startJointNumber,
                 endJointNumber = element.endJointNumber,
                 start = 0.0,


### PR DESCRIPTION
Kohtuullisen järeä review, pahoittelut etukäteen. Kannattaa ottaa ajan ja ajatuksen kanssa.

Ongelma kuvattu tiketillä https://extranet.vayla.fi/jira/browse/GVT-1691

Ratkaisu koostuu parista osasta:

Segmenttien geometria on eriytetty omaan tauluunsa:
- Geometrialla on oma id ja segmentti viittaa sillä
- Jos geometria ei muutu, seuraava versio segmentistä viittaa vain samaan geometriaan
- Myös aivan eri raiteiden segmentit voivat viitata samaan geometriaan sillä se on muuttumaton ja sisältää vain geometrian muodon (samuus tunnistettavissa hashilla)

Segmentin versiotaulu on nyt sen ainoa taulu:
- Nk. "päätaulu" on poistettu, eikä versiotaulua ei populoida enää triggerillä päätaulusta vaan sinne insertoidaan suoraan
- Alignmentin versio riittää yksilöimään myös segmenttien versiot, joten niillä ei ole omaa versionumeroa
- Upserttia ei tarvitse huolehtia, koska uudella versiolla ei pitäisi koskaan olla mitään päivitettävää riviä
- Deletointia ei tarvitse merkata versioon flagilla, seuraavassa alignment-versiossa ei vain ole ko. segmenttiä jos se poistui