### PR TITLE
GVT-1746: Välimuistin automaattinen tyhjennys päivityksen yhteydessä

### DIFF
--- a/ui/src/i18n/fi/fi.json
+++ b/ui/src/i18n/fi/fi.json
@@ -183,5 +183,8 @@
     },
     "environment": {
         "test": "Testiympäristö"
+    },
+    "version": {
+        "geoviite-updated": "Geoviitteen versio on päivittynyt. Välimuisti tyhjennetään."
     }
 }

--- a/ui/src/track-layout/track-layout-store.ts
+++ b/ui/src/track-layout/track-layout-store.ts
@@ -63,7 +63,7 @@ export const initialChangeTimes: ChangeTimes = {
 };
 
 export type TrackLayoutState = {
-    version: string;
+    version: string | undefined;
     publishType: PublishType;
     layoutMode: LayoutMode;
     map: Map;
@@ -77,7 +77,7 @@ export type TrackLayoutState = {
 };
 
 export const initialTrackLayoutState: TrackLayoutState = {
-    version: '',
+    version: undefined,
     publishType: 'OFFICIAL',
     layoutMode: 'DEFAULT',
     map: initialMapState,

--- a/ui/src/track-layout/track-layout-store.ts
+++ b/ui/src/track-layout/track-layout-store.ts
@@ -63,6 +63,7 @@ export const initialChangeTimes: ChangeTimes = {
 };
 
 export type TrackLayoutState = {
+    version: string;
     publishType: PublishType;
     layoutMode: LayoutMode;
     map: Map;
@@ -76,6 +77,7 @@ export type TrackLayoutState = {
 };
 
 export const initialTrackLayoutState: TrackLayoutState = {
+    version: '',
     publishType: 'OFFICIAL',
     layoutMode: 'DEFAULT',
     map: initialMapState,
@@ -370,6 +372,12 @@ const trackLayoutSlice = createSlice({
             { payload }: PayloadAction<string | undefined>,
         ): void => {
             state.selectedToolPanelTabId = payload;
+        },
+        setVersion: (
+            state: TrackLayoutState,
+            { payload: version }: PayloadAction<string>,
+        ): void => {
+            state.version = version;
         },
     },
 });

--- a/ui/src/version-holder/version-holder-view.tsx
+++ b/ui/src/version-holder/version-holder-view.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 import styles from './version-holder-view.scss';
-import { getEnvironmentInfo } from 'environment/environment-info';
 
-export const VersionHolderView: React.FC = () => {
+type VersionHolderViewProps = {
+    version: string;
+};
+
+export const VersionHolderView: React.FC<VersionHolderViewProps> = ({ version }) => {
     const clearStorage = () => {
         const isOk = confirm('Välimuisti tyhjennetään ja sivu ladataan uudelleen');
         if (isOk) {
@@ -11,11 +14,9 @@ export const VersionHolderView: React.FC = () => {
         }
     };
 
-    const version = getEnvironmentInfo()?.releaseVersion;
-
     return (
         <div className={styles['version-holder-view']} onClick={clearStorage}>
-            {version && version.substring(0, 8)}
+            {version.substring(0, 8)}
         </div>
     );
 };


### PR DESCRIPTION
Käytännössä tämä toimii nyt niin, että tallennetaan versioinformaatio `trackLayoutStore`en ja verrataan sitä backendiltä tulevaan. Tallennuspaikka ei ole ideaalinen, mutta en halunnut lähteä tekemään pelkästään tälle kokonaan omaa storea, ja `Main`-komponentissa käytettiin `trackLayoutStore`a jo valmiiksi.

Ensimmäisellä versiopäivityksellä storea ei vielä clearata, sillä tämän erikoistapauksen tunnistaminen olisi johtanut ylimääräiseen monimutkaisuuteen ja mahdollisiin false positiveihin resettikoodissa.