### PR TITLE
GVT-2307: Suunnitelman toolpanelista puuttuu käännösavain

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -345,7 +345,7 @@
         "geometry-plan": {
             "general-title": "Suunnitelman perustiedot",
             "quality-title": "Laatutiedot",
-            "remarks": "Huomiot",
+            "observations": "Huomiot",
             "author": "Yritys",
             "project": "Projekti",
             "file": "Tiedosto",

--- a/ui/src/tool-panel/geometry-plan-infobox.tsx
+++ b/ui/src/tool-panel/geometry-plan-infobox.tsx
@@ -80,7 +80,7 @@ const GeometryPlanInfobox: React.FC<GeometryPlanInfoboxProps> = ({
             <InfoboxContent>
                 <InfoboxField
                     qaId="geometry-plan-remarks"
-                    label={t('tool-panel.geometry-plan.message')}
+                    label={t('tool-panel.geometry-plan.observations')}
                     value={planHeader.message}
                 />
                 <InfoboxField


### PR DESCRIPTION
Lienee kääntynyt epähuomiossa julkaisulokijuttujen yhteydessä, koska siellä huomioista puhutaan remarkkeina. Kannassahan kenttä on tuo entinen `message`, mutta nykyisellään sille keksisi varmaan paljon parempiakin nimiä. InfraModel-näkymässä huomioista puhuttiin observationseina, joten päädyin muuttamaan nämäkin sille nimelle.