### PR TITLE
GVT-1941: Julkaisulokiin kenttäkohtaiset muutokset (UI-puoli)

### DIFF
--- a/ui/src/infra-model/list/infra-model-search-result.tsx
+++ b/ui/src/infra-model/list/infra-model-search-result.tsx
@@ -231,8 +231,8 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                                 onClick={() => setFilter(SortByValue.LINKED_BY)}>
                                 {t('im-form.linked-by-users-field')}
                             </Th>
-                            <th />
-                            <th />
+                            <Th />
+                            <Th />
                         </tr>
                     </thead>
                     <tbody id="infra-model-list-search-result__table-body">

--- a/ui/src/publication/table/publication-table-details.tsx
+++ b/ui/src/publication/table/publication-table-details.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Table, Th } from 'vayla-design-lib/table/table';
+import { useTranslation } from 'react-i18next';
+
+type PublicationTableDetailsProps = {
+    id: string;
+    // TODO Move somewhere else
+    items: {
+        propKey: string;
+        oldValue: string;
+        newValue: string;
+        remarks:
+            | {
+                  key: string;
+                  value: string;
+              }
+            | undefined;
+    }[];
+};
+
+export const PublicationTableDetails: React.FC<PublicationTableDetailsProps> = ({ id, items }) => {
+    const { t } = useTranslation();
+    return (
+        <Table wide>
+            <thead>
+                <tr>
+                    <Th>{t('publication-details-table.property')}</Th>
+                    <Th>{t('publication-details-table.old-value')}</Th>
+                    <Th>{t('publication-details-table.new-value')}</Th>
+                    <Th>{t('publication-details-table.remarks')}</Th>
+                </tr>
+            </thead>
+            <tbody>
+                {items.map((item) => (
+                    <tr key={`${id}_${item.propKey}`}>
+                        <td>{t(`publication-details-table.prop.${item.propKey}`)}</td>
+                        <td>{item.oldValue}</td>
+                        <td>{item.newValue}</td>
+                        <td>
+                            {item.remarks
+                                ? t(`publication-details-table.remark.${item.remarks.key}`, [
+                                      item.remarks.value,
+                                  ])
+                                : undefined}
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    );
+};

--- a/ui/src/publication/table/publication-table-row.tsx
+++ b/ui/src/publication/table/publication-table-row.tsx
@@ -7,6 +7,8 @@ import styles from './publication-table.scss';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { createClassName } from 'vayla-design-lib/utils';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import { AccordionToggle } from 'vayla-design-lib/accordion-toggle/accordion-toggle';
+import { PublicationTableDetails } from 'publication/table/publication-table-details';
 
 const formatKmNumber = (kmNumbers: KmNumber[]) => {
     return kmNumbers
@@ -42,9 +44,10 @@ const formatKmNumber = (kmNumbers: KmNumber[]) => {
         ));
 };
 
-type PublicationTableRowProps = Omit<PublicationTableItem, 'id'>;
+type PublicationTableRowProps = PublicationTableItem;
 
 export const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
+    id,
     name,
     trackNumbers,
     changedKmNumbers,
@@ -57,6 +60,7 @@ export const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
     const { t } = useTranslation();
     const messageRows = message.split('\n');
     const [messageExpanded, setMessageExpanded] = React.useState(false);
+    const [detailsVisible, setDetailsVisible] = React.useState<boolean>(false);
     const contentClassNames = createClassName(
         styles['publication-table__message-content'],
         messageExpanded
@@ -68,27 +72,81 @@ export const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
         messageExpanded ? styles['publication-table__message-icon--open'] : undefined,
     );
 
+    const rowClassNames = createClassName(
+        'publication-table__row',
+        detailsVisible && styles['publication-table__row-details--borderless'],
+    );
+
+    // TODO: Remove test data when real data is available
+    const testData = [
+        {
+            propKey: 'location-track',
+            oldValue: 'old name',
+            newValue: 'new name',
+            remarks: {
+                key: 'changed-x-meters',
+                value: '100',
+            },
+        },
+        {
+            propKey: 'track-number',
+            oldValue: 'old name',
+            newValue: 'new name',
+            remarks: {
+                key: 'moved-x-meters',
+                value: '100',
+            },
+        },
+        {
+            propKey: 'state',
+            oldValue: 'old name',
+            newValue: 'new name',
+            remarks: {
+                key: 'changed-kilometers',
+                value: '0001, 0003-0005, 0007-0010',
+            },
+        },
+    ];
+
     return (
-        <tr className={'publication-table__row'}>
-            <td>{name}</td>
-            <td>{trackNumbers.sort().join(', ')}</td>
-            <td>{changedKmNumbers ? formatKmNumber(changedKmNumbers) : ''}</td>
-            <td>{t(`enum.publish-operation.${operation}`)}</td>
-            <td>{formatDateFull(publicationTime)}</td>
-            <td>{publicationUser}</td>
-            <td className={styles['publication-table__message-column']} title={message}>
-                <Button
-                    className={chevronClassNames}
-                    icon={Icons.Down}
-                    variant={ButtonVariant.GHOST}
-                    size={ButtonSize.SMALL}
-                    onClick={() => setMessageExpanded(!messageExpanded)}
-                />
-                <div className={contentClassNames}>
-                    {messageExpanded ? message : messageRows[0]}
-                </div>
-            </td>
-            <td>{ratkoPushTime ? formatDateFull(ratkoPushTime) : t('no')}</td>
-        </tr>
+        <React.Fragment>
+            <tr className={rowClassNames}>
+                <td>
+                    <AccordionToggle
+                        open={detailsVisible}
+                        onToggle={() => setDetailsVisible(!detailsVisible)}
+                    />
+                </td>
+                <td>{name}</td>
+                <td>{trackNumbers.sort().join(', ')}</td>
+                <td>{changedKmNumbers ? formatKmNumber(changedKmNumbers) : ''}</td>
+                <td>{t(`enum.publish-operation.${operation}`)}</td>
+                <td>{formatDateFull(publicationTime)}</td>
+                <td>{publicationUser}</td>
+                <td className={styles['publication-table__message-column']} title={message}>
+                    <Button
+                        className={chevronClassNames}
+                        icon={Icons.Down}
+                        variant={ButtonVariant.GHOST}
+                        size={ButtonSize.SMALL}
+                        onClick={() => setMessageExpanded(!messageExpanded)}
+                    />
+                    <div className={contentClassNames}>
+                        {messageExpanded ? message : messageRows[0]}
+                    </div>
+                </td>
+                <td>{ratkoPushTime ? formatDateFull(ratkoPushTime) : t('no')}</td>
+            </tr>
+            {detailsVisible && (
+                <tr>
+                    <td className={styles['publication-table__row-details-left-bar-container']}>
+                        <span className={styles['publication-table__row-details-left-bar']}></span>
+                    </td>
+                    <td colSpan={8}>
+                        <PublicationTableDetails id={id} items={testData} />
+                    </td>
+                </tr>
+            )}
+        </React.Fragment>
     );
 };

--- a/ui/src/publication/table/publication-table.scss
+++ b/ui/src/publication/table/publication-table.scss
@@ -45,4 +45,24 @@
     &__table-container {
         position: relative;
     }
+
+    &__row-details {
+        &--borderless > td {
+            border: none;
+        }
+
+        &-left-bar {
+            &-container {
+                position: relative;
+            }
+
+            position: absolute;
+            width: 4px;
+            top: 0;
+            left: 24px;
+            height: 100%;
+            background-color: $color-blue-default;
+            z-index: 1;
+        }
+    }
 }

