### PR TITLE
GVT-826 use ids for selection panel visibilities

### DIFF
--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -148,7 +148,6 @@ const infraModelSlice = createSlice({
             state.validationResponse = response;
 
             if (response.planLayout) {
-                state.selection.planLayouts = [response.planLayout];
                 const bBox = response.planLayout.boundingBox;
                 state.map.viewport = {
                     ...state.map.viewport,

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -156,7 +156,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
             <div className={styles['infra-model-upload__map-container']}>
                 {showMap && (
                     <MapContext.Provider value="infra-model">
-                        <MapViewContainer />
+                        <MapViewContainer manuallySetPlan={planLayout ?? undefined} />
                     </MapContext.Provider>
                 )}
                 {!showMap && <div className={styles['infra-model-upload__error-photo']} />}

--- a/ui/src/map/layers/geometry/geometry-km-post-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-km-post-layer.ts
@@ -1,6 +1,6 @@
 import { Point as OlPoint } from 'ol/geom';
 import { Selection } from 'selection/selection-model';
-import { LayoutKmPost } from 'track-layout/track-layout-model';
+import { GeometryPlanLayout, LayoutKmPost, PlanAndStatus } from 'track-layout/track-layout-model';
 import { LayerItemSearchResult, MapLayer, SearchItemsOptions } from 'map/layers/utils/layer-model';
 import { clearFeatures } from 'map/layers/utils/layer-utils';
 import { PublishType } from 'common/common-model';
@@ -14,6 +14,8 @@ import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { filterNotEmpty } from 'utils/array-utils';
+import { getTrackLayoutPlan } from 'geometry/geometry-api';
+import { ChangeTimes } from 'common/common-slice';
 
 let newestLayerId = 0;
 
@@ -22,6 +24,8 @@ export function createGeometryKmPostLayer(
     existingOlLayer: VectorLayer<VectorSource<OlPoint | Rectangle>> | undefined,
     selection: Selection,
     publishType: PublishType,
+    changeTimes: ChangeTimes,
+    manuallySetPlan?: GeometryPlanLayout,
 ): MapLayer {
     const layerId = ++newestLayerId;
 
@@ -39,17 +43,30 @@ export function createGeometryKmPostLayer(
             );
         };
 
-        const planStatusPromises = selection.planLayouts.map((plan) =>
-            plan.planDataType == 'STORED'
-                ? getPlanLinkStatus(plan.planId, publishType).then((status) => ({ plan, status }))
-                : { plan, status: undefined },
+        // TODO: GVT-826 This section is identical in all layers: move to common util
+        const planLayoutsPromises = manuallySetPlan
+            ? [Promise.resolve(manuallySetPlan)]
+            : selection.visiblePlans.map((p) =>
+                  getTrackLayoutPlan(p.id, changeTimes.geometryPlan, true),
+              );
+        const planStatusPromises: Promise<PlanAndStatus | undefined>[] = planLayoutsPromises.map(
+            (planPromise) =>
+                planPromise.then((plan) => {
+                    if (!plan) return undefined;
+                    else if (plan.planDataType == 'TEMP') return { plan, status: undefined };
+                    else
+                        getPlanLinkStatus(plan.planId, publishType).then((status) => ({
+                            plan,
+                            status,
+                        }));
+                }),
         );
 
         Promise.all(planStatusPromises)
             .then((planStatuses) => {
                 if (layerId !== newestLayerId) return;
 
-                const features = planStatuses.flatMap(({ plan, status }) => {
+                const features = planStatuses.filter(filterNotEmpty).flatMap(({ plan, status }) => {
                     const kmPosts = plan.kmPosts.filter(
                         ({ kmNumber }) => Number.parseInt(kmNumber) % step === 0,
                     );

--- a/ui/src/map/map-view-container.tsx
+++ b/ui/src/map/map-view-container.tsx
@@ -11,6 +11,7 @@ import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 import { infraModelActionCreators } from 'infra-model/infra-model-slice';
 import { PublishType } from 'common/common-model';
 import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
+import { GeometryPlanLayout } from 'track-layout/track-layout-model';
 
 const emptyFn = () => void 0;
 
@@ -69,10 +70,12 @@ const getInfraModelProps = (): MapViewProps => {
 type MapViewContainerProps = {
     publishType?: PublishType;
     hoveredOverPlanSection?: HighlightedAlignment;
+    manuallySetPlan?: GeometryPlanLayout;
 };
 export const MapViewContainer: React.FC<MapViewContainerProps> = ({
     publishType,
     hoveredOverPlanSection,
+    manuallySetPlan,
 }) => {
     const mapContext = React.useContext(MapContext);
 
@@ -80,6 +83,7 @@ export const MapViewContainer: React.FC<MapViewContainerProps> = ({
 
     mapProps.publishType = publishType ? publishType : mapProps.publishType;
     mapProps.hoveredOverPlanSection = hoveredOverPlanSection;
+    mapProps.manuallySetPlan = manuallySetPlan;
 
     return <MapView {...mapProps} />;
 };

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -22,7 +22,7 @@ import { LineString, Point as OlPoint, Polygon } from 'ol/geom';
 import { LinkingState, LinkingSwitch, LinkPoint } from 'linking/linking-model';
 import { pointLocationTool } from 'map/tools/point-location-tool';
 import { LocationHolderView } from 'map/location-holder/location-holder-view';
-import { LAYOUT_SRID } from 'track-layout/track-layout-model';
+import { GeometryPlanLayout, LAYOUT_SRID } from 'track-layout/track-layout-model';
 import { PublishType } from 'common/common-model';
 import Overlay from 'ol/Overlay';
 import { useTranslation } from 'react-i18next';
@@ -89,6 +89,7 @@ export type MapViewProps = {
     onRemoveGeometryLinkPoint: (linkPoint: LinkPoint) => void;
     onRemoveLayoutLinkPoint: (linkPoint: LinkPoint) => void;
     hoveredOverPlanSection?: HighlightedAlignment | undefined;
+    manuallySetPlan?: GeometryPlanLayout;
     onDoneLoading: () => void;
 };
 
@@ -135,6 +136,7 @@ const MapView: React.FC<MapViewProps> = ({
     onSelect,
     onViewportUpdate,
     hoveredOverPlanSection,
+    manuallySetPlan,
     onSetLayoutClusterLinkPoint,
     onSetGeometryClusterLinkPoint,
     onRemoveLayoutLinkPoint,
@@ -408,6 +410,7 @@ const MapView: React.FC<MapViewProps> = ({
                             publishType,
                             changeTimes,
                             resolution,
+                            manuallySetPlan,
                         );
                     case 'geometry-km-post-layer':
                         return createGeometryKmPostLayer(
@@ -415,13 +418,17 @@ const MapView: React.FC<MapViewProps> = ({
                             existingOlLayer as VectorLayer<VectorSource<OlPoint | Rectangle>>,
                             selection,
                             publishType,
+                            changeTimes,
+                            manuallySetPlan,
                         );
                     case 'geometry-switch-layer':
                         return createGeometrySwitchLayer(
                             existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
                             selection,
                             publishType,
+                            changeTimes,
                             resolution,
+                            manuallySetPlan,
                         );
                     case 'alignment-linking-layer':
                         return createAlignmentLinkingLayer(
@@ -482,6 +489,7 @@ const MapView: React.FC<MapViewProps> = ({
         linkingState,
         map.layerSettings,
         hoveredOverPlanSection,
+        manuallySetPlan,
     ]);
 
     React.useEffect(() => {

--- a/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
+++ b/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
@@ -11,7 +11,11 @@ import {
     LocationTrackBadgeStatus,
 } from 'geoviite-design-lib/alignment/location-track-badge';
 import { Accordion } from 'geoviite-design-lib/accordion/accordion';
-import { OpenedPlanLayout, OptionalItemCollections } from 'selection/selection-model';
+import {
+    OpenedPlanLayout,
+    OptionalItemCollections,
+    VisiblePlanLayout,
+} from 'selection/selection-model';
 import styles from './geometry-plan-panel.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
@@ -21,6 +25,7 @@ import {
     ToggleKmPostPayload,
     TogglePlanWithSubItemsOpenPayload,
     ToggleSwitchPayload,
+    wholePlanVisibility,
 } from 'selection/selection-store';
 import { GeometryPlanLinkStatus } from 'linking/linking-model';
 import { useTranslation } from 'react-i18next';
@@ -35,7 +40,7 @@ type GeometryPlanProps = {
     onPlanHeaderSelection: (planHeader: GeometryPlanHeader) => void;
     publishType: PublishType;
     changeTimes: ChangeTimes;
-    onTogglePlanVisibility: (payload: GeometryPlanLayout | null) => void;
+    onTogglePlanVisibility: (payload: VisiblePlanLayout) => void;
     onToggleAlignmentVisibility: (payload: ToggleAlignmentPayload) => void;
     onToggleAlignmentSelection: (alignment: AlignmentHeader) => void;
     onToggleSwitchSelection: (switchItem: LayoutSwitch) => void;
@@ -43,7 +48,7 @@ type GeometryPlanProps = {
     onToggleKmPostSelection: (kmPost: LayoutKmPost) => void;
     onToggleKmPostVisibility: (payload: ToggleKmPostPayload) => void;
     selectedItems: OptionalItemCollections;
-    selectedPlanLayouts: GeometryPlanLayout[];
+    visiblePlans: VisiblePlanLayout[];
     togglePlanOpen: (payload: TogglePlanWithSubItemsOpenPayload) => void;
     openedPlanLayouts: OpenedPlanLayout[];
     togglePlanKmPostsOpen: (payload: ToggleAccordionOpenPayload) => void;
@@ -73,7 +78,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
     onToggleKmPostVisibility,
     onToggleKmPostSelection,
     selectedItems,
-    selectedPlanLayouts,
+    visiblePlans,
     togglePlanOpen,
     openedPlanLayouts,
     togglePlanKmPostsOpen,
@@ -99,29 +104,27 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
     });
 
     React.useEffect(() => {
-        const planHeaderSelected = selectedPlanLayouts.some((p) => p.planId == planHeader.id);
+        const planVisible = visiblePlans.some((v) => v.id === planHeader.id);
 
-        const allAlignmentsSelected = !!planLayout?.alignments.every((a) =>
-            selectedPlanLayouts.some((p) =>
-                p.alignments.some((pa) => pa.header.id === a.header.id),
-            ),
+        const allAlignmentsVisible = !!planLayout?.alignments.every((a) =>
+            visiblePlans.some((p) => p.alignments.includes(a.header.id)),
         );
 
-        const allSwitchesSelected = !!planLayout?.switches.every((s) =>
-            selectedPlanLayouts.some((p) => p.switches.some((pa) => pa.id === s.id)),
+        const allSwitchesVisible = !!planLayout?.switches.every((s) =>
+            visiblePlans.some((p) => p.switches.some((id) => id === s.sourceId)),
         );
 
-        const allKmPostsSelected = !!planLayout?.kmPosts.every((k) =>
-            selectedPlanLayouts.some((p) => p.kmPosts.some((pa) => pa.id === k.id)),
+        const allKmPostsVisible = !!planLayout?.kmPosts.every((k) =>
+            visiblePlans.some((p) => p.kmPosts.some((id) => id === k.sourceId)),
         );
 
         setVisibilities({
-            planHeader: planHeaderSelected,
-            alignments: allAlignmentsSelected,
-            switches: allSwitchesSelected,
-            kmPosts: allKmPostsSelected,
+            planHeader: planVisible,
+            alignments: allAlignmentsVisible,
+            switches: allSwitchesVisible,
+            kmPosts: allKmPostsVisible,
         });
-    }, [planLayout, selectedPlanLayouts]);
+    }, [planLayout, visiblePlans]);
 
     const onPlanToggle = () => {
         if (planLayout) {
@@ -152,46 +155,42 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
 
     const onPlanVisibilityToggle = () => {
         if (planLayout) {
-            onTogglePlanVisibility(planLayout);
+            onTogglePlanVisibility(wholePlanVisibility(planLayout));
         } else {
-            loadPlanLayout().then(onTogglePlanVisibility);
+            loadPlanLayout().then((p) => {
+                if (p) onTogglePlanVisibility(wholePlanVisibility(p));
+            });
         }
     };
 
-    const onAlignmentSelect = (
-        alignment: AlignmentHeader,
-        alignmentStatus: LocationTrackBadgeStatus,
-    ) => {
+    const onAlignmentSelect = (alignment: AlignmentHeader) => {
         if (planLayout) {
             onToggleAlignmentSelection(alignment);
             onToggleAlignmentVisibility({
-                alignment: alignment,
-                status: alignmentStatus,
-                planLayout,
+                alignmentId: alignment.id,
+                planId: planLayout.planId,
                 keepAlignmentVisible: true,
             });
         }
     };
 
-    const onSwitchSelect = (switchItem: LayoutSwitch, switchStatus: SwitchBadgeStatus) => {
-        if (planLayout) {
+    const onSwitchSelect = (switchItem: LayoutSwitch) => {
+        if (planLayout && switchItem.sourceId) {
             onToggleSwitchSelection(switchItem);
             onToggleSwitchVisibility({
-                switch: switchItem,
-                status: switchStatus,
-                planLayout,
+                switchId: switchItem.sourceId,
+                planId: planLayout.planId,
                 keepSwitchesVisible: true,
             });
         }
     };
 
-    const onKmPostSelect = (kmPostItem: LayoutKmPost, kmPostStatus: KmPostBadgeStatus) => {
-        if (planLayout) {
+    const onKmPostSelect = (kmPostItem: LayoutKmPost) => {
+        if (planLayout && kmPostItem.sourceId) {
             onToggleKmPostSelection(kmPostItem);
             onToggleKmPostVisibility({
-                kmPost: kmPostItem,
-                status: kmPostStatus,
-                planLayout,
+                kmPostId: kmPostItem.sourceId,
+                planId: planLayout.planId,
                 keepKmPostsVisible: true,
             });
         }
@@ -230,7 +229,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         planLayout,
                                         planKmPost,
                                         selectedItems,
-                                        selectedPlanLayouts,
+                                        visiblePlans,
                                         linkStatus,
                                         onKmPostSelect,
                                         onToggleKmPostVisibility,
@@ -258,7 +257,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         planLayout,
                                         alignment,
                                         selectedItems,
-                                        selectedPlanLayouts,
+                                        visiblePlans,
                                         linkStatus,
                                         onAlignmentSelect,
                                         onToggleAlignmentVisibility,
@@ -286,7 +285,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         planLayout,
                                         planSwitch,
                                         selectedItems,
-                                        selectedPlanLayouts,
+                                        visiblePlans,
                                         linkStatus,
                                         onSwitchSelect,
                                         onToggleSwitchVisibility,
@@ -310,7 +309,7 @@ function createKmPostRow(
     planLayout: GeometryPlanLayout,
     planKmPost: LayoutKmPost,
     selectedItems: OptionalItemCollections,
-    selectedPlanLayouts: GeometryPlanLayout[],
+    visiblePlans: VisiblePlanLayout[],
     linkStatus: GeometryPlanLinkStatus | null,
     onKmPostSelect: (kmPostItem: LayoutKmPost, kmPostStatus: KmPostBadgeStatus) => void,
     onToggleKmPostVisibility: (payload: ToggleKmPostPayload) => void,
@@ -318,8 +317,8 @@ function createKmPostRow(
     const isKmPostSelected = selectedItems.geometryKmPostIds?.some(
         ({ geometryId }) => geometryId === planKmPost.sourceId,
     );
-    const isKmPostVisible = selectedPlanLayouts.some((p) =>
-        p.kmPosts.some((k) => k.id === planKmPost.id),
+    const isKmPostVisible = visiblePlans.some((p) =>
+        p.kmPosts.some((id) => id === planKmPost.sourceId),
     );
 
     const kmPostStatus = linkStatus?.kmPosts?.some(
@@ -349,11 +348,11 @@ function createKmPostRow(
                     color={IconColor.INHERIT}
                     onClick={() =>
                         isKmPostSelected ||
-                        onToggleKmPostVisibility({
-                            kmPost: planKmPost,
-                            status: kmPostStatus,
-                            planLayout: planLayout,
-                        })
+                        (planKmPost.sourceId &&
+                            onToggleKmPostVisibility({
+                                kmPostId: planKmPost.sourceId,
+                                planId: planLayout.planId,
+                            }))
                     }
                 />
             </span>
@@ -365,7 +364,7 @@ function createAlignmentRow(
     planLayout: GeometryPlanLayout,
     alignment: PlanLayoutAlignment,
     selectedItems: OptionalItemCollections,
-    selectedPlanLayouts: GeometryPlanLayout[],
+    visiblePlans: VisiblePlanLayout[],
     linkStatus: GeometryPlanLinkStatus | null,
     onAlignmentSelect: (alignment: AlignmentHeader, status: LocationTrackBadgeStatus) => void,
     onToggleAlignmentVisibility: (payload: ToggleAlignmentPayload) => void,
@@ -379,9 +378,7 @@ function createAlignmentRow(
     const isAlignmentSelected = selectedItems.geometryAlignmentIds?.some(
         (a) => a.geometryId === alignment.header.id,
     );
-    const isAlignmentVisible = selectedPlanLayouts.some((p) =>
-        p.alignments.some((a) => a.header.id === alignment.header.id),
-    );
+    const isAlignmentVisible = visiblePlans.some((p) => p.alignments.includes(alignment.header.id));
 
     return (
         <li
@@ -407,9 +404,8 @@ function createAlignmentRow(
                     onClick={() =>
                         isAlignmentSelected ||
                         onToggleAlignmentVisibility({
-                            alignment: alignment.header,
-                            status: alignmentStatus,
-                            planLayout: planLayout,
+                            alignmentId: alignment.header.id,
+                            planId: planLayout.planId,
                         })
                     }
                 />
@@ -422,7 +418,7 @@ function createSwitchRow(
     planLayout: GeometryPlanLayout,
     planSwitch: LayoutSwitch,
     selectedItems: OptionalItemCollections,
-    selectedPlanLayouts: GeometryPlanLayout[],
+    visiblePlans: VisiblePlanLayout[],
     linkStatus: GeometryPlanLinkStatus | null,
     onSwitchSelect: (switchItem: LayoutSwitch, switchStatus: SwitchBadgeStatus) => void,
     onToggleSwitchVisibility: (payload: ToggleSwitchPayload) => void,
@@ -436,8 +432,8 @@ function createSwitchRow(
     const isSwitchSelected = selectedItems.geometrySwitchIds?.some(
         (s) => s.geometryId === planSwitch.sourceId,
     );
-    const isSwitchVisible = selectedPlanLayouts.some((p) =>
-        p.switches.some((a) => a.id === planSwitch.id),
+    const isSwitchVisible = visiblePlans.some((p) =>
+        p.switches.some((id) => id === planSwitch.sourceId),
     );
 
     return (
@@ -462,11 +458,11 @@ function createSwitchRow(
                     color={IconColor.INHERIT}
                     onClick={() =>
                         isSwitchSelected ||
-                        onToggleSwitchVisibility({
-                            switch: planSwitch,
-                            status: switchStatus,
-                            planLayout: planLayout,
-                        })
+                        (planSwitch.sourceId &&
+                            onToggleSwitchVisibility({
+                                switchId: planSwitch.sourceId,
+                                planId: planLayout.planId,
+                            }))
                     }
                 />
             </span>

--- a/ui/src/selection-panel/selection-panel-container.tsx
+++ b/ui/src/selection-panel/selection-panel-container.tsx
@@ -49,7 +49,7 @@ export const SelectionPanelContainer: React.FC = () => {
             changeTimes={changeTimes}
             publishType={state.publishType}
             selectedItems={state.selection.selectedItems}
-            selectedPlanLayouts={state.selection.planLayouts}
+            visiblePlans={state.selection.visiblePlans}
             kmPosts={kmPosts}
             referenceLines={referenceLines}
             locationTracks={locationTracks}

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styles from './selection-panel.scss';
 import {
-    GeometryPlanLayout,
     LayoutKmPost,
     LayoutLocationTrack,
     LayoutReferenceLine,
@@ -16,6 +15,7 @@ import {
     OpenedPlanLayout,
     OptionalItemCollections,
     SelectableItemType,
+    VisiblePlanLayout,
 } from 'selection/selection-model';
 import { KmPostsPanel } from 'selection-panel/km-posts-panel/km-posts-panel';
 import SwitchPanel from 'selection-panel/switch-panel/switch-panel';
@@ -49,7 +49,7 @@ type SelectionPanelProps = {
     changeTimes: ChangeTimes;
     publishType: PublishType;
     selectedItems: OptionalItemCollections;
-    selectedPlanLayouts: GeometryPlanLayout[];
+    visiblePlans: VisiblePlanLayout[];
     kmPosts: LayoutKmPost[];
     referenceLines: LayoutReferenceLine[];
     locationTracks: LayoutLocationTrack[];
@@ -57,7 +57,7 @@ type SelectionPanelProps = {
     viewport: MapViewport;
     onSelect: (options: OnSelectOptions) => void;
     selectableItemTypes: SelectableItemType[];
-    onTogglePlanVisibility: (payload: GeometryPlanLayout | null) => void;
+    onTogglePlanVisibility: (payload: VisiblePlanLayout) => void;
     onToggleAlignmentVisibility: (payload: ToggleAlignmentPayload) => void;
     onToggleSwitchVisibility: (payload: ToggleSwitchPayload) => void;
     onToggleKmPostVisibility: (payload: ToggleKmPostPayload) => void;
@@ -76,7 +76,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
     publishType,
     changeTimes,
     selectedItems,
-    selectedPlanLayouts,
+    visiblePlans,
     kmPosts,
     referenceLines,
     locationTracks,
@@ -228,7 +228,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                 publishType={publishType}
                 changeTimes={changeTimes}
                 selectedItems={selectedItems}
-                selectedPlanLayouts={selectedPlanLayouts}
+                visiblePlans={visiblePlans}
                 viewport={viewport}
                 onToggleAlignmentVisibility={onToggleAlignmentVisibility}
                 onToggleKmPostVisibility={onToggleKmPostVisibility}

--- a/ui/src/selection/selection-model.ts
+++ b/ui/src/selection/selection-model.ts
@@ -1,5 +1,4 @@
 import {
-    GeometryPlanLayout,
     LayoutKmPostId,
     LayoutSegmentId,
     LayoutSwitchId,
@@ -11,7 +10,6 @@ import {
     GeometryAlignmentId,
     GeometryKmPostId,
     GeometryPlanId,
-    GeometryPlanLayoutId,
     GeometrySwitchId,
 } from 'geometry/geometry-model';
 import {
@@ -99,17 +97,20 @@ export type Selection = {
     selectionModes: SelectionMode[];
     selectedItems: ItemCollections;
     highlightedItems: ItemCollections;
-    /**
-     * GeometryPlanLayout can be used to provide a plan object manually,
-     * e.g. when plan is not yet in DB and therefore there is no ID.
-     */
-    planLayouts: GeometryPlanLayout[];
+    // TODO: GVT-826 rename as just openPlans
     openedPlanLayouts: OpenedPlanLayout[];
+    visiblePlans: VisiblePlanLayout[];
     publication: PublicationId | undefined;
 };
 
+export type VisiblePlanLayout = {
+    id: GeometryPlanId;
+    switches: GeometrySwitchId[];
+    kmPosts: GeometryKmPostId[];
+    alignments: GeometryAlignmentId[];
+};
 export type OpenedPlanLayout = {
-    id: GeometryPlanLayoutId;
+    id: GeometryPlanId;
     isSwitchesOpen: boolean;
     isKmPostsOpen: boolean;
     isAlignmentsOpen: boolean;

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -319,42 +319,32 @@ export const selectionReducers = {
     },
     togglePlanVisibility: (
         state: Selection,
-        { payload: plan }: PayloadAction<GeometryPlanLayout | null>,
+        { payload: plan }: PayloadAction<VisiblePlanLayout>,
     ): void => {
-        const isPlanVisible = state.visiblePlans.some((p) => p.id === plan?.planId);
+        const isPlanVisible = state.visiblePlans.some((p) => p.id === plan?.id);
 
         if (isPlanVisible) {
             const selectedItems = state.selectedItems;
 
-            state.visiblePlans = [...state.visiblePlans.filter((p) => p.id !== plan?.planId)];
+            state.visiblePlans = [...state.visiblePlans.filter((p) => p.id !== plan?.id)];
 
             selectedItems.geometryKmPostIds = [
                 ...selectedItems.geometryKmPostIds.filter(
-                    ({ geometryId }) =>
-                        !plan?.kmPosts.some((kmPost) => kmPost.sourceId === geometryId),
+                    ({ geometryId }) => !plan?.kmPosts.includes(geometryId),
                 ),
             ];
             selectedItems.geometrySwitchIds = [
                 ...selectedItems.geometrySwitchIds.filter(
-                    ({ geometryId }) => !plan?.switches.some((s) => s.sourceId === geometryId),
+                    ({ geometryId }) => !plan?.switches.includes(geometryId),
                 ),
             ];
             selectedItems.geometryAlignmentIds = [
                 ...selectedItems.geometryAlignmentIds.filter(
-                    (ga) => !plan?.alignments.some((a) => a.header.id === ga.geometryId),
+                    (ga) => !plan?.alignments.includes(ga.geometryId),
                 ),
             ];
         } else {
-            const newVisiblePlan = plan
-                ? [
-                      {
-                          id: plan.planId,
-                          switches: plan.switches.map((s) => s.sourceId).filter(filterNotEmpty),
-                          kmPosts: plan.kmPosts.map((s) => s.sourceId).filter(filterNotEmpty),
-                          alignments: plan.alignments.map((a) => a.header.id),
-                      },
-                  ]
-                : [];
+            const newVisiblePlan = plan ? [plan] : [];
             state.visiblePlans = [...state.visiblePlans, ...newVisiblePlan];
         }
     },
@@ -480,4 +470,12 @@ function toggleVisibility(
 
 function arePlanPartsVisible(plan: VisiblePlanLayout): boolean {
     return plan.kmPosts.length > 0 || plan.switches.length > 0 || plan.alignments.length > 0;
+}
+export function wholePlanVisibility(plan: GeometryPlanLayout): VisiblePlanLayout {
+    return {
+        id: plan.planId,
+        switches: plan.switches.map((s) => s.sourceId).filter(filterNotEmpty),
+        kmPosts: plan.kmPosts.map((s) => s.sourceId).filter(filterNotEmpty),
+        alignments: plan.alignments.map((a) => a.header.id),
+    };
 }

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -20,6 +20,7 @@ import {
 } from 'common/common-model';
 import { deduplicateById } from 'utils/array-utils';
 import { AlignmentHeader, AlignmentPolyLine } from './layout-map-api';
+import { GeometryPlanLinkStatus } from 'linking/linking-model';
 
 export type LayoutState = 'IN_USE' | 'NOT_IN_USE' | 'PLANNED' | 'DELETED';
 export type LayoutStateCategory = 'EXISTING' | 'NOT_EXISTING' | 'FUTURE_EXISTING';
@@ -186,6 +187,11 @@ export type GeometryPlanLayout = {
     boundingBox: BoundingBox;
     planId: GeometryPlanLayoutId;
     planDataType: DataType;
+};
+
+export type PlanAndStatus = {
+    plan: GeometryPlanLayout;
+    status: GeometryPlanLinkStatus | undefined;
 };
 
 export type PlanLayoutAlignment = {

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -6,6 +6,7 @@ import {
     OnSelectOptions,
     SelectableItemType,
     Selection,
+    VisiblePlanLayout,
 } from 'selection/selection-model';
 import { wrapReducers } from 'store/store-utils';
 import {
@@ -389,11 +390,11 @@ const trackLayoutSlice = createSlice({
         },
         togglePlanVisibility: (
             state: TrackLayoutState,
-            action: PayloadAction<GeometryPlanLayout | null>,
+            action: PayloadAction<VisiblePlanLayout>,
         ): void => {
             if (!state.linkingState) {
                 const isPlanVisible = state.selection.visiblePlans.some(
-                    (p) => p.id === action.payload?.planId,
+                    (p) => p.id === action.payload?.id,
                 );
 
                 updateMapLayerVisibilities(state.map, isPlanVisible, [

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -20,20 +20,15 @@ import { LinkingState, LinkingType } from 'linking/linking-model';
 import { LayoutMode, PublishType } from 'common/common-model';
 import {
     GeometryPlanLayout,
-    LayoutKmPost,
     LayoutKmPostId,
-    LayoutSwitch,
     LayoutSwitchId,
     LayoutTrackNumberId,
     LocationTrackId,
-    PlanLayoutAlignment,
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import { Point } from 'model/geometry';
 import { addIfExists, subtract } from 'utils/array-utils';
 import { PublishRequestIds } from 'publication/publication-model';
-import { GeometryPlanLayoutId } from 'geometry/geometry-model';
-import { ValueOf } from 'utils/type-utils';
 import { ToolPanelAsset } from 'tool-panel/tool-panel';
 
 export type SelectedPublishChange = {
@@ -397,11 +392,11 @@ const trackLayoutSlice = createSlice({
             action: PayloadAction<GeometryPlanLayout | null>,
         ): void => {
             if (!state.linkingState) {
-                const isPlanLayoutSelected = state.selection.planLayouts.some(
-                    (p) => p.planId === action.payload?.planId,
+                const isPlanVisible = state.selection.visiblePlans.some(
+                    (p) => p.id === action.payload?.planId,
                 );
 
-                updateMapLayerVisibilities(state.map, isPlanLayoutSelected, [
+                updateMapLayerVisibilities(state.map, isPlanVisible, [
                     'geometry-alignment-layer',
                     'geometry-switch-layer',
                     'geometry-km-post-layer',
@@ -414,13 +409,11 @@ const trackLayoutSlice = createSlice({
             state: TrackLayoutState,
             action: PayloadAction<ToggleAlignmentPayload>,
         ) => {
-            const { planLayout, alignment, keepAlignmentVisible } = action.payload;
+            const { alignmentId, keepAlignmentVisible } = action.payload;
             const hideLayer = shouldHideMapLayer(
                 state,
-                planLayout.planId,
                 'alignments',
-                (i: PlanLayoutAlignment) => i.header.id,
-                alignment.id,
+                alignmentId,
                 keepAlignmentVisible,
             );
 
@@ -432,16 +425,9 @@ const trackLayoutSlice = createSlice({
             state: TrackLayoutState,
             action: PayloadAction<ToggleSwitchPayload>,
         ) => {
-            const { planLayout, switch: layoutSwitch, keepSwitchesVisible } = action.payload;
+            const { switchId, keepSwitchesVisible } = action.payload;
 
-            const hideLayer = shouldHideMapLayer(
-                state,
-                planLayout.planId,
-                'switches',
-                (i: LayoutSwitch) => i.id,
-                layoutSwitch.id,
-                keepSwitchesVisible,
-            );
+            const hideLayer = shouldHideMapLayer(state, 'switches', switchId, keepSwitchesVisible);
 
             updateMapLayerVisibilities(state.map, hideLayer, ['geometry-switch-layer']);
 
@@ -451,16 +437,9 @@ const trackLayoutSlice = createSlice({
             state: TrackLayoutState,
             action: PayloadAction<ToggleKmPostPayload>,
         ) => {
-            const { planLayout, kmPost, keepKmPostsVisible } = action.payload;
+            const { kmPostId, keepKmPostsVisible } = action.payload;
 
-            const hideLayer = shouldHideMapLayer(
-                state,
-                planLayout.planId,
-                'kmPosts',
-                (i: LayoutKmPost) => i.id,
-                kmPost.id,
-                keepKmPostsVisible,
-            );
+            const hideLayer = shouldHideMapLayer(state, 'kmPosts', kmPostId, keepKmPostsVisible);
 
             updateMapLayerVisibilities(state.map, hideLayer, ['geometry-km-post-layer']);
 
@@ -504,17 +483,9 @@ type GeometryItemType = Pick<GeometryPlanLayout, 'alignments' | 'kmPosts' | 'swi
 
 const shouldHideMapLayer = <T>(
     state: TrackLayoutState,
-    planId: GeometryPlanLayoutId,
     key: keyof GeometryItemType,
-    getId: (item: ValueOf<GeometryItemType>[number]) => T,
     id: T,
     keepVisible: boolean | undefined,
 ) => {
-    const plan = state.selection.planLayouts.find((p) => p.planId === planId)?.[key];
-
-    const numberOfItems = state.selection.planLayouts
-        .map((p) => p[key].length)
-        .reduce((a, b) => a + b, 0);
-
-    return plan?.some((i) => getId(i) === id) ? numberOfItems === 1 && !keepVisible : false;
+    return keepVisible || !state.selection.visiblePlans.some((p) => p[key].some((i) => i !== id));
 };


### PR DESCRIPTION
Suunnitelmien osien näkyvyysvalinnat kartan vasemmassa valikossa muutettu toimimaan ID:llä koko olion sijasta. Nyt jäljellä on enää InfraModel-näkymän validationResponse, joka on pakko säilytellä jossain koska sen suunnitelmaa ei löydy kannasta uuden uploadin tapauksessa. Senkin voisi nyt kuitenkin siirtää reduxista pois ja erikseen localstorageen jos niin halutaan - käyttöpaikkoja pitäisi olla enää vain 1, joten sen ei pitäisi olla iso homma.