### PR TITLE
General: Don't spam database connections in tests

### DIFF
--- a/infra/src/test/resources/application-test.yml
+++ b/infra/src/test/resources/application-test.yml
@@ -1,6 +1,8 @@
 spring:
   datasource:
     url: "jdbc:postgresql://${DB_URL:localhost:5436/geoviite}"
+    hikari:
+      minimum-idle: 0
 geoviite:
   cache:
     enabled: false


### PR DESCRIPTION
Jokainen erilainen Springin konfiguraatio testeissä luo uuden ApplicationContextin, ja näyttäisi, että Hikarin yhteysaltaat ovat juurikin kontekstikohtaisia. Näitä kun on riittävästi, ja käytetään application.yml:n oletusta eli että altaaseen tehdään heti 20 yhteyttä, riittävä määrä konfiguraatioita vetää yli postgressin 100 yhteyden rajasta.

0 tuntui loogiselta numerolta, koska miksipä luoda lainkaan yhteyttä sellaisissa testeissä, jotka eivät satu käyttämään tietokantaa.