### PR TITLE
GVT-1954 Remove button pressing wait

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/Button.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/Button.kt
@@ -9,8 +9,6 @@ class Button(fetch: () -> WebElement) : PageModel(fetch) {
     fun click() {
         logger.info("Click button '${webElement.text}'")
         webElement.waitUntilClickable()
-        // TODO: GVT-1947 Check if this is actually needed
-        Thread.sleep(500) //Fixes problems where button cannot be clicked while enabled
         webElement.waitAndClick()
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
@@ -169,7 +169,7 @@ class BasicMapTestUI @Autowired constructor(
         val editedKuvaus = "$orgKuvaus-edited"
         editDialog.editKuvaus(editedKuvaus)
         editDialog.editTila(CreateEditLocationTrackDialog.TilaTyyppi.KAYTOSTA_POISTETTU)
-        editDialog.tallenna()
+        editDialog.tallenna().close()
 
         navigationPanel.locationTracksList.waitUntilNameVisible(editedTunnus)
         val infoboxAfterFirstEdit = toolPanel.locationTrackGeneralInfo()


### PR DESCRIPTION
Näyttäisi lokaaliajojen perusteella siltä, että ainoa tästä odotuksesta saatava etu on, että yhdessä testissä uusi toasti ehtii odotettaessa korvata vanhan, ja siitähän selviää vaan sulkemalla vanhan toastin pois erikseen.