### PR TITLE
GVT-1833 Add check for not rendering address label too close to next km start

### DIFF
--- a/ui/src/vertical-geometry/labeled-ticks.tsx
+++ b/ui/src/vertical-geometry/labeled-ticks.tsx
@@ -72,14 +72,25 @@ export const LabeledTicks: React.FC<LabeledTicksProps> = ({ trackKmHeights, coor
                 )
                 .flatMap(({ kmNumber, trackMeterHeights }, trackKmIndex) =>
                     trackMeterHeights
-                        .filter(({ m, meter }) => {
+                        .filter(({ m, meter }, meterIndex) => {
                             const ordinaryTick = Number.isInteger(meter);
                             const inRenderedRange = m > startM && m < endM;
                             const hitsMeterStep =
                                 meter === 0 ||
                                 (trackMeterDisplayStep !== undefined &&
                                     meter % trackMeterDisplayStep === 0);
-                            return ordinaryTick && inRenderedRange && hitsMeterStep;
+                            const hasSpaceBeforeNextKm =
+                                trackKmIndex === trackKmHeights.length - 1 ||
+                                meterIndex === 0 ||
+                                (trackKmHeights[trackKmIndex + 1].trackMeterHeights[0].m - m) *
+                                    coordinates.mMeterLengthPxOverM >
+                                    minimumLabeledTickDistancePx;
+                            return (
+                                ordinaryTick &&
+                                inRenderedRange &&
+                                hitsMeterStep &&
+                                hasSpaceBeforeNextKm
+                            );
                         })
                         .map(({ m, meter }, meterIndex) => (
                             <TickLabel


### PR DESCRIPTION
Tämä tarkistus oli itse asiassa olemassa jo aiemmin. Luulin saaneeni sen yksinkertaistettua pois, mutta enpä saanutkaan.