### PR TITLE
General: Initialize springContextUtility before flywayConfiguration

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/FlywayConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/FlywayConfiguration.kt
@@ -7,8 +7,10 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.DependsOn
 
 @Configuration
+@DependsOn("springContextUtility")
 class FlywayConfiguration(@Value("\${geoviite.data.reset:false}") private val dataReset: Boolean) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)


### PR DESCRIPTION
Muilla tätä ongelmaa ei vaikuta olleen kertaakaan, mutta minulla jostain syystä testiajoja rikkoo joskus se, että Flyway-migrojen ajo yrittää tapahtua ennen kuin SpringContextUtility#setApplicationContext()ia on kutsuttu, ja menee rikki kun CsvMigration#getChecksum yrittää käydä kontekstia hakemassa.

En lähtenyt debuggaamaan, mistä syystä järjestys sattui joskus olemaan tuo, kun näemmä asia korjaantuu vaan kertomalla Springille riippuvuudesta.