### PR TITLE
GVT-2303: Splitatun raiteen badge piirtyy väärin splitin jälkeen

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -501,6 +501,7 @@ class LocationTrackService(
             "publishType" to publishType,
         )
         return get(publishType, locationTrackId)?.let { locationTrack ->
+            val alignment = locationTrack.alignmentVersion?.let(alignmentDao::fetch)
             val switches = getSwitchesForLocationTrack(locationTrackId, publishType)
                 .mapNotNull { switchDao.fetchVersion(it, publishType) }
                 .map { switchDao.fetch(it) }
@@ -516,7 +517,8 @@ class LocationTrackService(
                     val address = geocodingService
                         .getGeocodingContext(publishType, locationTrack.trackNumberId)
                         ?.getAddressAndM(location)
-                    SwitchOnLocationTrack(switch.id as IntId, switch.name, address?.address, location, address?.m)
+                    val mAlongAlignment = alignment?.getClosestPointM(location)?.first
+                    SwitchOnLocationTrack(switch.id as IntId, switch.name, address?.address, location, mAlongAlignment)
                 }
 
             val duplicateTracks = getLocationTrackDuplicates(locationTrackId, publishType).mapNotNull { duplicate ->


### PR DESCRIPTION
Ongelma juontui siitä, että splittauksessa vaihteiden m-arvot laskettiin ratanumeron alusta eikä raiteen alusta. Koko muu splittausmaailma pelaa sillä oletuksella, että m-arvot ovat raiteen alusta.