### PR TITLE
GVT-2127: Draw vertical geometry diagram display position guide when viewing a geometry plan

### DIFF
--- a/ui/src/vertical-geometry/displayed-position-guide.tsx
+++ b/ui/src/vertical-geometry/displayed-position-guide.tsx
@@ -26,6 +26,10 @@ export const DisplayedPositionGuide: React.FC<DisplayedPositionGuideProps> = ({
     coordinates,
     maxMeters,
 }) => {
+    if (maxMeters <= 0) {
+        return <React.Fragment />;
+    }
+
     const displayedMetersAtLeftEdge = coordinates.startM;
     const displayedMetersAtRightEdge = coordinates.endM;
 

--- a/ui/src/vertical-geometry/displayed-position-guide.tsx
+++ b/ui/src/vertical-geometry/displayed-position-guide.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import { PlanLinkingSummaryItem } from 'geometry/geometry-api';
 import { Coordinates } from 'vertical-geometry/coordinates';
-import { last } from 'utils/array-utils';
 import { Translate } from 'vertical-geometry/translate';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
 
@@ -21,23 +19,18 @@ const guideRectangleMinWidthPx = 1;
 
 export interface DisplayedPositionGuideProps {
     coordinates: Coordinates;
-    planLinkingSummary: PlanLinkingSummaryItem[] | undefined;
+    maxMeters: number;
 }
 
 export const DisplayedPositionGuide: React.FC<DisplayedPositionGuideProps> = ({
-    planLinkingSummary,
     coordinates,
+    maxMeters,
 }) => {
-    if (!planLinkingSummary || planLinkingSummary.length === 0) return <React.Fragment />;
-
-    const maxDisplayedMeters = last(planLinkingSummary).endM;
-
     const displayedMetersAtLeftEdge = coordinates.startM;
     const displayedMetersAtRightEdge = coordinates.endM;
 
     const metersCurrentlyDisplayed = displayedMetersAtRightEdge - displayedMetersAtLeftEdge;
-    const ratioOfCurrentlyDisplayedMetersToFullDiagram =
-        metersCurrentlyDisplayed / maxDisplayedMeters;
+    const ratioOfCurrentlyDisplayedMetersToFullDiagram = metersCurrentlyDisplayed / maxMeters;
 
     const guideWidthPx = 0.15 * coordinates.diagramWidthPx;
 
@@ -49,7 +42,7 @@ export const DisplayedPositionGuide: React.FC<DisplayedPositionGuideProps> = ({
         guideRectangleMinWidthPx,
     );
     const guideRectangleStartPx =
-        guideStartPx + guideWidthPx * (displayedMetersAtLeftEdge / maxDisplayedMeters);
+        guideStartPx + guideWidthPx * (displayedMetersAtLeftEdge / maxMeters);
 
     return (
         <Translate x={coordinates.diagramWidthPx - guideWidthPx - 40} y={0}>

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -241,10 +241,7 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
                         planLinkingSummary={linkingSummary}
                         planLinkingOnSelect={onSelect}
                     />
-                    <DisplayedPositionGuide
-                        coordinates={coordinates}
-                        planLinkingSummary={linkingSummary}
-                    />
+                    <DisplayedPositionGuide coordinates={coordinates} maxMeters={endM} />
                     <Translate x={0} y={240}>
                         <TrackAddressRuler
                             kmHeights={kmHeights}


### PR DESCRIPTION
GVT-2127: Draw vertical geometry diagram display position guide when viewing a geometry plan

Previously the position guide was not displayed when viewing the vertical geometry of a specific *geometry plan*. The guide was only displayed when viewing the vertical geometry of a *location track*.