### PR TITLE
GVT-2129: ProjektiVelhonäkymissä taulukon järjestyksen pitäisi säilyä navigoidessa

### DIFF
--- a/ui/src/infra-model/infra-model-main.scss
+++ b/ui/src/infra-model/infra-model-main.scss
@@ -1,4 +1,3 @@
 .infra-model-main {
-    display: flex;
-    flex: 1;
+    width: 100%;
 }

--- a/ui/src/infra-model/list/infra-model-list-store.ts
+++ b/ui/src/infra-model/list/infra-model-list-store.ts
@@ -5,17 +5,31 @@ import {
     GeometrySortBy,
 } from 'geometry/geometry-model';
 import { objectEquals } from 'utils/object-utils';
+import {
+    PVInitiallyUnsorted,
+    PVTableSortInformation,
+} from 'infra-model/projektivelho/pv-file-list-utils';
 
 export type SearchState = 'idle' | 'start' | 'search';
 
 export type InfraModelListState = {
     searchState: SearchState;
+    pvListState: PVDocumentListState;
     searchParams: GeometryPlanSearchParams;
     searchErrorMsg: string | undefined;
     plans: GeometryPlanHeader[];
     totalCount: number;
     page: number;
     pageSize: number;
+};
+
+export type PVDocumentListState = {
+    suggested: {
+        sortedBy: PVTableSortInformation;
+    };
+    rejected: {
+        sortedBy: PVTableSortInformation;
+    };
 };
 
 export const initialInfraModelListState: InfraModelListState = {
@@ -26,6 +40,14 @@ export const initialInfraModelListState: InfraModelListState = {
         sources: ['GEOMETRIAPALVELU'],
         sortBy: GeometrySortBy.NO_SORTING,
         sortOrder: undefined,
+    },
+    pvListState: {
+        suggested: {
+            sortedBy: PVInitiallyUnsorted,
+        },
+        rejected: {
+            sortedBy: PVInitiallyUnsorted,
+        },
     },
     searchErrorMsg: undefined,
     plans: [],
@@ -50,6 +72,18 @@ export const infraModelListReducers = {
             state.searchParams = searchParams;
             state.page = 0;
         }
+    },
+    onSortPVSuggestedList: (
+        state: InfraModelListState,
+        { payload: sortedBy }: PayloadAction<PVTableSortInformation>,
+    ) => {
+        state.pvListState.suggested.sortedBy = sortedBy;
+    },
+    onSortPVRejectedList: (
+        state: InfraModelListState,
+        { payload: sortedBy }: PayloadAction<PVTableSortInformation>,
+    ) => {
+        state.pvListState.rejected.sortedBy = sortedBy;
     },
     onNextPage: function (state: InfraModelListState) {
         if ((state.page + 1) * state.pageSize < state.totalCount) {

--- a/ui/src/infra-model/list/infra-model-list.module.scss
+++ b/ui/src/infra-model/list/infra-model-list.module.scss
@@ -4,7 +4,6 @@
 .infra-model-list {
     display: flex;
     flex-direction: column;
-    padding: 20px;
 }
 
 .infra-model-list__search-form {
@@ -25,6 +24,7 @@
 
 .infra-model-list-search-result__count {
     flex: 1;
+    padding-left: 20px;
 
     & > * {
         margin-right: 6px;
@@ -43,6 +43,11 @@
 }
 
 .infra-model-list-search-result {
+    &__table {
+        overflow: auto;
+        padding-left: 20px;
+    }
+
     &__project-name {
         min-width: 440px;
     }
@@ -98,6 +103,10 @@
 .infra-model-search-form {
     display: flex;
     align-items: flex-end;
+
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 20px;
 }
 
 .infra-model-search-form__auto-complete {

--- a/ui/src/infra-model/tabs/infra-model-tabs.scss
+++ b/ui/src/infra-model/tabs/infra-model-tabs.scss
@@ -44,6 +44,7 @@
     &__outlet {
         background: vayla-design.$color-white-default;
         flex: 1;
+        overflow: auto;
     }
 
     &__exclamation-point-container {

--- a/ui/src/infra-model/tabs/infra-model-tabs.tsx
+++ b/ui/src/infra-model/tabs/infra-model-tabs.tsx
@@ -96,10 +96,20 @@ const InfraModelTabs: React.FC<TabsProps> = ({ activeTab }) => {
                     />
                 </InfraModelTabContent>
                 <InfraModelTabContent tabId={InfraModelTabType.WAITING} activeTab={activeTab}>
-                    <PVFileListContainer listMode={'SUGGESTED'} changeTime={changeTime} />
+                    <PVFileListContainer
+                        listMode={'SUGGESTED'}
+                        changeTime={changeTime}
+                        sortPersistorFn={infraModelListDelegates.onSortPVSuggestedList}
+                        sorting={state.pvListState.suggested.sortedBy}
+                    />
                 </InfraModelTabContent>
                 <InfraModelTabContent tabId={InfraModelTabType.REJECTED} activeTab={activeTab}>
-                    <PVFileListContainer listMode={'REJECTED'} changeTime={changeTime} />
+                    <PVFileListContainer
+                        listMode={'REJECTED'}
+                        changeTime={changeTime}
+                        sortPersistorFn={infraModelListDelegates.onSortPVRejectedList}
+                        sorting={state.pvListState.rejected.sortedBy}
+                    />
                 </InfraModelTabContent>
             </div>
         </div>


### PR DESCRIPTION
Tallennetaan taulukoiden sorttaus reduxiin ja luetaan sieltä.

Lisäbonuksena ärsyynnyin inframodel-näkymän tabien scrollaamiseen sisällön mukana ja tappelin sen nyt sellaiseksi, että ainoastaan taulukot scrollaavat sivusuunnassa. Koitin säätää myös pystysuuntaisen scrollin toimimaan niin, että pelkästään taulukot scrollaisivat ja tabit jäisivät näkyviin ylös, but alas, it was once again not meant to be :pepehands: