### PR TITLE
GVT-1985 Allow a bit of slack when simplifying alignments

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.tracklayout.*
+import kotlin.math.roundToInt
 
 enum class MapAlignmentSource {
     GEOMETRY,
@@ -102,7 +103,7 @@ fun simplify(
     return segments
         .flatMap { s -> s.points.filter { p ->
             val result =
-                (resolution == null || p.m - previousM >= resolution || (p.m == alignment.length && previousM < p.m))
+                (resolution == null || (p.m - previousM).roundToInt() >= resolution || (p.m == alignment.length && previousM < p.m))
                         && (bbox == null || previousInBbox || bbox.contains(p))
             if (result) {
                 previousM = p.m


### PR DESCRIPTION
Tavoitteena saada linkityksessä näkymään kaikki pisteet, silloinkin kun m-arvojen ero on osalla pisteväleistä pikkuisen alle 1:n. 

En ole ihan varma tuosta kokonaisluvuksi asti pyöristämisestä: Se oli lähinnä esteettinen valinta, sillä perusteella että onhan `resolution` myös kokonaisluku. Periaatteessa riittäisi varmaan yhtä hyvin lisätä tuohon jokin maaginen aivan pikkusäätö tyyliin `p.m - previousM + 0.001`.