### PR TITLE
GVT-1714: Puuttuvan pystygeometrian korostamisen korjaus

### DIFF
--- a/ui/src/map/layers/alignment-layer.ts
+++ b/ui/src/map/layers/alignment-layer.ts
@@ -328,7 +328,7 @@ function addHighlight(
     const highlightLineStrings = highlight.ranges
         .map((range) => {
             const pointsWithinRange = segment.points.filter(
-                (segmentPoint) => segmentPoint.m >= range.start && segmentPoint.m <= range.end,
+                (segmentPoint) => segmentPoint.m >= range.min && segmentPoint.m <= range.max,
             );
             return pointsWithinRange.length > 1
                 ? new LineString(pointsWithinRange.map((point) => [point.x, point.y]))
@@ -639,8 +639,8 @@ adapterInfoRegister.add('alignment', {
                         trackNumberDrawDistance || 0,
                         mapLayer.showReferenceLines,
                         mapLayer.showMissingVerticalGeometry,
-                        mapLayer.showMissingLinking,
                         mapLayer.showSegmentsFromSelectedPlan,
+                        mapLayer.showMissingLinking,
                         mapLayer.showDuplicateTracks,
                         alignmentSectionsWithoutProfile,
                     );

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -156,5 +156,5 @@ export type MapTile = {
 
 export type AlignmentHighlight = {
     id: string;
-    ranges: { start: number; end: number }[];
+    ranges: { min: number; max: number }[];
 };


### PR DESCRIPTION
Range oli tyypitetty väärin. Lisäksi parametrien järjestys createFeaturesissa oli väärin, vaikka se ei tähän vaikuttanutkaan.