### PR TITLE
GVT-2000 List visible switches based on main visible joint, not all joints

### DIFF
--- a/ui/src/map/layers/switch/switch-layer.ts
+++ b/ui/src/map/layers/switch/switch-layer.ts
@@ -15,6 +15,7 @@ import { filterUniqueById } from 'utils/array-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
+import { fromExtent } from 'ol/geom/Polygon';
 
 let shownSwitchesCompare: string;
 let newestLayerId = 0;
@@ -79,7 +80,12 @@ export function createSwitchLayer(
                 clearFeatures(vectorSource);
                 vectorSource.addFeatures(features);
 
-                updateShownSwitches(switches.map((s) => s.id));
+                const visibleSwitches = findMatchingSwitches(
+                    fromExtent(olView.calculateExtent()),
+                    vectorSource,
+                    {},
+                ).map((s) => s.switch.id);
+                updateShownSwitches(visibleSwitches);
             })
             .catch(() => {
                 clearFeatures(vectorSource);


### PR DESCRIPTION
Tämä selventää vähän isoilla ratapihoilla toimimista, kun vaihdelista ei heti katoa näkyvistä liian monen vaihteen takia.

Tässä oli aiemmin arveltu syylliseksi samojen vaihteiden tulemista useamman MapTilen kautta, mutta sehän bugi oli korjattu jo GVT-1948:ssa.