### PR TITLE
GVT-1940 Tarkenna OpenLayers-renderöintien odottamisia

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/MapPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/MapPage.kt
@@ -13,7 +13,9 @@ import org.openqa.selenium.TimeoutException
 import org.openqa.selenium.interactions.Actions
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import waitUntilDoesNotExist
 import waitUntilValueIsNot
+import withNoImplicitWait
 import kotlin.math.roundToInt
 
 class MapPage {
@@ -100,6 +102,10 @@ class MapPage {
         while (!currentMapScale().contentEquals(targetScale)) {
             zoomIn()
         }
+    }
+
+    fun finishLoading() {
+        withNoImplicitWait { waitUntilDoesNotExist(By.className(".map__loading-spinner")) }
     }
 
     fun zoomOutToScale(targetScale: String) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/MapToolPanelElement.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/MapToolPanelElement.kt
@@ -411,8 +411,7 @@ class GeometryAlignmentLinkingInfoBox(by: By) : LinkingInfoBox(by) {
     fun lukitseValinta() = this {
         logger.info("Lock selection")
         clickButtonByText("Lukitse valinta")
-        //TODO: this might break things
-        //getButtonElement("Poista valinta")
+        waitChildVisible(byText("Poista valinta"))
     }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
@@ -303,10 +303,8 @@ class LinkingTestUI @Autowired constructor(
         val newStartPoint = LOCATION_TRACK_H.second.segments.first().points.last()
         val endPoint = LOCATION_TRACK_H.second.segments.last().points.last()
 
-        // TODO: GVT-1940 implement a way to know when the layer is clickable
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
+        mapPage.finishLoading()
         mapPage.clickAtCoordinates(startPoint)
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
         mapPage.clickAtCoordinates(newStartPoint)
 
         locationInfoBox.valmis().assertAndClose("Raiteen päätepisteet päivitetty")
@@ -645,16 +643,10 @@ class LinkingTestUI @Autowired constructor(
         alignmentLinkinInfobox.aloitaLinkitys()
         alignmentLinkinInfobox.linkTo(LOCATION_TRACK_F.first.name.toString())
         alignmentLinkinInfobox.lukitseValinta()
-
-
-        // TODO: GVT-1940 implement a way to know when the layer is clickable
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
+        mapPage.finishLoading()
         mapPage.clickAtCoordinates(geometryAlignmentStart)
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
         mapPage.clickAtCoordinates(geometryAlignmentEnd)
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
         mapPage.clickAtCoordinates(LOCATION_TRACK_F.second.segments.first().points.first())
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
         mapPage.clickAtCoordinates(LOCATION_TRACK_F.second.segments.first().points.last())
         alignmentLinkinInfobox.linkita().assertAndClose("Raide linkitetty ja vanhentuneen geometrian linkitys purettu")
 
@@ -694,14 +686,10 @@ class LinkingTestUI @Autowired constructor(
         val referenceLineStartPoint = REFERENCE_LINE_ESP1.second.segments.first().points.first()
         val referenceLineEndPoint = REFERENCE_LINE_ESP1.second.segments.first().points.last()
 
-        // TODO: GVT-1940 implement a way to know when the layer is clickable
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
+        mapPage.finishLoading()
         mapPage.clickAtCoordinates(geometryTrackStartPoint)
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
         mapPage.clickAtCoordinates(geometryTrackEndPoint)
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
         mapPage.clickAtCoordinates(referenceLineStartPoint)
-        Thread.sleep(500) // Wait until linking layer is clickable. If we don't do this, the click might come too early
         mapPage.clickAtCoordinates(referenceLineEndPoint)
 
         alignmentLinkingInfobox.linkita().assertAndClose("Raide linkitetty")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Browser.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Browser.kt
@@ -164,6 +164,16 @@ fun printNetworkLogsResponses() = try {
     logger.error("Failed to print network responses ${e.message}")
 }
 
+fun <T> withNoImplicitWait(act: () -> T): T {
+    val originalWait = browser().manage().timeouts().implicitWaitTimeout
+    browser().manage().timeouts().implicitlyWait(Duration.ofSeconds(0))
+    try {
+        return act()
+    } finally {
+        browser().manage().timeouts().implicitlyWait(originalWait)
+    }
+}
+
 private fun printLogEntries(source: LogSource, logEntries: LogEntries) {
     printLogEntries(source, logEntries.toList())
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Elements.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Elements.kt
@@ -1,10 +1,7 @@
 import fi.fta.geoviite.infra.ui.pagemodel.common.PageModel
 import fi.fta.geoviite.infra.ui.pagemodel.common.Toaster
 import fi.fta.geoviite.infra.ui.pagemodel.common.defaultToasterBy
-import org.openqa.selenium.By
-import org.openqa.selenium.Keys
-import org.openqa.selenium.NoSuchElementException
-import org.openqa.selenium.WebElement
+import org.openqa.selenium.*
 import org.openqa.selenium.interactions.Actions
 import org.openqa.selenium.support.ui.ExpectedCondition
 import org.openqa.selenium.support.ui.ExpectedConditions.*

--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -58,6 +58,7 @@ export const linkingReducers = {
                 errors: [],
             };
         }
+        state.map.loadingIndicatorVisible = true;
     },
     stopLinking: function (state: TrackLayoutState): void {
         state.linkingState = undefined;

--- a/ui/src/map/layers/alignment/location-track-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-alignment-layer.ts
@@ -47,9 +47,11 @@ export function createLocationTrackAlignmentLayer(
         }
     }
 
+    let inFlight = false;
     if (resolution <= Limits.ALL_ALIGNMENTS) {
         const showEndPointTicks = resolution <= Limits.SHOW_LOCATION_TRACK_BADGES;
 
+        inFlight = true;
         getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'LOCATION_TRACKS')
             .then((locationTracks) => {
                 if (layerId !== newestLayerId) return;
@@ -69,6 +71,9 @@ export function createLocationTrackAlignmentLayer(
             .catch(() => {
                 clearFeatures(vectorSource);
                 updateShownLocationTracks([]);
+            })
+            .finally(() => {
+                inFlight = false;
             });
     } else {
         clearFeatures(vectorSource);
@@ -86,5 +91,6 @@ export function createLocationTrackAlignmentLayer(
             };
         },
         onRemove: () => updateShownLocationTracks([]),
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/alignment/location-track-background-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-background-layer.ts
@@ -24,7 +24,9 @@ export function createLocationTrackBackgroundLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = false;
     if (resolution <= Limits.ALL_ALIGNMENTS) {
+        inFlight = true;
         getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'LOCATION_TRACKS')
             .then((locationTracks) => {
                 if (layerId === newestLayerId) {
@@ -34,7 +36,10 @@ export function createLocationTrackBackgroundLayer(
                     vectorSource.addFeatures(features);
                 }
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -42,5 +47,6 @@ export function createLocationTrackBackgroundLayer(
     return {
         name: 'location-track-background-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/alignment/location-track-badge-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-badge-layer.ts
@@ -31,9 +31,11 @@ export function createLocationTrackBadgeLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = false;
     if (resolution <= Limits.SHOW_LOCATION_TRACK_BADGES) {
         const badgeDrawDistance = getBadgeDrawDistance(resolution) || 0;
 
+        inFlight = true;
         getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'LOCATION_TRACKS')
             .then((locationTracks) => {
                 if (layerId !== newestLayerId) return;
@@ -48,7 +50,10 @@ export function createLocationTrackBadgeLayer(
                 clearFeatures(vectorSource);
                 vectorSource.addFeatures(features);
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -56,5 +61,6 @@ export function createLocationTrackBadgeLayer(
     return {
         name: 'location-track-badge-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
@@ -43,6 +43,7 @@ export function createReferenceLineAlignmentLayer(
         }
     }
 
+    let inFlight = true;
     getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'REFERENCE_LINES')
         .then((referenceLines) => {
             if (layerId !== newestLayerId) return;
@@ -61,6 +62,9 @@ export function createReferenceLineAlignmentLayer(
         .catch(() => {
             clearFeatures(vectorSource);
             updateShownReferenceLines([]);
+        })
+        .finally(() => {
+            inFlight = false;
         });
 
     return {
@@ -79,5 +83,6 @@ export function createReferenceLineAlignmentLayer(
             };
         },
         onRemove: () => updateShownReferenceLines([]),
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/alignment/reference-line-background-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-background-layer.ts
@@ -22,6 +22,7 @@ export function createReferenceLineBackgroundLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = true;
     getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'REFERENCE_LINES')
         .then((referenceLines) => {
             if (layerId === newestLayerId) {
@@ -31,10 +32,14 @@ export function createReferenceLineBackgroundLayer(
                 vectorSource.addFeatures(features);
             }
         })
-        .catch(() => clearFeatures(vectorSource));
+        .catch(() => clearFeatures(vectorSource))
+        .finally(() => {
+            inFlight = false;
+        });
 
     return {
         name: 'reference-line-background-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/alignment/reference-line-badge-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-badge-layer.ts
@@ -30,6 +30,7 @@ export function createReferenceLineBadgeLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = true;
     getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'REFERENCE_LINES')
         .then((referenceLines) => {
             if (layerId !== newestLayerId) return;
@@ -45,10 +46,14 @@ export function createReferenceLineBadgeLayer(
             clearFeatures(vectorSource);
             vectorSource.addFeatures(features);
         })
-        .catch(() => clearFeatures(vectorSource));
+        .catch(() => clearFeatures(vectorSource))
+        .finally(() => {
+            inFlight = false;
+        });
 
     return {
         name: 'reference-line-badge-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/background-map-layer.ts
+++ b/ui/src/map/layers/background-map-layer.ts
@@ -37,5 +37,7 @@ export function createBackgroundMapLayer(existingOlLayer: Tile<TileSource>): Map
     return {
         name: 'background-map-layer',
         layer: layer,
+        // the background map uses OL's native loading, so we don't need to worry about it
+        requestInFlight: () => false,
     };
 }

--- a/ui/src/map/layers/debug/debug-1m-points-layer.ts
+++ b/ui/src/map/layers/debug/debug-1m-points-layer.ts
@@ -84,13 +84,18 @@ export function createDebug1mPointsLayer(
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
     const selected = selection.selectedItems.locationTracks[0];
+    let inFlight = false;
     if (selected && resolution <= DEBUG_1M_POINTS) {
+        inFlight = true;
         getAddressPoints(selected, publishType)
             .then((addresses) => {
                 clearFeatures(vectorSource);
                 addresses && vectorSource.addFeatures(createAddressPointFeatures(addresses));
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -98,5 +103,6 @@ export function createDebug1mPointsLayer(
     return {
         name: 'debug-1m-points-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/debug/debug-layer.ts
+++ b/ui/src/map/layers/debug/debug-layer.ts
@@ -86,5 +86,6 @@ export function createDebugLayer(
     return {
         name: 'debug-layer',
         layer: layer,
+        requestInFlight: () => false,
     };
 }

--- a/ui/src/map/layers/geometry/geometry-alignment-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-alignment-layer.ts
@@ -166,6 +166,7 @@ export function createGeometryAlignmentLayer(
         changeTimes.layoutLocationTrack,
     );
 
+    let inFlight = true;
     Promise.all(
         selection.planLayouts.map((planLayout) =>
             getPlanLayoutAlignmentsWithLinking(
@@ -186,7 +187,10 @@ export function createGeometryAlignmentLayer(
                 vectorSource.addFeatures(f.flat());
             }
         })
-        .catch(() => clearFeatures(vectorSource));
+        .catch(() => clearFeatures(vectorSource))
+        .finally(() => {
+            inFlight = false;
+        });
 
     return {
         name: 'geometry-alignment-layer',
@@ -203,5 +207,6 @@ export function createGeometryAlignmentLayer(
 
             return { geometryAlignments };
         },
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/geometry/geometry-km-post-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-km-post-layer.ts
@@ -30,7 +30,9 @@ export function createGeometryKmPostLayer(
 
     const step = getKmPostStepByResolution(resolution);
 
+    let inFlight = false;
     if (step) {
+        inFlight = true;
         const isSelected = (kmPost: LayoutKmPost) => {
             return selection.selectedItems.geometryKmPosts.some(
                 ({ geometryItem }) => geometryItem.id === kmPost.id,
@@ -75,7 +77,10 @@ export function createGeometryKmPostLayer(
                 clearFeatures(vectorSource);
                 vectorSource.addFeatures(features);
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -91,5 +96,6 @@ export function createGeometryKmPostLayer(
                 })),
             };
         },
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/geometry/geometry-switch-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-switch-layer.ts
@@ -25,7 +25,9 @@ export function createGeometrySwitchLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = false;
     if (resolution <= Limits.SWITCH_SHOW) {
+        inFlight = true;
         const showLargeSymbols = resolution <= Limits.SWITCH_LARGE_SYMBOLS;
         const showLabels = resolution <= Limits.SWITCH_LABELS;
         const isSelected = (switchItem: LayoutSwitch) => {
@@ -81,6 +83,9 @@ export function createGeometrySwitchLayer(
             })
             .catch(() => {
                 clearFeatures(vectorSource);
+            })
+            .finally(() => {
+                inFlight = false;
             });
     } else {
         vectorSource.clear();
@@ -97,5 +102,6 @@ export function createGeometrySwitchLayer(
                 })),
             };
         },
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/geometry/plan-area-layer.ts
+++ b/ui/src/map/layers/geometry/plan-area-layer.ts
@@ -56,6 +56,7 @@ export function createPlanAreaLayer(
         getPlanAreasByTile(tile, changeTimes.geometryPlan),
     );
 
+    let inFlight = true;
     Promise.all(planAreaPromises)
         .then((planAreas) => deduplicatePlanAreas(planAreas.flat()))
         .then((planAreas) => {
@@ -66,10 +67,12 @@ export function createPlanAreaLayer(
                 vectorSource.addFeatures(features);
             }
         })
-        .catch(() => clearFeatures(vectorSource));
+        .catch(() => clearFeatures(vectorSource))
+        .finally(() => (inFlight = false));
 
     return {
         name: 'plan-area-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/highlight/duplicate-tracks-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/duplicate-tracks-highlight-layer.ts
@@ -37,7 +37,9 @@ export function createDuplicateTracksHighlightLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = false;
     if (resolution <= HIGHLIGHTS_SHOW) {
+        inFlight = true;
         getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'LOCATION_TRACKS')
             .then((locationTracks) => {
                 if (layerId === newestLayerId) {
@@ -47,7 +49,10 @@ export function createDuplicateTracksHighlightLayer(
                     vectorSource.addFeatures(features);
                 }
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -55,5 +60,6 @@ export function createDuplicateTracksHighlightLayer(
     return {
         name: 'duplicate-tracks-highlight-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/highlight/missing-linking-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/missing-linking-highlight-layer.ts
@@ -37,7 +37,9 @@ export function createMissingLinkingHighlightLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = false;
     if (resolution <= HIGHLIGHTS_SHOW) {
+        inFlight = true;
         const alignmentPromise = getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'ALL');
 
         const linkingStatusPromise = getAlignmentSectionsWithoutLinkingByTiles(
@@ -60,7 +62,10 @@ export function createMissingLinkingHighlightLayer(
                 clearFeatures(vectorSource);
                 vectorSource.addFeatures(features);
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -68,5 +73,6 @@ export function createMissingLinkingHighlightLayer(
     return {
         name: 'missing-linking-highlight-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/highlight/missing-profile-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/missing-profile-highlight-layer.ts
@@ -36,7 +36,9 @@ export function createMissingProfileHighlightLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = false;
     if (resolution <= HIGHLIGHTS_SHOW) {
+        inFlight = true;
         const locationTracksPromise = getMapAlignmentsByTiles(
             changeTimes,
             mapTiles,
@@ -63,7 +65,10 @@ export function createMissingProfileHighlightLayer(
                 clearFeatures(vectorSource);
                 vectorSource.addFeatures(features);
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -71,5 +76,6 @@ export function createMissingProfileHighlightLayer(
     return {
         name: 'missing-profile-highlight-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/highlight/plan-section-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/plan-section-highlight-layer.ts
@@ -64,7 +64,9 @@ export function createPlanSectionHighlightLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = false;
     if (resolution <= HIGHLIGHTS_SHOW) {
+        inFlight = true;
         getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'ALL')
             .then((alignments) => {
                 if (layerId === newestLayerId) {
@@ -74,7 +76,10 @@ export function createPlanSectionHighlightLayer(
                     vectorSource.addFeatures(features);
                 }
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -82,5 +87,6 @@ export function createPlanSectionHighlightLayer(
     return {
         name: 'plan-section-highlight-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/highlight/track-number-diagram-layer.ts
+++ b/ui/src/map/layers/highlight/track-number-diagram-layer.ts
@@ -73,6 +73,7 @@ export function createTrackNumberDiagramLayer(
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
     const fetchType = resolution > Limits.ALL_ALIGNMENTS ? 'REFERENCE_LINES' : 'ALL';
 
+    let inFlight = true;
     getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, fetchType)
         .then((alignments) => {
             if (layerId !== newestLayerId) return;
@@ -97,10 +98,14 @@ export function createTrackNumberDiagramLayer(
             clearFeatures(vectorSource);
             vectorSource.addFeatures(features);
         })
-        .catch(() => clearFeatures(vectorSource));
+        .catch(() => clearFeatures(vectorSource))
+        .finally(() => {
+            inFlight = false;
+        });
 
     return {
         name: 'track-number-diagram-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
+++ b/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
@@ -197,7 +197,9 @@ export function createTrackNumberEndPointAddressesLayer(
 
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = false;
     if (resolution <= Limits.ALL_ALIGNMENTS) {
+        inFlight = true;
         getMapAlignmentsByTiles(changeTimes, mapTiles, publishType, 'REFERENCE_LINES')
             .then((referenceLines) => {
                 const showAll = Object.values(layerSettings).every((s) => !s.selected);
@@ -226,7 +228,10 @@ export function createTrackNumberEndPointAddressesLayer(
                     vectorSource.addFeatures(features);
                 }
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -234,6 +239,7 @@ export function createTrackNumberEndPointAddressesLayer(
     return {
         name: 'track-number-addresses-layer',
         layer: layer,
+        requestInFlight: () => inFlight,
     };
 }
 

--- a/ui/src/map/layers/km-post/km-post-layer.ts
+++ b/ui/src/map/layers/km-post/km-post-layer.ts
@@ -50,11 +50,13 @@ export function createKmPostLayer(
         }
     }
 
+    let inFlight = false;
     const step = getKmPostStepByResolution(resolution);
     if (step == 0) {
         clearFeatures(vectorSource);
         updateShownKmPosts([]);
     } else {
+        inFlight = true;
         // Fetch every nth
         getKmPostsFromApi(step)
             .then((kmPosts) => {
@@ -80,6 +82,9 @@ export function createKmPostLayer(
             .catch(() => {
                 clearFeatures(vectorSource);
                 updateShownKmPosts([]);
+            })
+            .finally(() => {
+                inFlight = false;
             });
     }
 
@@ -94,5 +99,6 @@ export function createKmPostLayer(
             };
         },
         onRemove: () => updateShownKmPosts([]),
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/switch/switch-layer.ts
+++ b/ui/src/map/layers/switch/switch-layer.ts
@@ -47,8 +47,10 @@ export function createSwitchLayer(
         }
     }
 
+    let inFlight = false;
     const resolution = olView.getResolution() || 0;
     if (resolution <= Limits.SWITCH_SHOW) {
+        inFlight = true;
         Promise.all([getSwitchesFromApi(), getSwitchStructures()])
             .then(([switches, switchStructures]) => {
                 if (layerId !== newestLayerId) return;
@@ -82,6 +84,9 @@ export function createSwitchLayer(
             .catch(() => {
                 clearFeatures(vectorSource);
                 updateShownSwitches([]);
+            })
+            .finally(() => {
+                inFlight = false;
             });
     } else {
         clearFeatures(vectorSource);
@@ -99,5 +104,6 @@ export function createSwitchLayer(
             return { switches };
         },
         onRemove: () => updateShownSwitches([]),
+        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/switch/switch-linking-layer.ts
+++ b/ui/src/map/layers/switch/switch-linking-layer.ts
@@ -69,7 +69,9 @@ export function createSwitchLinkingLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
+    let inFlight = false;
     if (resolution <= SUGGESTED_SWITCH_SHOW) {
+        inFlight = true;
         const selectedSwitches = selection.selectedItems.suggestedSwitches;
 
         const getSuggestedSwitchesPromises = linkingState
@@ -99,7 +101,10 @@ export function createSwitchLinkingLayer(
                 clearFeatures(vectorSource);
                 vectorSource.addFeatures(features);
             })
-            .catch(() => clearFeatures(vectorSource));
+            .catch(() => clearFeatures(vectorSource))
+            .finally(() => {
+                inFlight = false;
+            });
     } else {
         clearFeatures(vectorSource);
     }
@@ -112,6 +117,7 @@ export function createSwitchLinkingLayer(
                 suggestedSwitches: findMatchingSwitches(hitArea, vectorSource, options),
             };
         },
+        requestInFlight: () => inFlight,
     };
 }
 

--- a/ui/src/map/layers/utils/layer-model.ts
+++ b/ui/src/map/layers/utils/layer-model.ts
@@ -14,4 +14,5 @@ export type MapLayer = {
     layer: BaseLayer;
     searchItems?: (hitArea: Rectangle, options: SearchItemsOptions) => LayerItemSearchResult;
     onRemove?: () => void;
+    requestInFlight: () => boolean;
 };

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -122,6 +122,7 @@ export type Map = {
     shownItems: ShownItems;
     clickLocation: Point | null;
     verticalGeometryDiagramVisible: boolean;
+    loadingIndicatorVisible: boolean;
 };
 
 export type MapTile = {

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -110,6 +110,7 @@ export const initialMapState: Map = {
     },
     clickLocation: null,
     verticalGeometryDiagramVisible: false,
+    loadingIndicatorVisible: false,
 };
 
 export const mapReducers = {
@@ -133,6 +134,7 @@ export const mapReducers = {
                   1.2
                 : state.viewport.resolution,
         };
+        state.loadingIndicatorVisible = true;
     },
     showLayers(state: Map, { payload: layers }: PayloadAction<MapLayerName[]>) {
         state.visibleLayers = deduplicate([
@@ -141,6 +143,7 @@ export const mapReducers = {
             ...layers,
             ...collectRelatedLayers(layers),
         ]);
+        state.loadingIndicatorVisible = true;
     },
     hideLayers(state: Map, { payload: layers }: PayloadAction<MapLayerName[]>) {
         const relatedLayers = collectRelatedLayers(layers);
@@ -192,6 +195,9 @@ export const mapReducers = {
         { payload: visibilitySetting }: PayloadAction<boolean>,
     ): void => {
         state.verticalGeometryDiagramVisible = visibilitySetting;
+    },
+    onDoneLoading: (state: Map): void => {
+        state.loadingIndicatorVisible = false;
     },
 };
 

--- a/ui/src/map/map-view-container.tsx
+++ b/ui/src/map/map-view-container.tsx
@@ -36,6 +36,7 @@ const getTrackLayoutProps = (): MapViewProps => {
         onViewportUpdate: delegates.onViewportChange,
         publishType: store.publishType,
         selection: store.selection,
+        onDoneLoading: delegates.onDoneLoading,
     };
 };
 
@@ -61,6 +62,7 @@ const getInfraModelProps = (): MapViewProps => {
         onViewportUpdate: delegates.onViewportChange,
         publishType: 'OFFICIAL',
         selection: store.selection,
+        onDoneLoading: emptyFn,
     };
 };
 

--- a/ui/src/map/map.module.scss
+++ b/ui/src/map/map.module.scss
@@ -237,3 +237,9 @@ $color-highlight-blue: #389bf6;
     padding: 2px 6px;
     border-radius: 4px;
 }
+
+.map__loading-spinner {
+    position: absolute;
+    top: 10px;
+    left: 40px;
+}


### PR DESCRIPTION
Meidän createFooLayer-funktiot toimivat OpenLayersin näkökulmasta niin, että ne hakevat täysin omia aikojaan tietoja ja tunkevat ne sisään tilaan yksi kerrallaan. Tästä syystä rendercomplete-tapahtumia voi tulla yhden päivityksen perusteella monia, niin monta kuin kartalla on tasoja.

Tässä tapauksessa yksinkertaisimmalta ratkaisulta näytti, että pidetään erikseen yllä tilaa siitä, onko kukin karttataso omasta mielestään tekemässä hakuja, ja jos on, oletetaan renderöinnin jatkuvan yhä.

Spinneri itsessään tuntuu hieman ylimääräiseltä visuaaliselta melulta ainakin joissain tapauksissa (esim. liikuttaessa normaalisti kartalla hiirellä), joten asetin sen näkymään vain tiettyjen operaatioiden jälkeen.