### PR TITLE
GVT-2049 Only set valid dates in DatePicker

### DIFF
--- a/ui/src/vayla-design-lib/datepicker/datepicker.tsx
+++ b/ui/src/vayla-design-lib/datepicker/datepicker.tsx
@@ -82,7 +82,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, ...prop
                 dateFormat="dd.MM.yyyy"
                 locale={fi}
                 selected={value}
-                onChange={(date: Date) => onChange && onChange(date)}
+                onChange={(date: Date) => onChange && !isNaN(date.getDate()) && onChange(date)}
                 calendarStartDay={1}
                 showWeekNumbers
                 popperModifiers={[


### PR DESCRIPTION
Invalidin Date-olion tunnistaminen on JavaScriptissa näemmä vähintään hämärää, esim. ainakaan Firefoxilla `isNaN(+date)` ei tässä kohdassa toiminut vaan päästi läpi invalideja olioita. Juuri getDate()n kutsumisessa ei ole siis sinällään mitään erikoista, kaikista gettereistä tulee NaNia jos olio itsessään ei ole validi.