### PR TITLE
GVT-1811: Esikatselun taulukoissa "Hylkää muutos" -valinta karkaa oikeaan alakulmaan

### DIFF
--- a/ui/src/vayla-design-lib/table/table.scss
+++ b/ui/src/vayla-design-lib/table/table.scss
@@ -85,7 +85,7 @@ $table-cell-padding: 10px 16px;
     }
 }
 
-.table__container {
+.table__container--loading {
     // For showing the backdrop when loading
     position: relative;
 }

--- a/ui/src/vayla-design-lib/table/table.tsx
+++ b/ui/src/vayla-design-lib/table/table.tsx
@@ -14,8 +14,12 @@ export const Table: React.FC<TableProps> = (props: TableProps) => {
         styles.table,
         props.wide && styles['table--wide'],
     );
+
+    const containerClassName = createClassName(
+        props.isLoading && styles['table__container--loading'],
+    );
     return (
-        <div className={styles['table__container']}>
+        <div className={containerClassName}>
             <table className={className}>{props.children}</table>
             {props.isLoading && <div className={styles['table--loading']} />}
         </div>


### PR DESCRIPTION
Tämä johtui viime viikolla tekemästäni muutoksesta, joka teki latausindikaatiosta taulukon ominaisuuden. Näköjään menut eivät tykänneet sen tuomasta position-relativesta. Muutettu se nyt niin, että relatiivisuus asetetaan päälle ainoastaan kun taulukko on latausindikaatiotilassa, jolloin taulukkoa ei voi kliksutella muutenkaan