### PR TITLE
GVT-2230: Syöttökentän punaisen korostuksen paksuus vaihtelee

### DIFF
--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -368,7 +368,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                 variant={ButtonVariant.SECONDARY}
                                 disabled={linkingCallInProgress}
                                 onClick={startLinking}>
-                                {t('tool-panel.alignment.geometry.cancel')}
+                                {t('tool-panel.alignment.geometry.return')}
                             </Button>
                             <Button
                                 size={ButtonSize.SMALL}

--- a/ui/src/vayla-design-lib/dropdown/dropdown.scss
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.scss
@@ -7,7 +7,7 @@
 $dropdown-padding-side: 12px;
 $dropdown-border-default: 1px;
 $dropdown-border-thick: 2px;
-$dropdown-border-error: 1.5px;
+$dropdown-border-error: 2px;
 
 @mixin dropdown-shadow($color, $width, $has-icon) {
     box-shadow: inset 0 0 0 $width $color;

--- a/ui/src/vayla-design-lib/text-field/text-field.scss
+++ b/ui/src/vayla-design-lib/text-field/text-field.scss
@@ -7,7 +7,7 @@ $text-field-input-height: size.$input-height;
 $text-field-input-padding-side: 12px;
 $text-field-input-border-default: 1px;
 $text-field-input-border-thick: 2px;
-$text-field-input-border-error: 1.5px;
+$text-field-input-border-error: 2px;
 
 @mixin text-field-shadow($color, $width, $icon: no-icon) {
     box-shadow: inset 0 0 0 $width $color;


### PR DESCRIPTION
Täällä syyllinen oli desimaaliarvojen käyttäminen paksuutena. Aiempien tapaan tämä näyttäytyi ainoastaan sopivan selaimen ja sopivan zoomitason combona (jos selaimena oli Chrome ja/tai Firefoxissa oli käytössä 100%:n monikerta zoomitasona, niin kaikki näkyi ok.)

Samalla revertattu myös yksi edellisellä tiketillä tehty käännösmuutos joka rikkoi E2E-testit