### PR TITLE
GVT-2148: Luo uusi -dialogien dropdown-valikot eivät avaudu

### DIFF
--- a/ui/src/vayla-design-lib/dialog/dialog.tsx
+++ b/ui/src/vayla-design-lib/dialog/dialog.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import styles from './dialog.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
@@ -62,7 +63,7 @@ export const Dialog: React.FC<DialogProps> = ({
         props.onClose && props.onClose();
     }
 
-    return (
+    return createPortal(
         <div
             className={styles['dialog']}
             onMouseUp={() => setDialogDragParams(undefined)}
@@ -106,7 +107,8 @@ export const Dialog: React.FC<DialogProps> = ({
                     </div>
                 )}
             </div>
-        </div>
+        </div>,
+        document.body,
     );
 };
 

--- a/ui/src/vayla-design-lib/dropdown/dropdown.scss
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.scss
@@ -160,7 +160,7 @@ $dropdown-border-error: 1.5px;
     @include typography.typography-body;
     @include shadows.shadow-8dp;
     position: absolute;
-    z-index: layers.$layer-menu;
+    z-index: layers.$layer-popup;
     display: flex;
     flex-direction: column;
     margin-top: 2px;


### PR DESCRIPTION
Z-indeksithän ne siellä. Suoraa syytä en tosin lyhyellä penkomisella löytänyt sille, että miksi aikaisemmin vain luontidialogin dropdownit bugasivat. Enivei nyt ne on korjattu.

Otin myös käyttöön kaikkien dialogien portaloinnin `<body>`-elementtiin. Olen miettinyt sitä jo aiemminkin, koska sillä saadaan dialogit rendaamaan konsistentisti samaan paikkaan, ja siten varmasti aina saman DOM:in ja tyylien vaikutusalueen alle. Tätä myötä sillä polulla mitä kautta mikäkin dialogi avataan ei pitäisi olla enää merkitystä sen toimivuuteen tai tyyleihin.