### PR TITLE
GVT-2191 Remove km posts from geocoding context

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -77,6 +77,7 @@ data class KmPostWithRejectedReason(val kmPost: TrackLayoutKmPost, val rejectedR
 data class GeocodingContextCreateResult(
     val geocodingContext: GeocodingContext,
     val rejectedKmPosts: List<KmPostWithRejectedReason>,
+    val validKmPosts: List<TrackLayoutKmPost>,
 )
 
 enum class KmPostRejectedReason {
@@ -91,7 +92,6 @@ data class GeocodingContext(
     val trackNumber: TrackLayoutTrackNumber,
     val startAddress: TrackMeter,
     val referenceLineGeometry: IAlignment,
-    val kmPosts: List<TrackLayoutKmPost>,
     val referencePoints: List<GeocodingReferencePoint>,
     val projectionLineDistanceDeviation: Double = PROJECTION_LINE_DISTANCE_DEVIATION,
     val projectionLineMaxAngleDelta: Double = PROJECTION_LINE_MAX_ANGLE_DELTA,
@@ -112,18 +112,6 @@ data class GeocodingContext(
                 .all { TrackMeter.isMetersValid(it) }
         ) {
             "Reference points are too far apart from each other, trackNumber=${trackNumber.number}"
-        }
-
-        require(kmPosts.none { it.location == null }) {
-            "Geocoding context created with kmPosts without location ${
-                kmPosts.filter { it.location == null }
-            }}"
-        }
-
-        require(kmPosts.distinctBy { it.kmNumber }.size == kmPosts.size) {
-            "There are km posts with duplicate km number, ${
-                kmPosts.groupingBy { it.kmNumber }.eachCount().filter { it.value > 1 }
-            }}"
         }
     }
 
