### PR TITLE
GVT-2225: Parannuksia muutosdialogeihin

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -312,7 +312,6 @@
         "created-successfully": "Uusi sijaintiraide lisätty rekisteriin",
         "modified-successfully": "Sijaintiraiteen tiedot päivitetty",
         "deleted-successfully": "Sijaintiraide poistettu",
-        "delete-draft": "Poista",
         "mandatory-field": "Pakollinen kenttä",
         "invalid-description": "Kuvauksen perusosan tulee olla 4-256 merkkiä pitkä",
         "invalid-name": "Virheellinen sijaintiraidetunnus",
@@ -390,7 +389,6 @@
                 "location": "Sijainti (km + m)",
                 "coordinates": "Koordinaatit (TM35FIN)",
                 "change-info-heading": "Lokitiedot",
-                "delete-draft": "Poista",
                 "no-kilometer-length": "Pituutta ei voida laskea",
                 "negative-kilometer-length": "Virheellinen sijainti"
             },
@@ -425,7 +423,6 @@
                 "owner": "Omistaja",
                 "show-on-map": "Kohdista kartalla",
                 "change-info-heading": "Lokitiedot",
-                "delete-draft": "Poista",
                 "joint-alignments-title": "Vaihteen linja",
                 "joint-alignments-location-tracks-title": "Linjan läpi kulkeva raide",
                 "joint-number-title": "Vaihteen piste",
@@ -559,7 +556,6 @@
             "end-location": "Loppusijainti (km + m)",
             "true-length": "Todellinen pituus (m)",
             "owner": "Omistaja",
-            "delete-draft": "Poista",
             "delete-dialog": {
                 "delete-draft-confirm": "Poistetaanko luonnos?",
                 "can-be-deleted": "Tätä sijaintiraidetta ei ole vielä julkaistu Ratkoon, joten voit poistaa sen kokonaan. Poiston jälkeen et voi enää palauttaa sijaintiraidetta.",
@@ -1366,7 +1362,6 @@
         "modify-succeeded": "Tasakilometripisteen tiedot päivitetty",
         "modify-failed": "Tasakilometripisteen muokkaus epäonnistui",
         "delete-successfully": "Tasakilometripiste poistettu",
-        "delete-draft": "Poista",
         "cant-open-deleted": "Tietoja ei voitu avata, koska tasakilometripiste on poistettu",
         "move-to-edit": "Siirry muokkaamaan tasakilometripistettä {{number}}"
     },
@@ -1426,7 +1421,6 @@
             "track-number": "Ratanumero",
             "reference-line": "Pituusmittauslinja",
             "metadata-heading": "Metatiedot",
-            "delete-draft": "Poista",
             "delete-non-draft": "Ratanumeron poistaminen paikannuspohjasta"
         },
         "dialog": {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -312,7 +312,7 @@
         "created-successfully": "Uusi sijaintiraide lisätty rekisteriin",
         "modified-successfully": "Sijaintiraiteen tiedot päivitetty",
         "deleted-successfully": "Sijaintiraide poistettu",
-        "delete-draft": "Poista luonnos",
+        "delete-draft": "Poista",
         "mandatory-field": "Pakollinen kenttä",
         "invalid-description": "Kuvauksen perusosan tulee olla 4-256 merkkiä pitkä",
         "invalid-name": "Virheellinen sijaintiraidetunnus",
@@ -390,7 +390,7 @@
                 "location": "Sijainti (km + m)",
                 "coordinates": "Koordinaatit (TM35FIN)",
                 "change-info-heading": "Lokitiedot",
-                "delete-draft": "Poista luonnos",
+                "delete-draft": "Poista",
                 "no-kilometer-length": "Pituutta ei voida laskea",
                 "negative-kilometer-length": "Virheellinen sijainti"
             },
@@ -425,7 +425,7 @@
                 "owner": "Omistaja",
                 "show-on-map": "Kohdista kartalla",
                 "change-info-heading": "Lokitiedot",
-                "delete-draft": "Poista luonnos",
+                "delete-draft": "Poista",
                 "joint-alignments-title": "Vaihteen linja",
                 "joint-alignments-location-tracks-title": "Linjan läpi kulkeva raide",
                 "joint-number-title": "Vaihteen piste",
@@ -559,7 +559,7 @@
             "end-location": "Loppusijainti (km + m)",
             "true-length": "Todellinen pituus (m)",
             "owner": "Omistaja",
-            "delete-draft": "Poista luonnos",
+            "delete-draft": "Poista",
             "delete-dialog": {
                 "delete-draft-confirm": "Poistetaanko luonnos?",
                 "can-be-deleted": "Tätä sijaintiraidetta ei ole vielä julkaistu Ratkoon, joten voit poistaa sen kokonaan. Poiston jälkeen et voi enää palauttaa sijaintiraidetta.",
@@ -1366,7 +1366,7 @@
         "modify-succeeded": "Tasakilometripisteen tiedot päivitetty",
         "modify-failed": "Tasakilometripisteen muokkaus epäonnistui",
         "delete-successfully": "Tasakilometripiste poistettu",
-        "delete-draft": "Poista luonnos",
+        "delete-draft": "Poista",
         "cant-open-deleted": "Tietoja ei voitu avata, koska tasakilometripiste on poistettu",
         "move-to-edit": "Siirry muokkaamaan tasakilometripistettä {{number}}"
     },
@@ -1426,7 +1426,7 @@
             "track-number": "Ratanumero",
             "reference-line": "Pituusmittauslinja",
             "metadata-heading": "Metatiedot",
