### PR TITLE
GVT-2231 Order track numbers by number whenever listed

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -42,6 +42,7 @@ class LayoutTrackNumberDao(
             where :publication_state = any(publication_states)
               and (:number::varchar is null or :number = number)
               and (:include_deleted = true or state != 'DELETED')
+            order by number
         """.trimIndent()
         val params = mapOf(
             "publication_state" to publicationState.name,


### PR DESCRIPTION
En enää muista, miksi en käyttänyt pullarissa https://github.com/finnishtransportagency/geoviite/pull/879 sitä vaihtoehtoa, että sorttaa nyt nuo ratanumerot vaan tietokannassa. Perffivaikutuskaan ei voi olla muuta kuin vainoharhaa, sorttaukseen menevä aikahan on aivan epäoleellista verrattuna kaikkeen muuhun, mitä track_number_publication_viewin näyttämisessä muutenkin tehdään.

Käyttöpaikkapohjaiseksi en tuota haluaisi, minusta on kohtuullista että ratanumeroilla on oletuksena järkevä järjestys.