### PR TITLE
GVT-2134: Raiteen geometriat -näkymän mukainen korostus näkyy kartalla väärin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
@@ -53,16 +53,26 @@ class LayoutAlignmentService(
             "boundingBox" to boundingBox
         )
         val sections = dao.fetchSegmentGeometriesAndPlanMetadata(alignmentVersion, externalId, boundingBox)
+        val alignment = dao.fetch(alignmentVersion)
         return sections.mapNotNull { section ->
-            val start = if (section.startPoint != null) context.getAddressAndM(section.startPoint)?.let { (address, distance, _) ->
-                PlanSectionPoint(
-                    address = address,
-                    m = distance,
-                )
-            } else null
-            val end = if (section.endPoint != null) context.getAddressAndM(section.endPoint)?.let {
-                (address, distance) -> PlanSectionPoint(address = address, m = distance)
-            } else null
+            val start = if (section.startPoint != null) context.getAddressAndM(section.startPoint)
+                ?.let { (address, distance, _) ->
+                    PlanSectionPoint(
+                        address = address,
+                        m = alignment.getClosestPointM(section.startPoint)?.first ?: throw IllegalArgumentException(
+                            "Could not find closest point for ${section.startPoint}"
+                        )
+                    )
+                } else null
+            val end =
+                if (section.endPoint != null) context.getAddressAndM(section.endPoint)?.let { (address, distance) ->
+                    PlanSectionPoint(
+                        address = address,
+                        m = alignment.getClosestPointM(section.endPoint)?.first ?: throw IllegalArgumentException(
+                            "Could not find closest point for ${section.endPoint}"
+                        )
+                    )
+                } else null
 
             if (start != null && end != null) AlignmentPlanSection(
                 planId = section.planId,
@@ -77,6 +87,5 @@ class LayoutAlignmentService(
     }
 }
 
-private fun asNew(alignment: LayoutAlignment) =
-    if (alignment.dataType == TEMP) alignment
-    else alignment.copy(id = StringId(), dataType = TEMP)
+private fun asNew(alignment: LayoutAlignment) = if (alignment.dataType == TEMP) alignment
+else alignment.copy(id = StringId(), dataType = TEMP)


### PR DESCRIPTION
Aiemmin sectioneiden alku- ja loppu-m-arvot laskettiin pituusmittauslinjaa pitkin. Raiteilla tämä johti siihen, että kun raiteen ja pituusmittauslinjan geometriat on kuitenkin usein vähintään hieman eriävät, niin highlightit piirtyivät vääriin paikkoihin