### PR TITLE
GVT-2086: Fix layout alignment segment's containing null sourceId values

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -79,12 +79,12 @@ class LayoutAlignmentDao(
     fun preloadAlignmentCache() {
         val sql = """
           select 
-            a.geometry_alignment_id,
+            a.geometry_alignment_id as alignment_geometry_alignment_id,
             sv.alignment_id,
             sv.alignment_version,
             sv.segment_index,
             sv.start,
-            sv.geometry_alignment_id,
+            sv.geometry_alignment_id as segment_geometry_alignment_id,
             sv.geometry_element_index,
             sv.source_start,
             sv.switch_id,
@@ -103,12 +103,12 @@ class LayoutAlignmentDao(
         val dataTriple = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
             val alignmentData = AlignmentData(
                 version = rs.getRowVersion("alignment_id", "alignment_version"),
-                sourceId = rs.getIntIdOrNull("geometry_alignment_id"),
+                sourceId = rs.getIntIdOrNull("alignment_geometry_alignment_id"),
             )
             val segmentData = SegmentData(
                 id = rs.getIndexedId("alignment_id", "segment_index"),
                 start = rs.getDouble("start"),
-                sourceId = rs.getIndexedIdOrNull("geometry_alignment_id", "geometry_element_index"),
+                sourceId = rs.getIndexedIdOrNull("segment_geometry_alignment_id", "geometry_element_index"),
                 sourceStart = rs.getDoubleOrNull("source_start"),
                 switchId = rs.getIntIdOrNull("switch_id"),
                 startJointNumber = rs.getJointNumberOrNull("switch_start_joint_number"),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -2,7 +2,6 @@ package fi.fta.geoviite.infra.tracklayout
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.common.*
-import fi.fta.geoviite.infra.geometry.GeometryAlignment
 import fi.fta.geoviite.infra.geometry.GeometryElement
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.math.*
@@ -20,7 +19,7 @@ enum class GeometrySource {
     IMPORTED, PLAN, GENERATED,
 }
 
-fun emptyAlignment() = LayoutAlignment(segments = listOf(), sourceId = null)
+fun emptyAlignment() = LayoutAlignment(segments = listOf())
 
 data class SegmentGeometryAndMetadata(
     val planId: IntId<GeometryPlan>?,
@@ -156,8 +155,7 @@ interface IAlignment {
 
 data class LayoutAlignment(
     override val segments: List<LayoutSegment>,
-    val sourceId: DomainId<GeometryAlignment>?,
-    override val id: DomainId<LayoutAlignment> = deriveFromSourceId("A", sourceId),
+    override val id: DomainId<LayoutAlignment> = StringId(),
     val dataType: DataType = DataType.TEMP,
 ) : IAlignment {
     override val boundingBox: BoundingBox? = boundingBoxCombining(segments.mapNotNull { s -> s.boundingBox })

--- a/infra/src/main/resources/db/migration/prod/V49__remove_geometry_alignment_id_from_layout_alignment.sql
+++ b/infra/src/main/resources/db/migration/prod/V49__remove_geometry_alignment_id_from_layout_alignment.sql
@@ -1,0 +1,2 @@
+alter table layout.alignment drop column geometry_alignment_id;
+alter table layout.alignment_version drop column geometry_alignment_id;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
@@ -410,7 +410,6 @@ class SwitchLinkingTest {
                     Point(10.0, 0.0),
                 )
             ),
-            sourceId = null
         )
 
         val locationTrack2 = locationTrack(IntId(1))
@@ -421,7 +420,6 @@ class SwitchLinkingTest {
                     Point(5.0, 5.0),
                 )
             ),
-            sourceId = null
         )
 
         val suggestedSwitch = createSuggestedSwitch(
@@ -495,7 +493,6 @@ class SwitchLinkingTest {
                     start = 15.0
                 )
             ),
-            sourceId = null
         )
 
         val suggestedSwitch = createSuggestedSwitch(
@@ -559,7 +556,6 @@ class SwitchLinkingTest {
                     start = 15.0
                 )
             ),
-            sourceId = null
         )
 
         val suggestedSwitch = createSuggestedSwitch(
@@ -622,7 +618,6 @@ class SwitchLinkingTest {
                     start = 11.0
                 )
             ),
-            sourceId = null
         )
 
         val suggestedSwitch = createSuggestedSwitch(
@@ -674,7 +669,6 @@ class SwitchLinkingTest {
                     start = 1.0
                 ),
             ),
-            sourceId = null
         )
 
         val suggestedSwitch = createSuggestedSwitch(
@@ -725,7 +719,6 @@ class SwitchLinkingTest {
                     start = 4.999
                 ),
             ),
-            sourceId = null
         )
 
         val suggestedSwitch = createSuggestedSwitch(
@@ -777,7 +770,6 @@ class SwitchLinkingTest {
                     start = 10.0
                 )
             ),
-            sourceId = null
         )
 
         val suggestedSwitch = createSuggestedSwitch(
@@ -847,7 +839,6 @@ class SwitchLinkingTest {
                     start = 16.0
                 )
             ),
-            sourceId = null
         )
 
         val locationTrack2 = locationTrack(IntId(1))
@@ -893,7 +884,6 @@ class SwitchLinkingTest {
                     start = 15.0
                 ),
             ),
-            sourceId = null
         )
 
 
@@ -955,7 +945,6 @@ class SwitchLinkingTest {
                     start = 15.0
                 )
             ),
-            sourceId = null
         )
 
         val suggestedSwitch = createSuggestedSwitch(
@@ -1007,7 +996,6 @@ class SwitchLinkingTest {
                     start = 15.0
                 )
             ),
-            sourceId = null
         )
 
         val suggestedSwitch = createSuggestedSwitch(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
@@ -78,7 +78,6 @@ fun assertMatches(expected: LayoutAlignment, actual: LayoutAlignment, idMatch: B
             dataType = expected.dataType,
         )
         assertEquals(expectedWithSameFloats, unified)
-        assertEquals(expected.sourceId != null, actual.sourceId != null)
     }
     assertEquals(expected.length, actual.length, LENGTH_DELTA)
     assertEquals(expected.segments.size, actual.segments.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -255,7 +255,6 @@ fun alignment(vararg segments: LayoutSegment) = alignment(segments.toList())
 
 fun alignment(segments: List<LayoutSegment>) = LayoutAlignment(
     segments = fixSegmentStarts(segments),
-    sourceId = null,
 )
 
 fun mapAlignment(vararg segments: PlanLayoutSegment) = mapAlignment(segments.toList())


### PR DESCRIPTION
GVT-2086: Fix layout alignment segment's containing null sourceId values

Additionally, the geometry_alignment_id was removed as a concept from LayoutAlignments: It was deemed unnecessary as a layout can be formed from multiple different geometry alignments via segments, which have their own geometry_alignment_id field.

The LayoutAlignment's field only had nulls stored in the database, and it was also not used during any proper business logic as a non-null value.