### PR TITLE
GVT-2185 & GVT-2186: CSS-korjauksia dropdowneihin

### DIFF
--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -282,6 +282,7 @@ export const ToolBar: React.FC<ToolbarParams> = (props: ToolbarParams) => {
                     onChange={onItemSelected}
                     size={DropdownSize.STRETCH}
                     wideList
+                    wide
                     qa-id="search-box"
                 />
                 <MapLayerMenu

--- a/ui/src/vayla-design-lib/dropdown/dropdown.scss
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.scss
@@ -133,6 +133,7 @@ $dropdown-border-error: 1.5px;
 
 .dropdown--searchable .dropdown__input {
     opacity: 1;
+    width: 100%;
 }
 
 .dropdown__current-value {
@@ -164,7 +165,7 @@ $dropdown-border-error: 1.5px;
     display: flex;
     flex-direction: column;
     margin-top: 2px;
-    max-height: 250px;
+    max-height: 270px;
     border-radius: 4px;
     background: colors.$color-white-default;
 }


### PR DESCRIPTION
Hakuehto vie nyt kaiken mahdollisen tilan mitä se vaan voi (eli ikoniin saakka, aiemmin se vei vaan noin puolet). Tämän lisäksi roplattu tulosjoukon maksimikorkeutta siten, että nyt meillä viimeisestä näkyvästä hakutuloksesta näytetään vaan osa. Tämä antaa operaattorille paremman indikaation siitä, että listalla on vielä enemmänkin nähtävää ja että sitä voi scrollata.