### PR TITLE
GVT-2093 Check integration configuration parameters are fully given

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClientConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClientConfiguration.kt
@@ -38,6 +38,13 @@ class PVClientConfiguration @Autowired constructor(
     @Value("\${geoviite.projektivelho.secret_key:}") private val projektiVelhoPassword: String,
 ) {
 
+    init {
+        require(projektiVelhoBaseUrl.isNotBlank()) { "PVClientConfiguration requires projektiVelhoBaseUrl" }
+        require(projektiVelhoAuthUrl.isNotBlank()) { "PVClientConfiguration requires projektiVelhoAuthUrl" }
+        require(projektiVelhoUsername.isNotBlank()) { "PVClientConfiguration requires projektiVelhoUsername" }
+        require(projektiVelhoPassword.isNotBlank()) { "PVClientConfiguration requires projektiVelhoPassword" }
+    }
+
     private val logger: Logger = LoggerFactory.getLogger(PVClient::class.java)
 
     @Bean

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientConfiguration.kt
@@ -32,6 +32,12 @@ class RatkoClientConfiguration @Autowired constructor(
     @Value("\${geoviite.ratko.password:}") private val basicAuthPassword: String,
 ) {
 
+    init {
+        require(ratkoBaseUrl.isNotBlank()) { "RatkoClientConfiguration requires ratkoBaseUrl" }
+        require(basicAuthUsername.isNotBlank()) { "RatkoClientConfiguration requires basicAuthUsername" }
+        require(basicAuthPassword.isNotBlank()) { "RatkoClientConfiguration requires basicAuthPassword" }
+    }
+
     private val logger: Logger = LoggerFactory.getLogger(RatkoClient::class.java)
 
     @Bean

--- a/infra/src/main/resources/application-e2e.yml
+++ b/infra/src/main/resources/application-e2e.yml
@@ -10,3 +10,5 @@ geoviite:
     url: http://localhost:12346
     auth_url: http://localhost:12346/oauth2/token
     test-port: 12346
+    client_id: foo
+    secret_key: bar

--- a/infra/src/main/resources/application-ratkotest.yml
+++ b/infra/src/main/resources/application-ratkotest.yml
@@ -2,3 +2,5 @@ geoviite:
   ratko:
     enabled: true
     url: http://localhost:12345
+    username: foo
+    password: bar

--- a/infra/src/test/resources/application-test.yml
+++ b/infra/src/test/resources/application-test.yml
@@ -19,9 +19,13 @@ geoviite:
   ratko:
     enabled: true
     url: http://localhost:12345
+    username: foo
+    password: bar
     test-port: 12345
   projektivelho:
     enabled: true
     url: http://localhost:12346
     auth_url: http://localhost:12346/oauth2/token
+    client_id: foo
+    secret_key: bar
     test-port: 12346


### PR DESCRIPTION
Tällä tarkistuksella estetään integraatioita huutamasta hämäriä sellaisessa tapauksessa, missä ongelma on, että jonkin konfiguraatioparametrin nimi on kirjoitettu väärin.

Huom. kunhan tämä tulee mainiin, voi joutua setvimään ajokonfigeista parametrien nimet paikoilleen: Ratkolle jokin RATKO_USERNAME ja RATKO_PASSWORD (lokaalisti ajettuna voi olla foobaria), Projektivelholle ProjektiVelho-TEMPLATEn mukaiset parametrit.