### PR TITLE
GVT-2143: Display actual topological connections that will be created during switch linking

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
@@ -86,6 +86,12 @@ data class SuggestedSwitch(
     val alignmentEndPoint: LocationTrackEndpoint?,
     val geometryPlanId: IntId<GeometryPlan>? = null,
     val geometrySwitchId: IntId<GeometrySwitch>? = null,
+    val topologicalJointConnections: List<TopologicalJointConnection>? = null,
+)
+
+data class TopologicalJointConnection(
+    val jointNumber: JointNumber,
+    val locationTrackIds: List<IntId<LocationTrack>>,
 )
 
 data class SwitchLinkingSegment(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -106,7 +106,7 @@ class LinkingService @Autowired constructor(
     ): LocationTrack {
         val startChanged = startChanged(oldAlignment, newAlignment)
         val endChanged = endChanged(oldAlignment, newAlignment)
-        return if (startChanged || endChanged) locationTrackService.calculateLocationTrackTopology(
+        return if (startChanged || endChanged) locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
             track = track,
             alignment = newAlignment,
             startChanged = startChanged,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -106,7 +106,7 @@ class LinkingService @Autowired constructor(
     ): LocationTrack {
         val startChanged = startChanged(oldAlignment, newAlignment)
         val endChanged = endChanged(oldAlignment, newAlignment)
-        return if (startChanged || endChanged) locationTrackService.updateTopology(
+        return if (startChanged || endChanged) locationTrackService.calculateLocationTrackTopology(
             track = track,
             alignment = newAlignment,
             startChanged = startChanged,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
@@ -991,11 +991,11 @@ class SwitchLinkingService @Autowired constructor(
         )
 
         suggestedSwitch
-            ?.let ( ::createTemporarySwitchLinkingParameters)
-            ?.let ( ::calculateModifiedLocationTracksAndAlignments)
-            ?.let ( ::updateTemporarySwitchLinkingToTemporaryLocationTracks)?.asSequence()
-            ?.filter ( ::locationTrackHasTemporaryTopologicalSwitchConnection)
-            ?.mapNotNull( ::topologicalConnectionJointNumberToTemporaryLocationTrackId)
+            ?.let (::createTemporarySwitchLinkingParameters)
+            ?.let (::calculateModifiedLocationTracksAndAlignments)
+            ?.let (::updateTemporarySwitchLinkingToTemporaryLocationTracks)?.asSequence()
+            ?.filter (::locationTrackHasTemporaryTopologicalSwitchConnection)
+            ?.mapNotNull(::topologicalConnectionJointNumberToTemporaryLocationTrackId)
             ?.groupBy (
                 { (jointNumber, _ ) -> jointNumber },
                 { (_, locationTrackId ) -> locationTrackId },

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
@@ -1362,8 +1362,8 @@ private fun getSwitchBoundsFromTracksAndAlignments(
                             segmentIndex == lastSegmentIndex && locationTrack.topologyEndSwitch?.switchId == switchId
 
                 listOfNotNull(
-                    if (startIsJoint) layoutSegment.geometry.points.first() else null,
-                    if (endIsJoint) layoutSegment.geometry.points.last() else null,
+                    if (startIsJoint) layoutSegment.geometry.segmentPoints.first() else null,
+                    if (endIsJoint) layoutSegment.geometry.segmentPoints.last() else null,
                 )
             }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -453,13 +453,13 @@ class LocationTrackService(
 
         val startSwitch =
             if (!track.exists || startPoint == null) null
-            else if (startChanged) findBestTopologySwitchMatch(startPoint, track.id, ownSwitches, nearbyTracks.aroundStart,null)
-            else findBestTopologySwitchMatch(startPoint, track.id, ownSwitches, nearbyTracks.aroundStart, track.topologyStartSwitch)
+            else if (startChanged) findBestTopologySwitchMatch(startPoint, ownSwitches, nearbyTracks.aroundStart, null)
+            else findBestTopologySwitchMatch(startPoint, ownSwitches, nearbyTracks.aroundStart, track.topologyStartSwitch)
 
         val endSwitch =
             if (!track.exists || endPoint == null) null
-            else if (endChanged) findBestTopologySwitchMatch(endPoint, track.id, ownSwitches, nearbyTracks.aroundEnd, null)
-            else findBestTopologySwitchMatch(endPoint, track.id, ownSwitches,  nearbyTracks.aroundEnd,  track.topologyEndSwitch,)
+            else if (endChanged) findBestTopologySwitchMatch(endPoint, ownSwitches, nearbyTracks.aroundEnd, null)
+            else findBestTopologySwitchMatch(endPoint, ownSwitches, nearbyTracks.aroundEnd, track.topologyEndSwitch)
 
         return if (track.topologyStartSwitch == startSwitch && track.topologyEndSwitch == endSwitch) {
             track
@@ -474,7 +474,6 @@ class LocationTrackService(
 
    fun findBestTopologySwitchMatch(
        target: IPoint,
-       ownId: DomainId<LocationTrack>,
        ownSwitches: Set<DomainId<TrackLayoutSwitch>>,
        nearbyTracksForSearch: List<Pair<LocationTrack, LayoutAlignment>>,
        currentTopologySwitch: TopologyLocationTrackSwitch?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -74,11 +74,11 @@ class LocationTrackService(
         )
 
         return if (locationTrack.state != LayoutState.DELETED) {
-            saveDraft(calculateLocationTrackTopology(locationTrack, originalAlignment))
+            saveDraft(fetchNearbyTracksAndCalculateLocationTrackTopology(locationTrack, originalAlignment))
         } else {
             val segmentsWithoutSwitch = originalAlignment.segments.map(LayoutSegment::withoutSwitch)
             val newAlignment = originalAlignment.withSegments(segmentsWithoutSwitch)
-            saveDraft(calculateLocationTrackTopology(locationTrack, newAlignment), newAlignment)
+            saveDraft(fetchNearbyTracksAndCalculateLocationTrackTopology(locationTrack, newAlignment), newAlignment)
         }
     }
 
@@ -396,13 +396,56 @@ class LocationTrackService(
         id, publishType
     )?.let(switchDao::fetch)?.let { switch -> LayoutSwitchIdAndName(id, switch.name) }
 
+    fun fetchNearbyLocationTracksWithAlignments(
+        targetPoint: LayoutPoint,
+    ): List<Pair<LocationTrack, LayoutAlignment>> {
+        return dao
+            .fetchVersionsNear(DRAFT, boundingBoxAroundPoint(targetPoint, 1.0))
+            .map { version -> getWithAlignmentInternal(version) }
+            .filter { (track, alignment) ->
+                alignment.segments.isNotEmpty() && track.exists
+            }
+    }
+
     @Transactional
+    fun fetchNearbyTracksAndCalculateLocationTrackTopology(
+        track: LocationTrack,
+        alignment: LayoutAlignment,
+        startChanged: Boolean = false,
+        endChanged: Boolean = false,
+    ): LocationTrack {
+        val nearbyTracksAroundStart =
+            alignment.start
+                ?.let(::fetchNearbyLocationTracksWithAlignments)
+                ?.filter { (nearbyLocationTrack, _) ->
+                    nearbyLocationTrack.id != track.id
+                } ?: listOf()
+
+        val nearbyTracksAroundEnd =
+            alignment.end
+                ?.let(::fetchNearbyLocationTracksWithAlignments)
+                ?.filter { (nearbyLocationTrack, _) ->
+                    nearbyLocationTrack.id != track.id
+                } ?: listOf()
+
+        return calculateLocationTrackTopology(
+            track,
+            alignment,
+            startChanged,
+            endChanged,
+            NearbyTracks(
+                aroundStart = nearbyTracksAroundStart,
+                aroundEnd = nearbyTracksAroundEnd,
+            )
+        )
+    }
+
     fun calculateLocationTrackTopology(
         track: LocationTrack,
         alignment: LayoutAlignment,
         startChanged: Boolean = false,
         endChanged: Boolean = false,
-        nearbyTracksForSearch: List<Pair<LocationTrack, LayoutAlignment>>? = null,
+        nearbyTracks: NearbyTracks,
     ): LocationTrack {
         val startPoint = alignment.firstSegmentStart
         val endPoint = alignment.lastSegmentEnd
@@ -410,13 +453,13 @@ class LocationTrackService(
 
         val startSwitch =
             if (!track.exists || startPoint == null) null
-            else if (startChanged) findBestTopologySwitchMatch(startPoint, track.id, ownSwitches, null, nearbyTracksForSearch)
-            else findBestTopologySwitchMatch(startPoint, track.id, ownSwitches, track.topologyStartSwitch, nearbyTracksForSearch)
+            else if (startChanged) findBestTopologySwitchMatch(startPoint, track.id, ownSwitches, nearbyTracks.aroundStart,null)
+            else findBestTopologySwitchMatch(startPoint, track.id, ownSwitches, nearbyTracks.aroundStart, track.topologyStartSwitch)
 
         val endSwitch =
             if (!track.exists || endPoint == null) null
-            else if (endChanged) findBestTopologySwitchMatch(endPoint, track.id, ownSwitches, null, nearbyTracksForSearch)
-            else findBestTopologySwitchMatch(endPoint, track.id, ownSwitches, track.topologyEndSwitch, nearbyTracksForSearch)
+            else if (endChanged) findBestTopologySwitchMatch(endPoint, track.id, ownSwitches, nearbyTracks.aroundEnd, null)
+            else findBestTopologySwitchMatch(endPoint, track.id, ownSwitches,  nearbyTracks.aroundEnd,  track.topologyEndSwitch,)
 
         return if (track.topologyStartSwitch == startSwitch && track.topologyEndSwitch == endSwitch) {
             track
@@ -433,21 +476,14 @@ class LocationTrackService(
        target: IPoint,
        ownId: DomainId<LocationTrack>,
        ownSwitches: Set<DomainId<TrackLayoutSwitch>>,
+       nearbyTracksForSearch: List<Pair<LocationTrack, LayoutAlignment>>,
        currentTopologySwitch: TopologyLocationTrackSwitch?,
-       nearbyTracksForSearch: List<Pair<LocationTrack, LayoutAlignment>>?,
     ): TopologyLocationTrackSwitch? {
-        val nearbyTracks = nearbyTracksForSearch ?: dao
-            .fetchVersionsNear(DRAFT, boundingBoxAroundPoint(target, 1.0))
-            .map { version -> getWithAlignmentInternal(version) }
-            .filter { (track, alignment) ->
-                alignment.segments.isNotEmpty() && track.id != ownId && track.exists
-            }
-
         val defaultSwitch = if (currentTopologySwitch?.switchId?.let(ownSwitches::contains) != false) null
         else currentTopologySwitch
-        return findBestTopologySwitchFromSegments(target, ownSwitches, nearbyTracks)
+        return findBestTopologySwitchFromSegments(target, ownSwitches, nearbyTracksForSearch)
             ?: defaultSwitch
-            ?: findBestTopologySwitchFromOtherTopology(target, ownSwitches, nearbyTracks)
+            ?: findBestTopologySwitchFromOtherTopology(target, ownSwitches, nearbyTracksForSearch)
     }
 
     @Transactional(readOnly = true)
@@ -524,6 +560,11 @@ class LocationTrackService(
         return (topologySwitches + segmentSwitches).distinct()
     }
 }
+
+data class NearbyTracks(
+    val aroundStart: List<Pair<LocationTrack, LayoutAlignment>>,
+    val aroundEnd: List<Pair<LocationTrack, LayoutAlignment>>,
+)
 
 private fun findBestTopologySwitchFromSegments(
     target: IPoint,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -229,7 +229,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.updateTopology(track, alignment)
+        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
         assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(1)), updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -258,7 +258,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.updateTopology(track, alignment)
+        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(2)), updatedTrack.topologyEndSwitch)
     }
@@ -287,7 +287,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.updateTopology(track, alignment)
+        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -316,7 +316,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.updateTopology(track, alignment)
+        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -343,7 +343,7 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track1.topologyStartSwitch)
         assertEquals(null, track1.topologyEndSwitch)
 
-        val updatedTrack1 = locationTrackService.updateTopology(track1, alignment1)
+        val updatedTrack1 = locationTrackService.calculateLocationTrackTopology(track1, alignment1)
         assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack1.topologyStartSwitch)
         assertEquals(null, updatedTrack1.topologyEndSwitch)
 
@@ -355,7 +355,7 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track2.topologyStartSwitch)
         assertEquals(null, track2.topologyEndSwitch)
 
-        val updatedTrack2 = locationTrackService.updateTopology(track2, alignment2)
+        val updatedTrack2 = locationTrackService.calculateLocationTrackTopology(track2, alignment2)
         assertEquals(TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack2.topologyStartSwitch)
         assertEquals(null, updatedTrack2.topologyEndSwitch)
 
@@ -367,7 +367,7 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track3.topologyStartSwitch)
         assertEquals(null, track3.topologyEndSwitch)
 
-        val updatedTrack3 = locationTrackService.updateTopology(track3, alignment3)
+        val updatedTrack3 = locationTrackService.calculateLocationTrackTopology(track3, alignment3)
         assertEquals(null, updatedTrack3.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack3.topologyEndSwitch)
 
@@ -379,7 +379,7 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track4.topologyStartSwitch)
         assertEquals(null, track4.topologyEndSwitch)
 
-        val updatedTrack4 = locationTrackService.updateTopology(track4, alignment4)
+        val updatedTrack4 = locationTrackService.calculateLocationTrackTopology(track4, alignment4)
         assertEquals(null, updatedTrack4.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack4.topologyEndSwitch)
     }
@@ -397,7 +397,7 @@ class LocationTrackServiceIT @Autowired constructor(
             ),
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
-        val updated = locationTrackService.updateTopology(track, alignment)
+        val updated = locationTrackService.calculateLocationTrackTopology(track, alignment)
         assertEquals(track.topologyStartSwitch, updated.topologyStartSwitch)
         assertEquals(track.topologyEndSwitch, updated.topologyEndSwitch)
     }
@@ -421,7 +421,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.updateTopology(track, alignment)
+        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
         assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(3)), updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -229,7 +229,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
         assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(1)), updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -258,7 +258,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(2)), updatedTrack.topologyEndSwitch)
     }
