### PR TITLE
GVT-2233 Use actual placeholder, +auto-select input text on focus in Dropdown

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EDropdown.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EDropdown.kt
@@ -31,9 +31,9 @@ class E2EDropdownList : E2EList<E2EDropdownListItem>(CONTAINER_BY, By.className(
 
 class E2EDropdown(dropdownBy: By) : E2EViewFragment(dropdownBy) {
 
-    private val valueBy: By = By.className("dropdown__current-value")
+    private val inputBy: By = By.tagName("input")
 
-    private val input: E2ETextInput = childTextInput(By.tagName("input"))
+    private val input: E2ETextInput = childTextInput(inputBy)
 
     private val optionsList: E2EDropdownList by lazy {
         E2EDropdownList()
@@ -41,9 +41,7 @@ class E2EDropdown(dropdownBy: By) : E2EViewFragment(dropdownBy) {
 
     val options: List<E2EDropdownListItem> get() = optionsList.items
 
-    val value: String get() = childText(valueBy)
-
-    val qaIdValue: String? get() = childElement(valueBy).getAttribute("qa-id")
+    val value: String get() = input.value
 
     fun open(): E2EDropdown = apply {
         logger.info("Open dropdown")
@@ -102,17 +100,6 @@ class E2EDropdown(dropdownBy: By) : E2EViewFragment(dropdownBy) {
     fun clearSearch(): E2EDropdown = apply {
         logger.info("Clear dropdown input")
 
-        val currentValueHolder = childElement(valueBy)
-
-        if (!currentValueHolder.isDisplayed) {
-            input.clear()
-        }
-    }
-
-    fun waitForValue(): E2EDropdown = apply {
-        logger.info("Wait for dropdown value")
-
-        waitUntilTextExists(childBy(valueBy))
-
+        input.clear()
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanelDialog.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanelDialog.kt
@@ -96,7 +96,7 @@ class E2ELocationTrackEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy)
     fun save() = waitUntilClosed {
         logger.info("Save location track changes")
 
-        val isDeleted = stateDropdown.qaIdValue == State.DELETED.name
+        val isDeleted = stateDropdown.value == "Poistettu"
         clickPrimaryButton()
 
         if (isDeleted) {
@@ -149,7 +149,7 @@ class E2ETrackNumberEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy) {
     fun save() = waitUntilClosed {
         logger.info("Save track number changes")
 
-        val isDeleted = stateDropdown.qaIdValue == E2ELocationTrackEditDialog.State.DELETED.name
+        val isDeleted = stateDropdown.value == "Poistettu"
         clickButton(byQaId("save-track-number-changes"))
 
         if (isDeleted) {
@@ -224,7 +224,7 @@ class E2ELayoutSwitchEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy) 
     fun save() = waitUntilClosed {
         logger.info("Save switch changes")
 
-        val isNotExisting = stateDropdown.qaIdValue == StateCategory.NOT_EXISTING.name
+        val isNotExisting = stateDropdown.value == "Poistunut kohde"
         clickButton(byQaId("save-switch-changes"))
 
         if (isNotExisting) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/LocationTrackDialogTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/LocationTrackDialogTestUI.kt
@@ -18,18 +18,14 @@ class LocationTrackDialogTestUI @Autowired constructor() : SeleniumTest() {
         val firstLoad = page.toolBar.createNewLocationTrack()
         assertEquals(
             "Väylävirasto",
-            firstLoad.ownerDropdown.waitForValue().value
+            firstLoad.ownerDropdown.value
         )
 
         firstLoad.cancel()
 
         assertEquals(
             "Väylävirasto",
-            page
-                .toolBar.createNewLocationTrack()
-                .ownerDropdown
-                .waitForValue()
-                .value
+            page.toolBar.createNewLocationTrack().ownerDropdown.value
         )
     }
 }

--- a/ui/src/vayla-design-lib/dropdown/dropdown.scss
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.scss
@@ -136,22 +136,6 @@ $dropdown-border-error: 2px;
     width: 100%;
 }
 
-.dropdown__current-value {
-    display: flex;
-    align-items: center;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 3px;
-    right: 0;
-
-    > * {
-        flex: 1;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-}
-
 .dropdown__icon {
     margin-left: 4px;
     padding-top: 10px;

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -104,13 +104,12 @@ export const Dropdown = function <TItemValue>({
             : loadedOptions;
     const filteredOptions = getFilteredOptions();
 
-    const selectedName = props.value
-        ? (props.getName && props.getName(props.value)) ||
-          options?.find((item) => item.value == props.value)?.name ||
-          ''
-        : props.placeholder;
-
-    const selectedQaId = options?.find((i) => i.value == props.value)?.qaId;
+    const selectedName =
+        (props.value !== undefined && props.getName !== undefined
+            ? props.getName(props.value)
+            : undefined) ??
+        options?.find((item) => item.value === props.value)?.name ??
+        '';
 
     function setHasFocus(value: boolean) {
         if (hasFocus && !value) {
@@ -123,6 +122,7 @@ export const Dropdown = function <TItemValue>({
 
     function focusInput() {
         inputRef.current?.focus();
+        inputRef.current?.select();
     }
 
     function openList() {
@@ -324,14 +324,10 @@ export const Dropdown = function <TItemValue>({
                         onKeyPress={handleInputKeyPress}
                         onKeyDown={handleInputKeyDown}
                         disabled={props.disabled}
-                        value={searchTerm}
+                        value={searchTerm || selectedName}
                         onChange={(e) => handleInputChange(e.target.value)}
+                        placeholder={props.placeholder}
                     />
-                    {!searchTerm && (
-                        <div className={styles['dropdown__current-value']} qa-id={selectedQaId}>
-                            <span>{selectedName}</span>
-                        </div>
-                    )}
                 </div>
                 <div className={styles['dropdown__icon']}>
                     {searchable && optionsIsFunc ? (


### PR DESCRIPTION
Isohko yksinkertaistus Dropdownin toimintaan.

Peruskäytössä ei tapahdu käyttäjille mitään muutosta: Käyttäjä vaan valitsee dropdownin ja alkaa kirjoittaa hakuehtoa. Visuaalinen ero on, sen kokoinen, että siinä, missä ennen aiempi valinta jäi kenttään ikään kuin placeholderina (mutta ei oikeana placeholderina) kun käyttäjä fokusoi kentän, nyt fokusointi maalaa automaattisesti tekstisisällön.

Samoin varsinainen placeholder kentässä nyt on ihan oikeasti inputin placeholder, tämä näkyy esim. toolbarin "Hae..."-tekstinä.

Muutoksen myötä tosin ei jäänyt oikein selkeää hyvää paikkaa esittää valitun arvon qa-id:tä suljetussa kentässä. Päätin tähän hätään, että en lähde keksimällä keksimään tuotantokoodissa paikkoja DOMiin tällaisille vain testien tarvitsemille arvoille, vaan jos ei ola selvää hyvää paikkaa niille, niin käytetään vaan käyttäjän näkemiä nimiä.