### PR TITLE
General: Fix bad distinctification in km post layer

### DIFF
--- a/ui/src/map/layers/km-post/km-post-layer.ts
+++ b/ui/src/map/layers/km-post/km-post-layer.ts
@@ -16,6 +16,7 @@ import {
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
+import { filterUniqueById } from 'utils/array-utils';
 
 let shownKmPostsCompare: string;
 let newestLayerId = 0;
@@ -36,7 +37,9 @@ export function createKmPostLayer(
             mapTiles.map(({ area }) =>
                 getKmPostsByTile(publishType, changeTimes.layoutKmPost, area, step),
             ),
-        ).then((kmPostGroups) => [...new Set(kmPostGroups.flat())]);
+        ).then((kmPostGroups) =>
+            kmPostGroups.flat().filter(filterUniqueById((kmPost) => kmPost.id)),
+        );
 
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource, style: null });


### PR DESCRIPTION
In this case (unlike GVT-1948), there was no consequence to getting the distinctification wrong, because km posts would have to hit a map tile border exactly in order to be fetched through multiple map tiles anyway.

The problem, as in the other case, is that Set does the usual sort of comparison in JavaScript, which doesn't look inside objects.