### PR TITLE
GVT-2187: Cancel Github Actions job at 60 minute mark

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   runner-job:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
     - name: Download repository on the runner


### PR DESCRIPTION
Defaulttina katkaisee vasta 360 minuutin kohdalla