### PR TITLE
GVT-2245 & GVT-2249 & GVT-2250: UI-korjauksia

### DIFF
--- a/ui/src/app-bar/app-bar.scss
+++ b/ui/src/app-bar/app-bar.scss
@@ -43,12 +43,6 @@ $appbar-height: 48px;
 
     &__menu-button {
         user-select: none;
-
-        &--active {
-            user-select: none;
-            color: vayla-design.$color-blue-light;
-            border-bottom-color: vayla-design.$color-blue-light;
-        }
     }
 }
 

--- a/ui/src/app-bar/data-products-menu.tsx
+++ b/ui/src/app-bar/data-products-menu.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styles from './app-bar.scss';
 import { Menu } from 'vayla-design-lib/menu/menu';
+import { createClassName } from 'vayla-design-lib/utils';
 
 const DataProductsMenu: React.FC = () => {
     const { t } = useTranslation();
@@ -43,8 +44,12 @@ const DataProductsMenu: React.FC = () => {
             ref={menuRef}
             className={
                 useLocation().pathname.includes('data-products')
-                    ? `${styles['app-bar__link']} ${styles['app-bar__menu-button--active']}`
-                    : `${styles['app-bar__link']} ${styles['app-bar__menu-button']}`
+                    ? createClassName(
+                          styles['app-bar__link'],
+                          styles['app-bar__link--active'],
+                          styles['app-bar__menu-button'],
+                      )
+                    : createClassName(styles['app-bar__link'], styles['app-bar__menu-button'])
             }
             qa-id="data-product-link"
             onClick={() => setShowMenu(!showMenu)}>

--- a/ui/src/infra-model/projektivelho/pv-file-list.scss
+++ b/ui/src/infra-model/projektivelho/pv-file-list.scss
@@ -46,10 +46,8 @@
 }
 
 .projektivelho-file-list__link {
-    display: flex;
     text-decoration: none;
     fill: vayla-design.$color-blue-dark;
-    align-items: center;
 
     :not(:first-child) {
         margin-left: 6px;

--- a/ui/src/infra-model/projektivelho/pv-file-list.tsx
+++ b/ui/src/infra-model/projektivelho/pv-file-list.tsx
@@ -408,11 +408,13 @@ const PVFileListRow = ({
                 </td>
                 <td>{item.project && item.project.name}</td>
                 <td>
-                    <Link
-                        className={styles['projektivelho-file-list__link']}
-                        href={projektivelhoDocumentDownloadUri(item.document.id)}>
-                        {item.document.name}
-                    </Link>
+                    <span>
+                        <Link
+                            className={styles['projektivelho-file-list__link']}
+                            href={projektivelhoDocumentDownloadUri(item.document.id)}>
+                            {item.document.name}
+                        </Link>
+                    </span>
                 </td>
                 <td>{item.document.description}</td>
                 <td>{formatDateFull(item.document.modified)}</td>

--- a/ui/src/infra-model/projektivelho/pv-file-list.tsx
+++ b/ui/src/infra-model/projektivelho/pv-file-list.tsx
@@ -408,13 +408,11 @@ const PVFileListRow = ({
                 </td>
                 <td>{item.project && item.project.name}</td>
                 <td>
-                    <span>
-                        <Link
-                            className={styles['projektivelho-file-list__link']}
-                            href={projektivelhoDocumentDownloadUri(item.document.id)}>
-                            {item.document.name}
-                        </Link>
-                    </span>
+                    <Link
+                        className={styles['projektivelho-file-list__link']}
+                        href={projektivelhoDocumentDownloadUri(item.document.id)}>
+                        {item.document.name}
+                    </Link>
                 </td>
                 <td>{item.document.description}</td>
                 <td>{formatDateFull(item.document.modified)}</td>

--- a/ui/src/publication/table/publication-table-row.tsx
+++ b/ui/src/publication/table/publication-table-row.tsx
@@ -48,7 +48,7 @@ export const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
     return (
         <React.Fragment>
             <tr className={rowClassNames}>
-                <td>
+                <td className={styles['publication-table__accordion-column']}>
                     <AccordionToggle
                         open={detailsVisible}
                         onToggle={() => setDetailsVisible(!detailsVisible)}

--- a/ui/src/publication/table/publication-table.scss
+++ b/ui/src/publication/table/publication-table.scss
@@ -9,6 +9,11 @@
         z-index: 1;
     }
 
+    &__accordion-column {
+        width: 0%;
+        padding-right: 0px;
+    }
+
     &__message-column {
         max-width: 200px;
     }


### PR DESCRIPTION
Täällä korjattu seuraavat:
* Julkaisuloki-näkymän taulukoissa liikaa bordereita
* Tietotuotteet-linkistä kadonnut highlight
* PV-dokumentin latauslinkki on koko solun levyinen