### PR TITLE
GVT-1795 Split inframodelview to components by type + include import IM

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
@@ -104,7 +104,7 @@ class ChangeTimeController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/velho-document")
+    @GetMapping("/velho-documents")
     fun getVelhoDocumentChangeTime(): Instant {
         logger.apiCall("getVelhoDocumentChangeTime")
         return Instant.now() // TODO: GVT-1797

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -254,6 +254,7 @@ class GeometryDao @Autowired constructor(
 
         logger.daoAccess(UPDATE, GeometryPlan::class, planId)
 
+        // TODO: GVT-1794 This appears unused -> just return rowversion/id
         return geometryPlan
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
@@ -1,5 +1,8 @@
 package fi.fta.geoviite.infra.inframodel
 
+import VelhoDocument
+import VelhoDocumentHeader
+import VelhoDocumentStatus
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
 import fi.fta.geoviite.infra.common.*
@@ -11,6 +14,7 @@ import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.XmlCharset
 import fi.fta.geoviite.infra.util.toFileDownloadResponse
+import fi.fta.geoviite.infra.velho.velhoDummyData
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -97,7 +101,7 @@ class InfraModelController @Autowired constructor(
     fun validateGeometryPlan(
         @PathVariable("planId") planId: IntId<GeometryPlan>,
         @RequestPart(value = "override-parameters") overrideParameters: OverrideParameters?,
-    ): ValidationResponse? {
+    ): ValidationResponse {
         logger.apiCall(
             "validateGeometryPlan",
             "planId" to planId,
@@ -106,7 +110,6 @@ class InfraModelController @Autowired constructor(
 
         return infraModelService.validateGeometryPlan(planId, overrideParameters)
     }
-
 
     @PreAuthorize(AUTH_ALL_WRITE)
     @PutMapping("/{planId}")
@@ -133,6 +136,60 @@ class InfraModelController @Autowired constructor(
             fileNameWithSuffix(infraModelFileAndSource.name),
             infraModelFileAndSource.content.toByteArray(),
         )
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/velho-import/documents")
+    fun getVelhoDocumentHeaders(@RequestParam("status") status: VelhoDocumentStatus?): List<VelhoDocumentHeader> {
+        logger.apiCall("getVelhoDocumentHeaders", "status" to status)
+        return velhoDummyData
+    }
+
+    @PreAuthorize(AUTH_ALL_WRITE)
+    @PutMapping("/velho-import/documents/{id}/status")
+    fun updateVelhoFileStatus(
+        @PathVariable("id") id: IntId<VelhoDocument>,
+        @RequestPart(value = "status") status: VelhoDocumentStatus,
+    ): IntId<VelhoDocument> {
+        logger.apiCall("updateVelhoFileStatus", "id" to id, "status" to status)
+//        TODO("Not implemented yet") // GVT-1797
+        return id
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @PostMapping("/velho-import/{documentId}/validate")
+    fun validateVelhoDocument(
+        @PathVariable("documentId") documentId: IntId<VelhoDocument>,
+        @RequestPart(value = "override-parameters") overrideParameters: OverrideParameters?,
+    ): ValidationResponse {
+        logger.apiCall(
+            "validateVelhoDocument",
+            "documentId" to documentId,
+            "overrideParameters" to overrideParameters,
+        )
+
+        return ValidationResponse(
+            listOf(),
+            null,
+            null,
+            overrideParameters?.source ?: PlanSource.GEOMETRIAPALVELU,
+        )
+    }
+
+    @PreAuthorize(AUTH_ALL_WRITE)
+    @PostMapping("/velho-import/{documentId}")
+    fun importVelhoDocument(
+        documentId: IntId<VelhoDocument>,
+        @RequestPart(value = "override-parameters") overrideParameters: OverrideParameters?,
+        @RequestPart(value = "extrainfo-parameters") extraInfoParameters: ExtraInfoParameters?,
+    ): InsertResponse {
+        logger.apiCall(
+            "importVelhoDocument",
+            "documentId" to documentId,
+            "overrideParameters" to overrideParameters,
+            "extraInfoParameters" to extraInfoParameters,
+        )
+        TODO("Not implemented yet")
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/velho/VelhoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/velho/VelhoController.kt
@@ -11,10 +11,6 @@ import VelhoProject
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.geometry.GeometryPlan
-import fi.fta.geoviite.infra.inframodel.ExtraInfoParameters
-import fi.fta.geoviite.infra.inframodel.OverrideParameters
-import fi.fta.geoviite.infra.inframodel.ValidationResponse
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
@@ -24,7 +20,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import java.time.Instant
 
-val dummyData = listOf(
+val velhoDummyData = listOf(
     VelhoDocumentHeader(
         id = IntId(1),
         project = VelhoProject(
@@ -85,39 +81,3 @@ val dummyData = listOf(
         ),
     )
 )
-
-@RestController
-@RequestMapping("/velho")
-class VelhoController {
-
-    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
-
-    @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/document-headers")
-    fun getDocumentHeaders(@RequestParam("status") status: VelhoDocumentStatus?): List<VelhoDocumentHeader> {
-        logger.apiCall("getDocumentHeaders", "status" to status)
-        return dummyData
-    }
-
-    @PreAuthorize(AUTH_ALL_READ)
-    @PostMapping("/validate/{id}")
-    fun validateVelhoFile(
-        @RequestPart(value = "override-parameters") overrideParameters: OverrideParameters?,
-    ): ValidationResponse {
-        logger.apiCall("override-parameters", "overrideParameters" to overrideParameters)
-        TODO("Not implemented yet") // GVT-1797
-    }
-
-    @PreAuthorize(AUTH_ALL_WRITE)
-    @PostMapping("/import/{id}")
-    fun importVelhoFile(
-        @RequestPart(value = "override-parameters") overrideParameters: OverrideParameters?,
-        @RequestPart(value = "extrainfo-parameters") extraInfoParameters: ExtraInfoParameters?,
-    ): IntId<GeometryPlan> {
-        logger.apiCall("importVelhoFile",
-            "overrideParameters" to overrideParameters,
-            "extraInfoParameters" to extraInfoParameters,
-        )
-        TODO("Not implemented yet") // GVT-1797
-    }
-}

--- a/ui/src/common/navigate.ts
+++ b/ui/src/common/navigate.ts
@@ -1,10 +1,12 @@
 import { GeometryPlanId } from 'geometry/geometry-model';
+import { VelhoDocumentId } from 'infra-model/velho/velho-api';
 import { useNavigate } from 'react-router-dom';
 
 const appPath = {
     'inframodel-list': '/infra-model',
     'inframodel-upload': '/infra-model/upload',
     'inframodel-edit': (id: GeometryPlanId) => `/infra-model/edit/${id}`,
+    'inframodel-import': (id: VelhoDocumentId) => `/infra-model/import/${id}`,
 } as const;
 
 type AppNavigateFunction = <K extends keyof typeof appPath>(

--- a/ui/src/common/navigate.ts
+++ b/ui/src/common/navigate.ts
@@ -1,5 +1,5 @@
 import { GeometryPlanId } from 'geometry/geometry-model';
-import { VelhoDocumentId } from 'infra-model/velho/velho-api';
+import { VelhoDocumentId } from 'infra-model/velho/velho-model';
 import { useNavigate } from 'react-router-dom';
 
 const appPath = {

--- a/ui/src/i18n/fi/fi.json
+++ b/ui/src/i18n/fi/fi.json
@@ -45,7 +45,7 @@
             "request-failed": "Pyyntö taustapalvelimelle epäonnistui",
             "parsing": {
                 "generic": "Tiedoston jäsentäminen epäonnistui",
-                "xml-invalid": "Tiedoston rakenne on virheellinen. Varmista että merkistö (XML:n alkutagin encoding-kenttä) on oikein.",
+                "xml-invalid": "Tiedoston rakenne on virheellinen. Varmista että merkistö (XML:n alkutagin encoding-kenttä) on oikein ja tiedosto on LandXML tyyppinen.",
                 "duplicate-inframodel-file-content": "Suunnitelma on jo olemassa Geoviitteessä samasta lähteestä nimellä {{0}}",
                 "missing-section": {
                     "coordinate-system": "Koordinaattijärjestelmän tiedot (CoordinateSystem-elementti) puuttuu",

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -126,7 +126,7 @@ export async function getVelhoDocuments(
 ): Promise<VelhoDocumentHeader[]> {
     const params = queryParams({ status: status });
     return documentHeadersCache.get(changeTime, status, () =>
-        getWithDefault<VelhoDocumentHeader[]>(`${VELHO_URI}/document-headers${params}`, []),
+        getWithDefault<VelhoDocumentHeader[]>(`${VELHO_URI}/documents${params}`, []),
     );
 }
 

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -7,34 +7,17 @@ import {
     queryParams,
     getWithDefault,
 } from 'api/api-fetch';
-import { GeometryPlanLayout } from 'track-layout/track-layout-model';
 import { GeometryPlan, GeometryPlanId } from 'geometry/geometry-model';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { updatePlanChangeTime } from 'common/change-time-api';
-import { ExtraInfraModelParameters, OverrideInfraModelParameters } from './infra-model-slice';
+import {
+    ExtraInfraModelParameters,
+    OverrideInfraModelParameters,
+    ValidationResponse,
+} from './infra-model-slice';
 import { VelhoDocumentHeader, VelhoDocumentId, VelhoFileStatus } from './velho/velho-model';
 import { asyncCache } from 'cache/cache';
 import { TimeStamp } from 'common/common-model';
-
-export type LocalizationKey = string;
-
-export type ErrorType =
-    | 'REQUEST_ERROR'
-    | 'PARSING_ERROR'
-    | 'TRANSFORMATION_ERROR'
-    | 'VALIDATION_ERROR'
-    | 'OBSERVATION_MAJOR'
-    | 'OBSERVATION_MINOR';
-export interface CustomValidationError {
-    localizationKey: LocalizationKey;
-    errorType: ErrorType;
-}
-
-export interface ValidationResponse {
-    validationErrors: CustomValidationError[];
-    geometryPlan: GeometryPlan | null;
-    planLayout: GeometryPlanLayout | null;
-}
 
 export interface InsertResponse {
     message: string;

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -4,11 +4,17 @@ import {
     postFormIgnoreError,
     postFormWithError,
     putFormIgnoreError,
+    queryParams,
+    getWithDefault,
 } from 'api/api-fetch';
 import { GeometryPlanLayout } from 'track-layout/track-layout-model';
 import { GeometryPlan, GeometryPlanId } from 'geometry/geometry-model';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { updatePlanChangeTime } from 'common/change-time-api';
+import { ExtraInfraModelParameters, OverrideInfraModelParameters } from './infra-model-slice';
+import { VelhoDocumentHeader, VelhoDocumentId, VelhoFileStatus } from './velho/velho-model';
+import { asyncCache } from 'cache/cache';
+import { TimeStamp } from 'common/common-model';
 
 export type LocalizationKey = string;
 
@@ -41,7 +47,10 @@ export const EMPTY_VALIDATION_RESPONSE: ValidationResponse = {
     planLayout: null,
 };
 
-export const INFRAMODEL_URI = `${API_URI}/inframodel`;
+const INFRAMODEL_URI = `${API_URI}/inframodel`;
+const VELHO_URI = `${INFRAMODEL_URI}/velho-import`;
+
+const documentHeadersCache = asyncCache<string, VelhoDocumentHeader[]>();
 
 export const inframodelDownloadUri = (planId: GeometryPlanId) => `${INFRAMODEL_URI}/${planId}/file`;
 
@@ -56,19 +65,29 @@ const defaultValidationErrorHandler = (response: ApiErrorResponse): ValidationRe
 });
 
 export const getValidationErrorsForInfraModelFile = async (
-    formData: FormData,
+    file?: File,
+    overrideParameters?: OverrideInfraModelParameters,
 ): Promise<ValidationResponse> => {
-    return postFormWithError<ValidationResponse, ValidationResponse>(
-        `${INFRAMODEL_URI}/validate`,
-        formData,
-        defaultValidationErrorHandler,
-    );
+    if (file) {
+        const formData = createFormData(file, undefined, overrideParameters);
+        return postFormWithError<ValidationResponse, ValidationResponse>(
+            `${INFRAMODEL_URI}/validate`,
+            formData,
+            defaultValidationErrorHandler,
+        );
+    } else {
+        return Promise.resolve({
+            ...EMPTY_VALIDATION_RESPONSE,
+            message: 'No file',
+        });
+    }
 };
 
 export const getValidationErrorsForGeometryPlan = async (
     planId: GeometryPlanId,
-    formData: FormData,
+    overrideParameters: OverrideInfraModelParameters,
 ): Promise<ValidationResponse> => {
+    const formData = createFormData(undefined, undefined, overrideParameters);
     return postFormWithError(
         `${INFRAMODEL_URI}/${planId}/validate`,
         formData,
@@ -76,7 +95,12 @@ export const getValidationErrorsForGeometryPlan = async (
     );
 };
 
-export const saveInfraModelFile = async (formData: FormData): Promise<InsertResponse | null> => {
+export const saveInfraModelFile = async (
+    file?: Blob,
+    extraParameters?: ExtraInfraModelParameters,
+    overrideParameters?: OverrideInfraModelParameters,
+): Promise<InsertResponse | null> => {
+    const formData = createFormData(file, extraParameters, overrideParameters);
     const response = await postFormIgnoreError<InsertResponse>(INFRAMODEL_URI, formData);
     if (response) {
         Snackbar.success(`IM-tiedosto tallennettu`);
@@ -87,9 +111,66 @@ export const saveInfraModelFile = async (formData: FormData): Promise<InsertResp
 
 export async function updateGeometryPlan(
     planId: GeometryPlanId,
-    formData: FormData,
+    extraParameters?: ExtraInfraModelParameters,
+    overrideParameters?: OverrideInfraModelParameters,
 ): Promise<GeometryPlan | null> {
+    const formData = createFormData(undefined, extraParameters, overrideParameters);
     const r = await putFormIgnoreError<GeometryPlan>(`${INFRAMODEL_URI}/${planId}`, formData);
     updatePlanChangeTime();
     return r;
 }
+
+export async function getVelhoDocuments(
+    changeTime: TimeStamp,
+    status: VelhoFileStatus,
+): Promise<VelhoDocumentHeader[]> {
+    const params = queryParams({ status: status });
+    return documentHeadersCache.get(changeTime, status, () =>
+        getWithDefault<VelhoDocumentHeader[]>(`${VELHO_URI}/document-headers${params}`, []),
+    );
+}
+
+export async function rejectVelhoDocument(id: VelhoDocumentId): Promise<null> {
+    console.log('Reject', id);
+    return null;
+}
+
+export const getValidationErrorsForVelhoDocument = async (
+    velhoDocumentId: VelhoDocumentId,
+    overrideParameters: OverrideInfraModelParameters,
+): Promise<ValidationResponse> => {
+    const formData = createFormData(undefined, undefined, overrideParameters);
+    return postFormWithError(
+        `${INFRAMODEL_URI}/velho-import/${velhoDocumentId}/validate`,
+        formData,
+        defaultValidationErrorHandler,
+    );
+};
+
+export async function importVelhoDocument(
+    id: VelhoDocumentId,
+    extraParameters?: ExtraInfraModelParameters,
+    overrideParameters?: OverrideInfraModelParameters,
+): Promise<GeometryPlanId | null> {
+    const _formData = createFormData(undefined, extraParameters, overrideParameters);
+    console.log('Import', id, 'extra', extraParameters, 'override', overrideParameters);
+    return null;
+}
+
+const createFormData = (
+    file?: Blob,
+    extraParameters?: ExtraInfraModelParameters,
+    overrideParameters?: OverrideInfraModelParameters,
+) => {
+    const formData = new FormData();
+
+    if (file) formData.set('file', file);
+    if (overrideParameters) formData.set('override-parameters', createJsonBlob(overrideParameters));
+    if (extraParameters) formData.set('extrainfo-parameters', createJsonBlob(extraParameters));
+
+    return formData;
+};
+
+const createJsonBlob = (object: unknown) => {
+    return new Blob([JSON.stringify(object)], { type: 'application/json' });
+};

--- a/ui/src/infra-model/infra-model-main-view.tsx
+++ b/ui/src/infra-model/infra-model-main-view.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import styles from './infra-model-main.scss';
-import { InfraModelViewContainer } from 'infra-model/view/infra-model-view-container';
+import {
+    InfraModelViewContainer,
+    InfraModelViewType,
+} from 'infra-model/view/infra-model-view-container';
 import { Route, Routes } from 'react-router-dom';
-import { InfraModelViewType } from 'infra-model/infra-model-slice';
 import TabContainer from 'infra-model/tabs/tab-container';
 import { useCommonDataAppSelector } from 'store/hooks';
 //import { InfraModelTabType } from 'common/common-slice';

--- a/ui/src/infra-model/infra-model-main-view.tsx
+++ b/ui/src/infra-model/infra-model-main-view.tsx
@@ -18,6 +18,10 @@ export const InfraModelMainView: React.FC = () => {
                     element={<InfraModelViewContainer viewType={InfraModelViewType.EDIT} />}
                 />
                 <Route
+                    path="/import/:id"
+                    element={<InfraModelViewContainer viewType={InfraModelViewType.IMPORT} />}
+                />
+                <Route
                     path="/upload"
                     element={<InfraModelViewContainer viewType={InfraModelViewType.UPLOAD} />}
                 />

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -41,7 +41,7 @@ export type InfraModelState = {
     selection: Selection;
     plan: GeometryPlan | null;
     planLayout: GeometryPlanLayout | null;
-    file: SerializableFile | undefined;
+    file: SerializableFile | undefined; // TODO: GVT-1795 move this to localstorage, stored by uploadloader
     extraInfraModelParameters: ExtraInfraModelParameters;
     overrideInfraModelParameters: OverrideInfraModelParameters;
     validationErrors: ValidationError<InfraModelParameters>[];
@@ -183,13 +183,6 @@ const infraModelSlice = createSlice({
             { payload: key }: PayloadAction<InfraModelParametersProp>,
         ) => {
             state.committedFields = [...state.committedFields, key];
-        },
-        onPlanUpdate: (state: InfraModelState) => {
-            state.validationErrors = validateParams(
-                state.plan,
-                state.extraInfraModelParameters,
-                state.overrideInfraModelParameters,
-            );
         },
         setInfraModelFile: (
             state: InfraModelState,

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -29,18 +29,11 @@ import {
 } from 'common/common-model';
 import { Prop } from 'utils/type-utils';
 
-export enum InfraModelViewType {
-    UPLOAD,
-    IMPORT,
-    EDIT,
-}
-
 export type InfraModelState = {
     map: Map;
     infraModelList: InfraModelListState;
     selection: Selection;
-    plan: GeometryPlan | null;
-    planLayout: GeometryPlanLayout | null;
+    validationResponse: ValidationResponse | null;
     file: SerializableFile | undefined; // TODO: GVT-1795 move this to localstorage, stored by uploadloader
     extraInfraModelParameters: ExtraInfraModelParameters;
     overrideInfraModelParameters: OverrideInfraModelParameters;
@@ -72,10 +65,25 @@ export type InfraModelParameters = ExtraInfraModelParameters & OverrideInfraMode
 
 export type InfraModelParametersProp = keyof InfraModelParameters;
 
-export type OnPlanFetchReady = {
-    plan: GeometryPlan | null;
+export type LocalizationKey = string;
+
+export type ErrorType =
+    | 'REQUEST_ERROR'
+    | 'PARSING_ERROR'
+    | 'TRANSFORMATION_ERROR'
+    | 'VALIDATION_ERROR'
+    | 'OBSERVATION_MAJOR'
+    | 'OBSERVATION_MINOR';
+export interface CustomValidationError {
+    localizationKey: LocalizationKey;
+    errorType: ErrorType;
+}
+
+export interface ValidationResponse {
+    validationErrors: CustomValidationError[];
+    geometryPlan: GeometryPlan | null;
     planLayout: GeometryPlanLayout | null;
-};
+}
 
 const visibleMapLayerTypes: MapLayerType[] = [
     'tile',
@@ -100,8 +108,7 @@ export const initialInfraModelState: InfraModelState = {
         ...initialSelectionState,
         selectionModes: ['segment', 'switch'],
     },
-    plan: null,
-    planLayout: null,
+    validationResponse: null,
     file: undefined,
     extraInfraModelParameters: {
         oid: undefined,
@@ -120,25 +127,19 @@ export const initialInfraModelState: InfraModelState = {
     committedFields: [],
 };
 
-export type GeometryPlanWithParameters = {
-    geometryPlan: GeometryPlan;
-    extraInfraModelParameters: ExtraInfraModelParameters;
-};
-
 const infraModelSlice = createSlice({
     name: 'infraModel',
     initialState: initialInfraModelState,
     reducers: {
-        onPlanFetchReady: (
+        onPlanValidated: (
             state: InfraModelState,
-            { payload: { plan, planLayout } }: PayloadAction<OnPlanFetchReady>,
+            { payload: response }: PayloadAction<ValidationResponse>,
         ) => {
-            state.plan = plan;
-            state.planLayout = planLayout;
+            state.validationResponse = response;
 
-            if (planLayout) {
-                state.selection.planLayouts = [planLayout];
-                const bBox = planLayout && planLayout.boundingBox;
+            if (response.planLayout) {
+                state.selection.planLayouts = [response.planLayout];
+                const bBox = response.planLayout.boundingBox;
                 state.map.viewport = {
                     ...state.map.viewport,
                     center: {
@@ -155,7 +156,7 @@ const infraModelSlice = createSlice({
         ) {
             state.extraInfraModelParameters[propEdit.key] = propEdit.value;
             state.validationErrors = validateParams(
-                state.plan,
+                state.validationResponse?.geometryPlan || null,
                 state.extraInfraModelParameters,
                 state.overrideInfraModelParameters,
             );
@@ -173,7 +174,7 @@ const infraModelSlice = createSlice({
         ) => {
             state.overrideInfraModelParameters = { ...payload };
             state.validationErrors = validateParams(
-                state.plan,
+                state.validationResponse?.geometryPlan || null,
                 state.extraInfraModelParameters,
                 state.overrideInfraModelParameters,
             );
@@ -190,7 +191,7 @@ const infraModelSlice = createSlice({
         ) => {
             state.file = file;
 
-            state.plan = initialInfraModelState.plan;
+            state.validationResponse = initialInfraModelState.validationResponse;
             state.selection = initialSelectionState;
             state.map.viewport = initialMapState.viewport;
             state.committedFields = [];
@@ -198,18 +199,22 @@ const infraModelSlice = createSlice({
             state.overrideInfraModelParameters =
                 initialInfraModelState.overrideInfraModelParameters;
             state.validationErrors = validateParams(
-                state.plan,
+                state.validationResponse?.geometryPlan || null,
                 state.extraInfraModelParameters,
                 state.overrideInfraModelParameters,
             );
         },
         setExistingInfraModel: (
             state: InfraModelState,
-            { payload }: PayloadAction<GeometryPlanWithParameters>,
+            { payload: plan }: PayloadAction<GeometryPlan>,
         ) => {
-            state.plan = payload.geometryPlan;
-            state.extraInfraModelParameters = payload.extraInfraModelParameters;
-
+            state.extraInfraModelParameters = {
+                oid: plan.oid ? plan.oid : undefined,
+                planPhase: plan.planPhase ? plan.planPhase : undefined,
+                decisionPhase: plan.decisionPhase ? plan.decisionPhase : undefined,
+                measurementMethod: plan.measurementMethod ? plan.measurementMethod : undefined,
+                message: plan.message ? plan.message : undefined,
+            };
             state.overrideInfraModelParameters =
                 initialInfraModelState.overrideInfraModelParameters;
             state.file = initialInfraModelState.file;

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -34,7 +34,7 @@ export type InfraModelState = {
     infraModelList: InfraModelListState;
     selection: Selection;
     validationResponse: ValidationResponse | null;
-    file: SerializableFile | undefined; // TODO: GVT-1795 move this to localstorage, stored by uploadloader
+    file: SerializableFile | undefined;
     extraInfraModelParameters: ExtraInfraModelParameters;
     overrideInfraModelParameters: OverrideInfraModelParameters;
     validationErrors: ValidationError<InfraModelParameters>[];

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -31,6 +31,7 @@ import { Prop } from 'utils/type-utils';
 
 export enum InfraModelViewType {
     UPLOAD,
+    IMPORT,
     EDIT,
 }
 

--- a/ui/src/infra-model/translations.fi.json
+++ b/ui/src/infra-model/translations.fi.json
@@ -67,6 +67,7 @@
             "title": "Tiedoston käsittely epäonnistui",
             "try-again": "Lataa uudelleen",
             "change-encoding": "Lataa toisella merkistöllä",
+            "try-change-encoding": "Jos merkistö on tiedostossa väärin, voit pakottaa sen toiseksi tässä:",
             "encoding": "Merkistö"
         },
         "critical-warnings-dialog": {

--- a/ui/src/infra-model/translations.fi.json
+++ b/ui/src/infra-model/translations.fi.json
@@ -61,7 +61,7 @@
         "missing-source": "Suunnitelman lähde puuttuu",
         "toolbar": {
             "files": "IM-tiedostot",
-            "upload": "Lataa uusi"
+            "upload": "Tuo uusi"
         },
         "file-handling-failed": {
             "title": "Tiedoston käsittely epäonnistui",

--- a/ui/src/infra-model/velho/velho-model.ts
+++ b/ui/src/infra-model/velho/velho-model.ts
@@ -1,5 +1,3 @@
-import { API_URI, getWithDefault, queryParams } from 'api/api-fetch';
-import { asyncCache } from 'cache/cache';
 import { TimeStamp } from 'common/common-model';
 
 export type VelhoFileStatus = 'REJECTED' | 'ACCEPTED' | 'PENDING';
@@ -31,17 +29,3 @@ export type VelhoDocumentHeader = {
     materialGroup: string;
     document: VelhoDocument;
 };
-
-const VELHO_URI = `${API_URI}/velho`;
-
-const documentHeadersCache = asyncCache<string, VelhoDocumentHeader[]>();
-
-export async function getVelhoDocuments(
-    changeTime: TimeStamp,
-    status: VelhoFileStatus,
-): Promise<VelhoDocumentHeader[]> {
-    const params = queryParams({ status: status });
-    return documentHeadersCache.get(changeTime, status, () =>
-        getWithDefault<VelhoDocumentHeader[]>(`${VELHO_URI}/document-headers${params}`, []),
-    );
-}

--- a/ui/src/infra-model/view/dialogs/charset-select-dialog.tsx
+++ b/ui/src/infra-model/view/dialogs/charset-select-dialog.tsx
@@ -1,0 +1,66 @@
+import dialogStyles from 'vayla-design-lib/dialog/dialog.scss';
+import { XmlCharset } from 'infra-model/infra-model-slice';
+import React from 'react';
+import styles from '../form/infra-model-form.module.scss';
+import { useTranslation } from 'react-i18next';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Dialog } from 'vayla-design-lib/dialog/dialog';
+import { Dropdown, Item } from 'vayla-design-lib/dropdown/dropdown';
+
+const xmlEncodingOptions: Item<XmlCharset>[] = [
+    { name: 'ISO-8859-1', value: 'ISO_8859_1' },
+    { name: 'UTF-8', value: 'UTF_8' },
+    { name: 'UTF-16', value: 'UTF_16' },
+    { name: 'US ASCII', value: 'US_ASCII' },
+];
+
+export type CharsetSelectDialogProps = {
+    title: string;
+    value: XmlCharset | undefined;
+    onSelect: (charset: XmlCharset | undefined) => void;
+    onCancel: () => void;
+    children?: React.ReactNode;
+};
+
+export const CharsetSelectDialog: React.FC<CharsetSelectDialogProps> = ({
+    title,
+    children,
+    value,
+    onSelect,
+    onCancel,
+}: CharsetSelectDialogProps) => {
+    const { t } = useTranslation();
+    const [overrideCharset, setOverrideCharset] = React.useState<XmlCharset | null>(null);
+    return (
+        <Dialog
+            title={title}
+            scrollable={false}
+            className={dialogStyles['dialog--wide']}
+            onClose={onCancel}
+            footerContent={
+                <React.Fragment>
+                    <Button variant={ButtonVariant.SECONDARY} onClick={onCancel}>
+                        {t('button.cancel')}
+                    </Button>
+                    <Button
+                        onClick={() => {
+                            onSelect(overrideCharset || undefined);
+                        }}>
+                        {t('im-form.file-handling-failed.try-again')}
+                    </Button>
+                </React.Fragment>
+            }>
+            {children}
+            <div className={styles['infra-model-upload-failed__encode-container']}>
+                <label className={styles['infra-model-upload-failed__checkbox-label']}>
+                    {t('im-form.file-handling-failed.encoding')}
+                </label>
+                <Dropdown
+                    options={xmlEncodingOptions}
+                    value={overrideCharset || value}
+                    onChange={(newEncoding: XmlCharset) => setOverrideCharset(newEncoding)}
+                />
+            </div>
+        </Dialog>
+    );
+};

--- a/ui/src/infra-model/view/form/infra-model-form.module.scss
+++ b/ui/src/infra-model/view/form/infra-model-form.module.scss
@@ -25,6 +25,7 @@
 
     padding: 0 16px;
     display: flex;
+    align-items: center;
     background: $color-white-dark;
     z-index: 1;
 

--- a/ui/src/infra-model/view/infra-model-edit-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-edit-loader.tsx
@@ -4,16 +4,15 @@ import { getGeometryPlan } from 'geometry/geometry-api';
 import { GeometryPlan } from 'geometry/geometry-model';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { InfraModelBaseProps, InfraModelView } from 'infra-model/view/infra-model-view';
-import { GeometryPlanWithParameters } from 'infra-model/infra-model-slice';
+import { ValidationResponse } from 'infra-model/infra-model-slice';
 import {
     getValidationErrorsForGeometryPlan,
     updateGeometryPlan,
-    ValidationResponse,
 } from 'infra-model/infra-model-api';
 
 export type InfraModelLoaderProps = {
-    setExistingInfraModel: (plan: GeometryPlanWithParameters) => void;
-    onValidation: (ValidationResponse: ValidationResponse) => void;
+    setExistingInfraModel: (plan: GeometryPlan) => void;
+    onValidation: (validationResponse: ValidationResponse) => void;
     setLoading: (loading: boolean) => void;
 } & InfraModelBaseProps;
 
@@ -35,10 +34,10 @@ export const InfraModelEditLoader: React.FC<InfraModelLoaderProps> = ({
         }
         return null;
     };
-    // Automatically re-validate whenever the plan or manually input data changes
+    // Automatically re-validate whenever the manually input data changes
     React.useEffect(() => {
         onValidate();
-    }, [planId, overrideParams]);
+    }, [overrideParams]);
 
     const onSave: () => Promise<boolean> = async () => {
         if (!planId) return false;
@@ -52,21 +51,8 @@ export const InfraModelEditLoader: React.FC<InfraModelLoaderProps> = ({
         if (planId !== undefined) {
             setIsLoading(true);
             getGeometryPlan(planId).then((plan: GeometryPlan | null) => {
-                if (plan) {
-                    setExistingInfraModel({
-                        geometryPlan: plan,
-                        extraInfraModelParameters: {
-                            oid: plan.oid ? plan.oid : undefined,
-                            planPhase: plan.planPhase ? plan.planPhase : undefined,
-                            decisionPhase: plan.decisionPhase ? plan.decisionPhase : undefined,
-                            measurementMethod: plan.measurementMethod
-                                ? plan.measurementMethod
-                                : undefined,
-                            message: plan.message ? plan.message : undefined,
-                        },
-                    });
-                    setIsLoading(false);
-                }
+                if (plan) setExistingInfraModel(plan);
+                setIsLoading(false);
             });
             onValidate();
         }

--- a/ui/src/infra-model/view/infra-model-edit-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-edit-loader.tsx
@@ -26,13 +26,12 @@ export const InfraModelEditLoader: React.FC<InfraModelLoaderProps> = ({
     const extraParams = props.extraInfraModelParameters;
     const overrideParams = props.overrideInfraModelParameters;
 
-    const onValidate: () => Promise<null> = async () => {
+    const onValidate: () => void = async () => {
         if (planId) {
             props.setLoading(true);
             props.onValidation(await getValidationErrorsForGeometryPlan(planId, overrideParams));
             props.setLoading(false);
         }
-        return null;
     };
     // Automatically re-validate whenever the manually input data changes
     React.useEffect(() => {
@@ -57,7 +56,6 @@ export const InfraModelEditLoader: React.FC<InfraModelLoaderProps> = ({
             onValidate();
         }
     }, [planId]);
-    useEffect;
 
     return isLoading ? (
         <Spinner />

--- a/ui/src/infra-model/view/infra-model-import-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-import-loader.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { InfraModelBaseProps, InfraModelView } from 'infra-model/view/infra-model-view';
+import {
+    getValidationErrorsForVelhoDocument,
+    importVelhoDocument,
+    ValidationResponse,
+} from 'infra-model/infra-model-api';
+
+export type InfraModelImportLoaderProps = InfraModelBaseProps & {
+    onValidation: (ValidationResponse: ValidationResponse) => void;
+    setLoading: (loading: boolean) => void;
+};
+
+export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ ...props }) => {
+    const { id: velhoDocId } = useParams<{ id: string }>();
+    const extraParams = props.extraInfraModelParameters;
+    const overrideParams = props.overrideInfraModelParameters;
+
+    const onValidate: () => Promise<null> = async () => {
+        if (velhoDocId) {
+            props.setLoading(true);
+            props.onValidation(
+                await getValidationErrorsForVelhoDocument(velhoDocId, overrideParams),
+            );
+            props.setLoading(false);
+        }
+        return null;
+    };
+    // Automatically re-validate whenever the plan or manually input data changes
+    React.useEffect(() => {
+        onValidate();
+    }, [velhoDocId, overrideParams]);
+
+    const onSave: () => Promise<boolean> = async () => {
+        if (!velhoDocId) return false;
+        props.setLoading(true);
+        const response = await importVelhoDocument(velhoDocId, extraParams, overrideParams);
+        props.setLoading(false);
+        return response != null;
+    };
+    return <InfraModelView {...props} onSave={onSave} onValidate={onValidate} />;
+};

--- a/ui/src/infra-model/view/infra-model-import-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-import-loader.tsx
@@ -17,7 +17,7 @@ export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ 
     const extraParams = props.extraInfraModelParameters;
     const overrideParams = props.overrideInfraModelParameters;
 
-    const onValidate: () => Promise<null> = async () => {
+    const onValidate: () => void = async () => {
         if (velhoDocId) {
             props.setLoading(true);
             props.onValidation(

--- a/ui/src/infra-model/view/infra-model-import-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-import-loader.tsx
@@ -4,11 +4,11 @@ import { InfraModelBaseProps, InfraModelView } from 'infra-model/view/infra-mode
 import {
     getValidationErrorsForVelhoDocument,
     importVelhoDocument,
-    ValidationResponse,
 } from 'infra-model/infra-model-api';
+import { ValidationResponse } from 'infra-model/infra-model-slice';
 
 export type InfraModelImportLoaderProps = InfraModelBaseProps & {
-    onValidation: (ValidationResponse: ValidationResponse) => void;
+    onValidation: (validationResponse: ValidationResponse) => void;
     setLoading: (loading: boolean) => void;
 };
 

--- a/ui/src/infra-model/view/infra-model-toolbar.tsx
+++ b/ui/src/infra-model/view/infra-model-toolbar.tsx
@@ -1,18 +1,26 @@
 import * as React from 'react';
+import styles from './form/infra-model-form.module.scss';
 import { Breadcrumb, BreadcrumbItem } from 'geoviite-design-lib/breadcrumb/breadcrumb';
 import { InfraModelViewType } from 'infra-model/infra-model-slice';
 import { useTranslation } from 'react-i18next';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+import { Menu, Item } from 'vayla-design-lib/menu/menu';
 
+export type FileMenuOption = 'fix-encoding';
 export type InfraModelToolbarProps = {
     navigateToList: () => void;
-    fileName?: string;
+    fileName: string;
     viewType: InfraModelViewType;
+    fileMenuItems: Item<FileMenuOption>[];
+    fileMenuItemSelected: (item: FileMenuOption) => void;
 };
 
 export const InfraModelToolbar: React.FC<InfraModelToolbarProps> = (
     props: InfraModelToolbarProps,
 ) => {
     const { t } = useTranslation();
+    const [fileMenuVisible, setFileMenuVisible] = React.useState(false);
 
     return (
         <div className="infra-model-upload__tool-bar">
@@ -23,9 +31,29 @@ export const InfraModelToolbar: React.FC<InfraModelToolbarProps> = (
                 <BreadcrumbItem>
                     {props.viewType === InfraModelViewType.EDIT
                         ? props.fileName
-                        : t('im-form.toolbar.upload')}
+                        : `${t('im-form.toolbar.upload')}: ${props.fileName}`}
                 </BreadcrumbItem>
             </Breadcrumb>
+
+            {props.fileMenuItems.length > 0 && (
+                <div className={styles['infra-model-upload__title-menu-container']}>
+                    <Button
+                        onClick={() => setFileMenuVisible(!fileMenuVisible)}
+                        variant={ButtonVariant.SECONDARY}
+                        icon={Icons.More}
+                    />
+                    {fileMenuVisible && (
+                        <div className={styles['infra-model-upload__title-menu']}>
+                            <Menu
+                                items={props.fileMenuItems}
+                                onChange={(item) => {
+                                    item && props.fileMenuItemSelected(item);
+                                    setFileMenuVisible(false);
+                                }}></Menu>
+                        </div>
+                    )}
+                </div>
+            )}
         </div>
     );
 };

--- a/ui/src/infra-model/view/infra-model-toolbar.tsx
+++ b/ui/src/infra-model/view/infra-model-toolbar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styles from './form/infra-model-form.module.scss';
 import { Breadcrumb, BreadcrumbItem } from 'geoviite-design-lib/breadcrumb/breadcrumb';
-import { InfraModelViewType } from 'infra-model/infra-model-slice';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
@@ -11,7 +10,6 @@ export type FileMenuOption = 'fix-encoding';
 export type InfraModelToolbarProps = {
     navigateToList: () => void;
     fileName: string;
-    viewType: InfraModelViewType;
     fileMenuItems: Item<FileMenuOption>[];
     fileMenuItemSelected: (item: FileMenuOption) => void;
 };
@@ -28,11 +26,7 @@ export const InfraModelToolbar: React.FC<InfraModelToolbarProps> = (
                 <BreadcrumbItem onClick={props.navigateToList}>
                     {t('im-form.toolbar.files')}
                 </BreadcrumbItem>
-                <BreadcrumbItem>
-                    {props.viewType === InfraModelViewType.EDIT
-                        ? props.fileName
-                        : `${t('im-form.toolbar.upload')}: ${props.fileName}`}
-                </BreadcrumbItem>
+                <BreadcrumbItem>{props.fileName}</BreadcrumbItem>
             </Breadcrumb>
 
             {props.fileMenuItems.length > 0 && (

--- a/ui/src/infra-model/view/infra-model-toolbar.tsx
+++ b/ui/src/infra-model/view/infra-model-toolbar.tsx
@@ -5,10 +5,10 @@ import { useTranslation } from 'react-i18next';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Menu, Item } from 'vayla-design-lib/menu/menu';
+import { useAppNavigate } from 'common/navigate';
 
 export type FileMenuOption = 'fix-encoding';
 export type InfraModelToolbarProps = {
-    navigateToList: () => void;
     fileName: string;
     fileMenuItems: Item<FileMenuOption>[];
     fileMenuItemSelected: (item: FileMenuOption) => void;
@@ -17,13 +17,14 @@ export type InfraModelToolbarProps = {
 export const InfraModelToolbar: React.FC<InfraModelToolbarProps> = (
     props: InfraModelToolbarProps,
 ) => {
+    const navigate = useAppNavigate();
     const { t } = useTranslation();
     const [fileMenuVisible, setFileMenuVisible] = React.useState(false);
 
     return (
         <div className="infra-model-upload__tool-bar">
             <Breadcrumb>
-                <BreadcrumbItem onClick={props.navigateToList}>
+                <BreadcrumbItem onClick={() => navigate('inframodel-list')}>
                     {t('im-form.toolbar.files')}
                 </BreadcrumbItem>
                 <BreadcrumbItem>{props.fileName}</BreadcrumbItem>

--- a/ui/src/infra-model/view/infra-model-upload-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-upload-loader.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import styles from './form/infra-model-form.module.scss';
+import { InfraModelBaseProps, InfraModelView } from 'infra-model/view/infra-model-view';
+import {
+    getValidationErrorsForInfraModelFile,
+    saveInfraModelFile,
+    ValidationResponse,
+} from 'infra-model/infra-model-api';
+import { convertToNativeFile, SerializableFile } from 'utils/file-utils';
+import { useTranslation } from 'react-i18next';
+import { useAppNavigate } from 'common/navigate';
+import { CharsetSelectDialog } from './dialogs/charset-select-dialog';
+
+export type InfraModelUploadLoaderProps = InfraModelBaseProps & {
+    file: SerializableFile | undefined; // TODO: GVT-1795 move this to localstorage, stored by uploadloader
+    onValidation: (ValidationResponse: ValidationResponse) => void;
+    setLoading: (loading: boolean) => void;
+};
+
+export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ ...props }) => {
+    const { t } = useTranslation();
+    const navigate = useAppNavigate();
+
+    const [file, setFile] = React.useState<File>();
+
+    const extraParams = props.extraInfraModelParameters;
+    const overrideParams = props.overrideInfraModelParameters;
+
+    React.useEffect(() => {
+        // Convert serializable file to native file
+        if (props.file) {
+            const file = convertToNativeFile(props.file);
+            setFile(file);
+        }
+    }, [props.file]);
+
+    const onValidate: () => Promise<null> = async () => {
+        props.setLoading(true);
+        props.onValidation(await getValidationErrorsForInfraModelFile(file, overrideParams));
+        props.setLoading(false);
+        return null;
+    };
+    // Automatically re-validate whenever the file or manually input data changes
+    React.useEffect(() => {
+        onValidate();
+    }, [file, overrideParams]);
+
+    const onSave: () => Promise<boolean> = async () => {
+        props.setLoading(true);
+        const response = await saveInfraModelFile(file, extraParams, overrideParams);
+        props.setLoading(false);
+        return response != null;
+    };
+
+    const fileHandlingFailedErrors =
+        props.validationResponse?.validationErrors
+            .filter((e) => e.errorType === 'PARSING_ERROR' || e.errorType === 'REQUEST_ERROR')
+            .map((item) => item.localizationKey) || [];
+    const showFileHandlingFailed = fileHandlingFailedErrors.length > 0;
+
+    return (
+        <>
+            <InfraModelView {...props} onSave={onSave} onValidate={onValidate} />
+
+            {showFileHandlingFailed && (
+                <CharsetSelectDialog
+                    title={t('im-form.file-handling-failed.title')}
+                    value={props.overrideInfraModelParameters.encoding}
+                    onCancel={() => {
+                        navigate('inframodel-list');
+                    }}
+                    onSelect={(charset) => {
+                        props.onOverrideParametersChange({
+                            ...props.overrideInfraModelParameters,
+                            encoding: charset,
+                        });
+                    }}>
+                    <ul className={styles['infra-model-upload-failed__errors']}>
+                        {fileHandlingFailedErrors.map((error) => (
+                            <li key={error}>{t(error)}</li>
+                        ))}
+                    </ul>
+                    <span>{t('im-form.file-handling-failed.try-change-encoding')}</span>
+                </CharsetSelectDialog>
+            )}
+        </>
+    );
+};

--- a/ui/src/infra-model/view/infra-model-upload-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-upload-loader.tsx
@@ -4,16 +4,16 @@ import { InfraModelBaseProps, InfraModelView } from 'infra-model/view/infra-mode
 import {
     getValidationErrorsForInfraModelFile,
     saveInfraModelFile,
-    ValidationResponse,
 } from 'infra-model/infra-model-api';
 import { convertToNativeFile, SerializableFile } from 'utils/file-utils';
 import { useTranslation } from 'react-i18next';
 import { useAppNavigate } from 'common/navigate';
 import { CharsetSelectDialog } from './dialogs/charset-select-dialog';
+import { ValidationResponse } from 'infra-model/infra-model-slice';
 
 export type InfraModelUploadLoaderProps = InfraModelBaseProps & {
     file: SerializableFile | undefined; // TODO: GVT-1795 move this to localstorage, stored by uploadloader
-    onValidation: (ValidationResponse: ValidationResponse) => void;
+    onValidation: (validationResponse: ValidationResponse) => void;
     setLoading: (loading: boolean) => void;
 };
 

--- a/ui/src/infra-model/view/infra-model-upload-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-upload-loader.tsx
@@ -7,19 +7,17 @@ import {
 } from 'infra-model/infra-model-api';
 import { convertToNativeFile, SerializableFile } from 'utils/file-utils';
 import { useTranslation } from 'react-i18next';
-import { useAppNavigate } from 'common/navigate';
 import { CharsetSelectDialog } from './dialogs/charset-select-dialog';
 import { ValidationResponse } from 'infra-model/infra-model-slice';
 
 export type InfraModelUploadLoaderProps = InfraModelBaseProps & {
-    file: SerializableFile | undefined; // TODO: GVT-1795 move this to localstorage, stored by uploadloader
+    file: SerializableFile | undefined;
     onValidation: (validationResponse: ValidationResponse) => void;
     setLoading: (loading: boolean) => void;
 };
 
 export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ ...props }) => {
     const { t } = useTranslation();
-    const navigate = useAppNavigate();
 
     const [file, setFile] = React.useState<File>();
 
@@ -34,11 +32,10 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
         }
     }, [props.file]);
 
-    const onValidate: () => Promise<null> = async () => {
+    const onValidate: () => void = async () => {
         props.setLoading(true);
         props.onValidation(await getValidationErrorsForInfraModelFile(file, overrideParams));
         props.setLoading(false);
-        return null;
     };
     // Automatically re-validate whenever the file or manually input data changes
     React.useEffect(() => {
@@ -66,9 +63,7 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
                 <CharsetSelectDialog
                     title={t('im-form.file-handling-failed.title')}
                     value={props.overrideInfraModelParameters.encoding}
-                    onCancel={() => {
-                        navigate('inframodel-list');
-                    }}
+                    onCancel={props.onClose}
                     onSelect={(charset) => {
                         props.onOverrideParametersChange({
                             ...props.overrideInfraModelParameters,

--- a/ui/src/infra-model/view/infra-model-validation-error-list.tsx
+++ b/ui/src/infra-model/view/infra-model-validation-error-list.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import styles from './form/infra-model-form.module.scss';
-import { CustomValidationError, ErrorType, ValidationResponse } from 'infra-model/infra-model-api';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { useTranslation } from 'react-i18next';
+import {
+    CustomValidationError,
+    ErrorType,
+    ValidationResponse,
+} from 'infra-model/infra-model-slice';
 
 type InframodelValidationErrorListProps = {
     validationResponse: ValidationResponse | null;

--- a/ui/src/infra-model/view/infra-model-view-container.tsx
+++ b/ui/src/infra-model/view/infra-model-view-container.tsx
@@ -1,6 +1,10 @@
-import { infraModelActionCreators, InfraModelViewType } from '../infra-model-slice';
+import {
+    infraModelActionCreators,
+    InfraModelState,
+    InfraModelViewType,
+} from '../infra-model-slice';
 import { createDelegates } from 'store/store-utils';
-import { InfraModelView } from 'infra-model/view/infra-model-view';
+import { InfraModelView, InfraModelViewProps } from 'infra-model/view/infra-model-view';
 import {
     GeometryElement,
     GeometryElementId,
@@ -53,19 +57,33 @@ export const InfraModelViewContainer: React.FC<InfraModelViewContainerProps> = (
         },
     };
 
-    return viewType == InfraModelViewType.UPLOAD ? (
-        <InfraModelView
-            {...infraModelState}
-            {...delegatesProps}
-            changeTimes={changeTimes}
-            viewType={viewType}
-        />
-    ) : (
-        <InfraModelEditLoader
-            {...infraModelState}
-            {...delegatesProps}
-            changeTimes={changeTimes}
-            viewType={viewType}
-        />
-    );
+    switch (viewType) {
+        case InfraModelViewType.EDIT:
+            return (
+                <InfraModelEditLoader
+                    {...infraModelState}
+                    {...delegatesProps}
+                    changeTimes={changeTimes}
+                    viewType={viewType}
+                />
+            );
+        case InfraModelViewType.IMPORT:
+            return (
+                <InfraModelView
+                    {...infraModelState}
+                    {...delegatesProps}
+                    changeTimes={changeTimes}
+                    viewType={viewType}
+                />
+            );
+        case InfraModelViewType.UPLOAD:
+            return (
+                <InfraModelView
+                    {...infraModelState}
+                    {...delegatesProps}
+                    changeTimes={changeTimes}
+                    viewType={viewType}
+                />
+            );
+    }
 };

--- a/ui/src/infra-model/view/infra-model-view-container.tsx
+++ b/ui/src/infra-model/view/infra-model-view-container.tsx
@@ -1,12 +1,17 @@
-import { infraModelActionCreators, InfraModelViewType } from '../infra-model-slice';
+import { infraModelActionCreators } from '../infra-model-slice';
 import { createDelegates } from 'store/store-utils';
 import React from 'react';
 import { InfraModelEditLoader } from 'infra-model/view/infra-model-edit-loader';
 import { useInfraModelAppSelector, useCommonDataAppSelector } from 'store/hooks';
 import { InfraModelImportLoader } from './infra-model-import-loader';
-import { ValidationResponse } from 'infra-model/infra-model-api';
 import { InfraModelUploadLoader } from './infra-model-upload-loader';
 import { InfraModelBaseProps } from './infra-model-view';
+
+export enum InfraModelViewType {
+    UPLOAD,
+    IMPORT,
+    EDIT,
+}
 
 type InfraModelViewContainerProps = {
     viewType: InfraModelViewType;
@@ -21,64 +26,37 @@ export const InfraModelViewContainer: React.FC<InfraModelViewContainerProps> = (
     const delegates = createDelegates(infraModelActionCreators);
 
     const [isLoading, setLoading] = React.useState(false);
-    // TODO: GVT-1795 this wont persist when visiting another tab. keep the whole response in redux?
-    const [validationResponse, setValidationResponse] = React.useState<ValidationResponse | null>(
-        null,
-    );
-    const onValidation = (validationResponse: ValidationResponse | null) => {
-        setValidationResponse(validationResponse);
-        delegates.onPlanFetchReady({
-            plan: validationResponse?.geometryPlan || null,
-            planLayout: validationResponse?.planLayout || null,
-        });
-    };
 
-    const delegatesProps = {
+    const generalProps: InfraModelBaseProps = {
+        ...infraModelState,
         onExtraParametersChange: delegates.onInfraModelExtraParametersChange,
         onOverrideParametersChange: delegates.onInfraModelOverrideParametersChange,
-        onPlanFetchReady: delegates.onPlanFetchReady,
         onSelect: delegates.onSelect,
         onHighlightItems: delegates.onHighlightItems,
         onHoverLocation: delegates.onHoverLocation,
         onClickLocation: delegates.onClickLocation,
         onViewportChange: delegates.onViewportChange,
         onCommitField: delegates.onCommitField,
-        showArea: delegates.showArea,
-    };
-    const generalProps: InfraModelBaseProps = {
-        ...infraModelState,
-        ...delegatesProps,
         changeTimes: changeTimes,
-        viewType: viewType,
         isLoading: isLoading,
-        validationResponse: validationResponse,
+    };
+    const loaderProps = {
+        ...generalProps,
+        setLoading: setLoading,
+        onValidation: delegates.onPlanValidated,
     };
 
     switch (viewType) {
         case InfraModelViewType.EDIT:
             return (
                 <InfraModelEditLoader
-                    {...generalProps}
-                    onValidation={onValidation}
+                    {...loaderProps}
                     setExistingInfraModel={delegates.setExistingInfraModel}
-                    setLoading={setLoading}
                 />
             );
         case InfraModelViewType.IMPORT:
-            return (
-                <InfraModelImportLoader
-                    {...generalProps}
-                    onValidation={onValidation}
-                    setLoading={setLoading}
-                />
-            );
+            return <InfraModelImportLoader {...loaderProps} />;
         case InfraModelViewType.UPLOAD:
-            return (
-                <InfraModelUploadLoader
-                    {...generalProps}
-                    onValidation={onValidation}
-                    setLoading={setLoading}
-                />
-            );
+            return <InfraModelUploadLoader {...loaderProps} />;
     }
 };

--- a/ui/src/infra-model/view/infra-model-view-container.tsx
+++ b/ui/src/infra-model/view/infra-model-view-container.tsx
@@ -6,6 +6,7 @@ import { useInfraModelAppSelector, useCommonDataAppSelector } from 'store/hooks'
 import { InfraModelImportLoader } from './infra-model-import-loader';
 import { InfraModelUploadLoader } from './infra-model-upload-loader';
 import { InfraModelBaseProps } from './infra-model-view';
+import { useAppNavigate } from 'common/navigate';
 
 export enum InfraModelViewType {
     UPLOAD,
@@ -20,6 +21,8 @@ type InfraModelViewContainerProps = {
 export const InfraModelViewContainer: React.FC<InfraModelViewContainerProps> = ({
     viewType,
 }: InfraModelViewContainerProps) => {
+    const navigate = useAppNavigate();
+
     const infraModelState = useInfraModelAppSelector((state) => state);
     const changeTimes = useCommonDataAppSelector((state) => state.changeTimes);
 
@@ -39,6 +42,7 @@ export const InfraModelViewContainer: React.FC<InfraModelViewContainerProps> = (
         onCommitField: delegates.onCommitField,
         changeTimes: changeTimes,
         isLoading: isLoading,
+        onClose: () => navigate('inframodel-list'),
     };
     const loaderProps = {
         ...generalProps,

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -2,30 +2,14 @@ import React from 'react';
 import MapView from 'map/map-view';
 import { MapViewport } from 'map/map-model';
 import styles from './form/infra-model-form.module.scss';
-import {
-    getValidationErrorsForGeometryPlan,
-    getValidationErrorsForInfraModelFile,
-    getValidationErrorsForVelhoDocument,
-    importVelhoDocument,
-    saveInfraModelFile,
-    updateGeometryPlan,
-    ValidationResponse,
-} from 'infra-model/infra-model-api';
+import { ValidationResponse } from 'infra-model/infra-model-api';
 import InfraModelForm from 'infra-model/view/form/infra-model-form';
 import {
     ExtraInfraModelParameters,
     InfraModelState,
     InfraModelViewType,
-    OnPlanFetchReady,
     OverrideInfraModelParameters,
-    XmlCharset,
 } from 'infra-model/infra-model-slice';
-import {
-    GeometryElement,
-    GeometryElementId,
-    GeometrySwitch,
-    GeometrySwitchId,
-} from 'geometry/geometry-model';
 import {
     OnClickLocationFunction,
     OnHighlightItemsFunction,
@@ -33,126 +17,58 @@ import {
     OnSelectFunction,
 } from 'selection/selection-model';
 import { Icons } from 'vayla-design-lib/icon/Icon';
-import { convertToNativeFile } from 'utils/file-utils';
-import { Title } from 'vayla-design-lib/title/title';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Dialog } from 'vayla-design-lib/dialog/dialog';
 import { Prop } from 'utils/type-utils';
 import { ValidationErrorType } from 'utils/validation-utils';
 import { useTranslation } from 'react-i18next';
-import { InfraModelToolbar } from 'infra-model/view/infra-model-toolbar';
-import { Dropdown, Item } from 'vayla-design-lib/dropdown/dropdown';
-import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { FileMenuOption, InfraModelToolbar } from 'infra-model/view/infra-model-toolbar';
 import dialogStyles from 'vayla-design-lib/dialog/dialog.scss';
 import InfraModelValidationErrorList from 'infra-model/view/infra-model-validation-error-list';
 import { useAppNavigate } from 'common/navigate';
 import { ChangeTimes } from 'common/common-slice';
 import { WriteRoleRequired } from 'user/write-role-required';
+import { Item } from 'vayla-design-lib/dropdown/dropdown';
+import { CharsetSelectDialog } from './dialogs/charset-select-dialog';
 
-// For now use whole state and some extras as params
-export type InfraModelViewProps = InfraModelState & {
+export type InfraModelBaseProps = InfraModelState & {
     viewType: InfraModelViewType;
-    onInfraModelExtraParametersChange: <TKey extends keyof ExtraInfraModelParameters>(
-        infraModelExtraParameters: Prop<ExtraInfraModelParameters, TKey>,
+    onExtraParametersChange: <TKey extends keyof ExtraInfraModelParameters>(
+        parameters: Prop<ExtraInfraModelParameters, TKey>,
     ) => void;
-    onInfraModelOverrideParametersChange: (
-        overrideInfraModelParameters: OverrideInfraModelParameters,
-    ) => void;
-    onPlanUpdate: () => void;
-    onPlanFetchReady: (plan: OnPlanFetchReady) => void;
+    onOverrideParametersChange: (parameters: OverrideInfraModelParameters) => void;
     onViewportChange: (viewport: MapViewport) => void;
     onHoverLocation: OnHoverLocationFunction;
     onClickLocation: OnClickLocationFunction;
     onSelect: OnSelectFunction;
     changeTimes: ChangeTimes;
     onHighlightItems: OnHighlightItemsFunction;
-    getGeometryElement: (geomElemId: GeometryElementId) => Promise<GeometryElement | null>;
-    getGeometrySwitch: (geomSwitchId: GeometrySwitchId) => Promise<GeometrySwitch | null>;
     onCommitField: (fieldName: string) => void;
+    isLoading: boolean;
+    validationResponse: ValidationResponse | null;
 };
-
-const xmlEncodingOptions: Item<XmlCharset>[] = [
-    { name: 'ISO-8859-1', value: 'ISO_8859_1' },
-    { name: 'UTF-8', value: 'UTF_8' },
-    { name: 'UTF-16', value: 'UTF_16' },
-    { name: 'US ASCII', value: 'US_ASCII' },
-];
+export type InfraModelViewProps = InfraModelBaseProps & {
+    onSave: () => Promise<boolean>;
+    onValidate: () => Promise<null>;
+};
 
 export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelViewProps) => {
     const { t } = useTranslation();
     const navigate = useAppNavigate();
 
-    const [file, setFile] = React.useState<File>();
-    const [loadingInProgress, setLoadingInProgress] = React.useState(false);
-
-    const [infraModelValidationResponse, setInfraModelValidationResponse] =
-        React.useState<ValidationResponse | null>(null);
-
-    const [fileHandlingFailedErrors, setFileHandlingFailedErrors] = React.useState<string[]>([]);
-    const [fileMenuVisible, setFileMenuVisible] = React.useState(false);
-
     const [showCriticalWarning, setShowCriticalWarning] = React.useState(false);
-    const [showFileHandlingFailed, setShowFileHandlingFailed] = React.useState(false);
     const [showChangeCharsetDialog, setShowChangeCharsetDialog] = React.useState(false);
-    const [showCharsetPicker, setShowCharsetPicker] = React.useState(false);
-    const [charsetOverride, setCharsetOverride] = React.useState<XmlCharset | undefined>(undefined);
 
-    const fileMenuItems = [
-        { value: 'fix-encoding', name: t('im-form.file-handling-failed.change-encoding') },
-    ];
+    const fileMenuItems: Item<FileMenuOption>[] =
+        props.viewType === InfraModelViewType.UPLOAD
+            ? [{ value: 'fix-encoding', name: t('im-form.file-handling-failed.change-encoding') }]
+            : [];
     const handleFileMenuItemChange = (item: string) => {
         if (item == 'fix-encoding') setShowChangeCharsetDialog(true);
-        setFileMenuVisible(false);
-    };
-
-    const doSave = async () => {
-        const overrideParams = charsetOverride
-            ? { ...props.overrideInfraModelParameters, encoding: charsetOverride }
-            : props.overrideInfraModelParameters;
-
-        const extraParams = {
-            ...props.extraInfraModelParameters,
-            oid: props.extraInfraModelParameters.oid || undefined, // TODO: GVT-1794 what?
-        };
-        const planId = props.plan?.id;
-        switch (props.viewType) {
-            case InfraModelViewType.EDIT:
-                if (!planId) throw Error('No plan to edit');
-                return (await updateGeometryPlan(planId, extraParams, overrideParams)) != null;
-            case InfraModelViewType.IMPORT:
-                return (await importVelhoDocument(velhoDocId, extraParams, overrideParams)) != null;
-            case InfraModelViewType.UPLOAD:
-                return (await saveInfraModelFile(file, extraParams, overrideParams)) != null;
-        }
-    };
-
-    const doValidate = async () => {
-        const overrideParams = charsetOverride
-            ? { ...props.overrideInfraModelParameters, encoding: charsetOverride }
-            : props.overrideInfraModelParameters;
-
-        const planId = props.plan?.id;
-        switch (props.viewType) {
-            case InfraModelViewType.EDIT:
-                if (!planId) throw Error('No plan to validate');
-                return await getValidationErrorsForGeometryPlan(planId, overrideParams);
-            case InfraModelViewType.IMPORT:
-                return await getValidationErrorsForVelhoDocument(velhoDocId, overrideParams);
-            case InfraModelViewType.UPLOAD:
-                return await getValidationErrorsForInfraModelFile(file, overrideParams);
-        }
     };
 
     const onSaveClick = async () => {
-        setShowCriticalWarning(false);
-        setLoadingInProgress(true);
-
-        const succeed = await doSave();
-
-        setLoadingInProgress(false);
-
-        if (succeed) {
+        if (await props.onSave()) {
             navigate('inframodel-list');
         }
     };
@@ -163,22 +79,10 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
             : onSaveClick();
     };
 
-    const validateFile = async () => {
-        const response = await doValidate();
-        setInfraModelValidationResponse(response);
-
-        const processingErrors =
-            response?.validationErrors
-                .filter((e) => e.errorType === 'PARSING_ERROR' || e.errorType === 'REQUEST_ERROR')
-                .map((item) => item.localizationKey) || [];
-        setFileHandlingFailedErrors(processingErrors);
-        setShowFileHandlingFailed(processingErrors.length > 0);
-
-        props.onPlanFetchReady({
-            plan: response?.geometryPlan || null,
-            planLayout: response?.planLayout || null,
-        });
-    };
+    const fileHandlingFailedErrors =
+        props.validationResponse?.validationErrors
+            .filter((e) => e.errorType === 'PARSING_ERROR' || e.errorType === 'REQUEST_ERROR')
+            .map((item) => item.localizationKey) || [];
 
     const getFieldValidationWarnings = () => {
         return props.validationErrors.filter((error) => error.type === ValidationErrorType.WARNING);
@@ -195,70 +99,28 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
         return fieldValidationErrors.length > 0 ? fieldValidationErrors.join(', ') : '';
     };
 
-    React.useEffect(() => {
-        props.onPlanUpdate();
-    }, [props.plan]);
-
-    // In first render convert serializable file to native file
-    React.useEffect(() => {
-        if (props.viewType === InfraModelViewType.UPLOAD && props.file) {
-            const file = convertToNativeFile(props.file);
-            setFile(file);
-        }
-    }, []);
-
-    // Automatically re-validate whenever the file or manually input data changes
-    React.useEffect(() => {
-        setLoadingInProgress(true);
-        validateFile().finally(() => setLoadingInProgress(false));
-    }, [file, props.overrideInfraModelParameters]);
-
     const navigateToList = () => navigate('inframodel-list');
-    const showMap = infraModelValidationResponse?.planLayout != undefined;
+    const showMap = props.validationResponse?.planLayout != undefined;
 
     return (
         <div className={styles['infra-model-upload']}>
             <InfraModelToolbar
-                fileName={props.plan?.fileName}
+                fileName={props.plan?.fileName || ''}
                 viewType={props.viewType}
                 navigateToList={navigateToList}
+                fileMenuItems={fileMenuItems}
+                fileMenuItemSelected={handleFileMenuItemChange}
             />
             <div className={styles['infra-model-upload__form-column']}>
-                <div className={styles['infra-model-upload__file-info-container']}>
-                    <Title>{file && file.name}</Title>
-                    {file && (
-                        <div className={styles['infra-model-upload__title-menu-container']}>
-                            <Button
-                                onClick={() => setFileMenuVisible(!fileMenuVisible)}
-                                variant={ButtonVariant.SECONDARY}
-                                icon={Icons.More}
-                            />
-                            {fileMenuVisible && (
-                                <div className={styles['infra-model-upload__title-menu']}>
-                                    <Menu
-                                        items={fileMenuItems}
-                                        onChange={(item) =>
-                                            item && handleFileMenuItemChange(item)
-                                        }></Menu>
-                                </div>
-                            )}
-                        </div>
-                    )}
-                </div>
-
                 <div className={styles['infra-model-upload__form-container']}>
                     {props.plan && (
                         <InfraModelForm
                             changeTimes={props.changeTimes}
                             validationErrors={props.validationErrors}
-                            upLoading={loadingInProgress}
+                            upLoading={props.isLoading}
                             geometryPlan={props.plan}
-                            onInfraModelOverrideParametersChange={
-                                props.onInfraModelOverrideParametersChange
-                            }
-                            onInfraModelExtraParametersChange={
-                                props.onInfraModelExtraParametersChange
-                            }
+                            onInfraModelOverrideParametersChange={props.onOverrideParametersChange}
+                            onInfraModelExtraParametersChange={props.onExtraParametersChange}
                             overrideInfraModelParameters={props.overrideInfraModelParameters}
                             extraInframodelParameters={props.extraInfraModelParameters}
                             onCommitField={props.onCommitField}
@@ -268,10 +130,8 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                     )}
                 </div>
 
-                {infraModelValidationResponse && (
-                    <InfraModelValidationErrorList
-                        validationResponse={infraModelValidationResponse}
-                    />
+                {props.validationResponse && (
+                    <InfraModelValidationErrorList validationResponse={props.validationResponse} />
                 )}
 
                 <div className={styles['infra-model-upload__buttons-container']}>
@@ -280,7 +140,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                         <Button
                             onClick={navigateToList}
                             variant={ButtonVariant.WARNING}
-                            disabled={loadingInProgress}
+                            disabled={props.isLoading}
                             icon={Icons.Delete}>
                             {t('button.cancel')}
                         </Button>
@@ -289,7 +149,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                         <Button
                             onClick={navigateToList}
                             variant={ButtonVariant.SECONDARY}
-                            disabled={loadingInProgress}>
+                            disabled={props.isLoading}>
                             {t('button.return')}
                         </Button>
                     )}
@@ -298,13 +158,13 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                             title={getVisibleErrors()}
                             onClick={() => onProgressClick()}
                             disabled={
-                                loadingInProgress ||
-                                infraModelValidationResponse == null ||
+                                props.isLoading ||
+                                props.validationResponse == null ||
                                 fileHandlingFailedErrors.length > 0 ||
                                 getFieldValidationErrors().length > 0
                             }
                             icon={Icons.Tick}
-                            isProcessing={loadingInProgress}>
+                            isProcessing={props.isLoading}>
                             {t(
                                 props.viewType === InfraModelViewType.EDIT
                                     ? 'im-form.save-changes'
@@ -339,15 +199,15 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                         <React.Fragment>
                             <Button
                                 variant={ButtonVariant.SECONDARY}
-                                disabled={loadingInProgress}
+                                disabled={props.isLoading}
                                 onClick={() => setShowCriticalWarning(false)}>
                                 {t('button.cancel')}
                             </Button>
                             <Button
                                 id="infra-model-upload-dialog-save-button"
                                 onClick={() => onSaveClick()}
-                                disabled={loadingInProgress}
-                                isProcessing={loadingInProgress}>
+                                disabled={props.isLoading}
+                                isProcessing={props.isLoading}>
                                 {t('button.save')}
                             </Button>
                         </React.Fragment>
@@ -365,98 +225,19 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                     </ul>
                 </Dialog>
             )}
-            {showFileHandlingFailed && (
-                <Dialog
-                    title={t('im-form.file-handling-failed.title')}
-                    scrollable={false}
-                    className={dialogStyles['dialog--wide']}
-                    onClose={() => setShowFileHandlingFailed(false)}
-                    footerContent={
-                        <React.Fragment>
-                            {showCharsetPicker && (
-                                <React.Fragment>
-                                    <Button
-                                        variant={ButtonVariant.SECONDARY}
-                                        onClick={() => setShowFileHandlingFailed(false)}>
-                                        {t('button.cancel')}
-                                    </Button>
-                                    <Button
-                                        onClick={() => {
-                                            setShowCharsetPicker(false);
-                                            setShowFileHandlingFailed(false);
-                                            validateFile();
-                                        }}>
-                                        {t('im-form.file-handling-failed.try-again')}
-                                    </Button>
-                                </React.Fragment>
-                            )}
-                            {!showCharsetPicker && (
-                                <Button
-                                    onClick={() => {
-                                        setShowFileHandlingFailed(false);
-                                    }}>
-                                    {t('button.ok')}
-                                </Button>
-                            )}
-                        </React.Fragment>
-                    }>
-                    <ul className={styles['infra-model-upload-failed__errors']}>
-                        {fileHandlingFailedErrors.map((error) => (
-                            <li key={error}>{t(error)}</li>
-                        ))}
-                    </ul>
-                    <Checkbox
-                        checked={showCharsetPicker}
-                        onChange={(e) => setShowCharsetPicker(e.target.checked)}>
-                        {t('im-form.file-handling-failed.change-encoding')}
-                    </Checkbox>
-                    {showCharsetPicker && (
-                        <div className={styles['infra-model-upload-failed__encode-container']}>
-                            <label className={styles['infra-model-upload-failed__checkbox-label']}>
-                                {t('im-form.file-handling-failed.encoding')}
-                            </label>
-                            <Dropdown
-                                options={xmlEncodingOptions}
-                                value={charsetOverride}
-                                onChange={setCharsetOverride}
-                            />
-                        </div>
-                    )}
-                </Dialog>
-            )}
             {showChangeCharsetDialog && (
-                <Dialog
+                <CharsetSelectDialog
                     title={t('im-form.file-handling-failed.change-encoding')}
-                    scrollable={false}
-                    className={dialogStyles['dialog--wide']}
-                    onClose={() => setShowChangeCharsetDialog(false)}
-                    footerContent={
-                        <React.Fragment>
-                            <Button
-                                variant={ButtonVariant.SECONDARY}
-                                onClick={() => setShowChangeCharsetDialog(false)}>
-                                {t('button.cancel')}
-                            </Button>
-                            <Button
-                                onClick={() => {
-                                    setShowChangeCharsetDialog(false);
-                                    validateFile();
-                                }}>
-                                {t('im-form.file-handling-failed.try-again')}
-                            </Button>
-                        </React.Fragment>
-                    }>
-                    <div className={styles['infra-model-upload-failed__encode-container']}>
-                        <label className={styles['infra-model-upload-failed__checkbox-label']}>
-                            {t('im-form.file-handling-failed.encoding')}
-                        </label>
-                        <Dropdown
-                            options={xmlEncodingOptions}
-                            value={charsetOverride}
-                            onChange={setCharsetOverride}
-                        />
-                    </div>
-                </Dialog>
+                    value={props.overrideInfraModelParameters.encoding}
+                    onSelect={(charset) => {
+                        setShowChangeCharsetDialog(false);
+                        props.onOverrideParametersChange({
+                            ...props.overrideInfraModelParameters,
+                            encoding: charset,
+                        });
+                    }}
+                    onCancel={() => setShowChangeCharsetDialog(false)}
+                />
             )}
         </div>
     );

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -23,7 +23,6 @@ import { useTranslation } from 'react-i18next';
 import { FileMenuOption, InfraModelToolbar } from 'infra-model/view/infra-model-toolbar';
 import dialogStyles from 'vayla-design-lib/dialog/dialog.scss';
 import InfraModelValidationErrorList from 'infra-model/view/infra-model-validation-error-list';
-import { useAppNavigate } from 'common/navigate';
 import { ChangeTimes } from 'common/common-slice';
 import { WriteRoleRequired } from 'user/write-role-required';
 import { Item } from 'vayla-design-lib/dropdown/dropdown';
@@ -42,15 +41,15 @@ export type InfraModelBaseProps = InfraModelState & {
     onHighlightItems: OnHighlightItemsFunction;
     onCommitField: (fieldName: string) => void;
     isLoading: boolean;
+    onClose: () => void;
 };
 export type InfraModelViewProps = InfraModelBaseProps & {
     onSave: () => Promise<boolean>;
-    onValidate: () => Promise<null>;
+    onValidate: () => void;
 };
 
 export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelViewProps) => {
     const { t } = useTranslation();
-    const navigate = useAppNavigate();
 
     const [showCriticalWarning, setShowCriticalWarning] = React.useState(false);
     const [showChangeCharsetDialog, setShowChangeCharsetDialog] = React.useState(false);
@@ -67,9 +66,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
     };
 
     const onSaveClick = async () => {
-        if (await props.onSave()) {
-            navigate('inframodel-list');
-        }
+        if (await props.onSave()) props.onClose();
     };
 
     const onProgressClick = () => {
@@ -100,14 +97,12 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
 
     const fileName = geometryPlan?.fileName || '';
     const toolbarName = `${isNewPlan ? `${t('im-form.toolbar.upload')}: ` : ''}${fileName}`;
-    const navigateToList = () => navigate('inframodel-list');
     const showMap = props.validationResponse?.planLayout != undefined;
 
     return (
         <div className={styles['infra-model-upload']}>
             <InfraModelToolbar
                 fileName={toolbarName}
-                navigateToList={navigateToList}
                 fileMenuItems={fileMenuItems}
                 fileMenuItemSelected={handleFileMenuItemChange}
             />
@@ -137,7 +132,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                 <div className={styles['infra-model-upload__buttons-container']}>
                     {isNewPlan && (
                         <Button
-                            onClick={navigateToList}
+                            onClick={props.onClose}
                             variant={ButtonVariant.WARNING}
                             disabled={props.isLoading}
                             icon={Icons.Delete}>
@@ -146,7 +141,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                     )}
                     {!isNewPlan && (
                         <Button
-                            onClick={navigateToList}
+                            onClick={props.onClose}
                             variant={ButtonVariant.SECONDARY}
                             disabled={props.isLoading}>
                             {t('button.return')}


### PR DESCRIPTION
Pääpointti (tosin pienehkö osa koodia) on velho importtia varten lisättävä toiminnallisuus jotta se menee saman inframodel näkymän kautta kun uuden lataus / olemassaolevan editointi. Jotta toiminnallisuus luiskahti sinne mukaan helposti, tein samalla remppaa itse näkymään niin että se niiden eroavat koodiosat ovat erillisissä komponenteissa (inframodel-x-loader.tsx) ja ne kaikki käyttää yhteistä komponenttia (vanha inframodel-view.tsx, rankasti yksinkertaistettuna) on mahdollisimman tyhmä näyttönäkymä. Lisäksi vähän koodin siirtelyä ja tilallisuuden purkamista ko. näkymästä.