### PR TITLE
GVT-2011: Ratanumeron alkuosoitteen muuttaminen ei päivity toolpaneeliin automaattisesti

### DIFF
--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -69,7 +69,11 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
     onHighlightItem,
 }: TrackNumberInfoboxProps) => {
     const { t } = useTranslation();
-    const startAndEndPoints = useReferenceLineStartAndEnd(referenceLine?.id, publishType);
+    const startAndEndPoints = useReferenceLineStartAndEnd(
+        referenceLine?.id,
+        publishType,
+        referenceLineChangeTime,
+    );
     const coordinateSystem = useCoordinateSystem(LAYOUT_SRID);
     const changeTimes = useReferenceLineChangeTimes(referenceLine?.id);
     const [showEditDialog, setShowEditDialog] = React.useState(false);

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -186,10 +186,11 @@ export function useTrackNumbersIncludingDeleted(
 export function useReferenceLineStartAndEnd(
     id: ReferenceLineId | undefined,
     publishType: PublishType | undefined,
+    changeTime: TimeStamp | undefined = undefined,
 ): AlignmentStartAndEnd | undefined {
     return useLoader(
         () => (id && publishType ? getReferenceLineStartAndEnd(id, publishType) : undefined),
-        [id, publishType],
+        [id, publishType, changeTime],
     );
 }
 


### PR DESCRIPTION
Yksinkertaisuudessaan tästä hausta puuttui muutosajan käyttäminen depsuna. Ka. depsu lisätty optionaalisena, sillä tuota hakua käytetään myös muutosdialogissa arvon hakemiseen, ja  järkeilin ettäsen auki ollessa ei haluttane että kenttien muuttuvat siellä