### PR TITLE
GVT-2317 Separate authority browser from consultants and deny browser access to csv downloads

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/Privileges.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/Privileges.kt
@@ -1,5 +1,7 @@
 package fi.fta.geoviite.infra.authorization
 
-const val AUTH_ALL_READ = "hasAuthority('all-read')"
+const val AUTH_ALL_READ = "hasAuthority('ui-read')"
 const val AUTH_ALL_WRITE = "hasAuthority('all-write')"
-const val AUTH_IM_DOWNLOAD = "hasAuthority('im-download')"
+const val AUTH_INFRAMODEL_DOWNLOAD = "hasAuthority('inframodel-download')"
+const val AUTH_DATAPRODUCT_DOWNLOAD = "hasAuthority('dataproduct-download')"
+const val AUTH_PUBLICATION_DOWNLOAD = "hasAuthority('publication-download')"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.geometry
 
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
+import fi.fta.geoviite.infra.authorization.AUTH_DATAPRODUCT_DOWNLOAD
 import fi.fta.geoviite.infra.common.IndexedId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType
@@ -171,7 +172,7 @@ class GeometryController @Autowired constructor(
         return geometryService.getElementListing(id, elementTypes)
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_DATAPRODUCT_DOWNLOAD)
     @GetMapping("/plans/{id}/element-listing/file")
     fun getPlanElementListingCsv(
         @PathVariable("id") id: IntId<GeometryPlan>,
@@ -196,7 +197,7 @@ class GeometryController @Autowired constructor(
         return geometryService.getElementListing(id, elementTypes, startAddress, endAddress)
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_DATAPRODUCT_DOWNLOAD)
     @GetMapping("/layout/location-tracks/{id}/element-listing/file")
     fun getTrackElementListingCSV(
         @PathVariable("id") id: IntId<LocationTrack>,
@@ -211,7 +212,7 @@ class GeometryController @Autowired constructor(
         return toFileDownloadResponse(filename.withSuffix(CSV), content.toByteArray(Charsets.UTF_8))
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_DATAPRODUCT_DOWNLOAD)
     @GetMapping("/rail-network/element-listing/file")
     fun getEntireNetworkElementListingCSV(): ResponseEntity<ByteArray> {
         log.apiCall("getPlanElementListCsv")
@@ -234,7 +235,7 @@ class GeometryController @Autowired constructor(
         return geometryService.getVerticalGeometryListing(id)
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_DATAPRODUCT_DOWNLOAD)
     @GetMapping("/plans/{id}/vertical-geometry/file")
     fun getTrackVerticalGeometryListingCsv(
         @PathVariable("id") id: IntId<GeometryPlan>,
@@ -257,7 +258,7 @@ class GeometryController @Autowired constructor(
         return geometryService.getVerticalGeometryListing(publicationType, id, startAddress, endAddress)
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_DATAPRODUCT_DOWNLOAD)
     @GetMapping("/layout/location-tracks/{id}/vertical-geometry/file")
     fun getTrackVerticalGeometryListingCsv(
         @PathVariable("id") id: IntId<LocationTrack>,
@@ -271,7 +272,7 @@ class GeometryController @Autowired constructor(
         return toFileDownloadResponse(filename.withSuffix(CSV), content)
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_DATAPRODUCT_DOWNLOAD)
     @GetMapping("/rail-network/vertical-geometry/file")
     fun getEntireNetworkVerticalGeometryListingCSV(): ResponseEntity<ByteArray> {
         log.apiCall("getEntireNetworkVerticalGeometryListingCSV")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
@@ -2,7 +2,7 @@ package fi.fta.geoviite.infra.inframodel
 
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
-import fi.fta.geoviite.infra.authorization.AUTH_IM_DOWNLOAD
+import fi.fta.geoviite.infra.authorization.AUTH_INFRAMODEL_DOWNLOAD
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geometry.GeometryPlan
@@ -100,7 +100,7 @@ class InfraModelController @Autowired constructor(
         return geometryService.getPlanLinkedItems(planId)
     }
 
-    @PreAuthorize(AUTH_IM_DOWNLOAD)
+    @PreAuthorize(AUTH_INFRAMODEL_DOWNLOAD)
     @GetMapping("{id}/file", MediaType.APPLICATION_OCTET_STREAM_VALUE)
     fun downloadFile(@PathVariable("id") id: IntId<GeometryPlan>): ResponseEntity<ByteArray> {
         logger.apiCall("downloadFile", "id" to id)
@@ -164,7 +164,7 @@ class InfraModelController @Autowired constructor(
         return pvDocumentService.importPVDocument(documentId, overrides, extraInfo)
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_INFRAMODEL_DOWNLOAD)
     @GetMapping("/projektivelho/{documentId}", MediaType.APPLICATION_OCTET_STREAM_VALUE)
     fun downloadPVDocument(@PathVariable("documentId") documentId: IntId<PVDocument>): ResponseEntity<ByteArray> {
         logger.apiCall("downloadPVDocument", "documentId" to documentId)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
+import fi.fta.geoviite.infra.authorization.AUTH_PUBLICATION_DOWNLOAD
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.error.PublicationFailureException
 import fi.fta.geoviite.infra.integration.CalculatedChanges
@@ -123,7 +124,7 @@ class PublicationController @Autowired constructor(
         )
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_PUBLICATION_DOWNLOAD)
     @GetMapping("csv")
     fun getPublicationsAsCsv(
         @RequestParam("from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
+import fi.fta.geoviite.infra.authorization.AUTH_DATAPRODUCT_DOWNLOAD
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.PublishType
@@ -13,7 +14,6 @@ import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.publication.ValidatedAsset
 import fi.fta.geoviite.infra.publication.getCsvResponseEntity
 import fi.fta.geoviite.infra.util.FileName
-import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.toResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -115,7 +115,7 @@ class LayoutTrackNumberController(
         return trackNumberService.getKmLengths(publishType, id) ?: emptyList()
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_DATAPRODUCT_DOWNLOAD)
     @GetMapping("/{publishType}/{id}/km-lengths/as-csv")
     fun getTrackNumberKmLengthsAsCsv(
         @PathVariable("publishType") publishType: PublishType,
@@ -141,7 +141,7 @@ class LayoutTrackNumberController(
         return getCsvResponseEntity(csv, fileName)
     }
 
-    @PreAuthorize(AUTH_ALL_READ)
+    @PreAuthorize(AUTH_DATAPRODUCT_DOWNLOAD)
     @GetMapping("/rail-network/km-lengths/file")
     fun getEntireRailNetworkKmLengthsAsCsv(
         @RequestParam(name = "lang", defaultValue = "fi") lang: String,

--- a/infra/src/main/resources/db/migration/repeatable/R__01_role_data.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__01_role_data.sql
@@ -3,7 +3,9 @@ create temp table new_role on commit drop as
 with temp(code, name, user_group) as (
     values
       ('operator', 'Operaattori', 'geoviite_operaattori'),
-      ('browser', 'Selaaja', 'geoviite_selaaja')
+      ('browser', 'Selaaja', 'geoviite_selaaja'), -- Deprecated: remove when users are updated in AD to "official"
+      ('ftia-user', 'Virastokäyttäjä', 'geoviite_virasto'),
+      ('consultant', 'Konsultti', 'geoviite_konsultti')
 )
 select *
   from temp;
@@ -11,9 +13,11 @@ select *
 create temp table new_privilege on commit drop as
 with temp(code, name, description) as (
     values
-      ('all-read', 'Lukuoikeus', 'Oikeus tarkastella kaikkia geoviitteen tietoja'),
-      ('all-write', 'Kirjoitusoikeus', 'Oikeus muokata kaikkia geoviitteen tietoja'),
-      ('im-download', 'InfraModel latausoikeus', 'Oikeus ladata geoviitteestä InfraModel-tiedostoja')
+      ('ui-read', 'Lukuoikeus', 'Oikeus tarkastella Geoviitteen tietoja käyttöliittymältä'),
+      ('all-write', 'Kirjoitusoikeus', 'Oikeus muokata kaikkia Geoviitteen tietoja'),
+      ('inframodel-download', 'InfraModel latausoikeus', 'Oikeus ladata Geoviitteestä InfraModel-tiedostoja'),
+      ('dataproduct-download', 'Tietotuotteiden latausoikeus', 'Oikeus ladata Geoviitteestä CSV-muotoisia tietotuote-tiedostoja'),
+      ('publication-download', 'Julkaisulokin latausoikeus', 'Oikeus ladata Geoviitteen julkaisuloki CSV-muodossa')
 )
 select *
   from temp;
@@ -21,10 +25,15 @@ select *
 create temp table new_role_privilege on commit drop as
 with temp(role_code, privilege_code) as (
     values
-      ('browser', 'all-read'),
-      ('operator', 'all-read'),
+      ('browser', 'ui-read'),
+      ('browser', 'publication-download'),
+      ('ftia-user', 'ui-read'),
+      ('ftia-user', 'publication-download'),
+      ('operator', 'ui-read'),
       ('operator', 'all-write'),
-      ('operator', 'im-download')
+      ('operator', 'inframodel-download'),
+      ('operator', 'dataproduct-download'),
+      ('operator', 'publication-download')
 )
 select *
   from temp;

--- a/infra/src/main/resources/db/migration/repeatable/R__01_role_data.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__01_role_data.sql
@@ -4,7 +4,7 @@ with temp(code, name, user_group) as (
     values
       ('operator', 'Operaattori', 'geoviite_operaattori'),
       ('browser', 'Selaaja', 'geoviite_selaaja'), -- Deprecated: remove when users are updated in AD to "official"
-      ('ftia-user', 'Virastokäyttäjä', 'geoviite_virasto'),
+      ('authority', 'Virastokäyttäjä', 'geoviite_virasto'),
       ('consultant', 'Konsultti', 'geoviite_konsultti')
 )
 select *
@@ -27,8 +27,8 @@ with temp(role_code, privilege_code) as (
     values
       ('browser', 'ui-read'),
       ('browser', 'publication-download'),
-      ('ftia-user', 'ui-read'),
-      ('ftia-user', 'publication-download'),
+      ('authority', 'ui-read'),
+      ('authority', 'publication-download'),
       ('operator', 'ui-read'),
       ('operator', 'all-write'),
       ('operator', 'inframodel-download'),

--- a/ui/src/data-products/element-list/element-list-view.tsx
+++ b/ui/src/data-products/element-list/element-list-view.tsx
@@ -9,6 +9,7 @@ import ElementTable from 'data-products/element-list/element-table';
 import { useDataProductsAppSelector } from 'store/hooks';
 import { dataProductsActions, SelectedGeometrySearch } from 'data-products/data-products-slice';
 import { EntireRailNetworkElementListing } from 'data-products/element-list/entire-rail-network-element-listing';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 const ElementListView = () => {
     const { t } = useTranslation();
@@ -38,12 +39,14 @@ const ElementListView = () => {
                             checked={state.selectedSearch === 'PLAN'}>
                             {t('data-products.element-list.plan-geometry')}
                         </Radio>
-                        <Radio
-                            qaId={'select-entire-rail-network'}
-                            onChange={() => handleRadioClick('ENTIRE_RAIL_NETWORK')}
-                            checked={state.selectedSearch === 'ENTIRE_RAIL_NETWORK'}>
-                            {t('data-products.element-list.entire-rail-network-geometry')}
-                        </Radio>
+                        <PrivilegeRequired privilege="dataproduct-download">
+                            <Radio
+                                qaId={'select-entire-rail-network'}
+                                onChange={() => handleRadioClick('ENTIRE_RAIL_NETWORK')}
+                                checked={state.selectedSearch === 'ENTIRE_RAIL_NETWORK'}>
+                                {t('data-products.element-list.entire-rail-network-geometry')}
+                            </Radio>
+                        </PrivilegeRequired>
                     </span>
                 </div>
                 {state.selectedSearch === 'LOCATION_TRACK' && (

--- a/ui/src/data-products/element-list/entire-rail-network-element-listing.tsx
+++ b/ui/src/data-products/element-list/entire-rail-network-element-listing.tsx
@@ -4,6 +4,7 @@ import styles from 'data-products/data-product-view.scss';
 import { getEntireRailNetworkElementsCsvUrl } from 'geometry/geometry-api';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Button } from 'vayla-design-lib/button/button';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 export const EntireRailNetworkElementListing = () => {
     const { t } = useTranslation();
@@ -16,15 +17,19 @@ export const EntireRailNetworkElementListing = () => {
             <p className={styles['data-product__search-legend']}>
                 {t('data-products.element-list.entire-rail-network-length-warning')}
             </p>
-            <div className={styles['data-products__search']}>
-                <a qa-id={'element-list-csv-download'} href={getEntireRailNetworkElementsCsvUrl()}>
-                    <Button
-                        className={`${styles['element-list__download-button--left-aligned']} ${styles['element-list__download-button']}`}
-                        icon={Icons.Download}>
-                        {t(`data-products.search.download-csv`)}
-                    </Button>
-                </a>
-            </div>
+            <PrivilegeRequired privilege="dataproduct-download">
+                <div className={styles['data-products__search']}>
+                    <a
+                        qa-id={'element-list-csv-download'}
+                        href={getEntireRailNetworkElementsCsvUrl()}>
+                        <Button
+                            className={`${styles['element-list__download-button--left-aligned']} ${styles['element-list__download-button']}`}
+                            icon={Icons.Download}>
+                            {t(`data-products.search.download-csv`)}
+                        </Button>
+                    </a>
+                </div>
+            </PrivilegeRequired>
         </React.Fragment>
     );
 };

--- a/ui/src/data-products/element-list/location-track-element-listing-search.tsx
+++ b/ui/src/data-products/element-list/location-track-element-listing-search.tsx
@@ -25,6 +25,7 @@ import {
     validTrackMeterOrUndefined,
 } from 'data-products/data-products-slice';
 import { getLocationTrackDescriptions } from 'track-layout/layout-location-track-api';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 type LocationTrackElementListingSearchProps = {
     state: ElementListContinuousGeometrySearchState;
@@ -221,27 +222,29 @@ const LocationTrackElementListingSearch = ({
                         ).map((error) => t(`data-products.search.${error}`))}
                     />
                 </div>
-                <a
-                    qa-id={'location-track-element-list-csv-download'}
-                    {...(state.searchParameters.locationTrack && {
-                        href: getLocationTrackElementsCsv(
-                            state.searchParameters.locationTrack?.id,
-                            selectedElementTypes(state.searchParameters.searchGeometries),
-                            validTrackMeterOrUndefined(state.searchParameters.startTrackMeter),
-                            validTrackMeterOrUndefined(state.searchParameters.endTrackMeter),
-                        ),
-                    })}>
-                    <Button
-                        className={styles['element-list__download-button']}
-                        disabled={
-                            !state.elements ||
-                            state.elements.length === 0 ||
-                            state.searchParameters.locationTrack === undefined
-                        }
-                        icon={Icons.Download}>
-                        {t(`data-products.search.download-csv`)}
-                    </Button>
-                </a>
+                <PrivilegeRequired privilege="dataproduct-download">
+                    <a
+                        qa-id={'location-track-element-list-csv-download'}
+                        {...(state.searchParameters.locationTrack && {
+                            href: getLocationTrackElementsCsv(
+                                state.searchParameters.locationTrack?.id,
+                                selectedElementTypes(state.searchParameters.searchGeometries),
+                                validTrackMeterOrUndefined(state.searchParameters.startTrackMeter),
+                                validTrackMeterOrUndefined(state.searchParameters.endTrackMeter),
+                            ),
+                        })}>
+                        <Button
+                            className={styles['element-list__download-button']}
+                            disabled={
+                                !state.elements ||
+                                state.elements.length === 0 ||
+                                state.searchParameters.locationTrack === undefined
+                            }
+                            icon={Icons.Download}>
+                            {t(`data-products.search.download-csv`)}
+                        </Button>
+                    </a>
+                </PrivilegeRequired>
             </div>
         </React.Fragment>
     );

--- a/ui/src/data-products/element-list/plan-geometry-element-listing-search.tsx
+++ b/ui/src/data-products/element-list/plan-geometry-element-listing-search.tsx
@@ -19,6 +19,7 @@ import {
     getVisibleErrorsByProp,
 } from 'data-products/data-products-utils';
 import { PlanGeometrySearchState, selectedElementTypes } from 'data-products/data-products-slice';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 type PlanGeometryElementListingSearchProps = {
     state: PlanGeometrySearchState;
@@ -167,21 +168,23 @@ const PlanGeometryElementListingSearch = ({
                         ).map((error) => t(`data-products.search.${error}`))}
                     />
                 </div>
-                <a
-                    qa-id={'plan-element-list-csv-download'}
-                    {...(state.plan && {
-                        href: getGeometryPlanElementsCsv(
-                            state.plan?.id,
-                            selectedElementTypes(state.searchGeometries),
-                        ),
-                    })}>
-                    <Button
-                        className={styles['element-list__download-button']}
-                        disabled={!state.elements || state.elements.length === 0}
-                        icon={Icons.Download}>
-                        {t(`data-products.search.download-csv`)}
-                    </Button>
-                </a>
+                <PrivilegeRequired privilege="dataproduct-download">
+                    <a
+                        qa-id={'plan-element-list-csv-download'}
+                        {...(state.plan && {
+                            href: getGeometryPlanElementsCsv(
+                                state.plan?.id,
+                                selectedElementTypes(state.searchGeometries),
+                            ),
+                        })}>
+                        <Button
+                            className={styles['element-list__download-button']}
+                            disabled={!state.elements || state.elements.length === 0}
+                            icon={Icons.Download}>
+                            {t(`data-products.search.download-csv`)}
+                        </Button>
+                    </a>
+                </PrivilegeRequired>
             </div>
         </React.Fragment>
     );

--- a/ui/src/data-products/kilometer-lengths/entire-rail-network-km-lengths-listing.tsx
+++ b/ui/src/data-products/kilometer-lengths/entire-rail-network-km-lengths-listing.tsx
@@ -4,6 +4,7 @@ import styles from 'data-products/data-product-view.scss';
 import { Button } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { getEntireRailNetworkKmLengthsCsvUrl } from 'track-layout/layout-km-post-api';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 export const EntireRailNetworkKmLengthsListing = () => {
     const { t } = useTranslation();
@@ -13,15 +14,19 @@ export const EntireRailNetworkKmLengthsListing = () => {
             <p className={styles['data-product__search-legend']}>
                 {t('data-products.km-lengths.legend')}
             </p>
-            <div className={styles['data-products__search']}>
-                <a qa-id="km-lengths-csv-download" href={getEntireRailNetworkKmLengthsCsvUrl()}>
-                    <Button
-                        className={styles['vertical-geometry-list__download-button--left-aligned']}
-                        icon={Icons.Download}>
-                        {t(`data-products.search.download-csv`)}
-                    </Button>
-                </a>
-            </div>
+            <PrivilegeRequired privilege="dataproduct-download">
+                <div className={styles['data-products__search']}>
+                    <a qa-id="km-lengths-csv-download" href={getEntireRailNetworkKmLengthsCsvUrl()}>
+                        <Button
+                            className={
+                                styles['vertical-geometry-list__download-button--left-aligned']
+                            }
+                            icon={Icons.Download}>
+                            {t(`data-products.search.download-csv`)}
+                        </Button>
+                    </a>
+                </div>
+            </PrivilegeRequired>
         </React.Fragment>
     );
 };

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
@@ -16,6 +16,7 @@ import {
 } from 'track-layout/layout-km-post-api';
 import { getVisibleErrorsByProp } from 'data-products/data-products-utils';
 import { KmLengthsSearchState } from 'data-products/data-products-slice';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 type KilometerLengthsSearchProps = {
     state: KmLengthsSearchState;
@@ -128,23 +129,25 @@ export const KilometerLengthsSearch: React.FC<KilometerLengthsSearchProps> = ({
                         'endKm',
                     ).map((error) => t(`data-products.search.${error}`))}
                 />
-                <a
-                    qa-id="km-lengths-csv-download"
-                    {...(state.trackNumber && {
-                        href: getKmLengthsAsCsv(
-                            'OFFICIAL',
-                            state.trackNumber?.id,
-                            state.startKm,
-                            state.endKm,
-                        ),
-                    })}>
-                    <Button
-                        className={styles['element-list__download-button']}
-                        disabled={!state.kmLengths || state.kmLengths.length === 0}
-                        icon={Icons.Download}>
-                        {t(`data-products.search.download-csv`)}
-                    </Button>
-                </a>
+                <PrivilegeRequired privilege="dataproduct-download">
+                    <a
+                        qa-id="km-lengths-csv-download"
+                        {...(state.trackNumber && {
+                            href: getKmLengthsAsCsv(
+                                'OFFICIAL',
+                                state.trackNumber?.id,
+                                state.startKm,
+                                state.endKm,
+                            ),
+                        })}>
+                        <Button
+                            className={styles['element-list__download-button']}
+                            disabled={!state.kmLengths || state.kmLengths.length === 0}
+                            icon={Icons.Download}>
+                            {t(`data-products.search.download-csv`)}
+                        </Button>
+                    </a>
+                </PrivilegeRequired>
             </div>
         </React.Fragment>
     );

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
@@ -10,6 +10,7 @@ import { LayoutKmLengthDetails } from 'track-layout/track-layout-model';
 import { dataProductsActions, SelectedKmLengthsSearch } from 'data-products/data-products-slice';
 import { Radio } from 'vayla-design-lib/radio/radio';
 import { EntireRailNetworkKmLengthsListing } from 'data-products/kilometer-lengths/entire-rail-network-km-lengths-listing';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 export const KilometerLengthsView = () => {
     const dataProductsDelegates = React.useMemo(() => createDelegates(dataProductsActions), []);
@@ -42,12 +43,14 @@ export const KilometerLengthsView = () => {
                             checked={state.selectedSearch === 'TRACK_NUMBER'}>
                             {t('data-products.km-lengths.track-number-km-lengths')}
                         </Radio>
-                        <Radio
-                            qaId="select-entire-rail-network"
-                            onChange={() => handleRadioClick('ENTIRE_RAIL_NETWORK')}
-                            checked={state.selectedSearch === 'ENTIRE_RAIL_NETWORK'}>
-                            {t('data-products.km-lengths.entire-rail-network-km-lengths')}
-                        </Radio>
+                        <PrivilegeRequired privilege="dataproduct-download">
+                            <Radio
+                                qaId="select-entire-rail-network"
+                                onChange={() => handleRadioClick('ENTIRE_RAIL_NETWORK')}
+                                checked={state.selectedSearch === 'ENTIRE_RAIL_NETWORK'}>
+                                {t('data-products.km-lengths.entire-rail-network-km-lengths')}
+                            </Radio>
+                        </PrivilegeRequired>
                     </span>
                 </div>
                 {state.selectedSearch === 'TRACK_NUMBER' && (

--- a/ui/src/data-products/vertical-geometry/entire-rail-network-vertical-geometry-listing.tsx
+++ b/ui/src/data-products/vertical-geometry/entire-rail-network-vertical-geometry-listing.tsx
@@ -4,6 +4,7 @@ import styles from 'data-products/data-product-view.scss';
 import { Button } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { getEntireRailNetworkVerticalGeometryCsvUrl } from 'geometry/geometry-api';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 export const EntireRailNetworkVerticalGeometryListing = () => {
     const { t } = useTranslation();
@@ -16,17 +17,21 @@ export const EntireRailNetworkVerticalGeometryListing = () => {
             <p className={styles['data-product__search-legend']}>
                 {t('data-products.vertical-geometry.entire-rail-network-length-warning')}
             </p>
-            <div className={styles['data-products__search']}>
-                <a
-                    href={getEntireRailNetworkVerticalGeometryCsvUrl()}
-                    qa-id="vertical-geometry-csv-download">
-                    <Button
-                        className={styles['vertical-geometry-list__download-button--left-aligned']}
-                        icon={Icons.Download}>
-                        {t(`data-products.search.download-csv`)}
-                    </Button>
-                </a>
-            </div>
+            <PrivilegeRequired privilege="dataproduct-download">
+                <div className={styles['data-products__search']}>
+                    <a
+                        href={getEntireRailNetworkVerticalGeometryCsvUrl()}
+                        qa-id="vertical-geometry-csv-download">
+                        <Button
+                            className={
+                                styles['vertical-geometry-list__download-button--left-aligned']
+                            }
+                            icon={Icons.Download}>
+                            {t(`data-products.search.download-csv`)}
+                        </Button>
+                    </a>
+                </div>
+            </PrivilegeRequired>
         </React.Fragment>
     );
 };

--- a/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
+++ b/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
@@ -26,6 +26,7 @@ import {
     validTrackMeterOrUndefined,
 } from 'data-products/data-products-slice';
 import { getLocationTrackDescriptions } from 'track-layout/layout-location-track-api';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 type LocationTrackVerticalGeometrySearchProps = {
     state: LocationTrackVerticalGeometrySearchState;
@@ -161,22 +162,26 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
                         'endTrackMeter',
                     ).map((error) => t(`data-products.search.${error}`))}
                 />
-                <a
-                    qa-id="vertical-geometry-csv-download"
-                    {...(state.searchParameters.locationTrack && {
-                        href: getLocationTrackVerticalGeometryCsv(
-                            state.searchParameters.locationTrack?.id,
-                            validTrackMeterOrUndefined(state.searchParameters.startTrackMeter),
-                            validTrackMeterOrUndefined(state.searchParameters.endTrackMeter),
-                        ),
-                    })}>
-                    <Button
-                        className={styles['element-list__download-button']}
-                        disabled={!state.verticalGeometry || state.verticalGeometry.length === 0}
-                        icon={Icons.Download}>
-                        {t(`data-products.search.download-csv`)}
-                    </Button>
-                </a>
+                <PrivilegeRequired privilege="dataproduct-download">
+                    <a
+                        qa-id="vertical-geometry-csv-download"
+                        {...(state.searchParameters.locationTrack && {
+                            href: getLocationTrackVerticalGeometryCsv(
+                                state.searchParameters.locationTrack?.id,
+                                validTrackMeterOrUndefined(state.searchParameters.startTrackMeter),
+                                validTrackMeterOrUndefined(state.searchParameters.endTrackMeter),
+                            ),
+                        })}>
+                        <Button
+                            className={styles['element-list__download-button']}
+                            disabled={
+                                !state.verticalGeometry || state.verticalGeometry.length === 0
+                            }
+                            icon={Icons.Download}>
+                            {t(`data-products.search.download-csv`)}
+                        </Button>
+                    </a>
+                </PrivilegeRequired>
             </div>
         </React.Fragment>
     );

--- a/ui/src/data-products/vertical-geometry/plan-vertical-geometry-search.tsx
+++ b/ui/src/data-products/vertical-geometry/plan-vertical-geometry-search.tsx
@@ -20,6 +20,7 @@ import {
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Button } from 'vayla-design-lib/button/button';
 import { PlanVerticalGeometrySearchState } from 'data-products/data-products-slice';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 type PlanVerticalGeometrySearchProps = {
     state: PlanVerticalGeometrySearchState;
@@ -111,18 +112,22 @@ export const PlanVerticalGeometrySearch: React.FC<PlanVerticalGeometrySearchProp
                         }
                     />
                 </div>
-                <a
-                    qa-id="vertical-geometry-csv-download"
-                    {...(state.plan && {
-                        href: getGeometryPlanVerticalGeometryCsv(state.plan?.id),
-                    })}>
-                    <Button
-                        className={styles['element-list__download-button']}
-                        disabled={!state.verticalGeometry || state.verticalGeometry.length === 0}
-                        icon={Icons.Download}>
-                        {t(`data-products.search.download-csv`)}
-                    </Button>
-                </a>
+                <PrivilegeRequired privilege="dataproduct-download">
+                    <a
+                        qa-id="vertical-geometry-csv-download"
+                        {...(state.plan && {
+                            href: getGeometryPlanVerticalGeometryCsv(state.plan?.id),
+                        })}>
+                        <Button
+                            className={styles['element-list__download-button']}
+                            disabled={
+                                !state.verticalGeometry || state.verticalGeometry.length === 0
+                            }
+                            icon={Icons.Download}>
+                            {t(`data-products.search.download-csv`)}
+                        </Button>
+                    </a>
+                </PrivilegeRequired>
             </div>
         </React.Fragment>
     );

--- a/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
+++ b/ui/src/data-products/vertical-geometry/vertical-geometry-view.tsx
@@ -9,6 +9,7 @@ import { createDelegates } from 'store/store-utils';
 import VerticalGeometryTable from 'data-products/vertical-geometry/vertical-geometry-table';
 import { dataProductsActions, SelectedGeometrySearch } from 'data-products/data-products-slice';
 import { EntireRailNetworkVerticalGeometryListing } from 'data-products/vertical-geometry/entire-rail-network-vertical-geometry-listing';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 const VerticalGeometryView = () => {
     const dataProductsDelegates = React.useMemo(() => createDelegates(dataProductsActions), []);
@@ -39,14 +40,16 @@ const VerticalGeometryView = () => {
                             qaId="select-plan-geometry">
                             {t('data-products.vertical-geometry.plan-vertical-geometry')}
                         </Radio>
-                        <Radio
-                            onChange={() => handleRadioClick('ENTIRE_RAIL_NETWORK')}
-                            checked={state.selectedSearch === 'ENTIRE_RAIL_NETWORK'}
-                            qaId="select-entire-rail-network">
-                            {t(
-                                'data-products.vertical-geometry.entire-rail-network-vertical-geometry',
-                            )}
-                        </Radio>
+                        <PrivilegeRequired privilege="dataproduct-download">
+                            <Radio
+                                onChange={() => handleRadioClick('ENTIRE_RAIL_NETWORK')}
+                                checked={state.selectedSearch === 'ENTIRE_RAIL_NETWORK'}
+                                qaId="select-entire-rail-network">
+                                {t(
+                                    'data-products.vertical-geometry.entire-rail-network-vertical-geometry',
+                                )}
+                            </Radio>
+                        </PrivilegeRequired>
                     </span>
                 </div>
                 {state.selectedSearch === 'LOCATION_TRACK' && (

--- a/ui/src/infra-model/list/infra-model-search-result.tsx
+++ b/ui/src/infra-model/list/infra-model-search-result.tsx
@@ -329,7 +329,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                                         <td>{linkingSummaryDate(plan.id)}</td>
                                         <td>{linkingSummaryUsers(plan.id)}</td>
                                         <td onClick={(e) => e.stopPropagation()}>
-                                            <PrivilegeRequired privilege="im-download">
+                                            <PrivilegeRequired privilege="inframodel-download">
                                                 <Button
                                                     title={t('im-form.download-file')}
                                                     onClick={() => downloadPlan(plan)}

--- a/ui/src/infra-model/projektivelho/pv-file-list.tsx
+++ b/ui/src/infra-model/projektivelho/pv-file-list.tsx
@@ -19,7 +19,6 @@ import { updatePVDocumentsChangeTime } from 'common/change-time-api';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { Oid, TimeStamp } from 'common/common-model';
-import { Link } from 'vayla-design-lib/link/link';
 import { WriteAccessRequired } from 'user/write-access-required';
 import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
 import {
@@ -32,6 +31,7 @@ import { getSortDirectionIcon, SortDirection } from 'utils/table-utils';
 import { Menu } from 'vayla-design-lib/menu/menu';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { PVRedirectLink } from 'infra-model/projektivelho/pv-redirect-link';
+import { PrivilegedLink } from 'user/privileged-link';
 
 type ListMode = 'SUGGESTED' | 'REJECTED';
 
@@ -408,11 +408,12 @@ const PVFileListRow = ({
                 </td>
                 <td>{item.project && item.project.name}</td>
                 <td>
-                    <Link
+                    <PrivilegedLink
+                        privilege="inframodel-download"
                         className={styles['projektivelho-file-list__link']}
                         href={projektivelhoDocumentDownloadUri(item.document.id)}>
                         {item.document.name}
-                    </Link>
+                    </PrivilegedLink>
                 </td>
                 <td>{item.document.description}</td>
                 <td>{formatDateFull(item.document.modified)}</td>

--- a/ui/src/infra-model/tabs/infra-model-tabs.tsx
+++ b/ui/src/infra-model/tabs/infra-model-tabs.tsx
@@ -11,6 +11,7 @@ import { useLoader } from 'utils/react-utils';
 import { getPVDocumentCount } from 'infra-model/infra-model-api';
 import { getGeometryPlanHeadersBySearchTerms } from 'geometry/geometry-api';
 import { createDelegates } from 'store/store-utils';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 export type TabsProps = {
     activeTab: InfraModelTabType;
@@ -68,22 +69,24 @@ const InfraModelTabs: React.FC<TabsProps> = ({ activeTab }) => {
                     activeTab={activeTab}
                     exclamationPointVisible={false}
                 />
-                <InfraModelTabNavItem
-                    title={t('im-form.tabs.projektivelho-files-waiting', {
-                        number: documentCounts?.suggested,
-                    })}
-                    tabId={InfraModelTabType.WAITING}
-                    activeTab={activeTab}
-                    exclamationPointVisible={!!documentCounts && documentCounts?.suggested > 0}
-                />
-                <InfraModelTabNavItem
-                    title={t('im-form.tabs.projektivelho-files-rejected', {
-                        number: documentCounts?.rejected,
-                    })}
-                    tabId={InfraModelTabType.REJECTED}
-                    activeTab={activeTab}
-                    exclamationPointVisible={false}
-                />
+                <PrivilegeRequired privilege="inframodel-download">
+                    <InfraModelTabNavItem
+                        title={t('im-form.tabs.projektivelho-files-waiting', {
+                            number: documentCounts?.suggested,
+                        })}
+                        tabId={InfraModelTabType.WAITING}
+                        activeTab={activeTab}
+                        exclamationPointVisible={!!documentCounts && documentCounts?.suggested > 0}
+                    />
+                    <InfraModelTabNavItem
+                        title={t('im-form.tabs.projektivelho-files-rejected', {
+                            number: documentCounts?.rejected,
+                        })}
+                        tabId={InfraModelTabType.REJECTED}
+                        activeTab={activeTab}
+                        exclamationPointVisible={false}
+                    />
+                </PrivilegeRequired>
             </ul>
             <div className={styles['tabs__outlet']}>
                 <InfraModelTabContent tabId={InfraModelTabType.PLAN} activeTab={activeTab}>

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -16,6 +16,7 @@ import {
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { PublicationTableItem } from 'publication/publication-model';
 import { Page } from 'api/api-fetch';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 export type PublicationLogProps = {
     onClose: () => void;
@@ -81,20 +82,22 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ onClose }) => {
                         }
                         errors={endDateErrors}
                     />
-                    <div className={styles['publication-log__export_button']}>
-                        <Button
-                            icon={Icons.Download}
-                            onClick={() =>
-                                (location.href = getPublicationsCsvUri(
-                                    startDate,
-                                    endDate && endOfDay(endDate),
-                                    sortInfo?.propName,
-                                    sortInfo?.direction,
-                                ))
-                            }>
-                            {t('publication-log.export-csv')}
-                        </Button>
-                    </div>
+                    <PrivilegeRequired privilege="publication-download">
+                        <div className={styles['publication-log__export_button']}>
+                            <Button
+                                icon={Icons.Download}
+                                onClick={() =>
+                                    (location.href = getPublicationsCsvUri(
+                                        startDate,
+                                        endDate && endOfDay(endDate),
+                                        sortInfo?.propName,
+                                        sortInfo?.direction,
+                                    ))
+                                }>
+                                {t('publication-log.export-csv')}
+                            </Button>
+                        </div>
+                    </PrivilegeRequired>
                 </div>
                 <div className={styles['publication-log__count-header']}>
                     <span

--- a/ui/src/tool-panel/geometry-plan-infobox.tsx
+++ b/ui/src/tool-panel/geometry-plan-infobox.tsx
@@ -24,6 +24,7 @@ import { TimeStamp } from 'common/common-model';
 import { GeometryPlanInfoboxVisibilities } from 'track-layout/track-layout-slice';
 import { ConfirmDownloadUnreliableInfraModelDialog } from 'infra-model/list/confirm-download-unreliable-infra-model-dialog';
 import ElevationMeasurementMethod from 'geoviite-design-lib/elevation-measurement-method/elevation-measurement-method';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 type GeometryPlanInfoboxProps = {
     planHeader: GeometryPlanHeader;
@@ -183,20 +184,22 @@ const GeometryPlanInfobox: React.FC<GeometryPlanInfoboxProps> = ({
                             onClick={() => navigate('inframodel-edit', planHeader.id)}>
                             {t('tool-panel.geometry-plan.open-inframodel')}
                         </Button>
-                        <Button
-                            size={ButtonSize.SMALL}
-                            variant={ButtonVariant.SECONDARY}
-                            className={styles['geometry-plan-tool-panel__download-link']}
-                            onClick={() => {
-                                if (planHeader.source === 'PAIKANNUSPALVELU') {
-                                    setDownloadConfirmPlan(planHeader);
-                                } else {
-                                    location.href = inframodelDownloadUri(planHeader.id);
-                                }
-                            }}>
-                            <Icons.Download size={IconSize.SMALL} />{' '}
-                            {t('tool-panel.geometry-plan.download-file')}
-                        </Button>
+                        <PrivilegeRequired privilege="inframodel-download">
+                            <Button
+                                size={ButtonSize.SMALL}
+                                variant={ButtonVariant.SECONDARY}
+                                className={styles['geometry-plan-tool-panel__download-link']}
+                                onClick={() => {
+                                    if (planHeader.source === 'PAIKANNUSPALVELU') {
+                                        setDownloadConfirmPlan(planHeader);
+                                    } else {
+                                        location.href = inframodelDownloadUri(planHeader.id);
+                                    }
+                                }}>
+                                <Icons.Download size={IconSize.SMALL} />{' '}
+                                {t('tool-panel.geometry-plan.download-file')}
+                            </Button>
+                        </PrivilegeRequired>
                     </InfoboxButtons>
                 </InfoboxContent>
             </Infobox>

--- a/ui/src/user/privileged-link.tsx
+++ b/ui/src/user/privileged-link.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { useCommonDataAppSelector } from 'store/hooks';
+import { PrivilegeCode } from './user-model';
+import { Link } from 'vayla-design-lib/link/link';
+
+type PrivilegedLinkProps = {
+    privilege: PrivilegeCode;
+    children: React.ReactNode;
+} & React.HTMLProps<HTMLAnchorElement>;
+
+export const PrivilegedLink: React.FC<PrivilegedLinkProps> = (props: PrivilegedLinkProps) => {
+    const userHasPrivilege = useCommonDataAppSelector((state) =>
+        state.userPrivileges.some((p) => p.code === props.privilege),
+    );
+
+    if (userHasPrivilege) {
+        return <Link {...props}>{props.children}</Link>;
+    } else {
+        return <React.Fragment>{props.children}</React.Fragment>;
+    }
+};

--- a/ui/src/user/user-model.ts
+++ b/ui/src/user/user-model.ts
@@ -5,7 +5,7 @@ export type PrivilegeCode =
     | 'ui-read'
     | 'inframodel-download'
     | 'dataproduct-download'
-    | 'publications-download';
+    | 'publication-download';
 
 export type User = {
     details: UserDetails;

--- a/ui/src/user/user-model.ts
+++ b/ui/src/user/user-model.ts
@@ -1,6 +1,11 @@
 export type UserId = string;
 export type RoleCode = 'operator' | 'browser';
-export type PrivilegeCode = 'all-write' | 'all-read' | 'im-download';
+export type PrivilegeCode =
+    | 'all-write'
+    | 'ui-read'
+    | 'inframodel-download'
+    | 'dataproduct-download'
+    | 'publications-download';
 
 export type User = {
     details: UserDetails;


### PR DESCRIPTION
Erotettu selaaja käyttäjä kahteen:
- Viraston käyttäjä: Vapaat lukuoikeudet käyttöliittymältä mutta ei pääsyä lataamaan IM-tiedostoja tai tietotuotteita
- Konsultit: Näiden oikeudet määritellään tarkemmin myöhemmin. Tässä kohtaa tein roolin jo valmiiksi mutta sillä ei ole mitään oikeuksia

Nykyinen selaaja säilytetty ja se antaa viraston käyttäjää vastaavat oikeudet. Kun saadaan AD:hen uudet roolitukset, tuo vanha voidaan poistaa.

Itse oikeudet on repeatable migraatiossa. Suurin osa muutoksista on ei-sallittujen UI-toimintojen piilottamista, sillä ilman oikeuksia backend vastaisi niihin vain 403.