### PR TITLE
GVT-1839/1836/1835 korkeuskaavion frontin integrointi

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
@@ -1,6 +1,9 @@
 package fi.fta.geoviite.infra.geometry
 
+import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.map.AlignmentHeader
+import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.util.FileName
 
 data class TrackMeterHeight(
@@ -17,12 +20,7 @@ data class PlanLinkingSummaryItem(
     val startM: Double,
     val endM: Double,
     val filename: FileName?,
-)
-
-data class AlignmentHeights (
-    val alignmentStartM: Double,
-    val alignmentEndM: Double,
-    val kmHeights: List<KmHeights>,
-    val linkingSummary: List<PlanLinkingSummaryItem>,
+    val alignmentHeader: AlignmentHeader<GeometryAlignment>?,
+    val planId: DomainId<GeometryPlan>?,
 )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -274,18 +274,44 @@ class GeometryController @Autowired constructor(
         @RequestParam("startDistance") startDistance: Double,
         @RequestParam("endDistance") endDistance: Double,
         @RequestParam("tickLength") tickLength: Int,
-    ): AlignmentHeights? {
+    ): List<KmHeights>? {
+        logger.apiCall(
+            "getPlanAlignmentHeights",
+            "planId" to planId,
+            "planAlignmentId" to planAlignmentId,
+            "startDistance" to startDistance,
+            "endDistance" to endDistance,
+            "tickLength" to tickLength
+        )
         return geometryService.getPlanAlignmentHeights(planId, planAlignmentId, startDistance, endDistance, tickLength)
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("{publishType}/layout/location-tracks/{id}/linking-summary")
+    fun getLocationTrackLinkingSummary(
+        @PathVariable("publishType") publishType: PublishType,
+        @PathVariable("id") id: IntId<LocationTrack>,
+    ): List<PlanLinkingSummaryItem>? {
+        logger.apiCall("getLocationTrackLinkingSummary", "publishType" to publishType, "id" to id)
+        return geometryService.getLocationTrackGeometryLinkingSummary(id, publishType)
     }
 
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{publishType}/layout/location-tracks/{id}/alignment-heights")
     fun getLayoutAlignmentHeights(
         @PathVariable("publishType") publishType: PublishType,
-        @PathVariable("id") locationTrackId: IntId<LocationTrack>,
+        @PathVariable("id") id: IntId<LocationTrack>,
         @RequestParam("startDistance") startDistance: Double,
         @RequestParam("endDistance") endDistance: Double,
         @RequestParam("tickLength") tickLength: Int,
-    ): AlignmentHeights? {
-        return geometryService.getLocationTrackHeights(locationTrackId, publishType, startDistance, endDistance, tickLength)
+    ): List<KmHeights>? {
+        logger.apiCall(
+            "getLayoutAlignmentHeights",
+            "publishType" to publishType,
+            "id" to id,
+            "startDistance" to startDistance,
+            "endDistance" to endDistance,
+            "tickLength" to tickLength
+        )
+        return geometryService.getLocationTrackHeights(id, publishType, startDistance, endDistance, tickLength)
     }}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.IndexedId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.geocoding.AlignmentStartAndEnd
 import fi.fta.geoviite.infra.geometry.GeometryPlanSortField.ID
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.math.BoundingBox
@@ -253,6 +254,16 @@ class GeometryController @Autowired constructor(
         val (filename, content) = geometryService
             .getVerticalGeometryListingCsv(id, startAddress, endAddress)
         return toFileDownloadResponse("${filename}.csv", content)
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/plans/{planId}/start-and-end/{planAlignmentId}")
+    fun getPlanAlignmentStartAndEnd(
+        @PathVariable("planId") planId: IntId<GeometryPlan>,
+        @PathVariable("planAlignmentId") planAlignmentId: IntId<GeometryAlignment>,
+    ): AlignmentStartAndEnd? {
+        logger.apiCall("getPlanAlignmentStartAndEnd", "planId" to planId, "planAlignmentId" to planAlignmentId)
+        return geometryService.getPlanAlignmentStartAndEnd(planId, planAlignmentId)
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -477,7 +477,8 @@ class GeometryService @Autowired constructor(
             // hit a specific segment; but points on different sides of a segment boundary are often the exact same
             // point, but potentially have different heights (or more often null/not-null heights).
             val allTicks = ((planBoundaryAddressesByKm[kmNumber] ?: listOf())
-                    + (0..referenceLineKmLength step tickLength).map { distance -> distance.toBigDecimal() to null }
+                    + (referencePoint.meters.toInt()..(referencePoint.meters.toInt() + referenceLineKmLength) step tickLength)
+                .map { distance -> distance.toBigDecimal() to null }
                     // special-case last point so front-end doesn't have to extrapolate heights at track end
                     ).sortedBy { (trackMeterInKm) -> trackMeterInKm }
 
@@ -510,11 +511,11 @@ private fun getKmLengthAtReferencePointIndex(
     referencePointIndex: Int,
     geocodingContext: GeocodingContext,
 ): Int = floor(
-    (if (referencePointIndex == geocodingContext.referencePoints.size - 1)
+    if (referencePointIndex == geocodingContext.referencePoints.size - 1)
         geocodingContext.referenceLineGeometry.length - geocodingContext.referencePoints[referencePointIndex].distance
     else
         geocodingContext.referencePoints[referencePointIndex + 1].distance - geocodingContext.referencePoints[referencePointIndex].distance
-            ) + geocodingContext.referencePoints[referencePointIndex].meters.toDouble()).toInt()
+).toInt()
 
 private fun trackNumbersMatch(
     header: GeometryPlanHeader,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.geometry
 
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
+import fi.fta.geoviite.infra.geocoding.AlignmentStartAndEnd
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.geography.CoordinateTransformationService
@@ -391,6 +392,20 @@ class GeometryService @Autowired constructor(
                 linkingSummary = linkingSummary,
             )
         }
+    }
+
+    fun getPlanAlignmentStartAndEnd(
+        planId: IntId<GeometryPlan>,
+        planAlignmentId: IntId<GeometryAlignment>,
+    ): AlignmentStartAndEnd? {
+        val planVersion = geometryDao.fetchPlanVersion(planId)
+        val plan = geometryDao.fetchPlan(planVersion)
+        val geocodingContext =
+            geocodingService.getGeocodingContext(plan.trackNumberId ?: return null, planVersion) ?: return null
+        val alignment =
+            planLayoutCache.getPlanLayout(planVersion).first?.alignments?.find { alignment -> alignment.id == planAlignmentId }
+                ?: return null
+        return geocodingContext.getStartAndEnd(alignment)
     }
 
     fun getPlanAlignmentHeights(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.map
 
 import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.geometry.GeometryAlignment
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.tracklayout.*
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -112,31 +112,36 @@ fun toMapAlignments(
                 includeGeometryData = includeGeometryData,
             )
 
-            val state = getLayoutStateOrDefault(alignment.state)
             val boundingBoxInLayoutSpace = alignment.bounds?.let {
                 val cornersInLayoutSpace = it.corners.map { corner -> planToLayout.transform(corner) }
                 boundingBoxAroundPoints(cornersInLayoutSpace)
             }
 
             PlanLayoutAlignment(
-                header = AlignmentHeader(
-                    id = alignment.id,
-                    name = alignment.name,
-                    alignmentSource = MapAlignmentSource.GEOMETRY,
-                    alignmentType = getAlignmentType(alignment.featureTypeCode),
-                    state = state,
-                    trackNumberId = alignment.trackNumberId,
-                    boundingBox = boundingBoxInLayoutSpace,
-                    length = alignment.elements.sumOf(GeometryElement::calculatedLength),
-                    segmentCount = alignment.elements.size,
-                    version = null,
-                    duplicateOf = null,
-                    trackType = null,
-                ),
+                header = toAlignmentHeader(alignment, boundingBoxInLayoutSpace),
                 segments = mapSegments,
             )
         }
 }
+
+fun toAlignmentHeader(
+    alignment: GeometryAlignment,
+    boundingBoxInLayoutSpace: BoundingBox? = null,
+) = AlignmentHeader(
+    id = alignment.id,
+    name = alignment.name,
+    alignmentSource = MapAlignmentSource.GEOMETRY,
+    alignmentType = getAlignmentType(alignment.featureTypeCode),
+    state = getLayoutStateOrDefault(alignment.state),
+    trackNumberId = alignment.trackNumberId,
+    boundingBox = boundingBoxInLayoutSpace,
+    length = alignment.elements.sumOf(GeometryElement::calculatedLength),
+    segmentCount = alignment.elements.size,
+    version = null,
+    duplicateOf = null,
+    trackType = null,
+)
+
 
 private fun toMapSegments(
     alignment: GeometryAlignment,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -47,7 +47,7 @@ class GeometryServiceIT @Autowired constructor(
                 segment(yRangeToSegmentPoints(15..17), sourceId = p1.alignments[0].elements[0].id, sourceStart = 0.0),
             )
         ).id
-        val heights = geometryService.getLocationTrackHeights(locationTrackId, PublishType.DRAFT, 0.0, 20.0, 5)!!
+        val kmHeights = geometryService.getLocationTrackHeights(locationTrackId, PublishType.DRAFT, 0.0, 20.0, 5)!!
         // this track is exactly straight on the reference line, so m-values and track meters coincide perfectly; also,
         // the profile is at exactly 50 meters height at every point where it's linked
         val expected = listOf(
@@ -64,17 +64,18 @@ class GeometryServiceIT @Autowired constructor(
             15 to 50,
             17 to 50
         ).map { (m, h) -> TrackMeterHeight(m.toDouble(), m.toDouble(), h?.toDouble()) }
-        assertEquals(expected, heights.kmHeights[0].trackMeterHeights)
+        assertEquals(expected, kmHeights[0].trackMeterHeights)
+        val linkingSummary = geometryService.getLocationTrackGeometryLinkingSummary(locationTrackId, PublishType.DRAFT)!!
         assertEquals(
             listOf(
-                PlanLinkingSummaryItem(0.0, 6.0, FileName("plan1.xml")),
-                PlanLinkingSummaryItem(6.0, 10.0, null),
-                PlanLinkingSummaryItem(10.0, 12.0, FileName("plan2.xml")),
-                PlanLinkingSummaryItem(12.0, 13.0, null),
-                PlanLinkingSummaryItem(13.0, 15.0, FileName("plan3.xml")),
-                PlanLinkingSummaryItem(15.0, 17.0, FileName("plan1.xml")),
+                Triple(0.0, 6.0, FileName("plan1.xml")),
+                Triple(6.0, 10.0, null),
+                Triple(10.0, 12.0, FileName("plan2.xml")),
+                Triple(12.0, 13.0, null),
+                Triple(13.0, 15.0, FileName("plan3.xml")),
+                Triple(15.0, 17.0, FileName("plan1.xml")),
             ),
-            heights.linkingSummary
+            linkingSummary.map { item -> Triple(item.startM, item.endM, item.filename) }
         )
     }
 

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -18,6 +18,7 @@ import {
     VerticalGeometryItem,
 } from 'geometry/geometry-model';
 import {
+    AlignmentStartAndEnd,
     GeometryPlanLayout,
     LayoutSwitch,
     LayoutTrackNumberId,
@@ -304,6 +305,15 @@ export async function getPlanAlignmentHeights(
     return getThrowError(
         `${GEOMETRY_URI}/plans/${planId}/plan-alignment-heights/${alignmentId}` +
             queryParams({ startDistance, endDistance, tickLength }),
+    );
+}
+
+export async function getPlanAlignmentStartAndEnd(
+    planId: GeometryPlanId,
+    alignmentId: GeometryAlignmentId,
+): Promise<AlignmentStartAndEnd | undefined> {
+    return getThrowError<AlignmentStartAndEnd>(
+        `${GEOMETRY_URI}/plans/${planId}/start-and-end/${alignmentId}`,
     );
 }
 

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -42,6 +42,7 @@ import { KmNumber, PublishType, TimeStamp } from 'common/common-model';
 import { bboxString } from 'common/common-api';
 import { filterNotEmpty } from 'utils/array-utils';
 import { GeometryTypeIncludingMissing } from 'data-products/data-products-slice';
+import { AlignmentHeader } from 'track-layout/layout-map-api';
 
 export const GEOMETRY_URI = `${API_URI}/geometry`;
 
@@ -274,7 +275,6 @@ export interface AlignmentHeights {
     kmHeights: TrackKmHeights[];
     alignmentStartM: number;
     alignmentEndM: number;
-    linkingSummary: PlanLinkingSummaryItem[];
 }
 
 export interface TrackMeterHeight {
@@ -288,6 +288,8 @@ export interface PlanLinkingSummaryItem {
     startM: number;
     endM: number;
     filename: string | null;
+    alignmentHeader: AlignmentHeader | null;
+    planId: GeometryPlanId | null;
 }
 
 export interface TrackKmHeights {
@@ -301,7 +303,7 @@ export async function getPlanAlignmentHeights(
     startDistance: number,
     endDistance: number,
     tickLength: number,
-): Promise<AlignmentHeights> {
+): Promise<TrackKmHeights[]> {
     return getThrowError(
         `${GEOMETRY_URI}/plans/${planId}/plan-alignment-heights/${alignmentId}` +
             queryParams({ startDistance, endDistance, tickLength }),
@@ -323,9 +325,18 @@ export async function getLocationTrackHeights(
     startDistance: number,
     endDistance: number,
     tickLength: number,
-): Promise<AlignmentHeights> {
+): Promise<TrackKmHeights[]> {
     return getThrowError(
         `${GEOMETRY_URI}/${publishType}/layout/location-tracks/${locationTrackId}/alignment-heights` +
             queryParams({ startDistance, endDistance, tickLength }),
+    );
+}
+
+export async function getLocationTrackLinkingSummary(
+    locationTrackId: LocationTrackId,
+    publishType: PublishType,
+): Promise<PlanLinkingSummaryItem[]> {
+    return getThrowError(
+        `${GEOMETRY_URI}/${publishType}/layout/location-tracks/${locationTrackId}/linking-summary`,
     );
 }

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -151,6 +151,7 @@ export type Map = {
     shownItems: ShownItems;
     hoveredLocation: Point | null;
     clickLocation: Point | null;
+    verticalGeometryDiagramVisible: boolean;
 };
 
 export type MapTile = {

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -131,6 +131,7 @@ export const initialMapState: Map = {
     settingsVisible: false,
     hoveredLocation: null,
     clickLocation: null,
+    verticalGeometryDiagramVisible: false,
 };
 
 export const mapReducers = {
@@ -223,6 +224,12 @@ export const mapReducers = {
     },
     onClickLocation: (state: Map, { payload: clickLocation }: PayloadAction<Point>): void => {
         state.clickLocation = clickLocation;
+    },
+    onVerticalGeometryDiagramVisibilityChange: (
+        state: Map,
+        { payload: visibilitySetting }: PayloadAction<boolean>,
+    ): void => {
+        state.verticalGeometryDiagramVisible = visibilitySetting;
     },
 };
 

--- a/ui/src/tool-panel/location-track/location-track-infobox-linking-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-linking-container.tsx
@@ -21,6 +21,7 @@ type LocationTrackInfoboxLinkingContainerProps = {
     viewport: MapViewport;
     visibilities: LocationTrackInfoboxVisibilities;
     onVisibilityChange: (visibilities: LocationTrackInfoboxVisibilities) => void;
+    verticalGeometryDiagramVisible: boolean;
 };
 
 const LocationTrackInfoboxLinkingContainer: React.FC<LocationTrackInfoboxLinkingContainerProps> = ({
@@ -33,6 +34,7 @@ const LocationTrackInfoboxLinkingContainer: React.FC<LocationTrackInfoboxLinking
     viewport,
     visibilities,
     onVisibilityChange,
+    verticalGeometryDiagramVisible,
 }: LocationTrackInfoboxLinkingContainerProps) => {
     const delegates = createDelegates(TrackLayoutActions);
     const locationTrack = useLocationTrack(locationTrackId, publishType, locationTrackChangeTime);
@@ -54,6 +56,10 @@ const LocationTrackInfoboxLinkingContainer: React.FC<LocationTrackInfoboxLinking
                 onUnselect={onUnselect}
                 onSelect={delegates.onSelect}
                 viewport={viewport}
+                onVerticalGeometryDiagramVisibilityChange={
+                    delegates.onVerticalGeometryDiagramVisibilityChange
+                }
+                verticalGeometryDiagramVisible={verticalGeometryDiagramVisible}
             />
         );
 };

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -44,6 +44,7 @@ import { AssetValidationInfoboxContainer } from 'tool-panel/asset-validation-inf
 import { getEndLinkPoints } from 'track-layout/layout-map-api';
 import { LocationTrackInfoboxVisibilities } from 'track-layout/track-layout-slice';
 import { WriteRoleRequired } from 'user/write-role-required';
+import { LocationTrackVerticalGeometryInfobox } from 'tool-panel/location-track/location-track-vertical-geometry-infobox';
 
 type LocationTrackInfoboxProps = {
     locationTrack: LayoutLocationTrack;
@@ -59,6 +60,8 @@ type LocationTrackInfoboxProps = {
     viewport: MapViewport;
     visibilities: LocationTrackInfoboxVisibilities;
     onVisibilityChange: (visibilities: LocationTrackInfoboxVisibilities) => void;
+    onVerticalGeometryDiagramVisibilityChange: (visibility: boolean) => void;
+    verticalGeometryDiagramVisible: boolean;
 };
 
 const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
@@ -74,6 +77,8 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     viewport,
     visibilities,
     onVisibilityChange,
+    verticalGeometryDiagramVisible,
+    onVerticalGeometryDiagramVisibilityChange,
 }: LocationTrackInfoboxProps) => {
     const { t } = useTranslation();
     const trackNumber = useTrackNumber(publishType, locationTrack?.trackNumberId);
@@ -371,6 +376,14 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 publishType={publishType}
                 locationTrackId={locationTrack.id}
                 viewport={viewport}
+            />
+            <LocationTrackVerticalGeometryInfobox
+                contentVisible={visibilities.verticalGeometry}
+                onContentVisibilityChange={() => visibilityChange('verticalGeometry')}
+                onVerticalGeometryDiagramVisibilityChange={
+                    onVerticalGeometryDiagramVisibilityChange
+                }
+                verticalGeometryDiagramVisible={verticalGeometryDiagramVisible}
             />
             {locationTrack.draftType !== 'NEW_DRAFT' && (
                 <AssetValidationInfoboxContainer

--- a/ui/src/tool-panel/location-track/location-track-vertical-geometry-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-vertical-geometry-infobox.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Infobox from 'tool-panel/infobox/infobox';
+import { Switch } from 'vayla-design-lib/switch/switch';
+import InfoboxField from 'tool-panel/infobox/infobox-field';
+import InfoboxContent from 'tool-panel/infobox/infobox-content';
+
+type LocationTrackVerticalGeometryInfoboxProps = {
+    contentVisible: boolean;
+    onContentVisibilityChange: () => void;
+    onVerticalGeometryDiagramVisibilityChange: (visibility: boolean) => void;
+    verticalGeometryDiagramVisible: boolean;
+};
+
+export const LocationTrackVerticalGeometryInfobox: React.FC<
+    LocationTrackVerticalGeometryInfoboxProps
+> = ({
+    contentVisible,
+    onContentVisibilityChange,
+    verticalGeometryDiagramVisible,
+    onVerticalGeometryDiagramVisibilityChange,
+}) => {
+    const { t } = useTranslation();
+
+    return (
+        <Infobox
+            title={t('tool-panel.location-track.vertical-geometry.heading')}
+            contentVisible={contentVisible}
+            onContentVisibilityChange={onContentVisibilityChange}>
+            <InfoboxContent>
+                <InfoboxField
+                    label={t('tool-panel.location-track.vertical-geometry.diagram-visibility')}
+                    value={
+                        <Switch
+                            checked={verticalGeometryDiagramVisible}
+                            onCheckedChange={onVerticalGeometryDiagramVisibilityChange}
+                        />
+                    }
+                />
+            </InfoboxContent>
+        </Infobox>
+    );
+};

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -79,6 +79,7 @@ const ToolPanelContainer: React.FC = () => {
             startSwitchPlacing={startSwitchPlacing}
             viewport={store.map.viewport}
             stopLinking={delegates.stopLinking}
+            verticalGeometryDiagramVisible={store.map.verticalGeometryDiagramVisible}
         />
     );
 };

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -65,6 +65,7 @@ type ToolPanelProps = {
     infoboxVisibilities: InfoboxVisibilities;
     onInfoboxVisibilityChange: (visibilities: InfoboxVisibilities) => void;
     stopLinking: () => void;
+    verticalGeometryDiagramVisible: boolean;
 };
 
 type ToolPanelTab = {
@@ -100,6 +101,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     infoboxVisibilities,
     onInfoboxVisibilityChange,
     stopLinking,
+    verticalGeometryDiagramVisible,
 }: ToolPanelProps) => {
     const [previousTabs, setPreviousTabs] = React.useState<ToolPanelTab[]>([]);
     const [tabs, setTabs] = React.useState<ToolPanelTab[]>([]);
@@ -343,6 +345,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                         onDataChange={onDataChange}
                         onUnselect={onUnSelectLocationTracks}
                         viewport={viewport}
+                        verticalGeometryDiagramVisible={verticalGeometryDiagramVisible}
                     />
                 ),
             };
@@ -396,6 +399,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         viewport,
         changeTimes,
         infoboxVisibilities,
+        verticalGeometryDiagramVisible,
     ]);
 
     React.useEffect(() => {

--- a/ui/src/tool-panel/translations.fi.json
+++ b/ui/src/tool-panel/translations.fi.json
@@ -237,6 +237,10 @@
                 "end-km": "Loppukilometri",
                 "push": "Vie Ratkoon"
             },
+            "vertical-geometry": {
+                "heading": "Raiteen pystygeometria",
+                "diagram-visibility": "Kuvaaja"
+            },
             "topological-connectivity": "Topologinen kytkeytyminen"
         },
         "disabled": {

--- a/ui/src/track-layout/track-layout-container.tsx
+++ b/ui/src/track-layout/track-layout-container.tsx
@@ -57,6 +57,7 @@ export const TrackLayoutContainer: React.FC = () => {
         onRemoveGeometryLinkPoint: delegates.removeGeometryLinkPoint,
         onRemoveLayoutLinkPoint: delegates.removeLayoutLinkPoint,
         onStopLinking: delegates.stopLinking,
+        onShowOnMap: delegates.showArea,
     };
 
     return <TrackLayoutView {...props} />;

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -209,7 +209,6 @@ export type LayoutTrackNumber = {
 export type AddressPoint = {
     point: LayoutPoint;
     address: TrackMeter;
-    distance: number;
 };
 
 export type AlignmentStartAndEnd = {

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -67,6 +67,7 @@ export type LocationTrackInfoboxVisibilities = {
     validation: boolean;
     ratkoPush: boolean;
     geometry: boolean;
+    verticalGeometry: boolean;
 };
 
 export type KmPostInfoboxVisibilities = {
@@ -125,6 +126,7 @@ const initialInfoboxVisibilities: InfoboxVisibilities = {
         validation: true,
         ratkoPush: true,
         geometry: true,
+        verticalGeometry: true,
     },
     kmPost: {
         basic: true,

--- a/ui/src/track-layout/track-layout-view.tsx
+++ b/ui/src/track-layout/track-layout-view.tsx
@@ -19,6 +19,8 @@ import { BoundingBox } from 'model/geometry';
 import { PublishType } from 'common/common-model';
 import { LinkPoint } from 'linking/linking-model';
 import { ChangeTimes } from 'common/common-slice';
+import VerticalGeometryDiagram from 'vertical-geometry/vertical-geometry-diagram';
+import { createClassName } from 'vayla-design-lib/utils';
 
 // For now use whole state and some extras as params
 export type TrackLayoutParams = TrackLayoutState & {
@@ -47,8 +49,14 @@ export type TrackLayoutParams = TrackLayoutState & {
 };
 
 export const TrackLayoutView: React.FC<TrackLayoutParams> = (props: TrackLayoutParams) => {
+    const verticalDiagramLocationTrackId = props.selection.selectedItems.locationTracks[0];
+    const showDiagram = verticalDiagramLocationTrackId != undefined;
+    const className = createClassName(
+        styles['track-layout'],
+        showDiagram && styles['track-layout--show-diagram'],
+    );
     return (
-        <div className={styles['track-layout']} qa-id="track-layout-content">
+        <div className={className} qa-id="track-layout-content">
             <ToolBar
                 settingsVisible={props.map.settingsVisible}
                 publishType={props.publishType}
@@ -89,6 +97,17 @@ export const TrackLayoutView: React.FC<TrackLayoutParams> = (props: TrackLayoutP
                         <SelectionPanelContainer />
                     </MapContext.Provider>
                 </div>
+
+                {verticalDiagramLocationTrackId && (
+                    <div className={styles['track-layout__diagram']}>
+                        <VerticalGeometryDiagram
+                            alignmentId={{
+                                locationTrackId: verticalDiagramLocationTrackId,
+                                publishType: props.publishType,
+                            }}
+                        />
+                    </div>
+                )}
 
                 <div className={styles['track-layout__map']}>
                     {props.map.settingsVisible && (

--- a/ui/src/track-layout/track-layout-view.tsx
+++ b/ui/src/track-layout/track-layout-view.tsx
@@ -1,5 +1,6 @@
 import styles from './track-layout.module.scss';
 import * as React from 'react';
+import { useMemo } from 'react';
 import { TrackLayoutState } from 'track-layout/track-layout-slice';
 import { MapContext } from 'map/map-store';
 import { MapViewport, OptionalShownItems } from 'map/map-model';
@@ -49,11 +50,20 @@ export type TrackLayoutParams = TrackLayoutState & {
 };
 
 export const TrackLayoutView: React.FC<TrackLayoutParams> = (props: TrackLayoutParams) => {
-    const verticalDiagramLocationTrackId = props.selection.selectedItems.locationTracks[0];
-    const showDiagram = verticalDiagramLocationTrackId != undefined;
+    const verticalDiagramAlignmentId = useMemo(
+        () =>
+            props.selection.selectedItems.locationTracks[0] && {
+                locationTrackId: props.selection.selectedItems.locationTracks[0],
+                publishType: props.publishType,
+            },
+        [props.selection.selectedItems.locationTracks[0], props.publishType],
+    );
+
+    const showVerticalGeometryDiagram =
+        props.map.verticalGeometryDiagramVisible && verticalDiagramAlignmentId != undefined;
     const className = createClassName(
         styles['track-layout'],
-        showDiagram && styles['track-layout--show-diagram'],
+        showVerticalGeometryDiagram && styles['track-layout--show-diagram'],
     );
     return (
         <div className={className} qa-id="track-layout-content">
@@ -98,13 +108,12 @@ export const TrackLayoutView: React.FC<TrackLayoutParams> = (props: TrackLayoutP
                     </MapContext.Provider>
                 </div>
 
-                {verticalDiagramLocationTrackId && (
+                {showVerticalGeometryDiagram && verticalDiagramAlignmentId && (
                     <div className={styles['track-layout__diagram']}>
                         <VerticalGeometryDiagram
-                            alignmentId={{
-                                locationTrackId: verticalDiagramLocationTrackId,
-                                publishType: props.publishType,
-                            }}
+                            alignmentId={verticalDiagramAlignmentId}
+                            onSelect={props.onSelect}
+                            changeTimes={props.changeTimes}
                         />
                     </div>
                 )}

--- a/ui/src/track-layout/track-layout.module.scss
+++ b/ui/src/track-layout/track-layout.module.scss
@@ -48,6 +48,7 @@
 .track-layout__diagram {
     grid-area: diagram;
     @include shadow-8dp;
+    padding: 0 8px;
 }
 
 .track-layout__tool-panel {

--- a/ui/src/track-layout/track-layout.module.scss
+++ b/ui/src/track-layout/track-layout.module.scss
@@ -11,29 +11,49 @@
     background: $color-white-default;
 }
 
+.track-layout__main-view {
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: 336px auto 380px;
+    grid-template-rows: auto 320px;
+
+    grid-template-areas:
+        'navi map tool-panel'
+        'navi map tool-panel';
+}
+.track-layout--show-diagram .track-layout__main-view {
+    grid-template-areas:
+        'navi map tool-panel'
+        'navi diagram tool-panel';
+}
+
+.track-layout__navi {
+    grid-area: navi;
+    overflow: auto;
+
+    @include shadow-8dp;
+
+    padding-bottom: 64px;
+    min-width: 336px;
+    width: 336px;
+    max-width: 336px;
+}
+
 .track-layout__map {
+    grid-area: map;
     position: relative;
     flex: 1;
 }
 
-.track-layout__main-view {
-    overflow: hidden;
-    display: flex;
-}
-
-.track-layout__map-settings {
+.track-layout__diagram {
+    grid-area: diagram;
     @include shadow-8dp;
-
-    position: absolute;
-    overflow-y: auto;
-    margin-top: 5px;
-    margin-left: 5px;
-    max-height: 100%;
-    border-radius: 6px;
-    z-index: $layer-popup;
 }
 
 .track-layout__tool-panel {
+    grid-area: tool-panel;
+    overflow: auto;
+
     @include shadow-8dp;
     width: 380px;
 
@@ -49,12 +69,14 @@
     }
 }
 
-.track-layout__navi {
+.track-layout__map-settings {
     @include shadow-8dp;
 
-    padding-bottom: 64px;
-    min-width: 336px;
-    width: 336px;
-    max-width: 336px;
-    overflow: auto;
+    position: absolute;
+    overflow-y: auto;
+    margin-top: 5px;
+    margin-left: 5px;
+    max-height: 100%;
+    border-radius: 6px;
+    z-index: $layer-popup;
 }

--- a/ui/src/utils/react-utils.tsx
+++ b/ui/src/utils/react-utils.tsx
@@ -89,9 +89,7 @@ export function useTwoPartEffect<TEntity>(
     const promise = useRef<Promise<void>>();
     let cancelled = false;
     useEffect(() => {
-        promise.current = loadFunc()
-            ?.then((r) => (cancelled ? Promise.reject('dependencies changed') : Promise.resolve(r)))
-            .then(onceOnFulfilled);
+        promise.current = loadFunc()?.then((r) => void (cancelled || onceOnFulfilled(r)));
         return () => {
             cancelled = true;
         };

--- a/ui/src/vertical-geometry/demo-page.tsx
+++ b/ui/src/vertical-geometry/demo-page.tsx
@@ -86,12 +86,7 @@ const VerticalGeometryDiagramDemoPage: React.FC = () => {
                 wide
             />
             {locationTrackAlignmentId && (
-                <VerticalGeometryDiagram
-                    key={locationTrackAlignmentId.locationTrackId}
-                    alignmentId={locationTrackAlignmentId}
-                    initialStartM={0}
-                    initialEndM={10000}
-                />
+                <VerticalGeometryDiagram alignmentId={locationTrackAlignmentId} />
             )}
             <br />
             Suunnitelma:
@@ -123,14 +118,7 @@ const VerticalGeometryDiagramDemoPage: React.FC = () => {
                 options={geometryAlignments.map((a) => ({ name: a.name, value: a }))}
                 onChange={setSelectedAlignment}
             />
-            {planAlignmentId && (
-                <VerticalGeometryDiagram
-                    key={`${planAlignmentId.planId}_${planAlignmentId.alignmentId}`}
-                    alignmentId={planAlignmentId}
-                    initialStartM={0}
-                    initialEndM={10000}
-                />
-            )}
+            {planAlignmentId && <VerticalGeometryDiagram alignmentId={planAlignmentId} />}
         </div>
     );
 };

--- a/ui/src/vertical-geometry/demo-page.tsx
+++ b/ui/src/vertical-geometry/demo-page.tsx
@@ -13,6 +13,8 @@ import VerticalGeometryDiagram from 'vertical-geometry/vertical-geometry-diagram
 import { GeometryAlignment, GeometryPlanHeader, PlanSource } from 'geometry/geometry-model';
 import { getGeometryPlan } from 'geometry/geometry-api';
 import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
+import { OnSelectOptions } from 'selection/selection-model';
+import { useCommonDataAppSelector } from 'store/hooks';
 
 const VerticalGeometryDiagramDemoPage: React.FC = () => {
     const { t } = useTranslation();
@@ -21,6 +23,7 @@ const VerticalGeometryDiagramDemoPage: React.FC = () => {
     const [geometryPlanHeader, setGeometryPlanHeader] = React.useState<GeometryPlanHeader>();
     const [selectedAlignment, setSelectedAlignment] = React.useState<GeometryAlignment>();
     const [geometryAlignments, setGeometryAlignments] = React.useState<GeometryAlignment[]>([]);
+    const changeTimes = useCommonDataAppSelector((state) => state.changeTimes);
 
     const getLocationTracks = React.useCallback(
         (searchTerm) =>
@@ -71,6 +74,12 @@ const VerticalGeometryDiagramDemoPage: React.FC = () => {
         [geometryPlanHeader, selectedAlignment],
     );
 
+    const noopActions = {
+        onSelect: (options: OnSelectOptions) => {
+            console.log(options);
+        },
+    };
+
     return (
         <div style={{ width: '100%' }}>
             Sijaintiraide:
@@ -86,7 +95,11 @@ const VerticalGeometryDiagramDemoPage: React.FC = () => {
                 wide
             />
             {locationTrackAlignmentId && (
-                <VerticalGeometryDiagram alignmentId={locationTrackAlignmentId} />
+                <VerticalGeometryDiagram
+                    alignmentId={locationTrackAlignmentId}
+                    {...noopActions}
+                    changeTimes={changeTimes}
+                />
             )}
             <br />
             Suunnitelma:
@@ -118,7 +131,13 @@ const VerticalGeometryDiagramDemoPage: React.FC = () => {
                 options={geometryAlignments.map((a) => ({ name: a.name, value: a }))}
                 onChange={setSelectedAlignment}
             />
-            {planAlignmentId && <VerticalGeometryDiagram alignmentId={planAlignmentId} />}
+            {planAlignmentId && (
+                <VerticalGeometryDiagram
+                    alignmentId={planAlignmentId}
+                    {...noopActions}
+                    changeTimes={changeTimes}
+                />
+            )}
         </div>
     );
 };

--- a/ui/src/vertical-geometry/labeled-ticks.tsx
+++ b/ui/src/vertical-geometry/labeled-ticks.tsx
@@ -4,72 +4,93 @@ import { Translate } from 'vertical-geometry/translate';
 import { lineGridStrokeColor } from 'vertical-geometry/height-lines';
 import { Coordinates, mToX } from 'vertical-geometry/coordinates';
 import { TrackKmHeights } from 'geometry/geometry-api';
+import {
+    minimumInterval,
+    minimumIntervalOrLongest,
+    minimumLabeledTickDistancePx,
+} from 'vertical-geometry/ticks-at-intervals';
 
-const labeledTicksEveryNthHorizontalTick = 10;
-const labeledTickKmCounts = [1, 2, 5, 10, 25, 100, 250];
-const minimumLabeledTickDistancePx = 100;
-const minPixelsBeforeLastLabeledTickOnKm = 10;
 export interface LabeledTicksProps {
     trackKmHeights: TrackKmHeights[];
     coordinates: Coordinates;
 }
+
+const TickLabel: React.FC<{
+    m: number;
+    meter: number;
+    kmNumber: string;
+    coordinates: Coordinates;
+}> = ({ m, kmNumber, meter, coordinates }) => {
+    const x = mToX(coordinates, m);
+    return (
+        <>
+            <Translate x={x - 50} y={coordinates.fullDiagramHeightPx - (meter === 0 ? 3 : 8)}>
+                <text scale="0.7 0.7">
+                    KM{' '}
+                    {formatTrackMeterWithoutMeters({
+                        kmNumber,
+                        meters: meter,
+                    })}
+                </text>
+                <line y={-40} stroke="black" />
+            </Translate>
+            <line
+                x1={x}
+                x2={x}
+                y1={0}
+                y2={coordinates.fullDiagramHeightPx - 20}
+                stroke={lineGridStrokeColor}
+                fill="none"
+                shapeRendering="crispEdges"
+            />
+        </>
+    );
+};
 
 export const LabeledTicks: React.FC<LabeledTicksProps> = ({ trackKmHeights, coordinates }) => {
     // avoid rendering too far off the screen for performance
     const startM = coordinates.startM - 80 / coordinates.mMeterLengthPxOverM;
     const endM = coordinates.endM + 25 / coordinates.mMeterLengthPxOverM;
 
-    // a rough approximation assuming track kilometers are 1000 m-value meters long is fine enough here
-    const lengthOfTrackKmInPixels = 1000 * coordinates.mMeterLengthPxOverM;
-    const labelsEveryNKilometers =
-        labeledTickKmCounts.find(
-            (kmCount) => kmCount * lengthOfTrackKmInPixels > minimumLabeledTickDistancePx,
-        ) ?? labeledTickKmCounts[labeledTickKmCounts.length - 1];
+    // rough approximations based on m-meter = track meter, and track km = 1000 meters
+    const trackKmLabelDisplayStep = minimumIntervalOrLongest(
+        1000 * coordinates.mMeterLengthPxOverM,
+        minimumLabeledTickDistancePx,
+    );
+    const trackMeterDisplayStep = minimumInterval(
+        coordinates.mMeterLengthPxOverM,
+        minimumLabeledTickDistancePx,
+    );
 
     return (
         <>
-            {trackKmHeights.flatMap(({ kmNumber, trackMeterHeights }, trackKmIndex) =>
-                trackMeterHeights
-                    .filter(({ meter }) => meter % coordinates.horizontalTickLengthMeters === 0)
-                    .filter(
-                        ({ m }, i) =>
-                            trackKmIndex % labelsEveryNKilometers === 0 &&
-                            i % labeledTicksEveryNthHorizontalTick === 0 &&
-                            m > startM &&
-                            m < endM &&
-                            (i == 0 ||
-                                trackKmIndex === trackKmHeights.length - 1 ||
-                                (trackKmHeights[trackKmIndex + 1].trackMeterHeights[0].m - m) *
-                                    coordinates.mMeterLengthPxOverM >
-                                    minPixelsBeforeLastLabeledTickOnKm),
-                    )
-                    .map(({ m, meter }) => {
-                        const x = mToX(coordinates, m);
-                        return (
-                            <React.Fragment key={`${kmNumber}_${meter}`}>
-                                <Translate x={x - 25} y={280 + (meter === 0 ? 17 : 12)}>
-                                    <text scale="0.7 0.7">
-                                        KM{' '}
-                                        {formatTrackMeterWithoutMeters({
-                                            kmNumber,
-                                            meters: meter,
-                                        })}
-                                    </text>
-                                    <line y={-40} stroke="black" />
-                                </Translate>
-                                <line
-                                    x1={x}
-                                    x2={x}
-                                    y1={0}
-                                    y2={280}
-                                    stroke={lineGridStrokeColor}
-                                    fill="none"
-                                    shapeRendering="crispEdges"
-                                />
-                            </React.Fragment>
-                        );
-                    }),
-            )}
+            {trackKmHeights
+                .filter(
+                    ({ kmNumber }) =>
+                        trackKmLabelDisplayStep === 1 ||
+                        parseInt(kmNumber) % trackKmLabelDisplayStep === 0,
+                )
+                .flatMap(({ kmNumber, trackMeterHeights }, trackKmIndex) =>
+                    trackMeterHeights
+                        .filter(({ m, meter }) => {
+                            const ordinaryTick = Number.isInteger(meter);
+                            const inRenderedRange = m > startM && m < endM;
+                            const hitsMeterStep =
+                                meter === 0 ||
+                                (trackMeterDisplayStep !== undefined &&
+                                    meter % trackMeterDisplayStep === 0);
+                            return ordinaryTick && inRenderedRange && hitsMeterStep;
+                        })
+                        .map(({ m, meter }, meterIndex) => (
+                            <TickLabel
+                                key={`${trackKmIndex}_${meterIndex}`}
+                                m={m}
+                                meter={meter}
+                                kmNumber={kmNumber}
+                                coordinates={coordinates}
+                            />
+                        )),
+                )}
         </>
     );
 };

--- a/ui/src/vertical-geometry/plan-linking.tsx
+++ b/ui/src/vertical-geometry/plan-linking.tsx
@@ -1,18 +1,25 @@
 import React from 'react';
 import { Coordinates, mToX } from 'vertical-geometry/coordinates';
 import { PlanLinkingSummaryItem } from 'geometry/geometry-api';
+import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
+import { OnSelectOptions } from 'selection/selection-model';
 
 export interface PlanLinkingProps {
     coordinates: Coordinates;
     planLinkingSummary: PlanLinkingSummaryItem[];
+    onSelect: (options: OnSelectOptions) => void;
 }
 
-export const PlanLinking: React.FC<PlanLinkingProps> = ({ coordinates, planLinkingSummary }) => {
+export const PlanLinking: React.FC<PlanLinkingProps> = ({
+    coordinates,
+    planLinkingSummary,
+    onSelect,
+}) => {
     const textBottomYPx = 10;
     const textDropAreaPx = 3;
     return (
         <>
-            {planLinkingSummary.map(({ startM, endM, filename }, i) => {
+            {planLinkingSummary.map(({ startM, endM, filename, planId, alignmentHeader }, i) => {
                 if (endM < coordinates.startM || startM > coordinates.endM) {
                     return <React.Fragment key={i} />;
                 }
@@ -40,6 +47,19 @@ export const PlanLinking: React.FC<PlanLinkingProps> = ({ coordinates, planLinki
                             shapeRendering="crispEdges"
                         />
                         <svg
+                            onClick={() =>
+                                planId &&
+                                alignmentHeader &&
+                                onSelect({
+                                    geometryAlignments: [
+                                        {
+                                            geometryItem: alignmentHeader,
+                                            planId: planId,
+                                        },
+                                    ],
+                                })
+                            }
+                            className={styles['vertical-geometry-diagram__plan-link']}
                             x={textStartX}
                             y={0}
                             width={endX - textStartX}

--- a/ui/src/vertical-geometry/pvi-geometry.tsx
+++ b/ui/src/vertical-geometry/pvi-geometry.tsx
@@ -9,7 +9,7 @@ import { approximateHeightAtM, polylinePoints } from 'vertical-geometry/util';
 import { radsToDegrees } from 'utils/math-utils';
 
 const minimumSpacePxForPviPointSideLabels = 10;
-const minimumSpacePxForPviPointTopLabel = 8;
+const minimumSpacePxForPviPointTopLabel = 16;
 const minimumSpaceForTangentArrowLabel = 14;
 
 function tangentArrow(

--- a/ui/src/vertical-geometry/ticks-at-intervals.ts
+++ b/ui/src/vertical-geometry/ticks-at-intervals.ts
@@ -1,0 +1,21 @@
+// Interval of 25 pointedly left out to have nicely placed divisors in the sequence. If we had an interval of 25, we'd
+// too easily end up in a situation where we're displaying ticks every 5 meters and labels every 25 meters, but then
+// when we zoom in a bit, the ticks move to being every 2 meters; so the labels at xx25 and xx75 meters disappear!
+const labelIntervalOptions = [1, 2, 5, 10, 50, 100, 250, 500, 1000];
+
+export const minimumApproximateHorizontalTickWidthPx = 15;
+export const minimumLabeledTickDistancePx = 120;
+
+// must be <=minimumApproximateHorizontalTickWidthPx, or we'll sometimes hide ticks when zooming in
+export const minimumRulerHeightLabelDistancePx = 15;
+
+export function minimumInterval(itemWidth: number, minimumWidth: number): number | undefined {
+    return labelIntervalOptions.find((interval) => itemWidth * interval >= minimumWidth);
+}
+
+export function minimumIntervalOrLongest(itemWidth: number, minimumWidth: number): number {
+    return (
+        minimumInterval(itemWidth, minimumWidth) ??
+        labelIntervalOptions[labelIntervalOptions.length - 1]
+    );
+}

--- a/ui/src/vertical-geometry/track-address-ruler.tsx
+++ b/ui/src/vertical-geometry/track-address-ruler.tsx
@@ -32,13 +32,15 @@ export const TrackAddressRuler: React.FC<TrackAddressRulerProps> = ({
     if (kmHeights.length === 0) {
         return <React.Fragment />;
     }
-    const kmPostMarkers = kmHeights.map(({ trackMeterHeights }, kmIndex) => (
-        <KmPostMarker
-            key={kmIndex}
-            x={mToX(coordinates, trackMeterHeights[0].m)}
-            heightPx={heightPx}
-        />
-    ));
+    const kmPostMarkers = kmHeights
+        .filter(({ trackMeterHeights }) => trackMeterHeights[0].meter === 0)
+        .map(({ trackMeterHeights }, kmIndex) => (
+            <KmPostMarker
+                key={kmIndex}
+                x={mToX(coordinates, trackMeterHeights[0].m)}
+                heightPx={heightPx}
+            />
+        ));
 
     // avoid rendering too far off the screen for performance
     const startM = coordinates.startM - 5 / coordinates.mMeterLengthPxOverM;

--- a/ui/src/vertical-geometry/track-address-ruler.tsx
+++ b/ui/src/vertical-geometry/track-address-ruler.tsx
@@ -1,12 +1,24 @@
 import React from 'react';
 import { Coordinates, mToX } from 'vertical-geometry/coordinates';
 import { TrackKmHeights } from 'geometry/geometry-api';
+import { Translate } from 'vertical-geometry/translate';
 
 export interface TrackAddressRulerProps {
     kmHeights: TrackKmHeights[];
     heightPx: number;
     coordinates: Coordinates;
 }
+
+const KmPostMarker: React.FC<{ x: number; heightPx: number }> = ({ x, heightPx }) => (
+    <Translate x={x} y={heightPx}>
+        <circle r={5} stroke="black" fill="white" />
+        <circle
+            r={5}
+            fill="black"
+            clipPath="polygon(0 50%, 100% 50%, 100% 100%, 50% 100%, 50% 0, 0 0)"
+        />
+    </Translate>
+);
 
 export const TrackAddressRuler: React.FC<TrackAddressRulerProps> = ({
     kmHeights,
@@ -17,12 +29,10 @@ export const TrackAddressRuler: React.FC<TrackAddressRulerProps> = ({
         return <React.Fragment />;
     }
     const kmPostMarkers = kmHeights.map(({ trackMeterHeights }, kmIndex) => (
-        <circle
+        <KmPostMarker
             key={kmIndex}
-            cx={mToX(coordinates, trackMeterHeights[0].m)}
-            cy={heightPx}
-            r={5}
-            stroke={'black'}
+            x={mToX(coordinates, trackMeterHeights[0].m)}
+            heightPx={heightPx}
         />
     ));
 

--- a/ui/src/vertical-geometry/util.ts
+++ b/ui/src/vertical-geometry/util.ts
@@ -1,4 +1,4 @@
-import { TrackKmHeights } from 'geometry/geometry-api';
+import { TrackKmHeights, TrackMeterHeight } from 'geometry/geometry-api';
 import {
     findTrackMeterIndexContainingM,
     getTrackMeterPairAroundIndex,

--- a/ui/src/vertical-geometry/util.ts
+++ b/ui/src/vertical-geometry/util.ts
@@ -1,4 +1,4 @@
-import { TrackKmHeights, TrackMeterHeight } from 'geometry/geometry-api';
+import { TrackKmHeights } from 'geometry/geometry-api';
 import {
     findTrackMeterIndexContainingM,
     getTrackMeterPairAroundIndex,

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.scss
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.scss
@@ -9,6 +9,10 @@
     }
 }
 
+.vertical-geometry-diagram__plan-link {
+    cursor: pointer;
+}
+
 .vertical-geometry-diagram__tooltip {
     background: $color-white-darker;
     color: $color-black-default;

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -85,7 +85,8 @@ function processGeometries(
                 geom.fileName === linkedAreaSourceFile(geom.start.station) ||
                 geom.fileName === linkedAreaSourceFile(geom.end.station) ||
                 geom.fileName === linkedAreaSourceFile(geom.point.station),
-        );
+        )
+        .sort((a, b) => a.point.station - b.point.station);
 }
 
 function minAndMaxHeights(

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -255,7 +255,7 @@ const VerticalGeometryDiagram: React.FC<{
     const elementPosition = ref.current?.getBoundingClientRect();
 
     if (alignmentHeights == undefined || geometry == undefined || elementPosition == undefined) {
-        return <div ref={ref} />;
+        return <svg width={diagramWidthPx} height={fullDiagramHeightPx} />;
     }
     if (
         geometry.length == 0 &&


### PR DESCRIPTION
Yritin varmaan puoli päivää erotella näitä käytännön testauksen perusteella järjestelmällisen epäjärjestelmällisesti tehtyjä tviikkejä erillisiksi pullareiksi, mutta siihenpä päädyin, ettei onnistu.

Pääasialliset muutokset korkealla tasolla:
- Korkeuskaavion APIt menee nyt enemmän yksi asia kerrallaan: Erikseen alignmentin alku- ja loppupisteen haku (start-and-end), joka sinällään aiheuttaa uutta alignmenttia ladattaessa yhden round-tripin, mutta yksinkertaistaa muuten toteutusta; sitten rinnakkaisina hakuina geometrian, korkeusviivan, ja suunnitelmien linkitysalueiden haut
- Pystygeometrialle uusi infoboksi sijaintiraiteille, ja sille alkuun tilaksi vaan yksittäinen frontin yhteinen tieto siitä, näytetäänkö sijaintiraiteiden korkeuskaaviota yleensä
- Kilometritolppien ja viivoittimen (eli sen kaavion alimman osan) asioiden renderöintiä säädetty vähän selkeämmäksi
- Kaavion piirto tehdään vain, jos kaikki kolme (tai suunnitelmapuolella kaksi) siihen liittyvää API-kutsua on tehty