### PR TITLE
GVT-1927: Korkeuskaavio huutaa konsoliin virheitä negatiivisista width-attribuuteista

### DIFF
--- a/ui/src/vertical-geometry/plan-linking.tsx
+++ b/ui/src/vertical-geometry/plan-linking.tsx
@@ -3,6 +3,7 @@ import { Coordinates, mToX } from 'vertical-geometry/coordinates';
 import { PlanLinkingSummaryItem } from 'geometry/geometry-api';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
 import { OnSelectOptions } from 'selection/selection-model';
+import { filterNotEmpty } from 'utils/array-utils';
 
 export interface PlanLinkingProps {
     coordinates: Coordinates;
@@ -21,69 +22,72 @@ export const PlanLinking: React.FC<PlanLinkingProps> = ({
     const textDropAreaPx = 3;
     return (
         <>
-            {planLinkingSummary.map((summary, i) => {
-                const {
-                    startM,
-                    endM,
-                    filename,
-                    planId,
-                    alignmentHeader,
-                    verticalCoordinateSystem,
-                } = summary;
-                if (endM < coordinates.startM || startM > coordinates.endM) {
-                    return <React.Fragment key={i} />;
-                }
-                const startX = mToX(coordinates, startM);
-                const textStartX = 2 + Math.max(3, mToX(coordinates, startM));
-                const endX = mToX(coordinates, endM);
-                return (
-                    <React.Fragment key={i}>
-                        <line
-                            x1={startX}
-                            x2={startX}
-                            y1={0}
-                            y2={coordinates.fullDiagramHeightPx}
-                            stroke="black"
-                            fill="none"
-                            shapeRendering="crispEdges"
-                        />
-                        <line
-                            x1={endX}
-                            x2={endX}
-                            y1={0}
-                            y2={coordinates.fullDiagramHeightPx}
-                            stroke="black"
-                            fill="none"
-                            shapeRendering="crispEdges"
-                        />
-                        <svg
-                            onClick={() =>
-                                planId &&
-                                alignmentHeader &&
-                                onSelect({
-                                    geometryAlignments: [
-                                        {
-                                            geometryItem: alignmentHeader,
-                                            planId: planId,
-                                        },
-                                    ],
-                                })
-                            }
-                            className={styles['vertical-geometry-diagram__plan-link']}
-                            x={textStartX}
-                            y={0}
-                            width={endX - textStartX}
-                            height={textLineTwoYPx + textDropAreaPx}>
-                            <text transform={`translate(0 ${textLineOneYPx}) scale(0.7)`}>
-                                {filename}
-                            </text>
-                            <text transform={`translate(0 ${textLineTwoYPx}) scale(0.7)`}>
-                                {verticalCoordinateSystem}
-                            </text>
-                        </svg>
-                    </React.Fragment>
-                );
-            })}
+            {planLinkingSummary
+                .map((summary, i) => {
+                    const {
+                        startM,
+                        endM,
+                        filename,
+                        planId,
+                        alignmentHeader,
+                        verticalCoordinateSystem,
+                    } = summary;
+                    if (endM < coordinates.startM || startM > coordinates.endM) {
+                        return <React.Fragment key={i} />;
+                    }
+                    const startX = mToX(coordinates, startM);
+                    const textStartX = 2 + Math.max(3, mToX(coordinates, startM));
+                    const endX = mToX(coordinates, endM);
+                    const width = endX - textStartX;
+                    return width >= 0 ? (
+                        <React.Fragment key={i}>
+                            <line
+                                x1={startX}
+                                x2={startX}
+                                y1={0}
+                                y2={coordinates.fullDiagramHeightPx}
+                                stroke="black"
+                                fill="none"
+                                shapeRendering="crispEdges"
+                            />
+                            <line
+                                x1={endX}
+                                x2={endX}
+                                y1={0}
+                                y2={coordinates.fullDiagramHeightPx}
+                                stroke="black"
+                                fill="none"
+                                shapeRendering="crispEdges"
+                            />
+                            <svg
+                                onClick={() =>
+                                    planId &&
+                                    alignmentHeader &&
+                                    onSelect({
+                                        geometryAlignments: [
+                                            {
+                                                geometryItem: alignmentHeader,
+                                                planId: planId,
+                                            },
+                                        ],
+                                    })
+                                }
+                                className={styles['vertical-geometry-diagram__plan-link']}
+                                x={textStartX}
+                                y={0}
+                                width={width}
+                                height={textLineTwoYPx + textDropAreaPx}>
+                                <text transform={`translate(0 ${textLineOneYPx}) scale(0.7)`}>
+                                    {filename}
+                                </text>
+                                <text transform={`translate(0 ${textLineTwoYPx}) scale(0.7)`}>
+                                    {verticalCoordinateSystem}
+                                </text>
+                            </svg>
+                        </React.Fragment>
+                    ) : undefined;
+                })
+                .filter(filterNotEmpty)}
         </>
     );
 };


### PR DESCRIPTION
Juurisyynä oli siis todella pitkillä raiteilla olevat hyvin lyhyet linkitykset (tai pikemminkin linkitysten välissä olevat aukot.) Esim. 11.3km mittaisella raiteella oleva 2.3mm aukko linkityksessä on tarpeeksi lyhyt, että se piirtyisi 0px levyisenä kaavioon. Suunnitelman nimeä offsetataan kuitenkin aina 2px verran, ja kun tämä otettiin huomioon myös leveyslaskennoissa, <2px leveillä osuuksilla leveys meni aina negatiiviseksi.