### PR TITLE
GVT-1743: Virhe kun validoidaan raidetta

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationValidation.kt
@@ -301,6 +301,11 @@ fun validateSegmentSwitchReferences(
                         jointSequence(segmentJoints),
                     )
                 },
+                validateWithParams(segmentJoints.isNotEmpty()) {
+                    "$VALIDATION_LOCATION_TRACK.switch.wrong-links" to listOf(
+                        switch.name.toString(),
+                    )
+                },
             )
         } else listOf()
 
@@ -484,7 +489,7 @@ fun structureJointGroupFound(structureJoints: List<JointNumber>, alignmentJointG
 
 fun jointGroupMatches(alignmentJoints: List<JointNumber>, structureJoints: List<JointNumber>): Boolean =
     if (!structureJoints.containsAll(alignmentJoints)) false
-    else if (alignmentJoints.size == 1) true
+    else if (alignmentJoints.size <= 1) true
     else {
         val alignmentStartAndEnd = listOf(alignmentJoints.first(), alignmentJoints.last())
         val structureStartAndEnd = listOf(structureJoints.first(), structureJoints.last())

--- a/ui/src/preview/translations.fi.json
+++ b/ui/src/preview/translations.fi.json
@@ -167,7 +167,8 @@
                     },
                     "alignment-not-continuous": "Sijaintiraide on kytketty vaihteelle {{0}} useammasta kuin yhdestä kohtaa",
                     "joint-location-mismatch": "Sijaintiraiteen ja vaihteen {{0}} vaihdepisteiden sijainnit eivät vastaa toisiaan",
-                    "wrong-joint-sequence": "Sijaintiraiteen vaihdepisteet ({{2}}) vaihteella {{0}} ({{1}}) eivät vastaa vaihderakenteen linjoja"
+                    "wrong-joint-sequence": "Sijaintiraiteen vaihdepisteet ({{2}}) vaihteella {{0}} ({{1}}) eivät vastaa vaihderakenteen linjoja",
+                    "wrong-links": "Vaihteen {{0}} linkitys on vajavainen ja se täytyy linkittää uudelleen"
                 }
             },
             "switch": {


### PR DESCRIPTION
Täällä korjattu alkuperäinen räjähtävä validaatio ja sen lisäksi lisätty ka. tilanteelle uusi validaatio, jossa pyydetään operaattoria linkittämään koko vaihde uudelleen raiteeseen.