### PR TITLE
GVT-2097: Linkitystoiminnon aikana luotava raide pitäisi valita automaattisesti

### DIFF
--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -181,11 +181,13 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
         });
     }, [planId, publishType, locationTrackChangeTime]);
 
-    function handleLocationTrackInsert(_id: LocationTrackId) {
+    function handleLocationTrackInsert(id: LocationTrackId) {
+        onSelect({ locationTracks: [id] });
         updateLocationTrackChangeTime();
     }
 
-    function handleTrackNumberSave(_id: LayoutTrackNumberId) {
+    function handleTrackNumberSave(id: LayoutTrackNumberId) {
+        onSelect({ trackNumbers: [id] });
         updateReferenceLineChangeTime().then(() => updateTrackNumberChangeTime());
     }
 
@@ -296,7 +298,9 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                 trackNumberChangeTime={trackNumberChangeTime}
                                 onSelect={onSelect}
                                 selectedLayoutReferenceLine={selectedLayoutReferenceLine}
-                                disableAddButton={linkingState.type !== LinkingType.UnknownAlignment}
+                                disableAddButton={
+                                    linkingState.type !== LinkingType.UnknownAlignment
+                                }
                                 onShowAddTrackNumberDialog={() => setShowAddTrackNumberDialog(true)}
                             />
                             <GeometryAlignmentLinkingLocationTrackCandidates
@@ -305,7 +309,9 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                 locationTrackChangeTime={locationTrackChangeTime}
                                 onSelect={onSelect}
                                 selectedLayoutLocationTrack={selectedLayoutLocationTrack}
-                                disableAddButton={linkingState.type !== LinkingType.UnknownAlignment}
+                                disableAddButton={
+                                    linkingState.type !== LinkingType.UnknownAlignment
+                                }
                                 onShowAddLocationTrackDialog={() =>
                                     setShowAddLocationTrackDialog(true)
                                 }


### PR DESCRIPTION
Täällä on selkeästi tapahtunut jossain yhteydessä joku epähuomio, koska id:t oli parametreina, mutta niitä ei käytetty. Säädetty tämä niin, että uutena luodut ratanumerot ja sijaintiraiteet valitaan automaagisesti luontinsa jälkeen (joka lienisi muutenkin varmaan fiksua, koska niille saatettaneen haluta tehdä jotain operaatioita lopullisesta linkityksestä riippumatta)