### PR TITLE
GVT-2014 Refactor front-end API call error handling

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -83,7 +83,9 @@
                 "plan-transformation-failed": "Suunnitelman muuntaminen kartalla esitettävään muotoon epäonnistui"
             }
         },
-        "entity-not-found": "Tietoa ei löydy"
+        "entity-not-found": "Tietoa ei löydy",
+        "entity-not-found-on-path": "Tietoa ei löytynyt kutsussa polkuun {{0}}",
+        "request-failed": "Pyyntö epäonnistui kutsussa polkuun {{0}}"
     },
     "unauthorized-request": {
         "title": "Istunto on vanhentunut.",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,6 @@
         "@jest/globals": "^29.5.0",
         "@teamsupercell/typings-for-css-modules-loader": "^2.5.1",
         "@types/js-cookie": "^3.0.2",
-        "@types/memory-cache": "^0.2.2",
         "@types/node": "^16.18.2",
         "@types/ol": "^6.5.3",
         "@types/proj4": "^2.5.2",

--- a/ui/src/api/api-fetch.ts
+++ b/ui/src/api/api-fetch.ts
@@ -46,10 +46,6 @@ export type Page<T> = {
     start: number;
 };
 
-const throwErrorHandler = (response: ApiErrorResponse) => {
-    throw response;
-};
-
 const ignoreErrorHandler = defaultValueErrorHandler(undefined);
 
 function defaultValueErrorHandler<T>(defaultValue: T): ErrorHandler<T> {
@@ -71,31 +67,86 @@ export function queryParams(params: Record<string, unknown>): string {
     return stringifiedParameters.length == 0 ? '' : `?${stringifiedParameters.join('&')}`;
 }
 
-// TODO: GVT-2014 unify these functions as described in the ticket
-
-/**
- * @deprecated Throwing loses type information. If you need to handle the error in your use-place, use getAdt instead, fetching a result object with output or error
- */
-export async function getThrowError<Output>(path: string): Promise<Output> {
-    return executeRequest<undefined, Output, Output>(
-        path,
-        undefined,
-        throwErrorHandler,
-        'GET',
-    ).then(verifyExists);
+export function getNonNull<Output>(path: string, toastFailure = true): Promise<Output> {
+    return getNullable<Output>(path, toastFailure).then((requestResult) => {
+        if (requestResult === undefined) {
+            if (toastFailure) {
+                Snackbar.error(i18n.t('error.entity-not-found-on-path', [path]));
+            }
+            const rv = Promise.reject(Error(`undefined return when querying ${path}`));
+            rv.catch(() => {
+                console.error('request returned undefined', path);
+            });
+            return rv;
+        } else {
+            return requestResult;
+        }
+    });
 }
 
-export async function getWithDefault<Output>(path: string, defaultValue: Output): Promise<Output> {
-    return executeRequest<undefined, Output, Output>(
-        path,
-        undefined,
-        defaultValueErrorHandler(defaultValue),
-        'GET',
-    ).then((val) => (val != undefined ? val : defaultValue));
+const wrapApiErrorResponse = Symbol('wrap api error response');
+type WrappedApiErrorResponse = { [k in typeof wrapApiErrorResponse]: ApiErrorResponse };
+function isWrappedApiError(x: unknown): x is WrappedApiErrorResponse {
+    return typeof x === 'object' && x !== null && wrapApiErrorResponse in x;
 }
 
-export async function getIgnoreError<Output>(path: string): Promise<Output | undefined> {
-    return executeRequest<undefined, Output, undefined>(path, undefined, ignoreErrorHandler, 'GET');
+export function getNullable<Output>(
+    path: string,
+    toastFailure = true,
+): Promise<Output | undefined> {
+    const rv = executeRequest<undefined, Output, WrappedApiErrorResponse>(
+        path,
+        undefined,
+        (error) => {
+            if (toastFailure) {
+                Snackbar.error(i18n.t('error.request-failed', [path]));
+            }
+            return { [wrapApiErrorResponse]: error };
+        },
+        'GET',
+    ).then((requestResult) =>
+        isWrappedApiError(requestResult)
+            ? Promise.reject(requestResult[wrapApiErrorResponse])
+            : requestResult,
+    );
+    return rv as Promise<Output | undefined>;
+}
+
+export function getNonNullAdt<Output>(
+    path: string,
+    toastFailure = true,
+): Promise<Result<Output, ApiErrorResponse>> {
+    return getNullableAdt<Output | undefined>(path, toastFailure).then((requestResult) => {
+        if (requestResult.isOk() && requestResult.value === undefined) {
+            Snackbar.error(i18n.t('error.entity-not-found-on-path', [path]));
+            return Promise.reject(Error(`undefined return when querying ${path}`));
+        } else {
+            return requestResult as Result<Output, ApiErrorResponse>;
+        }
+    });
+}
+
+export function getNullableAdt<Output>(
+    path: string,
+    toastError = true,
+): Promise<Result<Output | undefined, ApiErrorResponse>> {
+    return executeRequest<undefined, Output, WrappedApiErrorResponse>(
+        path,
+        undefined,
+        (e) => ({
+            [wrapApiErrorResponse]: e,
+        }),
+        'GET',
+    ).then((r) => {
+        if (isWrappedApiError(r)) {
+            if (toastError) {
+                Snackbar.error(i18n.t('error.request-failed', [path]));
+            }
+            return err(r[wrapApiErrorResponse]);
+        } else {
+            return ok(r);
+        }
+    });
 }
 
 export async function postIgnoreError<Input, Output>(
@@ -119,19 +170,6 @@ export async function deleteIgnoreError<Output>(path: string): Promise<Output | 
         ignoreErrorHandler,
         'DELETE',
     );
-}
-
-// Result object returning versions of HTTP methods (ADT)
-export async function getAdt<Output>(
-    path: string,
-    showErrorMessage = false,
-): Promise<Result<Output, ApiErrorResponse>> {
-    return await executeBodyRequestAdt<undefined, Output>(
-        path,
-        undefined,
-        'GET',
-        showErrorMessage,
-    ).then(verifyExistsAdt);
 }
 
 export async function postAdt<Input, Output>(

--- a/ui/src/common/change-time-api.ts
+++ b/ui/src/common/change-time-api.ts
@@ -1,6 +1,6 @@
 import { appStore } from 'store/store';
 
-import { API_URI, getIgnoreError, getWithDefault } from 'api/api-fetch';
+import { API_URI, getNonNull, getNullable } from 'api/api-fetch';
 import { createDelegates } from 'store/store-utils';
 import { TimeStamp } from 'common/common-model';
 import { ChangeTimes, commonActionCreators } from 'common/common-slice';
@@ -18,7 +18,7 @@ export function getChangeTimes(): ChangeTimes {
 }
 
 export function updateAllChangeTimes(): Promise<ChangeTimes> {
-    return getIgnoreError<ChangeTimes>(`${CHANGES_API}/collected`).then((newTimes) => {
+    return getNullable<ChangeTimes>(`${CHANGES_API}/collected`).then((newTimes) => {
         if (newTimes) {
             delegates.setChangeTimes(newTimes);
             return newTimes;
@@ -105,8 +105,14 @@ function updateChangeTime(
     storeUpdate: (ts: TimeStamp) => void,
     defaultValue: TimeStamp,
 ): Promise<TimeStamp> {
-    return getWithDefault<TimeStamp>(url, defaultValue).then((ts) => {
-        storeUpdate(ts);
-        return ts;
-    });
+    return getNonNull<TimeStamp>(url).then(
+        (ts) => {
+            storeUpdate(ts);
+            return ts;
+        },
+        () => {
+            storeUpdate(defaultValue);
+            return defaultValue;
+        },
+    );
 }

--- a/ui/src/common/common-api.ts
+++ b/ui/src/common/common-api.ts
@@ -1,4 +1,4 @@
-import { API_URI, getThrowError } from 'api/api-fetch';
+import { API_URI, getNonNull } from 'api/api-fetch';
 import {
     CoordinateSystem,
     Srid,
@@ -26,19 +26,19 @@ export function pointString(point: Point): string {
 
 export async function getCoordinateSystem(srid: Srid): Promise<CoordinateSystem> {
     return coordinateSystemCache.getImmutable(srid, () =>
-        getThrowError<CoordinateSystem>(`${GEOGRAPHY_URI}/coordinate-systems/${srid}`),
+        getNonNull<CoordinateSystem>(`${GEOGRAPHY_URI}/coordinate-systems/${srid}`),
     );
 }
 
 export async function getSridList(): Promise<CoordinateSystem[]> {
     return sridModelCache.getImmutable(undefined, () =>
-        getThrowError<CoordinateSystem[]>(`${GEOGRAPHY_URI}/coordinate-systems`),
+        getNonNull<CoordinateSystem[]>(`${GEOGRAPHY_URI}/coordinate-systems`),
     );
 }
 
 export async function getSwitchStructures(): Promise<SwitchStructure[]> {
     return switchStructureCache.getImmutable(undefined, () =>
-        getThrowError<SwitchStructure[]>(`${SWITCH_LIBRARY_URI}/switch-structures`).then(
+        getNonNull<SwitchStructure[]>(`${SWITCH_LIBRARY_URI}/switch-structures`).then(
             (switchStructures) => switchStructures.sort((s1, s2) => s1.type.localeCompare(s2.type)),
         ),
     );
@@ -46,7 +46,7 @@ export async function getSwitchStructures(): Promise<SwitchStructure[]> {
 
 export async function getSwitchOwners(): Promise<SwitchOwner[]> {
     return switchOwnerCache.getImmutable(undefined, () =>
-        getThrowError<SwitchOwner[]>(`${SWITCH_LIBRARY_URI}/switch-owners`).catch(() =>
+        getNonNull<SwitchOwner[]>(`${SWITCH_LIBRARY_URI}/switch-owners`).catch(() =>
             Promise.reject('failed to fetch switch owners'),
         ),
     );

--- a/ui/src/common/geocoding-api.ts
+++ b/ui/src/common/geocoding-api.ts
@@ -1,7 +1,7 @@
 import { LayoutPoint, LayoutTrackNumberId, LocationTrackId } from 'track-layout/track-layout-model';
 import { Point } from 'model/geometry';
 import { PublishType, TrackMeter } from 'common/common-model';
-import { API_URI, getIgnoreError, queryParams } from 'api/api-fetch';
+import { API_URI, getNullable, queryParams } from 'api/api-fetch';
 import { pointString } from 'common/common-api';
 
 export const GEOCODING_URI = `${API_URI}/geocoding`;
@@ -34,7 +34,7 @@ export async function getAddress(
     const params = queryParams({
         coordinate: pointString(coordinate),
     });
-    return getIgnoreError<TrackMeter>(
+    return getNullable<TrackMeter>(
         `${geocodingUri(publishType)}/address/${trackNumberId}${params}`,
     );
 }
@@ -43,7 +43,7 @@ export async function getAddressPoints(
     locationTrackId: LocationTrackId,
     publishType: PublishType,
 ): Promise<AlignmentAddresses | undefined> {
-    return getIgnoreError(`${geocodingUri(publishType)}/address-pointlist/${locationTrackId}`).then(
+    return getNullable(`${geocodingUri(publishType)}/address-pointlist/${locationTrackId}`).then(
         (data: AlignmentAddresses | undefined) => data,
     );
 }

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -1,8 +1,7 @@
 import {
     API_URI,
     ApiErrorResponse,
-    getIgnoreError,
-    getWithDefault,
+    getNonNull,
     postFormIgnoreError,
     postFormWithError,
     putFormIgnoreError,
@@ -137,13 +136,13 @@ export async function getPVDocuments(
 ): Promise<PVDocumentHeader[]> {
     const params = queryParams({ status: status });
     return pvDocumentHeadersByStateCache.get(changeTime, status, () =>
-        getWithDefault<PVDocumentHeader[]>(`${PROJEKTIVELHO_URI}/documents${params}`, []),
+        getNonNull<PVDocumentHeader[]>(`${PROJEKTIVELHO_URI}/documents${params}`),
     );
 }
 
 export const getPVRedirectUrl = (changeTime: TimeStamp, oid: Oid) =>
     pvRedirectUrlCache.get(changeTime, oid, () =>
-        getIgnoreError<string>(`${PROJEKTIVELHO_URI}/redirect/${oid}`),
+        getNonNull<string>(`${PROJEKTIVELHO_URI}/redirect/${oid}`),
     );
 
 export async function getPVDocument(
@@ -151,12 +150,12 @@ export async function getPVDocument(
     id: PVDocumentId,
 ): Promise<PVDocumentHeader | undefined> {
     return pvDocumentHeaderCache.get(changeTime, id, () =>
-        getIgnoreError<PVDocumentHeader>(`${PROJEKTIVELHO_URI}/documents/${id}`),
+        getNonNull<PVDocumentHeader>(`${PROJEKTIVELHO_URI}/documents/${id}`),
     );
 }
 
 export async function getPVDocumentCount(): Promise<PVDocumentCount | undefined> {
-    return getIgnoreError<PVDocumentCount>(`${PROJEKTIVELHO_URI}/documents/count`);
+    return getNonNull<PVDocumentCount>(`${PROJEKTIVELHO_URI}/documents/count`);
 }
 
 export async function rejectPVDocuments(ids: PVDocumentId[]): Promise<undefined> {

--- a/ui/src/linking/linking-api.ts
+++ b/ui/src/linking/linking-api.ts
@@ -7,8 +7,8 @@ import {
 } from 'track-layout/track-layout-model';
 import {
     API_URI,
-    getIgnoreError,
-    getThrowError,
+    getNonNull,
+    getNullable,
     postIgnoreError,
     putIgnoreError,
     queryParams,
@@ -66,7 +66,7 @@ export const getSuggestedContinuousLocationTracks = async (
         bbox: bboxString(bbox),
     });
     const uri = linkingUri('location-tracks', 'suggested');
-    return getThrowError<LayoutLocationTrack[]>(`${uri}${params}`);
+    return getNonNull<LayoutLocationTrack[]>(`${uri}${params}`);
 };
 
 export const linkGeometryWithReferenceLine = async (
@@ -159,7 +159,7 @@ export async function getPlanLinkStatus(
     );
 
     return geometryElementsLinkedStatusCache.get(maxChangeTime, `${publishType}_${planId}`, () =>
-        getThrowError(`${LINKING_URI}/${publishType}/plans/${planId}/status`),
+        getNonNull(`${LINKING_URI}/${publishType}/plans/${planId}/status`),
     );
 }
 
@@ -176,7 +176,7 @@ export async function getSuggestedSwitchesByTile(mapTile: MapTile): Promise<Sugg
                     getChangeTimes().layoutSwitch,
                 ),
                 key,
-                () => getThrowError(`${linkingUri('switches', 'suggested')}${params}`),
+                () => getNonNull(`${linkingUri('switches', 'suggested')}${params}`),
             )
             // IDs are needed to separate different suggested switches from each other.
             // If suggested switch is generated from geometry switch, geom switch id
@@ -202,7 +202,7 @@ export async function getSuggestedSwitchByPoint(
         switchStructureId: switchStructureId,
     });
     const uri = linkingUri('switches', 'suggested');
-    return getIgnoreError<SuggestedSwitch[]>(`${uri}${params}`).then((suggestedSwitches) => {
+    return getNullable<SuggestedSwitch[]>(`${uri}${params}`).then((suggestedSwitches) => {
         return (suggestedSwitches || []).map((suggestedSwitch) => {
             return {
                 ...suggestedSwitch,

--- a/ui/src/publication/card/publication-card.tsx
+++ b/ui/src/publication/card/publication-card.tsx
@@ -30,7 +30,7 @@ const parseRatkoConnectionError = (errorType: string, ratkoStatusCode: number, c
     );
 };
 
-const parseRatkoStatus = (ratkoStatus: RatkoStatus) => {
+const parseRatkoOfflineStatus = (ratkoStatus: { statusCode: number }) => {
     if (ratkoStatus.statusCode >= 500) {
         return ratkoStatus.statusCode === 503
             ? parseRatkoConnectionError(
@@ -79,7 +79,8 @@ const PublicationCard: React.FC<PublishListProps> = ({
         .filter((publication) => !ratkoPushFailed(publication.ratkoPushStatus))
         .slice(0, MAX_LISTED_PUBLICATIONS);
 
-    const ratkoConnectionError = ratkoStatus && ratkoStatus.statusCode >= 300;
+    const ratkoConnectionError =
+        ratkoStatus && !ratkoStatus.isOnline && ratkoStatus.statusCode >= 300;
 
     return (
         <Card
@@ -96,7 +97,7 @@ const PublicationCard: React.FC<PublishListProps> = ({
                             </h3>
                             {ratkoConnectionError && (
                                 <p className={styles['publication-card__title-errors']}>
-                                    {parseRatkoStatus(ratkoStatus)}
+                                    {parseRatkoOfflineStatus(ratkoStatus)}
                                 </p>
                             )}
                             {failures.length > 0 && (

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -1,7 +1,7 @@
 import {
     API_URI,
     deleteAdt,
-    getIgnoreError,
+    getNonNull,
     Page,
     postAdt,
     postIgnoreError,
@@ -25,7 +25,7 @@ import { SortDirection } from 'utils/table-utils';
 const PUBLICATION_URL = `${API_URI}/publications`;
 
 export const getPublishCandidates = () =>
-    getIgnoreError<PublishCandidates>(`${PUBLICATION_URL}/candidates`);
+    getNonNull<PublishCandidates>(`${PUBLICATION_URL}/candidates`);
 
 export const validatePublishCandidates = (request: PublishRequestIds) =>
     postIgnoreError<PublishRequestIds, ValidatedPublishCandidates>(
@@ -45,11 +45,11 @@ export const getLatestPublications = (count: number) => {
         count,
     });
 
-    return getIgnoreError<Page<PublicationDetails>>(`${PUBLICATION_URL}/latest${params}`);
+    return getNonNull<Page<PublicationDetails>>(`${PUBLICATION_URL}/latest${params}`);
 };
 
 export const getPublicationAsTableItems = (id: PublicationId) =>
-    getIgnoreError<PublicationTableItem[]>(
+    getNonNull<PublicationTableItem[]>(
         `${PUBLICATION_URL}/${id}/table-rows${queryParams({ lang: i18next.language })}`,
     );
 
@@ -69,7 +69,7 @@ export const getPublicationsAsTableItems = (
         lang: i18next.language,
     });
 
-    return getIgnoreError<Page<PublicationTableItem>>(`${PUBLICATION_URL}/table-rows${params}`);
+    return getNonNull<Page<PublicationTableItem>>(`${PUBLICATION_URL}/table-rows${params}`);
 };
 
 export const getPublicationsCsvUri = (

--- a/ui/src/ratko/ratko-api.ts
+++ b/ui/src/ratko/ratko-api.ts
@@ -1,4 +1,4 @@
-import { API_URI, getAdt, getIgnoreError, postAdt } from 'api/api-fetch';
+import { API_URI, getNonNull, getNonNullAdt, postAdt } from 'api/api-fetch';
 import { PublicationId } from 'publication/publication-model';
 import { RatkoPushError } from 'ratko/ratko-model';
 import { LocationTrackId } from 'track-layout/track-layout-model';
@@ -6,24 +6,24 @@ import { KmNumber } from 'common/common-model';
 
 const RATKO_URI = `${API_URI}/ratko`;
 
-export const pushToRatko = () => getIgnoreError(`${RATKO_URI}/push`);
+export const pushToRatko = () => getNonNull(`${RATKO_URI}/push`);
 
 export const getRatkoPushError = (publishId: PublicationId) =>
-    getIgnoreError<RatkoPushError>(`${RATKO_URI}/errors/${publishId}`);
+    getNonNull<RatkoPushError>(`${RATKO_URI}/errors/${publishId}`);
 
-export type RatkoStatus = {
-    statusCode: number;
-    isOnline: boolean;
-};
-export const getRatkoStatus = () =>
-    getAdt(`${RATKO_URI}/is-online`).then((result) => {
+export type RatkoStatus =
+    | { isOnline: true }
+    | {
+          isOnline: false;
+          statusCode: number;
+      };
+
+export const getRatkoStatus: () => Promise<RatkoStatus> = () =>
+    getNonNullAdt<RatkoStatus>(`${RATKO_URI}/is-online`).then((result) => {
         if (result.isOk()) {
-            return result.value;
+            return { isOnline: true };
         } else {
-            return {
-                statusCode: result.error.status,
-                isOnline: false,
-            };
+            return { statusCode: result.error.status, isOnline: false };
         }
     });
 

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -7,31 +7,14 @@ import {
     SwitchesAtEnds,
 } from 'track-layout/track-layout-model';
 import { ChangeTimes, PublishType, TimeStamp, TrackMeter } from 'common/common-model';
-import {
-    deleteAdt,
-    getIgnoreError,
-    getThrowError,
-    getWithDefault,
-    postAdt,
-    putAdt,
-    queryParams,
-} from 'api/api-fetch';
+import { deleteAdt, getNonNull, getNullable, postAdt, putAdt, queryParams } from 'api/api-fetch';
 import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
 import { asyncCache } from 'cache/cache';
 import { BoundingBox } from 'model/geometry';
 import { bboxString } from 'common/common-api';
-import {
-    LocationTrackEndpoint,
-    LocationTrackSaveError,
-    LocationTrackSaveRequest,
-} from 'linking/linking-model';
+import { LocationTrackSaveError, LocationTrackSaveRequest } from 'linking/linking-model';
 import { Result } from 'neverthrow';
-import {
-    getChangeTimes,
-    updateAllChangeTimes,
-    updateLocationTrackChangeTime,
-} from 'common/change-time-api';
-import { MapTile } from 'map/map-model';
+import { getChangeTimes, updateLocationTrackChangeTime } from 'common/change-time-api';
 import { isNilOrBlank } from 'utils/string-utils';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
 import { ValidatedAsset } from 'publication/publication-model';
@@ -39,7 +22,6 @@ import { GeometryPlanId } from 'geometry/geometry-model';
 import i18next from 'i18next';
 
 const locationTrackCache = asyncCache<string, LayoutLocationTrack | undefined>();
-const locationTrackEndpointsCache = asyncCache<string, LocationTrackEndpoint[]>();
 const locationTrackSwitchesAtEndsCache = asyncCache<string, SwitchesAtEnds | undefined>();
 
 type PlanSectionPoint = {
@@ -65,7 +47,7 @@ export async function getLocationTrack(
     changeTime: TimeStamp = getChangeTimes().layoutLocationTrack,
 ): Promise<LayoutLocationTrack | undefined> {
     return locationTrackCache.get(changeTime, cacheKey(id, publishType), () =>
-        getIgnoreError<LayoutLocationTrack>(layoutUri('location-tracks', publishType, id)),
+        getNullable<LayoutLocationTrack>(layoutUri('location-tracks', publishType, id)),
     );
 }
 
@@ -81,18 +63,17 @@ export async function getLocationTracksBySearchTerm(
         limit: limit,
         lang: i18next.language,
     });
-    return await getWithDefault<LayoutLocationTrack[]>(
+    return await getNonNull<LayoutLocationTrack[]>(
         `${layoutUri('location-tracks', publishType)}${params}`,
-        [],
     );
 }
 
-export async function getLocationTrackDescriptions(
+export function getLocationTrackDescriptions(
     locationTrackIds: LocationTrackId[],
     publishType: PublishType,
 ): Promise<LocationTrackDescription[] | undefined> {
     const params = queryParams({ ids: locationTrackIds.join(',') });
-    return getIgnoreError<LocationTrackDescription[]>(
+    return getNullable<LocationTrackDescription[]>(
         `${layoutUri('location-tracks', publishType)}/description/${params}`,
     );
 }
@@ -101,9 +82,8 @@ export async function getLocationTrackStartAndEnd(
     locationTrackId: LocationTrackId,
     publishType: PublishType,
 ): Promise<AlignmentStartAndEnd | undefined> {
-    return getWithDefault<AlignmentStartAndEnd | undefined>(
+    return getNullable<AlignmentStartAndEnd>(
         `${layoutUri('location-tracks', publishType, locationTrackId)}/start-and-end`,
-        undefined,
     );
 }
 
@@ -116,7 +96,7 @@ export async function getLocationTrackSwitchesAtEnds(
         changeTime,
         cacheKey(locationTrackId, publishType),
         () =>
-            getIgnoreError<SwitchesAtEnds>(
+            getNullable<SwitchesAtEnds>(
                 `${layoutUri('location-tracks', publishType, locationTrackId)}/switches-at-ends`,
             ),
     );
@@ -127,7 +107,7 @@ export async function getLocationTracksNear(
     bbox: BoundingBox,
 ): Promise<LayoutLocationTrack[]> {
     const params = queryParams({ bbox: bboxString(bbox) });
-    return getThrowError<LayoutLocationTrack[]>(
+    return getNonNull<LayoutLocationTrack[]>(
         `${layoutUri('location-tracks', publishType)}${params}`,
     );
 }
@@ -136,7 +116,7 @@ export async function getLocationTrackDuplicates(
     publishType: PublishType,
     id: LocationTrackId,
 ): Promise<LayoutLocationTrackDuplicate[]> {
-    return getThrowError<LayoutLocationTrackDuplicate[]>(
+    return getNonNull<LayoutLocationTrackDuplicate[]>(
         `${layoutUri('location-tracks', publishType, id)}/duplicate-of`,
     );
 }
@@ -198,7 +178,7 @@ export async function getLocationTracks(
             ids,
             (id) => cacheKey(id, publishType),
             (fetchIds) =>
-                getThrowError<LayoutLocationTrack[]>(
+                getNonNull<LayoutLocationTrack[]>(
                     `${layoutUri('location-tracks', publishType)}?ids=${fetchIds}`,
                 ).then((tracks) => {
                     const trackMap = indexIntoMap(tracks);
@@ -209,41 +189,14 @@ export async function getLocationTracks(
 }
 
 export async function getNonLinkedLocationTracks(): Promise<LayoutLocationTrack[]> {
-    return getWithDefault<LayoutLocationTrack[]>(
-        `${layoutUri('location-tracks', 'DRAFT')}/non-linked`,
-        [],
-    );
+    return getNonNull<LayoutLocationTrack[]>(`${layoutUri('location-tracks', 'DRAFT')}/non-linked`);
 }
 
 export const getLocationTrackChangeTimes = (
     id: LocationTrackId,
 ): Promise<ChangeTimes | undefined> => {
-    return getIgnoreError<ChangeTimes>(changeTimeUri('location-tracks', id));
+    return getNullable<ChangeTimes>(changeTimeUri('location-tracks', id));
 };
-
-export async function getLocationTrackEndpointsByTile(
-    mapTile: MapTile,
-    publishType: PublishType,
-): Promise<LocationTrackEndpoint[]> {
-    const key = mapTile.id + publishType;
-    const params = queryParams({
-        bbox: bboxString(mapTile.area),
-    });
-    // TODO: This is an odd hack. You should instead bind the changetime in through the using view
-    const changeTimes = await updateAllChangeTimes();
-    const uri = `${layoutUri('location-tracks', publishType)}/end-points${params}`;
-    return locationTrackEndpointsCache
-        .get(changeTimes.layoutLocationTrack, key, () => getWithDefault(uri, []))
-        .then((locationTrackEndpoints) =>
-            locationTrackEndpoints.map((locationTrackEndpoint) => ({
-                ...locationTrackEndpoint,
-                // Generate id
-                id:
-                    locationTrackEndpoint.locationTrackId +
-                    JSON.stringify(locationTrackEndpoint.location),
-            })),
-        );
-}
 
 export const getLocationTrackSectionsByPlan = async (
     publishType: PublishType,
@@ -251,7 +204,7 @@ export const getLocationTrackSectionsByPlan = async (
     bbox: BoundingBox | undefined = undefined,
 ) => {
     const params = queryParams({ bbox: bbox ? bboxString(bbox) : undefined });
-    return getIgnoreError<AlignmentPlanSection[]>(
+    return getNullable<AlignmentPlanSection[]>(
         `${layoutUri('location-tracks', publishType, id)}/plan-geometry/${params}`,
     );
 };
@@ -260,7 +213,7 @@ export async function getLocationTrackValidation(
     publishType: PublishType,
     id: LocationTrackId,
 ): Promise<ValidatedAsset> {
-    return getThrowError<ValidatedAsset>(
+    return getNonNull<ValidatedAsset>(
         `${layoutUri('location-tracks', publishType, id)}/validation`,
     );
 }

--- a/ui/src/track-layout/layout-reference-line-api.ts
+++ b/ui/src/track-layout/layout-reference-line-api.ts
@@ -5,7 +5,7 @@ import {
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import { ChangeTimes, PublishType, TimeStamp } from 'common/common-model';
-import { getIgnoreError, getThrowError, getWithDefault, queryParams } from 'api/api-fetch';
+import { getNonNull, getNullable, queryParams } from 'api/api-fetch';
 import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
 import { BoundingBox } from 'model/geometry';
 import { bboxString } from 'common/common-api';
@@ -24,7 +24,7 @@ export async function getReferenceLine(
     changeTime: TimeStamp = getChangeTimes().layoutReferenceLine,
 ): Promise<LayoutReferenceLine | undefined> {
     return referenceLineCache.get(changeTime, cacheKey(id, publishType), () =>
-        getIgnoreError<LayoutReferenceLine>(layoutUri('reference-lines', publishType, id)),
+        getNullable<LayoutReferenceLine>(layoutUri('reference-lines', publishType, id)),
     );
 }
 
@@ -39,7 +39,7 @@ export async function getReferenceLines(
             ids,
             (id) => cacheKey(id, publishType),
             (fetchIds) =>
-                getThrowError<LayoutReferenceLine[]>(
+                getNonNull<LayoutReferenceLine[]>(
                     `${layoutUri('reference-lines', publishType)}?ids=${fetchIds}`,
                 ).then((tracks) => {
                     const trackMap = indexIntoMap(tracks);
@@ -56,7 +56,7 @@ export async function getTrackNumberReferenceLine(
 ): Promise<LayoutReferenceLine | undefined> {
     const cacheKey = `TN_${trackNumberId}_${publishType}`;
     return referenceLineCache.get(changeTime, cacheKey, () =>
-        getIgnoreError<LayoutReferenceLine>(
+        getNullable<LayoutReferenceLine>(
             `${layoutUri('reference-lines', publishType)}/by-track-number/${trackNumberId}`,
         ),
     );
@@ -66,9 +66,8 @@ export async function getReferenceLineStartAndEnd(
     referenceLineId: ReferenceLineId,
     publishType: PublishType,
 ): Promise<AlignmentStartAndEnd | undefined> {
-    return getWithDefault<AlignmentStartAndEnd | undefined>(
+    return getNullable<AlignmentStartAndEnd>(
         `${layoutUri('reference-lines', publishType, referenceLineId)}/start-and-end`,
-        undefined,
     );
 }
 
@@ -77,20 +76,17 @@ export async function getReferenceLinesNear(
     bbox: BoundingBox,
 ): Promise<LayoutReferenceLine[]> {
     const params = queryParams({ bbox: bboxString(bbox) });
-    return getThrowError<LayoutReferenceLine[]>(
+    return getNonNull<LayoutReferenceLine[]>(
         `${layoutUri('reference-lines', publishType)}${params}`,
     );
 }
 
 export async function getNonLinkedReferenceLines(): Promise<LayoutReferenceLine[]> {
-    return getWithDefault<LayoutReferenceLine[]>(
-        `${layoutUri('reference-lines', 'DRAFT')}/non-linked`,
-        [],
-    );
+    return getNonNull<LayoutReferenceLine[]>(`${layoutUri('reference-lines', 'DRAFT')}/non-linked`);
 }
 
 export const getReferenceLineChangeTimes = (
     id: ReferenceLineId,
 ): Promise<ChangeTimes | undefined> => {
-    return getIgnoreError<ChangeTimes>(changeTimeUri('reference-lines', id));
+    return getNullable<ChangeTimes>(changeTimeUri('reference-lines', id));
 };

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -7,9 +7,8 @@ import {
 } from 'track-layout/track-layout-model';
 import {
     deleteIgnoreError,
-    getIgnoreError,
-    getThrowError,
-    getWithDefault,
+    getNonNull,
+    getNullable,
     postAdt,
     putAdt,
     queryParams,
@@ -24,7 +23,6 @@ import { TrackLayoutSaveError, TrackLayoutSwitchSaveRequest } from 'linking/link
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
 import { ValidatedAsset } from 'publication/publication-model';
 
-// TODO: GVT-2014 this should be a cache with nullable values as a switch might not exist in valid situations
 const switchCache = asyncCache<string, LayoutSwitch | undefined>();
 const switchGroupsCache = asyncCache<string, LayoutSwitch[]>();
 
@@ -41,10 +39,7 @@ export async function getSwitchesByBoundingBox(
         comparisonPoint: comparisonPoint && pointString(comparisonPoint),
         includeSwitchesWithNoJoints: includeSwitchesWithNoJoints,
     });
-    return await getWithDefault<LayoutSwitch[]>(
-        `${layoutUri('switches', publishType)}${params}`,
-        [],
-    );
+    return await getNonNull<LayoutSwitch[]>(`${layoutUri('switches', publishType)}${params}`);
 }
 
 export async function getSwitchesBySearchTerm(
@@ -56,10 +51,7 @@ export async function getSwitchesBySearchTerm(
         searchTerm: searchTerm,
         limit: limit,
     });
-    return await getWithDefault<LayoutSwitch[]>(
-        `${layoutUri('switches', publishType)}${params}`,
-        [],
-    );
+    return await getNonNull<LayoutSwitch[]>(`${layoutUri('switches', publishType)}${params}`);
 }
 
 export async function getSwitchesByTile(
@@ -79,7 +71,7 @@ export async function getSwitch(
     changeTime: TimeStamp = getChangeTimes().layoutSwitch,
 ): Promise<LayoutSwitch | undefined> {
     return switchCache.get(changeTime, cacheKey(switchId, publishType), () =>
-        getThrowError<LayoutSwitch>(layoutUri('switches', publishType, switchId)),
+        getNullable<LayoutSwitch>(layoutUri('switches', publishType, switchId)),
     );
 }
 
@@ -94,7 +86,7 @@ export async function getSwitches(
             switchIds,
             (id) => cacheKey(id, publishType),
             (fetchIds) =>
-                getThrowError<LayoutSwitch[]>(
+                getNonNull<LayoutSwitch[]>(
                     `${layoutUri('switches', publishType)}?ids=${fetchIds}`,
                 ).then((switches) => {
                     const switchMap = indexIntoMap<LayoutSwitchId, LayoutSwitch>(switches);
@@ -108,9 +100,8 @@ export async function getSwitchJointConnections(
     publishType: PublishType,
     id: LayoutSwitchId,
 ): Promise<LayoutSwitchJointConnection[]> {
-    return getWithDefault<LayoutSwitchJointConnection[]>(
+    return getNonNull<LayoutSwitchJointConnection[]>(
         `${layoutUri('switches', publishType, id)}/joint-connections`,
-        [],
     );
 }
 
@@ -160,9 +151,9 @@ export async function getSwitchValidation(
     publishType: PublishType,
     id: LayoutSwitchId,
 ): Promise<ValidatedAsset> {
-    return getThrowError<ValidatedAsset>(`${layoutUri('switches', publishType, id)}/validation`);
+    return getNonNull<ValidatedAsset>(`${layoutUri('switches', publishType, id)}/validation`);
 }
 
 export const getSwitchChangeTimes = (id: LayoutSwitchId): Promise<ChangeTimes | undefined> => {
-    return getIgnoreError<ChangeTimes>(changeTimeUri('switches', id));
+    return getNonNull<ChangeTimes>(changeTimeUri('switches', id));
 };

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -5,14 +5,7 @@ import {
     LocationTrackId,
 } from 'track-layout/track-layout-model';
 import { PublishType, TimeStamp } from 'common/common-model';
-import {
-    deleteAdt,
-    getIgnoreError,
-    getThrowError,
-    postIgnoreError,
-    putIgnoreError,
-    queryParams,
-} from 'api/api-fetch';
+import { deleteAdt, getNonNull, postIgnoreError, putIgnoreError, queryParams } from 'api/api-fetch';
 import { layoutUri } from 'track-layout/track-layout-api';
 import { TrackNumberSaveRequest } from 'tool-panel/track-number/dialog/track-number-edit-store';
 import {
@@ -46,7 +39,7 @@ export async function getTrackNumbers(
 ): Promise<LayoutTrackNumber[]> {
     const cacheKey = `${includeDeleted}_${publishType}`;
     return trackNumbersCache.get(changeTime, cacheKey, () =>
-        getThrowError<LayoutTrackNumber[]>(
+        getNonNull<LayoutTrackNumber[]>(
             layoutUri('track-numbers', publishType) + queryParams({ includeDeleted }),
         ),
     );
@@ -88,9 +81,7 @@ export async function getTrackNumberValidation(
     publishType: PublishType,
     id: LayoutTrackNumberId,
 ): Promise<ValidatedAsset> {
-    return getThrowError<ValidatedAsset>(
-        `${layoutUri('track-numbers', publishType, id)}/validation`,
-    );
+    return getNonNull<ValidatedAsset>(`${layoutUri('track-numbers', publishType, id)}/validation`);
 }
 
 export const getTrackNumberReferenceLineSectionsByPlan = async (
@@ -99,7 +90,7 @@ export const getTrackNumberReferenceLineSectionsByPlan = async (
     bbox: BoundingBox | undefined = undefined,
 ) => {
     const params = queryParams({ bbox: bbox ? bboxString(bbox) : undefined });
-    return getIgnoreError<AlignmentPlanSection[]>(
+    return getNonNull<AlignmentPlanSection[]>(
         `${layoutUri('track-numbers', publishType, id)}/plan-geometry/${params}`,
     );
 };

--- a/ui/src/user/user-api.ts
+++ b/ui/src/user/user-api.ts
@@ -1,6 +1,6 @@
 import { asyncCache } from 'cache/cache';
 import { User } from 'user/user-model';
-import { API_URI, getThrowError } from 'api/api-fetch';
+import { API_URI, getNonNull } from 'api/api-fetch';
 
 const AUTHORIZATION_URI = `${API_URI}/authorization`;
 
@@ -8,6 +8,6 @@ const userCache = asyncCache<string, User>();
 
 export async function getOwnUser(): Promise<User> {
     return userCache.getImmutable('own-details', () =>
-        getThrowError<User>(`${AUTHORIZATION_URI}/own-details`),
+        getNonNull<User>(`${AUTHORIZATION_URI}/own-details`),
     );
 }

--- a/ui/src/utils/react-utils.tsx
+++ b/ui/src/utils/react-utils.tsx
@@ -62,12 +62,14 @@ export function useLoaderWithStatus<TEntity>(
         let cancel = false;
         if (result) {
             setLoaderStatus(LoaderStatus.Loading);
-            result.then((r) => {
-                if (!cancel) {
-                    setEntity(r);
-                    setLoaderStatus(LoaderStatus.Ready);
-                }
-            });
+            result
+                .then((r) => {
+                    if (!cancel) {
+                        setEntity(r);
+                        setLoaderStatus(LoaderStatus.Ready);
+                    }
+                })
+                .catch((e) => console.log('loader promise rejected', e));
         } else setEntity(undefined);
 
         return () => {
@@ -96,13 +98,15 @@ export function useTwoPartEffectWithStatus<TEntity>(
         if (promise) {
             setLoaderStatus(LoaderStatus.Loading);
 
-            promise.then((r) => {
-                if (!cancelled) {
-                    setLoaderStatus(LoaderStatus.Ready);
+            promise
+                .then((r) => {
+                    if (!cancelled) {
+                        setLoaderStatus(LoaderStatus.Ready);
 
-                    onceOnFulfilled(r);
-                }
-            });
+                        onceOnFulfilled(r);
+                    }
+                })
+                .catch((e) => console.log('loader promise rejected', e));
         }
 
         return () => {
@@ -126,9 +130,11 @@ export function useLoaderWithTimer<TEntity>(
         function fetchEntities() {
             const result = loadFunc();
             if (result) {
-                result.then((r) => {
-                    if (!cancel) setEntity(r);
-                });
+                result
+                    .then((r) => {
+                        if (!cancel) setEntity(r);
+                    })
+                    .catch((e) => console.log('loader promise rejected', e));
             }
         }
         fetchEntities();


### PR DESCRIPTION
API-kutsujen virheenkäsittely menee nyt huomattavasti mielipiteellisemmäksi kuin ennen. Toteutus eroaa aika paljon alkuaan taskille suunnitellusta.

Jätin lopulta oletusarvojen passaamisen api-fetchin metodeille kokonaan pois: Jos kutsuja haluaa korvata virhetilanteessa paluuarvon oletusarvolla, se on hänen vastuunsa. Tämä siksi, koska koodissa oli niin paljon tapauksia, joissa annettiin oletusarvoja cachetetuille kutsuille, joissa siis tämä oletusarvo jäisi mahdollisen väliaikaisen virheen jälkeen cacheen roikkumaan.

Tosin noin yleensäkinhän noita oletusarvoja ei pitäisi juuri tarvita.Jos halutaan vaan näyttää frontilla jokin tieto, joka ladataan dynaamisesti, niin järjestään elementit toteutetaan niin, että ne voivat näyttää tyhjää, jos tietoa ei ole vielä ladattu, ja jos lataaminen ei onnistu lainkaan, niin komponentinhan voi vaan jättää tähän tilaan.

Taskilla oli alkuaan speksattu, että virheenkäsittelyt voisi koostaa API-funktioihin sisään niin, että hylkäysten käsittely olisi sitten niiden ulkopuolella valinnaista, mutta promise-virheenkäsittelyhän ei toimi näin, vaan hylkäykset pitää kiltisti käsitellä uloimmalla tasolla, mihin ne päästetään. Design-vaihtoehtojahan sinällään kyllä on, mutta yleensä koodin rakenne tässä kyllä tuntui selkeimmältä niin, että hakujen epäonnistumiset tosiaan kommunikoidaan hylkäyksillä, ja tämän tiedon pääasiallinen käyttäjä on cache, joka osaa sitten jättää muistamatta hylättyjen hakujen tuloksia.