### PR TITLE
Dev/fix e2e tests

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/MapToolPanelElement.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/MapToolPanelElement.kt
@@ -76,7 +76,6 @@ class LocationTrackLocationInfobox(by: By) : InfoBox(by) {
 
     fun valmis(): Toaster{
         clickButton("Valmis")
-        refreshRootElement()
         return waitAndGetToasterElement()
     }
 
@@ -348,15 +347,14 @@ open class LinkingInfoBox(by: By): InfoBox(by) {
 
     fun linkita(): Toaster {
         logger.info("Link")
+        val elementBeforeClick = rootElement
         clickButton("Linkitä")
         val toaster = waitAndGetToasterElement()
 
         //This works as a basic Thread.Sleep() if root element becomes stable very fast
         try {
-            waitUntilElementIsStale(rootElement, timeoutSeconds = 1)
-        } catch (_: TimeoutException) {
-
-        }
+            waitUntilElementIsStale(elementBeforeClick, timeoutSeconds = 1)
+        } catch (_: TimeoutException) { }
 
         return toaster
     }
@@ -494,10 +492,7 @@ class AddEndPointDialog : DialogPopUp() {
     private fun ok() = this  {
         clickButton("OK")
         getButtonElementByContent("Jatka")
-        refreshRootElement()
     }
-
-
 
     private fun selectRadioButton(buttonLabel: String) = this {
         logger.info("Select radio button $buttonLabel")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/PreviewChangesPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/PreviewChangesPage.kt
@@ -72,7 +72,7 @@ class PreviewChangesPage: PageModel(By.xpath("//div[@qa-id='preview-content']"))
 
 }
 
-class PreviewChangesSaveOrDiscardDialog(): DialogPopUp() {
+class PreviewChangesSaveOrDiscardDialog: DialogPopUp() {
 
     fun julkaise() {
         val messageBox = getElementWhenVisible(By.cssSelector("textarea[qa-id=publication-message]"))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
@@ -643,9 +643,8 @@ class LinkingTestUI @Autowired constructor(
 
 
         navigationPanel.selectLocationTrack(LOCATION_TRACK_F.first.name.toString())
-        val locationTrackLocationInfobox = toolPanel.locationTrackLocation()
-        val locationTrackLengthBeforeLinking = metersToDouble(locationTrackLocationInfobox.todellinenPituus())
-        val locationTrackEndBeforeLinking = locationTrackLocationInfobox.loppukoordinaatti()
+        val locationTrackLengthBeforeLinking = metersToDouble(toolPanel.locationTrackLocation().todellinenPituus())
+        val locationTrackEndBeforeLinking = toolPanel.locationTrackLocation().loppukoordinaatti()
 
         navigationPanel.geometryPlanByName(GEOMETRY_PLAN_NAME).selecAlignment(GEO_ALIGNMENT_F_NAME)
         val alignmentLinkinInfobox = toolPanel.geometryAlignmentLinking()
@@ -657,17 +656,17 @@ class LinkingTestUI @Autowired constructor(
         mapPage.clickAtCoordinates(geometryAlignmentStart)
         mapPage.clickAtCoordinates(geometryAlignmentEnd)
         mapPage.clickAtCoordinates(LOCATION_TRACK_F.second.segments.first().points.first())
-            mapPage.clickAtCoordinates(LOCATION_TRACK_F.second.segments.first().points.last())
+        mapPage.clickAtCoordinates(LOCATION_TRACK_F.second.segments.first().points.last())
         alignmentLinkinInfobox.linkita()
 
         val locationTrackAfterLinking = getLocationTrackAndAlignment(PublishType.DRAFT, LOCATION_TRACK_F_ID)
 
         toolPanel.selectToolPanelTab(LOCATION_TRACK_F.first.name.toString())
-        val lengthAfterLinking = metersToDouble(locationTrackLocationInfobox.todellinenPituus())
+        val lengthAfterLinking = metersToDouble(toolPanel.locationTrackLocation().todellinenPituus())
 
         assertThat(locationTrackLengthBeforeLinking).isLessThan(lengthAfterLinking)
-        assertEquals(pointToCoordinateString(geometryAlignmentStart), locationTrackLocationInfobox.alkukoordinaatti())
-        assertEquals(locationTrackEndBeforeLinking, locationTrackLocationInfobox.loppukoordinaatti())
+        assertEquals(pointToCoordinateString(geometryAlignmentStart), toolPanel.locationTrackLocation().alkukoordinaatti())
+        assertEquals(locationTrackEndBeforeLinking, toolPanel.locationTrackLocation().loppukoordinaatti())
         assertTrue(hasSegmentBetweenPoints(
             start = geometryAlignmentEnd,
             end = LOCATION_TRACK_F.second.segments.first().points.last().toPoint(),
@@ -677,7 +676,7 @@ class LinkingTestUI @Autowired constructor(
 
         publishChanges()
 
-        assertThatLatestPublicationDetailsIncludeMuutoskohde("Sijaintiraide ${LOCATION_TRACK_F.first.name.toString()}")
+        assertThatLatestPublicationDetailsIncludeMuutoskohde("Sijaintiraide ${LOCATION_TRACK_F.first.name}")
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
@@ -621,9 +621,8 @@ class LinkingTestUI @Autowired constructor(
         assertTrue(hasSegmentBetweenPoints(
             start = geometryAlignment.elements.last().end,
             end = LOCATION_TRACK_E.second.segments.first().points.first().toPoint(),
-            layoutAlignment = editedLocationTrack.second
-            )
-        )
+            layoutAlignment = editedLocationTrack.second,
+        ))
 
         assertNotEquals(locationTrackStartBeforeLinking, locationTrackLocationInfobox.alkukoordinaatti())
         assertEquals(pointToCoordinateString(geometryAlignment.elements.first().start), locationTrackLocationInfobox.alkukoordinaatti())
@@ -643,8 +642,9 @@ class LinkingTestUI @Autowired constructor(
 
 
         navigationPanel.selectLocationTrack(LOCATION_TRACK_F.first.name.toString())
-        val locationTrackLengthBeforeLinking = metersToDouble(toolPanel.locationTrackLocation().todellinenPituus())
-        val locationTrackEndBeforeLinking = toolPanel.locationTrackLocation().loppukoordinaatti()
+        val locationTrackLocationInfobox = toolPanel.locationTrackLocation()
+        val locationTrackLengthBeforeLinking = metersToDouble(locationTrackLocationInfobox.todellinenPituus())
+        val locationTrackEndBeforeLinking = locationTrackLocationInfobox.loppukoordinaatti()
 
         navigationPanel.geometryPlanByName(GEOMETRY_PLAN_NAME).selecAlignment(GEO_ALIGNMENT_F_NAME)
         val alignmentLinkinInfobox = toolPanel.geometryAlignmentLinking()
@@ -662,11 +662,11 @@ class LinkingTestUI @Autowired constructor(
         val locationTrackAfterLinking = getLocationTrackAndAlignment(PublishType.DRAFT, LOCATION_TRACK_F_ID)
 
         toolPanel.selectToolPanelTab(LOCATION_TRACK_F.first.name.toString())
-        val lengthAfterLinking = metersToDouble(toolPanel.locationTrackLocation().todellinenPituus())
+        val lengthAfterLinking = metersToDouble(locationTrackLocationInfobox.todellinenPituus())
 
         assertThat(locationTrackLengthBeforeLinking).isLessThan(lengthAfterLinking)
-        assertEquals(pointToCoordinateString(geometryAlignmentStart), toolPanel.locationTrackLocation().alkukoordinaatti())
-        assertEquals(locationTrackEndBeforeLinking, toolPanel.locationTrackLocation().loppukoordinaatti())
+        assertEquals(pointToCoordinateString(geometryAlignmentStart), locationTrackLocationInfobox.alkukoordinaatti())
+        assertEquals(locationTrackEndBeforeLinking, locationTrackLocationInfobox.loppukoordinaatti())
         assertTrue(hasSegmentBetweenPoints(
             start = geometryAlignmentEnd,
             end = LOCATION_TRACK_F.second.segments.first().points.last().toPoint(),


### PR DESCRIPTION
e2e testien korjailua, erityisesti liittyen stale elementteihin. Tuo on ongelmallista logiikka missä haetaan elementti ja säilytetään viite siihen, varsinkin kun se tapahtuu noiden elementti-olioiden sisällä. Tuo pitäisi kokonaisuudessaan rempata siihen suuntaan että säilytetään vain haku-xpath ja elementti haetaan aina uudelleen silloin kun sitä käytetään. 

Tämä muutos tekee tuon sille kantaluokalle, mutta ei kaikelle. Pitää vähän miettiä yleistä rakennetta ja tehdä jonkinlainen remppakierros noille.