### PR TITLE
GVT-1833 Pituuskaavion renderöintisotkuja kilometripisteiden ja suunnitelmanvaihdosten ympärillä vähemmäksi

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -52,7 +52,7 @@ class GeometryServiceIT @Autowired constructor(
         // the profile is at exactly 50 meters height at every point where it's linked
         val expected = listOf(
             0 to 50,
-            5 to 50,
+            // 5 to 50, // should be filtered due to being less than a half-tick distance from nearest
             6 to 50,
             6 to null,
             10 to null,

--- a/ui/src/vertical-geometry/snapped-point.ts
+++ b/ui/src/vertical-geometry/snapped-point.ts
@@ -195,6 +195,6 @@ function approximateTrackAddressAt(
                 ? leftMeter.meter + proportion * (rightMeter.meter - leftMeter.meter)
                 : // we can't accurately know the length of the last track meter in track address space, so let's just
                   // extrapolate based on assuming we're parallel with the reference line
-                  leftMeter.meter + proportion,
+                  leftMeter.meter + proportion * (rightMeter.m - leftMeter.m),
     };
 }

--- a/ui/src/vertical-geometry/snapped-point.ts
+++ b/ui/src/vertical-geometry/snapped-point.ts
@@ -194,7 +194,7 @@ function approximateTrackAddressAt(
             index.left.kmIndex === index.right.kmIndex
                 ? leftMeter.meter + proportion * (rightMeter.meter - leftMeter.meter)
                 : // we can't accurately know the length of the last track meter in track address space, so let's just
-                  // extrapolate based on assuming we're parallel with the reference line
+                  // assume it doesn't turn very hard here
                   leftMeter.meter + proportion * (rightMeter.m - leftMeter.m),
     };
 }


### PR DESCRIPTION
Lähetettäviä pisteitä nysvätään nyt hieman tarkemmin niin, että niitä ei tule enää niin lähekkäin aivan ratakilometrien lopuissa eikä suunnitelmanvaihdosten ympärillä. Ero näkyy käytännössä niin, että ilman tätä kommittia korkeuskaaviossa hyvin usein juuri ja juuri kilometria pitemmillä ratakilometreillä lähetettiin piste metrille 1000, ja erikseen seuraavan kilometrin alkuun, mikä näkyi suttuna kaavion piirtämisessä.