### PR TITLE
GVT-1788: Korjauksia elementtlilistauksen korjauksiin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
@@ -1,9 +1,13 @@
 package fi.fta.geoviite.infra.geometry
 
+import fi.fta.geoviite.infra.common.SwitchName
+
 const val ELEMENT_LISTING = "Elementtilistaus"
 const val VERTICAL_GEOMETRY = "Pystygeometria"
 const val VERTICAL_SECTIONS_OVERLAP = "Kaltevuusjakso on limittäin toisen jakson kanssa"
 const val UNKNOWN = "Ei tiedossa"
+const val IS_PARTIAL = "Raide sisältää vain osan geometriaelementistä"
+val connectedToSwitch = { switchName: SwitchName -> "Vaihteen ${switchName} elementti" }
 
 enum class ElementListingHeader {
     TRACK_NUMBER,
@@ -25,7 +29,8 @@ enum class ElementListingHeader {
     DIRECTION_END,
     PLAN_NAME,
     PLAN_SOURCE,
-    CRS
+    CRS,
+    REMARKS
 }
 
 fun translateElementListingHeader(header: ElementListingHeader) =
@@ -50,6 +55,7 @@ fun translateElementListingHeader(header: ElementListingHeader) =
         ElementListingHeader.PLAN_NAME -> "Suunnitelma"
         ElementListingHeader.PLAN_SOURCE -> "Lähde"
         ElementListingHeader.CRS -> "Koordinaatisto"
+        ElementListingHeader.REMARKS -> "Huomiot"
     }
 
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
@@ -121,9 +121,11 @@ fun toElementListing(
     }.map { listing ->
         val calculatedSegmentLength =
             lengthOfSegmentsConnectedToSameElement.find { (elementId, _) -> elementId == listing.elementId }?.second
-        listing.copy(isPartial = calculatedSegmentLength?.let {
-            abs(calculatedSegmentLength - listing.lengthMeters.toDouble()) > SEGMENT_AND_ELEMENT_LENGTH_MAX_DELTA
-        } ?: false)
+        listing.copy(
+            isPartial = if (calculatedSegmentLength != null && listing.planId != null)
+                abs(calculatedSegmentLength - listing.lengthMeters.toDouble()) > SEGMENT_AND_ELEMENT_LENGTH_MAX_DELTA
+            else false
+        )
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
@@ -12,12 +12,15 @@ import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.printCsv
 import java.math.BigDecimal
+import kotlin.math.abs
 
 const val COORDINATE_DECIMALS = 3
 const val ADDRESS_DECIMALS = 3
 const val LENGTH_DECIMALS = 3
 const val DIRECTION_DECIMALS = 6
 const val CANT_DECIMALS = 6
+
+const val SEGMENT_AND_ELEMENT_LENGTH_MAX_DELTA = 1.0
 
 data class ElementListing(
     val id: StringId<ElementListing>,
@@ -83,11 +86,15 @@ fun toElementListing(
     getSwitchName: (IntId<TrackLayoutSwitch>) -> SwitchName,
 ): List<ElementListing> {
     val linkedElementIds = collectLinkedElements(layoutAlignment.segments, context, startAddress, endAddress)
-    val linkedAlignmentIds = linkedElementIds.mapNotNull { (_, id) -> id?.let(::getAlignmentId) }.distinct()
+    val lengthOfSegmentsConnectedToSameElement = linkedElementIds.groupBy { it.second }.map {
+        it.key to it.value.map { (segment, _) -> segment.length }.sum()
+    }
+    val distinctLinkedElementIds = linkedElementIds.distinctBy { (segment, elementId) -> elementId ?: segment.id }
+    val linkedAlignmentIds = distinctLinkedElementIds.mapNotNull { (_, id) -> id?.let(::getAlignmentId) }.distinct()
     val headersAndAlignments = linkedAlignmentIds.associateWith { id -> getPlanHeaderAndAlignment(id) }
-    return linkedElementIds.mapNotNull { (segment, elementId) ->
+    return distinctLinkedElementIds.mapNotNull { (segment, elementId) ->
         if (elementId == null) {
-            if (elementTypes.contains(MISSING_SECTION)) segment to toMissingElementListing(context, track.trackNumberId, segment, track, getSwitchName)
+            if (elementTypes.contains(MISSING_SECTION)) toMissingElementListing(context, track.trackNumberId, segment, track, getSwitchName)
             else null
         }
         else {
@@ -97,30 +104,26 @@ fun toElementListing(
                 "Geometry element not found on its parent alignment: alignment=${alignment.id} element=$elementId"
             )
             if (elementTypes.contains(TrackGeometryElementType.of(element.type))) {
-                segment to toElementListing(context, getTransformation, track, planHeader, alignment, element, segment, getSwitchName)
+                toElementListing(
+                    context,
+                    getTransformation,
+                    track,
+                    planHeader,
+                    alignment,
+                    element,
+                    segment,
+                    getSwitchName
+                )
             } else {
                 null
             }
         }
-    }.let { elementList ->
-        elementList.mapIndexed { index, (segment, listing) ->
-            val next = elementList.getOrNull(index + 1)?.second
-            val prev = elementList.getOrNull(index - 1)?.second
-            listing.copy(
-                isPartial =
-                if (index == 0
-                    || listing.planId != next?.planId
-                    || index == elementList.lastIndex
-                    || listing.planId != prev?.planId
-                    ) calculateIsPartial(
-                        context,
-                        segment,
-                        listing.start,
-                        listing.end
-                    )
-                else false
-            )
-        }
+    }.map { listing ->
+        val calculatedSegmentLength =
+            lengthOfSegmentsConnectedToSameElement.find { (elementId, _) -> elementId == listing.elementId }?.second
+        listing.copy(isPartial = calculatedSegmentLength?.let {
+            abs(calculatedSegmentLength - listing.lengthMeters.toDouble()) > SEGMENT_AND_ELEMENT_LENGTH_MAX_DELTA
+        } ?: false)
     }
 }
 
@@ -267,6 +270,7 @@ private val commonElementListingCsvEntries = arrayOf(
     CsvEntry(translateElementListingHeader(ElementListingHeader.DIRECTION_END)) { it.end.directionGrads.toPlainString() },
     CsvEntry(translateElementListingHeader(ElementListingHeader.PLAN_NAME)) { it.fileName },
     CsvEntry(translateElementListingHeader(ElementListingHeader.PLAN_SOURCE)) { it.planSource },
+    CsvEntry(translateElementListingHeader(ElementListingHeader.REMARKS)) { remarks(it) }
 )
 
 fun locationTrackCsvEntries(trackNumbers: List<TrackLayoutTrackNumber>) = listOf(
@@ -279,6 +283,12 @@ fun planCsvEntries(trackNumbers: List<TrackLayoutTrackNumber>) = listOf(
     trackNumberCsvEntry(trackNumbers),
     *commonElementListingCsvEntries
 )
+
+private fun remarks(elementListing: ElementListing) =
+    listOf(
+        if (elementListing.isPartial) IS_PARTIAL else null,
+        if (elementListing.connectedSwitchName != null) connectedToSwitch(elementListing.connectedSwitchName) else null
+    ).filterNotNull().joinToString(separator = ", ")
 
 private fun elementListing(
     context: GeocodingContext?,
@@ -317,18 +327,6 @@ private fun elementListing(
         connectedSwitchName = segment?.switchId?.let { getSwitchName(segment.switchId as IntId) },
         isPartial = false,
     )
-}
-
-private fun calculateIsPartial(context: GeocodingContext?, segment: LayoutSegment?, start: ElementLocation, end: ElementLocation): Boolean {
-    return if (context != null && segment != null) {
-        val segmentStartAddress = context.getAddress(segment.points.first())?.first
-        val segmentEndAddress = context.getAddress(segment.points.last())?.first
-
-        val startIsBefore = if (start.address != null && segmentStartAddress != null) start.address < segmentStartAddress else false
-        val endIsAfter = if (end.address != null && segmentEndAddress != null) end.address > segmentEndAddress else false
-
-        return startIsBefore || endIsAfter
-    } else false
 }
 
 private fun getLocation(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ListingCommon.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ListingCommon.kt
@@ -13,7 +13,6 @@ fun collectLinkedElements(
 ) = segments
     .filter { segment -> overlapsAddressInterval(segment, context, startAddress, endAddress) }
     .map { s -> if (s.sourceId is IndexedId) s to s.sourceId else s to null }
-    .distinctBy { (segment, elementId) -> elementId ?: segment.id }
 
 private fun overlapsAddressInterval(
     segment: LayoutSegment,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
@@ -133,7 +133,7 @@ fun toVerticalGeometryListing(
         geocodingContext,
         startAddress,
         endAddress
-    ).mapNotNull { it.second }
+    ).distinctBy { (segment, elementId) -> elementId ?: segment.id }.mapNotNull { it.second }
     val headersAndAlignments = linkedElementIds
         .map(::getAlignmentId)
         .distinct()


### PR DESCRIPTION
Täällä tehty:
* Korjattu isPartial-laskenta (käytetään elementtien ja segmenttien pituuksia rataosoitteiden sijaan)
* Huomiot mukaan CSV:hen