### PR TITLE
GVT-2060: Allow newlines in infra model observations free text field

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -760,7 +760,7 @@ class GeometryDao @Autowired constructor(
             elevationMeasurementMethod = rs.getEnumOrNull<ElevationMeasurementMethod>("elevation_measurement_method"),
             decisionPhase = rs.getEnumOrNull<PlanDecisionPhase>("plan_decision"),
             planPhase = rs.getEnumOrNull<PlanPhase>("plan_phase"),
-            message = rs.getFreeTextOrNull("message"),
+            message = rs.getFreeTextWithNewLinesOrNull("message"),
             linkedAsPlanId = rs.getIntIdOrNull("linked_as_plan_id"),
             uploadTime = rs.getInstant("upload_time"),
             units = GeometryUnits(
@@ -929,7 +929,7 @@ class GeometryDao @Autowired constructor(
                 measurementMethod = rs.getEnumOrNull<MeasurementMethod>("measurement_method"),
                 elevationMeasurementMethod = rs.getEnumOrNull<ElevationMeasurementMethod>("elevation_measurement_method"),
                 dataType = DataType.STORED,
-                message = rs.getFreeTextOrNull("message"),
+                message = rs.getFreeTextWithNewLinesOrNull("message"),
                 uploadTime = rs.getInstant("upload_time"),
                 isHidden = rs.getBoolean("hidden"),
             )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
@@ -15,7 +15,7 @@ import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.FileName
-import fi.fta.geoviite.infra.util.FreeText
+import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import java.time.Instant
 
 
@@ -40,7 +40,7 @@ data class GeometryPlanHeader(
     val planPhase: PlanPhase?,
     val decisionPhase: PlanDecisionPhase?,
     val planTime: Instant?,
-    val message: FreeText?,
+    val message: FreeTextWithNewLines?,
     val linkedAsPlanId: IntId<GeometryPlan>?,
     val uploadTime: Instant,
     val units: GeometryUnits,
@@ -79,7 +79,7 @@ data class GeometryPlan(
     val decisionPhase: PlanDecisionPhase?,
     val measurementMethod: MeasurementMethod?,
     val elevationMeasurementMethod: ElevationMeasurementMethod?,
-    val message: FreeText?,
+    val message: FreeTextWithNewLines?,
     val isHidden: Boolean = false,
     val id: DomainId<GeometryPlan> = StringId(),
     val dataType: DataType = DataType.TEMP,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
@@ -5,7 +5,7 @@ import fi.fta.geoviite.infra.error.HasLocalizeMessageKey
 import fi.fta.geoviite.infra.geometry.*
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
-import fi.fta.geoviite.infra.util.FreeText
+import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import fi.fta.geoviite.infra.util.LocalizationKey
 import fi.fta.geoviite.infra.util.XmlCharset
 import java.time.Instant
@@ -27,7 +27,7 @@ data class ExtraInfoParameters(
     val decisionPhase: PlanDecisionPhase?,
     val measurementMethod: MeasurementMethod?,
     val elevationMeasurementMethod: ElevationMeasurementMethod?,
-    val message: FreeText?,
+    val message: FreeTextWithNewLines?,
 )
 
 data class OverrideParameters(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import fi.fta.geoviite.infra.util.LocalizationKey
+import fi.fta.geoviite.infra.util.normalizeLinebreaksToUnixFormat
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -184,6 +185,9 @@ class InfraModelService @Autowired constructor(
 
         val overrideCs = overrideParameters?.coordinateSystemSrid?.let(geographyService::getCoordinateSystem)
 
+        val messageWithNormalizedLinebreaks = extraInfoParameters
+            ?.message?.let { normalizeLinebreaksToUnixFormat(extraInfoParameters.message) }
+
         // Nullable fields that do not contain a default parameter via the elvis-operator are considered to be assignable
         // to null even if they have non-null values stored in the database.
         return plan.copy(
@@ -201,7 +205,7 @@ class InfraModelService @Autowired constructor(
             decisionPhase = extraInfoParameters?.decisionPhase,
             measurementMethod = extraInfoParameters?.measurementMethod,
             elevationMeasurementMethod = extraInfoParameters?.elevationMeasurementMethod,
-            message = extraInfoParameters?.message ?: plan.message,
+            message = messageWithNormalizedLinebreaks ?: plan.message,
             planTime = overrideParameters?.createdDate ?: plan.planTime,
             uploadTime = plan.uploadTime,
             source = overrideParameters?.source ?: plan.source,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -188,6 +188,8 @@ fun ResultSet.getFreeText(name: String): FreeText = verifyNotNull(name, ::getFre
 
 fun ResultSet.getFreeTextOrNull(name: String): FreeText? = getString(name)?.let(::FreeText)
 
+fun ResultSet.getFreeTextWithNewLinesOrNull(name: String): FreeTextWithNewLines? = getString(name)?.let(::FreeTextWithNewLines)
+
 fun ResultSet.getFileName(name: String): FileName = verifyNotNull(name, ::getFileNameOrNull)
 
 fun ResultSet.getFileNameOrNull(name: String): FileName? = getString(name)?.let(::FileName)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/SanitizedString.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/SanitizedString.kt
@@ -5,7 +5,13 @@ import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
 
 val codeRegex = Regex("^[A-Za-z0-9_\\-.]+\$")
-val freeTextRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 _\\\\\\-–+().,'/*<>:;!?&]*\$")
+
+const val newLineCharacter = "\n"
+const val freeTextCharacters = "A-ZÄÖÅa-zäöå0-9 _\\\\\\-–+().,'/*<>:;!?&"
+const val freeTextWithNewLineCharacters = freeTextCharacters + newLineCharacter
+
+val freeTextRegex = Regex("^[$freeTextCharacters]*\$")
+val freeTextWithNewLinesRegex = Regex("^[$freeTextWithNewLineCharacters]*\$")
 
 data class Code @JsonCreator(mode = DELEGATING) constructor(private val value: String)
     : Comparable<Code>, CharSequence by value {
@@ -26,4 +32,14 @@ data class FreeText @JsonCreator(mode = DELEGATING) constructor(private val valu
     override fun toString(): String = value
     override fun compareTo(other: FreeText): Int = value.compareTo(other.value)
     operator fun plus(addition: String) = FreeText("$value$addition")
+}
+
+data class FreeTextWithNewLines @JsonCreator(mode = DELEGATING) constructor(private val value: String)
+    : Comparable<FreeTextWithNewLines>, CharSequence by value {
+    init { assertSanitized<FreeTextWithNewLines>(value, freeTextWithNewLinesRegex) }
+
+    @JsonValue
+    override fun toString(): String = value
+    override fun compareTo(other: FreeTextWithNewLines): Int = value.compareTo(other.value)
+    operator fun plus(addition: String) = FreeTextWithNewLines("$value$addition")
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
@@ -6,6 +6,13 @@ import fi.fta.geoviite.infra.error.InputValidationException
 val lineBreakRegex = Regex("[\n\r\t]")
 const val UNSAFE_LOG_CHARACTERS = "[^A-Za-zäöÄÖåÅ0-9_-+!?.:;', �/]"
 
+const val UNIX_LINEBREAK = "\n"
+const val LEGACY_LINEBREAK = "\r" // Possibly used in older files were text may be copied and pasted from.
+const val WINDOWS_LINEBREAK = "\r\n"
+
+// Order matters due to both Windows style & legacy linebreaks containing the same special character.
+val linebreakNormalizationRegex = Regex("$WINDOWS_LINEBREAK|$LEGACY_LINEBREAK")
+
 const val UNSAFE_REPLACEMENT = "�"
 const val LINE_BREAK_REPLACEMENT = "^"
 
@@ -37,6 +44,9 @@ fun limitLength(input: String, maxLength: Int) =
 fun removeLogUnsafe(input: String) = input.replace(UNSAFE_LOG_CHARACTERS, UNSAFE_REPLACEMENT)
 
 fun removeLinebreaks(input: String) = input.replace(lineBreakRegex, LINE_BREAK_REPLACEMENT)
+
+fun normalizeLinebreaksToUnixFormat(input: String) = input.replace(linebreakNormalizationRegex, UNIX_LINEBREAK)
+fun normalizeLinebreaksToUnixFormat(input: FreeTextWithNewLines) = FreeTextWithNewLines(normalizeLinebreaksToUnixFormat(input.toString()))
 
 fun isSanitized(
     stringValue: String,

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -728,6 +728,7 @@
         "file-name": "Nimi",
         "name-help": "Jos suunnitteluprojekti ei löydy listalta, luo uusi.",
         "observations-field": "Huomiot",
+        "observations-field-default": "",
         "observations-help": "Huomiot näkyvät info-symbolina listanäkymässä.",
         "location-formgroup-title": "Sijaintitiedot",
         "tracknumberfield": "Ratanumero",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
@@ -11,6 +11,7 @@ import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
+import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
@@ -404,7 +405,7 @@ fun plan(
         decisionPhase = PlanDecisionPhase.APPROVED_PLAN,
         measurementMethod = measurementMethod,
         elevationMeasurementMethod = elevationMeasurementMethod,
-        message = FreeText("test text description"),
+        message = FreeTextWithNewLines("test text \n description"),
         uploadTime = Instant.now(),
     )
 }
@@ -433,7 +434,7 @@ fun planHeader(
     planTime = Instant.EPOCH,
     trackNumberId = trackNumberId,
     linkedAsPlanId = null,
-    message = FreeText("test text description"),
+    message = FreeTextWithNewLines("test text \n description"),
     uploadTime = Instant.now(),
     source = source,
     hasCant = false,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
@@ -5,6 +5,27 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 
+
+val allowedFreeTextCases = listOf(
+    "",
+    "Legal Free text: * -> 'asdf' (Äö/å) _-–\\ +123465790?!",
+)
+
+val illegalFreeTextCases = listOf(
+    "Illegal`",
+    "Illegal´",
+    "Illegal=",
+    "Illegal\"",
+    "Illegal\tName",
+)
+
+val freeTextWithNewLineCases = listOf(
+    "\nStarting line break is allowed",
+    "Ending line break is allowed\n",
+    "Legal Free text with newline in the middle: * -> 'asdf' \n (Äö/å) _-–\\ +123465790?!",
+    "Legal Free text with multiple newlines \n in the middle: * -> 'asdf' \n (Äö/å) _-–\\ +123465790?!",
+)
+
 class SanitizedStringTest {
 
     @Test
@@ -36,14 +57,32 @@ class SanitizedStringTest {
 
     @Test
     fun freeTextCantContainIllegalChars() {
-        assertDoesNotThrow { FreeText("Legal Free text: * -> 'asdf' (Äö/å) _-–\\ +123465790?!") } // both - and –
-        assertDoesNotThrow { FreeText("") }
-        assertThrows<InputValidationException> { FreeText("Illegal`") }
-        assertThrows<InputValidationException> { FreeText("Illegal´") }
-        assertThrows<InputValidationException> { FreeText("Illegal=") }
-        assertThrows<InputValidationException> { FreeText("Illegal\"") }
-        assertThrows<InputValidationException> { FreeText("Illegal\n") }
-        assertThrows<InputValidationException> { FreeText("Illegal\tName") }
+        allowedFreeTextCases.forEach { allowedFreeText ->
+            assertDoesNotThrow { FreeText(allowedFreeText) }
+        }
+
+        (illegalFreeTextCases + freeTextWithNewLineCases).forEach { illegalFreeText ->
+            assertThrows<InputValidationException> {
+                FreeText(illegalFreeText)
+            }
+        }
     }
+
+    @Test
+    fun freeTextWithNewLinesCanContainNewLines() {
+        (allowedFreeTextCases + freeTextWithNewLineCases).forEach { allowedFreeTextWithNewlines ->
+            assertDoesNotThrow { FreeTextWithNewLines(allowedFreeTextWithNewlines) }
+        }
+    }
+
+    @Test
+    fun freeTextWithNewLinesCantContainIllegalChars() {
+        illegalFreeTextCases.forEach { illegalFreeText ->
+            assertThrows<InputValidationException> {
+                FreeText(illegalFreeText)
+            }
+        }
+    }
+
 
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/StringUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/StringUtilsTest.kt
@@ -1,0 +1,27 @@
+package fi.fta.geoviite.infra.util
+
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+
+val linebreakNormalizationTestCases = listOf(
+    "string without linebreak is not modified" to "string without linebreak is not modified",
+    "ending unix linebreak is not modified\n" to "ending unix linebreak is not modified\n",
+    "ending Windows linebreak is modified to unix style\r\n" to "ending Windows linebreak is modified to unix style\n",
+    "ending Legacy linebreak is modified to unix style\r" to "ending Legacy linebreak is modified to unix style\n",
+    "Legacy linebreak modification doesn't result \r in additional linebreaks\r\r\n" to "Legacy linebreak modification doesn't result \n in additional linebreaks\n\n",
+    "\r\nMultiple \nlinebreaks are \r\n\r\ncorrectly modified to unix style\r" to "\nMultiple \nlinebreaks are \n\ncorrectly modified to unix style\n",
+)
+
+class StringUtilsTest {
+
+    @Test
+    fun linebreaksAreCorrectlyNormalized() {
+        linebreakNormalizationTestCases.forEach { (testCase, expectedResult) ->
+            val modifiedString = normalizeLinebreaksToUnixFormat(testCase)
+
+            assertEquals(expectedResult, modifiedString,"Test failed with expected: $expectedResult, modified: $modifiedString")
+        }
+    }
+
+}

--- a/ui/src/infra-model/view/form/infra-model-form.module.scss
+++ b/ui/src/infra-model/view/form/infra-model-form.module.scss
@@ -13,8 +13,8 @@
 
     .text-area {
         .text-area__input-element {
-            min-height: 40px;
-            height: 40px;
+            min-height: 60px;
+            height: 60px;
             resize: vertical;
         }
     }

--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -9,7 +9,6 @@ import {
 } from 'geometry/geometry-model';
 import styles from './infra-model-form.module.scss';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
-import { TextArea } from 'vayla-design-lib/text-area/text-area';
 import Formgroup from 'infra-model/view/formgroup/formgroup';
 import FormgroupContent from 'infra-model/view/formgroup/formgroup-content';
 import {
@@ -51,6 +50,7 @@ import { WriteAccessRequired } from 'user/write-access-required';
 import { usePvDocumentHeader } from 'track-layout/track-layout-react-utils';
 //import { PVRedirectLink } from 'infra-model/projektivelho/pv-redirect-link';
 import { PVOid } from 'infra-model/projektivelho/pv-oid';
+import FormgroupTextarea from 'infra-model/view/formgroup/formgroup-textarea';
 
 type InframodelViewFormContainerProps = {
     changeTimes: ChangeTimes;
@@ -71,6 +71,7 @@ type InframodelViewFormContainerProps = {
 
 export type EditablePlanField =
     | undefined
+    | 'observations'
     | 'planName'
     | 'planOid'
     | 'assignmentName'
@@ -248,18 +249,20 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                 <Formgroup>
                     <FieldLayout
                         label={t('im-form.observations-field')}
+                        help={t('im-form.observations-help')}
                         value={
-                            <TextArea
+                            <FormgroupTextarea
+                                label={t('im-form.observations-field')}
+                                defaultDisplayedValue={t('im-form.observations-field-default')}
                                 value={extraInframodelParameters.message}
-                                wide
-                                readOnly={false}
-                                maxlength={250}
+                                inEditMode={fieldInEdit === 'observations'}
+                                onEdit={() => setFieldInEdit('observations')}
+                                onClose={() => setFieldInEdit(undefined)}
                                 onChange={(e) =>
                                     changeInExtraParametersField(e.currentTarget.value, 'message')
                                 }
                             />
                         }
-                        help={t('im-form.observations-help')}
                     />
                 </Formgroup>
             </WriteAccessRequired>

--- a/ui/src/infra-model/view/formgroup/formgroup-textarea.tsx
+++ b/ui/src/infra-model/view/formgroup/formgroup-textarea.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styles from './formgroup.module.scss';
+import { Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { WriteAccessRequired } from 'user/write-access-required';
+import { TextAreaAutoResizing } from 'vayla-design-lib/text-area/text-area-autoresizing';
+
+type TextareaProps = {
+    label: string;
+    defaultDisplayedValue: string;
+    value?: string;
+    inEditMode?: boolean;
+    onEdit?: () => void;
+    onChange?: (e: React.FormEvent<HTMLTextAreaElement>) => void;
+    onClose?: () => void;
+};
+
+const FormgroupTextarea: React.FC<TextareaProps> = ({
+    label,
+    value,
+    defaultDisplayedValue,
+    inEditMode = false,
+    ...props
+}: TextareaProps) => {
+    return (
+        <div className={styles['formgroup__textarea']}>
+            <div className={styles['formgroup__textarea-content']}>
+                {inEditMode && props.onClose && (
+                    <TextAreaAutoResizing
+                        label={label}
+                        value={value}
+                        wide
+                        readOnly={false}
+                        maxlength={250}
+                        onChange={(e) => props.onChange && props.onChange(e)}
+                    />
+                )}
+                {!inEditMode && props.onEdit && (
+                    <p className={styles['formgroup__paragraph-with-linebreaks']}>
+                        {value ? value : defaultDisplayedValue}
+                    </p>
+                )}
+            </div>
+
+            <div className={styles['formgroup__edit-icon']}>
+                {!inEditMode && props.onEdit && (
+                    <WriteAccessRequired>
+                        <div onClick={() => props.onEdit && props.onEdit()}>
+                            <Icons.Edit size={IconSize.SMALL} />
+                        </div>
+                    </WriteAccessRequired>
+                )}
+                {inEditMode && props.onClose && (
+                    <div onClick={() => props.onClose && props.onClose()}>
+                        <Icons.Tick size={IconSize.SMALL} />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default FormgroupTextarea;

--- a/ui/src/infra-model/view/formgroup/formgroup.module.scss
+++ b/ui/src/infra-model/view/formgroup/formgroup.module.scss
@@ -35,8 +35,29 @@
     }
 
     &__edit-icon {
+        display: flex;
+        align-items: center;
         padding: 0 5px;
         cursor: pointer;
         margin-right: 20px;
+    }
+
+    &__textarea {
+        display: flex;
+        flex: 1;
+    }
+
+    &__textarea-content {
+        flex: 1;
+        margin-right: 10px;
+    }
+
+    &__textarea-content textarea {
+        overflow-y: hidden;
+    }
+
+    &__paragraph-with-linebreaks {
+        white-space: pre-line;
+        word-break: break-all;
     }
 }

--- a/ui/src/vayla-design-lib/text-area/text-area-autoresizing.tsx
+++ b/ui/src/vayla-design-lib/text-area/text-area-autoresizing.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import styles from './text-area.scss';
+import { IconColor, IconComponent, IconSize } from 'vayla-design-lib/icon/Icon';
+import { createClassName } from 'vayla-design-lib/utils';
+
+export type TextAreaProps = {
+    Icon?: IconComponent;
+    hasError?: boolean;
+    wide?: boolean;
+    maxlength?: number;
+} & React.HTMLProps<HTMLTextAreaElement>;
+
+export const TextAreaAutoResizing: React.FC<TextAreaProps> = ({
+    Icon,
+    hasError = false,
+    wide,
+    maxlength,
+    onChange,
+    ...props
+}: TextAreaProps) => {
+    const inputRef = React.useRef<HTMLTextAreaElement>(null);
+    const [hasFocus, setHasFocus] = React.useState(false);
+
+    // Set initial "hasFocus"
+    React.useEffect(() => {
+        setHasFocus(document.activeElement == inputRef.current);
+    });
+
+    const className = createClassName(
+        styles['text-area'],
+        Icon && styles['text-area--with-icon'],
+        props.disabled && styles['text-area--disabled'],
+        hasFocus && styles['text-area--focus'],
+        hasError && styles['text-area--has-error'],
+        wide && styles['text-area--wide'],
+    );
+
+    React.useEffect(() => {
+        const textarea = inputRef.current;
+        if (textarea) {
+            textarea.style.height = 'inherit';
+            textarea.style.height = `${textarea.scrollHeight}px`;
+        }
+    }, []);
+
+    const updateHeight = (e: React.FormEvent<HTMLTextAreaElement>) => {
+        const textarea = e.currentTarget;
+        textarea.style.height = 'inherit';
+        textarea.style.height = `${textarea.scrollHeight}px`;
+    };
+
+    return (
+        <div className={className}>
+            <div className={styles['text-area__input']}>
+                {Icon && (
+                    <div className={styles['text-area__icon']}>
+                        <Icon size={IconSize.SMALL} color={IconColor.INHERIT} />
+                    </div>
+                )}
+                <textarea
+                    className={styles['text-area__input-element']}
+                    {...props}
+                    ref={inputRef}
+                    maxLength={maxlength}
+                    onChange={(e) => {
+                        if (onChange) onChange(e);
+                        updateHeight(e);
+                    }}
+                    onFocus={() => setHasFocus(true)}
+                    onBlur={() => setHasFocus(false)}
+                />
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
The free text field is now also using the pen method to enable editing of the field as all are other fields in the infra model edit form.