### PR TITLE
General: Korjaa KKJ1-koordinaattimuunnokset

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/KkjEtrsTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/KkjEtrsTransformation.kt
@@ -6,7 +6,7 @@ import org.locationtech.jts.geom.Coordinate
 import org.opengis.referencing.crs.CoordinateReferenceSystem
 
 val KKJ0 = Srid(3386)
-val KKJ1 = Srid(2931)
+val KKJ1 = Srid(2391)
 val KKJ2 = Srid(2392)
 val KKJ3_YKJ = Srid(2393)
 val KKJ4 = Srid(2394)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/CoordinateTransformServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/CoordinateTransformServiceIT.kt
@@ -49,8 +49,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
 
     @Test
     fun `Transforms KKJ0 to TM35FIN accurately`() {
-        val kkj4point = Point(585436.3916, 6679828.4162)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ0, LAYOUT_SRID, kkj4point)
+        val kkj0point = Point(585436.3916, 6679828.4162)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ0, LAYOUT_SRID, kkj0point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(87158.652, transformedPoint.x, 0.001)
         Assertions.assertEquals(6699388.278, transformedPoint.y, 0.001)
@@ -58,8 +58,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
 
     @Test
     fun `Transforms KKJ1 to TM35FIN accurately`() {
-        val kkj4point = Point(1541730.796, 6818539.1569)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ1, LAYOUT_SRID, kkj4point)
+        val kkj1point = Point(1541730.796, 6818539.1569)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ1, LAYOUT_SRID, kkj1point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(222053.674, transformedPoint.x, 0.001)
         Assertions.assertEquals(6826549.907, transformedPoint.y, 0.001)
@@ -67,8 +67,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
 
     @Test
     fun `Transforms KKJ2 to TM35FIN accurately`() {
-        val kkj4point = Point(2488027.6005, 6820948.9609)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ2, LAYOUT_SRID, kkj4point)
+        val kkj2point = Point(2488027.6005, 6820948.9609)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ2, LAYOUT_SRID, kkj2point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(328183.073, transformedPoint.x, 0.001)
         Assertions.assertEquals(6822313.526, transformedPoint.y, 0.001)
@@ -85,8 +85,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
 
     @Test
     fun `Transforms KKJ5 to TM35FIN accurately`() {
-        val kkj4point = Point(5426728.7305, 6978302.5687)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ5, LAYOUT_SRID, kkj4point)
+        val kkj5point = Point(5426728.7305, 6978302.5687)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ5, LAYOUT_SRID, kkj5point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(731400.669, transformedPoint.x, 0.001)
         Assertions.assertEquals(6982768.023, transformedPoint.y, 0.001)
@@ -105,8 +105,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms TM35FIN to KKJ0 accurately`() {
         // Point is in western Åland, in case anybody decides to build a track there
-        val kkj0point = Point(87158.652, 6699388.278)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ0, kkj0point)
+        val point = Point(87158.652, 6699388.278)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ0, point)
         // Expected values are from paikkatietoikkuna. The KKJ0 transform is less accurate than the rest,
         // hence the larger delta
         Assertions.assertEquals(585436.3916, transformedPoint.x, 0.01)
@@ -116,8 +116,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms TM35FIN to KKJ1 accurately`() {
         // Point is at Pori railway station
-        val kkj1point = Point(222053.674, 6826549.907)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ1, kkj1point)
+        val point = Point(222053.674, 6826549.907)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ1, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(1541730.796, transformedPoint.x, 0.001)
         Assertions.assertEquals(6818539.1569, transformedPoint.y, 0.001)
@@ -125,8 +125,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
 
     @Test
     fun `Transforms TM35FIN to KKJ2 accurately`() {
-        val kkj2point = Point(328183.073, 6822313.526)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ2, kkj2point)
+        val point = Point(328183.073, 6822313.526)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ2, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(2488027.6005, transformedPoint.x, 0.001)
         Assertions.assertEquals(6820948.9609, transformedPoint.y, 0.001)
@@ -134,8 +134,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
 
     @Test
     fun `Transforms TM35FIN to KKJ4 accurately`() {
-        val kkj4point = Point(642412.7448, 6943735.9093)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ4, kkj4point)
+        val point = Point(642412.7448, 6943735.9093)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ4, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(4488552.946177, transformedPoint.x, 0.001)
         Assertions.assertEquals(6943595.611588, transformedPoint.y, 0.001)
@@ -143,8 +143,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
 
     @Test
     fun `Transforms TM35FIN to KKJ5 accurately`() {
-        val kkj5point = Point(731400.669, 6982768.023)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ5, kkj5point)
+        val point = Point(731400.669, 6982768.023)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ5, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(5426728.7305, transformedPoint.x, 0.001)
         Assertions.assertEquals(6978302.5687, transformedPoint.y, 0.001)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/CoordinateTransformServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/CoordinateTransformServiceIT.kt
@@ -2,9 +2,7 @@ package fi.fta.geoviite.infra.geometry
 
 import fi.fta.geoviite.infra.ITTestBase
 import fi.fta.geoviite.infra.common.Srid
-import fi.fta.geoviite.infra.geography.CoordinateTransformationService
-import fi.fta.geoviite.infra.geography.KKJ3_YKJ
-import fi.fta.geoviite.infra.geography.KKJ4
+import fi.fta.geoviite.infra.geography.*
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.ratko.model.RATKO_SRID
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
@@ -40,26 +38,62 @@ class CoordinateTransformServiceIT @Autowired constructor(
     }
 
     @Test
