### PR TITLE
GVT-2269 (part 2): Modify styling, simplify usage of navigable track meter component

### DIFF
--- a/ui/src/geoviite-design-lib/track-meter/navigable-track-meter.tsx
+++ b/ui/src/geoviite-design-lib/track-meter/navigable-track-meter.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import TrackMeter from 'geoviite-design-lib/track-meter/track-meter';
+import { TrackMeter as TrackMeterValue } from 'common/common-model';
+import { Point } from 'model/geometry';
+import {
+    calculateBoundingBoxToShowAroundLocation,
+    MAP_POINT_DEFAULT_BBOX_OFFSET,
+} from 'map/map-utils';
+import { createDelegates } from 'store/store-utils';
+import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
+
+type TrackMeterProps = {
+    trackMeter?: TrackMeterValue;
+    location?: Point;
+    placeholder?: string;
+    mapNavigationBboxOffset?: number;
+    displayDecimals?: boolean;
+};
+
+const NavigableTrackMeter: React.FC<TrackMeterProps> = ({
+    trackMeter,
+    location,
+    placeholder,
+    mapNavigationBboxOffset = MAP_POINT_DEFAULT_BBOX_OFFSET,
+    displayDecimals,
+}: TrackMeterProps) => {
+    const delegates = React.useMemo(() => createDelegates(trackLayoutActionCreators), []);
+
+    return (
+        <TrackMeter
+            onClickAction={() =>
+                location &&
+                delegates.showArea(
+                    calculateBoundingBoxToShowAroundLocation(location, mapNavigationBboxOffset),
+                )
+            }
+            trackMeter={trackMeter}
+            displayDecimals={displayDecimals}
+            placeholder={placeholder}
+        />
+    );
+};
+
+export default NavigableTrackMeter;

--- a/ui/src/geoviite-design-lib/track-meter/track-meter.scss
+++ b/ui/src/geoviite-design-lib/track-meter/track-meter.scss
@@ -1,7 +1,12 @@
 @use 'vayla-design-lib' as vayla-design;
 
+.track-meter-value-container {
+    display: inline-flex;
+    align-items: center;
+}
+
 .position-pin-container {
+    display: flex;
     cursor: pointer;
-    margin: 0 2px;
-    padding: 4px;
+    padding: 0 4px;
 }

