### PR TITLE
GVT-2241 Update km post infobox km lengths promptly

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -152,4 +152,14 @@ class LayoutKmPostController(
         logger.apiCall("getKmPostChangeTimes", "id" to kmPostId)
         return kmPostService.getDraftableChangeInfo(kmPostId)
     }
+
+    @PreAuthorize(AUTH_ALL_READ)
+    @GetMapping("/{publishType}/{id}/km-length")
+    fun getKmLength(
+        @PathVariable("publishType") publishType: PublishType,
+        @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
+    ): TrackLayoutKmPostLength {
+        logger.apiCall("getKmLength", "id" to kmPostId, "publishType" to publishType)
+        return TrackLayoutKmPostLength(kmPostService.getSingleKmPostLength(publishType, kmPostId))
+    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -3,7 +3,6 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.geography.create2DPolygonString
 import fi.fta.geoviite.infra.geometry.GeometryKmPost
-import fi.fta.geoviite.infra.geometry.KmPostError
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.BoundingBox
@@ -278,5 +277,32 @@ class LayoutKmPostDao(
         }.also { ids ->
             logger.daoAccess(AccessType.VERSION_FETCH, "fetchOnlyDraftVersions", ids)
         }
+    }
+
+    fun fetchNextWithLocationAfter(
+        trackNumberId: IntId<TrackLayoutTrackNumber>,
+        kmNumber: KmNumber,
+        publicationState: PublishType,
+        state: LayoutState,
+    ): RowVersion<TrackLayoutKmPost>? {
+        val sql = """
+            select row_id, row_version
+            from layout.km_post_publication_view
+            where track_number_id = :track_number_id
+              and state = :state::layout.state
+              and :publication_state = any (publication_states)
+              and location is not null
+              and km_number > :km_number
+            order by km_number asc
+            limit 1
+        """.trimIndent()
+        return jdbcTemplate.queryOptional(
+            sql, mapOf(
+                "track_number_id" to trackNumberId.intValue,
+                "state" to state.name,
+                "publication_state" to publicationState.name,
+                "km_number" to kmNumber.toString()
+            )
+        ) { rs, _ -> rs.getRowVersion("row_id", "row_version") }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -116,23 +116,31 @@ class LayoutKmPostService(
     fun getSingleKmPostLength(
         publishType: PublishType,
         id: IntId<TrackLayoutKmPost>,
+    ): Double? = dao.fetchVersionOrThrow(id, publishType).let(dao::fetch).getAsIntegral()?.let { kmPost ->
+        getReferenceLineAlignment(publishType, kmPost.trackNumberId)?.let { referenceLineAlignment ->
+            val kmPostM = referenceLineAlignment.getClosestPointM(kmPost.location)?.first
+            val kmEndM = getKmEndM(publishType, kmPost.trackNumberId, kmPost.kmNumber, referenceLineAlignment)
+            if (kmPostM == null || kmEndM == null) null else kmEndM - kmPostM
+        }
+    }
+
+    private fun getKmEndM(
+        publishType: PublishType,
+        trackNumberId: IntId<TrackLayoutTrackNumber>,
+        kmNumber: KmNumber,
+        referenceLineAlignment: LayoutAlignment,
     ): Double? {
-        val kmPost = dao.fetchVersion(id, publishType)?.let(dao::fetch) ?: return null
-        if (kmPost.state != LayoutState.IN_USE) return null
-        val kmPostLocation = kmPost.location ?: return null
-        val trackNumberId = kmPost.trackNumberId ?: return null
-        val referenceLineAlignment = referenceLineDao.fetchVersion(publishType, trackNumberId)
+        val nextKmPost = dao
+            .fetchNextWithLocationAfter(trackNumberId, kmNumber, publishType, LayoutState.IN_USE)
+            ?.let(dao::fetch)
+            ?.getAsIntegral()
+        return if (nextKmPost == null) referenceLineAlignment.length
+        else referenceLineAlignment.getClosestPointM(nextKmPost.location)?.first
+    }
+
+    private fun getReferenceLineAlignment(publishType: PublishType, trackNumberId: IntId<TrackLayoutTrackNumber>) =
+        referenceLineDao.fetchVersion(publishType, trackNumberId)
             ?.let(referenceLineDao::fetch)
             ?.let(ReferenceLine::alignmentVersion)
-            ?.let(alignmentDao::fetch) ?: return null
-        val nextKmPost = dao.fetchNextWithLocationAfter(trackNumberId, kmPost.kmNumber, publishType, LayoutState.IN_USE)
-            ?.let(dao::fetch)
-
-        val kmPostM = referenceLineAlignment.getClosestPointM(kmPostLocation)?.first ?: return null
-        val nextM =
-            if (nextKmPost?.location != null) referenceLineAlignment.getClosestPointM(nextKmPost.location)?.first
-                ?: return null
-            else referenceLineAlignment.length
-        return nextM - kmPostM
-    }
+            ?.let(alignmentDao::fetch)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -261,6 +261,10 @@ data class TrackLayoutKmLengthDetails(
     val length = endM - startM
 }
 
+data class TrackLayoutKmPostLength(
+    val length: Double?
+)
+
 data class TrackLayoutSwitchJointMatch(
     val locationTrackId: IntId<LocationTrack>,
     val location: Point,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -244,7 +244,17 @@ data class TrackLayoutKmPost(
 ) : Draftable<TrackLayoutKmPost> {
     @JsonIgnore
     val exists = !state.isRemoved()
+
+    fun getAsIntegral(): IntegralTrackLayoutKmPost? =
+        if (state != LayoutState.IN_USE || location == null || trackNumberId == null) null
+        else IntegralTrackLayoutKmPost(kmNumber, location, trackNumberId)
 }
+
+data class IntegralTrackLayoutKmPost(
+    val kmNumber: KmNumber,
+    val location: Point,
+    val trackNumberId: IntId<TrackLayoutTrackNumber>,
+)
 
 enum class TrackLayoutKmPostTableColumn {
     TRACK_NUMBER, KILOMETER, START_M, END_M, LENGTH, LOCATION_E, LOCATION_N, WARNING

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -11,7 +11,7 @@ import { PublishType, TimeStamp } from 'common/common-model';
 import { KmPostEditDialogContainer } from 'tool-panel/km-post/dialog/km-post-edit-dialog';
 import KmPostDeleteConfirmationDialog from 'tool-panel/km-post/dialog/km-post-delete-confirmation-dialog';
 import { Icons } from 'vayla-design-lib/icon/Icon';
-import { getKmLengths, getKmPost } from 'track-layout/layout-km-post-api';
+import { getKmPost, getSingleKmPostKmLength } from 'track-layout/layout-km-post-api';
 import { LoaderStatus, useLoader, useLoaderWithStatus } from 'utils/react-utils';
 import { TrackNumberLinkContainer } from 'geoviite-design-lib/track-number/track-number-link';
 import { AssetValidationInfoboxContainer } from 'tool-panel/asset-validation-infobox-container';
@@ -24,6 +24,7 @@ import { formatDateShort } from 'utils/date-utils';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { OnSelectOptions, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import LayoutState from 'geoviite-design-lib/layout-state/layout-state';
+import { roundToPrecision } from 'utils/rounding';
 import { ChangeTimes } from 'common/common-slice';
 
 type KmPostInfoboxProps = {
@@ -61,16 +62,16 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
         [kmPost.id, kmPostChangeTime, publishType],
     );
 
-    const [kmPostLength, kmPostLengthLoading] = useLoaderWithStatus(async () => {
-        const allKmLengths = await getKmLengths(publishType, kmPost.trackNumberId);
-        return allKmLengths.find((value) => value.kmNumber === kmPost.kmNumber)?.length;
-    }, [
-        kmPost.id,
-        kmPost.state,
-        publishType,
-        changeTimes.layoutKmPost,
-        changeTimes.layoutReferenceLine,
-    ]);
+    const [kmPostLength, kmPostLengthLoading] = useLoaderWithStatus(
+        async () => getSingleKmPostKmLength(publishType, kmPost.id).then((result) => result.length),
+        [
+            kmPost.id,
+            kmPost.state,
+            publishType,
+            changeTimes.layoutKmPost,
+            changeTimes.layoutReferenceLine,
+        ],
+    );
 
     function openEditDialog() {
         setShowEditDialog(true);
@@ -93,7 +94,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
             ? t('tool-panel.km-post.layout.no-kilometer-length')
             : kmPostLength < 0
             ? t('tool-panel.km-post.layout.negative-kilometer-length')
-            : `${kmPostLength} m`;
+            : `${roundToPrecision(kmPostLength, 3)} m`;
 
     return (
         <React.Fragment>

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -24,6 +24,7 @@ import { formatDateShort } from 'utils/date-utils';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { OnSelectOptions, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import LayoutState from 'geoviite-design-lib/layout-state/layout-state';
+import { ChangeTimes } from 'common/common-slice';
 
 type KmPostInfoboxProps = {
     publishType: PublishType;
@@ -35,6 +36,7 @@ type KmPostInfoboxProps = {
     onDataChange: () => void;
     visibilities: KmPostInfoboxVisibilities;
     onVisibilityChange: (visibilities: KmPostInfoboxVisibilities) => void;
+    changeTimes: ChangeTimes;
 };
 
 const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
@@ -47,9 +49,10 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     onDataChange,
     visibilities,
     onVisibilityChange,
+    changeTimes,
 }: KmPostInfoboxProps) => {
     const { t } = useTranslation();
-    const changeTimes = useKmPostChangeTimes(kmPost.id);
+    const kmPostCreatedAndChangedTime = useKmPostChangeTimes(kmPost.id);
 
     const [showEditDialog, setShowEditDialog] = React.useState(false);
     const [confirmingDraftDelete, setConfirmingDraftDelete] = React.useState(false);
@@ -61,7 +64,13 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     const [kmPostLength, kmPostLengthLoading] = useLoaderWithStatus(async () => {
         const allKmLengths = await getKmLengths(publishType, kmPost.trackNumberId);
         return allKmLengths.find((value) => value.kmNumber === kmPost.kmNumber)?.length;
-    }, [kmPost.trackNumberId, kmPost.kmNumber, publishType]);
+    }, [
+        kmPost.id,
+        kmPost.state,
+        publishType,
+        changeTimes.layoutKmPost,
+        changeTimes.layoutReferenceLine,
+    ]);
 
     function openEditDialog() {
         setShowEditDialog(true);
@@ -168,15 +177,15 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                 contentVisible={visibilities.log}
                 onContentVisibilityChange={() => visibilityChange('log')}>
                 <InfoboxContent>
-                    {changeTimes && (
+                    {kmPostCreatedAndChangedTime && (
                         <React.Fragment>
                             <InfoboxField
                                 label={t('tool-panel.created')}
-                                value={formatDateShort(changeTimes.created)}
+                                value={formatDateShort(kmPostCreatedAndChangedTime.created)}
                             />
                             <InfoboxField
                                 label={t('tool-panel.changed')}
-                                value={formatDateShort(changeTimes.changed)}
+                                value={formatDateShort(kmPostCreatedAndChangedTime.changed)}
                             />
                         </React.Fragment>
                     )}

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -261,6 +261,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                 title: k.kmNumber,
                 element: (
                     <KmPostInfobox
+                        changeTimes={changeTimes}
                         visibilities={infoboxVisibilities.kmPost}
                         onVisibilityChange={(visibilities) =>
                             infoboxVisibilityChange('kmPost', visibilities)

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -4,6 +4,7 @@ import {
     LayoutKmPost,
     LayoutKmPostId,
     LayoutTrackNumberId,
+    TrackLayoutKmPostLength,
 } from 'track-layout/track-layout-model';
 import { DraftableChangeInfo, KmNumber, PublishType, TimeStamp } from 'common/common-model';
 import { deleteAdt, getNonNull, getNullable, postAdt, putAdt, queryParams } from 'api/api-fetch';
@@ -170,6 +171,15 @@ export async function getKmLengths(
 ): Promise<LayoutKmLengthDetails[]> {
     return getNonNull<LayoutKmLengthDetails[]>(
         `${layoutUri('track-numbers', publishType, id)}/km-lengths`,
+    );
+}
+
+export async function getSingleKmPostKmLength(
+    publishType: PublishType,
+    id: LayoutKmPostId,
+): Promise<TrackLayoutKmPostLength> {
+    return getNonNull<TrackLayoutKmPostLength>(
+        `${layoutUri('km-posts', publishType, id)}/km-length`,
     );
 }
 

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -202,6 +202,10 @@ export type LayoutKmLengthDetails = {
     location?: Point;
 };
 
+export type TrackLayoutKmPostLength = {
+    length?: number;
+};
+
 export type PlanArea = {
     id: GeometryPlanId;
     fileName: string;


### PR DESCRIPTION
Varsinainen alkuperäinen bugi oli puuttuvat depsut infoboksin kilometripituuden loaderissa.

Mutta toteutusta testatessa tuli vähän sellainen olo, että olisipa jees, jos päivityksen jälkeen uusi kilometripituus latautuisikin silmänräpäyksessä eikä sekunnin murto-osassa. Isosta optimoinnista tuossa getSingleKmPostLength()issa siis ei ole kyse, mutta ero on kuitenkin selvä.