### PR TITLE
GVT-2218 Filter trackLayoutPlan loading by displayed tiles

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -75,12 +75,12 @@ class GeometryController @Autowired constructor(
 
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/plans/{geometryPlanId}/layout")
-    fun getTackLayoutPlan(
+    fun getTrackLayoutPlan(
         @PathVariable("geometryPlanId") geometryPlanId: IntId<GeometryPlan>,
         @RequestParam("includeGeometryData") includeGeometryData: Boolean = true,
     ): GeometryPlanLayout? {
         log.apiCall(
-            "getTackLayoutPlan",
+            "getTrackLayoutPlan",
             "planId" to geometryPlanId, "includeGeometryData" to includeGeometryData
         )
         return planLayoutService.getLayoutPlan(geometryPlanId, includeGeometryData).first

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -53,7 +53,7 @@ export const GEOMETRY_URI = `${API_URI}/geometry`;
 
 const trackLayoutPlanCache = asyncCache<GeometryPlanId, GeometryPlanLayout | undefined>();
 const geometryPlanCache = asyncCache<GeometryPlanId, GeometryPlan | undefined>();
-const geometryPlanAreaCache = asyncCache<GeometryPlanId, PlanArea[]>();
+const geometryPlanAreaCache = asyncCache<string, PlanArea[]>(); // map tile ID => plan area[]
 
 const projectCache = asyncCache<undefined, Project[]>();
 
@@ -271,16 +271,6 @@ export async function getTrackLayoutPlan(
     const url = `${GEOMETRY_URI}/plans/${planId}/layout?includeGeometryData=${includeGeometryData}`;
     const key = `${planId}-${includeGeometryData}`;
     return trackLayoutPlanCache.get(changeTime, key, () => getNullable(url));
-}
-
-export async function getTrackLayoutPlans(
-    planIds: GeometryPlanId[],
-    includeGeometryData = true,
-): Promise<GeometryPlanLayout[]> {
-    const changeTime = getChangeTimes().geometryPlan;
-    return Promise.all(
-        planIds.map((planId) => getTrackLayoutPlan(planId, changeTime, includeGeometryData)),
-    ).then((plans) => plans.filter(filterNotEmpty));
 }
 
 export async function getProjects(changeTime = getChangeTimes().project): Promise<Project[]> {

--- a/ui/src/map/layers/geometry/geometry-alignment-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-alignment-layer.ts
@@ -9,11 +9,10 @@ import {
     LayoutPoint,
     PlanLayoutAlignment,
 } from 'track-layout/track-layout-model';
-import { clearFeatures, pointToCoords } from 'map/layers/utils/layer-utils';
+import { clearFeatures, getVisiblePlans, pointToCoords } from 'map/layers/utils/layer-utils';
 import { LayerItemSearchResult, MapLayer, SearchItemsOptions } from 'map/layers/utils/layer-model';
 import * as Limits from 'map/layers/utils/layer-visibility-limits';
 import { getLinkedAlignmentIdsInPlan } from 'linking/linking-api';
-import { getTrackLayoutPlan } from 'geometry/geometry-api';
 import { PublishType } from 'common/common-model';
 import { filterNotEmpty, filterUniqueById } from 'utils/array-utils';
 import { AlignmentHeader, toMapAlignmentResolution } from 'track-layout/layout-map-api';
@@ -28,6 +27,7 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import { cache } from 'cache/cache';
+import { MapTile } from 'map/map-model';
 
 const alignmentFeatureCache = cache<string, Feature<LineString>>(500);
 
@@ -142,6 +142,7 @@ type PlanAlignments = {
     alignments: AlignmentWithLinking[];
 };
 export function createGeometryAlignmentLayer(
+    mapTiles: MapTile[],
     existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
     selection: Selection,
     publishType: PublishType,
@@ -161,11 +162,8 @@ export function createGeometryAlignmentLayer(
 
     const plansPromise: Promise<GeometryPlanLayout[]> = manuallySetPlan
         ? Promise.resolve([manuallySetPlan])
-        : Promise.all(
-              selection.visiblePlans.map((p) =>
-                  getTrackLayoutPlan(p.id, changeTimes.geometryPlan, true),
-              ),
-          ).then((plans) => plans.filter(filterNotEmpty).filter((p) => !p.planHidden));
+        : getVisiblePlans(selection.visiblePlans, mapTiles, changeTimes);
+
     const planAlignmentsPromise: Promise<PlanAlignments[]> = plansPromise.then((plans) =>
         Promise.all(
             plans.map((plan: GeometryPlanLayout) => {

--- a/ui/src/map/layers/geometry/geometry-km-post-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-km-post-layer.ts
@@ -18,10 +18,12 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { filterNotEmpty } from 'utils/array-utils';
 import { ChangeTimes } from 'common/common-slice';
+import { MapTile } from 'map/map-model';
 
 let newestLayerId = 0;
 
 export function createGeometryKmPostLayer(
+    mapTiles: MapTile[],
     resolution: number,
     existingOlLayer: VectorLayer<VectorSource<OlPoint | Rectangle>> | undefined,
     selection: Selection,
@@ -51,7 +53,7 @@ export function createGeometryKmPostLayer(
 
         const plansPromise: Promise<PlanAndStatus[]> = manuallySetPlan
             ? getManualPlanWithStatus(manuallySetPlan, publishType)
-            : getVisiblePlansWithStatus(selection.visiblePlans, publishType, changeTimes);
+            : getVisiblePlansWithStatus(selection.visiblePlans, mapTiles, publishType, changeTimes);
 
         plansPromise
             .then((planStatuses) => {

--- a/ui/src/map/layers/geometry/geometry-switch-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-switch-layer.ts
@@ -16,9 +16,11 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { filterNotEmpty } from 'utils/array-utils';
 import { ChangeTimes } from 'common/common-slice';
+import { MapTile } from 'map/map-model';
 
 let newestLayerId = 0;
 export function createGeometrySwitchLayer(
+    mapTiles: MapTile[],
     existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
     selection: Selection,
     publishType: PublishType,
@@ -60,7 +62,7 @@ export function createGeometrySwitchLayer(
 
     const plansPromise: Promise<PlanAndStatus[]> = manuallySetPlan
         ? getManualPlanWithStatus(manuallySetPlan, publishType)
-        : getVisiblePlansWithStatus(selection.visiblePlans, publishType, changeTimes);
+        : getVisiblePlansWithStatus(selection.visiblePlans, mapTiles, publishType, changeTimes);
 
     Promise.all([getSwitchStructures(), plansPromise])
         .then(([switchStructures, planStatuses]) => {

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -417,6 +417,7 @@ const MapView: React.FC<MapViewProps> = ({
                         );
                     case 'geometry-alignment-layer':
                         return createGeometryAlignmentLayer(
+                            mapTiles,
                             existingOlLayer as VectorLayer<VectorSource<LineString>>,
                             selection,
                             publishType,
@@ -426,6 +427,7 @@ const MapView: React.FC<MapViewProps> = ({
                         );
                     case 'geometry-km-post-layer':
                         return createGeometryKmPostLayer(
+                            mapTiles,
                             resolution,
                             existingOlLayer as VectorLayer<VectorSource<OlPoint | Rectangle>>,
                             selection,
@@ -435,6 +437,7 @@ const MapView: React.FC<MapViewProps> = ({
                         );
                     case 'geometry-switch-layer':
                         return createGeometrySwitchLayer(
+                            mapTiles,
                             existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
                             selection,
                             publishType,

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -1,6 +1,7 @@
 import {
     GeometryAlignmentId,
     GeometryKmPostId,
+    GeometryPlanId,
     GeometryPlanLayoutId,
     GeometrySwitchId,
     GeometryTrackNumberId,
@@ -201,9 +202,8 @@ export type LayoutKmLengthDetails = {
     location?: Point;
 };
 
-export type PlanAreaId = string;
 export type PlanArea = {
-    id: PlanAreaId;
+    id: GeometryPlanId;
     fileName: string;
     polygon: Point[];
 };


### PR DESCRIPTION
Teoriassa nyt jos sivun refreshaa, niin suunnitelmien lataamiseen voi juuri sopivassa tilanteessa mennä hetken verran pidemmän kuin ennen, koska nyt käydään ensiksi katsomassa (jo olemassaolevalla suunnitelman alueiden haulla) että mitä suunnitelmia kartalla näkyvällä alueella on, ja vasta sitten käydään hakemassa niistä ne, jotka olivat sekä näkyvällä alueella että silmällä valittuja; mutta useimmissa refreshauksissa latauksien määrä vähenee.