### PR TITLE
GVT-2200 Raiteiden omistajien päättely, toinen yritys

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -396,6 +396,7 @@ class LocationTrackDao(
             id,
             name
         from common.location_track_owner
+        order by sort_priority, name
     """.trimIndent()
 
         val locationTrackOwners = jdbcTemplate.query(sql) { rs, _ ->

--- a/infra/src/main/resources/db/migration/prod/V55__setup_location_track_owners_schema_and_base_owners.sql
+++ b/infra/src/main/resources/db/migration/prod/V55__setup_location_track_owners_schema_and_base_owners.sql
@@ -1,13 +1,18 @@
 create table common.location_track_owner
 (
   id   int primary key generated always as identity,
-  name varchar(100) not null unique
+  name varchar(100) not null unique,
+  sort_priority int not null default 2
 );
 
 select common.add_table_metadata('common', 'location_track_owner');
 comment on table common.location_track_owner is 'Location track owners';
 
-insert into common.location_track_owner(name) values ('Väylävirasto'), ('Ei tiedossa');
+insert into common.location_track_owner(name, sort_priority)
+  values
+    ('Väylävirasto', 0),
+    ('Väylävirasto / yksityinen', 0),
+    ('Muu yksityinen', 1);
 
 alter table layout.location_track
   add column owner_id int references common.location_track_owner (id);

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -332,7 +332,9 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         });
 
     const moveToEditLinkText = (track: LayoutLocationTrack) => {
-        return track.state === 'DELETED' ? t('location-track-dialog.move-to-edit-deleted') : t('location-track-dialog.move-to-edit', {name: track.name});
+        return track.state === 'DELETED'
+            ? t('location-track-dialog.move-to-edit-deleted')
+            : t('location-track-dialog.move-to-edit', { name: track.name });
     };
     return (
         <React.Fragment>
@@ -410,10 +412,17 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                             errors={getVisibleErrorsByProp('name')}>
                             {trackWithSameName && (
                                 <>
-                                    <div className={styles['location-track-edit-dialog__alert-color']}>
-                                        {trackWithSameName.state === 'DELETED' ? t('location-track-dialog.name-in-use-deleted') : t('location-track-dialog.name-in-use')}
+                                    <div
+                                        className={
+                                            styles['location-track-edit-dialog__alert-color']
+                                        }>
+                                        {trackWithSameName.state === 'DELETED'
+                                            ? t('location-track-dialog.name-in-use-deleted')
+                                            : t('location-track-dialog.name-in-use')}
                                     </div>
-                                    <Link className={styles['location-track-edit-dialog__alert']} onClick={() => props.onEditTrack(trackWithSameName.id)}>
+                                    <Link
+                                        className={styles['location-track-edit-dialog__alert']}
+                                        onClick={() => props.onEditTrack(trackWithSameName.id)}>
                                         {moveToEditLinkText(trackWithSameName)}
                                     </Link>
                                 </>

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -132,13 +132,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         qaId: tc.value,
     }));
 
-    const locationTrackOwners = useLoader(
-        () =>
-            getLocationTrackOwners().then((owners) =>
-                owners.sort((a, b) => sortUnknownLocationTrackOwnerAsLast(a.name, b.name)),
-            ),
-        [],
-    );
+    const locationTrackOwners = useLoader(getLocationTrackOwners, []);
 
     const duplicate = useLocationTrack(
         props.locationTrack?.duplicateOf,
@@ -148,16 +142,6 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     React.useEffect(() => {
         if (duplicate && !selectedDuplicateTrack) setSelectedDuplicateTrack(duplicate);
     }, [duplicate]);
-
-    function sortUnknownLocationTrackOwnerAsLast(a: string, b: string) {
-        if (b === 'Ei tiedossa') {
-            return -1;
-        } else if (a === b) {
-            return 0;
-        } else {
-            return a < b ? -1 : 1;
-        }
-    }
 
     const trackWithSameName = useConflictingTracks(
         state.locationTrack.trackNumberId,


### PR DESCRIPTION
Hyvin heittopullari. Tällä hetkellä tämä ei edes toteuta taskin speksistä sitä osaa, että "Ei tiedossa"-omistajaa tulisi lainkaan, koska en ole ihan varma, oliko se nyt edes ihan oikeasti oleellinen asia.

Oleelliset muutokset:

- Suurin osa tiedosta siitä, että jokin omistaja on nyt toisia erikoisempi, on nyt sort_priority-kentässä kantataulussa: Tämä yksinkertaistaa kälikoodia jonkin verran (tosin se asia tämän kommitin ulkopuolella kälikoodissa vielä on olemassa, että Väylävirasto on oletusomistaja)
- Migrassa asetetut vaihtoehdot on nyt siis Väylävirasto, "Muu yksityinen", ja se välitila, tuon yksityisten osien pituuksia katsovan logiikan perusteella. Tuotantoonmenon aikaan voi sitten samalla koodilla rakennella ritoille raportin siitä, kuinka paljon yksityistä pituutta milläkin raiteella nähtiin.