### PR TITLE
GVT-2285, GVT-2295: Bugeja draft-only-reverteissä

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/DraftableObjectDao.kt
@@ -44,7 +44,7 @@ interface IDraftableObjectReader<T : Draftable<T>> {
     fun fetch(version: RowVersion<T>): T
 
     fun fetchChangeTime(): Instant
-    fun fetchDraftableChangeInfo(id: IntId<T>): DraftableChangeInfo
+    fun fetchDraftableChangeInfo(id: IntId<T>, publishType: PublishType): DraftableChangeInfo?
 
     fun fetchAllVersions(): List<RowVersion<T>>
     fun fetchVersions(publicationState: PublishType, includeDeleted: Boolean): List<RowVersion<T>>
@@ -84,8 +84,7 @@ interface IDraftableObjectReader<T : Draftable<T>> {
         OFFICIAL -> fetch(fetchOfficialVersionOrThrow(id))
     }
 
-    fun getOfficialAtMoment(id: IntId<T>, moment: Instant): T? =
-        fetchOfficialVersionAtMoment(id, moment)?.let(::fetch)
+    fun getOfficialAtMoment(id: IntId<T>, moment: Instant): T? = fetchOfficialVersionAtMoment(id, moment)?.let(::fetch)
 
     fun getMany(publishType: PublishType, ids: List<IntId<T>>): List<T> = when (publishType) {
         DRAFT -> fetchDraftVersions(ids)
@@ -110,9 +109,11 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
         Caffeine.newBuilder().maximumSize(cacheSize).expireAfterAccess(layoutCacheDuration).build()
 
     @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-    override fun fetch(version: RowVersion<T>): T =
-        if (cacheEnabled) cache.get(version, ::fetchInternal)
-        else fetchInternal(version)
+    override fun fetch(version: RowVersion<T>): T = if (cacheEnabled) {
+        cache.get(version, ::fetchInternal)
+    } else {
+        fetchInternal(version)
+    }
 
     protected abstract fun fetchInternal(version: RowVersion<T>): T
 
@@ -132,9 +133,11 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
         // Empty lists don't play nice in the SQL, but the result would be empty anyhow
         if (ids.isEmpty()) return listOf()
         val distinctIds = ids.distinct()
-        if (distinctIds.size != ids.size) logger.warn(
-            "Requested publication versions with duplicate ids: duplicated=${ids.size - distinctIds.size} requested=$ids"
-        )
+        if (distinctIds.size != ids.size) {
+            logger.warn(
+                "Requested publication versions with duplicate ids: duplicated=${ids.size - distinctIds.size} requested=$ids"
+            )
+        }
         val params = mapOf("ids" to distinctIds.map { id -> id.intValue })
         return jdbcTemplate.query<ValidationVersion<T>>(publicationVersionsSql, params) { rs, _ ->
             ValidationVersion(
@@ -151,27 +154,50 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
     override fun fetchChangeTime(): Instant = fetchLatestChangeTime(table)
 
     private val draftableChangeInfoSql = """
-        select
-          greatest(main_row.change_time, draft_row.change_time) as change_time,
-          case when main_row.draft then null else main_row.change_time end as official_change_time,
-          case when main_row.draft then main_row.change_time else draft_row.change_time end as draft_change_time,
-          version1.change_time as creation_time
-        from ${table.fullName} main_row
-          left join ${table.fullName} draft_row on draft_row.${table.draftLink} = main_row.id
-          inner join ${table.versionTable} version1 on main_row.id = version1.id and version1.version = 1
-        where (main_row.${table.draftLink} is null)
-          and (main_row.id = :id or draft_row.id = :id)
+      with newest_draft as (
+        select 
+          change_time, 
+          draft, 
+          deleted 
+        from ${table.versionTable} 
+        where id = :id or ${table.draftLink} = :id 
+        order by change_time desc limit 1
+      ),
+      newest_official as (
+        select 
+          change_time, 
+          draft, 
+          deleted 
+        from ${table.versionTable} 
+        where id = :id and draft = false 
+        order by change_time desc limit 1
+      )
+      select 
+        first.change_time as creation_time, 
+        newest_official.change_time as official_change_time, 
+        newest_draft.change_time as draft_change_time, 
+        newest_draft.deleted as draft_deleted 
+      from ${table.versionTable} first 
+        left join newest_draft on true 
+        left join newest_official on true 
+      where id = :id and version = 1 limit 1
     """.trimIndent()
 
-    override fun fetchDraftableChangeInfo(id: IntId<T>): DraftableChangeInfo {
-        return jdbcTemplate.queryForObject(draftableChangeInfoSql, mapOf("id" to id.intValue)) { rs, _ ->
-            DraftableChangeInfo(
-                created = rs.getInstant("creation_time"),
-                changed = rs.getInstant("change_time"),
-                officialChanged = rs.getInstantOrNull("official_change_time"),
-                draftChanged = rs.getInstantOrNull("draft_change_time"),
-            )
-        } ?: throw NoSuchEntityException(table.name, id)
+    override fun fetchDraftableChangeInfo(id: IntId<T>, publishType: PublishType): DraftableChangeInfo? {
+        return jdbcTemplate.query(draftableChangeInfoSql, mapOf("id" to id.intValue)) { rs, _ ->
+            val draftDeleted = rs.getBoolean("draft_deleted")
+            if (publishType == OFFICIAL) {
+                DraftableChangeInfo(
+                    created = rs.getInstant("creation_time"),
+                    changed = rs.getInstant("official_change_time"),
+                )
+            } else {
+                DraftableChangeInfo(
+                    created = rs.getInstant("creation_time"),
+                    changed = if (draftDeleted) rs.getInstant("official_change_time") else rs.getInstant("draft_change_time"),
+                )
+            }
+        }.firstOrNull()
     }
 
     override fun draftExists(id: IntId<T>): Boolean = fetchVersionPair(id).draft != null
@@ -230,9 +256,11 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
     override fun fetchOfficialVersions(ids: List<IntId<T>>): List<RowVersion<T>> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.versionTable, ids)
         val params = mapOf("ids" to ids.distinct().map { it.intValue })
-        val versions: List<RowVersion<T>> =
-            if (ids.isEmpty()) emptyList()
-            else jdbcTemplate.query(multiOfficialVersionSql, params, ::toRowVersion)
+        val versions: List<RowVersion<T>> = if (ids.isEmpty()) {
+            emptyList()
+        } else {
+            jdbcTemplate.query(multiOfficialVersionSql, params, ::toRowVersion)
+        }
         return versions
     }
 
@@ -249,8 +277,11 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
     override fun fetchDraftVersions(ids: List<IntId<T>>): List<RowVersion<T>> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, ids)
         val params = mapOf("ids" to ids.distinct().map { it.intValue })
-        val versions: List<RowVersion<T>> = if (ids.isEmpty()) emptyList()
-        else jdbcTemplate.query(multiDraftVersionSql, params, ::toRowVersion)
+        val versions: List<RowVersion<T>> = if (ids.isEmpty()) {
+            emptyList()
+        } else {
+            jdbcTemplate.query(multiDraftVersionSql, params, ::toRowVersion)
+        }
         return versions
     }
 
@@ -282,9 +313,13 @@ abstract class DraftableDaoBase<T : Draftable<T>>(
 
     @Transactional
     override fun deleteDraft(id: IntId<T>): DaoResponse<T> = deleteDraftsInternal(id).let { r ->
-        if (r.size > 1) error { "Multiple rows deleted with one ID: type=${table.name} id=$id" }
-        else if (r.isEmpty()) throw DeletingFailureException("Trying to delete a non-existing draft object: type=${table.name} id=$id")
-        else r.first()
+        if (r.size > 1) {
+            error { "Multiple rows deleted with one ID: type=${table.name} id=$id" }
+        } else if (r.isEmpty()) {
+            throw DeletingFailureException("Trying to delete a non-existing draft object: type=${table.name} id=$id")
+        } else {
+            r.first()
+        }
     }
 
     @Transactional
@@ -324,8 +359,11 @@ private fun draftFetchSql(table: DbTable, fetchType: FetchType) = """
 inline fun <reified T : Draftable<T>> draftOfId(item: T) = draftOfId(item.id, item.draft)
 
 inline fun <reified T : Draftable<T>> draftOfId(id: DomainId<T>, draft: Draft<T>?): IntId<T>? =
-    if (draft != null && draft.draftRowId != id) toDbId(T::class, id)
-    else null
+    if (draft != null && draft.draftRowId != id) {
+        toDbId(T::class, id)
+    } else {
+        null
+    }
 
 inline fun <reified T : Draftable<T>> verifyDraftableInsert(item: T) = verifyDraftableInsert(item.id, item.draft)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -147,10 +147,13 @@ class LayoutKmPostController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{id}/change-times")
-    fun getKmPostChangeInfo(@PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>): DraftableChangeInfo {
+    @GetMapping("/{publishType}/{id}/change-times")
+    fun getKmPostChangeInfo(
+        @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
+        @PathVariable("publishType") publishType: PublishType,
+    ): ResponseEntity<DraftableChangeInfo> {
         logger.apiCall("getKmPostChangeTimes", "id" to kmPostId)
-        return kmPostService.getDraftableChangeInfo(kmPostId)
+        return toResponse(kmPostService.getDraftableChangeInfo(kmPostId, publishType))
     }
 
     @PreAuthorize(AUTH_ALL_READ)
@@ -158,8 +161,8 @@ class LayoutKmPostController(
     fun getKmLength(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
-    ): TrackLayoutKmPostLength {
+    ): ResponseEntity<Double> {
         logger.apiCall("getKmLength", "id" to kmPostId, "publishType" to publishType)
-        return TrackLayoutKmPostLength(kmPostService.getSingleKmPostLength(publishType, kmPostId))
+        return toResponse(kmPostService.getSingleKmPostLength(publishType, kmPostId))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -110,7 +110,7 @@ class LayoutKmPostService(
     fun getSingleKmPostLength(
         publishType: PublishType,
         id: IntId<TrackLayoutKmPost>,
-    ): Double? = dao.getOrThrow(publishType, id).getAsIntegral()?.let { kmPost ->
+    ): Double? = dao.get(publishType, id)?.getAsIntegral()?.let { kmPost ->
         referenceLineService
             .getByTrackNumberWithAlignment(publishType, kmPost.trackNumberId)
             ?.let { (_, referenceLineAlignment) ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -122,9 +122,12 @@ class LayoutSwitchController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{id}/change-times")
-    fun getSwitchChangeInfo(@PathVariable("id") switchId: IntId<TrackLayoutSwitch>): DraftableChangeInfo {
+    @GetMapping("/{publishType}/{id}/change-times")
+    fun getSwitchChangeInfo(
+        @PathVariable("id") switchId: IntId<TrackLayoutSwitch>,
+        @PathVariable("publishType") publishType: PublishType,
+    ): ResponseEntity<DraftableChangeInfo> {
         logger.apiCall("getSwitchChangeTimes", "id" to switchId)
-        return switchService.getDraftableChangeInfo(switchId)
+        return toResponse(switchService.getDraftableChangeInfo(switchId, publishType))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -164,9 +164,12 @@ class LayoutTrackNumberController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{id}/change-times")
-    fun getTrackNumberChangeInfo(@PathVariable("id") id: IntId<TrackLayoutTrackNumber>): DraftableChangeInfo {
+    @GetMapping("/{publishType}/{id}/change-times")
+    fun getTrackNumberChangeInfo(
+        @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
+        @PathVariable("publishType") publishType: PublishType,
+    ): ResponseEntity<DraftableChangeInfo> {
         logger.apiCall("getTrackNumberChangeInfo", "id" to id)
-        return trackNumberService.getDraftableChangeInfo(id)
+        return toResponse(trackNumberService.getDraftableChangeInfo(id, publishType))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -162,9 +162,10 @@ class LocationTrackController(
         logger.apiCall("validateLocationTrackSwitches", "publishType" to publishType, "id" to id)
         val switchIds = locationTrackService.getSwitchesForLocationTrack(id, publishType)
         val switchValidation = publicationService.validateSwitches(switchIds, publishType)
-        val switchSuggestions = switchLinkingService.getSuggestedSwitchesAtPresentationJointLocations(switchIds
-            .distinct()
-            .let { swId -> switchService.getMany(publishType, swId) })
+        val switchSuggestions = switchLinkingService.getSuggestedSwitchesAtPresentationJointLocations(
+            switchIds
+                .distinct()
+                .let { swId -> switchService.getMany(publishType, swId) })
         return switchValidation.map { validatedAsset ->
             SwitchValidationWithSuggestedSwitch(
                 validatedAsset.id, validatedAsset, switchSuggestions.find { it.first == validatedAsset.id }?.second
@@ -204,10 +205,13 @@ class LocationTrackController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/location-tracks/{id}/change-times")
-    fun getLocationTrackChangeInfo(@PathVariable("id") id: IntId<LocationTrack>): DraftableChangeInfo {
+    @GetMapping("/location-tracks/{publishType}/{id}/change-times")
+    fun getLocationTrackChangeInfo(
+        @PathVariable("id") id: IntId<LocationTrack>,
+        @PathVariable("publishType") publishType: PublishType,
+    ): ResponseEntity<DraftableChangeInfo> {
         logger.apiCall("getLocationTrackChangeInfo", "id" to id)
-        return locationTrackService.getDraftableChangeInfo(id)
+        return toResponse(locationTrackService.getDraftableChangeInfo(id, publishType))
     }
 
     @PreAuthorize(AUTH_ALL_READ)
@@ -251,12 +255,12 @@ class LocationTrackController(
     fun getSplittingInitializationParameters(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") id: IntId<LocationTrack>,
-    ): SplittingInitializationParameters {
+    ): ResponseEntity<SplittingInitializationParameters> {
         logger.apiCall(
             "getSplittingInitializationParameters",
             "publishType" to publishType,
             "id" to id,
         )
-        return locationTrackService.getSplittingInitializationParameters(id, publishType)
+        return toResponse(locationTrackService.getSplittingInitializationParameters(id, publishType))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
@@ -84,9 +84,12 @@ class ReferenceLineController(
     }
 
     @PreAuthorize(AUTH_ALL_READ)
-    @GetMapping("/{id}/change-times")
-    fun getReferenceLineChangeInfo(@PathVariable("id") id: IntId<ReferenceLine>): DraftableChangeInfo {
+    @GetMapping("/{publishType}/{id}/change-times")
+    fun getReferenceLineChangeInfo(
+        @PathVariable("id") id: IntId<ReferenceLine>,
+        @PathVariable("publishType") publishType: PublishType,
+    ): ResponseEntity<DraftableChangeInfo> {
         logger.apiCall("getReferenceLineChangeInfo", "id" to id)
-        return referenceLineService.getDraftableChangeInfo(id)
+        return toResponse(referenceLineService.getDraftableChangeInfo(id, publishType))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -303,7 +303,7 @@ data class TrackLayoutKmLengthDetails(
 }
 
 data class TrackLayoutKmPostLength(
-    val length: Double?
+    val length: Double?,
 )
 
 data class TrackLayoutSwitchJointMatch(
@@ -339,8 +339,6 @@ data class TrackLayoutSwitchJointConnection(
 data class DraftableChangeInfo(
     val created: Instant,
     val changed: Instant,
-    val officialChanged: Instant?,
-    val draftChanged: Instant?,
 )
 
 data class TrackNumberAndChangeTime(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -302,10 +302,6 @@ data class TrackLayoutKmLengthDetails(
     val length = endM - startM
 }
 
-data class TrackLayoutKmPostLength(
-    val length: Double
-)
-
 data class TrackLayoutSwitchJointMatch(
     val locationTrackId: IntId<LocationTrack>,
     val location: Point,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -50,10 +50,13 @@ enum class DbTable(schema: String, table: String, sortColumns: List<String> = li
 
     //language=SQL
     val changeTimeSql = "select max(change_time) change_time from $versionTable"
+
     //language=SQL
     val singleRowVersionSql = "select id, version from $fullName where id ${idOrIdsEqualSqlFragment(SINGLE)}"
+
     //language=SQL
     val multiRowVersionSql = "select id, version from $fullName where id ${idOrIdsEqualSqlFragment(MULTI)}"
+
     //language=SQL
     val rowVersionsSql = "select id, version from $fullName order by $orderBy"
 }
@@ -106,18 +109,16 @@ open class DaoBase(private val jdbcTemplateParam: NamedParameterJdbcTemplate?) {
     protected fun <T> queryRowVersionOrNull(sql: String, id: IntId<T>): RowVersion<T>? =
         jdbcTemplate.queryOptional(sql, mapOf("id" to id.intValue), ::toRowVersionOrNull)
 
-    protected fun <T> toRowVersion(rs: ResultSet, index: Int): RowVersion<T> =
-        rs.getRowVersion("id", "version")
+    protected fun <T> toRowVersion(rs: ResultSet, index: Int): RowVersion<T> = rs.getRowVersion("id", "version")
 
-    protected fun <T> toRowVersionOrNull(rs: ResultSet, index: Int): RowVersion<T> =
-        rs.getRowVersion("id", "version")
+    protected fun <T> toRowVersionOrNull(rs: ResultSet, index: Int): RowVersion<T> = rs.getRowVersion("id", "version")
 }
 
 inline fun <reified T, reified S> getOne(id: DomainId<T>, result: List<S>) =
     getOptional(id, result) ?: throw NoSuchEntityException(T::class, id)
 
 inline fun <reified T, reified S> getOptional(id: DomainId<T>, result: List<S>): S? {
-    require (result.size <= 1) {
+    require(result.size <= 1) {
         val idDesc = if (S::class == T::class) "id $id" else "${T::class.simpleName}.id $id"
         "Found more than one ${S::class.simpleName} with same $idDesc"
     }
@@ -130,10 +131,8 @@ fun <T, S> getOne(name: String, id: DomainId<T>, result: List<S>): S {
     return result.first()
 }
 
-inline fun <reified T> toDbId(id: DomainId<T>): IntId<T> =
-    if (id is IntId) id
-    else throw NoSuchEntityException(T::class, id)
+inline fun <reified T> toDbId(id: DomainId<T>): IntId<T> = if (id is IntId) id
+else throw NoSuchEntityException(T::class, id)
 
-fun <T> toDbId(clazz: KClass<*>, id: DomainId<T>): IntId<T> =
-    if (id is IntId) id
-    else throw NoSuchEntityException(clazz, id)
+fun <T> toDbId(clazz: KClass<*>, id: DomainId<T>): IntId<T> = if (id is IntId) id
+else throw NoSuchEntityException(clazz, id)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
@@ -4,6 +4,7 @@ import assertPlansMatch
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.common.ProjectName
+import fi.fta.geoviite.infra.common.PublishType
 import fi.fta.geoviite.infra.inframodel.InfraModelFile
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.ValidationVersion
@@ -208,7 +209,8 @@ class GeometryDaoIT @Autowired constructor(
         )
         val trackVersion = locationTrackService.saveDraft(track.first, track.second)
         locationTrackService.publish(ValidationVersion(trackVersion.id, trackVersion.rowVersion))
-        val trackChangeTime = locationTrackService.getDraftableChangeInfo(trackVersion.id).officialChanged!!
+        val trackChangeTime =
+            locationTrackService.getDraftableChangeInfo(trackVersion.id, PublishType.OFFICIAL)?.changed
 
         val expectedSummary = GeometryPlanLinkingSummary(trackChangeTime, listOf(UserName("TEST_USER")), true)
         val summaries = geometryDao.getLinkingSummaries(listOf(planVersion.id))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -157,13 +157,13 @@ class LayoutKmPostServiceIT @Autowired constructor(
     @Test
     fun kmPostLengthMatchesTrackNumberService() {
         val trackNumberId = insertDraftTrackNumber()
-        referenceLineService.saveDraft(referenceLine(trackNumberId), alignment(segment(
-            Point(0.0, 0.0),
-            Point(0.0, 5.0),
-            Point(1.0, 10.0),
-            Point(3.0, 15.0),
-            Point(4.0, 20.0)
-        )))
+        referenceLineService.saveDraft(
+            referenceLine(trackNumberId), alignment(
+                segment(
+                    Point(0.0, 0.0), Point(0.0, 5.0), Point(1.0, 10.0), Point(3.0, 15.0), Point(4.0, 20.0)
+                )
+            )
+        )
         val kmPosts = listOf(
             kmPost(trackNumberId, KmNumber(1), Point(0.0, 3.0)),
             kmPost(trackNumberId, KmNumber(2), Point(0.0, 5.0)),
@@ -177,6 +177,6 @@ class LayoutKmPostServiceIT @Autowired constructor(
         val expected = trackNumberService.getKmLengths(DRAFT, trackNumberId)!!.drop(1)
         val actual = kmPosts.mapNotNull { kmPost -> kmPostService.getSingleKmPostLength(DRAFT, kmPost) }
         assertEquals(expected.size, actual.size)
-        expected.zip(actual) { e, a -> assertEquals(e.length.toDouble(), a.length, 0.001) }
+        expected.zip(actual) { e, a -> assertEquals(e.length.toDouble(), a, 0.001) }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -109,9 +109,9 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(insertedTrack.alignmentVersion, updatedTrack.alignmentVersion)
         val changeTimeAfterUpdate = locationTrackService.getChangeTime()
 
-        val changeInfo = locationTrackService.getDraftableChangeInfo(id)
-        assertEquals(changeTimeAfterInsert, changeInfo.created)
-        assertEquals(changeTimeAfterUpdate, changeInfo.draftChanged)
+        val changeInfo = locationTrackService.getDraftableChangeInfo(id, DRAFT)
+        assertEquals(changeTimeAfterInsert, changeInfo?.created)
+        assertEquals(changeTimeAfterUpdate, changeInfo?.changed)
     }
 
     @Test
@@ -509,8 +509,7 @@ class LocationTrackServiceIT @Autowired constructor(
     private fun asLocationTrackDuplicate(locationTrack: LocationTrack) =
         LocationTrackDuplicate(locationTrack.id as IntId, locationTrack.name, locationTrack.externalId)
 
-    private fun insertAndFetch(switch: TrackLayoutSwitch) =
-        switchDao.fetch(switchService.saveDraft(switch).rowVersion)
+    private fun insertAndFetch(switch: TrackLayoutSwitch) = switchDao.fetch(switchService.saveDraft(switch).rowVersion)
 
     private fun insertAndFetch(
         locationTrack: LocationTrack,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
@@ -74,9 +74,9 @@ class ReferenceLineServiceIT @Autowired constructor(
         assertEquals(referenceLine.alignmentVersion, updatedLine.alignmentVersion)
         val changeTimeAfterUpdate = referenceLineService.getChangeTime()
 
-        val changeInfo = referenceLineService.getDraftableChangeInfo(referenceLineId)
-        assertEquals(changeTimeAfterInsert, changeInfo.created)
-        assertEquals(changeTimeAfterUpdate, changeInfo.draftChanged)
+        val changeInfo = referenceLineService.getDraftableChangeInfo(referenceLineId, DRAFT)
+        assertEquals(changeTimeAfterInsert, changeInfo?.created)
+        assertEquals(changeTimeAfterUpdate, changeInfo?.changed)
     }
 
     @Test

--- a/ui/src/preview/publication-request-dependency-list.tsx
+++ b/ui/src/preview/publication-request-dependency-list.tsx
@@ -1,6 +1,7 @@
 import { PublishRequestIds } from 'publication/publication-model';
 import * as React from 'react';
 import {
+    LayoutKmPostId,
     LayoutSwitchId,
     LayoutTrackNumberId,
     LocationTrackId,
@@ -9,6 +10,7 @@ import {
 import { TimeStamp } from 'common/common-model';
 import { useTranslation } from 'react-i18next';
 import {
+    useKmPost,
     useLocationTrack,
     useReferenceLine,
     useSwitch,
@@ -94,6 +96,18 @@ const SwitchItem: React.FC<{ switchId: LayoutSwitchId }> = ({ switchId }) => {
     );
 };
 
+const KmPostItem: React.FC<{ kmPostId: LayoutKmPostId }> = ({ kmPostId }) => {
+    const { t } = useTranslation();
+    const kmPost = useKmPost(kmPostId, 'DRAFT');
+    return kmPost === undefined ? (
+        <li />
+    ) : (
+        <li>
+            {t('publish.revert-confirm.dependency-list.km-post')} {kmPost.kmNumber}
+        </li>
+    );
+};
+
 export const publicationRequestTypeTranslationKey = (type: PreviewSelectType) => {
     switch (type) {
         case 'trackNumber':
@@ -171,6 +185,9 @@ export const PublicationRequestDependencyList: React.FC<PublicationRequestDepend
                     ))}
                     {dependencies.switches.map((sw) => (
                         <SwitchItem switchId={sw} key={sw} />
+                    ))}
+                    {dependencies.kmPosts.map((kmPost) => (
+                        <KmPostItem kmPostId={kmPost} key={kmPost} />
                     ))}
                 </ul>
             </>

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -53,7 +53,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     changeTimes,
 }: KmPostInfoboxProps) => {
     const { t } = useTranslation();
-    const kmPostCreatedAndChangedTime = useKmPostChangeTimes(kmPost.id);
+    const kmPostCreatedAndChangedTime = useKmPostChangeTimes(kmPost.id, publishType);
 
     const [showEditDialog, setShowEditDialog] = React.useState(false);
     const [confirmingDraftDelete, setConfirmingDraftDelete] = React.useState(false);
@@ -63,7 +63,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     );
 
     const [kmPostLength, kmPostLengthLoading] = useLoaderWithStatus(
-        async () => getSingleKmPostKmLength(publishType, kmPost.id).then((result) => result.length),
+        async () => getSingleKmPostKmLength(publishType, kmPost.id),
         [
             kmPost.id,
             kmPost.state,

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -114,7 +114,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
         publishType,
         locationTrackChangeTime,
     );
-    const changeTimes = useLocationTrackChangeTimes(locationTrack?.id);
+    const changeTimes = useLocationTrackChangeTimes(locationTrack?.id, publishType);
     const coordinateSystem = useCoordinateSystem(LAYOUT_SRID);
     const officialLocationTrack = useLocationTrack(
         locationTrack.id,

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -150,7 +150,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
         () => getSwitchJointConnections(publishType, switchId),
         [publishType, layoutSwitch],
     );
-    const switchChangeTimes = useSwitchChangeTimes(layoutSwitch?.id);
+    const switchChangeTimes = useSwitchChangeTimes(layoutSwitch?.id, publishType);
 
     const switchJointTrackMeters = useLoader(() => {
         return switchJointConnections

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -88,8 +88,8 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
         trackNumberChangeTime,
     );
     const coordinateSystem = useCoordinateSystem(LAYOUT_SRID);
-    const tnChangeTimes = useTrackNumberChangeTimes(trackNumber?.id);
-    const rlChangeTimes = useReferenceLineChangeTimes(referenceLine?.id);
+    const tnChangeTimes = useTrackNumberChangeTimes(trackNumber?.id, publishType);
+    const rlChangeTimes = useReferenceLineChangeTimes(referenceLine?.id, publishType);
     const createdTime =
         tnChangeTimes?.created && rlChangeTimes?.created
             ? getMinTimestamp(tnChangeTimes.created, rlChangeTimes.created)

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -4,7 +4,6 @@ import {
     LayoutKmPost,
     LayoutKmPostId,
     LayoutTrackNumberId,
-    TrackLayoutKmPostLength,
 } from 'track-layout/track-layout-model';
 import { DraftableChangeInfo, KmNumber, PublishType, TimeStamp } from 'common/common-model';
 import { deleteAdt, getNonNull, getNullable, postAdt, putAdt, queryParams } from 'api/api-fetch';
@@ -177,10 +176,8 @@ export async function getKmLengths(
 export async function getSingleKmPostKmLength(
     publishType: PublishType,
     id: LayoutKmPostId,
-): Promise<TrackLayoutKmPostLength> {
-    return getNonNull<TrackLayoutKmPostLength>(
-        `${layoutUri('km-posts', publishType, id)}/km-length`,
-    );
+): Promise<number | undefined> {
+    return getNullable<number>(`${layoutUri('km-posts', publishType, id)}/km-length`);
 }
 
 export const getKmLengthsAsCsv = (
@@ -197,8 +194,8 @@ export const getKmLengthsAsCsv = (
     return `${layoutUri('track-numbers', publishType, trackNumberId)}/km-lengths/as-csv${params}`;
 };
 
-export const getKmPostChangeTimes = (id: LayoutKmPostId) =>
-    getNullable<DraftableChangeInfo>(changeTimeUri('km-posts', id));
+export const getKmPostChangeTimes = (id: LayoutKmPostId, publishType: PublishType) =>
+    getNullable<DraftableChangeInfo>(changeTimeUri('km-posts', id, publishType));
 
 export const getEntireRailNetworkKmLengthsCsvUrl = () =>
     `${TRACK_LAYOUT_URI}/track-numbers/rail-network/km-lengths/file`;

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -252,8 +252,9 @@ export async function getNonLinkedLocationTracks(): Promise<LayoutLocationTrack[
 
 export const getLocationTrackChangeTimes = (
     id: LocationTrackId,
+    publishType: PublishType,
 ): Promise<DraftableChangeInfo | undefined> => {
-    return getNullable<DraftableChangeInfo>(changeTimeUri('location-tracks', id));
+    return getNullable<DraftableChangeInfo>(changeTimeUri('location-tracks', id, publishType));
 };
 
 export const getLocationTrackSectionsByPlan = async (

--- a/ui/src/track-layout/layout-reference-line-api.ts
+++ b/ui/src/track-layout/layout-reference-line-api.ts
@@ -87,6 +87,7 @@ export async function getNonLinkedReferenceLines(): Promise<LayoutReferenceLine[
 
 export const getReferenceLineChangeTimes = (
     id: ReferenceLineId,
+    publishType: PublishType,
 ): Promise<DraftableChangeInfo | undefined> => {
-    return getNullable<DraftableChangeInfo>(changeTimeUri('reference-lines', id));
+    return getNullable<DraftableChangeInfo>(changeTimeUri('reference-lines', id, publishType));
 };

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -154,6 +154,7 @@ export async function getSwitchValidation(
 
 export const getSwitchChangeTimes = (
     id: LayoutSwitchId,
+    publishType: PublishType,
 ): Promise<DraftableChangeInfo | undefined> => {
-    return getNonNull<DraftableChangeInfo>(changeTimeUri('switches', id));
+    return getNonNull<DraftableChangeInfo>(changeTimeUri('switches', id, publishType));
 };

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -104,6 +104,7 @@ export const getTrackNumberReferenceLineSectionsByPlan = async (
 
 export const getTrackNumberChangeTimes = (
     id: LayoutTrackNumberId,
+    publishType: PublishType,
 ): Promise<DraftableChangeInfo | undefined> => {
-    return getNullable<DraftableChangeInfo>(changeTimeUri('track-numbers', id));
+    return getNullable<DraftableChangeInfo>(changeTimeUri('track-numbers', id, publishType));
 };

--- a/ui/src/track-layout/track-layout-api.ts
+++ b/ui/src/track-layout/track-layout-api.ts
@@ -10,8 +10,12 @@ type LayoutDataType =
 
 export const TRACK_LAYOUT_URI = `${API_URI}/track-layout`;
 
-export function changeTimeUri(dataType: LayoutDataType, id: string): string {
-    return `${TRACK_LAYOUT_URI}/${dataType}/${id}/change-times`;
+export function changeTimeUri(
+    dataType: LayoutDataType,
+    id: string,
+    publishType: PublishType,
+): string {
+    return `${TRACK_LAYOUT_URI}/${dataType}/${publishType}/${id}/change-times`;
 }
 
 export function layoutUri(dataType: LayoutDataType, publishType: PublishType, id?: string): string {

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -202,10 +202,6 @@ export type LayoutKmLengthDetails = {
     location?: Point;
 };
 
-export type TrackLayoutKmPostLength = {
-    length?: number;
-};
-
 export type PlanArea = {
     id: GeometryPlanId;
     fileName: string;

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -246,32 +246,52 @@ export function usePlanHeader(id: GeometryPlanId | undefined): GeometryPlanHeade
 
 export function useTrackNumberChangeTimes(
     id: LayoutTrackNumberId | undefined,
+    publishType: PublishType,
 ): DraftableChangeInfo | undefined {
-    return useOptionalLoader(() => (id ? getTrackNumberChangeTimes(id) : undefined), [id]);
+    return useOptionalLoader(
+        () => (id ? getTrackNumberChangeTimes(id, publishType) : undefined),
+        [id],
+    );
 }
 
 export function useReferenceLineChangeTimes(
     id: ReferenceLineId | undefined,
+    publishType: PublishType,
 ): DraftableChangeInfo | undefined {
-    return useOptionalLoader(() => (id ? getReferenceLineChangeTimes(id) : undefined), [id]);
+    return useOptionalLoader(
+        () => (id ? getReferenceLineChangeTimes(id, publishType) : undefined),
+        [id, publishType],
+    );
 }
 
 export function useLocationTrackChangeTimes(
     id: LocationTrackId | undefined,
+    publishType: PublishType,
 ): DraftableChangeInfo | undefined {
-    return useOptionalLoader(() => (id ? getLocationTrackChangeTimes(id) : undefined), [id]);
+    return useOptionalLoader(
+        () => (id ? getLocationTrackChangeTimes(id, publishType) : undefined),
+        [id, publishType],
+    );
 }
 
 export function useSwitchChangeTimes(
     id: LayoutSwitchId | undefined,
+    publishType: PublishType,
 ): DraftableChangeInfo | undefined {
-    return useOptionalLoader(() => (id ? getSwitchChangeTimes(id) : undefined), [id]);
+    return useOptionalLoader(
+        () => (id ? getSwitchChangeTimes(id, publishType) : undefined),
+        [id, publishType],
+    );
 }
 
 export function useKmPostChangeTimes(
     id: LayoutKmPostId | undefined,
+    publishType: PublishType,
 ): DraftableChangeInfo | undefined {
-    return useOptionalLoader(() => (id ? getKmPostChangeTimes(id) : undefined), [id]);
+    return useOptionalLoader(
+        () => (id ? getKmPostChangeTimes(id, publishType) : undefined),
+        [id, publishType],
+    );
 }
 
 export function useCoordinateSystem(srid: Srid): CoordinateSystem | undefined {


### PR DESCRIPTION
Täällä korjattu useampikin bugi. Merkkailen korjaukset koodiin.

Huom.: Täällä ei ole vielä toteutettuna a) indeksiä kantaan `DraftChangeInfo`:n haulle (ei ole kauhean hidas näinkään ainakaan lokaalisti) ja b) selection-muutoksia. Taidan ehkä tehdä näistä oman ja erillisen tiketin kun tämä paisui näinkin isoksi jutuksi muutenkin.