### PR TITLE
GVT-2330 & GVT-2333: Raiteen splittauksen UI-parannuksia

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -612,7 +612,7 @@
                     "invalid-description": "Kuvauksen perusosan tulee olla 4-256 merkkiä pitkä",
                     "invalid-name": "Virheellinen sijaintiraidetunnus",
                     "missing-fields": "Pakollisia tietoja puuttuu",
-                    "missing-switch": "Katkaisukohdan vaihde on poistettu",
+                    "missing-switch": "Katkaisukohdan vaihde on poistettu. Poista katkaisukohta tai peruuta vaihteen poisto",
                     "has-errors": "Tiedoissa on virheitä",
                     "show": "näytä"
                 }

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -605,12 +605,14 @@
                 "description-base": "Kuvauksen perusosa",
                 "description-suffix": "Kuvauksen lisäosa",
                 "validation": {
+                    "track-draft-exists": "Muokattua sijaintiraidetta ei voi jakaa. Julkaise tai kumoa muutokset.",
                     "conflicts-with-split": "Tunnus on jo käytössä toisella katkaisukohdalla",
                     "conflicts-with-track": "Tunnus on jo käytössä toisella raiteella",
                     "mandatory-field": "Pakollinen kenttä",
                     "invalid-description": "Kuvauksen perusosan tulee olla 4-256 merkkiä pitkä",
                     "invalid-name": "Virheellinen sijaintiraidetunnus",
                     "missing-fields": "Pakollisia tietoja puuttuu",
+                    "missing-switch": "Katkaisukohdan vaihde on poistettu",
                     "has-errors": "Tiedoissa on virheitä",
                     "show": "näytä"
                 }

--- a/ui/src/geoviite-design-lib/message-box/message-box.scss
+++ b/ui/src/geoviite-design-lib/message-box/message-box.scss
@@ -5,6 +5,10 @@
     background-color: vayla-design.$color-lemon-light;
     color: vayla-design.$color-black-default;
     overflow: hidden;
