### PR TITLE
GVT-1733: API: Raiteen pystygeometria

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
@@ -32,24 +32,33 @@ data class GeometryAlignment(
     @get:JsonIgnore
     val bounds by lazy { boundingBoxAroundPointsOrNull(elements.flatMap { e -> e.bounds }) }
 
-    private fun foldElementLengths(elements: List<GeometryElement>) =
-        elements.fold(mutableListOf<Pair<Double, GeometryElement>>()) { acc, element ->
-            val prev = acc.lastOrNull()
-            val lengthUntilElementStart = prev?.let { prev.first + prev.second.calculatedLength } ?: 0.0
-            acc.add(lengthUntilElementStart to element)
-            acc
-        }
-
-    fun getCoordinateAt(distance: Double) =
+    fun getElementAt(distance: Double) =
         foldElementLengths(elements).findLast { element -> element.first <= distance }
             .let { match ->
                 match?.let {
                     val distanceLeft = distance - match.first
-                    if (distanceLeft <= match.second.calculatedLength) match.second.getCoordinateAt(distanceLeft)
+                    if (distanceLeft <= match.second.calculatedLength) match
                     else null
                 }
             }
 
+    fun getCoordinateAt(distance: Double) =
+        getElementAt(distance)?.let { match -> match.second.getCoordinateAt(distance - match.first) }
+
     fun stationValueNormalized(station: Double) =
         station - (elements.firstOrNull()?.staStart?.toDouble() ?: 0.0)
 }
+
+private fun foldElementLengths(elements: List<GeometryElement>) =
+    elements.fold(mutableListOf<Pair<Double, GeometryElement>>()) { acc, element ->
+        val prev = acc.lastOrNull()
+        val lengthUntilElementStart = prev?.let { prev.first + prev.second.calculatedLength } ?: 0.0
+        acc.add(lengthUntilElementStart to element)
+        acc
+    }
+
+fun elementRange(alignment: GeometryAlignment, elementId: DomainId<GeometryElement>) =
+    foldElementLengths(alignment.elements)
+        .find { elementAndLength -> elementAndLength.second.id == elementId }
+        ?.let { match -> match.first..(match.first + match.second.calculatedLength) }
+        ?: throw IllegalArgumentException("Blaa")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
@@ -47,6 +47,12 @@ data class GeometryAlignment(
 
     fun stationValueNormalized(station: Double) =
         station - (elements.firstOrNull()?.staStart?.toDouble() ?: 0.0)
+
+    fun getElementStationRangeWithinAlignment(elementId: DomainId<GeometryElement>) =
+        foldElementLengths(elements)
+            .find { elementAndLength -> elementAndLength.second.id == elementId }
+            ?.let { match -> match.first..(match.first + match.second.calculatedLength) }
+            ?: throw IllegalArgumentException("Element not found from alignment")
 }
 
 private fun foldElementLengths(elements: List<GeometryElement>) =
@@ -56,9 +62,3 @@ private fun foldElementLengths(elements: List<GeometryElement>) =
         acc.add(lengthUntilElementStart to element)
         acc
     }
-
-fun elementRange(alignment: GeometryAlignment, elementId: DomainId<GeometryElement>) =
-    foldElementLengths(alignment.elements)
-        .find { elementAndLength -> elementAndLength.second.id == elementId }
-        ?.let { match -> match.first..(match.first + match.second.calculatedLength) }
-        ?: throw IllegalArgumentException("Blaa")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -211,7 +211,7 @@ class GeometryController @Autowired constructor(private val geometryService: Geo
         @PathVariable("id") id: IntId<GeometryPlan>,
     ): List<VerticalGeometryListing> {
         log.apiCall("getPlanVerticalGeometryListing", "id" to id)
-        return geometryService.getGeometryProfile(id)
+        return geometryService.getVerticalGeometryListing(id)
     }
 
     @PreAuthorize(AUTH_ALL_READ)
