### PR TITLE
GVT-2116: Fix vertical geometry diagram drawing related edge cases

### DIFF
--- a/ui/src/geometry/geometry-model.ts
+++ b/ui/src/geometry/geometry-model.ts
@@ -324,3 +324,12 @@ export type VerticalGeometryItem = {
     layoutPointStation?: number;
     layoutEndStation?: number;
 };
+
+export type VerticalGeometryDiagramDisplayItem = Omit<
+    VerticalGeometryItem,
+    'layoutStartStation' | 'layoutPointStation' | 'layoutEndStation' | 'start' | 'point' | 'end'
+> & {
+    start: CircularCurve | undefined;
+    point: StationPoint | undefined;
+    end: CircularCurve | undefined;
+};

--- a/ui/src/utils/math-utils.ts
+++ b/ui/src/utils/math-utils.ts
@@ -112,11 +112,11 @@ export function distToSegmentSquared(p: Point, start: Point, end: Point) {
     });
 }
 
-export function linearFunctionFromPoints(
-    { x: x1, y: y1 }: Point,
-    { x: x2, y: y2 }: Point,
-    intercept: number,
-): (x: number) => number {
-    const slope = (y1 - y2) / (x1 - x2);
-    return (x: number) => slope * x + intercept; // ax + b
+export type Slope = number;
+export function slopeFromPoints({ x: x1, y: y1 }: Point, { x: x2, y: y2 }: Point): Slope {
+    return (y1 - y2) / (x1 - x2);
+}
+
+export function linearFunction(slope: Slope, intercept: number): (x: number) => number {
+    return (x: number) => slope * x + intercept;
 }

--- a/ui/src/vertical-geometry/snapped-point.ts
+++ b/ui/src/vertical-geometry/snapped-point.ts
@@ -5,7 +5,7 @@ import {
     getTrackMeterPairAroundIndex,
     TrackMeterIndex,
 } from 'vertical-geometry/track-meter-index';
-import { StationPoint, VerticalGeometryItem } from 'geometry/geometry-model';
+import { StationPoint, VerticalGeometryDiagramDisplayItem } from 'geometry/geometry-model';
 import { filterNotEmpty, minimumIndexBy } from 'utils/array-utils';
 import { Coordinates, heightToY, mToX, xToM } from 'vertical-geometry/coordinates';
 import { TrackKmHeights } from 'geometry/geometry-api';
@@ -66,7 +66,7 @@ function getSnapOverRuler(
 
 function getSnapOverChart(
     xCoordinateM: number,
-    geometry: VerticalGeometryItem[],
+    geometry: VerticalGeometryDiagramDisplayItem[],
     withinSnapDistance: (snappedM: number) => boolean,
     approximatedPoint: (
         maybeApproximateM: number,
@@ -106,7 +106,7 @@ function getSnapOverChart(
 export function getSnappedPoint(
     mousePositionInElement: [number, number] | undefined,
     trackKmHeights: TrackKmHeights[],
-    geometry: VerticalGeometryItem[],
+    geometry: VerticalGeometryDiagramDisplayItem[],
     coordinates: Coordinates,
     drawTangentArrows: boolean,
 ): SnappedPoint | undefined {
@@ -181,14 +181,20 @@ function toGeometrySnapPoint(
 }
 function closestGeometrySnapPoint(
     m: number,
-    geometry: VerticalGeometryItem[],
+    geometry: VerticalGeometryDiagramDisplayItem[],
     drawTangents: boolean,
 ) {
     const allGeometryPoints = geometry.flatMap((geom) =>
         [
-            toGeometrySnapPoint(geom.fileName, geom.point, 'intersectionPoint'),
-            drawTangents ? toGeometrySnapPoint(geom.fileName, geom.start, 'endPoint') : undefined,
-            drawTangents ? toGeometrySnapPoint(geom.fileName, geom.end, 'endPoint') : undefined,
+            geom.point
+                ? toGeometrySnapPoint(geom.fileName, geom.point, 'intersectionPoint')
+                : undefined,
+            drawTangents && geom.start
+                ? toGeometrySnapPoint(geom.fileName, geom.start, 'endPoint')
+                : undefined,
+            drawTangents && geom.end
+                ? toGeometrySnapPoint(geom.fileName, geom.end, 'endPoint')
+                : undefined,
         ].filter(filterNotEmpty),
     );
     const minIndex = minimumIndexBy(allGeometryPoints, (snapPoint) => Math.abs(m - snapPoint.m));

--- a/ui/src/vertical-geometry/util.ts
+++ b/ui/src/vertical-geometry/util.ts
@@ -176,45 +176,30 @@ export function sumPaddings(p1: string, p2: string) {
     return parseFloat(p1) + parseFloat(p2);
 }
 
-function isLayoutGeometryItem(verticalGeometryItem: VerticalGeometryItem): boolean {
-    const layoutGeometryKeys: Array<keyof VerticalGeometryItem> = [
-        'layoutStartStation',
-        'layoutPointStation',
-        'layoutEndStation',
-    ];
-
-    return layoutGeometryKeys.some((layoutKey) => verticalGeometryItem[layoutKey] !== undefined);
-}
-
 export function substituteLayoutStationsForGeometryStations(
     geometryItem: VerticalGeometryItem,
 ): VerticalGeometryDiagramDisplayItem {
-    const [start, point, end] = isLayoutGeometryItem(geometryItem)
-        ? [
-              geometryItem.layoutStartStation,
-              geometryItem.layoutPointStation,
-              geometryItem.layoutEndStation,
-          ]
-        : [geometryItem.start.station, geometryItem.point.station, geometryItem.end.station];
-
     return {
         ...geometryItem,
-        start: start
+
+        start: geometryItem.layoutStartStation
             ? {
                   ...geometryItem.start,
-                  station: start,
+                  station: geometryItem.layoutStartStation,
               }
             : undefined,
-        point: point
+
+        point: geometryItem.layoutPointStation
             ? {
                   ...geometryItem.point,
-                  station: point,
+                  station: geometryItem.layoutPointStation,
               }
             : undefined,
-        end: end
+
+        end: geometryItem.layoutEndStation
             ? {
                   ...geometryItem.end,
-                  station: end,
+                  station: geometryItem.layoutEndStation,
               }
             : undefined,
     };

--- a/ui/src/vertical-geometry/util.ts
+++ b/ui/src/vertical-geometry/util.ts
@@ -4,14 +4,20 @@ import {
     getTrackMeterPairAroundIndex,
     TrackMeterIndex,
 } from 'vertical-geometry/track-meter-index';
-import { VerticalGeometryItem } from 'geometry/geometry-model';
+import { VerticalGeometryDiagramDisplayItem, VerticalGeometryItem } from 'geometry/geometry-model';
 import { filterNotEmpty, findLastIndex } from 'utils/array-utils';
-import { linearFunctionFromPoints } from 'utils/math-utils';
+import { linearFunction, slopeFromPoints } from 'utils/math-utils';
+import { Point } from 'model/geometry';
 
 type HeightValue = number;
 type LowerHeightBound = number;
 type UpperHeightBound = number;
 type HeightBounds = [LowerHeightBound, UpperHeightBound];
+
+type AdjacentVerticalGeometryItems = [
+    VerticalGeometryDiagramDisplayItem | undefined,
+    VerticalGeometryDiagramDisplayItem | undefined,
+];
 
 export function approximateHeightAtM(m: number, kmHeights: TrackKmHeights[]): number | undefined {
     const index = findTrackMeterIndexContainingM(m, kmHeights);
@@ -45,7 +51,7 @@ export function polylinePoints(points: readonly (readonly [number, number])[]): 
 
 export function getBottomAndTopTicks(
     kmHeights: TrackKmHeights[],
-    geometry: VerticalGeometryItem[],
+    geometry: VerticalGeometryDiagramDisplayItem[],
     visibleStartM: number,
     visibleEndM: number,
 ): [number, number] {
@@ -72,31 +78,21 @@ export function getBottomAndTopTicks(
     // diagram. This was unwanted behavior as the vertical geometry diagram's height should scale correctly even with
     // large changes between values, which is what the following condition should account for.
     if (heightBoundsFromTrackKm) {
-        const approximateHeightAtLeftEdge = approximateHeightAtVerticalGeometryDiagramLeftEdge(
-            heightBoundsFromTrackKm,
-            geometry,
-            visibleStartM,
-        );
-
-        const approximateHeightAtRightEdge = approximateHeightAtVerticalGeometryDiagramRightEdge(
-            heightBoundsFromTrackKm,
-            geometry,
-            visibleEndM,
-        );
-
         heightBoundsFromTrackKm = heightsToBounds(
             [
                 ...heightBoundsFromTrackKm,
-                approximateHeightAtLeftEdge,
-                approximateHeightAtRightEdge,
-            ].filter((height): height is number => height !== undefined),
+                approximateHeightAtLeftEdge(heightBoundsFromTrackKm, geometry, visibleStartM),
+                approximateHeightAtRightEdge(heightBoundsFromTrackKm, geometry, visibleEndM),
+            ].filter(filterNotEmpty),
         );
     }
 
     return (
         heightBoundsFromTrackKm ??
         heightsToBounds(
-            geometry.flatMap((p) => [p.start.height, p.point.height, p.end.height]),
+            geometry
+                .flatMap((p) => [p.start?.height, p.point?.height, p.end?.height])
+                .filter(filterNotEmpty),
         ) ?? [0, 100]
     );
 }
@@ -105,79 +101,71 @@ function heightIsOutOfBounds(heightBounds: HeightBounds, height: HeightValue) {
     return height && (height < heightBounds[0] || height > heightBounds[1]);
 }
 
-function approximateHeightAtVerticalGeometryDiagramLeftEdge(
-    heightBounds: HeightBounds,
-    geometry: VerticalGeometryItem[],
+function approximateHeightAtLeftEdge(
+    previousHeightBounds: HeightBounds,
+    geometry: VerticalGeometryDiagramDisplayItem[],
     visibleStartM: number,
 ): number | undefined {
-    const indexOfFirstVisibleGeometryItem = geometry.findIndex((geometryItem) => {
-        return geometryItem.start.station > visibleStartM;
-    });
+    const firstVisibleItemIndex = geometry.findIndex((item) =>
+        item.start ? item.start.station > visibleStartM : false,
+    );
 
-    if (indexOfFirstVisibleGeometryItem > 0) {
-        const lastNotVisibleGeometryItem = geometry[indexOfFirstVisibleGeometryItem - 1];
-        const firstVisibleGeometryItem = geometry[indexOfFirstVisibleGeometryItem];
-
-        if (heightIsOutOfBounds(heightBounds, lastNotVisibleGeometryItem.end.height)) {
-            const linearFunctionFromLastKnownHeightToNextKnownHeight = linearFunctionFromPoints(
-                {
-                    x: lastNotVisibleGeometryItem.end.station,
-                    y: lastNotVisibleGeometryItem.end.height,
-                },
-                {
-                    x: firstVisibleGeometryItem.start.station,
-                    y: firstVisibleGeometryItem.start.height,
-                },
-                lastNotVisibleGeometryItem.end.height,
-            );
-
-            // Approximate height at the left edge of the vertical geometry diagram.
-            return linearFunctionFromLastKnownHeightToNextKnownHeight(
-                visibleStartM - lastNotVisibleGeometryItem.end.station,
-            );
-        }
-    }
-
-    return undefined;
+    return approximateHeight(
+        previousHeightBounds,
+        [geometry[firstVisibleItemIndex - 1], geometry[firstVisibleItemIndex]],
+        visibleStartM,
+    );
 }
 
-function approximateHeightAtVerticalGeometryDiagramRightEdge(
-    heightBounds: HeightBounds,
-    geometry: VerticalGeometryItem[],
+function approximateHeightAtRightEdge(
+    previousHeightBounds: HeightBounds,
+    geometry: VerticalGeometryDiagramDisplayItem[],
     visibleEndM: number,
 ): number | undefined {
-    const indexOfLastVisibleGeometryItem = findLastIndex(geometry, (geometryItem) => {
-        return geometryItem.end.station < visibleEndM;
-    });
+    const lastVisibleItemIndex = findLastIndex(geometry, (item) =>
+        item.end ? item.end.station < visibleEndM : false,
+    );
 
-    if (
-        indexOfLastVisibleGeometryItem >= 0 &&
-        indexOfLastVisibleGeometryItem + 1 < geometry.length
-    ) {
-        const lastVisibleGeometryItem = geometry[indexOfLastVisibleGeometryItem];
-        const firstNotVisibleGeometryItem = geometry[indexOfLastVisibleGeometryItem + 1];
+    return approximateHeight(
+        previousHeightBounds,
+        [geometry[lastVisibleItemIndex], geometry[lastVisibleItemIndex + 1]],
+        visibleEndM,
+    );
+}
 
-        if (heightIsOutOfBounds(heightBounds, firstNotVisibleGeometryItem.start.height)) {
-            const linearFunctionFromLastKnownHeightToNextKnownHeight = linearFunctionFromPoints(
-                {
-                    x: lastVisibleGeometryItem.end.station,
-                    y: lastVisibleGeometryItem.end.height,
-                },
-                {
-                    x: firstNotVisibleGeometryItem.start.station,
-                    y: firstNotVisibleGeometryItem.start.height,
-                },
-                lastVisibleGeometryItem.end.height,
-            );
-
-            // Approximate height at the right edge of the vertical geometry diagram.
-            return linearFunctionFromLastKnownHeightToNextKnownHeight(
-                visibleEndM - lastVisibleGeometryItem.end.station,
-            );
-        }
+function approximateHeight(
+    previousHeightBounds: HeightBounds,
+    adjacentVerticalGeometryItems: AdjacentVerticalGeometryItems,
+    evaluateHeightAtX: number,
+): number | undefined {
+    if (!adjacentVerticalGeometryItems[0]?.end || !adjacentVerticalGeometryItems[1]?.start) {
+        return undefined;
     }
 
-    return undefined;
+    const [previousPoint, nextPoint]: [Point, Point] = [
+        {
+            x: adjacentVerticalGeometryItems[0].end.station,
+            y: adjacentVerticalGeometryItems[0].end.height,
+        },
+        {
+            x: adjacentVerticalGeometryItems[1].start.station,
+            y: adjacentVerticalGeometryItems[1].start.height,
+        },
+    ];
+
+    if (
+        !heightIsOutOfBounds(previousHeightBounds, previousPoint.y) &&
+        !heightIsOutOfBounds(previousHeightBounds, nextPoint.y)
+    ) {
+        // Optimization: Neither of the points is out of bounds in the y-axis,
+        // meaning that a straight line between them is not going to be either.
+        return undefined;
+    }
+
+    return linearFunction(
+        slopeFromPoints(previousPoint, nextPoint),
+        previousPoint.y,
+    )(evaluateHeightAtX - previousPoint.x);
 }
 
 export function zeroSafeDivision(a: number, b: number): number {
@@ -188,23 +176,47 @@ export function sumPaddings(p1: string, p2: string) {
     return parseFloat(p1) + parseFloat(p2);
 }
 
+function isLayoutGeometryItem(verticalGeometryItem: VerticalGeometryItem): boolean {
+    const layoutGeometryKeys: Array<keyof VerticalGeometryItem> = [
+        'layoutStartStation',
+        'layoutPointStation',
+        'layoutEndStation',
+    ];
+
+    return layoutGeometryKeys.some((layoutKey) => verticalGeometryItem[layoutKey] !== undefined);
+}
+
 export function substituteLayoutStationsForGeometryStations(
     geometryItem: VerticalGeometryItem,
-): VerticalGeometryItem {
+): VerticalGeometryDiagramDisplayItem {
+    const [start, point, end] = isLayoutGeometryItem(geometryItem)
+        ? [
+              geometryItem.layoutStartStation,
+              geometryItem.layoutPointStation,
+              geometryItem.layoutEndStation,
+          ]
+        : [geometryItem.start.station, geometryItem.point.station, geometryItem.end.station];
+
     return {
         ...geometryItem,
-        start: {
-            ...geometryItem.start,
-            station: geometryItem.layoutStartStation ?? geometryItem.start.station,
-        },
-        point: {
-            ...geometryItem.point,
-            station: geometryItem.layoutPointStation ?? geometryItem.point.station,
-        },
-        end: {
-            ...geometryItem.end,
-            station: geometryItem.layoutEndStation ?? geometryItem.end.station,
-        },
+        start: start
+            ? {
+                  ...geometryItem.start,
+                  station: start,
+              }
+            : undefined,
+        point: point
+            ? {
+                  ...geometryItem.point,
+                  station: point,
+              }
+            : undefined,
+        end: end
+            ? {
+                  ...geometryItem.end,
+                  station: end,
+              }
+            : undefined,
     };
 }
 
@@ -214,12 +226,14 @@ export function processLayoutGeometries(
 ) {
     const linkedAreaSourceFile = (layoutM: number) =>
         linkingSummary.find((linkingSummaryItem) => linkingSummaryItem.endM >= layoutM)?.filename;
+
     return geometry
         .map(substituteLayoutStationsForGeometryStations)
         .filter(
             (geom) =>
-                geom.fileName === linkedAreaSourceFile(geom.start.station) ||
-                geom.fileName === linkedAreaSourceFile(geom.end.station) ||
-                geom.fileName === linkedAreaSourceFile(geom.point.station),
+                (geom.start?.station &&
+                    geom.fileName === linkedAreaSourceFile(geom.start.station)) ||
+                (geom.end?.station && geom.fileName === linkedAreaSourceFile(geom.end.station)) ||
+                (geom.point?.station && geom.fileName === linkedAreaSourceFile(geom.point.station)),
         );
 }

--- a/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { VerticalGeometryDiagram } from 'vertical-geometry/vertical-geometry-diagram';
 import { useAlignmentHeights } from 'vertical-geometry/km-heights-fetch';
 import { ChangeTimes } from 'common/common-slice';
-import { VerticalGeometryItem } from 'geometry/geometry-model';
+import { VerticalGeometryDiagramDisplayItem, VerticalGeometryItem } from 'geometry/geometry-model';
 import {
     getGeometryPlanVerticalGeometry,
     getLocationTrackLinkingSummary,
@@ -88,7 +88,8 @@ export const VerticalGeometryDiagramHolder: React.FC<VerticalGeometryDiagramHold
     const [diagramHeight, setDiagramHeight] = React.useState<number>();
     const [diagramWidth, setDiagramWidth] = React.useState<number>();
     const [linkingSummary, setLinkingSummary] = React.useState<PlanLinkingSummaryItem[]>();
-    const [processedGeometry, setProcessedGeometry] = React.useState<VerticalGeometryItem[]>();
+    const [processedGeometry, setProcessedGeometry] =
+        React.useState<VerticalGeometryDiagramDisplayItem[]>();
     const [alignmentAndExtents, setAlignmentAndExtents] = React.useState<AlignmentAndExtents>();
     const { t } = useTranslation();
 
@@ -151,7 +152,9 @@ export const VerticalGeometryDiagramHolder: React.FC<VerticalGeometryDiagramHold
                         (linkingSummary
                             ? processLayoutGeometries(geometry, linkingSummary)
                             : geometry
-                        ).sort((a, b) => a.point.station - b.point.station),
+                        ).sort((a, b) =>
+                            !a.point || !b.point ? 0 : a.point.station - b.point.station,
+                        ),
                     );
 
                     setStartM(start);

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -13,7 +13,7 @@ import { getSnappedPoint } from 'vertical-geometry/snapped-point';
 import { Coordinates, xToM } from 'vertical-geometry/coordinates';
 import { getBottomAndTopTicks, sumPaddings, zeroSafeDivision } from 'vertical-geometry/util';
 import { PlanLinkingSummaryItem, TrackKmHeights } from 'geometry/geometry-api';
-import { VerticalGeometryItem } from 'geometry/geometry-model';
+import { VerticalGeometryDiagramDisplayItem } from 'geometry/geometry-model';
 import {
     findTrackMeterIndexContainingM,
     getTrackMeterPairAroundIndex,
@@ -31,7 +31,7 @@ const minimumPixelWidthToDrawTangentArrows = 0.05;
 
 type VerticalGeometryDiagramProps = {
     kmHeights: TrackKmHeights[];
-    geometry: VerticalGeometryItem[];
+    geometry: VerticalGeometryDiagramDisplayItem[];
     visibleStartM: number;
     visibleEndM: number;
     startM: number;


### PR DESCRIPTION
Previously the vertical geometry diagram sometimes drew lines based on invalid points which were from another context. These points were also used for the height axis bounds calculation, resulting in possibly invalid bounds being used, causing the vertical geometry diagram to have buggy rendering in some specific cases.

Additionally, this pull request includes some review fixes related to GVT-1918 (#718).

---

Korjausperiaate:

1. Määritellään pystygeometriadiagrammia varten derivoitu tyyppi aiemmasta `VerticalGeometryItem`-tyypistä. Tälle uudelle `VerticalGeometryDiagramDisplayItem`-tyypille .start/.point/.end-kentät voi asettaa undefineksi verrattuna alkuperäiseen. Nämä kentäthän ovat sinällään ihan hyvän nimisiä, mutta niihin päätyy oletusarvoisesti oikeaa dataa vain tietyn *geometriasuunnitelman* korkeusgeometriadiagrammia piirrettäessä. Näiden kenttien arvoja korvattiin aiemmin piirrettäessä *sijaintiraiteen* korkeusgeometriaa, mutta niihin ei välttämättä päätynyt oikeaa arvoa lainkaan (koska sitä ei oikeasti ollut), jolloin piirtokoodi käytti *suunnitelmasta* peräisin olevia arvoja, jotka ovat usein väärin piirrettäessä *sijaintiraiteen* pystygeometriaa.

2. ~Pyritään tunnistamaan milloin pystygeometriadiagrammia piirretään sijaintiraiteelle. Tunnistusperiaatteena on tällä hetkellä "jos mikä tahansa kentistä `'layoutStartStation', 'layoutPointStation', 'layoutEndStation'` on määritetty" (eli ei undefined), niin todetaan piirtotilanne sijaintiraiteelle tarkoitetuksi.~ (edit: Tämä siis olikin jo olemassa vanhan koodin osalta.) Kaikki .start/.point./end-kentät korvataan mahdollisesti määrittämättömillä arvoilla, sillä *suunnitelmaan* perustuvia metripisteiden arvoja ei voida *sijaintiraiteen* piirtotilanteessa (ainakaan aina) käyttää.

3. Piirretään pystygeometriadiagrammin elementtejä vain tilanteessa, jossa arvot eivät ole määrittämättömiä. Tämä siis aiheuttaa vähän ikävää iffittelykohinaa, jota on kuitenkin pyritty rajaamaan refaktoroimalla piirtokoodia pienempiin komponentteihin (ja käyttämällä näissä early-returneja). Tämä vähentää myös koodin sisennyksen määrää ja parantaa kokonaiskuvan saamista diagrammin piirtologiikasta. Noita komponentteja voisi tuolta edelleen lohkoa, mutta tämä pullari oli tässä vaiheessa jo ihan riittävän pitkä ja monimutkainen.