### PR TITLE
GVT-1899: Pystygeometrioiden CSV-eksportin luomisaika selkeämmäksi

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
@@ -10,6 +10,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.printCsv
+import fi.fta.geoviite.infra.util.toCsvDate
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.stream.Collectors
@@ -334,7 +335,7 @@ private val locationTrackCsvEntry =
 private val commonVerticalGeometryListingCsvEntries = arrayOf(
     CsvEntry<VerticalGeometryListing>(translateVerticalGeometryListingHeader(VerticalGeometryListingHeader.PLAN_NAME)) { it.fileName },
     CsvEntry(translateVerticalGeometryListingHeader(VerticalGeometryListingHeader.CRS)) { it.coordinateSystemSrid ?: it.coordinateSystemName },
-    CsvEntry(translateVerticalGeometryListingHeader(VerticalGeometryListingHeader.CREATION_DATE)) { it.creationTime },
+    CsvEntry(translateVerticalGeometryListingHeader(VerticalGeometryListingHeader.CREATION_DATE)) { it.creationTime?.let(::toCsvDate) },
     CsvEntry(translateVerticalGeometryListingHeader(VerticalGeometryListingHeader.PLAN_TRACK)) { it.alignmentName },
     CsvEntry(translateVerticalGeometryListingHeader(VerticalGeometryListingHeader.TRACK_ADDRESS_START)) {
         it.start.address?.let { address ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/CSVPrintingUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/CSVPrintingUtils.kt
@@ -2,11 +2,21 @@ package fi.fta.geoviite.infra.util
 
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVPrinter
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 data class CsvEntry<T>(
     val header: String,
     val getValue: (data: T) -> Any?,
 )
+
+val csvDateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+fun toCsvDate(date: Instant) = csvDateFormatter
+    // Default to Finnish time. Stored dates are at midnight Finnish time (22:00 UTC previous day),
+    // so a timezone offset is added to make sure the correct date is shown
+    .withZone(ZoneId.of("UTC+2"))
+    .format(date)
 
 fun <T> printCsv(columns: List<CsvEntry<T>>, data: List<T>): String {
     val csvBuilder = StringBuilder()


### PR DESCRIPTION
Tämä ongelma olikin pelkästään pystygeometriaexportissa. Muualla joko ei ollut ollenkaan päivämääriä/timestampeja, tai sitten oli handlattu paikallisesti ja eri formaatissa