### PR TITLE
GVT-2159: Add support for searching track numbers in the map view

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -51,7 +51,9 @@ class LayoutTrackNumberController(
         @RequestParam("searchTerm", required = true) searchTerm: FreeText,
         @RequestParam("limit", required = true) limit: Int,
     ): List<TrackLayoutTrackNumber> {
-        logger.apiCall("searchTrackNumbers", "searchTerm" to searchTerm, "limit" to limit)
+        logger.apiCall(
+            "searchTrackNumbers", "publishType" to publishType, "searchTerm" to searchTerm, "limit" to limit,
+        )
         return trackNumberService.list(publishType, searchTerm, limit)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.publication.ValidatedAsset
 import fi.fta.geoviite.infra.publication.getCsvResponseEntity
 import fi.fta.geoviite.infra.util.FileName
+import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.toResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -41,6 +42,17 @@ class LayoutTrackNumberController(
     ): List<TrackLayoutTrackNumber> {
         logger.apiCall("getTrackNumbers", "publishType" to publishType)
         return trackNumberService.list(publishType, includeDeleted)
+    }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/{publishType}", params = ["searchTerm", "limit"])
+    fun searchSwitches(
+        @PathVariable("publishType") publishType: PublishType,
+        @RequestParam("searchTerm", required = true) searchTerm: FreeText,
+        @RequestParam("limit", required = true) limit: Int,
+    ): List<TrackLayoutTrackNumber> {
+        logger.apiCall("searchTrackNumbers", "searchTerm" to searchTerm, "limit" to limit)
+        return trackNumberService.list(publishType, searchTerm, limit)
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.util.FreeText
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -32,6 +33,11 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
     private val alignmentDao: LayoutAlignmentDao,
     private val kmPostDao: LayoutKmPostDao,
 ) : DBTestBase() {
+
+    @BeforeEach
+    fun cleanup() {
+        deleteFromTables("layout", "track_number", "reference_line")
+    }
 
     @Test
     fun updatingExternalIdWorks() {
@@ -140,6 +146,74 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
         )
     }
 
+    @Test
+    fun `free text search should find multiple matching track numbers, and not the ones that did not match`() {
+        val trackNumbers = listOf(
+            TrackNumber("track number 1"),
+            TrackNumber("track number 11"),
+            TrackNumber("number 111"),
+            TrackNumber("number111 111")
+        )
+
+        saveTrackNumbersWithSaveRequests(
+            trackNumbers,
+            LayoutState.IN_USE,
+        )
+
+        assertEquals(2, trackNumberService.list(DRAFT, FreeText("tRaCk number"), null).size)
+        assertEquals(3, trackNumberService.list(DRAFT, FreeText("11"), null).size)
+        assertEquals(4, trackNumberService.list(DRAFT, FreeText("1"), null).size)
+    }
+
+    @Test
+    fun `free text search should limit the amount of returned track numbers as specified`() {
+        val trackNumbers = (0..15).map { number ->
+            TrackNumber("some track $number")
+        }
+
+        saveTrackNumbersWithSaveRequests(
+            trackNumbers,
+            LayoutState.IN_USE,
+        )
+
+        assertEquals(5, trackNumberService.list(DRAFT, FreeText("some track"), 5).size)
+        assertEquals(10, trackNumberService.list(DRAFT, FreeText("some track"), 10).size)
+        assertEquals(15, trackNumberService.list(DRAFT, FreeText("some track"), 15).size)
+    }
+
+    @Test
+    fun `free text search should not return deleted track numbers when its domain id or external id does not match the search term`() {
+        val trackNumbers = listOf(
+            TrackNumber("track number 1"),
+            TrackNumber("track number 11"),
+        )
+
+        saveTrackNumbersWithSaveRequests(trackNumbers, LayoutState.DELETED)
+        assertEquals(0, trackNumberService.list(DRAFT, FreeText("tRaCk number"), null).size)
+    }
+
+    @Test
+    fun `free text search should return deleted track number when its domain id or external id matches`() {
+        val trackNumbers = listOf(
+            TrackNumber("track number 1"),
+            TrackNumber("track number 11"),
+        )
+
+        saveTrackNumbersWithSaveRequests(
+            trackNumbers,
+            LayoutState.DELETED,
+        ).forEachIndexed { index, trackNumberId ->
+            val oid = Oid<TrackLayoutTrackNumber>("1.2.3.4.5.6.$index")
+            trackNumberService.updateExternalId(trackNumberId, oid)
+
+            assertEquals(1, trackNumberService.list(DRAFT, FreeText(oid.toString()), null).size)
+            assertEquals(1, trackNumberService.list(DRAFT, FreeText(trackNumberId.toString()), null).size)
+        }
+
+        // LayoutState was set to DELETED, meaning that these track numbers should not be found by free text.
+        assertEquals(0, trackNumberService.list(DRAFT, FreeText("tRaCk number"), null).size)
+    }
+
     fun createTrackNumberAndReferenceLineAndAlignment(): Triple<TrackLayoutTrackNumber, ReferenceLine, LayoutAlignment> {
         val saveRequest = TrackNumberSaveRequest(
             getUnusedTrackNumber(), FreeText(trackNumberDescription), LayoutState.IN_USE, TrackMeter(
@@ -154,6 +228,21 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
         )!! // Always exists, since we just created it
 
         return Triple(trackNumber, referenceLine, alignment)
+    }
+
+    private fun saveTrackNumbersWithSaveRequests(
+        trackNumbers: List<TrackNumber>,
+        layoutState: LayoutState,
+    ): List<IntId<TrackLayoutTrackNumber>> {
+        return trackNumbers.map { trackNumber ->
+            TrackNumberSaveRequest(
+                trackNumber, FreeText("some description"), layoutState, TrackMeter(
+                    KmNumber(5555), 5.5, 1
+                )
+            )
+        }.map { saveRequest ->
+            trackNumberService.insert(saveRequest)
+        }
     }
 
     private fun publishTrackNumber(id: IntId<TrackLayoutTrackNumber>) =

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -46,6 +46,7 @@ import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { MapLayerMenu } from 'map/layer-menu/map-layer-menu';
 import { MapLayerMenuChange, MapLayerMenuGroups } from 'map/map-model';
 import { getTrackNumbersBySearchTerm } from 'track-layout/layout-track-number-api';
+import { getTrackNumberReferenceLine } from 'track-layout/layout-reference-line-api';
 
 export type ToolbarParams = {
     onSelectTrackNumber: (trackNumberId: LayoutTrackNumberId) => void;
@@ -198,7 +199,14 @@ export const ToolBar: React.FC<ToolbarParams> = (props: ToolbarParams) => {
                 return props.onSelectSwitch(item.layoutSwitch.id);
 
             case 'trackNumberSearchItem':
+                getTrackNumberReferenceLine(item.trackNumber.id, 'DRAFT').then((referenceLine) => {
+                    if (referenceLine?.boundingBox) {
+                        props.showArea(referenceLine.boundingBox);
+                    }
+                });
+
                 return props.onSelectTrackNumber(item.trackNumber.id);
+
             default:
                 return;
         }

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -107,3 +107,17 @@ export const getTrackNumberChangeTimes = (
 ): Promise<DraftableChangeInfo | undefined> => {
     return getNullable<DraftableChangeInfo>(changeTimeUri('track-numbers', id));
 };
+
+export async function getTrackNumbersBySearchTerm(
+    searchTerm: string,
+    publishType: PublishType,
+    limit: number,
+): Promise<LayoutTrackNumber[]> {
+    const params = queryParams({
+        searchTerm: searchTerm,
+        limit: limit,
+    });
+    return await getNonNull<LayoutTrackNumber[]>(
+        `${layoutUri('track-numbers', publishType)}${params}`,
+    );
+}

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -241,6 +241,14 @@ function filterItemSelectOptions(
         }
     }
 
+    if (options?.trackNumbers && options.trackNumbers.length > 0) {
+        options.locationTracks = [];
+    }
+
+    if (options?.locationTracks && options.locationTracks.length > 0) {
+        options.trackNumbers = [];
+    }
+
     return {
         ...options,
 


### PR DESCRIPTION
GVT-2159: Add support for searching track numbers in the map view

Previously the search bar supported searching for location tracks and switches.