--- a/ui/src/geoviite-design-lib/track-meter/track-meter.tsx
+++ b/ui/src/geoviite-design-lib/track-meter/track-meter.tsx
@@ -25,7 +25,7 @@ const TrackMeter: React.FC<TrackMeterProps> = ({
         : placeholder;
 
     return onClickAction ? (
-        <span>
+        <span className={styles['track-meter-value-container']}>
             {displayedValue}
             <a className={styles['position-pin-container']} onClick={onClickAction}>
                 <Icons.PositionPin size={IconSize.SMALL} />

--- a/ui/src/map/map-utils.ts
+++ b/ui/src/map/map-utils.ts
@@ -4,7 +4,7 @@ import TileGrid from 'ol/tilegrid/TileGrid';
 import { BoundingBox, Point } from 'model/geometry';
 
 // offset used for defining a suitable boundingBox around a single location (Point)
-const MAP_POINT_DEFAULT_BBOX_OFFSET = 178;
+export const MAP_POINT_DEFAULT_BBOX_OFFSET = 178;
 export const MAP_POINT_CLOSEUP_BBOX_OFFSET = 78;
 
 // Resolutions to use to load stuff from backend

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -9,12 +9,7 @@ import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/tr
 import { LayoutTrackNumberId, LocationTrackId } from 'track-layout/track-layout-model';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import { useTrackLayoutAppSelector } from 'store/hooks';
-import { BoundingBox } from 'model/geometry';
-import TrackMeter from 'geoviite-design-lib/track-meter/track-meter';
-import {
-    calculateBoundingBoxToShowAroundLocation,
-    MAP_POINT_CLOSEUP_BBOX_OFFSET,
-} from 'map/map-utils';
+import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
 
 type HighlightedItemBase = {
     startM: number;
@@ -38,12 +33,11 @@ type AlignmentPlanSectionInfoboxContentProps = {
     onHighlightItem: (item: HighlightedAlignment | undefined) => void;
     id: LocationTrackId | LayoutTrackNumberId;
     type: 'LOCATION_TRACK' | 'REFERENCE_LINE';
-    showArea: (boundingBox: BoundingBox) => void;
 };
 
 export const AlignmentPlanSectionInfoboxContent: React.FC<
     AlignmentPlanSectionInfoboxContentProps
-> = ({ sections, type, id, onHighlightItem, showArea }) => {
+> = ({ sections, type, id, onHighlightItem }) => {
     const { t } = useTranslation();
 
     const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
@@ -156,18 +150,10 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
                             <div className={styles['alignment-plan-section-infobox__meters']}>
                                 <span>
                                     {section.start ? (
-                                        <TrackMeter
-                                            onClickAction={() =>
-                                                section?.start?.location &&
-                                                showArea(
-                                                    calculateBoundingBoxToShowAroundLocation(
-                                                        section.start.location,
-                                                        MAP_POINT_CLOSEUP_BBOX_OFFSET,
-                                                    ),
-                                                )
-                                            }
+                                        <NavigableTrackMeter
+                                            trackMeter={section?.start?.address}
+                                            location={section?.start?.location}
                                             displayDecimals={false}
-                                            trackMeter={section.start.address}
                                         />
                                     ) : (
                                         errorFragment(
@@ -179,18 +165,10 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
                                 </span>{' '}
                                 <span>
                                     {section.end ? (
-                                        <TrackMeter
-                                            onClickAction={() =>
-                                                section?.end?.location &&
-                                                showArea(
-                                                    calculateBoundingBoxToShowAroundLocation(
-                                                        section.end.location,
-                                                        MAP_POINT_CLOSEUP_BBOX_OFFSET,
-                                                    ),
-                                                )
-                                            }
+                                        <NavigableTrackMeter
+                                            trackMeter={section?.end?.address}
+                                            location={section?.end?.location}
                                             displayDecimals={false}
-                                            trackMeter={section.end.address}
                                         />
                                     ) : (
                                         errorFragment(

--- a/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
@@ -17,7 +17,6 @@ import {
     ProgressIndicatorType,
     ProgressIndicatorWrapper,
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
-import { BoundingBox } from 'model/geometry';
 
 type LocationTrackGeometryInfoboxProps = {
     publishType: PublishType;
@@ -26,7 +25,6 @@ type LocationTrackGeometryInfoboxProps = {
     contentVisible: boolean;
     onContentVisibilityChange: () => void;
     onHighlightItem: (item: HighlightedAlignment | undefined) => void;
-    showArea: (boundingBox: BoundingBox) => void;
 };
 
 export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfoboxProps> = ({
@@ -36,7 +34,6 @@ export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfobox
     contentVisible,
     onContentVisibilityChange,
     onHighlightItem,
-    showArea,
 }) => {
     const { t } = useTranslation();
     const [useBoundingBox, setUseBoundingBox] = React.useState(true);
@@ -82,7 +79,6 @@ export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfobox
                             id={locationTrackId}
                             sections={sections || []}
                             onHighlightItem={onHighlightItem}
-                            showArea={showArea}
                             type={'LOCATION_TRACK'}
                         />
                     )}

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -29,7 +29,6 @@ import { LocationTrackEditDialogContainer } from 'tool-panel/location-track/dial
 import { BoundingBox } from 'model/geometry';
 import 'i18n/config';
 import { useTranslation } from 'react-i18next';
-import TrackMeter from 'geoviite-design-lib/track-meter/track-meter';
 import LayoutState from 'geoviite-design-lib/layout-state/layout-state';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
 import { LocationTrackOwnerId, PublishType, TimeStamp } from 'common/common-model';
@@ -66,7 +65,7 @@ import { createDelegates } from 'store/store-utils';
 import { LocationTrackSplittingInfoboxContainer } from 'tool-panel/location-track/splitting/location-track-splitting-infobox';
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { getLocationTrackOwners } from 'common/common-api';
-import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
+import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
 
 type LocationTrackInfoboxProps = {
     locationTrack: LayoutLocationTrack;
@@ -334,7 +333,6 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     allowedSwitches={splittingState.allowedSwitches}
                     duplicateLocationTracks={extraInfo?.duplicates || []}
                     updateSplit={delegates.updateSplit}
-                    showArea={showArea}
                 />
             )}
             {startAndEndPoints && coordinateSystem && (
@@ -352,16 +350,9 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                     qaId="location-track-start-track-meter"
                                     label={t('tool-panel.location-track.start-location')}>
                                     {startAndEndPoints?.start?.address ? (
-                                        <TrackMeter
-                                            onClickAction={() =>
-                                                startAndEndPoints?.start &&
-                                                showArea(
-                                                    calculateBoundingBoxToShowAroundLocation(
-                                                        startAndEndPoints.start.point,
-                                                    ),
-                                                )
-                                            }
-                                            trackMeter={startAndEndPoints.start.address}
+                                        <NavigableTrackMeter
+                                            trackMeter={startAndEndPoints?.start?.address}
+                                            location={startAndEndPoints?.start?.point}
                                         />
                                     ) : (
                                         t('tool-panel.location-track.unset')
@@ -371,16 +362,9 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                     qaId="location-track-end-track-meter"
                                     label={t('tool-panel.location-track.end-location')}>
                                     {startAndEndPoints?.end?.address ? (
-                                        <TrackMeter
-                                            onClickAction={() =>
-                                                startAndEndPoints.end &&
-                                                showArea(
-                                                    calculateBoundingBoxToShowAroundLocation(
-                                                        startAndEndPoints.end.point,
-                                                    ),
-                                                )
-                                            }
-                                            trackMeter={startAndEndPoints.end.address}
+                                        <NavigableTrackMeter
+                                            trackMeter={startAndEndPoints?.end?.address}
+                                            location={startAndEndPoints?.end?.point}
                                         />
                                     ) : (
                                         t('tool-panel.location-track.unset')
@@ -520,7 +504,6 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 locationTrackId={locationTrack.id}
                 viewport={viewport}
                 onHighlightItem={onHighlightItem}
-                showArea={showArea}
             />
             <LocationTrackVerticalGeometryInfobox
                 contentVisible={visibilities.verticalGeometry}

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -5,7 +5,6 @@ import { getChangeTimes } from 'common/change-time-api';
 import { ValidationError } from 'utils/validation-utils';
 import styles from 'tool-panel/location-track/location-track-infobox.scss';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
-import TrackMeter from 'geoviite-design-lib/track-meter/track-meter';
 import { TextField } from 'vayla-design-lib/text-field/text-field';
 import { createClassName } from 'vayla-design-lib/utils';
 import InfoboxText from 'tool-panel/infobox/infobox-text';
@@ -18,14 +17,10 @@ import {
     LocationTrackId,
 } from 'track-layout/track-layout-model';
 import { InitialSplit, Split } from 'tool-panel/location-track/split-store';
-import { BoundingBox } from 'model/geometry';
-import {
-    calculateBoundingBoxToShowAroundLocation,
-    MAP_POINT_CLOSEUP_BBOX_OFFSET,
-} from 'map/map-utils';
+import { MAP_POINT_CLOSEUP_BBOX_OFFSET } from 'map/map-utils';
+import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
 
 type EndpointProps = {
-    showArea: (boundingBox: BoundingBox) => void;
     addressPoint: AddressPoint | undefined;
 };
 
@@ -39,26 +34,16 @@ type SplitProps = EndpointProps & {
     descriptionErrors: ValidationError<Split>[];
 };
 
-export const LocationTrackSplittingEndpoint: React.FC<EndpointProps> = ({
-    addressPoint,
-    showArea,
-}) => {
+export const LocationTrackSplittingEndpoint: React.FC<EndpointProps> = ({ addressPoint }) => {
     const { t } = useTranslation();
     return (
         <div className={styles['location-track-infobox__split-container']}>
             <div className={styles['location-track-infobox__split-item-ball']} />
             <InfoboxField label={t('tool-panel.location-track.splitting.end-address')}>
-                <TrackMeter
+                <NavigableTrackMeter
                     trackMeter={addressPoint?.address}
-                    onClickAction={() =>
-                        addressPoint?.point &&
-                        showArea(
-                            calculateBoundingBoxToShowAroundLocation(
-                                addressPoint.point,
-                                MAP_POINT_CLOSEUP_BBOX_OFFSET,
-                            ),
-                        )
-                    }
+                    location={addressPoint?.point}
+                    mapNavigationBboxOffset={MAP_POINT_CLOSEUP_BBOX_OFFSET}
                 />
             </InfoboxField>
         </div>
@@ -74,7 +59,6 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
     nameErrors,
     descriptionErrors,
     duplicateLocationTracks = [],
-    showArea,
 }) => {
     const { t } = useTranslation();
     const switchId = 'switchId' in split ? split.switchId : undefined;
@@ -104,17 +88,10 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                                 ? t('tool-panel.location-track.splitting.split-address')
                                 : t('tool-panel.location-track.splitting.start-address')
                         }>
-                        <TrackMeter
-                            onClickAction={() =>
-                                addressPoint?.point &&
-                                showArea(
-                                    calculateBoundingBoxToShowAroundLocation(
-                                        addressPoint.point,
-                                        MAP_POINT_CLOSEUP_BBOX_OFFSET,
-                                    ),
-                                )
-                            }
+                        <NavigableTrackMeter
                             trackMeter={addressPoint?.address}
+                            location={addressPoint?.point}
+                            mapNavigationBboxOffset={MAP_POINT_CLOSEUP_BBOX_OFFSET}
                         />
                     </InfoboxField>
                     <InfoboxField

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -32,7 +32,6 @@ import {
     LocationTrackSplittingEndpoint,
 } from 'tool-panel/location-track/splitting/location-track-split';
 import { filterNotEmpty } from 'utils/array-utils';
-import { BoundingBox } from 'model/geometry';
 import {
     validateLocationTrackDescriptionBase,
     validateLocationTrackName,
@@ -49,7 +48,6 @@ type LocationTrackSplittingInfoboxContainerProps = {
     locationTrackId: string;
     cancelSplitting: () => void;
     updateSplit: (updatedSplit: Split | InitialSplit) => void;
-    showArea: (boundingBox: BoundingBox) => void;
 };
 
 type LocationTrackSplittingInfoboxProps = {
@@ -65,7 +63,6 @@ type LocationTrackSplittingInfoboxProps = {
     startAndEnd: AlignmentStartAndEnd;
     cancelSplitting: () => void;
     updateSplit: (updatedSplit: Split | InitialSplit) => void;
-    showArea: (boundingBox: BoundingBox) => void;
 };
 
 const validateSplitName = (
@@ -121,7 +118,6 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
     removeSplit,
     cancelSplitting,
     updateSplit,
-    showArea,
 }) => {
     const locationTrack = useLocationTrack(locationTrackId, 'DRAFT');
     const [startAndEnd, _] = useLocationTrackStartAndEnd(locationTrackId, 'DRAFT');
@@ -148,7 +144,6 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
                 startAndEnd={startAndEnd}
                 conflictingLocationTracks={conflictingTracks?.map((t) => t.name) || []}
                 locationTrack={locationTrack}
-                showArea={showArea}
             />
         )
     );
@@ -167,7 +162,6 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
     startAndEnd,
     conflictingLocationTracks,
     locationTrack,
-    showArea,
 }) => {
     const { t } = useTranslation();
     const getSplitAddressPoint = (split: Split): AddressPoint | undefined => {
@@ -224,7 +218,6 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                             duplicateOf={initialSplit.duplicateOf}
                             nameErrors={initialSplitValidated.nameErrors}
                             descriptionErrors={initialSplitValidated.descriptionErrors}
-                            showArea={showArea}
                         />
                         {splitsValidated.map(({ split, nameErrors, descriptionErrors }) => {
                             return (
@@ -238,14 +231,10 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                                     duplicateOf={split.duplicateOf}
                                     nameErrors={nameErrors}
                                     descriptionErrors={descriptionErrors}
-                                    showArea={showArea}
                                 />
                             );
                         })}
-                        <LocationTrackSplittingEndpoint
-                            addressPoint={startAndEnd.end}
-                            showArea={showArea}
-                        />
+                        <LocationTrackSplittingEndpoint addressPoint={startAndEnd.end} />
                         {splits.length === 0 && (
                             <InfoboxContentSpread>
                                 <MessageBox>

--- a/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
@@ -3,35 +3,24 @@ import styles from './switch-infobox.scss';
 import { SwitchJointTrackMeter } from 'track-layout/track-layout-model';
 import { JointNumber } from 'common/common-model';
 import { LocationTrackLink } from 'tool-panel/location-track/location-track-link';
-import TrackMeter from 'geoviite-design-lib/track-meter/track-meter';
 import { groupBy } from 'utils/array-utils';
 import { useTranslation } from 'react-i18next';
 import { switchJointNumberToString } from 'utils/enum-localization-utils';
 import { ShowMoreButton } from 'show-more-button/show-more-button';
-import { BoundingBox } from 'model/geometry';
-import {
-    calculateBoundingBoxToShowAroundLocation,
-    MAP_POINT_CLOSEUP_BBOX_OFFSET,
-} from 'map/map-utils';
+import { MAP_POINT_CLOSEUP_BBOX_OFFSET } from 'map/map-utils';
+import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
 
 const formatJointTrackMeter = (
     jointTrackMeter: SwitchJointTrackMeter,
     addressPlaceHolder: string,
-    showArea: (area: BoundingBox) => void,
 ) => {
     return (
         <span>
             {jointTrackMeter.trackMeter && (
-                <TrackMeter
-                    onClickAction={() =>
-                        showArea(
-                            calculateBoundingBoxToShowAroundLocation(
-                                jointTrackMeter.location,
-                                MAP_POINT_CLOSEUP_BBOX_OFFSET,
-                            ),
-                        )
-                    }
+                <NavigableTrackMeter
                     trackMeter={jointTrackMeter.trackMeter}
+                    location={jointTrackMeter.location}
+                    mapNavigationBboxOffset={MAP_POINT_CLOSEUP_BBOX_OFFSET}
                     placeholder={addressPlaceHolder}
                 />
             )}
@@ -47,13 +36,11 @@ const formatJointTrackMeter = (
 export type SwitchInfoboxTrackMetersProps = {
     jointTrackMeters: SwitchJointTrackMeter[];
     presentationJoint?: JointNumber;
-    showArea: (area: BoundingBox) => void;
 };
 
 export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> = ({
     jointTrackMeters,
     presentationJoint,
-    showArea,
 }: SwitchInfoboxTrackMetersProps) => {
     const { t } = useTranslation();
 
@@ -82,7 +69,7 @@ export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> =
                         <li
                             key={pja.locationTrackId}
                             className={styles['switch-infobox-track-meters__track-meter']}>
-                            {formatJointTrackMeter(pja, addressMissingText, showArea)}
+                            {formatJointTrackMeter(pja, addressMissingText)}
                         </li>
                     ))}
                 </ol>
@@ -104,7 +91,7 @@ export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> =
                                         className={
                                             styles['switch-infobox-track-meters__track-meter']
                                         }>
-                                        {formatJointTrackMeter(a, addressMissingText, showArea)}
+                                        {formatJointTrackMeter(a, addressMissingText)}
                                     </li>
                                 ))}
                             </ol>

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -212,7 +212,6 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                             value={
                                 (switchJointTrackMeters && (
                                     <SwitchInfoboxTrackMeters
-                                        showArea={showArea}
                                         jointTrackMeters={switchJointTrackMeters}
                                         presentationJoint={structure?.presentationJointNumber}
                                     />

--- a/ui/src/tool-panel/track-number/alignment-plan-section-infobox.scss
+++ b/ui/src/tool-panel/track-number/alignment-plan-section-infobox.scss
@@ -29,5 +29,4 @@
     grid-template-columns: repeat(2, 50%);
     grid-column-gap: 6px;
     width: 100%;
-    cursor: pointer;
 }

--- a/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
@@ -17,7 +17,6 @@ import {
     ProgressIndicatorWrapper,
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
 import { getTrackNumberReferenceLineSectionsByPlan } from 'track-layout/layout-track-number-api';
-import { BoundingBox } from 'model/geometry';
 
 type TrackNumberGeometryInfoboxProps = {
     publishType: PublishType;
@@ -27,7 +26,6 @@ type TrackNumberGeometryInfoboxProps = {
     onContentVisibilityChange: () => void;
     onHighlightItem: (item: HighlightedAlignment | undefined) => void;
     changeTime: TimeStamp;
-    showArea: (boundingBox: BoundingBox) => void;
 };
 
 export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProps> = ({
@@ -38,7 +36,6 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
     onContentVisibilityChange,
     onHighlightItem,
     changeTime,
-    showArea,
 }) => {
     const { t } = useTranslation();
     const [useBoundingBox, setUseBoundingBox] = React.useState(true);
@@ -85,7 +82,6 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
                             sections={sections || []}
                             onHighlightItem={onHighlightItem}
                             type={'REFERENCE_LINE'}
-                            showArea={showArea}
                         />
                     )}
                 </ProgressIndicatorWrapper>

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -24,7 +24,6 @@ import { PublishType } from 'common/common-model';
 import { LinkingAlignment, LinkingState, LinkingType, LinkInterval } from 'linking/linking-model';
 import { BoundingBox } from 'model/geometry';
 import { updateReferenceLineGeometry } from 'linking/linking-api';
-import TrackMeter from 'geoviite-design-lib/track-meter/track-meter';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Precision, roundToPrecision } from 'utils/rounding';
@@ -43,7 +42,7 @@ import { ChangeTimes } from 'common/common-slice';
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import { ChangesBeingReverted } from 'preview/preview-view';
 import { onRequestDeleteTrackNumber } from 'tool-panel/track-number/track-number-deletion';
-import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
+import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
 
 type TrackNumberInfoboxProps = {
     trackNumber: LayoutTrackNumber;
@@ -187,16 +186,9 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                             qaId="track-number-start-track-meter"
                             label={t('tool-panel.reference-line.start-location')}
                             value={
-                                <TrackMeter
-                                    onClickAction={() =>
-                                        startAndEndPoints?.start &&
-                                        showArea(
-                                            calculateBoundingBoxToShowAroundLocation(
-                                                startAndEndPoints.start.point,
-                                            ),
-                                        )
-                                    }
+                                <NavigableTrackMeter
                                     trackMeter={startAndEndPoints?.start?.address}
+                                    location={startAndEndPoints?.start?.point}
                                 />
                             }
                             onEdit={() => setShowEditDialog(true)}
@@ -206,16 +198,9 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                             qaId="track-number-end-track-meter"
                             label={t('tool-panel.reference-line.end-location')}
                             value={
-                                <TrackMeter
-                                    onClickAction={() =>
-                                        startAndEndPoints?.end &&
-                                        showArea(
-                                            calculateBoundingBoxToShowAroundLocation(
-                                                startAndEndPoints.end.point,
-                                            ),
-                                        )
-                                    }
+                                <NavigableTrackMeter
                                     trackMeter={startAndEndPoints?.end?.address}
+                                    location={startAndEndPoints?.end?.point}
                                 />
                             }
                         />
@@ -323,7 +308,6 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                     viewport={viewport}
                     onHighlightItem={onHighlightItem}
                     changeTime={trackNumberChangeTime}
-                    showArea={showArea}
                 />
             )}
             {trackNumber.draftType !== 'NEW_DRAFT' && (


### PR DESCRIPTION
* A new navigable track meter component, which is basically just a container for the actual track meter component was created to reduce the amount of noise in usage places. 
* As an additional refactor, the passing of showArea was also removed to the usage places of the NavigableTrackMeter component for now, as the NavigableTrackMeter-component is now also responsible for getting the reference of the delegated showArea method. This also reduces code noise.
* The pin icon vertical alignment was modified to be more inline with the actual track address text.
* As an additional fix, the cursor style used in the plan listing of a given location track or reference line in the tool panel was modified from pointer to default as it was displayed on top of values that were not actually links or buttons of any kind.