### PR TITLE
GVT-2110 Disable detailed geometry change calculation in publication log

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -982,8 +982,6 @@ class PublicationService @Autowired constructor(
                 getGeocodingContext(it, newAndTime.second)?.getAddressAndM(newEnd)
             }
         } else null
-        val oldAlignment = locationTrackChanges.alignmentVersion.old?.let(alignmentDao::fetch)
-        val newAlignment = locationTrackChanges.alignmentVersion.new?.let(alignmentDao::fetch)
 
         return listOfNotNull(
             compareChangeValues(
@@ -1058,18 +1056,9 @@ class PublicationService @Autowired constructor(
                 remark = getAddressMovedRemarkOrNull(translation, oldEndPointAndM?.address, newEndPointAndM?.address)
             ),
             if (changedKmNumbers.isNotEmpty()) {
-                val remark = locationTrackChanges.trackNumberId.old ?.let { oldTrackNumberId ->
-                    getGeocodingContext(oldTrackNumberId, publicationTime)
-                }?.let { geocodingContext ->
-                    getKmNumbersChangedRemarkOrNull(
-                        translation,
-                        oldAlignment,
-                        newAlignment,
-                        geocodingContext,
-                        changedKmNumbers
-                    )
-                }
-                PublicationChange(PropKey("geometry"), ChangeValue(null, null), remark)
+                PublicationChange(PropKey("geometry"), ChangeValue(null, null), getKmNumbersChangedRemarkOrNull(
+                    translation, changedKmNumbers
+                ))
             } else null,
             compareChange(
                 { locationTrackChanges.linkedSwitches.old != locationTrackChanges.linkedSwitches.new },
@@ -1116,18 +1105,11 @@ class PublicationService @Autowired constructor(
                 getPointMovedRemarkOrNull(translation, changes.endPoint.old, changes.endPoint.new)
             ),
             if (changedKmNumbers.isNotEmpty()) {
-                val remark = changes.trackNumberId.old ?.let { oldTrackNumberId ->
-                    getGeocodingContext(oldTrackNumberId, oldTimestamp)
-                }?.let { geocodingContext ->
-                    getKmNumbersChangedRemarkOrNull(
-                        translation,
-                        changes.alignmentVersion.old?.let(alignmentDao::fetch),
-                        changes.alignmentVersion.new?.let(alignmentDao::fetch),
-                        geocodingContext,
-                        changedKmNumbers
+                PublicationChange(
+                    PropKey("geometry"), ChangeValue(null, null), getKmNumbersChangedRemarkOrNull(
+                        translation, changedKmNumbers
                     )
-                }
-                PublicationChange(PropKey("geometry"), ChangeValue(null, null), remark)
+                )
             } else null,
         )
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -311,41 +311,12 @@ data class GeometryChangeSummary(
 
 fun getKmNumbersChangedRemarkOrNull(
     translation: Translation,
-    oldAlignment: LayoutAlignment?,
-    newAlignment: LayoutAlignment?,
-    geocodingContext: GeocodingContext,
     changedKmNumbers: Set<KmNumber>,
-): String {
-    val summaries = if (oldAlignment != null && newAlignment != null) summarizeAlignmentChanges(
-        geocodingContext,
-        oldAlignment,
-        newAlignment
-    ) else null
-
-    return if (summaries.isNullOrEmpty()) {
-        publicationChangeRemark(
-            translation,
-            if (changedKmNumbers.size > 1) "changed-km-numbers" else "changed-km-number",
-            formatChangedKmNumbers(changedKmNumbers.toList())
-        )
-    } else summaries.joinToString { summary ->
-        val key =
-            "publication-details-table.remark.geometry-changed${if (summary.startKm == summary.endKm) "" else "-many-km"}"
-        translation.t(
-            key,
-            mapOf(
-                "changedLengthM" to roundTo1Decimal(summary.changedLengthM).toString(),
-                "maxDistance" to roundTo1Decimal(summary.maxDistance).toString(),
-                "addressRange" to
-                        if (summary.startKm == summary.endKm) summary.startKm.toString()
-                        else "${summary.startKm}-${summary.endKm}"
-            )
-        )
-    }
-}
-
-private fun isContiguous(numbers: List<Int>) =
-    numbers.zipWithNext { a, b -> a + 1 == b}.all { it }
+): String = publicationChangeRemark(
+    translation,
+    if (changedKmNumbers.size > 1) "changed-km-numbers" else "changed-km-number",
+    formatChangedKmNumbers(changedKmNumbers.toList())
+)
 
 private data class ComparisonPoints(
     val oldPoint: LayoutPoint,
@@ -404,5 +375,3 @@ private fun getChangedAlignmentRanges(old: LayoutAlignment, new: LayoutAlignment
 fun publicationChangeRemark(translation: Translation, key: String, value: String?) =
     translation.t("publication-details-table.remark.$key", if (value != null) mapOf("value" to value) else mapOf())
 
-fun publicationChangeRemark(translation: Translation, key: String, params: Map<String, String>) =
-    translation.t("publication-details-table.remark.$key", params)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1218,11 +1218,9 @@
         "remark": {
             "changed-x-meters": "Muutos {{value}} m",
             "moved-x-meters": "Siirtynyt {{value}} m",
-            "changed-km-number": "Geometria ei siirtynyt. Muita tietoja muuttunut kilometriltä {{value}}",
-            "changed-km-numbers": "Geometria ei siirtynyt. Muita tietoja muuttunut kilometreiltä {{value}}",
+            "changed-km-number": "Muuttunut kilometriltä {{value}}",
+            "changed-km-numbers": "Muuttunut kilometreiltä {{value}}",
             "km-number-changed": "Siirtynyt ratakilometrille {{value}}",
-            "geometry-changed-many-km": "Muuttunut kilometriväliltä {{addressRange}}, laajuus {{changedLengthM}} m, poikkeama {{maxDistance}} m",
-            "geometry-changed": "Muuttunut kilometriltä {{addressRange}}, laajuus {{changedLengthM}} m, poikkeama {{maxDistance}} m",
             "switch-link-added-singular": "Vaihde {{value}} linkitetty",
             "switch-link-added-plural": "Vaihteet {{value}} linkitetty",
             "switch-link-removed-singular": "Vaihteen {{value}} linkitys purettu",


### PR DESCRIPTION
Suurin osa geometriamuutosten laskennan koodista jää elämään, koska se kyllä näyttäisi toimivan perffiä lukuunottamatta ainakin oikeahkosti, ja vaihdelinkitysten laskenta käyttää siitä muutenkin isohkoa osaa. Varsinainen ominaisuus pitää vaan ottaa pois, koska se käyttää minuuttitolkulla aikaa geokoodauslaskentoihin pitempiä julkaisulokisivuja avattaessa.