### PR TITLE
GVT-2177 Julkaisulokin laskemisesta rinnakkaisuus pois + selkeämpi samannimisten vaihteiden käsittely

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -362,7 +362,6 @@ data class LocationTrackChanges(
     val endPoint: Change<Point>,
     val trackNumberId: Change<IntId<TrackLayoutTrackNumber>>,
     val alignmentVersion: Change<RowVersion<LayoutAlignment>>,
-    val linkedSwitches: Change<List<Pair<IntId<TrackLayoutSwitch>, String>>>,
 )
 
 // Todo: Consider making TrackLayoutSwitch use this for trapPoint as well
@@ -424,4 +423,11 @@ fun toValidationVersions(
     kmPosts = kmPosts.map(::toValidationVersion),
     locationTracks = locationTracks.map(::toValidationVersion),
     switches = switches.map(::toValidationVersion)
+)
+
+data class SwitchChangeIds(val name: String, val externalId: Oid<TrackLayoutSwitch>)
+
+data class LocationTrackPublicationSwitchLinkChanges(
+    val old: Map<IntId<TrackLayoutSwitch>, SwitchChangeIds>,
+    val new: Map<IntId<TrackLayoutSwitch>, SwitchChangeIds>,
 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -454,6 +454,98 @@ class PublicationDao(
         }.toMap().also { logger.daoAccess(FETCH, TrackNumberChanges::class, publicationId) }
     }
 
