### PR TITLE
GVT-1994 Fix calculating tickLength when track meter 0 is visible

### DIFF
--- a/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
@@ -79,7 +79,7 @@ export const VerticalGeometryDiagramHolder: React.FC<VerticalGeometryDiagramHold
     const ref = React.useRef<HTMLDivElement>(null);
 
     const horizontalTickLengthMeters = minimumIntervalOrLongest(
-        diagramWidth && visibleEndM && visibleStartM
+        diagramWidth !== undefined && visibleEndM !== undefined && visibleStartM !== undefined
             ? diagramWidth / (visibleEndM - visibleStartM)
             : 0,
         minimumApproximateHorizontalTickWidthPx,


### PR DESCRIPTION
Other checks vs. undefined for consistency. The one that matters is considering visibleStartM === 0 valid.