### PR TITLE
GVT-1830 Make height diagram width dynamic

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -63,6 +63,7 @@
                 "ts-loader": "^9.4.1",
                 "ts-node": "^10.9.1",
                 "typescript": "^4.8.4",
+                "use-resize-observer": "^9.1.0",
                 "webpack": "^5.74.0",
                 "webpack-cli": "^4.10.0",
                 "webpack-dev-server": "^4.11.1",
@@ -229,6 +230,12 @@
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
             }
+        },
+        "node_modules/@juggle/resize-observer": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+            "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+            "dev": true
         },
         "node_modules/@leichtgewicht/ip-codec": {
             "version": "2.0.4",
@@ -8975,6 +8982,19 @@
             "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/use-resize-observer": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
+            "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
+            "dev": true,
+            "dependencies": {
+                "@juggle/resize-observer": "^3.3.1"
+            },
+            "peerDependencies": {
+                "react": "16.8.0 - 18",
+                "react-dom": "16.8.0 - 18"
             }
         },
         "node_modules/use-sync-external-store": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,6 +40,7 @@
         "ts-loader": "^9.4.1",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.4",
+        "use-resize-observer": "^9.1.0",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1",

--- a/ui/src/vertical-geometry/demo-page.tsx
+++ b/ui/src/vertical-geometry/demo-page.tsx
@@ -9,7 +9,7 @@ import {
 } from 'data-products/data-products-utils';
 import { LayoutLocationTrack } from 'track-layout/track-layout-model';
 import { useTranslation } from 'react-i18next';
-import { VerticalGeometryDiagram } from 'vertical-geometry/vertical-geometry-diagram';
+import VerticalGeometryDiagram from 'vertical-geometry/vertical-geometry-diagram';
 import { GeometryAlignment, GeometryPlanHeader, PlanSource } from 'geometry/geometry-model';
 import { getGeometryPlan } from 'geometry/geometry-api';
 import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
@@ -72,7 +72,7 @@ const VerticalGeometryDiagramDemoPage: React.FC = () => {
     );
 
     return (
-        <div>
+        <div style={{ width: '100%' }}>
             Sijaintiraide:
             <Dropdown
                 value={locationTrack}

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.scss
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.scss
@@ -2,6 +2,7 @@
 @import '../vayla-design-lib/shadows';
 
 .vertical-geometry-diagram {
+    width: 100%;
     cursor: grab;
     &__panning {
         cursor: grabbing;


### PR DESCRIPTION
Rakensin korkeuskaavion alkuaan rajapintojen yksinkertaisuutta ajatellen niin, että se tietää sijaintinsa startM- ja endM-tietoina, mutta dynaamisen leveyden kanssa tämä valinta hankasi vähän vastaan, koska selainkäyttöliittymissähän on yleensä tapana, että ikkunan koon muuttaminen ei muuta zoomia vaan rajaa vaan näytettävää sisällön osaa: Siis luonnostaan pitäisi oikeastaan olla niin, että leveyden muuttuessa mMeterLengthPxOverM pysyy samana, ja endM muuttuu, ja siten siis mMeterLengthPxOverM on oikeastaan se, jonka pitäisi olla komponentin tilassa.

Mutta en tämän yhden epäsuoruuden takia nyt lähtenyt muuttamaan tilanhallintaa, vaan löin sen sijaan ResizeObserverilla reagoinnin että endM korjataan elementin leveyden muuttuessa.