### PR TITLE
GVT-2024 Prevent duplicate official names

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -1,6 +1,8 @@
 package fi.fta.geoviite.infra.error
 
+import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.idToString
 import fi.fta.geoviite.infra.inframodel.INFRAMODEL_PARSING_KEY_GENERIC
 import fi.fta.geoviite.infra.util.LocalizationKey
@@ -28,7 +30,6 @@ sealed class ClientException(
         localizedMessageParams: List<String> = listOf(),
     ) : this(status, message, cause, LocalizationKey(localizedMessageKey), localizedMessageParams)
 }
-
 
 class GeocodingFailureException(message: String, cause: Throwable? = null)
     : ClientException(BAD_REQUEST, "Geocoding failed: $message", cause, "error.geocoding.generic")
@@ -85,6 +86,29 @@ class NoSuchEntityException(
     constructor(type: String, id: DomainId<*>) : this(type, idToString(id))
     constructor(type: KClass<*>, id: String) : this(type.simpleName ?: type.toString(), id)
 }
+
+enum class DuplicateNameInPublication { SWITCH, TRACK_NUMBER }
+class DuplicateNameInPublicationException(
+    type: DuplicateNameInPublication,
+    duplicatedName: String,
+    cause: Throwable? = null,
+) : ClientException(
+    BAD_REQUEST,
+    "Duplicate $type in publication: $duplicatedName",
+    cause,
+    localizedMessageKey = "error.publication.duplicate-name-on.$type",
+    localizedMessageParams = listOf(duplicatedName),
+)
+class DuplicateLocationTrackNameInPublicationException(
+    alignmentName: AlignmentName,
+    trackNumber: TrackNumber,
+    cause: Throwable? = null
+) : ClientException(
+    BAD_REQUEST, "Duplicate location track $alignmentName in $trackNumber", cause,
+    localizedMessageKey = "error.publication.duplicate-name-on-location-track",
+    localizedMessageParams = listOf(alignmentName.toString(), trackNumber.value)
+)
+
 
 enum class Integration { RATKO, PROJEKTIVELHO }
 class IntegrationNotConfiguredException(type: Integration): ClientException(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -96,7 +96,7 @@ class DuplicateNameInPublicationException(
     BAD_REQUEST,
     "Duplicate $type in publication: $duplicatedName",
     cause,
-    localizedMessageKey = "error.publication.duplicate-name-on.$type",
+    localizedMessageKey = "error.publication.duplicate-name-on.${if (type == DuplicateNameInPublication.SWITCH) "switch" else "track-number"}",
     localizedMessageParams = listOf(duplicatedName),
 )
 class DuplicateLocationTrackNameInPublicationException(
@@ -105,7 +105,7 @@ class DuplicateLocationTrackNameInPublicationException(
     cause: Throwable? = null
 ) : ClientException(
     BAD_REQUEST, "Duplicate location track $alignmentName in $trackNumber", cause,
-    localizedMessageKey = "error.publication.duplicate-name-on-location-track",
+    localizedMessageKey = "error.publication.duplicate-name-on.location-track",
     localizedMessageParams = listOf(alignmentName.toString(), trackNumber.value)
 )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -592,7 +592,7 @@ class PublicationService @Autowired constructor(
         switch: TrackLayoutSwitch,
         id: IntId<TrackLayoutSwitch>
     ): List<PublishValidationError> {
-        return if (switchService.officialDuplicateNameExistsFor(id))
+        return if (switchService.duplicateNameExistsForPublicationCandidate(id))
             listOf(
                 PublishValidationError(
                     PublishValidationErrorType.WARNING,
@@ -674,7 +674,7 @@ class PublicationService @Autowired constructor(
         locationTrack: LocationTrack,
         id: IntId<LocationTrack>
     ): List<PublishValidationError> {
-        return if (locationTrackService.officialDuplicateNameExistsFor(id))
+        return if (locationTrackService.duplicateNameExistsFor(id))
             listOf(
                 PublishValidationError(
                     PublishValidationErrorType.WARNING,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -3,6 +3,9 @@ package fi.fta.geoviite.infra.publication
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
+import fi.fta.geoviite.infra.error.DuplicateLocationTrackNameInPublicationException
+import fi.fta.geoviite.infra.error.DuplicateNameInPublication
+import fi.fta.geoviite.infra.error.DuplicateNameInPublicationException
 import fi.fta.geoviite.infra.error.PublicationFailureException
 import fi.fta.geoviite.infra.geocoding.GeocodingCacheService
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
@@ -22,11 +25,14 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.LocalizationKey
 import fi.fta.geoviite.infra.util.SortOrder
+import org.postgresql.util.PSQLException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
 import java.time.ZoneId
 import java.util.*
@@ -53,8 +59,8 @@ class PublicationService @Autowired constructor(
     private val ratkoPushDao: RatkoPushDao,
     private val geometryDao: GeometryDao,
     private val geocodingCacheService: GeocodingCacheService,
+    private val transactionTemplate: TransactionTemplate,
 ) {
-
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @Transactional(readOnly = true)
@@ -460,8 +466,11 @@ class PublicationService @Autowired constructor(
     fun getCalculatedChanges(versions: ValidationVersions): CalculatedChanges =
         calculatedChangesService.getCalculatedChanges(versions)
 
-    @Transactional
-    fun publishChanges(versions: ValidationVersions, calculatedChanges: CalculatedChanges, message: String): PublishResult {
+    fun publishChanges(
+        versions: ValidationVersions,
+        calculatedChanges: CalculatedChanges,
+        message: String
+    ): PublishResult {
         logger.serviceCall(
             "publishChanges",
             "versions" to versions,
@@ -469,12 +478,24 @@ class PublicationService @Autowired constructor(
             "message" to message
         )
 
+        try {
+            return transactionTemplate.execute { publishChangesTransaction(versions, calculatedChanges, message) }
+                ?: throw Exception("unexpected null from publishChangesTransaction")
+        } catch (exception: DataIntegrityViolationException) {
+            enrichDuplicateNameExceptionOrRethrow(exception)
+        }
+    }
+
+    private fun publishChangesTransaction(
+        versions: ValidationVersions,
+        calculatedChanges: CalculatedChanges,
+        message: String
+    ): PublishResult {
         val trackNumbers = versions.trackNumbers.map(trackNumberService::publish).map { r -> r.rowVersion }
         val kmPosts = versions.kmPosts.map(kmPostService::publish).map { r -> r.rowVersion }
         val switches = versions.switches.map(switchService::publish).map { r -> r.rowVersion }
         val referenceLines = versions.referenceLines.map(referenceLineService::publish).map { r -> r.rowVersion }
         val locationTracks = versions.locationTracks.map(locationTrackService::publish).map { r -> r.rowVersion }
-
         val publishId = publicationDao.createPublication(message)
         publicationDao.insertCalculatedChanges(publishId, calculatedChanges)
 
@@ -509,9 +530,23 @@ class PublicationService @Autowired constructor(
         val geocodingErrors = if (trackNumber.exists && referenceLine != null) {
             validateGeocodingContext(cacheKeys[version.officialId], VALIDATION_TRACK_NUMBER)
         } else listOf()
-        return fieldErrors + referenceErrors + geocodingErrors
+        val duplicateNameErrors = validateTrackNumberNumberDuplication(trackNumber, version.validatedAssetVersion.id)
+        return fieldErrors + referenceErrors + geocodingErrors + duplicateNameErrors
     }
 
+    private fun validateTrackNumberNumberDuplication(
+        trackNumber: TrackLayoutTrackNumber,
+        id: IntId<TrackLayoutTrackNumber>
+    ): List<PublishValidationError> {
+        return if (trackNumberDao.officialDuplicateNumberExistsFor(id))
+            listOf(
+                PublishValidationError(
+                    PublishValidationErrorType.WARNING,
+                    "validation.layout.track-number.duplicate-name",
+                    listOf(trackNumber.number.toString())
+                )
+            ) else listOf()
+    }
     private fun validateKmPost(
         version: ValidationVersion<TrackLayoutKmPost>,
         validationVersions: ValidationVersions,
@@ -548,7 +583,23 @@ class PublicationService @Autowired constructor(
             validationVersions.locationTracks.map { it.officialId },
         )
         val structureErrors = validateSwitchLocationTrackLinkStructure(switch, structure, linkedTracksAndAlignments)
-        return fieldErrors + referenceErrors + structureErrors
+        val duplicationErrors =
+            if (switch.exists) validateSwitchNameDuplication(switch, version.validatedAssetVersion.id) else listOf()
+        return fieldErrors + referenceErrors + structureErrors + duplicationErrors
+    }
+
+    private fun validateSwitchNameDuplication(
+        switch: TrackLayoutSwitch,
+        id: IntId<TrackLayoutSwitch>
+    ): List<PublishValidationError> {
+        return if (switchService.officialDuplicateNameExistsFor(id))
+            listOf(
+                PublishValidationError(
+                    PublishValidationErrorType.WARNING,
+                    "validation.layout.switch.duplicate-name",
+                    listOf(switch.name.toString())
+                )
+            ) else listOf()
     }
 
     private fun validateReferenceLine(
@@ -611,7 +662,26 @@ class PublicationService @Autowired constructor(
                 validateAddressPoints(trackNumber, key, locationTrack, VALIDATION_LOCATION_TRACK)
             } ?: listOf(noGeocodingContext(VALIDATION_LOCATION_TRACK))
         } else listOf()
-        return fieldErrors + referenceErrors + switchErrors + duplicateErrors + alignmentErrors + geocodingErrors
+        val duplicateNameErrors =
+            if (locationTrack.exists) validateLocationTrackNameDuplication(
+                locationTrack,
+                version.validatedAssetVersion.id,
+            ) else listOf()
+        return fieldErrors + referenceErrors + switchErrors + duplicateErrors + alignmentErrors + geocodingErrors + duplicateNameErrors
+    }
+
+    private fun validateLocationTrackNameDuplication(
+        locationTrack: LocationTrack,
+        id: IntId<LocationTrack>
+    ): List<PublishValidationError> {
+        return if (locationTrackService.officialDuplicateNameExistsFor(id))
+            listOf(
+                PublishValidationError(
+                    PublishValidationErrorType.WARNING,
+                    "validation.layout.location-track.duplicate-name",
+                    listOf(locationTrack.name.toString())
+                )
+            ) else listOf()
     }
 
     private fun getTrackNumber(
@@ -1371,4 +1441,68 @@ class PublicationService @Autowired constructor(
         ratkoPushTime = if (publication.ratkoPushStatus == RatkoPushStatus.SUCCESSFUL) publication.ratkoPushTime else null,
         propChanges = propChanges,
     )
+
+    private fun enrichDuplicateNameExceptionOrRethrow(exception: DataIntegrityViolationException): Nothing {
+        val psqlException = exception.cause as? PSQLException ?: throw exception
+        val constraint = psqlException.serverErrorMessage?.constraint
+        val detail = psqlException.serverErrorMessage?.detail ?: throw exception
+
+        when (constraint) {
+            "switch_unique_official_name" -> maybeThrowDuplicateSwitchNameException(detail, exception)
+            "track_number_number_draft_unique" -> maybeThrowDuplicateTrackNumberNumberException(detail, exception)
+            "location_track_unique_official_name" -> maybeThrowDuplicateLocationTrackNameException(detail, exception)
+        }
+        throw exception
+    }
+
+    private val duplicateLocationTrackErrorRegex =
+        Regex("""Key \(track_number_id, name\)=\((\d+), ([^)]+)\) conflicts with existing key""")
+    private val duplicateTrackNumberErrorRegex =
+        Regex("""Key \(number, draft\)=\(([^)]+), ([tf])\) already exists""")
+    private val duplicateSwitchErrorRegex =
+        Regex("""Key \(name\)=\(([^)]+)\) conflicts with existing key""")
+
+    private fun maybeThrowDuplicateLocationTrackNameException(detail: String, exception: DataIntegrityViolationException) {
+        duplicateLocationTrackErrorRegex.matchAt(detail, 0)
+            ?.let { match ->
+                val trackIdString = match.groups[1]?.value
+                val nameString = match.groups[2]?.value
+                val trackId = IntId<TrackLayoutTrackNumber>(Integer.parseInt(trackIdString))
+                if (trackIdString != null && nameString != null) {
+                    val trackNumberVersion = trackNumberDao.fetchOfficialVersion(trackId)
+                    if (trackNumberVersion != null) {
+                        val trackNumber = trackNumberDao.fetch(trackNumberVersion)
+                        throw DuplicateLocationTrackNameInPublicationException(
+                            AlignmentName(nameString),
+                            trackNumber.number,
+                            exception
+                        )
+                    }
+                }
+            }
+    }
+
+    private fun maybeThrowDuplicateTrackNumberNumberException(detail: String, exception: DataIntegrityViolationException) {
+        duplicateTrackNumberErrorRegex.matchAt(detail, 0)
+            ?.let { match -> match.groups[1]?.value }
+            ?.let { name ->
+                throw DuplicateNameInPublicationException(
+                    DuplicateNameInPublication.TRACK_NUMBER,
+                    name,
+                    exception
+                )
+            }
+    }
+
+    private fun maybeThrowDuplicateSwitchNameException(detail: String, exception: DataIntegrityViolationException) {
+        duplicateSwitchErrorRegex.matchAt(detail, 0)
+            ?.let { match -> match.groups[1]?.value }
+            ?.let { name ->
+                throw DuplicateNameInPublicationException(
+                    DuplicateNameInPublication.SWITCH,
+                    name,
+                    exception
+                )
+            }
+    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -435,16 +435,17 @@ class LayoutSwitchDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
         }
     }
 
-    fun officialDuplicateNameExistsFor(switchId: IntId<TrackLayoutSwitch>): Boolean {
+    fun duplicateNameExistsForPublicationCandidate(switchId: IntId<TrackLayoutSwitch>): Boolean {
         val sql = """
             select
               exists(
                   select *
                     from layout.switch this_switch
                       join layout.switch duplicate_switch
-                           on this_switch.name = duplicate_switch.name and this_switch.id != duplicate_switch.id
-                    where not duplicate_switch.draft
-                      and duplicate_switch.state_category != 'NOT_EXISTING'
+                           on this_switch.name = duplicate_switch.name
+                             and this_switch.id != duplicate_switch.id
+                             and this_switch.draft_of_switch_id is distinct from duplicate_switch.id
+                    where duplicate_switch.state_category != 'NOT_EXISTING'
                       and this_switch.id = :switchId)
         """.trimIndent()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -198,9 +198,9 @@ class LayoutSwitchService @Autowired constructor(
             }
     }
 
-    fun officialDuplicateNameExistsFor(switchId: IntId<TrackLayoutSwitch>): Boolean {
-        logger.serviceCall("officialDuplicateNameExistsFor", "switchId" to switchId)
-        return dao.officialDuplicateNameExistsFor(switchId)
+    fun duplicateNameExistsForPublicationCandidate(switchId: IntId<TrackLayoutSwitch>): Boolean {
+        logger.serviceCall("duplicateNameExistsForPublicationCandidate", "switchId" to switchId)
+        return dao.duplicateNameExistsForPublicationCandidate(switchId)
     }
 
     private fun getTopologySwitchJointConnections(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -198,6 +198,11 @@ class LayoutSwitchService @Autowired constructor(
             }
     }
 
+    fun officialDuplicateNameExistsFor(switchId: IntId<TrackLayoutSwitch>): Boolean {
+        logger.serviceCall("officialDuplicateNameExistsFor", "switchId" to switchId)
+        return dao.officialDuplicateNameExistsFor(switchId)
+    }
+
     private fun getTopologySwitchJointConnections(
         publicationState: PublishType,
         layoutSwitchId: IntId<TrackLayoutSwitch>

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -208,6 +208,11 @@ class LayoutTrackNumberService(
             )
         } else listOf()
     }
+
+    fun officialDuplicateNameExistsFor(trackNumberId: IntId<TrackLayoutTrackNumber>): Boolean {
+        logger.serviceCall("officialDuplicateNameExistsFor", "trackNumberId" to trackNumberId)
+        return dao.officialDuplicateNumberExistsFor(trackNumberId)
+    }
 }
 
 private fun asCsvFile(items: List<TrackLayoutKmLengthDetails>): String {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -323,7 +323,7 @@ class LocationTrackDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
         }
     }
 
-    fun officialDuplicateNameExistsFor(locationTrackId: IntId<LocationTrack>): Boolean {
+    fun duplicateNameExistsForPublicationCandidate(locationTrackId: IntId<LocationTrack>): Boolean {
         val sql = """
             select
               exists(
@@ -333,8 +333,8 @@ class LocationTrackDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
                            on this_track.name = duplicate_track.name
                              and this_track.track_number_id = duplicate_track.track_number_id
                              and this_track.id != duplicate_track.id
-                    where not duplicate_track.draft
-                      and duplicate_track.state != 'DELETED'
+                             and this_track.draft_of_location_track_id is distinct from duplicate_track.id
+                    where duplicate_track.state != 'DELETED'
                       and this_track.id = :locationTrackId)
         """.trimIndent()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -314,9 +314,9 @@ class LocationTrackService(
         return getLocationTrackEndpoints(listWithAlignments(publishType), bbox)
     }
 
-    fun officialDuplicateNameExistsFor(locationTrackId: IntId<LocationTrack>): Boolean {
-        logger.serviceCall("checkDuplicateNames", "locationTrackId" to locationTrackId)
-        return dao.officialDuplicateNameExistsFor(locationTrackId)
+    fun duplicateNameExistsFor(locationTrackId: IntId<LocationTrack>): Boolean {
+        logger.serviceCall("duplicateNameExistsFor", "locationTrackId" to locationTrackId)
+        return dao.duplicateNameExistsForPublicationCandidate(locationTrackId)
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -313,6 +313,11 @@ class LocationTrackService(
         logger.serviceCall("getLocationTrackEndpoints", "bbox" to bbox)
         return getLocationTrackEndpoints(listWithAlignments(publishType), bbox)
     }
+
+    fun officialDuplicateNameExistsFor(locationTrackId: IntId<LocationTrack>): Boolean {
+        logger.serviceCall("checkDuplicateNames", "locationTrackId" to locationTrackId)
+        return dao.officialDuplicateNameExistsFor(locationTrackId)
+    }
 }
 
 private fun findBestTopologySwitchFromSegments(

--- a/infra/src/main/resources/db/migration/prod/V46__add_unique_layout_name_constraints.sql
+++ b/infra/src/main/resources/db/migration/prod/V46__add_unique_layout_name_constraints.sql
@@ -1,0 +1,11 @@
+alter table layout.switch
+  add constraint switch_unique_official_name
+    exclude (name with =)
+    where (state_category != 'NOT_EXISTING' and not draft)
+    deferrable initially deferred;
+
+alter table layout.location_track
+  add constraint location_track_unique_official_name
+    exclude (track_number_id with =, name with =)
+    where (state != 'DELETED' and not draft)
+    deferrable initially deferred;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/NoTransactionTemplate.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/NoTransactionTemplate.kt
@@ -1,0 +1,18 @@
+package fi.fta.geoviite.infra
+
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+
+
+@Profile("nodb")
+@Component
+class NoTransactionTemplate : TransactionTemplate() {
+    override fun <T> execute(action: TransactionCallback<T>): T? {
+        throw Exception("No transaction template in nodb tests")
+    }
+
+    override fun afterPropertiesSet() {
+    }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -286,12 +286,14 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 SwitchData(
                     Point(100.0, 0.0),
                     locationTrackIndexA = 1,
-                    locationTrackIndexB = 2
+                    locationTrackIndexB = 2,
+                    name = "switch-A",
                 ),
                 SwitchData(
                     Point(100.0, 0.0),
                     locationTrackIndexA = 1,
-                    locationTrackIndexB = 2
+                    locationTrackIndexB = 2,
+                    name = "switch-B",
                 )
             )
         )
@@ -1049,7 +1051,8 @@ class CalculatedChangesServiceIT @Autowired constructor(
     data class SwitchData(
         val location: IPoint,
         val locationTrackIndexA: Int,
-        val locationTrackIndexB: Int
+        val locationTrackIndexB: Int,
+        val name: String? = null,
     )
 
     /**
@@ -1176,6 +1179,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 refPoint + switch.location,
                 locationTracksAndAlignments[switch.locationTrackIndexA],
                 locationTracksAndAlignments[switch.locationTrackIndexB],
+                switch.name,
             )
         }
 
@@ -1212,9 +1216,15 @@ class CalculatedChangesServiceIT @Autowired constructor(
         switchLocation: IPoint,
         trackA: Pair<LocationTrack, LayoutAlignment>,
         trackB: Pair<LocationTrack, LayoutAlignment>,
+        name: String?,
     ): TrackLayoutSwitch {
         val switch = switchDao.fetch(
-            switchDao.insert(switch(name = "${trackA.first.name}-${trackB.first.name}", joints = listOf())).rowVersion
+            switchDao.insert(
+                switch(
+                    name = name ?: "${trackA.first.name}-${trackB.first.name}",
+                    joints = listOf()
+                )
+            ).rowVersion
         )
 
         val (locationTrackA, alignmentA) = trackA

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -1145,6 +1145,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
             ).rowVersion
         )
 
+        var locationTrackSequence = 0
         val locationTracksAndAlignments = locationTrackData.map { line ->
             val locationTrackGeometryVersion = layoutAlignmentDao.insert(
                 alignment(
@@ -1161,7 +1162,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                     locationTrack(
                         trackNumberId = trackNumber.id as IntId,
                         alignment = locationTrackGeometry,
-                        name = "TEST LocTr $sequence"
+                        name = "TEST LocTr $sequence ${locationTrackSequence++}"
                     ).copy(
                         alignmentVersion = locationTrackGeometryVersion
                     )
@@ -1213,7 +1214,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         trackB: Pair<LocationTrack, LayoutAlignment>,
     ): TrackLayoutSwitch {
         val switch = switchDao.fetch(
-            switchDao.insert(switch(joints = listOf())).rowVersion
+            switchDao.insert(switch(name = "${trackA.first.name}-${trackB.first.name}", joints = listOf())).rowVersion
         )
 
         val (locationTrackA, alignmentA) = trackA

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -31,12 +31,17 @@ class PublicationDaoIT @Autowired constructor(
 
     @BeforeEach
     fun setup() {
-        locationTrackDao.deleteDrafts()
-        referenceLineDao.deleteDrafts()
-        alignmentDao.deleteOrphanedAlignments()
-        switchDao.deleteDrafts()
-        kmPostDao.deleteDrafts()
-        trackNumberDao.deleteDrafts()
+        deleteFromTables(
+            "layout",
+            "location_track",
+            "reference_line",
+            "alignment",
+            "segment_version",
+            "switch_joint",
+            "switch",
+            "km_post",
+            "track_number"
+        )
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -797,7 +797,7 @@ class PublicationServiceIT @Autowired constructor(
                 trackNumbers = listOf(draftTrackNumberId)
             )
         }
-        assertEquals("error.publication.duplicate-name-on.TRACK_NUMBER", exception.localizedMessageKey.toString())
+        assertEquals("error.publication.duplicate-name-on.track-number", exception.localizedMessageKey.toString())
         assertEquals(listOf("TN"), exception.localizedMessageParams)
     }
 
@@ -813,7 +813,7 @@ class PublicationServiceIT @Autowired constructor(
         val exception = assertThrows<DuplicateLocationTrackNameInPublicationException> {
             publish(publicationService, locationTracks = listOf(draftLocationTrackId))
         }
-        assertEquals("error.publication.duplicate-name-on-location-track", exception.localizedMessageKey.toString())
+        assertEquals("error.publication.duplicate-name-on.location-track", exception.localizedMessageKey.toString())
         assertEquals(listOf("LT", "TN"), exception.localizedMessageParams)
     }
 
@@ -843,7 +843,7 @@ class PublicationServiceIT @Autowired constructor(
         val exception = assertThrows<DuplicateNameInPublicationException> {
             publish(publicationService, switches = listOf(draftSwitchId))
         }
-        assertEquals("error.publication.duplicate-name-on.SWITCH", exception.localizedMessageKey.toString())
+        assertEquals("error.publication.duplicate-name-on.switch", exception.localizedMessageKey.toString())
         assertEquals(listOf("SW123"), exception.localizedMessageParams)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -4,6 +4,8 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
+import fi.fta.geoviite.infra.error.DuplicateLocationTrackNameInPublicationException
+import fi.fta.geoviite.infra.error.DuplicateNameInPublicationException
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.integration.*
 import fi.fta.geoviite.infra.linking.*
@@ -42,7 +44,8 @@ class PublicationServiceIT @Autowired constructor(
 ): DBTestBase() {
 
     @BeforeEach
-    fun clearDrafts() {
+    fun cleanup() {
+        deleteFromTables("layout", "switch_joint", "switch", "location_track", "track_number", "reference_line")
         val request = publicationService.collectPublishCandidates().let {
             PublishRequestIds(
                 it.trackNumbers.map(TrackNumberPublishCandidate::id),
@@ -677,6 +680,135 @@ class PublicationServiceIT @Autowired constructor(
 
         val validation = publicationService.validateKmPost(kmPostId, OFFICIAL)
         assertEquals(validation.errors.size, 1)
+    }
+
+    @Test
+    fun `Publication validation identifies duplicate names`() {
+        trackNumberDao.insert(trackNumber(number = TrackNumber("TN")))
+        val draftTrackNumberId = trackNumberDao.insert(draft(trackNumber(number = TrackNumber("TN")))).id
+
+        val someAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        val referenceLineId =
+            referenceLineDao.insert(draft(referenceLine(draftTrackNumberId, alignmentVersion = someAlignment))).id
+        locationTrackDao.insert(locationTrack(draftTrackNumberId, name = "LT", alignmentVersion = someAlignment))
+        val draftLocationTrackId = locationTrackDao.insert(
+            draft(
+                locationTrack(
+                    draftTrackNumberId,
+                    name = "LT",
+                    alignmentVersion = someAlignment
+                )
+            )
+        ).id
+
+        switchDao.insert(switch(123, name = "SW").copy(stateCategory = LayoutStateCategory.EXISTING))
+        val draftSwitchId =
+            switchDao.insert(draft(switch(123, name = "SW").copy(stateCategory = LayoutStateCategory.EXISTING))).id
+
+        val validation = publicationService.validatePublishCandidates(
+            publicationService.collectPublishCandidates(),
+            PublishRequestIds(
+                trackNumbers = listOf(draftTrackNumberId),
+                locationTracks = listOf(draftLocationTrackId),
+                kmPosts = listOf(),
+                referenceLines = listOf(referenceLineId),
+                switches = listOf(draftSwitchId)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                PublishValidationError(
+                    PublishValidationErrorType.WARNING,
+                    "validation.layout.location-track.duplicate-name",
+                    listOf("LT")
+                )
+            ), validation.validatedAsPublicationUnit.locationTracks[0].errors
+        )
+
+        assertEquals(
+            listOf(
+                PublishValidationError(
+                    PublishValidationErrorType.WARNING,
+                    "validation.layout.switch.duplicate-name",
+                    listOf("SW")
+                )
+            ),
+            validation.validatedAsPublicationUnit.switches[0].errors.filter { it.localizationKey.toString() == "validation.layout.switch.duplicate-name" }
+        )
+
+        assertEquals(
+            listOf(
+                PublishValidationError(
+                    PublishValidationErrorType.WARNING,
+                    "validation.layout.track-number.duplicate-name",
+                    listOf("TN")
+                )
+            ), validation.validatedAsPublicationUnit.trackNumbers[0].errors
+        )
+    }
+
+    @Test
+    fun `Publication rejects duplicate track number names`() {
+        trackNumberDao.insert(trackNumber(number = TrackNumber("TN")))
+        val draftTrackNumberId = trackNumberDao.insert(draft(trackNumber(number = TrackNumber("TN")))).id
+
+        val someAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        referenceLineDao.insert(draft(referenceLine(draftTrackNumberId, alignmentVersion = someAlignment))).id
+        val exception = assertThrows<DuplicateNameInPublicationException> {
+            publish(
+                publicationService,
+                trackNumbers = listOf(draftTrackNumberId)
+            )
+        }
+        assertEquals("error.publication.duplicate-name-on.TRACK_NUMBER", exception.localizedMessageKey.toString())
+        assertEquals(listOf("TN"), exception.localizedMessageParams)
+    }
+
+    @Test
+    fun `Publication rejects duplicate location track names`() {
+        val trackNumberId = trackNumberDao.insert(trackNumber(number = TrackNumber("TN"))).id
+        val someAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        referenceLineDao.insert(draft(referenceLine(trackNumberId, alignmentVersion = someAlignment))).id
+
+        val lt = locationTrack(trackNumberId, name = "LT", alignmentVersion = someAlignment, externalId = null)
+        locationTrackDao.insert(lt)
+        val draftLocationTrackId = locationTrackDao.insert(draft(lt)).id
+        val exception = assertThrows<DuplicateLocationTrackNameInPublicationException> {
+            publish(publicationService, locationTracks = listOf(draftLocationTrackId))
+        }
+        assertEquals("error.publication.duplicate-name-on-location-track", exception.localizedMessageKey.toString())
+        assertEquals(listOf("LT", "TN"), exception.localizedMessageParams)
+    }
+
+    @Test
+    fun `Location tracks can be renamed over each other`() {
+        val trackNumberId = trackNumberDao.insert(trackNumber(number = TrackNumber("TN"))).id
+        val someAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        referenceLineDao.insert(draft(referenceLine(trackNumberId, alignmentVersion = someAlignment))).id
+
+        val lt1 = locationTrack(trackNumberId, name = "LT1", alignmentVersion = someAlignment, externalId = null)
+        val lt1OriginalVersion = locationTrackDao.insert(lt1).rowVersion
+        val lt1RenamedDraft =
+            locationTrackDao.insert(draft(locationTrackDao.fetch(lt1OriginalVersion).copy(name = AlignmentName("LT2"))))
+
+        val lt2 = locationTrack(trackNumberId, name = "LT2", alignmentVersion = someAlignment, externalId = null)
+        val lt2OriginalVersion = locationTrackDao.insert(lt2).rowVersion
+        val lt2RenamedDraft =
+            locationTrackDao.insert(draft(locationTrackDao.fetch(lt2OriginalVersion).copy(name = AlignmentName("LT1"))))
+
+        publish(publicationService, locationTracks = listOf(lt1RenamedDraft.id, lt2RenamedDraft.id))
+    }
+
+    @Test
+    fun `Publication rejects duplicate switch names`() {
+        switchDao.insert(switch(123, name = "SW123"))
+        val draftSwitchId = switchDao.insert(draft(switch(123, name = "SW123"))).id
+        val exception = assertThrows<DuplicateNameInPublicationException> {
+            publish(publicationService, switches = listOf(draftSwitchId))
+        }
+        assertEquals("error.publication.duplicate-name-on.SWITCH", exception.localizedMessageKey.toString())
+        assertEquals(listOf("SW123"), exception.localizedMessageParams)
     }
 
     fun createOfficialAndDraftSwitch(seed: Int): IntId<TrackLayoutSwitch> {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/DraftIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/DraftIT.kt
@@ -7,6 +7,7 @@ import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.math.Point
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,6 +29,11 @@ class DraftIT @Autowired constructor(
     private val alignmentDao: LayoutAlignmentDao,
     private val trackNumberDao: LayoutTrackNumberDao,
 ): DBTestBase() {
+
+    @BeforeEach
+    fun cleanup() {
+        deleteFromTables("layout", "switch")
+    }
 
     @Test
     fun tempReferenceLineDraftDoesntChangeId() {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
@@ -8,6 +8,7 @@ import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -21,6 +22,11 @@ import kotlin.test.assertContains
 class LayoutSwitchDaoIT @Autowired constructor(
     private val switchDao: LayoutSwitchDao,
 ): DBTestBase() {
+
+    @BeforeEach
+    fun cleanup() {
+        deleteFromTables("layout", "switch_joint", "switch")
+    }
 
     @Test
     fun switchExternalIdIsUnique() {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -12,6 +12,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao.LocationTrackIdentifiers
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,6 +32,12 @@ class LayoutSwitchServiceIT @Autowired constructor(
     private val alignmentDao: LayoutAlignmentDao,
     private val locationTrackDao: LocationTrackDao,
 ): DBTestBase() {
+
+    @BeforeEach
+    fun cleanup() {
+        deleteFromTables("layout", "switch_joint", "switch", "location_track")
+    }
+
     @Test
     fun switchOwnerIsReturned() {
         val dummyOwner = SwitchOwner(id = IntId(4), name = MetaDataName("Cinia"))
@@ -274,7 +281,8 @@ class LayoutSwitchServiceIT @Autowired constructor(
                 alignment = alignmentDao.fetch(alignment1Version),
                 trackNumberId = trackNumberId,
                 externalId = locationTrack1Oid,
-                alignmentVersion = alignment1Version
+                alignmentVersion = alignment1Version,
+                name = "LT 1",
             ).copy(
                 topologyStartSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(1)),
             )
@@ -285,7 +293,8 @@ class LayoutSwitchServiceIT @Autowired constructor(
             locationTrack(
                 alignment = alignmentDao.fetch(alignment2Version),
                 trackNumberId = trackNumberId,
-                alignmentVersion = alignment2Version
+                alignmentVersion = alignment2Version,
+                name = "LT 2",
             ).copy(
                 topologyEndSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
             )
@@ -307,7 +316,8 @@ class LayoutSwitchServiceIT @Autowired constructor(
                 alignment = alignmentDao.fetch(alignment3Version),
                 trackNumberId = trackNumberId,
                 externalId = locationTrack3Oid,
-                alignmentVersion = alignment3Version
+                alignmentVersion = alignment3Version,
+                name = "LT 3",
             ).copy(
                 topologyEndSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
             )
@@ -399,9 +409,10 @@ class LayoutSwitchServiceIT @Autowired constructor(
         return "$first.$second.$third"
     }
 
+    private var dummySwitchNameSequence = 0
     private fun generateDummySwitch(): TrackLayoutSwitch {
         return TrackLayoutSwitch(
-            name = SwitchName("ABC123"),
+            name = SwitchName("ABC123 ${dummySwitchNameSequence++}"),
             switchStructureId = switchStructureYV60_300_1_9().id as IntId,
             stateCategory = LayoutStateCategory.EXISTING,
             joints = listOf(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -186,9 +186,11 @@ fun referenceLine(
     alignmentVersion = alignmentVersion,
 )
 
+private var locationTrackNameCounter = 0
+
 fun locationTrackAndAlignment(
     vararg segments: LayoutSegment,
-    name: String = "T001",
+    name: String = "T001 ${locationTrackNameCounter++}",
     description: String = "test-alignment 001",
 ): Pair<LocationTrack, LayoutAlignment> =
     locationTrackAndAlignment(IntId(0), segments.toList(), name=name, description=description)
@@ -197,7 +199,7 @@ fun locationTrackAndAlignment(
 fun locationTrackAndAlignment(
     trackNumberId: IntId<TrackLayoutTrackNumber>,
     vararg segments: LayoutSegment,
-    name: String = "T001",
+    name: String = "T001 ${locationTrackNameCounter++}",
     description: String = "test-alignment 001",
 ): Pair<LocationTrack, LayoutAlignment> =
     locationTrackAndAlignment(trackNumberId, segments.toList(), name=name, description=description)
@@ -208,7 +210,7 @@ fun locationTrackAndAlignment(
     segments: List<LayoutSegment>,
     id: IntId<LocationTrack>? = null,
     draft: Draft<LocationTrack>? = null,
-    name: String = "T001",
+    name: String = "T001 ${locationTrackNameCounter++}",
     description: String = "test-alignment 001",
 ): Pair<LocationTrack, LayoutAlignment> {
     val alignment = alignment(segments)
@@ -221,7 +223,7 @@ fun locationTrack(
     alignment: LayoutAlignment? = null,
     id: IntId<LocationTrack>? = null,
     draft: Draft<LocationTrack>? = null,
-    name: String = "T001",
+    name: String = "T001 ${locationTrackNameCounter++}",
     description: String = "test-alignment 001",
     type: LocationTrackType = LocationTrackType.SIDE,
     state: LayoutState = LayoutState.IN_USE,

--- a/ui/src/i18n/fi/fi.json
+++ b/ui/src/i18n/fi/fi.json
@@ -13,9 +13,11 @@
             "generic": "Julkaisu epäonnistui",
             "lock-obtain-failed": "Toinen julkaisu käynnissä - yritä hetken kuluttua uudelleen",
             "validation-failed": "Julkaisuvalidointi epäonnistui",
-            "duplicate-name-on-location-track": "Julkaisussa on useammalla sijaintiraiteella sama nimi {{0}} (ratanumerolla {{1}})",
-            "error.publication.duplicate-name-on.SWITCH": "Julkaisussa on useammalla vaihteella sama nimi {{0}}",
-            "error.publication.duplicate-name-on.TRACK_NUMBER": "Julkaisussa on useammalla radalla sama ratanumero {{0}}"
+            "duplicate-name-on": {
+                "location-track": "Julkaisussa on useammalla sijaintiraiteella sama nimi {{0}} (ratanumerolla {{1}})",
+                "switch": "Julkaisussa on useammalla vaihteella sama nimi {{0}}",
+                "track-number": "Julkaisussa on useammalla radalla sama ratanumero {{0}}"
+            }
         },
         "input": {
             "generic": "Tarkasta syötekentät ja yritä uudestaan",

--- a/ui/src/i18n/fi/fi.json
+++ b/ui/src/i18n/fi/fi.json
@@ -13,9 +13,9 @@
             "generic": "Julkaisu epäonnistui",
             "lock-obtain-failed": "Toinen julkaisu käynnissä - yritä hetken kuluttua uudelleen",
             "validation-failed": "Julkaisuvalidointi epäonnistui",
-            "duplicate-name-on-location-track": "Julkaisussa olisi useammalla sijaintiraiteella sama nimi {{0}} (ratanumerolla {{1}})",
-            "error.publication.duplicate-name-on.SWITCH": "Julkaisussa olisi useammalla vaihteella sama nimi {{0}}",
-            "error.publication.duplicate-name-on.TRACK_NUMBER": "Julkaisussa olisi useammalla radalla sama ratanumero {{0}}"
+            "duplicate-name-on-location-track": "Julkaisussa on useammalla sijaintiraiteella sama nimi {{0}} (ratanumerolla {{1}})",
+            "error.publication.duplicate-name-on.SWITCH": "Julkaisussa on useammalla vaihteella sama nimi {{0}}",
+            "error.publication.duplicate-name-on.TRACK_NUMBER": "Julkaisussa on useammalla radalla sama ratanumero {{0}}"
         },
         "input": {
             "generic": "Tarkasta syötekentät ja yritä uudestaan",

--- a/ui/src/i18n/fi/fi.json
+++ b/ui/src/i18n/fi/fi.json
@@ -12,7 +12,10 @@
         "publication": {
             "generic": "Julkaisu epäonnistui",
             "lock-obtain-failed": "Toinen julkaisu käynnissä - yritä hetken kuluttua uudelleen",
-            "validation-failed": "Julkaisuvalidointi epäonnistui"
+            "validation-failed": "Julkaisuvalidointi epäonnistui",
+            "duplicate-name-on-location-track": "Julkaisussa olisi useammalla sijaintiraiteella sama nimi {{0}} (ratanumerolla {{1}})",
+            "error.publication.duplicate-name-on.SWITCH": "Julkaisussa olisi useammalla vaihteella sama nimi {{0}}",
+            "error.publication.duplicate-name-on.TRACK_NUMBER": "Julkaisussa olisi useammalla radalla sama ratanumero {{0}}"
         },
         "input": {
             "generic": "Tarkasta syötekentät ja yritä uudestaan",

--- a/ui/src/preview/translations.fi.json
+++ b/ui/src/preview/translations.fi.json
@@ -169,7 +169,8 @@
                     "joint-location-mismatch": "Sijaintiraiteen ja vaihteen {{0}} vaihdepisteiden sijainnit eivät vastaa toisiaan",
                     "wrong-joint-sequence": "Sijaintiraiteen vaihdepisteet ({{2}}) vaihteella {{0}} ({{1}}) eivät vastaa vaihderakenteen linjoja",
                     "wrong-links": "Vaihteen {{0}} linkitys on vajavainen ja se täytyy linkittää uudelleen"
-                }
+                },
+                "duplicate-name": "Sijaintiraiteen nimi {{0}} on jo käytössä jollain olemassaolevalla julkaistulla saman ratanumeron sijaintiraiteella"
             },
             "switch": {
                 "not-draft": "Virhe julkaisun sisällössä: julkaistava vaihde ei ole luonnos",


### PR DESCRIPTION
Samassa kommitissa sievästi sekaisin kahta eri asiaa: Yhtäältä julkaisuvalidoinnissa varoitetaan (mutta ei anneta virhettä) päällekkäisistä nimistä, toisaalta varsinaisessa julkaisussa vältetään constrainteilla päällekkäiset viralliset nimet, ja parsitaan sitten tietokannan virheistä, mitä sen mielestä julkaisussa oikeasti meni pieleen.

Validointi antaa vain varoituksen mutta ei virhettä, jotta käyttäjä saa julkaisun temppuilematta läpi, jos tarvitsee vaihtaa nimiä päittäin. Samasta syystä myös varsinaisen julkaisun virheenkäsittely tapahtuu vasta kommitissa: Konstrainttien tarkistus kun pitää myös jättää loppuun, jotta päittäin vaihtamiset kerkiää menemään läpi.