### PR TITLE
Make switch handedness non-nullable

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
@@ -307,13 +307,13 @@ fun convertToRatkoSwitch(
         ),
         RatkoAssetProperty(
             name = "handedness",
-            enumValue = switchStructure.hand?.let { hand ->
+            enumValue = switchStructure.hand.let { hand ->
                 when (hand) {
                     SwitchHand.LEFT -> "Vasenkätinen"
                     SwitchHand.RIGHT -> "Oikeakätinen"
                     else -> "Ei kätisyyttä"
                 }
-            } ?: "Ei tiedossa",
+            }
         )
     ),
     locations = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -65,7 +65,7 @@ data class SwitchTypeParts(
     val curveRadius: List<Int>,
     val spread: String?,
     val ratio: String, // has complex formats, like "2x1:9-4.8", use more structured type if needed
-    val hand: SwitchHand?,
+    val hand: SwitchHand,
 )
 
 private fun parseCurveRadius(curveRadiusList: String): List<Int> {
@@ -73,8 +73,9 @@ private fun parseCurveRadius(curveRadiusList: String): List<Int> {
         .split("/").mapNotNull { radius -> radius.toIntOrNull() }
 }
 
-private fun findSwitchTypeHand(abbreviation: String): SwitchHand? {
+private fun findSwitchTypeHand(abbreviation: String): SwitchHand {
     return SwitchHand.values().find { hand -> hand.abbreviation == abbreviation }
+        ?: SwitchHand.NONE
 }
 
 /**
@@ -84,8 +85,8 @@ fun parseSwitchType(typeName: String): SwitchTypeParts? {
     val matchResult = SWITCH_TYPE_REGEX.find(typeName) ?: return null
     val captured = matchResult.destructured.toList()
     val hand =
-        if (captured.count() <= 5 || captured[5] == "") null
-        else findSwitchTypeHand(captured[5]) ?: return null
+        if (captured.count() <= 5 || captured[5] == "") SwitchHand.NONE
+        else findSwitchTypeHand(captured[5])
 
     return SwitchTypeParts(
         baseType = SwitchBaseType.valueOf(captured[0]),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureTest.kt
@@ -188,7 +188,7 @@ class SwitchStructureTest {
             SwitchType("YV60-900P-1:18-O").parts
         )
         assertEquals(
-            SwitchTypeParts(SwitchBaseType.KRV, 43, listOf(270), null, "1:9,514", null),
+            SwitchTypeParts(SwitchBaseType.KRV, 43, listOf(270), null, "1:9,514", SwitchHand.NONE),
             SwitchType("KRV43-270-1:9,514").parts
         )
         assertEquals(
@@ -196,7 +196,7 @@ class SwitchStructureTest {
             SwitchType("YV60-5000/2500-1:26-V").parts
         )
         assertEquals(
-            SwitchTypeParts(SwitchBaseType.SRR, 54, listOf(), null, "2x1:9-6,0", null),
+            SwitchTypeParts(SwitchBaseType.SRR, 54, listOf(), null, "2x1:9-6,0", SwitchHand.NONE),
             SwitchType("SRR54-2x1:9-6,0").parts
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtilsTest.kt
@@ -11,7 +11,7 @@ class RatkoUtilsTest {
     fun `should reformat switch structure string without handedness`() {
         switchStructures.forEach { switchStructure ->
             val ratkoFormat = asSwitchTypeString(switchStructure.type)
-            if (switchStructure.type.parts.hand == null) {
+            if (switchStructure.type.parts.hand == SwitchHand.NONE) {
                 assertEquals(ratkoFormat, switchStructure.type.toString())
             } else {
                 assertEquals(ratkoFormat, switchStructure.type.toString().dropLast(2))
@@ -23,7 +23,7 @@ class RatkoUtilsTest {
     @Test
     fun `should format unique Ratko switch types from Geoviite types`() {
         val ratkoTypes = switchStructures.mapNotNull { switchStructure ->
-            // Include non left handed switches only to pick only one of each YV/KV etc. switch type
+            // Include non-left-handed switches only to pick only one of each YV/KV etc. switch type
             if (switchStructure.type.parts.hand != SwitchHand.LEFT)
                 asSwitchTypeString(switchStructure.type)
             else null


### PR DESCRIPTION
As switch handedness is derived from the switch structure, we always know if it is right/left/none.