### PR TITLE
GVT-2039: Add publication state validation for topologically connected switches of location track

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -499,7 +499,7 @@ private fun getTopologySwitchJointDataHolder(
     fetchStructure: (structureId: IntId<SwitchStructure>) -> SwitchStructure,
 ): Pair<IntId<TrackLayoutSwitch>, List<SwitchJointDataHolder>>? {
     val switch = fetchSwitch(topologySwitch.switchId)
-        ?: throw NoSuchEntityException(TrackLayoutSwitch::class, topologySwitch.switchId)
+        ?: return null
     // Use presentation joint to filter joints to update because
     // - that is joint number that is normally used to connect tracks and switch topologically
     // - and Ratko may not want other joint numbers in this case

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -690,7 +690,8 @@ class PublicationService @Autowired constructor(
             locationTrack, validationVersions
         ) else listOf()
 
-        return fieldErrors + referenceErrors + switchErrorsSegments + switchErrorsTopological + duplicateErrors + alignmentErrors + geocodingErrors + duplicateNameErrors
+        return fieldErrors + referenceErrors + switchErrorsSegments + switchErrorsTopological +
+               duplicateErrors + alignmentErrors + geocodingErrors + duplicateNameErrors
     }
 
     private fun validateLocationTrackNameDuplication(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -302,6 +302,17 @@ fun validateSegmentSwitchReferences(
     }
 }
 
+fun validateTopologicallyConnectedSwitchReferences(
+    topologicallyConnectedSwitches: List<TrackLayoutSwitch>,
+    publishSwitchIds: List<IntId<TrackLayoutSwitch>>,
+): List<PublishValidationError> {
+    return topologicallyConnectedSwitches.mapNotNull { switch ->
+        validateWithParams(isPublished(switch, publishSwitchIds)) {
+            "$VALIDATION_LOCATION_TRACK.switch.not-published" to listOf(switch.name.toString())
+        }
+    }
+}
+
 private fun jointSequence(joints: List<JointNumber>) =
     joints.joinToString("-") { jointNumber -> "${jointNumber.intValue}" }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1461,6 +1461,155 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals(2, rows3.size)
         assertTrue { rows3[0].name.contains("1234") }
     }
