### PR TITLE
General: Raiteen topologiavaihteet näkyviin UI:hin

### DIFF
--- a/ui/src/geoviite-design-lib/demo/examples/badge-examples.tsx
+++ b/ui/src/geoviite-design-lib/demo/examples/badge-examples.tsx
@@ -29,6 +29,8 @@ const layoutLocationTrack: LayoutLocationTrack = {
     draftType: 'NEW_DRAFT',
     duplicateOf: null,
     topologicalConnectivity: 'NONE',
+    topologyStartSwitch: null,
+    topologyEndSwitch: null,
 };
 const kmPost = {
     id: '',

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -30,7 +30,7 @@ import { Heading, HeadingSize } from 'vayla-design-lib/heading/heading';
 import { FormLayout, FormLayoutColumn } from 'geoviite-design-lib/form-layout/form-layout';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { useTranslation } from 'react-i18next';
-import { useLocationTrackStartAndEnd } from 'track-layout/track-layout-react-utils';
+import { useLocationTrackStartAndEnd, useSwitch } from 'track-layout/track-layout-react-utils';
 import { formatTrackMeter } from 'utils/geography-utils';
 import { Precision, roundToPrecision } from 'utils/rounding';
 import { PublishType, TimeStamp } from 'common/common-model';
@@ -66,6 +66,14 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
             props.publishType,
             props.locationTrackChangeTime,
         );
+    const topologicalStartSwitch = useSwitch(
+        props.locationTrack?.topologyStartSwitch?.switchId,
+        props.publishType,
+    );
+    const topologicalEndSwitch = useSwitch(
+        props.locationTrack?.topologyEndSwitch?.switchId,
+        props.publishType,
+    );
     const firstInputRef = React.useRef<HTMLInputElement>(null);
     const [state, dispatcher] = React.useReducer(reducer, initialLocationTrackEditState);
     const [selectedDuplicateTrack, setSelectedDuplicateTrack] = React.useState<
@@ -479,6 +487,32 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                                   Precision.alignmentLengthMeters,
                                               )
                                             : '-'
+                                    }
+                                    wide
+                                    disabled
+                                />
+                            }
+                        />
+                        <FieldLayout
+                            label={t('location-track-dialog.topological-start-switch')}
+                            value={
+                                <TextField
+                                    value={
+                                        topologicalStartSwitch?.name ??
+                                        t('location-track-dialog.no-topological-switch')
+                                    }
+                                    wide
+                                    disabled
+                                />
+                            }
+                        />
+                        <FieldLayout
+                            label={t('location-track-dialog.topological-end-switch')}
+                            value={
+                                <TextField
+                                    value={
+                                        topologicalEndSwitch?.name ??
+                                        t('location-track-dialog.no-topological-switch')
                                     }
                                     wide
                                     disabled

--- a/ui/src/tool-panel/location-track/dialog/translations.fi.json
+++ b/ui/src/tool-panel/location-track/dialog/translations.fi.json
@@ -25,7 +25,10 @@
         "duplicate-of": "Duplikaatti raiteelle",
         "not-a-duplicate": "Ei duplikaatti",
         "search": "Hae...",
-        "topological-connectivity": "Topologinen kytkeytyminen"
+        "topological-connectivity": "Topologinen kytkeytyminen",
+        "topological-start-switch": "Vaihde raiteen alussa",
+        "topological-end-switch": "Vaihde raiteen lopussa",
+        "no-topological-switch": "Ei vaihdetta"
     },
     "location-track-delete-dialog": {
         "title": "Sijaintiraiteen poistaminen paikannuspohjasta",

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -15,6 +15,7 @@ import {
     useLocationTrackChangeTimes,
     useLocationTrackDuplicates,
     useLocationTrackStartAndEnd,
+    useSwitch,
     useTrackNumber,
 } from 'track-layout/track-layout-react-utils';
 import InfoboxText from 'tool-panel/infobox/infobox-text';
@@ -97,6 +98,11 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
         'OFFICIAL',
         locationTrackChangeTime,
     );
+    const topologicalStartSwitch = useSwitch(
+        locationTrack.topologyStartSwitch?.switchId,
+        publishType,
+    );
+    const topologicalEndSwitch = useSwitch(locationTrack.topologyEndSwitch?.switchId, publishType);
     const [showEditDialog, setShowEditDialog] = React.useState(false);
     const [updatingLength, setUpdatingLength] = React.useState<boolean>(false);
     const [canUpdate, setCanUpdate] = React.useState<boolean>();
@@ -260,6 +266,20 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                         }
                         onEdit={openEditLocationTrackDialog}
                         iconDisabled={isOfficial()}
+                    />
+                    <InfoboxField
+                        label={t('tool-panel.location-track.topological-start-switch')}
+                        value={
+                            topologicalStartSwitch?.name ??
+                            t('tool-panel.location-track.no-topological-switch')
+                        }
+                    />
+                    <InfoboxField
+                        label={t('tool-panel.location-track.topological-end-switch')}
+                        value={
+                            topologicalEndSwitch?.name ??
+                            t('tool-panel.location-track.no-topological-switch')
+                        }
                     />
 
                     <InfoboxButtons>

--- a/ui/src/tool-panel/translations.fi.json
+++ b/ui/src/tool-panel/translations.fi.json
@@ -238,7 +238,10 @@
                 "heading": "Raiteen pystygeometria",
                 "diagram-visibility": "Kuvaaja"
             },
-            "topological-connectivity": "Topologinen kytkeytyminen"
+            "topological-connectivity": "Topologinen kytkeytyminen",
+            "topological-start-switch": "Vaihde raiteen alussa",
+            "topological-end-switch": "Vaihde raiteen lopussa",
+            "no-topological-switch": "Ei vaihdetta"
         },
         "disabled": {
             "activity-disabled-in-official-mode": "Toiminto on aktiivinen vain luonnostilassa."

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -77,6 +77,11 @@ export type LayoutLocationTrackDuplicate = {
     id: LocationTrackId;
 };
 
+export type TopologyLocationTrackSwitch = {
+    switchId: LayoutSwitchId;
+    joint: JointNumber;
+};
+
 export type LayoutLocationTrack = {
     name: string;
     description: string | null;
@@ -94,6 +99,8 @@ export type LayoutLocationTrack = {
     draftType: DraftType;
     duplicateOf: LocationTrackId | null;
     topologicalConnectivity: TopologicalConnectivityType;
+    topologyStartSwitch: TopologyLocationTrackSwitch | null;
+    topologyEndSwitch: TopologyLocationTrackSwitch | null;
 };
 
 export type AlignmentId = LocationTrackId | ReferenceLineId | GeometryAlignmentId;


### PR DESCRIPTION
Tämä on periaatteessa tehty tiketin GVT-1910 (https://extranet.vayla.fi/jira/browse/GVT-1910) yhteydessä, mutta tämä ei oikeastaan liity siihen suoraan. Tämän lisäksi ka. tiketin jutut tulevat menemään niin täysin eri tavalla kuin mitä alkuperäinen speksi tiketillä sanoi, että sen kanssa otettaneen vähän lisäaikaa. Näistä johtuen päädyin tekemään tämän täysin omana, virallisesti tikettiin liittymättömänä pullarinaan.