### PR TITLE
GVT-2135: Bäkkäriin lähtee useita API-kutsuja kun tiedostoa tuodaan ProjektiVelhosta

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
@@ -23,6 +23,7 @@ data class CollectedChangeTimes(
     val layoutKmPost: Instant,
     val geometryPlan: Instant,
     val project: Instant,
+    val author: Instant,
     val publication: Instant,
     val ratkoPush: Instant,
     val pvDocument: Instant,
@@ -56,6 +57,7 @@ class ChangeTimeController(
             layoutSwitch = switchService.getChangeTime(),
             geometryPlan = geometryService.getGeometryPlanChangeTime(),
             project = geometryService.getProjectChangeTime(),
+            author = geometryService.getAuthorChangeTime(),
             publication = publicationService.getChangeTime(),
             ratkoPush = ratkoPushDao.getRatkoPushChangeTime(),
             pvDocument = pvDocumentService.getDocumentChangeTime(),
@@ -109,6 +111,13 @@ class ChangeTimeController(
     fun getProjectChangeTime(): Instant {
         logger.apiCall("getProjectChangeTime")
         return geometryService.getProjectChangeTime()
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/authors")
+    fun getAuthorChangeTime(): Instant {
+        logger.apiCall("getAuthorChangeTime")
+        return geometryService.getAuthorChangeTime()
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -24,8 +24,7 @@ import fi.fta.geoviite.infra.publication.RemovedTrackNumberReferenceIds
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.*
-import fi.fta.geoviite.infra.util.DbTable.GEOMETRY_PLAN
-import fi.fta.geoviite.infra.util.DbTable.GEOMETRY_PLAN_PROJECT
+import fi.fta.geoviite.infra.util.DbTable.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
@@ -1002,6 +1001,8 @@ class GeometryDao @Autowired constructor(
     }
 
     fun fetchProjectChangeTime(): Instant = fetchLatestChangeTime(GEOMETRY_PLAN_PROJECT)
+
+    fun fetchAuthorChangeTime(): Instant = fetchLatestChangeTime(GEOMETRY_PLAN_AUTHOR)
 
     fun findAuthor(companyName: MetaDataName): Author? {
         val sql = """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -142,6 +142,11 @@ class GeometryService @Autowired constructor(
         return geometryDao.fetchProjectChangeTime()
     }
 
+    fun getAuthorChangeTime(): Instant {
+        logger.serviceCall("getAuthorChangeTime")
+        return geometryDao.fetchAuthorChangeTime()
+    }
+
     fun getProject(id: IntId<Project>): Project {
         logger.serviceCall("getProject", "id" to id)
         return geometryDao.getProject(id)
@@ -399,18 +404,18 @@ class GeometryService @Autowired constructor(
         }
         val verticalGeometryListingWithTrackNumbers =
             locationTrackService.list(OFFICIAL, includeDeleted = false).sortedWith(
-                    compareBy(
-                        { locationTrack -> trackNumberAndGeocodingContextCache[locationTrack.trackNumberId]?.first?.number },
-                        { locationTrack -> locationTrack.name },
-                    )
-                ).flatMap { locationTrack ->
-                    val verticalGeometryListingWithoutTrackNumbers =
-                        getVerticalGeometryListing(OFFICIAL, locationTrack.id as IntId, null, null)
+                compareBy(
+                    { locationTrack -> trackNumberAndGeocodingContextCache[locationTrack.trackNumberId]?.first?.number },
+                    { locationTrack -> locationTrack.name },
+                )
+            ).flatMap { locationTrack ->
+                val verticalGeometryListingWithoutTrackNumbers =
+                    getVerticalGeometryListing(OFFICIAL, locationTrack.id as IntId, null, null)
 
-                    verticalGeometryListingWithoutTrackNumbers.map { verticalGeometryListing ->
-                        verticalGeometryListing.copy(trackNumber = trackNumberAndGeocodingContextCache[locationTrack.trackNumberId]?.first?.number)
-                    }
+                verticalGeometryListingWithoutTrackNumbers.map { verticalGeometryListing ->
+                    verticalGeometryListing.copy(trackNumber = trackNumberAndGeocodingContextCache[locationTrack.trackNumberId]?.first?.number)
                 }
+            }
 
         val csvFileContent = entireTrackNetworkVerticalGeometryListingToCsv(verticalGeometryListingWithTrackNumbers)
         val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneId.of("Europe/Helsinki"))
@@ -496,10 +501,7 @@ class GeometryService @Autowired constructor(
                 val plan = geometryDao.fetchPlan(planVersion)
                 val planAlignment =
                     plan.alignments.find { alignment -> alignment.id == planAlignmentId } ?: return@map SegmentSource(
-                        null,
-                        null,
-                        null,
-                        plan
+                        null, null, null, plan
                     )
                 val planProfile = planAlignment.profile ?: return@map SegmentSource(null, null, null, plan)
                 val planElement = planAlignment.elements[sourceId.index]
@@ -644,8 +646,7 @@ class GeometryService @Autowired constructor(
             alignment.getPointAtM(boundary.distanceOnAlignment)?.let { point ->
                 geocodingContext.getAddress(point)?.let { address -> address.first to boundary.segmentIndex }
             }
-        }
-            .groupBy({ (trackMeter) -> trackMeter.kmNumber },
+        }.groupBy({ (trackMeter) -> trackMeter.kmNumber },
                 { (trackMeter, segmentIndex) -> trackMeter.meters to segmentIndex })
 
         val (alignmentStart, alignmentEnd) = geocodingContext.getStartAndEnd(alignment).let { startAndEnd ->
@@ -686,16 +687,16 @@ class GeometryService @Autowired constructor(
             KmHeights(
                 referencePoint.kmNumber,
                 ticksToSend.mapNotNull { (trackMeterInKm, segmentIndex) ->
-                        val trackMeter = TrackMeter(kmNumber, trackMeterInKm)
-                        geocodingContext.getTrackLocation(alignment, trackMeter)?.let { address ->
-                            TrackMeterHeight(
-                                address.point.m,
-                                address.address.meters.toDouble(),
-                                getHeightAt(address.point, segmentIndex),
-                                address.point.toPoint(),
-                            )
-                        }
-                    }.distinct(), // don't bother sending segment boundary sides with the same location and height
+                    val trackMeter = TrackMeter(kmNumber, trackMeterInKm)
+                    geocodingContext.getTrackLocation(alignment, trackMeter)?.let { address ->
+                        TrackMeterHeight(
+                            address.point.m,
+                            address.address.meters.toDouble(),
+                            getHeightAt(address.point, segmentIndex),
+                            address.point.toPoint(),
+                        )
+                    }
+                }.distinct(), // don't bother sending segment boundary sides with the same location and height
                 endM,
             )
         }.collect(Collectors.toList()).filter { km -> km.trackMeterHeights.isNotEmpty() }

--- a/ui/src/common/common-slice.ts
+++ b/ui/src/common/common-slice.ts
@@ -11,6 +11,7 @@ export type ChangeTimes = {
     layoutKmPost: TimeStamp;
     geometryPlan: TimeStamp;
     project: TimeStamp;
+    author: TimeStamp;
     publication: TimeStamp;
     ratkoPush: TimeStamp;
     pvDocument: TimeStamp;
@@ -25,6 +26,7 @@ export const initialChangeTimes: ChangeTimes = {
     layoutKmPost: initialChangeTime,
     geometryPlan: initialChangeTime,
     project: initialChangeTime,
+    author: initialChangeTime,
     publication: initialChangeTime,
     ratkoPush: initialChangeTime,
     pvDocument: initialChangeTime,

--- a/ui/src/infra-model/infra-model-main.scss
+++ b/ui/src/infra-model/infra-model-main.scss
@@ -1,3 +1,5 @@
 .infra-model-main {
+    display: flex;
+    flex: 1;
     width: 100%;
 }

--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -124,7 +124,7 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
     const [trackNumberList, setTrackNumberList] = React.useState<LayoutTrackNumber[]>();
     const [project, setProject] = React.useState<Project>();
     const pvDocument = usePvDocumentHeader(geometryPlan.pvDocumentId);
-    const authors = useLoader(() => fetchAuthors(), [changeTimes.geometryPlan]) || [];
+    const authors = useLoader(() => fetchAuthors(), [changeTimes.author]) || [];
 
     const planSourceOptions = [
         {

--- a/ui/src/infra-model/view/infra-model-edit-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-edit-loader.tsx
@@ -56,9 +56,5 @@ export const InfraModelEditLoader: React.FC<InfraModelLoaderProps> = ({ ...props
         }
     }, [planId]);
 
-    return isLoading ? (
-        <Spinner />
-    ) : (
-        <InfraModelView {...props} onSave={onSave} onValidate={onValidate} />
-    );
+    return isLoading ? <Spinner /> : <InfraModelView {...props} onSave={onSave} />;
 };

--- a/ui/src/infra-model/view/infra-model-import-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-import-loader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { InfraModelBaseProps, InfraModelView } from 'infra-model/view/infra-model-view';
 import { getValidationErrorsForPVDocument, importPVDocument } from 'infra-model/infra-model-api';
@@ -43,7 +43,7 @@ export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ 
         onValidate();
     }, [overrideParams]);
 
-    useEffect(() => {
+    React.useEffect(() => {
         onInit();
     }, [pvDocumentId]);
 
@@ -54,5 +54,5 @@ export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ 
         props.setLoading(false);
         return !!response;
     };
-    return <InfraModelView {...props} onSave={onSave} onValidate={onValidate} />;
+    return <InfraModelView {...props} onSave={onSave} />;
 };

--- a/ui/src/infra-model/view/infra-model-upload-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-upload-loader.tsx
@@ -63,7 +63,7 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
 
     return (
         <>
-            <InfraModelView {...props} onSave={onSave} onValidate={onValidate} />
+            <InfraModelView {...props} onSave={onSave} />
 
             {showFileHandlingFailed && (
                 <CharsetSelectDialog

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -35,7 +35,6 @@ export type InfraModelBaseProps = InfraModelState & {
 };
 export type InfraModelViewProps = InfraModelBaseProps & {
     onSave: () => Promise<boolean>;
-    onValidate: () => void;
 };
 
 export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelViewProps) => {


### PR DESCRIPTION
Suurimpana juttuna tässä Authorien hakemisen refaktorointi ulos useEffectistä. Nyt ne haetaan changeTimen mukaan. Se aikaisempi logiikka oli muutenkin jotenkin todella härö.

Devmodessa haetaan edelleen asioita tuplana, mutta tämä johtuu siitä, että `<StrictMode>` päällä React ajaa kaikki Effectit tuplana. Näitä en lähtenyt korjaamaan sillä se menisi vaikeaksi, sillä myös `useLoader`-kutsut jne. ajetaan tuplana. Näihin pitäisi kehittää jonkinlainen "älä aja hakua uusiksi jos vanha haku on jo päällä" -logiikka, joka enivei tod.näk. toimisi ainoastaan jos bäkkäri vastaa tarpeeksi hitaasti.