### PR TITLE
General: Don't pass unnecessary test-port

### DIFF
--- a/infra/src/main/resources/application-ratkotest.yml
+++ b/infra/src/main/resources/application-ratkotest.yml
@@ -2,4 +2,3 @@ geoviite:
   ratko:
     enabled: true
     url: http://localhost:12345
-    test-port: 12345


### PR DESCRIPTION
Selkeysfiksi. Infran tarvitsee tietää vain ratko.url, testien taas vain ratko.test-port, ja tämä on infralle menevä konffi.