### PR TITLE
GVT-826 Use geometry-id to denote geometry selection (rather than temp layout-id)

### DIFF
--- a/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
+++ b/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
@@ -196,6 +196,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
         planHeader.source == 'PAIKANNUSPALVELU'
             ? t(`enum.plan-source.${planHeader.source}`)
             : undefined;
+    // TODO: GVT-826 This function is way too long and deep-indented. split it up.
     return (
         <div className={styles['geometry-plan-panel']}>
             <Accordion
@@ -224,7 +225,8 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                     planLayout.kmPosts.map((planKmPost) => {
                                         const isKmPostSelected =
                                             selectedItems?.geometryKmPostIds?.some(
-                                                ({ id }) => id === planKmPost.id,
+                                                ({ geometryId }) =>
+                                                    geometryId === planKmPost.sourceId,
                                             );
                                         const isKmPostVisible = selectedPlanLayouts?.some((p) =>
                                             p.kmPosts.some((k) => k.id === planKmPost.id),
@@ -403,7 +405,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
 
                                         const isSwitchSelected =
                                             selectedItems?.geometrySwitchIds?.some(
-                                                (s) => s.id === planSwitch.id,
+                                                (s) => s.geometryId === planSwitch.sourceId,
                                             );
                                         const isSwitchVisible = selectedPlanLayouts?.some((p) =>
                                             p.switches.some((a) => a.id === planSwitch.id),

--- a/ui/src/selection-panel/selection-panel-geometry-section.tsx
+++ b/ui/src/selection-panel/selection-panel-geometry-section.tsx
@@ -196,12 +196,14 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
                                 onToggleSwitchSelection={(switchItem) =>
                                     onSelect({
                                         ...createEmptyItemCollections(),
-                                        geometrySwitchIds: [
-                                            {
-                                                id: switchItem.id,
-                                                planId: h.id,
-                                            },
-                                        ],
+                                        geometrySwitchIds: switchItem.sourceId
+                                            ? [
+                                                  {
+                                                      geometryId: switchItem.sourceId,
+                                                      planId: h.id,
+                                                  },
+                                              ]
+                                            : [],
                                         isToggle: true,
                                     })
                                 }
@@ -209,12 +211,14 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
                                 onToggleKmPostSelection={(kmPost) =>
                                     onSelect({
                                         ...createEmptyItemCollections(),
-                                        geometryKmPostIds: [
-                                            {
-                                                id: kmPost.id,
-                                                planId: h.id,
-                                            },
-                                        ],
+                                        geometryKmPostIds: kmPost.sourceId
+                                            ? [
+                                                  {
+                                                      geometryId: kmPost.sourceId,
+                                                      planId: h.id,
+                                                  },
+                                              ]
+                                            : [],
                                         isToggle: true,
                                     })
                                 }

--- a/ui/src/selection/selection-model.ts
+++ b/ui/src/selection/selection-model.ts
@@ -7,7 +7,12 @@ import {
     LocationTrackId,
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
-import { GeometryPlanId, GeometryPlanLayoutId } from 'geometry/geometry-model';
+import {
+    GeometryKmPostId,
+    GeometryPlanId,
+    GeometryPlanLayoutId,
+    GeometrySwitchId,
+} from 'geometry/geometry-model';
 import {
     ClusterPoint,
     LinkPoint,
@@ -26,9 +31,9 @@ export type SelectionMode = 'alignment' | 'segment' | 'point' | 'switch' | 'trac
 export type ItemCollections = {
     locationTracks: LocationTrackId[];
     kmPosts: LayoutKmPostId[];
-    geometryKmPostIds: SelectedGeometryItemId<LayoutKmPostId>[];
+    geometryKmPostIds: SelectedGeometryItemId<GeometryKmPostId>[];
     switches: LayoutSwitchId[];
-    geometrySwitchIds: SelectedGeometryItemId<LayoutSwitchId>[];
+    geometrySwitchIds: SelectedGeometryItemId<GeometrySwitchId>[];
     trackNumbers: LayoutTrackNumberId[];
     geometryAlignments: SelectedGeometryItem<AlignmentHeader>[];
     layoutLinkPoints: LinkPoint[];
@@ -64,10 +69,10 @@ export type SelectedGeometryItem<T> = {
     geometryItem: T;
 };
 
-export type GeometryItemId = LayoutKmPostId | LayoutSwitchId;
+export type GeometryItemId = GeometryKmPostId | GeometrySwitchId;
 export type SelectedGeometryItemId<T extends GeometryItemId> = {
     planId: GeometryPlanId;
-    id: T;
+    geometryId: T;
 };
 
 export type SelectableItemType = keyof ItemCollections;

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -129,7 +129,8 @@ function getNewGeometryItemIdCollection<T extends GeometryItemId>(
         items,
         newItems,
         flags,
-        (item) => item.planId + item.id,
+        // TODO: GVT-826 Why this custom ID? geometryId is just as unique as planId+geometryId
+        (item) => item.planId + item.geometryId,
     );
 }
 
@@ -141,7 +142,7 @@ function filterGeometryItemIdCollection<T extends GeometryItemId>(
         return items;
     }
 
-    return items.filter((i) => !unselectItemIds.some((u) => u === i.id));
+    return items.filter((i) => !unselectItemIds.some((u) => u === i.geometryId));
 }
 
 function getNewItemCollectionUsingCustomId<TEntity, TId>(
@@ -362,12 +363,14 @@ export const selectionReducers = {
 
             selectedItems.geometryKmPostIds = [
                 ...selectedItems.geometryKmPostIds.filter(
-                    (gKmPost) => !planLayout?.kmPosts.some((kmPost) => kmPost.id === gKmPost.id),
+                    ({ geometryId }) =>
+                        !planLayout?.kmPosts.some((kmPost) => kmPost.sourceId === geometryId),
                 ),
             ];
             selectedItems.geometrySwitchIds = [
                 ...selectedItems.geometrySwitchIds.filter(
-                    (gs) => !planLayout?.switches.some((s) => s.id === gs.id),
+                    ({ geometryId }) =>
+                        !planLayout?.switches.some((s) => s.sourceId === geometryId),
                 ),
             ];
             selectedItems.geometryAlignments = [


### PR DESCRIPTION
Tämä ei itse asiassa oleellisesti muuttanut paljoakaan koodin kannalta, joten olen hiukan epävarma onko tästä oikeastaan hyötyä. Se tuntuu silti jollain tapaa oikeammalta - kun kerran puhutaan geometriapuolen asioiden valinnoista niin miksipä ei puhua niistä geometriapuolen asioiden id:llä.

Taustatietona: Näissä ID:ssä on siis kyse siitä millä id:llä merkataan geometriapuolen valintoja. Kun geometriaolioita näytetään kartalla jne, niille muodostetaan lennossa layout-versio ja ne saavat sieltä stabiilit temp-id:t (id ei ole kannassa mutta generoidaan geometria-id:n pohjalta niin että se on samalla geometriaoliolla aina sama). Noita on käytetty paikoin historiallisista syistä sillä näin generoitu olio käyttäytyy aivan kuten layout-olio frontin kannalta. Layout-oliolla on sourceId-kentässä viittaus geometriapuoleen silloin kun on, mutta näillä geometriasta generoiduilla se toki on 100% varmuudella. Tässä vaihdettiin tuo geometriavalinta käyttämään varsinaista geometria-id:tä eikä siitä generoitua layout-puolen temp-id:tä, lähinnä koska "tuntuu oikeammalta". Käytännön vaikutus jäi pieneksi.