@@ -180,6 +168,7 @@ data class GeocodingContext(
             referenceLineGeometry: IAlignment,
             kmPosts: List<TrackLayoutKmPost>,
         ): GeocodingContextCreateResult {
+            requireKmPostsSanity(kmPosts)
             val (validatedKmPosts, invalidKmPosts) = validateKmPosts(kmPosts, startAddress)
 
             val (validReferencePoints, kmPostsOutsideGeometry) = createReferencePoints(
@@ -195,13 +184,21 @@ data class GeocodingContext(
             return GeocodingContextCreateResult(
                 geocodingContext = GeocodingContext(
                     trackNumber = trackNumber,
-                    kmPosts = validKmPosts,
                     referenceLineGeometry = referenceLineGeometry,
                     referencePoints = validReferencePoints,
                     startAddress = startAddress
                 ),
-                rejectedKmPosts = invalidKmPosts + kmPostsOutsideGeometry
+                rejectedKmPosts = invalidKmPosts + kmPostsOutsideGeometry,
+                validKmPosts = validKmPosts,
             )
+        }
+
+        private fun requireKmPostsSanity(kmPosts: List<TrackLayoutKmPost>) {
+            require(kmPosts.distinctBy { it.kmNumber }.size == kmPosts.size) {
+                "There are km posts with duplicate km number, ${
+                    kmPosts.groupingBy { it.kmNumber }.eachCount().filter { it.value > 1 }
+                }}"
+            }
         }
 
         private fun createReferencePoints(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -109,11 +109,17 @@ class GeocodingService(
     fun getGeocodingContext(geocodingContextCacheKey: GeocodingContextCacheKey) =
         geocodingCacheService.getGeocodingContext(geocodingContextCacheKey)
 
+    fun getGeocodingContextCreateResult(
+        publicationState: PublishType,
+        trackNumberId: IntId<TrackLayoutTrackNumber>,
+    ): GeocodingContextCreateResult? = geocodingDao.getLayoutGeocodingContextCacheKey(publicationState, trackNumberId)
+        ?.let(geocodingCacheService::getGeocodingContextWithReasons)
+
     fun getGeocodingContext(
         publicationState: PublishType,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): GeocodingContext? =
-        geocodingDao.getLayoutGeocodingContextCacheKey(publicationState, trackNumberId)?.let(geocodingCacheService::getGeocodingContext)
+        getGeocodingContextCreateResult(publicationState, trackNumberId)?.geocodingContext
 
     fun getGeocodingContextAtMoment(
         trackNumberId: IntId<TrackLayoutTrackNumber>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -11,7 +11,6 @@ import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.roundTo3Decimals
 import fi.fta.geoviite.infra.util.CsvEntry
-import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.printCsv
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -122,8 +121,9 @@ class LayoutTrackNumberService(
             "publishType" to publishType,
         )
 
-        return geocodingService.getGeocodingContext(publishType, trackNumberId)?.let { context ->
-            val distances = getKmPostDistances(context)
+        return geocodingService.getGeocodingContextCreateResult(publishType, trackNumberId)?.let { contextResult ->
+            val context = contextResult.geocodingContext
+            val distances = getKmPostDistances(context, contextResult.validKmPosts)
             val referenceLineLength = context.referenceLineGeometry.length
             val trackNumber = context.trackNumber
             val startPoint = context.referenceLineAddresses.startPoint
@@ -190,7 +190,7 @@ class LayoutTrackNumberService(
         return asCsvFile(kmLengths)
     }
 
-    private fun getKmPostDistances(context: GeocodingContext) = context.kmPosts.map { kmPost ->
+    private fun getKmPostDistances(context: GeocodingContext, kmPosts: List<TrackLayoutKmPost>) = kmPosts.map { kmPost ->
         val distance = kmPost.location?.let { loc ->
             context.getM(loc)?.first
         }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -89,7 +89,6 @@ val context = GeocodingContext(
     trackNumber,
     startAddress,
     alignment,
-    kmPosts,
     addressPoints,
     // test-data is inaccurate so allow more delta in validation
     projectionLineDistanceDeviation = 0.05,
@@ -345,18 +344,6 @@ class GeocodingTest {
         val projectionContext = GeocodingContext(
             trackNumber = trackNumber,
             startAddress = startAddress,
-            kmPosts = listOf(
-                kmPost(
-                    trackNumberId = null,
-                    km = KmNumber(2),
-                    location = checkNotNull(alignment.getPointAtM(0.0)).toPoint()
-                ),
-                kmPost(
-                    trackNumberId = null,
-                    km = KmNumber(3),
-                    location = checkNotNull(alignment.getPointAtM(3.0)).toPoint()
-                ),
-            ),
             referenceLineGeometry = alignment,
             referencePoints = listOf(
                 GeocodingReferencePoint(KmNumber(2), BigDecimal("100.0"), 0.0, 0.0, WITHIN),
@@ -468,13 +455,6 @@ class GeocodingTest {
         return GeocodingContext(
             trackNumber = trackNumber,
             startAddress = startAddress,
-            kmPosts = combinedReferencePoints.map { p ->
-                kmPost(
-                    trackNumberId = null,
-                    km = p.kmNumber,
-                    location = checkNotNull(alignment.getPointAtM(p.distance)).toPoint()
-                )
-            },
             referenceLineGeometry = alignment,
             referencePoints = combinedReferencePoints,
         )
@@ -493,7 +473,6 @@ class GeocodingTest {
             trackNumber,
             startAddress,
             verticalAlignment,
-            listOf(kmPost(trackNumberId = null, km = startAddress.kmNumber, location = start)),
             listOf(
                 GeocodingReferencePoint(
                     kmNumber = startAddress.kmNumber,
@@ -611,7 +590,6 @@ class GeocodingTest {
                 startAddress = TrackMeter(KmNumber(10), 100),
                 referenceLineGeometry = startAlignment,
                 referencePoints = emptyList(),
-                kmPosts = emptyList(),
             )
         }
     }
@@ -628,7 +606,6 @@ class GeocodingTest {
                 startAddress = TrackMeter(KmNumber(10), 100),
                 referenceLineGeometry = startAlignment,
                 referencePoints = emptyList(),
-                kmPosts = emptyList(),
             )
         }
     }
@@ -642,7 +619,6 @@ class GeocodingTest {
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         )
 
-        val kmPost = kmPost(IntId(1), KmNumber(11), null)
         val referencePoints = GeocodingReferencePoint(startAddress.kmNumber, startAddress.meters, 0.0, 0.0, WITHIN)
 
         assertThrows<IllegalArgumentException>("Geocoding context created with kmPosts without location") {
@@ -651,7 +627,6 @@ class GeocodingTest {
                 startAddress = startAddress,
                 referenceLineGeometry = startAlignment,
                 referencePoints = listOf(referencePoints),
-                kmPosts = listOf(kmPost),
             )
         }
     }
@@ -679,7 +654,7 @@ class GeocodingTest {
         }
 
         assertTrue("Geocoding context contained km posts without location") {
-            result.geocodingContext.kmPosts.isEmpty()
+            result.validKmPosts.isEmpty()
         }
     }
 


### PR DESCRIPTION
Varsin simppeli muutos, geokoodauskontekstihan ei tarvitse varsinaisia kilometritolppia, joten miksipä pitää niitä mukana. Kaikki muu data näytti olevan ihan oikeasti tarpeen, tai järkevintä pitää mukana nykymuodossaan.