### PR TITLE
GVT-2054 Update height diagram on geometry plan changes

### DIFF
--- a/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
@@ -27,6 +27,7 @@ import {
     VerticalGeometryDiagramAlignmentId,
     VisibleExtentLookup,
 } from 'vertical-geometry/store';
+import { getMaxTimestamp } from 'utils/date-utils';
 
 type VerticalGeometryDiagramHolderProps = {
     alignmentId: VerticalGeometryDiagramAlignmentId;
@@ -130,7 +131,7 @@ export const VerticalGeometryDiagramHolder: React.FC<VerticalGeometryDiagramHold
             'planId' in alignmentId
                 ? undefined
                 : getLocationTrackLinkingSummary(
-                      changeTimes.layoutLocationTrack,
+                      getMaxTimestamp(changeTimes.geometryPlan, changeTimes.layoutLocationTrack),
                       alignmentId.locationTrackId,
                       alignmentId.publishType,
                   );


### PR DESCRIPTION
Geometriasuunnitelmien muutosaikoja pitää vetää aika monestakin paikasta läpi, jotta auki olevassa kaaviossa osaa geometriasuunnitelman muutoksista päivittyä sekä otsikkotiedot, että korkeusjärjestelmän muutoksesta myös korkeusviiva.