### PR TITLE
GVT-1768: Bäkkärirajapinta X uusimman julkaisun hakemiseen

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationController.kt
@@ -94,17 +94,32 @@ class PublicationController @Autowired constructor(
 
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping
-    fun getPublications(
+    fun getPublicationsBetween(
         @RequestParam("from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
         @RequestParam("to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
     ): Page<PublicationDetails> {
-        logger.apiCall("getPublications", "from" to from, "to" to to)
-        val publications = publicationService.fetchPublicationDetails(from, to)
+        logger.apiCall("getPublicationsBetween", "from" to from, "to" to to)
+        val publications = publicationService.fetchPublicationDetailsBetweenInstants(from, to)
 
         return Page(
             totalCount = publications.size,
             start = 0,
             items = publications.take(50) //Prevents frontend from going kaput, todo: replace with proper paging
+        )
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("latest")
+    fun getLatestPublications(
+        @RequestParam("count") count: Int
+    ): Page<PublicationDetails> {
+        logger.apiCall("getLatestPublications", "count" to count)
+        val publications = publicationService.fetchLatestPublicationDetails(count)
+
+        return Page(
+            totalCount = publications.size,
+            start = 0,
+            items = publications
         )
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationDao.kt
@@ -336,7 +336,7 @@ class PublicationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
     }
 
     //Inclusive from/start time, but exclusive to/end time
-    fun fetchPublications(from: Instant?, to: Instant?): List<Publication> {
+    fun fetchPublicationsBetween(from: Instant?, to: Instant?): List<Publication> {
         val sql = """
             select id, publication_user, publication_time, message
             from publication.publication
@@ -346,6 +346,28 @@ class PublicationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
         val params = mapOf(
             "from" to from?.let { Timestamp.from(it) },
             "to" to to?.let { Timestamp.from(it) },
+        )
+
+        return jdbcTemplate.query(sql, params) { rs, _ ->
+            Publication(
+                id = rs.getIntId("id"),
+                publicationUser = rs.getString("publication_user").let(::UserName),
+                publicationTime = rs.getInstant("publication_time"),
+                message = rs.getString("message")
+            )
+        }.also { publications -> logger.daoAccess(FETCH, Publication::class, publications.map { it.id }) }
+    }
+
+    //Inclusive from/start time, but exclusive to/end time
+    fun fetchLatestPublications(count: Int): List<Publication> {
+        val sql = """
+            select id, publication_user, publication_time, message
+            from publication.publication
+            order by id desc limit :count
+        """.trimIndent()
+
+        val params = mapOf(
+            "count" to count
         )
 
         return jdbcTemplate.query(sql, params) { rs, _ ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/PublicationService.kt
@@ -695,12 +695,17 @@ class PublicationService @Autowired constructor(
 
     fun fetchPublications(from: Instant? = null, to: Instant? = null): List<Publication> {
         logger.serviceCall("fetchPublications", "from" to from, "to" to to)
-        return publicationDao.fetchPublications(from, to)
+        return publicationDao.fetchPublicationsBetween(from, to)
     }
 
-    fun fetchPublicationDetails(from: Instant? = null, to: Instant? = null): List<PublicationDetails> {
-        logger.serviceCall("fetchPublicationDetails", "from" to from, "to" to to)
-        return publicationDao.fetchPublications(from, to).map { getPublicationDetails(it.id) }
+    fun fetchPublicationDetailsBetweenInstants(from: Instant? = null, to: Instant? = null): List<PublicationDetails> {
+        logger.serviceCall("fetchPublicationDetailsBetweenInstants", "from" to from, "to" to to)
+        return publicationDao.fetchPublicationsBetween(from, to).map { getPublicationDetails(it.id) }
+    }
+
+    fun fetchLatestPublicationDetails(count: Int): List<PublicationDetails> {
+        logger.serviceCall("fetchLatestPublicationDetails", "count" to count)
+        return publicationDao.fetchLatestPublications(count).map { getPublicationDetails(it.id) }
     }
 
     fun fetchPublicationDetails(
@@ -717,7 +722,7 @@ class PublicationService @Autowired constructor(
             "order" to order,
         )
 
-        return fetchPublicationDetails(from, to)
+        return fetchPublicationDetailsBetweenInstants(from, to)
             .flatMap(this::mapToPublicationTableItems)
             .let { publications ->
                 if (sortBy == null) publications

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -39,7 +39,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
         // Mark off any old junk as done
         transactional {
             val lastSuccessTime = ratkoPushDao.getLatestPushedPublicationMoment()
-            val hangingPublications = publicationDao.fetchPublications(lastSuccessTime, null)
+            val hangingPublications = publicationDao.fetchPublicationsBetween(lastSuccessTime, null)
                 .filterNot { it.publicationTime == lastSuccessTime }
             if (hangingPublications.isNotEmpty()) ratkoPushDao.startPushing(
                 getCurrentUserName(),
@@ -99,7 +99,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
         val lastPush = ratkoPushDao.getLatestPushedPublicationMoment()
         Assertions.assertTrue(lastPush < layoutPublishMoment)
 
-        val publications = publicationDao.fetchPublications(lastPush, null)
+        val publications = publicationDao.fetchPublicationsBetween(lastPush, null)
         val publishedLocationTracks = publicationDao.fetchPublishedLocationTracks(publications[1].id)
 
         assertEquals(layoutPublishId, publications[1].id)
@@ -113,7 +113,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
         val latestPushMoment = ratkoPushDao.getLatestPushedPublicationMoment()
         assertEquals(layoutPublishMoment, latestPushMoment)
-        val publications = publicationDao.fetchPublications(latestPushMoment, null)
+        val publications = publicationDao.fetchPublicationsBetween(latestPushMoment, null)
         assertEquals(1, publications.size)
     }
 
@@ -124,7 +124,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
         val latestPushedPublish = ratkoPushDao.getLatestPushedPublicationMoment()
         Assertions.assertTrue(latestPushedPublish < layoutPublishMoment)
-        val publications = publicationDao.fetchPublications(latestPushedPublish, null)
+        val publications = publicationDao.fetchPublicationsBetween(latestPushedPublish, null)
         val publishedLocationTracks = publicationDao.fetchPublishedLocationTracks(publications[1].id)
 
         assertEquals(2, publications.size)
@@ -139,7 +139,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
         val latestPushedMoment = ratkoPushDao.getLatestPushedPublicationMoment()
         Assertions.assertTrue(latestPushedMoment < layoutPublishMoment)
-        val publications = publicationDao.fetchPublications(latestPushedMoment, null)
+        val publications = publicationDao.fetchPublicationsBetween(latestPushedMoment, null)
 
         val fetchedLayoutPublish = publications.find { it.id == layoutPublishId }
         val fetchedLayoutPublish2 = publications.find { it.id == layoutPublishId2 }
@@ -156,6 +156,20 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
         assertEquals(locationTrackId, publishLocationTracks[0].version.id)
         assertEquals(locationTrack2Response.id, publish2LocationTracks[0].version.id)
+    }
+
+    @Test
+    fun `Should return latest publications`() {
+        val locationTrack1Response = insertAndPublishLocationTrack()
+        val layoutPublishId1 = createPublication(locationTracks = listOf(locationTrack1Response.rowVersion), message = "Test")
+        val locationTrack2Response = insertAndPublishLocationTrack()
+        val layoutPublishId2 = createPublication(locationTracks = listOf(locationTrack2Response.rowVersion), message = "Test")
+
+        val publications = publicationDao.fetchLatestPublications(2)
+
+        assertEquals(publications.size, 2)
+        assertEquals(publications[0].id, layoutPublishId2)
+        assertEquals(publications[1].id, layoutPublishId1)
     }
 
     @Test

--- a/ui/src/frontpage/frontpage.tsx
+++ b/ui/src/frontpage/frontpage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PublicationCard from 'publication/card/publication-card';
+import PublicationCard, { MAX_LISTED_PUBLICATIONS } from 'publication/card/publication-card';
 import styles from './frontpage.scss';
 import PublicationDetailsView from 'publication/publication';
 import { PublicationDetails, PublicationId } from 'publication/publication-model';
@@ -7,7 +7,7 @@ import { useLoader, useLoaderWithTimer } from 'utils/react-utils';
 import { UserCardContainer } from 'user/user-card-container';
 import { getRatkoStatus, RatkoStatus } from 'ratko/ratko-api';
 import PublicationLog from 'publication/log/publication-log';
-import { getPublicationDetails } from 'publication/publication-api';
+import { getLatestPublications } from 'publication/publication-api';
 import { ratkoPushFailed } from 'ratko/ratko-model';
 import { TimeStamp } from 'common/common-model';
 
@@ -28,7 +28,10 @@ const Frontpage: React.FC<FrontPageProps> = ({
 
     const publication = publications?.find((p) => p.id == selectedPublication);
     useLoader(
-        () => getPublicationDetails().then((result) => setPublications(result?.items)),
+        () =>
+            getLatestPublications(MAX_LISTED_PUBLICATIONS).then((result) =>
+                setPublications(result?.items),
+            ),
         [changeTime],
     );
     useLoaderWithTimer(setRatkoStatus, getRatkoStatus, [], 30000);

--- a/ui/src/publication/card/publication-card.tsx
+++ b/ui/src/publication/card/publication-card.tsx
@@ -58,7 +58,7 @@ const parseRatkoStatus = (ratkoStatus: RatkoStatus) => {
     }
 };
 
-const MAX_LISTED_PUBLICATIONS = 8;
+export const MAX_LISTED_PUBLICATIONS = 8;
 
 const PublicationCard: React.FC<PublishListProps> = ({
     publications,

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -50,6 +50,14 @@ export const getPublicationDetails = (fromDate?: Date, toDate?: Date) => {
     return getIgnoreError<Page<PublicationDetails>>(`${PUBLICATION_URL}${params}`);
 };
 
+export const getLatestPublications = (count: number) => {
+    const params = queryParams({
+        count,
+    });
+
+    return getIgnoreError<Page<PublicationDetails>>(`${PUBLICATION_URL}/latest${params}`);
+};
+
 export const getPublicationAsTableItems = (id: PublicationId) =>
     getIgnoreError<PublicationTableItem[]>(`${PUBLICATION_URL}/${id}/table-rows`);
 


### PR DESCRIPTION
Tästä tuli vähän välimallin ratkaisu. Tämäkin on (mielestäni) fiksu steppi tähän, mutta myös itse julkaisujen haku kaipaisi vähän rakastavaa kosketusta. Siellä tehdään nyt varmaan toistakymmentä round-trippiä kantaan _per julkaisu_, ja niitä olisi todennäköisesti mahdollista yhdistää yksittäisiksi hauiksi