### PR TITLE
GVT-2271: Fix horizontal scrollbar being visible only at the bottom of the inframodel list

### DIFF
--- a/ui/src/infra-model/list/infra-model-list.module.scss
+++ b/ui/src/infra-model/list/infra-model-list.module.scss
@@ -44,7 +44,6 @@
 
 .infra-model-list-search-result {
     &__table {
-        overflow: auto;
         padding-left: 20px;
     }
 


### PR DESCRIPTION
Ylemmältä elementiltä päätyvä overflow-käyttäytyminen toteuttaa jo halutunlaisen scrollauksen (testattu chromiumilla ja firefoxilla).