-    fun `Transforms YKJ to TM35FIN accurately`() {
+    fun `Transforms YKJ (KKJ3) to TM35FIN accurately`() {
         // Point is in Hervanta, Tampere
         val point = Point(3332494.083, 6819936.144)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(Srid(2393) /* KKJ3 */, LAYOUT_SRID, point)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ3_YKJ, LAYOUT_SRID, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(332391.7884, transformedPoint.x, 0.001)
         Assertions.assertEquals(6817075.2561, transformedPoint.y, 0.001)
     }
 
     @Test
+    fun `Transforms KKJ0 to TM35FIN accurately`() {
+        val kkj4point = Point(585436.3916, 6679828.4162)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ0, LAYOUT_SRID, kkj4point)
+        // Expected values are from paikkatietoikkuna
+        Assertions.assertEquals(87158.652, transformedPoint.x, 0.001)
+        Assertions.assertEquals(6699388.278, transformedPoint.y, 0.001)
+    }
+
+    @Test
+    fun `Transforms KKJ1 to TM35FIN accurately`() {
+        val kkj4point = Point(1541730.796, 6818539.1569)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ1, LAYOUT_SRID, kkj4point)
+        // Expected values are from paikkatietoikkuna
+        Assertions.assertEquals(222053.674, transformedPoint.x, 0.001)
+        Assertions.assertEquals(6826549.907, transformedPoint.y, 0.001)
+    }
+
+    @Test
+    fun `Transforms KKJ2 to TM35FIN accurately`() {
+        val kkj4point = Point(2488027.6005, 6820948.9609)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ2, LAYOUT_SRID, kkj4point)
+        // Expected values are from paikkatietoikkuna
+        Assertions.assertEquals(328183.073, transformedPoint.x, 0.001)
+        Assertions.assertEquals(6822313.526, transformedPoint.y, 0.001)
+    }
+
+    @Test
     fun `Transforms KKJ4 to TM35FIN accurately`() {
         val kkj4point = Point(4488552.946177, 6943595.611588)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(Srid(2394) /* KKJ4 */, LAYOUT_SRID, kkj4point)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ4, LAYOUT_SRID, kkj4point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(642412.7448, transformedPoint.x, 0.001)
         Assertions.assertEquals(6943735.9093, transformedPoint.y, 0.001)
     }
 
     @Test
-    fun `Transforms TM35FIN to YKJ accurately`() {
+    fun `Transforms KKJ5 to TM35FIN accurately`() {
+        val kkj4point = Point(5426728.7305, 6978302.5687)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ5, LAYOUT_SRID, kkj4point)
+        // Expected values are from paikkatietoikkuna
+        Assertions.assertEquals(731400.669, transformedPoint.x, 0.001)
+        Assertions.assertEquals(6982768.023, transformedPoint.y, 0.001)
+    }
+
+    @Test
+    fun `Transforms TM35FIN to YKJ (KKJ3) accurately`() {
         // Point is in Hervanta, Tampere
         val point = Point(332391.7884, 6817075.2561)
         val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ3_YKJ, point)
@@ -69,11 +103,50 @@ class CoordinateTransformServiceIT @Autowired constructor(
     }
 
     @Test
+    fun `Transforms TM35FIN to KKJ0 accurately`() {
+        // Point is in western Åland, in case anybody decides to build a track there
+        val kkj0point = Point(87158.652, 6699388.278)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ0, kkj0point)
+        // Expected values are from paikkatietoikkuna. The KKJ0 transform is less accurate than the rest,
+        // hence the larger delta
+        Assertions.assertEquals(585436.3916, transformedPoint.x, 0.01)
+        Assertions.assertEquals(6679828.4162, transformedPoint.y, 0.01)
+    }
+
+    @Test
+    fun `Transforms TM35FIN to KKJ1 accurately`() {
+        // Point is at Pori railway station
+        val kkj1point = Point(222053.674, 6826549.907)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ1, kkj1point)
+        // Expected values are from paikkatietoikkuna
+        Assertions.assertEquals(1541730.796, transformedPoint.x, 0.001)
+        Assertions.assertEquals(6818539.1569, transformedPoint.y, 0.001)
+    }
+
+    @Test
+    fun `Transforms TM35FIN to KKJ2 accurately`() {
+        val kkj2point = Point(328183.073, 6822313.526)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ2, kkj2point)
+        // Expected values are from paikkatietoikkuna
+        Assertions.assertEquals(2488027.6005, transformedPoint.x, 0.001)
+        Assertions.assertEquals(6820948.9609, transformedPoint.y, 0.001)
+    }
+
+    @Test
     fun `Transforms TM35FIN to KKJ4 accurately`() {
         val kkj4point = Point(642412.7448, 6943735.9093)
         val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ4, kkj4point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(4488552.946177, transformedPoint.x, 0.001)
         Assertions.assertEquals(6943595.611588, transformedPoint.y, 0.001)
+    }
+
+    @Test
+    fun `Transforms TM35FIN to KKJ5 accurately`() {
+        val kkj5point = Point(731400.669, 6982768.023)
+        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ5, kkj5point)
+        // Expected values are from paikkatietoikkuna
+        Assertions.assertEquals(5426728.7305, transformedPoint.x, 0.001)
+        Assertions.assertEquals(6978302.5687, transformedPoint.y, 0.001)
     }
 }


### PR DESCRIPTION
Pohjimmaisena bugina tässä oli se, että KKJ1-koordinaatiston SRID:hen oli lipsahtanut näppäilyvirhe. Tämä on nyt korjattu, ja tämän lisäksi tehty testit jotka varmistavat, että kaikki KKJ-TM35-muunnokset varmasti toimivat oikein molempiin suuntiin