### PR TITLE
GVT-2110 Expand publication log remarks about alignment geometry changes

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
@@ -14,6 +14,7 @@ import org.locationtech.jts.geom.Polygon
 import org.locationtech.jts.geom.PrecisionModel
 import org.opengis.referencing.crs.CoordinateReferenceSystem
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.getOrSet
 
 fun transformNonKKJCoordinate(sourceSrid: Srid, targetSrid: Srid, point: IPoint): Point {
     return Transformation.nonTriangulableTransform(sourceSrid, targetSrid).transform(point)
@@ -24,8 +25,8 @@ fun calculateDistance(points: List<IPoint>, srid: Srid): Double = calculateDista
 fun calculateDistance(srid: Srid, vararg points: IPoint): Double = calculateDistance(points.toList(), crs(srid))
 
 private object GeodeticCalculatorCache {
-    val cache: MutableMap<CoordinateReferenceSystem, GeodeticCalculator> = ConcurrentHashMap()
-    fun get(crs: CoordinateReferenceSystem) = cache.computeIfAbsent(crs, ::GeodeticCalculator)
+    val cache: ThreadLocal<Map<CoordinateReferenceSystem, GeodeticCalculator>> = ThreadLocal()
+    fun get(crs: CoordinateReferenceSystem) = cache.getOrSet { HashMap() }.getOrElse(crs) { GeodeticCalculator(crs) }
 }
 
 fun calculateDistance(points: List<IPoint>, ref: CoordinateReferenceSystem): Double {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -59,7 +59,7 @@ data class ChangeValue<T>(
 data class PublicationChange<T>(
     val propKey: PropKey,
     val value: ChangeValue<T>,
-    val remark: PublicationChangeRemark?,
+    val remark: String?,
 )
 
 data class PropKey(
@@ -67,13 +67,6 @@ data class PropKey(
     val params: LocalizationParams = emptyMap(),
 ) {
     constructor(key: String, params: LocalizationParams = emptyMap()) : this(LocalizationKey(key), params)
-}
-
-data class PublicationChangeRemark(
-    val key: LocalizationKey,
-    val value: String,
-) {
-    constructor(key: String, value: String) : this(LocalizationKey(key), value)
 }
 
 open class Publication(
@@ -368,6 +361,7 @@ data class LocationTrackChanges(
     val startPoint: Change<Point>,
     val endPoint: Change<Point>,
     val trackNumberId: Change<IntId<TrackLayoutTrackNumber>>,
+    val alignmentVersion: Change<RowVersion<LayoutAlignment>>,
 )
 
 // Todo: Consider making TrackLayoutSwitch use this for trapPoint as well
@@ -393,6 +387,7 @@ data class ReferenceLineChanges(
     val length: Change<Double>,
     val startPoint: Change<Point>,
     val endPoint: Change<Point>,
+    val alignmentVersion: Change<RowVersion<LayoutAlignment>>,
 )
 
 data class TrackNumberChanges(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -475,6 +475,10 @@ class PublicationDao(
               old_av.length as old_length,
               ltv.track_number_id as track_number_id,
               old_ltv.track_number_id as old_track_number_id,
+              ltv.alignment_id,
+              old_ltv.alignment_id as old_alignment_id,
+              ltv.alignment_version,
+              old_ltv.alignment_version as old_alignment_version,
               postgis.st_x(postgis.st_startpoint(old_sg_first.geometry)) as old_start_x,
               postgis.st_y(postgis.st_startpoint(old_sg_first.geometry)) as old_start_y,
               postgis.st_x(postgis.st_endpoint(old_sg_last.geometry)) as old_end_x,
@@ -538,6 +542,7 @@ class PublicationDao(
                 duplicateOf = rs.getChange("duplicate_of_location_track_id", rs::getIntIdOrNull),
                 type = rs.getChange("type", { rs.getEnumOrNull<LocationTrackType>(it) }),
                 length = rs.getChange("length", rs::getDoubleOrNull),
+                alignmentVersion = rs.getChangeRowVersion<LayoutAlignment>("alignment_id", "alignment_version")
             )
         }.toMap().also { logger.daoAccess(FETCH, LocationTrackChanges::class, publicationId) }
     }
@@ -588,6 +593,10 @@ class PublicationDao(
               old_reference_line_version.track_number_id as old_track_number_id,
               av.length,
               old_av.length as old_length,
+              reference_line_version.alignment_id,
+              old_reference_line_version.alignment_id as old_alignment_id,
+              reference_line_version.alignment_version,
+              old_reference_line_version.alignment_version as old_alignment_version,
               postgis.st_x(postgis.st_startpoint(old_sg_first.geometry)) as old_start_x,
               postgis.st_y(postgis.st_startpoint(old_sg_first.geometry)) as old_start_y,
               postgis.st_x(postgis.st_endpoint(old_sg_last.geometry)) as old_end_x,
@@ -633,7 +642,8 @@ class PublicationDao(
                 trackNumberId = rs.getChange("track_number_id", rs::getIntIdOrNull),
                 length = rs.getChange("length", rs::getDoubleOrNull),
                 startPoint = rs.getChangePoint("start_x", "start_y"),
-                endPoint = rs.getChangePoint("end_x", "end_y")
+                endPoint = rs.getChangePoint("end_x", "end_y"),
+                alignmentVersion = rs.getChangeRowVersion("alignment_id", "alignment_version"),
             )
         }.toMap().also { logger.daoAccess(FETCH, ReferenceLineChanges::class, publicationId) }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -2,11 +2,15 @@ package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.localization.Translation
 import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.switchLibrary.SwitchBaseType
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutPoint
+import fi.fta.geoviite.infra.tracklayout.LayoutSegment
 import fi.fta.geoviite.infra.util.*
 import org.springframework.http.ContentDisposition
 import org.springframework.http.HttpHeaders
@@ -17,6 +21,7 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlin.math.abs
+import kotlin.math.hypot
 
 fun getDateStringForFileName(instant1: Instant?, instant2: Instant?, timeZone: ZoneId): String? {
     val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(timeZone)
@@ -65,12 +70,7 @@ fun asCsvFile(items: List<PublicationTableItem>, timeZone: ZoneId, translation: 
                 "${
                     translation.t("publication-details-table.prop.${change.propKey.key}", change.propKey.params)
                 }: ${formatChangeValue(translation, change.value)}${
-                    if (change.remark != null) " (${
-                        translation.t(
-                            "publication-details-table.remark.${change.remark.key}",
-                            mapOf("value" to change.remark.value)
-                        )
-                    })" else ""
+                    if (change.remark != null) " (${change.remark})" else ""
                 }"
             }
         }).map { (column, fn) ->
@@ -174,37 +174,36 @@ fun lengthDifference(len1: BigDecimal, len2: BigDecimal) = abs(abs(len1.toDouble
 fun pointsAreSame(point1: IPoint?, point2: IPoint?) =
     point1 == point2 || point1 != null && point2 != null && point1.isSame(point2, DISTANCE_CHANGE_THRESHOLD)
 
-fun getLengthChangedRemarkOrNull(length1: Double?, length2: Double?) =
+fun getLengthChangedRemarkOrNull(translation: Translation, length1: Double?, length2: Double?) =
     if (length1 != null && length2 != null) lengthDifference(length1, length2).let { lengthDifference ->
-        if (lengthDifference > DISTANCE_CHANGE_THRESHOLD) PublicationChangeRemark(
-            "changed-x-meters", formatDistance(lengthDifference)
+        if (lengthDifference > DISTANCE_CHANGE_THRESHOLD) publicationChangeRemark(
+            translation, "changed-x-meters", formatDistance(lengthDifference)
         )
         else null
     }
     else null
 
-fun getPointMovedRemarkOrNull(oldPoint: Point?, newPoint: Point?) = oldPoint?.let { p1 ->
+fun getPointMovedRemarkOrNull(translation: Translation, oldPoint: Point?, newPoint: Point?) = oldPoint?.let { p1 ->
     newPoint?.let { p2 ->
         if (!pointsAreSame(p1, p2)) {
             val distance = calculateDistance(listOf(p1, p2), LAYOUT_SRID)
-            if (distance > DISTANCE_CHANGE_THRESHOLD) PublicationChangeRemark(
-                "moved-x-meters", formatDistance(distance)
+            if (distance > DISTANCE_CHANGE_THRESHOLD) publicationChangeRemark(
+                translation, "moved-x-meters", formatDistance(distance)
             )
             else null
         } else null
     }
 }
 
-fun getAddressMovedRemarkOrNull(oldAddress: TrackMeter?, newAddress: TrackMeter?) =
+fun getAddressMovedRemarkOrNull(translation: Translation, oldAddress: TrackMeter?, newAddress: TrackMeter?) =
     if (newAddress == null || oldAddress == null) null
-    else if (newAddress.kmNumber != oldAddress.kmNumber) PublicationChangeRemark(
-        "km-number-changed", "${newAddress.kmNumber}"
+    else if (newAddress.kmNumber != oldAddress.kmNumber) publicationChangeRemark(
+        translation, "km-number-changed", "${newAddress.kmNumber}"
     )
     else if (lengthDifference(
             newAddress.meters, oldAddress.meters
-        ) > DISTANCE_CHANGE_THRESHOLD
-    ) PublicationChangeRemark(
-        "moved-x-meters", formatDistance(
+        ) > DISTANCE_CHANGE_THRESHOLD) publicationChangeRemark(
+        translation, "moved-x-meters", formatDistance(
             lengthDifference(
                 newAddress.meters, oldAddress.meters
             )
@@ -212,16 +211,11 @@ fun getAddressMovedRemarkOrNull(oldAddress: TrackMeter?, newAddress: TrackMeter?
     )
     else null
 
-fun getKmNumbersChangedRemarkOrNull(changedKmNumbers: Set<KmNumber>) = PublicationChangeRemark(
-    if (changedKmNumbers.size > 1) "changed-km-numbers" else "changed-km-number",
-    formatChangedKmNumbers(changedKmNumbers.toList())
-)
-
 fun <T, U> compareChangeValues(
     change: Change<T>,
     valueTransform: (T) -> U,
     propKey: PropKey,
-    remark: PublicationChangeRemark? = null,
+    remark: String? = null,
     enumLocalizationKey: String? = null,
 ) = compareChange(
     predicate = { change.new != change.old },
@@ -239,7 +233,7 @@ fun <U> compareLength(
     threshold: Double,
     valueTransform: (Double) -> U,
     propKey: PropKey,
-    remark: PublicationChangeRemark? = null,
+    remark: String? = null,
     enumLocalizationKey: String? = null,
 ) = compareChange(
     predicate = {
@@ -261,7 +255,7 @@ fun <T, U> compareChange(
     newValue: T?,
     valueTransform: (T) -> U,
     propKey: PropKey,
-    remark: PublicationChangeRemark? = null,
+    remark: String? = null,
     enumLocalizationKey: String? = null,
 ) = if (predicate()) {
     PublicationChange(
@@ -284,3 +278,105 @@ fun switchBaseTypeToProp(translation: Translation, switchBaseType: SwitchBaseTyp
         "publication-details-table.joint.math-point"
     )
 }
+
+data class GeometryChangeSummary(
+    val changedLengthM: Double,
+    val maxDistance: Double,
+    val startKm: KmNumber,
+    val endKm: KmNumber,
+)
+
+fun getKmNumbersChangedRemarkOrNull(
+    translation: Translation,
+    oldAlignment: LayoutAlignment?,
+    newAlignment: LayoutAlignment?,
+    geocodingContext: GeocodingContext,
+    changedKmNumbers: Set<KmNumber>,
+): String {
+    val summaries = if (oldAlignment != null && newAlignment != null) summarizeAlignmentChanges(
+        geocodingContext,
+        oldAlignment,
+        newAlignment
+    ) else null
+
+    return if (summaries.isNullOrEmpty()) {
+        publicationChangeRemark(
+            translation,
+            if (changedKmNumbers.size > 1) "changed-km-numbers" else "changed-km-number",
+            formatChangedKmNumbers(changedKmNumbers.toList())
+        )
+    } else summaries.joinToString { summary ->
+        val key =
+            "publication-details-table.remark.geometry-changed${if (summary.startKm == summary.endKm) "" else "-many-km"}"
+        translation.t(
+            key,
+            mapOf(
+                "changedLengthM" to roundTo1Decimal(summary.changedLengthM).toString(),
+                "maxDistance" to roundTo1Decimal(summary.maxDistance).toString(),
+                "addressRange" to
+                        if (summary.startKm == summary.endKm) summary.startKm.toString()
+                        else "${summary.startKm}-${summary.endKm}"
+            )
+        )
+    }
+}
+
+private fun isContiguous(numbers: List<Int>) =
+    numbers.zipWithNext { a, b -> a + 1 == b}.all { it }
+
+private data class ComparisonPoints(
+    val oldPoint: LayoutPoint,
+    val newPoint: LayoutPoint,
+) {
+    val roughDistance = hypot(oldPoint.x - newPoint.x, oldPoint.y - newPoint.y)
+    fun distance() = calculateDistance(LAYOUT_SRID, oldPoint, newPoint)
+}
+
+fun summarizeAlignmentChanges(
+    geocodingContext: GeocodingContext,
+    oldAlignment: LayoutAlignment,
+    newAlignment: LayoutAlignment,
+    changeThreshold: Double = 1.0,
+): List<GeometryChangeSummary> {
+    val changedRanges = getChangedAlignmentRanges(oldAlignment, newAlignment)
+    return changedRanges.mapNotNull { oldSegments ->
+        val oldPoints = oldSegments.flatMap { segment -> segment.points }
+        val changedPoints = oldPoints.mapIndexedNotNull { index, oldPoint ->
+            geocodingContext.getAddress(oldPoint)?.let { address ->
+                val comparison =
+                    geocodingContext.getTrackLocation(newAlignment, address.first)?.let { newAddressPoint ->
+                        ComparisonPoints(oldPoint, newAddressPoint.point)
+                    }
+                if (comparison != null && comparison.roughDistance < changeThreshold) null
+                else index to comparison
+            }
+        }
+
+        if (changedPoints.isEmpty()) null else {
+            val startKm = geocodingContext.getAddress(oldPoints[changedPoints.first().first])?.first?.kmNumber
+            val endKm = geocodingContext.getAddress(oldPoints[changedPoints.last().first])?.first?.kmNumber
+
+            if (startKm == null || endKm == null) null else
+                GeometryChangeSummary(
+                    oldPoints[changedPoints.last().first].m - oldPoints[changedPoints.first().first].m,
+                    changedPoints.mapNotNull { it.second }.maxByOrNull { it.roughDistance }?.distance() ?: 0.0,
+                    startKm,
+                    endKm,
+                )
+        }
+    }
+}
+
+private fun getChangedAlignmentRanges(old: LayoutAlignment, new: LayoutAlignment): List<List<LayoutSegment>> {
+    val newIndexByGeometryId = new.segments.mapIndexed { i, s -> i to s }.associate { (index, segment) -> segment.geometry.id to index }
+    val changedOldSegmentIndexRanges = rangesOfConsecutiveIndicesOf(
+        false,
+        old.segments.map { segment -> newIndexByGeometryId.containsKey(segment.geometry.id) }
+    )
+    return changedOldSegmentIndexRanges.map { oldSegmentIndexRange ->
+        old.segments.subList(oldSegmentIndexRange.start, oldSegmentIndexRange.endInclusive)
+    }
+}
+
+fun publicationChangeRemark(translation: Translation, key: String, value: String?) =
+    translation.t("publication-details-table.remark.$key", if (value != null) mapOf("value" to value) else mapOf())

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -17,6 +17,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchConnectivityType
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.switchConnectivityType
 import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.util.rangesOfConsecutiveIndicesOf
 import kotlin.math.PI
 
 const val VALIDATION = "validation.layout"
@@ -650,18 +651,6 @@ private fun areDirectionsContinuous(points: List<LayoutPoint>): Boolean {
         angleOk
     }.all { it }
 }
-
-private fun rangesOfConsecutiveIndicesOf(
-    value: Boolean,
-    ts: List<Boolean>,
-    offsetRangeEndsBy: Int = 0,
-): List<ClosedRange<Int>> =
-    sequence { yield(!value); yieldAll(ts.asSequence()); yield(!value) }
-        .zipWithNext()
-        .mapIndexedNotNull { i, (a, b) -> if (a != b) i else null }
-        .chunked(2)
-        .map { c -> c[0]..c[1] + offsetRangeEndsBy }
-        .toList()
 
 private fun discontinuousDirectionRangeIndices(points: List<LayoutPoint>) =
     rangesOfConsecutiveIndicesOf(false, points.zipWithNext(::directionBetweenPoints).zipWithNext(::isAngleDiffOk), 2)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
@@ -5,3 +5,15 @@ fun <T : Comparable<T>> nullsLastComparator(a: T?, b: T?) = if (a == null && b =
 else if (a == null) 1
 else if (b == null) -1
 else a.compareTo(b)
+
+fun rangesOfConsecutiveIndicesOf(
+    value: Boolean,
+    ts: List<Boolean>,
+    offsetRangeEndsBy: Int = 0,
+): List<ClosedRange<Int>> =
+    sequence { yield(!value); yieldAll(ts.asSequence()); yield(!value) }
+        .zipWithNext()
+        .mapIndexedNotNull { i, (a, b) -> if (a != b) i else null }
+        .chunked(2)
+        .map { c -> c[0]..c[1] + offsetRangeEndsBy }
+        .toList()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -225,6 +225,9 @@ fun <T> ResultSet.getChange(name: String, getter: (name: String) -> T?): Change<
 fun ResultSet.getChangePoint(nameX: String, nameY: String) =
     Change(getPointOrNull("old_$nameX", "old_$nameY"), getPointOrNull(nameX, nameY))
 
+fun <T> ResultSet.getChangeRowVersion(idName: String, versionName: String): Change<RowVersion<T>> =
+    Change(getRowVersionOrNull("old_$idName", "old_$versionName"), getRowVersionOrNull(idName, versionName))
+
 inline fun <reified T> verifyNotNull(column: String, nullableGet: (column: String) -> T?): T =
     requireNotNull(nullableGet(column)) { "Value was null: type=${T::class.simpleName} column=$column" }
 

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1218,9 +1218,11 @@
         "remark": {
             "changed-x-meters": "Muutos {{value}} m",
             "moved-x-meters": "Siirtynyt {{value}} m",
-            "changed-km-number": "Muuttunut kilometriltä {{value}}",
-            "changed-km-numbers": "Muuttunut kilometreiltä {{value}}",
-            "km-number-changed": "Siirtynyt ratakilometrille {{value}}"
+            "changed-km-number": "Geometria ei siirtynyt. Muita tietoja muuttunut kilometriltä {{value}}",
+            "changed-km-numbers": "Geometria ei siirtynyt. Muita tietoja muuttunut kilometreiltä {{value}}",
+            "km-number-changed": "Siirtynyt ratakilometrille {{value}}",
+            "geometry-changed-many-km": "Muuttunut kilometriväliltä {{addressRange}}, laajuus {{changedLengthM}} m, poikkeama {{maxDistance}} m",
+            "geometry-changed": "Muuttunut kilometriltä {{addressRange}}, laajuus {{changedLengthM}} m, poikkeama {{maxDistance}} m"
         },
         "joint": {
             "math-point": "Matemaattinen piste",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -945,6 +945,7 @@ class PublicationServiceIT @Autowired constructor(
         )
 
         val diff = publicationService.diffTrackNumber(
+            localizationService.getLocalization("fi"),
             changes.getValue(trackNumber.id as IntId),
             thisAndPreviousPublication.first().publicationTime,
             thisAndPreviousPublication.last().publicationTime
@@ -991,6 +992,7 @@ class PublicationServiceIT @Autowired constructor(
         val updatedTrackNumber = trackNumberService.getOrThrow(OFFICIAL, idOfUpdated)
 
         val diff = publicationService.diffTrackNumber(
+            localizationService.getLocalization("fi"),
             changes.getValue(trackNumber.id as IntId),
             thisAndPreviousPublication.first().publicationTime,
             thisAndPreviousPublication.last().publicationTime
@@ -1078,6 +1080,7 @@ class PublicationServiceIT @Autowired constructor(
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
 
         val diff = publicationService.diffLocationTrack(
+            localizationService.getLocalization("fi"),
             changes.getValue(locationTrack.id as IntId<LocationTrack>),
             latestPub.publicationTime,
             previousPub.publicationTime,
@@ -1124,6 +1127,7 @@ class PublicationServiceIT @Autowired constructor(
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
 
         val diff = publicationService.diffLocationTrack(
+            localizationService.getLocalization("fi"),
             changes.getValue(locationTrack.id as IntId<LocationTrack>),
             latestPub.publicationTime,
             previousPub.publicationTime,
@@ -1187,6 +1191,7 @@ class PublicationServiceIT @Autowired constructor(
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
 
         val diff = publicationService.diffKmPost(
+            localizationService.getLocalization("fi"),
             changes.getValue(kmPost.id as IntId),
             latestPub.publicationTime,
             previousPub.publicationTime,
@@ -1222,6 +1227,7 @@ class PublicationServiceIT @Autowired constructor(
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
 
         val diff = publicationService.diffKmPost(
+            localizationService.getLocalization("fi"),
             changes.getValue(kmPost.id as IntId),
             latestPub.publicationTime,
             previousPub.publicationTime,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationUtilsTest.kt
@@ -1,6 +1,9 @@
 package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.geocodingContext
+import fi.fta.geoviite.infra.tracklayout.segment
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -52,4 +55,75 @@ class PublicationUtilsTest {
         val formatted = formatLocation(location)
         assertEquals(formatted, "1.000 E, 2.000 N")
     }
+
+    @Test
+    fun `summarizeAlignmentChanges detects change in the middle of track`() {
+        val oldAlignment = alignment(
+            segment(Point(0.0, 0.0), Point(1.0, 0.0), Point(2.0, 0.0), Point(3.0, 0.0), Point(4.0, 0.0))
+        )
+        val newAlignment = alignment(
+            segment(Point(0.0, 0.0), Point(1.0, 1.2), Point(2.0, 1.4), Point(3.0, 1.2), Point(4.0, 0.0))
+        )
+
+        val result = summarizeAlignmentChanges(xAxisGeocodingContext(), oldAlignment, newAlignment)
+        assertEquals(1, result.size)
+        val row = result[0]
+        assertEquals(2.0, row.changedLengthM)
+        assertEquals(row.maxDistance, 1.4, 0.1)
+    }
+
+    @Test
+    fun `summarizeAlignmentChanges detects track shortened by removing segment at start`() {
+        val oldAlignment = alignment(
+            segment(Point(0.0, 0.0), Point(1.0, 0.0), Point(2.0, 0.0)),
+            segment(Point(2.0, 0.0), Point(3.0, 0.0), Point(4.0, 0.0)),
+        )
+        val newAlignment = alignment(oldAlignment.segments[1])
+        val result = summarizeAlignmentChanges(xAxisGeocodingContext(), oldAlignment, newAlignment)
+        assertEquals(1, result.size)
+        val row = result[0]
+        assertEquals(1.0, row.changedLengthM, 0.1)
+    }
+
+    @Test
+    fun `summarizeAlignmentChanges detects track shortened by removing segment at end`() {
+        val oldAlignment = alignment(
+            segment(Point(0.0, 0.0), Point(1.0, 0.0), Point(2.0, 0.0)),
+            segment(Point(2.0, 0.0), Point(3.0, 0.0), Point(4.0, 0.0)),
+        )
+        val newAlignment = alignment(oldAlignment.segments[0])
+        val result = summarizeAlignmentChanges(xAxisGeocodingContext(), oldAlignment, newAlignment)
+        assertEquals(1, result.size)
+        val row = result[0]
+        assertEquals(1.0, row.changedLengthM, 0.1)
+    }
+
+    @Test
+    fun `summarizeAlignmentChanges detects multiple changes based on segment identity match`() {
+        val oldAlignment = alignment(
+            ((0..4).map { segmentIx ->
+                segment(*(0..4).map { pointIx ->
+                    Point(segmentIx * 4.0 + pointIx * 1.0, 0.0)
+                }.toTypedArray())
+            })
+        )
+        val newAlignment = alignment(
+            oldAlignment.segments[0],
+            segment(Point(4.0, 0.0), Point(5.0, 1.2), Point(6.0, 1.5), Point(7.0, 1.2), Point(8.0, 0.0)),
+            oldAlignment.segments[2],
+            segment(Point(12.0, 0.0), Point(13.0, 1.2), Point(15.0, 2.0)),
+            segment(Point(15.0, 2.0), Point(16.0, 3.0), Point(17.0, 4.0), Point(18.0, 5.0)),
+        )
+
+        val result = summarizeAlignmentChanges(xAxisGeocodingContext(), oldAlignment, newAlignment)
+        print(result)
+        assertEquals(2, result.size)
+        assertEquals(1.5, result[0].maxDistance, 0.1)
+        assertEquals(2.0, result[0].changedLengthM)
+        assertEquals(5.0, result[1].maxDistance, 0.1)
+        assertEquals(7.0, result[1].changedLengthM)
+    }
+
+    private fun xAxisGeocodingContext() = geocodingContext((0..30).map { x -> Point(x.toDouble(), 0.0)})
 }
+

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -183,13 +183,8 @@ export type ChangeValue = {
 export type PublicationChange = {
     propKey: PropKey;
     value: ChangeValue;
-    remark?: PublicationChangeRemark;
+    remark?: string;
     enumKey?: string;
-};
-
-export type PublicationChangeRemark = {
-    key: string;
-    value: string;
 };
 
 export type ValidatedAsset = {

--- a/ui/src/publication/table/publication-table-details.tsx
+++ b/ui/src/publication/table/publication-table-details.tsx
@@ -50,13 +50,7 @@ export const PublicationTableDetails: React.FC<PublicationTableDetailsProps> = (
                         </td>
                         <td>{formatValue(change.value.oldValue, change.value.localizationKey)}</td>
                         <td>{formatValue(change.value.newValue, change.value.localizationKey)}</td>
-                        <td>
-                            {change.remark
-                                ? t(`publication-details-table.remark.${change.remark.key}`, {
-                                      value: change.remark.value,
-                                  })
-                                : ''}
-                        </td>
+                        <td>{change.remark}</td>
                     </tr>
                 ))}
             </tbody>


### PR DESCRIPTION
Plus bugifiksiä, ja pari muuta asiaan liittyvää muutosta. Pääteemat:

- Julkaisulokin remarkkien rakenne meni vähän liian monimutkaiseksi viitsiä yrittää viedä frontille rakenteellisena; viedään siis vain tekstinä, ja siksi PublicationChangeRemark poistuu kokonaan
- Geometrioiden haku julkaisulokia näyttäessä vaati hieman perffimiettimisiä, tosin ei isoja
- Varsinainen algoritmi erojen laskemiseen omana mötikkänään