### PR TITLE
GVT-1880: Paremmat suodatukset projektivelhon suunnitelmille

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel.kt
@@ -13,6 +13,7 @@ interface InfraModel {
 
 interface InfraModelFeatureDictionary {
     val name: String
+    val version: String?
 }
 
 interface InfraModelUnits {
@@ -30,6 +31,7 @@ interface InfraModelMetric {
 interface InfraModelProject {
     val name: String
     val desc: String?
+    val feature: InfraModelFeature?
 }
 
 interface InfraModelApplication{

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel403.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel403.kt
@@ -27,6 +27,7 @@ data class InfraModel403(
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelFeatureDictionary403(
     @field:XmlAttribute override val name: String = "",
+    @field:XmlAttribute override val version: String? = null
 ):InfraModelFeatureDictionary
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -48,6 +49,8 @@ data class InfraModelMetric403(
 data class InfraModelProject403(
     @field:XmlAttribute override val name: String = "",
     @field:XmlAttribute override val desc: String? = null,
+    @field:XmlElement(name = "Feature", namespace = XMLNS_403)
+    override val feature: InfraModelFeature403? = null,
 ):InfraModelProject
 
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel404.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel404.kt
@@ -27,6 +27,7 @@ data class InfraModel404(
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelFeatureDictionary404(
     @field:XmlAttribute override val name: String = "",
+    @field:XmlAttribute override val version: String? = null
 ):InfraModelFeatureDictionary
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -48,6 +49,8 @@ data class InfraModelMetric404(
 data class InfraModelProject404(
     @field:XmlAttribute override val name: String = "",
     @field:XmlAttribute override val desc: String? = null,
+    @field:XmlElement(name = "Feature", namespace = XMLNS_404)
+    override val feature: InfraModelFeature404? = null,
 ):InfraModelProject
 
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
@@ -61,6 +61,19 @@ fun toGvtPlan(
         )
     }
 
+    if (!isSupportedInframodelVersion(infraModel.featureDictionary?.version)) {
+        throw InframodelParsingException(
+            message = "Plan InfraModel version isn't supported. version=${infraModel.featureDictionary?.version}",
+            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.parsing.unsupported-version"
+        )
+    }
+    checkBlacklistedCodings(infraModel.project?.feature?.properties ?: emptyList()) { org ->
+        throw InframodelParsingException(
+            message = "Plan is from a blacklisted organization. org=${org}",
+            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.parsing.blacklisted-organization"
+        )
+    }
+
     val units = parseUnits(coordinateSystem, metricUnits, coordinateSystemNameToSrid)
     val gvtSwitches =
         collectGeometrySwitches(switchStructuresByType, switchTypeNameAliases, infraModel.alignmentGroups)
@@ -148,6 +161,17 @@ fun parseUnits(
         linearUnit = parseEnum("Plan linear measurement unit", metricUnits.linearUnit),
     )
 }
+
+private val SUPPORTED_INFRAMODEL_VERSIONS = listOf("4.0.3", "4.0.4")
+private fun isSupportedInframodelVersion(versionString: String?) =
+    versionString == null || SUPPORTED_INFRAMODEL_VERSIONS.contains(versionString)
+
+private val BLACKLISTED_CODINGS = listOf("Tielaitos")
+
+private fun checkBlacklistedCodings(properties: List<InfraModelProperty>, onFail: (blacklistedCoding: String) -> Unit) =
+    properties
+        .find { prop -> BLACKLISTED_CODINGS.contains(prop.value) }
+        ?.let { org -> onFail(org.value) }
 
 fun parseTime(timeString: String): Instant =
     if (timeString.endsWith("Z")) Instant.parse(timeString)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
@@ -11,9 +11,7 @@ import fi.fta.geoviite.infra.authorization.withUser
 import fi.fta.geoviite.infra.common.FeatureTypeCode
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
-import fi.fta.geoviite.infra.inframodel.InfraModelService
-import fi.fta.geoviite.infra.inframodel.censorAuthorIdentifyingInfo
-import fi.fta.geoviite.infra.inframodel.toInfraModelFile
+import fi.fta.geoviite.infra.inframodel.*
 import fi.fta.geoviite.infra.integration.DatabaseLock
 import fi.fta.geoviite.infra.integration.LockDao
 import fi.fta.geoviite.infra.logging.serviceCall
@@ -34,7 +32,7 @@ val SECONDS_IN_A_YEAR: Long = Duration.ofDays(365).toSeconds()
 
 @Service
 @ConditionalOnBean(PVClientConfiguration::class)
-class PVService @Autowired constructor(
+class PVIntegrationService @Autowired constructor(
     private val PVClient: PVClient,
     private val pvDao: PVDao,
     private val lockDao: LockDao,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
@@ -56,9 +56,9 @@ val projectDictionaries: Map<PVDictionaryType, List<PVDictionaryEntry>> = mapOf(
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest(properties = ["geoviite.projektivelho=true"])
-class PVServiceIT @Autowired constructor(
+class PVIntegrationServiceIT @Autowired constructor(
     @Value("\${geoviite.projektivelho.test-port:12345}") private val velhoPort: Int,
-    private val pvService: PVService,
+    private val pvIntegrationService: PVIntegrationService,
     private val pvDao: PVDao,
     private val pvDocumentService: PVDocumentService,
     private val jsonMapper: ObjectMapper,
@@ -87,7 +87,7 @@ class PVServiceIT @Autowired constructor(
     fun `Spinning up search works`(): Unit = fakeVelho().use { fakeVelho ->
         fakeVelho.login()
         fakeVelho.search()
-        val search = pvService.search()
+        val search = pvIntegrationService.search()
         assertNotNull(search)
         assertEquals(search.searchId, pvDao.fetchLatestSearch()?.token)
     }
@@ -101,7 +101,7 @@ class PVServiceIT @Autowired constructor(
 
         fakeVelho.fetchDictionaries(MATERIAL, materialDictionaries)
         fakeVelho.fetchDictionaries(PROJECT, projectDictionaries)
-        pvService.updateDictionaries()
+        pvIntegrationService.updateDictionaries()
         PVDictionaryType.values().forEach { type ->
             assertEquals(
                 (materialDictionaries+projectDictionaries)[type]!!.map { e -> e.code to e.name }.associate { it },
@@ -145,7 +145,7 @@ class PVServiceIT @Autowired constructor(
         )
         fakeVelho.fetchDictionaries(MATERIAL, materialDictionaries2)
         fakeVelho.fetchDictionaries(PROJECT, projectDictionaries2)
-        pvService.updateDictionaries()
+        pvIntegrationService.updateDictionaries()
         PVDictionaryType.values().forEach { type ->
             assertEquals(
                 (materialDictionaries2+projectDictionaries2)[type]!!.map { e -> e.code to e.name }.associate { it },
@@ -182,12 +182,12 @@ class PVServiceIT @Autowired constructor(
         )
         fakeVelho.fileContent(documentOid)
 
-        pvService.updateDictionaries()
+        pvIntegrationService.updateDictionaries()
         pvDao.insertFetchInfo(searchId, Instant.now().plusSeconds(3600))
         val search = pvDao.fetchLatestSearch()!!
-        val status = pvService.getSearchStatusIfReady(search)!!
+        val status = pvIntegrationService.getSearchStatusIfReady(search)!!
 
-        pvService.importFilesFromProjektiVelho(search, status)
+        pvIntegrationService.importFilesFromProjektiVelho(search, status)
         assertDocumentExists(
             documentOid,
             PVDocumentStatus.SUGGESTED,

--- a/ui/src/i18n/fi/fi.json
+++ b/ui/src/i18n/fi/fi.json
@@ -47,6 +47,8 @@
                 "generic": "Tiedoston jäsentäminen epäonnistui",
                 "xml-invalid": "Tiedoston rakenne on virheellinen. Varmista että merkistö (XML:n alkutagin encoding-kenttä) on oikein ja tiedosto on LandXML-tyyppinen.",
                 "duplicate-inframodel-file-content": "Suunnitelma on jo olemassa Geoviitteessä samasta lähteestä nimellä {{0}}",
+                "unsupported-version": "Tiedoston InfraModel-versio ei ole tuettu",
+                "blacklisted-organization": "Suunnitelman koodaus (terrainCoding, surfaceCoding) on mustalla listalla",
                 "missing-section": {
                     "coordinate-system": "Koordinaattijärjestelmän tiedot (CoordinateSystem-elementti) puuttuu",
                     "units": "Yksikkötiedot (Units-elementti) puuttuu",


### PR DESCRIPTION
Jyrki olikin tehnyt tästä jo osan aiemmin. Lisätty täällä tarkistuksia InfraModelin versiolle sekä mustalistattu Tielaitoksen IM:t. Samalla uudelleennimetty `PVService` nimelle `PVIntegrationService`, sillä se on rinnakkain `PVDocumentService`:n kanssa ja se näytti oudolta