### PR TITLE
GVT-1902: Pystygeometrian kuvaajan tulisi näyttää saman raiteen tietoja kuin ominaisuustietonäkymä

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -277,9 +277,10 @@ class GeometryController @Autowired constructor(
     fun getPlanAlignmentStartAndEnd(
         @PathVariable("planId") planId: IntId<GeometryPlan>,
         @PathVariable("planAlignmentId") planAlignmentId: IntId<GeometryAlignment>,
-    ): AlignmentStartAndEnd? {
+    ): ResponseEntity<AlignmentStartAndEnd> {
         logger.apiCall("getPlanAlignmentStartAndEnd", "planId" to planId, "planAlignmentId" to planAlignmentId)
-        return geometryService.getPlanAlignmentStartAndEnd(planId, planAlignmentId)
+        return toResponse(geometryService.getPlanAlignmentStartAndEnd(planId, planAlignmentId))
+
     }
 
     @PreAuthorize(AUTH_ALL_READ)
@@ -290,7 +291,7 @@ class GeometryController @Autowired constructor(
         @RequestParam("startDistance") startDistance: Double,
         @RequestParam("endDistance") endDistance: Double,
         @RequestParam("tickLength") tickLength: Int,
-    ): List<KmHeights>? {
+    ): List<KmHeights> {
         logger.apiCall(
             "getPlanAlignmentHeights",
             "planId" to planId,
@@ -300,6 +301,7 @@ class GeometryController @Autowired constructor(
             "tickLength" to tickLength
         )
         return geometryService.getPlanAlignmentHeights(planId, planAlignmentId, startDistance, endDistance, tickLength)
+            ?: emptyList()
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -343,8 +343,9 @@ export async function getPlanAlignmentStartAndEnd(
     planId: GeometryPlanId,
     alignmentId: GeometryAlignmentId,
 ): Promise<AlignmentStartAndEnd | undefined> {
-    return getThrowError<AlignmentStartAndEnd>(
+    return getWithDefault<AlignmentStartAndEnd | undefined>(
         `${GEOMETRY_URI}/plans/${planId}/start-and-end/${alignmentId}`,
+        undefined,
     );
 }
 
@@ -355,9 +356,10 @@ export async function getLocationTrackHeights(
     endDistance: number,
     tickLength: number,
 ): Promise<TrackKmHeights[]> {
-    return getThrowError(
+    return getWithDefault(
         `${GEOMETRY_URI}/${publishType}/layout/location-tracks/${locationTrackId}/alignment-heights` +
             queryParams({ startDistance, endDistance, tickLength }),
+        [],
     );
 }
 

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
-import { toolPanelPlanTabId } from 'tool-panel/tool-panel';
 import { LayoutTrackNumberId, LocationTrackId } from 'track-layout/track-layout-model';
 
 type HoveredOverItemBase = {
@@ -81,9 +80,10 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
                                                     delegates.onSelect({
                                                         geometryPlans: [section.planId],
                                                     });
-                                                    delegates.setToolPanelTab(
-                                                        toolPanelPlanTabId(section.planId),
-                                                    );
+                                                    delegates.setToolPanelTab({
+                                                        id: section.planId,
+                                                        type: 'GEOMETRY_PLAN',
+                                                    });
                                                 }
                                             }}
                                             title={`${section.planName} (${section.alignmentName})`}>

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -80,8 +80,8 @@ const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({ setHoveredOverI
             suggestedSwitches={store.selection.selectedItems.suggestedSwitches}
             onDataChange={typeChange}
             onUnselect={delegates.onUnselect}
-            setSelectedTabId={delegates.setToolPanelTab}
-            selectedTabId={store.selectedToolPanelTabId}
+            setSelectedAsset={delegates.setToolPanelTab}
+            selectedAsset={store.selectedToolPanelTab}
             startSwitchPlacing={startSwitchPlacing}
             viewport={store.map.viewport}
             stopSwitchLinking={() => {

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -431,7 +431,9 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             } else {
                 changeTab(tabs[0].asset);
             }
-        } else {
+        }
+
+        if (!tabs.length) {
             setSelectedAsset(undefined);
         }
         setPreviousTabs(tabs);

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -59,8 +59,8 @@ type ToolPanelProps = {
     publishType: PublishType;
     onDataChange: () => void;
     onUnselect: (items: OptionalUnselectableItemCollections) => void;
-    selectedTabId: string | undefined;
-    setSelectedTabId: (id: string | undefined) => void;
+    selectedAsset: ToolPanelAsset | undefined;
+    setSelectedAsset: (id: ToolPanelAsset | undefined) => void;
     startSwitchPlacing: (layoutSwitch: LayoutSwitch) => void;
     viewport: MapViewport;
     infoboxVisibilities: InfoboxVisibilities;
@@ -70,15 +70,28 @@ type ToolPanelProps = {
     onHoverOverPlanSection: (item: HoveredOverItem | undefined) => void;
 };
 
+export type ToolPanelAsset = {
+    id: string;
+    type:
+        | 'LOCATION_TRACK'
+        | 'SWITCH'
+        | 'KM_POST'
+        | 'REFERENCE_LINE'
+        | 'TRACK_NUMBER'
+        | 'GEOMETRY_ALIGNMENT'
+        | 'GEOMETRY_PLAN'
+        | 'GEOMETRY_KM_POST'
+        | 'GEOMETRY_SWITCH';
+};
+
 type ToolPanelTab = {
-    id: GeometryPlanId;
+    asset: ToolPanelAsset;
     title: string;
     element: React.ReactElement;
 };
 
-export function toolPanelPlanTabId(planId: GeometryPlanId): string {
-    return 'plan-header_' + planId;
-}
+const isSameAsset = (a: ToolPanelAsset | undefined, b: ToolPanelAsset | undefined) =>
+    !!a && !!b && a.id === b.id && a.type === b.type;
 
 const ToolPanel: React.FC<ToolPanelProps> = ({
     planIds,
@@ -96,8 +109,8 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     publishType,
     onDataChange,
     onUnselect,
-    selectedTabId,
-    setSelectedTabId,
+    selectedAsset,
+    setSelectedAsset,
     startSwitchPlacing,
     viewport,
     infoboxVisibilities,
@@ -174,7 +187,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         }
         const planTabs = planHeaders.map((p: GeometryPlanHeader) => {
             return {
-                id: toolPanelPlanTabId(p.id),
+                asset: { type: 'GEOMETRY_PLAN', id: p.id },
                 title: p.fileName,
                 element: (
                     <GeometryPlanInfobox
@@ -185,7 +198,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                         }
                     />
                 ),
-            };
+            } as ToolPanelTab;
         });
 
         const trackNumberTabs = trackNumberIds
@@ -193,7 +206,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             .filter(filterNotEmpty)
             .map((t) => {
                 return {
-                    id: 'track-number_' + t.id,
+                    asset: { type: 'TRACK_NUMBER', id: t.id },
                     title: t.number,
                     element: (
                         <TrackNumberInfoboxLinkingContainer
@@ -210,12 +223,12 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                             onHoverOverPlanSection={onHoverOverPlanSection}
                         />
                     ),
-                };
+                } as ToolPanelTab;
             });
 
         const layoutKmPostTabs = kmPosts.filter(visibleByTypeAndPublishType).map((k) => {
             return {
-                id: 'km-post_' + k.id,
+                asset: { type: 'KM_POST', id: k.id },
                 title: k.kmNumber,
                 element: (
                     <KmPostInfobox
@@ -238,12 +251,12 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                         }
                     />
                 ),
-            };
+            } as ToolPanelTab;
         });
 
         const geometryKmPostTabs = geometryKmPosts.map((k) => {
             return {
-                id: 'geometry-km-post_' + k.geometryItem.id,
+                asset: { type: 'GEOMETRY_KM_POST', id: k.geometryItem.id },
                 title: k.geometryItem.kmNumber,
                 element: (
                     <GeometryKmPostInfobox
@@ -261,12 +274,12 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                         }
                     />
                 ),
-            };
+            } as ToolPanelTab;
         });
 
         const switchTabs = switches.filter(visibleByTypeAndPublishType).map((s) => {
             return {
-                id: 'switch_' + s.id,
+                asset: { type: 'SWITCH', id: s.id },
                 title: s.name,
                 element: (
                     <SwitchInfobox
@@ -289,7 +302,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                         stopLinking={stopSwitchLinking}
                     />
                 ),
-            };
+            } as ToolPanelTab;
         });
 
         const uniqueGeometrySwitches = [
@@ -311,7 +324,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
 
         const geometrySwitchTabs = uniqueGeometrySwitches.map((s) => {
             return {
-                id: 'geometry-switch_' + s.id,
+                asset: { type: 'GEOMETRY_SWITCH', id: s.id },
                 title: s.name || '-',
                 element: (
                     <GeometrySwitchInfobox
@@ -329,12 +342,12 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                         onShowOnMap={onShowMapLocation}
                     />
                 ),
-            };
+            } as ToolPanelTab;
         });
 
         const locationTrackTabs = locationTracks.map((track) => {
             return {
-                id: 'location-track_' + track.id,
+                asset: { type: 'LOCATION_TRACK', id: track.id },
                 title: track.name,
                 element: (
                     <LocationTrackInfoboxLinkingContainer
@@ -353,12 +366,12 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                         onHoverOverPlanSection={onHoverOverPlanSection}
                     />
                 ),
-            };
+            } as ToolPanelTab;
         });
 
         const geometryAlignmentTabs = geometryAlignments.map((a) => {
             return {
-                id: 'geometry-alignment_' + a.geometryItem.id,
+                asset: { type: 'GEOMETRY_ALIGNMENT', id: a.geometryItem.id },
                 title: a.geometryItem.name,
                 element: (
                     <GeometryAlignmentLinkingContainer
@@ -374,7 +387,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                         publishType={publishType}
                     />
                 ),
-            };
+            } as ToolPanelTab;
         });
 
         const allTabs = [
@@ -408,47 +421,59 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     ]);
 
     React.useEffect(() => {
-        const newTabs = tabs.filter((t) => !previousTabs.some((pt) => t.id == pt.id));
+        const newTabs = tabs.filter(
+            (t) => !previousTabs.some((pt) => isSameAsset(t.asset, pt.asset)),
+        );
 
         if (newTabs.length) {
-            if (selectedTabId && newTabs.some((nt) => nt.id == selectedTabId)) {
-                changeTab(selectedTabId);
+            if (selectedAsset && newTabs.some((nt) => isSameAsset(nt.asset, selectedAsset))) {
+                changeTab(selectedAsset);
             } else {
-                changeTab(tabs[0].id);
+                changeTab(tabs[0].asset);
             }
+        } else {
+            setSelectedAsset(undefined);
         }
         setPreviousTabs(tabs);
     }, [tabs]);
 
-    function changeTab(tabId: string) {
-        let lockToTabId;
+    function changeTab(tab: ToolPanelAsset) {
+        let lockToAsset;
 
         if (linkingState?.type === LinkingType.LinkingAlignment) {
-            lockToTabId = tabs.find(
-                (t) => t.id === 'location-track_' + linkingState.layoutAlignmentId,
-            )?.id;
+            lockToAsset = tabs.find(
+                (t) =>
+                    t.asset.type === 'LOCATION_TRACK' &&
+                    t.asset.id === linkingState.layoutAlignmentId,
+            )?.asset;
         } else if (
             linkingState?.type === LinkingType.LinkingGeometryWithEmptyAlignment ||
             linkingState?.type === LinkingType.LinkingGeometryWithAlignment ||
             linkingState?.type === LinkingType.UnknownAlignment
         ) {
-            lockToTabId = tabs.find(
-                (t) => t.id === 'geometry-alignment_' + linkingState.geometryAlignmentId,
-            )?.id;
+            lockToAsset = tabs.find(
+                (t) =>
+                    t.asset.type === 'GEOMETRY_ALIGNMENT' &&
+                    t.asset.id === linkingState.geometryAlignmentId,
+            )?.asset;
         } else if (linkingState?.type === LinkingType.LinkingSwitch) {
-            lockToTabId = tabs.find((t) => {
+            lockToAsset = tabs.find((t) => {
                 return (
-                    t.id === 'geometry-switch_' + linkingState.suggestedSwitch.geometrySwitchId ||
-                    suggestedSwitches.some((s) => t.id === 'geometry-switch_' + s.id)
+                    (t.asset.type === 'GEOMETRY_SWITCH' &&
+                        t.asset.id === linkingState.suggestedSwitch.geometrySwitchId) ||
+                    suggestedSwitches.some((s) => t.asset.id === s.id)
                 );
-            })?.id;
+            })?.asset;
         } else if (linkingState?.type === LinkingType.LinkingKmPost) {
-            lockToTabId = tabs.find((t) => {
-                return t.id === 'geometry-km-post_' + linkingState.geometryKmPostId;
-            })?.id;
+            lockToAsset = tabs.find((t) => {
+                return (
+                    t.asset.type === 'GEOMETRY_KM_POST' &&
+                    t.asset.id === linkingState.geometryKmPostId
+                );
+            })?.asset;
         }
 
-        setSelectedTabId(lockToTabId ? lockToTabId : tabId);
+        setSelectedAsset(lockToAsset ? lockToAsset : tab);
     }
 
     return (
@@ -458,22 +483,22 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                     {tabs.map((t) => {
                         return (
                             <Button
-                                key={t.id}
+                                key={t.asset.type + '_' + t.asset.id}
                                 variant={
-                                    selectedTabId == t.id
+                                    isSameAsset(t.asset, selectedAsset)
                                         ? ButtonVariant.PRIMARY
                                         : ButtonVariant.SECONDARY
                                 }
                                 size={ButtonSize.SMALL}
-                                onClick={() => changeTab(t.id)}
-                                isPressed={t.id == selectedTabId}>
+                                onClick={() => changeTab(t.asset)}
+                                isPressed={isSameAsset(t.asset, selectedAsset)}>
                                 {t.title}
                             </Button>
                         );
                     })}
                 </div>
             )}
-            {tabs.find((t) => t.id === selectedTabId)?.element || tabs[0]?.element}
+            {tabs.find((t) => isSameAsset(t.asset, selectedAsset))?.element || tabs[0]?.element}
         </div>
     );
 };

