### PR TITLE
General: Increase detekt constructor parameter amount warning threshold

### DIFF
--- a/infra/detekt.yml
+++ b/infra/detekt.yml
@@ -132,7 +132,7 @@ complexity:
   LongParameterList:
     active: true
     functionThreshold: 6
-    constructorThreshold: 7
+    constructorThreshold: 21
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotatedParameter: []


### PR DESCRIPTION
General: Increase detekt constructor parameter amount warning threshold

The amount of dependency injected resources to class constructors is very often already more than the default limit of detekt.

In the future it might be useful to split classes requiring large amount of external resources (such as services), but for now increasing the constructor parameter amount threshold of detekt seemed like a sane option in order to reduce the amount of detekt-related noise.