### PR TITLE
Projektivelhon auth-urlin parametrin rename

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClientConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClientConfiguration.kt
@@ -19,21 +19,21 @@ import reactor.netty.http.client.HttpClient
 import java.time.Duration
 
 val defaultResponseTimeout: Duration = Duration.ofMinutes(5L)
-val maxFileSize: Int = 100*1024*1024
+val maxFileSize: Int = 100 * 1024 * 1024
 
 class PVWebClient(
-    val client: WebClient
-): WebClient by client
+    val client: WebClient,
+) : WebClient by client
 
 class PVLoginWebClient(
-    val client: WebClient
-): WebClient by client
+    val client: WebClient,
+) : WebClient by client
 
 @Configuration
 @ConditionalOnProperty(prefix = "geoviite.projektivelho", name = ["enabled"], havingValue = "true")
 class PVClientConfiguration @Autowired constructor(
     @Value("\${geoviite.projektivelho.url:}") private val projektiVelhoBaseUrl: String,
-    @Value("\${geoviite.projektivelho.login_url:}") private val projektiVelhoLoginUrl: String,
+    @Value("\${geoviite.projektivelho.auth_url:}") private val projektiVelhoAuthUrl: String,
     @Value("\${geoviite.projektivelho.client_id:}") private val projektiVelhoUsername: String,
     @Value("\${geoviite.projektivelho.client_secret:}") private val projektiVelhoPassword: String,
 ) {
@@ -46,7 +46,7 @@ class PVClientConfiguration @Autowired constructor(
 
         val webClientBuilder = WebClient.builder()
             .clientConnector(ReactorClientHttpConnector(httpClient))
-            .baseUrl(projektiVelhoLoginUrl)
+            .baseUrl(projektiVelhoAuthUrl)
             .filter(logRequest())
             .filter(logResponse())
             .defaultHeader(CONTENT_TYPE, APPLICATION_FORM_URLENCODED_VALUE)
@@ -57,10 +57,7 @@ class PVClientConfiguration @Autowired constructor(
 
     @Bean
     fun pvWebClient(): PVWebClient {
-        val httpClient = HttpClient.create()
-            .responseTimeout(defaultResponseTimeout)
-            .secure()
-            .compress(true)
+        val httpClient = HttpClient.create().responseTimeout(defaultResponseTimeout).secure().compress(true)
 
         val connector = ReactorClientHttpConnector(httpClient.followRedirect(true))
         val webClientBuilder = WebClient.builder()

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -60,7 +60,7 @@ geoviite:
   projektivelho:
     enabled: "${PROJEKTIVELHO_ENABLED:false}"
     url: "${PROJEKTIVELHO_URL:}"
-    login_url: "${PROJEKTIVELHO_LOGIN_URL:}"
+    auth_url: "${PROJEKTIVELHO_AUTH_URL:}"
     client_id: "${PROJEKTIVELHO_CLIENT_ID:}"
     client_secret: "${PROJEKTIVELHO_CLIENT_SECRET:}"
     search-poll:

--- a/infra/src/test/resources/application-test.yml
+++ b/infra/src/test/resources/application-test.yml
@@ -23,5 +23,5 @@ geoviite:
   projektivelho:
     enabled: true
     url: http://localhost:12345
-    login_url: http://localhost:12345/oauth2/token
+    auth_url: http://localhost:12345/oauth2/token
     test-port: 12345


### PR DESCRIPTION
Integraatio ei toiminut dev- ja test-ympäristöissä, koska niissä muilutettiin arvo `PROJEKTIVELHO_AUTH_URL`-nimiseen muuttujaan, mutta koodi oletti sen olevan `PROJEKTIVELHO_LOGIN_URL`-nimen takana. Yhdistetty nyt nimeämiset `AUTH_URL`:iksi