### PR TITLE
Remove broken reference lines

### DIFF
--- a/infra/src/main/resources/db/migration/prod/V49__fix_broken_refence_line_draft_refs.sql
+++ b/infra/src/main/resources/db/migration/prod/V49__fix_broken_refence_line_draft_refs.sql
@@ -1,0 +1,9 @@
+delete from layout.reference_line rl
+where rl.draft
+  and exists (
+  select 1
+    from layout.track_number tn
+    where tn.id = rl.track_number_id
+      and tn.draft
+      and tn.draft_of_track_number_id is not null
+);


### PR DESCRIPTION
This migration fixes any broken reference lines cause by migration
      V43__generates_missing_reference_lines.sql
    
    The issue there was that it handled inter-object references via row ID rather than official ID:
    - Correct: reference_line.track_number_id = coalesce(track_number.draft_of_track_number_id, track_number.id)
    - Actual: reference_line.track_number_id = track_number.id