### PR TITLE
GVT-1932 Position height tooltip against viewport as intended

### DIFF
--- a/ui/src/vertical-geometry/height-tooltip.tsx
+++ b/ui/src/vertical-geometry/height-tooltip.tsx
@@ -37,7 +37,7 @@ export const HeightTooltip: React.FC<HeightTooltipProps> = ({
             ref={ref}
             className="vertical-geometry-diagram__tooltip"
             style={{
-                position: 'absolute',
+                position: 'fixed',
                 left: Math.min(
                     parentElementRect.left + point.xPositionPx + 20,
                     parentElementRect.right - width,


### PR DESCRIPTION
Menin nyt siitä missä aita on matalin, eli kun olin jo aiemmin toteuttanut tämän elementin asemoimaan itsensä suhteessa koko selainikkunaan, niin jatkan samalla linjalla. Ero oli siis tuo edellisessä kommitissa tullut muutos että korkeuskaaviolla itsellään on `position: relative`, joka teki siitä positioidun elementin, mikä sitten muuttaa `position: absolute`n tulkinnan olemaankin suhteessa häneen.