### PR TITLE
GVT-1722 Backend for fetching alignment heights

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -218,7 +218,7 @@ data class GeocodingContext(
         } else null
     }
 
-    fun getTrackLocation(alignment: LayoutAlignment, address: TrackMeter): AddressPoint? {
+    fun getTrackLocation(alignment: IAlignment, address: TrackMeter): AddressPoint? {
         val alignmentStart = alignment.start
         val alignmentEnd = alignment.end
         val startAddress = alignmentStart?.let(::getAddress)?.first
@@ -234,7 +234,7 @@ data class GeocodingContext(
         }
     }
 
-    fun getStartAndEnd(alignment: LayoutAlignment): AlignmentStartAndEnd {
+    fun getStartAndEnd(alignment: IAlignment): AlignmentStartAndEnd {
         val startAddress = alignment.start?.let(::toAddressPoint)
         val endAddress = alignment.end?.let(::toAddressPoint)
         return AlignmentStartAndEnd(startAddress?.first, endAddress?.first)
@@ -322,7 +322,7 @@ fun <T, R : Comparable<R>> getSublistForRangeInOrderedList(
 
 fun getProjectedAddressPoint(
     projection: ProjectionLine,
-    alignment: LayoutAlignment,
+    alignment: IAlignment,
 ): AddressPoint? {
     val segment = getCollisionSegment(projection.projection, alignment)
     val segmentEdges = segment?.let { s -> getPolyLineEdges(s, null, null) }
@@ -421,7 +421,7 @@ private fun validateProjectionLines(
     }
 }
 
-private fun getCollisionSegment(projection: Line, alignment: LayoutAlignment): LayoutSegment? {
+private fun getCollisionSegment(projection: Line, alignment: IAlignment): ISegment? {
     return alignment.segments
         .mapNotNull { s ->
             val intersection = lineIntersection(s.points.first(), s.points.last(), projection.start, projection.end)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
@@ -1,0 +1,28 @@
+package fi.fta.geoviite.infra.geometry
+
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.util.FileName
+
+data class TrackMeterHeight(
+    val m: Double,
+    val meter: Double,
+    val height: Double?,
+)
+data class KmHeights(
+    val kmNumber: KmNumber,
+    val trackMeterHeights: List<TrackMeterHeight>,
+)
+
+data class PlanLinkingSummaryItem(
+    val startM: Double,
+    val endM: Double,
+    val filename: FileName?,
+)
+
+data class AlignmentHeights (
+    val alignmentStartM: Double,
+    val alignmentEndM: Double,
+    val kmHeights: List<KmHeights>,
+    val linkingSummary: List<PlanLinkingSummaryItem>,
+)
+

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -253,4 +253,26 @@ class GeometryController @Autowired constructor(
             .getVerticalGeometryListingCsv(id, startAddress, endAddress)
         return toFileDownloadResponse("${filename}.csv", content)
     }
-}
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/plans/{planId}/plan-alignment-heights/{planAlignmentId}")
+    fun getPlanAlignmentHeights(
+        @PathVariable("planId") planId: IntId<GeometryPlan>,
+        @PathVariable("planAlignmentId") planAlignmentId: IntId<GeometryAlignment>,
+        @RequestParam("startDistance") startDistance: Double,
+        @RequestParam("endDistance") endDistance: Double,
+        @RequestParam("tickLength") tickLength: Int,
+    ): AlignmentHeights? {
+        return geometryService.getPlanAlignmentHeights(planId, planAlignmentId, startDistance, endDistance, tickLength)
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/layout/location-tracks/{id}/alignment-heights")
+    fun getLayoutAlignmentHeights(
+        @PathVariable("id") locationTrackId: IntId<LocationTrack>,
+        @RequestParam("startDistance") startDistance: Double,
+        @RequestParam("endDistance") endDistance: Double,
+        @RequestParam("tickLength") tickLength: Int,
+    ): AlignmentHeights? {
+        return geometryService.getLocationTrackHeights(locationTrackId, startDistance, endDistance, tickLength)
+    }}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -308,11 +308,8 @@ class GeometryService @Autowired constructor(
         val planAlignmentIdToPlans: MutableMap<IntId<GeometryAlignment>, RowVersion<GeometryPlan>> = mutableMapOf()
 
         return alignment.segments.map { segment ->
-            if (segment.sourceId == null || segment.sourceStart == null) {
-                return@map SegmentSource(null, null, null)
-            }
             val sourceId = segment.sourceId
-            if (sourceId !is IndexedId) {
+            if (sourceId == null || sourceId !is IndexedId || segment.sourceStart == null) {
                 SegmentSource(null, null, null)
             } else {
                 val planAlignmentId = IntId<GeometryAlignment>(sourceId.parentId)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -13,7 +13,6 @@ import java.time.Instant
 import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.max
-import kotlin.math.min
 
 const val POINT_SEEK_TOLERANCE = 1.0
 
@@ -88,11 +87,13 @@ interface IAlignment {
         else if (m >= length) end
         else getSegmentAtM(m)?.seekPointAtM(m, snapDistance)?.point
 
-    fun getSegmentAtM(m: Double) = segments.getOrNull(segments.binarySearch { s ->
+    fun getSegmentIndexAtM(m: Double) = segments.binarySearch { s ->
         if (m < s.startM) 1
         else if (m > s.endM) -1
         else 0
-    })
+    }
+
+    fun getSegmentAtM(m: Double) = segments.getOrNull(getSegmentIndexAtM(m))
 
     fun findClosestSegmentIndex(target: IPoint): Int? {
         return approximateClosestSegmentIndex(target)?.let { approximation ->


### PR DESCRIPTION
Pystygeometriakaavion korkeusviivan haun rakenteessa frontin tarpeet osoittautuivat lopulta sellaiksi, että:
- Frontti tietää näyttämänsä välin alku-ja loppukohdan etäisyyksinä raiteella (m-arvo), ja pyytää bäkkäriltä tämän välin korkeusviivaa
- Frontti esitettää haluamansa korkeusviivan tarkkuuden metreinä rataosoiteavaruudessa, niin että paras mahdollinen tarkkuus on ilmoittaa korkeus jokaiselle metrille eli tickLength=1, mutta jos näytetään pitkää raidetta kokonaisuutena, se voi mennä vaikka tasolle että tickLength=500 tai tickLength=1000
- Bäkkäri palauttaa tulokset ratakilometreittäin niin, että niille saa helposti tulevaisuudessa tehtyä ratakilometri+tickLength-yhdistelmällä frontissa pyörivän cachen

Lisäksi lasken nyt samassa syssyssä ja lähetän jokaisen pyynnön mukana koko raiteelta tiedon siitä, miten sitä on linkitetty geometrioihin (PlanLinkingSummary). Tätä tarvitaan joka tapauksessa sitä varten, että kyseinen tieto saadaan kaaviossa mukana näkyviin, ja sen voisi periaatteessa laittaa omankin API:n taakse, mutta sen laskeminen sattuu sujumaan helposti ja kevyesti samassa yhteydessä, joten tällä hetkellä se on vielä mukana tässä korkeusviivan haussa.

Hieman ylimääräisenä ominaisuutena koodi laskee vielä ylimääräisiä korkeusviivan pisteitä niiltä kohdilta, missä raiteen linkitys muuttuu. Ajatuksena tässä on, että näin frontti pystyy näyttämään korkeusviivan oikeasti tarkkaan niillä kohdilla, millä se on laskettavissa: Vaikka korkeusviivan näyttämisessä tehdäänkin interpolaatiota, se on sentään interpolaatiota samasta profiilista saman linkityksen kautta tulleiden pisteiden välillä; ja ekstrapolaatiota ei tarvita tehdä missään kohdassa.

Tunnetuiksi tulevaisuuden haaveiksi jää vielä: Kirjoittaa tälle koodille testejä, ja käyttää luotettavampaa tietoa geometriaelementtien paaluluvuista kuin suunnitelmasta saadut staStart-tiedot.