### PR TITLE
GVT-2115: Pystygeometrian kuvaajan sisään zoomauksen paikkaindikaattorille minimileveys

### DIFF
--- a/ui/src/vertical-geometry/displayed-position-guide.tsx
+++ b/ui/src/vertical-geometry/displayed-position-guide.tsx
@@ -17,6 +17,7 @@ const guideTrackPositionPx = guideDividerTopPositionPx + 6;
 
 const guideRectangleTopPositionPx = guideDividerTopPositionPx + 4;
 const guideRectangleHeightPx = 4;
+const guideRectangleMinWidthPx = 1;
 
 export interface DisplayedPositionGuideProps {
     coordinates: Coordinates;
@@ -43,7 +44,10 @@ export const DisplayedPositionGuide: React.FC<DisplayedPositionGuideProps> = ({
     const guideBackgroundStartPositionPx = guideStartPx;
     const guideBackgroundWidthPx = guideWidthPx;
 
-    const guideRectangleWidthPx = guideWidthPx * ratioOfCurrentlyDisplayedMetersToFullDiagram;
+    const guideRectangleWidthPx = Math.max(
+        guideWidthPx * ratioOfCurrentlyDisplayedMetersToFullDiagram,
+        guideRectangleMinWidthPx,
+    );
     const guideRectangleStartPx =
         guideStartPx + guideWidthPx * (displayedMetersAtLeftEdge / maxDisplayedMeters);
 


### PR DESCRIPTION
Kuvaajalle asetetaan nyt minimileveys, jota kapeammaksi se ei saa koskaan mennä. Mietin itse alunperin vähän leveämpää minimileveyttä (esim. 2px,) mutta tässä ongelmaksi tulee se, että indikaattoripalkki tulee läpi kuvaajan oikeasta reunasta. Tällaisenakin tämä on mielestäni jo ihan käytettävä.