--- a/ui/src/track-layout/track-layout-container.tsx
+++ b/ui/src/track-layout/track-layout-container.tsx
@@ -30,6 +30,7 @@ export const TrackLayoutContainer: React.FC = () => {
             changeTimes={changeTimes}
             onStopLinking={delegates.stopLinking}
             linkingState={trackLayoutState.linkingState}
+            selectedToolPanelTab={trackLayoutState.selectedToolPanelTab}
         />
     );
 };

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -34,6 +34,7 @@ import { addIfExists, subtract } from 'utils/array-utils';
 import { PublishRequestIds } from 'publication/publication-model';
 import { GeometryPlanLayoutId } from 'geometry/geometry-model';
 import { ValueOf } from 'utils/type-utils';
+import { ToolPanelAsset } from 'tool-panel/tool-panel';
 
 export type SelectedPublishChange = {
     trackNumber: LayoutTrackNumberId | undefined;
@@ -188,7 +189,7 @@ export type TrackLayoutState = {
     linkingState?: LinkingState;
     linkingIssuesSelectedBeforeLinking: boolean;
     switchLinkingSelectedBeforeLinking: boolean;
-    selectedToolPanelTabId: string | undefined;
+    selectedToolPanelTab: ToolPanelAsset | undefined;
     infoboxVisibilities: InfoboxVisibilities;
 };
 
@@ -200,7 +201,7 @@ export const initialTrackLayoutState: TrackLayoutState = {
     stagedPublicationRequestIds: initialPublicationRequestIds,
     linkingIssuesSelectedBeforeLinking: false,
     switchLinkingSelectedBeforeLinking: false,
-    selectedToolPanelTabId: undefined,
+    selectedToolPanelTab: undefined,
     infoboxVisibilities: initialInfoboxVisibilities,
 };
 
@@ -482,9 +483,9 @@ const trackLayoutSlice = createSlice({
         },
         setToolPanelTab: (
             state: TrackLayoutState,
-            { payload }: PayloadAction<string | undefined>,
+            { payload }: PayloadAction<ToolPanelAsset | undefined>,
         ): void => {
-            state.selectedToolPanelTabId = payload;
+            state.selectedToolPanelTab = payload;
         },
     },
 });

