### PR TITLE
GVT-1787: Pystygeometria-tietotuotteen muutokset

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
@@ -2,6 +2,8 @@ package fi.fta.geoviite.infra.geometry
 
 const val ELEMENT_LISTING = "Elementtilistaus"
 const val VERTICAL_GEOMETRY = "Pystygeometria"
+const val VERTICAL_SECTIONS_OVERLAP = "Kaltevuusjakso on limittäin toisen jakson kanssa"
+const val UNKNOWN = "Ei tiedossa"
 
 enum class ElementListingHeader {
     TRACK_NUMBER,
@@ -81,6 +83,8 @@ enum class VerticalGeometryListingHeader {
     LINEAR_SECTION_FORWARD_LINEAR_SECTION,
     LINEAR_SECTION_BACKWARD_LENGTH,
     LINEAR_SECTION_BACKWARD_LINEAR_SECTION,
+    VERTICAL_COORDINATE_SYSTEM,
+    REMARKS,
 }
 
 fun translateVerticalGeometryListingHeader(header: VerticalGeometryListingHeader) =
@@ -105,4 +109,6 @@ fun translateVerticalGeometryListingHeader(header: VerticalGeometryListingHeader
         VerticalGeometryListingHeader.LINEAR_SECTION_FORWARD_LINEAR_SECTION -> "Kaltevuusjakson eteenpäin suora osa"
         VerticalGeometryListingHeader.RADIUS -> "Pyöristyssäde"
         VerticalGeometryListingHeader.TANGENT -> "Tangentti"
+        VerticalGeometryListingHeader.VERTICAL_COORDINATE_SYSTEM -> "Korkeusjärjestelmä"
+        VerticalGeometryListingHeader.REMARKS -> "Huomiot"
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
@@ -1,9 +1,6 @@
 package fi.fta.geoviite.infra.geometry
 
-import fi.fta.geoviite.infra.common.AlignmentName
-import fi.fta.geoviite.infra.common.FeatureTypeCode
-import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.util.FileName
@@ -221,6 +218,7 @@ class VerticalGeometryListingTest() {
             linear as List<LinearProfileSegment>,
             TrackMeter.ZERO,
             TrackMeter.ZERO,
+            VerticalCoordinateSystem.N2000,
         )
 
         assertEquals(verticalGeometryEntry.start.station.toDouble(), 4.0, 0.001)

--- a/ui/src/data-products/data-product-table.scss
+++ b/ui/src/data-products/data-product-table.scss
@@ -2,6 +2,7 @@
 
 .data-product-table {
     &__table-container {
+        position: relative;
         overflow: auto;
         padding-left: 32px;
         flex-grow: 1;
@@ -9,6 +10,10 @@
 
     &__element-count {
         padding-left: 32px;
+    }
+
+    &__overlaps-another {
+        fill: $color-lemon-dark;
     }
 
     &__table-heading {

--- a/ui/src/data-products/element-list/element-list-view.tsx
+++ b/ui/src/data-products/element-list/element-list-view.tsx
@@ -10,10 +10,11 @@ import { ElementTable } from 'data-products/element-list/element-table';
 import { useDataProductsAppDispatch, useDataProductsAppSelector } from 'store/hooks';
 
 const ElementListView = () => {
+    const { t } = useTranslation();
     const rootDispatch = useDataProductsAppDispatch();
     const dataProductsDelegates = createDelegates(rootDispatch, dataProductsActions);
     const state = useDataProductsAppSelector((state) => state.dataProducts.elementList);
-    const { t } = useTranslation();
+    const [loading, setLoading] = React.useState(false);
     const continuousGeometrySelected = state.selectedSearch === 'LOCATION_TRACK';
 
     const handleRadioClick = () => {
@@ -42,12 +43,14 @@ const ElementListView = () => {
                         onUpdateProp={dataProductsDelegates.onUpdateLocationTrackSearchProp}
                         onCommitField={dataProductsDelegates.onCommitLocationTrackSearchField}
                         setElements={dataProductsDelegates.onSetLocationTrackElements}
+                        setLoading={setLoading}
                     />
                 ) : (
                     <PlanGeometryElementListingSearch
                         state={state.planSearch}
                         onUpdateProp={dataProductsDelegates.onUpdatePlanSearchProp}
                         setElements={dataProductsDelegates.onSetPlanElements}
+                        setLoading={setLoading}
                     />
                 )}
             </div>
@@ -58,6 +61,7 @@ const ElementListView = () => {
                         : state.planSearch.elements
                 }
                 showLocationTrackName={continuousGeometrySelected}
+                isLoading={loading}
             />
         </div>
     );

--- a/ui/src/data-products/element-list/element-table.tsx
+++ b/ui/src/data-products/element-list/element-table.tsx
@@ -17,9 +17,10 @@ import {
 type ElementTableProps = {
     elements: ElementItem[];
     showLocationTrackName: boolean;
+    isLoading: boolean;
 };
 
-export const ElementTable = ({ elements, showLocationTrackName }: ElementTableProps) => {
+export const ElementTable = ({ elements, showLocationTrackName, isLoading }: ElementTableProps) => {
     const { t } = useTranslation();
     const trackNumbers = useTrackNumbers('OFFICIAL');
     const amount = elements.length;
@@ -60,7 +61,7 @@ export const ElementTable = ({ elements, showLocationTrackName }: ElementTablePr
                 {t(`data-products.element-list.geometry-elements`, { amount })}
             </p>
             <div className={styles['data-product-table__table-container']}>
-                <Table wide>
+                <Table wide isLoading={isLoading}>
                     <thead className={styles['data-product-table__table-heading']}>
                         <tr>
                             {tableHeadingsToShowInUI.map((heading) => (

--- a/ui/src/data-products/element-list/location-track-element-listing-search.tsx
+++ b/ui/src/data-products/element-list/location-track-element-listing-search.tsx
@@ -13,7 +13,7 @@ import {
 } from 'data-products/data-products-store';
 import { debounceAsync } from 'utils/async-utils';
 import { PropEdit } from 'utils/validation-utils';
-import { useLoader } from 'utils/react-utils';
+import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { getLocationTrackElements, getLocationTrackElementsCsv } from 'geometry/geometry-api';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Button } from 'vayla-design-lib/button/button';
@@ -32,6 +32,7 @@ type LocationTrackElementListingSearchProps = {
         propEdit: PropEdit<ContinuousSearchParameters, TKey>,
     ) => void;
     onCommitField: <TKey extends keyof ContinuousSearchParameters>(key: TKey) => void;
+    setLoading: (isLoading: boolean) => void;
 };
 
 const debouncedTrackElementsFetch = debounceAsync(getLocationTrackElements, 250);
@@ -41,6 +42,7 @@ const LocationTrackElementListingSearch = ({
     onUpdateProp,
     onCommitField,
     setElements,
+    setLoading,
 }: LocationTrackElementListingSearchProps) => {
     const { t } = useTranslation();
 
@@ -64,7 +66,7 @@ const LocationTrackElementListingSearch = ({
         });
     }
 
-    const elementList = useLoader(() => {
+    const [elementList, fetchStatus] = useLoaderWithStatus(() => {
         return !state.searchParameters.locationTrack ||
             hasErrors(state.committedFields, state.validationErrors, 'searchGeometries') ||
             hasErrors(state.committedFields, state.validationErrors, 'startTrackMeter') ||
@@ -79,6 +81,7 @@ const LocationTrackElementListingSearch = ({
     }, [state.searchParameters]);
 
     React.useEffect(() => setElements(elementList ?? []), [elementList]);
+    React.useEffect(() => setLoading(fetchStatus !== LoaderStatus.Ready), [fetchStatus]);
 
     return (
         <React.Fragment>

--- a/ui/src/data-products/element-list/plan-geometry-element-listing-search.tsx
+++ b/ui/src/data-products/element-list/plan-geometry-element-listing-search.tsx
@@ -9,7 +9,7 @@ import { debounceAsync } from 'utils/async-utils';
 import { PropEdit } from 'utils/validation-utils';
 import { getGeometryPlanElements, getGeometryPlanElementsCsv } from 'geometry/geometry-api';
 import { ElementItem, GeometryPlanHeader, PlanSource } from 'geometry/geometry-model';
-import { useLoader } from 'utils/react-utils';
+import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Button } from 'vayla-design-lib/button/button';
 import { planSources } from 'utils/enum-localization-utils';
@@ -26,6 +26,7 @@ type PlanGeometryElementListingSearchProps = {
         propEdit: PropEdit<PlanGeometrySearchState, TKey>,
     ) => void;
     setElements: (elements: ElementItem[]) => void;
+    setLoading: (isLoading: boolean) => void;
 };
 
 const debouncedGetPlanElements = debounceAsync(getGeometryPlanElements, 250);
@@ -34,6 +35,7 @@ const PlanGeometryElementListingSearch = ({
     state,
     onUpdateProp,
     setElements,
+    setLoading,
 }: PlanGeometryElementListingSearchProps) => {
     const { t } = useTranslation();
     // Use memoized function to make debouncing functionality work when re-rendering
@@ -62,7 +64,7 @@ const PlanGeometryElementListingSearch = ({
         );
     }
 
-    const elementList = useLoader(() => {
+    const [elementList, fetchStatus] = useLoaderWithStatus(() => {
         return !state.plan || hasErrors('searchGeometries')
             ? Promise.resolve([])
             : debouncedGetPlanElements(state.plan.id, selectedElementTypes(state.searchGeometries));
@@ -74,6 +76,7 @@ const PlanGeometryElementListingSearch = ({
     };
 
     React.useEffect(() => setElements(elementList ?? []), [elementList]);
+    React.useEffect(() => setLoading(fetchStatus !== LoaderStatus.Ready), [fetchStatus]);
 
     return (
         <React.Fragment>

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
@@ -5,7 +5,7 @@ import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { Dropdown, DropdownSize } from 'vayla-design-lib/dropdown/dropdown';
 import { KmLengthsSearchState } from 'data-products/data-products-store';
 import { PropEdit } from 'utils/validation-utils';
-import { useLoader } from 'utils/react-utils';
+import { LoaderStatus, useLoader, useLoaderWithStatus } from 'utils/react-utils';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Button } from 'vayla-design-lib/button/button';
 import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
@@ -23,12 +23,14 @@ type KilometerLengthsSearchProps = {
         propEdit: PropEdit<KmLengthsSearchState, TKey>,
     ) => void;
     setLengths: (lengths: LayoutKmPostLengthDetails[]) => void;
+    setLoading: (isLoading: boolean) => void;
 };
 
 export const KilometerLengthsSearch: React.FC<KilometerLengthsSearchProps> = ({
     state,
     onUpdateProp,
     setLengths,
+    setLoading,
 }) => {
     const { t } = useTranslation();
     const trackNumbers =
@@ -54,13 +56,19 @@ export const KilometerLengthsSearch: React.FC<KilometerLengthsSearchProps> = ({
         });
     }
 
+    const [kmLengths, fetchStatus] = useLoaderWithStatus(
+        () =>
+            state.trackNumber
+                ? getKmPostLengths('OFFICIAL', state.trackNumber.id)
+                : Promise.resolve([]),
+        [state.trackNumber],
+    );
     React.useEffect(() => {
-        if (state.trackNumber) {
-            getKmPostLengths('OFFICIAL', state.trackNumber.id).then((kmPosts) => {
-                setLengths(kmPosts);
-            });
-        } else setLengths([]);
-    }, [state.trackNumber]);
+        setLengths(kmLengths ?? []);
+    }, [kmLengths]);
+    React.useEffect(() => {
+        setLoading(fetchStatus !== LoaderStatus.Ready);
+    }, [fetchStatus]);
 
     return (
         <div className={styles['data-products__search']}>

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-table.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-table.tsx
@@ -12,9 +12,10 @@ import { LayoutKmPostLengthDetails } from 'track-layout/track-layout-model';
 
 type KilometerLengthsTableProps = {
     kmLengths: LayoutKmPostLengthDetails[];
+    isLoading: boolean;
 };
 
-export const KilometerLengthsTable = ({ kmLengths }: KilometerLengthsTableProps) => {
+export const KilometerLengthsTable = ({ kmLengths, isLoading }: KilometerLengthsTableProps) => {
     const { t } = useTranslation();
     const amount = kmLengths.length;
     const headings: ElementHeading[] = [
@@ -34,7 +35,7 @@ export const KilometerLengthsTable = ({ kmLengths }: KilometerLengthsTableProps)
                 {t(`data-products.km-lengths.amount`, { amount })}
             </p>
             <div className={styles['data-product-table__table-container']}>
-                <Table wide>
+                <Table wide isLoading={isLoading}>
                     <thead className={styles['data-product-table__table-heading']}>
                         <tr>
                             {headings.map((heading) => (

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
@@ -10,10 +10,11 @@ import { KmNumber } from 'common/common-model';
 import { LayoutKmPostLengthDetails } from 'track-layout/track-layout-model';
 
 export const KilometerLengthsView = () => {
+    const { t } = useTranslation();
     const rootDispatch = useDataProductsAppDispatch();
     const dataProductsDelegates = createDelegates(rootDispatch, dataProductsActions);
     const state = useDataProductsAppSelector((state) => state.dataProducts.kmLenghts);
-    const { t } = useTranslation();
+    const [loading, setLoading] = React.useState(false);
 
     const startIndex = state.startKm ? findIndex(state.startKm, state.kmLengths) : 0;
     const endIndex = state.endKm
@@ -32,9 +33,10 @@ export const KilometerLengthsView = () => {
                     setLengths={dataProductsDelegates.onSetKmLengths}
                     state={state}
                     onUpdateProp={dataProductsDelegates.onUpdateKmLengthsSearchProp}
+                    setLoading={setLoading}
                 />
             </div>
-            <KilometerLengthsTable kmLengths={kmLengths} />
+            <KilometerLengthsTable kmLengths={kmLengths} isLoading={loading} />
         </div>
     );
 };

--- a/ui/src/data-products/translations.fi.json
+++ b/ui/src/data-products/translations.fi.json
@@ -57,11 +57,14 @@
             }
         },
         "vertical-geometry": {
+            "pvi-points": "Taitepisteet ({{amount}} kpl)",
             "vertical-geometry-title": "Pystygeometria",
             "location-track-vertical-geometry": "Raiteen pystygeometria",
             "plan-vertical-geometry": "Suunnitelman pystygeometria",
             "location-track-search-legend": "Raiteen pystygeometria näyttää luettelossa paikannuspohjan raiteeseen liityvät taitepisteet. Paikannuspohjan raide voi olla koostettu useasta suunnitelmasta, eikä täysin vastaa sitä suunnitelmakokonaisuutta, jonka mukaan raide on rakennettu, joten luettelon tietoja on syytä pitää epäluotettavina. Luettelon tietoja voi käyttää esim. kokonaiskuvan hahmottamiseen tai ongelmien selvittämiseen, mutta niitä ei pidä käyttää esim. tukemiskoneen työn lähtötietona.",
             "plan-search-legend": "Suunnitelman pystygeometria näyttää luettelossa suunnitelman sisältämät taitepisteet. Rataosoiteet on laskettu paikannuspohjan pituusmittauksen mukaan, joten rataosoitteiden tarkkuutta on syytä pitää epäluotettavana. Myös  paikannuspalvelun suunnitelmien elementtien tietoja on syytä pitää epäluotettavina, joten niitä ei pidä käyttää esim. tukemiskoneen työn lähtötietona.",
+            "overlaps-another": "Kaltevuusjakso on limittäin toisen jakson kanssa",
+            "unknown": "Ei tiedossa",
             "table": {
                 "location-track": "Sijaintiraide",
                 "plan": "Suunnitelma",
@@ -81,7 +84,9 @@
                 "linear-section-backward": "Kaltevuusjakso taaksepäin",
                 "curve-start": "Pyöristyksen alku",
                 "curve-end": "Pyöristyksen loppu",
-                "point-of-vertical-intersection": "Taite"
+                "point-of-vertical-intersection": "Taite",
+                "vertical-coordinate-system": "Korkeusjärjestelmä",
+                "remarks": "Huomiot"
             }
         },
         "km-lengths": {

--- a/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
+++ b/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
@@ -15,7 +15,7 @@ import {
     getLocationTrackVerticalGeometry,
     getLocationTrackVerticalGeometryCsv,
 } from 'geometry/geometry-api';
-import { useLoader } from 'utils/react-utils';
+import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { Button } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import {
@@ -35,13 +35,14 @@ type LocationTrackVerticalGeometrySearchProps = {
         key: TKey,
     ) => void;
     setVerticalGeometry: (verticalGeometry: VerticalGeometryItem[]) => void;
+    setLoading: (loading: boolean) => void;
 };
 
 const debouncedTrackElementsFetch = debounceAsync(getLocationTrackVerticalGeometry, 250);
 
 export const LocationTrackVerticalGeometrySearch: React.FC<
     LocationTrackVerticalGeometrySearchProps
-> = ({ state, onCommitField, onUpdateProp, setVerticalGeometry }) => {
+> = ({ state, onCommitField, onUpdateProp, setVerticalGeometry, setLoading }) => {
     const { t } = useTranslation();
     const getLocationTracks = React.useCallback(
         (searchTerm) =>
@@ -62,7 +63,7 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
         });
     }
 
-    const verticalGeometries = useLoader(() => {
+    const [verticalGeometries, fetchStatus] = useLoaderWithStatus(() => {
         if (!state.searchParameters.locationTrack) {
             return Promise.resolve([]);
         }
@@ -80,6 +81,7 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
         );
     }, [state.searchParameters]);
     React.useEffect(() => setVerticalGeometry(verticalGeometries ?? []), [verticalGeometries]);
+    React.useEffect(() => setLoading(fetchStatus !== LoaderStatus.Ready), [fetchStatus]);
 
     return (
         <React.Fragment>
@@ -98,7 +100,6 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
                             searchable
                             onChange={(e) => updateProp('locationTrack', e)}
                             onBlur={() => onCommitField('locationTrack')}
-                            canUnselect={true}
                             unselectText={t('data-products.search.not-selected')}
                             wideList
                             wide

--- a/ui/src/data-products/vertical-geometry/plan-vertical-geometry-search.tsx
+++ b/ui/src/data-products/vertical-geometry/plan-vertical-geometry-search.tsx
@@ -13,7 +13,7 @@ import {
 import { PlanVerticalGeometrySearchState } from 'data-products/data-products-store';
 import { PropEdit } from 'utils/validation-utils';
 import { debounceAsync } from 'utils/async-utils';
-import { useLoader } from 'utils/react-utils';
+import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import {
     debouncedGetGeometryPlanHeaders,
     getGeometryPlanOptions,
@@ -27,6 +27,7 @@ type PlanVerticalGeometrySearchProps = {
         propEdit: PropEdit<PlanVerticalGeometrySearchState, TKey>,
     ) => void;
     setVerticalGeometry: (verticalGeometry: VerticalGeometryItem[]) => void;
+    setLoading: (loading: boolean) => void;
 };
 
 const debouncedGetPlanVerticalGeometry = debounceAsync(getGeometryPlanVerticalGeometry, 250);
@@ -35,6 +36,7 @@ export const PlanVerticalGeometrySearch: React.FC<PlanVerticalGeometrySearchProp
     state,
     onUpdateProp,
     setVerticalGeometry,
+    setLoading,
 }) => {
     const { t } = useTranslation();
     // Use memoized function to make debouncing functionality work when re-rendering
@@ -62,10 +64,11 @@ export const PlanVerticalGeometrySearch: React.FC<PlanVerticalGeometrySearchProp
         updateProp('plan', undefined);
     };
 
-    const verticalGeometries = useLoader(() => {
+    const [verticalGeometries, fetchStatus] = useLoaderWithStatus(() => {
         return !state.plan ? Promise.resolve([]) : debouncedGetPlanVerticalGeometry(state.plan.id);
     }, [state.plan]);
     React.useEffect(() => setVerticalGeometry(verticalGeometries ?? []), [verticalGeometries]);
+    React.useEffect(() => setLoading(fetchStatus !== LoaderStatus.Ready), [fetchStatus]);
 
     return (
         <React.Fragment>
@@ -98,7 +101,6 @@ export const PlanVerticalGeometrySearch: React.FC<PlanVerticalGeometrySearchProp
                                 options={geometryPlanHeaders}
                                 searchable
                                 onChange={(e) => updateProp('plan', e)}
-                                canUnselect={true}
                                 unselectText={t('data-products.search.not-selected')}
                                 wideList
                                 wide

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-table-item.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-table-item.tsx
@@ -4,19 +4,35 @@ import { VerticalGeometryItem } from 'geometry/geometry-model';
 import styles from 'data-products/data-product-table.scss';
 import { Precision, roundToPrecision } from 'utils/rounding';
 import { PlanNameLink } from 'geoviite-design-lib/geometry-plan/plan-name-link';
+import { useTranslation } from 'react-i18next';
+import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 
 type VerticalGeometryTableItemProps = {
     verticalGeometry: VerticalGeometryItem;
     showLocationTrack: boolean;
+    overlapsAnother: boolean;
 };
 
 export const VerticalGeometryTableItem: React.FC<VerticalGeometryTableItemProps> = ({
     verticalGeometry,
     showLocationTrack,
+    overlapsAnother,
 }) => {
+    const { t } = useTranslation();
     return (
         <tr>
-            {showLocationTrack && <td>{verticalGeometry.locationTrackName}</td>}
+            {showLocationTrack && (
+                <td>
+                    {overlapsAnother && (
+                        <span
+                            className={'data-product-table__overlaps-another'}
+                            title={t('data-products.vertical-geometry.overlaps-another')}>
+                            <Icons.Info color={IconColor.INHERIT} size={IconSize.MEDIUM_SMALL} />
+                        </span>
+                    )}{' '}
+                    {verticalGeometry.locationTrackName}
+                </td>
+            )}
             <td>
                 <PlanNameLink
                     planId={verticalGeometry.planId}
@@ -96,6 +112,15 @@ export const VerticalGeometryTableItem: React.FC<VerticalGeometryTableItemProps>
             </td>
             <td className={styles['data-product-table__column--number']}>
                 {roundToPrecision(verticalGeometry.end.station, Precision.measurementMeterDistance)}
+            </td>
+            <td>
+                {verticalGeometry.verticalCoordinateSystem ??
+                    t('data-products.vertical-geometry.unknown')}
+            </td>
+            <td>
+                {overlapsAnother
+                    ? t('data-products.vertical-geometry.overlaps-another')
+                    : undefined}
             </td>
         </tr>
     );

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-table.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-table.tsx
@@ -14,6 +14,7 @@ import { createClassName } from 'vayla-design-lib/utils';
 type VerticalGeometryTableProps = {
     verticalGeometry: VerticalGeometryItem[];
     showLocationTrack: boolean;
+    isLoading: boolean;
 };
 
 const COMMON_HEADINGS = [
@@ -36,11 +37,14 @@ const COMMON_HEADINGS = [
     withSeparator(numericHeading('station-start')),
     numericHeading('station-vertical-intersection'),
     numericHeading('station-end'),
+    withSeparator(nonNumericHeading('vertical-coordinate-system')),
+    nonNumericHeading('remarks'),
 ];
 
 export const VerticalGeometryTable: React.FC<VerticalGeometryTableProps> = ({
     verticalGeometry,
     showLocationTrack,
+    isLoading,
 }) => {
     const { t } = useTranslation();
     const separatorAndCenteredClassName = createClassName(
@@ -58,91 +62,107 @@ export const VerticalGeometryTable: React.FC<VerticalGeometryTableProps> = ({
     );
 
     return (
-        <div className={styles['data-product-table__table-container']}>
-            <Table wide>
-                <thead className={styles['data-product-table__table-heading']}>
-                    <tr>
-                        <Th
-                            colSpan={showLocationTrack ? 3 : 2}
-                            scope={'colgroup'}
-                            variant={ThVariant.MULTILINE_TOP}
-                            className={styles['data-product-table__table-heading--centered']}
-                        />
-                        <Th
-                            colSpan={3}
-                            scope={'colgroup'}
-                            variant={ThVariant.MULTILINE_TOP}
-                            className={separatorAndCenteredClassName}>
-                            {t(`data-products.vertical-geometry.table.curve-start`)}
-                        </Th>
-                        <Th
-                            colSpan={2}
-                            scope={'colgroup'}
-                            variant={ThVariant.MULTILINE_TOP}
-                            className={separatorAndCenteredClassName}>
-                            {t(
-                                `data-products.vertical-geometry.table.point-of-vertical-intersection`,
-                            )}
-                        </Th>
-                        <Th
-                            colSpan={3}
-                            scope={'colgroup'}
-                            variant={ThVariant.MULTILINE_TOP}
-                            className={separatorAndCenteredClassName}>
-                            {t(`data-products.vertical-geometry.table.curve-end`)}
-                        </Th>
-                        <Th
-                            colSpan={2}
-                            scope={'colgroup'}
-                            variant={ThVariant.MULTILINE_TOP}
-                            className={separatorAndCenteredClassName}
-                        />
-                        <Th
-                            colSpan={2}
-                            scope={'colgroup'}
-                            variant={ThVariant.MULTILINE_TOP}
-                            className={separatorAndCenteredClassName}>
-                            {t(`data-products.vertical-geometry.table.linear-section-backward`)}
-                        </Th>
-                        <Th
-                            colSpan={2}
-                            scope={'colgroup'}
-                            variant={ThVariant.MULTILINE_TOP}
-                            className={separatorAndCenteredClassName}>
-                            {t(`data-products.vertical-geometry.table.linear-section-forward`)}
-                        </Th>
-                        <Th
-                            colSpan={3}
-                            scope={'colgroup'}
-                            variant={ThVariant.MULTILINE_TOP}
-                            className={separatorAndCenteredClassName}>
-                            {t(`data-products.vertical-geometry.table.station`)}
-                        </Th>
-                    </tr>
-                    <tr>
-                        {headings.map((heading, index) => (
+        <React.Fragment>
+            <p className={styles['data-product-table__element-count']}>
+                {t(`data-products.vertical-geometry.pvi-points`, {
+                    amount: verticalGeometry.length,
+                })}
+            </p>
+            <div className={styles['data-product-table__table-container']}>
+                <Table wide isLoading={isLoading}>
+                    <thead className={styles['data-product-table__table-heading']}>
+                        <tr>
                             <Th
-                                // The table contains columns with the same heading, so heading names can't be used as indexes.
-                                // Also columns never change dynamically, so dynamic data integrity is not a concern.
-                                key={index}
-                                className={headingClassName(heading.numeric, heading.hasSeparator)}
+                                colSpan={showLocationTrack ? 3 : 2}
                                 scope={'colgroup'}
-                                variant={ThVariant.MULTILINE_BOTTOM}>
-                                {t(`data-products.vertical-geometry.table.${heading.name}`)}
+                                variant={ThVariant.MULTILINE_TOP}
+                                className={styles['data-product-table__table-heading--centered']}
+                            />
+                            <Th
+                                colSpan={3}
+                                scope={'colgroup'}
+                                variant={ThVariant.MULTILINE_TOP}
+                                className={separatorAndCenteredClassName}>
+                                {t(`data-products.vertical-geometry.table.curve-start`)}
                             </Th>
+                            <Th
+                                colSpan={2}
+                                scope={'colgroup'}
+                                variant={ThVariant.MULTILINE_TOP}
+                                className={separatorAndCenteredClassName}>
+                                {t(
+                                    `data-products.vertical-geometry.table.point-of-vertical-intersection`,
+                                )}
+                            </Th>
+                            <Th
+                                colSpan={3}
+                                scope={'colgroup'}
+                                variant={ThVariant.MULTILINE_TOP}
+                                className={separatorAndCenteredClassName}>
+                                {t(`data-products.vertical-geometry.table.curve-end`)}
+                            </Th>
+                            <Th
+                                colSpan={2}
+                                scope={'colgroup'}
+                                variant={ThVariant.MULTILINE_TOP}
+                                className={separatorAndCenteredClassName}
+                            />
+                            <Th
+                                colSpan={2}
+                                scope={'colgroup'}
+                                variant={ThVariant.MULTILINE_TOP}
+                                className={separatorAndCenteredClassName}>
+                                {t(`data-products.vertical-geometry.table.linear-section-backward`)}
+                            </Th>
+                            <Th
+                                colSpan={2}
+                                scope={'colgroup'}
+                                variant={ThVariant.MULTILINE_TOP}
+                                className={separatorAndCenteredClassName}>
+                                {t(`data-products.vertical-geometry.table.linear-section-forward`)}
+                            </Th>
+                            <Th
+                                colSpan={3}
+                                scope={'colgroup'}
+                                variant={ThVariant.MULTILINE_TOP}
+                                className={separatorAndCenteredClassName}>
+                                {t(`data-products.vertical-geometry.table.station`)}
+                            </Th>
+                            <Th
+                                colSpan={2}
+                                scope={'colgroup'}
+                                variant={ThVariant.MULTILINE_TOP}
+                                className={separatorAndCenteredClassName}></Th>
+                        </tr>
+                        <tr>
+                            {headings.map((heading, index) => (
+                                <Th
+                                    // The table contains columns with the same heading, so heading names can't be used as indexes.
+                                    // Also columns never change dynamically, so dynamic data integrity is not a concern.
+                                    key={index}
+                                    className={headingClassName(
+                                        heading.numeric,
+                                        heading.hasSeparator,
+                                    )}
+                                    scope={'colgroup'}
+                                    variant={ThVariant.MULTILINE_BOTTOM}>
+                                    {t(`data-products.vertical-geometry.table.${heading.name}`)}
+                                </Th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {verticalGeometry.map((verticalGeom) => (
+                            <VerticalGeometryTableItem
+                                key={verticalGeom.id}
+                                verticalGeometry={verticalGeom}
+                                showLocationTrack={showLocationTrack}
+                                overlapsAnother={verticalGeom.overlapsAnother}
+                            />
                         ))}
-                    </tr>
-                </thead>
-                <tbody>
-                    {verticalGeometry.map((verticalGeom) => (
-                        <VerticalGeometryTableItem
-                            key={verticalGeom.id}
-                            verticalGeometry={verticalGeom}
-                            showLocationTrack={showLocationTrack}
-                        />
-                    ))}
-                </tbody>
-            </Table>
-        </div>
+                    </tbody>
+                </Table>
+            </div>
+        </React.Fragment>
     );
 };

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
@@ -13,6 +13,7 @@ const VerticalGeometryView = () => {
     const rootDispatch = useDataProductsAppDispatch();
     const dataProductsDelegates = createDelegates(rootDispatch, dataProductsActions);
     const state = useDataProductsAppSelector((state) => state.dataProducts.verticalGeometry);
+    const [loading, setLoading] = React.useState(false);
 
     const { t } = useTranslation();
     const locationTrackSelected = state.selectedSearch === 'LOCATION_TRACK';
@@ -49,12 +50,14 @@ const VerticalGeometryView = () => {
                         setVerticalGeometry={
                             dataProductsDelegates.onSetLocationTrackVerticalGeometry
                         }
+                        setLoading={setLoading}
                     />
                 ) : (
                     <PlanVerticalGeometrySearch
                         state={state.planSearch}
                         onUpdateProp={dataProductsDelegates.onUpdatePlanVerticalGeometrySearchProp}
                         setVerticalGeometry={dataProductsDelegates.onSetPlanVerticalGeometry}
+                        setLoading={setLoading}
                     />
                 )}
             </div>
@@ -65,6 +68,7 @@ const VerticalGeometryView = () => {
                         : state.planSearch.verticalGeometry
                 }
                 showLocationTrack={state.selectedSearch === 'LOCATION_TRACK'}
+                isLoading={loading}
             />
         </div>
     );

--- a/ui/src/geometry/geometry-model.ts
+++ b/ui/src/geometry/geometry-model.ts
@@ -306,4 +306,6 @@ export type VerticalGeometryItem = {
     linearSectionBackward: LinearSection;
     linearSectionForward: LinearSection;
     locationTrackName: string;
+    overlapsAnother: boolean;
+    verticalCoordinateSystem: VerticalCoordinateSystem | null;
 };

--- a/ui/src/publication/table/publication-table.scss
+++ b/ui/src/publication/table/publication-table.scss
@@ -45,14 +45,4 @@
     &__table-container {
         position: relative;
     }
-
-    &__backdrop {
-        position: absolute;
-        z-index: 1;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba($color-white-default, 0.67);
-    }
 }

--- a/ui/src/publication/table/publication-table.tsx
+++ b/ui/src/publication/table/publication-table.tsx
@@ -62,7 +62,7 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
                 </span>
             </div>
             <div className={styles['publication-table__table-container']}>
-                <Table wide>
+                <Table wide isLoading={isLoading}>
                     <thead className={styles['publication-table__table-header']}>
                         <tr>
                             {sortableTableHeader(
@@ -115,7 +115,6 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
                         ))}
                     </tbody>
                 </Table>
-                {isLoading && <div className={styles['publication-table__backdrop']} />}
             </div>
         </div>
     );

--- a/ui/src/vayla-design-lib/table/table.scss
+++ b/ui/src/vayla-design-lib/table/table.scss
@@ -73,6 +73,21 @@ $table-cell-padding: 10px 16px;
             }
         }
     }
+
+    &--loading {
+        position: absolute;
+        z-index: 1;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba($color-white-default, 0.67);
+    }
+}
+
+.table__container {
+    // For showing the backdrop when loading
+    position: relative;
 }
 
 .table--wide {

--- a/ui/src/vayla-design-lib/table/table.tsx
+++ b/ui/src/vayla-design-lib/table/table.tsx
@@ -5,6 +5,7 @@ import { IconComponent, IconSize } from 'vayla-design-lib/icon/Icon';
 
 export type TableProps = {
     wide?: boolean;
+    isLoading?: boolean;
 } & React.HTMLProps<HTMLTableElement>;
 
 export const Table: React.FC<TableProps> = (props: TableProps) => {
@@ -13,7 +14,12 @@ export const Table: React.FC<TableProps> = (props: TableProps) => {
         styles.table,
         props.wide && styles['table--wide'],
     );
-    return <table className={className}>{props.children}</table>;
+    return (
+        <div className={styles['table__container']}>
+            <table className={className}>{props.children}</table>
+            {props.isLoading && <div className={styles['table--loading']} />}
+        </div>
+    );
 };
 
 export enum TdVariant {


### PR DESCRIPTION
Tiketillä oli mainittu pitkä lista muutoksia, ja niistä on toteutettu melkein kaikki. Ainoastaan pyöristyksettömien raiteiden indikointi jäi pois, sillä en keksinyt UI-teknisesti fiksua tapaa näyttää niitä, kun koko nykyinen taulukko nojaa pyöristysten olemassaoloon. Näiden lisäksi taulukoiden latausbackdropista tehty `Table`-komponentin ominaisuus ja lisätty sen käyttö muillekin tietotuotteille