### PR TITLE
GVt-1993: Fix CloseableModal using old references for calculating its…

### DIFF
--- a/ui/src/geoviite-design-lib/closeable-modal/closeable-modal.tsx
+++ b/ui/src/geoviite-design-lib/closeable-modal/closeable-modal.tsx
@@ -44,8 +44,8 @@ export const CloseableModal: React.FC<CloseableModalProps> = ({
     useResizeObserver({
         ref: document.body,
         onResize: () => {
-            setX(boundingRect?.x);
-            setY(boundingRect?.y);
+            setX(positionRef.current?.getBoundingClientRect().x);
+            setY(positionRef.current?.getBoundingClientRect().y);
         },
     });
 


### PR DESCRIPTION
Olipahan työmaa selvittää että mistä tämä aiheutuu. Lopulta kuitenkin `CloseableModal`:in resizessa haettiin `positionRef`-elementin kokotieto lokaalista muuttujasta, ja ka. lokaali muuttuja ei luonnollisesti päivity ilman redrawia