### PR TITLE
GVT-1959 E2E test for front page & Ratko send

### DIFF
--- a/infra/src/main/resources/application-ratkotest.yml
+++ b/infra/src/main/resources/application-ratkotest.yml
@@ -1,0 +1,5 @@
+geoviite:
+  ratko:
+    enabled: true
+    url: http://localhost:12345
+    test-port: 12345

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/SeleniumTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/SeleniumTest.kt
@@ -58,6 +58,7 @@ open class SeleniumTest : DBTestBase(UI_TEST_USER) {
                 "reference_line",
                 "switch",
                 "track_number",
+                "track_number_km",
                 "publication",
             )
         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/frontpage/FrontPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/frontpage/FrontPage.kt
@@ -5,10 +5,15 @@ import org.openqa.selenium.By
 
 class FrontPage : PageModel(By.cssSelector("div.frontpage")) {
 
+    fun openNthPublication(index: Int): PublicationDetails {
+        logger.info("Open publication index=$index")
+        waitChildVisible(By.cssSelector("div.publication-list-item"))
+        childElements(By.cssSelector("div.publication-list-item"))[index].findElement(By.tagName("a")).click()
+        return publicationDetails()
+    }
+
     fun openLatestPublication(): PublicationDetails {
-        logger.info("Open latest publication")
-        clickChild(By.cssSelector("div.publication-list-item__text a"))
-        return PublicationDetails()
+        return openNthPublication(0)
     }
 
     fun publications() = PublicationList()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -1,0 +1,120 @@
+package fi.fta.geoviite.infra.ui.testgroup1
+
+import clickElement
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.TrackNumber
+import fi.fta.geoviite.infra.integration.*
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.publication.PublicationDao
+import fi.fta.geoviite.infra.ratko.FakeRatkoService
+import fi.fta.geoviite.infra.ratko.RatkoPushDao
+import fi.fta.geoviite.infra.ratko.ratkoRouteNumber
+import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.ui.SeleniumTest
+import fi.fta.geoviite.infra.ui.pagemodel.frontpage.FrontPage
+import fi.fta.geoviite.infra.ui.testdata.createTrackLayoutTrackNumber
+import fi.fta.geoviite.infra.ui.util.byQaId
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+@ActiveProfiles("dev", "test", "e2e")
+@SpringBootTest
+class FrontPageTestUI @Autowired constructor(
+    private val trackNumberDao: LayoutTrackNumberDao,
+    private val referenceLineDao: ReferenceLineDao,
+    private val alignmentDao: LayoutAlignmentDao,
+    private val publicationDao: PublicationDao,
+    private val fakeRatkoService: FakeRatkoService,
+    private val ratkoPushDao: RatkoPushDao,
+) : SeleniumTest() {
+
+    @BeforeEach
+    fun setup() {
+        clearAllTestData()
+        deleteFromTables("integrations", "ratko_push_content")
+    }
+
+    @Test
+    fun `Retry failed publication`() {
+        val originalTrackNumberVersion =
+            trackNumberDao.insert(createTrackLayoutTrackNumber("original name").copy(externalId = Oid("1.2.3.4.5"))).rowVersion
+        val trackNumberId = originalTrackNumberVersion.id
+        val alignmentVersion =
+            alignmentDao.insert(alignment(segment(toTrackLayoutPoints(Point(0.0, 0.0), Point(10.0, 0.0)))))
+        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = alignmentVersion))
+
+        val successfulPublicationId = publicationDao.createPublication("successful")
+        publicationDao.insertCalculatedChanges(successfulPublicationId, changesTouchingTrackNumber(trackNumberId))
+
+        trackNumberDao.update(
+            trackNumberDao.fetch(originalTrackNumberVersion).copy(number = TrackNumber("updated name"))
+        )
+
+        val failingPublicationId = publicationDao.createPublication("failing test publication")
+        publicationDao.insertCalculatedChanges(failingPublicationId, changesTouchingTrackNumber(trackNumberId))
+
+        val failedRatkoPushId = ratkoPushDao.startPushing(listOf(failingPublicationId))
+        ratkoPushDao.updatePushStatus(failedRatkoPushId, RatkoPushStatus.FAILED)
+
+        startGeoviite()
+
+        // two publications; an original one that succeeded (with the original name), then a new one above it that
+        // failed
+        FrontPage()
+            .openNthPublication(1)
+            .apply { this.waitUntilItemMatches { row -> row.index == 0 && row.ratanumero == "original name" } }
+            .returnToFrontPage()
+            .openNthPublication(0)
+            .apply {
+                this.waitUntilItemMatches { row -> row.index == 0 && row.ratanumero == "updated name" && row.vietyRatkoon == "Ei" }
+            }
+            .returnToFrontPage()
+
+        val fakeRatko = fakeRatkoService.start()
+        fakeRatko.isOnline()
+        fakeRatko.hasRouteNumber(ratkoRouteNumber("1.2.3.4.5"))
+
+        clickElement(byQaId("publish-to-ratko"))
+        clickElement(byQaId("confirm-publish-to-ratko"))
+
+        // the publication list will only update with the changeTimes mechanism, which can take up to 15 seconds,
+        // so we're not going to bother checking that; we'll just poll Ratko to see that the change went through instead
+        val maxWaitUntil = LocalDateTime.now().plusSeconds(2)
+        while (LocalDateTime.now().isBefore(maxWaitUntil)) {
+            if (fakeRatko.getPushedRouteNumber(Oid("1.2.3.4.5")).isNotEmpty()) {
+                break
+            }
+            Thread.sleep(100)
+        }
+        assertEquals("updated name", fakeRatko.getPushedRouteNumber(Oid("1.2.3.4.5"))[0].name)
+    }
+
+    private fun changesTouchingTrackNumber(trackNumberId: IntId<TrackLayoutTrackNumber>): CalculatedChanges =
+        CalculatedChanges(
+            DirectChanges(
+                trackNumberChanges = listOf(
+                    TrackNumberChange(
+                        trackNumberId,
+                        changedKmNumbers = setOf(),
+                        isStartChanged = false,
+                        isEndChanged = false
+                    )
+                ),
+                kmPostChanges = listOf(),
+                switchChanges = listOf(),
+                locationTrackChanges = listOf(),
+                referenceLineChanges = listOf(),
+            ),
+            IndirectChanges(
+                trackNumberChanges = listOf(),
+                switchChanges = listOf(),
+                locationTrackChanges = listOf()
+            )
+        )
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 
@@ -85,11 +86,8 @@ class FrontPageTestUI @Autowired constructor(
 
         // the publication list will only update with the changeTimes mechanism, which can take up to 15 seconds,
         // so we're not going to bother checking that; we'll just poll Ratko to see that the change went through instead
-        val maxWaitUntil = LocalDateTime.now().plusSeconds(2)
-        while (LocalDateTime.now().isBefore(maxWaitUntil)) {
-            if (fakeRatko.getPushedRouteNumber(Oid("1.2.3.4.5")).isNotEmpty()) {
-                break
-            }
+        val maxWaitUntil = Instant.now().plusSeconds(2)
+        while (Instant.now().isBefore(maxWaitUntil) && fakeRatko.getPushedRouteNumber(Oid("1.2.3.4.5")).isEmpty()) {
             Thread.sleep(100)
         }
         assertEquals("updated name", fakeRatko.getPushedRouteNumber(Oid("1.2.3.4.5"))[0].name)

--- a/ui/src/ratko/ratko-publish-button.tsx
+++ b/ui/src/ratko/ratko-publish-button.tsx
@@ -32,7 +32,8 @@ const RatkoPublishButton: React.FC<RatkoPublishButtonProps> = ({ size, disabled 
                     isProcessing={isPublishing}
                     variant={ButtonVariant.PRIMARY}
                     size={size}
-                    icon={Icons.Redo}>
+                    icon={Icons.Redo}
+                    qa-id="publish-to-ratko">
                     {t('publishing.publish-to-ratko')}
                 </Button>
             </WriteAccessRequired>
@@ -48,7 +49,10 @@ const RatkoPublishButton: React.FC<RatkoPublishButtonProps> = ({ size, disabled 
                                 variant={ButtonVariant.SECONDARY}>
                                 {t('button.cancel')}
                             </Button>
-                            <Button onClick={publishToRatko} variant={ButtonVariant.PRIMARY}>
+                            <Button
+                                qa-id="confirm-publish-to-ratko"
+                                onClick={publishToRatko}
+                                variant={ButtonVariant.PRIMARY}>
                                 {t('button.ok')}
                             </Button>
                         </React.Fragment>


### PR DESCRIPTION
Uusi ratkotest-profiili kertoo Infra-TEST-konfigilla ajettaessa geoviitteelle että täältä löytyy Ratko. Sitä varten envirepossa erikseen https://github.com/finnishtransportagency/geoviite-env/commit/7c70f2c1efb4547517b69ad1cb29583396cc80a7 asettamaan profiilin päälle. Tämä siis tarvitaan siksi, koska testi itsessäänhän sörkkii vaan selainta, eli sen profiili ei kerro mitään siitä, mitä mieltä testattava Geoviite on siitä, mistä löytää Ratkon. Tätä pitää sitten viljellä muihinkin paikkoihin, missä aiotaan E2E-testejä ajella.