### PR TITLE
GVT-2285: Korjauksia

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -334,7 +334,7 @@ data class TrackLayoutSwitchJointConnection(
 
 data class DraftableChangeInfo(
     val created: Instant,
-    val changed: Instant,
+    val changed: Instant?,
 )
 
 data class TrackNumberAndChangeTime(

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -93,9 +93,7 @@ export type ElementLocation = {
 
 export type DraftableChangeInfo = {
     created: TimeStamp;
-    changed: TimeStamp;
-    officialChanged?: TimeStamp;
-    draftChanged?: TimeStamp;
+    changed: TimeStamp | undefined;
 };
 
 export type Message = string;

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -191,7 +191,10 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                             />
                             <InfoboxField
                                 label={t('tool-panel.changed')}
-                                value={formatDateShort(kmPostCreatedAndChangedTime.changed)}
+                                value={
+                                    kmPostCreatedAndChangedTime.changed &&
+                                    formatDateShort(kmPostCreatedAndChangedTime.changed)
+                                }
                             />
                         </React.Fragment>
                     )}

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -532,7 +532,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                         <InfoboxField
                             qaId="location-track-changed-date"
                             label={t('tool-panel.changed')}
-                            value={formatDateShort(changeTimes.changed)}
+                            value={changeTimes.changed && formatDateShort(changeTimes.changed)}
                         />
                         {officialLocationTrack === undefined && (
                             <InfoboxButtons>

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -354,7 +354,10 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                             />
                             <InfoboxField
                                 label={t('tool-panel.changed')}
-                                value={formatDateShort(switchChangeTimes.changed)}
+                                value={
+                                    switchChangeTimes.changed &&
+                                    formatDateShort(switchChangeTimes.changed)
+                                }
                             />
                         </React.Fragment>
                     )}


### PR DESCRIPTION
Täällä toteutettu Jyrkin mainitsemat review-korjaukset muutosaikojen haku-SQL:ään ja sen lisäksi mahdollistettu `changed`-arvon nullaantuminen. Autoformatterin otin pois päältä, mutta en lähtenyt uudelleenformatoimaan aiemmin autoformatoituneita kohtia.