@@ -222,6 +222,6 @@ class GeometryController @Autowired constructor(private val geometryService: Geo
         @RequestParam("endAddress") endAddress: TrackMeter? = null,
     ): List<VerticalGeometryListing> {
         log.apiCall("getTrackVerticalGeometryListing", "id" to id)
-        return geometryService.getGeometryProfile(id, startAddress, endAddress)
+        return geometryService.getVerticalGeometryListing(id, startAddress, endAddress)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -213,4 +213,15 @@ class GeometryController @Autowired constructor(private val geometryService: Geo
         log.apiCall("getPlanVerticalGeometryListing", "id" to id)
         return geometryService.getGeometryProfile(id)
     }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/layout/location-tracks/{id}/vertical-geometry")
+    fun getTrackVerticalGeometryListing(
+        @PathVariable("id") id: IntId<LocationTrack>,
+        @RequestParam("startAddress") startAddress: TrackMeter? = null,
+        @RequestParam("endAddress") endAddress: TrackMeter? = null,
+    ): List<VerticalGeometryListing> {
+        log.apiCall("getTrackVerticalGeometryListing", "id" to id)
+        return geometryService.getGeometryProfile(id, startAddress, endAddress)
+    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -241,6 +241,7 @@ class GeometryService @Autowired constructor(
                     toVerticalGeometryListing(
                         segment,
                         alignment,
+                        null,
                         coordinateTransform,
                         planHeader.id,
                         planHeader.source,
@@ -289,6 +290,7 @@ class GeometryService @Autowired constructor(
             toVerticalGeometryListing(
                 segment,
                 context.geometryAlignment,
+                track.name,
                 context.planHeader.units.coordinateSystemSrid
                     ?.let { coordinateTransformationService
                         .getLayoutTransformation(context.planHeader.units.coordinateSystemSrid)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -2,10 +2,8 @@ package fi.fta.geoviite.infra.geometry
 
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
-import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.geography.CoordinateTransformationService
-import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.geometry.PlanSource.PAIKANNUSPALVELU
 import fi.fta.geoviite.infra.inframodel.InfraModelFile
 import fi.fta.geoviite.infra.logging.serviceCall
@@ -230,7 +228,6 @@ class GeometryService @Autowired constructor(
         val planHeader = getPlanHeader(planId)
         val alignments = geometryDao.fetchAlignments(planHeader.units, planId)
         val geocodingContext = geocodingService.getGeocodingContext(OFFICIAL, planHeader.trackNumberId)
-        val coordinateTransform = planHeader.units.coordinateSystemSrid?.let(coordinateTransformationService::getLayoutTransformation)
 
         return toVerticalGeometryListing(alignments, coordinateTransformationService::getLayoutTransformation, planHeader, geocodingContext)
     }
@@ -240,8 +237,8 @@ class GeometryService @Autowired constructor(
         startAddress: TrackMeter?,
         endAddress: TrackMeter?,
     ): List<VerticalGeometryListing> {
-        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(PublishType.OFFICIAL, locationTrackId)
-        val geocodingContext = geocodingService.getGeocodingContext(PublishType.OFFICIAL, track.trackNumberId)
+        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(OFFICIAL, locationTrackId)
+        val geocodingContext = geocodingService.getGeocodingContext(OFFICIAL, track.trackNumberId)
         return toVerticalGeometryListing(track, alignment, startAddress, endAddress, geocodingContext, coordinateTransformationService::getLayoutTransformation, ::getHeaderAndAlignment)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ListingCommon.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ListingCommon.kt
@@ -1,0 +1,31 @@
+package fi.fta.geoviite.infra.geometry
+
+import fi.fta.geoviite.infra.common.IndexedId
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.geocoding.GeocodingContext
+import fi.fta.geoviite.infra.tracklayout.LayoutSegment
+
+fun collectLinkedElements(
+    segments: List<LayoutSegment>,
+    context: GeocodingContext?,
+    startAddress: TrackMeter?,
+    endAddress: TrackMeter?,
+) = segments
+    .filter { segment -> overlapsAddressInterval(segment, context, startAddress, endAddress) }
+    .map { s -> if (s.sourceId is IndexedId) s to s.sourceId else s to null }
+    .distinctBy { (segment, elementId) -> elementId ?: segment.id }
+
+private fun overlapsAddressInterval(
+    segment: LayoutSegment,
+    context: GeocodingContext?,
+    start: TrackMeter?,
+    end: TrackMeter?,
+): Boolean =
+    (end == null || context != null && getStartAddress(segment, context)?.let { it < end } == true) &&
+            (start == null || context != null && getEndAddress(segment, context)?.let { it > start } == true)
+
+private fun getStartAddress(segment: LayoutSegment, context: GeocodingContext) =
+    context.getAddress(segment.points.first())?.first
+
+private fun getEndAddress(segment: LayoutSegment, context: GeocodingContext) =
+    context.getAddress(segment.points.last())?.first

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
@@ -4,8 +4,17 @@ import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.math.*
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.util.FileName
 import kotlin.math.tan
+
+data class GeometryProfileCalculationContext(
+    val geometryAlignment: GeometryAlignment,
+    val planHeader: GeometryPlanHeader,
+    val curvedProfileSegments: List<CurvedProfileSegment>,
+    val linearProfileSegments: List<LinearProfileSegment>,
+)
 
 data class CurvedSectionEndpoint(
     val address: TrackMeter?,
@@ -43,6 +52,78 @@ data class VerticalGeometryListing(
     val linearSectionForward: LinearSection,
     val linearSectionBackward: LinearSection,
 )
+
+fun toVerticalGeometryListing(
+    planAlignments: List<GeometryAlignment>,
+    getTransformation: (srid: Srid) -> Transformation,
+    planHeader: GeometryPlanHeader,
+    geocodingContext: GeocodingContext?
+): List<VerticalGeometryListing> {
+    return planAlignments.filter { it.profile != null }.map { alignment ->
+        val (curvedSegments, linearSegments) =
+            alignment.profile?.segments
+                ?.let(::separateCurvedAndLinearProfileSegments)
+                ?: (emptyList<CurvedProfileSegment>() to emptyList())
+        curvedSegments.map { segment ->
+            toVerticalGeometryListing(
+                segment,
+                alignment,
+                null,
+                planHeader.units.coordinateSystemSrid?.let(getTransformation),
+                planHeader.id,
+                planHeader.source,
+                planHeader.fileName,
+                geocodingContext,
+                curvedSegments,
+                linearSegments
+            )
+        }
+    }.flatten()
+}
+
+fun toVerticalGeometryListing(
+    track: LocationTrack,
+    layoutAlignment: LayoutAlignment,
+    startAddress: TrackMeter?,
+    endAddress: TrackMeter?,
+    geocodingContext: GeocodingContext?,
+    getTransformation: (srid: Srid) -> Transformation,
+    getPlanHeaderAndAlignment: (id: IntId<GeometryAlignment>) -> Pair<GeometryPlanHeader, GeometryAlignment>,
+): List<VerticalGeometryListing> {
+    val linkedElementIds = collectLinkedElements(
+        layoutAlignment.segments,
+        geocodingContext,
+        startAddress,
+        endAddress
+    ).mapNotNull { it.second }
+    val headersAndAlignments = linkedElementIds
+        .map(::getAlignmentId)
+        .distinct()
+        .associateWith(getPlanHeaderAndAlignment)
+
+    val curvedSegmentsAndGeometryListingContexts = linkedElementIds
+        .map { elementId ->
+            getCurvedProfileSegmentsAndContextsOverlappingElement(headersAndAlignments, elementId)
+        }
+        .flatten()
+        .distinctBy { it.first }
+
+    return curvedSegmentsAndGeometryListingContexts.map { (segment, context) ->
+        toVerticalGeometryListing(
+            segment,
+            context.geometryAlignment,
+            track.name,
+            context.planHeader.units.coordinateSystemSrid
+                ?.let(getTransformation),
+            context.planHeader.id,
+            context.planHeader.source,
+            context.planHeader.fileName,
+            geocodingContext,
+            context.curvedProfileSegments,
+            context.linearProfileSegments
+        )
+    }
+}
 
 fun toVerticalGeometryListing(
     segment: CurvedProfileSegment,
@@ -157,7 +238,7 @@ fun angleFractionBetweenPoints(point1: IPoint, point2: IPoint) =
 fun getCurvedProfileSegmentsAndContextsOverlappingElement(
     headersAndAlignments: Map<IntId<GeometryAlignment>, Pair<GeometryPlanHeader, GeometryAlignment>>,
     elementId: IndexedId<GeometryElement>
-): List<Pair<CurvedProfileSegment, GeometryService.GeometryProfileCalculationContext>> {
+): List<Pair<CurvedProfileSegment, GeometryProfileCalculationContext>> {
     val (planHeader, geometryAlignment) = headersAndAlignments.getValue(getAlignmentId(elementId))
     val (curvedSegments, linearSegments) =
         geometryAlignment.profile?.segments
@@ -171,7 +252,7 @@ fun getCurvedProfileSegmentsAndContextsOverlappingElement(
         }
 
     return segmentsOverlappingElement.map { curve ->
-        curve to GeometryService.GeometryProfileCalculationContext(
+        curve to GeometryProfileCalculationContext(
             geometryAlignment,
             planHeader,
             curvedSegments,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
@@ -19,8 +19,8 @@ data class CurvedSectionEndpoint(
 
 data class IntersectionPoint(
     val address: TrackMeter?,
-    val height: Double?,
-    val station: Double?,
+    val height: Double,
+    val station: Double,
 )
 
 data class LinearSection(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
@@ -47,6 +47,7 @@ data class VerticalGeometryListing(
 fun toVerticalGeometryListing(
     segment: CurvedProfileSegment,
     alignment: GeometryAlignment,
+    locationTrackName: AlignmentName?,
     coordinateTransform: Transformation?,
     planId: DomainId<GeometryPlan>,
     planSource: PlanSource,
@@ -54,7 +55,6 @@ fun toVerticalGeometryListing(
     geocodingContext: GeocodingContext?,
     curvedSegments: List<CurvedProfileSegment>,
     linearSegments: List<LinearProfileSegment>,
-
     ): VerticalGeometryListing {
     val stationPoint = circCurveStationPoint(segment)
     val stationPointCoordinates = alignment.getCoordinateAt(alignment.stationValueNormalized(stationPoint.x))
@@ -71,7 +71,7 @@ fun toVerticalGeometryListing(
         fileName = planFileName,
         alignmentId = alignment.id,
         alignmentName = alignment.name,
-        null,
+        locationTrackName,
         start = CurvedSectionEndpoint(
             address = startCoordinates?.let { geocodingContext?.getAddress(startCoordinates)?.first },
             height = segment.start.y,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
@@ -211,6 +211,7 @@ class VerticalGeometryListingTest() {
                 trackNumberId = IntId(1)
             ),
             null,
+            null,
             IntId(1),
             PlanSource.GEOMETRIAPALVELU,
             FileName("test"),
@@ -224,10 +225,10 @@ class VerticalGeometryListingTest() {
         assertEquals(verticalGeometryEntry.end.station, 6.0, 0.0001)
         assertEquals(verticalGeometryEntry.end.angle!!, -1.0, 0.0001)
         assertEquals(verticalGeometryEntry.tangent!!, sqrt(2.0), 0.0001)
-        assertEquals(verticalGeometryEntry.point.station!!, 5.0, 0.0001)
+        assertEquals(verticalGeometryEntry.point.station, 5.0, 0.0001)
         assertEquals(verticalGeometryEntry.start.height, 0.0, 0.0001)
         assertEquals(verticalGeometryEntry.end.height, 0.0, 0.0001)
-        assertEquals(verticalGeometryEntry.point.height!!, 1.0, 0.0001)
+        assertEquals(verticalGeometryEntry.point.height, 1.0, 0.0001)
         assertEquals(verticalGeometryEntry.radius, 1.0, 0.0001)
         assertEquals(verticalGeometryEntry.fileName, FileName("test"))
         assertEquals(verticalGeometryEntry.planId, IntId<GeometryPlan>(1))

--- a/ui/src/data-products/translations.fi.json
+++ b/ui/src/data-products/translations.fi.json
@@ -59,6 +59,7 @@
             "location-track-search-legend": "Raiteen pystygeometria näyttää luettelossa paikannuspohjan raiteeseen liityvät taitepisteet. Paikannuspohjan raide voi olla koostettu useasta suunnitelmasta, eikä täysin vastaa sitä suunnitelmakokonaisuutta, jonka mukaan raide on rakennettu, joten luettelon tietoja on syytä pitää epäluotettavina. Luettelon tietoja voi käyttää esim. kokonaiskuvan hahmottamiseen tai ongelmien selvittämiseen, mutta niitä ei pidä käyttää esim. tukemiskoneen työn lähtötietona.",
             "plan-search-legend": "Suunnitelman pystygeometria näyttää luettelossa suunnitelman sisältämät taitepisteet. Rataosoiteet on laskettu paikannuspohjan pituusmittauksen mukaan, joten rataosoitteiden tarkkuutta on syytä pitää epäluotettavana. Myös  paikannuspalvelun suunnitelmien elementtien tietoja on syytä pitää epäluotettavina, joten niitä ei pidä käyttää esim. tukemiskoneen työn lähtötietona.",
             "table": {
+                "location-track": "Sijaintiraide",
                 "plan": "Suunnitelma",
                 "alignment": "Suunnitelman raide",
                 "track-address": "Rataosoite",

--- a/ui/src/data-products/translations.fi.json
+++ b/ui/src/data-products/translations.fi.json
@@ -71,7 +71,7 @@
                 "linear-section": "Suora osa",
                 "station-start": "Alku",
                 "station-vertical-intersection": "Taite",
-                "station-end": "End",
+                "station-end": "Loppu",
                 "station": "Paaluluku",
                 "linear-section-forward": "Kaltevuusjakso eteenpäin",
                 "linear-section-backward": "Kaltevuusjakso taaksepäin",

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-table-item.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-table-item.tsx
@@ -7,13 +7,16 @@ import { PlanNameLink } from 'geoviite-design-lib/geometry-plan/plan-name-link';
 
 type VerticalGeometryTableItemProps = {
     verticalGeometry: VerticalGeometryItem;
+    showLocationTrack: boolean;
 };
 
 export const VerticalGeometryTableItem: React.FC<VerticalGeometryTableItemProps> = ({
     verticalGeometry,
+    showLocationTrack,
 }) => {
     return (
         <tr>
+            {showLocationTrack && <td>{verticalGeometry.locationTrackName}</td>}
             <td>
                 <PlanNameLink
                     planId={verticalGeometry.planId}

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-table.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-table.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Table, Th } from 'vayla-design-lib/table/table';
+import { Table, Th, ThVariant } from 'vayla-design-lib/table/table';
 import { VerticalGeometryTableItem } from 'data-products/vertical-geometry/vertical-geometry-table-item';
 import { VerticalGeometryItem } from 'geometry/geometry-model';
 import styles from 'data-products/data-product-table.scss';
@@ -13,9 +13,10 @@ import { createClassName } from 'vayla-design-lib/utils';
 
 type VerticalGeometryTableProps = {
     verticalGeometry: VerticalGeometryItem[];
+    showLocationTrack: boolean;
 };
 
-const HEADINGS = [
+const COMMON_HEADINGS = [
     nonNumericHeading('plan'),
     nonNumericHeading('alignment'),
     withSeparator(numericHeading('track-address')),
@@ -39,6 +40,7 @@ const HEADINGS = [
 
 export const VerticalGeometryTable: React.FC<VerticalGeometryTableProps> = ({
     verticalGeometry,
+    showLocationTrack,
 }) => {
     const { t } = useTranslation();
     const separatorAndCenteredClassName = createClassName(
@@ -51,25 +53,32 @@ export const VerticalGeometryTable: React.FC<VerticalGeometryTableProps> = ({
             hasSeparator && styles['data-product-table__table-heading--separator'],
         );
 
+    const headings = (showLocationTrack ? [nonNumericHeading('location-track')] : []).concat(
+        COMMON_HEADINGS,
+    );
+
     return (
         <div className={styles['data-product-table__table-container']}>
             <Table wide>
                 <thead className={styles['data-product-table__table-heading']}>
                     <tr>
                         <Th
-                            colSpan={2}
+                            colSpan={showLocationTrack ? 3 : 2}
                             scope={'colgroup'}
+                            variant={ThVariant.MULTILINE_TOP}
                             className={styles['data-product-table__table-heading--centered']}
                         />
                         <Th
                             colSpan={3}
                             scope={'colgroup'}
+                            variant={ThVariant.MULTILINE_TOP}
                             className={separatorAndCenteredClassName}>
                             {t(`data-products.vertical-geometry.table.curve-start`)}
                         </Th>
                         <Th
                             colSpan={2}
                             scope={'colgroup'}
+                            variant={ThVariant.MULTILINE_TOP}
                             className={separatorAndCenteredClassName}>
                             {t(
                                 `data-products.vertical-geometry.table.point-of-vertical-intersection`,
@@ -78,41 +87,47 @@ export const VerticalGeometryTable: React.FC<VerticalGeometryTableProps> = ({
                         <Th
                             colSpan={3}
                             scope={'colgroup'}
+                            variant={ThVariant.MULTILINE_TOP}
                             className={separatorAndCenteredClassName}>
                             {t(`data-products.vertical-geometry.table.curve-end`)}
                         </Th>
                         <Th
                             colSpan={2}
                             scope={'colgroup'}
+                            variant={ThVariant.MULTILINE_TOP}
                             className={separatorAndCenteredClassName}
                         />
                         <Th
                             colSpan={2}
                             scope={'colgroup'}
+                            variant={ThVariant.MULTILINE_TOP}
                             className={separatorAndCenteredClassName}>
                             {t(`data-products.vertical-geometry.table.linear-section-backward`)}
                         </Th>
                         <Th
                             colSpan={2}
                             scope={'colgroup'}
+                            variant={ThVariant.MULTILINE_TOP}
                             className={separatorAndCenteredClassName}>
                             {t(`data-products.vertical-geometry.table.linear-section-forward`)}
                         </Th>
                         <Th
                             colSpan={3}
                             scope={'colgroup'}
+                            variant={ThVariant.MULTILINE_TOP}
                             className={separatorAndCenteredClassName}>
                             {t(`data-products.vertical-geometry.table.station`)}
                         </Th>
                     </tr>
                     <tr>
-                        {HEADINGS.map((heading, index) => (
+                        {headings.map((heading, index) => (
                             <Th
                                 // The table contains columns with the same heading, so heading names can't be used as indexes.
                                 // Also columns never change dynamically, so dynamic data integrity is not a concern.
                                 key={index}
                                 className={headingClassName(heading.numeric, heading.hasSeparator)}
-                                scope={'colgroup'}>
+                                scope={'colgroup'}
+                                variant={ThVariant.MULTILINE_BOTTOM}>
                                 {t(`data-products.vertical-geometry.table.${heading.name}`)}
                             </Th>
                         ))}
@@ -123,6 +138,7 @@ export const VerticalGeometryTable: React.FC<VerticalGeometryTableProps> = ({
                         <VerticalGeometryTableItem
                             key={verticalGeom.id}
                             verticalGeometry={verticalGeom}
+                            showLocationTrack={showLocationTrack}
                         />
                     ))}
                 </tbody>

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
@@ -64,6 +64,7 @@ const VerticalGeometryView = () => {
                         ? state.locationTrackSearch.verticalGeometry
                         : state.planSearch.verticalGeometry
                 }
+                showLocationTrack={state.selectedSearch === 'LOCATION_TRACK'}
             />
         </div>
     );

--- a/ui/src/geometry/geometry-model.ts
+++ b/ui/src/geometry/geometry-model.ts
@@ -305,4 +305,5 @@ export type VerticalGeometryItem = {
     tangent: number;
     linearSectionBackward: LinearSection;
     linearSectionForward: LinearSection;
+    locationTrackName: string;
 };

--- a/ui/src/vayla-design-lib/table/table.scss
+++ b/ui/src/vayla-design-lib/table/table.scss
@@ -17,7 +17,6 @@ $table-cell-padding: 10px 16px;
             // Heading cell
             @include typography-table-heading;
             background: $color-white-dark;
-            padding: $table-cell-padding;
             white-space: break-spaces;
 
             &.table__th--clickable {
@@ -28,6 +27,18 @@ $table-cell-padding: 10px 16px;
                     background: $color-white-darker;
                 }
             }
+        }
+
+        > .table__th--regular {
+            padding: $table-cell-padding;
+        }
+
+        > .table__th--multiline-top {
+            padding: 10px 16px 5px;
+        }
+
+        > .table__th--multiline-bottom {
+            padding: 5px 16px 10px;
         }
     }
 

--- a/ui/src/vayla-design-lib/table/table.tsx
+++ b/ui/src/vayla-design-lib/table/table.tsx
@@ -45,7 +45,11 @@ export const Td: React.FC<TdProps> = ({ variant, narrow, nowrap, ...props }: TdP
     );
 };
 
-export enum ThVariant {}
+export enum ThVariant {
+    SINGLE_LINE,
+    MULTILINE_TOP,
+    MULTILINE_BOTTOM,
+}
 
 export type ThProps = {
     variant?: ThVariant;
@@ -53,7 +57,12 @@ export type ThProps = {
     icon?: IconComponent;
 } & React.HTMLProps<HTMLTableCellElement>;
 
-export const Th: React.FC<ThProps> = ({ narrow, icon, ...props }: ThProps) => {
+export const Th: React.FC<ThProps> = ({
+    narrow,
+    icon,
+    variant = ThVariant.SINGLE_LINE,
+    ...props
+}: ThProps) => {
     const Icon = icon;
     const className = createClassName(
         styles.table__th,
@@ -61,6 +70,9 @@ export const Th: React.FC<ThProps> = ({ narrow, icon, ...props }: ThProps) => {
         props.onClick && styles['table__th--clickable'],
         styles['table__th--align-left'],
         props.className,
+        variant === ThVariant.SINGLE_LINE && styles['table__th--regular'],
+        variant === ThVariant.MULTILINE_BOTTOM && styles['table__th--multiline-bottom'],
+        variant === ThVariant.MULTILINE_TOP && styles['table__th--multiline-top'],
     );
     return (
         <th {...props} className={className}>


### PR DESCRIPTION
Täällä toteutettuna siis suunnitelman pystygeometria-API:a vastaava API myös sijaintiraiteille. Samalla tehty vähän refaktorointia, sillä osa aiemmin elementtiluettelospesifisestä koodista on validia täälläkin. Ne on nyt eriytetty elementtiluettelosta vielä kokonaan omaksi kokonaisuudekseen, jota nämä molemmat käyttävät.