### PR TITLE
GVT-2174 Hide reverted items in preview view

### DIFF
--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useRef } from 'react';
 import styles from './preview-view.scss';
 import { useTranslation } from 'react-i18next';
 import { useLoader } from 'utils/react-utils';
@@ -40,6 +41,11 @@ import { debounceAsync } from 'utils/async-utils';
 import { BoundingBox } from 'model/geometry';
 import { MapContext } from 'map/map-store';
 import { MapViewContainer } from 'map/map-view-container';
+import {
+    addPublishRequestIds,
+    dropIdsFromPublishCandidates,
+    intersectPublishRequestIds,
+} from 'publication/publication-utils';
 
 type Candidate = {
     id: AssetId;
@@ -268,43 +274,47 @@ const getCalculatedChangesDebounced = debounceAsync(
 export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const { t } = useTranslation();
 
-    // Explanation for update token: The base data set for both the staged and unstaged change
-    // tables comes from the backend while staged changes are always only stored in the front end.
-    // This lead to situations where reverting a staged change would remove the row from staged
-    // changes (a front-end only operation) while the  fetch for a new change set (a backend
-    // operation) had not yet finished. The reverted row would thus pop up as an unstaged change
-    // for this time before disappearing completely. Thus redraw needs to be controlled manually,
-    // instead of relying on React's dependency-based redraw.
-    const [changeTableUpdateToken, setChangeTableUpdateToken] = React.useState<number>();
-    const updateChangeTables = () => setChangeTableUpdateToken(Date.now());
+    const revertedCandidatesSoFar = useRef(publishCandidateIds(emptyChanges));
+
     const [onlyShowMine, setOnlyShowMine] = React.useState(false);
     const user = useLoader(getOwnUser, []);
 
     const entireChangeset = useLoader(() => getPublishCandidates(), [props.changeTimes]);
     const validatedChangeset = useLoader(
         () =>
-            validateDebounced(props.selectedPublishCandidateIds).then(
-                (validatedPublishCandidates) => {
-                    updateChangeTables();
-                    return validatedPublishCandidates;
-                },
-            ),
+            validateDebounced(props.selectedPublishCandidateIds).then((validated) => {
+                if (validated !== undefined) {
+                    // forget any reversions that the backend acknowledged, in case the user is working on multiple tabs
+                    // and might re-draft an object after reverting it
+                    revertedCandidatesSoFar.current = intersectPublishRequestIds(
+                        revertedCandidatesSoFar.current,
+                        publishCandidateIds(validated.allChangesValidated),
+                    );
+                }
+                return validated;
+            }),
         [props.selectedPublishCandidateIds],
     );
     const unstagedChanges = validatedChangeset
         ? getUnstagedChanges(
-              validatedChangeset?.allChangesValidated,
+              dropIdsFromPublishCandidates(
+                  validatedChangeset.allChangesValidated,
+                  revertedCandidatesSoFar.current,
+              ),
               props.selectedPublishCandidateIds,
           )
         : undefined;
     const stagedChangesValidated = validatedChangeset
         ? getStagedChanges(
-              validatedChangeset.validatedAsPublicationUnit,
+              dropIdsFromPublishCandidates(
+                  validatedChangeset.validatedAsPublicationUnit,
+                  revertedCandidatesSoFar.current,
+              ),
               props.selectedPublishCandidateIds,
           )
         : undefined;
 
-    const unstagedPreviewChanges: PreviewCandidates = React.useMemo(() => {
+    const unstagedPreviewChanges: PreviewCandidates = (() => {
         const allUnstagedChangesValidated = unstagedChanges
             ? {
                   trackNumbers: unstagedChanges.trackNumbers.map(nonPendingCandidate),
@@ -317,19 +327,16 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
         return user && onlyShowMine
             ? previewCandidatesByUser(user, allUnstagedChangesValidated)
             : allUnstagedChangesValidated;
-    }, [changeTableUpdateToken]);
+    })();
 
-    const stagedPreviewChanges: PreviewCandidates = React.useMemo(
-        () =>
-            stagedChangesValidated && entireChangeset
-                ? previewChanges(
-                      stagedChangesValidated,
-                      props.selectedPublishCandidateIds,
-                      entireChangeset,
-                  )
-                : emptyChanges,
-        [changeTableUpdateToken],
-    );
+    const stagedPreviewChanges: PreviewCandidates =
+        stagedChangesValidated && entireChangeset
+            ? previewChanges(
+                  stagedChangesValidated,
+                  props.selectedPublishCandidateIds,
+                  entireChangeset,
+              )
+            : emptyChanges;
 
     const calculatedChanges = useLoader(
         () => getCalculatedChangesDebounced(props.selectedPublishCandidateIds),
@@ -362,6 +369,10 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
             .then((r) => {
                 if (r.isOk()) {
                     Snackbar.success(t('publish.revert-success'));
+                    revertedCandidatesSoFar.current = addPublishRequestIds(
+                        revertedCandidatesSoFar.current,
+                        changesBeingReverted.changeIncludingDependencies,
+                    );
                     props.onPublishPreviewRemove(changesBeingReverted.changeIncludingDependencies);
                 }
             })
@@ -375,12 +386,10 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
         props.onPublishPreviewRemove(
             singleRowPublishRequestOfSelectedPublishChange(selectedChange),
         );
-        updateChangeTables();
     };
 
     const onPreviewSelect = (selectedChange: SelectedPublishChange): void => {
         props.onPreviewSelect(selectedChange);
-        updateChangeTables();
     };
 
     return (
@@ -399,7 +408,6 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                         checked={onlyShowMine}
                                         onChange={(e) => {
                                             setOnlyShowMine(e.target.checked);
-                                            updateChangeTables();
                                         }}>
                                         {t('preview-view.show-only-mine')}
                                     </Checkbox>

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -1,0 +1,46 @@
+import { PublishCandidates, PublishRequestIds } from 'publication/publication-model';
+import { filterByIdNotIn, filterIn, filterNotIn } from 'utils/array-utils';
+
+export const addPublishRequestIds = (
+    a: PublishRequestIds,
+    b: PublishRequestIds,
+): PublishRequestIds => ({
+    trackNumbers: [...new Set([...a.trackNumbers, ...b.trackNumbers])],
+    locationTracks: [...new Set([...a.locationTracks, ...b.locationTracks])],
+    referenceLines: [...new Set([...a.referenceLines, ...b.referenceLines])],
+    switches: [...new Set([...a.switches, ...b.switches])],
+    kmPosts: [...new Set([...a.kmPosts, ...b.kmPosts])],
+});
+
+export const subtractPublishRequestIds = (a: PublishRequestIds, b: PublishRequestIds) => ({
+    trackNumbers: a.trackNumbers.filter(filterNotIn(b.trackNumbers)),
+    locationTracks: a.locationTracks.filter(filterNotIn(b.locationTracks)),
+    referenceLines: a.referenceLines.filter(filterNotIn(b.referenceLines)),
+    switches: a.switches.filter(filterNotIn(b.switches)),
+    kmPosts: a.kmPosts.filter(filterNotIn(b.kmPosts)),
+});
+
+export const intersectPublishRequestIds = (a: PublishRequestIds, b: PublishRequestIds) => ({
+    trackNumbers: a.trackNumbers.filter(filterIn(b.trackNumbers)),
+    locationTracks: a.locationTracks.filter(filterIn(b.locationTracks)),
+    referenceLines: a.referenceLines.filter(filterIn(b.referenceLines)),
+    switches: a.switches.filter(filterIn(b.switches)),
+    kmPosts: a.kmPosts.filter(filterIn(b.kmPosts)),
+});
+
+export const dropIdsFromPublishCandidates = (
+    publishCandidates: PublishCandidates,
+    ids: PublishRequestIds,
+): PublishCandidates => ({
+    trackNumbers: publishCandidates.trackNumbers.filter(
+        filterByIdNotIn(ids.trackNumbers, ({ id }) => id),
+    ),
+    referenceLines: publishCandidates.referenceLines.filter(
+        filterByIdNotIn(ids.referenceLines, ({ id }) => id),
+    ),
+    switches: publishCandidates.switches.filter(filterByIdNotIn(ids.switches, ({ id }) => id)),
+    locationTracks: publishCandidates.locationTracks.filter(
+        filterByIdNotIn(ids.locationTracks, ({ id }) => id),
+    ),
+    kmPosts: publishCandidates.kmPosts.filter(filterByIdNotIn(ids.kmPosts, ({ id }) => id)),
+});

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -28,10 +28,11 @@ import {
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import { Point } from 'model/geometry';
-import { addIfExists, subtract } from 'utils/array-utils';
+import { addIfExists } from 'utils/array-utils';
 import { PublishRequestIds } from 'publication/publication-model';
 import { ToolPanelAsset } from 'tool-panel/tool-panel';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { subtractPublishRequestIds } from 'publication/publication-utils';
 
 export type SelectedPublishChange = {
     trackNumber: LayoutTrackNumberId | undefined;
@@ -370,24 +371,10 @@ const trackLayoutSlice = createSlice({
         ): void {
             const stateCandidates = state.stagedPublicationRequestIds;
             const toRemove = action.payload;
-            const trackNumbers = subtract(stateCandidates.trackNumbers, toRemove.trackNumbers);
-            const referenceLines = subtract(
-                stateCandidates.referenceLines,
-                toRemove.referenceLines,
+            state.stagedPublicationRequestIds = subtractPublishRequestIds(
+                stateCandidates,
+                toRemove,
             );
-            const locationTracks = subtract(
-                stateCandidates.locationTracks,
-                toRemove.locationTracks,
-            );
-            const switches = subtract(stateCandidates.switches, toRemove.switches);
-            const kmPosts = subtract(stateCandidates.kmPosts, toRemove.kmPosts);
-            state.stagedPublicationRequestIds = {
-                trackNumbers,
-                referenceLines,
-                locationTracks,
-                switches,
-                kmPosts,
-            };
         },
 
         onHighlightItems: function (

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -8,6 +8,30 @@ export function filterNotEmpty<TValue>(value: TValue | undefined): value is TVal
     return value !== undefined;
 }
 
+export function filterIn<T>(others: T[]): (item: T) => boolean {
+    return filterByIdInOrNotIn(others, (id) => id, true);
+}
+
+export function filterNotIn<T>(others: T[]): (item: T) => boolean {
+    return filterByIdNotIn(others, (id) => id);
+}
+
+export function filterByIdNotIn<T, Id>(
+    others: Id[],
+    getId: (thing: T) => Id,
+): (item: T) => boolean {
+    return filterByIdInOrNotIn(others, getId, false);
+}
+
+function filterByIdInOrNotIn<T, Id>(
+    others: Id[],
+    getId: (thing: T) => Id,
+    yesIn: boolean,
+): (item: T) => boolean {
+    const othersSet = new Set(others);
+    return (item: T) => yesIn == othersSet.has(getId(item));
+}
+
 /**
  * Usage:
  * persons.filter(filterUniqueById((person) => person.id))
@@ -202,14 +226,6 @@ export function first<T>(array: T[]): T {
 
 export function last<T>(array: T[]): T {
     return array[array.length - 1];
-}
-
-export function subtract<T>(originalCollection: T[], valuesToRemove: T[]): T[] {
-    if (valuesToRemove.length === 0) {
-        return originalCollection;
-    }
-    const setToRemove = new Set(valuesToRemove);
-    return originalCollection.filter((x) => !setToRemove.has(x));
 }
 
 export function removeIfExists<T>(originalCollection: T[], valueToRemove: T | undefined) {


### PR DESCRIPTION
Samassa syssyssä koottu vähän yhteen kasaa PublishRequestIds-tietoja käsitteleviä funktiota.

Se, että revertedCandidatesSoFar on refissä, menee vähän Reactin ohi, mutta tässä tapauksessa sillä sattuu saamaan parhaiten tilanhallinnan pysymään synkassa, ja muuten vaatisi enemmän kiemuroita välttää listojen välkkymiset.