@@ -287,7 +287,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -316,7 +316,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -343,7 +343,7 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track1.topologyStartSwitch)
         assertEquals(null, track1.topologyEndSwitch)
 
-        val updatedTrack1 = locationTrackService.calculateLocationTrackTopology(track1, alignment1)
+        val updatedTrack1 = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track1, alignment1)
         assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack1.topologyStartSwitch)
         assertEquals(null, updatedTrack1.topologyEndSwitch)
 
@@ -355,7 +355,7 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track2.topologyStartSwitch)
         assertEquals(null, track2.topologyEndSwitch)
 
-        val updatedTrack2 = locationTrackService.calculateLocationTrackTopology(track2, alignment2)
+        val updatedTrack2 = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track2, alignment2)
         assertEquals(TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack2.topologyStartSwitch)
         assertEquals(null, updatedTrack2.topologyEndSwitch)
 
@@ -367,7 +367,7 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track3.topologyStartSwitch)
         assertEquals(null, track3.topologyEndSwitch)
 
-        val updatedTrack3 = locationTrackService.calculateLocationTrackTopology(track3, alignment3)
+        val updatedTrack3 = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track3, alignment3)
         assertEquals(null, updatedTrack3.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack3.topologyEndSwitch)
 
@@ -379,7 +379,7 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track4.topologyStartSwitch)
         assertEquals(null, track4.topologyEndSwitch)
 
