### PR TITLE
GVT-1875: Etusivun automaattinen tilan päivitys ei toimi

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.common
 
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_READ
 import fi.fta.geoviite.infra.geometry.GeometryService
+import fi.fta.geoviite.infra.integration.RatkoPushDao
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.tracklayout.*
@@ -21,6 +22,7 @@ data class CollectedChangeTimes(
     val layoutKmPost: Instant,
     val geometryPlan: Instant,
     val publication: Instant,
+    val ratkoPush: Instant,
 )
 
 @RestController
@@ -33,6 +35,7 @@ class ChangeTimeController(
     private val locationTrackService: LocationTrackService,
     private val referenceLineService: ReferenceLineService,
     private val publicationService: PublicationService,
+    private val ratkoPushDao: RatkoPushDao,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -49,6 +52,7 @@ class ChangeTimeController(
             layoutSwitch = switchService.getChangeTime(),
             geometryPlan = geometryService.getGeometryPlanChangeTime(),
             publication = publicationService.getChangeTime(),
+            ratkoPush = ratkoPushDao.getRatkoPushChangeTime(),
         )
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDao.kt
@@ -239,6 +239,21 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
             .also { logger.daoAccess(AccessType.FETCH, Publication::class) }
     }
 
+    fun getRatkoPushChangeTime(): Instant {
+        val sql = """
+            select coalesce(
+                greatest(
+                    max(ratko_push.end_time), 
+                    max(ratko_push.start_time)
+                ), 
+                now()
+            ) as latest_ratko_push_time
+            from integrations.ratko_push
+        """.trimIndent()
+        return jdbcTemplate.queryOne(sql) { rs, _, -> rs.getInstant("latest_ratko_push_time") }
+            .also { logger.daoAccess(AccessType.FETCH, Publication::class) }
+    }
+
     fun getRatkoStatus(publicationId: IntId<Publication>): List<RatkoPush> {
         val sql = """
             select

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -76,6 +76,33 @@ internal class RatkoPushDaoIT @Autowired constructor(
     }
 
     @Test
+    fun `ChangeTime fetch should fetch the start time of an ended push`() {
+        val ratkoPublishId = ratkoPushDao.startPushing(getCurrentUserName(), listOf(layoutPublishId))
+        val startTime = jdbc.query(
+            "select start_time from integrations.ratko_push where id = :id",
+            mapOf("id" to ratkoPublishId.intValue)
+        ) { rs, _ ->
+            rs.getInstantOrNull("start_time")
+        }.first()
+        val changeTime = ratkoPushDao.getRatkoPushChangeTime()
+        assertEquals(startTime, changeTime)
+    }
+
+    @Test
+    fun `ChangeTime fetch should fetch the end time of an ended push`() {
+        val ratkoPublishId = ratkoPushDao.startPushing(getCurrentUserName(), listOf(layoutPublishId))
+        ratkoPushDao.updatePushStatus(getCurrentUserName(), ratkoPublishId, status = RatkoPushStatus.SUCCESSFUL)
+        val endTime = jdbc.query(
+            "select end_time from integrations.ratko_push where id = :id",
+            mapOf("id" to ratkoPublishId.intValue)
+        ) { rs, _ ->
+                rs.getInstantOrNull("end_time")
+        }.first()
+        val changeTime = ratkoPushDao.getRatkoPushChangeTime()
+        assertEquals(endTime, changeTime)
+    }
+
+    @Test
     fun shouldSetEndTimeWhenFinishedPublishing() {
         val ratkoPublishId = ratkoPushDao.startPushing(getCurrentUserName(), listOf(layoutPublishId))
         ratkoPushDao.updatePushStatus(getCurrentUserName(), ratkoPublishId, status = RatkoPushStatus.SUCCESSFUL)

--- a/ui/src/common/common-slice.ts
+++ b/ui/src/common/common-slice.ts
@@ -11,6 +11,7 @@ export type ChangeTimes = {
     layoutKmPost: TimeStamp;
     geometryPlan: TimeStamp;
     publication: TimeStamp;
+    ratkoPush: TimeStamp;
 };
 
 export const initialChangeTime: TimeStamp = '1970-01-01T00:00:00.000Z';
@@ -22,6 +23,7 @@ export const initialChangeTimes: ChangeTimes = {
     layoutKmPost: initialChangeTime,
     geometryPlan: initialChangeTime,
     publication: initialChangeTime,
+    ratkoPush: initialChangeTime,
 };
 
 export type CommonState = {
@@ -67,6 +69,9 @@ const commonSlice = createSlice({
             }
             if (toDate(changeTimes.publication) < toDate(payload.publication)) {
                 changeTimes.publication = payload.publication;
+            }
+            if (toDate(changeTimes.ratkoPush) < toDate(payload.ratkoPush)) {
+                changeTimes.ratkoPush = payload.ratkoPush;
             }
         },
         setLayoutTrackNumberChangeTime: function (
@@ -117,6 +122,12 @@ const commonSlice = createSlice({
         ) {
             if (toDate(changeTimes.publication) < toDate(payload))
                 changeTimes.publication = payload;
+        },
+        setRatkoPushChangeTime: function (
+            { changeTimes }: CommonState,
+            { payload }: PayloadAction<TimeStamp>,
+        ) {
+            if (toDate(changeTimes.ratkoPush) < toDate(payload)) changeTimes.ratkoPush = payload;
         },
         setUserPrivileges: (
             state: CommonState,

--- a/ui/src/frontpage/frontpage-container.tsx
+++ b/ui/src/frontpage/frontpage-container.tsx
@@ -5,14 +5,18 @@ import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks
 import Frontpage from 'frontpage/frontpage';
 
 export const FrontpageContainer: React.FC = () => {
-    const changeTime = useCommonDataAppSelector((state) => state.changeTimes.publication);
+    const publicationChangeTime = useCommonDataAppSelector(
+        (state) => state.changeTimes.publication,
+    );
+    const ratkoPushChangeTime = useCommonDataAppSelector((state) => state.changeTimes.ratkoPush);
     const publication = useTrackLayoutAppSelector((state) => state.selection.publication);
     const delegates = createDelegates(trackLayoutActionCreators);
 
     return (
         <Frontpage
             selectedPublication={publication}
-            changeTime={changeTime}
+            publicationChangeTime={publicationChangeTime}
+            ratkoPushChangeTime={ratkoPushChangeTime}
             onSelectedPublicationChanged={delegates.onSelectedPublicationChanged}
         />
     );

--- a/ui/src/frontpage/frontpage.tsx
+++ b/ui/src/frontpage/frontpage.tsx
@@ -14,13 +14,15 @@ import { TimeStamp } from 'common/common-model';
 type FrontPageProps = {
     selectedPublication: PublicationId | undefined;
     onSelectedPublicationChanged: (item: PublicationId | undefined) => void;
-    changeTime: TimeStamp;
+    publicationChangeTime: TimeStamp;
+    ratkoPushChangeTime: TimeStamp;
 };
 
 const Frontpage: React.FC<FrontPageProps> = ({
     selectedPublication,
     onSelectedPublicationChanged,
-    changeTime,
+    publicationChangeTime,
+    ratkoPushChangeTime,
 }) => {
     const [publications, setPublications] = React.useState<PublicationDetails[] | null>();
     const [ratkoStatus, setRatkoStatus] = React.useState<RatkoStatus | undefined>();
@@ -32,7 +34,7 @@ const Frontpage: React.FC<FrontPageProps> = ({
             getLatestPublications(MAX_LISTED_PUBLICATIONS).then((result) =>
                 setPublications(result?.items),
             ),
-        [changeTime],
+        [publicationChangeTime, ratkoPushChangeTime],
     );
     useLoaderWithTimer(setRatkoStatus, getRatkoStatus, [], 30000);
 
@@ -63,7 +65,7 @@ const Frontpage: React.FC<FrontPageProps> = ({
             )}
             {publication && (
                 <PublicationDetailsView
-                    changeTime={changeTime}
+                    changeTime={publicationChangeTime}
                     publication={publication}
                     onPublicationUnselected={() => onSelectedPublicationChanged(undefined)}
                     anyFailed={anyFailed}


### PR DESCRIPTION
Ongelman pääsyynä tässä oli, että etusivulla käytettiin julkaisujen ChangeTimea. Ne eivät päivity ratkopuskujen tilojen mukana, sillä itse julkaisu ei tällöin muutu. Tein rinnalle ratkopuskuille oman ChangeTimen, jota käytetään näissä