### PR TITLE
GVT-2024 Add missing i18ns, fix overeager track number duplicate name detection

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -187,7 +187,9 @@ class LayoutTrackNumberDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
                   select *
                     from layout.track_number this_tn
                       join layout.track_number duplicate_tn
-                           on this_tn.number = duplicate_tn.number and this_tn.id != duplicate_tn.id
+                           on this_tn.number = duplicate_tn.number
+                             and this_tn.id != duplicate_tn.id
+                             and this_tn.draft_of_track_number_id is distinct from duplicate_tn.id
                     where not duplicate_tn.draft
                       and duplicate_tn.state != 'DELETED'
                       and this_tn.id = :trackNumberId)

--- a/ui/src/preview/translations.fi.json
+++ b/ui/src/preview/translations.fi.json
@@ -91,7 +91,8 @@
                 "km-post": {
                     "reference-deleted": "Poistettavaan ratanumeroon viittaa edelleen poistamattomia tasakilometripisteitä: {{0}}",
                     "not-published": "Ratanumeron tasakilometripisteillä ({{0}}) on julkaisemattomia muutoksia"
-                }
+                },
+                "duplicate-name": "Ratanumeron numero {{0}} on jo käytössä"
             },
             "km-post": {
                 "no-context": "Ratanumerolta ei voida laskea tasametripisteitä koska sitä puuttuu tietoja",
@@ -170,7 +171,7 @@
                     "wrong-joint-sequence": "Sijaintiraiteen vaihdepisteet ({{2}}) vaihteella {{0}} ({{1}}) eivät vastaa vaihderakenteen linjoja",
                     "wrong-links": "Vaihteen {{0}} linkitys on vajavainen ja se täytyy linkittää uudelleen"
                 },
-                "duplicate-name": "Sijaintiraiteen nimi {{0}} on jo käytössä jollain olemassaolevalla julkaistulla saman ratanumeron sijaintiraiteella"
+                "duplicate-name": "Sijaintiraiteen nimi {{0}} on jo käytössä saman ratanumeron sijaintiraiteella"
             },
             "switch": {
                 "not-draft": "Virhe julkaisun sisällössä: julkaistava vaihde ei ole luonnos",
@@ -184,7 +185,8 @@
                     "joint-location-mismatch": "Vaihteen ja sijaintiraiteen vaihdepisteiden sijainnit eivät kohtaa: {{0}}",
                     "wrong-joint-sequence": "Kaikki vaihteeseen kytketyt raiteet ({{0}}) eivät vastaa vaihderakenteen linjoja",
                     "unlinked": "Jotkut vaihteen linjoista ({{0}}) eivät ole kytkettynä mihinkään sijaintiraiteiseen"
-                }
+                },
+                "duplicate-name": "Vaihteed nimi {{0}} on jo käytössä"
             },
             "geocoding": {
                 "sharp-angle": "Sijaintiraiteen {{1}} tasametripisteet menevät taaksepäin, koska kulma ratanumeron {{0}} pituusmittauslinjaan eroaa liikaa. Rataosoitevälit: {{2}}",


### PR DESCRIPTION
Vielä duplikaattinimijuttuja. Virheenkäsittelyn puolella i18n-viestit oli paikoillaan, mutta olin sattunut tekemään tämän niin, että validoinnin puolella on omat viestinsä, ja siellä oli puutteita. Ja ratanumeron päivityksen rietale vieläpä varoitti siitä, että ihan normaalisti päivitettiin olemassaolevaa ratanumeroa.