### PR TITLE
GVT-1876 separate projektivelho schema

### DIFF
--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     implementation("com.zaxxer:HikariCP")
-    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-core:9.18.0")
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.6")
     implementation("org.geotools:gt-main:$geotoolsVersion") {
         // Excluded as the license (JDL or JRL) compatibility is unconfirmed. We don't need this.

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/velho/VelhoDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/velho/VelhoDao.kt
@@ -37,20 +37,20 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
         projectGroupOid: Oid<PVProjectGroup>?,
     ): IntId<PVApiFileMetadata> {
         val sql = """
-            insert into integrations.projektivelho_file_metadata(
+            insert into projektivelho.file_metadata(
                 oid,
                 filename,
                 file_version,
                 file_change_time,
                 description,
-                projektivelho_document_type_code,
-                projektivelho_material_state_code,
-                projektivelho_material_category_code,
-                projektivelho_material_group_code,
+                document_type_code,
+                material_state_code,
+                material_category_code,
+                material_group_code,
                 status,
-                projektivelho_assignment_oid,
-                projektivelho_project_oid,
-                projektivelho_project_group_oid
+                assignment_oid,
+                project_oid,
+                project_group_oid
             ) values (
                 :oid,
                 :filename,
@@ -61,10 +61,10 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
                 :material_state,
                 :material_category,
                 :material_group,
-                :status::integrations.projektivelho_file_status,
-                :projektivelho_assignment_oid,
-                :projektivelho_project_oid,
-                :projektivelho_project_group_oid
+                :status::projektivelho.file_status,
+                :assignment_oid,
+                :project_oid,
+                :project_group_oid
             ) 
             on conflict (oid) do 
               update set
@@ -72,15 +72,15 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
                 file_version = :file_version,
                 file_change_time = :file_change_time,
                 description = :description,
-                projektivelho_document_type_code = :document_type,
-                projektivelho_material_state_code = :material_state,
-                projektivelho_material_category_code = :material_category,
-                projektivelho_material_group_code = :material_group,
-                status = :status::integrations.projektivelho_file_status,
-                projektivelho_assignment_oid = :projektivelho_assignment_oid,
-                projektivelho_project_oid = :projektivelho_project_oid,
-                projektivelho_project_group_oid = :projektivelho_project_group_oid
-              where integrations.projektivelho_file_metadata.file_version <> :file_version
+                document_type_code = :document_type,
+                material_state_code = :material_state,
+                material_category_code = :material_category,
+                material_group_code = :material_group,
+                status = :status::projektivelho.file_status,
+                assignment_oid = :assignment_oid,
+                project_oid = :project_oid,
+                project_group_oid = :project_group_oid
+              where projektivelho.file_metadata.file_version <> :file_version
         """.trimIndent()
         val params = mapOf(
             "filename" to latestVersion.name,
@@ -93,15 +93,15 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
             "material_group" to metadata.materialGroup,
             "file_change_time" to Timestamp.from(latestVersion.changeTime),
             "status" to status.name,
-            "projektivelho_assignment_oid" to assignmentOid,
-            "projektivelho_project_oid" to  projectOid,
-            "projektivelho_project_group_oid" to projectGroupOid,
+            "assignment_oid" to assignmentOid,
+            "project_oid" to  projectOid,
+            "project_group_oid" to projectGroupOid,
         )
         jdbcTemplate.setUser()
         jdbcTemplate.update(sql, params)
 
         // We can't get the id via a returning clause since it won't see the row id if it's not updated
-        val selectSql = "select id from integrations.projektivelho_file_metadata where oid = :oid"
+        val selectSql = "select id from projektivelho.file_metadata where oid = :oid"
         val selectParams = mapOf("oid" to oid)
         return jdbcTemplate.query(selectSql, selectParams) { rs, _ ->
             rs.getIntId<PVApiFileMetadata>("id")
@@ -111,17 +111,17 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
     @Transactional
     fun upsertProject(project: PVApiProject) {
         val sql = """
-            insert into integrations.projektivelho_project (oid, name, state, created_at, modified)
+            insert into projektivelho.project (oid, name, state, created_at, modified)
             values (:oid, :name, :state, :created_at, :modified)
             on conflict (oid) do update 
               set name = :name, 
                   state = :state,
                   created_at = :created_at,
                   modified = :modified
-              where integrations.projektivelho_project.name <> :name
-                 or integrations.projektivelho_project.state <> :state
-                 or integrations.projektivelho_project.created_at <> :created_at
-                 or integrations.projektivelho_project.modified <> :modified;
+              where projektivelho.project.name <> :name
+                 or projektivelho.project.state <> :state
+                 or projektivelho.project.created_at <> :created_at
+                 or projektivelho.project.modified <> :modified;
         """.trimIndent()
         val params = mapOf(
             "oid" to project.oid,
@@ -138,17 +138,17 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
     @Transactional
     fun upsertProjectGroup(projectGroup: PVApiProjectGroup) {
         val sql = """
-            insert into integrations.projektivelho_project_group (oid, name, state, created_at, modified)
+            insert into projektivelho.project_group (oid, name, state, created_at, modified)
             values (:oid, :name, :state, :created_at, :modified)
             on conflict (oid) do update 
               set name = :name,
                   state = :state,
                   created_at = :created_at,
                   modified = :modified
-              where integrations.projektivelho_project_group.name <> :name
-                 or integrations.projektivelho_project_group.state <> :state
-                 or integrations.projektivelho_project_group.created_at <> :created_at
-                 or integrations.projektivelho_project_group.modified <> :modified
+              where projektivelho.project_group.name <> :name
+                 or projektivelho.project_group.state <> :state
+                 or projektivelho.project_group.created_at <> :created_at
+                 or projektivelho.project_group.modified <> :modified
         """.trimIndent()
         val params = mapOf(
             "oid" to projectGroup.oid,
@@ -165,17 +165,17 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
     @Transactional
     fun upsertAssignment(assignment: PVApiAssignment) {
         val sql = """
-            insert into integrations.projektivelho_assignment (oid, name, state, created_at, modified)
+            insert into projektivelho.assignment (oid, name, state, created_at, modified)
             values (:oid, :name, :state, :created_at, :modified)
             on conflict (oid) do update 
               set name = :name,
                   state = :state,
                   created_at = :created_at,
                   modified = :modified
-              where integrations.projektivelho_assignment.name <> :name
-                 or integrations.projektivelho_assignment.state <> :state
-                 or integrations.projektivelho_assignment.created_at <> :created_at
-                 or integrations.projektivelho_assignment.modified <> :modified
+              where projektivelho.assignment.name <> :name
+                 or projektivelho.assignment.state <> :state
+                 or projektivelho.assignment.created_at <> :created_at
+                 or projektivelho.assignment.modified <> :modified
         """.trimIndent()
         val params = mapOf(
             "oid" to assignment.oid,
@@ -192,18 +192,18 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
     @Transactional
     fun insertFileContent(content: String, metadataId: IntId<PVApiFileMetadata>): IntId<PVApiFileMetadata> {
         val sql = """
-            insert into integrations.projektivelho_file(
+            insert into projektivelho.file(
                 content,
-                projektivelho_file_metadata_id
+                file_metadata_id
             ) values (
                 xmlparse(document :content),
                 :metadata_id
-            ) returning projektivelho_file_metadata_id
+            ) returning file_metadata_id
         """.trimIndent()
         jdbcTemplate.setUser()
         val params = mapOf("metadata_id" to metadataId.intValue, "content" to content)
         return jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getIntId<PVApiFileMetadata>("projektivelho_file_metadata_id")
+            rs.getIntId<PVApiFileMetadata>("file_metadata_id")
         }.single()
             .also { id -> logger.daoAccess(INSERT, "PVApiFileContent", id) }
     }
@@ -211,12 +211,12 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
     @Transactional
     fun insertFetchInfo(searchToken: PVId, validUntil: Instant): IntId<PVSearch> {
         val sql = """
-            insert into integrations.projektivelho_search(
+            insert into projektivelho.search(
                 status,
                 token,
                 valid_until
             ) values (
-                :status::integrations.projektivelho_search_status,
+                :status::projektivelho.search_status,
                 :token,
                 :valid_until
             ) returning id
@@ -236,8 +236,8 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
     @Transactional
     fun updateFetchState(id: IntId<PVSearch>, status: PVFetchStatus): IntId<PVSearch> {
         val sql = """
-            update integrations.projektivelho_search 
-            set status = :status::integrations.projektivelho_search_status
+            update projektivelho.search 
+            set status = :status::projektivelho.search_status
             where id = :id
             returning id
         """.trimIndent()
@@ -251,7 +251,7 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
     fun fetchLatestFile(): Pair<Oid<PVDocument>, Instant>? {
         val sql = """
             select change_time, oid 
-            from integrations.projektivelho_file_metadata 
+            from projektivelho.file_metadata 
             order by change_time desc, oid desc 
             limit 1
         """.trimIndent()
@@ -264,7 +264,7 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
     fun fetchLatestSearch(): PVSearch? {
         val sql = """
             select id, token, status, valid_until 
-            from integrations.projektivelho_search 
+            from projektivelho.search 
             order by valid_until desc 
             limit 1
         """.trimIndent()
@@ -283,8 +283,8 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
     fun updateFileStatus(id: IntId<PVDocument>, status: PVDocumentStatus): IntId<PVDocument> {
         logger.daoAccess(UPDATE, PVDocument::class, id)
         val sql = """
-            update integrations.projektivelho_file_metadata
-            set status = :status::integrations.projektivelho_file_status
+            update projektivelho.file_metadata
+            set status = :status::projektivelho.file_status
             where id = :id
             returning id
         """.trimIndent()
@@ -306,32 +306,25 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
               metadata.description,
               metadata.change_time, 
               metadata.status,
-              project.oid project_oid,
+              metadata.project_oid,
               project.name project_name,
-              project_group.oid project_group_oid,
+              metadata.project_group_oid,
               project_group.name project_group_name,
-              assignment.oid assignment_oid,
+              metadata.assignment_oid,
               assignment.name assignment_name,
               document_type.name document_type,
               material_state.name material_state,
               material_group.name material_group,
               material_category.name material_category
-            from integrations.projektivelho_file_metadata metadata
-              left join integrations.projektivelho_project project 
-                on project.oid = metadata.projektivelho_project_oid
-              left join integrations.projektivelho_project_group project_group 
-                on project_group.oid = metadata.projektivelho_project_group_oid
-              left join integrations.projektivelho_assignment assignment 
-                on assignment.oid = metadata.projektivelho_assignment_oid
-              left join integrations.projektivelho_document_type document_type 
-                on document_type.code = metadata.projektivelho_document_type_code
-              left join integrations.projektivelho_material_state material_state 
-                on material_state.code = metadata.projektivelho_material_state_code
-              left join integrations.projektivelho_material_group material_group 
-                on material_group.code = metadata.projektivelho_material_group_code
-              left join integrations.projektivelho_material_category material_category 
-                on material_category.code = metadata.projektivelho_material_category_code
-            where (:status::integrations.projektivelho_file_status is null or status = :status::integrations.projektivelho_file_status)
+            from projektivelho.file_metadata metadata
+              left join projektivelho.project on project.oid = metadata.project_oid
+              left join projektivelho.project_group on project_group.oid = metadata.project_group_oid
+              left join projektivelho.assignment on assignment.oid = metadata.assignment_oid
+              left join projektivelho.document_type on document_type.code = metadata.document_type_code
+              left join projektivelho.material_state on material_state.code = metadata.material_state_code
+              left join projektivelho.material_group on material_group.code = metadata.material_group_code
+              left join projektivelho.material_category on material_category.code = metadata.material_category_code
+            where (:status::projektivelho.file_status is null or status = :status::projektivelho.file_status)
         """.trimIndent()
         val params = mapOf("status" to status?.name)
         return jdbcTemplate.query(sql, params) { rs, _ -> PVDocumentHeader(
@@ -365,8 +358,8 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
             select 
               metadata.filename,
               xmlserialize(document content.content as varchar) as file_content
-            from integrations.projektivelho_file_metadata metadata
-              inner join integrations.projektivelho_file content on metadata.id = content.projektivelho_file_metadata_id
+            from projektivelho.file_metadata metadata
+              inner join projektivelho.file content on metadata.id = content.file_metadata_id
             where metadata.id = :id
         """.trimIndent()
         val params = mapOf("id" to id.intValue)
@@ -400,12 +393,12 @@ class VelhoDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
         }.associate { it }.also { _ -> logger.daoAccess(FETCH, PVDictionaryType::class) }
     }
 
-    private fun tableName(type: PVDictionaryType) = "integrations.${when(type) {
-        DOCUMENT_TYPE -> "projektivelho_document_type"
-        MATERIAL_STATE -> "projektivelho_material_state"
-        MATERIAL_CATEGORY -> "projektivelho_material_category"
-        MATERIAL_GROUP -> "projektivelho_material_group"
-        TECHNICS_FIELD -> "projektivelho_technics_field"
-        PROJECT_STATE -> "projektivelho_project_state"
+    private fun tableName(type: PVDictionaryType) = "projektivelho.${when(type) {
+        DOCUMENT_TYPE -> "document_type"
+        MATERIAL_STATE -> "material_state"
+        MATERIAL_CATEGORY -> "material_category"
+        MATERIAL_GROUP -> "material_group"
+        TECHNICS_FIELD -> "technics_field"
+        PROJECT_STATE -> "project_state"
     }}"
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/velho/VelhoService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/velho/VelhoService.kt
@@ -69,12 +69,14 @@ class VelhoService @Autowired constructor(
         } else {
             updateDictionaries()
             latestSearch
-                ?.takeIf { search -> search.state == PVFetchStatus.WAITING }
-                ?.let { search -> velhoClient.fetchVelhoSearchStatus(search.token) }
-                ?.takeIf { status -> status.state == PROJEKTIVELHO_SEARCH_STATE_READY }
+                ?.let(::getSearchStatusIfReady)
                 ?.let { status -> importFilesFromProjektiVelho(latestSearch, status) }
         }
     }
+    fun getSearchStatusIfReady(pvSearch: PVSearch) = pvSearch
+        .takeIf { search -> search.state == PVFetchStatus.WAITING }
+        ?.let { search -> velhoClient.fetchVelhoSearchStatus(search.token) }
+        ?.takeIf { status -> status.state == PROJEKTIVELHO_SEARCH_STATE_READY }
 
     fun updateDictionaries() {
         logger.serviceCall("updateDictionaries")

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
     url: "${spring.datasource.url}"
     user: "${spring.datasource.username}"
     password: "${spring.datasource.password}"
-    schemas: flyway,postgis,common,geometry,layout,publication,integrations
+    schemas: flyway,postgis,common,geometry,layout,publication,integrations,projektivelho
     lock-retry-count: 900
 
 geoviite:

--- a/infra/src/main/resources/db/migration/prod/V39__add_projektivelho_dictionaries.sql
+++ b/infra/src/main/resources/db/migration/prod/V39__add_projektivelho_dictionaries.sql
@@ -1,53 +1,53 @@
-create table integrations.projektivelho_document_type
+create table projektivelho.document_type
 (
   code varchar(50) primary key not null,
   name varchar(100)            not null
 );
-comment on table integrations.projektivelho_document_type is 'Localized ProjektiVelho document types (dokumenttityyppi)';
-select common.add_metadata_columns('integrations', 'projektivelho_document_type');
-select common.add_table_versioning('integrations', 'projektivelho_document_type');
+comment on table projektivelho.document_type is 'Localized ProjektiVelho document types (dokumenttityyppi)';
+select common.add_metadata_columns('projektivelho', 'document_type');
+select common.add_table_versioning('projektivelho', 'document_type');
 
-create table integrations.projektivelho_material_state
+create table projektivelho.material_state
 (
   code varchar(50) primary key not null,
   name varchar(100)            not null
 );
-comment on table integrations.projektivelho_material_state is 'Localized ProjektiVelho material states (ainestotila)';
-select common.add_metadata_columns('integrations', 'projektivelho_material_state');
-select common.add_table_versioning('integrations', 'projektivelho_material_state');
+comment on table projektivelho.material_state is 'Localized ProjektiVelho material states (ainestotila)';
+select common.add_metadata_columns('projektivelho', 'material_state');
+select common.add_table_versioning('projektivelho', 'material_state');
 
-create table integrations.projektivelho_material_group
+create table projektivelho.material_group
 (
   code varchar(50) primary key not null,
   name varchar(100)            not null
 );
-comment on table integrations.projektivelho_material_group is 'Localized Projektivelho material group (aineistoryhmä) options';
-select common.add_metadata_columns('integrations', 'projektivelho_material_group');
-select common.add_table_versioning('integrations', 'projektivelho_material_group');
+comment on table projektivelho.material_group is 'Localized Projektivelho material group (aineistoryhmä) options';
+select common.add_metadata_columns('projektivelho', 'material_group');
+select common.add_table_versioning('projektivelho', 'material_group');
 
-create table integrations.projektivelho_material_category
+create table projektivelho.material_category
 (
   code varchar(50) primary key not null,
   name varchar(100)            not null
 );
-comment on table integrations.projektivelho_material_category is 'Localized Projektivelho material category (ainestolaji) options';
-select common.add_metadata_columns('integrations', 'projektivelho_material_category');
-select common.add_table_versioning('integrations', 'projektivelho_material_category');
+comment on table projektivelho.material_category is 'Localized Projektivelho material category (ainestolaji) options';
+select common.add_metadata_columns('projektivelho', 'material_category');
+select common.add_table_versioning('projektivelho', 'material_category');
 
-create table integrations.projektivelho_technics_field
+create table projektivelho.technics_field
 (
   code varchar(50) primary key not null,
   name varchar(100)            not null
 );
-comment on table integrations.projektivelho_technics_field is 'Localized Projektivelho technics field (tekniikka-ala) options';
-select common.add_metadata_columns('integrations', 'projektivelho_technics_field');
-select common.add_table_versioning('integrations', 'projektivelho_technics_field');
+comment on table projektivelho.technics_field is 'Localized Projektivelho technics field (tekniikka-ala) options';
+select common.add_metadata_columns('projektivelho', 'technics_field');
+select common.add_table_versioning('projektivelho', 'technics_field');
 
-create table integrations.projektivelho_project_state
+create table projektivelho.project_state
 (
   code varchar(50) primary key not null,
   name varchar(100)            not null
 );
-comment on table integrations.projektivelho_project_state is 'Localized Projektivelho project state (projektin tila) options';
-select common.add_metadata_columns('integrations', 'projektivelho_project_state');
-select common.add_table_versioning('integrations', 'projektivelho_project_state');
+comment on table projektivelho.project_state is 'Localized Projektivelho project state (projektin tila) options';
+select common.add_metadata_columns('projektivelho', 'project_state');
+select common.add_table_versioning('projektivelho', 'project_state');

--- a/infra/src/main/resources/db/migration/prod/V40__add_projektivelho_integration.sql
+++ b/infra/src/main/resources/db/migration/prod/V40__add_projektivelho_integration.sql
@@ -1,87 +1,87 @@
-create type integrations.projektivelho_file_status as enum ('NOT_IM', 'SUGGESTED', 'REJECTED', 'ACCEPTED');
-create type integrations.projektivelho_search_status as enum ('WAITING', 'FETCHING', 'FINISHED', 'ERROR');
+create type projektivelho.file_status as enum ('NOT_IM', 'SUGGESTED', 'REJECTED', 'ACCEPTED');
+create type projektivelho.search_status as enum ('WAITING', 'FETCHING', 'FINISHED', 'ERROR');
 
-create table integrations.projektivelho_search
+create table projektivelho.search
 (
   id          int primary key generated always as identity,
-  status      integrations.projektivelho_search_status not null,
+  status      projektivelho.search_status not null,
   token       varchar(50)                              not null,
   valid_until timestamp with time zone                 not null
 );
-comment on table integrations.projektivelho_search is 'Status for ProjektiVelho asynchronous search operations';
-select common.add_metadata_columns('integrations', 'projektivelho_search');
-select common.add_table_versioning('integrations', 'projektivelho_search');
+comment on table projektivelho.search is 'Status for ProjektiVelho asynchronous search operations';
+select common.add_metadata_columns('projektivelho', 'search');
+select common.add_table_versioning('projektivelho', 'search');
 
-create table integrations.projektivelho_assignment
+create table projektivelho.assignment
 (
   oid        varchar(50)              not null primary key,
   name       varchar(100)             not null,
   state      varchar(100)             not null
-    references integrations.projektivelho_project_state (code),
+    references projektivelho.project_state (code),
   created_at timestamp with time zone not null,
   modified   timestamp with time zone not null
 );
-comment on table integrations.projektivelho_assignment is 'ProjektiVelho assignment';
-select common.add_metadata_columns('integrations', 'projektivelho_assignment');
-select common.add_table_versioning('integrations', 'projektivelho_assignment');
+comment on table projektivelho.assignment is 'ProjektiVelho assignment';
+select common.add_metadata_columns('projektivelho', 'assignment');
+select common.add_table_versioning('projektivelho', 'assignment');
 
-create table integrations.projektivelho_project
+create table projektivelho.project
 (
   oid        varchar(50)              not null primary key,
   name       varchar(100)             not null,
   state      varchar(100)             not null
-    references integrations.projektivelho_project_state (code),
+    references projektivelho.project_state (code),
   created_at timestamp with time zone not null,
   modified   timestamp with time zone not null
 );
-comment on table integrations.projektivelho_project is 'ProjektiVelho project';
-select common.add_metadata_columns('integrations', 'projektivelho_project');
-select common.add_table_versioning('integrations', 'projektivelho_project');
+comment on table projektivelho.project is 'ProjektiVelho project';
+select common.add_metadata_columns('projektivelho', 'project');
+select common.add_table_versioning('projektivelho', 'project');
 
-create table integrations.projektivelho_project_group
+create table projektivelho.project_group
 (
   oid        varchar(50)              not null primary key,
   name       varchar(100)             not null,
   state      varchar(100)             not null
-    references integrations.projektivelho_project_state (code),
+    references projektivelho.project_state (code),
   created_at timestamp with time zone not null,
   modified   timestamp with time zone not null
 );
-comment on table integrations.projektivelho_project_group is 'ProjektiVelho project group';
-select common.add_metadata_columns('integrations', 'projektivelho_project_group');
-select common.add_table_versioning('integrations', 'projektivelho_project_group');
+comment on table projektivelho.project_group is 'ProjektiVelho project group';
+select common.add_metadata_columns('projektivelho', 'project_group');
+select common.add_table_versioning('projektivelho', 'project_group');
 
-create table integrations.projektivelho_file_metadata
+create table projektivelho.file_metadata
 (
   id                                   int primary key generated always as identity,
   oid                                  varchar(50) unique                     not null,
   filename                             varchar(100)                           not null,
   file_version                         varchar(50)                            not null,
   description                          varchar(150),
-  projektivelho_document_type_code     varchar(50)                            not null
-    references integrations.projektivelho_document_type (code),
-  projektivelho_material_state_code    varchar(50)                            not null
-    references integrations.projektivelho_material_state (code),
-  projektivelho_material_group_code    varchar(50)                            not null
-    references integrations.projektivelho_material_group (code),
-  projektivelho_material_category_code varchar(50)                            not null
-    references integrations.projektivelho_material_category (code),
+  document_type_code     varchar(50)                            not null
+    references projektivelho.document_type (code),
+  material_state_code    varchar(50)                            not null
+    references projektivelho.material_state (code),
+  material_group_code    varchar(50)                            not null
+    references projektivelho.material_group (code),
+  material_category_code varchar(50)                            not null
+    references projektivelho.material_category (code),
   file_change_time                     timestamp with time zone               not null,
-  status                               integrations.projektivelho_file_status not null,
-  projektivelho_assignment_oid         varchar(50)                            null
-    references integrations.projektivelho_assignment (oid),
-  projektivelho_project_oid            varchar(50)                            null
-    references integrations.projektivelho_project (oid),
-  projektivelho_project_group_oid      varchar(50)                            null
-    references integrations.projektivelho_project_group (oid)
+  status                               projektivelho.file_status not null,
+  assignment_oid         varchar(50)                            null
+    references projektivelho.assignment (oid),
+  project_oid            varchar(50)                            null
+    references projektivelho.project (oid),
+  project_group_oid      varchar(50)                            null
+    references projektivelho.project_group (oid)
 );
-comment on table integrations.projektivelho_file_metadata is 'Handling status & metadata for Projektivelho files';
-select common.add_metadata_columns('integrations', 'projektivelho_file_metadata');
-select common.add_table_versioning('integrations', 'projektivelho_file_metadata');
+comment on table projektivelho.file_metadata is 'Handling status & metadata for Projektivelho files';
+select common.add_metadata_columns('projektivelho', 'file_metadata');
+select common.add_table_versioning('projektivelho', 'file_metadata');
 
-create table integrations.projektivelho_file
+create table projektivelho.file
 (
-  projektivelho_file_metadata_id int primary key references integrations.projektivelho_file_metadata (id),
+  file_metadata_id int primary key references projektivelho.file_metadata (id),
   content                        xml not null
 );
-comment on table integrations.projektivelho_file is 'File contents for non-discarded files, fetched from ProjektiVelho';
+comment on table projektivelho.file is 'File contents for non-discarded files, fetched from ProjektiVelho';

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/velho/VelhoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/velho/VelhoServiceIT.kt
@@ -56,13 +56,17 @@ class VelhoServiceIT @Autowired constructor(
     @BeforeEach
     fun setup() {
         transactional {
-            jdbc.update("delete from integrations.projektivelho_file where true", mapOf<String, Any>())
-            jdbc.update("delete from integrations.projektivelho_file_metadata where true", mapOf<String, Any>())
-            jdbc.update("delete from integrations.projektivelho_document_type where true", mapOf<String, Any>())
-            jdbc.update("delete from integrations.projektivelho_material_category where true", mapOf<String, Any>())
-            jdbc.update("delete from integrations.projektivelho_material_group where true", mapOf<String, Any>())
-            jdbc.update("delete from integrations.projektivelho_material_state where true", mapOf<String, Any>())
-            jdbc.update("delete from integrations.projektivelho_technics_field where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.file where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.file_metadata where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.document_type where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.material_category where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.material_group where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.material_state where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.technics_field where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.project_state where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.assignment where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.project where true", mapOf<String, Any>())
+            jdbc.update("delete from projektivelho.project_group where true", mapOf<String, Any>())
         }
     }
 
@@ -158,7 +162,7 @@ class VelhoServiceIT @Autowired constructor(
         velhoService.updateDictionaries()
         velhoDao.insertFetchInfo(searchId, Instant.now().plusSeconds(3600))
         val search = velhoDao.fetchLatestSearch()!!
-        val status = velhoService.fetchSearchStatus(searchId)!!
+        val status = velhoService.getSearchStatusIfReady(search)!!
 
         velhoService.importFilesFromProjektiVelho(search, status)
         assertDocumentExists(


### PR DESCRIPTION
Tauluja alkoi tulla aika paljon ja nimenä integrations.projektivelho_taulunimi alkoi olla turhan pitkä käyttää -> siirretty omaan schemaan. Ei muita muutoksia.