### PR TITLE
GVT-2114: Sisään zoomatun pystygeometrian kuvaajan draggaaminen loppuu kun kursori siirtyy ulos kuvaajan alueelta

### DIFF
--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -197,13 +197,17 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
     return (
         <div
             className={diagramClasses}
-            onMouseDown={(e) => {
+            onPointerDown={(e) => {
+                ref?.current?.setPointerCapture(e.pointerId);
                 e.preventDefault();
                 setPanning(e.clientX);
             }}
-            onMouseUp={() => setPanning(undefined)}
-            onMouseMove={onMouseMove}
-            onMouseLeave={() => {
+            onPointerUp={(e) => {
+                ref?.current?.releasePointerCapture(e.pointerId);
+                setPanning(undefined);
+            }}
+            onPointerMove={onMouseMove}
+            onPointerLeave={() => {
                 setPanning(undefined);
                 setMousePositionInElement(undefined);
             }}


### PR DESCRIPTION
Vaihdettu hiirispesifeistä eventeistä pointer-eventteihin, sillä ne tukevat capturea (ts. eventin saa laukeamaan ka. eventille vaikka pointteri liikkuisi sen ulkopuolelle)