### PR TITLE
GVT-1753 & GVT-1754 & GVT-1755: Kilometrien pituus -sivun UI-jutut

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -48,6 +48,16 @@ class LayoutKmPostController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/{publishType}/on-track-number/{trackNumberId}")
+    fun getKmPostsOnTrackNumber(
+        @PathVariable("publishType") publishType: PublishType,
+        @PathVariable("trackNumberId") id: IntId<TrackLayoutTrackNumber>,
+    ): List<TrackLayoutKmPost> {
+        logger.apiCall("getKmPost", "publishType" to publishType, "id" to id)
+        return kmPostService.list(publishType, id)
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{publishType}", params=["bbox", "step"])
     fun findKmPosts(
         @PathVariable("publishType") publishType: PublishType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -53,7 +53,7 @@ class LayoutKmPostController(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("trackNumberId") id: IntId<TrackLayoutTrackNumber>,
     ): List<TrackLayoutKmPost> {
-        logger.apiCall("getKmPost", "publishType" to publishType, "id" to id)
+        logger.apiCall("getKmPostsOnTrackNumber", "publishType" to publishType, "id" to id)
         return kmPostService.list(publishType, id)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -42,13 +42,13 @@ class LayoutKmPostService(dao: LayoutKmPostDao) : DraftableObjectService<TrackLa
     override fun createPublished(item: TrackLayoutKmPost) = published(item)
 
     fun list(publicationState: PublishType, filter: ((kmPost: TrackLayoutKmPost) -> Boolean)?): List<TrackLayoutKmPost> {
-        logger.serviceCall("getKmPosts", "publicationState" to publicationState, "filter" to (filter != null))
+        logger.serviceCall("list", "publicationState" to publicationState, "filter" to (filter != null))
         val all = listInternal(publicationState, false)
         return filter?.let(all::filter) ?: all
     }
 
     fun list(publicationState: PublishType, trackNumberId: IntId<TrackLayoutTrackNumber>): List<TrackLayoutKmPost> {
-        logger.serviceCall("getKmPosts",
+        logger.serviceCall("list",
             "publicationState" to publicationState, "trackNumberId" to trackNumberId)
         return listInternal(publicationState, false, trackNumberId)
     }

--- a/ui/src/app-bar/app-bar.tsx
+++ b/ui/src/app-bar/app-bar.tsx
@@ -79,8 +79,12 @@ export const AppBar: React.FC = () => {
                                             {t('app-bar.data-products.vertical-geometry')}
                                         </NavLink>
                                     </div>
-                                    <div className={styles['menu__item']}>
-                                        {t('app-bar.data-products.km-lengths')}
+                                    <div>
+                                        <NavLink
+                                            className={styles['menu__item']}
+                                            to={'data-products/kilometer-lengths'}>
+                                            {t('app-bar.data-products.km-lengths')}
+                                        </NavLink>
                                     </div>
                                 </EnvRestricted>
                             </div>

--- a/ui/src/app-bar/app-bar.tsx
+++ b/ui/src/app-bar/app-bar.tsx
@@ -71,14 +71,14 @@ export const AppBar: React.FC = () => {
                                         {t('app-bar.data-products.element-list')}
                                     </NavLink>
                                 </div>
+                                <div>
+                                    <NavLink
+                                        className={styles['menu__item']}
+                                        to={'data-products/vertical-geometry'}>
+                                        {t('app-bar.data-products.vertical-geometry')}
+                                    </NavLink>
+                                </div>
                                 <EnvRestricted restrictTo={'dev'}>
-                                    <div>
-                                        <NavLink
-                                            className={styles['menu__item']}
-                                            to={'data-products/vertical-geometry'}>
-                                            {t('app-bar.data-products.vertical-geometry')}
-                                        </NavLink>
-                                    </div>
                                     <div>
                                         <NavLink
                                             className={styles['menu__item']}

--- a/ui/src/data-products/data-product-view.scss
+++ b/ui/src/data-products/data-product-view.scss
@@ -25,10 +25,10 @@
     > :not(:last-child) {
         margin-right: 16px;
     }
-}
 
-.element-list__geometry-checkboxes {
-    margin-top: 22px;
+    &--no-label {
+        margin-top: 22px;
+    }
 }
 
 .element-list__geometry-checkbox > :not(:last-child) {

--- a/ui/src/data-products/data-product-view.scss
+++ b/ui/src/data-products/data-product-view.scss
@@ -29,6 +29,10 @@
     &--no-label {
         margin-top: 22px;
     }
+
+    &--combined-field > :not(:last-child) {
+        margin-right: 16px;
+    }
 }
 
 .element-list__geometry-checkbox > :not(:last-child) {
@@ -36,7 +40,7 @@
 }
 
 .element-list__download-button {
-    align-self: center;
+    margin-top: 22px;
     margin-left: auto;
     margin-right: 24px;
 }

--- a/ui/src/data-products/data-products-store.ts
+++ b/ui/src/data-products/data-products-store.ts
@@ -9,7 +9,11 @@ import {
 import { filterNotEmpty } from 'utils/array-utils';
 import { ElementItem, GeometryPlanHeader, GeometryType, PlanSource } from 'geometry/geometry-model';
 import { compareTrackMeterStrings, trackMeterIsValid } from 'common/common-model';
-import { LayoutLocationTrack } from 'track-layout/track-layout-model';
+import {
+    LayoutKmPost,
+    LayoutLocationTrack,
+    LayoutTrackNumber,
+} from 'track-layout/track-layout-model';
 import { wrapReducers } from 'store/store-utils';
 
 type SearchGeometries = {
@@ -51,6 +55,13 @@ export type PlanVerticalGeometrySearchState = {
     validationErrors: ValidationError<PlanVerticalGeometrySearchState>[];
     committedFields: (keyof PlanVerticalGeometrySearchState)[];
     verticalGeometry: never[];
+};
+
+export type KmLengthsSearchState = {
+    trackNumber: LayoutTrackNumber | undefined;
+    startKm: LayoutKmPost | undefined;
+    endKm: LayoutKmPost | undefined;
+    kmLengths: never[];
 };
 
 enum MissingSection {
@@ -142,6 +153,13 @@ const initialPlanVerticalGeometrySearchState: PlanVerticalGeometrySearchState = 
     validationErrors: [],
     committedFields: [],
     verticalGeometry: [],
+};
+
+const initialKmLengthsSearchState: KmLengthsSearchState = {
+    trackNumber: undefined,
+    startKm: undefined,
+    endKm: undefined,
+    kmLengths: [],
 };
 
 const spiralTypes = [GeometryType.CLOTHOID, GeometryType.BIQUADRATIC_PARABOLA];
@@ -387,6 +405,25 @@ export const planVerticalGeometrySearchSlice = createSlice({
     },
 });
 
+export const kmLengthsSearchSlice = createSlice({
+    name: 'kmLengthsSearch',
+    initialState: initialKmLengthsSearchState,
+    reducers: {
+        onUpdateKmLengthsSearchProp: function <TKey extends keyof KmLengthsSearchState>(
+            state: KmLengthsSearchState,
+            { payload: propEdit }: PayloadAction<PropEdit<KmLengthsSearchState, TKey>>,
+        ) {
+            state[propEdit.key] = propEdit.value;
+        },
+        onSetKmLengths: function (
+            state: KmLengthsSearchState,
+            { payload: kmLengths }: PayloadAction<never[]>,
+        ) {
+            state.kmLengths = kmLengths;
+        },
+    },
+});
+
 type SelectedSearch = 'PLAN' | 'LOCATION_TRACK';
 
 type DataProductsState = {
@@ -400,6 +437,7 @@ type DataProductsState = {
         planSearch: PlanVerticalGeometrySearchState;
         locationTrackSearch: LocationTrackVerticalGeometrySearchState;
     };
+    kmLenghts: KmLengthsSearchState;
 };
 
 const initialDataProductsState: DataProductsState = {
@@ -413,6 +451,7 @@ const initialDataProductsState: DataProductsState = {
         planSearch: initialPlanVerticalGeometrySearchState,
         locationTrackSearch: initialLocationTrackVerticalGeometrySearchState,
     },
+    kmLenghts: initialKmLengthsSearchState,
 };
 
 const dataProductsSlice = createSlice({
@@ -446,6 +485,10 @@ const dataProductsSlice = createSlice({
         ...wrapReducers(
             (state: DataProductsState) => state.verticalGeometry.planSearch,
             planVerticalGeometrySearchSlice.caseReducers,
+        ),
+        ...wrapReducers(
+            (state: DataProductsState) => state.kmLenghts,
+            kmLengthsSearchSlice.caseReducers,
         ),
     },
 });

--- a/ui/src/data-products/data-products-store.ts
+++ b/ui/src/data-products/data-products-store.ts
@@ -7,10 +7,17 @@ import {
     ValidationErrorType,
 } from 'utils/validation-utils';
 import { filterNotEmpty } from 'utils/array-utils';
-import { ElementItem, GeometryPlanHeader, GeometryType, PlanSource } from 'geometry/geometry-model';
+import {
+    ElementItem,
+    GeometryPlanHeader,
+    GeometryType,
+    PlanSource,
+    VerticalGeometryItem,
+} from 'geometry/geometry-model';
 import { compareTrackMeterStrings, trackMeterIsValid } from 'common/common-model';
 import {
     LayoutKmPost,
+    LayoutKmPostLengthDetails,
     LayoutLocationTrack,
     LayoutTrackNumber,
 } from 'track-layout/track-layout-model';
@@ -45,7 +52,7 @@ export type LocationTrackVerticalGeometrySearchState = {
 
     validationErrors: ValidationError<LocationTrackVerticalGeometrySearchParameters>[];
     committedFields: (keyof LocationTrackVerticalGeometrySearchParameters)[];
-    verticalGeometry: never[];
+    verticalGeometry: VerticalGeometryItem[];
 };
 
 export type PlanVerticalGeometrySearchState = {
@@ -54,7 +61,7 @@ export type PlanVerticalGeometrySearchState = {
 
     validationErrors: ValidationError<PlanVerticalGeometrySearchState>[];
     committedFields: (keyof PlanVerticalGeometrySearchState)[];
-    verticalGeometry: never[];
+    verticalGeometry: VerticalGeometryItem[];
 };
 
 export type KmLengthsSearchState = {
@@ -64,7 +71,7 @@ export type KmLengthsSearchState = {
 
     validationErrors: ValidationError<KmLengthsSearchState>[];
     committedFields: (keyof KmLengthsSearchState)[];
-    kmLengths: never[];
+    kmLengths: LayoutKmPostLengthDetails[];
 };
 
 enum MissingSection {
@@ -379,7 +386,7 @@ export const locationTrackVerticalGeometrySearchSlice = createSlice({
         },
         onSetLocationTrackVerticalGeometry: function (
             state: LocationTrackVerticalGeometrySearchState,
-            { payload: verticalGeometry }: PayloadAction<never[]>,
+            { payload: verticalGeometry }: PayloadAction<VerticalGeometryItem[]>,
         ) {
             state.verticalGeometry = verticalGeometry;
         },
@@ -404,7 +411,7 @@ export const planVerticalGeometrySearchSlice = createSlice({
         },
         onSetPlanVerticalGeometry: function (
             state: PlanVerticalGeometrySearchState,
-            { payload: verticalGeometry }: PayloadAction<never[]>,
+            { payload: verticalGeometry }: PayloadAction<VerticalGeometryItem[]>,
         ) {
             state.verticalGeometry = verticalGeometry;
         },
@@ -444,7 +451,7 @@ export const kmLengthsSearchSlice = createSlice({
         },
         onSetKmLengths: function (
             state: KmLengthsSearchState,
-            { payload: kmLengths }: PayloadAction<never[]>,
+            { payload: kmLengths }: PayloadAction<LayoutKmPostLengthDetails[]>,
         ) {
             state.kmLengths = kmLengths;
         },

--- a/ui/src/data-products/element-list/location-track-element-listing-search.tsx
+++ b/ui/src/data-products/element-list/location-track-element-listing-search.tsx
@@ -145,7 +145,7 @@ const LocationTrackElementListingSearch = ({
                         'endTrackMeter',
                     ).map((error) => t(`data-products.search.${error}`))}
                 />
-                <div className={styles['element-list__geometry-checkboxes']}>
+                <div className={styles['data-products__search--no-label']}>
                     <FieldLayout
                         label={''}
                         value={

--- a/ui/src/data-products/element-list/plan-geometry-element-listing-search.tsx
+++ b/ui/src/data-products/element-list/plan-geometry-element-listing-search.tsx
@@ -117,7 +117,7 @@ const PlanGeometryElementListingSearch = ({
                         }
                     />
                 </div>
-                <div className={styles['element-list__geometry-checkboxes']}>
+                <div className={styles['data-products__search--no-label']}>
                     <FieldLayout
                         value={
                             <div className={styles['element-list__geometry-checkbox']}>

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-container-with-provider.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-container-with-provider.tsx
@@ -1,0 +1,20 @@
+import { connect, Provider } from 'react-redux';
+import { dataProductsStore } from 'store/store';
+import React from 'react';
+import { PersistGate } from 'redux-persist/integration/react';
+import { persistStore } from 'redux-persist';
+import { KilometerLengthsView } from 'data-products/kilometer-lengths/kilometer-lengths-view';
+
+const persistorDp = persistStore(dataProductsStore);
+
+const DataProductsMainContainer = connect()(KilometerLengthsView);
+
+export const KilometerLengthsContainerWithProvider: React.FC = () => {
+    return (
+        <Provider store={dataProductsStore}>
+            <PersistGate loading={null} persistor={persistorDp}>
+                <DataProductsMainContainer />
+            </PersistGate>
+        </Provider>
+    );
+};

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from 'data-products/data-product-view.scss';
+import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
+import { Dropdown, DropdownSize } from 'vayla-design-lib/dropdown/dropdown';
+import { KmLengthsSearchState } from 'data-products/data-products-store';
+import { PropEdit } from 'utils/validation-utils';
+import { useLoader } from 'utils/react-utils';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+import { Button } from 'vayla-design-lib/button/button';
+import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
+import { LayoutKmPost, LayoutTrackNumber } from 'track-layout/track-layout-model';
+import { getKmLengthsCsv, getKmPostsOnTrackNumber } from 'track-layout/layout-km-post-api';
+
+type KilometerLengthsSearchProps = {
+    state: KmLengthsSearchState;
+    onUpdateProp: <TKey extends keyof KmLengthsSearchState>(
+        propEdit: PropEdit<KmLengthsSearchState, TKey>,
+    ) => void;
+    setLengths: (lengths: never[]) => void;
+};
+
+export const KilometerLengthsSearch: React.FC<KilometerLengthsSearchProps> = ({
+    state,
+    onUpdateProp,
+    setLengths,
+}) => {
+    const { t } = useTranslation();
+    const geometryPlanHeaders =
+        useTrackNumbers('OFFICIAL')?.map((tn) => ({ name: tn.number, value: tn })) || [];
+
+    const kmPosts =
+        useLoader(
+            () => state.trackNumber && getKmPostsOnTrackNumber('OFFICIAL', state.trackNumber.id),
+            [],
+        )?.map((km) => ({
+            name: km.kmNumber,
+            value: km,
+        })) || [];
+
+    function updateProp<TKey extends keyof KmLengthsSearchState>(
+        key: TKey,
+        value: KmLengthsSearchState[TKey],
+    ) {
+        onUpdateProp({
+            key: key,
+            value: value,
+            editingExistingValue: false,
+        });
+    }
+
+    const kmLengths = useLoader(() => {
+        return !state.trackNumber ? Promise.resolve([]) : Promise.resolve([]);
+    }, [state.trackNumber]);
+    React.useEffect(() => setLengths([]), [kmLengths]);
+
+    return (
+        <React.Fragment>
+            <div className={styles['data-products__search']}>
+                <FieldLayout
+                    label={t(`data-products.search.track-number`)}
+                    value={
+                        <Dropdown
+                            value={state.trackNumber}
+                            getName={(item: LayoutTrackNumber) => item.number}
+                            placeholder={t('location-track-dialog.search')}
+                            options={geometryPlanHeaders}
+                            searchable
+                            onChange={(e) => updateProp('trackNumber', e)}
+                            canUnselect={true}
+                            unselectText={t('data-products.search.not-selected')}
+                            wideList
+                            wide
+                        />
+                    }
+                />
+                <FieldLayout
+                    label={t(`data-products.search.track-meter-range`)}
+                    value={
+                        <Dropdown
+                            value={state.startKm}
+                            getName={(item: LayoutKmPost) => item.kmNumber}
+                            placeholder={t('location-track-dialog.search')}
+                            options={kmPosts}
+                            searchable
+                            onChange={(e) => updateProp('startKm', e)}
+                            canUnselect={true}
+                            wideList
+                            size={DropdownSize.SMALL}
+                        />
+                    }
+                />
+                <div className={styles['data-products__search--no-label']}>
+                    <Dropdown
+                        value={state.endKm}
+                        getName={(item: LayoutKmPost) => item.kmNumber}
+                        placeholder={t('location-track-dialog.search')}
+                        options={kmPosts}
+                        searchable
+                        onChange={(e) => updateProp('endKm', e)}
+                        canUnselect={true}
+                        wideList
+                        size={DropdownSize.SMALL}
+                    />
+                </div>
+                <Button
+                    className={styles['element-list__download-button']}
+                    disabled={!state.kmLengths || state.kmLengths.length === 0}
+                    onClick={() => {
+                        if (state.trackNumber) {
+                            location.href = getKmLengthsCsv(state.trackNumber?.id);
+                        }
+                    }}
+                    icon={Icons.Download}>
+                    {t(`data-products.search.download-csv`)}
+                </Button>
+            </div>
+        </React.Fragment>
+    );
+};
+
+export default KilometerLengthsSearch;

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
@@ -9,7 +9,11 @@ import { useLoader } from 'utils/react-utils';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Button } from 'vayla-design-lib/button/button';
 import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
-import { LayoutKmPost, LayoutTrackNumber } from 'track-layout/track-layout-model';
+import {
+    LayoutKmPost,
+    LayoutKmPostLengthDetails,
+    LayoutTrackNumber,
+} from 'track-layout/track-layout-model';
 import { getKmLengthsCsv, getKmPostsOnTrackNumber } from 'track-layout/layout-km-post-api';
 import { getVisibleErrorsByProp } from 'data-products/data-products-utils';
 
@@ -18,7 +22,7 @@ type KilometerLengthsSearchProps = {
     onUpdateProp: <TKey extends keyof KmLengthsSearchState>(
         propEdit: PropEdit<KmLengthsSearchState, TKey>,
     ) => void;
-    setLengths: (lengths: never[]) => void;
+    setLengths: (lengths: LayoutKmPostLengthDetails[]) => void;
 };
 
 export const KilometerLengthsSearch: React.FC<KilometerLengthsSearchProps> = ({

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
@@ -11,6 +11,7 @@ import { Button } from 'vayla-design-lib/button/button';
 import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
 import { LayoutKmPost, LayoutTrackNumber } from 'track-layout/track-layout-model';
 import { getKmLengthsCsv, getKmPostsOnTrackNumber } from 'track-layout/layout-km-post-api';
+import { getVisibleErrorsByProp } from 'data-products/data-products-utils';
 
 type KilometerLengthsSearchProps = {
     state: KmLengthsSearchState;
@@ -32,7 +33,7 @@ export const KilometerLengthsSearch: React.FC<KilometerLengthsSearchProps> = ({
     const kmPosts =
         useLoader(
             () => state.trackNumber && getKmPostsOnTrackNumber('OFFICIAL', state.trackNumber.id),
-            [],
+            [state.trackNumber],
         )?.map((km) => ({
             name: km.kmNumber,
             value: km,
@@ -77,32 +78,37 @@ export const KilometerLengthsSearch: React.FC<KilometerLengthsSearchProps> = ({
                 <FieldLayout
                     label={t(`data-products.search.track-meter-range`)}
                     value={
-                        <Dropdown
-                            value={state.startKm}
-                            getName={(item: LayoutKmPost) => item.kmNumber}
-                            placeholder={t('location-track-dialog.search')}
-                            options={kmPosts}
-                            searchable
-                            onChange={(e) => updateProp('startKm', e)}
-                            canUnselect={true}
-                            wideList
-                            size={DropdownSize.SMALL}
-                        />
+                        <span className={styles['data-products__search--combined-field']}>
+                            <Dropdown
+                                value={state.startKm}
+                                getName={(item: LayoutKmPost) => item.kmNumber}
+                                placeholder={t('location-track-dialog.search')}
+                                options={kmPosts}
+                                searchable
+                                onChange={(e) => updateProp('startKm', e)}
+                                canUnselect={true}
+                                wideList
+                                size={DropdownSize.SMALL}
+                            />
+                            <Dropdown
+                                value={state.endKm}
+                                getName={(item: LayoutKmPost) => item.kmNumber}
+                                placeholder={t('location-track-dialog.search')}
+                                options={kmPosts}
+                                searchable
+                                onChange={(e) => updateProp('endKm', e)}
+                                canUnselect={true}
+                                wideList
+                                size={DropdownSize.SMALL}
+                            />
+                        </span>
                     }
+                    errors={getVisibleErrorsByProp(
+                        state.committedFields,
+                        state.validationErrors,
+                        'endKm',
+                    ).map((error) => t(`data-products.search.${error}`))}
                 />
-                <div className={styles['data-products__search--no-label']}>
-                    <Dropdown
-                        value={state.endKm}
-                        getName={(item: LayoutKmPost) => item.kmNumber}
-                        placeholder={t('location-track-dialog.search')}
-                        options={kmPosts}
-                        searchable
-                        onChange={(e) => updateProp('endKm', e)}
-                        canUnselect={true}
-                        wideList
-                        size={DropdownSize.SMALL}
-                    />
-                </div>
                 <Button
                     className={styles['element-list__download-button']}
                     disabled={!state.kmLengths || state.kmLengths.length === 0}

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-table-item.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-table-item.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Precision, roundToPrecision } from 'utils/rounding';
+import styles from '../data-product-table.scss';
+
+export type KilometerLengthsTableItemProps = {
+    trackNumber: string | undefined;
+    kilometer: string;
+    length: number;
+    stationStart: number;
+    stationEnd: number;
+    locationE: number;
+    locationN: number;
+};
+
+export const KilometerLengthTableItem: React.FC<KilometerLengthsTableItemProps> = ({
+    trackNumber,
+    kilometer,
+    stationStart,
+    stationEnd,
+    locationE,
+    locationN,
+}) => {
+    return (
+        <React.Fragment>
+            <tr>
+                <td>{trackNumber}</td>
+                <td>{kilometer}</td>
+                <td className={styles['data-product-table__column--number']}>
+                    {roundToPrecision(length, Precision.measurementMeterDistance)}
+                </td>
+                <td className={styles['data-product-table__column--number']}>
+                    {roundToPrecision(stationStart, Precision.measurementMeterDistance)}
+                </td>
+                <td className={styles['data-product-table__column--number']}>
+                    {roundToPrecision(stationEnd, Precision.measurementMeterDistance)}
+                </td>
+                <td className={styles['data-product-table__column--number']}>
+                    {roundToPrecision(locationE, Precision.TM35FIN)}
+                </td>
+                <td className={styles['data-product-table__column--number']}>
+                    {roundToPrecision(locationN, Precision.TM35FIN)}
+                </td>
+            </tr>
+        </React.Fragment>
+    );
+};

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-table.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-table.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { Table, Th } from 'vayla-design-lib/table/table';
+import { useTranslation } from 'react-i18next';
+import styles from '../data-product-table.scss';
+import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
+import {
+    ElementHeading,
+    nonNumericHeading,
+    numericHeading,
+} from 'data-products/data-products-utils';
+import { KilometerLengthTableItem } from 'data-products/kilometer-lengths/kilometer-lengths-table-item';
+import { LayoutKmPostLengthDetails } from 'track-layout/track-layout-model';
+
+type KilometerLengthsTableProps = {
+    kmLengths: LayoutKmPostLengthDetails[];
+};
+
+export const KilometerLengthsTable = ({ kmLengths }: KilometerLengthsTableProps) => {
+    const { t } = useTranslation();
+    const trackNumbers = useTrackNumbers('OFFICIAL');
+    const amount = kmLengths.length;
+    const headings: ElementHeading[] = [
+        nonNumericHeading('track-number'),
+        nonNumericHeading('kilometer'),
+        numericHeading('station-start'),
+        numericHeading('station-end'),
+        numericHeading('length'),
+        numericHeading('location-e'),
+        numericHeading('location-n'),
+    ];
+
+    return (
+        <React.Fragment>
+            <p className={styles['data-product-table__element-count']}>
+                {t(`data-products.km-lengths.amount`, { amount })}
+            </p>
+            <div className={styles['data-product-table__table-container']}>
+                <Table wide>
+                    <thead className={styles['data-product-table__table-heading']}>
+                        <tr>
+                            {headings.map((heading) => (
+                                <Th
+                                    key={heading.name}
+                                    className={
+                                        heading.numeric
+                                            ? styles['data-product-table__column--number']
+                                            : ''
+                                    }>
+                                    {t(`data-products.km-lengths.table.${heading.name}`)}
+                                </Th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {kmLengths.map((item) => (
+                            <React.Fragment key={`${item.kmNumber}`}>
+                                <KilometerLengthTableItem
+                                    trackNumber={
+                                        trackNumbers?.find((tn) => tn.id == item.trackNumberId)
+                                            ?.number
+                                    }
+                                    length={item.length}
+                                    kilometer={item.kmNumber}
+                                    stationStart={item.stationStart}
+                                    stationEnd={item.stationEnd}
+                                    locationE={item.location.x}
+                                    locationN={item.location.y}
+                                />
+                            </React.Fragment>
+                        ))}
+                    </tbody>
+                </Table>
+            </div>
+        </React.Fragment>
+    );
+};

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
@@ -5,6 +5,7 @@ import { useDataProductsAppDispatch, useDataProductsAppSelector } from 'store/ho
 import { createDelegates } from 'store/store-utils';
 import { dataProductsActions } from 'data-products/data-products-store';
 import KilometerLengthsSearch from 'data-products/kilometer-lengths/kilometer-lengths-search';
+import { KilometerLengthsTable } from 'data-products/kilometer-lengths/kilometer-lengths-table';
 
 export const KilometerLengthsView = () => {
     const rootDispatch = useDataProductsAppDispatch();
@@ -12,6 +13,21 @@ export const KilometerLengthsView = () => {
     const state = useDataProductsAppSelector((state) => state.dataProducts.kmLenghts);
 
     const { t } = useTranslation();
+
+    // TODO Remove when a proper backend exists for fetching this stuff
+    const testData = [
+        {
+            trackNumberId: 'INT_1',
+            kmNumber: '0001',
+            length: 1024.0,
+            stationStart: -500.0,
+            stationEnd: 524.0,
+            location: {
+                x: 6660000.0,
+                y: 3330000.0,
+            },
+        },
+    ];
 
     return (
         <div className={styles['data-product-view']}>
@@ -26,6 +42,7 @@ export const KilometerLengthsView = () => {
                     onUpdateProp={dataProductsDelegates.onUpdateKmLengthsSearchProp}
                 />
             </div>
+            <KilometerLengthsTable kmLengths={testData} />
         </div>
     );
 };

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from 'data-products/data-product-view.scss';
+import { useDataProductsAppDispatch, useDataProductsAppSelector } from 'store/hooks';
+import { createDelegates } from 'store/store-utils';
+import { dataProductsActions } from 'data-products/data-products-store';
+import KilometerLengthsSearch from 'data-products/kilometer-lengths/kilometer-lengths-search';
+
+export const KilometerLengthsView = () => {
+    const rootDispatch = useDataProductsAppDispatch();
+    const dataProductsDelegates = createDelegates(rootDispatch, dataProductsActions);
+    const state = useDataProductsAppSelector((state) => state.dataProducts.kmLenghts);
+
+    const { t } = useTranslation();
+
+    return (
+        <div className={styles['data-product-view']}>
+            <div className={styles['data-product-view__header-container']}>
+                <h2>{t('data-products.km-lengths.title')}</h2>
+                <p className={styles['data-product__search-legend']}>
+                    {t('data-products.km-lengths.legend')}
+                </p>
+                <KilometerLengthsSearch
+                    setLengths={dataProductsDelegates.onSetKmLengths}
+                    state={state}
+                    onUpdateProp={dataProductsDelegates.onUpdateKmLengthsSearchProp}
+                />
+            </div>
+        </div>
+    );
+};

--- a/ui/src/data-products/translations.fi.json
+++ b/ui/src/data-products/translations.fi.json
@@ -13,9 +13,10 @@
             "no-types-selected": "Valitse vähintään yksi elementin tyyppi",
             "invalid-track-meter": "Tarkista osoitteen muoto",
             "end-before-start": "Rataosoitteen loppu on ennen alkua",
+            "km-end-before-start": "Loppukilometri on ennen alkua",
             "not-selected": "Ei valittu",
             "download-csv": "Lataa CSV",
-            "track-meter-range": "Metriväli",
+            "track-meter-range": "Kilometriväli",
             "track-number": "Ratanumero"
         },
         "element-list": {
@@ -83,8 +84,18 @@
             }
         },
         "km-lengths": {
+            "amount": "Kilometrit ({{amount}} kpl)",
             "title": "Kilometrien pituudet",
-            "legend": "Kilometrien tiedot on laskettu paikannuspohjan tietojen perusteella. Paikannuspohjan tiedot eivät ole tarkkoja, joten luettelon tietoja on syytä pitää epäluotettavina. Luettelon tietoja voi käyttää esim. tilastointiin tai ongelmien selvittämiseen, mutta niitä ei pidä käyttää esim. suunnittelytyön lähtötietona."
+            "legend": "Kilometrien tiedot on laskettu paikannuspohjan tietojen perusteella. Paikannuspohjan tiedot eivät ole tarkkoja, joten luettelon tietoja on syytä pitää epäluotettavina. Luettelon tietoja voi käyttää esim. tilastointiin tai ongelmien selvittämiseen, mutta niitä ei pidä käyttää esim. suunnittelytyön lähtötietona.",
+            "table": {
+                "track-number": "Ratanumero",
+                "kilometer": "Kilometri",
+                "station-start": "Alkupaalu",
+                "station-end": "Loppupaalu",
+                "length": "Pituus",
+                "location-e": "Koordinaatti E",
+                "location-n": "Koordinaatti N"
+            }
         }
     }
 }

--- a/ui/src/data-products/translations.fi.json
+++ b/ui/src/data-products/translations.fi.json
@@ -14,7 +14,9 @@
             "invalid-track-meter": "Tarkista osoitteen muoto",
             "end-before-start": "Rataosoitteen loppu on ennen alkua",
             "not-selected": "Ei valittu",
-            "download-csv": "Lataa CSV"
+            "download-csv": "Lataa CSV",
+            "track-meter-range": "Metriväli",
+            "track-number": "Ratanumero"
         },
         "element-list": {
             "element-list-title": "Elementtiluettelo",
@@ -79,6 +81,10 @@
                 "curve-end": "Pyöristyksen loppu",
                 "point-of-vertical-intersection": "Taite"
             }
+        },
+        "km-lengths": {
+            "title": "Kilometrien pituudet",
+            "legend": "Kilometrien tiedot on laskettu paikannuspohjan tietojen perusteella. Paikannuspohjan tiedot eivät ole tarkkoja, joten luettelon tietoja on syytä pitää epäluotettavina. Luettelon tietoja voi käyttää esim. tilastointiin tai ongelmien selvittämiseen, mutta niitä ei pidä käyttää esim. suunnittelytyön lähtötietona."
         }
     }
 }

--- a/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
+++ b/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
@@ -24,6 +24,7 @@ import {
     getVisibleErrorsByProp,
     hasErrors,
 } from 'data-products/data-products-utils';
+import { VerticalGeometryItem } from 'geometry/geometry-model';
 
 type LocationTrackVerticalGeometrySearchProps = {
     state: LocationTrackVerticalGeometrySearchState;
@@ -33,7 +34,7 @@ type LocationTrackVerticalGeometrySearchProps = {
     onCommitField: <TKey extends keyof LocationTrackVerticalGeometrySearchParameters>(
         key: TKey,
     ) => void;
-    setVerticalGeometry: (verticalGeometry: never[]) => void;
+    setVerticalGeometry: (verticalGeometry: VerticalGeometryItem[]) => void;
 };
 
 const debouncedTrackElementsFetch = debounceAsync(getLocationTrackVerticalGeometry, 250);

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -138,7 +138,7 @@ export async function getLocationTrackVerticalGeometry(
     id: LocationTrackId,
     startAddress: string | undefined,
     endAddress: string | undefined,
-): Promise<never[] | null> {
+): Promise<VerticalGeometryItem[] | null> {
     const params = queryParams({
         startAddress: startAddress,
         endAddress: endAddress,

--- a/ui/src/main/main.tsx
+++ b/ui/src/main/main.tsx
@@ -29,6 +29,7 @@ import { createDelegates } from 'store/store-utils';
 import { actionCreators } from 'track-layout/track-layout-store';
 import { Dialog } from 'vayla-design-lib/dialog/dialog';
 import { Button } from 'vayla-design-lib/button/button';
+import { KilometerLengthsContainerWithProvider } from 'data-products/kilometer-lengths/kilometer-lengths-container-with-provider';
 
 type MainProps = {
     layoutMode: LayoutMode;
@@ -69,6 +70,10 @@ const Main: React.VFC<MainProps> = (props: MainProps) => {
                     <Route
                         path="/data-products/vertical-geometry"
                         element={<VerticalGeometryContainerWithProvider />}
+                    />
+                    <Route
+                        path="/data-products/kilometer-lengths"
+                        element={<KilometerLengthsContainerWithProvider />}
                     />
                     <Route path="/monitoring" element={<HttpStatusCodeGenerator />} />
                 </Routes>

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -22,6 +22,7 @@ import { KmPostSaveError, KmPostSaveRequest } from 'linking/linking-model';
 import { Result } from 'neverthrow';
 import { ValidatedAsset } from 'publication/publication-model';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
+import { GEOMETRY_URI } from 'geometry/geometry-api';
 
 const kmPostListCache = asyncCache<string, LayoutKmPost[]>();
 const kmPostForLinkingCache = asyncCache<string, LayoutKmPost[]>();
@@ -159,3 +160,15 @@ export async function getKmPostValidation(
 ): Promise<ValidatedAsset> {
     return getThrowError<ValidatedAsset>(`${layoutUri('km-posts', publishType, id)}/validation`);
 }
+
+export async function getKmPostsOnTrackNumber(
+    publishType: PublishType,
+    id: LayoutTrackNumberId,
+): Promise<LayoutKmPost[]> {
+    return getThrowError<LayoutKmPost[]>(
+        `${layoutUri('km-posts', publishType)}/on-track-number/${id}`,
+    );
+}
+
+export const getKmLengthsCsv = (trackNumberId: LayoutTrackNumberId) =>
+    `${GEOMETRY_URI}/track-numbers/${trackNumberId}/km-lengths/file`;

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -223,6 +223,15 @@ export type LayoutKmPost = {
     draftType: DraftType;
 };
 
+export type LayoutKmPostLengthDetails = {
+    trackNumberId: LayoutTrackNumberId;
+    kmNumber: KmNumber;
+    length: number;
+    stationStart: number;
+    stationEnd: number;
+    location: Point;
+};
+
 export type PlanAreaId = string;
 export type PlanArea = {
     id: PlanAreaId;


### PR DESCRIPTION
Nämä oli kätevintä tehdä yhtenä isona möllinä. Menee hyvin samalla kaavalla kuin elementtiluettelo ja pystygeometriat. Muita täällä tehtyjä pikkujuttuja:
- `EnvRestricted` pois pystygeometrialistan ympäriltä, kun se on menossa tuotantoon
- Siivoiltu never-tyypityksiä järkevämmiksi frontissa (pääasiassa pystygeometrian osalta)