### PR TITLE
GVT-2336: Raiteen infoboxissa näkyy vanha osoite

### DIFF
--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -346,6 +346,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                     onClose={() => setShowAddLocationTrackDialog(false)}
                     onSave={handleLocationTrackSave}
                     locationTrackChangeTime={changeTimes.layoutLocationTrack}
+                    switchChangeTime={changeTimes.layoutSwitch}
                 />
             )}
 

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-infobox.tsx
@@ -31,6 +31,7 @@ type GeometryAlignmentInfoboxProps = {
     selectedLayoutReferenceLine?: LayoutReferenceLine;
     planId: GeometryPlanId;
     locationTrackChangeTime: TimeStamp;
+    switchChangeTime: TimeStamp;
     trackNumberChangeTime: TimeStamp;
     linkingState?: LinkingState;
     onLinkingStart: (startParams: GeometryPreliminaryLinkingParameters) => void;
@@ -53,6 +54,7 @@ const GeometryAlignmentInfobox: React.FC<GeometryAlignmentInfoboxProps> = ({
     selectedLayoutReferenceLine,
     planId,
     locationTrackChangeTime,
+    switchChangeTime,
     trackNumberChangeTime,
     linkingState,
     onLinkingStart,
@@ -121,6 +123,7 @@ const GeometryAlignmentInfobox: React.FC<GeometryAlignmentInfoboxProps> = ({
                     selectedLayoutReferenceLine={selectedLayoutReferenceLine}
                     planId={planId}
                     locationTrackChangeTime={locationTrackChangeTime}
+                    switchChangeTime={switchChangeTime}
                     trackNumberChangeTime={trackNumberChangeTime}
                     linkingState={linkingState}
                     onLinkingStart={onLinkingStart}

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-container.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-container.tsx
@@ -67,6 +67,7 @@ const GeometryAlignmentLinkingContainer: React.FC<GeometryAlignmentLinkingContai
                 changeTimes.layoutReferenceLine,
                 changeTimes.layoutLocationTrack,
             )}
+            switchChangeTime={changeTimes.layoutSwitch}
             trackNumberChangeTime={changeTimes.layoutTrackNumber}
             linkingState={linkingState}
             onLinkingStart={(params) => {

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -111,6 +111,7 @@ type GeometryAlignmentLinkingInfoboxProps = {
     planId: GeometryPlanId;
     locationTrackChangeTime: TimeStamp;
     trackNumberChangeTime: TimeStamp;
+    switchChangeTime: TimeStamp;
     linkingState?:
         | LinkingGeometryWithAlignment
         | LinkingGeometryWithEmptyAlignment
@@ -134,6 +135,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
     selectedLayoutReferenceLine,
     planId,
     locationTrackChangeTime,
+    switchChangeTime,
     trackNumberChangeTime,
     linkingState,
     onLinkingStart,
@@ -429,6 +431,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                     onClose={() => setShowAddLocationTrackDialog(false)}
                     onSave={handleLocationTrackSave}
                     locationTrackChangeTime={locationTrackChangeTime}
+                    switchChangeTime={switchChangeTime}
                 />
             )}
             {showAddTrackNumberDialog && (

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -63,6 +63,7 @@ type LocationTrackDialogContainerProps = {
     onClose: () => void;
     onSave?: (locationTrackId: LocationTrackId) => void;
     locationTrackChangeTime: TimeStamp;
+    switchChangeTime: TimeStamp;
 };
 
 export const LocationTrackEditDialogContainer: React.FC<LocationTrackDialogContainerProps> = (
@@ -78,6 +79,7 @@ export const LocationTrackEditDialogContainer: React.FC<LocationTrackDialogConta
             onClose={props.onClose}
             onSave={props.onSave}
             locationTrackChangeTime={props.locationTrackChangeTime}
+            switchChangeTime={props.switchChangeTime}
             onEditTrack={(id) => setEditTrackId(id)}
         />
     );
@@ -88,6 +90,7 @@ type LocationTrackDialogProps = {
     onClose: () => void;
     onSave?: (locationTrackId: LocationTrackId) => void;
     locationTrackChangeTime: TimeStamp;
+    switchChangeTime: TimeStamp;
     onEditTrack: (id: LocationTrackId) => void;
 };
 
@@ -120,7 +123,12 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         props.locationTrackChangeTime,
     );
 
-    const [extraInfo] = useLocationTrackInfoboxExtras(props.locationTrack?.id, 'DRAFT');
+    const [extraInfo] = useLocationTrackInfoboxExtras(
+        props.locationTrack?.id,
+        'DRAFT',
+        props.locationTrackChangeTime,
+        props.switchChangeTime,
+    );
 
     const stateOptions = layoutStates
         .filter((ls) => !state.isNewLocationTrack || ls.value != 'DELETED')

--- a/ui/src/tool-panel/location-track/location-track-infobox-linking-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-linking-container.tsx
@@ -20,6 +20,7 @@ type LocationTrackInfoboxLinkingContainerProps = {
     publishType: PublishType;
     locationTrackChangeTime: TimeStamp;
     switchChangeTime: TimeStamp;
+    trackNumberChangeTime: TimeStamp;
     onDataChange: () => void;
     viewport: MapViewport;
     visibilities: LocationTrackInfoboxVisibilities;
@@ -35,6 +36,7 @@ const LocationTrackInfoboxLinkingContainer: React.FC<LocationTrackInfoboxLinking
     publishType,
     locationTrackChangeTime,
     switchChangeTime,
+    trackNumberChangeTime,
     onDataChange,
     viewport,
     visibilities,
@@ -67,6 +69,7 @@ const LocationTrackInfoboxLinkingContainer: React.FC<LocationTrackInfoboxLinking
                 publishType={publishType}
                 locationTrackChangeTime={locationTrackChangeTime}
                 switchChangeTime={switchChangeTime}
+                trackNumberChangeTime={trackNumberChangeTime}
                 onSelect={delegates.onSelect}
                 onUnselect={delegates.onUnselect}
                 viewport={viewport}

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -77,6 +77,7 @@ type LocationTrackInfoboxProps = {
     onDataChange: () => void;
     publishType: PublishType;
     locationTrackChangeTime: TimeStamp;
+    trackNumberChangeTime: TimeStamp;
     switchChangeTime: TimeStamp;
     onSelect: OnSelectFunction;
     onUnselect: (items: OptionalUnselectableItemCollections) => void;
@@ -98,6 +99,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     onDataChange,
     publishType,
     locationTrackChangeTime,
+    trackNumberChangeTime,
     switchChangeTime,
     onSelect,
     onUnselect,
@@ -115,6 +117,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
         locationTrack?.id,
         publishType,
         locationTrackChangeTime,
+        trackNumberChangeTime,
     );
     const changeTimes = useLocationTrackChangeTimes(locationTrack?.id, publishType);
     const coordinateSystem = useCoordinateSystem(LAYOUT_SRID);
@@ -199,6 +202,8 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     const [extraInfo, extraInfoLoadingStatus] = useLocationTrackInfoboxExtras(
         locationTrack?.id,
         publishType,
+        locationTrackChangeTime,
+        switchChangeTime,
     );
 
     const visibilityChange = (key: keyof LocationTrackInfoboxVisibilities) => {
@@ -612,6 +617,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     onSave={handleLocationTrackSave}
                     locationTrackId={locationTrack.id}
                     locationTrackChangeTime={locationTrackChangeTime}
+                    switchChangeTime={switchChangeTime}
                 />
             )}
         </React.Fragment>

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -407,6 +407,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                             publishType={publishType}
                             locationTrackChangeTime={changeTimes.layoutLocationTrack}
                             switchChangeTime={changeTimes.layoutSwitch}
+                            trackNumberChangeTime={changeTimes.layoutTrackNumber}
                             onDataChange={onDataChange}
                             viewport={viewport}
                             verticalGeometryDiagramVisible={verticalGeometryDiagramVisible}

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -49,7 +49,7 @@ import {
 import { getKmPost, getKmPostChangeTimes, getKmPosts } from 'track-layout/layout-km-post-api';
 import { PVDocumentHeader, PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { getPVDocument } from 'infra-model/infra-model-api';
-import { getChangeTimes, updateAllChangeTimes } from 'common/change-time-api';
+import { updateAllChangeTimes } from 'common/change-time-api';
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import {
     updateKmPostChangeTime,
@@ -58,6 +58,7 @@ import {
 } from 'common/change-time-api';
 import { deduplicate } from 'utils/array-utils';
 import { validateLocationTrackName } from 'tool-panel/location-track/dialog/location-track-validation';
+import { getMaxTimestampFromArray } from 'utils/date-utils';
 
 export function useTrackNumberReferenceLine(
     trackNumberId: LayoutTrackNumberId | undefined,
@@ -201,25 +202,30 @@ export function useReferenceLineStartAndEnd(
 export function useLocationTrackStartAndEnd(
     id: LocationTrackId | undefined,
     publishType: PublishType | undefined,
-    changeTime: TimeStamp = getChangeTimes().layoutLocationTrack,
+    ...changeTimes: TimeStamp[]
 ): [AlignmentStartAndEnd | undefined, LoaderStatus] {
     return useLoaderWithStatus(
         () =>
             id && publishType
-                ? getLocationTrackStartAndEnd(id, publishType, changeTime)
+                ? getLocationTrackStartAndEnd(
+                      id,
+                      publishType,
+                      getMaxTimestampFromArray(changeTimes),
+                  )
                 : undefined,
-        [id, publishType, changeTime],
+        [id, publishType, ...changeTimes],
     );
 }
 
 export function useLocationTrackInfoboxExtras(
     id: LocationTrackId | undefined,
     publishType: PublishType,
-    changeTime: TimeStamp = getChangeTimes().layoutLocationTrack,
+    locationTrackChangeTime: TimeStamp,
+    switchChangeTime: TimeStamp,
 ): [LocationTrackInfoboxExtras | undefined, LoaderStatus] {
     return useLoaderWithStatus(
         () => (id === undefined ? undefined : getLocationTrackInfoboxExtras(id, publishType)),
-        [id, publishType, changeTime],
+        [id, publishType, locationTrackChangeTime, switchChangeTime],
     );
 }
 export function useConflictingTracks(

--- a/ui/src/utils/date-utils.ts
+++ b/ui/src/utils/date-utils.ts
@@ -71,9 +71,11 @@ export function getMinTimestamp(time1: TimeStamp, ...others: TimeStamp[]) {
     return minOf([time1, ...others], compareTimestamps) as TimeStamp;
 }
 
-export function getMaxTimestamp(time1: TimeStamp, ...others: TimeStamp[]) {
-    return maxOf([time1, ...others], compareTimestamps) as TimeStamp;
-}
+export const getMaxTimestamp = (time1: TimeStamp, ...others: TimeStamp[]) =>
+    getMaxTimestampFromArray([time1, ...others]);
+
+export const getMaxTimestampFromArray = (timestamps: TimeStamp[]) =>
+    maxOf(timestamps, compareTimestamps) as TimeStamp;
 
 export function createYearRange(fromYear: number, toYear: number): number[] {
     const years = [];


### PR DESCRIPTION
Syyllisenä oli raiteen alku- ja loppupisteiden haku, joka ei päivittynyt ratanumeron päivittyessä. Refaktoroitu alun ja lopun hakumekanismi siten, että sille voi antaa useamman changeTimen. Samalla korjattu vastaava fiba InfoboxExtras-hausta