### PR TITLE
GVT-2259 Precalculate location track alignment addresses for publication validation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
@@ -32,8 +32,6 @@ const val CACHE_PLAN_GEOCODING_CONTEXTS = "plan-geocoding-contexts"
 
 const val CACHE_RATKO_HEALTH_STATUS = "ratko-health-status"
 
-const val CACHE_ADDRESS_POINTS = "track-address-points"
-
 const val CACHE_PUBLISHED_LOCATION_TRACKS = "published-location-tracks"
 const val CACHE_PUBLISHED_SWITCHES = "published-switches"
 
@@ -69,8 +67,6 @@ class CacheConfiguration @Autowired constructor(
             manager.registerCustomCache(CACHE_GEOMETRY_PLAN_LAYOUT, cache(100, planCacheDuration))
             manager.registerCustomCache(CACHE_GEOMETRY_SWITCH, cache(10000, planCacheDuration))
             manager.registerCustomCache(CACHE_PLAN_GEOCODING_CONTEXTS, cache(50, planCacheDuration))
-
-            manager.registerCustomCache(CACHE_ADDRESS_POINTS, cache(2000, layoutCacheDuration))
 
             manager.registerCustomCache(CACHE_RATKO_HEALTH_STATUS, ephemeralCache(1, healthCheckLifetime))
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
@@ -1,9 +1,11 @@
 package fi.fta.geoviite.infra.geocoding
 
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.common.RowVersion
-import fi.fta.geoviite.infra.configuration.CACHE_ADDRESS_POINTS
+import fi.fta.geoviite.infra.configuration.layoutCacheDuration
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
@@ -11,7 +13,6 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,6 +20,14 @@ data class AddressPointCacheKey(
     val alignmentVersion: RowVersion<LayoutAlignment>,
     val geocodingContextCacheKey: GeocodingContextCacheKey,
 )
+
+data class AddressPointCalculationData(
+    val key: AddressPointCacheKey,
+    val alignment: LayoutAlignment,
+    val geocodingContext: GeocodingContext,
+)
+
+const val ADDRESS_POINT_CACHE_SIZE = 2000L
 
 @Component
 class AddressPointsCache(
@@ -28,6 +37,8 @@ class AddressPointsCache(
     val geocodingCacheService: GeocodingCacheService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val cache: Cache<AddressPointCacheKey, AlignmentAddresses?> =
+        Caffeine.newBuilder().maximumSize(ADDRESS_POINT_CACHE_SIZE).expireAfterAccess(layoutCacheDuration).build()
 
     @Transactional(readOnly = true)
     fun getAddressPointCacheKey(
@@ -48,11 +59,16 @@ class AddressPointsCache(
     /** This is for caching address points. Please don't call this directly if possible, please
     prefer GeocodingService's getAddressPoints method instead
      **/
-    @Cacheable(CACHE_ADDRESS_POINTS, sync = true)
     fun getAddressPoints(cacheKey: AddressPointCacheKey): AlignmentAddresses? {
         logger.serviceCall("getAddressPoints", "cacheKey" to cacheKey)
-        val alignment = alignmentDao.fetch(cacheKey.alignmentVersion)
-        return geocodingCacheService.getGeocodingContext(cacheKey.geocodingContextCacheKey)
-            ?.getAddressPoints(alignment)
+        return getAddressPointCalculationData(cacheKey)?.let(::getAddressPoints)
     }
+
+    fun getAddressPointCalculationData(cacheKey: AddressPointCacheKey): AddressPointCalculationData? =
+        geocodingCacheService.getGeocodingContext(cacheKey.geocodingContextCacheKey)?.let { geocodingContext ->
+            AddressPointCalculationData(cacheKey, alignmentDao.fetch(cacheKey.alignmentVersion), geocodingContext)
+        }
+
+    fun getAddressPoints(input: AddressPointCalculationData): AlignmentAddresses? =
+        cache.get(input.key) { input.geocodingContext.getAddressPoints(input.alignment) }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -7,10 +7,7 @@ import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType
 import fi.fta.geoviite.infra.math.IntersectType.WITHIN
 import fi.fta.geoviite.infra.publication.ValidationVersions
-import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
-import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import fi.fta.geoviite.infra.tracklayout.ReferenceLine
-import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -45,6 +42,19 @@ class GeocodingService(
             "contextKey" to contextKey,
         )
         return addressPointsCache.getAddressPoints(AddressPointCacheKey(alignmentVersion, contextKey))
+    }
+
+    /**
+     * Prepares a calculation (with results cached) to calculate address points. The returned calculation itself is
+     * safe to run on a worker thread.
+     */
+    fun collectDataForGetAddressPoints(
+        contextKey: GeocodingContextCacheKey,
+        alignmentVersion: RowVersion<LayoutAlignment>,
+    ): () -> AlignmentAddresses? {
+        val calculationData =
+            addressPointsCache.getAddressPointCalculationData(AddressPointCacheKey(alignmentVersion, contextKey))
+        return { calculationData?.let(addressPointsCache::getAddressPoints) }
     }
 
     fun getAddress(


### PR DESCRIPTION
Hieman pomppimista koodissa, koska halusin pitäytyä siinä, että AddressPointCache olisi GeocodingServicen toteutusdetalji, vaikka onkin periaatteessa oma palvelunsa.

precacheLocationTrackAlignmentAddresses palauttaa paluutietonsa ainoastaan AddressPointCachen kakutuksen kautta. Periaatteessa parallelStream()ikin on sille siksi ylimääräistä työtä, koska voisihan tehdä myös vaan niin, että rinnakkaistaa vaan kaikki pois ja jatkaa eteenpäin mitään odottelematta, ja cachesta löytyy sitten myöhemmin sijaintiraiteita validoitaessa niiden raiteiden osoitepisteet, jotka rinnakkaisajot sattui ehtimään laskea: Jätin kokeilun perusteella sen kuitenkin tekemättä, koska siitä tulee enemmän koodillista outoutta kuin perffiä, eritoten jos kakut on muutenkin kuumina validointiin tultaessa.