### PR TITLE
GVT-1918: Fix vertical geometry diagram height axis bounds calculation

### DIFF
--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -228,3 +228,10 @@ export function minimumIndexBy<T, B>(objs: readonly T[], by: (obj: T) => B): num
     }
     return minIndex;
 }
+
+export function findLastIndex<T, B>(objs: readonly T[], predicate: (obj: T) => B): number {
+    for (let i = objs.length - 1; i >= 0; i--) {
+        if (predicate(objs[i])) return i;
+    }
+    return -1;
+}

--- a/ui/src/utils/math-utils.ts
+++ b/ui/src/utils/math-utils.ts
@@ -111,3 +111,12 @@ export function distToSegmentSquared(p: Point, start: Point, end: Point) {
         y: start.y + t * (end.y - start.y),
     });
 }
+
+export function linearFunctionFromPoints(
+    { x: x1, y: y1 }: Point,
+    { x: x2, y: y2 }: Point,
+    intercept: number,
+): (x: number) => number {
+    const slope = (y1 - y2) / (x1 - x2);
+    return (x: number) => slope * x + intercept; // ax + b
+}

--- a/ui/src/vertical-geometry/util.ts
+++ b/ui/src/vertical-geometry/util.ts
@@ -5,7 +5,13 @@ import {
     TrackMeterIndex,
 } from 'vertical-geometry/track-meter-index';
 import { VerticalGeometryItem } from 'geometry/geometry-model';
