### PR TITLE
GVT-2113: Snap slightly overlapping switch segments to nearby segments when linking

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -390,7 +390,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
     }
 
     @Test
-    fun `Overlapping switch linking should not remove previous switch from overlapping layout segment (specific case)`() {
+    fun `Switch linking slight overlap correction should not remove previous switch linking`() {
         val switchOverlapAmount = 4.99
         val testLocation = createLocationTracksWithLinkedSwitch()
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -630,11 +630,12 @@ fun switch(
     joints: List<TrackLayoutSwitchJoint> = joints(seed),
     name: String = "TV$seed",
     externalId: String? = null,
+    stateCategory: LayoutStateCategory = getSomeValue(seed),
 ) = TrackLayoutSwitch(
     externalId = if (externalId != null) Oid(externalId) else null,
     sourceId = null,
     name = SwitchName(name),
-    stateCategory = getSomeValue(seed),
+    stateCategory = stateCategory,
     joints = joints,
     switchStructureId = structureId,
     trapPoint = false,


### PR DESCRIPTION
GVT-2113: Snap slightly overlapping switch segments to nearby segments when linking

Previously the existing switch linking was removed when the new switch had even a slight overlap with the previous switch. If the overlap is too large or a nearby segment without switch information is not found, the previous switch linking is still removed.