### PR TITLE
GVT-2001: Vaihteen Lokitiedot-infoboksi on tyhjä

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -138,4 +138,11 @@ class LayoutKmPostController(
         logger.apiCall("deleteDraftKmPost", "kmPostId" to kmPostId)
         return kmPostService.deleteUnpublishedDraft(kmPostId).id
     }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/{id}/change-times")
+    fun getKmPostChangeTimes(@PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>): ChangeTimes {
+        logger.apiCall("getKmPostChangeTimes", "id" to kmPostId)
+        return kmPostService.getChangeTimes(kmPostId)
+    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -123,4 +123,11 @@ class LayoutSwitchController(
         logger.apiCall("deleteDraftSwitch", "switchId" to switchId)
         return switchService.deleteDraftSwitch(switchId)
     }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/{id}/change-times")
+    fun getSwitchChangeTimes(@PathVariable("id") switchId: IntId<TrackLayoutSwitch>): ChangeTimes {
+        logger.apiCall("getSwitchChangeTimes", "id" to switchId)
+        return switchService.getChangeTimes(switchId)
+    }
 }

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -16,6 +16,8 @@ import { useLoader } from 'utils/react-utils';
 import { TrackNumberLinkContainer } from 'geoviite-design-lib/track-number/track-number-link';
 import { AssetValidationInfoboxContainer } from 'tool-panel/asset-validation-infobox-container';
 import { KmPostInfoboxVisibilities } from 'track-layout/track-layout-slice';
+import { useKmPostChangeTimes } from 'track-layout/track-layout-react-utils';
+import { formatDateShort } from 'utils/date-utils';
 
 type KmPostInfoboxProps = {
     publishType: PublishType;
@@ -45,6 +47,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
         () => getKmPost(kmPost.id, publishType),
         [kmPost, kmPostChangeTime, publishType],
     );
