### PR TITLE
GVT-General

### DIFF
--- a/ui/src/map/layers/alignment/badge-layer-utils.ts
+++ b/ui/src/map/layers/alignment/badge-layer-utils.ts
@@ -38,7 +38,7 @@ function createBadgeFeatures(
         const badgePadding = 16;
         const badgeHeight = 14;
         const fontSize = 12;
-        const badgeNoseWidth = 7;
+        const badgeNoseWidth = 4;
 
         const renderer = ([x, y]: Coordinate, state: State) => {
             const ctx = state.context;
@@ -60,12 +60,20 @@ function createBadgeFeatures(
 
             ctx.fillStyle = badgeStyle.background;
 
-            ctx.fillRect(
+            ctx.rect(
                 x - (badgeRotation.drawFromEnd ? badgeWidth : 0),
                 y - halfHeight,
                 badgeWidth,
                 height,
             );
+
+            if (badgeStyle.backgroundBorder) {
+                ctx.strokeStyle = badgeStyle.backgroundBorder;
+                ctx.lineWidth = state.pixelRatio;
+                ctx.stroke();
+            }
+
+            ctx.fill();
 
             //Won't work with LIGHT badge color, but for now only reference lines have pointy badge
             if (color === AlignmentBadgeColor.DARK) {
@@ -73,18 +81,15 @@ function createBadgeFeatures(
 
                 const offsetDirection = badgeRotation.drawFromEnd ? -1 : 1;
 
-                ctx.moveTo(x + (badgeWidth + badgeNoseWidth) * offsetDirection, y);
+                ctx.moveTo(
+                    x + (badgeWidth + badgeNoseWidth * state.pixelRatio) * offsetDirection,
+                    y,
+                );
                 ctx.lineTo(x + badgeWidth * offsetDirection, y - halfHeight);
                 ctx.lineTo(x + badgeWidth * offsetDirection, y + halfHeight);
             }
 
             ctx.fill();
-
-            if (badgeStyle.backgroundBorder) {
-                ctx.strokeStyle = badgeStyle.backgroundBorder;
-                ctx.lineWidth = 1;
-                ctx.stroke();
-            }
 
             ctx.fillStyle = badgeStyle.color;
             ctx.textAlign = 'center';
@@ -92,7 +97,7 @@ function createBadgeFeatures(
             ctx.fillText(
                 name,
                 x + ((badgeRotation.drawFromEnd ? -1 : 1) * badgeWidth) / 2,
-                y + 1 * state.pixelRatio,
+                y + state.pixelRatio,
             );
 
             ctx.restore();

--- a/ui/src/map/layers/alignment/track-number-end-point-addresses-layer.ts
+++ b/ui/src/map/layers/alignment/track-number-end-point-addresses-layer.ts
@@ -124,7 +124,7 @@ function createFeature(
 
         ctx.fillStyle = 'rgba(255, 255, 255, 0.85)';
         ctx.fillRect(
-            xEndPosition - textWidth - textPadding * 2,
+            xEndPosition - (positiveXOffset ? textWidth + textPadding * 2 : 0),
             positiveYOffset === pointAtEnd ? y - textBackgroundHeight : y,
             textWidth + textPadding * 2,
             textBackgroundHeight,
@@ -142,7 +142,7 @@ function createFeature(
         ctx.fillStyle = color;
         ctx.textAlign = positiveXOffset ? 'right' : 'left';
         ctx.textBaseline = 'bottom';
-        ctx.fillText(text, xEndPosition - textPadding, yEndPosition);
+        ctx.fillText(text, xEndPosition + textPadding * (positiveXOffset ? -1 : 1), yEndPosition);
 
         ctx.restore();
     };

--- a/ui/src/map/tools/select-tool.ts
+++ b/ui/src/map/tools/select-tool.ts
@@ -8,7 +8,18 @@ export const selectTool: MapTool = {
         const clickEvent = map.on('click', ({ coordinate }) => {
             const hitArea = getDefaultHitArea(map, coordinate);
             const items = searchItemsFromLayers(hitArea, layers, { limit: 1 });
-            options.onSelect(items);
+
+            options.onSelect({
+                ...items,
+                geometryKmPosts: items.geometryKmPosts ?? [],
+                kmPosts: items.kmPosts ?? [],
+                geometrySwitches: items.geometrySwitches ?? [],
+                switches: items.switches ?? [],
+                geometryAlignments: items.geometryAlignments ?? [],
+                locationTracks: items.locationTracks ?? [],
+                trackNumbers: items.trackNumbers ?? [],
+                geometryPlans: items.geometryPlans ?? [],
+            });
         });
 
         // Return function to clean up this tool

--- a/ui/src/selection-panel/selection-panel-geometry-section.tsx
+++ b/ui/src/selection-panel/selection-panel-geometry-section.tsx
@@ -82,19 +82,21 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
     const [plansBeingLoaded, startLoadingPlan, finishLoadingPlan] = useSetState<GeometryPlanId>();
 
     React.useEffect(() => {
-        getGeometryPlanHeadersBySearchTerms(
-            MAX_PLAN_HEADERS,
-            0,
-            viewport.area,
-            ['GEOMETRIAPALVELU', 'PAIKANNUSPALVELU'],
-            selectedTrackNumbers,
-            undefined,
-            SortByValue.UPLOADED_AT,
-            SortOrderValue.ASCENDING,
-        ).then((page) => {
-            setPlanHeadersInView(page.items);
-            setPlanHeaderCount(page.totalCount);
-        });
+        if (viewport.area) {
+            getGeometryPlanHeadersBySearchTerms(
+                MAX_PLAN_HEADERS,
+                0,
+                viewport.area,
+                ['GEOMETRIAPALVELU', 'PAIKANNUSPALVELU'],
+                selectedTrackNumbers,
+                undefined,
+                SortByValue.UPLOADED_AT,
+                SortOrderValue.ASCENDING,
+            ).then((page) => {
+                setPlanHeadersInView(page.items);
+                setPlanHeaderCount(page.totalCount);
+            });
+        }
     }, [viewport.area, changeTimes.geometryPlan, selectedTrackNumbers.sort().join('')]);
 
     React.useEffect(

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -54,6 +54,7 @@ export type ToolbarParams = {
     publishType: PublishType;
     changeTimes: ChangeTimes;
     onStopLinking: () => void;
+    disableNewMenu: boolean;
 };
 
 type LocationTrackItemValue = {
@@ -247,7 +248,7 @@ export const ToolBar: React.FC<ToolbarParams> = (props: ToolbarParams) => {
                         <Button
                             variant={ButtonVariant.SECONDARY}
                             icon={Icons.Append}
-                            disabled={props.publishType !== 'DRAFT'}
+                            disabled={props.publishType !== 'DRAFT' || props.disableNewMenu}
                             onClick={() => setShowAddMenu(!showAddMenu)}
                         />
                     </WriteAccessRequired>

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-candidates.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-candidates.tsx
@@ -51,6 +51,7 @@ type GeometryAlignmentLinkingReferenceLineCandidatesProps = {
         | PreliminaryLinkingGeometry;
     onSelect: (options: OnSelectOptions) => void;
     onShowAddTrackNumberDialog: () => void;
+    disableAddButton: boolean;
 };
 
 type GeometryAlignmentLinkingLocationTrackCandidatesProps = {
@@ -64,6 +65,7 @@ type GeometryAlignmentLinkingLocationTrackCandidatesProps = {
         | PreliminaryLinkingGeometry;
     onSelect: (options: OnSelectOptions) => void;
     onShowAddLocationTrackDialog: () => void;
+    disableAddButton: boolean;
 };
 
 type AlignmentRef = {
@@ -90,6 +92,7 @@ export const GeometryAlignmentLinkingReferenceLineCandidates: React.FC<
     linkingState,
     onSelect,
     onShowAddTrackNumberDialog,
+    disableAddButton,
 }) => {
     const { t } = useTranslation();
     const trackNumbers = useTrackNumbers(publishType, trackNumberChangeTime);
@@ -152,6 +155,7 @@ export const GeometryAlignmentLinkingReferenceLineCandidates: React.FC<
                     variant={ButtonVariant.GHOST}
                     size={ButtonSize.SMALL}
                     icon={Icons.Append}
+                    disabled={disableAddButton}
                     onClick={() => onShowAddTrackNumberDialog()}
                     qa-id="create-tracknumer-button"
                 />
@@ -210,6 +214,7 @@ export const GeometryAlignmentLinkingLocationTrackCandidates: React.FC<
     linkingState,
     onSelect,
     onShowAddLocationTrackDialog,
+    disableAddButton,
 }) => {
     const { t } = useTranslation();
     const [locationTrackRefs, setLocationTrackRefs] = React.useState<AlignmentRef[]>([]);
@@ -270,6 +275,7 @@ export const GeometryAlignmentLinkingLocationTrackCandidates: React.FC<
                     variant={ButtonVariant.GHOST}
                     size={ButtonSize.SMALL}
                     icon={Icons.Append}
+                    disabled={disableAddButton}
                     onClick={() => onShowAddLocationTrackDialog()}
                     qa-id="create-location-track-button"
                 />

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -296,6 +296,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                 trackNumberChangeTime={trackNumberChangeTime}
                                 onSelect={onSelect}
                                 selectedLayoutReferenceLine={selectedLayoutReferenceLine}
+                                disableAddButton={linkingState.type !== LinkingType.UnknownAlignment}
                                 onShowAddTrackNumberDialog={() => setShowAddTrackNumberDialog(true)}
                             />
                             <GeometryAlignmentLinkingLocationTrackCandidates
@@ -304,6 +305,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                 locationTrackChangeTime={locationTrackChangeTime}
                                 onSelect={onSelect}
                                 selectedLayoutLocationTrack={selectedLayoutLocationTrack}
+                                disableAddButton={linkingState.type !== LinkingType.UnknownAlignment}
                                 onShowAddLocationTrackDialog={() =>
                                     setShowAddLocationTrackDialog(true)
                                 }

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
@@ -33,4 +33,8 @@
 
 .geometry-km-post-linking-infobox__layout-km-post {
     padding: 4px 0;
+
+    .km-post-badge {
+        cursor: pointer;
+    }
 }

--- a/ui/src/track-layout/track-layout-view.tsx
+++ b/ui/src/track-layout/track-layout-view.tsx
@@ -15,7 +15,7 @@ import { SwitchSuggestionCreatorContainer } from 'linking/switch-suggestion-crea
 import ToolPanelContainer from 'tool-panel/tool-panel-container';
 import { BoundingBox } from 'model/geometry';
 import { PublishType } from 'common/common-model';
-import { LinkingState, LinkPoint } from 'linking/linking-model';
+import { LinkingState, LinkingType, LinkPoint } from 'linking/linking-model';
 import { ChangeTimes } from 'common/common-slice';
 import { MapLayerMenu } from 'map/layer-menu/map-layer-menu';
 import VerticalGeometryDiagram from 'vertical-geometry/vertical-geometry-diagram';
@@ -87,6 +87,10 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = (props: TrackLayo
     return (
         <div className={className} qa-id="track-layout-content">
             <ToolBar
+                disableNewMenu={
+                    props.linkingState?.type === LinkingType.LinkingGeometryWithAlignment ||
+                    props.linkingState?.type === LinkingType.LinkingGeometryWithEmptyAlignment
+                }
                 layerMenuVisible={layerMenuVisible}
                 publishType={props.publishType}
                 onMapLayerVisibilityChange={setLayerMenuVisible}


### PR DESCRIPTION
Useita pienempi korjauksia samassa pullarissa:

- GVT-1937: Taustaväri piirty väärin osalle ratanumeron päätepisteille
- GVT-1332: Suunnitelmat haettiin kahdesti kohdistamisen jälkeen
- GVT-1929: Sijaintiraiteiden badgeista puuttui borderit
- GVT-1933: Jätetään linkityspallurat piirtämättä kun ollaan zoomattuna
- GVT-1931&GVT-1668: Kaikkia kartan valintoja ei tyhjennetty mikäli kyseinen karttataso ei ollut päällä
- GVT-1335: Disabloidaan uuden sijaintiraiteen ja pituusmittauslinjan luonti sen jälkeen kun käyttäjä on käynnistänyt linkityksen