### PR TITLE
GVT-1980 Adjust and extend switch topology validation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -331,3 +331,25 @@ fun transformSwitchPoint(transformation: SwitchPositionTransformation, point: Po
         point
     ) + transformation.translation
 }
+
+data class SwitchConnectivityType(
+    val trackLinkedAlignmentsJoints: List<List<JointNumber>>,
+    val frontJoint: JointNumber?,
+)
+
+fun switchConnectivityType(structure: SwitchStructure) = when (structure.baseType) {
+    SwitchBaseType.YV, SwitchBaseType.TYV, SwitchBaseType.YRV, SwitchBaseType.SKV, SwitchBaseType.UKV -> SwitchConnectivityType(
+        structure.alignments.map { it.jointNumbers }, JointNumber(1)
+    )
+
+    SwitchBaseType.KV -> SwitchConnectivityType(
+        structure.alignments.map { it.jointNumbers }, JointNumber(1)
+    )
+
+    SwitchBaseType.KRV, SwitchBaseType.RR, SwitchBaseType.SRR -> SwitchConnectivityType(structure.alignments.filter { it.jointNumbers.size == 3 }
+        .flatMap { alignment ->
+            val joints = alignment.jointNumbers
+            listOf(listOf(joints[0], joints[1]), listOf(joints[1], joints[2]))
+        }, null
+    )
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -338,11 +338,7 @@ data class SwitchConnectivityType(
 )
 
 fun switchConnectivityType(structure: SwitchStructure) = when (structure.baseType) {
-    SwitchBaseType.YV, SwitchBaseType.TYV, SwitchBaseType.YRV, SwitchBaseType.SKV, SwitchBaseType.UKV -> SwitchConnectivityType(
-        structure.alignments.map { it.jointNumbers }, JointNumber(1)
-    )
-
-    SwitchBaseType.KV -> SwitchConnectivityType(
+    SwitchBaseType.YV, SwitchBaseType.TYV, SwitchBaseType.YRV, SwitchBaseType.SKV, SwitchBaseType.UKV, SwitchBaseType.KV -> SwitchConnectivityType(
         structure.alignments.map { it.jointNumbers }, JointNumber(1)
     )
 

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1136,7 +1136,13 @@
                     "unlinked": "Jotkut vaihteen linjoista ({{0}}) eivät ole kytkettynä mihinkään sijaintiraiteiseen"
                 },
                 "duplicate-name-official": "Vaihteen nimi {{0}} on jo käytössä jollain toisella paikannuspohjan vaihteella",
-                "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{0}}"
+                "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{0}}",
+                "track-linkage": {
+                    "front-joint-not-connected":  "Vaihteen etujatkokselta ei jatku raidetta",
+                    "front-joint-only-duplicate-connected":  "Vaihteen etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
+                    "switch-alignment-not-connected":  "Joitakin vaihteen linjoja ei ole liitetty raiteelle: {{0}}",
+                    "multiple-tracks-through-joint": "Joistain vaihteen pisteistä menee läpi enemmän kuin yksi raide: {{0}}"
+                }
             },
             "geocoding": {
                 "sharp-angle": "Sijaintiraiteen {{1}} tasametripisteet menevät taaksepäin, koska kulma ratanumeron {{0}} pituusmittauslinjaan eroaa liikaa. Rataosoitevälit: {{2}}",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -283,7 +283,7 @@ class PublicationValidationTest {
             hasError = true,
             switch = switch,
             tracks = broken,
-            error = "$VALIDATION_SWITCH.location-track.unlinked",
+            error = "$VALIDATION_SWITCH.track-linkage.switch-alignment-not-connected",
         )
     }
 


### PR DESCRIPTION
Uusi validaatiokoodi vastaa nyt paremmin totuutta siitä, mitä asioita vaihteiden validoinnissa oikeasti voi mennä vikaan, ja mistä ei tarvitse välittää:

- validateFrontJointTopology on kokonaan uusi; en löytänyt paikannuspohjasta yhtään kohtaa, missä se olisi ollut väärässä, ts. vaihde olisi oikeasti järkevästi jossain kohdassa, mutta etujatkokselta vaan ei lähde raidetta (mutta tämä, samoin kuin muut validaatiot, on ainakin tähän hätään vain varoitustasoinen). Näissä oli yleistä, että puute johtui siitä, että väärä raide oli merkitty duplikaatiksi; siksi otin sen validaatiossakin huomioon.
- validateExcessTracksThroughJoint on myös uusi: Tarkistetaan, että kunkin vaihdepisteen läpi menee enintään yksi ei-duplikaattiraide (paitsi pisteen 5 läpi, se kun löytyy raideristeysten keskeltä)
- validateSwitchAlignmentTopology vastaa poistettua structureJointGroupFound-validaatiota, mutta yhtäältä valittaa nyt, jos vaihteen linjalta on raiteella vain yksi piste (eli vastaten nyt sitä, millä vaihteen sijaintitietoihin saa linjan näkyviin), toisaalta ei valita niistä raideristeysten sivulla menevistä raiteista, joita ei tule geometrioissa eikä siten tule paikannuspohjaankaan