### PR TITLE
GVT-1841 Tyhjien kaavioiden käsittely pystygeometriakaaviossa

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -422,7 +422,7 @@ class GeometryService @Autowired constructor(
         val geocodingContext =
             geocodingService.getGeocodingContext(plan.trackNumberId ?: return null, planVersion) ?: return null
         val geometryAlignment = plan.alignments.find { alignment -> alignment.id == planAlignmentId } ?: return null
-        val profile = geometryAlignment.profile ?: return null
+        val profile = geometryAlignment.profile
         val alignment =
             planLayoutCache.getPlanLayout(planVersion).first?.alignments?.find { alignment -> alignment.id == planAlignmentId }
                 ?: return null
@@ -432,7 +432,7 @@ class GeometryService @Autowired constructor(
             geocodingContext,
             alignment,
             tickLength
-        ) { distance, _ -> profile.getHeightAt(distance) }
+        ) { distance, _ -> profile?.getHeightAt(distance) }
     }
 
     private fun collectTrackMeterHeights(

--- a/ui/src/vertical-geometry/height-lines.tsx
+++ b/ui/src/vertical-geometry/height-lines.tsx
@@ -23,6 +23,9 @@ function chooseVerticalTickLength(bottomTickHeight: number, topTickHeight: numbe
 }
 
 function heightTicks(coordinates: Coordinates) {
+    if (coordinates.topHeightTick <= coordinates.bottomHeightTick) {
+        return [];
+    }
     const tickLength = chooseVerticalTickLength(
         coordinates.bottomHeightTick,
         coordinates.topHeightTick,


### PR DESCRIPTION
Lähinnä yksinkertaistettu hähmäisen monimutkaista minAndMaxHeightsiä ja siirretty asioita niin, että isoissa funktioissa on vähemmän muuttujia skoopissa. Tästä ei tule juuri käyttäjälle näkyvää muutosta, tosin selainkonsoliin ei tule enää varoituksia siitä, kun HeightLinesin renderöinnissä yritetään piirtää NaN-koordinaatteja.

Oleellinen käyttäjälle näkyvä muutos siinä, että jos suunnitelman alignmentilla ei ole korkeusprofiilia lainkaan, niin kaavio näkyy, mutta näkyy tyhjänä, sen sijaan että ei lataudu lainkaan.