### PR TITLE
GVT-2217 Optimize logging message string creation in sevice calls + code cleanup

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationController.kt
@@ -23,7 +23,7 @@ class AuthorizationController @Autowired constructor(private val signer: CookieS
     @PreAuthorize(AUTH_ALL_READ)
     @GetMapping("/own-details")
     fun getOwnDetails(): User {
-        logger.apiCall("getMyRole")
+        logger.apiCall("getOwnDetails")
         return SecurityContextHolder.getContext().authentication.principal as User
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -443,7 +443,6 @@ fun getProjectedAddressPoints(
     projectionLines: List<ProjectionLine>,
     alignment: IAlignment,
 ): List<AddressPoint> {
-
     val alignmentEdges = getPolyLineEdges(alignment)
     var edgeIndex = 0
     var projectionIndex = 0

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
@@ -162,7 +162,7 @@ class GeocodingDao(
         } else null
     }
 
-    private fun <T> toRowVersions(ids: List<IntId<T>>, versions: List<Int>) =
-        if (ids.size == versions.size) ids.mapIndexed { index, id -> RowVersion(id, versions[index]) }
-        else throw IllegalStateException("Unmatched row-versions: ids=$ids versions=$versions")
+    private fun <T> toRowVersions(ids: List<IntId<T>>, versions: List<Int>) = ids
+        .also { check(it.size == versions.size) { "Unmatched row-versions: ids=$ids versions=$versions" } }
+        .mapIndexed { index, id -> RowVersion(id, versions[index]) }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/KkjTm35finTriangulationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/KkjTm35finTriangulationDao.kt
@@ -16,39 +16,41 @@ import org.springframework.stereotype.Component
 
 enum class TriangulationDirection(val direction: String) {
     KKJ_TO_TM35FIN("KKJ_TO_TM35FIN"),
-    TM35FIN_TO_KKJ("TM35FIN_TO_KKJ")
+    TM35FIN_TO_KKJ("TM35FIN_TO_KKJ"),
 }
 
 //language=SQL
 val KKJ_TO_TM35FIN_SQL = """
-              select
-            postgis.st_x(t1.coord_kkj) as x1,
-            postgis.st_y(t1.coord_kkj) as y1,
-            postgis.st_x(t2.coord_kkj) as x2,
-            postgis.st_y(t2.coord_kkj) as y2,
-            postgis.st_x(t3.coord_kkj) as x3,
-            postgis.st_y(t3.coord_kkj) as y3,
-              a1, a2, delta_e, delta_n, b1, b2 from common.kkj_etrs_triangulation_network
-            inner join common.kkj_etrs_triangle_corner_point t1 on kkj_etrs_triangulation_network.coord1_id = t1.id
-            inner join common.kkj_etrs_triangle_corner_point t2 on kkj_etrs_triangulation_network.coord2_id = t2.id
-            inner join common.kkj_etrs_triangle_corner_point t3 on kkj_etrs_triangulation_network.coord3_id = t3.id
-              where kkj_etrs_triangulation_network.direction = 'KKJ_TO_TM35FIN'
+  select
+    postgis.st_x(t1.coord_kkj) as x1,
+    postgis.st_y(t1.coord_kkj) as y1,
+    postgis.st_x(t2.coord_kkj) as x2,
+    postgis.st_y(t2.coord_kkj) as y2,
+    postgis.st_x(t3.coord_kkj) as x3,
+    postgis.st_y(t3.coord_kkj) as y3,
+    a1, a2, delta_e, delta_n, b1, b2 
+  from common.kkj_etrs_triangulation_network
+    inner join common.kkj_etrs_triangle_corner_point t1 on kkj_etrs_triangulation_network.coord1_id = t1.id
+    inner join common.kkj_etrs_triangle_corner_point t2 on kkj_etrs_triangulation_network.coord2_id = t2.id
+    inner join common.kkj_etrs_triangle_corner_point t3 on kkj_etrs_triangulation_network.coord3_id = t3.id
+  where kkj_etrs_triangulation_network.direction = 'KKJ_TO_TM35FIN'
 """.trimIndent()
 
 //language=SQL
 val TM35FIN_TO_KKJ_SQL = """
-              select
-            postgis.st_x(t1.coord_etrs) as x1,
-            postgis.st_y(t1.coord_etrs) as y1,
-            postgis.st_x(t2.coord_etrs) as x2,
-            postgis.st_y(t2.coord_etrs) as y2,
-            postgis.st_x(t3.coord_etrs) as x3,
-            postgis.st_y(t3.coord_etrs) as y3,
-              a1, a2, delta_e, delta_n, b1, b2 from common.kkj_etrs_triangulation_network
-            inner join common.kkj_etrs_triangle_corner_point t1 on kkj_etrs_triangulation_network.coord1_id = t1.id
-            inner join common.kkj_etrs_triangle_corner_point t2 on kkj_etrs_triangulation_network.coord2_id = t2.id
-            inner join common.kkj_etrs_triangle_corner_point t3 on kkj_etrs_triangulation_network.coord3_id = t3.id
-              where kkj_etrs_triangulation_network.direction = 'TM35FIN_TO_KKJ'
+  select
+    postgis.st_x(t1.coord_etrs) as x1,
+    postgis.st_y(t1.coord_etrs) as y1,
+    postgis.st_x(t2.coord_etrs) as x2,
+    postgis.st_y(t2.coord_etrs) as y2,
+    postgis.st_x(t3.coord_etrs) as x3,
+    postgis.st_y(t3.coord_etrs) as y3,
+    a1, a2, delta_e, delta_n, b1, b2
+  from common.kkj_etrs_triangulation_network
+    inner join common.kkj_etrs_triangle_corner_point t1 on kkj_etrs_triangulation_network.coord1_id = t1.id
+    inner join common.kkj_etrs_triangle_corner_point t2 on kkj_etrs_triangulation_network.coord2_id = t2.id
+    inner join common.kkj_etrs_triangle_corner_point t3 on kkj_etrs_triangulation_network.coord3_id = t3.id
+  where kkj_etrs_triangulation_network.direction = 'TM35FIN_TO_KKJ'
 """.trimIndent()
 
 @Component
@@ -62,7 +64,7 @@ class KkjTm35finTriangulationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
         }
 
         val triangles = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, i ->
-            val heightTriangle = KkjTm35finTriangle(
+            KkjTm35finTriangle(
                 corner1 = rs.getPoint("x1", "y1"),
                 corner2 = rs.getPoint("x2", "y2"),
                 corner3 = rs.getPoint("x3", "y3"),
@@ -77,7 +79,6 @@ class KkjTm35finTriangulationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
                     TriangulationDirection.TM35FIN_TO_KKJ -> LAYOUT_CRS
                 }
             )
-            heightTriangle
         }
         return triangulationNetworkToRTree(triangles)
     }
