### PR TITLE
General: Memoize data product lists

### DIFF
--- a/ui/src/data-products/element-list/element-list-view.tsx
+++ b/ui/src/data-products/element-list/element-list-view.tsx
@@ -5,7 +5,7 @@ import { Radio } from 'vayla-design-lib/radio/radio';
 import LocationTrackElementListingSearch from 'data-products/element-list/location-track-element-listing-search';
 import { createDelegates } from 'store/store-utils';
 import PlanGeometryElementListingSearch from 'data-products/element-list/plan-geometry-element-listing-search';
-import { ElementTable } from 'data-products/element-list/element-table';
+import ElementTable from 'data-products/element-list/element-table';
 import { useDataProductsAppSelector } from 'store/hooks';
 import { dataProductsActions, SelectedGeometrySearch } from 'data-products/data-products-slice';
 import { EntireRailNetworkElementListing } from 'data-products/element-list/entire-rail-network-element-listing';

--- a/ui/src/data-products/element-list/element-table.tsx
+++ b/ui/src/data-products/element-list/element-table.tsx
@@ -17,7 +17,7 @@ type ElementTableProps = {
     isLoading: boolean;
 };
 
-export const ElementTable = ({ elements, showLocationTrackName, isLoading }: ElementTableProps) => {
+const ElementTable = ({ elements, showLocationTrackName, isLoading }: ElementTableProps) => {
     const { t } = useTranslation();
     const trackNumbers = useTrackNumbers('OFFICIAL');
     const amount = elements.length;
@@ -117,3 +117,5 @@ export const ElementTable = ({ elements, showLocationTrackName, isLoading }: Ele
         </React.Fragment>
     );
 };
+
+export default React.memo(ElementTable);

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-table.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-table.tsx
@@ -15,7 +15,7 @@ type KilometerLengthsTableProps = {
     isLoading: boolean;
 };
 
-export const KilometerLengthsTable = ({ kmLengths, isLoading }: KilometerLengthsTableProps) => {
+const KilometerLengthsTable = ({ kmLengths, isLoading }: KilometerLengthsTableProps) => {
     const { t } = useTranslation();
     const amount = kmLengths.length;
     const headings: ElementHeading[] = [
@@ -72,3 +72,5 @@ export const KilometerLengthsTable = ({ kmLengths, isLoading }: KilometerLengths
         </React.Fragment>
     );
 };
+
+export default React.memo(KilometerLengthsTable);

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
@@ -4,7 +4,7 @@ import styles from 'data-products/data-product-view.scss';
 import { useDataProductsAppSelector } from 'store/hooks';
 import { createDelegates } from 'store/store-utils';
 import KilometerLengthsSearch from 'data-products/kilometer-lengths/kilometer-lengths-search';
-import { KilometerLengthsTable } from 'data-products/kilometer-lengths/kilometer-lengths-table';
+import KilometerLengthsTable from 'data-products/kilometer-lengths/kilometer-lengths-table';
 import { KmNumber } from 'common/common-model';
 import { LayoutKmLengthDetails } from 'track-layout/track-layout-model';
 import { dataProductsActions, SelectedKmLengthsSearch } from 'data-products/data-products-slice';
@@ -25,7 +25,10 @@ export const KilometerLengthsView = () => {
     const endIndex = state.endKm
         ? findIndex(state.endKm, state.kmLengths) + 1
         : state.kmLengths.length;
-    const kmLengths = state.kmLengths.slice(startIndex, endIndex);
+    const kmLengths =
+        startIndex === 0 && endIndex == state.kmLengths.length
+            ? state.kmLengths
+            : state.kmLengths.slice(startIndex, endIndex);
 
     return (
         <div className={styles['data-product-view']}>

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-table.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-table.tsx
@@ -50,7 +50,7 @@ const COMMON_HEADINGS = [
     nonNumericHeading('remarks'),
 ];
 
-export const VerticalGeometryTable: React.FC<VerticalGeometryTableProps> = ({
+const VerticalGeometryTable: React.FC<VerticalGeometryTableProps> = ({
     verticalGeometry,
     showLocationTrack,
     isLoading,
@@ -175,3 +175,5 @@ export const VerticalGeometryTable: React.FC<VerticalGeometryTableProps> = ({
         </React.Fragment>
     );
 };
+
+export default React.memo(VerticalGeometryTable);

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
@@ -6,7 +6,7 @@ import PlanVerticalGeometrySearch from 'data-products/vertical-geometry/plan-ver
 import LocationTrackVerticalGeometrySearch from 'data-products/vertical-geometry/location-track-vertical-geometry-search';
 import { useDataProductsAppSelector } from 'store/hooks';
 import { createDelegates } from 'store/store-utils';
-import { VerticalGeometryTable } from 'data-products/vertical-geometry/vertical-geometry-table';
+import VerticalGeometryTable from 'data-products/vertical-geometry/vertical-geometry-table';
 import { dataProductsActions, SelectedGeometrySearch } from 'data-products/data-products-slice';
 import { EntireRailNetworkVerticalGeometryListing } from 'data-products/vertical-geometry/entire-rail-network-vertical-geometry-listing';
 


### PR DESCRIPTION
Vaikutus näkyy käytännössä varmaan parhaiten siinä, että jos on iso lista jotain tietotuotetta auki (vaikkapa sijaintiraiteen geometriaelementtien lista), niin fokuksen vieminen vaikka sijaintiraidevalintaboksiin ja siitä pois ei aiheuta näkyvää kälin pysähdystä.