+
+    &--error {
+        background-color: vayla-design.$color-red-lighter;
+    }
 }
 
 .message-box__inner {

--- a/ui/src/geoviite-design-lib/message-box/message-box.tsx
+++ b/ui/src/geoviite-design-lib/message-box/message-box.tsx
@@ -3,16 +3,24 @@ import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 import styles from './message-box.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 
+type MessageBoxType = 'INFO' | 'ERROR';
+
 type MessageBoxProps = {
     children?: React.ReactNode;
     pop?: boolean;
+    type?: MessageBoxType;
 };
 
-export const MessageBox: React.FC<MessageBoxProps> = ({ children, pop }: MessageBoxProps) => {
+export const MessageBox: React.FC<MessageBoxProps> = ({
+    children,
+    pop,
+    type = 'INFO',
+}: MessageBoxProps) => {
     const classes = createClassName(
         styles['message-box'],
         pop != undefined && styles['message-box--poppable'],
         pop && styles['message-box--popped'],
+        type === 'ERROR' && styles['message-box--error'],
     );
 
     return (

--- a/ui/src/map/layers/alignment/location-track-split-location-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-location-layer.ts
@@ -8,6 +8,11 @@ import { Circle, Fill, Stroke } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
 import { clearFeatures, pointToCoords } from 'map/layers/utils/layer-utils';
 import { SplittingState } from 'tool-panel/location-track/split-store';
+import { getSwitches } from 'track-layout/layout-switch-api';
+import { LayoutSwitchId } from 'track-layout/track-layout-model';
+import { Point } from 'model/geometry';
+
+let newestLayerId = 0;
 
 const splitPointStyle = new Style({
     image: new Circle({
@@ -17,27 +22,57 @@ const splitPointStyle = new Style({
     }),
 });
 
+const deletedSplitPointStyle = new Style({
+    image: new Circle({
+        radius: 8,
+        fill: new Fill({ color: mapStyles.splitPointDeletedCircleColor }),
+        stroke: new Stroke({ color: mapStyles.alignmentBadgeWhite, width: 2 }),
+    }),
+});
+
+type SwitchIdAndLocation = {
+    switchId: LayoutSwitchId | undefined;
+    location: Point;
+};
+
 export const createLocationTrackSplitLocationLayer = (
     existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
     splittingState: SplittingState | undefined,
 ): MapLayer => {
+    const layerId = ++newestLayerId;
+
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
     if (splittingState) {
-        const points = splittingState.splits
-            .map((split) => split.location)
-            .concat([splittingState.initialSplit.location, splittingState.endLocation]);
+        getSwitches(
+            splittingState.splits.map((sw) => sw.switchId),
+            'DRAFT',
+        ).then((switches) => {
+            if (layerId !== newestLayerId) return;
 
-        const features = points.map((location) => {
-            const feature = new Feature({
-                geometry: new OlPoint(pointToCoords(location)),
+            const firstAndLast: SwitchIdAndLocation[] = [
+                { location: splittingState.initialSplit.location, switchId: undefined },
+                { location: splittingState.endLocation, switchId: undefined },
+            ];
+            const splits: SwitchIdAndLocation[] = splittingState.splits.map((split) => ({
+                location: split.location,
+                switchId: split.switchId,
+            }));
+            const switchesAndLocations = firstAndLast.concat(splits);
+
+            const features = switchesAndLocations.map(({ location, switchId }) => {
+                const isDeleted =
+                    switches.find((sw) => sw.id === switchId)?.stateCategory === 'NOT_EXISTING';
+                const feature = new Feature({
+                    geometry: new OlPoint(pointToCoords(location)),
+                });
+                feature.setStyle(isDeleted ? deletedSplitPointStyle : splitPointStyle);
+                return feature;
             });
-            feature.setStyle(splitPointStyle);
-            return feature;
-        });
 
-        clearFeatures(vectorSource);
-        vectorSource.addFeatures(features);
+            clearFeatures(vectorSource);
+            vectorSource.addFeatures(features);
+        });
     } else {
         clearFeatures(vectorSource);
     }

--- a/ui/src/map/layers/switch/switch-layer.ts
+++ b/ui/src/map/layers/switch/switch-layer.ts
@@ -38,7 +38,7 @@ export function createSwitchLayer(
                 ? getSwitches(
                       splittingState.allowedSwitches.map((sw) => sw.switchId),
                       publishType,
-                  )
+                  ).then((switches) => switches.filter((sw) => sw.stateCategory !== 'NOT_EXISTING'))
                 : Promise.all(
                       mapTiles.map((t) =>
                           getSwitchesByTile(changeTimes.layoutSwitch, t, publishType),

--- a/ui/src/map/map.module.scss
+++ b/ui/src/map/map.module.scss
@@ -109,6 +109,7 @@
 // Location track split point styling
 :export {
     splitPointCircleColor: vayla-design.$color-blue-default;
+    splitPointDeletedCircleColor: vayla-design.$color-red-default;
 }
 
 //Measure tooltip styling

--- a/ui/src/tool-panel/infobox/infobox-text.tsx
+++ b/ui/src/tool-panel/infobox/infobox-text.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import styles from './infobox.module.scss';
+import { createClassName } from 'vayla-design-lib/utils';
 
 type InfoboxTextProps = {
     value?: string;
+    className?: string;
 };
 
-const InfoboxText: React.FC<InfoboxTextProps> = ({ value }: InfoboxTextProps) => {
-    return <div className={styles['infobox__text']}>{value}</div>;
+const InfoboxText: React.FC<InfoboxTextProps> = ({ value, className }: InfoboxTextProps) => {
+    return <div className={createClassName(styles['infobox__text'], className)}>{value}</div>;
 };
 
 export default InfoboxText;

--- a/ui/src/tool-panel/location-track/location-track-infobox-linking-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-linking-container.tsx
@@ -19,6 +19,7 @@ type LocationTrackInfoboxLinkingContainerProps = {
     splittingState?: SplittingState;
     publishType: PublishType;
     locationTrackChangeTime: TimeStamp;
+    switchChangeTime: TimeStamp;
     onDataChange: () => void;
     viewport: MapViewport;
     visibilities: LocationTrackInfoboxVisibilities;
@@ -33,6 +34,7 @@ const LocationTrackInfoboxLinkingContainer: React.FC<LocationTrackInfoboxLinking
     splittingState,
     publishType,
     locationTrackChangeTime,
+    switchChangeTime,
     onDataChange,
     viewport,
     visibilities,
@@ -64,6 +66,7 @@ const LocationTrackInfoboxLinkingContainer: React.FC<LocationTrackInfoboxLinking
                 showArea={delegates.showArea}
                 publishType={publishType}
                 locationTrackChangeTime={locationTrackChangeTime}
+                switchChangeTime={switchChangeTime}
                 onSelect={delegates.onSelect}
                 onUnselect={delegates.onUnselect}
                 viewport={viewport}

--- a/ui/src/tool-panel/location-track/location-track-infobox.scss
+++ b/ui/src/tool-panel/location-track/location-track-infobox.scss
@@ -49,15 +49,22 @@
     width: 20px;
     height: 20px;
     fill: vayla-design.$color-white-default;
-    background-color: vayla-design.$color-blue-default;
     display: flex;
     justify-content: center;
     align-items: center;
-    cursor: pointer;
 
-    &:hover {
-        fill: vayla-design.$color-white-default;
-        background: vayla-design.$color-blue-light;
+    &--disabled {
+        background-color: vayla-design.$color-black-lighter;
+    }
+
+    &--enabled {
+        background-color: vayla-design.$color-blue-default;
+        cursor: pointer;
+
+        &:hover {
+            fill: vayla-design.$color-white-default;
+            background: vayla-design.$color-blue-light;
+        }
     }
 }
 
@@ -87,6 +94,10 @@
     width: 18px;
     height: 18px;
     background-color: vayla-design.$color-blue-default;
+
+    &--disabled {
+        background-color: vayla-design.$color-red-default;
+    }
 }
 
 .location-track-infobox__split-item-line {
@@ -97,6 +108,10 @@
     height: 100%;
     width: 6px;
     background-color: vayla-design.$color-blue-default;
+
+    &--disabled {
+        background-color: vayla-design.$color-red-default;
+    }
 }
 
 .location-track-infobox__split-item-field-label {

--- a/ui/src/tool-panel/location-track/location-track-infobox.scss
+++ b/ui/src/tool-panel/location-track/location-track-infobox.scss
@@ -81,7 +81,7 @@
     }
 }
 
-.location-track-infobox__split-error .infobox__text {
+.location-track-infobox__split-error {
     color: vayla-design.$color-red-dark;
 }
 

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -77,6 +77,7 @@ type LocationTrackInfoboxProps = {
     onDataChange: () => void;
     publishType: PublishType;
     locationTrackChangeTime: TimeStamp;
+    switchChangeTime: TimeStamp;
     onSelect: OnSelectFunction;
     onUnselect: (items: OptionalUnselectableItemCollections) => void;
     viewport: MapViewport;
@@ -97,6 +98,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     onDataChange,
     publishType,
     locationTrackChangeTime,
+    switchChangeTime,
     onSelect,
     onUnselect,
     viewport,
@@ -129,10 +131,10 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
         [locationTrack?.id, publishType, locationTrackChangeTime],
     );
     const locationTrackOwners = useLoader(() => getLocationTrackOwners(), []);
-    const splitInitializationParameters = useLoader(
+    /*const splitInitializationParameters = useLoader(
         () => getSplittingInitializationParameters(publishType, locationTrack.id),
         [publishType, locationTrack.id],
-    );
+    );*/
 
     const [showEditDialog, setShowEditDialog] = React.useState(false);
     const [updatingLength, setUpdatingLength] = React.useState<boolean>(false);
@@ -140,9 +142,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     const [confirmingDraftDelete, setConfirmingDraftDelete] = React.useState<boolean>();
     const [showRatkoPushDialog, setShowRatkoPushDialog] = React.useState<boolean>(false);
 
-    function isOfficial(): boolean {
-        return publishType === 'OFFICIAL';
-    }
+    const canEdit = () => publishType === 'OFFICIAL' || !!linkingState || !!splittingState;
 
     function openEditLocationTrackDialog() {
         setShowEditDialog(true);
@@ -231,35 +231,35 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                         label={t('tool-panel.location-track.track-name')}
                         value={locationTrack.name}
                         onEdit={openEditLocationTrackDialog}
-                        iconDisabled={isOfficial()}
+                        iconDisabled={canEdit()}
                     />
                     <InfoboxField
                         qaId="location-track-state"
                         label={t('tool-panel.location-track.state')}
                         value={<LayoutState state={locationTrack.state} />}
                         onEdit={openEditLocationTrackDialog}
-                        iconDisabled={isOfficial()}
+                        iconDisabled={canEdit()}
                     />
                     <InfoboxField
                         qaId="location-track-type"
                         label={t('tool-panel.location-track.type')}
                         value={<LocationTrackTypeLabel type={locationTrack.type} />}
                         onEdit={openEditLocationTrackDialog}
-                        iconDisabled={isOfficial()}
+                        iconDisabled={canEdit()}
                     />
                     <InfoboxField
                         qaId="location-track-description"
                         label={t('tool-panel.location-track.description')}
                         value={description}
                         onEdit={openEditLocationTrackDialog}
-                        iconDisabled={isOfficial()}
+                        iconDisabled={canEdit()}
                     />
                     <InfoboxField
                         qaId="location-track-track-number"
                         label={t('tool-panel.location-track.track-number')}
                         value={<TrackNumberLinkContainer trackNumberId={trackNumber?.id} />}
                         onEdit={openEditLocationTrackDialog}
-                        iconDisabled={isOfficial()}
+                        iconDisabled={canEdit()}
                     />
                     <InfoboxText value={trackNumber?.description} />
                     <InfoboxField
@@ -279,7 +279,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                             />
                         }
                         onEdit={openEditLocationTrackDialog}
-                        iconDisabled={isOfficial()}
+                        iconDisabled={canEdit()}
                     />
                     <InfoboxField
                         label={t('tool-panel.location-track.topological-connectivity')}
@@ -289,13 +289,13 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                             />
                         }
                         onEdit={openEditLocationTrackDialog}
-                        iconDisabled={isOfficial()}
+                        iconDisabled={canEdit()}
                     />
                     <InfoboxField
                         label={t('tool-panel.location-track.owner')}
                         value={getLocationTrackOwnerName(locationTrack.ownerId)}
                         onEdit={openEditLocationTrackDialog}
-                        iconDisabled={isOfficial()}
+                        iconDisabled={canEdit()}
                     />
                     <InfoboxField
                         label={t('tool-panel.location-track.start-switch')}
@@ -325,14 +325,18 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     initialSplit={splittingState.initialSplit}
                     splits={splittingState.splits || []}
                     locationTrackId={splittingState.originLocationTrack.id}
+                    locationTrackChangeTime={locationTrackChangeTime}
                     removeSplit={delegates.removeSplit}
                     cancelSplitting={() => {
                         delegates.cancelSplitting();
                         delegates.hideLayers(['location-track-split-location-layer']);
                     }}
                     allowedSwitches={splittingState.allowedSwitches}
+                    switchChangeTime={switchChangeTime}
                     duplicateLocationTracks={extraInfo?.duplicates || []}
                     updateSplit={delegates.updateSplit}
+                    setSplittingDisabled={delegates.setDisabled}
+                    disabled={splittingState.disabled}
                 />
             )}
             {startAndEndPoints && coordinateSystem && (
@@ -433,27 +437,34 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                         <Button
                                             variant={ButtonVariant.SECONDARY}
                                             size={ButtonSize.SMALL}
+                                            disabled={locationTrack.draftType !== 'OFFICIAL'}
                                             onClick={() => {
-                                                if (
-                                                    startAndEndPoints?.start &&
-                                                    startAndEndPoints?.end
-                                                ) {
-                                                    delegates.onStartSplitting({
-                                                        locationTrack: locationTrack,
-                                                        allowedSwitches:
-                                                            splitInitializationParameters?.switches ||
-                                                            [],
-                                                        duplicateTracks:
-                                                            splitInitializationParameters?.duplicates ||
-                                                            [],
-                                                        startLocation:
-                                                            startAndEndPoints.start.point,
-                                                        endLocation: startAndEndPoints.end.point,
-                                                    });
-                                                    delegates.showLayers([
-                                                        'location-track-split-location-layer',
-                                                    ]);
-                                                }
+                                                getSplittingInitializationParameters(
+                                                    'DRAFT',
+                                                    locationTrack.id,
+                                                ).then((splitInitializationParameters) => {
+                                                    if (
+                                                        startAndEndPoints?.start &&
+                                                        startAndEndPoints?.end
+                                                    ) {
+                                                        delegates.onStartSplitting({
+                                                            locationTrack: locationTrack,
+                                                            allowedSwitches:
+                                                                splitInitializationParameters?.switches ||
+                                                                [],
+                                                            duplicateTracks:
+                                                                splitInitializationParameters?.duplicates ||
+                                                                [],
+                                                            startLocation:
+                                                                startAndEndPoints.start.point,
+                                                            endLocation:
+                                                                startAndEndPoints.end.point,
+                                                        });
+                                                        delegates.showLayers([
+                                                            'location-track-split-location-layer',
+                                                        ]);
+                                                    }
+                                                });
                                             }}>
                                             {t('tool-panel.location-track.start-splitting')}
                                         </Button>

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -131,10 +131,6 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
         [locationTrack?.id, publishType, locationTrackChangeTime],
     );
     const locationTrackOwners = useLoader(() => getLocationTrackOwners(), []);
-    /*const splitInitializationParameters = useLoader(
-        () => getSplittingInitializationParameters(publishType, locationTrack.id),
-        [publishType, locationTrack.id],
-    );*/
 
     const [showEditDialog, setShowEditDialog] = React.useState(false);
     const [updatingLength, setUpdatingLength] = React.useState<boolean>(false);
@@ -438,6 +434,13 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                             variant={ButtonVariant.SECONDARY}
                                             size={ButtonSize.SMALL}
                                             disabled={locationTrack.draftType !== 'OFFICIAL'}
+                                            title={
+                                                locationTrack.draftType !== 'OFFICIAL'
+                                                    ? t(
+                                                          'tool-panel.location-track.splitting.validation.track-draft-exists',
+                                                      )
+                                                    : undefined
+                                            }
                                             onClick={() => {
                                                 getSplittingInitializationParameters(
                                                     'DRAFT',

--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -34,6 +34,7 @@ export type SplittingState = {
     duplicateTracks: SplitDuplicate[];
     initialSplit: InitialSplit;
     splits: Split[];
+    disabled: boolean;
 };
 
 type SplitStart = {
@@ -80,6 +81,7 @@ export const splitReducers = {
             duplicateTracks: payload.duplicateTracks,
             splits: [],
             endLocation: payload.endLocation,
+            disabled: payload.locationTrack.draftType !== 'OFFICIAL',
             initialSplit: {
                 name:
                     duplicateTrackClosestToStart &&
@@ -100,12 +102,18 @@ export const splitReducers = {
     cancelSplitting: (state: TrackLayoutState): void => {
         state.splittingState = undefined;
     },
+    setDisabled: (state: TrackLayoutState, { payload }: PayloadAction<boolean>): void => {
+        if (state.splittingState) {
+            state.splittingState.disabled = payload;
+        }
+    },
     addSplit: (state: TrackLayoutState, { payload }: PayloadAction<LayoutSwitchId>): void => {
         const allowedSwitch = state.splittingState?.allowedSwitches?.find(
             (sw) => sw.switchId == payload,
         );
         if (
             state.splittingState &&
+            !state.splittingState.disabled &&
             allowedSwitch?.location &&
             allowedSwitch?.distance &&
             !state.splittingState.splits.some((split) => split.switchId === payload)

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -22,6 +22,7 @@ import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track
 
 type EndpointProps = {
     addressPoint: AddressPoint | undefined;
+    editingDisabled: boolean;
 };
 
 type SplitProps = EndpointProps & {
@@ -34,13 +35,22 @@ type SplitProps = EndpointProps & {
     descriptionErrors: ValidationError<Split>[];
     nameRef?: React.RefObject<HTMLInputElement>;
     descriptionBaseRef?: React.RefObject<HTMLInputElement>;
+    deletingDisabled: boolean;
 };
 
-export const LocationTrackSplittingEndpoint: React.FC<EndpointProps> = ({ addressPoint }) => {
+export const LocationTrackSplittingEndpoint: React.FC<EndpointProps> = ({
+    addressPoint,
+    editingDisabled,
+}) => {
     const { t } = useTranslation();
     return (
         <div className={styles['location-track-infobox__split-container']}>
-            <div className={styles['location-track-infobox__split-item-ball']} />
+            <div
+                className={createClassName(
+                    styles['location-track-infobox__split-item-ball'],
+                    editingDisabled && styles['location-track-infobox__split-item-ball--disabled'],
+                )}
+            />
             <InfoboxField label={t('tool-panel.location-track.splitting.end-address')}>
                 <NavigableTrackMeter
                     trackMeter={addressPoint?.address}
@@ -61,6 +71,8 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
     nameErrors,
     descriptionErrors,
     duplicateLocationTracks = [],
+    editingDisabled,
+    deletingDisabled,
     nameRef,
     descriptionBaseRef,
 }) => {
@@ -91,8 +103,18 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
 
     return (
         <div className={styles['location-track-infobox__split-container']}>
-            <div className={styles['location-track-infobox__split-item-line']} />
-            <div className={styles['location-track-infobox__split-item-ball']} />
+            <div
+                className={createClassName(
+                    styles['location-track-infobox__split-item-line'],
+                    editingDisabled && styles['location-track-infobox__split-item-line--disabled'],
+                )}
+            />
+            <div
+                className={createClassName(
+                    styles['location-track-infobox__split-item-ball'],
+                    editingDisabled && styles['location-track-infobox__split-item-ball--disabled'],
+                )}
+            />
             <div className={styles['location-track-infobox__split-fields-container']}>
                 <div>
                     <InfoboxField
@@ -115,6 +137,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                             ref={nameRef}
                             defaultValue={split.name}
                             hasError={nameErrorsVisible}
+                            disabled={editingDisabled}
                             onChange={(e) => {
                                 const duplicateId = duplicateLocationTracks.find(
                                     (lt) => lt.name === e.target.value,
@@ -166,7 +189,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                                     : split.descriptionBase
                             }
                             hasError={descriptionErrorsVisible}
-                            disabled={!!duplicateOf}
+                            disabled={editingDisabled || !!duplicateOf}
                             onChange={(e) => {
                                 updateSplit({ ...split, descriptionBase: e.target.value });
                             }}
@@ -207,15 +230,20 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                                 updateSplit({ ...split, suffixMode: mode });
                             }}
                             onBlur={() => {}}
-                            disabled={!!duplicateOf}
+                            disabled={editingDisabled || !!duplicateOf}
                         />
                     </InfoboxField>
                 </div>
                 <div className={styles['location-track-infobox__close-split-button-column']}>
                     {onRemove && (
                         <div
-                            className={styles['location-track-infobox__split-close-button']}
-                            onClick={() => switchId && onRemove(switchId)}>
+                            className={createClassName(
+                                styles['location-track-infobox__split-close-button'],
+                                deletingDisabled
+                                    ? styles['location-track-infobox__split-close-button--disabled']
+                                    : styles['location-track-infobox__split-close-button--enabled'],
+                            )}
+                            onClick={() => !deletingDisabled && switchId && onRemove(switchId)}>
                             <Icons.Close size={IconSize.SMALL} color={IconColor.INHERIT} />
                         </div>
                     )}

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -33,6 +33,7 @@ type SplitProps = EndpointProps & {
     duplicateOf: LocationTrackId | undefined;
     nameErrors: ValidationError<Split>[];
     descriptionErrors: ValidationError<Split>[];
+    switchErrors: ValidationError<Split>[];
     nameRef?: React.RefObject<HTMLInputElement>;
     descriptionBaseRef?: React.RefObject<HTMLInputElement>;
     deletingDisabled: boolean;
@@ -70,6 +71,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
     duplicateOf,
     nameErrors,
     descriptionErrors,
+    switchErrors,
     duplicateLocationTracks = [],
     editingDisabled,
     deletingDisabled,
@@ -123,11 +125,21 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                                 ? t('tool-panel.location-track.splitting.split-address')
                                 : t('tool-panel.location-track.splitting.start-address')
                         }>
-                        <NavigableTrackMeter
-                            trackMeter={addressPoint?.address}
-                            location={addressPoint?.point}
-                            mapNavigationBboxOffset={MAP_POINT_NEAR_BBOX_OFFSET}
-                        />
+                        <div>
+                            <NavigableTrackMeter
+                                trackMeter={addressPoint?.address}
+                                location={addressPoint?.point}
+                                mapNavigationBboxOffset={MAP_POINT_NEAR_BBOX_OFFSET}
+                            />
+                            {switchErrors.some((err) => err.reason === 'switch-not-found') && (
+                                <InfoboxText
+                                    className={styles['location-track-infobox__split-error']}
+                                    value={t(
+                                        'tool-panel.location-track.splitting.validation.missing-switch',
+                                    )}
+                                />
+                            )}
+                        </div>
                     </InfoboxField>
                     <InfoboxField
                         className={styles['location-track-infobox__split-item-field-label']}

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -242,21 +242,6 @@ function findAndFocusFirstErroredField(
     }
 }
 
-function findAndScrollIntoView(
-    splitComponents: SplitComponentAndRefs[],
-    predicate: (errorReason: string) => boolean,
-) {
-    const index = splitComponents.findIndex((s) =>
-        hasErrors(
-            s.split.switchErrors.map((err) => err.reason),
-            predicate,
-        ),
-    );
-    if (index !== -1) {
-        splitComponents[index]?.nameRef?.current?.scrollIntoView();
-    }
-}
-
 const getSplitAddressPoint = (
     allowedSwitches: SwitchOnLocationTrack[],
     startAndEnd: AlignmentStartAndEnd | undefined,
@@ -325,7 +310,6 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
         ...validated.switchErrors,
     ]);
     const anyMissingFields = allErrors.map((s) => s.reason).some(mandatoryFieldMissing);
-    const anyMissingSwitches = allErrors.map((s) => s.reason).some(switchDeleted);
     const anyOtherErrors = allErrors.map((s) => s.reason).some(otherError);
 
     const splitComponents: SplitComponentAndRefs[] = allValidated.map((splitValidated) => {
@@ -337,7 +321,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                 (s) => 'switchId' in splitValidated.split && s.id === splitValidated.split.switchId,
             )?.stateCategory !== 'NOT_EXISTING';
 
-        const { split, nameErrors, descriptionErrors } = splitValidated;
+        const { split, nameErrors, descriptionErrors, switchErrors } = splitValidated;
         return {
             component: (
                 <LocationTrackSplit
@@ -350,6 +334,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                     duplicateOf={split.duplicateOf}
                     nameErrors={nameErrors}
                     descriptionErrors={descriptionErrors}
+                    switchErrors={switchErrors}
                     editingDisabled={disabled || !switchExists}
                     deletingDisabled={disabled}
                     nameRef={nameRef}
@@ -407,27 +392,6 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                                                     findAndFocusFirstErroredField(
                                                         splitComponents,
                                                         mandatoryFieldMissing,
-                                                    )
-                                                }>
-                                                {t(
-                                                    'tool-panel.location-track.splitting.validation.show',
-                                                )}
-                                            </Link>
-                                        </MessageBox>
-                                    </InfoboxContentSpread>
-                                )}
-                                {anyMissingSwitches && (
-                                    <InfoboxContentSpread>
-                                        <MessageBox>
-                                            {t(
-                                                'tool-panel.location-track.splitting.validation.missing-switch',
-                                            )}
-                                            ,{' '}
-                                            <Link
-                                                onClick={() =>
-                                                    findAndScrollIntoView(
-                                                        splitComponents,
-                                                        switchDeleted,
                                                     )
                                                 }>
                                                 {t(

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -10,6 +10,7 @@ import {
     AddressPoint,
     AlignmentStartAndEnd,
     LayoutLocationTrack,
+    LayoutSwitch,
     LayoutSwitchId,
     LocationTrackDuplicate,
     LocationTrackId,
@@ -25,6 +26,7 @@ import {
     useConflictingTracks,
     useLocationTrack,
     useLocationTrackStartAndEnd,
+    useSwitches,
 } from 'track-layout/track-layout-react-utils';
 import { ValidationError, ValidationErrorType } from 'utils/validation-utils';
 import {
@@ -37,6 +39,7 @@ import {
     validateLocationTrackName,
 } from 'tool-panel/location-track/dialog/location-track-validation';
 import { Link } from 'vayla-design-lib/link/link';
+import { TimeStamp } from 'common/common-model';
 
 type LocationTrackSplittingInfoboxContainerProps = {
     duplicateLocationTracks: LocationTrackDuplicate[];
@@ -45,10 +48,14 @@ type LocationTrackSplittingInfoboxContainerProps = {
     initialSplit: InitialSplit;
     splits: Split[];
     allowedSwitches: SwitchOnLocationTrack[];
+    switchChangeTime: TimeStamp;
+    disabled: boolean;
     removeSplit: (switchId: LayoutSwitchId) => void;
     locationTrackId: string;
+    locationTrackChangeTime: TimeStamp;
     cancelSplitting: () => void;
     updateSplit: (updatedSplit: Split | InitialSplit) => void;
+    setSplittingDisabled: (disabled: boolean) => void;
 };
 
 type LocationTrackSplittingInfoboxProps = {
@@ -58,6 +65,8 @@ type LocationTrackSplittingInfoboxProps = {
     initialSplit: InitialSplit;
     splits: Split[];
     allowedSwitches: SwitchOnLocationTrack[];
+    switches: LayoutSwitch[];
+    disabled: boolean;
     removeSplit: (switchId: LayoutSwitchId) => void;
     locationTrack: LayoutLocationTrack;
     conflictingLocationTracks: string[];
@@ -106,10 +115,26 @@ const validateSplitDescription = (
     return errors;
 };
 
+const validateSplitSwitch = (split: Split, switches: LayoutSwitch[]) => {
+    const errors: ValidationError<Split>[] = [];
+    if ('switchId' in split) {
+        const switchAtSplit = switches.find((s) => s.id === split.switchId);
+        if (!switchAtSplit || switchAtSplit.stateCategory === 'NOT_EXISTING') {
+            errors.push({
+                field: 'switchId',
+                reason: 'switch-not-found',
+                type: ValidationErrorType.ERROR,
+            });
+        }
+    }
+    return errors;
+};
+
 type ValidatedSplit = {
     split: Split | InitialSplit;
     nameErrors: ValidationError<Split>[];
     descriptionErrors: ValidationError<Split>[];
+    switchErrors: ValidationError<Split>[];
 };
 
 type SplitComponentAndRefs = {
@@ -120,30 +145,48 @@ type SplitComponentAndRefs = {
 };
 
 const mandatoryFieldMissing = (error: string) => error === 'mandatory-field';
-const otherError = (error: string) => error !== 'mandatory-field';
+const switchDeleted = (error: string) => error === 'switch-not-found';
+const otherError = (error: string) => !mandatoryFieldMissing(error) && !switchDeleted(error);
 
 export const LocationTrackSplittingInfoboxContainer: React.FC<
     LocationTrackSplittingInfoboxContainerProps
 > = ({
     locationTrackId,
+    locationTrackChangeTime,
     initialSplit,
     splits,
     duplicateLocationTracks,
     visibilities,
     visibilityChange,
     allowedSwitches,
+    switchChangeTime,
     removeSplit,
     cancelSplitting,
     updateSplit,
+    setSplittingDisabled,
+    disabled,
 }) => {
-    const locationTrack = useLocationTrack(locationTrackId, 'DRAFT');
-    const [startAndEnd, _] = useLocationTrackStartAndEnd(locationTrackId, 'DRAFT');
+    const locationTrack = useLocationTrack(locationTrackId, 'DRAFT', locationTrackChangeTime);
+    const [startAndEnd, _] = useLocationTrackStartAndEnd(
+        locationTrackId,
+        'DRAFT',
+        locationTrackChangeTime,
+    );
     const conflictingTracks = useConflictingTracks(
         locationTrack?.trackNumberId,
         [initialSplit, ...splits].map((s) => s.name),
         [initialSplit, ...splits].map((s) => s.duplicateOf).filter(filterNotEmpty),
         'DRAFT',
     );
+    const switches = useSwitches(
+        allowedSwitches.map((sw) => sw.switchId),
+        'DRAFT',
+        switchChangeTime,
+    );
+
+    React.useEffect(() => {
+        locationTrack && setSplittingDisabled(locationTrack?.draftType !== 'OFFICIAL');
+    }, [locationTrack, locationTrackChangeTime]);
 
     return (
         locationTrack &&
@@ -155,12 +198,14 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
                 initialSplit={initialSplit}
                 splits={splits}
                 allowedSwitches={allowedSwitches}
+                switches={switches}
                 removeSplit={removeSplit}
                 cancelSplitting={cancelSplitting}
                 updateSplit={updateSplit}
                 startAndEnd={startAndEnd}
                 conflictingLocationTracks={conflictingTracks?.map((t) => t.name) || []}
                 locationTrack={locationTrack}
+                disabled={disabled}
             />
         )
     );
@@ -197,6 +242,45 @@ function findAndFocusFirstErroredField(
     }
 }
 
+function findAndScrollIntoView(
+    splitComponents: SplitComponentAndRefs[],
+    predicate: (errorReason: string) => boolean,
+) {
+    const index = splitComponents.findIndex((s) =>
+        hasErrors(
+            s.split.switchErrors.map((err) => err.reason),
+            predicate,
+        ),
+    );
+    if (index !== -1) {
+        splitComponents[index]?.nameRef?.current?.scrollIntoView();
+    }
+}
+
+const getSplitAddressPoint = (
+    allowedSwitches: SwitchOnLocationTrack[],
+    startAndEnd: AlignmentStartAndEnd | undefined,
+    split: Split | InitialSplit,
+): AddressPoint | undefined => {
+    if ('switchId' in split) {
+        const switchAtSplit = allowedSwitches.find((s) => s.switchId === split.switchId);
+
+        if (switchAtSplit?.location && switchAtSplit?.address) {
+            return {
+                point: { ...switchAtSplit.location, m: -1 },
+                address: switchAtSplit.address,
+            };
+        }
+    } else if (startAndEnd && startAndEnd.start) {
+        return {
+            point: startAndEnd.start.point,
+            address: startAndEnd.start.address,
+        };
+    }
+
+    return undefined;
+};
+
 export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfoboxProps> = ({
     duplicateLocationTracks,
     visibilities,
@@ -204,36 +288,16 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
     initialSplit,
     splits,
     allowedSwitches,
+    switches,
     removeSplit,
     cancelSplitting,
     updateSplit,
     startAndEnd,
     conflictingLocationTracks,
     locationTrack,
+    disabled,
 }) => {
     const { t } = useTranslation();
-    const getSplitAddressPoint = (
-        split: Split | InitialSplit,
-        startAndEnd: AlignmentStartAndEnd | undefined,
-    ): AddressPoint | undefined => {
-        if ('switchId' in split) {
-            const switchAtSplit = allowedSwitches.find((s) => s.switchId === split.switchId);
-
-            if (switchAtSplit?.location && switchAtSplit?.address) {
-                return {
-                    point: { ...switchAtSplit.location, m: -1 },
-                    address: switchAtSplit.address,
-                };
-            }
-        } else if (startAndEnd && startAndEnd.start) {
-            return {
-                point: startAndEnd.start.point,
-                address: startAndEnd.start.address,
-            };
-        }
-
-        return undefined;
-    };
 
     const sortedSplits = sortSplitsByDistance(splits);
     const allSplitNames = [initialSplit, ...splits].map((s) => s.name);
@@ -245,24 +309,33 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
             initialSplit.descriptionBase,
             initialSplit.duplicateOf,
         ),
+        switchErrors: [],
     };
     const splitsValidated = sortedSplits.map((s) => ({
         split: s,
         nameErrors: validateSplitName(s.name, allSplitNames, conflictingLocationTracks),
         descriptionErrors: validateSplitDescription(s.descriptionBase, s.duplicateOf),
+        switchErrors: validateSplitSwitch(s, switches),
     }));
     const allValidated = [initialSplitValidated, ...splitsValidated];
 
     const allErrors = allValidated.flatMap((validated) => [
         ...validated.descriptionErrors,
         ...validated.nameErrors,
+        ...validated.switchErrors,
     ]);
     const anyMissingFields = allErrors.map((s) => s.reason).some(mandatoryFieldMissing);
+    const anyMissingSwitches = allErrors.map((s) => s.reason).some(switchDeleted);
     const anyOtherErrors = allErrors.map((s) => s.reason).some(otherError);
 
     const splitComponents: SplitComponentAndRefs[] = allValidated.map((splitValidated) => {
         const nameRef = React.createRef<HTMLInputElement>();
         const descriptionBaseRef = React.createRef<HTMLInputElement>();
+
+        const switchExists =
+            switches.find(
+                (s) => 'switchId' in splitValidated.split && s.id === splitValidated.split.switchId,
+            )?.stateCategory !== 'NOT_EXISTING';
 
         const { split, nameErrors, descriptionErrors } = splitValidated;
         return {
@@ -270,13 +343,15 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                 <LocationTrackSplit
                     key={`${split.location.x}_${split.location.y}`}
                     split={split}
-                    addressPoint={getSplitAddressPoint(split, startAndEnd)}
+                    addressPoint={getSplitAddressPoint(allowedSwitches, startAndEnd, split)}
                     onRemove={removeSplit}
                     duplicateLocationTracks={duplicateLocationTracks}
                     updateSplit={updateSplit}
                     duplicateOf={split.duplicateOf}
                     nameErrors={nameErrors}
                     descriptionErrors={descriptionErrors}
+                    editingDisabled={disabled || !switchExists}
+                    deletingDisabled={disabled}
                     nameRef={nameRef}
                     descriptionBaseRef={descriptionBaseRef}
                 />
@@ -296,49 +371,94 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                     title={t('tool-panel.location-track.splitting.title')}>
                     <InfoboxContent className={styles['location-track-infobox__split']}>
                         {splitComponents.map((split) => split.component)}
-                        <LocationTrackSplittingEndpoint addressPoint={startAndEnd.end} />
-                        {splits.length === 0 && (
+                        <LocationTrackSplittingEndpoint
+                            addressPoint={startAndEnd.end}
+                            editingDisabled={disabled}
+                        />
+                        {disabled && (
                             <InfoboxContentSpread>
-                                <MessageBox>
-                                    {t('tool-panel.location-track.splitting.splitting-guide')}
-                                </MessageBox>
-                            </InfoboxContentSpread>
-                        )}
-                        {anyMissingFields && (
-                            <InfoboxContentSpread>
-                                <MessageBox>
+                                <MessageBox type={'ERROR'}>
                                     {t(
-                                        'tool-panel.location-track.splitting.validation.missing-fields',
+                                        'tool-panel.location-track.splitting.validation.track-draft-exists',
                                     )}
-                                    ,{' '}
-                                    <Link
-                                        onClick={() =>
-                                            findAndFocusFirstErroredField(
-                                                splitComponents,
-                                                mandatoryFieldMissing,
-                                            )
-                                        }>
-                                        {t('tool-panel.location-track.splitting.validation.show')}
-                                    </Link>
                                 </MessageBox>
                             </InfoboxContentSpread>
                         )}
-                        {anyOtherErrors && (
-                            <InfoboxContentSpread>
-                                <MessageBox>
-                                    {t('tool-panel.location-track.splitting.validation.has-errors')}
-                                    ,{' '}
-                                    <Link
-                                        onClick={() =>
-                                            findAndFocusFirstErroredField(
-                                                splitComponents,
-                                                otherError,
-                                            )
-                                        }>
-                                        {t('tool-panel.location-track.splitting.validation.show')}
-                                    </Link>
-                                </MessageBox>
-                            </InfoboxContentSpread>
+                        {!disabled && (
+                            <React.Fragment>
+                                {splits.length === 0 && (
+                                    <InfoboxContentSpread>
+                                        <MessageBox>
+                                            {t(
+                                                'tool-panel.location-track.splitting.splitting-guide',
+                                            )}
+                                        </MessageBox>
+                                    </InfoboxContentSpread>
+                                )}
+                                {anyMissingFields && (
+                                    <InfoboxContentSpread>
+                                        <MessageBox>
+                                            {t(
+                                                'tool-panel.location-track.splitting.validation.missing-fields',
+                                            )}
+                                            ,{' '}
+                                            <Link
+                                                onClick={() =>
+                                                    findAndFocusFirstErroredField(
+                                                        splitComponents,
+                                                        mandatoryFieldMissing,
+                                                    )
+                                                }>
+                                                {t(
+                                                    'tool-panel.location-track.splitting.validation.show',
+                                                )}
+                                            </Link>
+                                        </MessageBox>
+                                    </InfoboxContentSpread>
+                                )}
+                                {anyMissingSwitches && (
+                                    <InfoboxContentSpread>
+                                        <MessageBox>
+                                            {t(
+                                                'tool-panel.location-track.splitting.validation.missing-switch',
+                                            )}
+                                            ,{' '}
+                                            <Link
+                                                onClick={() =>
+                                                    findAndScrollIntoView(
+                                                        splitComponents,
+                                                        switchDeleted,
+                                                    )
+                                                }>
+                                                {t(
+                                                    'tool-panel.location-track.splitting.validation.show',
+                                                )}
+                                            </Link>
+                                        </MessageBox>
+                                    </InfoboxContentSpread>
+                                )}
+                                {anyOtherErrors && (
+                                    <InfoboxContentSpread>
+                                        <MessageBox>
+                                            {t(
+                                                'tool-panel.location-track.splitting.validation.has-errors',
+                                            )}
+                                            ,{' '}
+                                            <Link
+                                                onClick={() =>
+                                                    findAndFocusFirstErroredField(
+                                                        splitComponents,
+                                                        otherError,
+                                                    )
+                                                }>
+                                                {t(
+                                                    'tool-panel.location-track.splitting.validation.show',
+                                                )}
+                                            </Link>
+                                        </MessageBox>
+                                    </InfoboxContentSpread>
+                                )}
+                            </React.Fragment>
                         )}
                         <InfoboxButtons>
                             <Button
@@ -349,7 +469,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                             </Button>
                             <Button
                                 size={ButtonSize.SMALL}
-                                disabled={anyMissingFields || anyOtherErrors}>
+                                disabled={disabled || anyMissingFields || anyOtherErrors}>
                                 {t('tool-panel.location-track.splitting.confirm-split')}
                             </Button>
                         </InfoboxButtons>

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -406,6 +406,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                             splittingState={splittingState}
                             publishType={publishType}
                             locationTrackChangeTime={changeTimes.layoutLocationTrack}
+                            switchChangeTime={changeTimes.layoutSwitch}
                             onDataChange={onDataChange}
                             viewport={viewport}
                             verticalGeometryDiagramVisible={verticalGeometryDiagramVisible}


### PR DESCRIPTION
Täällä tehty seuraavat asiat:
* Raiteen splittausta ei voi aloittaa mikäli raiteesta on olemassa draft
* Jos splittaaminen on jo aloitettu, disabloidaan splittauksen jatkaminen
* Raiteen vaihteet päivittyvät nyt splittauksessa kartalle reaaliajassa (aiemmin vaihteiden poistot ym. eivät päivittyneet ollenkaan.) Poistetut splitit näytetään punaisella
* Näytetään virhe ja disabloidaan splittauksen lopettaminen mikäli splittauksessa mukana oleva vaihde katoaa muokkauksen seurauksena
* Lisähuomiona korjattu tiketin GVT-2333 asiat, eli nyt ei enää pääse sijaintiraiteen muokkausdialogiin kun linkitys- tai splittaustila on auki