### PR TITLE
GVT-2203 Use publication revert code for deleting track numbers

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -375,7 +375,7 @@
             "start-address": "Alkusijainti (km + m)",
             "delete-dialog": {
                 "delete-draft-confirm": "Poistetaanko luonnos?",
-                "can-be-deleted": "Tätä ratanumeroa ei ole vielä julkaistu Ratkoon, joten voit poistaa sen kokonaan. Poiston jälkeen et voi enää palauttaa ratanumeroa. Ratanumeron poistaminen poistaa myös siihen liittyvän pituusmittauslinjan.",
+                "can-be-deleted": "Tätä ratanumeroa ei ole vielä julkaistu Ratkoon, joten voit poistaa sen kokonaan. Poiston jälkeen et voi enää palauttaa ratanumeroa.",
                 "delete-succeeded": "Ratanumero poistettu.",
                 "delete-failed": "Poisto epäonnistui."
             }
@@ -1441,7 +1441,7 @@
             "track-number": "Ratanumero",
             "reference-line": "Pituusmittauslinja",
             "metadata-heading": "Metatiedot",
-            "delete-non-draft": "Ratanumeron poistaminen paikannuspohjasta"
+            "delete-draft": "Poista luonnos"
         },
         "dialog": {
             "deleted-track-numbers-not-allowed": "Poistettu-tilainen ratanumero ei voi olla osa paikannuspohjaa.",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1441,7 +1441,8 @@
             "track-number": "Ratanumero",
             "reference-line": "Pituusmittauslinja",
             "metadata-heading": "Metatiedot",
-            "delete-draft": "Poista luonnos"
+            "delete-draft": "Poista luonnos",
+            "delete-non-draft": "Ratanumeron poistaminen paikannuspohjasta"
         },
         "dialog": {
             "deleted-track-numbers-not-allowed": "Poistettu-tilainen ratanumero ei voi olla osa paikannuspohjaa.",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1441,7 +1441,7 @@
             "track-number": "Ratanumero",
             "reference-line": "Pituusmittauslinja",
             "metadata-heading": "Metatiedot",
-            "delete-draft": "Poista luonnos",
+            "delete-draft": "Poista",
             "delete-non-draft": "Ratanumeron poistaminen paikannuspohjasta"
         },
         "dialog": {

--- a/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
+++ b/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
@@ -4,150 +4,27 @@ import * as React from 'react';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { useTranslation } from 'react-i18next';
-import { PreviewSelectType } from 'preview/preview-table';
-import {
-    LayoutSwitchId,
-    LayoutTrackNumberId,
-    LocationTrackId,
-    ReferenceLineId,
-} from 'track-layout/track-layout-model';
 import { ChangesBeingReverted } from 'preview/preview-view';
 import {
-    useLocationTrack,
-    useReferenceLine,
-    useSwitch,
-    useTrackNumbers,
-} from 'track-layout/track-layout-react-utils';
-import { TimeStamp } from 'common/common-model';
-import { PublishRequestIds } from 'publication/publication-model';
-import { ChangeTimes } from 'common/common-slice';
+    onlyDependencies,
+    PublicationRequestDependencyList,
+    publicationRequestTypeTranslationKey,
+} from 'preview/publication-request-dependency-list';
+import { getChangeTimes } from 'common/change-time-api';
 
 export interface PreviewRejectConfirmDialogProps {
     changesBeingReverted: ChangesBeingReverted;
-    changeTimes: ChangeTimes;
     confirmRevertChanges: () => void;
     cancelRevertChanges: () => void;
 }
 
