### PR TITLE
GVT-1764: Implement frontend caching for projects

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
@@ -22,6 +22,7 @@ data class CollectedChangeTimes(
     val layoutSwitch: Instant,
     val layoutKmPost: Instant,
     val geometryPlan: Instant,
+    val project: Instant,
     val publication: Instant,
     val ratkoPush: Instant,
     val pvDocument: Instant,
@@ -54,6 +55,7 @@ class ChangeTimeController(
             layoutKmPost = kmPostService.getChangeTime(),
             layoutSwitch = switchService.getChangeTime(),
             geometryPlan = geometryService.getGeometryPlanChangeTime(),
+            project = geometryService.getProjectChangeTime(),
             publication = publicationService.getChangeTime(),
             ratkoPush = ratkoPushDao.getRatkoPushChangeTime(),
             pvDocument = pvDocumentService.getDocumentChangeTime(),
@@ -100,6 +102,13 @@ class ChangeTimeController(
     fun getGeometryPlanChangeTime(): Instant {
         logger.apiCall("getGeometryPlanChangeTime")
         return geometryService.getGeometryPlanChangeTime()
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/projects")
+    fun getProjectChangeTime(): Instant {
+        logger.apiCall("getProjectChangeTime")
+        return geometryService.getProjectChangeTime()
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -22,6 +22,7 @@ import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.*
 import fi.fta.geoviite.infra.util.DbTable.GEOMETRY_PLAN
+import fi.fta.geoviite.infra.util.DbTable.GEOMETRY_PLAN_PROJECT
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -856,6 +857,8 @@ class GeometryDao @Autowired constructor(
         logger.daoAccess(FETCH, Project::class)
         return projects
     }
+
+    fun fetchProjectChangeTime(): Instant = fetchLatestChangeTime(GEOMETRY_PLAN_PROJECT)
 
     fun findAuthor(companyName: MetaDataName): Author? {
         val sql = """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -113,6 +113,11 @@ class GeometryService @Autowired constructor(
         return geometryDao.fetchProjects()
     }
 
+    fun getProjectChangeTime(): Instant {
+        logger.serviceCall("getProjectChangeTime")
+        return geometryDao.fetchProjectChangeTime()
+    }
+
     fun getProject(id: IntId<Project>): Project {
         logger.serviceCall("getProject", "id" to id)
         return geometryDao.getProject(id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -33,6 +33,7 @@ enum class DbTable(schema: String, table: String, sortColumns: List<String> = li
     LAYOUT_TRACK_NUMBER("layout", "track_number"),
 
     GEOMETRY_PLAN("geometry", "plan"),
+    GEOMETRY_PLAN_PROJECT("geometry", "plan_project"),
     GEOMETRY_ALIGNMENT("geometry", "alignment"),
     GEOMETRY_SWITCH("geometry", "switch"),
     GEOMETRY_KM_POST("geometry", "km_post", listOf("track_number_id", "km_number")),

--- a/ui/src/common/change-time-api.ts
+++ b/ui/src/common/change-time-api.ts
@@ -76,6 +76,14 @@ export function updatePlanChangeTime(): Promise<TimeStamp> {
     );
 }
 
+export function updateProjectChangeTime(): Promise<TimeStamp> {
+    return updateChangeTime(
+        `${CHANGES_API}/projects`,
+        delegates.setProjectChangeTime,
+        getChangeTimes().project,
+    );
+}
+
 export function updatePublicationChangeTime(): Promise<TimeStamp> {
     return updateChangeTime(
         `${CHANGES_API}/publications`,

--- a/ui/src/common/common-slice.ts
+++ b/ui/src/common/common-slice.ts
@@ -10,6 +10,7 @@ export type ChangeTimes = {
     layoutSwitch: TimeStamp;
     layoutKmPost: TimeStamp;
     geometryPlan: TimeStamp;
+    project: TimeStamp;
     publication: TimeStamp;
     ratkoPush: TimeStamp;
     pvDocument: TimeStamp;
@@ -23,6 +24,7 @@ export const initialChangeTimes: ChangeTimes = {
     layoutSwitch: initialChangeTime,
     layoutKmPost: initialChangeTime,
     geometryPlan: initialChangeTime,
+    project: initialChangeTime,
     publication: initialChangeTime,
     ratkoPush: initialChangeTime,
     pvDocument: initialChangeTime,
@@ -94,6 +96,12 @@ const commonSlice = createSlice({
             { payload }: PayloadAction<TimeStamp>,
         ) {
             updateChangeTime(changeTimes, 'geometryPlan', payload);
+        },
+        setProjectChangeTime: function (
+            { changeTimes }: CommonState,
+            { payload }: PayloadAction<TimeStamp>,
+        ) {
+            updateChangeTime(changeTimes, 'project', payload);
         },
         setPublicationChangeTime: function (
             { changeTimes }: CommonState,

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -275,9 +275,7 @@ export async function getTrackLayoutPlans(
     ).then((plans) => plans.filter(filterNotEmpty));
 }
 
-export async function getProjects(): Promise<Project[]> {
-    const changeTime = getChangeTimes().project;
-
+export async function getProjects(changeTime = getChangeTimes().project): Promise<Project[]> {
     return projectCache.get(changeTime, undefined, () =>
         getThrowError<Project[]>(`${GEOMETRY_URI}/projects`),
     );

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -50,6 +50,8 @@ const trackLayoutPlanCache = asyncCache<GeometryPlanId, GeometryPlanLayout | nul
 const geometryPlanCache = asyncCache<GeometryPlanId, GeometryPlan | null>();
 const geometryPlanAreaCache = asyncCache<GeometryPlanId, PlanArea[]>();
 
+const projectCache = asyncCache<undefined, Project[]>();
+
 type PlanVerticalGeometryKey = GeometryPlanId;
 const planVerticalGeometryCache = asyncCache<
     PlanVerticalGeometryKey,
@@ -273,12 +275,22 @@ export async function getTrackLayoutPlans(
     ).then((plans) => plans.filter(filterNotEmpty));
 }
 
-export async function fetchProjects(): Promise<Project[]> {
-    return await getThrowError<Project[]>(`${GEOMETRY_URI}/projects`);
+export async function getProjects(): Promise<Project[]> {
+    const changeTime = getChangeTimes().project;
+
+    return projectCache.get(changeTime, undefined, () =>
+        getThrowError<Project[]>(`${GEOMETRY_URI}/projects`),
+    );
 }
 
 export async function getProject(id: ProjectId): Promise<Project> {
-    return await getThrowError<Project>(`${GEOMETRY_URI}/projects/${id}`);
+    return getProjects().then((projects) => {
+        const project = projects.find((project) => project.id === id);
+        if (!project) {
+            throw new Error(`Couldn't find project ${id}`);
+        }
+        return project;
+    });
 }
 
 export async function createProject(project: Project): Promise<Project | null> {

--- a/ui/src/infra-model/view/dialogs/new-project-dialog.tsx
+++ b/ui/src/infra-model/view/dialogs/new-project-dialog.tsx
@@ -9,7 +9,7 @@ import { TextField } from 'vayla-design-lib/text-field/text-field';
 import { useTranslation } from 'react-i18next';
 import { Project } from 'geometry/geometry-model';
 import { debounce } from 'ts-debounce';
-import { createProject, fetchProjects } from 'geometry/geometry-api';
+import { createProject, getProjects } from 'geometry/geometry-api';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { isEqualWithoutWhitespace } from 'utils/string-utils';
 import { useLoader } from 'utils/react-utils';
@@ -25,7 +25,7 @@ export const NewProjectDialog: React.FC<NewProjectDialogProps> = ({ onClose, onS
     const [canSave, setCanSave] = React.useState<boolean>(false);
     const [duplicateName, setDuplicateName] = React.useState<boolean>(false);
     const [saveInProgress, setSaveInProgress] = React.useState<boolean>(false);
-    const projects = useLoader(fetchProjects, []);
+    const projects = useLoader(getProjects, []);
 
     const debouncer = React.useCallback(
         debounce((newName: string) => {

--- a/ui/src/infra-model/view/form/fields/infra-model-project-field.tsx
+++ b/ui/src/infra-model/view/form/fields/infra-model-project-field.tsx
@@ -5,7 +5,7 @@ import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { ProjectId } from 'geometry/geometry-model';
 import { useTranslation } from 'react-i18next';
-import { fetchProjects } from 'geometry/geometry-api';
+import { getProjects } from 'geometry/geometry-api';
 
 type ProjectDropdownProps = {
     id: ProjectId;
@@ -19,7 +19,7 @@ export const ProjectDropdown: React.FC<ProjectDropdownProps> = ({
     onAddProject,
 }) => {
     const { t } = useTranslation();
-    const [projects, projectLoaderStatus] = useLoaderWithStatus(fetchProjects, [id]);
+    const [projects, projectLoaderStatus] = useLoaderWithStatus(getProjects, [id]);
     return projectLoaderStatus != LoaderStatus.Ready ? (
         <Spinner />
     ) : (

--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -38,7 +38,11 @@ import CoordinateSystemView from 'geoviite-design-lib/coordinate-system/coordina
 import { filterNotEmpty } from 'utils/array-utils';
 import { getTrackNumbers } from 'track-layout/layout-track-number-api';
 import { TrackNumberEditDialogContainer } from 'tool-panel/track-number/dialog/track-number-edit-dialog';
-import { updateReferenceLineChangeTime, updateTrackNumberChangeTime } from 'common/change-time-api';
+import {
+    updateReferenceLineChangeTime,
+    updateTrackNumberChangeTime,
+    updateProjectChangeTime,
+} from 'common/change-time-api';
 import { OnSelectFunction } from 'selection/selection-model';
 import { ProjectDropdown } from 'infra-model/view/form/fields/infra-model-project-field';
 import { ChangeTimes } from 'common/common-slice';
@@ -550,6 +554,7 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                     onSave={(project) => {
                         setShowNewProjectDialog(false);
                         changeInOverrideParametersField(project.id, 'projectId');
+                        updateProjectChangeTime();
                     }}></NewProjectDialog>
             )}
             {showNewTrackNumberDialog && trackNumberList && (


### PR DESCRIPTION
Previously the whole list of projects was loaded via an API request every time the project selection dropdown was opened in the infra-model edit page. Changes to the list of projects should be rare, so they can be cached client (browser) side instead.

The projects cache will be invalidated immediately upon adding a new project within the local browser and external updates are checked every 15 seconds also for the projects cache. If the projects cache is invalidated, the whole list of projects will be loaded from the API to the cache once again.

Similarly it is unnecessary to fetch a single project's information from the API if all project data is already cached in the browser. The `getProject`-function that is responsible for fetching a single project's data was refactored to use the cached list of projects, although this could be further improved by caching also each individual result as well (due to `.find(...)` having linear time complexity).

The previously used `fetchProjects`-function was renamed to `getProjects` as this seems to be the more common naming scheme within the ui-codebase. Usage of this function was modified accordingly.