### PR TITLE
GVT-2037: Add file generation date for the entire rail network's vertical geometry

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -389,9 +389,11 @@ class GeometryService @Autowired constructor(
             }
 
         val csvFileContent = entireTrackNetworkVerticalGeometryListingToCsv(verticalGeometryListingWithTrackNumbers)
+        val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneId.of("Europe/Helsinki"))
+
         verticalGeometryListingFileDao.upsertVerticalGeometryListingFile(
             VerticalGeometryListingFile(
-                name = FileName(VERTICAL_GEOMETRY_ENTIRE_RAIL_NETWORK),
+                name = FileName("$VERTICAL_GEOMETRY_ENTIRE_RAIL_NETWORK ${dateFormatter.format(Instant.now())}"),
                 content = csvFileContent
             )
         )


### PR DESCRIPTION
This unifies the file naming style for the data products of the entire track network.