### PR TITLE
General: Map scale does not always change when zooming in or out

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/TrackLayoutPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/TrackLayoutPage.kt
@@ -11,7 +11,6 @@ import org.openqa.selenium.By
 import org.openqa.selenium.interactions.Actions
 import tryWait
 import waitUntilNotExist
-import waitUntilTextIsNot
 import kotlin.math.roundToInt
 
 class E2ETrackLayoutPage : E2EViewFragment(byQaId("track-layout-content")) {
@@ -115,15 +114,15 @@ class E2ETrackLayoutPage : E2EViewFragment(byQaId("track-layout-content")) {
     }
 
     private fun zoomOut() {
-        val currentScale = mapScale.value
         clickChild(By.className("ol-zoom-out"))
-        waitUntilTextIsNot(childBy(By.className("ol-scale-line-inner")), currentScale)
+        //Prevents Selenium from reading the same zoom scale too soon
+        Thread.sleep(250)
     }
 
     private fun zoomIn() {
-        val currentScale = mapScale.value
         clickChild(By.className("ol-zoom-in"))
-        waitUntilTextIsNot(childBy(By.className("ol-scale-line-inner")), currentScale)
+        //Prevents Selenium from reading the same zoom scale too soon
+        Thread.sleep(250)
     }
 
 }


### PR DESCRIPTION
Hieman mälsää käyttää sleeppiä, mutta joillakin zoomitasoilla skaalan arvo säilyy samana vaikka zoomaiskin ulos/sisään, jotenka siihen ei voida luottaa. Ja taas ilman sleeppiä on pienen pieni riski, että zoomataankin kahdesti koska arvo ei ole ehtinyt päivittyä. 

