### PR TITLE
GVT-1847: Korkeukaavio pomppii kun selaimen leveys on suurempi kuin kaavion

### DIFF
--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -174,7 +174,12 @@ const VerticalGeometryDiagramSizeHolder: React.FC<VerticalGeometryDiagramProps> 
             ) {
                 return;
             }
-            setEndM(startM + (endM - startM) * (width / oldWidth));
+            const oldWidthRelativeEndM = startM + (endM - startM) * (width / oldWidth);
+            setEndM(
+                alignmentEndM
+                    ? Math.min(oldWidthRelativeEndM, alignmentEndM)
+                    : oldWidthRelativeEndM,
+            );
         },
     });
 


### PR DESCRIPTION
Pakotetaan kaavion oikean reunan M-arvo pysymään näytettävän alignmentin rajojen sisällä. Tämä samalla korjasi sen, että kaavion mennessä nollan levyiseksi sitä ei saanut enää resizattua.