### PR TITLE
General: Simplify and do getMaxDirectionDeltaRads in-place

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
@@ -288,7 +288,7 @@ fun inferSwitchTransformation(
         else 2
     }
 
-    val allPoints = alignment.allSegmentPoints
+    val allPoints = alignment.allSegmentPoints.toList()
     //Find the "start" point for switch joint
     //It's usually the first or the last point of alignment
     val startPointIndex = allPoints.indexOfFirst { point ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -62,9 +62,9 @@ interface IAlignment : Loggable {
     val start: AlignmentPoint? get() = segments.firstOrNull()?.alignmentStart
     val end: AlignmentPoint? get() = segments.lastOrNull()?.alignmentEnd
 
-    val allSegmentPoints: List<SegmentPoint> get() = segments.flatMapIndexed { index, segment ->
-        if (index == segments.lastIndex) segment.segmentPoints
-        else segment.segmentPoints.take(segment.segmentPoints.size - 1)
+    val allSegmentPoints: Sequence<SegmentPoint> get() = segments.asSequence().flatMapIndexed { index, segment ->
+        if (index == segments.lastIndex) segment.segmentPoints.asSequence()
+        else segment.segmentPoints.asSequence().take(segment.segmentPoints.size - 1)
     }
 
     fun filterSegmentsByBbox(bbox: BoundingBox): List<ISegment> {
@@ -167,10 +167,7 @@ interface IAlignment : Loggable {
         ?.let { (_, index) -> index }
 
     fun getMaxDirectionDeltaRads(): Double =
-        allSegmentPoints.zipWithNext(::directionBetweenPoints).zipWithNext(::angleDeltaRads).maxOrNull() ?: 0.0
-
-    private fun angleDeltaRads(dir1: Double?, dir2: Double?): Double =
-        if (dir1 != null && dir2 != null) angleDiffRads(dir1, dir2) else 0.0
+        allSegmentPoints.zipWithNext(::directionBetweenPoints).zipWithNext(::angleDiffRads).maxOrNull() ?: 0.0
 
     override fun toLog(): String = logFormat("id" to id, "segments" to segments.size, "length" to round(length, 3))
 }


### PR DESCRIPTION
Oleellista perffivaikutusta tällä ei ole, mutta kyllähän tällä periaatteessa säästää hyvin lyhytikäisen allokaation, ja nuo asSequence()-kutsut on asetettu niin, että isoja taulukoita ei pitäisi arvita kopioida missään vaiheessa.

Erillisenä juttuna vielä getMaxDirectionDeltaRads()issa osoittautui, että siellähän oli ylimääräisiä null-tarkistuksia. Muuten sen toteutus ei olisi sequencen käytön myötä muuttunut lainkaan.