+
+    @Test
+    fun `Location track validation accounts for the publication state of topologically linked switches`() {
+
+        fun getLocationTrackValidationResult(
+            locationTrackId: IntId<LocationTrack>,
+            stagedSwitches: List<IntId<TrackLayoutSwitch>> = listOf(),
+        ): LocationTrackPublishCandidate? {
+            val publishRequestIds = PublishRequestIds(
+                trackNumbers = listOf(),
+                locationTracks = listOf(locationTrackId),
+                referenceLines = listOf(),
+                switches = stagedSwitches,
+                kmPosts = listOf(),
+            )
+
+            val validationResult = publicationService
+                .validatePublishCandidates(publicationService.collectPublishCandidates(), publishRequestIds)
+
+            return validationResult.validatedAsPublicationUnit.locationTracks
+                .find { lt -> lt.id == locationTrackId }
+        }
+
+        val switchSection1 = Point(0.0, 0.0) to Point(1.0, 0.0)
+        val locationTrackAlignment = alignment(segment(Point(1.0, 0.0), Point(2.0, 0.0)))
+        val switchSection2 = Point(2.0, 0.0) to Point(3.0, 0.0)
+
+        val switchIds = listOf(switchSection1, switchSection2)
+            .mapIndexed { i, switchSection ->
+                switch(name="Topology test switch $i").copy(
+                    joints=listOf(
+                        TrackLayoutSwitchJoint(
+                            number=JointNumber(1),
+                            location=switchSection.first,
+                            locationAccuracy = null
+                        ),
+                        TrackLayoutSwitchJoint(
+                            number=JointNumber(3),
+                            location=switchSection.second,
+                            locationAccuracy = null
+                        )
+                    )
+                )
+            }
+            .map{ switch -> switchDao.insert(draft(switch)).id}
+
+        val locationTracksUnderTest = listOf(
+            locationTrack(
+                trackNumberId = getUnusedTrackNumberId(),
+            ),
+
+            locationTrack(
+                trackNumberId = getUnusedTrackNumberId(),
+                topologyStartSwitch = TopologyLocationTrackSwitch(
+                    switchId = switchIds.first(),
+                    jointNumber = JointNumber(3)
+                )
+            ),
+
+            locationTrack(
+                trackNumberId = getUnusedTrackNumberId(),
+                topologyEndSwitch = TopologyLocationTrackSwitch(
+                    switchId = switchIds.first(),
+                    jointNumber = JointNumber(1)
+                )
+            ),
+
+            locationTrack(
+                trackNumberId = getUnusedTrackNumberId(),
+                topologyStartSwitch = TopologyLocationTrackSwitch(
+                    switchId = switchIds.first(),
+                    jointNumber = JointNumber(3)
+                ),
+                topologyEndSwitch = TopologyLocationTrackSwitch(
+                    switchId = switchIds.last(),
+                    jointNumber = JointNumber(1)
+                )
+            )
+        )
+
+        val locationTrackIdsUnderTest = locationTracksUnderTest
+            .map { locationTrack ->
+                locationTrack.copy(alignmentVersion = alignmentDao.insert(locationTrackAlignment))
+            }
+            .map { locationTrack ->
+                locationTrackDao.insert(draft(locationTrack)).id to locationTrack
+            }
+
+        assertEquals(2, switchIds.size)
+        assertEquals(4, locationTrackIdsUnderTest.size)
+
+        // During these tests, a single geocoding validation error is expected in all cases.
+        // However, it is currently unmatched, partially due to validation errors not having type information available.
+        // Matching could still be accomplished with language strings, but this is currently not done.
+        val expectedValidationErrors = 1;
+
+        val singleTopologicallyConnectedSwitchValidationErrors = 1;
+        val doubleTopologicallyConnectedSwitchValidationErrors = 2;
+
+        // Location track validation should fail for unofficial and unstaged topologically linked switches.
+        locationTrackIdsUnderTest.forEach { (locationTrackId, lt) ->
+            val validationErrorAmount = getLocationTrackValidationResult(locationTrackId)?.errors?.size;
+
+            when {
+                lt.topologyStartSwitch == null && lt.topologyEndSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
+                lt.topologyStartSwitch == null -> assertEquals(
+                    expectedValidationErrors + singleTopologicallyConnectedSwitchValidationErrors,
+                    validationErrorAmount
+                )
+                lt.topologyEndSwitch == null -> assertEquals(
+                    expectedValidationErrors + singleTopologicallyConnectedSwitchValidationErrors,
+                    validationErrorAmount
+                )
+                else -> assertEquals(
+                    expectedValidationErrors + doubleTopologicallyConnectedSwitchValidationErrors,
+                    validationErrorAmount
+                )
+            }
+        }
+
+        // Location track validation should succeed for unofficial, but staged topologically linked switches.
+        locationTrackIdsUnderTest.forEach { (locationTrackId, lt) ->
+            val validationErrorAmount = getLocationTrackValidationResult(
+                locationTrackId,
+                switchIds,
+            )?.errors?.size;
+
+            when {
+                lt.topologyStartSwitch == null && lt.topologyEndSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
+                lt.topologyStartSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
+                lt.topologyEndSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
+                else -> assertEquals(expectedValidationErrors, validationErrorAmount)
+            }
+        }
+
+        // Location track validation should succeed for official switches.
+        publish(publicationService, switches = switchIds)
+
+        locationTrackIdsUnderTest.forEach { (locationTrackId, lt) ->
+            val validationErrorAmount = getLocationTrackValidationResult(locationTrackId)?.errors?.size;
+
+            when {
+                lt.topologyStartSwitch == null && lt.topologyEndSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
+                lt.topologyStartSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
+                lt.topologyEndSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
+                else -> assertEquals(expectedValidationErrors, validationErrorAmount)
+            }
+        }
+    }
 }
 
 private fun assertEqualsCalculatedChanges(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -229,6 +229,8 @@ fun locationTrack(
     state: LayoutState = LayoutState.IN_USE,
     externalId: Oid<LocationTrack>? = someOid(),
     alignmentVersion: RowVersion<LayoutAlignment>? = null,
+    topologyStartSwitch: TopologyLocationTrackSwitch? = null,
+    topologyEndSwitch: TopologyLocationTrackSwitch? = null,
 ) = LocationTrack(
     name = AlignmentName(name),
     description = FreeText(description),
@@ -243,8 +245,8 @@ fun locationTrack(
     draft = draft,
     duplicateOf = null,
     topologicalConnectivity = TopologicalConnectivityType.START,
-    topologyStartSwitch = null,
-    topologyEndSwitch = null,
+    topologyStartSwitch = topologyStartSwitch,
+    topologyEndSwitch = topologyEndSwitch,
     alignmentVersion = alignmentVersion,
 ).let { lt -> if (id != null) lt.copy(id = id) else lt }
 


### PR DESCRIPTION
Previously the publication state of the switches that were connected topologically to a location track were not validated. However, this did not cause critical issues during publication: Another part of the topological switch reference fetching functionality did not find these switches, which in turn resulted in a `throw`. This `throw` related error was displayed to a user opening the publication staging view in a with a "404" snackbar error in case a location track and switch(es) were created in specific order.

* Topologically connected switches are considered valid when they are officially published or in draft state in the same publishing group as a draft location track that is referencing them.
* Test for the previously missing validation was added.
* Tests to ensure that valid switch references can be used as topological connections to a location track were added.