--- a/ui/src/track-layout/track-layout-view.tsx
+++ b/ui/src/track-layout/track-layout-view.tsx
@@ -18,9 +18,12 @@ import { PublishType } from 'common/common-model';
 import { LinkingState, LinkPoint } from 'linking/linking-model';
 import { ChangeTimes } from 'common/common-slice';
 import { MapLayerMenu } from 'map/layer-menu/map-layer-menu';
-import VerticalGeometryDiagram from 'vertical-geometry/vertical-geometry-diagram';
+import VerticalGeometryDiagram, {
+    VerticalGeometryDiagramAlignmentId,
+} from 'vertical-geometry/vertical-geometry-diagram';
 import { createClassName } from 'vayla-design-lib/utils';
 import { HoveredOverItem } from 'tool-panel/alignment-plan-section-infobox-content';
+import { ToolPanelAsset } from 'tool-panel/tool-panel';
 
 // For now use whole state and some extras as params
 export type TrackLayoutViewProps = {
@@ -43,6 +46,7 @@ export type TrackLayoutViewProps = {
     onLayerMenuItemChange: (change: MapLayerMenuChange) => void;
     changeTimes: ChangeTimes;
     onStopLinking: () => void;
+    selectedToolPanelTab: ToolPanelAsset | undefined;
 };
 
 export const TrackLayoutView: React.FC<TrackLayoutViewProps> = (props: TrackLayoutViewProps) => {
@@ -69,8 +73,31 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = (props: TrackLayo
         [firstSelectedLocationTrack, props.publishType],
     );
 
-    const verticalDiagramAlignmentId =
-        verticalDiagramPlanAlignmentId ?? verticalDiagramLayoutAlignmentId;
+    const hasGeometryAlignmentTab = (id: VerticalGeometryDiagramAlignmentId) =>
+        'planId' in id &&
+        props.selection.selectedItems.geometryAlignments.some(
+            (ga) => ga.geometryItem.id === id.alignmentId,
+        );
+
+    const hasLocationTrackTab = (id: VerticalGeometryDiagramAlignmentId) =>
+        'locationTrackId' in id &&
+        props.selection.selectedItems.locationTracks.some((lt) => lt === id.locationTrackId);
+
+    const [verticalDiagramAlignmentId, setVerticalDiagramAlignmentId] =
+        React.useState<VerticalGeometryDiagramAlignmentId>();
+    React.useEffect(() => {
+        if (props.selectedToolPanelTab?.type === 'GEOMETRY_ALIGNMENT') {
+            setVerticalDiagramAlignmentId(verticalDiagramPlanAlignmentId);
+        } else if (props.selectedToolPanelTab?.type === 'LOCATION_TRACK') {
+            setVerticalDiagramAlignmentId(verticalDiagramLayoutAlignmentId);
+        } else if (
+            !verticalDiagramAlignmentId ||
+            (!hasGeometryAlignmentTab(verticalDiagramAlignmentId) &&
+                !hasLocationTrackTab(verticalDiagramAlignmentId))
+        ) {
+            setVerticalDiagramAlignmentId(undefined);
+        }
+    }, [props.selectedToolPanelTab]);
 
     const showVerticalGeometryDiagram =
         props.map.verticalGeometryDiagramVisible && verticalDiagramAlignmentId != undefined;


### PR DESCRIPTION
Tässä tuli samalla refaktoroitua toolpaneelin tabinvalintalogiikkaa jonkin verran. Vanhalla, id-pohjaisella mallilla oli helppoa tutkia onko esim. jonkun sijaintiraiteen tabi auki, mutta tutkinta siitä että minkä sijaintiraiteen tabi oli kyseessä meni paljon vaikeammaksi. Koska tämä tabitieto oli ainoa asia joka hoiti kommunikaatiota toolpanelista kuvaajaan, kuvaajan pitämisessä auki silloin kuin tabi vaihtuu johonkin ei-raidetabiin käytännössä vaati sitä, että tämä tieto saatiin ulos tuosta rakenteesta. Muutin sen nyt oliorakenteeksi, jossa on tallessa näytettävän sekä tyyppi että sen id.