### PR TITLE
GVT-2016: Fix frontend packaging to be operating system agnostic

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -32,7 +32,10 @@ const acceptedLicenses = [
 ];
 const licenseOverrides = {};
 
-const glyphLocations = [/geoviite-design-lib\/glyphs/, /vayla-design-lib\/icon/];
+const glyphLocations = [
+    path.resolve(__dirname, 'src/geoviite-design-lib/glyphs'),
+    path.resolve(__dirname, 'src/vayla-design-lib/icon'),
+];
 
 module.exports = (env) => {
     return {


### PR DESCRIPTION
Previously the SVG glyph paths were matched using regular expressions containing Unix-style path separators, which caused errors when trying to package the frontend service on a Windows platform.