+    fun fetchPublicationLocationTrackSwitchLinkChanges(
+        publicationId: IntId<Publication>,
+    ): Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges> =
+        fetchPublicationLocationTrackSwitchLinkChanges(publicationId, null, null)[publicationId] ?: mapOf()
+
+    fun fetchPublicationLocationTrackSwitchLinkChanges(
+        publicationId: IntId<Publication>?,
+        from: Instant?,
+        to: Instant?,
+    ): Map<IntId<Publication>, Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges>> {
+        val sql = """
+            select
+              change_side,
+              plt.publication_id,
+              location_track_id,
+              switch_version.id as switch_id,
+              switch_version.name as switch_name,
+              switch_version.external_id as switch_oid
+              from publication.publication
+                join publication.location_track plt on publication.id = plt.publication_id
+                join lateral
+                (select 'new' as change_side, topology_start_switch_id, topology_end_switch_id, alignment_id, alignment_version
+                   from layout.location_track_version ltv
+                   where plt.location_track_id = ltv.id and plt.location_track_version = ltv.version
+                 union all
+                 select 'old', topology_start_switch_id, topology_end_switch_id, alignment_id, alignment_version
+                   from layout.location_track_version ltv
+                   where plt.location_track_id = ltv.id
+                     and plt.location_track_version = ltv.version + 1
+                     and not ltv.draft) ltvs on (true)
+                join lateral
+                (select distinct switch_id
+                   from (
+                     select ltvs.topology_start_switch_id as switch_id
+                     union all
+                     select ltvs.topology_end_switch_id
+                     union all
+                     select switch_id
+                       from layout.segment_version
+                       where segment_version.alignment_id = ltvs.alignment_id
+                         and segment_version.alignment_version = ltvs.alignment_version
+                   ) s
+                   where switch_id is not null) switch_ids on (true)
+                join layout.switch_version on switch_ids.switch_id = switch_version.id and not switch_version.draft
+              where direct_change
+                and not exists(
+                  select *
+                  from publication.switch psw
+                  where psw.switch_id = switch_version.id
+                    and direct_change
+                    and (psw.switch_version = switch_version.version and psw.publication_id > plt.publication_id
+                      or psw.switch_version > switch_version.version and psw.publication_id <= plt.publication_id))
+                and (:publicationId::integer is null or :publicationId = publication.id)
+                and (:from::timestamptz is null or :from <= publication_time)
+                and (:to::timestamptz is null or :to >= publication_time)
+        """.trimIndent()
+
+        data class ResultRow(
+            val changeSide: String,
+            val publicationId: IntId<Publication>,
+            val locationTrackId: IntId<LocationTrack>,
+            val switchId: IntId<TrackLayoutSwitch>,
+            val switchName: String,
+            val switchOid: Oid<TrackLayoutSwitch>,
+        )
+
+        return jdbcTemplate.query(
+            sql,
+            mapOf(
+                "publicationId" to publicationId?.intValue,
+                "from" to from?.let { Timestamp.from(it) },
+                "to" to to?.let { Timestamp.from(it) })
+        ) { rs, _ ->
+            ResultRow(
+                rs.getString("change_side"),
+                rs.getIntId("publication_id"),
+                rs.getIntId("location_track_id"),
+                rs.getIntId("switch_id"),
+                rs.getString("switch_name"),
+                rs.getOid("switch_oid"),
+            )
+        }.groupBy { it.publicationId }.mapValues { (_, publicationResults) ->
+            publicationResults.groupBy { it.locationTrackId }.mapValues { (_, locationTrackResults) ->
+                val (olds, news) = locationTrackResults.partition { it.changeSide == "old" }
+                LocationTrackPublicationSwitchLinkChanges(
+                    old = olds.associateBy({ it.switchId }, { SwitchChangeIds(it.switchName, it.switchOid) }),
+                    new = news.associateBy({ it.switchId }, { SwitchChangeIds(it.switchName, it.switchOid) }),
+                )
+            }
+        }
+    }
+
     fun fetchPublicationLocationTrackChanges(publicationId: IntId<Publication>): Map<IntId<LocationTrack>, LocationTrackChanges> {
         val sql = """
             select
@@ -490,23 +582,7 @@ class PublicationDao(
               postgis.st_x(postgis.st_startpoint(sg_first.geometry)) as start_x,
               postgis.st_y(postgis.st_startpoint(sg_first.geometry)) as start_y,
               postgis.st_x(postgis.st_endpoint(sg_last.geometry)) as end_x,
-              postgis.st_y(postgis.st_endpoint(sg_last.geometry)) as end_y,
-              (select array_agg(sw.id || ' ' || sw.name)
-                from layout.switch_at(publication_time) sw
-                 where sw.id = ltv.topology_start_switch_id or sw.id = ltv.topology_end_switch_id or
-                   exists (select *
-                           from layout.segment_version sv
-                           where sv.alignment_id = ltv.alignment_id
-                             and sv.alignment_version = ltv.alignment_version
-                             and sw.id = sv.switch_id)) as linked_switches,
-              (select array_agg(sw.id || ' ' || sw.name)
-                from layout.switch_at(publication_time) sw
-                 where sw.id = old_ltv.topology_start_switch_id or sw.id = old_ltv.topology_end_switch_id or
-                   exists (select *
-                           from layout.segment_version sv
-                           where sv.alignment_id = old_ltv.alignment_id
-                             and sv.alignment_version = old_ltv.alignment_version
-                             and sw.id = sv.switch_id)) as old_linked_switches
+              postgis.st_y(postgis.st_endpoint(sg_last.geometry)) as end_y
               from publication.location_track
                 join publication.publication on location_track.publication_id = publication.id
                 left join layout.location_track_version ltv
@@ -564,7 +640,6 @@ class PublicationDao(
                 type = rs.getChange("type", { rs.getEnumOrNull<LocationTrackType>(it) }),
                 length = rs.getChange("length", rs::getDoubleOrNull),
                 alignmentVersion = rs.getChangeRowVersion<LayoutAlignment>("alignment_id", "alignment_version"),
-                linkedSwitches = rs.getChange("linked_switches") { rs.getStringArrayOrNull(it)?.map(::parseSwitchChangeReference) }
             )
         }.toMap().also { logger.daoAccess(FETCH, LocationTrackChanges::class, publicationId) }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -864,7 +864,7 @@ class PublicationService @Autowired constructor(
             publications.mapIndexed { index, publicationDetails ->
                 val previousPublication = publications.getOrNull(index - 1)
                 publicationDetails to (previousPublication?.publicationTime ?: publicationDetails.publicationTime.minusMillis(1))
-            }.parallelStream().map { (publicationDetails, timeDiff) ->
+            }.flatMap { (publicationDetails, timeDiff) ->
                 mapToPublicationTableItems(
                     translation,
                     publicationDetails,
@@ -872,7 +872,7 @@ class PublicationService @Autowired constructor(
                     getGeocodingContextOrNull,
                     trackNumbersCache,
                 )
-            }.collect(Collectors.toList()).flatMap { rows -> rows}
+            }
         }.let { publications ->
             if (sortBy == null) publications
             else publications.sortedWith(getComparator(sortBy, order))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -38,7 +38,6 @@ import java.time.Instant
 import java.time.ZoneId
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import java.util.stream.Collectors
 
 
 @Service
@@ -810,6 +809,7 @@ class PublicationService @Autowired constructor(
                 .find { it.key < publication.publicationTime }
             mapToPublicationTableItems(translation,
                 publication,
+                publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(publication.id),
                 previousPublication?.key ?: publication.publicationTime.minusMillis(1),
                 { trackNumberId: IntId<TrackLayoutTrackNumber>, timestamp: Instant ->
                     getOrPutGeocodingContext(
@@ -853,6 +853,8 @@ class PublicationService @Autowired constructor(
             "order" to order,
         )
 
+        val switchLinkChanges = publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(null, from, to)
+
         return fetchPublicationDetailsBetweenInstants(from, to).sortedBy { it.publicationTime }.let { publications ->
             val geocodingContextCache =
                 ConcurrentHashMap<Instant, MutableMap<IntId<TrackLayoutTrackNumber>, Optional<GeocodingContext>>>()
@@ -868,6 +870,7 @@ class PublicationService @Autowired constructor(
                 mapToPublicationTableItems(
                     translation,
                     publicationDetails,
+                    switchLinkChanges[publicationDetails.id] ?: mapOf(),
                     timeDiff,
                     getGeocodingContextOrNull,
                     trackNumbersCache,
@@ -953,6 +956,7 @@ class PublicationService @Autowired constructor(
     fun diffLocationTrack(
         translation: Translation,
         locationTrackChanges: LocationTrackChanges,
+        switchLinkChanges: LocationTrackPublicationSwitchLinkChanges?,
         publicationTime: Instant,
         previousPublicationTime: Instant,
         trackNumberCache: List<TrackNumberAndChangeTime>,
@@ -1060,13 +1064,13 @@ class PublicationService @Autowired constructor(
                     translation, changedKmNumbers
                 ))
             } else null,
-            compareChange(
-                { locationTrackChanges.linkedSwitches.old != locationTrackChanges.linkedSwitches.new },
+            if (switchLinkChanges == null) null else compareChange(
+                { switchLinkChanges.old != switchLinkChanges.new },
                 null,
                 null,
                 { it  },
                 PropKey("linked-switches"), getSwitchLinksChangedRemark(
-                    translation, locationTrackChanges)
+                    translation, switchLinkChanges)
             )
             // TODO owner
         )
@@ -1290,6 +1294,7 @@ class PublicationService @Autowired constructor(
     private fun mapToPublicationTableItems(
         translation: Translation,
         publication: PublicationDetails,
+        switchLinkChanges: Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges>,
         previousComparisonTime: Instant,
         geocodingContextGetter: (IntId<TrackLayoutTrackNumber>, Instant) -> GeocodingContext?,
         trackNumberNamesCache: List<TrackNumberAndChangeTime> = trackNumberDao.fetchTrackNumberNames(),
@@ -1351,6 +1356,7 @@ class PublicationService @Autowired constructor(
                 propChanges = diffLocationTrack(
                     translation,
                     publicationLocationTrackChanges.getOrElse(lt.version.id) { error("Location track changes not found") },
+                    switchLinkChanges[lt.version.id],
                     publication.publicationTime,
                     previousComparisonTime,
                     trackNumberNamesCache,
@@ -1411,6 +1417,7 @@ class PublicationService @Autowired constructor(
                 propChanges = diffLocationTrack(
                     translation,
                     publicationLocationTrackChanges.getOrElse(lt.version.id) { error("Location track changes not found") },
+                    switchLinkChanges[lt.version.id],
                     publication.publicationTime,
                     previousComparisonTime,
                     trackNumberNamesCache,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -212,21 +212,24 @@ fun getAddressMovedRemarkOrNull(translation: Translation, oldAddress: TrackMeter
 
 fun getSwitchLinksChangedRemark(
     translation: Translation,
-    locationTrackChanges: LocationTrackChanges,
+    switchLinkChanges: LocationTrackPublicationSwitchLinkChanges,
 ): String {
-    val old = (locationTrackChanges.linkedSwitches.old ?: listOf()).toMap()
-    val new = (locationTrackChanges.linkedSwitches.new ?: listOf()).toMap()
-    val removed = old.minus(new.keys)
-    val added = new.minus(old.keys)
+    val removed = switchLinkChanges.old.minus(switchLinkChanges.new.keys)
+    val added = switchLinkChanges.new.minus(switchLinkChanges.old.keys)
+    val commonNames = removed.values.map { it.name }.intersect(added.values.map { it.name }.toSet())
+
+    fun remarkOnIds(ids: SwitchChangeIds) =
+        if (commonNames.contains(ids.name)) "${ids.name} (${ids.externalId})" else ids.name
+
     val remarkRemoved = publicationChangeRemark(
         translation,
         if (removed.size > 1) "switch-link-removed-plural" else "switch-link-removed-singular",
-        removed.values.sorted().joinToString()
+        removed.values.map(::remarkOnIds).sorted().joinToString()
     )
     val remarkAdded = publicationChangeRemark(
         translation,
         if (added.size > 1) "switch-link-added-plural" else "switch-link-added-singular",
-        added.values.sorted().joinToString()
+        added.values.map(::remarkOnIds).sorted().joinToString()
     )
     return if (removed.isNotEmpty() && added.isNotEmpty()) "${remarkRemoved}. ${remarkAdded}."
         else if (removed.isNotEmpty()) remarkRemoved

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1082,6 +1082,7 @@ class PublicationServiceIT @Autowired constructor(
         val diff = publicationService.diffLocationTrack(
             localizationService.getLocalization("fi"),
             changes.getValue(locationTrack.id as IntId<LocationTrack>),
+            null,
             latestPub.publicationTime,
             previousPub.publicationTime,
             trackNumberDao.fetchTrackNumberNames(),
@@ -1129,6 +1130,7 @@ class PublicationServiceIT @Autowired constructor(
         val diff = publicationService.diffLocationTrack(
             localizationService.getLocalization("fi"),
             changes.getValue(locationTrack.id as IntId<LocationTrack>),
+            null,
             latestPub.publicationTime,
             previousPub.publicationTime,
             trackNumberDao.fetchTrackNumberNames(),
@@ -1349,17 +1351,16 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `Location track switch link changes are reported`() {
-        val switchUnlinkedFromTopology = switchDao.insert(switch(name = "sw-unlinked-from-topology"))
-        val switchUnlinkedFromAlignment = switchDao.insert(switch(name = "sw-unlinked-from-alignment"))
-        val switchAddedToTopologyStart = switchDao.insert(switch(name = "sw-added-to-topo-start"))
-        val switchAddedToTopologyEnd = switchDao.insert(switch(name = "sw-added-to-topo-end"))
-        val switchAddedToAlignment = switchDao.insert(switch(name = "sw-added-to-alignment"))
-        val switchDeleted = switchDao.insert(switch(name = "sw-deleted"))
-        val switchMerelyRenamed = switchDao.insert(switch(name = "sw-merely-renamed"))
-        val originalSwitchReplacedWithNewSameName = switchDao.insert(switch(name = "sw-replaced-with-new-same-name"))
+        val switchUnlinkedFromTopology = switchDao.insert(switch(name = "sw-unlinked-from-topology", externalId = "1.1.1.1.1"))
+        val switchUnlinkedFromAlignment = switchDao.insert(switch(name = "sw-unlinked-from-alignment", externalId = "1.1.1.1.2"))
+        val switchAddedToTopologyStart = switchDao.insert(switch(name = "sw-added-to-topo-start", externalId = "1.1.1.1.3"))
+        val switchAddedToTopologyEnd = switchDao.insert(switch(name = "sw-added-to-topo-end", externalId = "1.1.1.1.4"))
+        val switchAddedToAlignment = switchDao.insert(switch(name = "sw-added-to-alignment", externalId = "1.1.1.1.5"))
+        val switchDeleted = switchDao.insert(switch(name = "sw-deleted", externalId = "1.1.1.1.6"))
+        val switchMerelyRenamed = switchDao.insert(switch(name = "sw-merely-renamed", externalId = "1.1.1.1.7"))
+        val originalSwitchReplacedWithNewSameName = switchDao.insert(switch(name = "sw-replaced-with-new-same-name", externalId = "1.1.1.1.8"))
 
         val trackNumberId = getUnusedTrackNumberId()
-
 
         val originalLocationTrack = locationTrackService.saveDraft(
             locationTrack(trackNumberId, topologyStartSwitch = TopologyLocationTrackSwitch(switchUnlinkedFromTopology.id, JointNumber(1))),
@@ -1380,7 +1381,7 @@ class PublicationServiceIT @Autowired constructor(
         switchService.saveDraft(
             switchDao.fetch(switchMerelyRenamed.rowVersion).copy(name = SwitchName("sw-with-new-name"))
         )
-        val newSwitchReplacingOldWithSameName = switchService.saveDraft(switch(8, name = "sw-replaced-with-new-same-name"))
+        val newSwitchReplacingOldWithSameName = switchService.saveDraft(switch(name = "sw-replaced-with-new-same-name", externalId = "1.1.1.1.9"))
 
         locationTrackService.saveDraft(
             locationTrackDao.fetch(locationTrackDao.fetchVersion(originalLocationTrack.id, OFFICIAL)!!).copy(
@@ -1411,7 +1412,8 @@ class PublicationServiceIT @Autowired constructor(
 
         val diff = publicationService.diffLocationTrack(
             localizationService.getLocalization("fi"),
-            changes.getValue(originalLocationTrack.id as IntId),
+            changes.getValue(originalLocationTrack.id),
+            publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(latestPub.id)[originalLocationTrack.id],
             latestPub.publicationTime,
             previousPub.publicationTime,
             trackNumberDao.fetchTrackNumberNames(),
@@ -1421,9 +1423,9 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals(1, diff.size)
         assertEquals("linked-switches", diff[0].propKey.key.toString())
         assertEquals("""
-            Vaihteiden sw-deleted, sw-replaced-with-new-same-name, sw-unlinked-from-alignment,
+            Vaihteiden sw-deleted, sw-replaced-with-new-same-name (1.1.1.1.8), sw-unlinked-from-alignment,
             sw-unlinked-from-topology linkitys purettu. Vaihteet sw-added-to-alignment, sw-added-to-topo-end,
-            sw-added-to-topo-start, sw-replaced-with-new-same-name linkitetty.
+            sw-added-to-topo-start, sw-replaced-with-new-same-name (1.1.1.1.9) linkitetty.
         """.trimIndent().replace("\n", " "), diff[0].remark)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -629,8 +629,9 @@ fun switch(
     structureId: IntId<SwitchStructure> = switchStructureYV60_300_1_9().id as IntId,
     joints: List<TrackLayoutSwitchJoint> = joints(seed),
     name: String = "TV$seed",
+    externalId: String? = null,
 ) = TrackLayoutSwitch(
-    externalId = null,
+    externalId = if (externalId != null) Oid(externalId) else null,
     sourceId = null,
     name = SwitchName(name),
     stateCategory = getSomeValue(seed),


### PR DESCRIPTION
Vaihdelinkkien muutosten haku on suht monimutkainen ja eroteltu nyt omaksi massahaukseen, tosin postgressi osaisi näemmä hoitaa sen nyt melkein kohtuudella julkaisu kerrallaankin haettaessa, mutta silti selvästi nopeammin näin.

fetchPublicationLocationTrackSwitchLinkChanges-haun logiikka ylätasolla:

- haetaan aikavälin julkaisut
- niistä haetaan sijaintiraiteille tehdyt suorat muutokset (epäsuorilla ei ole merkitystä, tässä kun katsotaan vaihdelinkkejä, kun taas epäsuorien muutosten käsittely on osoitemuutoksia varten)
- niistä haetaan vanhan ja uuden version vaihdelinkityksiin liittyvät tiedot, rikastettuna sillä, oliko kyseessä nyt siis muutoksen vanha vai uusi puoli
- nämä puretaan varsinaisiksi vaihde-iideiksi
- näille haetaan switch_versionista kaikki versiot, joista tietenkin vain yksi voi olla se, joka oikeasti oli raiteen julkaisuhetkellä voimassa oleva
- ylimääräiset vaihdeversiot suodatetaan pois sillä, että ne ovat joko liian uusia (juuri tämä vaihdeversio on julkaistu isommalla julkaisu-id:llä kuin raide) tai liian vanhoja (on jokin uudempi vaihdeversio, jonka julkaisu näkyy tämän raiteen julkaisulle)