### PR TITLE
GVT-1894: Hylkäämissyyn tallentaminen hylätyistä inframalleista

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
@@ -64,13 +64,13 @@ fun toGvtPlan(
     if (!isSupportedInframodelVersion(infraModel.featureDictionary?.version)) {
         throw InframodelParsingException(
             message = "Plan InfraModel version isn't supported. version=${infraModel.featureDictionary?.version}",
-            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.parsing.unsupported-version"
+            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.unsupported-version"
         )
     }
     checkBlacklistedCodings(infraModel.project?.feature?.properties ?: emptyList()) { org ->
         throw InframodelParsingException(
             message = "Plan is from a blacklisted organization. org=${org}",
-            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.parsing.blacklisted-organization"
+            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.blacklisted-organization"
         )
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocument.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocument.kt
@@ -1,5 +1,7 @@
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.projektivelho.PVApiFileMetadata
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import java.time.Instant
@@ -16,6 +18,12 @@ data class PVProjectGroup(val oid: Oid<PVProjectGroup>, val name: PVDictionaryNa
 data class PVProject(val oid: Oid<PVProject>, val name: PVDictionaryName, val state: PVDictionaryName)
 
 data class PVAssignment(val oid: Oid<PVAssignment>, val name: PVDictionaryName, val state: PVDictionaryName)
+
+data class PVDocumentRejection(
+    val id: IntId<PVDocumentRejection>,
+    val metadataVersion: RowVersion<PVApiFileMetadata>,
+    val reason: String,
+)
 
 data class PVDocument(
     val id: IntId<PVDocument>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
@@ -10,6 +10,7 @@ import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.authorization.withUser
 import fi.fta.geoviite.infra.common.FeatureTypeCode
 import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.error.InframodelParsingException
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
 import fi.fta.geoviite.infra.inframodel.*
 import fi.fta.geoviite.infra.integration.DatabaseLock
@@ -164,10 +165,15 @@ class PVIntegrationService @Autowired constructor(
     }
 
     private fun insertFileToDatabase(file: PVFileHolder, assignment: PVAssignmentHolder) {
-        val xmlContent = file.content
-            ?.takeIf { content -> isRailroadXml(content ,file.latestVersion.name) }
-            ?.let { content -> censorAuthorIdentifyingInfo(content) }
-        val metadataId = pvDao.insertFileMetadata(
+        val (passedValidation, reasonIfRejected) = file.content?.let {
+            isRailroadXml(
+                file.content,
+                file.latestVersion.name
+            )
+        }
+            ?: (false to "Failed to fetch")
+        val xmlContent = if (passedValidation) file.content?.let(::censorAuthorIdentifyingInfo) else null
+        val metadataRowVersion = pvDao.insertFileMetadata(
             file.oid,
             file.metadata,
             file.latestVersion,
@@ -176,16 +182,24 @@ class PVIntegrationService @Autowired constructor(
             assignment.project?.oid,
             assignment.projectGroup?.oid,
         )
-        xmlContent?.let { content -> pvDao.insertFileContent(content, metadataId) }
+        xmlContent?.let { content -> pvDao.insertFileContent(content, metadataRowVersion.id) }
+            ?: pvDao.insertRejection(metadataRowVersion, reasonIfRejected ?: "")
     }
 
     fun isRailroadXml(xml: String, filename: FileName) =
         try {
             val parsed = infraModelService.parseInfraModel(toInfraModelFile(filename, xml))
-            parsed.alignments.isNotEmpty() && parsed.alignments.all(::isRailroadAlignment)
+            parsed.alignments.let { alignments ->
+                if (alignments.isEmpty()) false to "error.infra-model.parsing.alignments.no-alignment"
+                else if (parsed.alignments.any { !isRailroadAlignment(it) }) false to "error.infra-model.parsing.alignments.non-railroad-alignments"
+                else true to null
+            }
+        } catch (e: InframodelParsingException) {
+            logger.info("Rejecting XML as not-IM: file=$filename error=${e.message?.let(::formatForLog)}")
+            false to e.localizedMessageKey.toString()
         } catch (e: Exception) {
             logger.info("Rejecting XML as not-IM: file=$filename error=${e.message?.let(::formatForLog)}")
-            false
+            false to "error.infra-model.parsing.generic"
         }
 
     val railroadAlignmentFeatureTypes = listOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
@@ -171,7 +171,7 @@ class PVIntegrationService @Autowired constructor(
                 file.latestVersion.name
             )
         }
-            ?: (false to "Failed to fetch")
+            ?: (false to "error.infra-model.parsing.generic")
         val xmlContent = if (passedValidation) file.content?.let(::censorAuthorIdentifyingInfo) else null
         val metadataRowVersion = pvDao.insertFileMetadata(
             file.oid,
@@ -190,8 +190,8 @@ class PVIntegrationService @Autowired constructor(
         try {
             val parsed = infraModelService.parseInfraModel(toInfraModelFile(filename, xml))
             parsed.alignments.let { alignments ->
-                if (alignments.isEmpty()) false to "error.infra-model.parsing.alignments.no-alignment"
-                else if (parsed.alignments.any { !isRailroadAlignment(it) }) false to "error.infra-model.parsing.alignments.non-railroad-alignments"
+                if (alignments.isEmpty()) false to INFRAMODEL_PARSING_KEY_GENERIC
+                else if (parsed.alignments.any { !isRailroadAlignment(it) }) false to "$INFRAMODEL_PARSING_KEY_PARENT.alignments.non-railroad-alignments"
                 else true to null
             }
         } catch (e: InframodelParsingException) {
@@ -199,7 +199,7 @@ class PVIntegrationService @Autowired constructor(
             false to e.localizedMessageKey.toString()
         } catch (e: Exception) {
             logger.info("Rejecting XML as not-IM: file=$filename error=${e.message?.let(::formatForLog)}")
-            false to "error.infra-model.parsing.generic"
+            false to INFRAMODEL_PARSING_KEY_GENERIC
         }
 
     val railroadAlignmentFeatureTypes = listOf(

--- a/infra/src/main/resources/db/migration/prod/V40__add_projektivelho_integration.sql
+++ b/infra/src/main/resources/db/migration/prod/V40__add_projektivelho_integration.sql
@@ -68,6 +68,8 @@ create table projektivelho.file_metadata
 comment on table projektivelho.file_metadata is 'Handling status & metadata for Projektivelho files';
 select common.add_metadata_columns('projektivelho', 'file_metadata');
 select common.add_table_versioning('projektivelho', 'file_metadata');
+alter table projektivelho.file_metadata
+  add constraint file_metadata_id_version_unique unique (id, version);
 
 create table projektivelho.file
 (
@@ -75,3 +77,15 @@ create table projektivelho.file
   content          xml not null
 );
 comment on table projektivelho.file is 'File contents for non-discarded files, fetched from ProjektiVelho';
+
+create table projektivelho.file_metadata_rejection
+(
+  id            int primary key generated always as identity,
+  file_id       int not null references projektivelho.file_metadata (id),
+  file_version  int not null,
+  reason        varchar(150) not null,
+
+  constraint projektivelho_file_rejection_file_metadata_fkey
+    foreign key (file_id, file_version) references projektivelho.file_metadata (id, version)
+);
+comment on table projektivelho.file_metadata_rejection is 'Rejection information for discarded ProjektiVelho files';

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
@@ -210,6 +210,17 @@ class PVIntegrationServiceIT @Autowired constructor(
         assertEquals(1, counts.rejected)
     }
 
+    @Test
+    fun `Document rejection works`() {
+        insertTestDictionary()
+        val version = insertDocumentMetaWithStatus(Oid("1.2.3.4.7"), PVDocumentStatus.REJECTED)
+        pvDao.insertRejection(version, "test")
+        val rejection = pvDao.getRejection(version)
+
+        assertEquals(version, rejection.metadataVersion)
+        assertEquals("test", rejection.reason)
+    }
+
     private fun assertDocumentExists(
         oid: Oid<PVDocument>,
         status: PVDocumentStatus,

--- a/ui/src/i18n/fi/fi.json
+++ b/ui/src/i18n/fi/fi.json
@@ -57,6 +57,10 @@
                     "project": "Projektin tiedot (Project-elementti) puuttuu",
                     "alignment-group": "Keskilinjojen ryhmä (AlignmentGroup) puuttuu tai ei ole yksiselitteinen",
                     "prof-align": "Keskilinjan pystygeometrialta (Profile) puuttuu geometria (ProfAlign-elementti)"
+                },
+                "alignments": {
+                    "no-alignments": "Suunnitelma ei sisällä yhtään keskilinjaa",
+                    "non-railroad-alignments": "Suunnitelman kaikki keskilinjat eivät ole ratageometriakeskilinjoja"
                 }
             },
             "transformation": {


### PR DESCRIPTION
Täällä toteutettu inframallin hylkäämissyyn muiluttaminen ulos tiedoston lukemisesta. Lisäksi toteutettu PV-scheman kantaan paikka, jonne ka. tiedon voi tallentaa.