### PR TITLE
GVT-2256 Optimize transaction boundaries across the application

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationService.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.authorization
 import fi.fta.geoviite.infra.util.Code
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 const val LDAP_GROUP_GEOVIITE_PREFIX = "geoviite_"
 
@@ -13,6 +14,7 @@ class AuthorizationService @Autowired constructor(private val authorizationDao: 
         return authorizationDao.getRole(roleCode)
     }
 
+    @Transactional(readOnly = true)
     fun getRoleByUserGroups(ldapGroupNames: List<Code>): Role? {
         return ldapGroupNames
             .filter { groupName -> groupName.startsWith(LDAP_GROUP_GEOVIITE_PREFIX) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
@@ -10,6 +10,7 @@ import fi.fta.geoviite.infra.tracklayout.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -47,6 +48,7 @@ class ChangeTimeController(
 
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/collected")
+    @Transactional(readOnly = true)
     fun getCollectedChangeTimes(): CollectedChangeTimes {
         logger.apiCall("getCollectedChangeTimes")
         return CollectedChangeTimes(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
@@ -43,8 +43,7 @@ class GeocodingController(
         @RequestParam("address") address: TrackMeter,
     ): ResponseEntity<AddressPoint> {
         logger.apiCall("getTrackPoint", "locationTrackId" to locationTrackId, "address" to address)
-        val locationTrackAndAlignment = locationTrackService.getWithAlignment(OFFICIAL, locationTrackId)
-        return toResponse(locationTrackAndAlignment?.let { (locationTrack, alignment) -> geocodingService.getTrackLocation(locationTrack, alignment, address, OFFICIAL) })
+        return toResponse(locationTrackService.getTrackPoint(OFFICIAL, locationTrackId, address))
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
@@ -14,7 +14,6 @@ import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
 
-
 @Transactional(readOnly = true)
 @Component
 class GeocodingDao(
@@ -26,10 +25,19 @@ class GeocodingDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
 ) : DaoBase(jdbcTemplateParam) {
 
+    fun listLayoutGeocodingContextCacheKeys(publicationState: PublishType): List<LayoutGeocodingContextCacheKey> =
+        getLayoutGeocodingContextCacheKeysInternal(publicationState, null)
+
     fun getLayoutGeocodingContextCacheKey(
         publicationState: PublishType,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
-    ): LayoutGeocodingContextCacheKey? {
+    ): LayoutGeocodingContextCacheKey? =
+        getOptional(trackNumberId, getLayoutGeocodingContextCacheKeysInternal(publicationState, trackNumberId))
+
+    private fun getLayoutGeocodingContextCacheKeysInternal(
+        publicationState: PublishType,
+        trackNumberId: IntId<TrackLayoutTrackNumber>?,
+    ): List<LayoutGeocodingContextCacheKey> {
         //language=SQL
         val sql = """
             select
@@ -48,14 +56,14 @@ class GeocodingDao(
                 and :publication_state = any(kmp.publication_states)
                 and kmp.state = 'IN_USE'
             where :publication_state = any(tn.publication_states)
-              and :tn_id = tn.official_id
+              and (:tn_id::int is null or :tn_id = tn.official_id)
             group by tn.row_id, tn.row_version, rl.row_id, rl.row_version
         """.trimIndent()
         val params = mapOf(
-            "tn_id" to trackNumberId.intValue,
+            "tn_id" to trackNumberId?.intValue,
             "publication_state" to publicationState.name,
         )
-        return jdbcTemplate.queryOptional(sql, params) { rs, _ -> toGeocodingContextCacheKey(rs) }
+        return jdbcTemplate.query(sql, params) { rs, _ -> toGeocodingContextCacheKey(rs) }
     }
 
     fun getLayoutGeocodingContextCacheKey(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -14,6 +14,7 @@ import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
 @Service
@@ -118,6 +119,12 @@ class GeocodingService(
         )
         return getGeocodingContext(publicationState, locationTrack.trackNumberId)?.getTrackLocation(alignment, address)
     }
+
+    @Transactional(readOnly = true)
+    fun getGeocodingContexts(publicationState: PublishType): Map<IntId<TrackLayoutTrackNumber>, GeocodingContext?> =
+        geocodingDao
+            .listLayoutGeocodingContextCacheKeys(publicationState)
+            .associate { key -> key.trackNumberVersion.id to geocodingCacheService.getGeocodingContext(key) }
 
     fun getGeocodingContext(
         publicationState: PublishType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -7,7 +7,10 @@ import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType
 import fi.fta.geoviite.infra.math.IntersectType.WITHIN
 import fi.fta.geoviite.infra.publication.ValidationVersions
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -18,7 +21,6 @@ class GeocodingService(
     private val addressPointsCache: AddressPointsCache,
     private val geocodingDao: GeocodingDao,
     private val geocodingCacheService: GeocodingCacheService,
-    private val trackNumberDao: LayoutTrackNumberDao,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -27,7 +29,8 @@ class GeocodingService(
         logger.serviceCall(
             "getAddressPoints", "locationTrackId" to locationTrackId, "publicationState" to publicationState
         )
-        return addressPointsCache.getAddressPointCacheKey(publicationState, locationTrackId)
+        return addressPointsCache
+            .getAddressPointCacheKey(publicationState, locationTrackId)
             ?.let(addressPointsCache::getAddressPoints)
     }
 
@@ -68,7 +71,8 @@ class GeocodingService(
             "location" to location,
             "publicationState" to publicationState
         )
-        return getGeocodingContext(publicationState, trackNumberId)?.getAddress(location)
+        return getGeocodingContext(publicationState, trackNumberId)
+            ?.getAddress(location)
             ?.let { (address, intersect) -> if (intersect != WITHIN) null else address }
     }
 
@@ -97,9 +101,7 @@ class GeocodingService(
             "referenceLine" to referenceLine,
             "alignment" to alignment
         )
-        return getGeocodingContext(
-            publicationState, referenceLine.trackNumberId
-        )?.getStartAndEnd(alignment)
+        return getGeocodingContext(publicationState, referenceLine.trackNumberId)?.getStartAndEnd(alignment)
     }
 
     fun getTrackLocation(
@@ -120,50 +122,42 @@ class GeocodingService(
     fun getGeocodingContext(
         publicationState: PublishType,
         trackNumberId: DomainId<TrackLayoutTrackNumber>?,
-    ) = if (trackNumberId is IntId) getGeocodingContext(publicationState, trackNumberId) else null
+    ): GeocodingContext? = if (trackNumberId is IntId) getGeocodingContext(publicationState, trackNumberId) else null
 
     fun getGeocodingContext(geocodingContextCacheKey: GeocodingContextCacheKey) =
         geocodingCacheService.getGeocodingContext(geocodingContextCacheKey)
 
-    fun getGeocodingContextCreateResult(
-        publicationState: PublishType,
-        trackNumberId: IntId<TrackLayoutTrackNumber>,
-    ): GeocodingContextCreateResult? = geocodingDao.getLayoutGeocodingContextCacheKey(publicationState, trackNumberId)
-        ?.let(geocodingCacheService::getGeocodingContextWithReasons)
-
     fun getGeocodingContext(
         publicationState: PublishType,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
-    ): GeocodingContext? = getGeocodingContextCreateResult(publicationState, trackNumberId)
-        ?.geocodingContext
+    ): GeocodingContext? = getGeocodingContextCreateResult(publicationState, trackNumberId)?.geocodingContext
 
-    fun getGeocodingContextAtMoment(
+    fun getGeocodingContextCreateResult(
+        publicationState: PublishType,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
-        moment: Instant,
-    ): GeocodingContext? = geocodingDao.getLayoutGeocodingContextCacheKey(trackNumberId, moment)
-        ?.let(geocodingCacheService::getGeocodingContext)
+    ): GeocodingContextCreateResult? =
+        geocodingCacheService.getGeocodingContextCreateResult(publicationState, trackNumberId)
+
+    fun getGeocodingContextAtMoment(trackNumberId: IntId<TrackLayoutTrackNumber>, moment: Instant): GeocodingContext? =
+        geocodingCacheService.getGeocodingContextAtMoment(trackNumberId, moment)
 
     fun getGeocodingContext(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         plan: RowVersion<GeometryPlan>,
-    ): GeocodingContext? = trackNumberDao.fetchVersion(trackNumberId, PublishType.OFFICIAL)?.let { trackNumberVersion ->
-        getGeocodingContext(GeometryGeocodingContextCacheKey(trackNumberVersion, plan))
-    }
+    ): GeocodingContext? = geocodingCacheService.getGeocodingContext(trackNumberId, plan)
 
     fun getGeocodingContextCacheKey(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         publicationState: PublishType,
-    ) = geocodingDao.getLayoutGeocodingContextCacheKey(publicationState, trackNumberId)
+    ): LayoutGeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(publicationState, trackNumberId)
 
     fun getGeocodingContextCacheKey(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         versions: ValidationVersions,
-    ) = geocodingDao.getLayoutGeocodingContextCacheKey(trackNumberId, versions)
+    ): GeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(trackNumberId, versions)
 
     fun getGeocodingContextCacheKey(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         moment: Instant,
-    ) = geocodingDao.getLayoutGeocodingContextCacheKey(trackNumberId, moment)
-
-
+    ): GeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(trackNumberId, moment)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateSystemDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateSystemDao.kt
@@ -11,7 +11,9 @@ import fi.fta.geoviite.infra.util.getStringListFromString
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
+@Transactional(readOnly = true)
 @Component
 class CoordinateSystemDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTemplateParam) {
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -119,7 +119,6 @@ class GeometryController @Autowired constructor(
         return geometryService.getGeometryElement(geometryElementId)
     }
 
-
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/projects")
     fun getProjects(): List<Project> {
@@ -136,7 +135,7 @@ class GeometryController @Autowired constructor(
 
     @PreAuthorize(AUTH_ALL_WRITE)
     @PostMapping("/projects")
-    fun createProject(@RequestBody project: Project): Project {
+    fun createProject(@RequestBody project: Project): IntId<Project> {
         log.apiCall("createProject", "project" to project)
         return geometryService.createProject(project)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -781,6 +781,11 @@ class GeometryDao @Autowired constructor(
         )
     }
 
+    fun fetchPlanHeaders(
+        sources: List<PlanSource>,
+        bbox: BoundingBox?,
+    ): List<GeometryPlanHeader> = fetchPlanVersions().map(::getPlanHeader)
+
     fun fetchPlanVersions(
         sources: List<PlanSource>,
         bbox: BoundingBox?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -781,10 +781,8 @@ class GeometryDao @Autowired constructor(
         )
     }
 
-    fun fetchPlanHeaders(
-        sources: List<PlanSource>,
-        bbox: BoundingBox?,
-    ): List<GeometryPlanHeader> = fetchPlanVersions().map(::getPlanHeader)
+    fun fetchPlanHeaders(sources: List<PlanSource>, bbox: BoundingBox?): List<GeometryPlanHeader> =
+        fetchPlanVersions(sources, bbox).map(::getPlanHeader)
 
     fun fetchPlanVersions(
         sources: List<PlanSource>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -35,7 +35,6 @@ import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
 
-
 enum class VerticalIntersectionType {
     POINT, CIRCULAR_CURVE,
 }
@@ -680,6 +679,10 @@ class GeometryDao @Autowired constructor(
         logger.daoAccess(FETCH, GeometryPlanHeader::class, headers.keys)
         headerCache.putAll(headers)
     }
+
+    fun getPlanHeader(planId: IntId<GeometryPlan>) = getPlanHeader(fetchPlanVersion(planId))
+
+    fun getPlanHeaders(planIds: List<IntId<GeometryPlan>>) = fetchManyPlanVersions(planIds).map(::getPlanHeader)
 
     fun getPlanHeader(rowVersion: RowVersion<GeometryPlan>): GeometryPlanHeader =
         if (cacheEnabled) headerCache.get(rowVersion) { v -> getPlanHeaderInternal(v) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -87,7 +87,6 @@ class GeometryService @Autowired constructor(
         return geometryDao.fetchPlanAreas(boundingBox)
     }
 
-    @Transactional(readOnly = true)
     fun getPlanHeaders(
         sources: List<PlanSource> = listOf(),
         bbox: BoundingBox? = null,
@@ -96,8 +95,8 @@ class GeometryService @Autowired constructor(
         logger.serviceCall(
             "getPlanHeaders", "sources" to sources, "bbox" to bbox, "filtered" to (filter != null)
         )
-        return geometryDao.fetchPlanVersions(sources = sources, bbox = bbox)
-            .map(geometryDao::getPlanHeader)
+        return geometryDao
+            .fetchPlanHeaders(sources = sources, bbox = bbox)
             .let { all -> filter?.let(all::filter) ?: all }
     }
 
@@ -208,6 +207,7 @@ class GeometryService @Autowired constructor(
         return geometryDao.getLinkingSummaries(planIds)
     }
 
+    @Transactional(readOnly = true)
     fun fetchDuplicateGeometryPlanHeader(newFile: InfraModelFile, source: PlanSource): GeometryPlanHeader? {
         logger.serviceCall("fetchDuplicateGeometryPlanHeader", "newFile" to newFile, "source" to source)
         return geometryDao.fetchDuplicateGeometryPlanVersion(newFile, source)?.let(geometryDao::getPlanHeader)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -299,7 +299,7 @@ class GeometryService @Autowired constructor(
     }
 
     @Scheduled(cron = "\${geoviite.rail-network-export.schedule}")
-    @Scheduled(initialDelay = 1000 * 3, fixedDelay = Long.MAX_VALUE)
+    @Scheduled(initialDelay = 1000 * 300, fixedDelay = Long.MAX_VALUE)
     fun makeElementListingCsv() = runElementListGeneration {
         logger.serviceCall("makeElementListingCsv")
         val geocodingContexts = geocodingService.getGeocodingContexts(OFFICIAL)
@@ -393,7 +393,7 @@ class GeometryService @Autowired constructor(
     }
 
     @Scheduled(cron = "\${geoviite.rail-network-export.vertical-geometry-schedule}")
-    @Scheduled(initialDelay = 1000 * 3, fixedDelay = Long.MAX_VALUE)
+    @Scheduled(initialDelay = 1000 * 300, fixedDelay = Long.MAX_VALUE)
     fun makeEntireVerticalGeometryListingCsv() = runVerticalGeometryListGeneration {
         logger.serviceCall("makeEntireVerticalGeometryListingCsv")
         val geocodingContexts = geocodingService.getGeocodingContexts(OFFICIAL)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.inframodel
 
 import fi.fta.geoviite.infra.codeDictionary.CodeDictionaryService
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.error.InframodelParsingException
 import fi.fta.geoviite.infra.geography.CoordinateTransformationService
@@ -19,6 +20,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 
 const val VALIDATION_LAYOUT_POINTS_RESOLUTION = 10
@@ -45,9 +47,11 @@ class InfraModelService @Autowired constructor(
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
+    @Transactional
     fun saveInfraModel(file: MultipartFile, overrides: OverrideParameters?, extraInfo: ExtraInfoParameters?) =
         saveInfraModel(toInfraModelFile(file, overrides?.encoding?.charset), overrides, extraInfo)
 
+    @Transactional
     fun saveInfraModel(
         file: InfraModelFile,
         overrides: OverrideParameters?,
@@ -68,6 +72,7 @@ class InfraModelService @Autowired constructor(
         return geometryDao.insertPlan(geometryPlan, file, transformedBoundingBox)
     }
 
+    @Transactional(readOnly = true)
     fun parseInfraModel(
         file: InfraModelFile,
         overrides: OverrideParameters? = null,
@@ -78,7 +83,7 @@ class InfraModelService @Autowired constructor(
             "file.name" to file.name, "overrides" to overrides, "extraInfo" to extraInfo
         )
         val switchStructuresByType = switchLibraryService.getSwitchStructures().associateBy { it.type }
-        val trackNumberIdsByNumber = trackNumberService.listOfficial().associate { tn -> tn.number to tn.id as IntId }
+        val trackNumberIdsByNumber = trackNumberService.list(OFFICIAL).associate { tn -> tn.number to tn.id as IntId }
 
         val parsed = parseInfraModelFile(
             overrides?.source ?: PlanSource.GEOMETRIAPALVELU,
@@ -122,6 +127,7 @@ class InfraModelService @Autowired constructor(
         return validateAndTransformToLayoutPlan(geometryPlan)
     }
 
+    @Transactional(readOnly = true)
     fun validateGeometryPlan(
         planId: IntId<GeometryPlan>,
         overrideParameters: OverrideParameters?,
@@ -147,6 +153,7 @@ class InfraModelService @Autowired constructor(
         return ValidationResponse(validationErrors, plan, planLayout?.withLayoutGeometry(), plan.source)
     }
 
+    @Transactional
     fun updateInfraModel(
         planId: IntId<GeometryPlan>,
         overrideParameters: OverrideParameters?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -19,14 +19,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
-
 fun isAlignmentConnected(
     location: Point,
     locationTrackPointUpdateType: LocationTrackPointUpdateType,
     alignment: LayoutAlignment,
     distanceTolerance: Double,
 ): Boolean {
-
     val firstPoint = alignment.segments.first().points.first()
     val lastPoint = alignment.segments.last().points.last()
 
@@ -55,7 +53,8 @@ class LinkingService @Autowired constructor(
         locationTrackPointUpdateType: LocationTrackPointUpdateType,
         bbox: BoundingBox,
     ): List<LocationTrack> {
-        return locationTrackService.listNearWithAlignments(DRAFT, bbox)
+        return locationTrackService
+            .listNearWithAlignments(DRAFT, bbox)
             .filter { (first, _) -> first.id != locationTrackId }
             .filter { (_, second) -> isAlignmentConnected(location, locationTrackPointUpdateType, second, 2.0) }
             .map { (first, _) -> first }
@@ -67,7 +66,9 @@ class LinkingService @Autowired constructor(
 
         val referenceLineId = parameters.layoutInterval.alignmentId
         logger.serviceCall(
-            "Save ReferenceLine linking: " + "geometryAlignmentId=${parameters.geometryInterval.alignmentId} " + "referenceLineId=$referenceLineId"
+            "saveReferenceLineLinking",
+            "geometryAlignmentId" to parameters.geometryInterval.alignmentId,
+            "referenceLineId" to referenceLineId,
         )
 
         val (referenceLine, layoutAlignment) = referenceLineService.getWithAlignmentOrThrow(DRAFT, referenceLineId)
@@ -82,7 +83,9 @@ class LinkingService @Autowired constructor(
 
         val locationTrackId = parameters.layoutInterval.alignmentId
         logger.serviceCall(
-            "Save LocationTrack linking: " + "geometryAlignmentId=${parameters.geometryInterval.alignmentId} " + "locationTrackId=$locationTrackId"
+            "saveLocationTrackLinking",
+            "geometryAlignmentId" to parameters.geometryInterval.alignmentId,
+            "locationTrackId" to locationTrackId,
         )
 
         val (locationTrack, layoutAlignment) = locationTrackService.getWithAlignmentOrThrow(DRAFT, locationTrackId)
@@ -133,7 +136,9 @@ class LinkingService @Autowired constructor(
         val geometryInterval = parameters.geometryInterval
 
         logger.serviceCall(
-            "Save empty ReferenceLine linking: " + "geometryAlignmentId=${parameters.geometryInterval.alignmentId} " + "referenceLineId=$referenceLineId"
+            "saveReferenceLineLinking",
+            "geometryAlignmentId" to parameters.geometryInterval.alignmentId,
+            "referenceLineId" to referenceLineId,
         )
 
         val (referenceLine, layoutAlignment) = referenceLineService.getWithAlignmentOrThrow(DRAFT, referenceLineId)
@@ -152,7 +157,9 @@ class LinkingService @Autowired constructor(
         val geometryInterval = parameters.geometryInterval
 
         logger.serviceCall(
-            "Save empty LocationTrack linking: " + "geometryAlignmentId=${parameters.geometryInterval.alignmentId} " + "locationTrackId=$locationTrackId"
+            "saveLocationTrackLinking",
+            "geometryAlignmentId" to parameters.geometryInterval.alignmentId,
+            "locationTrackId" to locationTrackId,
         )
 
         val (locationTrack, layoutAlignment) = locationTrackService.getWithAlignmentOrThrow(DRAFT, locationTrackId)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
@@ -49,7 +49,6 @@ fun calculateLayoutSwitchJoints(
     }
 }
 
-
 fun findSuggestedSwitchJointMatches(
     joint: SwitchJoint,
     locationTrack: LocationTrack,
@@ -561,7 +560,6 @@ private fun getSegmentsByLinkingJoints(
                     endSplitSegment?.let {
                         acc.add(setStartJointNumber(endSplitSegment, layoutSwitchId, jointNumber))
                     }
-
                 }
             }
         }
@@ -928,7 +926,6 @@ fun createSuggestedSwitchByPoint(
     val farthestJoint = findFarthestJoint(switchStructure, sharedSwitchJoint, switchAlignmentsContainingSharedJoint[0])
     return selectBestSuggestedSwitch(suggestedSwitches, farthestJoint, point)
 }
-
 
 @Service
 class SwitchLinkingService @Autowired constructor(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocumentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocumentService.kt
@@ -1,8 +1,6 @@
 package fi.fta.geoviite.infra.projektivelho
 
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.error.Integration
-import fi.fta.geoviite.infra.error.IntegrationNotConfiguredException
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.inframodel.*
 import fi.fta.geoviite.infra.logging.serviceCall
@@ -16,13 +14,9 @@ import java.time.Instant
 @Service
 class PVDocumentService @Autowired constructor(
     private val pvDao: PVDao,
-    private val pvClientParam: PVClient?,
     private val infraModelService: InfraModelService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
-    private val pvClient: PVClient by lazy {
-        pvClientParam ?: throw IntegrationNotConfiguredException(Integration.PROJEKTIVELHO)
-    }
 
     fun getDocumentHeaders(status: PVDocumentStatus?): List<PVDocumentHeader> {
         logger.serviceCall("getDocumentHeaders", "status" to status)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -56,7 +56,7 @@ class PublicationDao(
                 draftChangeTime = rs.getInstant("change_time"),
                 operation = rs.getEnum("operation"),
                 userName = UserName(rs.getString("change_user")),
-                boundingBox = referenceLineDao.fetchVersion(PublishType.DRAFT, id)
+                boundingBox = referenceLineDao.fetchVersionByTrackNumberId(PublishType.DRAFT, id)
                     ?.let(referenceLineDao::fetch)?.boundingBox
             )
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateService.kt
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
 import java.util.concurrent.Executors
 
@@ -25,15 +26,15 @@ class PublicationGeometryChangeRemarksUpdateService constructor(
     private val executor =
         Executors.newSingleThreadExecutor { task -> Thread(task).also { it.name = "geometry change remarks updater" } }
 
+    @Transactional
     @EventListener(ContextRefreshedEvent::class)
     fun enqueueUpdateAllUnprocessedGeometryChangeRemarks() {
         executor.execute(::updateUnprocessedGeometryChangeRemarks)
     }
 
+    @Transactional
     fun processPublication(publicationId: IntId<Publication>) {
-        publicationDao.fetchUnprocessedGeometryChangeRemarks(publicationId).forEach { unprocessed ->
-            processOne(unprocessed)
-        }
+        publicationDao.fetchUnprocessedGeometryChangeRemarks(publicationId).forEach(::processOne)
     }
 
     private fun updateUnprocessedGeometryChangeRemarks() {
@@ -42,8 +43,7 @@ class PublicationGeometryChangeRemarksUpdateService constructor(
             while (unprocessedRemarksWereLeft) {
                 val unprocessed = publicationDao.fetchUnprocessedGeometryChangeRemarks(null)
                 unprocessedRemarksWereLeft = unprocessed.isNotEmpty()
-                if (unprocessed.isNotEmpty())
-                    processBatch(unprocessed)
+                if (unprocessed.isNotEmpty()) processBatch(unprocessed)
             }
         }
     }
@@ -63,7 +63,8 @@ class PublicationGeometryChangeRemarksUpdateService constructor(
         publicationDao.upsertGeometryChangeSummaries(
             unprocessedChange.publicationId,
             unprocessedChange.locationTrackId,
-            if (geocodingContext == null || unprocessedChange.oldAlignmentVersion == null) listOf() else summarizeAlignmentChanges(
+            if (geocodingContext == null || unprocessedChange.oldAlignmentVersion == null) listOf()
+            else summarizeAlignmentChanges(
                 geocodingContext = geocodingContext,
                 oldAlignment = alignmentDao.fetch(unprocessedChange.oldAlignmentVersion),
                 newAlignment = alignmentDao.fetch(unprocessedChange.newAlignmentVersion)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -77,6 +77,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
+    @Transactional(readOnly = true)
     fun validatePublishCandidates(
         candidates: PublishCandidates,
         request: PublishRequestIds,
@@ -88,6 +89,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
+    @Transactional(readOnly = true)
     fun validateTrackNumberAndReferenceLine(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         publishType: PublishType,
@@ -134,6 +136,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
+    @Transactional(readOnly = true)
     fun validateLocationTrack(
         locationTrackId: IntId<LocationTrack>,
         publishType: PublishType,
@@ -172,6 +175,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
+    @Transactional(readOnly = true)
     fun validateSwitches(
         switchIds: List<IntId<TrackLayoutSwitch>>,
         publishType: PublishType,
@@ -190,9 +194,10 @@ class PublicationService @Autowired constructor(
             switches = switches, locationTracks = (locationTracks + previouslyLinkedTracks).map(locationTrackDao::fetch)
         )
 
-        val linkedTracks =
-            publicationDao.fetchLinkedLocationTracks(switchIds, DRAFT).mapValues { (_, tracks) -> tracks.toSet() }
-        val allOfficialSwitches = switchService.listOfficial()
+        val linkedTracks = publicationDao
+            .fetchLinkedLocationTracks(switchIds, DRAFT)
+            .mapValues { (_, tracks) -> tracks.toSet() }
+        val allOfficialSwitches = switchService.list(OFFICIAL)
         return switches.map { switch ->
             ValidatedAsset(
                 validateSwitch(
@@ -206,11 +211,13 @@ class PublicationService @Autowired constructor(
         }
     }
 
+    @Transactional(readOnly = true)
     fun validateSwitch(
         switchId: IntId<TrackLayoutSwitch>,
         publishType: PublishType,
     ): ValidatedAsset<TrackLayoutSwitch> = validateSwitches(listOf(switchId), publishType).single()
 
+    @Transactional(readOnly = true)
     fun validateKmPost(
         kmPostId: IntId<TrackLayoutKmPost>,
         publishType: PublishType,
@@ -280,6 +287,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
+    @Transactional(readOnly = true)
     fun validatePublishRequest(versions: ValidationVersions) {
         logger.serviceCall("validatePublishRequest", "versions" to versions)
         val cacheKeys = collectCacheKeys(versions)
@@ -474,7 +482,6 @@ class PublicationService @Autowired constructor(
     fun getCalculatedChanges(versions: ValidationVersions): CalculatedChanges =
         calculatedChangesService.getCalculatedChanges(versions)
 
-
     fun publishChanges(
         versions: ValidationVersions,
         calculatedChanges: CalculatedChanges,
@@ -545,9 +552,9 @@ class PublicationService @Autowired constructor(
         trackNumber: TrackLayoutTrackNumber,
         versions: ValidationVersions,
     ): List<PublishValidationError> {
-        val drafts = versions.trackNumbers.map { it.officialId to trackNumberService.get(it.validatedAssetVersion) }
+        val drafts = versions.trackNumbers.map { it.officialId to trackNumberDao.fetch(it.validatedAssetVersion) }
         val officials =
-            trackNumberDao.fetchVersions(OFFICIAL, false).map(trackNumberService::get).filterNot { official ->
+            trackNumberDao.fetchVersions(OFFICIAL, false).map(trackNumberDao::fetch).filterNot { official ->
                 drafts.map { draft -> draft.first }.contains(official.id)
             }
         val officialDuplicateExists =
@@ -617,7 +624,7 @@ class PublicationService @Autowired constructor(
         versions: ValidationVersions,
         allOfficialSwitches: List<TrackLayoutSwitch> = switchService.list(OFFICIAL),
     ): List<PublishValidationError> {
-        val drafts = versions.switches.map { it.officialId to switchService.get(it.validatedAssetVersion) }
+        val drafts = versions.switches.map { it.officialId to switchDao.fetch(it.validatedAssetVersion) }
         val officials = allOfficialSwitches.filterNot { official ->
             drafts.map { draft -> draft.first }.contains(official.id)
         }
@@ -711,13 +718,12 @@ class PublicationService @Autowired constructor(
         locationTrack: LocationTrack,
         versions: ValidationVersions,
     ): List<PublishValidationError> {
-        val drafts = versions.locationTracks.map { it.officialId to locationTrackService.get(it.validatedAssetVersion) }
+        val drafts = versions.locationTracks
+            .map { it.officialId to locationTrackDao.fetch(it.validatedAssetVersion) }
             .filter { (_, lt) -> lt.trackNumberId == locationTrack.trackNumberId }
-        val officials = locationTrackDao.fetchVersions(OFFICIAL, false, locationTrack.trackNumberId)
-            .map(locationTrackService::get)
-            .filterNot { official ->
-                drafts.map { draft -> draft.first }.contains(official.id)
-            }
+        val officials = locationTrackDao
+            .list(OFFICIAL, false, locationTrack.trackNumberId)
+            .filterNot { official -> drafts.map { draft -> draft.first }.contains(official.id) }
         val officialDuplicateExists = officials.any { official ->
             official.id != locationTrack.id && official.name == locationTrack.name
         }
@@ -756,7 +762,7 @@ class PublicationService @Autowired constructor(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         versions: ValidationVersions,
     ) = versions.referenceLines.map { v -> referenceLineDao.fetch(v.validatedAssetVersion) }
-        .find { line -> line.trackNumberId == trackNumberId } ?: referenceLineDao.fetchVersion(OFFICIAL, trackNumberId)
+        .find { line -> line.trackNumberId == trackNumberId } ?: referenceLineDao.fetchVersionByTrackNumberId(OFFICIAL, trackNumberId)
         ?.let(referenceLineDao::fetch)
 
     private fun getKmPostsByTrackNumber(
@@ -928,7 +934,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
-    fun diffTrackNumber(
+    private fun diffTrackNumber(
         translation: Translation,
         trackNumberChanges: TrackNumberChanges,
         newTimestamp: Instant,
@@ -972,7 +978,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
-    fun diffLocationTrack(
+    private fun diffLocationTrack(
         translation: Translation,
         locationTrackChanges: LocationTrackChanges,
         switchLinkChanges: LocationTrackPublicationSwitchLinkChanges?,
@@ -1108,7 +1114,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
-    fun diffReferenceLine(
+    private fun diffReferenceLine(
         translation: Translation,
         changes: ReferenceLineChanges,
         newTimestamp: Instant,
@@ -1152,7 +1158,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
-    fun diffKmPost(
+    private fun diffKmPost(
         translation: Translation,
         changes: KmPostChanges,
         publicationTime: Instant,
@@ -1174,7 +1180,7 @@ class PublicationService @Autowired constructor(
         ),
     )
 
-    fun diffSwitch(
+    private fun diffSwitch(
         translation: Translation,
         changes: SwitchChanges,
         newTimestamp: Instant,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoStatusService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoStatusService.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.configuration.CACHE_RATKO_HEALTH_STATUS
 import fi.fta.geoviite.infra.integration.RatkoAssetType.*
 import fi.fta.geoviite.infra.integration.RatkoPushErrorWithAsset
@@ -27,9 +28,9 @@ class RatkoStatusService @Autowired constructor(
     fun getRatkoPushError(publishId: IntId<Publication>): RatkoPushErrorWithAsset? {
         return ratkoPushDao.getLatestRatkoPushErrorFor(publishId)?.let { ratkoError ->
             val asset = when (ratkoError.assetType) {
-                TRACK_NUMBER -> trackNumberService.getOfficial(ratkoError.assetId as IntId<TrackLayoutTrackNumber>)
-                LOCATION_TRACK -> locationTrackService.getOfficial(ratkoError.assetId as IntId<LocationTrack>)
-                SWITCH -> switchService.getOfficial(ratkoError.assetId as IntId<TrackLayoutSwitch>)
+                TRACK_NUMBER -> trackNumberService.get(OFFICIAL, ratkoError.assetId as IntId<TrackLayoutTrackNumber>)
+                LOCATION_TRACK -> locationTrackService.get(OFFICIAL, ratkoError.assetId as IntId<LocationTrack>)
+                SWITCH -> switchService.get(OFFICIAL, ratkoError.assetId as IntId<TrackLayoutSwitch>)
             }
             checkNotNull(asset) { "No asset found for id! ${ratkoError.assetType} ${ratkoError.assetId}" }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -272,7 +272,7 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
 
     @Transactional
     override fun deleteDraft(id: IntId<T>): DaoResponse<T> = deleteDraftsInternal(id).let { r ->
-        if (r.size > 1) throw IllegalStateException("Multiple rows deleted with one ID: type=${table.name} id=$id")
+        if (r.size > 1) error { "Multiple rows deleted with one ID: type=${table.name} id=$id" }
         else if (r.isEmpty()) throw DeletingFailureException("Trying to delete a non-existing draft object: type=${table.name} id=$id")
         else r.first()
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -19,6 +19,7 @@ import fi.fta.geoviite.infra.util.*
 import fi.fta.geoviite.infra.util.FetchType.MULTI
 import fi.fta.geoviite.infra.util.FetchType.SINGLE
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.sql.Timestamp
 import java.time.Instant
@@ -108,6 +109,7 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
     protected val cache: Cache<RowVersion<T>, T> =
         Caffeine.newBuilder().maximumSize(cacheSize).expireAfterAccess(layoutCacheDuration).build()
 
+    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
     override fun fetch(version: RowVersion<T>): T =
         if (cacheEnabled) cache.get(version, ::fetchInternal)
         else fetchInternal(version)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -9,17 +9,19 @@ import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.configuration.layoutCacheDuration
+import fi.fta.geoviite.infra.error.DeletingFailureException
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.AccessType.DELETE
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.util.*
+import fi.fta.geoviite.infra.util.FetchType.MULTI
+import fi.fta.geoviite.infra.util.FetchType.SINGLE
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.transaction.annotation.Transactional
 import java.sql.Timestamp
 import java.time.Instant
-
 
 data class VersionPair<T>(val official: RowVersion<T>?, val draft: RowVersion<T>?) {
     fun getOfficialId() = official?.id ?: draft?.id
@@ -32,11 +34,11 @@ interface IDraftableObjectWriter<T : Draftable<T>> {
 
     fun update(updatedItem: T): DaoResponse<T>
 
-    fun deleteUnpublishedDraft(id: IntId<T>): DaoResponse<T>
     fun deleteDraft(id: IntId<T>): DaoResponse<T>
     fun deleteDrafts(): List<DaoResponse<T>>
 }
 
+@Transactional(readOnly = true)
 interface IDraftableObjectReader<T : Draftable<T>> {
     fun fetch(version: RowVersion<T>): T
 
@@ -70,6 +72,27 @@ interface IDraftableObjectReader<T : Draftable<T>> {
         OFFICIAL -> fetchOfficialVersionOrThrow(id)
         DRAFT -> fetchDraftVersionOrThrow(id)
     }
+
+    fun get(publishType: PublishType, id: IntId<T>): T? = when (publishType) {
+        DRAFT -> fetchDraftVersion(id)?.let(::fetch)
+        OFFICIAL -> fetchOfficialVersion(id)?.let(::fetch)
+    }
+
+    fun getOrThrow(publishType: PublishType, id: IntId<T>): T = when (publishType) {
+        DRAFT -> fetch(fetchDraftVersionOrThrow(id))
+        OFFICIAL -> fetch(fetchOfficialVersionOrThrow(id))
+    }
+
+    fun getOfficialAtMoment(id: IntId<T>, moment: Instant): T? =
+        fetchOfficialVersionAtMoment(id, moment)?.let(::fetch)
+
+    fun getMany(publishType: PublishType, ids: List<IntId<T>>): List<T> = when (publishType) {
+        DRAFT -> fetchDraftVersions(ids)
+        OFFICIAL -> fetchOfficialVersions(ids)
+    }.map(::fetch)
+
+    fun list(publishType: PublishType, includeDeleted: Boolean): List<T> =
+        fetchVersions(publishType, includeDeleted).map(::fetch)
 }
 
 interface IDraftableObjectDao<T : Draftable<T>> : IDraftableObjectReader<T>, IDraftableObjectWriter<T>
@@ -85,12 +108,23 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
     protected val cache: Cache<RowVersion<T>, T> =
         Caffeine.newBuilder().maximumSize(cacheSize).expireAfterAccess(layoutCacheDuration).build()
 
-    override fun fetch(version: RowVersion<T>): T = if (cacheEnabled) cache.get(version, ::fetchInternal)
-    else fetchInternal(version)
+    override fun fetch(version: RowVersion<T>): T =
+        if (cacheEnabled) cache.get(version, ::fetchInternal)
+        else fetchInternal(version)
 
     protected abstract fun fetchInternal(version: RowVersion<T>): T
 
     abstract fun preloadCache()
+
+    private val publicationVersionsSql = """
+        select
+          coalesce(${table.draftLink}, id) as official_id,
+          id as row_id,
+          version as row_version
+        from ${table.fullName}
+        where coalesce(${table.draftLink}, id) in (:ids)
+          and draft = true
+    """.trimIndent()
 
     override fun fetchPublicationVersions(ids: List<IntId<T>>): List<ValidationVersion<T>> {
         // Empty lists don't play nice in the SQL, but the result would be empty anyhow
@@ -99,17 +133,8 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
         if (distinctIds.size != ids.size) logger.warn(
             "Requested publication versions with duplicate ids: duplicated=${ids.size - distinctIds.size} requested=$ids"
         )
-        val sql = """
-            select
-              coalesce(${table.draftLink}, id) as official_id,
-              id as row_id,
-              version as row_version
-            from ${table.fullName}
-            where coalesce(${table.draftLink}, id) in (:ids)
-              and draft = true
-        """.trimIndent()
         val params = mapOf("ids" to distinctIds.map { id -> id.intValue })
-        return jdbcTemplate.query<ValidationVersion<T>>(sql, params) { rs, _ ->
+        return jdbcTemplate.query<ValidationVersion<T>>(publicationVersionsSql, params) { rs, _ ->
             ValidationVersion(
                 rs.getIntId("official_id"),
                 rs.getRowVersion("row_id", "row_version"),
@@ -123,20 +148,21 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
 
     override fun fetchChangeTime(): Instant = fetchLatestChangeTime(table)
 
+    private val draftableChangeInfoSql = """
+        select
+          greatest(main_row.change_time, draft_row.change_time) as change_time,
+          case when main_row.draft then null else main_row.change_time end as official_change_time,
+          case when main_row.draft then main_row.change_time else draft_row.change_time end as draft_change_time,
+          version1.change_time as creation_time
+        from ${table.fullName} main_row
+          left join ${table.fullName} draft_row on draft_row.${table.draftLink} = main_row.id
+          inner join ${table.versionTable} version1 on main_row.id = version1.id and version1.version = 1
+        where (main_row.${table.draftLink} is null)
+          and (main_row.id = :id or draft_row.id = :id)
+    """.trimIndent()
+
     override fun fetchDraftableChangeInfo(id: IntId<T>): DraftableChangeInfo {
-        val sql = """
-            select
-              greatest(main_row.change_time, draft_row.change_time) as change_time,
-              case when main_row.draft then null else main_row.change_time end as official_change_time,
-              case when main_row.draft then main_row.change_time else draft_row.change_time end as draft_change_time,
-              version1.change_time as creation_time
-            from ${table.fullName} main_row
-              left join ${table.fullName} draft_row on draft_row.${table.draftLink} = main_row.id
-              inner join ${table.versionTable} version1 on main_row.id = version1.id and version1.version = 1
-            where (main_row.${table.draftLink} is null)
-              and (main_row.id = :id or draft_row.id = :id)
-        """.trimMargin()
-        return jdbcTemplate.queryForObject(sql, mapOf("id" to id.intValue)) { rs, _ ->
+        return jdbcTemplate.queryForObject(draftableChangeInfoSql, mapOf("id" to id.intValue)) { rs, _ ->
             DraftableChangeInfo(
                 created = rs.getInstant("creation_time"),
                 changed = rs.getInstant("change_time"),
@@ -151,15 +177,16 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
 
     override fun fetchAllVersions(): List<RowVersion<T>> = fetchRowVersions(table)
 
+    private val versionPairSql = """
+        select o.id, o.version, o.draft
+        from ${table.fullName} o left join ${table.fullName} d
+          on o.${table.draftLink} = d.id or d.${table.draftLink} = o.id
+        where o.id = :id or d.id = :id
+    """.trimIndent()
+
     override fun fetchVersionPair(id: IntId<T>): VersionPair<T> {
-        val sql = """
-            select o.id, o.version, o.draft
-            from ${table.fullName} o left join ${table.fullName} d
-              on o.${table.draftLink} = d.id or d.${table.draftLink} = o.id
-            where o.id = :id or d.id = :id
-        """
         val params = mapOf("id" to id.intValue)
-        val versions: List<Pair<Boolean, RowVersion<T>>> = jdbcTemplate.query(sql, params) { rs, _ ->
+        val versions: List<Pair<Boolean, RowVersion<T>>> = jdbcTemplate.query(versionPairSql, params) { rs, _ ->
             rs.getBoolean("draft") to rs.getRowVersion("id", "version")
         }
         return VersionPair(
@@ -168,100 +195,83 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
         )
     }
 
+    private val singleDraftVersionSql = draftFetchSql(table, SINGLE)
+    private val multiDraftVersionSql = draftFetchSql(table, MULTI)
+
+    private val singleOfficialVersionSql = officialFetchSql(table, SINGLE)
+    private val multiOfficialVersionSql = officialFetchSql(table, MULTI)
+
     override fun fetchDraftVersion(id: IntId<T>): RowVersion<T>? = fetchDraftRowVersion(id, table)
 
-    override fun fetchOfficialVersion(id: IntId<T>): RowVersion<T>? = fetchVersionPair(id).official
+    override fun fetchOfficialVersion(id: IntId<T>): RowVersion<T>? = fetchOfficialRowVersion(id, table)
 
     override fun fetchOfficialVersionOrThrow(id: IntId<T>): RowVersion<T> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
-        return queryRowVersion(officialFetchSql(table, FetchType.SINGLE), id)
-    }
-
-    override fun fetchDraftVersionOrThrow(id: IntId<T>): RowVersion<T> {
-        logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
-        return queryRowVersion(draftFetchSql(table, FetchType.SINGLE), id)
+        return queryRowVersion(singleOfficialVersionSql, id)
     }
 
     private fun fetchOfficialRowVersion(id: IntId<T>, table: DbTable): RowVersion<T>? {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
-        return queryRowVersionOrNull(officialFetchSql(table, FetchType.SINGLE), id)
+        return queryRowVersionOrNull(singleOfficialVersionSql, id)
     }
 
     override fun fetchOfficialVersions(ids: List<IntId<T>>): List<RowVersion<T>> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.versionTable, ids)
         val params = mapOf("ids" to ids.distinct().map { it.intValue })
-        val versions: List<RowVersion<T>> = if (ids.isEmpty()) emptyList()
-        else jdbcTemplate.query(officialFetchSql(table, FetchType.MULTI), params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        }
+        val versions: List<RowVersion<T>> =
+            if (ids.isEmpty()) emptyList()
+            else jdbcTemplate.query(multiOfficialVersionSql, params, ::toRowVersion)
         return versions
+    }
+
+    override fun fetchDraftVersionOrThrow(id: IntId<T>): RowVersion<T> {
+        logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
+        return queryRowVersion(singleDraftVersionSql, id)
     }
 
     private fun <T> fetchDraftRowVersion(id: IntId<T>, table: DbTable): RowVersion<T>? {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
-        return queryRowVersionOrNull(draftFetchSql(table, FetchType.SINGLE), id)
+        return queryRowVersionOrNull(singleDraftVersionSql, id)
     }
 
     override fun fetchDraftVersions(ids: List<IntId<T>>): List<RowVersion<T>> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, ids)
         val params = mapOf("ids" to ids.distinct().map { it.intValue })
         val versions: List<RowVersion<T>> = if (ids.isEmpty()) emptyList()
-        else jdbcTemplate.query(draftFetchSql(table, FetchType.MULTI), params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        }
+        else jdbcTemplate.query(multiDraftVersionSql, params, ::toRowVersion)
         return versions
     }
 
     override fun fetchOfficialVersionAtMomentOrThrow(id: IntId<T>, moment: Instant): RowVersion<T> =
         fetchOfficialVersionAtMoment(id, moment) ?: throw NoSuchEntityException(table.name, id)
 
+    //language=SQL
+    private val officialVersionAtMomentSql = """
+        select
+          case when v.deleted then null else v.id end as id,
+          case when v.deleted then null else v.version end as version
+        from ${table.versionTable} v
+        where
+          v.id = :id
+          and v.change_time <= :moment
+          and not v.draft
+        order by v.change_time desc
+        limit 1
+    """.trimIndent()
+
     override fun fetchOfficialVersionAtMoment(id: IntId<T>, moment: Instant): RowVersion<T>? {
-        //language=SQL
-        val sql = """
-            select
-              case when v.deleted then null else v.id end as id,
-              case when v.deleted then null else v.version end as version
-            from ${table.versionTable} v
-            where
-              v.id = :id
-              and v.change_time <= :moment
-              and not v.draft
-            order by v.change_time desc
-            limit 1
-        """.trimIndent()
         val params = mapOf(
             "id" to id.intValue,
             "moment" to Timestamp.from(moment),
         )
         logger.daoAccess(AccessType.VERSION_FETCH, LocationTrack::class, id)
-        return jdbcTemplate.queryOptional(sql, params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        }
-    }
-
-    @Transactional
-    override fun deleteUnpublishedDraft(id: IntId<T>): DaoResponse<T> {
-        val sql = """
-            delete from ${table.fullName}
-            where draft = true
-              and id = :id 
-              and ${table.draftLink} is null
-            returning id, version
-        """.trimIndent()
-        val params = mapOf("id" to id.intValue)
-        logger.daoAccess(DELETE, table.fullName, id)
-        jdbcTemplate.setUser()
-        val response: List<DaoResponse<T>> = jdbcTemplate.query(sql, params) { rs, _ ->
-            // Draft-only (there is no official row) -> id is also the official id
-            rs.getDaoResponse("id", "id", "version")
-        }
-        return getOne(table.name, id, response)
+        return jdbcTemplate.queryOptional(officialVersionAtMomentSql, params, ::toRowVersion)
     }
 
     @Transactional
     override fun deleteDraft(id: IntId<T>): DaoResponse<T> = deleteDraftsInternal(id).let { r ->
-        if (r.size > 1) throw IllegalStateException("Multiple rows deleted with one ID: $id")
-        else if (r.isEmpty()) throw NoSuchEntityException(table.name, id)
+        if (r.size > 1) throw IllegalStateException("Multiple rows deleted with one ID: type=${table.name} id=$id")
+        else if (r.isEmpty()) throw DeletingFailureException("Trying to delete a non-existing draft object: type=${table.name} id=$id")
         else r.first()
     }
 
@@ -283,22 +293,21 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
             rs.getDaoResponse("official_id", "row_id", "row_version")
         }.also { deleted -> logger.daoAccess(DELETE, table.fullName, deleted) }
     }
-
-    private fun officialFetchSql(table: DbTable, fetchType: FetchType) = """
-            select o.id, o.version
-            from ${table.fullName} o left join ${table.fullName} d on d.${table.draftLink} = o.id
-            where (o.id ${idOrIdsEqualSqlFragment(fetchType)} or d.id ${idOrIdsEqualSqlFragment(fetchType)}) and o.draft = false
-        """
-
-    private fun draftFetchSql(table: DbTable, fetchType: FetchType) = """
-            select o.id, o.version 
-            from ${table.fullName} o
-            where o.${table.draftLink} ${idOrIdsEqualSqlFragment(fetchType)} 
-               or (o.id ${idOrIdsEqualSqlFragment(fetchType)} 
-                  and not exists(select 1 from ${table.fullName} d where d.${table.draftLink} = o.id))
-        """
-
 }
+
+private fun officialFetchSql(table: DbTable, fetchType: FetchType) = """
+    select o.id, o.version
+    from ${table.fullName} o left join ${table.fullName} d on d.${table.draftLink} = o.id
+    where (o.id ${idOrIdsEqualSqlFragment(fetchType)} or d.id ${idOrIdsEqualSqlFragment(fetchType)}) and o.draft = false
+"""
+
+private fun draftFetchSql(table: DbTable, fetchType: FetchType) = """
+    select o.id, o.version 
+    from ${table.fullName} o
+    where o.${table.draftLink} ${idOrIdsEqualSqlFragment(fetchType)} 
+       or (o.id ${idOrIdsEqualSqlFragment(fetchType)} 
+          and not exists(select 1 from ${table.fullName} d where d.${table.draftLink} = o.id))
+"""
 
 inline fun <reified T : Draftable<T>> draftOfId(item: T) = draftOfId(item.id, item.draft)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -17,6 +17,7 @@ import fi.fta.geoviite.infra.util.DbTable.LAYOUT_ALIGNMENT
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.sql.ResultSet
 import java.util.stream.Collectors
@@ -48,9 +49,14 @@ class LayoutAlignmentDao(
 
     fun fetchVersions() = fetchRowVersions<LayoutAlignment>(LAYOUT_ALIGNMENT)
 
+    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
     fun fetch(alignmentVersion: RowVersion<LayoutAlignment>): LayoutAlignment =
         if (cacheEnabled) alignmentsCache.get(alignmentVersion, ::fetchInternal)
         else fetchInternal(alignmentVersion)
+
+    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+    fun fetchMany(versions: List<RowVersion<LayoutAlignment>>): Map<RowVersion<LayoutAlignment>, LayoutAlignment> =
+        versions.associateWith(::fetch)
 
     private fun fetchInternal(alignmentVersion: RowVersion<LayoutAlignment>): LayoutAlignment {
         val sql = """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
@@ -88,5 +88,6 @@ class LayoutAlignmentService(
     }
 }
 
-private fun asNew(alignment: LayoutAlignment) = if (alignment.dataType == TEMP) alignment
-else alignment.copy(id = StringId(), dataType = TEMP)
+private fun asNew(alignment: LayoutAlignment) =
+    if (alignment.dataType == TEMP) alignment
+    else alignment.copy(id = StringId(), dataType = TEMP)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -143,7 +143,7 @@ class LayoutKmPostController(
     @DeleteMapping("/draft/{id}")
     fun deleteDraftKmPost(@PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>): IntId<TrackLayoutKmPost> {
         logger.apiCall("deleteDraftKmPost", "kmPostId" to kmPostId)
-        return kmPostService.deleteUnpublishedDraft(kmPostId).id
+        return kmPostService.deleteDraft(kmPostId).id
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -3,7 +3,6 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.geography.create2DPolygonString
 import fi.fta.geoviite.infra.geometry.GeometryKmPost
-import fi.fta.geoviite.infra.geometry.KmPostError
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.BoundingBox
@@ -26,6 +25,13 @@ class LayoutKmPostDao(
 
     override fun fetchVersions(publicationState: PublishType, includeDeleted: Boolean) =
         fetchVersions(publicationState, includeDeleted, null, null)
+
+    fun list(
+        publicationState: PublishType,
+        includeDeleted: Boolean,
+        trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
+        bbox: BoundingBox? = null,
+    ): List<TrackLayoutKmPost> = fetchVersions(publicationState, includeDeleted, trackNumberId, bbox).map(::fetch)
 
     fun fetchVersions(
         publicationState: PublishType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.PublishType
+import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.linking.TrackLayoutKmPostSaveRequest
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.BoundingBox
@@ -30,7 +31,7 @@ class LayoutKmPostService(dao: LayoutKmPostDao) : DraftableObjectService<TrackLa
     @Transactional
     fun updateKmPost(id: IntId<TrackLayoutKmPost>, kmPost: TrackLayoutKmPostSaveRequest): IntId<TrackLayoutKmPost> {
         logger.serviceCall("updateKmPost", "id" to id, "kmPost" to kmPost)
-        val trackLayoutKmPost = getDraftInternal(id).copy(
+        val trackLayoutKmPost = dao.getOrThrow(DRAFT, id).copy(
             kmNumber = kmPost.kmNumber,
             state = kmPost.state,
         )
@@ -46,7 +47,7 @@ class LayoutKmPostService(dao: LayoutKmPostDao) : DraftableObjectService<TrackLa
         filter: ((kmPost: TrackLayoutKmPost) -> Boolean)?,
     ): List<TrackLayoutKmPost> {
         logger.serviceCall("list", "publicationState" to publicationState, "filter" to (filter != null))
-        val all = listInternal(publicationState, false)
+        val all = dao.list(publicationState, false)
         return filter?.let(all::filter) ?: all
     }
 
@@ -54,23 +55,16 @@ class LayoutKmPostService(dao: LayoutKmPostDao) : DraftableObjectService<TrackLa
         logger.serviceCall(
             "list", "publicationState" to publicationState, "trackNumberId" to trackNumberId
         )
-        return listInternal(publicationState, false, trackNumberId)
+        return dao.list(publicationState, false, trackNumberId)
     }
-
-    private fun listInternal(
-        publicationState: PublishType,
-        includeDeleted: Boolean,
-        trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
-        boundingBox: BoundingBox? = null,
-    ) = dao.fetchVersions(publicationState, includeDeleted, trackNumberId, boundingBox).map(dao::fetch)
 
     fun list(publicationState: PublishType, boundingBox: BoundingBox, step: Int): List<TrackLayoutKmPost> {
         logger.serviceCall(
             "getKmPosts", "publicationState" to publicationState, "boundingBox" to boundingBox, "step" to step
         )
-        return listInternal(
-            publicationState, false, boundingBox = boundingBox
-        ).filter { p -> (step <= 1 || (p.kmNumber.isPrimary() && p.kmNumber.number % step == 0)) }
+        return dao
+            .list(publicationState, false, bbox = boundingBox)
+            .filter { p -> (step <= 1 || (p.kmNumber.isPrimary() && p.kmNumber.number % step == 0)) }
     }
 
     fun getByKmNumber(
@@ -103,7 +97,7 @@ class LayoutKmPostService(dao: LayoutKmPostDao) : DraftableObjectService<TrackLa
             "offset" to offset,
             "limit" to limit
         )
-        val allPosts = listInternal(publicationState, false, trackNumberId)
+        val allPosts = dao.list(publicationState, false, trackNumberId)
         val postsByDistance = allPosts.map { post -> associateByDistance(post, location) { item -> item.location } }
         return pageToList(postsByDistance, offset, limit, ::compareByDistanceNullsFirst).map { (kmPost, _) -> kmPost }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -492,23 +492,4 @@ class LayoutSwitchDao(
             )
         }
     }
-
-    fun duplicateNameExistsForPublicationCandidate(switchId: IntId<TrackLayoutSwitch>): Boolean {
-        val sql = """
-            select
-              exists(
-                  select *
-                    from layout.switch this_switch
-                      join layout.switch duplicate_switch
-                           on this_switch.name = duplicate_switch.name
-                             and this_switch.id != duplicate_switch.id
-                             and this_switch.draft_of_switch_id is distinct from duplicate_switch.id
-                    where duplicate_switch.state_category != 'NOT_EXISTING'
-                      and this_switch.id = :switchId)
-        """.trimIndent()
-
-        return jdbcTemplate.queryForObject(
-            sql, mapOf("switchId" to switchId.intValue)
-        ) { rs, _ -> rs.getBoolean("exists") } ?: throw IllegalStateException("Unexpected null from exists-query")
-    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.PublishType
+import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.logging.apiCall
@@ -13,7 +14,6 @@ import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.publication.ValidatedAsset
 import fi.fta.geoviite.infra.publication.getCsvResponseEntity
 import fi.fta.geoviite.infra.util.FileName
-import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.toResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -86,7 +86,7 @@ class LayoutTrackNumberController(
     @DeleteMapping("/draft/{id}")
     fun deleteDraftTrackNumber(@PathVariable("id") id: IntId<TrackLayoutTrackNumber>): IntId<TrackLayoutTrackNumber> {
         logger.apiCall("deleteDraftTrackNumber", "id" to id)
-        return trackNumberService.deleteDraftOnlyTrackNumberAndReferenceLine(id)
+        return trackNumberService.deleteDraftAndReferenceLine(id)
     }
 
     @PreAuthorize(AUTH_ALL_READ)
@@ -149,10 +149,9 @@ class LayoutTrackNumberController(
         logger.apiCall("getEntireRailNetworkTrackNumberKmLengthsAsCsv", "lang" to lang)
 
         val csv = trackNumberService.getAllKmLengthsAsCsv(
-            publishType = PublishType.OFFICIAL,
-            trackNumberIds = trackNumberService.listOfficial().map { tn ->
-                tn.id as IntId
-            })
+            publishType = OFFICIAL,
+            trackNumberIds = trackNumberService.list(OFFICIAL).map { tn -> tn.id as IntId },
+        )
 
         val localization = localizationService.getLocalization(lang)
         val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneId.of("Europe/Helsinki"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -194,7 +194,7 @@ class LocationTrackController(
     @DeleteMapping("/draft/{id}")
     fun deleteLocationTrack(@PathVariable("id") id: IntId<LocationTrack>): IntId<LocationTrack> {
         logger.apiCall("deleteLocationTrack", "id" to id)
-        return locationTrackService.deleteUnpublishedDraft(id).id
+        return locationTrackService.deleteDraft(id).id
     }
 
     @PreAuthorize(AUTH_ALL_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -198,11 +198,11 @@ class LocationTrackService(
     }
 
     @Transactional(readOnly = true)
-    fun getManyWithAlignment(
+    fun getManyWithAlignments(
         publishType: PublishType,
         ids: List<IntId<LocationTrack>>,
     ): List<Pair<LocationTrack, LayoutAlignment>> {
-        logger.serviceCall("getManyWithAlignment", "publishType" to publishType, "ids" to ids)
+        logger.serviceCall("getManyWithAlignments", "publishType" to publishType, "ids" to ids)
         return dao.getMany(publishType, ids).let(::associateWithAlignments)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
@@ -60,17 +60,20 @@ class MapAlignmentService(
         return (referenceLines + locationTracks).filter { pl -> pl.points.isNotEmpty() }
     }
 
+    @Transactional(readOnly = true)
     fun getAlignmentPolyline(
         id: IntId<LocationTrack>,
         publishType: PublishType,
         bbox: BoundingBox,
         resolution: Int,
     ): AlignmentPolyLine<LocationTrack>? {
-        return locationTrackService.get(publishType, id)
+        return locationTrackService
+            .get(publishType, id)
             ?.takeIf { t -> t.state != LayoutState.DELETED }
             ?.let { toAlignmentPolyLine(it.id, LOCATION_TRACK, it.alignmentVersion, bbox, resolution) }
     }
 
+    @Transactional(readOnly = true)
     fun getSectionsWithoutLinking(
         publishType: PublishType,
         bbox: BoundingBox,
@@ -88,6 +91,7 @@ class MapAlignmentService(
         return referenceLines + locationTracks
     }
 
+    @Transactional(readOnly = true)
     fun getSectionsWithoutProfile(
         publishType: PublishType,
         bbox: BoundingBox,
@@ -117,6 +121,7 @@ class MapAlignmentService(
             ) }
     }
 
+    @Transactional(readOnly = true)
     fun getReferenceLineHeaders(
         publishType: PublishType,
         referenceLineIds: List<IntId<ReferenceLine>>,
@@ -133,6 +138,7 @@ class MapAlignmentService(
         }
     }
 
+    @Transactional(readOnly = true)
     fun getLocationTrackHeaders(
         publishType: PublishType,
         locationTrackIds: List<IntId<LocationTrack>>,
@@ -170,9 +176,12 @@ class MapAlignmentService(
         publishType: PublishType,
         bbox: BoundingBox,
         resolution: Int,
-    ) = locationTrackService.list(publishType).filter(LocationTrack::exists).mapNotNull { locationTrack ->
-        toAlignmentPolyLine(locationTrack.id, LOCATION_TRACK, locationTrack.alignmentVersion, bbox, resolution)
-    }
+    ): List<AlignmentPolyLine<LocationTrack>> = locationTrackService
+        .list(publishType)
+        .filter(LocationTrack::exists)
+        .mapNotNull { locationTrack ->
+            toAlignmentPolyLine(locationTrack.id, LOCATION_TRACK, locationTrack.alignmentVersion, bbox, resolution)
+        }
 
     private fun getReferenceLinePolyLines(
         publishType: PublishType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
@@ -124,7 +124,7 @@ class MapAlignmentService(
         publishType: PublishType,
         referenceLineIds: List<IntId<ReferenceLine>>,
     ): List<AlignmentHeader<ReferenceLine>> {
-        val referenceLines = referenceLineService.getManyWithAlignment(publishType, referenceLineIds)
+        val referenceLines = referenceLineService.getManyWithAlignments(publishType, referenceLineIds)
         val trackNumbers = trackNumberService
             .getMany(publishType, referenceLines.map { (rl, _) -> rl.trackNumberId })
             .associateBy(TrackLayoutTrackNumber::id)
@@ -141,7 +141,7 @@ class MapAlignmentService(
         locationTrackIds: List<IntId<LocationTrack>>,
     ): List<AlignmentHeader<LocationTrack>> {
         return locationTrackService
-            .getManyWithAlignment(publishType, locationTrackIds)
+            .getManyWithAlignments(publishType, locationTrackIds)
             .map { (track, alignment) -> toAlignmentHeader(track, alignment) }
     }
 
@@ -184,7 +184,7 @@ class MapAlignmentService(
     ): List<AlignmentPolyLine<*>> {
         val trackNumbers = trackNumberService.mapById(publishType)
         return referenceLineService
-            .listWithAlignment(publishType, includeDeleted = false)
+            .listWithAlignments(publishType, includeDeleted = false)
             .mapNotNull { (line, alignment) ->
                 val trackNumber = trackNumbers[line.trackNumberId]
                 if (trackNumber != null) toAlignmentPolyLine(line.id, REFERENCE_LINE, alignment, resolution, bbox)
@@ -204,7 +204,7 @@ class MapAlignmentService(
         bbox: BoundingBox,
     ): List<MapAlignmentHighlight<ReferenceLine>> {
         return referenceLineService
-            .listWithAlignment(publishType, boundingBox = bbox, includeDeleted = false)
+            .listWithAlignments(publishType, boundingBox = bbox, includeDeleted = false)
             .mapNotNull { (line, alignment) -> getMissingLinkings(line.id, REFERENCE_LINE, alignment) }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -169,7 +169,10 @@ class ReferenceLineDao(
         return result
     }
 
-    fun fetchVersion(
+    fun getByTrackNumber(publicationState: PublishType, trackNumberId: IntId<TrackLayoutTrackNumber>): ReferenceLine? =
+        fetchVersionByTrackNumberId(publicationState, trackNumberId)?.let(::fetch)
+
+    fun fetchVersionByTrackNumberId(
         publicationState: PublishType,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): RowVersion<ReferenceLine>? {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -159,21 +159,21 @@ class ReferenceLineService(
     }
 
     @Transactional(readOnly = true)
-    fun getManyWithAlignment(
+    fun getManyWithAlignments(
         publishType: PublishType,
         ids: List<IntId<ReferenceLine>>,
     ): List<Pair<ReferenceLine, LayoutAlignment>> {
-        logger.serviceCall("getManyWithAlignment", "publishType" to publishType, "ids" to ids)
+        logger.serviceCall("getManyWithAlignments", "publishType" to publishType, "ids" to ids)
         return dao.getMany(publishType, ids).let(::associateWithAlignments)
     }
 
     @Transactional(readOnly = true)
-    fun listWithAlignment(
+    fun listWithAlignments(
         publishType: PublishType,
         includeDeleted: Boolean = false,
         boundingBox: BoundingBox? = null,
     ): List<Pair<ReferenceLine, LayoutAlignment>> {
-        logger.serviceCall("listWithAlignment", "publishType" to publishType, "includeDeleted" to includeDeleted)
+        logger.serviceCall("listWithAlignments", "publishType" to publishType, "includeDeleted" to includeDeleted)
         return dao
             .list(publishType, includeDeleted)
             .let { list -> filterByBoundingBox(list, boundingBox) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -20,7 +20,7 @@ enum class FetchType {
 }
 
 fun idOrIdsEqualSqlFragment(fetchType: FetchType) = when (fetchType) {
-    FetchType.MULTI -> "in (:ids)"
+    MULTI -> "in (:ids)"
     SINGLE -> "= :id"
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -6,9 +6,12 @@ import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.logging.AccessType.VERSION_FETCH
 import fi.fta.geoviite.infra.logging.daoAccess
+import fi.fta.geoviite.infra.util.FetchType.MULTI
+import fi.fta.geoviite.infra.util.FetchType.SINGLE
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import java.sql.ResultSet
 import java.time.Instant
 import kotlin.reflect.KClass
 
@@ -18,7 +21,7 @@ enum class FetchType {
 
 fun idOrIdsEqualSqlFragment(fetchType: FetchType) = when (fetchType) {
     FetchType.MULTI -> "in (:ids)"
-    FetchType.SINGLE -> "= :id"
+    SINGLE -> "= :id"
 }
 
 enum class DbTable(schema: String, table: String, sortColumns: List<String> = listOf("id")) {
@@ -44,6 +47,15 @@ enum class DbTable(schema: String, table: String, sortColumns: List<String> = li
     val versionTable = "$schema.${table}_version"
     val draftLink: String = "draft_of_${table}_id"
     val orderBy: String = sortColumns.joinToString(",")
+
+    //language=SQL
+    val changeTimeSql = "select max(change_time) change_time from $versionTable"
+    //language=SQL
+    val singleRowVersionSql = "select id, version from $fullName where id ${idOrIdsEqualSqlFragment(SINGLE)}"
+    //language=SQL
+    val multiRowVersionSql = "select id, version from $fullName where id ${idOrIdsEqualSqlFragment(MULTI)}"
+    //language=SQL
+    val rowVersionsSql = "select id, version from $fullName order by $orderBy"
 }
 
 open class DaoBase(private val jdbcTemplateParam: NamedParameterJdbcTemplate?) {
@@ -60,34 +72,26 @@ open class DaoBase(private val jdbcTemplateParam: NamedParameterJdbcTemplate?) {
 
     protected fun <T> fetchRowVersion(id: IntId<T>, table: DbTable): RowVersion<T> {
         logger.daoAccess(VERSION_FETCH, "fetchRowVersion", "id" to id, "table" to table.fullName)
-        return queryRowVersion(
-            "select id, version from ${table.fullName} where id ${idOrIdsEqualSqlFragment(FetchType.SINGLE)}",
-            id
-        )
+        return queryRowVersion(table.singleRowVersionSql, id)
     }
 
     protected fun <T> fetchManyRowVersions(ids: List<IntId<T>>, table: DbTable): List<RowVersion<T>> {
         logger.daoAccess(VERSION_FETCH, "fetchManyRowVersions", "id" to ids, "table" to table.fullName)
-        return if (ids.isEmpty()) emptyList() else jdbcTemplate.query(
-            "select id, version from ${table.fullName} where id ${idOrIdsEqualSqlFragment(FetchType.MULTI)}",
-            mapOf("ids" to ids.map { it.intValue })
-        ) { rs, _ ->
-            rs.getRowVersion("id", "version")
+        return if (ids.isEmpty()) {
+            emptyList()
+        } else {
+            jdbcTemplate.query(table.multiRowVersionSql, mapOf("ids" to ids.map { it.intValue }), ::toRowVersion)
         }
     }
-
 
     protected fun <T> fetchRowVersions(table: DbTable): List<RowVersion<T>> {
         logger.daoAccess(VERSION_FETCH, "fetchRowVersions", "table" to table.fullName)
-        val sql = "select id, version from ${table.fullName} order by ${table.orderBy}"
-        return jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        }
+        return jdbcTemplate.query(table.rowVersionsSql, mapOf<String, Any>(), ::toRowVersion)
     }
 
     protected fun fetchLatestChangeTime(table: DbTable): Instant {
-        val sql = "select max(change_time) change_time from ${table.versionTable}"
-        return jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ -> rs.getInstantOrNull("change_time") }
+        return jdbcTemplate
+            .query(table.changeTimeSql, mapOf<String, Any>()) { rs, _ -> rs.getInstantOrNull("change_time") }
             .firstOrNull() ?: Instant.EPOCH
     }
 
@@ -97,37 +101,39 @@ open class DaoBase(private val jdbcTemplateParam: NamedParameterJdbcTemplate?) {
     }
 
     protected fun <T> queryRowVersion(sql: String, id: IntId<T>): RowVersion<T> =
-        jdbcTemplate.queryOne(sql, mapOf("id" to id.intValue), id.toString()) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        }
+        jdbcTemplate.queryOne(sql, mapOf("id" to id.intValue), id.toString(), ::toRowVersion)
 
     protected fun <T> queryRowVersionOrNull(sql: String, id: IntId<T>): RowVersion<T>? =
-        jdbcTemplate.queryOptional(sql, mapOf("id" to id.intValue)) { rs, _ ->
-            rs.getRowVersionOrNull("id", "version")
-        }
+        jdbcTemplate.queryOptional(sql, mapOf("id" to id.intValue), ::toRowVersionOrNull)
+
+    protected fun <T> toRowVersion(rs: ResultSet, index: Int): RowVersion<T> =
+        rs.getRowVersion("id", "version")
+
+    protected fun <T> toRowVersionOrNull(rs: ResultSet, index: Int): RowVersion<T> =
+        rs.getRowVersion("id", "version")
 }
 
 inline fun <reified T, reified S> getOne(id: DomainId<T>, result: List<S>) =
     getOptional(id, result) ?: throw NoSuchEntityException(T::class, id)
 
 inline fun <reified T, reified S> getOptional(id: DomainId<T>, result: List<S>): S? {
-    if (result.size > 1) {
+    require (result.size <= 1) {
         val idDesc = if (S::class == T::class) "id $id" else "${T::class.simpleName}.id $id"
-        throw IllegalStateException("Found more than one ${S::class.simpleName} with same $idDesc")
+        "Found more than one ${S::class.simpleName} with same $idDesc"
     }
     return result.firstOrNull()
 }
 
 fun <T, S> getOne(name: String, id: DomainId<T>, result: List<S>): S {
     if (result.isEmpty()) throw NoSuchEntityException(name, id)
-    else if (result.size > 1) {
-        throw IllegalStateException("Found more than one $name with id: $id")
-    }
+    else if (result.size > 1) error("Found more than one $name with id: $id")
     return result.first()
 }
 
-inline fun <reified T> toDbId(id: DomainId<T>): IntId<T> = if (id is IntId) id
-else throw NoSuchEntityException(T::class, id)
+inline fun <reified T> toDbId(id: DomainId<T>): IntId<T> =
+    if (id is IntId) id
+    else throw NoSuchEntityException(T::class, id)
 
-fun <T> toDbId(clazz: KClass<*>, id: DomainId<T>): IntId<T> = if (id is IntId) id
-else throw NoSuchEntityException(clazz, id)
+fun <T> toDbId(clazz: KClass<*>, id: DomainId<T>): IntId<T> =
+    if (id is IntId) id
+    else throw NoSuchEntityException(clazz, id)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
@@ -1,8 +1,9 @@
 package fi.fta.geoviite.infra.geometry
 
-import fi.fta.geoviite.infra.common.*
-import fi.fta.geoviite.infra.geography.KKJ2
-import fi.fta.geoviite.infra.geography.KKJ3_YKJ
+import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.FeatureTypeCode
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.util.FileName
@@ -218,8 +219,6 @@ class VerticalGeometryListingTest() {
             linear as List<LinearProfileSegment>,
             TrackMeter.ZERO,
             TrackMeter.ZERO,
-            null,
-            null,
         )
 
         assertEquals(verticalGeometryEntry.start.station.toDouble(), 4.0, 0.001)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -131,7 +131,7 @@ class LinkingServiceIT @Autowired constructor(
 
         val kmPost = kmPost(insertOfficialTrackNumber(), someKmNumber())
         val kmPostId = kmPostDao.insert(kmPost).id
-        val officialKmPost = kmPostService.getOfficial(kmPostId)
+        val officialKmPost = kmPostService.get(OFFICIAL, kmPostId)
 
         assertMatches(officialKmPost!!, kmPostService.getOrThrow(DRAFT, kmPostId))
 
@@ -149,7 +149,7 @@ class LinkingServiceIT @Autowired constructor(
 
         linkingService.saveKmPostLinking(kmPostLinkingParameters)
 
-        assertEquals(officialKmPost, kmPostService.getOfficial(kmPostId))
+        assertEquals(officialKmPost, kmPostService.get(OFFICIAL, kmPostId))
 
         val draftKmPost = kmPostService.getOrThrow(DRAFT, kmPostId)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -214,8 +214,8 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals(0, publishResult.kmPosts)
 
         assertEquals(
-            referenceLineService.getOfficial(draftId)!!.startAddress,
-            referenceLineService.getDraft(draftId)!!.startAddress,
+            referenceLineService.get(OFFICIAL, draftId)!!.startAddress,
+            referenceLineService.get(DRAFT, draftId)!!.startAddress,
         )
 
         assertEqualsCalculatedChanges(draftCalculatedChanges, publication)
@@ -226,7 +226,7 @@ class PublicationServiceIT @Autowired constructor(
         val (line, alignment) = referenceLineAndAlignment(someTrackNumber())
         val draftId = referenceLineService.saveDraft(line, alignment).id
         assertThrows<NoSuchEntityException> { referenceLineService.getWithAlignmentOrThrow(OFFICIAL, draftId) }
-        assertEquals(draftId, referenceLineService.getDraft(draftId)!!.id)
+        assertEquals(draftId, referenceLineService.get(DRAFT, draftId)!!.id)
 
         val publishRequest = publishRequest(referenceLines = listOf(draftId))
         val versions = publicationService.getValidationVersions(publishRequest)
@@ -235,7 +235,7 @@ class PublicationServiceIT @Autowired constructor(
         val publicationDetails = publicationService.getPublicationDetails(publication.publishId!!)
         assertEquals(1, publicationDetails.referenceLines.size)
         assertEquals(Operation.CREATE, publicationDetails.referenceLines[0].operation)
-        val publishedReferenceLine = referenceLineService.getOfficial(draftId)!!
+        val publishedReferenceLine = referenceLineService.get(OFFICIAL, draftId)!!
 
         val updateResponse = referenceLineService.updateTrackNumberReferenceLine(
             publishedReferenceLine.trackNumberId, publishedReferenceLine.startAddress.copy(
@@ -261,7 +261,7 @@ class PublicationServiceIT @Autowired constructor(
         referenceLineService.saveDraft(referenceLine(track.trackNumberId), alignment)
         val draftId = locationTrackService.saveDraft(track, alignment).id
         assertThrows<NoSuchEntityException> { locationTrackService.getWithAlignmentOrThrow(OFFICIAL, draftId) }
-        assertEquals(draftId, locationTrackService.getDraft(draftId)!!.id)
+        assertEquals(draftId, locationTrackService.get(DRAFT, draftId)!!.id)
 
         val publishResult = publish(publicationService, locationTracks = listOf(draftId))
 
@@ -273,8 +273,8 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals(0, publishResult.kmPosts)
 
         assertEquals(
-            locationTrackService.getOfficial(draftId)!!.name,
-            locationTrackService.getDraft(draftId)!!.name,
+            locationTrackService.get(OFFICIAL, draftId)!!.name,
+            locationTrackService.get(DRAFT, draftId)!!.name,
         )
     }
 
@@ -299,8 +299,8 @@ class PublicationServiceIT @Autowired constructor(
             )
         )
         assertNotEquals(
-            referenceLineService.getOfficial(officialId)!!.startAddress,
-            referenceLineService.getDraft(officialId)!!.startAddress,
+            referenceLineService.get(OFFICIAL, officialId)!!.startAddress,
+            referenceLineService.get(DRAFT, officialId)!!.startAddress,
         )
 
 
@@ -310,8 +310,8 @@ class PublicationServiceIT @Autowired constructor(
         publishAndVerify(publishRequest(referenceLines = listOf(officialId)))
 
         assertEquals(
-            referenceLineService.getOfficial(officialId)!!.startAddress,
-            referenceLineService.getDraft(officialId)!!.startAddress,
+            referenceLineService.get(OFFICIAL, officialId)!!.startAddress,
+            referenceLineService.get(DRAFT, officialId)!!.startAddress,
         )
         assertEquals(2, referenceLineService.getWithAlignmentOrThrow(OFFICIAL, officialId).second.segments.size)
         assertEquals(
@@ -348,8 +348,8 @@ class PublicationServiceIT @Autowired constructor(
             )
         )
         assertNotEquals(
-            locationTrackService.getOfficial(officialId)!!.name,
-            locationTrackService.getDraft(officialId)!!.name,
+            locationTrackService.get(OFFICIAL, officialId)!!.name,
+            locationTrackService.get(DRAFT, officialId)!!.name,
         )
         assertEquals(1, locationTrackService.getWithAlignmentOrThrow(OFFICIAL, officialId).second.segments.size)
         assertEquals(2, locationTrackService.getWithAlignmentOrThrow(DRAFT, officialId).second.segments.size)
@@ -357,8 +357,8 @@ class PublicationServiceIT @Autowired constructor(
         publishAndVerify(publishRequest(locationTracks = listOf(officialId)))
 
         assertEquals(
-            locationTrackService.getOfficial(officialId)!!.name,
-            locationTrackService.getDraft(officialId)!!.name,
+            locationTrackService.get(OFFICIAL, officialId)!!.name,
+            locationTrackService.get(DRAFT, officialId)!!.name,
         )
         assertEquals(2, locationTrackService.getWithAlignmentOrThrow(OFFICIAL, officialId).second.segments.size)
         assertEquals(
@@ -370,8 +370,8 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun publishingNewSwitchWorks() {
         val draftId = switchService.saveDraft(switch(123)).id
-        assertNull(switchService.getOfficial(draftId))
-        assertEquals(draftId, switchService.getDraft(draftId)!!.id)
+        assertNull(switchService.get(OFFICIAL, draftId))
+        assertEquals(draftId, switchService.get(DRAFT, draftId)!!.id)
 
         val publishResult = publish(publicationService, switches = listOf(draftId))
         assertNotNull(publishResult.publishId)
@@ -382,8 +382,8 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals(0, publishResult.kmPosts)
 
         assertEquals(
-            switchService.getOfficial(draftId)!!.name,
-            switchService.getDraft(draftId)!!.name,
+            switchService.get(OFFICIAL, draftId)!!.name,
+            switchService.get(DRAFT, draftId)!!.name,
         )
     }
 
@@ -397,28 +397,28 @@ class PublicationServiceIT @Autowired constructor(
         ).id
 
         switchService.saveDraft(
-            switchService.getDraft(officialId)!!.copy(
+            switchService.get(DRAFT, officialId)!!.copy(
                 name = SwitchName("DRAFT TST 001"),
                 joints = listOf(switchJoint(2), switchJoint(3), switchJoint(4)),
             )
         )
         assertNotEquals(
-            switchService.getOfficial(officialId)!!.name,
-            switchService.getDraft(officialId)!!.name,
+            switchService.get(OFFICIAL, officialId)!!.name,
+            switchService.get(DRAFT, officialId)!!.name,
         )
-        assertEquals(2, switchService.getOfficial(officialId)!!.joints.size)
-        assertEquals(3, switchService.getDraft(officialId)!!.joints.size)
+        assertEquals(2, switchService.get(OFFICIAL, officialId)!!.joints.size)
+        assertEquals(3, switchService.get(DRAFT, officialId)!!.joints.size)
 
         publishAndVerify(publishRequest(switches = listOf(officialId)))
 
         assertEquals(
-            switchService.getOfficial(officialId)!!.name,
-            switchService.getDraft(officialId)!!.name,
+            switchService.get(OFFICIAL, officialId)!!.name,
+            switchService.get(DRAFT, officialId)!!.name,
         )
-        assertEquals(3, switchService.getOfficial(officialId)!!.joints.size)
+        assertEquals(3, switchService.get(OFFICIAL, officialId)!!.joints.size)
         assertEquals(
-            switchService.getOfficial(officialId)!!.joints,
-            switchService.getDraft(officialId)!!.joints,
+            switchService.get(OFFICIAL, officialId)!!.joints,
+            switchService.get(DRAFT, officialId)!!.joints,
         )
     }
 
@@ -426,8 +426,8 @@ class PublicationServiceIT @Autowired constructor(
     fun publishingNewTrackNumberWorks() {
         val trackNumber = trackNumber(getUnusedTrackNumber())
         val draftId = trackNumberService.saveDraft(trackNumber).id
-        assertNull(trackNumberService.getOfficial(draftId))
-        assertEquals(draftId, trackNumberService.getDraft(draftId)!!.id)
+        assertNull(trackNumberService.get(OFFICIAL, draftId))
+        assertEquals(draftId, trackNumberService.get(DRAFT, draftId)!!.id)
 
         val publishResult = publish(publicationService, trackNumbers = listOf(draftId))
 
@@ -439,8 +439,8 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals(0, publishResult.kmPosts)
 
         assertEquals(
-            trackNumberService.getOfficial(draftId)!!.number,
-            trackNumberService.getDraft(draftId)!!.number,
+            trackNumberService.get(OFFICIAL, draftId)!!.number,
+            trackNumberService.get(DRAFT, draftId)!!.number,
         )
     }
 
@@ -454,18 +454,18 @@ class PublicationServiceIT @Autowired constructor(
         ).id
 
         trackNumberService.saveDraft(
-            trackNumberService.getDraft(officialId)!!.copy(
+            trackNumberService.get(DRAFT, officialId)!!.copy(
                 number = getUnusedTrackNumber(),
                 description = FreeText("Test 2"),
             )
         )
 
         assertNotEquals(
-            trackNumberService.getOfficial(officialId)!!.number, trackNumberService.getDraft(officialId)!!.number
+            trackNumberService.get(OFFICIAL, officialId)!!.number, trackNumberService.get(DRAFT, officialId)!!.number
         )
 
-        assertEquals(FreeText("Test 1"), trackNumberService.getOfficial(officialId)!!.description)
-        assertEquals(FreeText("Test 2"), trackNumberService.getDraft(officialId)!!.description)
+        assertEquals(FreeText("Test 1"), trackNumberService.get(OFFICIAL, officialId)!!.description)
+        assertEquals(FreeText("Test 2"), trackNumberService.get(DRAFT, officialId)!!.description)
 
         val publishResult = publish(publicationService, trackNumbers = listOf(officialId))
 
@@ -477,13 +477,13 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals(0, publishResult.kmPosts)
 
         assertEquals(
-            trackNumberService.getOfficial(officialId)!!.number,
-            trackNumberService.getDraft(officialId)!!.number,
+            trackNumberService.get(OFFICIAL, officialId)!!.number,
+            trackNumberService.get(DRAFT, officialId)!!.number,
         )
 
         assertEquals(
-            trackNumberService.getOfficial(officialId)!!.description,
-            trackNumberService.getDraft(officialId)!!.description,
+            trackNumberService.get(OFFICIAL, officialId)!!.description,
+            trackNumberService.get(DRAFT, officialId)!!.description,
         )
     }
 
@@ -497,7 +497,7 @@ class PublicationServiceIT @Autowired constructor(
         val (track, alignment) = locationTrackAndAlignment(trackNumberId)
         val draftId = locationTrackService.saveDraft(track, alignment).id
         assertThrows<NoSuchEntityException> { locationTrackService.getWithAlignmentOrThrow(OFFICIAL, draftId) }
-        assertEquals(draftId, locationTrackService.getDraft(draftId)!!.id)
+        assertEquals(draftId, locationTrackService.get(DRAFT, draftId)!!.id)
 
         val publicationCountBeforePublishing = publicationService.fetchPublications().size
 
@@ -576,8 +576,8 @@ class PublicationServiceIT @Autowired constructor(
         )
 
         assertEquals(revertResult.switches, 1)
-        assertNull(switchService.getDraft(switch1))
-        assertDoesNotThrow { switchService.getDraft(switch2) }
+        assertNull(switchService.get(DRAFT, switch1))
+        assertDoesNotThrow { switchService.get(DRAFT, switch2) }
     }
 
     @Test
@@ -677,8 +677,8 @@ class PublicationServiceIT @Autowired constructor(
 
         assertEquals(2, publish1Result.trackNumbers)
 
-        val trackNumber1 = trackNumberService.getOfficial(trackNumber1Id)
-        val trackNumber2 = trackNumberService.getOfficial(trackNumber2Id)
+        val trackNumber1 = trackNumberService.get(OFFICIAL, trackNumber1Id)
+        val trackNumber2 = trackNumberService.get(OFFICIAL, trackNumber2Id)
         assertNotNull(trackNumber1)
         assertNotNull(trackNumber2)
 
@@ -949,7 +949,7 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Track number diff finds all changed fields`() {
         val address = TrackMeter(0, 0)
-        val trackNumber = trackNumberService.getDraft(
+        val trackNumber = trackNumberService.get(DRAFT,
             trackNumberService.insert(
                 TrackNumberSaveRequest(
                     getUnusedTrackNumber(),
@@ -1040,7 +1040,7 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `Location track diff finds all changed fields`() {
-        val duplicate = locationTrackService.get(
+        val duplicate = locationTrackDao.fetch(
             locationTrackService.insert(
                 LocationTrackSaveRequest(
                     AlignmentName("TEST duplicate"),
@@ -1056,7 +1056,7 @@ class PublicationServiceIT @Autowired constructor(
             ).rowVersion
         )
 
-        val duplicate2 = locationTrackService.get(
+        val duplicate2 = locationTrackDao.fetch(
             locationTrackService.insert(
                 LocationTrackSaveRequest(
                     AlignmentName("TEST duplicate 2"),
@@ -1072,7 +1072,7 @@ class PublicationServiceIT @Autowired constructor(
             ).rowVersion
         )
 
-        val locationTrack = locationTrackService.get(
+        val locationTrack = locationTrackDao.fetch(
             locationTrackService.insert(
                 LocationTrackSaveRequest(
                     AlignmentName("TEST"),
@@ -1097,7 +1097,7 @@ class PublicationServiceIT @Autowired constructor(
             )
         )
 
-        val updatedLocationTrack = locationTrackService.get(
+        val updatedLocationTrack = locationTrackDao.fetch(
             locationTrackService.update(
                 locationTrack.id as IntId, LocationTrackSaveRequest(
                     name = AlignmentName("TEST2"),
@@ -1151,12 +1151,12 @@ class PublicationServiceIT @Autowired constructor(
             IntId(1)
         )
 
-        val locationTrack = locationTrackService.get(
+        val locationTrack = locationTrackDao.fetch(
             locationTrackService.insert(saveReq).rowVersion
         )
         publish(publicationService, locationTracks = listOf(locationTrack.id as IntId<LocationTrack>))
 
-        val updatedLocationTrack = locationTrackService.get(
+        val updatedLocationTrack = locationTrackDao.fetch(
             locationTrackService.update(
                 locationTrack.id as IntId, saveReq.copy(descriptionBase = FreeText("TEST2"))
             ).rowVersion

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.geometry.geometryAlignment
 import fi.fta.geoviite.infra.geometry.lineFromOrigin
@@ -84,7 +85,7 @@ class RatkoServiceIT @Autowired constructor(
         val officialVersion = locationTrackDao.insert(
             locationTrack(trackNumberId = trackNumberId).copy(alignmentVersion = locationTrackAlignmentVersion)
         )
-        val draft = locationTrackService.getDraft(officialVersion.id)!!.let { orig ->
+        val draft = locationTrackService.get(DRAFT, officialVersion.id)!!.let { orig ->
             orig.copy(name = AlignmentName("${orig.name}-draft"))
         }
         locationTrackService.saveDraft(draft, alignmentDao.fetch(locationTrackAlignmentVersion)).rowVersion
@@ -426,7 +427,7 @@ class RatkoServiceIT @Autowired constructor(
         referenceLineService.saveDraft(
             draft(
                 referenceLineDao.fetch(
-                    referenceLineDao.fetchVersion(
+                    referenceLineDao.fetchVersionByTrackNumberId(
                         PublishType.OFFICIAL, originalTrackNumberVersion.id
                     )!!
                 )
@@ -478,7 +479,7 @@ class RatkoServiceIT @Autowired constructor(
         referenceLineService.saveDraft(
             draft(
                 referenceLineDao.fetch(
-                    referenceLineDao.fetchVersion(
+                    referenceLineDao.fetchVersionByTrackNumberId(
                         PublishType.OFFICIAL, originalTrackNumberVersion.id
                     )!!
                 )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/DraftIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/DraftIT.kt
@@ -4,6 +4,8 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.PublishType.DRAFT
+import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.math.Point
 import org.junit.jupiter.api.Assertions.*
@@ -83,16 +85,16 @@ class DraftIT @Autowired constructor(
         assertNotEquals(dbDraft.first.draft?.draftRowId, dbDraft.first.id)
 
         assertMatches(
-            dbLineAndAlignment.first, referenceLineService.getOfficial(dbLineAndAlignment.first.id as IntId)!!, true
+            dbLineAndAlignment.first, referenceLineService.get(OFFICIAL, dbLineAndAlignment.first.id as IntId)!!, true
         )
         assertMatches(
             dbLineAndAlignment.first,
-            referenceLineService.getOfficial(dbDraft.first.draft!!.draftRowId as IntId)!!,
+            referenceLineService.get(OFFICIAL, dbDraft.first.draft!!.draftRowId as IntId)!!,
             true
         )
 
-        assertMatches(dbDraft.first, referenceLineService.getDraft(dbDraft.first.id as IntId)!!, true)
-        assertMatches(dbDraft.first, referenceLineService.getDraft(dbDraft.first.draft!!.draftRowId as IntId)!!, true)
+        assertMatches(dbDraft.first, referenceLineService.get(DRAFT, dbDraft.first.id as IntId)!!, true)
+        assertMatches(dbDraft.first, referenceLineService.get(DRAFT, dbDraft.first.draft!!.draftRowId as IntId)!!, true)
     }
 
     @Test
@@ -107,16 +109,16 @@ class DraftIT @Autowired constructor(
         assertNotEquals(dbDraft.first.draft?.draftRowId, dbDraft.first.id)
 
         assertMatches(
-            dbTrackAndAlignment.first, locationTrackService.getOfficial(dbTrackAndAlignment.first.id as IntId)!!, true
+            dbTrackAndAlignment.first, locationTrackService.get(OFFICIAL, dbTrackAndAlignment.first.id as IntId)!!, true
         )
         assertMatches(
             dbTrackAndAlignment.first,
-            locationTrackService.getOfficial(dbDraft.first.draft!!.draftRowId as IntId)!!,
+            locationTrackService.get(OFFICIAL, dbDraft.first.draft!!.draftRowId as IntId)!!,
             true
         )
 
-        assertMatches(dbDraft.first, locationTrackService.getDraft(dbDraft.first.id as IntId)!!, true)
-        assertMatches(dbDraft.first, locationTrackService.getDraft(dbDraft.first.draft!!.draftRowId as IntId)!!, true)
+        assertMatches(dbDraft.first, locationTrackService.get(DRAFT, dbDraft.first.id as IntId)!!, true)
+        assertMatches(dbDraft.first, locationTrackService.get(DRAFT, dbDraft.first.draft!!.draftRowId as IntId)!!, true)
     }
 
     @Test
@@ -125,11 +127,11 @@ class DraftIT @Autowired constructor(
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbSwitch)))
         assertNotEquals(dbSwitch, dbDraft)
 
-        assertMatches(dbSwitch, switchService.getOfficial(dbSwitch.id as IntId)!!, true)
-        assertMatches(dbSwitch, switchService.getOfficial(dbDraft.draft!!.draftRowId as IntId)!!, true)
+        assertMatches(dbSwitch, switchService.get(OFFICIAL, dbSwitch.id as IntId)!!, true)
+        assertMatches(dbSwitch, switchService.get(OFFICIAL, dbDraft.draft!!.draftRowId as IntId)!!, true)
 
-        assertMatches(dbDraft, switchService.getDraft(dbDraft.id as IntId)!!, true)
-        assertMatches(dbDraft, switchService.getDraft(dbDraft.draft!!.draftRowId as IntId)!!, true)
+        assertMatches(dbDraft, switchService.get(DRAFT, dbDraft.id as IntId)!!, true)
+        assertMatches(dbDraft, switchService.get(DRAFT, dbDraft.draft!!.draftRowId as IntId)!!, true)
     }
 
 
@@ -139,11 +141,11 @@ class DraftIT @Autowired constructor(
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbKmPost)))
         assertNotEquals(dbKmPost, dbDraft)
 
-        assertMatches(dbKmPost, kmPostService.getOfficial(dbKmPost.id as IntId)!!, true)
-        assertMatches(dbKmPost, kmPostService.getOfficial(dbDraft.draft!!.draftRowId as IntId)!!, true)
+        assertMatches(dbKmPost, kmPostService.get(OFFICIAL, dbKmPost.id as IntId)!!, true)
+        assertMatches(dbKmPost, kmPostService.get(OFFICIAL, dbDraft.draft!!.draftRowId as IntId)!!, true)
 
-        assertMatches(dbDraft, kmPostService.getDraft(dbDraft.id as IntId)!!, true)
-        assertMatches(dbDraft, kmPostService.getDraft(dbDraft.draft!!.draftRowId as IntId)!!, true)
+        assertMatches(dbDraft, kmPostService.get(DRAFT, dbDraft.id as IntId)!!, true)
+        assertMatches(dbDraft, kmPostService.get(DRAFT, dbDraft.draft!!.draftRowId as IntId)!!, true)
     }
 
     @Test
@@ -199,8 +201,8 @@ class DraftIT @Autowired constructor(
         val dbOfficial = insertAndVerifyLine(createReferenceLineAndAlignment())
         val dbDraft = insertAndVerifyLine(alterLine(createAndVerifyDraftLine(dbOfficial)))
 
-        val officials = referenceLineService.listOfficial()
-        val drafts = referenceLineService.listDraft()
+        val officials = referenceLineService.list(OFFICIAL)
+        val drafts = referenceLineService.list(DRAFT)
 
         assertFalse(officials.contains(dbDraft.first))
         assertFalse(drafts.contains(dbOfficial.first))
@@ -214,8 +216,8 @@ class DraftIT @Autowired constructor(
         val dbOfficial = insertAndVerifyTrack(createLocationTrackAndAlignment())
         val dbDraft = insertAndVerifyTrack(alterTrack(createAndVerifyDraftTrack(dbOfficial)))
 
-        val officials = locationTrackService.listOfficial()
-        val drafts = locationTrackService.listDraft()
+        val officials = locationTrackService.list(OFFICIAL)
+        val drafts = locationTrackService.list(DRAFT)
 
         assertFalse(officials.contains(dbDraft.first))
         assertFalse(drafts.contains(dbOfficial.first))
@@ -229,8 +231,8 @@ class DraftIT @Autowired constructor(
         val dbSwitch = insertAndVerify(switch(456))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbSwitch)))
 
-        val officials = switchService.listOfficial()
-        val drafts = switchService.listDraft()
+        val officials = switchService.list(OFFICIAL)
+        val drafts = switchService.list(DRAFT)
 
         assertFalse(officials.contains(dbDraft))
         assertFalse(drafts.contains(dbSwitch))
@@ -244,8 +246,8 @@ class DraftIT @Autowired constructor(
         val dbKmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber()))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbKmPost)))
 
-        val officials = kmPostService.listOfficial()
-        val drafts = kmPostService.listDraft()
+        val officials = kmPostService.list(OFFICIAL)
+        val drafts = kmPostService.list(DRAFT)
 
         assertFalse(officials.contains(dbDraft))
         assertFalse(drafts.contains(dbKmPost))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -26,7 +26,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
     @Test
     fun nearbyKmPostsAreReturnedInOrder() {
         val trackNumberId = insertOfficialTrackNumber()
-        val kmPost1 = kmPostService.get(
+        val kmPost1 = kmPostDao.fetch(
             kmPostDao.insert(
                 kmPost(
                     trackNumberId = trackNumberId,
@@ -35,7 +35,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                 )
             ).rowVersion
         )
-        val kmPost2 = kmPostService.get(
+        val kmPost2 = kmPostDao.fetch(
             kmPostDao.insert(
                 kmPost(
                     trackNumberId = trackNumberId,
@@ -44,7 +44,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                 )
             ).rowVersion
         )
-        val kmPost3 = kmPostService.get(
+        val kmPost3 = kmPostDao.fetch(
             kmPostDao.insert(
                 kmPost(
                     trackNumberId = trackNumberId,
@@ -72,7 +72,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
     @Test
     fun findsKmPostAtKmNumber() {
         val trackNumberId = insertOfficialTrackNumber()
-        val kmPost = kmPostService.get(
+        val kmPost = kmPostDao.fetch(
             kmPostDao.insert(
                 kmPost(
                     trackNumberId = trackNumberId,
@@ -105,7 +105,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
     fun doesntFindKmPostOnWrongTrack() {
         val trackNumber1Id = insertOfficialTrackNumber()
         val trackNumber2Id = insertOfficialTrackNumber()
-        val kmPost = kmPostService.get(
+        val kmPost = kmPostDao.fetch(
             kmPostDao.insert(
                 kmPost(
                     trackNumberId = trackNumber1Id,
@@ -124,11 +124,11 @@ class LayoutKmPostServiceIT @Autowired constructor(
         val kmPost = TrackLayoutKmPost(KmNumber(7654), Point(123.4, 234.5), LayoutState.IN_USE, trackNumberId, null)
 
         val draftId = kmPostService.saveDraft(draft(kmPost)).id
-        val draftFromDb = kmPostService.getDraft(draftId)
+        val draftFromDb = kmPostService.get(DRAFT, draftId)
 
         assertEquals(1, kmPostService.list(DRAFT) { k -> k == draftFromDb }.size)
 
-        kmPostService.deleteUnpublishedDraft(draftId)
+        kmPostService.deleteDraft(draftId)
 
         assertEquals(0, kmPostService.list(DRAFT) { k -> k == draftFromDb }.size)
     }
@@ -143,8 +143,8 @@ class LayoutKmPostServiceIT @Autowired constructor(
         )
         val kmPostId = kmPostService.insertKmPost(kmPost)
 
-        val fetchedKmPost = kmPostService.getDraft(kmPostId)!!
-        assertNull(kmPostService.getOfficial(kmPostId))
+        val fetchedKmPost = kmPostService.get(DRAFT, kmPostId)!!
+        assertNull(kmPostService.get(OFFICIAL, kmPostId))
 
         assertEquals(DataType.STORED, fetchedKmPost.dataType)
         assertEquals(kmPost.kmNumber, fetchedKmPost.kmNumber)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.error.DeletingFailureException
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -87,7 +88,7 @@ class LayoutSwitchDaoIT @Autowired constructor(
         val (insertedId, insertedVersion) = switchDao.insert(draftSwitch)
         val insertedSwitch = switchDao.fetch(insertedVersion)
 
-        val deletedId = switchDao.deleteUnpublishedDraft(insertedId)
+        val deletedId = switchDao.deleteDraft(insertedId)
         assertEquals(insertedId, deletedId.id)
         assertFalse(switchDao.fetchAllVersions().any { id -> id == insertedId })
 
@@ -100,8 +101,8 @@ class LayoutSwitchDaoIT @Autowired constructor(
         val switch = switch(1)
         val insertedSwitch = switchDao.insert(switch)
 
-        assertThrows<NoSuchEntityException> {
-            switchDao.deleteUnpublishedDraft(insertedSwitch.id)
+        assertThrows<DeletingFailureException> {
+            switchDao.deleteDraft(insertedSwitch.id)
         }
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -47,13 +47,13 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
             )
         )
         val id = trackNumberService.insert(saveRequest)
-        val trackNumber = trackNumberService.getDraft(id)!!
+        val trackNumber = trackNumberService.get(DRAFT, id)!!
 
         assertNull(trackNumber.externalId)
 
         trackNumberService.updateExternalId(trackNumber.id as IntId, externalIdForTrackNumber())
 
-        val updatedTrackNumber = trackNumberService.getDraft(id)!!
+        val updatedTrackNumber = trackNumberService.get(DRAFT, id)!!
         assertNotNull(updatedTrackNumber.externalId)
     }
 
@@ -63,7 +63,7 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
         assertEquals(referenceLine.alignmentVersion?.id, alignment.id as IntId)
         val trackNumberId = trackNumber.id as IntId
 
-        assertDoesNotThrow { trackNumberService.deleteDraftOnlyTrackNumberAndReferenceLine(trackNumberId) }
+        assertDoesNotThrow { trackNumberService.deleteDraftAndReferenceLine(trackNumberId) }
         assertThrows<NoSuchEntityException> {
             referenceLineService.getOrThrow(DRAFT, referenceLine.id as IntId)
         }
@@ -80,7 +80,7 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
         publishReferenceLine(referenceLine.id as IntId)
 
         assertThrows<DeletingFailureException> {
-            trackNumberService.deleteDraftOnlyTrackNumberAndReferenceLine(trackNumber.id as IntId)
+            trackNumberService.deleteDraft(trackNumber.id as IntId)
         }
     }
 
@@ -285,7 +285,7 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
             )
         )
         val id = trackNumberService.insert(saveRequest)
-        val trackNumber = trackNumberService.getDraft(id)!!
+        val trackNumber = trackNumberService.get(DRAFT, id)!!
 
         val (referenceLine, alignment) = referenceLineService.getByTrackNumberWithAlignment(
             DRAFT, trackNumber.id as IntId<TrackLayoutTrackNumber>

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
@@ -7,7 +7,7 @@ import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.common.TrackMeter
-import fi.fta.geoviite.infra.error.NoSuchEntityException
+import fi.fta.geoviite.infra.error.DeletingFailureException
 import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.ValidationVersion
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.context.ActiveProfiles
-
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -33,14 +32,15 @@ class ReferenceLineServiceIT @Autowired constructor(
     @Test
     fun creatingAndDeletingUnpublishedReferenceLineWithAlignmentWorks() {
         val trackNumberId = createTrackNumber() // automatically creates first version of reference line
-        val (savedLine, savedAlignment) = referenceLineService.getByTrackNumberWithAlignment(DRAFT, trackNumberId)
-            ?: throw IllegalStateException("Reference line was not automatically created")
+        val (savedLine, savedAlignment) = requireNotNull(
+            referenceLineService.getByTrackNumberWithAlignment(DRAFT, trackNumberId)
+        ) { "Reference line was not automatically created" }
         assertTrue(alignmentExists(savedLine.alignmentVersion!!.id))
         assertEquals(savedLine.alignmentVersion?.id, savedAlignment.id as IntId)
-        assertThrows<DataIntegrityViolationException> { trackNumberService.deleteUnpublishedDraft(trackNumberId) }
-        referenceLineService.deleteUnpublishedDraft(savedLine.id as IntId)
+        assertThrows<DataIntegrityViolationException> { trackNumberService.deleteDraft(trackNumberId) }
+        referenceLineService.deleteDraft(savedLine.id as IntId)
         assertFalse(alignmentExists(savedLine.alignmentVersion!!.id))
-        assertDoesNotThrow { trackNumberService.deleteUnpublishedDraft(trackNumberId) }
+        assertDoesNotThrow { trackNumberService.deleteDraft(trackNumberId) }
     }
 
     @Test
@@ -50,7 +50,7 @@ class ReferenceLineServiceIT @Autowired constructor(
         publish(referenceLineId)
         val (line, _) = referenceLineService.getWithAlignmentOrThrow(OFFICIAL, referenceLineId)
         assertNull(line.draft)
-        assertThrows<NoSuchEntityException> { referenceLineService.deleteUnpublishedDraft(referenceLineId) }
+        assertThrows<DeletingFailureException> { referenceLineService.deleteDraft(referenceLineId) }
     }
 
     @Test
@@ -68,7 +68,7 @@ class ReferenceLineServiceIT @Autowired constructor(
         val address = address(2)
         val updateResponse = referenceLineService.updateTrackNumberReferenceLine(trackNumberId, address)
         assertEquals(referenceLineId, updateResponse?.id)
-        val updatedLine = referenceLineService.getDraft(referenceLineId)!!
+        val updatedLine = referenceLineService.get(DRAFT, referenceLineId)!!
         assertEquals(address, updatedLine.startAddress)
         assertEquals(trackNumberId, updatedLine.trackNumberId)
         assertEquals(referenceLine.alignmentVersion, updatedLine.alignmentVersion)
@@ -99,7 +99,7 @@ class ReferenceLineServiceIT @Autowired constructor(
         assertEquals(publishedVersion.id, editResponse2?.id)
         assertNotEquals(publishedVersion.rowVersion.id, editResponse2?.rowVersion?.id)
 
-        val editedDraft2 = referenceLineService.getDraft(publishedVersion.id)!!
+        val editedDraft2 = referenceLineService.get(DRAFT, publishedVersion.id)!!
         assertEquals(TrackMeter(8, 9), editedDraft2.startAddress)
         assertNotEquals(published.alignmentVersion!!.id, editedDraft2.alignmentVersion!!.id)
         // Second edit to same draft should not duplicate alignment again
@@ -188,7 +188,7 @@ class ReferenceLineServiceIT @Autowired constructor(
     }
 
     private fun getAndVerifyDraft(id: IntId<ReferenceLine>): ReferenceLine {
-        val draft = referenceLineService.getDraft(id)!!
+        val draft = referenceLineService.get(DRAFT, id)!!
         assertEquals(id, draft.id)
         assertNotNull(draft.draft)
         return draft

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -289,8 +289,8 @@ export async function getProject(id: ProjectId): Promise<Project> {
     });
 }
 
-export async function createProject(project: Project): Promise<Project | undefined> {
-    return await postIgnoreError<Project, Project>(`${GEOMETRY_URI}/projects`, project);
+export async function createProject(project: Project): Promise<ProjectId | undefined> {
+    return await postIgnoreError<Project, ProjectId>(`${GEOMETRY_URI}/projects`, project);
 }
 
 export async function fetchAuthors(): Promise<Author[]> {

--- a/ui/src/infra-model/view/dialogs/new-project-dialog.tsx
+++ b/ui/src/infra-model/view/dialogs/new-project-dialog.tsx
@@ -7,7 +7,7 @@ import { FormLayoutColumn } from 'geoviite-design-lib/form-layout/form-layout';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { TextField } from 'vayla-design-lib/text-field/text-field';
 import { useTranslation } from 'react-i18next';
-import { Project } from 'geometry/geometry-model';
+import { Project, ProjectId } from 'geometry/geometry-model';
 import { debounce } from 'ts-debounce';
 import { createProject, getProjects } from 'geometry/geometry-api';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
@@ -16,7 +16,7 @@ import { useLoader } from 'utils/react-utils';
 
 type NewProjectDialogProps = {
     onClose: () => void;
-    onSave: (project: Project) => void;
+    onSave: (projectId: ProjectId) => void;
 };
 
 export const NewProjectDialog: React.FC<NewProjectDialogProps> = ({ onClose, onSave }) => {
@@ -54,13 +54,13 @@ export const NewProjectDialog: React.FC<NewProjectDialogProps> = ({ onClose, onS
 
     const saveProject = () => {
         setSaveInProgress(true);
-        createProject({ name: projectName } as Project).then((p) => {
+        createProject({ name: projectName } as Project).then((id) => {
             setCanSave(false);
             setSaveInProgress(false);
 
             if (p) {
                 Snackbar.success('im-form.new-project-created');
-                onSave(p);
+                onSave(id);
             } else {
                 Snackbar.error('im-form.new-project-creation-failed');
             }

--- a/ui/src/infra-model/view/dialogs/new-project-dialog.tsx
+++ b/ui/src/infra-model/view/dialogs/new-project-dialog.tsx
@@ -58,7 +58,7 @@ export const NewProjectDialog: React.FC<NewProjectDialogProps> = ({ onClose, onS
             setCanSave(false);
             setSaveInProgress(false);
 
-            if (p) {
+            if (id) {
                 Snackbar.success('im-form.new-project-created');
                 onSave(id);
             } else {

--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -571,9 +571,9 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
             {showNewProjectDialog && (
                 <NewProjectDialog
                     onClose={() => setShowNewProjectDialog(false)}
-                    onSave={(project) => {
+                    onSave={(projectId) => {
                         setShowNewProjectDialog(false);
-                        changeInOverrideParametersField(project.id, 'projectId');
+                        changeInOverrideParametersField(projectId, 'projectId');
                         updateProjectChangeTime();
                     }}></NewProjectDialog>
             )}


### PR DESCRIPTION
Erityisesti tässä on siis pointtina että meillä tapahtuu (by-design) paljon yksittäisten objektien hakuja mutta ne on käytännössä lähes aina cachessa. Jos tuo cachetettu haku kuitenkin tekee oman transaktionsa, se avaa tietokantayhteyden ja rouskuttelee paljon aikaa hukkaa siinä vaikkei koskaan päädykään koko yhteyttä käyttämään. Ongelma hälvenee jos transaktio on jo tehty ylempänä, mutta silti springin annotaatiorajan yritys tekee jonkun verran ylimääräistä työtä.

Toisaalta, koska nuo kuumat cachet ei ole enää springin cache-abstraktiolla toteutettu vaan erikseen caffeinella, fetch/list versions + fetch(version) kutsut voidaan yhdistää dao:ssa ja saada ne siellä yhden transaktio-annotaation alle. Tämä vaati vähän jumppaa joten tiedostoja on aika monta.