### PR TITLE
GVT-1950 Turvallisempi pystygeometrian kuvaajan raiteen vaihtamisen hallinta

### DIFF
--- a/ui/src/vertical-geometry/track-meter-index.ts
+++ b/ui/src/vertical-geometry/track-meter-index.ts
@@ -18,7 +18,7 @@ export function findTrackMeterIndexContainingM(
     kmHeights: TrackKmHeights[],
 ): TrackMeterIndex | null {
     const nextKmIndex = kmHeights.findIndex(({ trackMeterHeights }) => trackMeterHeights[0].m > m);
-    if (nextKmIndex === 0) {
+    if (nextKmIndex === 0 || kmHeights.length === 0) {
         return null;
     }
     const kmIndex = nextKmIndex === -1 ? kmHeights.length - 1 : nextKmIndex - 1;


### PR DESCRIPTION
Periaatteessa tuo track-meter-indexin muutos on se, jolla vältetään yleensä kaatuminen, jos yleensä mistä tahansa syystä kaavio yrittää laskea sijainteja raiteella silloin, kun korkeusviivaa ei ole lainkaan (eli yleensä siksi, koska yritetään näyttää kohtaa, joka on raiteen ulkopuolella).

startAndEndin haun seuraaminen tarkentaa erikseen juuri tämän taskin tapausta, eli että mitä jos alignmenttia vaihdettaessa uusi korkeusviiva ja geometria saadaankin haettua ennen kuin startAndEnd saadaan.