### PR TITLE
GVT-2120 Review fixes: allow using other languages than Fi

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -44,11 +44,12 @@ class GeometryController @Autowired constructor(
         @RequestParam("offset") offset: Int?,
         @RequestParam("sortField") sortField: GeometryPlanSortField?,
         @RequestParam("sortOrder") sortOrder: SortOrder?,
+        @RequestParam("lang") lang: String,
     ): Page<GeometryPlanHeader> {
         log.apiCall("getPlanHeaders", "sources" to sources)
         val filter = geometryService.getFilter(freeText, trackNumberIds ?: listOf())
         val headers = geometryService.getPlanHeaders(sources, bbox, filter)
-        val comparator = geometryService.getComparator(sortField ?: ID, sortOrder ?: ASCENDING)
+        val comparator = geometryService.getComparator(sortField ?: ID, sortOrder ?: ASCENDING, lang)
         return page(items = headers, offset = offset ?: 0, limit = limit ?: 50, comparator = comparator)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -59,7 +59,6 @@ class GeometryService @Autowired constructor(
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
-    private val localization = localizationService.getLocalization("fi")
 
     private fun runElementListGeneration(op: () -> Unit) {
         MDC.put(USER_HEADER, ELEMENT_LISTING_GENERATION_USER)
@@ -436,13 +435,14 @@ class GeometryService @Autowired constructor(
         return header to geometryAlignment
     }
 
-    fun getComparator(sortField: GeometryPlanSortField, sortOrder: SortOrder): Comparator<GeometryPlanHeader> =
-        if (sortOrder == SortOrder.ASCENDING) getComparator(sortField)
-        else getComparator(sortField).reversed()
+    fun getComparator(sortField: GeometryPlanSortField, sortOrder: SortOrder, lang: String): Comparator<GeometryPlanHeader> =
+        if (sortOrder == SortOrder.ASCENDING) getComparator(sortField, lang)
+        else getComparator(sortField, lang).reversed()
 
-    private fun getComparator(sortField: GeometryPlanSortField): Comparator<GeometryPlanHeader> {
+    private fun getComparator(sortField: GeometryPlanSortField, lang: String): Comparator<GeometryPlanHeader> {
         val trackNumbers by lazy { trackNumberService.mapById(PublishType.DRAFT) }
         val linkingSummaries by lazy { geometryDao.getLinkingSummaries() }
+        val translation = localizationService.getLocalization(lang)
         return when (sortField) {
             GeometryPlanSortField.ID -> Comparator.comparing { h -> h.id.intValue }
             GeometryPlanSortField.PROJECT_NAME -> stringComparator { h -> h.project.name }
@@ -458,9 +458,8 @@ class GeometryService @Autowired constructor(
                     a.kmNumberRange?.max, b.kmNumberRange?.max
                 )
             }
-
-            GeometryPlanSortField.PLAN_PHASE -> stringComparator { h -> localization.t("enum.plan-phase.${h.planPhase?.name}") }
-            GeometryPlanSortField.DECISION_PHASE -> stringComparator { h -> localization.t("enum.plan-decision.${h.decisionPhase?.name}") }
+            GeometryPlanSortField.PLAN_PHASE -> stringComparator { h -> translation.t("enum.plan-phase.${h.planPhase?.name}") }
+            GeometryPlanSortField.DECISION_PHASE -> stringComparator { h -> translation.t("enum.plan-decision.${h.decisionPhase?.name}") }
             GeometryPlanSortField.CREATED_AT -> Comparator { a, b -> nullsLastComparator(a.planTime, b.planTime) }
             GeometryPlanSortField.UPLOADED_AT -> Comparator.comparing { h -> h.uploadTime }
             GeometryPlanSortField.FILE_NAME -> stringComparator { h -> h.fileName }

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -48,6 +48,7 @@ import { bboxString } from 'common/common-api';
 import { filterNotEmpty } from 'utils/array-utils';
 import { GeometryTypeIncludingMissing } from 'data-products/data-products-slice';
 import { AlignmentHeader } from 'track-layout/layout-map-api';
+import i18next from 'i18next';
 
 export const GEOMETRY_URI = `${API_URI}/geometry`;
 
@@ -110,6 +111,7 @@ export async function getGeometryPlanHeadersBySearchTerms(
             typeof sortOrder === 'undefined' || sortField === GeometrySortBy.NO_SORTING
                 ? undefined
                 : GeometrySortOrder[sortOrder],
+        lang: i18next.language,
     });
 
     return getNonNull<Page<GeometryPlanHeader>>(`${GEOMETRY_URI}/plan-headers${params}`);


### PR DESCRIPTION
Review korjaus liittyen aiempaan PR:ään: https://github.com/finnishtransportagency/geoviite/pull/736

Eli ei käytetä backendissä kovakoodattua fi-arvoa, vaan valutetaan oikea arvo frontin puolelta. 