### PR TITLE
GVT-2202 Tighten duplicate location track validation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -289,6 +289,7 @@ fun validateDuplicateOfState(
     locationTrack: LocationTrack,
     duplicateOfLocationTrack: LocationTrack?,
     publishLocationTrackIds: List<IntId<LocationTrack>>,
+    duplicates: List<LocationTrack>,
 ): List<PublishValidationError> {
     return if (duplicateOfLocationTrack == null) listOf()
     else {
@@ -302,8 +303,16 @@ fun validateDuplicateOfState(
             }, validateWithParams(locationTrack.state.isRemoved() || duplicateOfLocationTrack.state.isLinkable()) {
                 "$VALIDATION_LOCATION_TRACK.duplicate-of.state.${duplicateOfLocationTrack.state}" to duplicateNameParams
             }, validateWithParams(duplicateOfLocationTrack.duplicateOf == null) {
-                "$VALIDATION_LOCATION_TRACK.duplicate-of.duplicate" to duplicateNameParams
-            })
+                "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-of-duplicated" to duplicateNameParams
+            }, validateWithParams(duplicates.isEmpty()) {
+                "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-while-duplicated" to LocalizationParams(
+                    mapOf("duplicateTrack" to duplicateOfLocationTrack.name,
+                        "otherDuplicates" to duplicates.map { track -> track.name }
+                            .distinct()
+                            .joinToString { it })
+                )
+            },
+        )
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -26,15 +26,15 @@ class LocationTrackDao(
     @Value("\${geoviite.cache.enabled}") cacheEnabled: Boolean,
 ) : DraftableDaoBase<LocationTrack>(jdbcTemplateParam, LAYOUT_LOCATION_TRACK, cacheEnabled, LOCATIONTRACK_CACHE_SIZE) {
 
-    fun fetchDuplicates(id: IntId<LocationTrack>, publicationState: PublishType): List<RowVersion<LocationTrack>> {
+    fun fetchDuplicates(id: IntId<LocationTrack>, publicationState: PublishType? = null): List<RowVersion<LocationTrack>> {
         val sql = """
             select row_id, row_version
             from layout.location_track_publication_view
             where duplicate_of_location_track_id = :id
-              and :publication_state = any(publication_states)
+              and (:publication_state::varchar is null or :publication_state = any(publication_states))
               and state != 'DELETED'
         """.trimIndent()
-        val params = mapOf("id" to id.intValue, "publication_state" to publicationState.name)
+        val params = mapOf("id" to id.intValue, "publication_state" to publicationState?.name)
         val locationTracks = jdbcTemplate.query(sql, params) { rs, _ ->
             rs.getRowVersion<LocationTrack>("row_id", "row_version")
         }

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1127,7 +1127,7 @@
                     "not-official": "Raide viittaa duplikaattiraiteen {{duplicateTrack}} luonnosriviin",
                     "not-published": "Raide viittaa julkaisemattomaan duplikaattiraiteeseen {{duplicateTrack}}",
                     "publishing-duplicate-of-duplicated": "Raide on merkitty duplikaatiksi raiteelle {{duplicateTrack}}, joka itse on myös duplikaatti",
-                    "publishing-duplicate-while-duplicated": "Raide on merkitty duplikaatiksi, mutta julkaistut tai julkaistavat raiteet {{otherDuplicates}} ovat tämän raiteen duplikaatteja"
+                    "publishing-duplicate-while-duplicated": "Raide on merkitty duplikaatiksi, mutta raiteet {{otherDuplicates}} ovat tämän raiteen duplikaatteja"
                 },
                 "empty-segments": "Sijaintiraiteella ei ole geometriaa",
                 "points": {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1126,7 +1126,8 @@
                     },
                     "not-official": "Raide viittaa duplikaattiraiteen {{duplicateTrack}} luonnosriviin",
                     "not-published": "Raide viittaa julkaisemattomaan duplikaattiraiteeseen {{duplicateTrack}}",
-                    "duplicate": "Raide on merkitty duplikaatiksi raiteelle {{duplicateTrack}}, joka itse on myös duplikaatti"
+                    "publishing-duplicate-of-duplicated": "Raide on merkitty duplikaatiksi raiteelle {{duplicateTrack}}, joka itse on myös duplikaatti",
+                    "publishing-duplicate-while-duplicated": "Raide on merkitty duplikaatiksi, mutta julkaistut tai julkaistavat raiteet {{otherDuplicates}} ovat tämän raiteen duplikaatteja"
                 },
                 "empty-segments": "Sijaintiraiteella ei ole geometriaa",
                 "points": {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -605,8 +605,8 @@ class PublicationValidationTest {
         val lt = locationTrack(IntId(0)).copy(duplicateOf = IntId(0))
         assertContainsError(
             true,
-            validateDuplicateOfState(lt, lt, listOf(IntId(0))),
-            "$VALIDATION_LOCATION_TRACK.duplicate-of.duplicate"
+            validateDuplicateOfState(lt, lt, listOf(IntId(0)), listOf()),
+            "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-of-duplicated"
         )
     }
 


### PR DESCRIPTION
Lisätään tarkistus, että tuleeko julkaisuun raiteita, jotka ovat itse duplikaatteja, ja joihin on duplikaattiviittauksia jostain sellaisesta raiteesta, joka olisi tulossa julkaistuksi (joko nyt jo julkaistu, tai mukana julkaistavassa joukossa).