### PR TITLE
GVT-2285: Vielä yksi korjaus

### DIFF
--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -49,11 +49,9 @@ import {
 import { getKmPost, getKmPostChangeTimes, getKmPosts } from 'track-layout/layout-km-post-api';
 import { PVDocumentHeader, PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { getPVDocument } from 'infra-model/infra-model-api';
-import { getChangeTimes } from 'common/change-time-api';
+import { getChangeTimes, updateAllChangeTimes } from 'common/change-time-api';
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import {
-    updateReferenceLineChangeTime,
-    updateTrackNumberChangeTime,
     updateKmPostChangeTime,
     updateSwitchChangeTime,
     updateLocationTrackChangeTime,
@@ -338,14 +336,12 @@ export function refreshTrackNumberSelection(
     onUnselect: (items: OptionalUnselectableItemCollections) => void,
 ): (id: LayoutTrackNumberId) => void {
     return (id) => {
-        Promise.all([updateTrackNumberChangeTime(), updateReferenceLineChangeTime()]).then(
-            ([ts, _]) => {
-                getTrackNumberById(id, publicationState, ts).then((tn) => {
-                    if (tn) onSelect({ trackNumbers: [id] });
-                    else onUnselect({ trackNumbers: [id] });
-                });
-            },
-        );
+        Promise.all([updateAllChangeTimes()]).then(([changeTimes]) => {
+            getTrackNumberById(id, publicationState, changeTimes.layoutTrackNumber).then((tn) => {
+                if (tn) onSelect({ trackNumbers: [id] });
+                else onUnselect({ trackNumbers: [id] });
+            });
+        });
     };
 }
 


### PR DESCRIPTION
Päivitetään kaikki changetimet, sillä jos selection päivitetään sen vuoksi että ratanumero poistettiin, niin sen mukana on saattanut kadota muunkintyyppisiä assetteja. Ilman tätä ne jäisivät elämään frontille seuraavaan automaattipäivitykseen saakka.