### PR TITLE
GVT-2005: Pituusgeometriakaavion zoomaaminen käyttäytyy väärin ikkunan resizaamisen jälkeen

### DIFF
--- a/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
@@ -186,19 +186,6 @@ export const VerticalGeometryDiagramHolder: React.FC<VerticalGeometryDiagramHold
         onResize: ({ width, height }) => {
             setDiagramWidth(width ?? 0);
             setDiagramHeight(height ?? 0);
-
-            if (
-                width === undefined ||
-                visibleStartM === undefined ||
-                visibleEndM === undefined ||
-                diagramWidth === undefined
-            ) {
-                return;
-            }
-
-            const oldWidthRelativeEndM =
-                visibleStartM + (visibleEndM - visibleStartM) * (width / diagramWidth);
-            setEndM(endM ? Math.min(oldWidthRelativeEndM, endM) : oldWidthRelativeEndM);
         },
     });
 


### PR DESCRIPTION
Pitkällisen debuggaamisen lopputuloksena selvisi, että syntipukkina oli wanha logiikka, jolla pääteltiin ettei kaavio saa piirtyä yli rajojensa kun kaavion leveys kasvaa. Ka. tilanne tarkastellaan nykyään myös jossain muualla, niin poistin tämän ongelmallisen logiikan.