-        val updatedTrack4 = locationTrackService.calculateLocationTrackTopology(track4, alignment4)
+        val updatedTrack4 = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track4, alignment4)
         assertEquals(null, updatedTrack4.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack4.topologyEndSwitch)
     }
@@ -397,7 +397,7 @@ class LocationTrackServiceIT @Autowired constructor(
             ),
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
-        val updated = locationTrackService.calculateLocationTrackTopology(track, alignment)
+        val updated = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
         assertEquals(track.topologyStartSwitch, updated.topologyStartSwitch)
         assertEquals(track.topologyEndSwitch, updated.topologyEndSwitch)
     }
@@ -421,7 +421,7 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.calculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
         assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(3)), updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -250,7 +250,7 @@ export type SuggestedSwitchJointMatch = {
     locationTrackId: LocationTrackId;
     layoutSwitchId?: LayoutSwitchId;
     segmentIndex: number;
-    segmentM: number;
+    m: number;
 };
 
 export type SuggestedSwitchJoint = {
@@ -258,6 +258,11 @@ export type SuggestedSwitchJoint = {
     location: Point;
     matches: SuggestedSwitchJointMatch[];
     locationAccuracy?: LocationAccuracy;
+};
+
+export type TopologicalJointConnection = {
+    jointNumber: JointNumber;
+    locationTrackIds: LocationTrackId[];
 };
 
 export type SuggestedSwitch = {
@@ -268,12 +273,13 @@ export type SuggestedSwitch = {
     joints: SuggestedSwitchJoint[];
     geometrySwitchId?: GeometrySwitchId;
     alignmentEndPoint?: LocationTrackEndpoint;
+    topologicalJointConnections?: TopologicalJointConnection[];
 };
 
 export type SwitchLinkingSegment = {
     locationTrackId: LocationTrackId;
     segmentIndex: number;
-    segmentM: number;
+    m: number;
 };
 
 export type SwitchLinkingJoint = {

--- a/ui/src/linking/linking-utils.ts
+++ b/ui/src/linking/linking-utils.ts
@@ -91,7 +91,7 @@ export function getSuggestedSwitchId(suggestedSwitch: SuggestedSwitch): string {
     return `${suggestedSwitch.geometrySwitchId}_${
         suggestedSwitch.alignmentEndPoint?.locationTrackId
     }_${suggestedSwitch.joints.map(
-        (j) => j.number + j.matches.map((m) => m.locationTrackId + m.segmentIndex + m.segmentM),
+        (j) => j.number + j.matches.map((m) => m.locationTrackId + m.segmentIndex + m.m),
     )}`;
 }
 

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -5,7 +5,12 @@ import { useTranslation } from 'react-i18next';
 import styles from './switch-infobox.scss';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
-import { LinkingState, LinkingSwitch, SuggestedSwitch } from 'linking/linking-model';
+import {
+    LinkingState,
+    LinkingSwitch,
+    SuggestedSwitch,
+    SwitchLinkingSegment,
+} from 'linking/linking-model';
 import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 import { SwitchEditDialogContainer } from './dialog/switch-edit-dialog';
 import { LayoutSwitch } from 'track-layout/track-layout-model';
@@ -154,7 +159,7 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
                     return {
                         jointNumber: joint.number,
                         location: joint.location,
-                        segments: joint.matches,
+                        segments: joint.matches satisfies SwitchLinkingSegment[],
                         locationAccuracy: joint.locationAccuracy,
                     };
                 }),

--- a/ui/src/tool-panel/switch/switch-joint-infobox-container.tsx
+++ b/ui/src/tool-panel/switch/switch-joint-infobox-container.tsx
@@ -22,6 +22,7 @@ export const SwitchJointInfoboxContainer: React.FC<SwitchJointInfoboxContainerPr
         <SwitchJointInfobox
             switchAlignments={switchAlignments}
             jointConnections={jointConnections}
+            topologicalJointConnections={suggestedSwitch?.topologicalJointConnections}
             publishType={publishType}
         />
     ) : (


### PR DESCRIPTION
GVT-2143: Display actual topological connections that will be created during switch linking

Previously the switch linking view did not always display the topological connections that would actually be created after the user clicked the "Link" button having confirmed the suggested switch linking. It was not possible to calculate the exact expected topological switch connections without actually linking a switch to the database. This was due to the topological connections being defined in the backend after the database had already been modified to contain switch data for segments. 

The frontend previously used another algorithm for expected topological connections for switches during linking, sometimes leading to incorrect results.

This PR includes a way to calculate the expected topological switch connections on the fly, without modifying the database. The expected topological switch connection data will be included in the suggested switch response.