### PR TITLE
GVT-2243 Remove duplicates from element list

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
@@ -123,7 +123,7 @@ fun toElementListing(
                 null
             }
         }
-    }.map { listing ->
+    }.distinctBy(ElementListing::id).map { listing ->
         val calculatedSegmentLength =
             lengthOfSegmentsConnectedToSameElement.find { (elementId, _) -> elementId == listing.elementId }?.second
         listing.copy(


### PR DESCRIPTION
Lisäsin pikaisen testin, koska kyseessä regressio GVT-1687 toteutuksesta. Geometriapuolella on oma elementtilistausfunktio, johon en nyt lähtenyt lisäämään samaa duplikaattien poistoa, koska siinä ei ole riskiä, että duplikaatteja alkuunkaan luotaisiin.