### PR TITLE
GVT-1888 Pass ref to detect map view resizes properly

### DIFF
--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -174,7 +174,10 @@ const MapView: React.FC<MapViewProps> = ({
         }
     };
 
-    useResizeObserver({ onResize: () => olMap?.updateSize() });
+    useResizeObserver({
+        ref: olMapContainer,
+        onResize: () => olMap?.updateSize(),
+    });
 
     // Initialize OpenLayers map. Do this only once, in subsequent
     // renders we just want to update OpenLayers layers. In this way map


### PR DESCRIPTION
Toimi tämä ilmankin tuota reffiä jollain tavalla, tosin en tiedä että miksi toimi lainkaan; mutta näemmä se pitää passata, jotta tässä tapauksessa tämä resizeObserver osaa observoida yhtikäs mitään.