### PR TITLE
GVT-2041 Use Selenium's native driver manager

### DIFF
--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -30,6 +30,7 @@ configurations {
 }
 
 val geotoolsVersion = "27.2"
+ext["selenium.version"] = "4.11.0"
 dependencies {
     // Version overrides for transitive deps (due to known vulnerabilities)
 
@@ -86,8 +87,7 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.8.21")
-    testImplementation("org.seleniumhq.selenium:selenium-java:4.9.1")
-    testImplementation("io.github.bonigarcia:webdrivermanager:5.3.3")
+    testImplementation("org.seleniumhq.selenium:selenium-java:4.11.0")
     testImplementation("org.mock-server:mockserver-netty-no-dependencies:5.14.0")
     testImplementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Browser.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Browser.kt
@@ -1,4 +1,3 @@
-import io.github.bonigarcia.wdm.WebDriverManager
 import org.apache.commons.io.FileUtils
 import org.json.JSONObject
 import org.openqa.selenium.JavascriptExecutor
@@ -24,7 +23,6 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Level
 
 private fun createChromeDriver(headless: Boolean): WebDriver {
-    WebDriverManager.chromedriver().setup()
     val options = ChromeOptions()
 
     if (headless) options.addArguments("--headless")
@@ -54,7 +52,6 @@ private fun createChromeDriver(headless: Boolean): WebDriver {
 }
 
 private fun createFirefoxDriver(headless: Boolean): WebDriver {
-    WebDriverManager.firefoxdriver().setup()
     val firefoxOptions = FirefoxOptions()
     if (headless) firefoxOptions.addArguments("-headless")
     firefoxOptions.addArguments("-private")


### PR DESCRIPTION
Siirrytään käyttämään uusia Seleniumin omaa selainten ja selainajurien hallintaa, kts. https://www.selenium.dev/blog/2022/introducing-selenium-manager/ . Juuri tämä uusin versio 4.11.0 osaa myös käyttää vastajulkaistua Chrome for Testingiä, jonka pitäisi osaltaan auttaa versiojärjestelyiden kanssa: https://www.selenium.dev/blog/2023/whats-new-in-selenium-manager-with-selenium-4.11.0/

Tämä ei varmastikaan poista kaikkia selain- ja ajurisäätöjä, esim. minulla näillä konffeilla toimii lokaalisti vain chrome-puoli kun taas Firefox-puolen tekosista en tiedä mitään. Mutta tuurilla voisi olla niin, että tämä riittää AWS-ympäristön selainversio-ongelmien hallintaan.

Gradle-filussa Spring Bootin riippuvuuksienhallinta sörkkii asioita aivan Gradlen ohi, siksi sille pitää erikseen kertoa haluttu Selenium-versio, kts. https://nexocode.com/blog/posts/spring-dependencies-in-gradle/ .

