### PR TITLE
GVT-1951: Add support for downloading the entire track network's vertical geometry

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.SwitchName
 const val ELEMENT_LISTING = "Elementtilistaus"
 const val ELEMENT_LISTING_ENTIRE_RAIL_NETWORK = "$ELEMENT_LISTING (koko rataverkko)"
 const val VERTICAL_GEOMETRY = "Pystygeometria"
+const val VERTICAL_GEOMETRY_ENTIRE_RAIL_NETWORK = "$VERTICAL_GEOMETRY (koko rataverkko)"
 const val VERTICAL_SECTIONS_OVERLAP = "Kaltevuusjakso on limittäin toisen jakson kanssa"
 const val IS_PARTIAL = "Raide sisältää vain osan geometriaelementistä"
 val connectedToSwitch = { switchName: SwitchName -> "Vaihteen $switchName elementti" }
@@ -69,6 +70,7 @@ fun translateTrackGeometryElementType(type: TrackGeometryElementType) =
     }
 
 enum class VerticalGeometryListingHeader {
+    TRACK_NUMBER,
     PLAN_NAME,
     LOCATION_TRACK,
     CREATION_DATE,
@@ -103,6 +105,7 @@ enum class VerticalGeometryListingHeader {
 
 fun translateVerticalGeometryListingHeader(header: VerticalGeometryListingHeader) =
     when (header) {
+        VerticalGeometryListingHeader.TRACK_NUMBER -> "Ratanumero"
         VerticalGeometryListingHeader.PLAN_NAME -> "Suunnitelma"
         VerticalGeometryListingHeader.LOCATION_TRACK -> "Sijaintiraide"
         VerticalGeometryListingHeader.PLAN_TRACK -> "Suunnitelman raide"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -272,6 +272,20 @@ class GeometryController @Autowired constructor(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/rail-network/vertical-geometry/file")
+    fun getEntireNetworkVerticalGeometryListingCSV(): ResponseEntity<ByteArray> {
+        log.apiCall("getEntireNetworkVerticalGeometryListingCSV")
+        val verticalGeometryListingFile = geometryService.getEntireVerticalGeometryListingCsv()
+        return verticalGeometryListingFile?.let {
+            toFileDownloadResponse(
+                verticalGeometryListingFile.name.withSuffix(CSV),
+                verticalGeometryListingFile.content.toByteArray(Charsets.UTF_8)
+            )
+        }
+            ?: ResponseEntity(HttpStatus.NO_CONTENT)
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/plans/{planId}/start-and-end/{planAlignmentId}")
     fun getPlanAlignmentStartAndEnd(
         @PathVariable("planId") planId: IntId<GeometryPlan>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -375,7 +375,7 @@ class GeometryService @Autowired constructor(
                 { locationTrack -> locationTrack.name },
             ))
             .flatMap { locationTrack ->
-                val verticalGeometryListingWithoutTrackNumbers = getVerticalGeometryListing(OFFICIAL, locationTrack.id as IntId<LocationTrack>, null, null)
+                val verticalGeometryListingWithoutTrackNumbers = getVerticalGeometryListing(OFFICIAL, locationTrack.id as IntId, null, null)
 
                 verticalGeometryListingWithoutTrackNumbers.map { verticalGeometryListing ->
                     verticalGeometryListing.copy(trackNumber = trackNumberAndGeocodingContextCache[locationTrack.trackNumberId]?.first?.number)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -362,7 +362,7 @@ class GeometryService @Autowired constructor(
     }
 
     @Scheduled(
-        cron = "\${geoviite.rail-network-export.schedule}"
+        cron = "\${geoviite.rail-network-export.vertical-geometry-schedule}"
     )
     fun makeEntireVerticalGeometryListingCsv() = runVerticalGeometryListGeneration {
         logger.serviceCall("makeVerticalGeometryListingCsv")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -370,8 +370,10 @@ class GeometryService @Autowired constructor(
             tn.id to (tn to geocodingService.getGeocodingContext(OFFICIAL, tn.id))
         }
         val verticalGeometryListingWithTrackNumbers = locationTrackService.list(OFFICIAL, includeDeleted = false)
-            .sortedBy { locationTrack -> locationTrack.name }
-            .sortedBy { locationTrack -> trackNumberAndGeocodingContextCache[locationTrack.trackNumberId]?.first?.number }
+            .sortedWith(compareBy(
+                { locationTrack -> trackNumberAndGeocodingContextCache[locationTrack.trackNumberId]?.first?.number },
+                { locationTrack -> locationTrack.name },
+            ))
             .flatMap { locationTrack ->
                 val verticalGeometryListingWithoutTrackNumbers = getVerticalGeometryListing(OFFICIAL, locationTrack.id as IntId<LocationTrack>, null, null)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
@@ -85,6 +85,8 @@ data class VerticalGeometryListing(
     val layoutStartStation: Double? = null,
     val layoutPointStation: Double? = null,
     val layoutEndStation: Double? = null,
+
+    val trackNumber: TrackNumber? = null,
 )
 
 fun toVerticalGeometryListing(
@@ -324,8 +326,16 @@ fun toVerticalGeometryListing(
 fun locationTrackVerticalGeometryListingToCsv(listing: List<VerticalGeometryListing>) =
     printCsv(listOf(locationTrackCsvEntry) + commonVerticalGeometryListingCsvEntries, listing)
 
+fun entireTrackNetworkVerticalGeometryListingToCsv(listing: List<VerticalGeometryListing>) =
+    printCsv(listOf(trackNumberCsvEntry, locationTrackCsvEntry) + commonVerticalGeometryListingCsvEntries, listing)
+
 fun planVerticalGeometryListingToCsv(listing: List<VerticalGeometryListing>) =
     printCsv(commonVerticalGeometryListingCsvEntries.toList(), listing)
+
+private val trackNumberCsvEntry =
+    CsvEntry<VerticalGeometryListing>(translateVerticalGeometryListingHeader(VerticalGeometryListingHeader.TRACK_NUMBER)) {
+       verticalGeometryListing -> verticalGeometryListing.trackNumber ?: ""
+    }
 
 private val locationTrackCsvEntry =
     CsvEntry<VerticalGeometryListing>(translateVerticalGeometryListingHeader(VerticalGeometryListingHeader.LOCATION_TRACK)) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDao.kt
@@ -67,8 +67,8 @@ class VerticalGeometryListingFileDao @Autowired constructor(
             select max(change_time) change_time 
             from layout.vertical_geometry_listing_file
         """.trimIndent()
-        return jdbcTemplate.query(sql, mapOf<String,Any>()) { rs, _ -> rs.getInstantOrNull("change_time") }
+
+        return jdbcTemplate.queryOne(sql) { rs , _ -> rs.getInstantOrNull("change_time") ?: Instant.EPOCH }
             .also { logger.daoAccess(AccessType.FETCH, "${VerticalGeometryListingFile::class.simpleName}.changeTime") }
-            .firstOrNull() ?: Instant.EPOCH
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDao.kt
@@ -1,0 +1,74 @@
+package fi.fta.geoviite.infra.geometry
+
+import fi.fta.geoviite.infra.logging.AccessType
+import fi.fta.geoviite.infra.logging.daoAccess
+import fi.fta.geoviite.infra.util.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+data class VerticalGeometryListingFile(val name: FileName, val content: String)
+
+@Transactional(readOnly = true)
+@Component
+class VerticalGeometryListingFileDao @Autowired constructor(
+    jdbcTemplateParam: NamedParameterJdbcTemplate?,
+) : DaoBase(jdbcTemplateParam) {
+
+    @Transactional
+    fun upsertVerticalGeometryListingFile(file: VerticalGeometryListingFile) {
+        val sql = """
+            insert into layout.vertical_geometry_listing_file(
+              name,
+              content,
+              change_time,
+              change_user
+            )
+            values (
+              :name,
+              :content,
+              now(),
+              current_setting('geoviite.edit_user')
+            )
+            on conflict (id) do update set 
+              name = :name,
+              content = :content,
+              change_time = now(),
+              change_user = current_setting('geoviite.edit_user')
+        """.trimIndent()
+        val params = mapOf(
+            "name" to file.name,
+            "content" to file.content,
+        )
+        jdbcTemplate.setUser()
+        jdbcTemplate.update(sql, params).also {
+            logger.daoAccess(AccessType.UPSERT, VerticalGeometryListingFile::class, file.name)
+        }
+    }
+
+    fun getVerticalGeometryListingFile(): VerticalGeometryListingFile? {
+        val sql = """
+            select name, content
+            from layout.vertical_geometry_listing_file
+            where id = 1
+        """.trimIndent()
+        return jdbcTemplate.query(sql, mapOf<String,Any>()) { rs, _ -> VerticalGeometryListingFile(
+            name = rs.getFileName("name"),
+            content = rs.getString("content"),
+        ) }
+            .firstOrNull()
+            .also { file -> logger.daoAccess(AccessType.FETCH, VerticalGeometryListingFile::class, "${file?.name}") }
+    }
+
+    fun getLastFileListingTime(): Instant {
+        val sql = """
+            select max(change_time) change_time 
+            from layout.vertical_geometry_listing_file
+        """.trimIndent()
+        return jdbcTemplate.query(sql, mapOf<String,Any>()) { rs, _ -> rs.getInstantOrNull("change_time") }
+            .also { logger.daoAccess(AccessType.FETCH, "${VerticalGeometryListingFile::class.simpleName}.changeTime") }
+            .firstOrNull() ?: Instant.EPOCH
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/LockDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/LockDao.kt
@@ -10,6 +10,7 @@ enum class DatabaseLock {
     PUBLICATION,
     RATKO,
     ELEMENT_LIST_GEN,
+    VERTICAL_GEOMETRY_LIST_GEN,
     PROJEKTIVELHO
 }
 

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -67,3 +67,4 @@ geoviite:
       rate: "PT15M"
   rail-network-export:
     schedule: "0 0 3 * * *"
+    vertical-geometry-schedule: "0 0 4 * * *"

--- a/infra/src/main/resources/db/migration/prod/V44__add_vertical_geometry_listing_file_table.sql
+++ b/infra/src/main/resources/db/migration/prod/V44__add_vertical_geometry_listing_file_table.sql
@@ -1,0 +1,8 @@
+create table layout.vertical_geometry_listing_file
+(
+  id          int primary key generated always as (1) stored,
+  name        varchar(100) not null,
+  content     varchar      not null,
+  change_time timestamptz  not null,
+  change_user varchar(30)  not null
+);

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDaoIT.kt
@@ -1,0 +1,57 @@
+package fi.fta.geoviite.infra.geometry
+
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.util.FileName
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class VerticalGeometryListingFileDaoIT @Autowired constructor(
+    private val verticalGeometryListingFileDao: VerticalGeometryListingFileDao,
+): DBTestBase() {
+
+    @BeforeEach
+    fun setUp() {
+        jdbc.update("delete from layout.vertical_geometry_listing_file where id = 1", mapOf<String, Any>())
+    }
+
+    @Test
+    fun `Entire track network vertical geometry file is correctly upserted and fetched`() {
+        assertNull(verticalGeometryListingFileDao.getVerticalGeometryListingFile())
+        assertEquals(Instant.EPOCH, verticalGeometryListingFileDao.getLastFileListingTime())
+
+        val originalFile = VerticalGeometryListingFile(
+            name = FileName("vertical geometry test file name 1"),
+            content = """
+                vert_geom_header1, vert_geom_header2, vert_geom_header3
+                vert_geom_col1_val1, vert_geom_col2_val1, vert_geom_col3_val1
+                vert_geom_col1_val2, vert_geom_col2_val2, vert_geom_col3_val2
+            """.trimIndent()
+        )
+        verticalGeometryListingFileDao.upsertVerticalGeometryListingFile(originalFile)
+        assertEquals(originalFile, verticalGeometryListingFileDao.getVerticalGeometryListingFile())
+        val originalChangeTime = verticalGeometryListingFileDao.getLastFileListingTime()
+        assertTrue(originalChangeTime > Instant.EPOCH)
+
+        val updatedFile = VerticalGeometryListingFile(
+            name = FileName("vertical geometry test file name 2"),
+            content = """
+                vert_geom_header1, vert_geom_header2, vert_geom_header3
+                vert_geom_col1_val1_new, vert_geom_col2_val1_new, vert_geom_col3_val1_new
+                vert_geom_col1_val2_new, vert_geom_col2_val2_new, vert_geom_col3_val2_new
+            """.trimIndent()
+        )
+        verticalGeometryListingFileDao.upsertVerticalGeometryListingFile(updatedFile)
+        assertEquals(updatedFile, verticalGeometryListingFileDao.getVerticalGeometryListingFile())
+        val updatedChangeTime = verticalGeometryListingFileDao.getLastFileListingTime()
+        assertTrue(updatedChangeTime > originalChangeTime)
+    }
+}

--- a/ui/src/data-products/data-product-view.scss
+++ b/ui/src/data-products/data-product-view.scss
@@ -45,7 +45,8 @@
     margin-right: 24px;
 }
 
-.element-list__download-button--left-aligned {
+.element-list__download-button--left-aligned,
+.vertical-geometry-list__download-button--left-aligned {
     margin-top: 22px;
     margin-right: 24px;
 }

--- a/ui/src/data-products/translations.fi.json
+++ b/ui/src/data-products/translations.fi.json
@@ -72,6 +72,9 @@
             "location-track-search-legend": "Raiteen pystygeometria näyttää luettelossa paikannuspohjan raiteeseen liityvät taitepisteet. Paikannuspohjan raide voi olla koostettu useasta suunnitelmasta, eikä täysin vastaa sitä suunnitelmakokonaisuutta, jonka mukaan raide on rakennettu, joten luettelon tietoja on syytä pitää epäluotettavina. Luettelon tietoja voi käyttää esim. kokonaiskuvan hahmottamiseen tai ongelmien selvittämiseen, mutta niitä ei pidä käyttää esim. tukemiskoneen työn lähtötietona.",
             "plan-search-legend": "Suunnitelman pystygeometria näyttää luettelossa suunnitelman sisältämät taitepisteet. Rataosoiteet on laskettu paikannuspohjan pituusmittauksen mukaan, joten rataosoitteiden tarkkuutta on syytä pitää epäluotettavana. Myös  paikannuspalvelun suunnitelmien elementtien tietoja on syytä pitää epäluotettavina, joten niitä ei pidä käyttää esim. tukemiskoneen työn lähtötietona.",
             "overlaps-another": "Kaltevuusjakso on limittäin toisen jakson kanssa",
+            "entire-rail-network-vertical-geometry": "Koko rataverkon pystygeometria",
+            "entire-rail-network-vertical-geometry-legend": "Koko rataverkon pystygeometria on luettelo kaikkien paikannuspohjan raiteiden kaikista taitepisteistä. Paikannuspohjan raiteet voivat olla koostettu useasta suunnitelmasta, eivätkä täysin vastaa sitä suunnitelmakokonaisuutta, jonka mukaan raiteet on maastoon rakennettu, joten luettelon tietoja on syytä pitää epäluotettavina. Luettelon tietoja voi käyttää esim. kokonaiskuvan hahmottamiseen tai ongelmien selvittämiseen, mutta niitä ei pidä käyttää esim. tukemistyön lähtötietona.",
+            "entire-rail-network-length-warning": "Koska koko rataverkon aineisto on laaja, se tuotetaan vain kerran vuorokaudessa.",
             "unknown": "Ei tiedossa",
             "table": {
                 "location-track": "Sijaintiraide",

--- a/ui/src/data-products/vertical-geometry/entire-rail-network-vertical-geometry-listing.tsx
+++ b/ui/src/data-products/vertical-geometry/entire-rail-network-vertical-geometry-listing.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from 'data-products/data-product-view.scss';
+import { Button } from 'vayla-design-lib/button/button';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+import { getEntireRailNetworkVerticalGeometryCsvUrl } from 'geometry/geometry-api';
+
+export const EntireRailNetworkVerticalGeometryListing = () => {
+    const { t } = useTranslation();
+
+    return (
+        <React.Fragment>
+            <p className={styles['data-product__search-legend']}>
+                {t('data-products.vertical-geometry.entire-rail-network-vertical-geometry-legend')}
+            </p>
+            <p className={styles['data-product__search-legend']}>
+                {t('data-products.vertical-geometry.entire-rail-network-length-warning')}
+            </p>
+            <div className={styles['data-products__search']}>
+                <Button
+                    className={styles['vertical-geometry-list__download-button--left-aligned']}
+                    onClick={() => (location.href = getEntireRailNetworkVerticalGeometryCsvUrl())}
+                    icon={Icons.Download}>
+                    {t(`data-products.search.download-csv`)}
+                </Button>
+            </div>
+        </React.Fragment>
+    );
+};

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
@@ -8,6 +8,7 @@ import { useDataProductsAppSelector } from 'store/hooks';
 import { createDelegates } from 'store/store-utils';
 import { VerticalGeometryTable } from 'data-products/vertical-geometry/vertical-geometry-table';
 import { dataProductsActions, SelectedGeometrySearch } from 'data-products/data-products-slice';
+import { EntireRailNetworkVerticalGeometryListing } from 'data-products/vertical-geometry/entire-rail-network-vertical-geometry-listing';
 
 const VerticalGeometryView = () => {
     const dataProductsDelegates = React.useMemo(() => createDelegates(dataProductsActions), []);
@@ -36,6 +37,13 @@ const VerticalGeometryView = () => {
                             checked={state.selectedSearch === 'PLAN'}>
                             {t('data-products.vertical-geometry.plan-vertical-geometry')}
                         </Radio>
+                        <Radio
+                            onChange={() => handleRadioClick('ENTIRE_RAIL_NETWORK')}
+                            checked={state.selectedSearch === 'ENTIRE_RAIL_NETWORK'}>
+                            {t(
+                                'data-products.vertical-geometry.entire-rail-network-vertical-geometry',
+                            )}
+                        </Radio>
                     </span>
                 </div>
                 {state.selectedSearch === 'LOCATION_TRACK' && (
@@ -60,6 +68,9 @@ const VerticalGeometryView = () => {
                         setVerticalGeometry={dataProductsDelegates.onSetPlanVerticalGeometry}
                         setLoading={setLoading}
                     />
+                )}
+                {state.selectedSearch === 'ENTIRE_RAIL_NETWORK' && (
+                    <EntireRailNetworkVerticalGeometryListing />
                 )}
             </div>
             {state.selectedSearch !== 'ENTIRE_RAIL_NETWORK' && (

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
@@ -7,7 +7,7 @@ import LocationTrackVerticalGeometrySearch from 'data-products/vertical-geometry
 import { useDataProductsAppSelector } from 'store/hooks';
 import { createDelegates } from 'store/store-utils';
 import { VerticalGeometryTable } from 'data-products/vertical-geometry/vertical-geometry-table';
-import { dataProductsActions } from 'data-products/data-products-slice';
+import { dataProductsActions, SelectedGeometrySearch } from 'data-products/data-products-slice';
 
 const VerticalGeometryView = () => {
     const dataProductsDelegates = React.useMemo(() => createDelegates(dataProductsActions), []);
@@ -15,12 +15,9 @@ const VerticalGeometryView = () => {
     const [loading, setLoading] = React.useState(false);
 
     const { t } = useTranslation();
-    const locationTrackSelected = state.selectedSearch === 'LOCATION_TRACK';
 
-    const handleRadioClick = () => {
-        dataProductsDelegates.setSelectedVerticalGeometrySearch(
-            locationTrackSelected ? 'PLAN' : 'LOCATION_TRACK',
-        );
+    const handleRadioClick = (selected: SelectedGeometrySearch) => {
+        dataProductsDelegates.setSelectedVerticalGeometrySearch(selected);
     };
 
     return (
@@ -29,15 +26,19 @@ const VerticalGeometryView = () => {
                 <h2>{t('data-products.vertical-geometry.vertical-geometry-title')}</h2>
                 <div>
                     <span className={styles['data-product-view__radio-layout']}>
-                        <Radio onChange={handleRadioClick} checked={locationTrackSelected}>
+                        <Radio
+                            onChange={() => handleRadioClick('LOCATION_TRACK')}
+                            checked={state.selectedSearch === 'LOCATION_TRACK'}>
                             {t('data-products.vertical-geometry.location-track-vertical-geometry')}
                         </Radio>
-                        <Radio onChange={handleRadioClick} checked={!locationTrackSelected}>
+                        <Radio
+                            onChange={() => handleRadioClick('PLAN')}
+                            checked={state.selectedSearch === 'PLAN'}>
                             {t('data-products.vertical-geometry.plan-vertical-geometry')}
                         </Radio>
                     </span>
                 </div>
-                {locationTrackSelected ? (
+                {state.selectedSearch === 'LOCATION_TRACK' && (
                     <LocationTrackVerticalGeometrySearch
                         state={state.locationTrackSearch}
                         onUpdateProp={
@@ -51,7 +52,8 @@ const VerticalGeometryView = () => {
                         }
                         setLoading={setLoading}
                     />
-                ) : (
+                )}
+                {state.selectedSearch === 'PLAN' && (
                     <PlanVerticalGeometrySearch
                         state={state.planSearch}
                         onUpdateProp={dataProductsDelegates.onUpdatePlanVerticalGeometrySearchProp}
@@ -60,15 +62,17 @@ const VerticalGeometryView = () => {
                     />
                 )}
             </div>
-            <VerticalGeometryTable
-                verticalGeometry={
-                    state.selectedSearch === 'LOCATION_TRACK'
-                        ? state.locationTrackSearch.verticalGeometry
-                        : state.planSearch.verticalGeometry
-                }
-                showLocationTrack={state.selectedSearch === 'LOCATION_TRACK'}
-                isLoading={loading}
-            />
+            {state.selectedSearch !== 'ENTIRE_RAIL_NETWORK' && (
+                <VerticalGeometryTable
+                    verticalGeometry={
+                        state.selectedSearch === 'LOCATION_TRACK'
+                            ? state.locationTrackSearch.verticalGeometry
+                            : state.planSearch.verticalGeometry
+                    }
+                    showLocationTrack={state.selectedSearch === 'LOCATION_TRACK'}
+                    isLoading={loading}
+                />
+            )}
         </div>
     );
 };

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -200,6 +200,9 @@ export const getLocationTrackVerticalGeometryCsv = (
 export const getGeometryPlanVerticalGeometryCsv = (planId: GeometryPlanId) =>
     `${GEOMETRY_URI}/plans/${planId}/vertical-geometry/file`;
 
+export const getEntireRailNetworkVerticalGeometryCsvUrl = () =>
+    `${GEOMETRY_URI}/rail-network/vertical-geometry/file`;
+
 export const getLocationTrackElementsCsv = (
     locationTrackId: LocationTrackId,
     elementTypes: GeometryTypeIncludingMissing[],


### PR DESCRIPTION
Previously downloading the entire track network's horizontal geometry was supported. Given that a user may also want to explore the vertical geometry data in an external application, download support for the entire track network's vertical geometry was deemed useful.