### PR TITLE
GVT-1722 Initial vertical geometry diagram front-end

### DIFF
--- a/ui/src/app-bar/app-bar.tsx
+++ b/ui/src/app-bar/app-bar.tsx
@@ -21,6 +21,11 @@ const links: Link[] = [
     { link: '/infra-model', name: 'app-bar.infra-model', type: 'prod' },
     { link: '/design-lib-demo', name: 'app-bar.components', type: 'dev' },
     { link: '/localization-demo', name: 'app-bar.localization', type: 'dev' },
+    {
+        link: '/vertical-geometry-diagram-demo',
+        name: 'app-bar.vertical-geometry-diagram-demo',
+        type: 'dev',
+    },
 ];
 
 export const AppBar: React.FC = () => {

--- a/ui/src/app-bar/translations.fi.json
+++ b/ui/src/app-bar/translations.fi.json
@@ -11,6 +11,7 @@
             "element-list": "Elementtiluettelo",
             "vertical-geometry": "Pystygeometria",
             "km-lengths": "Ratakilometrien pituudet"
-        }
+        },
+        "vertical-geometry-diagram-demo": "Korkeuskaavio-demo"
     }
 }

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -38,7 +38,7 @@ import {
 import { BoundingBox } from 'model/geometry';
 import { MapTile } from 'map/map-model';
 import { getChangeTimes } from 'common/change-time-api';
-import { TimeStamp } from 'common/common-model';
+import { KmNumber, PublishType, TimeStamp } from 'common/common-model';
 import { bboxString } from 'common/common-api';
 import { filterNotEmpty } from 'utils/array-utils';
 import { GeometryTypeIncludingMissing } from 'data-products/data-products-slice';
@@ -276,4 +276,55 @@ export async function getGeometryPlanLinkingSummaries(
         { [key: GeometryPlanId]: GeometryPlanLinkingSummary }
     >(`${GEOMETRY_URI}/plans/linking-summaries/`, planIds);
     return r.isOk() ? r.value : null;
+}
+
+export interface AlignmentHeights {
+    kmHeights: TrackKmHeights[];
+    alignmentStartM: number;
+    alignmentEndM: number;
+    linkingSummary: PlanLinkingSummaryItem[];
+}
+
+export interface TrackMeterHeight {
+    /** m-value in entire alignment */
+    m: number;
+    meter: number;
+    height: number | null;
+}
+
+export interface PlanLinkingSummaryItem {
+    startM: number;
+    endM: number;
+    filename: string | null;
+}
+
+export interface TrackKmHeights {
+    kmNumber: KmNumber;
+    trackMeterHeights: TrackMeterHeight[];
+}
+
+export async function getPlanAlignmentHeights(
+    planId: GeometryPlanId,
+    alignmentId: GeometryAlignmentId,
+    startDistance: number,
+    endDistance: number,
+    tickLength: number,
+): Promise<AlignmentHeights> {
+    return getThrowError(
+        `${GEOMETRY_URI}/plans/${planId}/plan-alignment-heights/${alignmentId}` +
+            queryParams({ startDistance, endDistance, tickLength }),
+    );
+}
+
+export async function getLocationTrackHeights(
+    locationTrackId: LocationTrackId,
+    publishType: PublishType,
+    startDistance: number,
+    endDistance: number,
+    tickLength: number,
+): Promise<AlignmentHeights> {
+    return getThrowError(
+        `${GEOMETRY_URI}/${publishType}/layout/location-tracks/${locationTrackId}/alignment-heights` +
+            queryParams({ startDistance, endDistance, tickLength }),
+    );
 }

--- a/ui/src/geometry/geometry-model.ts
+++ b/ui/src/geometry/geometry-model.ts
@@ -285,7 +285,7 @@ type LinearSection = {
     linearSegmentLength: number | null;
 };
 
-type StationPoint = {
+export type StationPoint = {
     address: TrackMeter | null;
     height: number;
     station: number;
@@ -296,6 +296,7 @@ type CircularCurve = StationPoint & {
 };
 
 export type VerticalGeometryItem = {
+    alignmentId: string;
     id: string;
     planId: GeometryPlanId;
     fileName: string;
@@ -310,4 +311,8 @@ export type VerticalGeometryItem = {
     locationTrackName: string;
     overlapsAnother: boolean;
     verticalCoordinateSystem: VerticalCoordinateSystem | null;
+
+    layoutStartStation: number | null;
+    layoutPointStation: number | null;
+    layoutEndStation: number | null;
 };

--- a/ui/src/main/main.tsx
+++ b/ui/src/main/main.tsx
@@ -27,6 +27,7 @@ import ElementListView from 'data-products/element-list/element-list-view';
 import { KilometerLengthsView } from 'data-products/kilometer-lengths/kilometer-lengths-view';
 import VerticalGeometryView from 'data-products/vertical-geometry/vertical-geometry-view';
 import { commonActionCreators } from 'common/common-slice';
+import VerticalGeometryDiagramDemoPage from 'vertical-geometry/demo-page';
 import { getOwnUser } from 'user/user-api';
 
 type MainProps = {
@@ -62,6 +63,10 @@ const Main: React.VFC<MainProps> = (props: MainProps) => {
                     <Route
                         path="/data-products/vertical-geometry"
                         element={<VerticalGeometryView />}
+                    />
+                    <Route
+                        path="/vertical-geometry-diagram-demo"
+                        element={<VerticalGeometryDiagramDemoPage />}
                     />
                     <Route
                         path="/data-products/kilometer-lengths"

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -184,3 +184,19 @@ export function addIfExists<T>(originalCollection: T[], newValue: T | undefined)
 export function indexIntoMap<Id, Obj extends { id: Id }>(objs: Obj[]): Map<Id, Obj> {
     return objs.reduce((map, obj) => map.set(obj.id, obj), new Map());
 }
+
+export function minimumIndexBy<T, B>(objs: readonly T[], by: (obj: T) => B): number | null {
+    if (objs.length == 0) {
+        return null;
+    }
+    const values = objs.map((obj) => by(obj));
+    let min = values[0];
+    let minIndex = 0;
+    for (let i = 1; i < values.length; i++) {
+        if (values[i] < min) {
+            min = values[i];
+            minIndex = i;
+        }
+    }
+    return minIndex;
+}

--- a/ui/src/utils/math-utils.ts
+++ b/ui/src/utils/math-utils.ts
@@ -16,3 +16,7 @@ function normalizeRads(rads: number): number {
 function normalizeToRangeNonInclusive(value: number, range: number): number {
     return value < 0 || value >= range ? value - range * Math.floor(value / range) : value;
 }
+
+export function radsToDegrees(rads: number): number {
+    return (180 / Math.PI) * rads;
+}

--- a/ui/src/vertical-geometry/coordinates.ts
+++ b/ui/src/vertical-geometry/coordinates.ts
@@ -1,0 +1,30 @@
+export interface Coordinates {
+    startM: number;
+    endM: number;
+    meterHeightPx: number;
+    mMeterLengthPxOverM: number;
+    fullDiagramHeightPx: number;
+    diagramWidthPx: number;
+    horizontalTickLengthMeters: number;
+
+    bottomHeightPaddingPx: number;
+    bottomHeightTick: number;
+    topHeightTick: number;
+    chartHeightPx: number;
+}
+
+export function mToX(coordinates: Coordinates, m: number): number {
+    return (m - coordinates.startM) * coordinates.mMeterLengthPxOverM;
+}
+
+export function xToM(coordinates: Coordinates, x: number): number {
+    return x / coordinates.mMeterLengthPxOverM + coordinates.startM;
+}
+
+export function heightToY(coordinates: Coordinates, height: number): number {
+    return (
+        coordinates.chartHeightPx -
+        coordinates.bottomHeightPaddingPx +
+        (coordinates.bottomHeightTick - height) * coordinates.meterHeightPx
+    );
+}

--- a/ui/src/vertical-geometry/demo-page.tsx
+++ b/ui/src/vertical-geometry/demo-page.tsx
@@ -1,0 +1,138 @@
+import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
+import * as React from 'react';
+import { useMemo } from 'react';
+import {
+    debouncedGetGeometryPlanHeaders,
+    debouncedSearchTracks,
+    getGeometryPlanOptions,
+    getLocationTrackOptions,
+} from 'data-products/data-products-utils';
+import { LayoutLocationTrack } from 'track-layout/track-layout-model';
+import { useTranslation } from 'react-i18next';
+import { VerticalGeometryDiagram } from 'vertical-geometry/vertical-geometry-diagram';
+import { GeometryAlignment, GeometryPlanHeader, PlanSource } from 'geometry/geometry-model';
+import { getGeometryPlan } from 'geometry/geometry-api';
+import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
+
+const VerticalGeometryDiagramDemoPage: React.FC = () => {
+    const { t } = useTranslation();
+    const [locationTrack, setLocationTrack] = React.useState<LayoutLocationTrack>();
+    const [planSource, setPlanSource] = React.useState<PlanSource>('PAIKANNUSPALVELU');
+    const [geometryPlanHeader, setGeometryPlanHeader] = React.useState<GeometryPlanHeader>();
+    const [selectedAlignment, setSelectedAlignment] = React.useState<GeometryAlignment>();
+    const [geometryAlignments, setGeometryAlignments] = React.useState<GeometryAlignment[]>([]);
+
+    const getLocationTracks = React.useCallback(
+        (searchTerm) =>
+            debouncedSearchTracks(searchTerm, 'OFFICIAL', 10).then((locationTracks) =>
+                getLocationTrackOptions(locationTracks, locationTrack),
+            ),
+        [locationTrack],
+    );
+    const getGeometryPlanHeaders = React.useCallback(
+        (searchTerm) =>
+            debouncedGetGeometryPlanHeaders('PAIKANNUSPALVELU', searchTerm).then(
+                (geometryPlanHeaders) =>
+                    getGeometryPlanOptions(geometryPlanHeaders, geometryPlanHeader),
+            ),
+        [geometryPlanHeader],
+    );
+
+    const selectGeometrySource = (source: PlanSource) => {
+        setGeometryPlanHeader(undefined);
+        setGeometryAlignments([]);
+        setSelectedAlignment(undefined);
+        setPlanSource(source);
+    };
+
+    const selectGeometryPlan = (header: GeometryPlanHeader) => {
+        setGeometryPlanHeader(header);
+        setGeometryAlignments([]);
+        setSelectedAlignment(undefined);
+        getGeometryPlan(header.id).then((plan) => setGeometryAlignments(plan?.alignments ?? []));
+    };
+
+    const locationTrackAlignmentId = useMemo(
+        () =>
+            locationTrack != undefined && {
+                locationTrackId: locationTrack.id,
+                publishType: 'OFFICIAL' as const,
+            },
+        [locationTrack],
+    );
+
+    const planAlignmentId = useMemo(
+        () =>
+            geometryPlanHeader != undefined &&
+            selectedAlignment != undefined && {
+                planId: geometryPlanHeader.id,
+                alignmentId: selectedAlignment.id,
+            },
+        [geometryPlanHeader, selectedAlignment],
+    );
+
+    return (
+        <div>
+            Sijaintiraide:
+            <Dropdown
+                value={locationTrack}
+                getName={(item) => item.name}
+                placeholder={t('data-products.search.search')}
+                options={getLocationTracks}
+                searchable
+                onChange={setLocationTrack}
+                unselectText={t('data-products.search.not-selected')}
+                wideList
+                wide
+            />
+            {locationTrackAlignmentId && (
+                <VerticalGeometryDiagram
+                    key={locationTrackAlignmentId.locationTrackId}
+                    alignmentId={locationTrackAlignmentId}
+                    initialStartM={0}
+                    initialEndM={10000}
+                />
+            )}
+            <br />
+            Suunnitelma:
+            <Checkbox
+                checked={planSource === 'PAIKANNUSPALVELU'}
+                onChange={() => selectGeometrySource('PAIKANNUSPALVELU')}>
+                Paikannuspalvelu
+            </Checkbox>
+            <Checkbox
+                checked={planSource === 'GEOMETRIAPALVELU'}
+                onChange={() => selectGeometrySource('GEOMETRIAPALVELU')}>
+                Geometriapalvelu
+            </Checkbox>
+            <Dropdown
+                value={geometryPlanHeader}
+                getName={(item: GeometryPlanHeader) => item.fileName}
+                placeholder={t('data-products.search.search')}
+                options={getGeometryPlanHeaders}
+                searchable
+                onChange={selectGeometryPlan}
+                unselectText={t('data-products.search.not-selected')}
+                wideList
+                wide
+            />
+            Suunnitelman raide:
+            <Dropdown
+                value={selectedAlignment}
+                getName={(item: GeometryAlignment) => item.name}
+                options={geometryAlignments.map((a) => ({ name: a.name, value: a }))}
+                onChange={setSelectedAlignment}
+            />
+            {planAlignmentId && (
+                <VerticalGeometryDiagram
+                    key={`${planAlignmentId.planId}_${planAlignmentId.alignmentId}`}
+                    alignmentId={planAlignmentId}
+                    initialStartM={0}
+                    initialEndM={10000}
+                />
+            )}
+        </div>
+    );
+};
+
+export default VerticalGeometryDiagramDemoPage;

--- a/ui/src/vertical-geometry/height-graph.tsx
+++ b/ui/src/vertical-geometry/height-graph.tsx
@@ -1,0 +1,40 @@
+import { Coordinates, heightToY, mToX } from 'vertical-geometry/coordinates';
+import { TrackKmHeights } from 'geometry/geometry-api';
+import React from 'react';
+import { polylinePoints } from 'vertical-geometry/util';
+
+interface HeightGraphProps {
+    coordinates: Coordinates;
+    kmHeights: TrackKmHeights[];
+}
+
+export const HeightGraph: React.FC<HeightGraphProps> = ({ coordinates, kmHeights }) => {
+    const lines: JSX.Element[] = [];
+    let linePoints: [number, number][] = [];
+    let lineIndex = 0;
+    const finishLineIfStarted = () => {
+        if (linePoints.length > 0) {
+            lines.push(
+                <polyline
+                    key={lineIndex++}
+                    points={polylinePoints(linePoints)}
+                    stroke="black"
+                    fill="none"
+                    strokeWidth={2}
+                />,
+            );
+            linePoints = [];
+        }
+    };
+    for (const { trackMeterHeights } of kmHeights) {
+        for (const { height, m } of trackMeterHeights) {
+            if (height == null) {
+                finishLineIfStarted();
+            } else {
+                linePoints.push([mToX(coordinates, m), heightToY(coordinates, height)]);
+            }
+        }
+    }
+    finishLineIfStarted();
+    return <>{lines}</>;
+};

--- a/ui/src/vertical-geometry/height-lines.tsx
+++ b/ui/src/vertical-geometry/height-lines.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Coordinates, heightToY } from 'vertical-geometry/coordinates';
+
+export const lineGridStrokeColor = '#999';
+// vertical guidance lines, including the top and bottom lines
+const maxVerticalTickCount = 5;
+const verticalTickLengthsMeter = [1.0, 2.0, 5.0, 10.0, 25.0];
+
+function chooseVerticalTickLength(bottomTickHeight: number, topTickHeight: number): number | null {
+    // we want to find the tick height giving the maximum number of vertical ticks that's at most the max count
+    const tickHeightIndexR = verticalTickLengthsMeter.findIndex((tickLength) => {
+        // the indices that the lowest and highest ticks would have, if we were counting up from zero by tickLength
+        // meters each time
+        const minMidTickIndex = Math.ceil((bottomTickHeight + tickLength / 2) / tickLength);
+        const maxMidTickIndex = Math.floor((topTickHeight - tickLength / 2) / tickLength);
+        return maxMidTickIndex - minMidTickIndex < maxVerticalTickCount;
+    });
+    return tickHeightIndexR == -1 ? null : verticalTickLengthsMeter[tickHeightIndexR];
+}
+
+function heightTicks(coordinates: Coordinates) {
+    const tickLength = chooseVerticalTickLength(
+        coordinates.bottomHeightTick,
+        coordinates.topHeightTick,
+    );
+    return tickLength == null
+        ? [coordinates.bottomHeightTick, coordinates.topHeightTick]
+        : (() => {
+              const firstMidTick =
+                  tickLength * Math.ceil(coordinates.bottomHeightTick / tickLength);
+              return [
+                  coordinates.bottomHeightTick,
+                  // todo: enumerateInStepsUpTo is inclusive, so we might return the top tick twice
+                  ...enumerateInStepsUpTo(firstMidTick, tickLength, coordinates.topHeightTick),
+                  coordinates.topHeightTick,
+              ];
+          })();
+}
+
+function enumerateInStepsUpTo(start: number, stepSize: number, upTo: number) {
+    const rv: number[] = [];
+    for (let x = start; x <= upTo; x += stepSize) {
+        rv.push(x);
+    }
+    return rv;
+}
+
+export interface HeightLinesProps {
+    coordinates: Coordinates;
+}
+export const HeightLabels: React.FC<HeightLinesProps> = ({ coordinates }) => (
+    <>
+        <rect
+            x={0}
+            y={20}
+            width={18}
+            height={heightToY(coordinates, coordinates.bottomHeightTick) - 20}
+            stroke="none"
+            fill="white"
+            opacity={0.9}
+        />
+        {heightTicks(coordinates).map((heightMeters, i) => {
+            const heightPx = heightToY(coordinates, heightMeters);
+            return (
+                <React.Fragment key={i}>
+                    <line
+                        key={i}
+                        x1={0}
+                        x2={20}
+                        y1={heightPx}
+                        y2={heightPx}
+                        stroke={lineGridStrokeColor}
+                        fill="none"
+                        shapeRendering="crispEdges"
+                    />
+                    <text x={0} y={heightPx - 2}>
+                        {heightMeters}
+                    </text>
+                </React.Fragment>
+            );
+        })}
+    </>
+);
+
+export const HeightLines: React.FC<HeightLinesProps> = ({ coordinates }) => (
+    <>
+        {heightTicks(coordinates).map((heightMeters, i) => {
+            const heightPx = heightToY(coordinates, heightMeters);
+            return (
+                <line
+                    key={i}
+                    x1={0}
+                    x2={coordinates.diagramWidthPx}
+                    y1={heightPx}
+                    y2={heightPx}
+                    stroke={lineGridStrokeColor}
+                    fill="none"
+                    shapeRendering="crispEdges"
+                />
+            );
+        })}
+    </>
+);

--- a/ui/src/vertical-geometry/height-lines.tsx
+++ b/ui/src/vertical-geometry/height-lines.tsx
@@ -6,6 +6,10 @@ export const lineGridStrokeColor = '#999';
 const maxVerticalTickCount = 5;
 const verticalTickLengthsMeter = [1.0, 2.0, 5.0, 10.0, 25.0];
 
+const heightLabelsBackgroundWidthPx = 18;
+// essentially, the amount of room we give the plan linking label
+const heightLabelsBackgroundStartYPx = 20;
+
 function chooseVerticalTickLength(bottomTickHeight: number, topTickHeight: number): number | null {
     // we want to find the tick height giving the maximum number of vertical ticks that's at most the max count
     const tickHeightIndexR = verticalTickLengthsMeter.findIndex((tickLength) => {
@@ -52,9 +56,12 @@ export const HeightLabels: React.FC<HeightLinesProps> = ({ coordinates }) => (
     <>
         <rect
             x={0}
-            y={20}
-            width={18}
-            height={heightToY(coordinates, coordinates.bottomHeightTick) - 20}
+            y={heightLabelsBackgroundStartYPx}
+            width={heightLabelsBackgroundWidthPx}
+            height={
+                heightToY(coordinates, coordinates.bottomHeightTick) -
+                heightLabelsBackgroundStartYPx
+            }
             stroke="none"
             fill="white"
             opacity={0.9}
@@ -66,7 +73,7 @@ export const HeightLabels: React.FC<HeightLinesProps> = ({ coordinates }) => (
                     <line
                         key={i}
                         x1={0}
-                        x2={20}
+                        x2={heightLabelsBackgroundWidthPx}
                         y1={heightPx}
                         y2={heightPx}
                         stroke={lineGridStrokeColor}

--- a/ui/src/vertical-geometry/height-tooltip.tsx
+++ b/ui/src/vertical-geometry/height-tooltip.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { SnappedPoint } from 'vertical-geometry/snapped-point';
+import { Coordinates } from 'vertical-geometry/coordinates';
+import { formatTrackMeter, formatTrackMeterWithoutMeters } from 'utils/geography-utils';
+
+interface HeightTooltipProps {
+    point: SnappedPoint;
+    elementPosition: DOMRect;
+    coordinates: Coordinates;
+}
+
+export const HeightTooltip: React.FC<HeightTooltipProps> = ({
+    point,
+    elementPosition,
+    coordinates,
+}) => {
+    const displayedAddress =
+        point.snapTarget === 'segmentBoundary' ||
+        point.snapTarget === 'geometryElement' ||
+        (point.snapTarget === 'didNotSnap' && coordinates.mMeterLengthPxOverM > 20)
+            ? formatTrackMeter(point.address)
+            : formatTrackMeterWithoutMeters(point.address);
+    return (
+        <div
+            className="vertical-geometry-diagram__tooltip"
+            style={{
+                position: 'absolute',
+                left: elementPosition.left + point.xPositionPx + 20,
+                top: elementPosition.top + point.yPositionPx + 20,
+            }}>
+            {displayedAddress}
+            <br />
+            kt=
+            {point.height.toLocaleString(undefined, {
+                maximumFractionDigits: 2,
+            })}
+        </div>
+    );
+};

--- a/ui/src/vertical-geometry/labeled-ticks.tsx
+++ b/ui/src/vertical-geometry/labeled-ticks.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { formatTrackMeterWithoutMeters } from 'utils/geography-utils';
+import { Translate } from 'vertical-geometry/translate';
+import { lineGridStrokeColor } from 'vertical-geometry/height-lines';
+import { Coordinates, mToX } from 'vertical-geometry/coordinates';
+import { TrackKmHeights } from 'geometry/geometry-api';
+
+const labeledTicksEveryNthHorizontalTick = 10;
+const labeledTickKmCounts = [1, 2, 5, 10, 25, 100, 250];
+const minimumLabeledTickDistancePx = 100;
+const minPixelsBeforeLastLabeledTickOnKm = 10;
+export interface LabeledTicksProps {
+    trackKmHeights: TrackKmHeights[];
+    coordinates: Coordinates;
+}
+
+export const LabeledTicks: React.FC<LabeledTicksProps> = ({ trackKmHeights, coordinates }) => {
+    // avoid rendering too far off the screen for performance
+    const startM = coordinates.startM - 80 / coordinates.mMeterLengthPxOverM;
+    const endM = coordinates.endM + 25 / coordinates.mMeterLengthPxOverM;
+
+    // a rough approximation assuming track kilometers are 1000 m-value meters long is fine enough here
+    const lengthOfTrackKmInPixels = 1000 * coordinates.mMeterLengthPxOverM;
+    const labelsEveryNKilometers =
+        labeledTickKmCounts.find(
+            (kmCount) => kmCount * lengthOfTrackKmInPixels > minimumLabeledTickDistancePx,
+        ) ?? labeledTickKmCounts[labeledTickKmCounts.length - 1];
+
+    return (
+        <>
+            {trackKmHeights.flatMap(({ kmNumber, trackMeterHeights }, trackKmIndex) =>
+                trackMeterHeights
+                    .filter(({ meter }) => meter % coordinates.horizontalTickLengthMeters === 0)
+                    .filter(
+                        ({ m }, i) =>
+                            trackKmIndex % labelsEveryNKilometers === 0 &&
+                            i % labeledTicksEveryNthHorizontalTick === 0 &&
+                            m > startM &&
+                            m < endM &&
+                            (i == 0 ||
+                                trackKmIndex === trackKmHeights.length - 1 ||
+                                (trackKmHeights[trackKmIndex + 1].trackMeterHeights[0].m - m) *
+                                    coordinates.mMeterLengthPxOverM >
+                                    minPixelsBeforeLastLabeledTickOnKm),
+                    )
+                    .map(({ m, meter }) => {
+                        const x = mToX(coordinates, m);
+                        return (
+                            <React.Fragment key={`${kmNumber}_${meter}`}>
+                                <Translate x={x - 25} y={280 + (meter === 0 ? 17 : 12)}>
+                                    <text scale="0.7 0.7">
+                                        KM{' '}
+                                        {formatTrackMeterWithoutMeters({
+                                            kmNumber,
+                                            meters: meter,
+                                        })}
+                                    </text>
+                                    <line y={-40} stroke="black" />
+                                </Translate>
+                                <line
+                                    x1={x}
+                                    x2={x}
+                                    y1={0}
+                                    y2={280}
+                                    stroke={lineGridStrokeColor}
+                                    fill="none"
+                                    shapeRendering="crispEdges"
+                                />
+                            </React.Fragment>
+                        );
+                    }),
+            )}
+        </>
+    );
+};

--- a/ui/src/vertical-geometry/plan-linking.tsx
+++ b/ui/src/vertical-geometry/plan-linking.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Coordinates, mToX } from 'vertical-geometry/coordinates';
+import { PlanLinkingSummaryItem } from 'geometry/geometry-api';
+
+export interface PlanLinkingProps {
+    coordinates: Coordinates;
+    planLinkingSummary: PlanLinkingSummaryItem[];
+}
+
+export const PlanLinking: React.FC<PlanLinkingProps> = ({ coordinates, planLinkingSummary }) => {
+    const textBottomYPx = 10;
+    const textDropAreaPx = 3;
+    return (
+        <>
+            {planLinkingSummary.map(({ startM, endM, filename }, i) => {
+                if (endM < coordinates.startM || startM > coordinates.endM) {
+                    return <React.Fragment key={i} />;
+                }
+                const startX = mToX(coordinates, startM);
+                const textStartX = 2 + Math.max(3, mToX(coordinates, startM));
+                const endX = mToX(coordinates, endM);
+                return (
+                    <React.Fragment key={i}>
+                        <line
+                            x1={startX}
+                            x2={startX}
+                            y1={0}
+                            y2={coordinates.fullDiagramHeightPx}
+                            stroke="black"
+                            fill="none"
+                            shapeRendering="crispEdges"
+                        />
+                        <line
+                            x1={endX}
+                            x2={endX}
+                            y1={0}
+                            y2={coordinates.fullDiagramHeightPx}
+                            stroke="black"
+                            fill="none"
+                            shapeRendering="crispEdges"
+                        />
+                        <svg
+                            x={textStartX}
+                            y={0}
+                            width={endX - textStartX}
+                            height={textBottomYPx + textDropAreaPx}>
+                            <text transform={`translate(0 ${textBottomYPx}) scale(0.7)`}>
+                                {filename}
+                            </text>
+                        </svg>
+                    </React.Fragment>
+                );
+            })}
+        </>
+    );
+};

--- a/ui/src/vertical-geometry/point-indicator.tsx
+++ b/ui/src/vertical-geometry/point-indicator.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { SnappedPoint } from 'vertical-geometry/snapped-point';
+
+export const PointIndicator: React.FC<{ point: SnappedPoint }> = ({ point }) => {
+    const roundedPoint = {
+        xPositionPx: Math.floor(point.xPositionPx) + 1,
+        yPositionPx: Math.floor(point.yPositionPx),
+    };
+    const strokeWidth = 2;
+    const strokeColor = '#004d99';
+    const crossLength = 4;
+    return (
+        <>
+            <line
+                fill="none"
+                stroke={strokeColor}
+                strokeWidth={strokeWidth}
+                shapeRendering="crispEdges"
+                x1={roundedPoint.xPositionPx - crossLength}
+                x2={roundedPoint.xPositionPx + crossLength}
+                y1={roundedPoint.yPositionPx - crossLength}
+                y2={roundedPoint.yPositionPx + crossLength}
+            />
+            <line
+                fill="none"
+                stroke={strokeColor}
+                strokeWidth={strokeWidth}
+                shapeRendering="crispEdges"
+                x1={roundedPoint.xPositionPx - crossLength}
+                x2={roundedPoint.xPositionPx + crossLength}
+                y1={roundedPoint.yPositionPx + crossLength}
+                y2={roundedPoint.yPositionPx - crossLength}
+            />
+        </>
+    );
+};

--- a/ui/src/vertical-geometry/pvi-geometry.tsx
+++ b/ui/src/vertical-geometry/pvi-geometry.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import { VerticalGeometryItem } from 'geometry/geometry-model';
+import { formatTrackMeterWithoutMeters } from 'utils/geography-utils';
+
+import { Coordinates, heightToY, mToX } from 'vertical-geometry/coordinates';
+import { TrackKmHeights } from 'geometry/geometry-api';
+import { filterNotEmpty } from 'utils/array-utils';
+import { approximateHeightAtM, polylinePoints } from 'vertical-geometry/util';
+
+const minimumSpacePxForTangentSideLabels = 10;
+const minimumSpacePxForTangentTopLabel = 8;
+
+function tangentArrow(
+    left: boolean,
+    tangentStation: number,
+    tangentHeight: number,
+    tangent: number,
+    pviAssistLineHeightPx: number,
+    pviKey: number,
+    coordinates: Coordinates,
+): JSX.Element {
+    const tangentX = mToX(coordinates, tangentStation);
+    const tangentBottomPx = heightToY(coordinates, tangentHeight);
+    const tangentTopPx = tangentBottomPx - pviAssistLineHeightPx / 1.5;
+
+    const arrowWidth = 3;
+    const arrowHeight = 3;
+
+    const arrowPoints = polylinePoints([
+        [tangentX - arrowWidth, tangentTopPx + arrowHeight],
+        [tangentX, tangentTopPx],
+        [tangentX + arrowWidth, tangentTopPx + arrowHeight],
+    ]);
+
+    return (
+        <React.Fragment key={pviKey}>
+            <line
+                x1={tangentX}
+                x2={tangentX}
+                y1={tangentBottomPx}
+                y2={tangentTopPx}
+                stroke="black"
+                fill="none"
+            />
+            <polyline points={arrowPoints} stroke="black" fill="none" />,
+            <text
+                transform={`translate (${tangentX + (left ? 10 : -4)},${
+                    tangentBottomPx - 2
+                }) rotate(-90) scale(0.7)`}>
+                {tangent.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </text>
+        </React.Fragment>
+    );
+}
+
+export interface PviGeometryProps {
+    geometry: VerticalGeometryItem[];
+    kmHeights: TrackKmHeights[];
+    coordinates: Coordinates;
+    drawTangentArrows: boolean;
+}
+
+export const PviGeometry: React.FC<PviGeometryProps> = ({
+    geometry,
+    kmHeights,
+    coordinates,
+    drawTangentArrows,
+}) => {
+    if (geometry.length == 0) {
+        return <React.Fragment />;
+    }
+    const pvis: JSX.Element[] = [];
+    const pviAssistLineHeightPx = 40;
+    let pviKey = 0;
+    const leftmostPviInViewR = geometry.findIndex((s) => s.point.station >= coordinates.startM);
+    const leftPviI = leftmostPviInViewR < 1 ? 0 : leftmostPviInViewR - 1;
+    const pastRightmostPviInViewR = geometry.findIndex((s) => s.point.station >= coordinates.endM);
+    const rightPviI = pastRightmostPviInViewR == -1 ? geometry.length - 1 : pastRightmostPviInViewR;
+    if (leftPviI === 0) {
+        const start = geometry[0];
+        pvis.push(
+            <line
+                key={pviKey++}
+                x1={mToX(
+                    coordinates,
+                    start.start.station - (start.linearSectionBackward.linearSegmentLength ?? 0),
+                )}
+                x2={mToX(coordinates, start.point.station)}
+                y1={
+                    heightToY(
+                        coordinates,
+                        start.start.height -
+                            (start.linearSectionBackward.linearSegmentLength ?? 0) *
+                                (start.start.angle ?? 0),
+                    ) - pviAssistLineHeightPx
+                }
+                y2={heightToY(coordinates, start.point.height) - pviAssistLineHeightPx}
+                stroke="black"
+                fill="none"
+            />,
+        );
+    }
+    if (rightPviI == geometry.length - 1) {
+        const end = geometry[geometry.length - 1];
+        pvis.push(
+            <line
+                key={pviKey++}
+                x1={mToX(coordinates, end.point.station)}
+                x2={mToX(
+                    coordinates,
+                    end.end.station + (end.linearSectionForward.linearSegmentLength ?? 0),
+                )}
+                y1={heightToY(coordinates, end.point.height) - pviAssistLineHeightPx}
+                y2={
+                    heightToY(
+                        coordinates,
+                        end.end.height +
+                            (end.linearSectionForward.linearSegmentLength ?? 0) *
+                                (end.end.angle ?? 0),
+                    ) - pviAssistLineHeightPx
+                }
+            />,
+        );
+    }
+    for (let i = leftPviI; i <= Math.min(rightPviI, geometry.length - 2); i++) {
+        const geo = geometry[i];
+        const nextGeo = geometry[i + 1];
+
+        const approximateAngleTextLengthPx = 100;
+        const angleTextScale = 0.7;
+        const approximateAngleTextLengthM =
+            (approximateAngleTextLengthPx / coordinates.mMeterLengthPxOverM) * angleTextScale;
+        pvis.push(
+            <line
+                key={pviKey++}
+                x1={mToX(coordinates, geo.point.station)}
+                x2={mToX(coordinates, nextGeo.point.station)}
+                y1={heightToY(coordinates, geo.point.height) - pviAssistLineHeightPx}
+                y2={heightToY(coordinates, nextGeo.point.height) - pviAssistLineHeightPx}
+                stroke="black"
+                fill="none"
+            />,
+        );
+        if (nextGeo.point.station - geo.point.station > approximateAngleTextLengthM) {
+            const midpoint = geo.point.station + (nextGeo.point.station - geo.point.station) * 0.5;
+            const angleTextStartM = midpoint - approximateAngleTextLengthM * 0.5;
+            const angleTextStartProportion =
+                (angleTextStartM - geo.point.station) / (nextGeo.point.station - geo.point.station);
+            const angleTextStartHeight =
+                (1 - angleTextStartProportion) * geo.point.height +
+                angleTextStartProportion * nextGeo.point.height;
+            const textStartX = mToX(coordinates, angleTextStartM);
+            const textStartY =
+                heightToY(coordinates, angleTextStartHeight) - pviAssistLineHeightPx - 2;
+            const radToDeg = 180 / Math.PI;
+            const aspectRatio = coordinates.meterHeightPx / coordinates.mMeterLengthPxOverM;
+            const angle =
+                geo.end.angle == null ? 0 : -Math.atan(geo.end.angle) * radToDeg * aspectRatio;
+            pvis.push(
+                <text
+                    key={pviKey++}
+                    transform={`translate(${textStartX},${textStartY}) rotate(${angle}) scale(${angleTextScale})`}>
+                    {(nextGeo.point.station - geo.point.station).toLocaleString(undefined, {
+                        maximumFractionDigits: 3,
+                    })}
+                    {' : '}
+                    {geo.end.angle?.toLocaleString(undefined, { maximumFractionDigits: 3 })}
+                </text>,
+            );
+        }
+    }
+    for (let i = leftPviI; i <= rightPviI; i++) {
+        const geo = geometry[i];
+        const x = mToX(coordinates, geo.point.station);
+        // bottomY is on the height line (unless approximateHeightAt fails for whatever reason), topY is at the PVI
+        // line
+        const bottomHeight = approximateHeightAtM(geo.point.station, kmHeights) ?? geo.point.height;
+        const bottomY = heightToY(coordinates, bottomHeight);
+        const topY = heightToY(coordinates, geo.point.height) - pviAssistLineHeightPx;
+
+        pvis.push(
+            <line key={pviKey++} x1={x} x2={x} y1={bottomY} y2={topY} stroke="black" fill="none" />,
+        );
+        const diamondHeight = 5;
+        const diamondWidth = 2;
+        const diamondPoints = polylinePoints([
+            [x, topY],
+            [x - diamondWidth, topY - diamondHeight],
+            [x, topY - 2 * diamondHeight],
+            [x + diamondWidth, topY - diamondHeight],
+            [x, topY],
+        ]);
+
+        pvis.push(<polyline key={pviKey++} points={diamondPoints} fill="black" stroke="black" />);
+
+        const minimumSpaceAroundPointPx =
+            Math.min(
+                ...[
+                    i === 0 ? null : geo.point.station - geometry[i - 1].point.station,
+                    i === geometry.length - 1
+                        ? null
+                        : geometry[i + 1].point.station - geo.point.station,
+                ].filter(filterNotEmpty),
+            ) * coordinates.mMeterLengthPxOverM;
+
+        if (minimumSpaceAroundPointPx > minimumSpacePxForTangentSideLabels) {
+            if (geo.point.address != null) {
+                pvis.push(
+                    <text
+                        key={pviKey++}
+                        transform={`translate(${x - 8},${topY - 4}) rotate(-90) scale(0.7)`}>
+                        KM {formatTrackMeterWithoutMeters(geo.point.address)}
+                    </text>,
+                );
+            }
+            pvis.push(
+                <text
+                    key={pviKey++}
+                    transform={`translate(${x + 10},${bottomY - 4}) rotate(-90) scale(0.7)`}>
+                    kt={geo.point.height.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+                </text>,
+            );
+        }
+        if (minimumSpaceAroundPointPx > minimumSpacePxForTangentTopLabel) {
+            pvis.push(
+                <text
+                    key={pviKey++}
+                    transform={`translate(${x + diamondWidth},${
+                        topY - diamondHeight - 10
+                    }) rotate(-90) scale(0.6)`}>
+                    S={geo.radius}
+                </text>,
+            );
+        }
+        if (geo.tangent !== null && drawTangentArrows) {
+            pvis.push(
+                tangentArrow(
+                    true,
+                    geo.start.station,
+                    geo.start.height,
+                    geo.tangent,
+                    pviAssistLineHeightPx,
+                    pviKey++,
+                    coordinates,
+                ),
+            );
+            pvis.push(
+                tangentArrow(
+                    false,
+                    geo.end.station,
+                    geo.end.height,
+                    geo.tangent,
+                    pviAssistLineHeightPx,
+                    pviKey++,
+                    coordinates,
+                ),
+            );
+        }
+    }
+    return <>{pvis}</>;
+};

--- a/ui/src/vertical-geometry/pvi-geometry.tsx
+++ b/ui/src/vertical-geometry/pvi-geometry.tsx
@@ -6,6 +6,7 @@ import { Coordinates, heightToY, mToX } from 'vertical-geometry/coordinates';
 import { TrackKmHeights } from 'geometry/geometry-api';
 import { filterNotEmpty } from 'utils/array-utils';
 import { approximateHeightAtM, polylinePoints } from 'vertical-geometry/util';
+import { radsToDegrees } from 'utils/math-utils';
 
 const minimumSpacePxForTangentSideLabels = 10;
 const minimumSpacePxForTangentTopLabel = 8;
@@ -152,10 +153,9 @@ export const PviGeometry: React.FC<PviGeometryProps> = ({
             const textStartX = mToX(coordinates, angleTextStartM);
             const textStartY =
                 heightToY(coordinates, angleTextStartHeight) - pviAssistLineHeightPx - 2;
-            const radToDeg = 180 / Math.PI;
             const aspectRatio = coordinates.meterHeightPx / coordinates.mMeterLengthPxOverM;
             const angle =
-                geo.end.angle == null ? 0 : -Math.atan(geo.end.angle) * radToDeg * aspectRatio;
+                geo.end.angle == null ? 0 : radsToDegrees(-Math.atan(geo.end.angle) * aspectRatio);
             pvis.push(
                 <text
                     key={pviKey++}

--- a/ui/src/vertical-geometry/snapped-point.ts
+++ b/ui/src/vertical-geometry/snapped-point.ts
@@ -1,0 +1,200 @@
+import { TrackMeter } from 'common/common-model';
+import {
+    findTrackMeterIndexContainingM,
+    getTrackAddressAtSingleIndex,
+    getTrackMeterPairAroundIndex,
+    TrackMeterIndex,
+} from 'vertical-geometry/track-meter-index';
+import { StationPoint, VerticalGeometryItem } from 'geometry/geometry-model';
+import { filterNotEmpty, minimumIndexBy } from 'utils/array-utils';
+import { Coordinates, heightToY, mToX, xToM } from 'vertical-geometry/coordinates';
+import { TrackKmHeights } from 'geometry/geometry-api';
+import { approximateHeightAt } from 'vertical-geometry/util';
+
+export type SnapTarget =
+    | 'trackMeterRulerTick'
+    | 'segmentBoundary'
+    | 'geometryElement'
+    | 'didNotSnap';
+
+export interface SnappedPoint {
+    snapTarget: SnapTarget;
+    m: number;
+    xPositionPx: number;
+    yPositionPx: number;
+    height: number;
+    address: TrackMeter;
+}
+
+function getSnapOverRuler(
+    xCoordinateM: number,
+    trackKmHeights: TrackKmHeights[],
+    onScreen: (snappedM: number) => boolean,
+    approximatedPoint: (
+        maybeApproximateM: number,
+    ) => null | { address: TrackMeter | null; height: number | null },
+): { address: TrackMeter | null; m: number; snapTarget: SnapTarget; height: number | null } {
+    const closest = closestRulerTickM(xCoordinateM, trackKmHeights);
+    if (closest == null || !onScreen(closest.m)) {
+        const approximated = approximatedPoint(xCoordinateM);
+        return {
+            snapTarget: 'didNotSnap',
+            m: xCoordinateM,
+            height: approximated?.height ?? null,
+            address: approximated?.address ?? null,
+        };
+    } else {
+        const address = getTrackAddressAtSingleIndex(closest.index, trackKmHeights);
+        return {
+            snapTarget:
+                address.meters === Math.floor(address.meters)
+                    ? 'trackMeterRulerTick'
+                    : 'segmentBoundary',
+            m: closest.m,
+            address: getTrackAddressAtSingleIndex(closest.index, trackKmHeights),
+            height: approximateHeightAt(closest.m, closest.interval, trackKmHeights),
+        };
+    }
+}
+
+function getSnapOverChart(
+    xCoordinateM: number,
+    geometry: VerticalGeometryItem[],
+    withinSnapDistance: (snappedM: number) => boolean,
+    approximatedPoint: (
+        maybeApproximateM: number,
+    ) => null | { address: TrackMeter | null; height: number | null },
+    drawTangents: boolean,
+): { address: TrackMeter | null; m: number; snapTarget: SnapTarget; height: number | null } {
+    const closest = closestGeometrySnapPoint(xCoordinateM, geometry, drawTangents);
+    if (closest == null || !withinSnapDistance(closest.m)) {
+        const approximated = approximatedPoint(xCoordinateM);
+        return {
+            snapTarget: 'didNotSnap',
+            m: xCoordinateM,
+            height: approximated?.height ?? null,
+            address: approximated?.address ?? null,
+        };
+    }
+
+    const height =
+        closest.type === 'intersectionPoint'
+            ? approximatedPoint(closest.m)?.height ?? closest.height
+            : closest.height;
+    return {
+        snapTarget: 'geometryElement',
+        height,
+        address: closest.address,
+        m: closest.m,
+    };
+}
+
+export function getSnappedPoint(
+    mousePositionInElement: [number, number] | null,
+    trackKmHeights: TrackKmHeights[],
+    geometry: VerticalGeometryItem[],
+    coordinates: Coordinates,
+    drawTangentArrows: boolean,
+): SnappedPoint | null {
+    if (mousePositionInElement == null) {
+        return null;
+    }
+    const [mouseX, mouseY] = mousePositionInElement;
+    const mouseCursorOverArea = mouseY > coordinates.chartHeightPx ? 'ruler' : 'chart';
+    const xCoordinateM = xToM(coordinates, mouseX);
+    const maxSnapDistanceOnChartM = coordinates.horizontalTickLengthMeters / 2;
+
+    const approximatedPoint = (maybeApproximateM: number) => {
+        const kmIndex = findTrackMeterIndexContainingM(maybeApproximateM, trackKmHeights);
+        if (kmIndex == null) {
+            return null;
+        }
+        const height = approximateHeightAt(maybeApproximateM, kmIndex, trackKmHeights);
+        const address = approximateTrackAddressAt(maybeApproximateM, kmIndex, trackKmHeights);
+
+        return { height, address };
+    };
+
+    const onScreen = (snappedM: number) =>
+        snappedM >= coordinates.startM && snappedM <= coordinates.endM;
+    const withinSnapDistance = (snappedM: number) =>
+        Math.abs(snappedM - xCoordinateM) <= maxSnapDistanceOnChartM && onScreen(snappedM);
+
+    const { snapTarget, height, address, m } =
+        mouseCursorOverArea === 'ruler'
+            ? getSnapOverRuler(xCoordinateM, trackKmHeights, onScreen, approximatedPoint)
+            : (() => {
+                  return getSnapOverChart(
+                      xCoordinateM,
+                      geometry,
+                      withinSnapDistance,
+                      approximatedPoint,
+                      drawTangentArrows,
+                  );
+              })();
+
+    if (height == null || address == null) {
+        return null;
+    }
+
+    const x = mToX(coordinates, m);
+    const y = heightToY(coordinates, height);
+
+    return { snapTarget, m, xPositionPx: x, yPositionPx: y, height, address };
+}
+
+function toGeometrySnapPoint(stationPoint: StationPoint, type: 'intersectionPoint' | 'endPoint') {
+    return stationPoint.address == null
+        ? null
+        : {
+              m: stationPoint.station,
+              height: stationPoint.height,
+              address: stationPoint.address,
+              type,
+          };
+}
+function closestGeometrySnapPoint(
+    m: number,
+    geometry: VerticalGeometryItem[],
+    drawTangents: boolean,
+) {
+    const allGeometryPoints = geometry.flatMap((geom) =>
+        [
+            toGeometrySnapPoint(geom.point, 'intersectionPoint'),
+            drawTangents ? toGeometrySnapPoint(geom.start, 'endPoint') : null,
+            drawTangents ? toGeometrySnapPoint(geom.end, 'endPoint') : null,
+        ].filter(filterNotEmpty),
+    );
+    const minIndex = minimumIndexBy(allGeometryPoints, (snapPoint) => Math.abs(m - snapPoint.m));
+    return minIndex == null ? null : allGeometryPoints[minIndex];
+}
+
+function closestRulerTickM(m: number, trackKmHeights: TrackKmHeights[]) {
+    const index = findTrackMeterIndexContainingM(m, trackKmHeights);
+    if (index == null) {
+        return null;
+    }
+    const [left, right] = getTrackMeterPairAroundIndex(index, trackKmHeights);
+    return Math.abs(m - left.m) < Math.abs(m - right.m)
+        ? { m: left.m, index: index.left, interval: index }
+        : { m: right.m, index: index.right, interval: index };
+}
+
+function approximateTrackAddressAt(
+    m: number,
+    index: TrackMeterIndex,
+    kmHeights: TrackKmHeights[],
+): TrackMeter | null {
+    const [leftMeter, rightMeter] = getTrackMeterPairAroundIndex(index, kmHeights);
+    const leftKm = kmHeights[index.left.kmIndex];
+    const proportion = (m - leftMeter.m) / (rightMeter.m - leftMeter.m);
+    return {
+        kmNumber: leftKm.kmNumber,
+        meters:
+            index.left.kmIndex === index.right.kmIndex
+                ? leftMeter.meter + proportion * (rightMeter.meter - leftMeter.meter)
+                : // we can't accurately know the length of the last track meter in track address space, so let's just
+                  // extrapolate based on assuming we're parallel with the reference line
+                  leftMeter.meter + proportion,
+    };
+}

--- a/ui/src/vertical-geometry/track-address-ruler.tsx
+++ b/ui/src/vertical-geometry/track-address-ruler.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Coordinates, mToX } from 'vertical-geometry/coordinates';
+import { TrackKmHeights } from 'geometry/geometry-api';
+
+export interface TrackAddressRulerProps {
+    kmHeights: TrackKmHeights[];
+    heightPx: number;
+    coordinates: Coordinates;
+}
+
+export const TrackAddressRuler: React.FC<TrackAddressRulerProps> = ({
+    kmHeights,
+    heightPx,
+    coordinates,
+}) => {
+    if (kmHeights.length === 0) {
+        return <React.Fragment />;
+    }
+    const kmPostMarkers = kmHeights.map(({ trackMeterHeights }, kmIndex) => (
+        <circle
+            key={kmIndex}
+            cx={mToX(coordinates, trackMeterHeights[0].m)}
+            cy={heightPx}
+            r={5}
+            stroke={'black'}
+        />
+    ));
+
+    // avoid rendering too far off the screen for performance
+    const startM = coordinates.startM - 5 / coordinates.mMeterLengthPxOverM;
+    const endM = coordinates.endM + 5 / coordinates.mMeterLengthPxOverM;
+
+    const ticks = kmHeights.map((kmHeight, i) => {
+        return kmHeight.trackMeterHeights
+            .filter(({ m }) => m > startM && m < endM)
+            .map(({ m, height }, mi) => {
+                const tickX = mToX(coordinates, m);
+                return (
+                    <g transform={`translate(${tickX} ${heightPx})`} key={`tick_${i}_${mi}`}>
+                        <line y2={-5} stroke={'black'} />
+                        {height && (
+                            <text transform={`translate(3 -6) scale(0.7) rotate(-90)`}>
+                                {height.toLocaleString('fi', { maximumFractionDigits: 2 })}
+                            </text>
+                        )}
+                    </g>
+                );
+            });
+    });
+
+    return (
+        <>
+            {ticks}
+            {kmPostMarkers}
+            <line
+                x1={0}
+                x2={coordinates.diagramWidthPx}
+                y1={heightPx}
+                y2={heightPx}
+                stroke="black"
+                fill="none"
+                shapeRendering="crispEdges"
+            />
+        </>
+    );
+};

--- a/ui/src/vertical-geometry/track-meter-index.ts
+++ b/ui/src/vertical-geometry/track-meter-index.ts
@@ -1,0 +1,81 @@
+import { TrackMeter } from 'common/common-model';
+import { TrackKmHeights, TrackMeterHeight } from 'geometry/geometry-api';
+
+export interface SingleTrackMeterIndex {
+    kmIndex: number;
+    meterIndex: number;
+}
+
+// Track meter indices turn out to be used for interpolation between adjacent points almost constantly; so we bite the
+// bullet and look up both the left and right side of the two adjacent points we might see
+export interface TrackMeterIndex {
+    left: SingleTrackMeterIndex;
+    right: SingleTrackMeterIndex;
+}
+
+export function findTrackMeterIndexContainingM(
+    m: number,
+    kmHeights: TrackKmHeights[],
+): TrackMeterIndex | null {
+    const nextKmIndex = kmHeights.findIndex(({ trackMeterHeights }) => trackMeterHeights[0].m > m);
+    if (nextKmIndex === 0) {
+        return null;
+    }
+    const kmIndex = nextKmIndex === -1 ? kmHeights.length - 1 : nextKmIndex - 1;
+    const km = kmHeights[kmIndex];
+    const meterIndex = km.trackMeterHeights.findIndex((trackM) => trackM.m >= m);
+    // if this the last track km on the alignment, then the last track meter is a sentinel sent by the backend to mark
+    // the alignment's end, and can be considered to have zero length; hence, if we're past it, we've fallen past the
+    // alignment
+    if (kmIndex == kmHeights.length - 1 && meterIndex == -1) {
+        return null;
+    }
+    // otherwise, meterIndex will be -1 exactly if we were on a track km's last meter
+    const right =
+        meterIndex == -1 ? { kmIndex: kmIndex + 1, meterIndex: 0 } : { kmIndex, meterIndex };
+
+    const left = previousSingleTrackMeterIndex(right, kmHeights);
+    return left == null ? null : { left, right };
+}
+
+function previousSingleTrackMeterIndex(
+    { kmIndex, meterIndex }: SingleTrackMeterIndex,
+    kmHeights: TrackKmHeights[],
+): SingleTrackMeterIndex | null {
+    if (meterIndex == 0 && kmIndex == 0) {
+        return null;
+    } else if (meterIndex == 0) {
+        return {
+            kmIndex: kmIndex - 1,
+            meterIndex: kmHeights[kmIndex - 1].trackMeterHeights.length - 1,
+        };
+    } else {
+        return { kmIndex, meterIndex: meterIndex - 1 };
+    }
+}
+
+export function getTrackAddressAtSingleIndex(
+    index: SingleTrackMeterIndex,
+    kmHeights: TrackKmHeights[],
+): TrackMeter {
+    const kmNumber = kmHeights[index.kmIndex].kmNumber;
+    const meters = getTrackMeterAtSingleIndex(index, kmHeights).meter;
+    return { kmNumber, meters };
+}
+
+export function getTrackMeterAtSingleIndex(
+    { kmIndex, meterIndex }: SingleTrackMeterIndex,
+    kmHeights: TrackKmHeights[],
+) {
+    return kmHeights[kmIndex].trackMeterHeights[meterIndex];
+}
+
+export function getTrackMeterPairAroundIndex(
+    { left, right }: TrackMeterIndex,
+    kmHeights: TrackKmHeights[],
+): [TrackMeterHeight, TrackMeterHeight] {
+    return [
+        getTrackMeterAtSingleIndex(left, kmHeights),
+        getTrackMeterAtSingleIndex(right, kmHeights),
+    ];
+}

--- a/ui/src/vertical-geometry/translate.tsx
+++ b/ui/src/vertical-geometry/translate.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export interface TranslateProps {
+    x?: number;
+    y?: number;
+}
+
+export const Translate: React.FC<TranslateProps> = ({ x, y, children }) =>
+    x === undefined && y === undefined ? (
+        <>{children}</>
+    ) : (
+        <g transform={`translate(${x ?? 0},${y ?? 0})`}>{children}</g>
+    );

--- a/ui/src/vertical-geometry/util.ts
+++ b/ui/src/vertical-geometry/util.ts
@@ -1,0 +1,36 @@
+import { TrackKmHeights } from 'geometry/geometry-api';
+import {
+    findTrackMeterIndexContainingM,
+    getTrackMeterPairAroundIndex,
+    TrackMeterIndex,
+} from 'vertical-geometry/track-meter-index';
+
+export function approximateHeightAtM(m: number, kmHeights: TrackKmHeights[]): number | null {
+    const index = findTrackMeterIndexContainingM(m, kmHeights);
+    if (index == null) {
+        return null;
+    }
+    return approximateHeightAt(m, index, kmHeights);
+}
+
+export function approximateHeightAt(
+    m: number,
+    index: TrackMeterIndex,
+    kmHeights: TrackKmHeights[],
+): number | null {
+    const [leftMeter, rightMeter] = getTrackMeterPairAroundIndex(index, kmHeights);
+    // We don't try to extrapolate heights; this is why the back-end puts in some extra effort to make sure to send
+    // heights to cover all intervals where we might want to display heights (and hence can always interpolate)
+    if (rightMeter.height == null) {
+        return leftMeter.height;
+    }
+    if (leftMeter.height == null) {
+        return rightMeter.height;
+    }
+    const proportion = (m - leftMeter.m) / (rightMeter.m - leftMeter.m);
+    return (1 - proportion) * leftMeter.height + proportion * rightMeter.height;
+}
+
+export function polylinePoints(points: readonly (readonly [number, number])[]): string {
+    return points.map(([x, y]) => `${x},${y}`).join(' ');
+}

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.scss
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.scss
@@ -1,0 +1,16 @@
+@import '../vayla-design-lib/colors';
+@import '../vayla-design-lib/shadows';
+
+.vertical-geometry-diagram {
+    cursor: grab;
+    &__panning {
+        cursor: grabbing;
+    }
+}
+
+.vertical-geometry-diagram__tooltip {
+    background: $color-white-darker;
+    color: $color-black-default;
+    border-radius: 2px;
+    padding: 4px 8px;
+}

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -1,0 +1,325 @@
+import React, { MouseEvent, useMemo, useRef, useState, WheelEvent } from 'react';
+import { PublishType } from 'common/common-model';
+import { useLoader } from 'utils/react-utils';
+import { GeometryAlignmentId, GeometryPlanId, VerticalGeometryItem } from 'geometry/geometry-model';
+import {
+    AlignmentHeights,
+    getGeometryPlanVerticalGeometry,
+    getLocationTrackHeights,
+    getLocationTrackVerticalGeometry,
+    getPlanAlignmentHeights,
+    TrackKmHeights,
+} from 'geometry/geometry-api';
+import styles from './vertical-geometry-diagram.scss';
+import { Translate } from 'vertical-geometry/translate';
+import { TrackAddressRuler } from 'vertical-geometry/track-address-ruler';
+import { HeightLabels, HeightLines } from 'vertical-geometry/height-lines';
+import { PviGeometry } from 'vertical-geometry/pvi-geometry';
+import { LabeledTicks } from 'vertical-geometry/labeled-ticks';
+import { LocationTrackId } from 'track-layout/track-layout-model';
+import { debounceAsync } from 'utils/async-utils';
+import { PlanLinking } from 'vertical-geometry/plan-linking';
+import { getSnappedPoint } from 'vertical-geometry/snapped-point';
+import { Coordinates } from 'vertical-geometry/coordinates';
+import { PointIndicator } from 'vertical-geometry/point-indicator';
+import { HeightGraph } from 'vertical-geometry/height-graph';
+import { HeightTooltip } from 'vertical-geometry/height-tooltip';
+
+const maxHorizontalTickDensity = 100;
+const diagramWidthPx = 1200;
+const chartHeightPx = 240;
+const topHeightPaddingPx = 120;
+const bottomHeightPaddingPx = 0;
+const fullDiagramHeightPx = 300;
+const minimumPixelWidthToDrawTangentArrows = 0.05;
+
+// units of track meter distance; but the tick length is chosen based on m-value distances, so curved side tracks can
+// stretch or shrink on the diagram
+// values beyond 1000 don't make much sense, as the backend returns at least a starting tick for each track kilometer
+// in order to keep in sync with track addressing
+// values have to be integers for backend implementation simplicity
+const horizontalTickLengthsMeters = [1000, 500, 250, 100, 50, 25, 10, 5, 2, 1];
+
+type VerticalGeometryDiagramAlignmentId =
+    | { planId: GeometryPlanId; alignmentId: GeometryAlignmentId }
+    | { locationTrackId: LocationTrackId; publishType: PublishType };
+
+interface VerticalGeometryDiagramProps {
+    alignmentId: VerticalGeometryDiagramAlignmentId;
+    initialStartM: number;
+    initialEndM: number;
+}
+
+function chooseHorizontalTickLengthMeters(distanceMeters: number): number {
+    const firstTooDenseIndex = horizontalTickLengthsMeters.findIndex(
+        (widthM) => distanceMeters / widthM > maxHorizontalTickDensity,
+    );
+    return firstTooDenseIndex == -1
+        ? horizontalTickLengthsMeters[horizontalTickLengthsMeters.length - 1]
+        : horizontalTickLengthsMeters[Math.max(0, firstTooDenseIndex - 1)];
+}
+
+// we don't really need the station values in the plan geometry for anything in this entire diagram
+function substituteLayoutStationsForGeometryStations(
+    geometryItem: VerticalGeometryItem,
+): VerticalGeometryItem {
+    return {
+        ...geometryItem,
+        start: {
+            ...geometryItem.start,
+            station: geometryItem.layoutStartStation ?? geometryItem.start.station,
+        },
+        point: {
+            ...geometryItem.point,
+            station: geometryItem.layoutPointStation ?? geometryItem.point.station,
+        },
+        end: {
+            ...geometryItem.end,
+            station: geometryItem.layoutEndStation ?? geometryItem.end.station,
+        },
+    };
+}
+
+function minAndMaxHeights(
+    kmHeights: TrackKmHeights[],
+    geometry: VerticalGeometryItem[],
+): [number, number] {
+    if (kmHeights.length !== 0) {
+        return kmHeights
+            .flatMap(({ trackMeterHeights }) => trackMeterHeights.map(({ height }) => height))
+            .reduce(
+                ([min, max], height) => [
+                    Math.min(min, height ?? min),
+                    Math.max(max, height ?? max),
+                ],
+                [1 / 0, -1 / 0],
+            );
+    } else {
+        // fallback approximation for when we want to display a part of track that does have a PVI aid line going
+        // through it, but no plan linkage and hence no heights
+        return geometry
+            .flatMap((p) => [p.start.height, p.point.height, p.end.height])
+            .reduce(
+                ([min, max], height) => [Math.min(min, height), Math.max(max, height)],
+                [1 / 0, -1 / 0],
+            );
+    }
+}
+
+function loadAlignmentHeights(
+    alignmentId: VerticalGeometryDiagramAlignmentId,
+    startM: number,
+    endM: number,
+    horizontalTickLengthMeters: number,
+): Promise<AlignmentHeights> {
+    return 'planId' in alignmentId
+        ? getPlanAlignmentHeights(
+              alignmentId.planId,
+              alignmentId.alignmentId,
+              startM,
+              endM,
+              horizontalTickLengthMeters,
+          )
+        : getLocationTrackHeights(
+              alignmentId.locationTrackId,
+              alignmentId.publishType,
+              startM,
+              endM,
+              horizontalTickLengthMeters,
+          );
+}
+
+function loadGeometry(
+    alignmentId:
+        | { planId: GeometryPlanId; alignmentId: GeometryAlignmentId }
+        | { locationTrackId: LocationTrackId; publishType: PublishType },
+): Promise<VerticalGeometryItem[] | null | undefined> {
+    return 'planId' in alignmentId
+        ? getGeometryPlanVerticalGeometry(alignmentId.planId).then((allPlanGeometries) =>
+              allPlanGeometries?.filter((vgl) => vgl.alignmentId == alignmentId.alignmentId),
+          )
+        : getLocationTrackVerticalGeometry(alignmentId.locationTrackId, undefined, undefined).then(
+              (geometry) =>
+                  geometry == null
+                      ? null
+                      : geometry.map(substituteLayoutStationsForGeometryStations),
+          );
+}
+
+const VerticalGeometryDiagramBase: React.FC<VerticalGeometryDiagramProps> = ({
+    initialStartM,
+    initialEndM,
+    alignmentId,
+}) => {
+    const ref = useRef<HTMLDivElement>(null);
+    /**
+     startM and endM are the endpoints of the visible parts of the diagram, in m-values (not necessarily hitting the
+     m-values of actual points on the alignment)
+     */
+    const [startM, setStartM] = useState(initialStartM);
+    const [endM, setEndM] = useState(initialEndM);
+    /**
+     panning is the X pixel value where our last panning movement started, or null if we're not currently panning
+     */
+    const [panning, setPanning] = useState<null | number>(null);
+    const [mousePositionInElement, setMousePositionInElement] = useState<null | [number, number]>(
+        null,
+    );
+    const horizontalTickLengthMeters = chooseHorizontalTickLengthMeters(endM - startM);
+
+    const debouncedLoadAlignmentHeights = useMemo(
+        () => debounceAsync(loadAlignmentHeights, 250),
+        [alignmentId],
+    );
+
+    const alignmentHeights = useLoader(
+        () => debouncedLoadAlignmentHeights(alignmentId, startM, endM, horizontalTickLengthMeters),
+        [alignmentId, startM, endM, horizontalTickLengthMeters],
+    );
+
+    const geometry = useLoader(() => loadGeometry(alignmentId), [alignmentId]);
+
+    if (alignmentHeights == undefined || geometry == undefined) {
+        return <svg width={diagramWidthPx} height={fullDiagramHeightPx} />;
+    }
+    if (
+        geometry.length == 0 &&
+        !alignmentHeights.kmHeights.some((km) => km.trackMeterHeights.some((h) => h.height != null))
+    ) {
+        return <>(ei korkeuksia raiteella)</>;
+    }
+
+    const { kmHeights, alignmentStartM, alignmentEndM, linkingSummary } = alignmentHeights;
+    const mMeterLengthPxOverM = diagramWidthPx / (endM - startM);
+
+    const [minHeight, maxHeight] = minAndMaxHeights(kmHeights, geometry);
+
+    const topHeightTick = Math.ceil(maxHeight);
+    const bottomHeightTick = Math.floor(minHeight);
+    const meterHeightPx =
+        (chartHeightPx - topHeightPaddingPx + bottomHeightPaddingPx) /
+        (topHeightTick - bottomHeightTick);
+
+    const coordinates: Coordinates = {
+        bottomHeightPaddingPx,
+        topHeightTick,
+        bottomHeightTick,
+        chartHeightPx,
+        meterHeightPx,
+        mMeterLengthPxOverM,
+        diagramWidthPx,
+        endM,
+        fullDiagramHeightPx,
+        startM,
+        horizontalTickLengthMeters,
+    };
+
+    const onMouseMove: React.EventHandler<MouseEvent<unknown>> = (e: MouseEvent<SVGSVGElement>) => {
+        const elementBounds = ref.current?.getBoundingClientRect();
+        if (elementBounds == null) {
+            return;
+        }
+        setMousePositionInElement([e.clientX - elementBounds.x, e.clientY - elementBounds.y]);
+        if (!panning) {
+            return;
+        }
+        const requestedPanDistance = (panning - e.clientX) / mMeterLengthPxOverM;
+        const panDistance = Math.min(
+            alignmentEndM - endM,
+            Math.max(alignmentStartM - startM, requestedPanDistance),
+        );
+
+        setStartM(startM + panDistance);
+        setEndM(endM + panDistance);
+        setPanning(e.clientX);
+    };
+
+    const onWheel: React.EventHandler<WheelEvent<unknown>> = (e) => {
+        const elementLeft = ref.current?.getBoundingClientRect()?.x;
+        if (elementLeft == null) {
+            return;
+        }
+        const focusM = (e.clientX - elementLeft) / mMeterLengthPxOverM + startM;
+        // downward should zoom out (push startM/endM further out), upward should zoom in
+        // upward = negative delta
+        const factor = Math.pow(1.05, e.deltaY * 0.01);
+        const leftDistanceM = startM - focusM;
+        const rightDistanceM = endM - focusM;
+        const newStartM = Math.max(
+            alignmentStartM,
+            startM - leftDistanceM + factor * leftDistanceM,
+        );
+        const newEndM = Math.min(alignmentEndM, endM - rightDistanceM + factor * rightDistanceM);
+
+        setStartM(newStartM);
+        setEndM(newEndM);
+    };
+
+    const drawTangentArrows =
+        coordinates.mMeterLengthPxOverM > minimumPixelWidthToDrawTangentArrows;
+    const snap = getSnappedPoint(
+        mousePositionInElement,
+        kmHeights,
+        geometry,
+        coordinates,
+        drawTangentArrows,
+    );
+
+    const elementPosition = ref.current?.getBoundingClientRect();
+
+    return (
+        <div
+            style={{ width: diagramWidthPx, height: fullDiagramHeightPx }}
+            ref={ref}
+            onMouseDown={(e) => {
+                e.preventDefault();
+                setPanning(e.clientX);
+            }}
+            onMouseUp={() => setPanning(null)}
+            onMouseMove={onMouseMove}
+            onMouseLeave={() => {
+                setPanning(null);
+                setMousePositionInElement(null);
+            }}
+            onWheel={onWheel}>
+            {snap && elementPosition && (
+                <HeightTooltip
+                    point={snap}
+                    elementPosition={elementPosition}
+                    coordinates={coordinates}
+                />
+            )}
+            <svg
+                className={`${styles['vertical-geometry-diagram']} ${
+                    panning != null && styles['vertical-geometry-diagram__panning']
+                }`}
+                viewBox="0 0 1200 300"
+                width={diagramWidthPx}
+                height={fullDiagramHeightPx}>
+                <HeightLines coordinates={coordinates} />
+                <LabeledTicks trackKmHeights={kmHeights} coordinates={coordinates} />
+                {'locationTrackId' in alignmentId && (
+                    <PlanLinking coordinates={coordinates} planLinkingSummary={linkingSummary} />
+                )}
+                <HeightGraph coordinates={coordinates} kmHeights={kmHeights} />
+                <PviGeometry
+                    geometry={geometry}
+                    kmHeights={kmHeights}
+                    coordinates={coordinates}
+                    drawTangentArrows={drawTangentArrows}
+                />
+                <HeightLabels coordinates={coordinates} />
+                <Translate x={0} y={240}>
+                    <TrackAddressRuler
+                        kmHeights={kmHeights}
+                        heightPx={40}
+                        coordinates={coordinates}
+                    />
+                </Translate>
+                {snap && <PointIndicator point={snap} />}
+            </svg>
+        </div>
+    );
+};
+
+export const VerticalGeometryDiagram = React.memo(VerticalGeometryDiagramBase);


### PR DESCRIPTION
Koodikasa. Tämä tuo siis nyt ensimmäisen version korkeuskaavion fronttipuolesta, ja väliaikaisen vain devissä näkyvän sivun, jolla kokeilla eri alignmenttien (paikannuspohja- ja geometriapuolelta) lataamista ja näyttämistä.

Tärkeimmät konseptit koodin lukuun:
- Kaikki on ihan vaan puhdasta SVG:tä (ja vähän perinteistä HTML:ääkin) käsittelevää React-koodia
- Koordinaatisto on pikseleitä tai ainakin jotain pikselinoloisia otuksia SVG:n viewboxin määrittelemässä avaruudessa
- Kaikki oliot asetellaan leveysakselille m-arvon mukaan; konversioita m-arvojen ja pikseliarvojen välillä tapahtuu ehkä vielä vähän liian monessa paikassa
- SVG:n piirtäminen menee maalarin algoritmilla, eli jokainen uusi elementti piirtyy aina entisten päälle; elementtien järjestyksellä on tällä tavalla väliä

Käytännössä aika moni kohta menee saatesanoilla "aion vielä säätää", mutta isompia huomioita törkeyksistä otetaan mielellään vastaan.