### PR TITLE
GVT-2081: Ratakilometrin pituuden jälkiparannukset

### DIFF
--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -51,6 +51,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     const changeTimes = useKmPostChangeTimes(kmPost.id);
 
     React.useEffect(() => {
+        setKmPostLength(undefined);
         getKmLengths(publishType, kmPost.trackNumberId).then((details) => {
             details.find((value) => value.kmNumber === kmPost.kmNumber)
                 ? setKmPostLength(
@@ -116,7 +117,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                     {kmPostLength && (
                         <InfoboxField
                             label={t('tool-panel.km-post.layout.kilometer-length')}
-                            value={kmPostLength}
+                            value={`${kmPostLength} m`}
                         />
                     )}
                     <InfoboxButtons>


### PR DESCRIPTION
* Piilotetaan ratakilometrin pituus hakemisen ajaksi (konsistentti muiden bäkkäriltä erillisellä haulla haettavien asioiden kanssa)
* Lisätty yksikkö kentän loppuun