### PR TITLE
GVT-2265 Update known feature type codes + allow saving with unknown feature type

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
@@ -35,6 +35,11 @@ const val VALIDATION_CANT = "cant"
 const val VALIDATION_SWITCH = "switch"
 const val VALIDATION_KM_POST = "km-post"
 
+val trackTypeCodes = listOf(
+    FeatureTypeCode("281"),
+    FeatureTypeCode("111"),
+)
+
 interface ValidationError {
     val localizationKey: LocalizationKey
     val errorType: ErrorType
@@ -43,17 +48,21 @@ interface ValidationError {
 data class ValidationErrorData(
     override val localizationKey: LocalizationKey,
     override val errorType: ErrorType,
-): ValidationError {
-    constructor(parentKey: String, errorKey: String, errorType: ErrorType):
-            this(LocalizationKey("$VALIDATION.$parentKey.$errorKey"), errorType)
+) : ValidationError {
+    constructor(parentKey: String, errorKey: String, errorType: ErrorType) : this(
+        LocalizationKey("$VALIDATION.$parentKey.$errorKey"),
+        errorType,
+    )
 }
 
 data class MetadataError(
     @JsonIgnore private val data: ValidationErrorData,
     val value: String?,
 ) : ValidationError by data {
-    constructor(key: String, type: ErrorType, value: String? = null):
-            this(ValidationErrorData(VALIDATION_METADATA, key, type), value)
+    constructor(key: String, type: ErrorType, value: String? = null) : this(
+        ValidationErrorData(VALIDATION_METADATA, key, type),
+        value,
+    )
 }
 
 data class SwitchDefinitionError(
@@ -72,7 +81,7 @@ data class SwitchDefinitionError(
         jointNumbers: List<JointNumber>? = null,
         structureJointNumbers: List<JointNumber>? = null,
         alignmentName: AlignmentName? = null,
-    ): this(
+    ) : this(
         data = ValidationErrorData(VALIDATION_SWITCH, key, type),
         switchName = switchName,
         switchType = switchType,
@@ -87,8 +96,11 @@ data class AlignmentError(
     val alignmentName: AlignmentName,
     val value: String?,
 ) : ValidationError by data {
-    constructor(key: String, type: ErrorType, alignmentName: AlignmentName, value: String? = null):
-            this(ValidationErrorData(VALIDATION_ALIGNMENT, key, type), alignmentName, value)
+    constructor(key: String, type: ErrorType, alignmentName: AlignmentName, value: CharSequence? = null) : this(
+        ValidationErrorData(VALIDATION_ALIGNMENT, key, type),
+        alignmentName,
+        value?.toString(),
+    )
 }
 
 data class ElementError(
@@ -104,7 +116,7 @@ data class ElementError(
         alignmentName: AlignmentName,
         element: GeometryElement,
         value: String? = null
-    ): this(
+    ) : this(
         data = ValidationErrorData(VALIDATION_ELEMENT, key, type),
         alignmentName = alignmentName,
         elementName = element.name ?: element.oidPart,
@@ -119,8 +131,13 @@ data class ProfileError(
     val viName: PlanElementName,
     val value: String?,
 ) : ValidationError by data {
-    constructor(key: String, type: ErrorType, profileName: PlanElementName, viName: PlanElementName, value: String? = null):
-            this(ValidationErrorData(VALIDATION_PROFILE, key, type), profileName, viName, value)
+    constructor(
+        key: String,
+        type: ErrorType,
+        profileName: PlanElementName,
+        viName: PlanElementName,
+        value: String? = null,
+    ) : this(ValidationErrorData(VALIDATION_PROFILE, key, type), profileName, viName, value)
 }
 
 data class CantError(
@@ -138,16 +155,21 @@ data class KmPostError(
     val kmPostName: PlanElementName,
     val value: String?,
 ) : ValidationError by data {
-    constructor(key: String, type: ErrorType, kmPostName: PlanElementName, value: String? = null):
-            this(ValidationErrorData(VALIDATION_KM_POST, key, type), kmPostName, value)
+    constructor(key: String, type: ErrorType, kmPostName: PlanElementName, value: String? = null) : this(
+        ValidationErrorData(VALIDATION_KM_POST, key, type),
+        kmPostName,
+        value,
+    )
 }
 
 data class CollectionError(
     @JsonIgnore private val data: ValidationErrorData,
     val value: String?,
 ) : ValidationError by data {
-    constructor(key: String, groupingType: String, type: ErrorType, value: String? = null):
-            this(ValidationErrorData(groupingType, key, type), value)
+    constructor(key: String, groupingType: String, type: ErrorType, value: CharSequence? = null) : this(
+        ValidationErrorData(groupingType, key, type),
+        value?.toString(),
+    )
 }
 
 private const val COORDINATE_DELTA = 0.1
@@ -269,7 +291,7 @@ private fun validateKmPostCollection(kmPosts: List<GeometryKmPost>): List<Collec
         },
         validate(firstKmPost != null && firstKmPost.staAhead <= BigDecimal.ZERO) {
             CollectionError("sta-ahead-not-negative", VALIDATION_KM_POST, VALIDATION_ERROR, firstKmPost?.staAhead?.toString())
-        }
+        },
     )
     return generalErrors
 }
@@ -284,14 +306,17 @@ fun validateKmPost(post: GeometryKmPost) = listOfNotNull(
 )
 
 fun validateAlignmentCollection(alignments: List<GeometryAlignment>): List<ValidationError> {
-    val referenceLineAlignments = alignments.filter { alignment -> alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE }
+    val referenceLineAlignments = alignments.filter { alignment ->
+        alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE
+    }
     return listOfNotNull(
         validate(referenceLineAlignments.isNotEmpty()) {
             CollectionError("no-reference-lines", VALIDATION_ALIGNMENT, OBSERVATION_MAJOR)
         },
         validate(referenceLineAlignments.size <= 1) {
             CollectionError("multiple-reference-lines", VALIDATION_ALIGNMENT, VALIDATION_ERROR)
-        })
+        },
+    )
 }
 
 fun validateAlignmentGeometry(alignment: GeometryAlignment): List<ValidationError> {
@@ -341,17 +366,18 @@ fun validateAlignmentCant(alignment: GeometryAlignment): List<ValidationError> {
 
 fun validateAlignment(alignment: GeometryAlignment, featureTypes: List<FeatureType>): List<ValidationError> {
     val typeCode = alignment.featureTypeCode
+    val type = typeCode?.let { c -> featureTypes.find { ft -> ft.code == c } }
+    val typeCodeError = if (typeCode == null) {
+        AlignmentError("no-feature-type", OBSERVATION_MAJOR, alignment.name)
+    } else if (type == null) {
+        AlignmentError("unknown-feature-type", OBSERVATION_MAJOR, alignment.name, typeCode)
+    } else if (type.code !in trackTypeCodes) {
+        AlignmentError("wrong-feature-type", OBSERVATION_MINOR, alignment.name, "${type.code} (${type.description})")
+    } else {
+        null
+    }
     val alignmentErrors = listOfNotNull(
-        validate(typeCode != null) {
-            AlignmentError("no-feature-type", OBSERVATION_MAJOR, alignment.name)
-        },
-        validate(typeCode == null || featureTypes.any { ft -> ft.code == typeCode }) {
-            AlignmentError("unknown-feature-type", OBSERVATION_MAJOR, alignment.name, typeCode?.toString())
-        },
-        // TypeCode 121 is for road center-line. Should use 281 instead for tracks.
-        validate(typeCode == null || typeCode != FeatureTypeCode("121")) {
-            AlignmentError("wrong-feature-type", OBSERVATION_MINOR, alignment.name, value = typeCode?.toString())
-        },
+        typeCodeError,
         validate(alignment.state != null) {
             AlignmentError("no-state", OBSERVATION_MINOR, alignment.name)
         },
@@ -363,7 +389,6 @@ fun validateAlignment(alignment: GeometryAlignment, featureTypes: List<FeatureTy
 }
 
 private fun validateElement(alignmentName: AlignmentName, element: GeometryElement): List<ElementError> {
-
     val lengthDelta = abs(element.length.toDouble() - element.calculatedLength)
     val fieldErrors = listOfNotNull(
         validate(element.length > BigDecimal.ZERO) {
@@ -685,7 +710,6 @@ private fun validateCantPoint(
     )
 }
 
-
 private fun validateCantPointVsPrevious(
     cantName: PlanElementName,
     cantPoint: GeometryCantPoint,
@@ -697,7 +721,6 @@ private fun validateCantPointVsPrevious(
         },
     )
 }
-
 
 fun validateSwitch(
     switch: GeometrySwitch,
@@ -722,13 +745,9 @@ fun validateSwitch(
         },
     )
 
-    val geometryErrors =
-        if (structure != null) validateSwitchGeometry(switch, structure)
-        else listOf()
+    val geometryErrors = structure?.let { s -> validateSwitchGeometry(switch, s) } ?: emptyList()
 
-    val alignmentErrors =
-        if (structure != null) validateSwitchAlignments(switch, structure, alignmentSwitches)
-        else listOf()
+    val alignmentErrors = structure?.let { s -> validateSwitchAlignments(switch, s, alignmentSwitches) } ?: emptyList()
 
     return fieldErrors + geometryErrors + alignmentErrors
 }
@@ -742,11 +761,9 @@ fun validateSwitchGeometry(
         if (joints.size > 1) getSwitchPositionTransformation(switchStructure, joints)
         else null
     return if (positionTransformation == null) {
-        listOfNotNull(
-            validate(joints.size <= 1) {
-                SwitchDefinitionError("location-difference", OBSERVATION_MAJOR, switch.name)
-            }
-        )
+        listOfNotNull(validate(joints.size <= 1) {
+            SwitchDefinitionError("location-difference", OBSERVATION_MAJOR, switch.name)
+        })
     } else {
         val locationPairs = joints.mapNotNull { joint ->
             switchStructure.joints

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -65,7 +65,7 @@ class InfraModelService @Autowired constructor(
             "extraInfo" to extraInfo,
         )
 
-        val geometryPlan = cleanMissingValues(parseInfraModel(file, overrides, extraInfo))
+        val geometryPlan = cleanMissingFeatureTypeCodes(parseInfraModel(file, overrides, extraInfo))
         val transformedBoundingBox = geometryPlan.units.coordinateSystemSrid
             ?.let { planSrid -> coordinateTransformationService.getTransformation(planSrid, LAYOUT_SRID) }
             ?.let { transformation -> getBoundingPolygonPointsFromAlignments(geometryPlan.alignments, transformation) }
@@ -132,7 +132,7 @@ class InfraModelService @Autowired constructor(
         return validateAndTransformToLayoutPlan(geometryPlan)
     }
 
-    private fun cleanMissingValues(plan: GeometryPlan): GeometryPlan {
+    private fun cleanMissingFeatureTypeCodes(plan: GeometryPlan): GeometryPlan {
         val codes = codeDictionaryService.getFeatureTypes().map(FeatureType::code)
         val cleanedAlignments = plan.alignments.map { a ->
             if (a.featureTypeCode != null && a.featureTypeCode !in codes) a.copy(featureTypeCode = null)

--- a/infra/src/main/resources/db/migration/repeatable/R__07.01_feature_type_data.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__07.01_feature_type_data.sql
@@ -1,0 +1,64 @@
+-- Codes from https://wiki.buildingsmart.fi/fi/04_Julkaisut_ja_Standardit/infrabim_nimikkeisto
+create temp table new_feature_type on commit drop as
+with temp(code, description) as (
+    values
+      ('101', 'Mittalinja (tie/katu/vesiväylä)'),
+      ('102', 'Ajoradan mittalinja (moniajorataiset)'),
+      ('103', 'TSV'),
+      ('104', 'Ajoradan keskilinja (suravage)'),
+      ('111', 'Pituusmittausraide'),
+      ('115', 'Väylälinja haraustasossa, vesiväylän mittalinja'),
+      ('116', 'Väylälinjan jatke'),
+      ('117', 'Väylän reunalinja haraustasossa'),
+      ('120', 'Tien reuna'),
+      ('121', 'Keskilinja'),
+      ('122', 'Päällysteen reuna'),
+      ('123', 'Sisäluiskan yläreuna'),
+      ('124', 'Sisäluiskan alareuna'),
+      ('125', 'Ulkoluiskan alareuna'),
+      ('126', 'Ulkoluiskan yläreuna'),
+      ('127', 'Muu pinnan taite'),
+      ('130', 'Reunakivilinja, alareuna'),
+      ('131', 'Reunakivilinja, yläreuna'),
+      ('134', 'Vallin alareuna'),
+      ('135', 'Vallin yläreuna'),
+      ('140', 'Ojan reuna'),
+      ('141', 'Ojan pohja'),
+      ('142', 'Ulkoluiskan taite'),
+      ('150', 'Rakenneluiskan alareuna'),
+      ('151', 'Rakenneluiskan yläreuna'),
+      ('152', 'Rakennekerroksen taite'),
+      ('153', 'Maalaatikon/penkereen kulma'),
+      ('154', 'Palle'),
+      ('155', 'Kaivannon alareuna'),
+      ('156', 'Kaivannon yläreuna'),
+      ('157', 'Rakenneluiskan reuna'),
+      ('158', 'Siirtymäkiila'),
+      ('159', 'Muu rakenne, reuna'),
+      ('192', 'Kallioleikkauksen alareuna'),
+      ('193', 'Kallioleikkauksen yläreuna'),
+      ('194', 'Kallioleikkauksen taite'),
+      ('195', 'Kalliohyllyn ja maaleikkauksen raja'),
+      ('196', 'Kalliokaivannon alareuna'),
+      ('197', 'Kalliokaivannon yläreuna'),
+      ('220', 'Kaide yleensä'),
+      ('280', 'Rautatiekiskon selkä'),
+      ('281', 'Raiteen keskilinja'),
+      ('292', 'Maaliviiva')
+)
+select *
+  from temp;
+
+-- Remove ones that are no longer on the list
+delete
+  from common.feature_type
+  where not exists(select from new_feature_type where new_feature_type.code = feature_type.code);
+
+-- Upsert using 'except' to avoid updating rows that are already identical
+insert into common.feature_type(code, description)
+select *
+  from new_feature_type
+except
+select code, description
+  from common.feature_type
+on conflict (code) do update set description = excluded.description;

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -895,8 +895,8 @@
                 "cant-rotation-point-center": "Kallistuksen mittauspiste (rotationPoint) määritelty keskelle raidetta keskilinjalla {{alignmentName}}",
                 "cant-gauge-invalid": "Ilmoitettu raideleveys \"{{value}}\" keskilinjalla {{alignmentName}} ei vastaa suomen raideleveyttä 1.524",
                 "no-feature-type": "Keskilinjalta {{alignmentName}} puuttuu tyyppikoodi",
-                "unknown-feature-type": "Keskilinjan {{alignmentName}} tyyppikoodi {{value}} ei vastaa raiteilla käytettyjä (111, 281)",
-                "wrong-feature-type": "Keskilinjan {{alignmentName}} tyyppikoodia {{value}} ei pitäisi käyttää raiteilla: keskilinjan koodi on 281",
+                "unknown-feature-type": "Keskilinjan {{alignmentName}} tyyppikoodi {{value}} ei ole tunnettu. Raiteen keskilinjan koodi on 281, pituusmittausraiteen 111.",
+                "wrong-feature-type": "Keskilinjan {{alignmentName}} tyyppikoodia {{value}} ei pitäisi käyttää raiteilla. Raiteen keskilinjan koodi on 281, pituusmittausraiteen 111.",
                 "no-state": "Keskilinjalle {{alignmentName}} ei ole annettu tilatietoa",
                 "multiple-reference-lines": "Suunnitelma sisältää useamman kuin yhden pituusmittauslinjan",
                 "no-reference-lines": "Suunnitelma ei sisällä pituusmittauslinjaa"


### PR DESCRIPTION
Korjattu 500-error joka aiheutui tyyppikoodista jota ei ole kannassa. Oikeastaan korjaus on tehty 2 kertaa, mutta se tuntui järkevältä:
- Päivitetty tunnettujen tyyppikoodien lista kattavammaksi buildingsmartin dokumentaation mukaan -> sisältää tuonkin tiedoston koodin
- Muutettu tallennusta niin että jos koodi on tuntematon, tallennetaan se nullina sen sijaan että heitetään 500 error koska viite on rikki
- Päivitetty muutenkin validointivirheitä feature type codejen ympärillä