### PR TITLE
GVT-2077 Recreating a previously deleted tracknumber

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -20,7 +20,9 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
-import java.time.*
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
 
 
 val publicationMaxDuration: Duration = Duration.ofMinutes(15)
@@ -54,9 +56,7 @@ class PublicationController @Autowired constructor(
     @PostMapping("/calculated-changes")
     fun getCalculatedChanges(@RequestBody request: PublishRequestIds): CalculatedChanges {
         logger.apiCall("getCalculatedChanges", "request" to request)
-        return calculatedChangesService.getCalculatedChanges(
-            publicationService.getValidationVersions(request)
-        )
+        return calculatedChangesService.getCalculatedChanges(publicationService.getValidationVersions(request))
     }
 
     @PreAuthorize(AUTH_ALL_WRITE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -20,6 +20,7 @@ import fi.fta.geoviite.infra.linking.*
 import fi.fta.geoviite.infra.localization.Translation
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.roundTo1Decimal
+import fi.fta.geoviite.infra.publication.PublishValidationErrorType.ERROR
 import fi.fta.geoviite.infra.ratko.RatkoClient
 import fi.fta.geoviite.infra.ratko.RatkoPushDao
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
@@ -448,7 +449,7 @@ class PublicationService @Autowired constructor(
     private inline fun <reified T> assertNoErrors(
         version: ValidationVersion<T>, errors: List<PublishValidationError>,
     ) {
-        val severeErrors = errors.filter { error -> error.type == PublishValidationErrorType.ERROR }
+        val severeErrors = errors.filter { error -> error.type == ERROR }
         if (severeErrors.isNotEmpty()) {
             logger.warn("Validation errors in published ${T::class.simpleName}: item=$version errors=$severeErrors")
             throw PublicationFailureException(
@@ -543,14 +544,10 @@ class PublicationService @Autowired constructor(
 
         return listOfNotNull(
             if (!stagedDuplicateExists && officialDuplicateExists) PublishValidationError(
-                PublishValidationErrorType.ERROR,
-                "$VALIDATION_TRACK_NUMBER.duplicate-name-official",
-                mapOf("trackNumber" to trackNumber.number)
+                ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-official", mapOf("trackNumber" to trackNumber.number)
             ) else null,
             if (stagedDuplicateExists) PublishValidationError(
-                PublishValidationErrorType.ERROR,
-                "$VALIDATION_TRACK_NUMBER.duplicate-name-draft",
-                mapOf("trackNumber" to trackNumber.number)
+                ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-draft", mapOf("trackNumber" to trackNumber.number)
             ) else null,
         )
     }
@@ -615,14 +612,10 @@ class PublicationService @Autowired constructor(
 
         return listOfNotNull(
             if (!stagedDuplicateExists && officialDuplicateExists) PublishValidationError(
-                PublishValidationErrorType.ERROR,
-                "$VALIDATION_SWITCH.duplicate-name-official",
-                mapOf("switch" to switch.name)
+                ERROR, "$VALIDATION_SWITCH.duplicate-name-official", mapOf("switch" to switch.name)
             ) else null,
             if (stagedDuplicateExists) PublishValidationError(
-                PublishValidationErrorType.ERROR,
-                "$VALIDATION_SWITCH.duplicate-name-draft",
-                mapOf("switch" to switch.name)
+                ERROR, "$VALIDATION_SWITCH.duplicate-name-draft", mapOf("switch" to switch.name)
             ) else null,
         )
     }
@@ -719,11 +712,11 @@ class PublicationService @Autowired constructor(
 
         return listOfNotNull(
             if (stagedDuplicateExists) PublishValidationError(
-                PublishValidationErrorType.ERROR,
+                ERROR,
                 "$VALIDATION_LOCATION_TRACK.duplicate-name-draft",
                 mapOf("locationTrack" to locationTrack.name, "trackNumber" to trackNumberName)
             ) else null, if (!stagedDuplicateExists && officialDuplicateExists) PublishValidationError(
-                PublishValidationErrorType.ERROR,
+                ERROR,
                 "$VALIDATION_LOCATION_TRACK.duplicate-name-official",
                 mapOf("locationTrack" to locationTrack.name, "trackNumber" to trackNumberName)
             ) else null
@@ -765,16 +758,6 @@ class PublicationService @Autowired constructor(
         officials = locationTrackDao.fetchVersions(OFFICIAL, false, trackNumberId),
         validations = versions.locationTracks
     ).map(locationTrackDao::fetch).filter { lt -> lt.trackNumberId == trackNumberId }
-
-    private fun <T> combineVersions(
-        officials: List<RowVersion<T>>,
-        validations: List<ValidationVersion<T>>,
-    ): Collection<RowVersion<T>> {
-        val officialVersions = officials.filterNot { officialId -> validations.any { v -> v.officialId == officialId } }
-        val validationVersions = validations.map { it.validatedAssetVersion }
-
-        return (officialVersions + validationVersions).distinct()
-    }
 
     private fun getReferenceLineAndAlignment(version: RowVersion<ReferenceLine>) =
         referenceLineWithAlignment(referenceLineDao, alignmentDao, version)
@@ -957,8 +940,7 @@ class PublicationService @Autowired constructor(
                     translation, trackNumberChanges.startAddress.old, trackNumberChanges.startAddress.new
                 )
             ),
-            compareChange(
-                { oldEndAddress != newEndAddress },
+            compareChange({ oldEndAddress != newEndAddress },
                 oldEndAddress,
                 newEndAddress,
                 { it.toString() },
@@ -1027,8 +1009,7 @@ class PublicationService @Autowired constructor(
                 PropKey("description-suffix"),
                 enumLocalizationKey = "location-track-description-suffix"
             ),
-            compareChange(
-                { oldAndTime.first != newAndTime.first },
+            compareChange({ oldAndTime.first != newAndTime.first },
                 oldAndTime,
                 newAndTime,
                 { (duplicateOf, timestamp) ->
@@ -1207,8 +1188,7 @@ class PublicationService @Autowired constructor(
                     PropKey("switch-joint-location", jointPropKeyParams),
                     getPointMovedRemarkOrNull(translation, oldLocation, joint.point),
                     null
-                ), compareChange(
-                    { oldAddress != joint.address },
+                ), compareChange({ oldAddress != joint.address },
                     oldAddress,
                     joint.address,
                     { it.toString() },
@@ -1251,8 +1231,7 @@ class PublicationService @Autowired constructor(
 
     private fun validateGeocodingContext(cacheKey: GeocodingContextCacheKey?, localizationKey: String) =
         cacheKey?.let(geocodingCacheService::getGeocodingContextWithReasons)
-            ?.let { context -> validateGeocodingContext(context) }
-            ?: listOf(noGeocodingContext(localizationKey))
+            ?.let { context -> validateGeocodingContext(context) } ?: listOf(noGeocodingContext(localizationKey))
 
     private fun validateAddressPoints(
         trackNumber: TrackLayoutTrackNumber,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -1230,8 +1230,9 @@ class PublicationService @Autowired constructor(
         .orElse(null)
 
     private fun validateGeocodingContext(cacheKey: GeocodingContextCacheKey?, localizationKey: String) =
-        cacheKey?.let(geocodingCacheService::getGeocodingContextWithReasons)
-            ?.let { context -> validateGeocodingContext(context) } ?: listOf(noGeocodingContext(localizationKey))
+        cacheKey?.let(geocodingCacheService::getGeocodingContextWithReasons)?.let { context ->
+            validateGeocodingContext(context)
+        } ?: listOf(noGeocodingContext(localizationKey))
 
     private fun validateAddressPoints(
         trackNumber: TrackLayoutTrackNumber,
@@ -1286,14 +1287,12 @@ class PublicationService @Autowired constructor(
     }
 
     private fun collectCacheKeys(versions: ValidationVersions): Map<IntId<TrackLayoutTrackNumber>, GeocodingContextCacheKey?> {
-        val trackNumberIds =
-            (versions.trackNumbers.map { version -> version.officialId } + versions.kmPosts.mapNotNull { v ->
-                kmPostDao.fetch(v.validatedAssetVersion).trackNumberId
-            } + versions.locationTracks.map { v -> locationTrackDao.fetch(v.validatedAssetVersion).trackNumberId } + versions.referenceLines.map { v ->
-                referenceLineDao.fetch(
-                    v.validatedAssetVersion
-                ).trackNumberId
-            }).toSet()
+        val trackNumberIds = listOf(
+            versions.trackNumbers.map { version -> version.officialId },
+            versions.kmPosts.mapNotNull { v -> kmPostDao.fetch(v.validatedAssetVersion).trackNumberId },
+            versions.locationTracks.map { v -> locationTrackDao.fetch(v.validatedAssetVersion).trackNumberId },
+            versions.referenceLines.map { v -> referenceLineDao.fetch(v.validatedAssetVersion).trackNumberId },
+        ).flatten().toSet()
         return trackNumberIds.associateWith { tnId -> geocodingService.getGeocodingContextCacheKey(tnId, versions) }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -121,10 +121,10 @@ fun validateSwitchLocationTrackLinkStructure(
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
 ): List<PublishValidationError> {
     val existingTracks = locationTracks.filter { (track, _) -> track.exists }
-    val segmentGroups =
-        locationTracks.filter { (track, _) -> track.exists } // Only consider the non-deleted tracks for switch alignments
-            .map { (track, alignment) -> track to alignment.segments.filter { segment -> segment.switchId == switch.id } }
-            .filter { (_, segments) -> segments.isNotEmpty() }
+    val segmentGroups = locationTracks
+        .filter { (track, _) -> track.exists } // Only consider the non-deleted tracks for switch alignments
+        .map { (track, alignment) -> track to alignment.segments.filter { segment -> segment.switchId == switch.id } }
+        .filter { (_, segments) -> segments.isNotEmpty() }
 
     val structureJoints = collectJoints(structure)
     val segmentJoints = segmentGroups.map { (track, group) -> collectJoints(track, group) }
@@ -221,7 +221,8 @@ private fun validateExcessTracksThroughJoint(
     val excesses =
         tracksThroughJoint.filter { (joint, tracks) -> joint != connectivityType.sharedJoint && tracks.size > 1 }
     return validateWithParams(excesses.isEmpty(), WARNING) {
-        val trackNames = excesses.entries.sortedBy { (jointNumber, _) -> jointNumber.intValue }
+        val trackNames = excesses.entries
+            .sortedBy { (jointNumber, _) -> jointNumber.intValue }
             .joinToString { (jointNumber, tracks) ->
                 "${jointNumber.intValue} (${tracks.sortedBy { it.name }.joinToString { it.name }})"
             }
@@ -403,7 +404,8 @@ fun validateGeocodingContext(stuff: GeocodingContextCreateResult): List<PublishV
             }
         }
 
-    val kmPostsFarFromLine = context.referencePoints.filter { point -> point.intersectType == WITHIN }
+    val kmPostsFarFromLine = context.referencePoints
+        .filter { point -> point.intersectType == WITHIN }
         .filter { point -> point.kmPostOffset > MAX_KM_POST_OFFSET }
         .let { farAwayPoints ->
             validateWithParams(farAwayPoints.isEmpty(), WARNING) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -1,9 +1,6 @@
 package fi.fta.geoviite.infra.publication
 
-import fi.fta.geoviite.infra.common.DomainId
-import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.JointNumber
-import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.error.ClientException
 import fi.fta.geoviite.infra.error.LocalizationParams
 import fi.fta.geoviite.infra.geocoding.*
@@ -34,9 +31,7 @@ const val MAX_LAYOUT_METER_LENGTH = 2.0
 const val MAX_KM_POST_OFFSET = 10.0
 
 fun validateDraftTrackNumberFields(trackNumber: TrackLayoutTrackNumber): List<PublishValidationError> =
-    listOfNotNull(
-        validate(trackNumber.state.isPublishable()) { "$VALIDATION_TRACK_NUMBER.state.${trackNumber.state}" }
-    )
+    listOfNotNull(validate(trackNumber.state.isPublishable()) { "$VALIDATION_TRACK_NUMBER.state.${trackNumber.state}" })
 
 fun validateTrackNumberReferences(
     trackNumber: TrackLayoutTrackNumber,
@@ -82,51 +77,43 @@ fun validateKmPostReferences(
     trackNumber: TrackLayoutTrackNumber?,
     referenceLine: ReferenceLine?,
     publishTrackNumberIds: List<IntId<TrackLayoutTrackNumber>>,
-): List<PublishValidationError> =
-    listOfNotNull(
-        validate(trackNumber != null) { "$VALIDATION_KM_POST.track-number.null" },
-        validate(referenceLine != null) { "$VALIDATION_KM_POST.reference-line.null" },
-        validateWithParams(!kmPost.exists || trackNumber == null || trackNumber.state.isLinkable()) {
-            "$VALIDATION_KM_POST.track-number.state.${trackNumber?.state}" to mapOf("trackNumber" to trackNumber?.number?.toString())
-        },
-        validateWithParams(trackNumber == null || kmPost.trackNumberId == trackNumber.id) {
-            "$VALIDATION_KM_POST.track-number.not-official" to mapOf("trackNumber" to trackNumber?.number?.toString())
-        },
-        validateWithParams(trackNumber == null || isPublished(trackNumber, publishTrackNumberIds)) {
-            "$VALIDATION_KM_POST.track-number.not-published" to mapOf("trackNumber" to trackNumber?.number?.toString())
-        },
-    )
+): List<PublishValidationError> = listOfNotNull(
+    validate(trackNumber != null) { "$VALIDATION_KM_POST.track-number.null" },
+    validate(referenceLine != null) { "$VALIDATION_KM_POST.reference-line.null" },
+    validateWithParams(!kmPost.exists || trackNumber == null || trackNumber.state.isLinkable()) {
+        "$VALIDATION_KM_POST.track-number.state.${trackNumber?.state}" to mapOf("trackNumber" to trackNumber?.number?.toString())
+    },
+    validateWithParams(trackNumber == null || kmPost.trackNumberId == trackNumber.id) {
+        "$VALIDATION_KM_POST.track-number.not-official" to mapOf("trackNumber" to trackNumber?.number?.toString())
+    },
+    validateWithParams(trackNumber == null || isPublished(trackNumber, publishTrackNumberIds)) {
+        "$VALIDATION_KM_POST.track-number.not-published" to mapOf("trackNumber" to trackNumber?.number?.toString())
+    },
+)
 
-fun validateDraftSwitchFields(switch: TrackLayoutSwitch): List<PublishValidationError> =
-    listOfNotNull(
-        validate(switch.stateCategory.isPublishable()) { "$VALIDATION_SWITCH.state-category.${switch.stateCategory}" },
-    )
+fun validateDraftSwitchFields(switch: TrackLayoutSwitch): List<PublishValidationError> = listOfNotNull(
+    validate(switch.stateCategory.isPublishable()) { "$VALIDATION_SWITCH.state-category.${switch.stateCategory}" },
+)
 
 fun validateSwitchLocationTrackLinkReferences(
     switch: TrackLayoutSwitch,
     locationTracks: List<LocationTrack>,
     publishLocationTrackIds: List<IntId<LocationTrack>>,
-) = locationTracks
-    .mapNotNull { locationTrack ->
-        validateWithParams(isPublished(locationTrack, publishLocationTrackIds)) {
-            "$VALIDATION_SWITCH.location-track.not-published" to mapOf("locationTrack" to locationTrack.name.toString())
-        }
-    } + listOfNotNull(
-    locationTracks
-        .filter(LocationTrack::exists)
-        .let { existingTracks ->
-            validateWithParams(switch.exists || existingTracks.isEmpty()) {
-                val existingNames = existingTracks.joinToString(", ") { track -> track.name }
-                "$VALIDATION_SWITCH.location-track.reference-deleted" to mapOf("locationTracks" to existingNames)
-            }
-        }
-)
-
-fun validateSwitchLocation(switch: TrackLayoutSwitch): List<PublishValidationError> = listOfNotNull(
-    validate(switch.joints.isNotEmpty()) {
-        "$VALIDATION_SWITCH.no-location"
+) = locationTracks.mapNotNull { locationTrack ->
+    validateWithParams(isPublished(locationTrack, publishLocationTrackIds)) {
+        "$VALIDATION_SWITCH.location-track.not-published" to mapOf("locationTrack" to locationTrack.name.toString())
     }
-)
+} + listOfNotNull(locationTracks.filter(LocationTrack::exists).let { existingTracks ->
+    validateWithParams(switch.exists || existingTracks.isEmpty()) {
+        val existingNames = existingTracks.joinToString(", ") { track -> track.name }
+        "$VALIDATION_SWITCH.location-track.reference-deleted" to mapOf("locationTracks" to existingNames)
+    }
+})
+
+fun validateSwitchLocation(switch: TrackLayoutSwitch): List<PublishValidationError> =
+    listOfNotNull(validate(switch.joints.isNotEmpty()) {
+        "$VALIDATION_SWITCH.no-location"
+    })
 
 fun validateSwitchLocationTrackLinkStructure(
     switch: TrackLayoutSwitch,
@@ -134,10 +121,10 @@ fun validateSwitchLocationTrackLinkStructure(
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
 ): List<PublishValidationError> {
     val existingTracks = locationTracks.filter { (track, _) -> track.exists }
-    val segmentGroups = locationTracks
-        .filter { (track, _) -> track.exists } // Only consider the non-deleted tracks for switch alignments
-        .map { (track, alignment) -> track to alignment.segments.filter { segment -> segment.switchId == switch.id } }
-        .filter { (_, segments) -> segments.isNotEmpty() }
+    val segmentGroups =
+        locationTracks.filter { (track, _) -> track.exists } // Only consider the non-deleted tracks for switch alignments
+            .map { (track, alignment) -> track to alignment.segments.filter { segment -> segment.switchId == switch.id } }
+            .filter { (_, segments) -> segments.isNotEmpty() }
 
     val structureJoints = collectJoints(structure)
     val segmentJoints = segmentGroups.map { (track, group) -> collectJoints(track, group) }
@@ -145,34 +132,30 @@ fun validateSwitchLocationTrackLinkStructure(
     val topologyLinks = collectTopologyEndLinks(existingTracks, switch)
 
     return if (switch.exists) listOfNotNull(
-        segmentGroups.filterNot { (_, group) -> areSegmentsContinuous(group) }
-            .let { errorGroups ->
-                validateWithParams(errorGroups.isEmpty()) {
-                    val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                    "$VALIDATION_SWITCH.location-track.not-continuous" to mapOf("locationTracks" to errorTrackNames)
-                }
-            },
-        segmentGroups.filterNot { (_, group) -> segmentAndJointLocationsAgree(switch, group) }
-            .let { errorGroups ->
-                validateWithParams(errorGroups.isEmpty(), WARNING) {
-                    val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                    "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to mapOf("locationTracks" to errorTrackNames)
-                }
-            },
-        topologyLinks.filterNot { (_, group) -> topologyLinkAndJointLocationsAgree(switch, group) }
-            .let { errorGroups ->
-                validateWithParams(errorGroups.isEmpty(), WARNING) {
-                    val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                    "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to mapOf("locationTracks" to errorTrackNames)
-                }
-            },
-        segmentJoints.filterNot { (_, group) -> alignmentJointGroupFound(group, structureJoints) }
-            .let { errorGroups ->
-                validateWithParams(errorGroups.isEmpty()) {
-                    val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                    "$VALIDATION_SWITCH.location-track.wrong-joint-sequence" to mapOf("locationTracks" to errorTrackNames)
-                }
-            },
+        segmentGroups.filterNot { (_, group) -> areSegmentsContinuous(group) }.let { errorGroups ->
+            validateWithParams(errorGroups.isEmpty()) {
+                val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
+                "$VALIDATION_SWITCH.location-track.not-continuous" to mapOf("locationTracks" to errorTrackNames)
+            }
+        },
+        segmentGroups.filterNot { (_, group) -> segmentAndJointLocationsAgree(switch, group) }.let { errorGroups ->
+            validateWithParams(errorGroups.isEmpty(), WARNING) {
+                val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
+                "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to mapOf("locationTracks" to errorTrackNames)
+            }
+        },
+        topologyLinks.filterNot { (_, group) -> topologyLinkAndJointLocationsAgree(switch, group) }.let { errorGroups ->
+            validateWithParams(errorGroups.isEmpty(), WARNING) {
+                val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
+                "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to mapOf("locationTracks" to errorTrackNames)
+            }
+        },
+        segmentJoints.filterNot { (_, group) -> alignmentJointGroupFound(group, structureJoints) }.let { errorGroups ->
+            validateWithParams(errorGroups.isEmpty()) {
+                val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
+                "$VALIDATION_SWITCH.location-track.wrong-joint-sequence" to mapOf("locationTracks" to errorTrackNames)
+            }
+        },
     ) + validateSwitchTopologicalConnectivity(switch, structure, locationTracks) else listOf()
 }
 
@@ -184,15 +167,14 @@ private fun validateSwitchTopologicalConnectivity(
     val connectivityType = switchConnectivityType(structure)
     val nonDuplicateTracks = locationTracks.filter { it.first.duplicateOf == null }
 
-    val tracksThroughJoint = structure.joints.map { it.number }
-        .associateWith { jointNumber ->
-            nonDuplicateTracks.filter { (_, alignment) ->
-                val jointLinkedIndexRange = alignment.segments.mapIndexedNotNull { i, segment ->
-                    if (segment.switchId == switch.id && (segment.startJointNumber == jointNumber || segment.endJointNumber == jointNumber)) i else null
-                }
-                jointLinkedIndexRange.isNotEmpty() && jointLinkedIndexRange.first() > 0 && jointLinkedIndexRange.last() < alignment.segments.lastIndex
-            }.map { (locationTrack, _) -> locationTrack }
-        }
+    val tracksThroughJoint = structure.joints.map { it.number }.associateWith { jointNumber ->
+        nonDuplicateTracks.filter { (_, alignment) ->
+            val jointLinkedIndexRange = alignment.segments.mapIndexedNotNull { i, segment ->
+                if (segment.switchId == switch.id && (segment.startJointNumber == jointNumber || segment.endJointNumber == jointNumber)) i else null
+            }
+            jointLinkedIndexRange.isNotEmpty() && jointLinkedIndexRange.first() > 0 && jointLinkedIndexRange.last() < alignment.segments.lastIndex
+        }.map { (locationTrack, _) -> locationTrack }
+    }
 
     return listOfNotNull(
         validateFrontJointTopology(switch.id, tracksThroughJoint, connectivityType, locationTracks),
@@ -239,8 +221,7 @@ private fun validateExcessTracksThroughJoint(
     val excesses =
         tracksThroughJoint.filter { (joint, tracks) -> joint != connectivityType.sharedJoint && tracks.size > 1 }
     return validateWithParams(excesses.isEmpty(), WARNING) {
-        val trackNames = excesses.entries
-            .sortedBy { (jointNumber, _) -> jointNumber.intValue }
+        val trackNames = excesses.entries.sortedBy { (jointNumber, _) -> jointNumber.intValue }
             .joinToString { (jointNumber, tracks) ->
                 "${jointNumber.intValue} (${tracks.sortedBy { it.name }.joinToString { it.name }})"
             }
@@ -282,66 +263,57 @@ fun validateDuplicateOfState(
     locationTrack: LocationTrack,
     duplicateOfLocationTrack: LocationTrack?,
     publishLocationTrackIds: List<IntId<LocationTrack>>,
-): List<PublishValidationError> =
-    if (duplicateOfLocationTrack == null) listOf()
-    else listOfNotNull(
-        validateWithParams(locationTrack.duplicateOf == duplicateOfLocationTrack.id) {
-            "$VALIDATION_REFERENCE_LINE.duplicate-of.not-official" to mapOf("duplicateTrack" to duplicateOfLocationTrack.name.toString())
-        },
-        validateWithParams(isPublished(duplicateOfLocationTrack, publishLocationTrackIds)) {
-            "$VALIDATION_LOCATION_TRACK.duplicate-of.not-published" to mapOf("duplicateTrack" to duplicateOfLocationTrack.name.toString())
-        },
-        validateWithParams(locationTrack.state.isRemoved() || duplicateOfLocationTrack.state.isLinkable()) {
-            "$VALIDATION_LOCATION_TRACK.duplicate-of.state.${duplicateOfLocationTrack.state}" to mapOf(
-                "duplicateTrack" to duplicateOfLocationTrack.name.toString()
-            )
-        },
-        validateWithParams(duplicateOfLocationTrack.duplicateOf == null) {
-            "$VALIDATION_LOCATION_TRACK.duplicate-of.duplicate" to mapOf("duplicateTrack" to duplicateOfLocationTrack.name.toString())
-        }
+): List<PublishValidationError> = if (duplicateOfLocationTrack == null) listOf()
+else listOfNotNull(validateWithParams(locationTrack.duplicateOf == duplicateOfLocationTrack.id) {
+    "$VALIDATION_REFERENCE_LINE.duplicate-of.not-official" to mapOf("duplicateTrack" to duplicateOfLocationTrack.name.toString())
+}, validateWithParams(isPublished(duplicateOfLocationTrack, publishLocationTrackIds)) {
+    "$VALIDATION_LOCATION_TRACK.duplicate-of.not-published" to mapOf("duplicateTrack" to duplicateOfLocationTrack.name.toString())
+}, validateWithParams(locationTrack.state.isRemoved() || duplicateOfLocationTrack.state.isLinkable()) {
+    "$VALIDATION_LOCATION_TRACK.duplicate-of.state.${duplicateOfLocationTrack.state}" to mapOf(
+        "duplicateTrack" to duplicateOfLocationTrack.name.toString()
     )
+}, validateWithParams(duplicateOfLocationTrack.duplicateOf == null) {
+    "$VALIDATION_LOCATION_TRACK.duplicate-of.duplicate" to mapOf("duplicateTrack" to duplicateOfLocationTrack.name.toString())
+})
 
-fun validateDraftLocationTrackFields(locationTrack: LocationTrack): List<PublishValidationError> =
-    listOfNotNull(
-        validate(locationTrack.state.isPublishable()) { "$VALIDATION_LOCATION_TRACK.state.${locationTrack.state}" },
-    )
+fun validateDraftLocationTrackFields(locationTrack: LocationTrack): List<PublishValidationError> = listOfNotNull(
+    validate(locationTrack.state.isPublishable()) { "$VALIDATION_LOCATION_TRACK.state.${locationTrack.state}" },
+)
 
 fun validateReferenceLineReference(
     referenceLine: ReferenceLine,
     trackNumber: TrackLayoutTrackNumber?,
     publishTrackNumberIds: List<IntId<TrackLayoutTrackNumber>>,
-) =
-    if (trackNumber == null) listOf(
-        PublishValidationError(ERROR, "$VALIDATION_REFERENCE_LINE.track-number.null", emptyMap())
-    )
-    else listOfNotNull(
-        validateWithParams(referenceLine.trackNumberId == trackNumber.id) {
-            "$VALIDATION_REFERENCE_LINE.track-number.not-official" to mapOf("trackNumber" to trackNumber.number.toString())
-        },
-        validateWithParams(isPublished(trackNumber, publishTrackNumberIds)) {
-            "$VALIDATION_REFERENCE_LINE.track-number.not-published" to mapOf("trackNumber" to trackNumber.number.toString())
-        },
-    )
+) = if (trackNumber == null) listOf(
+    PublishValidationError(ERROR, "$VALIDATION_REFERENCE_LINE.track-number.null", emptyMap())
+)
+else listOfNotNull(
+    validateWithParams(referenceLine.trackNumberId == trackNumber.id) {
+        "$VALIDATION_REFERENCE_LINE.track-number.not-official" to mapOf("trackNumber" to trackNumber.number.toString())
+    },
+    validateWithParams(isPublished(trackNumber, publishTrackNumberIds)) {
+        "$VALIDATION_REFERENCE_LINE.track-number.not-published" to mapOf("trackNumber" to trackNumber.number.toString())
+    },
+)
 
 fun validateLocationTrackReference(
     locationTrack: LocationTrack,
     trackNumber: TrackLayoutTrackNumber?,
     publishTrackNumberIds: List<IntId<TrackLayoutTrackNumber>>,
-) =
-    if (trackNumber == null) listOf(
-        PublishValidationError(ERROR, "$VALIDATION_LOCATION_TRACK.track-number.null", emptyMap())
-    )
-    else listOfNotNull(
-        validateWithParams(locationTrack.trackNumberId == trackNumber.id) {
-            "$VALIDATION_LOCATION_TRACK.track-number.not-official" to mapOf("trackNumber" to trackNumber.number.toString())
-        },
-        validateWithParams(isPublished(trackNumber, publishTrackNumberIds)) {
-            "$VALIDATION_LOCATION_TRACK.track-number.not-published" to mapOf("trackNumber" to trackNumber.number.toString())
-        },
-        validateWithParams(locationTrack.state.isRemoved() || trackNumber.state.isLinkable()) {
-            "$VALIDATION_LOCATION_TRACK.track-number.state.${trackNumber.state}" to mapOf("trackNumber" to trackNumber.number.toString())
-        },
-    )
+) = if (trackNumber == null) listOf(
+    PublishValidationError(ERROR, "$VALIDATION_LOCATION_TRACK.track-number.null", emptyMap())
+)
+else listOfNotNull(
+    validateWithParams(locationTrack.trackNumberId == trackNumber.id) {
+        "$VALIDATION_LOCATION_TRACK.track-number.not-official" to mapOf("trackNumber" to trackNumber.number.toString())
+    },
+    validateWithParams(isPublished(trackNumber, publishTrackNumberIds)) {
+        "$VALIDATION_LOCATION_TRACK.track-number.not-published" to mapOf("trackNumber" to trackNumber.number.toString())
+    },
+    validateWithParams(locationTrack.state.isRemoved() || trackNumber.state.isLinkable()) {
+        "$VALIDATION_LOCATION_TRACK.track-number.state.${trackNumber.state}" to mapOf("trackNumber" to trackNumber.number.toString())
+    },
+)
 
 data class SegmentSwitch(
     val switch: TrackLayoutSwitch,
@@ -417,9 +389,8 @@ fun noGeocodingContext(validationTargetLocalizationPrefix: String) =
 
 fun validateGeocodingContext(stuff: GeocodingContextCreateResult): List<PublishValidationError> {
     val context = stuff.geocodingContext
-    val kmPostsInWrongOrder = context.referencePoints
-        .filter { point -> point.intersectType == WITHIN }
-        .filterIndexed { index, point ->
+    val kmPostsInWrongOrder =
+        context.referencePoints.filter { point -> point.intersectType == WITHIN }.filterIndexed { index, point ->
             val previous = context.referencePoints.getOrNull(index - 1)
             val next = context.referencePoints.getOrNull(index + 1)
             !isOrderOk(previous, point) || !isOrderOk(point, next)
@@ -432,8 +403,7 @@ fun validateGeocodingContext(stuff: GeocodingContextCreateResult): List<PublishV
             }
         }
 
-    val kmPostsFarFromLine = context.referencePoints
-        .filter { point -> point.intersectType == WITHIN }
+    val kmPostsFarFromLine = context.referencePoints.filter { point -> point.intersectType == WITHIN }
         .filter { point -> point.kmPostOffset > MAX_KM_POST_OFFSET }
         .let { farAwayPoints ->
             validateWithParams(farAwayPoints.isEmpty(), WARNING) {
@@ -449,33 +419,23 @@ fun validateGeocodingContext(stuff: GeocodingContextCreateResult): List<PublishV
 
         when (reason) {
             KmPostRejectedReason.TOO_FAR_APART -> PublishValidationError(
-                ERROR,
-                "$VALIDATION_GEOCODING.km-post-too-long",
-                params
+                ERROR, "$VALIDATION_GEOCODING.km-post-too-long", params
             )
 
             KmPostRejectedReason.NO_LOCATION -> PublishValidationError(
-                ERROR,
-                "$VALIDATION_GEOCODING.km-post-no-location",
-                params
+                ERROR, "$VALIDATION_GEOCODING.km-post-no-location", params
             )
 
             KmPostRejectedReason.IS_BEFORE_START_ADDRESS -> PublishValidationError(
-                WARNING,
-                "$VALIDATION_GEOCODING.km-post-smaller-than-track-number-start",
-                params
+                WARNING, "$VALIDATION_GEOCODING.km-post-smaller-than-track-number-start", params
             )
 
             KmPostRejectedReason.INTERSECTS_BEFORE_REFERENCE_LINE -> PublishValidationError(
-                WARNING,
-                "$VALIDATION_GEOCODING.km-post-outside-line-before",
-                params
+                WARNING, "$VALIDATION_GEOCODING.km-post-outside-line-before", params
             )
 
             KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE -> PublishValidationError(
-                WARNING,
-                "$VALIDATION_GEOCODING.km-post-outside-line-after",
-                params
+                WARNING, "$VALIDATION_GEOCODING.km-post-outside-line-after", params
             )
         }
     }
@@ -492,20 +452,17 @@ fun validateAddressPoints(
     locationTrack: LocationTrack,
     validationTargetLocalizationPrefix: String,
     geocode: () -> AlignmentAddresses?,
-): List<PublishValidationError> =
-    try {
-        geocode()?.let { addresses ->
-            validateAddressPoints(trackNumber, locationTrack, addresses)
-        } ?: listOf(
-            PublishValidationError(
-                ERROR,
-                "$validationTargetLocalizationPrefix.no-context",
-                emptyMap()
-            )
+): List<PublishValidationError> = try {
+    geocode()?.let { addresses ->
+        validateAddressPoints(trackNumber, locationTrack, addresses)
+    } ?: listOf(
+        PublishValidationError(
+            ERROR, "$validationTargetLocalizationPrefix.no-context", emptyMap()
         )
-    } catch (e: ClientException) {
-        listOf(PublishValidationError(ERROR, e.localizedMessageKey))
-    }
+    )
+} catch (e: ClientException) {
+    listOf(PublishValidationError(ERROR, e.localizedMessageKey))
+}
 
 fun validateAddressPoints(
     trackNumber: TrackLayoutTrackNumber,
@@ -562,11 +519,9 @@ fun validateAddressPoints(
     )
 }
 
-fun validateReferenceLineAlignment(alignment: LayoutAlignment) =
-    validateAlignment(VALIDATION_REFERENCE_LINE, alignment)
+fun validateReferenceLineAlignment(alignment: LayoutAlignment) = validateAlignment(VALIDATION_REFERENCE_LINE, alignment)
 
-fun validateLocationTrackAlignment(alignment: LayoutAlignment) =
-    validateAlignment(VALIDATION_LOCATION_TRACK, alignment)
+fun validateLocationTrackAlignment(alignment: LayoutAlignment) = validateAlignment(VALIDATION_LOCATION_TRACK, alignment)
 
 private fun validateAlignment(errorParent: String, alignment: LayoutAlignment) = listOfNotNull(
     validate(alignment.segments.isNotEmpty()) { "$errorParent.empty-segments" },
@@ -608,25 +563,22 @@ private fun jointGroupMatches(alignmentJoints: List<JointNumber>, structureJoint
         alignmentStartAndEnd == structureStartAndEnd || alignmentStartAndEnd == structureStartAndEnd.reversed()
     }
 
-private fun collectJoints(structure: SwitchStructure) =
-    structure.alignments.flatMap { alignment ->
-        // For RR/KRV/YRV etc. structures partial alignments are also OK (like 1-5 and 5-2)
-        val firstJointNumber = alignment.jointNumbers.first()
-        val lastJointNumber = alignment.jointNumbers.last()
-        val presentationJointIndex =
-            alignment.jointNumbers.indexOfFirst { jointNumber -> jointNumber == structure.presentationJointNumber }
-        val partialAlignments = if (presentationJointIndex != -1 &&
-            firstJointNumber != structure.presentationJointNumber &&
-            lastJointNumber != structure.presentationJointNumber
-        ) {
+private fun collectJoints(structure: SwitchStructure) = structure.alignments.flatMap { alignment ->
+    // For RR/KRV/YRV etc. structures partial alignments are also OK (like 1-5 and 5-2)
+    val firstJointNumber = alignment.jointNumbers.first()
+    val lastJointNumber = alignment.jointNumbers.last()
+    val presentationJointIndex =
+        alignment.jointNumbers.indexOfFirst { jointNumber -> jointNumber == structure.presentationJointNumber }
+    val partialAlignments =
+        if (presentationJointIndex != -1 && firstJointNumber != structure.presentationJointNumber && lastJointNumber != structure.presentationJointNumber) {
             listOf(
                 alignment.jointNumbers.subList(0, presentationJointIndex + 1),
                 alignment.jointNumbers.subList(presentationJointIndex, alignment.jointNumbers.lastIndex + 1)
             )
         } else listOf()
 
-        listOf(alignment.jointNumbers) + partialAlignments
-    }
+    listOf(alignment.jointNumbers) + partialAlignments
+}
 
 private fun collectJoints(track: LocationTrack, segments: List<LayoutSegment>): Pair<LocationTrack, List<JointNumber>> =
     track to collectJoints(segments)
@@ -636,10 +588,9 @@ private fun collectJoints(segments: List<LayoutSegment>): List<JointNumber> {
     return allJoints.filterIndexed { index, jointNumber -> index == 0 || allJoints[index - 1] != jointNumber }
 }
 
-private fun areSegmentsContinuous(segments: List<LayoutSegment>): Boolean =
-    segments.mapIndexed { index, segment ->
-        index == 0 || segments[index - 1].points.last().isSame(segment.points.first(), LAYOUT_COORDINATE_DELTA)
-    }.all { it }
+private fun areSegmentsContinuous(segments: List<LayoutSegment>): Boolean = segments.mapIndexed { index, segment ->
+    index == 0 || segments[index - 1].points.last().isSame(segment.points.first(), LAYOUT_COORDINATE_DELTA)
+}.all { it }
 
 private fun areDirectionsContinuous(points: List<LayoutPoint>): Boolean {
     var prevDirection: Double? = null
@@ -677,32 +628,39 @@ private fun validateWithParams(
     valid: Boolean,
     type: PublishValidationErrorType = ERROR,
     error: () -> Pair<String, LocalizationParams>,
-): PublishValidationError? =
-    if (!valid) error().let { (key, params) -> PublishValidationError(type, key, params) }
-    else null
+): PublishValidationError? = if (!valid) error().let { (key, params) -> PublishValidationError(type, key, params) }
+else null
 
 private fun <T : Draftable<T>> isPublished(item: T, publishItemIds: List<IntId<T>>) =
     item.draft == null || publishItemIds.contains(item.id)
 
 data class TopologyEndLink(
     val topologySwitch: TopologyLocationTrackSwitch,
-    val point: LayoutPoint
+    val point: LayoutPoint,
 )
 
 private fun collectTopologyEndLinks(
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
-    switch: TrackLayoutSwitch
-) = locationTracks
-    .map { (track, alignment) ->
-        track to listOfNotNull(
-            track.topologyStartSwitch?.let { topologySwitch ->
-                if (topologySwitch.switchId == switch.id)
-                    alignment.start?.let { p -> TopologyEndLink(topologySwitch, p) }
-                else null
-            }, track.topologyEndSwitch?.let { topologySwitch ->
-                if (topologySwitch.switchId == switch.id)
-                    alignment.end?.let { p -> TopologyEndLink(topologySwitch, p) }
-                else null
-            }
-        )
-    }.filter { (_, ends) -> ends.isNotEmpty() }
+    switch: TrackLayoutSwitch,
+) = locationTracks.map { (track, alignment) ->
+    track to listOfNotNull(track.topologyStartSwitch?.let { topologySwitch ->
+        if (topologySwitch.switchId == switch.id) alignment.start?.let { p ->
+            TopologyEndLink(
+                topologySwitch, p
+            )
+        }
+        else null
+    }, track.topologyEndSwitch?.let { topologySwitch ->
+        if (topologySwitch.switchId == switch.id) alignment.end?.let { p -> TopologyEndLink(topologySwitch, p) }
+        else null
+    })
+}.filter { (_, ends) -> ends.isNotEmpty() }
+
+fun <T> combineVersions(
+    officials: List<RowVersion<T>>,
+    validations: List<ValidationVersion<T>>,
+): Collection<RowVersion<T>> {
+    val officialVersions = officials.filterNot { official -> validations.any { v -> v.officialId == official.id } }
+    val validationVersions = validations.map { it.validatedAssetVersion }
+    return (officialVersions + validationVersions).distinct()
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -456,9 +456,7 @@ fun validateAddressPoints(
     geocode()?.let { addresses ->
         validateAddressPoints(trackNumber, locationTrack, addresses)
     } ?: listOf(
-        PublishValidationError(
-            ERROR, "$validationTargetLocalizationPrefix.no-context", emptyMap()
-        )
+        PublishValidationError(ERROR, "$validationTargetLocalizationPrefix.no-context", emptyMap()),
     )
 } catch (e: ClientException) {
     listOf(PublishValidationError(ERROR, e.localizedMessageKey))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -147,7 +147,8 @@ class LayoutTrackNumberController(
     ): ResponseEntity<ByteArray> {
         logger.apiCall("getEntireRailNetworkTrackNumberKmLengthsAsCsv", "lang" to lang)
 
-        val csv = trackNumberService.getAllKmLengthsAsCsv(publishType = PublishType.OFFICIAL,
+        val csv = trackNumberService.getAllKmLengthsAsCsv(
+            publishType = PublishType.OFFICIAL,
             trackNumberIds = trackNumberService.listOfficial().map { tn ->
                 tn.id as IntId
             })

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -37,7 +37,7 @@ class LayoutTrackNumberController(
     @GetMapping("/{publishType}")
     fun getTrackNumbers(
         @PathVariable("publishType") publishType: PublishType,
-        @RequestParam("includeDeleted", defaultValue = "false") includeDeleted: Boolean
+        @RequestParam("includeDeleted", defaultValue = "false") includeDeleted: Boolean,
     ): List<TrackLayoutTrackNumber> {
         logger.apiCall("getTrackNumbers", "publishType" to publishType)
         return trackNumberService.list(publishType, includeDeleted)
@@ -96,8 +96,7 @@ class LayoutTrackNumberController(
         @RequestParam("bbox") boundingBox: BoundingBox? = null,
     ): List<AlignmentPlanSection> {
         logger.apiCall(
-            "getTrackSectionsByPlan",
-            "publishType" to publishType, "id" to id, "bbox" to boundingBox
+            "getTrackSectionsByPlan", "publishType" to publishType, "id" to id, "bbox" to boundingBox
         )
         return trackNumberService.getMetadataSections(id, publishType, boundingBox)
     }
@@ -109,9 +108,7 @@ class LayoutTrackNumberController(
         @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
     ): List<TrackLayoutKmLengthDetails> {
         logger.apiCall(
-            "getTrackNumberKmLengths",
-            "publishType" to publishType,
-            "id" to id
+            "getTrackNumberKmLengths", "publishType" to publishType, "id" to id
         )
 
         return trackNumberService.getKmLengths(publishType, id) ?: emptyList()
@@ -134,10 +131,7 @@ class LayoutTrackNumberController(
         )
 
         val csv = trackNumberService.getKmLengthsAsCsv(
-            publishType = publishType,
-            trackNumberId = id,
-            startKmNumber = startKmNumber,
-            endKmNumber = endKmNumber
+            publishType = publishType, trackNumberId = id, startKmNumber = startKmNumber, endKmNumber = endKmNumber
         )
 
         val trackNumber = trackNumberService.getOrThrow(publishType, id)
@@ -153,19 +147,25 @@ class LayoutTrackNumberController(
     ): ResponseEntity<ByteArray> {
         logger.apiCall("getEntireRailNetworkTrackNumberKmLengthsAsCsv", "lang" to lang)
 
-        val csv = trackNumberService.getAllKmLengthsAsCsv(
-            publishType = PublishType.OFFICIAL,
-            trackNumberIds = trackNumberService.listOfficial().map {
-                tn -> tn.id as IntId
-            }
-        )
+        val csv = trackNumberService.getAllKmLengthsAsCsv(publishType = PublishType.OFFICIAL,
+            trackNumberIds = trackNumberService.listOfficial().map { tn ->
+                tn.id as IntId
+            })
 
         val localization = localizationService.getLocalization(lang)
         val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneId.of("Europe/Helsinki"))
 
-        val fileDescription = localization.t("data-products.km-lengths.entire-rail-network-km-lengths-file-name-without-date")
+        val fileDescription =
+            localization.t("data-products.km-lengths.entire-rail-network-km-lengths-file-name-without-date")
         val fileDate = dateFormatter.format(Instant.now())
 
         return getCsvResponseEntity(csv, FileName("$fileDescription $fileDate.csv"))
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/{id}/change-times")
+    fun getTrackNumberChangeInfo(@PathVariable("id") id: IntId<TrackLayoutTrackNumber>): ChangeTimes {
+        logger.apiCall("getTrackNumberChangeInfo", "id" to id)
+        return trackNumberService.getChangeTimes(id)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
@@ -49,8 +49,7 @@ class ReferenceLineController(
         @PathVariable("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): ResponseEntity<ReferenceLine> {
         logger.apiCall(
-            "getTrackNumberReferenceLine",
-            "publishType" to publishType, "trackNumberId" to trackNumberId
+            "getTrackNumberReferenceLine", "publishType" to publishType, "trackNumberId" to trackNumberId
         )
         return toResponse(referenceLineService.getByTrackNumber(publishType, trackNumberId))
     }
@@ -72,15 +71,9 @@ class ReferenceLineController(
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): ResponseEntity<AlignmentStartAndEnd> {
         logger.apiCall("getReferenceLineStartAndEnd", "publishType" to publishType, "id" to id)
-        return toResponse(
-            referenceLineService.getWithAlignment(publishType, id)
-                ?.let { (referenceLine, alignment) ->
-                    geocodingService.getReferenceLineStartAndEnd(
-                        publishType,
-                        referenceLine,
-                        alignment
-                    )
-                })
+        return toResponse(referenceLineService.getWithAlignment(publishType, id)?.let { (referenceLine, alignment) ->
+            geocodingService.getReferenceLineStartAndEnd(publishType, referenceLine, alignment)
+        })
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1167,8 +1167,8 @@
                 "duplicate-name-official": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{switch}}",
                 "track-linkage": {
-                    "front-joint-not-connected":  "Vaihteen etujatkokselta ei jatku raidetta",
-                    "front-joint-only-duplicate-connected":  "Vaihteen etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
+                    "front-joint-not-connected": "Vaihteen etujatkokselta ei jatku raidetta",
+                    "front-joint-only-duplicate-connected": "Vaihteen etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
                     "switch-alignment-not-connected": "Joitakin vaihteen linjoja ei ole liitetty raiteelle: {{locationTracks}}",
                     "multiple-tracks-through-joint": "Joistain vaihteen pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}"
                 }
@@ -1432,7 +1432,8 @@
         },
         "action": {
             "cancel": "Poistu",
-            "save": "Tallenna"
+            "save": "Tallenna",
+            "move-to-edit": "Siirry muokkaamaan ratanumeroa {{number}}"
         },
         "result": {
             "failed": "Ratanumeron tallennus epäonnistui.",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1056,7 +1056,7 @@
     "validation": {
         "layout": {
             "track-number": {
-                "no-context": "Ratanumerolta ei voida laskea tasametripisteitä koska sitä puuttuu tietoja",
+                "no-context": "Ratanumerolta ei voida laskea tasametripisteitä koska siltä puuttuu tietoja",
                 "not-draft": "Virhe julkaisun sisällössä: julkaistava ratanumero ei ole luonnos",
                 "state": {
                     "PLANNED": "Ratanumero on tilassa \"Suunniteltu\""
@@ -1076,7 +1076,7 @@
                 "duplicate-name-draft": "Muutosjoukossa on monta ratanumeroa nimellä {{trackNumber}}"
             },
             "km-post": {
-                "no-context": "Ratanumerolta ei voida laskea tasametripisteitä koska sitä puuttuu tietoja",
+                "no-context": "Ratanumerolta ei voida laskea tasametripisteitä koska siltä puuttuu tietoja",
                 "not-draft": "Virhe julkaisun sisällössä: julkaistava tasakilometripiste ei ole luonnos",
                 "state": {
                     "PLANNED": "Tasakilometripiste on tilassa \"Suunniteltu\""
@@ -1096,7 +1096,7 @@
                 }
             },
             "reference-line": {
-                "no-context": "Pituusmittauslinjalle ei voida laskea tasametripisteitä koska sitä puuttuu tietoja",
+                "no-context": "Pituusmittauslinjalle ei voida laskea tasametripisteitä koska siltä puuttuu tietoja",
                 "not-draft": "Virhe julkaisun sisällössä: julkaistava pituusmittauslinja ei ole luonnos",
                 "track-number": {
                     "null": "Pituusmittauslinjan ratanumero ei ole mukana julkaisussa",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -95,10 +95,8 @@ class PublicationValidationTest {
     fun trackNumberValidationCatchesUnpublishedKmPost() {
         val trackNumber = trackNumber().copy(id = IntId(1))
         val referenceLine = referenceLine(trackNumberId = trackNumber.id as IntId).copy(id = IntId(1))
-        val unpublished = kmPost(trackNumber.id as IntId, KmNumber(1))
-            .copy(draft = Draft(IntId(2)), id = IntId(1))
-        val published = kmPost(trackNumber.id as IntId, KmNumber(1))
-            .copy(draft = null, id = IntId(1))
+        val unpublished = kmPost(trackNumber.id as IntId, KmNumber(1)).copy(draft = Draft(IntId(2)), id = IntId(1))
+        val published = kmPost(trackNumber.id as IntId, KmNumber(1)).copy(draft = null, id = IntId(1))
         assertTrackNumberReferenceError(
             true,
             trackNumber,
@@ -195,10 +193,7 @@ class PublicationValidationTest {
             id = IntId(1),
         ).first
         assertSwitchSegmentError(
-            false,
-            switch,
-            published,
-            "$VALIDATION_SWITCH.location-track.not-published"
+            false, switch, published, "$VALIDATION_SWITCH.location-track.not-published"
         )
         assertSwitchSegmentError(
             false,
@@ -220,19 +215,23 @@ class PublicationValidationTest {
         val switch = switch(structureId = structure.id as IntId).copy(id = IntId(1))
         val good = locationTrackAndAlignment(
             IntId(0),
-            segment(Point(0.0, 0.0), Point(10.0, 10.0))
-                .copy(switchId = switch.id, endJointNumber = switch.joints.last().number),
-            segment(Point(10.0, 10.0), Point(20.0, 20.0))
-                .copy(switchId = switch.id, startJointNumber = switch.joints.first().number),
+            segment(Point(0.0, 0.0), Point(10.0, 10.0)).copy(
+                switchId = switch.id, endJointNumber = switch.joints.last().number
+            ),
+            segment(Point(10.0, 10.0), Point(20.0, 20.0)).copy(
+                switchId = switch.id, startJointNumber = switch.joints.first().number
+            ),
             segment(Point(20.0, 20.0), Point(30.0, 30.0)),
         )
         val broken = locationTrackAndAlignment(
             IntId(0),
-            segment(Point(0.0, 0.0), Point(10.0, 10.0))
-                .copy(switchId = switch.id, endJointNumber = switch.joints.last().number),
+            segment(Point(0.0, 0.0), Point(10.0, 10.0)).copy(
+                switchId = switch.id, endJointNumber = switch.joints.last().number
+            ),
             segment(Point(10.0, 10.0), Point(20.0, 20.0)),
-            segment(Point(20.0, 20.0), Point(30.0, 30.0))
-                .copy(switchId = switch.id, startJointNumber = switch.joints.first().number),
+            segment(Point(20.0, 20.0), Point(30.0, 30.0)).copy(
+                switchId = switch.id, startJointNumber = switch.joints.first().number
+            ),
         )
 
         assertSwitchSegmentStructureError(
@@ -478,8 +477,7 @@ class PublicationValidationTest {
             )
         }
         assertSingleAddressPointErrorRangeDescription(
-            geocode,
-            "0000+0000..0000+0050, 0000+0060..0000+0110"
+            geocode, "0000+0000..0000+0050, 0000+0060..0000+0110"
         )
     }
 
@@ -606,7 +604,8 @@ class PublicationValidationTest {
     fun validationCatchesLoopyDuplicate() {
         val lt = locationTrack(IntId(0)).copy(duplicateOf = IntId(0))
         assertContainsError(
-            true, validateDuplicateOfState(lt, lt, listOf(IntId(0))),
+            true,
+            validateDuplicateOfState(lt, lt, listOf(IntId(0))),
             "$VALIDATION_LOCATION_TRACK.duplicate-of.duplicate"
         )
     }
@@ -614,23 +613,24 @@ class PublicationValidationTest {
     @Test
     fun validationCatchesMisplacedTopologyLink() {
         val wrongPlaceSwitch =
-            switch(seed = 123, joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(100.0, 100.0), null)))
-                .copy(id = IntId(1))
+            switch(seed = 123, joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(100.0, 100.0), null))).copy(
+                id = IntId(1)
+            )
         val rightPlaceSwitch =
-            switch(seed = 124, joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(200.0, 200.0), null)))
-                .copy(id = IntId(2))
+            switch(seed = 124, joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(200.0, 200.0), null))).copy(
+                id = IntId(2)
+            )
         val unlinkedTrack = locationTrackAndAlignment(
-            IntId(0),
-            segment(Point(150.0, 150.0), Point(200.0, 200.0))
+            IntId(0), segment(Point(150.0, 150.0), Point(200.0, 200.0))
         )
-        val lt = unlinkedTrack.first
-            .copy(
-                topologyStartSwitch = TopologyLocationTrackSwitch(wrongPlaceSwitch.id as IntId, JointNumber(1)),
-                topologyEndSwitch = TopologyLocationTrackSwitch(rightPlaceSwitch.id as IntId, JointNumber(1))
-            ) to unlinkedTrack.second
+        val lt = unlinkedTrack.first.copy(
+            topologyStartSwitch = TopologyLocationTrackSwitch(wrongPlaceSwitch.id as IntId, JointNumber(1)),
+            topologyEndSwitch = TopologyLocationTrackSwitch(rightPlaceSwitch.id as IntId, JointNumber(1))
+        ) to unlinkedTrack.second
 
         assertContainsError(
-            true, validateSwitchLocationTrackLinkStructure(wrongPlaceSwitch, switchStructureYV60_300_1_9(), listOf(lt)),
+            true,
+            validateSwitchLocationTrackLinkStructure(wrongPlaceSwitch, switchStructureYV60_300_1_9(), listOf(lt)),
             "$VALIDATION_SWITCH.location-track.joint-location-mismatch"
         )
 
@@ -638,6 +638,29 @@ class PublicationValidationTest {
             false,
             validateSwitchLocationTrackLinkStructure(rightPlaceSwitch, switchStructureYV60_300_1_9(), listOf(lt)),
             "$VALIDATION_SWITCH.location-track.joint-location-mismatch"
+        )
+    }
+
+    @Test
+    fun `Combine versions overrides official version with validation version`() {
+        val officialVersions: List<RowVersion<PublicationValidationTest>> = listOf(
+            RowVersion(IntId(1), 2),
+            RowVersion(IntId(2), 3),
+            RowVersion(IntId(3), 4),
+        )
+        val validationVersions: List<ValidationVersion<PublicationValidationTest>> = listOf(
+            ValidationVersion(IntId(2), RowVersion(IntId(16), 1)),
+            ValidationVersion(IntId(4), RowVersion(IntId(17), 1)),
+        )
+        assertEquals(
+            listOf(
+                RowVersion(IntId(1), 2),
+                // Official version for row 2 gets replace by draft 16_1
+                RowVersion(IntId(3), 4),
+                RowVersion(IntId(16), 1),
+                RowVersion(IntId(17), 1),
+            ),
+            combineVersions(officialVersions, validationVersions),
         )
     }
 

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -92,8 +92,8 @@ export type ElementLocation = {
 };
 
 export type ChangeTimes = {
-    changed: Date;
-    created: Date;
+    changed: TimeStamp;
+    created: TimeStamp;
 };
 
 export type Message = string;

--- a/ui/src/geoviite-design-lib/track-meter/track-meter.tsx
+++ b/ui/src/geoviite-design-lib/track-meter/track-meter.tsx
@@ -4,10 +4,11 @@ import { TrackMeter } from 'common/common-model';
 
 type TrackMeterProps = {
     value?: TrackMeter;
+    placeholder?: string;
 };
 
-const TrackMeter: React.FC<TrackMeterProps> = ({ value }: TrackMeterProps) => {
-    return <React.Fragment>{value ? formatTrackMeter(value) : ''}</React.Fragment>;
+const TrackMeter: React.FC<TrackMeterProps> = ({ value, placeholder }: TrackMeterProps) => {
+    return <React.Fragment>{value ? formatTrackMeter(value) : placeholder ?? ''}</React.Fragment>;
 };
 
 export default TrackMeter;

--- a/ui/src/geoviite-design-lib/track-number/track-number-link.tsx
+++ b/ui/src/geoviite-design-lib/track-number/track-number-link.tsx
@@ -9,6 +9,7 @@ import { createEmptyItemCollections } from 'selection/selection-store';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { LoaderStatus } from 'utils/react-utils';
 import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
+import { useTranslation } from 'react-i18next';
 
 export type TrackNumberLinkContainerProps = {
     trackNumberId?: LayoutTrackNumberId;
@@ -50,16 +51,23 @@ export const TrackNumberLink: React.FC<TrackNumberLinkProps> = ({
     changeTime,
     onClick,
 }: TrackNumberLinkProps) => {
+    const { t } = useTranslation();
     const [trackNumber, status] = useTrackNumberWithStatus(
         publicationType,
         trackNumberId,
         changeTime,
     );
     const clickAction = onClick || createSelectAction();
+    const name = trackNumber?.number || '';
     return status === LoaderStatus.Ready ? (
-        <Link onClick={() => trackNumber && clickAction(trackNumber.id)}>
-            {trackNumber?.number || ''}
-        </Link>
+        <React.Fragment>
+            <Link onClick={() => trackNumber && clickAction(trackNumber.id)}>{name}</Link>
+            {trackNumber?.state === 'DELETED' ? (
+                <span>&nbsp;({t('enum.layout-state.DELETED')})</span>
+            ) : (
+                ''
+            )}
+        </React.Fragment>
     ) : (
         <Spinner />
     );

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -76,7 +76,9 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
     const { t } = useTranslation();
     const [trackNumbers, setTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
     React.useEffect(() => {
-        getTrackNumbers('DRAFT').then((trackNumbers) => setTrackNumbers(trackNumbers));
+        getTrackNumbers('DRAFT', undefined, true).then((trackNumbers) =>
+            setTrackNumbers(trackNumbers),
+        );
     }, []);
 
     const [sortInfo, setSortInfo] = React.useState<SortInformation>(InitiallyUnsorted);

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -118,7 +118,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     // Load track numbers once
     React.useEffect(() => {
         stateActions.onStartLoadingTrackNumbers();
-        getTrackNumbers('DRAFT').then((trackNumbers) => {
+        getTrackNumbers('DRAFT', undefined, true).then((trackNumbers) => {
             stateActions.onTrackNumbersLoaded(trackNumbers);
         });
     }, []);
@@ -300,6 +300,14 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         const number = parseInt(numberPart, 10);
         return !isNaN(number) ? `V${number.toString(10).padStart(3, '0')}` : undefined;
     };
+    const trackNumberOptions = state.trackNumbers
+        .filter(
+            (tn) => tn.id === state.existingLocationTrack?.trackNumberId || tn.state !== 'DELETED',
+        )
+        .map((tn) => {
+            const note = tn.state === 'DELETED' ? ` (${t('enum.layout-state.DELETED')})` : '';
+            return { name: tn.number + note, value: tn.id };
+        });
 
     return (
         <React.Fragment>
@@ -373,10 +381,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                             value={
                                 <Dropdown
                                     value={state.locationTrack?.trackNumberId}
-                                    options={state.trackNumbers.map((trackNumber) => ({
-                                        name: trackNumber.number,
-                                        value: trackNumber.id,
-                                    }))}
+                                    options={trackNumberOptions}
                                     onChange={(value) => updateProp('trackNumberId', value)}
                                     onBlur={() => stateActions.onCommitField('trackNumberId')}
                                     hasError={hasErrors('trackNumberId')}

--- a/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
@@ -9,10 +9,13 @@ import { useTranslation } from 'react-i18next';
 import { switchJointNumberToString } from 'utils/enum-localization-utils';
 import { ShowMoreButton } from 'show-more-button/show-more-button';
 
-const formatJointTrackMeter = (jointTrackMeter: SwitchJointTrackMeter) => {
+const formatJointTrackMeter = (
+    jointTrackMeter: SwitchJointTrackMeter,
+    addressPlaceHolder: string,
+) => {
     return (
         <span>
-            <TrackMeter value={jointTrackMeter.trackMeter} />
+            <TrackMeter value={jointTrackMeter.trackMeter} placeholder={addressPlaceHolder} />
             <br />
             <LocationTrackLink
                 locationTrackId={jointTrackMeter.locationTrackId}
@@ -47,18 +50,18 @@ export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> =
         setShowOtherJoints(false);
     }, [jointTrackMeters, presentationJoint]);
 
+    const addressMissingText = t('tool-panel.switch.layout.no-location');
+
     return (
         <div className="switch-infobox-track-meters">
             <section>
-                {presentationJointAddress.length === 0 && (
-                    <span>{t('tool-panel.switch.layout.no-location')}</span>
-                )}
+                {presentationJointAddress.length === 0 && <span>{addressMissingText}</span>}
                 <ol className={styles['switch-infobox-track-meters__track-meters']}>
                     {presentationJointAddress.map((pja) => (
                         <li
                             key={pja.locationTrackId}
                             className={styles['switch-infobox-track-meters__track-meter']}>
-                            {formatJointTrackMeter(pja)}
+                            {formatJointTrackMeter(pja, addressMissingText)}
                         </li>
                     ))}
                 </ol>
@@ -80,7 +83,7 @@ export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> =
                                         className={
                                             styles['switch-infobox-track-meters__track-meter']
                                         }>
-                                        {formatJointTrackMeter(a)}
+                                        {formatJointTrackMeter(a, addressMissingText)}
                                     </li>
                                 ))}
                             </ol>

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -60,7 +60,7 @@ type SwitchInfoboxProps = {
 const mapToSwitchJointTrackMeter = (
     jointNumber: JointNumber,
     locationTrack: LayoutLocationTrack,
-    trackMeter: TrackMeter,
+    trackMeter: TrackMeter | undefined,
 ): SwitchJointTrackMeter => {
     return {
         locationTrackId: locationTrack.id,
@@ -92,9 +92,7 @@ const getTrackMeterForPoint = async (
         location,
     );
 
-    return trackMeter
-        ? mapToSwitchJointTrackMeter(jointNumber, locationTrack, trackMeter)
-        : undefined;
+    return mapToSwitchJointTrackMeter(jointNumber, locationTrack, trackMeter);
 };
 
 const getSwitchJointTrackMeters = async (
@@ -139,7 +137,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
         () => getSwitch(switchId, publishType),
         [switchId, changeTimes.layoutSwitch, publishType],
     );
-    const switchStructure = switchStructures?.find(
+    const structure = switchStructures?.find(
         (structure) => structure.id === layoutSwitch?.switchStructureId,
     );
     const switchJointConnections = useLoader(
@@ -154,12 +152,11 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
             : undefined;
     }, [switchJointConnections, publishType, changeTimes]);
 
-    const SwitchImage =
-        switchStructure && makeSwitchImage(switchStructure.baseType, switchStructure.hand);
+    const SwitchImage = structure && makeSwitchImage(structure.baseType, structure.hand);
     const switchLocation =
-        switchStructure &&
+        structure &&
         layoutSwitch &&
-        getSwitchPresentationJoint(layoutSwitch, switchStructure.presentationJointNumber)?.location;
+        getSwitchPresentationJoint(layoutSwitch, structure.presentationJointNumber)?.location;
 
     const [showEditDialog, setShowEditDialog] = React.useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
@@ -214,7 +211,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                                 (switchJointTrackMeters && (
                                     <SwitchInfoboxTrackMeters
                                         jointTrackMeters={switchJointTrackMeters}
-                                        presentationJoint={switchStructure?.presentationJointNumber}
+                                        presentationJoint={structure?.presentationJointNumber}
                                     />
                                 )) || <Spinner />
                             }
@@ -257,13 +254,13 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                 title={t('tool-panel.switch.layout.structure-heading')}
                 qa-id="switch-structure-infobox">
                 <InfoboxContent>
-                    <p>{switchStructure ? switchStructure.type : ''}</p>
+                    <p>{structure ? structure.type : ''}</p>
                     {SwitchImage && (
                         <SwitchImage size={IconSize.ORIGINAL} color={IconColor.INHERIT} />
                     )}
                     <InfoboxField
                         label={t('tool-panel.switch.layout.hand')}
-                        value={switchStructure && <SwitchHand hand={switchStructure.hand} />}
+                        value={structure && <SwitchHand hand={structure.hand} />}
                     />
                     <InfoboxField
                         label={t('tool-panel.switch.layout.trap-point')}
@@ -284,9 +281,9 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                         label={t('tool-panel.switch.layout.coordinates')}
                         value={switchLocation ? formatToTM35FINString(switchLocation) : '-'}
                     />
-                    {switchStructure && switchJointConnections && (
+                    {structure && switchJointConnections && (
                         <SwitchJointInfobox
-                            switchAlignments={switchStructure.alignments}
+                            switchAlignments={structure.alignments}
                             jointConnections={switchJointConnections}
                             publishType={publishType}
                         />

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -141,7 +141,11 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     }, []);
 
     const tracksSwitchesKmPostsPlans = useLoader(() => {
-        const trackNumbersPromise = getTrackNumbers(publishType, changeTimes.layoutTrackNumber);
+        const trackNumbersPromise = getTrackNumbers(
+            publishType,
+            changeTimes.layoutTrackNumber,
+            true,
+        );
         const locationTracksPromise = getLocationTracks(locationTrackIds, publishType);
         const switchesPromise = getSwitches(switchIds, publishType);
         const kmPostsPromise = getKmPosts(kmPostIds, publishType);
@@ -245,7 +249,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                             publishType={publishType}
                             linkingState={linkingState}
                             onUnselect={onUnselect}
-                            referenceLineChangeTime={changeTimes.layoutReferenceLine}
+                            changeTimes={changeTimes}
                             viewport={viewport}
                             onHoverOverPlanSection={onHoverOverPlanSection}
                         />

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -10,7 +10,7 @@ import { createTrackNumber, updateTrackNumber } from 'track-layout/layout-track-
 import {
     useReferenceLineStartAndEnd,
     useTrackNumberReferenceLine,
-    useTrackNumbers,
+    useTrackNumbersIncludingDeleted,
 } from 'track-layout/track-layout-react-utils';
 import { Heading, HeadingSize } from 'vayla-design-lib/heading/heading';
 import {
@@ -35,6 +35,7 @@ import styles from 'vayla-design-lib/dialog/dialog.scss';
 import dialogStyles from 'vayla-design-lib/dialog/dialog.scss';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import TrackNumberDeleteConfirmationDialog from 'tool-panel/track-number/dialog/track-number-delete-confirmation-dialog';
+import { Link } from 'vayla-design-lib/link/link';
 
 type TrackNumberEditDialogContainerProps = {
     editTrackNumberId?: LayoutTrackNumberId;
@@ -49,6 +50,7 @@ type TrackNumberEditDialogProps = {
     trackNumbers: LayoutTrackNumber[];
     onClose: () => void;
     onSave?: (trackNumberId: LayoutTrackNumberId) => void;
+    onEditTrackNumber: (trackNumberId: LayoutTrackNumberId) => void;
 };
 
 export const TrackNumberEditDialogContainer: React.FC<TrackNumberEditDialogContainerProps> = ({
@@ -56,19 +58,23 @@ export const TrackNumberEditDialogContainer: React.FC<TrackNumberEditDialogConta
     onClose,
     onSave,
 }: TrackNumberEditDialogContainerProps) => {
-    const trackNumbers = useTrackNumbers('DRAFT');
-    const editReferenceLine = useTrackNumberReferenceLine(editTrackNumberId, 'DRAFT');
+    const trackNumbers = useTrackNumbersIncludingDeleted('DRAFT');
+    const [trackNumberId, setTrackNumberId] = React.useState<LayoutTrackNumberId | undefined>(
+        editTrackNumberId,
+    );
+    const editReferenceLine = useTrackNumberReferenceLine(trackNumberId, 'DRAFT');
     const isDeletable = editReferenceLine?.draftType === 'NEW_DRAFT';
 
-    if (trackNumbers !== undefined && (!editTrackNumberId || editReferenceLine)) {
+    if (trackNumbers !== undefined && trackNumberId == editReferenceLine?.trackNumberId) {
         return (
             <TrackNumberEditDialog
-                inEditTrackNumber={trackNumbers.find((tn) => tn.id == editTrackNumberId)}
+                inEditTrackNumber={trackNumbers.find((tn) => tn.id == trackNumberId)}
                 inEditReferenceLine={editReferenceLine}
                 trackNumbers={trackNumbers}
                 isNewDraft={isDeletable}
                 onClose={onClose}
                 onSave={onSave}
+                onEditTrackNumber={setTrackNumberId}
             />
         );
     } else {
@@ -83,6 +89,7 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
     isNewDraft,
     onClose,
     onSave,
+    onEditTrackNumber,
 }: TrackNumberEditDialogProps) => {
     const { t } = useTranslation();
 
@@ -118,7 +125,7 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
     };
 
     const saveOrConfirm = () => {
-        if (state.request?.state === 'DELETED') {
+        if (state.request?.state === 'DELETED' && inEditTrackNumber?.state !== 'DELETED') {
             setNonDraftDeleteConfirmationVisible(true);
         } else {
             saveTrackNumber();
@@ -152,6 +159,12 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
     const stateErrors = getErrors(state, 'state');
     const descriptionErrors = getErrors(state, 'description');
     const startAddressErrors = getErrors(state, 'startAddress');
+
+    const otherTrackNumber = trackNumbers.find(
+        (tn) =>
+            tn.number.toLowerCase() === state.request.number.toLowerCase() &&
+            tn.id !== inEditTrackNumber?.id,
+    );
 
     return (
         <React.Fragment>
@@ -218,6 +231,13 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
                             }
                             errors={numberErrors.map((e) => t(e.reason))}
                         />
+                        {otherTrackNumber && (
+                            <Link onClick={() => onEditTrackNumber(otherTrackNumber.id)}>
+                                {t('track-number-edit.action.move-to-edit', {
+                                    number: otherTrackNumber.number,
+                                })}
+                            </Link>
+                        )}
                         <FieldLayout
                             label={`${t('track-number-edit.field.state')} *`}
                             value={

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -229,15 +229,17 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
                                     wide
                                 />
                             }
-                            errors={numberErrors.map((e) => t(e.reason))}
-                        />
-                        {otherTrackNumber && (
-                            <Link onClick={() => onEditTrackNumber(otherTrackNumber.id)}>
-                                {t('track-number-edit.action.move-to-edit', {
-                                    number: otherTrackNumber.number,
-                                })}
-                            </Link>
-                        )}
+                            errors={numberErrors.map((e) => t(e.reason))}>
+                            {otherTrackNumber && (
+                                <Link
+                                    className="move-to-edit-link"
+                                    onClick={() => onEditTrackNumber(otherTrackNumber.id)}>
+                                    {t('track-number-edit.action.move-to-edit', {
+                                        number: otherTrackNumber.number,
+                                    })}
+                                </Link>
+                            )}
+                        </FieldLayout>
                         <FieldLayout
                             label={`${t('track-number-edit.field.state')} *`}
                             value={

--- a/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
@@ -5,7 +5,7 @@ import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
-import { PublishType } from 'common/common-model';
+import { PublishType, TimeStamp } from 'common/common-model';
 import { MapViewport } from 'map/map-model';
 import {
     AlignmentPlanSectionInfoboxContent,
@@ -25,6 +25,7 @@ type TrackNumberGeometryInfoboxProps = {
     contentVisible: boolean;
     onContentVisibilityChange: () => void;
     onHighlightItem: (item: HighlightedAlignment | undefined) => void;
+    changeTime: TimeStamp;
 };
 
 export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProps> = ({
@@ -34,6 +35,7 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
     contentVisible,
     onContentVisibilityChange,
     onHighlightItem,
+    changeTime,
 }) => {
     const { t } = useTranslation();
     const [useBoundingBox, setUseBoundingBox] = React.useState(true);
@@ -45,7 +47,7 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
                 trackNumberId,
                 useBoundingBox ? viewport.area : undefined,
             ),
-        [trackNumberId, publishType, viewportDep],
+        [trackNumberId, publishType, viewportDep, changeTime],
     );
 
     return (

--- a/ui/src/tool-panel/track-number/track-number-infobox-linking-container.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox-linking-container.tsx
@@ -6,18 +6,19 @@ import {
     trackLayoutActionCreators as TrackLayoutActions,
     TrackNumberInfoboxVisibilities,
 } from 'track-layout/track-layout-slice';
-import { PublishType, TimeStamp } from 'common/common-model';
+import { PublishType } from 'common/common-model';
 import { useTrackNumberReferenceLine } from 'track-layout/track-layout-react-utils';
 import TrackNumberInfobox from 'tool-panel/track-number/track-number-infobox';
 import { OptionalUnselectableItemCollections } from 'selection/selection-model';
 import { MapViewport } from 'map/map-model';
 import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
+import { ChangeTimes } from 'common/common-slice';
 
 type TrackNumberInfoboxLinkingContainerProps = {
     trackNumber: LayoutTrackNumber;
     linkingState?: LinkingState;
     publishType: PublishType;
-    referenceLineChangeTime: TimeStamp;
+    changeTimes: ChangeTimes;
     onUnselect: (items: OptionalUnselectableItemCollections) => void;
     viewport: MapViewport;
     visibilities: TrackNumberInfoboxVisibilities;
@@ -29,7 +30,7 @@ const TrackNumberInfoboxLinkingContainer: React.FC<TrackNumberInfoboxLinkingCont
     trackNumber,
     linkingState,
     publishType,
-    referenceLineChangeTime,
+    changeTimes,
     onUnselect,
     viewport,
     visibilities,
@@ -40,7 +41,7 @@ const TrackNumberInfoboxLinkingContainer: React.FC<TrackNumberInfoboxLinkingCont
     const referenceLine = useTrackNumberReferenceLine(
         trackNumber.id,
         publishType,
-        referenceLineChangeTime,
+        changeTimes.layoutReferenceLine,
     );
 
     return (
@@ -59,7 +60,7 @@ const TrackNumberInfoboxLinkingContainer: React.FC<TrackNumberInfoboxLinkingCont
             showArea={delegates.showArea}
             publishType={publishType}
             viewport={viewport}
-            referenceLineChangeTime={referenceLineChangeTime}
+            changeTimes={changeTimes}
             visibilities={visibilities}
             onVisibilityChange={onVisibilityChange}
             onUnselect={() =>

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -71,10 +71,14 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
     onHighlightItem,
 }: TrackNumberInfoboxProps) => {
     const { t } = useTranslation();
+    const trackNumberChangeTime = getMaxTimestamp(
+        changeTimes.layoutTrackNumber,
+        changeTimes.layoutReferenceLine,
+    );
     const startAndEndPoints = useReferenceLineStartAndEnd(
         referenceLine?.id,
         publishType,
-        changeTimes.layoutReferenceLine,
+        trackNumberChangeTime,
     );
     const coordinateSystem = useCoordinateSystem(LAYOUT_SRID);
     const tnChangeTimes = useTrackNumberChangeTimes(trackNumber?.id);
@@ -284,6 +288,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                     publishType={publishType}
                     viewport={viewport}
                     onHighlightItem={onHighlightItem}
+                    changeTime={trackNumberChangeTime}
                 />
             )}
             {trackNumber.draftType !== 'NEW_DRAFT' && (
@@ -293,10 +298,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                     id={trackNumber.id}
                     type={'TRACK_NUMBER'}
                     publishType={publishType}
-                    changeTime={getMaxTimestamp(
-                        changeTimes.layoutTrackNumber,
-                        changeTimes.layoutReferenceLine,
-                    )}
+                    changeTime={trackNumberChangeTime}
                 />
             )}
             {createdTime && changedTime && (

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -421,7 +421,7 @@ export async function getTrackMeter(
         changeTime,
         `${trackNumberId}_${publishType}_${pointString(location)}`,
         () => {
-            return getNonNull<TrackMeter>(
+            return getNullable<TrackMeter>(
                 `${geocodingUri(publishType)}/address/${trackNumberId}${params}`,
             );
         },

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -126,10 +126,12 @@ export async function getReferenceLineMapAlignmentsByTiles(
     mapTiles: MapTile[],
     publishType: PublishType,
 ) {
+    const changeTime = getMaxTimestamp(
+        changeTimes.layoutReferenceLine,
+        changeTimes.layoutTrackNumber,
+    );
     const polyLines = await Promise.all(
-        mapTiles.map((tile) =>
-            getPolyLines(tile, changeTimes.layoutReferenceLine, publishType, 'REFERENCE_LINES'),
-        ),
+        mapTiles.map((tile) => getPolyLines(tile, changeTime, publishType, 'REFERENCE_LINES')),
     ).then((p) => p.flat());
 
     return getAlignmentDataHolder('REFERENCE_LINE', polyLines, publishType, changeTimes);

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -4,9 +4,16 @@ import {
     LayoutTrackNumberId,
     LocationTrackId,
 } from 'track-layout/track-layout-model';
-import { PublishType, TimeStamp } from 'common/common-model';
-import { deleteAdt, getNonNull, postIgnoreError, putIgnoreError, queryParams } from 'api/api-fetch';
-import { layoutUri } from 'track-layout/track-layout-api';
+import { ChangeTimes, PublishType, TimeStamp } from 'common/common-model';
+import {
+    deleteAdt,
+    getNonNull,
+    getNullable,
+    postIgnoreError,
+    putIgnoreError,
+    queryParams,
+} from 'api/api-fetch';
+import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
 import { TrackNumberSaveRequest } from 'tool-panel/track-number/dialog/track-number-edit-store';
 import {
     getChangeTimes,
@@ -27,7 +34,7 @@ export async function getTrackNumberById(
     publishType: PublishType,
     changeTime?: TimeStamp,
 ): Promise<LayoutTrackNumber | undefined> {
-    return getTrackNumbers(publishType, changeTime).then((trackNumbers) =>
+    return getTrackNumbers(publishType, changeTime, true).then((trackNumbers) =>
         trackNumbers.find((trackNumber) => trackNumber.id == trackNumberId),
     );
 }
@@ -93,4 +100,10 @@ export const getTrackNumberReferenceLineSectionsByPlan = async (
     return getNonNull<AlignmentPlanSection[]>(
         `${layoutUri('track-numbers', publishType, id)}/plan-geometry/${params}`,
     );
+};
+
+export const getTrackNumberChangeTimes = (
+    id: LayoutTrackNumberId,
+): Promise<ChangeTimes | undefined> => {
+    return getNullable<ChangeTimes>(changeTimeUri('track-numbers', id));
 };

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -272,7 +272,7 @@ export type SwitchJointTrackMeter = {
     jointNumber: JointNumber;
     locationTrackId: LocationTrackId;
     locationTrackName: string;
-    trackMeter: TrackMeter;
+    trackMeter: TrackMeter | undefined;
 };
 
 export function combineLayoutPoints(points: LayoutPoint[][]): LayoutPoint[] {

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -40,7 +40,11 @@ import {
     getLocationTrackStartAndEnd,
 } from 'track-layout/layout-location-track-api';
 import { getSwitch, getSwitchChangeTimes, getSwitches } from 'track-layout/layout-switch-api';
-import { getTrackNumberById, getTrackNumbers } from 'track-layout/layout-track-number-api';
+import {
+    getTrackNumberById,
+    getTrackNumberChangeTimes,
+    getTrackNumbers,
+} from 'track-layout/layout-track-number-api';
 import { getKmPost, getKmPostChangeTimes, getKmPosts } from 'track-layout/layout-km-post-api';
 import { PVDocumentHeader, PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { getPVDocument } from 'infra-model/infra-model-api';
@@ -210,6 +214,12 @@ export function useLocationTrackInfoboxExtras(
 
 export function usePlanHeader(id: GeometryPlanId | undefined): GeometryPlanHeader | undefined {
     return useLoader(() => (id ? getGeometryPlanHeader(id) : undefined), [id]);
+}
+
+export function useTrackNumberChangeTimes(
+    id: LayoutTrackNumberId | undefined,
+): ChangeTimes | undefined {
+    return useOptionalLoader(() => (id ? getTrackNumberChangeTimes(id) : undefined), [id]);
 }
 
 export function useReferenceLineChangeTimes(

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -129,10 +129,13 @@ export function groupBy<T, K extends string | number>(
     array: T[],
     getKey: (item: T) => K,
 ): Record<K, T[]> {
-    return array.reduce((acc, item) => {
-        (acc[getKey(item)] ||= []).push(item);
-        return acc;
-    }, {} as Record<K, T[]>);
+    return array.reduce(
+        (acc, item) => {
+            (acc[getKey(item)] ||= []).push(item);
+            return acc;
+        },
+        {} as Record<K, T[]>,
+    );
 }
 
 /**
@@ -161,6 +164,16 @@ export function itemsEqual<T>(
                     ),
             ))
     );
+}
+
+export function minOf<T>(values: T[], comparator: (v1: T, v2: T) => number): T | undefined {
+    return values.reduce<T | undefined>((old, candidate, index) => {
+        if (index == 0 || comparator(old as T, candidate) > 0) {
+            return candidate;
+        } else {
+            return old;
+        }
+    }, undefined);
 }
 
 export function maxOf<T>(values: T[], comparator: (v1: T, v2: T) => number): T | undefined {

--- a/ui/src/utils/date-utils.ts
+++ b/ui/src/utils/date-utils.ts
@@ -1,5 +1,5 @@
 import { TimeStamp } from 'common/common-model';
-import { maxOf } from 'utils/array-utils';
+import { maxOf, minOf } from 'utils/array-utils';
 import { format, getYear, startOfToday } from 'date-fns';
 
 export const currentDay = startOfToday();
@@ -46,6 +46,10 @@ export function toDateOrUndefined(timestampStr: TimeStamp): Date | undefined {
 export function compareTimestamps(t1: TimeStamp, t2: TimeStamp): number {
     const d1 = toDateOrUndefined(t1);
     const d2 = toDateOrUndefined(t2);
+    return compareDates(d1, d2);
+}
+
+export function compareDates(d1: Date | undefined, d2: Date | undefined): number {
     if (!d1 && !d2) {
         return 0;
     } else if (!d1) {
@@ -61,6 +65,10 @@ export function compareTimestamps(t1: TimeStamp, t2: TimeStamp): number {
     }
     // should never happen, compiler does not understand this
     throw new Error('Logic of compareTimestamps fails!');
+}
+
+export function getMinTimestamp(time1: TimeStamp, ...others: TimeStamp[]) {
+    return minOf([time1, ...others], compareTimestamps) as TimeStamp;
 }
 
 export function getMaxTimestamp(time1: TimeStamp, ...others: TimeStamp[]) {

--- a/ui/src/vayla-design-lib/field-layout/field-layout.tsx
+++ b/ui/src/vayla-design-lib/field-layout/field-layout.tsx
@@ -8,6 +8,7 @@ export type FieldLayoutProps = {
     help?: React.ReactNode;
     warnings?: string[];
     errors?: string[];
+    children?: React.ReactNode;
 };
 
 export const FieldLayout: React.FC<FieldLayoutProps> = (props: FieldLayoutProps) => {
@@ -40,6 +41,8 @@ export const FieldLayout: React.FC<FieldLayoutProps> = (props: FieldLayoutProps)
                     ))}
                 </div>
             )}
+
+            {props.children}
         </div>
     );
 };

--- a/ui/src/vayla-design-lib/layers.scss
+++ b/ui/src/vayla-design-lib/layers.scss
@@ -1,3 +1,3 @@
-$layer-popup: 90;
+$layer-popup: 100;
 $layer-menu: 100;
 $layer-glass: 110;

--- a/ui/src/vayla-design-lib/layers.scss
+++ b/ui/src/vayla-design-lib/layers.scss
@@ -1,3 +1,3 @@
-$layer-menu: 90;
-$layer-popup: 100;
+$layer-popup: 90;
+$layer-menu: 100;
 $layer-glass: 110;


### PR DESCRIPTION
Tätä tutkiessa törmäsin joukkoon muita ongelmia joita paljastui aina edellisen takaa seuraava. Korjattu nämä:
- Ratanumeron pituusmittauslinja ei poistu heti kartalta kun se merkkaa poistetuksi
- Ratanumeron poistuessa sen toolpanelin infoboxin tiedot eivät päivity kaikilta osin (validointi, geometria, jne)
- Validointi valittaa poistettuun ratanumeroon viittaavastakm-pisteestä ja raiteesta vaikka nekin olisi jo poistettu
- Ratanumeron poiston seurauksena vaihteen tietojen katselussa lensi virheitä johtuen osoitteiden haun epäonnistumisesta
- Poistettu ratanumero ei näy esikatselun raiteiden/km-pisteiden tiedoissa ratanumero-columnissa
- Kun ratanumero on poistettu, raiteen ratanumero-kenttä toolpanelissa näyttää loputonta spinneriä
- UI:lla esitetty ratanumerolinkki poistettuun ratanumeroon jättää panelin tyhjäksi
- Kun ratanumero on poistettu, raiteen/km-pylvään edit-dialogin ratanumero-kenttä näyttää tyhjää
- Poistetun ratanumeron edit-dialogi on rikki (luulee olevansa uuden lisäysdialogi), joten sitä ei voi palauttaa
- Ratanumeron luotu/muokattu -ajat näytetään vain pituusmittauslinjan muutosten mukaan, ei itse ratanumeron
- Poistetun ratanumeron muusta muokkauksesta (jossa tilaan ei kosketa) tulee poisto-varoitus-dialogi
- Poistetun ratanumeron palauttaminen antaa julkaisuvirheen, koska geokoodauskontekstin haku epäonnistuu

Lisäksi korjattu alkuperäisen bugin ongelma:
- Ei voi luoda uutta ratanumeroa poistetun tilalle -> korjattu niin että ohjaa editoimaan vanhaa. Puhutaan tästä vielä dailyssä (onko tämä haluttu tapa vai pitäisikö oikeasti tehdä vain uusi)