### PR TITLE
GVT-1834: Puuttuvan pystygeometrian korostuksen suorituskykyongelmat

### DIFF
--- a/ui/src/map/layers/alignment-layer.ts
+++ b/ui/src/map/layers/alignment-layer.ts
@@ -27,7 +27,7 @@ import {
 import { getTrackNumbers } from 'track-layout/layout-track-number-api';
 import {
     getAlignmentsByTiles,
-    getAlignmentSectionsWithoutProfile,
+    getAlignmentSectionsWithoutProfileByTiles,
 } from 'track-layout/layout-map-api';
 import {
     addBbox,
@@ -49,7 +49,6 @@ import { getMaxTimestamp } from 'utils/date-utils';
 import { Coordinate } from 'ol/coordinate';
 import { State } from 'ol/render';
 import { GeometryPlanId } from 'geometry/geometry-model';
-import { combineBoundingBoxes } from 'model/geometry';
 import { ChangeTimes } from 'common/common-slice';
 
 export const FEATURE_PROPERTY_SEGMENT_DATA = 'segment-data';
@@ -611,9 +610,10 @@ adapterInfoRegister.add('alignment', {
         );
         const trackNumbersFetch = getTrackNumbers(publishType, changeTimes.layoutTrackNumber);
         const alignmentSectionsWithoutProfile = mapLayer.showMissingVerticalGeometry
-            ? getAlignmentSectionsWithoutProfile(
+            ? getAlignmentSectionsWithoutProfileByTiles(
+                  changeTimes.layoutLocationTrack,
                   publishType,
-                  combineBoundingBoxes(mapTiles.map((tile) => tile.area)),
+                  mapTiles,
               )
             : Promise.resolve<AlignmentHighlight[] | null>(null);
         Promise.all([alignmentsFetch, trackNumbersFetch, alignmentSectionsWithoutProfile])

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -1,7 +1,7 @@
 import { asyncCache } from 'cache/cache';
 import { AlignmentHighlight, MapTile } from 'map/map-model';
 import { AlignmentId, LocationTrackId, MapAlignment, MapAlignmentType } from './track-layout-model';
-import { API_URI, getIgnoreError, getThrowError, getWithDefault, queryParams } from 'api/api-fetch';
+import { API_URI, getThrowError, getWithDefault, queryParams } from 'api/api-fetch';
 import { BoundingBox, combineBoundingBoxes, Point } from 'model/geometry';
 import { MAP_RESOLUTION_MULTIPLIER } from 'map/layers/layer-visibility-limits';
 import { getChangeTimes } from 'common/change-time-api';
@@ -12,10 +12,12 @@ import { getGeometryAlignmentLayout } from 'geometry/geometry-api';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
 import { createLinkPoints } from 'linking/linking-store';
+import { filterNotEmpty } from 'utils/array-utils';
 
 const locationTrackEndsCache = asyncCache<string, MapAlignment>();
 const referenceLineEndsCache = asyncCache<string, MapAlignment>();
 const alignmentTilesCache = asyncCache<string, MapAlignment[]>();
+const sectionsWithoutProfileCache = asyncCache<string, AlignmentHighlight[]>();
 
 export const GEOCODING_URI = `${API_URI}/geocoding`;
 
@@ -60,15 +62,32 @@ export async function getAlignmentsByTiles(
     ).flat();
 }
 
-export async function getAlignmentSectionsWithoutProfile(
+export async function getAlignmentSectionsWithoutProfileByTile(
+    changeTime: TimeStamp,
     publishType: PublishType,
-    bbox: BoundingBox,
+    mapTile: MapTile,
 ): Promise<AlignmentHighlight[] | null> {
-    return await getIgnoreError(
-        `${mapUri('alignments', publishType)}/without-profile${queryParams({
-            bbox: bboxString(bbox),
-        })}`,
+    const tileKey = `${mapTile.id}_${publishType}}`;
+    return sectionsWithoutProfileCache.get(changeTime, tileKey, () =>
+        getWithDefault<AlignmentHighlight[]>(
+            `${mapUri('alignments', publishType)}/without-profile${queryParams({
+                bbox: bboxString(mapTile.area),
+            })}`,
+            [],
+        ),
     );
+}
+
+export async function getAlignmentSectionsWithoutProfileByTiles(
+    changeTime: TimeStamp,
+    publishType: PublishType,
+    mapTiles: MapTile[],
+): Promise<AlignmentHighlight[] | null> {
+    return await Promise.all(
+        mapTiles.map((tile) =>
+            getAlignmentSectionsWithoutProfileByTile(changeTime, publishType, tile),
+        ),
+    ).then((res) => res.filter(filterNotEmpty).flat());
 }
 
 export async function getReferenceLineSegmentEnds(


### PR DESCRIPTION
Täällä käytännössä toteutettu pyyntöjen tiletys ja ka. tilejen cachetus. Tämä nopeuttaa jo itsessään pyyntöjä niin merkittävästi, että en katsonut bäkkärioptimointien porttaamista toisesta branchista järkeväksi tässä kohtaa