### PR TITLE
Rename second changetimes

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -41,7 +41,7 @@ interface IDraftableObjectReader<T : Draftable<T>> {
     fun fetch(version: RowVersion<T>): T
 
     fun fetchChangeTime(): Instant
-    fun fetchChangeTimes(id: IntId<T>): ChangeTimes
+    fun fetchChangeTimes(id: IntId<T>): DraftableChangeInfo
 
     fun fetchAllVersions(): List<RowVersion<T>>
     fun fetchVersions(publicationState: PublishType, includeDeleted: Boolean): List<RowVersion<T>>
@@ -123,7 +123,7 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
 
     override fun fetchChangeTime(): Instant = fetchLatestChangeTime(table)
 
-    override fun fetchChangeTimes(id: IntId<T>): ChangeTimes {
+    override fun fetchChangeTimes(id: IntId<T>): DraftableChangeInfo {
         val sql = """
             select
               greatest(main_row.change_time, draft_row.change_time) as change_time,
@@ -137,7 +137,7 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
               and (main_row.id = :id or draft_row.id = :id)
         """.trimMargin()
         return jdbcTemplate.queryForObject(sql, mapOf("id" to id.intValue)) { rs, _ ->
-            ChangeTimes(
+            DraftableChangeInfo(
                 created = rs.getInstant("creation_time"),
                 changed = rs.getInstant("change_time"),
                 officialChanged = rs.getInstantOrNull("official_change_time"),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
@@ -66,7 +66,7 @@ abstract class DraftableObjectService<ObjectType : Draftable<ObjectType>, DaoTyp
         return dao.fetchChangeTime()
     }
 
-    fun getChangeTimes(id: IntId<ObjectType>): ChangeTimes {
+    fun getChangeTimes(id: IntId<ObjectType>): DraftableChangeInfo {
         logger.serviceCall("getChangeTimes", "id" to id)
         return dao.fetchChangeTimes(id)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -58,7 +58,7 @@ class LayoutKmPostController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{publishType}", params=["bbox", "step"])
+    @GetMapping("/{publishType}", params = ["bbox", "step"])
     fun findKmPosts(
         @PathVariable("publishType") publishType: PublishType,
         @RequestParam("bbox") bbox: BoundingBox,
@@ -69,7 +69,7 @@ class LayoutKmPostController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{publishType}", params=["location", "offset", "limit"])
+    @GetMapping("/{publishType}", params = ["location", "offset", "limit"])
     fun findKmPosts(
         @PathVariable("publishType") publishType: PublishType,
         @RequestParam("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>?,
@@ -79,8 +79,11 @@ class LayoutKmPostController(
     ): List<TrackLayoutKmPost> {
         logger.apiCall(
             "getNearbyKmPostsOnTrack",
-            "publishType" to publishType, "trackNumberId" to trackNumberId,
-            "location" to location, "offset" to offset, "limit" to limit
+            "publishType" to publishType,
+            "trackNumberId" to trackNumberId,
+            "location" to location,
+            "offset" to offset,
+            "limit" to limit
         )
         return kmPostService.listNearbyOnTrackPaged(
             publicationState = publishType,
@@ -92,15 +95,14 @@ class LayoutKmPostController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{publishType}", params=["trackNumberId", "kmNumber"])
+    @GetMapping("/{publishType}", params = ["trackNumberId", "kmNumber"])
     fun getKmPost(
         @PathVariable("publishType") publishType: PublishType,
         @RequestParam("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>,
         @RequestParam("kmNumber") kmNumber: KmNumber,
     ): ResponseEntity<TrackLayoutKmPost> {
         logger.apiCall(
-            "getKmPostOnTrack",
-            "publishType" to publishType, "trackNumberId" to trackNumberId, "kmNumber" to kmNumber
+            "getKmPostOnTrack", "publishType" to publishType, "trackNumberId" to trackNumberId, "kmNumber" to kmNumber
         )
         return toResponse(kmPostService.getByKmNumber(publishType, trackNumberId, kmNumber))
     }
@@ -141,7 +143,7 @@ class LayoutKmPostController(
 
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{id}/change-times")
-    fun getKmPostChangeTimes(@PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>): ChangeTimes {
+    fun getKmPostChangeTimes(@PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>): DraftableChangeInfo {
         logger.apiCall("getKmPostChangeTimes", "id" to kmPostId)
         return kmPostService.getChangeTimes(kmPostId)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -40,8 +40,13 @@ class LayoutSwitchController(
     ): List<TrackLayoutSwitch> {
         logger.apiCall(
             "getTrackLayoutSwitches",
-            "publishType" to publishType, "bbox" to bbox, "name" to name, "offset" to offset,
-            "limit" to limit, "comparisonPoint" to comparisonPoint, "switchType" to switchType
+            "publishType" to publishType,
+            "bbox" to bbox,
+            "name" to name,
+            "offset" to offset,
+            "limit" to limit,
+            "comparisonPoint" to comparisonPoint,
+            "switchType" to switchType
         )
         val filter = switchService.switchFilter(name, switchType, bbox, includeSwitchesWithNoJoints)
         return switchService.pageSwitchesByFilter(publishType, filter, offset, limit, comparisonPoint)
@@ -125,7 +130,7 @@ class LayoutSwitchController(
 
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{id}/change-times")
-    fun getSwitchChangeTimes(@PathVariable("id") switchId: IntId<TrackLayoutSwitch>): ChangeTimes {
+    fun getSwitchChangeTimes(@PathVariable("id") switchId: IntId<TrackLayoutSwitch>): DraftableChangeInfo {
         logger.apiCall("getSwitchChangeTimes", "id" to switchId)
         return switchService.getChangeTimes(switchId)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -165,7 +165,7 @@ class LayoutTrackNumberController(
 
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{id}/change-times")
-    fun getTrackNumberChangeInfo(@PathVariable("id") id: IntId<TrackLayoutTrackNumber>): ChangeTimes {
+    fun getTrackNumberChangeInfo(@PathVariable("id") id: IntId<TrackLayoutTrackNumber>): DraftableChangeInfo {
         logger.apiCall("getTrackNumberChangeInfo", "id" to id)
         return trackNumberService.getChangeTimes(id)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -6,7 +6,8 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.geocoding.AlignmentStartAndEnd
 import fi.fta.geoviite.infra.geocoding.GeocodingService
-import fi.fta.geoviite.infra.linking.*
+import fi.fta.geoviite.infra.linking.LocationTrackEndpoint
+import fi.fta.geoviite.infra.linking.LocationTrackSaveRequest
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.publication.PublicationService
@@ -165,7 +166,7 @@ class LocationTrackController(
 
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{id}/change-times")
-    fun getLocationTrackChangeInfo(@PathVariable("id") id: IntId<LocationTrack>): ChangeTimes {
+    fun getLocationTrackChangeInfo(@PathVariable("id") id: IntId<LocationTrack>): DraftableChangeInfo {
         logger.apiCall("getLocationTrackChangeInfo", "id" to id)
         return locationTrackService.getChangeTimes(id)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
@@ -85,7 +85,7 @@ class ReferenceLineController(
 
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/{id}/change-times")
-    fun getReferenceLineChangeInfo(@PathVariable("id") id: IntId<ReferenceLine>): ChangeTimes {
+    fun getReferenceLineChangeInfo(@PathVariable("id") id: IntId<ReferenceLine>): DraftableChangeInfo {
         logger.apiCall("getReferenceLineChangeInfo", "id" to id)
         return referenceLineService.getChangeTimes(id)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -268,7 +268,7 @@ data class TrackLayoutSwitchJointConnection(
     }
 }
 
-data class ChangeTimes(
+data class DraftableChangeInfo(
     val created: Instant,
     val changed: Instant,
     val officialChanged: Instant?,

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -91,9 +91,11 @@ export type ElementLocation = {
     cant?: number;
 };
 
-export type ChangeTimes = {
-    changed: TimeStamp;
+export type DraftableChangeInfo = {
     created: TimeStamp;
+    changed: TimeStamp;
+    officialChanged?: TimeStamp;
+    draftChanged?: TimeStamp;
 };
 
 export type Message = string;

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -5,7 +5,7 @@ import {
     LayoutKmPostId,
     LayoutTrackNumberId,
 } from 'track-layout/track-layout-model';
-import { ChangeTimes, KmNumber, PublishType, TimeStamp } from 'common/common-model';
+import { DraftableChangeInfo, KmNumber, PublishType, TimeStamp } from 'common/common-model';
 import { deleteAdt, getNonNull, getNullable, postAdt, putAdt, queryParams } from 'api/api-fetch';
 import { changeTimeUri, layoutUri, TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
 import { getChangeTimes, updateKmPostChangeTime } from 'common/change-time-api';
@@ -186,7 +186,7 @@ export const getKmLengthsAsCsv = (
 };
 
 export const getKmPostChangeTimes = (id: LayoutKmPostId) =>
-    getNullable<ChangeTimes>(changeTimeUri('km-posts', id));
+    getNullable<DraftableChangeInfo>(changeTimeUri('km-posts', id));
 
 export const getEntireRailNetworkKmLengthsCsvUrl = () =>
     `${TRACK_LAYOUT_URI}/track-numbers/rail-network/km-lengths/file`;

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -5,7 +5,7 @@ import {
     LocationTrackId,
     LocationTrackInfoboxExtras,
 } from 'track-layout/track-layout-model';
-import { ChangeTimes, PublishType, TimeStamp, TrackMeter } from 'common/common-model';
+import { DraftableChangeInfo, PublishType, TimeStamp, TrackMeter } from 'common/common-model';
 import { deleteAdt, getNonNull, getNullable, postAdt, putAdt, queryParams } from 'api/api-fetch';
 import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
 import { asyncCache } from 'cache/cache';
@@ -201,8 +201,8 @@ export async function getNonLinkedLocationTracks(): Promise<LayoutLocationTrack[
 
 export const getLocationTrackChangeTimes = (
     id: LocationTrackId,
-): Promise<ChangeTimes | undefined> => {
-    return getNullable<ChangeTimes>(changeTimeUri('location-tracks', id));
+): Promise<DraftableChangeInfo | undefined> => {
+    return getNullable<DraftableChangeInfo>(changeTimeUri('location-tracks', id));
 };
 
 export const getLocationTrackSectionsByPlan = async (

--- a/ui/src/track-layout/layout-reference-line-api.ts
+++ b/ui/src/track-layout/layout-reference-line-api.ts
@@ -4,7 +4,7 @@ import {
     LayoutTrackNumberId,
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
-import { ChangeTimes, PublishType, TimeStamp } from 'common/common-model';
+import { DraftableChangeInfo, PublishType, TimeStamp } from 'common/common-model';
 import { getNonNull, getNullable, queryParams } from 'api/api-fetch';
 import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
 import { BoundingBox } from 'model/geometry';
@@ -87,6 +87,6 @@ export async function getNonLinkedReferenceLines(): Promise<LayoutReferenceLine[
 
 export const getReferenceLineChangeTimes = (
     id: ReferenceLineId,
-): Promise<ChangeTimes | undefined> => {
-    return getNullable<ChangeTimes>(changeTimeUri('reference-lines', id));
+): Promise<DraftableChangeInfo | undefined> => {
+    return getNullable<DraftableChangeInfo>(changeTimeUri('reference-lines', id));
 };

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -1,5 +1,5 @@
 import { BoundingBox, Point } from 'model/geometry';
-import { ChangeTimes, PublishType, TimeStamp } from 'common/common-model';
+import { DraftableChangeInfo, PublishType, TimeStamp } from 'common/common-model';
 import {
     LayoutSwitch,
     LayoutSwitchId,
@@ -154,6 +154,8 @@ export async function getSwitchValidation(
     return getNonNull<ValidatedAsset>(`${layoutUri('switches', publishType, id)}/validation`);
 }
 
-export const getSwitchChangeTimes = (id: LayoutSwitchId): Promise<ChangeTimes | undefined> => {
-    return getNonNull<ChangeTimes>(changeTimeUri('switches', id));
+export const getSwitchChangeTimes = (
+    id: LayoutSwitchId,
+): Promise<DraftableChangeInfo | undefined> => {
+    return getNonNull<DraftableChangeInfo>(changeTimeUri('switches', id));
 };

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -4,7 +4,7 @@ import {
     LayoutTrackNumberId,
     LocationTrackId,
 } from 'track-layout/track-layout-model';
-import { ChangeTimes, PublishType, TimeStamp } from 'common/common-model';
+import { DraftableChangeInfo, PublishType, TimeStamp } from 'common/common-model';
 import {
     deleteAdt,
     getNonNull,
@@ -104,6 +104,6 @@ export const getTrackNumberReferenceLineSectionsByPlan = async (
 
 export const getTrackNumberChangeTimes = (
     id: LayoutTrackNumberId,
-): Promise<ChangeTimes | undefined> => {
-    return getNullable<ChangeTimes>(changeTimeUri('track-numbers', id));
+): Promise<DraftableChangeInfo | undefined> => {
+    return getNullable<DraftableChangeInfo>(changeTimeUri('track-numbers', id));
 };

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -14,8 +14,8 @@ import {
 } from 'track-layout/track-layout-model';
 import { LoaderStatus, useLoader, useLoaderWithStatus, useOptionalLoader } from 'utils/react-utils';
 import {
-    ChangeTimes,
     CoordinateSystem,
+    DraftableChangeInfo,
     PublishType,
     Srid,
     SwitchStructure,
@@ -218,27 +218,31 @@ export function usePlanHeader(id: GeometryPlanId | undefined): GeometryPlanHeade
 
 export function useTrackNumberChangeTimes(
     id: LayoutTrackNumberId | undefined,
-): ChangeTimes | undefined {
+): DraftableChangeInfo | undefined {
     return useOptionalLoader(() => (id ? getTrackNumberChangeTimes(id) : undefined), [id]);
 }
 
 export function useReferenceLineChangeTimes(
     id: ReferenceLineId | undefined,
-): ChangeTimes | undefined {
+): DraftableChangeInfo | undefined {
     return useOptionalLoader(() => (id ? getReferenceLineChangeTimes(id) : undefined), [id]);
 }
 
 export function useLocationTrackChangeTimes(
     id: LocationTrackId | undefined,
-): ChangeTimes | undefined {
+): DraftableChangeInfo | undefined {
     return useOptionalLoader(() => (id ? getLocationTrackChangeTimes(id) : undefined), [id]);
 }
 
-export function useSwitchChangeTimes(id: LayoutSwitchId | undefined): ChangeTimes | undefined {
+export function useSwitchChangeTimes(
+    id: LayoutSwitchId | undefined,
+): DraftableChangeInfo | undefined {
     return useOptionalLoader(() => (id ? getSwitchChangeTimes(id) : undefined), [id]);
 }
 
-export function useKmPostChangeTimes(id: LayoutKmPostId | undefined): ChangeTimes | undefined {
+export function useKmPostChangeTimes(
+    id: LayoutKmPostId | undefined,
+): DraftableChangeInfo | undefined {
     return useOptionalLoader(() => (id ? getKmPostChangeTimes(id) : undefined), [id]);
 }
 


### PR DESCRIPTION
Meillä on frontissa 2 luokkaa nimellä ChangeTimes: toinen on se johon kerätään kaikkien käsitteiden muutosajat reduxiin ja toinen on se joka kuvaa yhden objektin luonti/muutos aikoja. Sama nimi on johtanut harhaan sen verran monta kertaa että jälkimmäinen noista on nyt nimetty uudelleen.