-const typeTranslationKey = (type: PreviewSelectType) => {
-    switch (type) {
-        case 'trackNumber':
-            return 'track-number';
-        case 'referenceLine':
-            return 'reference-line';
-        case 'locationTrack':
-            return 'location-track';
-        case 'switch':
-            return 'switch';
-        case 'kmPost':
-            return 'km-post';
-    }
-};
-
-const onlyDependencies = (changesBeingReverted: ChangesBeingReverted): PublishRequestIds => {
-    const allChanges = changesBeingReverted.changeIncludingDependencies;
-    const reqType = changesBeingReverted.requestedRevertChange.type;
-    const reqId = changesBeingReverted.requestedRevertChange.id;
-    return {
-        trackNumbers: allChanges.trackNumbers.filter(
-            (tn) => reqType != PreviewSelectType.trackNumber || tn !== reqId,
-        ),
-        kmPosts: allChanges.kmPosts.filter(
-            (kmPost) => reqType != PreviewSelectType.kmPost || kmPost !== reqId,
-        ),
-        referenceLines: allChanges.referenceLines.filter(
-            (rl) => reqType != PreviewSelectType.referenceLine || rl !== reqId,
-        ),
-        switches: allChanges.switches.filter(
-            (sw) => reqType != PreviewSelectType.switch || sw !== reqId,
-        ),
-        locationTracks: allChanges.locationTracks.filter(
-            (lt) => reqType != PreviewSelectType.locationTrack || lt !== reqId,
-        ),
-    };
-};
-
-const publicationRequestSize = (req: PublishRequestIds): number =>
-    req.switches.length +
-    req.trackNumbers.length +
-    req.locationTracks.length +
-    req.referenceLines.length +
-    req.kmPosts.length;
-
-const TrackNumberItem: React.FC<{ trackNumberId: LayoutTrackNumberId; changeTime: TimeStamp }> = (
-    props,
-) => {
-    const { t } = useTranslation();
-    const trackNumbers = useTrackNumbers('DRAFT', props.changeTime);
-    const trackNumber = trackNumbers && trackNumbers.find((tn) => tn.id === props.trackNumberId);
-    return trackNumber === undefined ? (
-        <li />
-    ) : (
-        <li>
-            {t('publish.revert-confirm.dependency-list.track-number')} {trackNumber.number}
-        </li>
-    );
-};
-
-const ReferenceLineItem: React.FC<{
-    referenceLineId: ReferenceLineId;
-    changeTimes: ChangeTimes;
-}> = (props) => {
-    const { t } = useTranslation();
-    const trackNumbers = useTrackNumbers('DRAFT', props.changeTimes.layoutTrackNumber);
-    const referenceLine = useReferenceLine(
-        props.referenceLineId,
-        'DRAFT',
-        props.changeTimes.layoutReferenceLine,
-    );
-    if (referenceLine === undefined || trackNumbers === undefined) {
-        return <li />;
-    }
-    const trackNumber = trackNumbers.find((tn) => tn.id === referenceLine.trackNumberId);
-    return trackNumber === undefined ? (
-        <li />
-    ) : (
-        <li>
-            {t('publish.revert-confirm.dependency-list.reference-line')} {trackNumber.number}
-        </li>
-    );
-};
-
-const LocationTrackItem: React.FC<{ locationTrackId: LocationTrackId; changeTime: TimeStamp }> = (
-    props,
-) => {
-    const { t } = useTranslation();
-    const locationTrack = useLocationTrack(props.locationTrackId, 'DRAFT', props.changeTime);
-    return locationTrack === undefined ? (
-        <li />
-    ) : (
-        <li>
-            {t('publish.revert-confirm.dependency-list.location-track')} {locationTrack.name}
-        </li>
-    );
-};
-
-const SwitchItem: React.FC<{ switchId: LayoutSwitchId }> = ({ switchId }) => {
-    const { t } = useTranslation();
-    const switchObj = useSwitch(switchId, 'DRAFT');
-    return switchObj === undefined ? (
-        <li />
-    ) : (
-        <li>
-            {t('publish.revert-confirm.dependency-list.switch')} {switchObj.name}
-        </li>
-    );
-};
-
 export const PreviewConfirmRevertChangesDialog: React.FC<PreviewRejectConfirmDialogProps> = ({
     changesBeingReverted,
-    changeTimes,
     cancelRevertChanges,
     confirmRevertChanges,
 }) => {
     const { t } = useTranslation();
     const [isReverting, setIsReverting] = React.useState(false);
-    const dependencies = onlyDependencies(changesBeingReverted);
 
     return (
         <Dialog
@@ -177,42 +54,14 @@ export const PreviewConfirmRevertChangesDialog: React.FC<PreviewRejectConfirmDia
                 </div>
             }>
             <div>{`${t('publish.revert-confirm.description')} ${t(
-                `publish.revert-confirm.revert-target.${typeTranslationKey(
+                `publish.revert-confirm.revert-target.${publicationRequestTypeTranslationKey(
                     changesBeingReverted.requestedRevertChange.type,
                 )}`,
             )} ${changesBeingReverted.requestedRevertChange.name}?`}</div>
-            {publicationRequestSize(dependencies) > 0 && (
-                <>
-                    <div>{t(`publish.revert-confirm.dependencies`)}</div>
-                    <ul>
-                        {dependencies.trackNumbers.map((tn) => (
-                            <TrackNumberItem
-                                trackNumberId={tn}
-                                changeTime={changeTimes.layoutTrackNumber}
-                                key={tn}
-                            />
-                        ))}
-
-                        {dependencies.referenceLines.map((rl) => (
-                            <ReferenceLineItem
-                                referenceLineId={rl}
-                                changeTimes={changeTimes}
-                                key={rl}
-                            />
-                        ))}
-                        {dependencies.locationTracks.map((lt) => (
-                            <LocationTrackItem
-                                locationTrackId={lt}
-                                changeTime={changeTimes.layoutLocationTrack}
-                                key={lt}
-                            />
-                        ))}
-                        {dependencies.switches.map((sw) => (
-                            <SwitchItem switchId={sw} key={sw} />
-                        ))}
-                    </ul>
-                </>
-            )}
+            <PublicationRequestDependencyList
+                changeTimes={getChangeTimes()}
+                dependencies={onlyDependencies(changesBeingReverted)}
+            />
         </Dialog>
     );
 };

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -66,7 +66,7 @@ export type PreviewCandidates = {
 };
 
 export type ChangesBeingReverted = {
-    requestedRevertChange: PreviewTableEntry;
+    requestedRevertChange: { type: PreviewSelectType; name: string; id: string };
     changeIncludingDependencies: PublishRequestIds;
 };
 
@@ -470,7 +470,6 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
             </div>
             {changesBeingReverted !== undefined && (
                 <PreviewConfirmRevertChangesDialog
-                    changeTimes={props.changeTimes}
                     changesBeingReverted={changesBeingReverted}
                     cancelRevertChanges={() => {
                         setChangesBeingReverted(undefined);

--- a/ui/src/preview/publication-request-dependency-list.tsx
+++ b/ui/src/preview/publication-request-dependency-list.tsx
@@ -1,0 +1,179 @@
+import { PublishRequestIds } from 'publication/publication-model';
+import * as React from 'react';
+import {
+    LayoutSwitchId,
+    LayoutTrackNumberId,
+    LocationTrackId,
+    ReferenceLineId,
+} from 'track-layout/track-layout-model';
+import { TimeStamp } from 'common/common-model';
+import { useTranslation } from 'react-i18next';
+import {
+    useLocationTrack,
+    useReferenceLine,
+    useSwitch,
+    useTrackNumbers,
+    useTrackNumbersIncludingDeleted,
+} from 'track-layout/track-layout-react-utils';
+import { ChangeTimes } from 'common/common-slice';
+import { PreviewSelectType } from 'preview/preview-table';
+import { ChangesBeingReverted } from 'preview/preview-view';
+
+const publicationRequestSize = (req: PublishRequestIds): number =>
+    req.switches.length +
+    req.trackNumbers.length +
+    req.locationTracks.length +
+    req.referenceLines.length +
+    req.kmPosts.length;
+
+const TrackNumberItem: React.FC<{ trackNumberId: LayoutTrackNumberId; changeTime: TimeStamp }> = (
+    props,
+) => {
+    const { t } = useTranslation();
+    const trackNumbers = useTrackNumbers('DRAFT', props.changeTime);
+    const trackNumber = trackNumbers && trackNumbers.find((tn) => tn.id === props.trackNumberId);
+    return trackNumber === undefined ? (
+        <li />
+    ) : (
+        <li>
+            {t('publish.revert-confirm.dependency-list.track-number')} {trackNumber.number}
+        </li>
+    );
+};
+
+const ReferenceLineItem: React.FC<{
+    referenceLineId: ReferenceLineId;
+    changeTimes: ChangeTimes;
+}> = (props) => {
+    const { t } = useTranslation();
+    const trackNumbers = useTrackNumbersIncludingDeleted(
+        'DRAFT',
+        props.changeTimes.layoutTrackNumber,
+    );
+    const referenceLine = useReferenceLine(
+        props.referenceLineId,
+        'DRAFT',
+        props.changeTimes.layoutReferenceLine,
+    );
+    if (referenceLine === undefined || trackNumbers === undefined) {
+        return <li />;
+    }
+    const trackNumber = trackNumbers.find((tn) => tn.id === referenceLine.trackNumberId);
+    return trackNumber === undefined ? (
+        <li />
+    ) : (
+        <li>
+            {t('publish.revert-confirm.dependency-list.reference-line')} {trackNumber.number}
+        </li>
+    );
+};
+
+const LocationTrackItem: React.FC<{ locationTrackId: LocationTrackId; changeTime: TimeStamp }> = (
+    props,
+) => {
+    const { t } = useTranslation();
+    const locationTrack = useLocationTrack(props.locationTrackId, 'DRAFT', props.changeTime);
+    return locationTrack === undefined ? (
+        <li />
+    ) : (
+        <li>
+            {t('publish.revert-confirm.dependency-list.location-track')} {locationTrack.name}
+        </li>
+    );
+};
+
+const SwitchItem: React.FC<{ switchId: LayoutSwitchId }> = ({ switchId }) => {
+    const { t } = useTranslation();
+    const switchObj = useSwitch(switchId, 'DRAFT');
+    return switchObj === undefined ? (
+        <li />
+    ) : (
+        <li>
+            {t('publish.revert-confirm.dependency-list.switch')} {switchObj.name}
+        </li>
+    );
+};
+
+export const publicationRequestTypeTranslationKey = (type: PreviewSelectType) => {
+    switch (type) {
+        case 'trackNumber':
+            return 'track-number';
+        case 'referenceLine':
+            return 'reference-line';
+        case 'locationTrack':
+            return 'location-track';
+        case 'switch':
+            return 'switch';
+        case 'kmPost':
+            return 'km-post';
+    }
+};
+
+export const onlyDependencies = (changesBeingReverted: ChangesBeingReverted): PublishRequestIds => {
+    const allChanges = changesBeingReverted.changeIncludingDependencies;
+    const reqType = changesBeingReverted.requestedRevertChange.type;
+    const reqId = changesBeingReverted.requestedRevertChange.id;
+    return {
+        trackNumbers: allChanges.trackNumbers.filter(
+            (tn) => reqType != PreviewSelectType.trackNumber || tn !== reqId,
+        ),
+        kmPosts: allChanges.kmPosts.filter(
+            (kmPost) => reqType != PreviewSelectType.kmPost || kmPost !== reqId,
+        ),
+        referenceLines: allChanges.referenceLines.filter(
+            (rl) => reqType != PreviewSelectType.referenceLine || rl !== reqId,
+        ),
+        switches: allChanges.switches.filter(
+            (sw) => reqType != PreviewSelectType.switch || sw !== reqId,
+        ),
+        locationTracks: allChanges.locationTracks.filter(
+            (lt) => reqType != PreviewSelectType.locationTrack || lt !== reqId,
+        ),
+    };
+};
+
+export interface PublicationRequestDependencyListProps {
+    dependencies: PublishRequestIds;
+    changeTimes: ChangeTimes;
+}
+
+export const PublicationRequestDependencyList: React.FC<PublicationRequestDependencyListProps> = ({
+    dependencies,
+    changeTimes,
+}) => {
+    const { t } = useTranslation();
+    return (
+        publicationRequestSize(dependencies) > 0 && (
+            <>
+                <div>{t(`publish.revert-confirm.dependencies`)}</div>
+                <ul>
+                    {dependencies.trackNumbers.map((tn) => (
+                        <TrackNumberItem
+                            trackNumberId={tn}
+                            changeTime={changeTimes.layoutTrackNumber}
+                            key={tn}
+                        />
+                    ))}
+
+                    {dependencies.referenceLines.map((rl) => (
+                        <ReferenceLineItem
+                            referenceLineId={rl}
+                            changeTimes={changeTimes}
+                            key={rl}
+                        />
+                    ))}
+                    {dependencies.locationTracks.map((lt) => (
+                        <LocationTrackItem
+                            locationTrackId={lt}
+                            changeTime={changeTimes.layoutLocationTrack}
+                            key={lt}
+                        />
+                    ))}
+                    {dependencies.switches.map((sw) => (
+                        <SwitchItem switchId={sw} key={sw} />
+                    ))}
+                </ul>
+            </>
+        )
+    );
+};

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -169,6 +169,14 @@ export type PublishRequestIds = {
     kmPosts: LayoutKmPostId[];
 };
 
+export const publishNothing: PublishRequestIds = {
+    trackNumbers: [],
+    referenceLines: [],
+    locationTracks: [],
+    switches: [],
+    kmPosts: [],
+};
+
 export type PropKey = {
     key: string;
     params: LocalizationParams;

--- a/ui/src/tool-panel/track-number/track-number-deletion.ts
+++ b/ui/src/tool-panel/track-number/track-number-deletion.ts
@@ -1,0 +1,23 @@
+import { getRevertRequestDependencies } from 'publication/publication-api';
+import { publishNothing } from 'publication/publication-model';
+import { PreviewSelectType } from 'preview/preview-table';
+import { LayoutTrackNumber } from 'track-layout/track-layout-model';
+import { ChangesBeingReverted } from 'preview/preview-view';
+
+export const onRequestDeleteTrackNumber = (
+    trackNumber: LayoutTrackNumber,
+    setChangesBeingReverted: (changes: ChangesBeingReverted) => void,
+) => {
+    getRevertRequestDependencies({ ...publishNothing, trackNumbers: [trackNumber.id] }).then(
+        (changeIncludingDependencies) =>
+            changeIncludingDependencies &&
+            setChangesBeingReverted({
+                requestedRevertChange: {
+                    type: PreviewSelectType.trackNumber,
+                    name: trackNumber.number,
+                    id: trackNumber.id,
+                },
+                changeIncludingDependencies,
+            }),
+    );
+};

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -41,6 +41,8 @@ import { getEndLinkPoints } from 'track-layout/layout-map-api';
 import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
 import { ChangeTimes } from 'common/common-slice';
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
+import { ChangesBeingReverted } from 'preview/preview-view';
+import { onRequestDeleteTrackNumber } from 'tool-panel/track-number/track-number-deletion';
 
 type TrackNumberInfoboxProps = {
     trackNumber: LayoutTrackNumber;
@@ -99,7 +101,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
     const [showEditDialog, setShowEditDialog] = React.useState(false);
     const [canUpdate, setCanUpdate] = React.useState<boolean>();
     const [updatingLength, setUpdatingLength] = React.useState<boolean>(false);
-    const [confirmingDraftDelete, setConfirmingDraftDelete] = React.useState<boolean>();
+    const [deleting, setDeleting] = React.useState<ChangesBeingReverted>();
     const isOfficial = publishType === 'OFFICIAL';
     const officialTrackNumbers = useTrackNumbers('OFFICIAL');
     const isDeletable =
@@ -134,6 +136,8 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
     };
 
     const handleTrackNumberSave = refreshTrackNumberSelection('DRAFT', onSelect, onUnselect);
+
+    const onRequestDelete = () => onRequestDeleteTrackNumber(trackNumber, setDeleting);
 
     return (
         <React.Fragment>
@@ -314,7 +318,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                         {isDeletable && (
                             <InfoboxButtons>
                                 <Button
-                                    onClick={() => setConfirmingDraftDelete(true)}
+                                    onClick={onRequestDelete}
                                     icon={Icons.Delete}
                                     variant={ButtonVariant.WARNING}
                                     size={ButtonSize.SMALL}>
@@ -325,11 +329,12 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                     </InfoboxContent>
                 </Infobox>
             )}
-            {confirmingDraftDelete && (
+            {deleting !== undefined && (
                 <TrackNumberDeleteConfirmationDialog
-                    id={trackNumber.id}
-                    onClose={() => setConfirmingDraftDelete(false)}
+                    changesBeingReverted={deleting}
+                    onClose={() => setDeleting(undefined)}
                     onSave={handleTrackNumberSave}
+                    changeTimes={changeTimes}
                 />
             )}
             {showEditDialog && (


### PR DESCRIPTION
Isohko määrä koodimuutoksia, koska yksinkertaistin tässä hieman ratanumerodialogin logiikkaa:
- Uutta ratanumeroa luotaessa poistettu-tila on disabloitu (mutta selkeyden vuoksi silti näkyvillä); uuden dialogissa luodun ratanumeron tallentamiseen poistettu-tilaisena ei ole mitään käsittelyä, koska käyttäjä ei pysty sellaista tekemään
- varsinainen ratanumeroiden draftien delete-api ja sen JS-puoli on yhä olemassa, mutta niitä ei tällä hetkellä käytetä lainkaan (ehkä voisi poistaakin)
- Riippuvuuslista näytetään samalla koodilla kuin julkaisupuolella