### PR TITLE
GVT-2108 Combine infobox extra info loading, +sort duplicate tracks

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -7,7 +7,6 @@ import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.geocoding.AlignmentStartAndEnd
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.linking.*
-import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.publication.PublicationService
@@ -71,16 +70,6 @@ class LocationTrackController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{publishType}/{id}/duplicate-of")
-    fun getLocationTrackDuplicateOfList(
-        @PathVariable("publishType") publishType: PublishType,
-        @PathVariable("id") id: IntId<LocationTrack>,
-    ): List<LocationTrackDuplicate> {
-        logger.apiCall("getLocationTrack", "id" to id, "publishType" to publishType, "id" to id)
-        return locationTrackService.getDuplicates(id, publishType)
-    }
-
-    @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{publishType}/{id}/start-and-end")
     fun getLocationTrackStartAndEnd(
         @PathVariable("publishType") publishType: PublishType,
@@ -96,13 +85,13 @@ class LocationTrackController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{publishType}/{id}/switches-at-ends")
-    fun getLocationTrackSwitchesAtEnds(
+    @GetMapping("/{publishType}/{id}/infobox-extras")
+    fun getLocationTrackInfoboxExtras(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") id: IntId<LocationTrack>,
-    ): ResponseEntity<SwitchesAtEnds> {
-        logger.apiCall("getLocationTrackSwitchesAtEnds", "publishType" to publishType, "id" to id)
-        return toResponse(locationTrackService.getSwitchesAtEnds(id, publishType))
+    ): ResponseEntity<LocationTrackInfoboxExtras> {
+        logger.apiCall("getLocationTrackInfoboxExtras", "publishType" to publishType, "id" to id)
+        return toResponse(locationTrackService.getInfoboxExtras(publishType, id))
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -23,12 +23,9 @@ class LocationTrackDao(
     @Value("\${geoviite.cache.enabled}") cacheEnabled: Boolean,
 ) : DraftableDaoBase<LocationTrack>(jdbcTemplateParam, LAYOUT_LOCATION_TRACK, cacheEnabled, LOCATIONTRACK_CACHE_SIZE) {
 
-    fun fetchDuplicates(id: IntId<LocationTrack>, publicationState: PublishType): List<LocationTrackDuplicate> {
+    fun fetchDuplicates(id: IntId<LocationTrack>, publicationState: PublishType): List<RowVersion<LocationTrack>> {
         val sql = """
-            select
-              official_id,
-              external_id, 
-              name
+            select row_id, row_version
             from layout.location_track_publication_view
             where duplicate_of_location_track_id = :id
               and :publication_state = any(publication_states)
@@ -36,11 +33,7 @@ class LocationTrackDao(
         """.trimIndent()
         val params = mapOf("id" to id.intValue, "publication_state" to publicationState.name)
         val locationTracks = jdbcTemplate.query(sql, params) { rs, _ ->
-            LocationTrackDuplicate(
-                id = rs.getIntId("official_id"),
-                externalId = rs.getOidOrNull("external_id"),
-                name = AlignmentName(rs.getString("name")),
-            )
+            rs.getRowVersion<LocationTrack>("row_id", "row_version")
         }
         logger.daoAccess(AccessType.FETCH, LocationTrack::class, id)
         return locationTracks

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -111,6 +111,14 @@ val locationTrackDescriptionLength = 4..256
 enum class DescriptionSuffixType {
     NONE, SWITCH_TO_SWITCH, SWITCH_TO_BUFFER
 }
+data class LayoutSwitchIdAndName(val id: IntId<TrackLayoutSwitch>, val name: SwitchName)
+
+data class LocationTrackInfoboxExtras(
+    val duplicateOf: LocationTrackDuplicate?,
+    val duplicates: List<LocationTrackDuplicate>,
+    val switchAtStart: LayoutSwitchIdAndName?,
+    val switchAtEnd: LayoutSwitchIdAndName?,
+)
 
 data class LocationTrack(
     val name: AlignmentName,
@@ -271,11 +279,6 @@ data class TrackNumberAndChangeTime(
     val id: IntId<TrackLayoutTrackNumber>,
     val number: TrackNumber,
     val changeTime: Instant,
-)
-
-data class SwitchesAtEnds(
-    val start: IntId<TrackLayoutSwitch>?,
-    val end: IntId<TrackLayoutSwitch>?,
 )
 
 fun getTranslation(key: String) = kmLengthTranslations[key] ?: ""

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -211,6 +211,7 @@ fun locationTrack(
     alignmentVersion: RowVersion<LayoutAlignment>? = null,
     topologyStartSwitch: TopologyLocationTrackSwitch? = null,
     topologyEndSwitch: TopologyLocationTrackSwitch? = null,
+    duplicateOf: IntId<LocationTrack>? = null,
 ) = LocationTrack(
     name = AlignmentName(name),
     descriptionBase = FreeText(description),
@@ -224,7 +225,7 @@ fun locationTrack(
     segmentCount = alignment?.segments?.size ?: 0,
     length = alignment?.length ?: 0.0,
     draft = draft,
-    duplicateOf = null,
+    duplicateOf = duplicateOf,
     topologicalConnectivity = TopologicalConnectivityType.START,
     topologyStartSwitch = topologyStartSwitch,
     topologyEndSwitch = topologyEndSwitch,

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -37,8 +37,8 @@ import { FormLayout, FormLayoutColumn } from 'geoviite-design-lib/form-layout/fo
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { useTranslation } from 'react-i18next';
 import {
+    useLocationTrackInfoboxExtras,
     useLocationTrackStartAndEnd,
-    useLocationTrackSwitchesAtEnds,
 } from 'track-layout/track-layout-react-utils';
 import { formatTrackMeter } from 'utils/geography-utils';
 import { Precision, roundToPrecision } from 'utils/rounding';
@@ -69,11 +69,6 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
 ) => {
     const { t } = useTranslation();
 
-    const switchesAtEnds = useLocationTrackSwitchesAtEnds(
-        props.locationTrack,
-        props.publishType,
-        props.locationTrackChangeTime,
-    );
     const firstInputRef = React.useRef<HTMLInputElement>(null);
     const [state, dispatcher] = React.useReducer(reducer, initialLocationTrackEditState);
     const [selectedDuplicateTrack, setSelectedDuplicateTrack] = React.useState<
@@ -95,6 +90,8 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         props.publishType,
         props.locationTrackChangeTime,
     );
+
+    const [extraInfo] = useLocationTrackInfoboxExtras(props.locationTrack?.id, props.publishType);
 
     const locationTrackStateOptions = layoutStates
         .filter((ls) => !state.isNewLocationTrack || ls.value != 'DELETED')
@@ -255,14 +252,14 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     }
 
     const switchToSwitchDescriptionSuffix = () =>
-        `${shortenSwitchName(switchesAtEnds?.start?.name) ?? '???'} - ${
-            shortenSwitchName(switchesAtEnds?.end?.name) ?? '???'
+        `${shortenSwitchName(extraInfo?.switchAtStart?.name) ?? '???'} - ${
+            shortenSwitchName(extraInfo?.switchAtEnd?.name) ?? '???'
         }`;
 
     const switchToBufferDescriptionSuffix = () =>
         `${
-            shortenSwitchName(switchesAtEnds?.start?.name) ??
-            shortenSwitchName(switchesAtEnds?.end?.name) ??
+            shortenSwitchName(extraInfo?.switchAtStart?.name) ??
+            shortenSwitchName(extraInfo?.switchAtEnd?.name) ??
             '???'
         } - ${t('location-track-dialog.buffer')}`;
 
@@ -577,7 +574,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                     className={
                                         styles['location-track-edit-dialog__readonly-value']
                                     }>
-                                    {switchesAtEnds?.start?.name ??
+                                    {extraInfo?.switchAtStart?.name ??
                                         t('location-track-dialog.no-start-or-end-switch')}
                                 </span>
                             }
@@ -589,7 +586,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                     className={
                                         styles['location-track-edit-dialog__readonly-value']
                                     }>
-                                    {switchesAtEnds?.end?.name ??
+                                    {extraInfo?.switchAtEnd?.name ??
                                         t('location-track-dialog.no-start-or-end-switch')}
                                 </span>
                             }

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
-import { LayoutLocationTrack, LayoutLocationTrackDuplicate } from 'track-layout/track-layout-model';
+import { LocationTrackDuplicate } from 'track-layout/track-layout-model';
 import { LocationTrackLink } from 'tool-panel/location-track/location-track-link';
 import styles from './location-track-infobox.scss';
+import { PublishType, TimeStamp } from 'common/common-model';
 
 export type LocationTrackInfoboxDuplicateOfProps = {
-    existingDuplicate: LayoutLocationTrack | undefined;
-    duplicatesOfLocationTrack: LayoutLocationTrackDuplicate[] | undefined;
+    publishType: PublishType;
+    changeTime: TimeStamp;
+    existingDuplicate: LocationTrackDuplicate | undefined;
+    duplicatesOfLocationTrack: LocationTrackDuplicate[] | undefined;
 };
 
 export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDuplicateOfProps> = ({
@@ -19,16 +22,14 @@ export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDupli
         />
     ) : duplicatesOfLocationTrack ? (
         <ul className={styles['location-track-infobox-duplicate-of__ul']}>
-            {duplicatesOfLocationTrack
-                .sort((a, b) => (a.name > b.name ? 1 : -1))
-                .map((duplicate) => (
-                    <li key={duplicate.id}>
-                        <LocationTrackLink
-                            locationTrackId={duplicate.id}
-                            locationTrackName={duplicate.name}
-                        />
-                    </li>
-                ))}
+            {duplicatesOfLocationTrack.map((duplicate) => (
+                <li key={duplicate.id}>
+                    <LocationTrackLink
+                        locationTrackId={duplicate.id}
+                        locationTrackName={duplicate.name}
+                    />
+                </li>
+            ))}
         </ul>
     ) : (
         <React.Fragment />

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import styles from './location-track-infobox.scss';
 import Infobox from 'tool-panel/infobox/infobox';
-import { LAYOUT_SRID, LayoutLocationTrack, LayoutSwitchId } from 'track-layout/track-layout-model';
+import {
+    LAYOUT_SRID,
+    LayoutLocationTrack,
+    LayoutSwitchIdAndName,
+} from 'track-layout/track-layout-model';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { Precision, roundToPrecision } from 'utils/rounding';
@@ -13,9 +17,8 @@ import {
     useCoordinateSystem,
     useLocationTrack,
     useLocationTrackChangeTimes,
-    useLocationTrackDuplicates,
+    useLocationTrackInfoboxExtras,
     useLocationTrackStartAndEnd,
-    useLocationTrackSwitchesAtEnds,
     useTrackNumber,
 } from 'track-layout/track-layout-react-utils';
 import InfoboxText from 'tool-panel/infobox/infobox-text';
@@ -32,10 +35,7 @@ import { PublishType, TimeStamp } from 'common/common-model';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { TrackNumberLinkContainer } from 'geoviite-design-lib/track-number/track-number-link';
 import LocationTrackDeleteConfirmationDialog from 'tool-panel/location-track/location-track-delete-confirmation-dialog';
-import {
-    getLocationTrackDescriptions,
-    getLocationTracksBySearchTerm,
-} from 'track-layout/layout-location-track-api';
+import { getLocationTrackDescriptions } from 'track-layout/layout-location-track-api';
 import LocationTrackTypeLabel from 'geoviite-design-lib/alignment/location-track-type-label';
 import { LoaderStatus, useLoader } from 'utils/react-utils';
 import { OnSelectFunction } from 'selection/selection-model';
@@ -46,15 +46,19 @@ import { LocationTrackGeometryInfobox } from 'tool-panel/location-track/location
 import { MapViewport } from 'map/map-model';
 import { AssetValidationInfoboxContainer } from 'tool-panel/asset-validation-infobox-container';
 import { getEndLinkPoints } from 'track-layout/layout-map-api';
-import { LocationTrackInfoboxVisibilities } from 'track-layout/track-layout-slice';
+import {
+    LocationTrackInfoboxVisibilities,
+    trackLayoutActionCreators as TrackLayoutActions,
+} from 'track-layout/track-layout-slice';
 import { WriteAccessRequired } from 'user/write-access-required';
 import { LocationTrackVerticalGeometryInfobox } from 'tool-panel/location-track/location-track-vertical-geometry-infobox';
 import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
-import { SwitchLinkContainer } from 'geoviite-design-lib/switch/switch-link';
 import {
     ProgressIndicatorType,
     ProgressIndicatorWrapper,
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
+import { Link } from 'vayla-design-lib/link/link';
+import { createDelegates } from 'store/store-utils';
 
 type LocationTrackInfoboxProps = {
     locationTrack: LayoutLocationTrack;
@@ -93,6 +97,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     onHighlightItem,
 }: LocationTrackInfoboxProps) => {
     const { t } = useTranslation();
+    const delegates = createDelegates(TrackLayoutActions);
     const trackNumber = useTrackNumber(publishType, locationTrack?.trackNumberId);
     const [startAndEndPoints, startAndEndPointFetchStatus] = useLocationTrackStartAndEnd(
         locationTrack?.id,
@@ -104,11 +109,6 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     const officialLocationTrack = useLocationTrack(
         locationTrack.id,
         'OFFICIAL',
-        locationTrackChangeTime,
-    );
-    const switchesAtEnds = useLocationTrackSwitchesAtEnds(
-        locationTrack,
-        publishType,
         locationTrackChangeTime,
     );
     const description = useLoader(
@@ -162,11 +162,19 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     function closeLocationTrackPushDialog() {
         setShowRatkoPushDialog(false);
     }
-    function getSwitchLink(id?: LayoutSwitchId) {
-        if (switchesAtEnds === undefined) {
-            return '';
-        } else if (id) {
-            return <SwitchLinkContainer switchId={id} />;
+    function getSwitchLink(sw?: LayoutSwitchIdAndName) {
+        if (sw) {
+            const switchId = sw.id;
+            return (
+                <Link
+                    onClick={() =>
+                        delegates.onSelect({
+                            switches: [switchId],
+                        })
+                    }>
+                    {sw.name}
+                </Link>
+            );
         } else {
             return t('tool-panel.location-track.no-start-or-end-switch');
         }
@@ -195,16 +203,10 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
         }
     };
 
-    const existingDuplicateOfList = useLoader(() => {
-        const duplicateOfTrack =
-            locationTrack?.duplicateOf &&
-            getLocationTracksBySearchTerm(locationTrack?.duplicateOf, publishType, 1);
-        if (duplicateOfTrack === '') return undefined;
-        else return duplicateOfTrack;
-    }, [locationTrack]);
-
-    const existingDuplicate = existingDuplicateOfList && existingDuplicateOfList[0];
-    const duplicatesOfLocationTrack = useLocationTrackDuplicates(locationTrack.id, publishType);
+    const [extraInfo, extraInfoLoadingStatus] = useLocationTrackInfoboxExtras(
+        locationTrack?.id,
+        publishType,
+    );
 
     const visibilityChange = (key: keyof LocationTrackInfoboxVisibilities) => {
         onVisibilityChange({ ...visibilities, [key]: !visibilities[key] });
@@ -213,7 +215,9 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     return (
         <React.Fragment>
             <Infobox
-                contentVisible={visibilities.basic}
+                contentVisible={
+                    visibilities.basic && extraInfoLoadingStatus != LoaderStatus.Loading
+                }
                 onContentVisibilityChange={() => visibilityChange('basic')}
                 title={t('tool-panel.location-track.basic-info-heading')}
                 qa-id="location-track-infobox">
@@ -255,31 +259,25 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                         iconDisabled={isOfficial()}
                     />
                     <InfoboxText value={trackNumber?.description} />
-
-                    {duplicatesOfLocationTrack !== undefined && (
-                        <InfoboxField
-                            label={
-                                duplicatesOfLocationTrack.length > 0
-                                    ? t('tool-panel.location-track.has-duplicates')
-                                    : existingDuplicate
-                                    ? t('tool-panel.location-track.duplicate-of')
-                                    : t('tool-panel.location-track.not-a-duplicate')
-                            }
-                            value={
-                                <LocationTrackInfoboxDuplicateOf
-                                    existingDuplicate={existingDuplicate}
-                                    duplicatesOfLocationTrack={duplicatesOfLocationTrack}
-                                />
-                            }
-                            onEdit={
-                                duplicatesOfLocationTrack.length > 0
-                                    ? undefined
-                                    : openEditLocationTrackDialog
-                            }
-                            iconDisabled={isOfficial()}
-                        />
-                    )}
-
+                    <InfoboxField
+                        label={
+                            locationTrack.duplicateOf
+                                ? t('tool-panel.location-track.duplicate-of')
+                                : extraInfo?.duplicates?.length ?? 0 > 0
+                                ? t('tool-panel.location-track.has-duplicates')
+                                : t('tool-panel.location-track.not-a-duplicate')
+                        }
+                        value={
+                            <LocationTrackInfoboxDuplicateOf
+                                existingDuplicate={extraInfo?.duplicateOf}
+                                duplicatesOfLocationTrack={extraInfo?.duplicates ?? []}
+                                publishType={publishType}
+                                changeTime={locationTrackChangeTime}
+                            />
+                        }
+                        onEdit={openEditLocationTrackDialog}
+                        iconDisabled={isOfficial()}
+                    />
                     <InfoboxField
                         label={t('tool-panel.location-track.topological-connectivity')}
                         value={
@@ -292,13 +290,12 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     />
                     <InfoboxField
                         label={t('tool-panel.location-track.start-switch')}
-                        value={getSwitchLink(switchesAtEnds?.start?.id)}
+                        value={extraInfo && getSwitchLink(extraInfo.switchAtStart)}
                     />
                     <InfoboxField
                         label={t('tool-panel.location-track.end-switch')}
-                        value={getSwitchLink(switchesAtEnds?.end?.id)}
+                        value={extraInfo && getSwitchLink(extraInfo.switchAtEnd)}
                     />
-
                     <InfoboxButtons>
                         <Button
                             variant={ButtonVariant.SECONDARY}
@@ -528,11 +525,6 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     publishType={publishType}
                     locationTrackChangeTime={locationTrackChangeTime}
                     onUnselect={() => onUnselect(locationTrack)}
-                    existingDuplicateTrack={existingDuplicate}
-                    duplicatesExist={
-                        duplicatesOfLocationTrack !== undefined &&
-                        duplicatesOfLocationTrack.length > 0
-                    }
                 />
             )}
         </React.Fragment>

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -73,12 +73,6 @@ export type LayoutReferenceLine = {
     draftType: DraftType;
 };
 
-export type LayoutLocationTrackDuplicate = {
-    name: string;
-    externalId?: Oid;
-    id: LocationTrackId;
-};
-
 export type TopologyLocationTrackSwitch = {
     switchId: LayoutSwitchId;
     joint: JointNumber;
@@ -115,6 +109,20 @@ export const locationTrackDescription = (lt: {
     descriptionBase?: string;
     descriptionSuffix?: string;
 }) => `${lt.descriptionBase}${lt.descriptionSuffix ? ` ${lt.descriptionSuffix}` : ''}`;
+
+export type LocationTrackDuplicate = {
+    id: LocationTrackId;
+    name: string;
+    externalId: Oid;
+};
+export type LayoutSwitchIdAndName = { id: LayoutSwitchId; name: string };
+
+export type LocationTrackInfoboxExtras = {
+    duplicateOf?: LocationTrackDuplicate;
+    duplicates: LocationTrackDuplicate[];
+    switchAtStart?: LayoutSwitchIdAndName;
+    switchAtEnd?: LayoutSwitchIdAndName;
+};
 
 export type AlignmentId = LocationTrackId | ReferenceLineId | GeometryAlignmentId;
 
@@ -247,10 +255,6 @@ export type AlignmentStartAndEnd = {
     end?: AddressPoint;
 };
 
-export type SwitchesAtEnds = {
-    start?: LayoutSwitchId;
-    end?: LayoutSwitchId;
-};
 export function getSwitchPresentationJoint(
     layoutSwitch: LayoutSwitch,
     presentationJointNumber: JointNumber,

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -3,13 +3,13 @@ import {
     LayoutKmPost,
     LayoutKmPostId,
     LayoutLocationTrack,
-    LayoutLocationTrackDuplicate,
     LayoutReferenceLine,
     LayoutSwitch,
     LayoutSwitchId,
     LayoutTrackNumber,
     LayoutTrackNumberId,
     LocationTrackId,
+    LocationTrackInfoboxExtras,
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import { LoaderStatus, useLoader, useLoaderWithStatus, useOptionalLoader } from 'utils/react-utils';
@@ -35,10 +35,9 @@ import {
 import {
     getLocationTrack,
     getLocationTrackChangeTimes,
-    getLocationTrackDuplicates,
+    getLocationTrackInfoboxExtras,
     getLocationTracks,
     getLocationTrackStartAndEnd,
-    getLocationTrackSwitchesAtEnds,
 } from 'track-layout/layout-location-track-api';
 import { getSwitch, getSwitchChangeTimes, getSwitches } from 'track-layout/layout-switch-api';
 import { getTrackNumberById, getTrackNumbers } from 'track-layout/layout-track-number-api';
@@ -81,16 +80,6 @@ export function useReferenceLines(
             () => (ids ? getReferenceLines(ids, publishType, changeTime) : undefined),
             [ids, publishType, changeTime],
         ) || []
-    );
-}
-
-export function useLocationTrackDuplicates(
-    id: LocationTrackId | undefined,
-    publishType: PublishType,
-): LayoutLocationTrackDuplicate[] | undefined {
-    return useLoader(
-        () => (id ? getLocationTrackDuplicates(publishType, id) : undefined),
-        [id, publishType],
     );
 }
 
@@ -201,29 +190,22 @@ export function useLocationTrackStartAndEnd(
     changeTime: TimeStamp,
 ): [AlignmentStartAndEnd | undefined, LoaderStatus] {
     return useLoaderWithStatus(
-        () => (id && publishType ? getLocationTrackStartAndEnd(id, publishType) : undefined),
+        () =>
+            id && publishType
+                ? getLocationTrackStartAndEnd(id, publishType, changeTime)
+                : undefined,
         [id, publishType, changeTime],
     );
 }
 
-export function useLocationTrackSwitchesAtEnds(
-    locationTrack: LayoutLocationTrack | undefined,
+export function useLocationTrackInfoboxExtras(
+    id: LocationTrackId | undefined,
     publishType: PublishType,
-    changeTime: TimeStamp,
-): { start: LayoutSwitch | undefined; end: LayoutSwitch | undefined } | undefined {
-    const id = locationTrack?.id;
-    const [switchIds, status] = useLoaderWithStatus(
-        () =>
-            id === undefined
-                ? undefined
-                : getLocationTrackSwitchesAtEnds(id, publishType, changeTime),
-        [id, publishType, changeTime],
+): [LocationTrackInfoboxExtras | undefined, LoaderStatus] {
+    return useLoaderWithStatus(
+        () => (id === undefined ? undefined : getLocationTrackInfoboxExtras(id, publishType)),
+        [id, publishType],
     );
-    const start = useSwitch(switchIds?.start ?? undefined, publishType);
-    const end = useSwitch(switchIds?.end ?? undefined, publishType);
-    return id === undefined || switchIds === undefined || status !== LoaderStatus.Ready
-        ? undefined
-        : { start, end };
 }
 
 export function usePlanHeader(id: GeometryPlanId | undefined): GeometryPlanHeader | undefined {

--- a/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
@@ -50,10 +50,17 @@ type AlignmentAndExtents = {
 };
 
 // we don't really need the station values in the plan geometry for anything in this entire diagram
-async function getStartAndEnd(alignmentId: VerticalGeometryDiagramAlignmentId) {
+async function getStartAndEnd(
+    changeTimes: ChangeTimes,
+    alignmentId: VerticalGeometryDiagramAlignmentId,
+) {
     return 'planId' in alignmentId
         ? getPlanAlignmentStartAndEnd(alignmentId.planId, alignmentId.alignmentId)
-        : getLocationTrackStartAndEnd(alignmentId.locationTrackId, alignmentId.publishType);
+        : getLocationTrackStartAndEnd(
+              alignmentId.locationTrackId,
+              alignmentId.publishType,
+              changeTimes.layoutLocationTrack,
+          );
 }
 
 async function getVerticalGeometry(
@@ -138,7 +145,7 @@ export const VerticalGeometryDiagramHolder: React.FC<VerticalGeometryDiagramHold
                   );
 
         const geometryPromise = getVerticalGeometry(changeTimes, alignmentId);
-        const startEndPromise = getStartAndEnd(alignmentId);
+        const startEndPromise = getStartAndEnd(changeTimes, alignmentId);
 
         Promise.all([linkingSummaryPromise, geometryPromise, startEndPromise]).then(
             async ([linkingSummary, geometry, startEnd]) => {


### PR DESCRIPTION
Ainoa varsinainen funktionaalinen muutos on, että sijaintiraiteen duplikaattien järjestely menee nyt duplikaatin alun rataosoitteen mukaan, eikä nimen mukaan.

Mutta samassa tuli mukana aika kasa muutosta sille, miten sijaintiraiteen infoboksin tiedot ladataan, siihen kun oli alkanut kertyä aika paljon eri dynaamisten tietojen lataamista pienissä osissa (esim. nyt aiemmin ensiksi päissä olevien vaihteiden id-tietojen lataaminen, sitten erikseen vaihteiden lataaminen id:n perusteella). Tämä aiheuttaa tarpeetonta kellottelua. Nyt ylimääräiset tiedot tulevat yhdessä pompsissa LocationTrackInfoboxExtras-oliossa, ja koko infoboksi näytetään vasta kun se on ladattu.