### PR TITLE
GVT-2263 Validate reference line start km sanity

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -551,7 +551,7 @@ class PublicationService @Autowired constructor(
             validationVersions.locationTracks.map { it.officialId },
         )
         val geocodingErrors = if (trackNumber.exists && referenceLine != null) {
-            validateGeocodingContext(cacheKeys[version.officialId], VALIDATION_TRACK_NUMBER)
+            validateGeocodingContext(cacheKeys[version.officialId], VALIDATION_TRACK_NUMBER, trackNumber.number)
         } else listOf()
         val duplicateNameErrors = validateTrackNumberNumberDuplication(trackNumber, validationVersions)
         return fieldErrors + referenceErrors + geocodingErrors + duplicateNameErrors
@@ -597,7 +597,7 @@ class PublicationService @Autowired constructor(
             validationVersions.trackNumbers.map { it.officialId },
         )
         val geocodingErrors = if (kmPost.exists && trackNumber?.exists == true && referenceLine != null) {
-            validateGeocodingContext(cacheKeys[kmPost.trackNumberId], VALIDATION_KM_POST)
+            validateGeocodingContext(cacheKeys[kmPost.trackNumberId], VALIDATION_KM_POST, trackNumber.number)
         } else listOf()
         return fieldErrors + referenceErrors + geocodingErrors
     }
@@ -667,7 +667,7 @@ class PublicationService @Autowired constructor(
         val alignmentErrors = if (trackNumber?.exists == true) validateReferenceLineAlignment(alignment) else listOf()
         val geocodingErrors: List<PublishValidationError> = if (trackNumber?.exists == true) {
             val contextKey = cacheKeys[referenceLine.trackNumberId]
-            val contextErrors = validateGeocodingContext(contextKey, VALIDATION_REFERENCE_LINE)
+            val contextErrors = validateGeocodingContext(contextKey, VALIDATION_REFERENCE_LINE, trackNumber.number)
             val addressErrors = contextKey?.let { key ->
                 val locationTracks = getLocationTracksByTrackNumber(trackNumber.id as IntId, validationVersions)
                 locationTracks.flatMap { track ->
@@ -1295,9 +1295,9 @@ class PublicationService @Autowired constructor(
         )
     }.orElse(null)
 
-    private fun validateGeocodingContext(cacheKey: GeocodingContextCacheKey?, localizationKey: String) =
+    private fun validateGeocodingContext(cacheKey: GeocodingContextCacheKey?, localizationKey: String, trackNumber: TrackNumber) =
         cacheKey?.let(geocodingCacheService::getGeocodingContextWithReasons)
-            ?.let { context -> validateGeocodingContext(context) } ?: listOf(noGeocodingContext(localizationKey))
+            ?.let { context -> validateGeocodingContext(context, trackNumber) } ?: listOf(noGeocodingContext(localizationKey))
 
     private fun validateAddressPoints(
         trackNumber: TrackLayoutTrackNumber,

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1211,7 +1211,8 @@
                 "km-post-outside-line-after": "Tasakilometripiste ({{kmNumber}}) sijaitsee linjan {{trackNumber}} jälkeen",
                 "km-post-smaller-than-track-number-start": "Tasakilometripiste ({{kmNumber}}) on pienempi kuin ratanumeron {{trackNumber}} aloitusarvo",
                 "km-posts-invalid": "Ratanumeron {{trackNumber}} tasakilometripisteet ({{kmNumbers}}) ovat väärässä järjestyksessä",
-                "km-posts-far-from-line": "Ratanumeron {{trackNumber}} tasakilometripisteet ({{kmNumbers}}) sijaitsevat kaukana pituusmittauslinjasta"
+                "km-posts-far-from-line": "Ratanumeron {{trackNumber}} tasakilometripisteet ({{kmNumbers}}) sijaitsevat kaukana pituusmittauslinjasta",
+                "start-km-too-long": "Alkukilometri ottaen huomioon alkupisteen metrit on liian pitkä"
             }
         }
     },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -254,7 +254,7 @@ class GeocodingTest {
             startAddress = startAddress,
             referenceLineGeometry = alignment(startSegment, connectSegment, endSegment),
             kmPosts = listOf(),
-        ).geocodingContext
+        ).geocodingContext!!
 
         val addressPoints = ctx.getAddressPoints(alignment(segment(
             Point(7.0, -2.0),
@@ -537,7 +537,7 @@ class GeocodingTest {
             startAddress = referenceLine.startAddress,
             referenceLineGeometry = referenceLineAlignment,
             kmPosts = listOf(),
-        ).geocodingContext
+        ).geocodingContext!!
 
         val result = testContext.getSwitchPoints(alignment(
             segment(start + Point(0.0, 1.0), start + Point(0.0, 5.5)),
@@ -729,6 +729,23 @@ class GeocodingTest {
         }
     }
 
+    @Test
+    fun `should require start km to have sane length`() {
+        val trackNumber = trackNumber(TrackNumber("T001"))
+        val startAlignment = LayoutAlignment(
+            segments = listOf(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
+        )
+        val kmPost = kmPost(IntId(1), KmNumber(1), Point(15.0, 0.0))
+        val result = GeocodingContext.create(
+            trackNumber = trackNumber,
+            startAddress = TrackMeter(KmNumber(0), 9990),
+            referenceLineGeometry = startAlignment,
+            kmPosts = listOf(kmPost),
+        )
+
+        assertEquals(null, result.geocodingContext)
+        assertEquals(StartPointRejectedReason.TOO_LONG, result.startPointRejectedReason)
+    }
 
     private fun assertProjectionLinesMatch(result: List<ProjectionLine>, vararg expected: Pair<TrackMeter, Line>) {
         assertEquals(expected.size, result.size,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -543,7 +543,8 @@ class PublicationValidationTest {
                         kmPost(IntId(1), KmNumber(1), Point(12.0, 0.0)),
                         kmPost(IntId(1), KmNumber(2), Point(18.0, 0.0)),
                     ),
-                )
+                ),
+                TrackNumber("001"),
             ),
             error,
         )
@@ -557,7 +558,8 @@ class PublicationValidationTest {
                         kmPost(IntId(1), KmNumber(2), Point(18.0, 0.0)),
                         kmPost(IntId(1), KmNumber(1), Point(12.0, 0.0)),
                     ),
-                )
+                ),
+                TrackNumber("001"),
             ),
             error,
         )
