### PR TITLE
GVT-1843: Ääkköset InfraModelin tidostonimessä rikkoo chromen downloadin ja uploadin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResponseEntity.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResponseEntity.kt
@@ -14,6 +14,6 @@ fun toFileDownloadResponse(fileName: String, content: ByteArray): ResponseEntity
     headers.contentType = MediaType.APPLICATION_OCTET_STREAM
     headers.set(
         HttpHeaders.CONTENT_DISPOSITION,
-        ContentDisposition.attachment().filename(fileName).build().toString())
+        ContentDisposition.attachment().filename(fileName, Charsets.UTF_8).build().toString())
     return ResponseEntity.ok().headers(headers).body(content)
 }


### PR DESCRIPTION
Alkuperäinen Chromen kaatumisbugi ei toistunut mulla, joten epäiltiin Jyrkin kanssa Linux-Chrome-spesifistä ongelmaa. Tässä kuitenkin korjattuna se, että Chrome latasi ääkkösiä sisältävät tiedostot väärällä tiedostonimillä (tiedostonimeksi tuli pelkkä "file"/"tiedosto")