### PR TITLE
GVT-1722 Tests and fixes for alignment heights backend

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.authorization.AUTH_ALL_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
 import fi.fta.geoviite.infra.common.IndexedId
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.geometry.GeometryPlanSortField.ID
 import fi.fta.geoviite.infra.logging.apiCall
@@ -267,12 +268,13 @@ class GeometryController @Autowired constructor(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/layout/location-tracks/{id}/alignment-heights")
+    @GetMapping("/{publishType}/layout/location-tracks/{id}/alignment-heights")
     fun getLayoutAlignmentHeights(
+        @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") locationTrackId: IntId<LocationTrack>,
         @RequestParam("startDistance") startDistance: Double,
         @RequestParam("endDistance") endDistance: Double,
         @RequestParam("tickLength") tickLength: Int,
     ): AlignmentHeights? {
-        return geometryService.getLocationTrackHeights(locationTrackId, startDistance, endDistance, tickLength)
+        return geometryService.getLocationTrackHeights(locationTrackId, publishType, startDistance, endDistance, tickLength)
     }}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -1,0 +1,116 @@
+package fi.fta.geoviite.infra.geometry
+
+import fi.fta.geoviite.infra.ITTestBase
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.PublishType
+import fi.fta.geoviite.infra.inframodel.InfraModelFile
+import fi.fta.geoviite.infra.inframodel.PlanElementName
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.util.FileName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class GeometryServiceIT @Autowired constructor(
+    private val layoutTrackNumberDao: LayoutTrackNumberDao,
+    private val referenceLineService: ReferenceLineService,
+    private val locationTrackService: LocationTrackService,
+    private val geometryDao: GeometryDao,
+    private val geometryService: GeometryService,
+) : ITTestBase() {
+
+    @Test
+    fun getLocationTrackHeightsReturnsBothOrdinaryTicksAndPlanBoundaries() {
+        val trackNumber = trackNumber(getUnusedTrackNumber())
+        val trackNumberId = layoutTrackNumberDao.insert(trackNumber).id
+        referenceLineService.saveDraft(
+            referenceLine(trackNumberId),
+            alignment(segment(Point(0.0, 0.0), Point(0.0, 100.0)))
+        )
+        val p1 = insertPlanWithGeometry("plan1.xml", trackNumberId)
+        val p2 = insertPlanWithGeometry("plan2.xml", trackNumberId)
+        val p3 = insertPlanWithGeometry("plan3.xml", trackNumberId)
+        val locationTrackId = locationTrackService.saveDraft(
+            locationTrack(trackNumberId),
+            alignment(
+                segment(yRangeToSegmentPoints(0..6), sourceId = p1.alignments[0].elements[0].id, sourceStart = 0.0),
+                segment(yRangeToSegmentPoints(6..10)),
+                segment(yRangeToSegmentPoints(10..12), sourceId = p2.alignments[0].elements[0].id, sourceStart = 0.0),
+                segment(yRangeToSegmentPoints(12..13)),
+                segment(yRangeToSegmentPoints(13..15), sourceId = p3.alignments[0].elements[0].id, sourceStart = 0.0),
+                segment(yRangeToSegmentPoints(15..17), sourceId = p1.alignments[0].elements[0].id, sourceStart = 0.0),
+            )
+        ).id
+        val heights = geometryService.getLocationTrackHeights(locationTrackId, PublishType.DRAFT, 0.0, 20.0, 5)!!
+        // this track is exactly straight on the reference line, so m-values and track meters coincide perfectly; also,
+        // the profile is at exactly 50 meters height at every point where it's linked
+        val expected = listOf(
+            0 to 50,
+            5 to 50,
+            6 to 50,
+            6 to null,
+            10 to null,
+            10 to 50,
+            12 to 50,
+            12 to null,
+            13 to null,
+            13 to 50,
+            15 to 50,
+            17 to 50
+        ).map { (m, h) -> TrackMeterHeight(m.toDouble(), m.toDouble(), h?.toDouble()) }
+        assertEquals(expected, heights.kmHeights[0].trackMeterHeights)
+        assertEquals(
+            listOf(
+                PlanLinkingSummaryItem(0.0, 6.0, FileName("plan1.xml")),
+                PlanLinkingSummaryItem(6.0, 10.0, null),
+                PlanLinkingSummaryItem(10.0, 12.0, FileName("plan2.xml")),
+                PlanLinkingSummaryItem(12.0, 13.0, null),
+                PlanLinkingSummaryItem(13.0, 15.0, FileName("plan3.xml")),
+                PlanLinkingSummaryItem(15.0, 17.0, FileName("plan1.xml")),
+            ),
+            heights.linkingSummary
+        )
+    }
+
+    fun yRangeToSegmentPoints(range: IntRange) =
+        toTrackLayoutPoints(to3DMPoints(range.map { i -> Point(0.0, i.toDouble()) }))
+
+    fun insertPlanWithGeometry(filename: String, trackNumberId: IntId<TrackLayoutTrackNumber>): GeometryPlan {
+        val version = geometryDao.insertPlan(
+            planWithGeometryAndHeights(trackNumberId), InfraModelFile(FileName(filename), "<a></a>"), null
+        )
+        return geometryDao.fetchPlan(version)
+    }
+
+    fun planWithGeometryAndHeights(trackNumberId: IntId<TrackLayoutTrackNumber>): GeometryPlan = plan(
+        trackNumberId,
+        LAYOUT_SRID,
+        geometryAlignment(
+            trackNumberId,
+            elements = listOf(lineFromOrigin(1.0)),
+            name = "foo",
+            profile = GeometryProfile(
+                PlanElementName("aoeu"),
+                listOf(
+                    // profile originally inspired by geometry alignment 2466 in order to make the numbers plausible;
+                    // but simplified and rounded
+                    VIPoint(PlanElementName("startpoint"), Point(0.0, 50.0)),
+                    VICircularCurve(
+                        PlanElementName("rounding"),
+                        Point(500.0, 50.0),
+                        BigDecimal(20000),
+                        BigDecimal(155),
+                    ),
+                    VIPoint(PlanElementName("endpoint"), Point(600.0, 51.0)),
+                )
+            )
+        ),
+    )
+
+}


### PR DESCRIPTION
Juuse oli spotannut aikaisemmasta bäkkäristä, että siinä haettiin vähän oudolla tavalla noita välejä, joissa suunnitelma muuttuu: Ja niinhän se olikin, että niiden käyttö oli päin honkia.

Nyt lasketaan suunnitelmien muutoskohdat korrektimmin ja vähemmällä indeksimuljailulla niin, että frontti saa aina korkeusviivan pisteet järjestyksessä; puuttuvien korkeuksien vierestä korkeusviivan pisteet mahdollisimman läheltä (jotta sen ei tarvitse ekstraploida korkeusviivaa); ja vielä myös erikseen yhteenvedon siitä, miten raidetta yleensäkin on linkitetty.

Pienenä bonusmuutoksena mukana myös sijaintiraiteen draft/official-tilan valinta.