### PR TITLE
General: Remove redundant linkness from plan name links

### DIFF
--- a/ui/src/geoviite-design-lib/geometry-plan/plan-name-link.tsx
+++ b/ui/src/geoviite-design-lib/geometry-plan/plan-name-link.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GeometryPlanId } from 'geometry/geometry-model';
+import styles from 'vayla-design-lib/link/link.scss';
 import { NavLink } from 'react-router-dom';
-import { Link } from 'vayla-design-lib/link/link';
 
 export type GeometryPlanNameLinkProps = {
     planId: GeometryPlanId;
@@ -12,8 +12,8 @@ export const PlanNameLink: React.FC<GeometryPlanNameLinkProps> = (
     props: GeometryPlanNameLinkProps,
 ) => {
     return (
-        <NavLink to={`/infra-model/edit/${props.planId}`}>
-            <Link>{props.planName}</Link>
+        <NavLink className={styles.link} to={`/infra-model/edit/${props.planId}`}>
+            {props.planName}
         </NavLink>
     );
 };


### PR DESCRIPTION
Tämä aiheutti Reactin DOM-validaatiossa mölinää a-elementistä a-elementin sisällä.