### PR TITLE
GVT-2270: Allow location track selection from badges in switch joint listing

### DIFF
--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -60,6 +60,7 @@ type SwitchInfoboxProps = {
     stopLinking: () => void;
     visibilities: SwitchInfoboxVisibilities;
     onVisibilityChange: (visibilities: SwitchInfoboxVisibilities) => void;
+    onSelectLocationTrackBadge: (locationTrackId: LocationTrackId) => void;
 };
 
 const mapToSwitchJointTrackMeter = (
@@ -135,6 +136,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
     visibilities,
     onVisibilityChange,
     stopLinking,
+    onSelectLocationTrackBadge,
 }: SwitchInfoboxProps) => {
     const { t } = useTranslation();
     const switchOwners = useLoader(() => getSwitchOwners(), []);
@@ -290,6 +292,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                             switchAlignments={structure.alignments}
                             jointConnections={switchJointConnections}
                             publishType={publishType}
+                            onSelectLocationTrackBadge={onSelectLocationTrackBadge}
                         />
                     )}
                     <WriteAccessRequired>

--- a/ui/src/tool-panel/switch/switch-joint-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-joint-infobox.tsx
@@ -60,6 +60,9 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
         .flat()
         .filter(filterNotEmpty);
 
+    const locationTrackBadgeOnClickHandler = (locationTrackId: LocationTrackId) =>
+        onSelectLocationTrackBadge ? () => onSelectLocationTrackBadge(locationTrackId) : undefined;
+
     function getLocationTracksForJointNumbers(jointNumbers: JointNumber[]) {
         const locationTrackIds = getMatchingLocationTrackIdsForJointNumbers(
             jointNumbers,
@@ -76,7 +79,7 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
                 <LocationTrackBadge
                     key={t.id}
                     locationTrack={t}
-                    onClick={() => onSelectLocationTrackBadge && onSelectLocationTrackBadge(t.id)}
+                    onClick={locationTrackBadgeOnClickHandler(t.id)}
                 />
             ));
     }

--- a/ui/src/tool-panel/switch/switch-joint-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-joint-infobox.tsx
@@ -21,6 +21,7 @@ type SwitchJointInfobox = {
     jointConnections: LayoutSwitchJointConnection[];
     topologicalJointConnections?: TopologicalJointConnection[];
     publishType: PublishType;
+    onSelectLocationTrackBadge?: (locationTrackId: LocationTrackId) => void;
 };
 
 const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
@@ -28,6 +29,7 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
     jointConnections,
     topologicalJointConnections,
     publishType,
+    onSelectLocationTrackBadge,
 }) => {
     const { t } = useTranslation();
     const locationTracksEndingAtJoint = combineLocationTrackIds(
@@ -70,7 +72,13 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
         return locationTrackIds
             .map((t) => locationTracks?.find((locationTrack) => locationTrack.id === t))
             .filter(filterNotEmpty)
-            .map((t) => <LocationTrackBadge key={t.id} locationTrack={t} />);
+            .map((t) => (
+                <LocationTrackBadge
+                    key={t.id}
+                    locationTrack={t}
+                    onClick={() => onSelectLocationTrackBadge && onSelectLocationTrackBadge(t.id)}
+                />
+            ));
     }
 
     return (

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -4,7 +4,7 @@ import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
 import { createDelegates } from 'store/store-utils';
 import { LinkingType, SuggestedSwitch } from 'linking/linking-model';
-import { LayoutSwitch } from 'track-layout/track-layout-model';
+import { LayoutSwitch, LocationTrackId } from 'track-layout/track-layout-model';
 import { getSuggestedSwitchByPoint } from 'linking/linking-api';
 import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
 
@@ -56,6 +56,17 @@ const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({ setHoveredOverI
         }
     }, [store.linkingState]);
 
+    const onSelectLocationTrackBadge = (locationTrackId: LocationTrackId) => {
+        delegates.onSelect({
+            locationTracks: [locationTrackId],
+        });
+
+        delegates.setToolPanelTab({
+            id: locationTrackId,
+            type: 'LOCATION_TRACK',
+        });
+    };
+
     return (
         <ToolPanel
             infoboxVisibilities={infoboxVisibilities}
@@ -87,6 +98,7 @@ const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({ setHoveredOverI
             }}
             verticalGeometryDiagramVisible={store.map.verticalGeometryDiagramState.visible}
             onHoverOverPlanSection={setHoveredOverItem}
+            onSelectLocationTrackBadge={onSelectLocationTrackBadge}
         />
     );
 };

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -76,6 +76,7 @@ type ToolPanelProps = {
     stopSwitchLinking: () => void;
     verticalGeometryDiagramVisible: boolean;
     onHoverOverPlanSection: (item: HighlightedAlignment | undefined) => void;
+    onSelectLocationTrackBadge: (locationTrackId: LocationTrackId) => void;
 };
 
 export type ToolPanelAsset = {
@@ -128,6 +129,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     stopSwitchLinking,
     verticalGeometryDiagramVisible,
     onHoverOverPlanSection,
+    onSelectLocationTrackBadge,
 }: ToolPanelProps) => {
     const [previousTabs, setPreviousTabs] = React.useState<ToolPanelTab[]>([]);
     const [tabs, setTabs] = React.useState<ToolPanelTab[]>([]);
@@ -331,6 +333,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                         }
                         startSwitchPlacing={startSwitchPlacing}
                         stopLinking={stopSwitchLinking}
+                        onSelectLocationTrackBadge={onSelectLocationTrackBadge}
                     />
                 ),
             } as ToolPanelTab;


### PR DESCRIPTION
GVT-2270: Allow location track selection from badges in switch joint listing

This should ease the selection navigation for the user. It is also more intuitive, as badges are clickable elsewhere in the UI.