### PR TITLE
GVT-2244: Assign context-specific min-widths and centering for element table columns

### DIFF
--- a/ui/src/data-products/data-product-table.scss
+++ b/ui/src/data-products/data-product-table.scss
@@ -35,6 +35,68 @@
         }
     }
 
+    &__header {
+        &--track-number {
+            min-width: 100px;
+        }
+
+        &--location-track {
+            min-width: 160px;
+        }
+
+        &--alignment {
+            min-width: 85px;
+        }
+
+        &--element-type {
+            min-width: 110px;
+        }
+
+        &--track-address {
+            min-width: 110px;
+        }
+
+        &--coordinate-system {
+            min-width: 135px;
+        }
+
+        &--location {
+            min-width: 100px;
+            text-align: center;
+        }
+
+        &--length {
+            min-width: 60px;
+        }
+
+        &--cant {
+            min-width: 55px;
+            text-align: center;
+        }
+
+        &--curve {
+            min-width: 70px;
+            text-align: center;
+        }
+
+        &--angle {
+            min-width: 90px;
+            text-align: center;
+        }
+
+        &--plan {
+            min-width: 350px;
+        }
+
+        &--source {
+            min-width: 100px;
+        }
+
+        &--remarks {
+            min-width: 400px;
+        }
+    }
+
     &__column--number {
         text-align: right;
     }

--- a/ui/src/data-products/data-products-utils.ts
+++ b/ui/src/data-products/data-products-utils.ts
@@ -91,5 +91,11 @@ export function nonNumericHeading(
 
 export const withSeparator = (heading: ElementHeading) => ({ ...heading, hasSeparator: true });
 
+export type ElementHeadingWithClassName = ElementHeading & { className: string };
+export const withClassName = (
+    heading: ElementHeading,
+    className: string,
+): ElementHeadingWithClassName => ({ ...heading, className });
+
 export const findCoordinateSystem = (srid: Srid, coordinateSystems: CoordinateSystem[]) =>
     coordinateSystems.find((crs) => crs.srid === srid);

--- a/ui/src/data-products/element-list/element-table.tsx
+++ b/ui/src/data-products/element-list/element-table.tsx
@@ -6,9 +6,10 @@ import styles from '../data-product-table.scss';
 import { ElementItem } from 'geometry/geometry-model';
 import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
 import {
-    ElementHeading,
+    ElementHeadingWithClassName,
     nonNumericHeading,
     numericHeading,
+    withClassName,
 } from 'data-products/data-products-utils';
 
 type ElementTableProps = {
@@ -21,35 +22,76 @@ const ElementTable = ({ elements, showLocationTrackName, isLoading }: ElementTab
     const { t } = useTranslation();
     const trackNumbers = useTrackNumbers('OFFICIAL');
     const amount = elements.length;
-    const commonTableHeadings: ElementHeading[] = [
-        nonNumericHeading('alignment'),
-        nonNumericHeading('element-type'),
-        numericHeading('track-address-start'),
-        numericHeading('track-address-end'),
-        nonNumericHeading('coordinate-system'),
-        numericHeading('location-start-e'),
-        numericHeading('location-start-n'),
-        numericHeading('location-end-e'),
-        numericHeading('location-end-n'),
-        numericHeading('length'),
-        numericHeading('curve-radius-start'),
-        numericHeading('curve-radius-end'),
-        numericHeading('cant-start'),
-        numericHeading('cant-end'),
-        numericHeading('angle-start'),
-        numericHeading('angle-end'),
-        nonNumericHeading('plan'),
-        nonNumericHeading('source'),
-        nonNumericHeading('remarks'),
+    const commonTableHeadings: ElementHeadingWithClassName[] = [
+        withClassName(
+            nonNumericHeading('alignment'),
+            styles['data-product-table__header--alignment'],
+        ),
+        withClassName(
+            nonNumericHeading('element-type'),
+            styles['data-product-table__header--element-type'],
+        ),
+        withClassName(
+            numericHeading('track-address-start'),
+            styles['data-product-table__header--track-address'],
+        ),
+        withClassName(
+            numericHeading('track-address-end'),
+            styles['data-product-table__header--track-address'],
+        ),
+        withClassName(
+            nonNumericHeading('coordinate-system'),
+            styles['data-product-table__header--coordinate-system'],
+        ),
+        withClassName(
+            numericHeading('location-start-e'),
+            styles['data-product-table__header--location'],
+        ),
+        withClassName(
+            numericHeading('location-start-n'),
+            styles['data-product-table__header--location'],
+        ),
+        withClassName(
+            numericHeading('location-end-e'),
+            styles['data-product-table__header--location'],
+        ),
+        withClassName(
+            numericHeading('location-end-n'),
+            styles['data-product-table__header--location'],
+        ),
+        withClassName(numericHeading('length'), styles['data-product-table__header--length']),
+        withClassName(
+            numericHeading('curve-radius-start'),
+            styles['data-product-table__header--curve'],
+        ),
+        withClassName(
+            numericHeading('curve-radius-end'),
+            styles['data-product-table__header--curve'],
+        ),
+        withClassName(numericHeading('cant-start'), styles['data-product-table__header--cant']),
+        withClassName(numericHeading('cant-end'), styles['data-product-table__header--cant']),
+        withClassName(numericHeading('angle-start'), styles['data-product-table__header--angle']),
+        withClassName(numericHeading('angle-end'), styles['data-product-table__header--angle']),
+        withClassName(nonNumericHeading('plan'), styles['data-product-table__header--plan']),
+        withClassName(nonNumericHeading('source'), styles['data-product-table__header--source']),
+        withClassName(nonNumericHeading('remarks'), styles['data-product-table__header--remarks']),
     ];
+
+    const trackNumberHeading = withClassName(
+        nonNumericHeading('track-number'),
+        styles['data-product-table__header--track-number'],
+    );
 
     const tableHeadingsToShowInUI = showLocationTrackName
         ? [
-              nonNumericHeading('track-number'),
-              nonNumericHeading('location-track'),
+              trackNumberHeading,
+              withClassName(
+                  nonNumericHeading('location-track'),
+                  styles['data-product-table__header--location-track'],
+              ),
               ...commonTableHeadings,
           ]
-        : [nonNumericHeading('track-number'), ...commonTableHeadings];
+        : [trackNumberHeading, ...commonTableHeadings];
 
     return (
         <React.Fragment>
@@ -64,11 +106,7 @@ const ElementTable = ({ elements, showLocationTrackName, isLoading }: ElementTab
                                 <Th
                                     qa-id={`data-products.element-list.element-list-table.${heading.name}`}
                                     key={heading.name}
-                                    className={
-                                        heading.numeric
-                                            ? styles['data-product-table__column--number']
-                                            : ''
-                                    }>
+                                    className={heading?.className ?? ''}>
                                     {t(
                                         `data-products.element-list.element-list-table.${heading.name}`,
                                     )}


### PR DESCRIPTION
GVT-2244: Assign context-specific min-widths and centering for element table columns

Previously the element table column headings were displayed with somewhat odd text-alignment. Data rows were also often broken up to multiple lines, making the table possibly more difficult to read.

The column min-widths are based on "maximum possible current length", expect for the plan file name column were somewhat of an average width was chosen due to some plan file names being much longer than the usual ones. This means that the plan file name column can sometimes still end up being multiple rows in height.