### PR TITLE
GVT-2305: Tasakilometripisteen editointidialogi jää "Poisto"-operaation jälkeen näkyviin

### DIFF
--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -353,7 +353,10 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                 <KmPostDeleteConfirmationDialog
                     id={props.kmPostId}
                     onClose={() => setDraftDeleteConfirmationVisible(false)}
-                    onSave={props.onSave}
+                    onSave={() => {
+                        props.kmPostId && props.onSave && props.onSave(props.kmPostId);
+                        props.onClose();
+                    }}
                 />
             )}
         </React.Fragment>

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -28,7 +28,11 @@ import {
 } from 'tool-panel/location-track/dialog/location-track-edit-store';
 import { createDelegatesWithDispatcher } from 'store/store-utils';
 import { Dropdown, Item } from 'vayla-design-lib/dropdown/dropdown';
-import { layoutStates, locationTrackTypes, topologicalConnectivityTypes } from 'utils/enum-localization-utils';
+import {
+    layoutStates,
+    locationTrackTypes,
+    topologicalConnectivityTypes,
+} from 'utils/enum-localization-utils';
 import { Heading, HeadingSize } from 'vayla-design-lib/heading/heading';
 import { FormLayout, FormLayoutColumn } from 'geoviite-design-lib/form-layout/form-layout';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
@@ -131,20 +135,21 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     const locationTrackOwners = useLoader(
         () =>
             getLocationTrackOwners().then((owners) =>
-                owners.sort((a, b) => sortUnknownLocationTrackOwnerAsLast(a.name,b.name))
-            ),[],
+                owners.sort((a, b) => sortUnknownLocationTrackOwnerAsLast(a.name, b.name)),
+            ),
+        [],
     );
 
     function sortUnknownLocationTrackOwnerAsLast(a: string, b: string) {
-        if (b === "Ei tiedossa") {
-            return -1
+        if (b === 'Ei tiedossa') {
+            return -1;
         } else if (a === b) {
-            return 0
+            return 0;
         } else {
             return a < b ? -1 : 1;
         }
     }
-    
+
     const trackWithSameName = useConflictingTrack(
         state.locationTrack.trackNumberId,
         state.locationTrack.name,
@@ -399,7 +404,9 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                             errors={getVisibleErrorsByProp('name')}>
                             {trackWithSameName && (
                                 <>
-                                    <div className={styles['location-track-edit-dialog__alert']}>{t('location-track-dialog.name-in-use')}</div>
+                                    <div className={styles['location-track-edit-dialog__alert']}>
+                                        {t('location-track-dialog.name-in-use')}
+                                    </div>
                                     <Link onClick={() => props.onEditTrack(trackWithSameName.id)}>
                                         {moveToEditLinkText(trackWithSameName)}
                                     </Link>
@@ -682,7 +689,12 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                 <LocationTrackDeleteConfirmationDialog
                     id={state.existingLocationTrack?.id}
                     onClose={() => setDraftDeleteConfirmationVisible(false)}
-                    onSave={props.onSave}
+                    onSave={() => {
+                        props.onSave &&
+                            state.existingLocationTrack &&
+                            props.onSave(state.existingLocationTrack.id);
+                        props.onClose();
+                    }}
                 />
             )}
         </React.Fragment>

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -368,7 +368,9 @@ export const SwitchEditDialog = ({
                             errors={getVisibleErrorsByProp('name')}>
                             {conflictingSwitch && (
                                 <>
-                                    <div className={styles['switch-edit-dialog__alert']}>{t('switch-dialog.name-in-use')}</div>
+                                    <div className={styles['switch-edit-dialog__alert']}>
+                                        {t('switch-dialog.name-in-use')}
+                                    </div>
                                     <Link onClick={() => onEdit(conflictingSwitch.id)}>
                                         {moveToEditLinkText(conflictingSwitch)}
                                     </Link>
@@ -513,7 +515,10 @@ export const SwitchEditDialog = ({
             {showDeleteDraftConfirmDialog && switchId && (
                 <SwitchDeleteConfirmationDialog
                     switchId={switchId}
-                    onSave={handleOnDelete}
+                    onSave={() => {
+                        handleOnDelete();
+                        onClose();
+                    }}
                     onClose={() => setShowDeleteDraftConfirmDialog(false)}
                 />
             )}

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -396,7 +396,10 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
                     changesBeingReverted={deletingDraft}
                     changeTimes={getChangeTimes()}
                     onClose={closeDraftDeleteConfirmation}
-                    onSave={onSave}
+                    onSave={() => {
+                        inEditTrackNumber && onSave && onSave(inEditTrackNumber.id);
+                        onClose();
+                    }}
                 />
             )}
         </React.Fragment>


### PR DESCRIPTION
Tämä sama toistui kaikilla muillakin assettityypeillä, joten korjattu kaikkialle. Korjaus on sinällään todella simppeli (suljetaan dialogi aina manuaalisesti tallentamisen jälkeen.) Meni pitkään keksiä että miksi suorat poistot toimivat mutta navigoinnin jälkeiset eivät, mutta vastauksena tähän oli se, että aiemmin poistettava asset on aina ollut valittuna, poiston läpimenon seurauksena ka. asset on samalla myös unselectattu, assetin infoboksi on kadonnut näkyvistä assetin unselectauksen myötä, ja poistodialogi on ollut Reactin komponenttipuussa infoboksin lapsena. Navigoiduissa poistoissa valintaan ei kosketa, joten dialogia ei voi sulkea tuolla tavalla.