### PR TITLE
GVT-2107 Add transaction boundaries around listing alignment polylines or switches

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -44,8 +44,7 @@ class LayoutSwitchController(
             "limit" to limit, "comparisonPoint" to comparisonPoint, "switchType" to switchType
         )
         val filter = switchService.switchFilter(name, switchType, bbox, includeSwitchesWithNoJoints)
-        val switches = switchService.list(publishType, filter)
-        return switchService.pageSwitches(switches, offset ?: 0, limit, comparisonPoint)
+        return switchService.pageSwitchesByFilter(publishType, filter, offset, limit, comparisonPoint)
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -24,6 +24,16 @@ class LayoutSwitchService @Autowired constructor(
     private val locationTrackService: LocationTrackService,
 ) : DraftableObjectService<TrackLayoutSwitch, LayoutSwitchDao>(dao) {
 
+    @Transactional(readOnly=true)
+    fun pageSwitchesByFilter(
+        publishType: PublishType,
+        filter: (TrackLayoutSwitch) -> Boolean,
+        offset: Int?,
+        limit: Int?,
+        comparisonPoint: Point?,
+    ): List<TrackLayoutSwitch> =
+        pageSwitches(list(publishType, filter), offset ?: 0, limit, comparisonPoint)
+
     @Transactional
     fun insertSwitch(request: TrackLayoutSwitchSaveRequest): IntId<TrackLayoutSwitch> {
         logger.serviceCall("insertSwitch", "request" to request)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
@@ -14,6 +14,7 @@ import fi.fta.geoviite.infra.math.combineContinuous
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 enum class AlignmentFetchType {
     LOCATION_TRACKS,
@@ -36,6 +37,7 @@ class MapAlignmentService(
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
+    @Transactional(readOnly=true)
     fun getAlignmentPolyLines(
         publishType: PublishType,
         bbox: BoundingBox,


### PR DESCRIPTION
Teoriassa transaktioraja getAlignmentPolylines()in päällä on aika kookas, sisältäähän se sentään toAlignmentPolyline()n ja sen kautta simplify()n, joka on sentään jonkin verran ei-triviaalia laskentaa.

Käytännössä sillä lienee tuskin kovin isoa merkitystä, ja koodia pitäisi pyöritellä enemmän kuin tämän triviaalin määrän verran, jotta saisi oikeasti eroteltua laskennat ja tietokantahaut erikseen (tosin ei sekään nyt vaikeaa olisi). Tällä muutoksella kuitenkin saa aikaan jo mojovan edun kartan nopeudessa isoille liikennepaikoille zoomatessa.