-import { filterNotEmpty } from 'utils/array-utils';
+import { filterNotEmpty, findLastIndex } from 'utils/array-utils';
+import { linearFunctionFromPoints } from 'utils/math-utils';
+
+type HeightValue = number;
+type LowerHeightBound = number;
+type UpperHeightBound = number;
+type HeightBounds = [LowerHeightBound, UpperHeightBound];
 
 export function approximateHeightAtM(m: number, kmHeights: TrackKmHeights[]): number | null {
     const index = findTrackMeterIndexContainingM(m, kmHeights);
@@ -40,8 +46,10 @@ export function polylinePoints(points: readonly (readonly [number, number])[]): 
 export function getBottomAndTopTicks(
     kmHeights: TrackKmHeights[],
     geometry: VerticalGeometryItem[],
+    visibleStartM: number,
+    visibleEndM: number,
 ): [number, number] {
-    const heightsToBounds = (heights: number[]): [number, number] | undefined =>
+    const heightsToBounds = (heights: number[]): HeightBounds | undefined =>
         heights.length === 0
             ? undefined
             : [Math.floor(Math.min(...heights)), Math.ceil(Math.max(...heights))];
@@ -49,16 +57,127 @@ export function getBottomAndTopTicks(
     // reaching across a whole track km and we're zoomed into it, in which case we'll fall back to using height bounds
     // calculated from the geometry; and sometimes there are no heights at all, in which case we don't need to worry
     // about how tall to display them anyway and can just use a (suitably strange) fallback
+    let heightBoundsFromTrackKm = heightsToBounds(
+        kmHeights
+            .flatMap(({ trackMeterHeights }) => trackMeterHeights.map(({ height }) => height))
+            .filter(filterNotEmpty),
+    );
+
+    // The vertical geometry diagram height bounds calculation should also account for the lines between the previously
+    // displayed known height value and the next known height value out of view (from the left or right edges of the
+    // vertical geometry diagram).
+    //
+    // When this was unaccounted for, especially long transfer lines with "unknown" height values in between known
+    // height values resulted in the transfer line being drawn to the top or the bottom edge of the vertical geometry
+    // diagram. This was unwanted behavior as the vertical geometry diagram's height should scale correctly even with
+    // large changes between values, which is what the following condition should account for.
+    if (heightBoundsFromTrackKm) {
+        const approximateHeightAtLeftEdge = approximateHeightAtVerticalGeometryDiagramLeftEdge(
+            heightBoundsFromTrackKm,
+            geometry,
+            visibleStartM,
+        );
+
+        const approximateHeightAtRightEdge = approximateHeightAtVerticalGeometryDiagramRightEdge(
+            heightBoundsFromTrackKm,
+            geometry,
+            visibleEndM,
+        );
+
+        heightBoundsFromTrackKm = heightsToBounds(
+            [
+                ...heightBoundsFromTrackKm,
+                approximateHeightAtLeftEdge,
+                approximateHeightAtRightEdge,
+            ].filter((height): height is number => height !== undefined),
+        );
+    }
+
     return (
-        heightsToBounds(
-            kmHeights
-                .flatMap(({ trackMeterHeights }) => trackMeterHeights.map(({ height }) => height))
-                .filter(filterNotEmpty),
-        ) ??
+        heightBoundsFromTrackKm ??
         heightsToBounds(
             geometry.flatMap((p) => [p.start.height, p.point.height, p.end.height]),
         ) ?? [0, 100]
     );
+}
+
+function heightIsOutOfBounds(heightBounds: HeightBounds, height: HeightValue) {
+    return height && (height < heightBounds[0] || height > heightBounds[1]);
+}
+
+function approximateHeightAtVerticalGeometryDiagramLeftEdge(
+    heightBounds: HeightBounds,
+    geometry: VerticalGeometryItem[],
+    visibleStartM: number,
+): number | undefined {
+    const indexOfFirstVisibleGeometryItem = geometry.findIndex((geometryItem) => {
+        return geometryItem.start.station > visibleStartM;
+    });
+
+    if (indexOfFirstVisibleGeometryItem > 0) {
+        const lastNotVisibleGeometryItem = geometry[indexOfFirstVisibleGeometryItem - 1];
+        const firstVisibleGeometryItem = geometry[indexOfFirstVisibleGeometryItem];
+
+        if (heightIsOutOfBounds(heightBounds, lastNotVisibleGeometryItem.end.height)) {
+            const linearFunctionFromLastKnownHeightToNextKnownHeight = linearFunctionFromPoints(
+                {
+                    x: lastNotVisibleGeometryItem.end.station,
+                    y: lastNotVisibleGeometryItem.end.height,
+                },
+                {
+                    x: firstVisibleGeometryItem.start.station,
+                    y: firstVisibleGeometryItem.start.height,
+                },
+                lastNotVisibleGeometryItem.end.height,
+            );
+
+            // Approximate height at the left edge of the vertical geometry diagram.
+            return linearFunctionFromLastKnownHeightToNextKnownHeight(
+                visibleStartM - lastNotVisibleGeometryItem.end.station,
+            );
+        }
+    }
+
+    return undefined;
+}
+
+function approximateHeightAtVerticalGeometryDiagramRightEdge(
+    heightBounds: HeightBounds,
+    geometry: VerticalGeometryItem[],
+    visibleEndM: number,
+): number | undefined {
+    const indexOfLastVisibleGeometryItem = findLastIndex(geometry, (geometryItem) => {
+        return geometryItem.end.station < visibleEndM;
+    });
+
+    if (
+        indexOfLastVisibleGeometryItem >= 0 &&
+        indexOfLastVisibleGeometryItem + 1 < geometry.length
+    ) {
+        const lastVisibleGeometryItem = geometry[indexOfLastVisibleGeometryItem];
+        const firstNotVisibleGeometryItem = geometry[indexOfLastVisibleGeometryItem + 1];
+
+        if (heightIsOutOfBounds(heightBounds, firstNotVisibleGeometryItem.start.height)) {
+            const linearFunctionFromLastKnownHeightToNextKnownHeight = linearFunctionFromPoints(
+                {
+                    x: lastVisibleGeometryItem.end.station,
+                    y: lastVisibleGeometryItem.end.height,
+                },
+                {
+                    x: firstNotVisibleGeometryItem.start.station,
+                    y: firstNotVisibleGeometryItem.start.height,
+                },
+                lastVisibleGeometryItem.end.height,
+            );
+
+            // Approximate height at the right edge of the vertical geometry diagram.
+            return linearFunctionFromLastKnownHeightToNextKnownHeight(
+                visibleEndM - lastVisibleGeometryItem.end.station,
+            );
+        }
+    }
+
+    return undefined;
 }
 
 export function zeroSafeDivision(a: number, b: number): number {

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -87,7 +87,12 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
         panning && styles['vertical-geometry-diagram--panning'],
     );
 
-    const [bottomHeightTick, topHeightTick] = getBottomAndTopTicks(kmHeights, geometry);
+    const [bottomHeightTick, topHeightTick] = getBottomAndTopTicks(
+        kmHeights,
+        geometry,
+        visibleStartM,
+        visibleEndM,
+    );
 
     const coordinates: Coordinates = {
         bottomHeightPaddingPx,


### PR DESCRIPTION
GVT-1918: Fix vertical geometry diagram height axis bounds calculation

Previously the calculation did not account for height values in between known values at the edges of the vertical geometry diagram, which resulted in the height transfer lines being drawn to the top or bottom edge of the diagram in cases with relatively large changes in the horizontal (track-km) and vertical (track height) axes.