@@ -85,14 +86,6 @@ class KkjTm35finTriangulationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?)
     private fun triangulationNetworkToRTree(triangulationNetwork: List<KkjTm35finTriangle>) =
         triangulationNetwork.fold(RTree.star().create<KkjTm35finTriangle, Rectangle>()) { tree, triangle ->
             val bbox = boundingBoxAroundPoints(triangle.corner1, triangle.corner2, triangle.corner3)
-            tree.add(
-                triangle,
-                Geometries.rectangle(
-                    bbox.min.y,
-                    bbox.min.x,
-                    bbox.max.y,
-                    bbox.max.x
-                )
-            )
+            tree.add(triangle, Geometries.rectangle(bbox.min.y, bbox.min.x, bbox.max.y, bbox.max.x))
         }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.FeatureTypeCode
 import fi.fta.geoviite.infra.common.StringId
+import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.boundingBoxAroundPointsOrNull
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.FreeText
@@ -28,7 +29,7 @@ data class GeometryAlignment(
     val cant: GeometryCant? = null,
     val trackNumberId: DomainId<TrackLayoutTrackNumber>?,
     val id: DomainId<GeometryAlignment> = StringId(),
-) {
+) : Loggable {
     @get:JsonIgnore
     val bounds by lazy { boundingBoxAroundPointsOrNull(elements.flatMap { e -> e.bounds }) }
 
@@ -51,6 +52,8 @@ data class GeometryAlignment(
             .find { elementAndLength -> elementAndLength.second.id == elementId }
             ?.let { match -> match.first..(match.first + match.second.calculatedLength) }
             ?: throw IllegalArgumentException("Element not found from alignment")
+
+    override fun toLog(): String = logFormat("id" to id, "name" to name, "elements" to elements.size)
 }
 
 private fun foldElementLengths(elements: List<GeometryElement>) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryKmPost.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryKmPost.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.inframodel.PlanElementName
+import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import java.math.BigDecimal
@@ -20,4 +21,6 @@ data class GeometryKmPost(
     val location: Point?,
     val trackNumberId: IntId<TrackLayoutTrackNumber>?,
     val id: DomainId<GeometryKmPost> = StringId(),
-)
+) : Loggable {
+    override fun toLog(): String = logFormat("id" to id, "trackNumber" to trackNumberId, "kmNumber" to kmNumber)
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.geography.CoordinateSystemName
 import fi.fta.geoviite.infra.inframodel.PlanElementName
+import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.AngularUnit
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Range
@@ -48,11 +49,13 @@ data class GeometryPlanHeader(
     val hasProfile: Boolean,
     val hasCant: Boolean,
     val isHidden: Boolean,
-) {
+) : Loggable {
     @get:JsonIgnore
     val searchParams: List<String> by lazy {
         listOfNotNull(fileName, project.name, message).map { o -> o.toString().lowercase() }
     }
+
+    override fun toLog(): String = logFormat("version" to version, "name" to fileName, "source" to source)
 }
 
 /**
@@ -83,9 +86,18 @@ data class GeometryPlan(
     val isHidden: Boolean = false,
     val id: DomainId<GeometryPlan> = StringId(),
     val dataType: DataType = DataType.TEMP,
-) {
+) : Loggable {
     @get:JsonIgnore
     val bounds by lazy { boundingBoxCombining(alignments.mapNotNull { a -> a.bounds }) }
+
+    override fun toLog(): String = logFormat(
+        "id" to id,
+        "name" to fileName,
+        "source" to source,
+        "alignments" to alignments.map(GeometryAlignment::toLog),
+        "switches" to switches.map(GeometrySwitch::toLog),
+        "kmPosts" to kmPosts.map(GeometryKmPost::toLog),
+    )
 }
 
 data class GeometryPlanArea(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -323,9 +323,8 @@ class GeometryService @Autowired constructor(
 
     fun getElementListingCsv() = elementListingFileDao.getElementListingFile()
 
-    fun getVerticalGeometryListing(
-        planId: IntId<GeometryPlan>,
-    ): List<VerticalGeometryListing> {
+
+    fun getVerticalGeometryListing(planId: IntId<GeometryPlan>): List<VerticalGeometryListing> {
         logger.serviceCall("getVerticalGeometryListing", "planId" to planId)
         val planHeader = getPlanHeader(planId)
         val alignments = geometryDao.fetchAlignments(planHeader.units, planId)
@@ -336,9 +335,7 @@ class GeometryService @Autowired constructor(
         )
     }
 
-    fun getVerticalGeometryListingCsv(
-        planId: IntId<GeometryPlan>,
-    ): Pair<FileName, ByteArray> {
+    fun getVerticalGeometryListingCsv(planId: IntId<GeometryPlan>): Pair<FileName, ByteArray> {
         logger.serviceCall("getVerticalGeometryListingCsv", "planId" to planId)
         val plan = getPlanHeader(planId)
         val verticalGeometryListing = getVerticalGeometryListing(planId)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometrySwitch.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometrySwitch.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.ISwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
@@ -16,12 +17,14 @@ data class GeometrySwitch(
     val typeName: GeometrySwitchTypeName,
     val joints: List<GeometrySwitchJoint>,
     val id: DomainId<GeometrySwitch> = StringId(),
-) {
+) : Loggable {
     fun getJoint(location: Point, delta: Double): GeometrySwitchJoint? =
         joints.find { j -> j.location.isSame(location, delta) }
 
     fun getJoint(number: JointNumber): GeometrySwitchJoint? =
         joints.find { j -> j.number == number }
+
+    override fun toLog(): String = logFormat("id" to id, "name" to name, "joints" to joints.map { j -> j.number.intValue })
 }
 
 data class GeometrySwitchJoint(override val number: JointNumber, override val location: Point) : ISwitchJoint

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelFile.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelFile.kt
@@ -2,13 +2,14 @@ package fi.fta.geoviite.infra.inframodel
 
 import fi.fta.geoviite.infra.error.InframodelParsingException
 import fi.fta.geoviite.infra.geometry.PlanSource
+import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.util.FileName
 import org.apache.commons.codec.digest.DigestUtils
 
 data class InfraModelFile(
     val name: FileName,
     val content: String,
-) {
+) : Loggable {
     val hash: String by lazy { DigestUtils.md5Hex(content) }
 
     init {
@@ -18,6 +19,8 @@ data class InfraModelFile(
             localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.empty",
         )
     }
+
+    override fun toLog(): String = logFormat("name" to name, "hash" to hash)
 }
 
 data class InfraModelFileWithSource(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -59,7 +59,7 @@ class InfraModelService @Autowired constructor(
     ): RowVersion<GeometryPlan> {
         logger.serviceCall(
             "saveInfraModel",
-            "file.name" to file.name, "overrides" to overrides, "extraInfo" to extraInfo
+            "file" to file, "overrides" to overrides, "extraInfo" to extraInfo
         )
 
         val geometryPlan = parseInfraModel(file, overrides, extraInfo)
@@ -80,7 +80,7 @@ class InfraModelService @Autowired constructor(
     ): GeometryPlan {
         logger.serviceCall(
             "parseInfraModel",
-            "file.name" to file.name, "overrides" to overrides, "extraInfo" to extraInfo
+            "file" to file, "overrides" to overrides, "extraInfo" to extraInfo
         )
         val switchStructuresByType = switchLibraryService.getSwitchStructures().associateBy { it.type }
         val trackNumberIdsByNumber = trackNumberService.list(OFFICIAL).associate { tn -> tn.number to tn.id as IntId }
@@ -117,7 +117,7 @@ class InfraModelService @Autowired constructor(
     ): ValidationResponse {
         logger.serviceCall(
             "validateInfraModelFile",
-            "file.name" to file.name, "overrideParameters" to overrideParameters
+            "file" to file, "overrideParameters" to overrideParameters
         )
         return tryParsing(overrideParameters?.source) { validateInternal(file, overrideParameters) }
     }
@@ -161,6 +161,7 @@ class InfraModelService @Autowired constructor(
     ): GeometryPlan {
         logger.serviceCall(
             "updateInfraModel",
+            "planId" to planId,
             "overrideParameters" to overrideParameters,
             "extraInfoParameters" to extraInfoParameters,
         )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/AddressChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/AddressChangesService.kt
@@ -8,8 +8,7 @@ import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import org.springframework.stereotype.Service
 
-
-fun addressPointsAreEqual(point1: AddressPoint?, point2: AddressPoint?) =
+fun addressPointsAreEqual(point1: AddressPoint?, point2: AddressPoint?): Boolean =
     if (point1 == null && point2 == null) true
     else if (point1 == null || point2 == null) false
     else point1.isSame(point2)
@@ -50,7 +49,6 @@ private fun findDiffAddresses(
             if (points2Index != null) points2Index++
             points1Index++
         }
-
     }
     return differences
 }
@@ -90,10 +88,9 @@ class AddressChangesService(val geocodingService: GeocodingService) {
             )
         }
 
-    private fun getAddresses(track: LocationTrack?, contextKey: GeocodingContextCacheKey?) =
+    private fun getAddresses(track: LocationTrack?, contextKey: GeocodingContextCacheKey?): AlignmentAddresses? =
         if (track == null || contextKey == null || !track.exists) null
         else geocodingService.getAddressPoints(contextKey, track.getAlignmentVersionOrThrow())
-
 }
 
 fun getAddressChanges(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -505,8 +505,9 @@ private fun getTopologySwitchJointDataHolder(
     // - and Ratko may not want other joint numbers in this case
     val presentationJointNumber = fetchStructure(switch.switchStructureId).presentationJointNumber
     val address = geocodingContext.getAddress(point)?.first
-    val joint = switch.getJoint(topologySwitch.jointNumber)
-        ?: throw IllegalStateException("Topology switch contains invalid joint number: $topologySwitch")
+    val joint = requireNotNull(switch.getJoint(topologySwitch.jointNumber)) {
+        "Topology switch contains invalid joint number: $topologySwitch"
+    }
     return if (presentationJointNumber == joint.number && address != null) {
         topologySwitch.switchId to listOf(SwitchJointDataHolder(address = address, point = point, joint = joint))
     } else null

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
@@ -95,7 +95,7 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
         """.trimIndent()
         val params = mapOf(
             "plan_id" to planId.intValue,
-            "publication_state" to publishType.name
+            "publication_state" to publishType.name,
         )
 
         val elements = jdbcTemplate.query(sql, params) { rs, _ ->
@@ -128,7 +128,10 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
                plan_id=:plan_id
               group by geometry_km_post.id
         """.trimIndent()
-        val params = mapOf("plan_id" to planId.intValue, "publication_state" to publishType.name)
+        val params = mapOf(
+            "plan_id" to planId.intValue,
+            "publication_state" to publishType.name,
+        )
 
         return jdbcTemplate.query(sql, params) { rs, _ ->
             GeometryKmPostLinkStatus(
@@ -172,7 +175,7 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
         """.trimIndent()
         val params = mapOf(
             "plan_id" to planId.intValue,
-            "publication_state" to publishType.name
+            "publication_state" to publishType.name,
         )
 
         return jdbcTemplate.query(sql, params) { rs, _ ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
@@ -29,7 +29,6 @@ constructor(@JsonValue val params: Map<String, Any?>) {
     companion object {
         fun empty() = LocalizationParams()
     }
-
 }
 
 data class Translation(val lang: String, val localization: String) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/Loggable.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/Loggable.kt
@@ -1,0 +1,7 @@
+package fi.fta.geoviite.infra.logging
+
+interface Loggable {
+    fun toLog(): String
+    fun logFormat(vararg params: Pair<String, Any?>) =
+        "${this::class.simpleName}[${params.joinToString(" ") { (key, value) -> "$key=$value" }}]"
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
@@ -13,15 +13,15 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import kotlin.reflect.KClass
 
-
-fun Logger.apiRequest(req: HttpServletRequest, requestIp: String) =
-    debug("Request: {}:{} ip={}", req.method, req.requestURL, requestIp)
+fun Logger.apiRequest(req: HttpServletRequest, requestIp: String) {
+    if (isDebugEnabled) debug("Request: {}:{} ip={}", req.method, req.requestURL, requestIp)
+}
 
 fun Logger.apiResponse(req: HttpServletRequest, res: HttpServletResponse, requestIp: String, startTime: Instant) {
     val timeMs = Duration.between(startTime, Instant.now()).toMillis()
     val timingMap = resetCollected()
     val timingString = if (timingMap.isEmpty()) " [no timings]" else " [$timingMap]"
-    info("Response: status=${res.status} time=${timeMs}ms${timingString} contentType=${res.contentType} ip=$requestIp request=${req.method}:${req.requestURL}")
+    if (isInfoEnabled) info("Response: status=${res.status} time=${timeMs}ms${timingString} contentType=${res.contentType} ip=$requestIp request=${req.method}:${req.requestURL}")
 }
 
 enum class AccessType { VERSION_FETCH, FETCH, INSERT, UPDATE, UPSERT, DELETE }
@@ -39,23 +39,25 @@ fun Logger.daoAccess(accessType: AccessType, objectType: String, vararg ids: Any
 }
 
 fun Logger.daoAccess(accessType: AccessType, objectType: String, ids: List<Any>) {
-
-    if (accessType == VERSION_FETCH || accessType == FETCH) debug(
-        "accessType={} objectType={} ids={}", accessType, objectType, ids
-    )
-    else info("accessType=$accessType objectType=$objectType ids=$ids")
+    if (accessType == VERSION_FETCH || accessType == FETCH) {
+        if (isDebugEnabled) debug("accessType={} objectType={} ids={}", accessType, objectType, ids)
+    } else {
+        if (isInfoEnabled) info("accessType=$accessType objectType=$objectType ids=$ids")
+    }
 }
 
 fun Logger.apiCall(method: String, vararg params: Pair<String, *>) {
-    info("method=$method params=${paramsToLog(params)}")
+    if (isInfoEnabled) info("method=$method params=${paramsToLog(params)}")
 }
 
 fun Logger.serviceCall(method: String, vararg params: Pair<String, *>) {
-    debug("method={} params={}", method, paramsToLog(params))
+    if (isDebugEnabled) debug("method={} params={}", method, paramsToLog(params))
 }
 
 fun paramsToLog(params: Array<out Pair<String, *>>): List<String> =
-    params.map { p -> "${p.first}=${p.second?.let { formatForLog(it.toString(), 1000) }}" }
+    params.map { p -> "${p.first}=${p.second?.let { obj ->
+        formatForLog(formatForLog(if (obj is Loggable) obj.toLog() else obj.toString(), 1000))
+    }}" }
 
 fun Logger.integrationCall(method: String, vararg params: Pair<String, *>) {
     info("method=$method params=${paramsToLog(params)}")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.tracklayout.*
 import kotlin.math.roundToInt
@@ -39,7 +40,9 @@ data class AlignmentPolyLine<T>(
     val id: DomainId<T>,
     val alignmentType: MapAlignmentType,
     val points: List<LayoutPoint>,
-)
+) : Loggable {
+    override fun toLog(): String = logFormat("id" to id, "type" to alignmentType, "points" to points.size)
+}
 
 fun toAlignmentHeader(
     trackNumber: TrackLayoutTrackNumber,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
@@ -68,8 +68,7 @@ class PVIntegrationService @Autowired constructor(
         logger.info("Poll for search results")
         pvDao.fetchLatestActiveSearch()?.let { latestSearch ->
             updateDictionaries()
-            getSearchStatusIfReady(latestSearch)
-                ?.let { status -> importFilesFromProjektiVelho(latestSearch, status) }
+            getSearchStatusIfReady(latestSearch)?.let { status -> importFilesFromProjektiVelho(latestSearch, status) }
         }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -10,6 +10,7 @@ import fi.fta.geoviite.infra.geometry.MetaDataName
 import fi.fta.geoviite.infra.integration.RatkoPushStatus
 import fi.fta.geoviite.infra.integration.SwitchJointChange
 import fi.fta.geoviite.infra.localization.LocalizationParams
+import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Range
@@ -170,7 +171,7 @@ data class PublishCandidates(
     val referenceLines: List<ReferenceLinePublishCandidate>,
     val switches: List<SwitchPublishCandidate>,
     val kmPosts: List<KmPostPublishCandidate>,
-) {
+) : Loggable {
     fun ids(): PublishRequestIds = PublishRequestIds(
         trackNumbers.map { candidate -> candidate.id },
         locationTracks.map { candidate -> candidate.id },
@@ -194,6 +195,16 @@ data class PublishCandidates(
         switches = switches.filter { candidate -> request.switches.contains(candidate.id) },
         kmPosts = kmPosts.filter { candidate -> request.kmPosts.contains(candidate.id) },
     )
+
+    override fun toLog(): String = logFormat(
+        "trackNumbers" to toLog(trackNumbers),
+        "locationTracks" to toLog(locationTracks),
+        "referenceLines" to toLog(referenceLines),
+        "switches" to toLog(switches),
+        "kmPosts" to toLog(kmPosts),
+    )
+
+    private fun <T : PublishCandidate<*>> toLog(list: List<T>): String = "${list.map(PublishCandidate<*>::rowVersion)}"
 }
 
 data class ValidationVersions(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -140,7 +140,7 @@ class PublicationController @Autowired constructor(
             "sortBy" to sortBy,
             "order" to order,
             "timeZone" to timeZone,
-            "lang" to lang
+            "lang" to lang,
         )
 
         val publicationsAsCsv = publicationService.fetchPublicationsAsCsv(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
@@ -44,7 +44,7 @@ class RatkoAssetService @Autowired constructor(
             .sortedBy { (switch, _) -> sortByDeletedStateFirst(switch.stateCategory) }
             .forEach { (layoutSwitch, changedJoints) ->
                 try {
-                    requireNotNull(layoutSwitch.externalId) {"OID required for switch, sw=${layoutSwitch.id}"}
+                    requireNotNull(layoutSwitch.externalId) { "OID required for switch, sw=${layoutSwitch.id}" }
                         .let { oid -> ratkoClient.getSwitchAsset(RatkoOid<RatkoSwitchAsset>(oid)) }
                         ?.also { existingRatkoSwitch ->
                             updateSwitch(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
@@ -33,7 +33,7 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
 
         updatePushContent(ratkoPushId, publicationIds = layoutPublishIds)
 
-        return ratkoPushId.also { logger.daoAccess(AccessType.INSERT, RatkoPush::class, ratkoPushId) }
+        return ratkoPushId.also { logger.daoAccess(AccessType.INSERT, "${RatkoPush::class}.id", ratkoPushId) }
     }
 
     @Transactional
@@ -97,7 +97,7 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                 status = rs.getEnum("status"),
             )
         }.first().also {
-            logger.daoAccess(AccessType.FETCH, RatkoPush::class, it)
+            logger.daoAccess(AccessType.FETCH, RatkoPush::class, it.id)
         }
     }
 
@@ -226,7 +226,7 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
 
         return jdbcTemplate.queryOne(sql) { rs, _ ->
             rs.getInstant("latest_publication_time")
-        }.also { logger.daoAccess(AccessType.FETCH, Publication::class) }
+        }.also { logger.daoAccess(AccessType.FETCH, "${Publication::class}.publicationTime") }
     }
 
     fun getLatestPublicationMoment(): Instant {
@@ -236,7 +236,7 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
             from publication.publication
         """.trimIndent()
         return jdbcTemplate.queryOne(sql) { rs, _ -> rs.getInstant("latest_publication_time") }
-            .also { logger.daoAccess(AccessType.FETCH, Publication::class) }
+            .also { logger.daoAccess(AccessType.FETCH, "${Publication::class}.publicationTime") }
     }
 
     fun getRatkoPushChangeTime(): Instant {
@@ -251,7 +251,7 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
             from integrations.ratko_push
         """.trimIndent()
         return jdbcTemplate.queryOne(sql) { rs, _ -> rs.getInstant("latest_ratko_push_time") }
-            .also { logger.daoAccess(AccessType.FETCH, Publication::class) }
+            .also { logger.daoAccess(AccessType.FETCH, "${RatkoPush::class.simpleName}.changeTime") }
     }
 
     fun getRatkoStatus(publicationId: IntId<Publication>): List<RatkoPush> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoRouteNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoRouteNumberService.kt
@@ -8,7 +8,9 @@ import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.publication.PublishedTrackNumber
 import fi.fta.geoviite.infra.ratko.model.*
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutState
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -29,6 +31,9 @@ class RatkoRouteNumberService @Autowired constructor(
         publishedTrackNumbers: Collection<PublishedTrackNumber>,
         publicationTime: Instant,
     ): List<Oid<TrackLayoutTrackNumber>> {
+        logger.serviceCall("pushTrackNumberChangesToRatko",
+            "publishedTrackNumbers" to publishedTrackNumbers, "publicationTime" to publicationTime
+        )
         return publishedTrackNumbers
             .groupBy { it.version.id }
             .map { (_, trackNumbers) ->
@@ -66,7 +71,7 @@ class RatkoRouteNumberService @Autowired constructor(
     }
 
     private fun deleteRouteNumber(trackNumber: TrackLayoutTrackNumber, existingRatkoRouteNumber: RatkoRouteNumber) {
-        logger.serviceCall("deleteRouteNumber", "trackNumber" to trackNumber)
+        logger.serviceCall("deleteRouteNumber", "trackNumber" to trackNumber, "existing" to existingRatkoRouteNumber)
         requireNotNull(trackNumber.externalId) { "Cannot delete route number without oid, id=${trackNumber.id}" }
 
         val deletedEndsPoints = existingRatkoRouteNumber.nodecollection?.let(::toNodeCollectionMarkingEndpointsNotInUse)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoStatusService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoStatusService.kt
@@ -5,9 +5,11 @@ import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
 import fi.fta.geoviite.infra.configuration.CACHE_RATKO_HEALTH_STATUS
 import fi.fta.geoviite.infra.integration.RatkoAssetType.*
 import fi.fta.geoviite.infra.integration.RatkoPushErrorWithAsset
+import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.ratko.RatkoClient.RatkoStatus
 import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.util.logger
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
@@ -22,11 +24,13 @@ class RatkoStatusService @Autowired constructor(
 ) {
     @Cacheable(CACHE_RATKO_HEALTH_STATUS, sync = true)
     fun getRatkoOnlineStatus(): RatkoStatus {
+        logger.serviceCall("getRatkoOnlineStatus")
         return ratkoClient?.getRatkoOnlineStatus() ?: RatkoStatus(false)
     }
 
-    fun getRatkoPushError(publishId: IntId<Publication>): RatkoPushErrorWithAsset? {
-        return ratkoPushDao.getLatestRatkoPushErrorFor(publishId)?.let { ratkoError ->
+    fun getRatkoPushError(publicationId: IntId<Publication>): RatkoPushErrorWithAsset? {
+        logger.serviceCall("getRatkoPushError", "publicationId" to publicationId)
+        return ratkoPushDao.getLatestRatkoPushErrorFor(publicationId)?.let { ratkoError ->
             val asset = when (ratkoError.assetType) {
                 TRACK_NUMBER -> trackNumberService.get(OFFICIAL, ratkoError.assetId as IntId<TrackLayoutTrackNumber>)
                 LOCATION_TRACK -> locationTrackService.get(OFFICIAL, ratkoError.assetId as IntId<LocationTrack>)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Draft.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Draft.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.DataType.TEMP
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.StringId
+import fi.fta.geoviite.infra.logging.Loggable
 
 enum class DraftType {
     OFFICIAL, EDITED_DRAFT, NEW_DRAFT
@@ -12,7 +13,7 @@ enum class DraftType {
 
 data class Draft<T>(val draftRowId: DomainId<T> = StringId())
 
-interface Draftable<T> {
+interface Draftable<T> : Loggable {
     val id: DomainId<T>
     val version: RowVersion<T>?
     val dataType: DataType

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectService.kt
@@ -95,7 +95,7 @@ abstract class DraftableObjectService<ObjectType : Draftable<ObjectType>, DaoTyp
 
     @Transactional
     open fun saveDraft(draft: ObjectType): DaoResponse<ObjectType> {
-        logger.serviceCall("saveDraft", "id" to draft.id)
+        logger.serviceCall("saveDraft", "draft" to draft)
         return saveDraftInternal(draft)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
@@ -7,6 +7,7 @@ import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
 import fi.fta.geoviite.infra.geometry.GeometryElement
 import fi.fta.geoviite.infra.geometry.GeometryPlan
+import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.map.AlignmentHeader
 import fi.fta.geoviite.infra.map.AlignmentPolyLine
 import fi.fta.geoviite.infra.map.getSegmentBorderMValues
@@ -24,7 +25,7 @@ data class GeometryPlanLayout(
     val planHidden: Boolean,
     val planDataType: DataType,
     val startAddress: TrackMeter?,
-) {
+) : Loggable {
     val boundingBox: BoundingBox? = boundingBoxCombining(alignments.mapNotNull { a -> a.boundingBox })
 
     fun withLayoutGeometry(resolution: Int? = null) = copy(
@@ -34,6 +35,13 @@ data class GeometryPlanLayout(
                 segmentMValues = getSegmentBorderMValues(alignment),
             )
         },
+    )
+
+    override fun toLog(): String = logFormat(
+        "plan" to planId,
+        "alignments" to alignments.map(PlanLayoutAlignment::toLog),
+        "switches" to switches.map(TrackLayoutSwitch::toLog),
+        "kmPosts" to kmPosts.map(TrackLayoutKmPost::toLog),
     )
 }
 
@@ -48,6 +56,13 @@ data class PlanLayoutAlignment(
 
     @get:JsonIgnore
     override val boundingBox: BoundingBox? get() = header.boundingBox
+
+    override fun toLog(): String = logFormat(
+        "id" to id,
+        "name" to header.name,
+        "segments" to segments.size,
+        "points" to polyLine?.points?.size,
+    )
 }
 
 data class PlanLayoutSegment(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 class LayoutAlignmentService(
     private val dao: LayoutAlignmentDao,
 ) {
-    protected val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     fun update(alignment: LayoutAlignment) = dao.update(alignment)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -88,7 +88,7 @@ class LayoutKmPostController(
         return kmPostService.listNearbyOnTrackPaged(
             publicationState = publishType,
             location = location,
-            trackNumberId = if (trackNumberId is IntId) trackNumberId else null,
+            trackNumberId = trackNumberId,
             offset = offset,
             limit = limit,
         )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -25,7 +25,7 @@ class LayoutTrackNumberService(
 
     @Transactional
     fun insert(saveRequest: TrackNumberSaveRequest): IntId<TrackLayoutTrackNumber> {
-        logger.serviceCall("insert", "trackNumber" to saveRequest.number)
+        logger.serviceCall("insert", "trackNumber" to saveRequest)
         val draftSaveResponse = saveDraftInternal(
             TrackLayoutTrackNumber(
                 number = saveRequest.number,
@@ -43,7 +43,7 @@ class LayoutTrackNumberService(
         id: IntId<TrackLayoutTrackNumber>,
         saveRequest: TrackNumberSaveRequest,
     ): IntId<TrackLayoutTrackNumber> {
-        logger.serviceCall("update", "trackNumber" to saveRequest.number)
+        logger.serviceCall("update", "trackNumber" to saveRequest)
         val original = dao.getOrThrow(DRAFT, id)
         val draftSaveResponse = saveDraftInternal(
             original.copy(
@@ -197,7 +197,7 @@ class LayoutTrackNumberService(
             "getSectionsByPlan",
             "trackNumberId" to trackNumberId,
             "publishType" to publishType,
-            "boundingBox" to boundingBox
+            "boundingBox" to boundingBox,
         )
         return get(publishType, trackNumberId)?.let { trackNumber ->
             val referenceLine = referenceLineService.getByTrackNumber(publishType, trackNumberId)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -91,7 +91,7 @@ class LocationTrackService(
 
     @Transactional
     fun saveDraft(draft: LocationTrack, alignment: LayoutAlignment): DaoResponse<LocationTrack> {
-        logger.serviceCall("save", "locationTrack" to draft.id, "alignment" to alignment.id)
+        logger.serviceCall("save", "locationTrack" to draft, "alignment" to alignment)
         val alignmentVersion =
             // If we're creating a new row or starting a draft, we duplicate the alignment to not edit any original
             if (draft.dataType == TEMP || draft.draft == null) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -62,7 +62,7 @@ class ReferenceLineService(
 
     @Transactional
     fun saveDraft(draft: ReferenceLine, alignment: LayoutAlignment): DaoResponse<ReferenceLine> {
-        logger.serviceCall("save", "locationTrack" to draft.id, "alignment" to alignment.id)
+        logger.serviceCall("save", "locationTrack" to draft, "alignment" to alignment)
         return saveDraftInternal(draft, alignment)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -71,6 +71,8 @@ data class TrackLayoutTrackNumber(
         require(description.isNotBlank()) { "TrackNumber should have a non-blank description" }
         require(description.length < 100) { "TrackNumber description too long: ${description.length}>100" }
     }
+
+    override fun toLog(): String = logFormat("version" to version, "draft" to getDraftType(), "number" to number)
 }
 
 enum class LocationTrackType {
@@ -102,6 +104,13 @@ data class ReferenceLine(
 
     fun getAlignmentVersionOrThrow(): RowVersion<LayoutAlignment> =
         alignmentVersion ?: throw IllegalStateException("ReferenceLine has no an alignment")
+
+    override fun toLog(): String = logFormat(
+        "version" to version,
+        "draft" to getDraftType(),
+        "trackNumber" to trackNumberId,
+        "alignment" to alignmentVersion,
+    )
 }
 
 data class TopologyLocationTrackSwitch(
@@ -193,9 +202,16 @@ data class LocationTrack(
     }
 
     fun getAlignmentVersionOrThrow(): RowVersion<LayoutAlignment> =
-        alignmentVersion ?: throw IllegalStateException("LocationTrack has no alignment")
-}
+        requireNotNull(alignmentVersion) { "LocationTrack has no alignment: version=$version" }
 
+    override fun toLog(): String = logFormat(
+        "version" to version,
+        "draft" to getDraftType(),
+        "name" to name,
+        "trackNumber" to trackNumberId,
+        "alignment" to alignmentVersion,
+    )
+}
 
 data class TrackLayoutSwitch(
     val name: SwitchName,
@@ -227,6 +243,14 @@ data class TrackLayoutSwitch(
         joints.find { j -> j.location.isSame(location, delta) }
 
     fun getJoint(number: JointNumber): TrackLayoutSwitchJoint? = joints.find { j -> j.number == number }
+
+    override fun toLog(): String = logFormat(
+        "version" to version,
+        "draft" to getDraftType(),
+        "source" to source,
+        "name" to name,
+        "joints" to joints.map { j -> j.number.intValue },
+    )
 }
 
 data class TrackLayoutSwitchJoint(val number: JointNumber, val location: Point, val locationAccuracy: LocationAccuracy?)
@@ -248,6 +272,13 @@ data class TrackLayoutKmPost(
     fun getAsIntegral(): IntegralTrackLayoutKmPost? =
         if (state != LayoutState.IN_USE || location == null || trackNumberId == null) null
         else IntegralTrackLayoutKmPost(kmNumber, location, trackNumberId)
+
+    override fun toLog(): String = logFormat(
+        "version" to version,
+        "draft" to getDraftType(),
+        "kmNumber" to kmNumber,
+        "trackNumber" to trackNumberId,
+    )
 }
 
 data class IntegralTrackLayoutKmPost(


### PR DESCRIPTION
Tajusin että tämä on aika erillinen osa tuota isoa optimointihaaraa ja vähemmän controversial, joten päätin repiä siitä irti oman pullarin. Tiedostoja on edelleenkin monta, mutta muutokset ovat aika samannäköisiä kun liittyy paremmin samaan asiaan.

Tässä on siis yleisesti viilailtu/korjailtu logitusta vähän ohessa mutta pääpointtina on tehty tuo Loggable-rajapinta ja optimoitu sen kautta logitettavan stringin muodostusta eri käsitteille. Nyt esimerkiksi alignmentin voi huoletta laittaa logitukseen parametrina ilman että logiin oikeasti päätyy jokainen alignmentin piste, jne. Tuo stringinmuodostus oli siis noissa caseissa ihan oikeasti näkyvä muisti/cpu syöppö.

Lisäksi LoggerExternalissa lisätty vähän iffittelyä ettei logitettavia stringejä muodosteta jos niitä ei meinata logittaa.