-            "delete-draft": "Poista luonnos",
+            "delete-draft": "Poista",
             "delete-non-draft": "Ratanumeron poistaminen paikannuspohjasta"
         },
         "dialog": {

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -368,7 +368,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                 variant={ButtonVariant.SECONDARY}
                                 disabled={linkingCallInProgress}
                                 onClick={startLinking}>
-                                {t('tool-panel.alignment.geometry.return')}
+                                {t('tool-panel.alignment.geometry.cancel')}
                             </Button>
                             <Button
                                 size={ButtonSize.SMALL}

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -200,12 +200,17 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                                 {t('km-post-dialog.delete-draft')}
                             </Button>
                         )}
-                        <div className={dialogStyles['dialog__footer-content--centered']}>
+                        <div
+                            className={
+                                state.existingKmPost?.draftType === 'NEW_DRAFT'
+                                    ? dialogStyles['dialog__footer-content--right-aligned']
+                                    : dialogStyles['dialog__footer-content--centered']
+                            }>
                             <Button
                                 variant={ButtonVariant.SECONDARY}
                                 disabled={state.isSaving}
                                 onClick={() => close()}>
-                                {t('button.return')}
+                                {t('button.cancel')}
                             </Button>
                             <span onClick={() => stateActions.validate()}>
                                 <Button

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -197,7 +197,7 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                                 }
                                 icon={Icons.Delete}
                                 variant={ButtonVariant.WARNING}>
-                                {t('km-post-dialog.delete-draft')}
+                                {t('button.delete')}
                             </Button>
                         )}
                         <div

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -187,7 +187,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                                 icon={Icons.Delete}
                                 variant={ButtonVariant.WARNING}
                                 size={ButtonSize.SMALL}>
-                                {t('tool-panel.km-post.layout.delete-draft')}
+                                {t('button.delete')}
                             </Button>
                         </InfoboxButtons>
                     )}

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -322,7 +322,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                         }
                                         icon={Icons.Delete}
                                         variant={ButtonVariant.WARNING}>
-                                        {t('location-track-dialog.delete-draft')}
+                                        {t('button.delete')}
                                     </Button>
                                 </div>
                             )}

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -331,7 +331,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                 variant={ButtonVariant.SECONDARY}
                                 disabled={state.isSaving}
                                 onClick={() => cancelSave()}>
-                                {t('button.return')}
+                                {t('button.cancel')}
                             </Button>
                             <Button
                                 disabled={!canSaveLocationTrack(state)}

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -463,7 +463,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                     icon={Icons.Delete}
                                     variant={ButtonVariant.WARNING}
                                     size={ButtonSize.SMALL}>
-                                    {t('tool-panel.location-track.delete-draft')}
+                                    {t('button.delete')}
                                 </Button>
                             </InfoboxButtons>
                         )}

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -311,7 +311,7 @@ export const SwitchEditDialog = ({
                                 onClick={() => setShowDeleteDraftConfirmDialog(true)}
                                 icon={Icons.Delete}
                                 variant={ButtonVariant.WARNING}>
-                                {t('tool-panel.switch.layout.delete-draft')}
+                                {t('button.delete')}
                             </Button>
                         )}
                         <div

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -314,9 +314,14 @@ export const SwitchEditDialog = ({
                                 {t('tool-panel.switch.layout.delete-draft')}
                             </Button>
                         )}
-                        <div className={dialogStyles['dialog__footer-content--centered']}>
+                        <div
+                            className={
+                                existingSwitch?.draftType === 'NEW_DRAFT'
+                                    ? dialogStyles['dialog__footer-content--right-aligned']
+                                    : dialogStyles['dialog__footer-content--centered']
+                            }>
                             <Button variant={ButtonVariant.SECONDARY} onClick={onClose}>
-                                {t('button.return')}
+                                {t('button.cancel')}
                             </Button>
                             <Button
                                 disabled={validationErrors.length > 0 || isSaving}

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -357,7 +357,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                                 icon={Icons.Delete}
                                 variant={ButtonVariant.WARNING}
                                 size={ButtonSize.SMALL}>
-                                {t('tool-panel.switch.layout.delete-draft')}
+                                {t('button.delete')}
                             </Button>
                         </InfoboxButtons>
                     )}

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -182,7 +182,7 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
                                     }}
                                     icon={Icons.Delete}
                                     variant={ButtonVariant.WARNING}>
-                                    {t('track-number-edit.title.delete-draft')}
+                                    {t('button.delete')}
                                 </Button>
                             </div>
                         )}

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -191,7 +191,7 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
                                 variant={ButtonVariant.SECONDARY}
                                 disabled={saveInProgress}
                                 onClick={onClose}>
-                                {t('track-number-edit.action.cancel')}
+                                {t('button.cancel')}
                             </Button>
                             <Button
                                 disabled={hasErrors || saveInProgress}

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -318,7 +318,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                                     icon={Icons.Delete}
                                     variant={ButtonVariant.WARNING}
                                     size={ButtonSize.SMALL}>
-                                    {t('tool-panel.location-track.delete-draft')}
+                                    {t('button.delete')}
                                 </Button>
                             </InfoboxButtons>
                         )}


### PR DESCRIPTION
Pääasiallisina muutoksina:
* Poistonapeissa teksti "Poista luonnos" typistetty vain muotoon "Poista"
* Muutettu dialogeista tallentamatta poistumisen nappuloissa "Poistu"-tekstimuodot "Peruuta":ksi
* Yksipalstaisissa dialogeissa alareunan tallenna- ja peruuta-nappulat tasattu oikeaan reunaan silloin jos luonnoksen poistonappula on näkyvissä
* Muutettu satunnaisesti vastaan tulleena myös linkitystilassa "Poistu"-napin tekstimuoto "Peruuta":ksi