### PR TITLE
GVT-2284 Report nonexistent km post's length with HTTP 204 as usual

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -158,8 +158,8 @@ class LayoutKmPostController(
     fun getKmLength(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
-    ): TrackLayoutKmPostLength {
+    ): ResponseEntity<TrackLayoutKmPostLength> {
         logger.apiCall("getKmLength", "id" to kmPostId, "publishType" to publishType)
-        return TrackLayoutKmPostLength(kmPostService.getSingleKmPostLength(publishType, kmPostId))
+        return toResponse(kmPostService.getSingleKmPostLength(publishType, kmPostId))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -110,7 +110,7 @@ class LayoutKmPostService(
     fun getSingleKmPostLength(
         publishType: PublishType,
         id: IntId<TrackLayoutKmPost>,
-    ): Double? = dao.getOrThrow(publishType, id).getAsIntegral()?.let { kmPost ->
+    ): TrackLayoutKmPostLength? = dao.get(publishType, id)?.getAsIntegral()?.let { kmPost ->
         referenceLineService
             .getByTrackNumberWithAlignment(publishType, kmPost.trackNumberId)
             ?.let { (_, referenceLineAlignment) ->
@@ -118,7 +118,7 @@ class LayoutKmPostService(
                 val kmEndM = getKmEndM(publishType, kmPost.trackNumberId, kmPost.kmNumber, referenceLineAlignment)
                 if (kmPostM == null || kmEndM == null) null else kmEndM - kmPostM
             }
-    }
+    }?.let(::TrackLayoutKmPostLength)
 
     private fun getKmEndM(
         publishType: PublishType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -303,7 +303,7 @@ data class TrackLayoutKmLengthDetails(
 }
 
 data class TrackLayoutKmPostLength(
-    val length: Double?
+    val length: Double
 )
 
 data class TrackLayoutSwitchJointMatch(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -177,6 +177,6 @@ class LayoutKmPostServiceIT @Autowired constructor(
         val expected = trackNumberService.getKmLengths(DRAFT, trackNumberId)!!.drop(1)
         val actual = kmPosts.mapNotNull { kmPost -> kmPostService.getSingleKmPostLength(DRAFT, kmPost) }
         assertEquals(expected.size, actual.size)
-        expected.zip(actual) { e, a -> assertEquals(e.length.toDouble(), a, 0.001) }
+        expected.zip(actual) { e, a -> assertEquals(e.length.toDouble(), a.length, 0.001) }
     }
 }

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -63,7 +63,8 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     );
 
     const [kmPostLength, kmPostLengthLoading] = useLoaderWithStatus(
-        async () => getSingleKmPostKmLength(publishType, kmPost.id).then((result) => result.length),
+        async () =>
+            getSingleKmPostKmLength(publishType, kmPost.id).then((result) => result?.length),
         [
             kmPost.id,
             kmPost.state,

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -177,8 +177,8 @@ export async function getKmLengths(
 export async function getSingleKmPostKmLength(
     publishType: PublishType,
     id: LayoutKmPostId,
-): Promise<TrackLayoutKmPostLength> {
-    return getNonNull<TrackLayoutKmPostLength>(
+): Promise<TrackLayoutKmPostLength | undefined> {
+    return getNullable<TrackLayoutKmPostLength>(
         `${layoutUri('km-posts', publishType, id)}/km-length`,
     );
 }

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -203,7 +203,7 @@ export type LayoutKmLengthDetails = {
 };
 
 export type TrackLayoutKmPostLength = {
-    length?: number;
+    length: number;
 };
 
 export type PlanArea = {


### PR DESCRIPTION
Näinhän tehdään muidenkin olioiden kanssa: Jos haku olisi muuten oikein, mutta haettavaa oliota ei vaan ole lainkaan olemassa, niin tulos on HTTP 204-tilainen.