+    const changeTimes = useKmPostChangeTimes(kmPost.id);
 
     function isOfficial(): boolean {
         return publishType === 'OFFICIAL';
@@ -145,6 +148,18 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                 contentVisible={visibilities.log}
                 onContentVisibilityChange={() => visibilityChange('log')}>
                 <InfoboxContent>
+                    {changeTimes && (
+                        <React.Fragment>
+                            <InfoboxField
+                                label={t('tool-panel.created')}
+                                value={formatDateShort(changeTimes.created)}
+                            />
+                            <InfoboxField
+                                label={t('tool-panel.changed')}
+                                value={formatDateShort(changeTimes.changed)}
+                            />
+                        </React.Fragment>
+                    )}
                     {kmPost?.draftType === 'NEW_DRAFT' && (
                         <InfoboxButtons>
                             <Button

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -402,11 +402,11 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     qa-id="location-track-log-infobox">
                     <InfoboxContent>
                         <InfoboxField
-                            label={t('tool-panel.location-track.created')}
+                            label={t('tool-panel.created')}
                             value={formatDateShort(changeTimes.created)}
                         />
                         <InfoboxField
-                            label={t('tool-panel.location-track.changed')}
+                            label={t('tool-panel.changed')}
                             value={formatDateShort(changeTimes.changed)}
                         />
                         {officialLocationTrack === undefined && (

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -40,6 +40,8 @@ import { AssetValidationInfoboxContainer } from 'tool-panel/asset-validation-inf
 import { ChangeTimes } from 'common/common-slice';
 import { SwitchInfoboxVisibilities } from 'track-layout/track-layout-slice';
 import { WriteAccessRequired } from 'user/write-access-required';
+import { formatDateShort } from 'utils/date-utils';
+import { useSwitchChangeTimes } from 'track-layout/track-layout-react-utils';
 
 type SwitchInfoboxProps = {
     switchId: LayoutSwitchId;
@@ -144,6 +146,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
         () => getSwitchJointConnections(publishType, switchId),
         [publishType, layoutSwitch],
     );
+    const switchChangeTimes = useSwitchChangeTimes(layoutSwitch?.id);
 
     const switchJointTrackMeters = useLoader(() => {
         return switchJointConnections
@@ -341,6 +344,18 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                 title={t('tool-panel.switch.layout.change-info-heading')}
                 qa-id="switch-heading-infobox">
                 <InfoboxContent>
+                    {switchChangeTimes && (
+                        <React.Fragment>
+                            <InfoboxField
+                                label={t('tool-panel.created')}
+                                value={formatDateShort(switchChangeTimes.created)}
+                            />
+                            <InfoboxField
+                                label={t('tool-panel.changed')}
+                                value={formatDateShort(switchChangeTimes.changed)}
+                            />
+                        </React.Fragment>
+                    )}
                     {layoutSwitch?.draftType === 'NEW_DRAFT' && (
                         <InfoboxButtons>
                             <Button

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -293,11 +293,11 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                     qa-id="track-number-log-infobox">
                     <InfoboxContent>
                         <InfoboxField
-                            label={t('tool-panel.reference-line.created')}
+                            label={t('tool-panel.created')}
                             value={formatDateShort(changeTimes.created)}
                         />
                         <InfoboxField
-                            label={t('tool-panel.reference-line.changed')}
+                            label={t('tool-panel.changed')}
                             value={formatDateShort(changeTimes.changed)}
                         />
                         {isDeletable && (

--- a/ui/src/tool-panel/translations.fi.json
+++ b/ui/src/tool-panel/translations.fi.json
@@ -138,8 +138,6 @@
             "true-length": "Todellinen pituus (m)",
             "start-coordinates": "Alkukoordinaatit",
             "end-coordinates": "Loppukoordinaatit",
-            "created": "Luotu",
-            "changed": "Muokattu",
             "end-points-updated": "Pituusmittauslinjan päätepisteet päivitetty",
             "reference-line-singular": "Pituusmittauslinja",
             "reference-line-plural": "Pituusmittauslinjat"
@@ -202,8 +200,6 @@
             "has-duplicates": "Duplikaattiraiteet",
             "not-a-duplicate": "Ei duplikaatti",
             "change-info-heading": "Lokitiedot",
-            "created": "Luotu",
-            "changed": "Muokattu",
             "type": "Raidetyyppi",
             "identifier": "Tunniste",
             "track-location-heading": "Raiteen sijaintitiedot",
@@ -266,6 +262,8 @@
             "all-ok": "Kaikki OK",
             "errors": "Virheet",
             "warnings": "Varoitukset"
-        }
+        },
+        "created": "Luotu",
+        "changed": "Muokattu"
     }
 }

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -5,7 +5,7 @@ import {
     LayoutKmPostId,
     LayoutTrackNumberId,
 } from 'track-layout/track-layout-model';
-import { KmNumber, PublishType, TimeStamp } from 'common/common-model';
+import { ChangeTimes, KmNumber, PublishType, TimeStamp } from 'common/common-model';
 import {
     deleteAdt,
     getAdt,
@@ -15,7 +15,7 @@ import {
     putAdt,
     queryParams,
 } from 'api/api-fetch';
-import { layoutUri } from 'track-layout/track-layout-api';
+import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
 import { getChangeTimes, updateKmPostChangeTime } from 'common/change-time-api';
 import { BoundingBox, Point } from 'model/geometry';
 import { bboxString, pointString } from 'common/common-api';
@@ -199,3 +199,6 @@ export const getKmLengthsAsCsv = (
 
     return `${layoutUri('track-numbers', publishType, trackNumberId)}/km-lengths/as-csv${params}`;
 };
+
+export const getKmPostChangeTimes = (id: LayoutKmPostId) =>
+    getIgnoreError<ChangeTimes>(changeTimeUri('km-posts', id));

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -1,5 +1,5 @@
 import { BoundingBox, Point } from 'model/geometry';
-import { PublishType, TimeStamp } from 'common/common-model';
+import { ChangeTimes, PublishType, TimeStamp } from 'common/common-model';
 import {
     LayoutSwitch,
     LayoutSwitchId,
@@ -7,13 +7,14 @@ import {
 } from 'track-layout/track-layout-model';
 import {
     deleteIgnoreError,
+    getIgnoreError,
     getThrowError,
     getWithDefault,
     postAdt,
     putAdt,
     queryParams,
 } from 'api/api-fetch';
-import { layoutUri } from 'track-layout/track-layout-api';
+import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
 import { bboxString, pointString } from 'common/common-api';
 import { getChangeTimes, updateSwitchChangeTime } from 'common/change-time-api';
 import { asyncCache } from 'cache/cache';
@@ -163,3 +164,7 @@ export async function getSwitchValidation(
 ): Promise<ValidatedAsset> {
     return getThrowError<ValidatedAsset>(`${layoutUri('switches', publishType, id)}/validation`);
 }
+
+export const getSwitchChangeTimes = (id: LayoutSwitchId): Promise<ChangeTimes | null> => {
+    return getIgnoreError<ChangeTimes>(changeTimeUri('switches', id));
+};

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -39,9 +39,9 @@ import {
     getLocationTracks,
     getLocationTrackStartAndEnd,
 } from 'track-layout/layout-location-track-api';
-import { getSwitch, getSwitches } from 'track-layout/layout-switch-api';
+import { getSwitch, getSwitchChangeTimes, getSwitches } from 'track-layout/layout-switch-api';
 import { getTrackNumberById, getTrackNumbers } from 'track-layout/layout-track-number-api';
-import { getKmPost, getKmPosts } from 'track-layout/layout-km-post-api';
+import { getKmPost, getKmPostChangeTimes, getKmPosts } from 'track-layout/layout-km-post-api';
 import { PVDocumentHeader, PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { getPVDocument } from 'infra-model/infra-model-api';
 
@@ -221,6 +221,14 @@ export function useLocationTrackChangeTimes(
     id: LocationTrackId | undefined,
 ): ChangeTimes | undefined {
     return useNullableLoader(() => (id ? getLocationTrackChangeTimes(id) : undefined), [id]);
+}
+
+export function useSwitchChangeTimes(id: LayoutSwitchId | undefined): ChangeTimes | undefined {
+    return useNullableLoader(() => (id ? getSwitchChangeTimes(id) : undefined), [id]);
+}
+
+export function useKmPostChangeTimes(id: LayoutKmPostId | undefined): ChangeTimes | undefined {
+    return useNullableLoader(() => (id ? getKmPostChangeTimes(id) : undefined), [id]);
 }
 
 export function useCoordinateSystem(srid: Srid): CoordinateSystem | undefined {


### PR DESCRIPTION
Lisätty samalla myös paikannuspohjan kilometripylväille, sillä niiltäkin puuttui.