@@ -574,7 +576,8 @@ class PublicationValidationTest {
                 geocodingContext(
                     toTrackLayoutPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
                     listOf(kmPost(IntId(1), KmNumber(1), Point(15.0, 0.0))),
-                )
+                ),
+                TrackNumber("001"),
             ),
             error,
         )
@@ -584,7 +587,8 @@ class PublicationValidationTest {
                 geocodingContext(
                     toTrackLayoutPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
                     listOf(kmPost(IntId(1), KmNumber(1), Point(5.0, 0.0))),
-                )
+                ),
+                TrackNumber("001"),
             ),
             kmPostsOutsideLineErrorBefore,
         )
@@ -594,7 +598,8 @@ class PublicationValidationTest {
                 geocodingContext(
                     toTrackLayoutPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
                     listOf(kmPost(IntId(1), KmNumber(1), Point(25.0, 0.0))),
-                )
+                ),
+                TrackNumber("001"),
             ),
             kmPostsOutsideLineErrorAfter,
         )
@@ -862,7 +867,7 @@ class PublicationValidationTest {
     }
 
     private fun simpleGeocodingContext(referenceLinePoints: List<LayoutPoint>): GeocodingContext =
-        geocodingContext(referenceLinePoints, listOf()).geocodingContext
+        geocodingContext(referenceLinePoints, listOf()).geocodingContext!!
 
     private fun geocodingContext(
         referenceLinePoints: List<LayoutPoint>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -420,7 +420,7 @@ fun geocodingContext(
         startAddress = startAddress,
         referenceLineGeometry = alignment,
         kmPosts = kmPosts,
-    ).geocodingContext
+    ).geocodingContext!!
 }
 
 abstract class TargetSegment


### PR DESCRIPTION
Varsinainen pihvi varsin suoraan nähtävissä oleva muutos (tuo startKmIsTooLong-tarkistus itsessään, ja validaation lisäys), mutta tämän myötä tulee mahdolliseksi ensimmäistä kertaa, että geokoodauskontekstille löytyy kyllä kaikin puolin dataa, mutta luomisvaiheessa nähdään, että eipä se nyt onnistunutkaan, ja sitä varten piti vielä tehdä GeocodingContextCreateResult#geocodingContextista nullable. Suurin osa koodimuutoksista siitä tulevaa noisea.