### PR TITLE
GVT-1768: Julkaisun manuaalinen vienti ei ole mahdollista mikäli edellisestä julkaisusta on yli viikko

### DIFF
--- a/ui/src/frontpage/frontpage.tsx
+++ b/ui/src/frontpage/frontpage.tsx
@@ -8,7 +8,6 @@ import { UserCardContainer } from 'user/user-card-container';
 import { getRatkoStatus, RatkoStatus } from 'ratko/ratko-api';
 import PublicationLog from 'publication/log/publication-log';
 import { getPublicationDetails } from 'publication/publication-api';
-import { startOfDay, subDays } from 'date-fns';
 import { ratkoPushFailed } from 'ratko/ratko-model';
 import { TimeStamp } from 'common/common-model';
 
@@ -29,10 +28,7 @@ const Frontpage: React.FC<FrontPageProps> = ({
 
     const publication = publications?.find((p) => p.id == selectedPublication);
     useLoader(
-        () =>
-            getPublicationDetails(startOfDay(subDays(new Date(), 7))).then((result) =>
-                setPublications(result?.items),
-            ),
+        () => getPublicationDetails().then((result) => setPublications(result?.items)),
         [changeTime],
     );
     useLoaderWithTimer(setRatkoStatus, getRatkoStatus, [], 30000);

--- a/ui/src/publication/card/publication-card.tsx
+++ b/ui/src/publication/card/publication-card.tsx
@@ -58,7 +58,7 @@ const parseRatkoStatus = (ratkoStatus: RatkoStatus) => {
     }
 };
 
-const MAX_SUCCESS_PUBLICATIONS = 8;
+const MAX_LISTED_PUBLICATIONS = 8;
 
 const PublicationCard: React.FC<PublishListProps> = ({
     publications,
@@ -71,13 +71,13 @@ const PublicationCard: React.FC<PublishListProps> = ({
         (i1, i2) => -compareTimestamps(i1.publicationTime, i2.publicationTime),
     );
 
-    const failures = allPublications.filter((publication) =>
-        ratkoPushFailed(publication.ratkoPushStatus),
-    );
+    const failures = allPublications
+        .filter((publication) => ratkoPushFailed(publication.ratkoPushStatus))
+        .slice(0, MAX_LISTED_PUBLICATIONS);
 
     const successes = allPublications
         .filter((publication) => !ratkoPushFailed(publication.ratkoPushStatus))
-        .slice(0, MAX_SUCCESS_PUBLICATIONS);
+        .slice(0, MAX_LISTED_PUBLICATIONS);
 
     const ratkoConnectionError = ratkoStatus && ratkoStatus.statusCode >= 300;
 

--- a/ui/src/publication/translations.fi.json
+++ b/ui/src/publication/translations.fi.json
@@ -29,7 +29,7 @@
         "title": "Julkaisut",
         "log-link": "Hae julkaisuja",
         "publish-issues": "Ongelmat Ratko-integraatiossa",
-        "no-success-publications": "Ei julkaisuja viimeisimmän viikon aikana."
+        "no-success-publications": "Ei julkaisuja."
     },
     "error-in-ratko-connection": {
         "connection-error-status-code": "Ratkoon ei saada yhteyttä. Virhe Ratko-yhteydessä ({{0}}). ",


### PR DESCRIPTION
Päädyin tässä poistamaan tuon viikkofiltteröinnin kokonaan ja vaan näyttämään X viimeisintä julkaisua. Ajattelin, että tämä on se, miten itse haluaisin tuon näkymän toimivan jos olisin itse operaattorin housuissa. API sivuttaa edelleen julkaisuja bäkkärin päässä, mutta kaiken järjen mukaan epäonnistuneiden julkaisujen pitäisi olla aina uusimpia julkaisuja, joten tiketillä kuvattu alkuperäinen ongelma pitäisi ratketa tällä