--- a/ui/src/publication/table/publication-table.tsx
+++ b/ui/src/publication/table/publication-table.tsx
@@ -65,6 +65,7 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
                 <Table wide isLoading={isLoading}>
                     <thead className={styles['publication-table__table-header']}>
                         <tr>
+                            <Th />
                             {sortableTableHeader(
                                 PublicationDetailsTableSortField.NAME,
                                 'publication-table.name',
@@ -103,6 +104,7 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
                         {items.map((entry) => (
                             <PublicationTableRow
                                 key={entry.id}
+                                id={entry.id}
                                 name={entry.name}
                                 trackNumbers={entry.trackNumbers}
                                 publicationTime={entry.publicationTime}

--- a/ui/src/publication/translations.fi.json
+++ b/ui/src/publication/translations.fi.json
@@ -17,6 +17,41 @@
         "calculated-change": "Laskettu muutos",
         "truncated": "Käyttöliittymässä näytetään {{number}} ensimmäistä muutosta"
     },
+    "publication-details-table": {
+        "property": "Muuttunut kohde",
+        "old-value": "Edellinen arvo",
+        "new-value": "Uusi arvo",
+        "remarks": "Huomioita",
+        "remark": {
+            "changed-x-meters": "Muutos {{0}}m",
+            "moved-x-meters": "Siirtynyt {{0}}m",
+            "changed-kilometers": "Muuttunut kilometreiltä {{0}}"
+        },
+        "prop": {
+            "location-track": "Sijaintiraidetunnus",
+            "track-number": "Ratanumero",
+            "state": "Tila",
+            "km-post": "Tasakilometripiste",
+            "description": "Kuvaus",
+            "topological-connection": "Topologinen yhteys",
+            "location-track-type": "Sijaintiraidetyyppi",
+            "duplicate-of": "Duplikaatti raiteelle",
+            "owner": "Omistaja",
+            "length": "Pituus",
+            "start-location": "Alkusijainti",
+            "end-location": "Loppusijainti",
+            "geometry": "Geometria",
+            "start-address": "Alkuosoite",
+            "end-address": "Loppuosoite",
+            "switch-id": "Vaihdetunnus",
+            "state-category": "Tilakategoria",
+            "switch-type": "Vaihdetyyppi",
+            "trap-point": "Turvavaihde",
+            "location-math-point": "Sijainti (matemaattinen piste)",
+            "location-forward-joint": "Sijainti (etujatkos)",
+            "address": "Rataosoite"
+        }
+    },
     "publication-log": {
         "breadcrumbs-text": "Julkaisuloki",
         "start-date": "Alkupvm.",

--- a/ui/src/vayla-design-lib/table/table.scss
+++ b/ui/src/vayla-design-lib/table/table.scss
@@ -16,7 +16,6 @@ $table-cell-padding: 10px 16px;
         > .table__th {
             // Heading cell
             @include typography-table-heading;
-            background: $color-white-dark;
             white-space: break-spaces;
 
             &.table__th--clickable {
@@ -26,6 +25,9 @@ $table-cell-padding: 10px 16px;
                 &:hover {
                     background: $color-white-darker;
                 }
+            }
+            &--has-background {
+                background: $color-white-dark;
             }
         }
 
@@ -40,38 +42,15 @@ $table-cell-padding: 10px 16px;
         > .table__th--multiline-bottom {
             padding: 5px 16px 10px;
         }
+
+        > .table__th--unpadded {
+            padding: 0;
+        }
     }
 
     > tbody > tr,
     > .table__tbody > .table__tr {
         // Body row
-
-        > td,
-        > .table__td {
-            // Body cell
-            @include typography-body;
-            padding: $table-cell-padding;
-            background: $color-white-default;
-            vertical-align: top;
-            border-bottom: 1px solid $color-white-dark;
-
-            &.table__td--number {
-                text-align: right;
-            }
-
-            &.table__td--narrow {
-                padding-left: 4px;
-                padding-right: 4px;
-            }
-
-            &.table__td--nowrap {
-                white-space: nowrap;
-            }
-
-            &.table__td--has-stretched-container {
-                position: relative;
-            }
-        }
     }
 
     &--loading {
@@ -82,6 +61,33 @@ $table-cell-padding: 10px 16px;
         width: 100%;
         height: 100%;
         background-color: rgba($color-white-default, 0.67);
+    }
+}
+
+td,
+.table__td {
+    // Body cell
+    @include typography-body;
+    padding: $table-cell-padding;
+    background: $color-white-default;
+    vertical-align: top;
+    border-bottom: 1px solid $color-white-dark;
+
+    &.table__td--number {
+        text-align: right;
+    }
+
+    &.table__td--narrow {
+        padding-left: 4px;
+        padding-right: 4px;
+    }
+
+    &.table__td--nowrap {
+        white-space: nowrap;
+    }
+
+    &.table__td--has-stretched-container {
+        position: relative;
     }
 }
 

--- a/ui/src/vayla-design-lib/table/table.tsx
+++ b/ui/src/vayla-design-lib/table/table.tsx
@@ -65,12 +65,14 @@ export type ThProps = {
     variant?: ThVariant;
     narrow?: boolean;
     icon?: IconComponent;
+    transparent?: boolean;
 } & React.HTMLProps<HTMLTableCellElement>;
 
 export const Th: React.FC<ThProps> = ({
     narrow,
     icon,
     variant = ThVariant.SINGLE_LINE,
+    transparent = false,
     ...props
 }: ThProps) => {
     const Icon = icon;
@@ -80,6 +82,7 @@ export const Th: React.FC<ThProps> = ({
         props.onClick && styles['table__th--clickable'],
         styles['table__th--align-left'],
         props.className,
+        transparent ? undefined : styles['table__th--has-background'],
         variant === ThVariant.SINGLE_LINE && styles['table__th--regular'],
         variant === ThVariant.MULTILINE_BOTTOM && styles['table__th--multiline-bottom'],
         variant === ThVariant.MULTILINE_TOP && styles['table__th--multiline-top'],


### PR DESCRIPTION
Bäkkärimuutokset tulevat myöhemmin omassa PR:ssään kunhan saan ne tehtyä. UI ei näytä tämän jäljiltä ihan täsmälleen samanlaiselta kuin Figmassa (aukeavan taulukon headerissa tausta ei ole valkoinen vaan normaalin harmaa, eikä taulukon otsikot ole capseilla). En kuitenkaan laske näitä varsinaisiksi ongelmiksi, sillä nykytila näyttää konsistentilta kaikkien muiden meidän taulukoiden kanssa. Tutkinen kuitenkin siitä huolimatta miten nuo saisi toteutettua jotenkin järkevästi, sillä nykyisellään rajoittavaksi tekijäksi tulee meidän taulukkokomponentti.