### PR TITLE
GVT-1739: Raiteen geometriat näkymässä suunnitelman klikkaus pitäisi valita suunnitelma + massahakujuttuja

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -53,6 +53,13 @@ class GeometryController @Autowired constructor(private val geometryService: Geo
     }
 
     @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/plan-headers", params = ["planIds"])
+    fun getPlanHeaders(@RequestParam("planIds", required = true) planIds: List<IntId<GeometryPlan>>): List<GeometryPlanHeader> {
+        log.apiCall("getPlanHeaders", "planIds" to planIds)
+        return geometryService.getManyPlanHeaders(planIds)
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/plans/areas")
     fun getGeometryPlanAreas(@RequestParam("bbox") bbox: BoundingBox): List<GeometryPlanArea> {
         log.apiCall("getGeometryPlanAreas", "bbox" to bbox)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -665,6 +665,8 @@ class GeometryDao @Autowired constructor(
 
     fun fetchPlanVersion(id: IntId<GeometryPlan>) = fetchRowVersion(id, GEOMETRY_PLAN)
 
+    fun fetchManyPlanVersions(ids: List<IntId<GeometryPlan>>) = fetchManyRowVersions(ids, GEOMETRY_PLAN)
+
     fun fetchAlignmentPlanVersion(alignmentId: IntId<GeometryAlignment>): RowVersion<GeometryPlan> {
         //language=SQL
         val sql = """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -72,6 +72,11 @@ class GeometryService @Autowired constructor(
         return geometryDao.fetchPlanVersion(planId).let(geometryDao::fetchPlanHeader)
     }
 
+    fun getManyPlanHeaders(planIds: List<IntId<GeometryPlan>>): List<GeometryPlanHeader> {
+        logger.serviceCall("getManyPlanHeaders", "planIds" to planIds)
+        return geometryDao.fetchManyPlanVersions(planIds).map(geometryDao::fetchPlanHeader)
+    }
+
     fun getTrackLayoutPlan(
         geometryPlanId: IntId<GeometryPlan>,
         includeGeometryData: Boolean = true,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -158,24 +158,24 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
 
     override fun fetchOfficialVersionOrThrow(id: IntId<T>): RowVersion<T> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
-        return queryRowVersion(officialFetchSql(table), id)
+        return queryRowVersion(officialFetchSql(table, FetchType.SINGLE), id)
     }
 
     override fun fetchDraftVersionOrThrow(id: IntId<T>): RowVersion<T> {
         logger.daoAccess(AccessType.VERSION_FETCH,  table.name, id)
-        return queryRowVersion(draftFetchSql(table), id)
+        return queryRowVersion(draftFetchSql(table, FetchType.SINGLE), id)
     }
 
     private fun <T> fetchOfficialRowVersion(id: IntId<T>, table: DbTable): RowVersion<T>? {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
-        return queryRowVersionOrNull(officialFetchSql(table), id)
+        return queryRowVersionOrNull(officialFetchSql(table, FetchType.SINGLE), id)
     }
 
     override fun fetchOfficialVersionsOrThrow(ids: List<IntId<T>>): List<RowVersion<T>> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.versionTable, ids)
         val versions: List<RowVersion<T>> =
             if (ids.isEmpty()) emptyList()
-            else jdbcTemplate.query(manyOfficialsFetchSql(table), mapOf("ids" to ids.map { it.intValue })) { rs, _ ->
+            else jdbcTemplate.query(officialFetchSql(table, FetchType.MULTI), mapOf("ids" to ids.map { it.intValue })) { rs, _ ->
                 rs.getRowVersion("id", "version")
             }
         require(versions.size == ids.size) { "RowVersions not found for some ids" }
@@ -184,14 +184,14 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
 
     private fun <T> fetchDraftRowVersion(id: IntId<T>, table: DbTable): RowVersion<T>? {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
-        return queryRowVersionOrNull(draftFetchSql(table), id)
+        return queryRowVersionOrNull(draftFetchSql(table, FetchType.SINGLE), id)
     }
 
     override fun fetchDraftVersionsOrThrow(ids: List<IntId<T>>): List<RowVersion<T>> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, ids)
         val versions: List<RowVersion<T>> =
             if (ids.isEmpty()) emptyList()
-            else jdbcTemplate.query(manyDraftsFetchSql(table), mapOf("ids" to ids.map { it.intValue })) { rs, _ ->
+            else jdbcTemplate.query(draftFetchSql(table, FetchType.MULTI), mapOf("ids" to ids.map { it.intValue })) { rs, _ ->
                 rs.getRowVersion("id", "version")
             }
         require(versions.size == ids.size) { "RowVersions not found for some ids" }
@@ -270,30 +270,17 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
         }.also { deleted -> logger.daoAccess(DELETE, table.fullName, deleted) }
     }
 
-    private fun officialFetchSql(table: DbTable) = """
+    private fun officialFetchSql(table: DbTable, fetchType: FetchType) = """
             select o.id, o.version
             from ${table.fullName} o left join ${table.fullName} d on d.${table.draftLink} = o.id
-            where (o.id = :id or d.id = :id) and o.draft = false
+            where (o.id = :id or d.id ${idsSqlFragment(fetchType)}) and o.draft = false
         """
 
-    private fun manyOfficialsFetchSql(table: DbTable) = """
-            select o.id, o.version
-            from ${table.fullName} o left join ${table.fullName} d on d.${table.draftLink} = o.id
-            where (o.id in (:ids) or d.id in (:ids)) and o.draft = false
-        """
-
-    private fun draftFetchSql(table: DbTable) = """
+    private fun draftFetchSql(table: DbTable, fetchType: FetchType) = """
             select o.id, o.version 
             from ${table.fullName} o
-            where o.${table.draftLink} = :id 
-               or (o.id = :id and not exists(select 1 from ${table.fullName} d where d.${table.draftLink} = :id))
-        """
-
-    private fun manyDraftsFetchSql(table: DbTable) = """
-            select o.id, o.version 
-            from ${table.fullName} o
-            where o.${table.draftLink} in (:ids) 
-               or (o.id in (:ids) 
+            where o.${table.draftLink} ${idsSqlFragment(fetchType)} 
+               or (o.id ${idsSqlFragment(fetchType)} 
                   and not exists(select 1 from ${table.fullName} d where d.${table.draftLink} = o.id))
         """
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -294,7 +294,7 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
             from ${table.fullName} o
             where o.${table.draftLink} in (:ids) 
                or (o.id in (:ids) 
-                  and not exists(select 1 from layout.location_track d where d.draft_of_location_track_id = o.id))
+                  and not exists(select 1 from ${table.fullName} d where d.${table.draftLink} = o.id))
         """
 
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -273,14 +273,14 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
     private fun officialFetchSql(table: DbTable, fetchType: FetchType) = """
             select o.id, o.version
             from ${table.fullName} o left join ${table.fullName} d on d.${table.draftLink} = o.id
-            where (o.id = :id or d.id ${idsSqlFragment(fetchType)}) and o.draft = false
+            where (o.id ${idOrIdsEqualSqlFragment(fetchType)} or d.id ${idOrIdsEqualSqlFragment(fetchType)}) and o.draft = false
         """
 
     private fun draftFetchSql(table: DbTable, fetchType: FetchType) = """
             select o.id, o.version 
             from ${table.fullName} o
-            where o.${table.draftLink} ${idsSqlFragment(fetchType)} 
-               or (o.id ${idsSqlFragment(fetchType)} 
+            where o.${table.draftLink} ${idOrIdsEqualSqlFragment(fetchType)} 
+               or (o.id ${idOrIdsEqualSqlFragment(fetchType)} 
                   and not exists(select 1 from ${table.fullName} d where d.${table.draftLink} = o.id))
         """
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
@@ -41,9 +41,9 @@ abstract class DraftableObjectService<ObjectType: Draftable<ObjectType>, DaoType
     fun getMany(publishType: PublishType, ids: List<IntId<ObjectType>>): List<ObjectType> {
         logger.serviceCall("getMany", "publishType" to publishType, "ids" to ids)
         return when (publishType) {
-            DRAFT -> dao.fetchDraftVersionsOrThrow(ids).map { dao.fetch(it) }
-            OFFICIAL -> dao.fetchOfficialVersionsOrThrow(ids).map{ dao.fetch(it) }
-        }
+            DRAFT -> dao.fetchDraftVersionsOrThrow(ids)
+            OFFICIAL -> dao.fetchOfficialVersionsOrThrow(ids)
+        }.map(dao::fetch)
     }
 
     fun get(rowVersion: RowVersion<ObjectType>): ObjectType {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -38,6 +38,16 @@ class LayoutKmPostController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/{publishType}", params = ["ids"])
+    fun getKmPosts(
+        @PathVariable("publishType") publishType: PublishType,
+        @RequestParam("ids", required = true) ids: List<IntId<TrackLayoutKmPost>>,
+    ): List<TrackLayoutKmPost> {
+        logger.apiCall("getKmPost", "publishType" to publishType, "ids" to ids)
+        return kmPostService.getMany(publishType, ids)
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{publishType}", params=["bbox", "step"])
     fun findKmPosts(
         @PathVariable("publishType") publishType: PublishType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -17,7 +17,7 @@ enum class FetchType {
     MULTI
 }
 
-fun idsSqlFragment(fetchType: FetchType) =
+fun idOrIdsEqualSqlFragment(fetchType: FetchType) =
     when (fetchType) {
         FetchType.MULTI -> "in (:ids)"
         FetchType.SINGLE -> "= :id"
@@ -58,13 +58,13 @@ open class DaoBase(private val jdbcTemplateParam: NamedParameterJdbcTemplate?) {
 
     protected fun <T> fetchRowVersion(id: IntId<T>, table: DbTable): RowVersion<T> {
         logger.daoAccess(VERSION_FETCH, "fetchRowVersion", "id" to id, "table" to table.fullName)
-        return queryRowVersion("select id, version from ${table.fullName} where id ${idsSqlFragment(FetchType.SINGLE)}", id)
+        return queryRowVersion("select id, version from ${table.fullName} where id ${idOrIdsEqualSqlFragment(FetchType.SINGLE)}", id)
     }
 
     protected fun <T> fetchManyRowVersions(ids: List<IntId<T>>, table: DbTable): List<RowVersion<T>> {
         logger.daoAccess(VERSION_FETCH, "fetchManyRowVersions", "id" to ids, "table" to table.fullName)
         return if (ids.isEmpty()) emptyList() else jdbcTemplate.query(
-                "select id, version from ${table.fullName} where id ${idsSqlFragment(FetchType.MULTI)}",
+                "select id, version from ${table.fullName} where id ${idOrIdsEqualSqlFragment(FetchType.MULTI)}",
                 mapOf("ids" to ids.map { it.intValue })
             ) { rs, _ ->
                 rs.getRowVersion("id", "version")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -50,6 +50,16 @@ open class DaoBase(private val jdbcTemplateParam: NamedParameterJdbcTemplate?) {
         return queryRowVersion("select id, version from ${table.fullName} where id = :id", id)
     }
 
+    protected fun <T> fetchManyRowVersions(ids: List<IntId<T>>, table: DbTable): List<RowVersion<T>> {
+        logger.daoAccess(VERSION_FETCH, "fetchManyRowVersions", "id" to ids, "table" to table.fullName)
+        return if (ids.isEmpty()) emptyList() else jdbcTemplate.query(
+                "select id, version from ${table.fullName} where id in (:ids)",
+                mapOf("ids" to ids.map { it.intValue })
+            ) { rs, _ ->
+                rs.getRowVersion("id", "version")
+            }
+    }
+
 
     protected fun <T> fetchRowVersions(table: DbTable): List<RowVersion<T>> {
         logger.daoAccess(VERSION_FETCH, "fetchRowVersions", "table" to table.fullName)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
@@ -212,4 +212,36 @@ class GeometryDaoIT @Autowired constructor(
         assertEquals(mapOf(planVersion.id to expectedSummary), summaries)
         assertContains(allSummaries.values, expectedSummary)
     }
+
+    @Test
+    fun `Geometry plan header mass fetch works`() {
+        val file1 = infraModelFile("${TEST_NAME_PREFIX}_file_min_elem_1.xml")
+        val file2 = infraModelFile("${TEST_NAME_PREFIX}_file_min_elem_2.xml")
+        val trackNumberId = insertOfficialTrackNumber()
+        val plan1 = plan(
+            trackNumberId = trackNumberId,
+            fileName = file1.name,
+            alignments = listOf(geometryAlignment(
+                elements = listOf(
+                    minimalLine(),
+                ),
+            )),
+        )
+        val plan2 = plan(
+            trackNumberId = trackNumberId,
+            fileName = file1.name,
+            alignments = listOf(geometryAlignment(
+                elements = listOf(
+                    minimalCurve(),
+                ),
+            )),
+        )
+        val plan1Version = geometryDao.insertPlan(plan1, file1, null)
+        val plan2Version = geometryDao.insertPlan(plan2, file2, null)
+
+        val expected = geometryDao.fetchManyPlanVersions(listOf(plan1Version.id, plan2Version.id))
+        assertEquals(expected.size, 2)
+        assertContains(expected, plan1Version)
+        assertContains(expected, plan2Version)
+    }
 }

--- a/ui/src/data-products/element-list/plan-geometry-search.tsx
+++ b/ui/src/data-products/element-list/plan-geometry-search.tsx
@@ -14,7 +14,7 @@ import { PropEdit } from 'utils/validation-utils';
 import {
     getGeometryPlanElements,
     getGeometryPlanElementsCsv,
-    getGeometryPlanHeaders,
+    getGeometryPlanHeadersBySearchTerms,
 } from 'geometry/geometry-api';
 import { ElementItem, GeometryPlanHeader, PlanSource } from 'geometry/geometry-model';
 import { useLoader } from 'utils/react-utils';
@@ -39,9 +39,14 @@ function searchGeometryPlanHeaders(
         return Promise.resolve([]);
     }
 
-    return getGeometryPlanHeaders(10, undefined, undefined, [source], [], searchTerm).then(
-        (t) => t.items,
-    );
+    return getGeometryPlanHeadersBySearchTerms(
+        10,
+        undefined,
+        undefined,
+        [source],
+        [],
+        searchTerm,
+    ).then((t) => t.items);
 }
 
 function getGeometryPlanOptions(

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -98,7 +98,9 @@ export async function getGeometryPlanHeader(planId: GeometryPlanId): Promise<Geo
 export async function getGeometryPlanHeaders(
     planIds: GeometryPlanId[],
 ): Promise<GeometryPlanHeader[]> {
-    return getThrowError<GeometryPlanHeader[]>(`${GEOMETRY_URI}/plan-headers?planIds=${planIds}`);
+    return planIds.length > 0
+        ? getThrowError<GeometryPlanHeader[]>(`${GEOMETRY_URI}/plan-headers?planIds=${planIds}`)
+        : Promise.resolve([]);
 }
 
 export async function getGeometryPlanElements(

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -60,7 +60,7 @@ async function getPlanAreas(bbox: BoundingBox): Promise<PlanArea[]> {
     return (await getIgnoreError<PlanArea[]>(path)) || [];
 }
 
-export async function getGeometryPlanHeaders(
+export async function getGeometryPlanHeadersBySearchTerms(
     limit: number,
     offset?: number,
     bbox?: BoundingBox,
@@ -93,6 +93,12 @@ export async function getGeometryPlanHeaders(
 
 export async function getGeometryPlanHeader(planId: GeometryPlanId): Promise<GeometryPlanHeader> {
     return getThrowError<GeometryPlanHeader>(`${GEOMETRY_URI}/plan-headers/${planId}`);
+}
+
+export async function getGeometryPlanHeaders(
+    planIds: GeometryPlanId[],
+): Promise<GeometryPlanHeader[]> {
+    return getThrowError<GeometryPlanHeader[]>(`${GEOMETRY_URI}/plan-headers?planIds=${planIds}`);
 }
 
 export async function getGeometryPlanElements(

--- a/ui/src/infra-model/list/infra-model-list-container.tsx
+++ b/ui/src/infra-model/list/infra-model-list-container.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { InfraModelListView } from 'infra-model/list/infra-model-list-view';
 
 import { createDelegates } from 'store/store-utils';
-import { getGeometryPlanHeaders } from 'geometry/geometry-api';
+import { getGeometryPlanHeadersBySearchTerms } from 'geometry/geometry-api';
 import { GeometryPlanId } from 'geometry/geometry-model';
 import { actionCreators } from 'infra-model/infra-model-store';
 import { useInframodelAppDispatch, useInframodelAppSelector } from 'store/hooks';
@@ -29,7 +29,7 @@ export const InfraModelListContainer: React.FC<InfraModelListContainerProps> = (
     React.useEffect(() => {
         if (state.searchState == 'start') {
             infraModelListDelegates.onPlanFetchStart();
-            getGeometryPlanHeaders(
+            getGeometryPlanHeadersBySearchTerms(
                 state.pageSize,
                 state.page * state.pageSize,
                 undefined,

--- a/ui/src/linking/linking-utils.ts
+++ b/ui/src/linking/linking-utils.ts
@@ -6,7 +6,7 @@ import {
     LayoutSwitchJointConnection,
     LocationTrackId,
 } from 'track-layout/track-layout-model';
-import { getLocationTrack } from 'track-layout/layout-location-track-api';
+import { getLocationTracks } from 'track-layout/layout-location-track-api';
 
 export enum SwitchTypeMatch {
     Exact,
@@ -80,8 +80,8 @@ export function getLocationTracksForJointConnections(
         .filter(filterUnique);
 
     // This currently flickers when using mass fetch. This can be moved to mass fetch after GVT-1428 is done
-    return Promise.all(locationTrackIds.map((id) => getLocationTrack(id, publishType))).then(
-        (tracks) => tracks.filter(filterNotEmpty),
+    return getLocationTracks(locationTrackIds, publishType).then((tracks) =>
+        tracks.filter(filterNotEmpty),
     );
 }
 

--- a/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
+++ b/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
@@ -208,7 +208,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                 onVisibilityToggle={onPlanVisibilityToggle}
                 visibility={visibilities.planHeader}
                 onHeaderClick={() => onPlanHeaderSelection(planHeader)}
-                headerSelected={selectedItems?.geometryPlans?.some((p) => p.id === planHeader.id)}
+                headerSelected={selectedItems?.geometryPlans?.some((id) => id === planHeader.id)}
                 fetchingContent={openingAccordion || planBeingLoaded}>
                 {planLayout && (
                     <div className={styles['geometry-plan-panel__alignments']}>

--- a/ui/src/selection-panel/selection-panel-geometry-section.tsx
+++ b/ui/src/selection-panel/selection-panel-geometry-section.tsx
@@ -170,7 +170,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
                                 onPlanHeaderSelection={(header) =>
                                     onSelect({
                                         ...createEmptyItemCollections(),
-                                        geometryPlans: [header],
+                                        geometryPlans: [header.id],
                                         isToggle: true,
                                     })
                                 }

--- a/ui/src/selection-panel/selection-panel-geometry-section.tsx
+++ b/ui/src/selection-panel/selection-panel-geometry-section.tsx
@@ -19,7 +19,7 @@ import {
 } from 'geometry/geometry-model';
 import { useTranslation } from 'react-i18next';
 import { useMapState, useSetState } from 'utils/react-utils';
-import { getGeometryPlanHeaders, getTrackLayoutPlan } from 'geometry/geometry-api';
+import { getGeometryPlanHeadersBySearchTerms, getTrackLayoutPlan } from 'geometry/geometry-api';
 import { GeometryPlanLayout, LayoutTrackNumber } from 'track-layout/track-layout-model';
 import { GeometryPlanLinkStatus } from 'linking/linking-model';
 import { getPlanLinkStatus } from 'linking/linking-api';
@@ -82,7 +82,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
     const [plansBeingLoaded, startLoadingPlan, finishLoadingPlan] = useSetState<GeometryPlanId>();
 
     React.useEffect(() => {
-        getGeometryPlanHeaders(
+        getGeometryPlanHeadersBySearchTerms(
             MAX_PLAN_HEADERS,
             0,
             viewport.area,

--- a/ui/src/selection/selection-model.ts
+++ b/ui/src/selection/selection-model.ts
@@ -11,7 +11,7 @@ import {
     MapSegment,
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
-import { GeometryPlanHeader, GeometryPlanId, GeometryPlanLayoutId } from 'geometry/geometry-model';
+import { GeometryPlanId, GeometryPlanLayoutId } from 'geometry/geometry-model';
 import {
     ClusterPoint,
     LinkPoint,
@@ -41,7 +41,7 @@ export type ItemCollections = {
     clusterPoints: ClusterPoint[];
     suggestedSwitches: SuggestedSwitch[];
     locationTrackEndPoints: LocationTrackEndpoint[];
-    geometryPlans: GeometryPlanHeader[];
+    geometryPlans: GeometryPlanId[];
 };
 
 export type UnselectableItemCollections = {

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -220,7 +220,7 @@ function updateItemCollectionsByOptions(
         options['locationTrackEndPoints'],
         flags,
     );
-    itemCollections['geometryPlans'] = getNewItemCollection(
+    itemCollections['geometryPlans'] = getNewIdCollection(
         itemCollections['geometryPlans'],
         options['geometryPlans'],
         flags,
@@ -283,7 +283,7 @@ function updateItemCollectionsByUnselecting(
         itemCollections['locationTrackEndPoints'],
         unselectItemCollections['locationTrackEndPoints'],
     );
-    itemCollections['geometryPlans'] = filterItemCollection(
+    itemCollections['geometryPlans'] = filterIdCollection(
         itemCollections['geometryPlans'],
         unselectItemCollections['geometryPlans'],
     );

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -3,11 +3,13 @@ import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { formatTrackMeterWithoutMeters } from 'utils/geography-utils';
 import styles from 'tool-panel/track-number/alignment-plan-section-infobox.scss';
 import { Link } from 'vayla-design-lib/link/link';
-import { GeometryPlanId } from 'geometry/geometry-model';
 import { AlignmentSectionByPlan } from 'track-layout/layout-location-track-api';
-import { useAppNavigate } from 'common/navigate';
 import { useTranslation } from 'react-i18next';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { createDelegates } from 'store/store-utils';
+import { actionCreators as TrackLayoutActions } from 'track-layout/track-layout-store';
+import { useTrackLayoutAppDispatch } from 'store/hooks';
+import { toolPanelPlanTabId } from 'tool-panel/tool-panel';
 
 type AlignmentPlanSectionInfoboxContentProps = {
     sections: AlignmentSectionByPlan[];
@@ -17,8 +19,9 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
     AlignmentPlanSectionInfoboxContentProps
 > = ({ sections }) => {
     const { t } = useTranslation();
-    const navigate = useAppNavigate();
-    const onSelectPlan = (planId: GeometryPlanId) => navigate('inframodel-edit', planId);
+
+    const dispatch = useTrackLayoutAppDispatch();
+    const delegates = createDelegates(dispatch, TrackLayoutActions);
 
     const errorFragment = (errorMessage = '') => (
         <span
@@ -38,9 +41,16 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
                             {section.planName ? (
                                 section.planId ? (
                                     <Link
-                                        onClick={() =>
-                                            section.planId && onSelectPlan(section.planId)
-                                        }
+                                        onClick={() => {
+                                            if (section.planId) {
+                                                delegates.setToolPanelTab(
+                                                    toolPanelPlanTabId(section.planId),
+                                                );
+                                                delegates.onSelect({
+                                                    geometryPlans: [section.planId],
+                                                });
+                                            }
+                                        }}
                                         title={section.planName}>
                                         {section.planName}
                                     </Link>

--- a/ui/src/tool-panel/geometry-plan-link.tsx
+++ b/ui/src/tool-panel/geometry-plan-link.tsx
@@ -5,25 +5,25 @@ import { useTrackLayoutAppDispatch } from 'store/hooks';
 import { createDelegates } from 'store/store-utils';
 import { actionCreators as TrackLayoutActions } from 'track-layout/track-layout-store';
 import { createEmptyItemCollections } from 'selection/selection-store';
-import { GeometryPlanHeader, GeometryPlanId } from 'geometry/geometry-model';
+import { GeometryPlanId } from 'geometry/geometry-model';
 
 export type GeometryPlanLinkProps = {
     planId?: GeometryPlanId;
-    onClick?: (planHeader: GeometryPlanHeader) => void;
+    onClick?: (planId: GeometryPlanId) => void;
 };
 
 function createSelectAction() {
     const dispatch = useTrackLayoutAppDispatch();
     const delegates = createDelegates(dispatch, TrackLayoutActions);
-    return (planHeader: GeometryPlanHeader) =>
+    return (planId: GeometryPlanId) =>
         delegates.onSelect({
             ...createEmptyItemCollections(),
-            geometryPlans: [planHeader],
+            geometryPlans: [planId],
         });
 }
 
 export const GeometryPlanLink: React.FC<GeometryPlanLinkProps> = (props: GeometryPlanLinkProps) => {
     const header = usePlanHeader(props.planId);
     const clickAction = props.onClick || createSelectAction();
-    return <Link onClick={() => header && clickAction(header)}>{header?.fileName || ''}</Link>;
+    return <Link onClick={() => header && clickAction(header.id)}>{header?.fileName || ''}</Link>;
 };

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -5,7 +5,7 @@ import { LayoutKmPost, LayoutKmPostId } from 'track-layout/track-layout-model';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { useTranslation } from 'react-i18next';
-import { useDebouncedState, useLoader } from 'utils/react-utils';
+import { useLoader } from 'utils/react-utils';
 import { getPlanLinkStatus, linkKmPost } from 'linking/linking-api';
 import { GeometryKmPostId, GeometryPlanId } from 'geometry/geometry-model';
 import { PublishType, TimeStamp } from 'common/common-model';
@@ -17,7 +17,7 @@ import styles from 'tool-panel/km-post/geometry-km-post-linking-infobox.scss';
 import InfoboxText from 'tool-panel/infobox/infobox-text';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { KmPostBadge, KmPostBadgeStatus } from 'geoviite-design-lib/km-post/km-post-badge';
-import { getKmPost, getKmPostForLinking } from 'track-layout/layout-km-post-api';
+import { getKmPost, getKmPostForLinking, getKmPosts } from 'track-layout/layout-km-post-api';
 import { TextField, TextFieldVariant } from 'vayla-design-lib/text-field/text-field';
 import { KmPostEditDialog } from 'tool-panel/km-post/dialog/km-post-edit-dialog';
 import { updateKmPostChangeTime } from 'common/change-time-api';
@@ -49,7 +49,6 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
     const { t } = useTranslation();
     const [searchTerm, setSearchTerm] = React.useState('');
     const [showAddDialog, setShowAddDialog] = React.useState(false);
-    const _debouncedSearchTerm = useDebouncedState(searchTerm, 200);
 
     const planStatus = useLoader(
         () => (planId ? getPlanLinkStatus(planId, publishType) : undefined),
@@ -61,8 +60,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
         const kmPostIds = planStatus.kmPosts
             .filter((linkStatus) => linkStatus.id == geometryKmPost.sourceId)
             .flatMap((linkStatus) => linkStatus.linkedKmPosts);
-        const kmPostPromises = kmPostIds.map((kmPostId) => getKmPost(kmPostId, publishType));
-        return Promise.all(kmPostPromises).then((posts) => posts.filter(filterNotEmpty));
+        return getKmPosts(kmPostIds, publishType).then((posts) => posts.filter(filterNotEmpty));
     }, [planStatus, geometryKmPost.sourceId]);
 
     const kmPosts =

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -62,7 +62,7 @@ const ToolPanelContainer: React.FC = () => {
 
     return (
         <ToolPanel
-            planHeaders={store.selection.selectedItems.geometryPlans}
+            planIds={store.selection.selectedItems.geometryPlans}
             trackNumberIds={store.selection.selectedItems.trackNumbers}
             kmPostIds={kmPostIds}
             geometryKmPosts={store.selection.selectedItems.geometryKmPosts}

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -29,7 +29,7 @@ import { PublishType } from 'common/common-model';
 import { filterNotEmpty, filterUniqueById } from 'utils/array-utils';
 import GeometryKmPostInfoboxContainer from 'tool-panel/km-post/geometry-km-post-infobox-container';
 import LocationTrackInfoboxLinkingContainer from 'tool-panel/location-track/location-track-infobox-linking-container';
-import { getKmPost } from 'track-layout/layout-km-post-api';
+import { getKmPosts } from 'track-layout/layout-km-post-api';
 import TrackNumberInfoboxLinkingContainer from 'tool-panel/track-number/track-number-infobox-linking-container';
 import { useLoader } from 'utils/react-utils';
 import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
@@ -112,18 +112,9 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
 
     const tracksSwitchesKmPostsPlans = useLoader(() => {
         const trackNumbersPromise = getTrackNumbers(publishType, changeTimes.layoutTrackNumber);
-        // Data accessed ToolPanel is most likely cached and mass fetches don't have caching implemented yet.
-        // These should be switched to using mass fetches once GVT-1428 is done
         const locationTracksPromise = getLocationTracks(locationTrackIds, publishType);
-
         const switchesPromise = getSwitches(switchIds, publishType);
-
-        const kmPostsPromise = Promise.all(
-            kmPostIds?.map((kmPostId) =>
-                getKmPost(kmPostId, publishType, changeTimes.layoutKmPost),
-            ),
-        );
-
+        const kmPostsPromise = getKmPosts(kmPostIds, publishType);
         const plansPromise = getGeometryPlanHeaders(planIds);
 
         return Promise.all([

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -34,10 +34,10 @@ import TrackNumberInfoboxLinkingContainer from 'tool-panel/track-number/track-nu
 import { useLoader } from 'utils/react-utils';
 import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
 import { getTrackNumbers } from 'track-layout/layout-track-number-api';
-import { getSwitch } from 'track-layout/layout-switch-api';
-import { getLocationTrack } from 'track-layout/layout-location-track-api';
+import { getSwitches } from 'track-layout/layout-switch-api';
+import { getLocationTracks } from 'track-layout/layout-location-track-api';
 import { MapViewport } from 'map/map-model';
-import { getGeometryPlanHeader } from 'geometry/geometry-api';
+import { getGeometryPlanHeaders } from 'geometry/geometry-api';
 
 type ToolPanelProps = {
     planIds: GeometryPlanId[];
@@ -114,13 +114,9 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         const trackNumbersPromise = getTrackNumbers(publishType, changeTimes.layoutTrackNumber);
         // Data accessed ToolPanel is most likely cached and mass fetches don't have caching implemented yet.
         // These should be switched to using mass fetches once GVT-1428 is done
-        const locationTracksPromise = Promise.all(
-            locationTrackIds.map((id) =>
-                getLocationTrack(id, publishType, changeTimes.layoutLocationTrack),
-            ),
-        );
+        const locationTracksPromise = getLocationTracks(locationTrackIds, publishType);
 
-        const switchesPromise = Promise.all(switchIds?.map((swId) => getSwitch(swId, publishType)));
+        const switchesPromise = getSwitches(switchIds, publishType);
 
         const kmPostsPromise = Promise.all(
             kmPostIds?.map((kmPostId) =>
@@ -128,7 +124,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             ),
         );
 
-        const plansPromise = Promise.all(planIds.map(getGeometryPlanHeader));
+        const plansPromise = getGeometryPlanHeaders(planIds);
 
         return Promise.all([
             locationTracksPromise.then((l) => l.filter(filterNotEmpty)),
@@ -390,7 +386,6 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         setSelectedTabId(lockToTabId ? lockToTabId : tabId);
     }
 
-    console.log(tabs.map((t) => t.id));
     return (
         <div className="tool-panel">
             {tabs.length > 1 && (

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -37,9 +37,10 @@ import { getTrackNumbers } from 'track-layout/layout-track-number-api';
 import { getSwitch } from 'track-layout/layout-switch-api';
 import { getLocationTrack } from 'track-layout/layout-location-track-api';
 import { MapViewport } from 'map/map-model';
+import { getGeometryPlanHeader } from 'geometry/geometry-api';
 
 type ToolPanelProps = {
-    planHeaders: GeometryPlanHeader[];
+    planIds: GeometryPlanId[];
     trackNumberIds: LayoutTrackNumberId[];
     kmPostIds: LayoutKmPostId[];
     geometryKmPosts: SelectedGeometryItem<LayoutKmPost>[];
@@ -67,8 +68,12 @@ type ToolPanelTab = {
     element: React.ReactElement;
 };
 
+export function toolPanelPlanTabId(planId: GeometryPlanId): string {
+    return 'plan-header_' + planId;
+}
+
 const ToolPanel: React.FC<ToolPanelProps> = ({
-    planHeaders,
+    planIds,
     trackNumberIds,
     kmPostIds,
     geometryKmPosts,
@@ -105,7 +110,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         onUnselect({ switches: [switchId] });
     }, []);
 
-    const tracksSwitchesKmPosts = useLoader(() => {
+    const tracksSwitchesKmPostsPlans = useLoader(() => {
         const trackNumbersPromise = getTrackNumbers(publishType, changeTimes.layoutTrackNumber);
         // Data accessed ToolPanel is most likely cached and mass fetches don't have caching implemented yet.
         // These should be switched to using mass fetches once GVT-1428 is done
@@ -123,11 +128,14 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             ),
         );
 
+        const plansPromise = Promise.all(planIds.map(getGeometryPlanHeader));
+
         return Promise.all([
             locationTracksPromise.then((l) => l.filter(filterNotEmpty)),
             switchesPromise.then((l) => l.filter(filterNotEmpty)),
             kmPostsPromise.then((l) => l.filter(filterNotEmpty)),
             trackNumbersPromise.then((l) => l.filter(filterNotEmpty)),
+            plansPromise.then((l) => l.filter(filterNotEmpty)),
         ]);
     }, [
         locationTrackIds,
@@ -138,24 +146,26 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         kmPostIds,
         changeTimes.layoutKmPost,
         changeTimes.layoutTrackNumber,
+        planIds,
     ]);
 
-    const locationTracks = (tracksSwitchesKmPosts && tracksSwitchesKmPosts[0]) || [];
-    const switches = (tracksSwitchesKmPosts && tracksSwitchesKmPosts[1]) || [];
-    const kmPosts = (tracksSwitchesKmPosts && tracksSwitchesKmPosts[2]) || [];
-    const trackNumbers = (tracksSwitchesKmPosts && tracksSwitchesKmPosts[3]) || [];
+    const locationTracks = (tracksSwitchesKmPostsPlans && tracksSwitchesKmPostsPlans[0]) || [];
+    const switches = (tracksSwitchesKmPostsPlans && tracksSwitchesKmPostsPlans[1]) || [];
+    const kmPosts = (tracksSwitchesKmPostsPlans && tracksSwitchesKmPostsPlans[2]) || [];
+    const trackNumbers = (tracksSwitchesKmPostsPlans && tracksSwitchesKmPostsPlans[3]) || [];
+    const planHeaders = (tracksSwitchesKmPostsPlans && tracksSwitchesKmPostsPlans[4]) || [];
 
     // Draft-only entities should be hidden when viewing in official mode. Show everything in draft mode
     const visibleByTypeAndPublishType = ({ draftType }: { draftType: DraftType }) =>
         publishType === 'DRAFT' || draftType !== 'NEW_DRAFT';
 
     React.useEffect(() => {
-        if (tracksSwitchesKmPosts === undefined) {
+        if (tracksSwitchesKmPostsPlans === undefined) {
             return;
         }
         const planTabs = planHeaders.map((p: GeometryPlanHeader) => {
             return {
-                id: 'plan-header_' + p.id,
+                id: toolPanelPlanTabId(p.id),
                 title: p.fileName,
                 element: <GeometryPlanInfobox planHeader={p} />,
             };
@@ -380,6 +390,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         setSelectedTabId(lockToTabId ? lockToTabId : tabId);
     }
 
+    console.log(tabs.map((t) => t.id));
     return (
         <div className="tool-panel">
             {tabs.length > 1 && (


### PR DESCRIPTION
Tämä eskaloitui taas vähän kun oli muitakin tätä kokonaisuutta läheltä liippaavia juttuja:
* Fronttipuolelle suunnitelmien geometriat -infoboksin suunnitelmalinkit valkkaavat nyt ka. suunnitelman toolpanelista
* Tämän takia selectionissa planheaderit piti muuttaa niin, että niistä tallennettiin pelkkä id
* Tätä myötä planheadereille oli fiksua tehdä massahaku ja ottaa se käyttöön kaikkialla
* Kun nyt tuli koskettua massahakuihin, niin tein samalla myös kilometripylväille massahaun ja otin sen käyttöön
* Samalla kävin läpi muutakin massahakukoodia ja korvasin muita vanhoja `Promise.all()`-muotoisia massahakuja uusilla, oikeilla massahauilla
* Tein täällä tiketin GVT-1437 review-korjaukset, koska ne liittyivät kanssa massahakuihin

Eli tän reviewin koodimuutoksista ehkä noin 20% liittyy alkuperäiseen tarpeeseen ja loput on kaikkea muuta :trollface: Enjoy