### PR TITLE
GVT-1868 Always send first tick for each track km of track heights

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -503,8 +503,8 @@ class GeometryService @Autowired constructor(
                     ).sortedBy { (trackMeterInKm) -> trackMeterInKm }
 
             val ticksToSend = allTicks.filterIndexed { i, (trackMeterInKm, segmentIndex) ->
-                segmentIndex != null ||
-                        (i == 0                  || trackMeterInKm - allTicks[i - 1].first >= minTickSpace) &&
+                segmentIndex != null || i == 0 ||
+                        (trackMeterInKm - allTicks[i - 1].first >= minTickSpace) &&
                         (i == allTicks.lastIndex || allTicks[i + 1].first - trackMeterInKm >= minTickSpace)
             } + if (kmNumber == lastAddress.kmNumber) listOf(lastAddress.meters to null) else listOf()
 


### PR DESCRIPTION
Frontti piirtää ensimmäiselle metrille (tai tarkkaan ottaen sille, jonka osoitteen metriosa on nolla) kilometritolpan, joten jos se jätetään lähettämättä, piirto rumentuu. Periaatteessa voi aiheuttaa vähän enemmän suttua kaavion piirtämisessä, mutta kokonaisuutena näyttää paremmalta.