### PR TITLE
GVT-2261: Disable assignment of PLANNED-state for km-posts

### DIFF
--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -73,9 +73,9 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
     const { t } = useTranslation();
     const [state, dispatcher] = React.useReducer(reducer, initialKmPostEditState);
     const stateActions = createDelegatesWithDispatcher(dispatcher, actions);
-    const kmPostStateOptions = layoutStates.filter(
-        (ls) => !state.isNewKmPost || ls.value != 'DELETED',
-    );
+    const kmPostStateOptions = layoutStates
+        .filter((ls) => !state.isNewKmPost || ls.value != 'DELETED')
+        .map((ls) => ({ ...ls, disabled: ls.value === 'PLANNED' }));
     const debouncedKmNumber = useDebouncedState(state.kmPost?.kmNumber, 300);
     const firstInputRef = React.useRef<HTMLInputElement>(null);
     const [nonDraftDeleteConfirmationVisible, setNonDraftDeleteConfirmationVisible] =


### PR DESCRIPTION
GVT-2261: Disable assignment of PLANNED-state for km-posts

This PLANNED-state is not yet considered to be a possible assignment for any resources, but the restriction is currently only done in the UI-side as the PLANNED-state will be allowed in the near future (and the users of this application are trusted in general).