### PR TITLE
GVT-2066 Display segment-linked switches as ends in track infobox

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -100,8 +100,8 @@ class LocationTrackController(
         val locationTrackAndAlignment = locationTrackService.getWithAlignment(publishType, id)
         return toResponse(locationTrackAndAlignment?.let { (_, alignment) ->
             SwitchesAtEnds(
-                if (alignment.segments.firstOrNull()?.startJointNumber == null) null else alignment.segments.firstOrNull()?.switchId,
-                if (alignment.segments.lastOrNull()?.endJointNumber == null) null else alignment.segments.lastOrNull()?.switchId
+                if (alignment.segments.firstOrNull()?.startJointNumber == null) null else alignment.segments.firstOrNull()?.switchId as IntId?,
+                if (alignment.segments.lastOrNull()?.endJointNumber == null) null else alignment.segments.lastOrNull()?.switchId as IntId?,
             )
         })
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -91,6 +91,22 @@ class LocationTrackController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/{publishType}/{id}/switches-at-ends")
+    fun getLocationTrackSwitchesAtEnds(
+        @PathVariable("publishType") publishType: PublishType,
+        @PathVariable("id") id: IntId<LocationTrack>,
+    ): ResponseEntity<SwitchesAtEnds> {
+        logger.apiCall("getLocationTrackSwitchesAtEnds", "publishType" to publishType, "id" to id)
+        val locationTrackAndAlignment = locationTrackService.getWithAlignment(publishType, id)
+        return toResponse(locationTrackAndAlignment?.let { (_, alignment) ->
+            SwitchesAtEnds(
+                if (alignment.segments.firstOrNull()?.startJointNumber == null) null else alignment.segments.firstOrNull()?.switchId,
+                if (alignment.segments.lastOrNull()?.endJointNumber == null) null else alignment.segments.lastOrNull()?.switchId
+            )
+        })
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("{publishType}/end-points")
     fun getLocationTrackAlignmentEndpoints(
         @PathVariable("publishType") publishType: PublishType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -280,8 +280,8 @@ data class TrackNumberAndChangeTime(
 )
 
 data class SwitchesAtEnds(
-    val start: DomainId<TrackLayoutSwitch>?,
-    val end: DomainId<TrackLayoutSwitch>?,
+    val start: IntId<TrackLayoutSwitch>?,
+    val end: IntId<TrackLayoutSwitch>?,
 )
 
 fun getTranslation(key: String) = kmLengthTranslations[key] ?: ""

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -279,6 +279,11 @@ data class TrackNumberAndChangeTime(
     val changeTime: Instant,
 )
 
+data class SwitchesAtEnds(
+    val start: DomainId<TrackLayoutSwitch>?,
+    val end: DomainId<TrackLayoutSwitch>?,
+)
+
 fun getTranslation(key: String) = kmLengthTranslations[key] ?: ""
 
 private val kmLengthTranslations = mapOf(

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -293,9 +293,9 @@
         "not-a-duplicate": "Ei duplikaatti",
         "search": "Hae...",
         "topological-connectivity": "Topologinen kytkeytyminen",
-        "topological-start-switch": "Vaihde raiteen alussa",
-        "topological-end-switch": "Vaihde raiteen lopussa",
-        "no-topological-switch": "Ei vaihdetta"
+        "start-switch": "Vaihde raiteen alussa",
+        "end-switch": "Vaihde raiteen lopussa",
+        "no-start-or-end-switch": "Ei vaihdetta"
     },
     "location-track-delete-dialog": {
         "title": "Sijaintiraiteen poistaminen paikannuspohjasta",
@@ -545,9 +545,9 @@
                 "diagram-visibility": "Kuvaaja"
             },
             "topological-connectivity": "Topologinen kytkeytyminen",
-            "topological-start-switch": "Vaihde raiteen alussa",
-            "topological-end-switch": "Vaihde raiteen lopussa",
-            "no-topological-switch": "Ei vaihdetta"
+            "start-switch": "Vaihde raiteen alussa",
+            "end-switch": "Vaihde raiteen lopussa",
+            "no-start-or-end-switch": "Ei vaihdetta"
         },
         "disabled": {
             "activity-disabled-in-official-mode": "Toiminto on aktiivinen vain luonnostilassa."

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -30,7 +30,10 @@ import { Heading, HeadingSize } from 'vayla-design-lib/heading/heading';
 import { FormLayout, FormLayoutColumn } from 'geoviite-design-lib/form-layout/form-layout';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { useTranslation } from 'react-i18next';
-import { useLocationTrackStartAndEnd, useSwitch } from 'track-layout/track-layout-react-utils';
+import {
+    useLocationTrackStartAndEnd,
+    useLocationTrackSwitchesAtEnds,
+} from 'track-layout/track-layout-react-utils';
 import { formatTrackMeter } from 'utils/geography-utils';
 import { Precision, roundToPrecision } from 'utils/rounding';
 import { PublishType, TimeStamp } from 'common/common-model';
@@ -59,6 +62,12 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     props: LocationTrackDialogProps,
 ) => {
     const { t } = useTranslation();
+
+    const switchesAtEnds = useLocationTrackSwitchesAtEnds(
+        props.locationTrack,
+        props.publishType,
+        props.locationTrackChangeTime,
+    );
     const firstInputRef = React.useRef<HTMLInputElement>(null);
     const [state, dispatcher] = React.useReducer(reducer, initialLocationTrackEditState);
     const [selectedDuplicateTrack, setSelectedDuplicateTrack] = React.useState<
@@ -74,15 +83,6 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         state.existingLocationTrack?.id,
         props.publishType,
         props.locationTrackChangeTime,
-    );
-
-    const topologicalStartSwitch = useSwitch(
-        state.existingLocationTrack?.topologyStartSwitch?.switchId,
-        props.publishType,
-    );
-    const topologicalEndSwitch = useSwitch(
-        state.existingLocationTrack?.topologyEndSwitch?.switchId,
-        props.publishType,
     );
 
     const locationTrackStateOptions = layoutStates
@@ -495,12 +495,12 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                             }
                         />
                         <FieldLayout
-                            label={t('location-track-dialog.topological-start-switch')}
+                            label={t('location-track-dialog.start-switch')}
                             value={
                                 <TextField
                                     value={
-                                        topologicalStartSwitch?.name ??
-                                        t('location-track-dialog.no-topological-switch')
+                                        switchesAtEnds?.start?.name ??
+                                        t('location-track-dialog.no-start-or-end-switch')
                                     }
                                     wide
                                     disabled
@@ -508,12 +508,12 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                             }
                         />
                         <FieldLayout
-                            label={t('location-track-dialog.topological-end-switch')}
+                            label={t('location-track-dialog.end-switch')}
                             value={
                                 <TextField
                                     value={
-                                        topologicalEndSwitch?.name ??
-                                        t('location-track-dialog.no-topological-switch')
+                                        switchesAtEnds?.end?.name ??
+                                        t('location-track-dialog.no-start-or-end-switch')
                                     }
                                     wide
                                     disabled

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -15,7 +15,7 @@ import {
     useLocationTrackChangeTimes,
     useLocationTrackDuplicates,
     useLocationTrackStartAndEnd,
-    useSwitch,
+    useLocationTrackSwitchesAtEnds,
     useTrackNumber,
 } from 'track-layout/track-layout-react-utils';
 import InfoboxText from 'tool-panel/infobox/infobox-text';
@@ -98,11 +98,11 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
         'OFFICIAL',
         locationTrackChangeTime,
     );
-    const topologicalStartSwitch = useSwitch(
-        locationTrack.topologyStartSwitch?.switchId,
+    const switchesAtEnds = useLocationTrackSwitchesAtEnds(
+        locationTrack,
         publishType,
+        locationTrackChangeTime,
     );
-    const topologicalEndSwitch = useSwitch(locationTrack.topologyEndSwitch?.switchId, publishType);
     const [showEditDialog, setShowEditDialog] = React.useState(false);
     const [updatingLength, setUpdatingLength] = React.useState<boolean>(false);
     const [canUpdate, setCanUpdate] = React.useState<boolean>();
@@ -268,17 +268,21 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                         iconDisabled={isOfficial()}
                     />
                     <InfoboxField
-                        label={t('tool-panel.location-track.topological-start-switch')}
+                        label={t('tool-panel.location-track.start-switch')}
                         value={
-                            topologicalStartSwitch?.name ??
-                            t('tool-panel.location-track.no-topological-switch')
+                            switchesAtEnds === undefined
+                                ? ''
+                                : switchesAtEnds.start?.name ??
+                                  t('tool-panel.location-track.no-start-or-end-switch')
                         }
                     />
                     <InfoboxField
-                        label={t('tool-panel.location-track.topological-end-switch')}
+                        label={t('tool-panel.location-track.end-switch')}
                         value={
-                            topologicalEndSwitch?.name ??
-                            t('tool-panel.location-track.no-topological-switch')
+                            switchesAtEnds === undefined
+                                ? ''
+                                : switchesAtEnds.end?.name ??
+                                  t('tool-panel.location-track.no-start-or-end-switch')
                         }
                     />
 

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -3,6 +3,7 @@ import {
     LayoutLocationTrack,
     LayoutLocationTrackDuplicate,
     LocationTrackId,
+    SwitchesAtEnds,
 } from 'track-layout/track-layout-model';
 import { ChangeTimes, PublishType, TimeStamp, TrackMeter } from 'common/common-model';
 import {
@@ -37,6 +38,7 @@ import { GeometryPlanId } from 'geometry/geometry-model';
 
 const locationTrackCache = asyncCache<string, LayoutLocationTrack | null>();
 const locationTrackEndpointsCache = asyncCache<string, LocationTrackEndpoint[]>();
+const locationTrackSwitchesAtEndsCache = asyncCache<string, SwitchesAtEnds | null>();
 
 type PlanSectionPoint = {
     address: TrackMeter;
@@ -89,6 +91,21 @@ export async function getLocationTrackStartAndEnd(
     return getWithDefault<AlignmentStartAndEnd | undefined>(
         `${layoutUri('location-tracks', publishType, locationTrackId)}/start-and-end`,
         undefined,
+    );
+}
+
+export async function getLocationTrackSwitchesAtEnds(
+    locationTrackId: LocationTrackId,
+    publishType: PublishType,
+    changeTime: TimeStamp,
+): Promise<SwitchesAtEnds | null> {
+    return locationTrackSwitchesAtEndsCache.get(
+        changeTime,
+        cacheKey(locationTrackId, publishType),
+        () =>
+            getIgnoreError<SwitchesAtEnds>(
+                `${layoutUri('location-tracks', publishType, locationTrackId)}/switches-at-ends`,
+            ),
     );
 }
 

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -235,6 +235,10 @@ export type AlignmentStartAndEnd = {
     end: AddressPoint | null;
 };
 
+export type SwitchesAtEnds = {
+    start: LayoutSwitchId | null;
+    end: LayoutSwitchId | null;
+};
 export function getSwitchPresentationJoint(
     layoutSwitch: LayoutSwitch,
     presentationJointNumber: JointNumber,

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -38,6 +38,7 @@ import {
     getLocationTrackDuplicates,
     getLocationTracks,
     getLocationTrackStartAndEnd,
+    getLocationTrackSwitchesAtEnds,
 } from 'track-layout/layout-location-track-api';
 import { getSwitch, getSwitchChangeTimes, getSwitches } from 'track-layout/layout-switch-api';
 import { getTrackNumberById, getTrackNumbers } from 'track-layout/layout-track-number-api';
@@ -203,6 +204,32 @@ export function useLocationTrackStartAndEnd(
         () => (id && publishType ? getLocationTrackStartAndEnd(id, publishType) : undefined),
         [id, publishType, changeTime],
     );
+}
+
+export function useLocationTrackSwitchesAtEnds(
+    locationTrack: LayoutLocationTrack | undefined,
+    publishType: PublishType,
+    changeTime: TimeStamp,
+): { start: LayoutSwitch | undefined; end: LayoutSwitch | undefined } | undefined {
+    const id = locationTrack?.id;
+    const [switchIds, status] = useLoaderWithStatus(
+        () =>
+            id === undefined
+                ? undefined
+                : getLocationTrackSwitchesAtEnds(id, publishType, changeTime),
+        [id, publishType, changeTime],
+    );
+    const start = useSwitch(
+        switchIds?.start ?? locationTrack?.topologyStartSwitch?.switchId,
+        publishType,
+    );
+    const end = useSwitch(
+        switchIds?.end ?? locationTrack?.topologyEndSwitch?.switchId,
+        publishType,
+    );
+    return id === undefined || switchIds === undefined || status !== LoaderStatus.Ready
+        ? undefined
+        : { start, end };
 }
 
 export function usePlanHeader(


### PR DESCRIPTION
Oman cachensa kautta menevä toteutus siksi, että pyritään yhtäältä ainakin vähän välttämään sellaisia tilanteita, että käyttäjä vaihtaa katsottavaa raidetta mutta näissä kentissä on väärää tietoa, mutta toisaalta että nämä vaihteiden nimet ei ainakaan kovin pahasti välkkyisi raiteita vaihdettaessa.