### PR TITLE
GVT-2057 Define edit dialogs' initial states better

### DIFF
--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
@@ -20,7 +20,7 @@ import { KmNumber } from 'common/common-model';
 export type KmPostEditState = {
     isNewKmPost: boolean;
     existingKmPost?: LayoutKmPost;
-    kmPost?: KmPostSaveRequest;
+    kmPost: KmPostSaveRequest;
     loading: {
         trackNumbers: boolean;
         kmPost: boolean;
@@ -37,7 +37,9 @@ export type KmPostEditState = {
 export const initialKmPostEditState: KmPostEditState = {
     isNewKmPost: false,
     existingKmPost: undefined,
-    kmPost: undefined,
+    kmPost: {
+        kmNumber: '',
+    },
     loading: {
         trackNumbers: false,
         kmPost: false,

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-store.ts
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-store.ts
@@ -23,7 +23,7 @@ export type LocationTrackEditState = {
     };
     isSaving: boolean;
     trackNumbers: LayoutTrackNumber[];
-    locationTrack?: LocationTrackSaveRequest;
+    locationTrack: LocationTrackSaveRequest;
     validationErrors: ValidationError<LocationTrackSaveRequest>[];
     committedFields: (keyof LocationTrackSaveRequest)[];
     allFieldsCommitted: boolean;
@@ -38,7 +38,13 @@ export const initialLocationTrackEditState: LocationTrackEditState = {
     },
     isSaving: false,
     trackNumbers: [],
-    locationTrack: undefined,
+    locationTrack: {
+        name: '',
+        state: undefined,
+        type: undefined,
+        description: '',
+        duplicateOf: null,
+    },
     validationErrors: [],
     committedFields: [],
     allFieldsCommitted: false,


### PR DESCRIPTION
Näitä dialogeja avattessa merkkijonokentät renderöidään ensiksi undefined-arvolla, ts. Reactin näkemyksestä kuin value-propsulle ei olisi annettu lainkaan arvoa, ja heti perään sitten oikealla arvolla, mistä React sitten mölisee kun näkee mielestään kontrolloimattoman komponentin muuttuvan kontrolloiduksi.

Korjataan selkeyttämällä muokkausdialogien tilanhallintaa niin, että merkkijonokenttien sisällöt ovat alusta lähtien merkkijonoja.