### PR TITLE
GVT-2273: Refactor frontpage & publication log state handling

### DIFF
--- a/ui/src/app-bar/app-bar.tsx
+++ b/ui/src/app-bar/app-bar.tsx
@@ -54,9 +54,9 @@ export const AppBar: React.FC = () => {
 
     function getFrontpageLink(): string {
         if (selectedPublicationId) {
-            return `/publication-log/${selectedPublicationId}`;
+            return `/publications/${selectedPublicationId}`;
         } else if (selectedPublicationSearch) {
-            return '/publication-log';
+            return '/publications';
         }
 
         return `/`;

--- a/ui/src/app-bar/app-bar.tsx
+++ b/ui/src/app-bar/app-bar.tsx
@@ -6,7 +6,7 @@ import geoviiteLogo from 'geoviite-design-lib/geoviite-logo.svg';
 import { EnvRestricted } from 'environment/env-restricted';
 import { Environment } from 'environment/environment-info';
 import { useTranslation } from 'react-i18next';
-import { useInfraModelAppSelector } from 'store/hooks';
+import { useInfraModelAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
 import { InfraModelTabType } from 'infra-model/infra-model-slice';
 import { InfraModelLink } from 'app-bar/infra-model-link';
 import { getPVDocumentCount } from 'infra-model/infra-model-api';
@@ -44,6 +44,24 @@ export const AppBar: React.FC = () => {
     const pvDocumentCounts = useLoader(() => getPVDocumentCount(), [changeTimes.pvDocument]);
     const exclamationPointVisibility = !!pvDocumentCounts && pvDocumentCounts?.suggested > 0;
 
+    const selectedPublicationId = useTrackLayoutAppSelector(
+        (state) => state.selection.publicationId,
+    );
+
+    const selectedPublicationSearch = useTrackLayoutAppSelector(
+        (state) => state.selection.publicationSearch,
+    );
+
+    function getFrontpageLink(): string {
+        if (selectedPublicationId) {
+            return `/publication-log/${selectedPublicationId}`;
+        } else if (selectedPublicationSearch) {
+            return '/publication-log';
+        }
+
+        return `/`;
+    }
+
     function getInfraModelLink(): string {
         switch (selectedInfraModelTab) {
             case InfraModelTabType.PLAN:
@@ -66,6 +84,47 @@ export const AppBar: React.FC = () => {
              ${isActive ? styles['app-bar__link--active'] : ''}`;
     }
 
+    function getNavLink(link: Link) {
+        switch (link.link) {
+            case '/':
+                return (
+                    <NavLink
+                        to={getFrontpageLink()}
+                        className={({ isActive }) =>
+                            `${styles['app-bar__link']} ${
+                                isActive ? styles['app-bar__link--active'] : ''
+                            }`
+                        }
+                        end>
+                        {t(link.name)}
+                    </NavLink>
+                );
+            case '/infra-model':
+                return (
+                    <NavLink
+                        to={getInfraModelLink()}
+                        className={({ isActive }) => getInfraModelLinkClassName(isActive)}
+                        end>
+                        <InfraModelLink exclamationPointVisibility={exclamationPointVisibility} />
+                    </NavLink>
+                );
+
+            default:
+                return (
+                    <NavLink
+                        to={link.link}
+                        className={({ isActive }) =>
+                            `${styles['app-bar__link']} ${
+                                isActive ? styles['app-bar__link--active'] : ''
+                            }`
+                        }
+                        end>
+                        {t(link.name)}
+                    </NavLink>
+                );
+        }
+    }
+
     return (
         <nav className={styles['app-bar']}>
             <div className={styles['app-bar__title']}>
@@ -76,31 +135,7 @@ export const AppBar: React.FC = () => {
                 {links.map((link) => {
                     return (
                         <EnvRestricted restrictTo={link.type} key={link.name}>
-                            <li qa-id={link.qaId}>
-                                {link.link !== '/infra-model' ? (
-                                    <NavLink
-                                        to={link.link}
-                                        className={({ isActive }) =>
-                                            `${styles['app-bar__link']} ${
-                                                isActive ? styles['app-bar__link--active'] : ''
-                                            }`
-                                        }
-                                        end>
-                                        {t(link.name)}
-                                    </NavLink>
-                                ) : (
-                                    <NavLink
-                                        to={getInfraModelLink()}
-                                        className={({ isActive }) =>
-                                            getInfraModelLinkClassName(isActive)
-                                        }
-                                        end>
-                                        <InfraModelLink
-                                            exclamationPointVisibility={exclamationPointVisibility}
-                                        />
-                                    </NavLink>
-                                )}
-                            </li>
+                            <li qa-id={link.qaId}>{getNavLink(link)}</li>
                         </EnvRestricted>
                     );
                 })}

--- a/ui/src/common/navigate.ts
+++ b/ui/src/common/navigate.ts
@@ -5,8 +5,8 @@ import { PublicationId } from 'preview/preview-table';
 
 const appPath = {
     'frontpage': '/',
-    'publication-search': '/publication-log',
-    'publication-view': (id: PublicationId) => `/publication-log/${id}`,
+    'publication-search': '/publications',
+    'publication-view': (id: PublicationId) => `/publications/${id}`,
     'inframodel-list': '/infra-model',
     'inframodel-upload': '/infra-model/upload',
     'inframodel-edit': (id: GeometryPlanId) => `/infra-model/edit/${id}`,

--- a/ui/src/common/navigate.ts
+++ b/ui/src/common/navigate.ts
@@ -1,8 +1,12 @@
 import { GeometryPlanId } from 'geometry/geometry-model';
 import { PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { useNavigate } from 'react-router-dom';
+import { PublicationId } from 'preview/preview-table';
 
 const appPath = {
+    'frontpage': '/',
+    'publication-search': '/publication-log',
+    'publication-view': (id: PublicationId) => `/publication-log/${id}`,
     'inframodel-list': '/infra-model',
     'inframodel-upload': '/infra-model/upload',
     'inframodel-edit': (id: GeometryPlanId) => `/infra-model/edit/${id}`,

--- a/ui/src/frontpage/frontpage-container.tsx
+++ b/ui/src/frontpage/frontpage-container.tsx
@@ -9,11 +9,9 @@ export const FrontpageContainer: React.FC = () => {
     const ratkoPushChangeTime = useCommonDataAppSelector((state) => state.changeTimes.ratkoPush);
 
     return (
-        <React.Fragment>
-            <Frontpage
-                publicationChangeTime={publicationChangeTime}
-                ratkoPushChangeTime={ratkoPushChangeTime}
-            />
-        </React.Fragment>
+        <Frontpage
+            publicationChangeTime={publicationChangeTime}
+            ratkoPushChangeTime={ratkoPushChangeTime}
+        />
     );
 };

--- a/ui/src/frontpage/frontpage-container.tsx
+++ b/ui/src/frontpage/frontpage-container.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
-import { createDelegates } from 'store/store-utils';
-import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
+import { useCommonDataAppSelector } from 'store/hooks';
 import Frontpage from 'frontpage/frontpage';
 
 export const FrontpageContainer: React.FC = () => {
@@ -9,15 +7,13 @@ export const FrontpageContainer: React.FC = () => {
         (state) => state.changeTimes.publication,
     );
     const ratkoPushChangeTime = useCommonDataAppSelector((state) => state.changeTimes.ratkoPush);
-    const publication = useTrackLayoutAppSelector((state) => state.selection.publication);
-    const delegates = React.useMemo(() => createDelegates(trackLayoutActionCreators), []);
 
     return (
-        <Frontpage
-            selectedPublication={publication}
-            publicationChangeTime={publicationChangeTime}
-            ratkoPushChangeTime={ratkoPushChangeTime}
-            onSelectedPublicationChanged={delegates.onSelectedPublicationChanged}
-        />
+        <React.Fragment>
+            <Frontpage
+                publicationChangeTime={publicationChangeTime}
+                ratkoPushChangeTime={ratkoPushChangeTime}
+            />
+        </React.Fragment>
     );
 };

--- a/ui/src/frontpage/frontpage.tsx
+++ b/ui/src/frontpage/frontpage.tsx
@@ -1,72 +1,40 @@
 import * as React from 'react';
 import PublicationCard, { MAX_LISTED_PUBLICATIONS } from 'publication/card/publication-card';
 import styles from './frontpage.scss';
-import PublicationDetailsView from 'publication/publication';
-import { PublicationId } from 'publication/publication-model';
+
 import { useLoaderWithStatus, useLoaderWithTimer } from 'utils/react-utils';
 import { UserCardContainer } from 'user/user-card-container';
 import { getRatkoStatus, RatkoStatus } from 'ratko/ratko-api';
-import PublicationLog from 'publication/log/publication-log';
+
 import { getLatestPublications } from 'publication/publication-api';
-import { ratkoPushFailed } from 'ratko/ratko-model';
+
 import { TimeStamp } from 'common/common-model';
 
 type FrontPageProps = {
-    selectedPublication: PublicationId | undefined;
-    onSelectedPublicationChanged: (item: PublicationId | undefined) => void;
     publicationChangeTime: TimeStamp;
     ratkoPushChangeTime: TimeStamp;
 };
 
-const Frontpage: React.FC<FrontPageProps> = ({
-    selectedPublication,
-    onSelectedPublicationChanged,
-    publicationChangeTime,
-    ratkoPushChangeTime,
-}) => {
+const Frontpage: React.FC<FrontPageProps> = ({ publicationChangeTime, ratkoPushChangeTime }) => {
     const [ratkoStatus, setRatkoStatus] = React.useState<RatkoStatus | undefined>();
-    const [showPublicationLog, setShowPublicationLog] = React.useState(false);
-
     const [publications, publicationFetchStatus] = useLoaderWithStatus(
         () => getLatestPublications(MAX_LISTED_PUBLICATIONS).then((result) => result?.items),
         [publicationChangeTime, ratkoPushChangeTime],
     );
 
-    const publication = publications?.find((p) => p.id == selectedPublication);
     useLoaderWithTimer(setRatkoStatus, getRatkoStatus, [], 30000);
-
-    const anyFailed = !!publications?.some((p) => ratkoPushFailed(p.ratkoPushStatus));
 
     return (
         <React.Fragment>
-            {!selectedPublication && !showPublicationLog && (
-                <React.Fragment>
-                    <div className={styles['frontpage']}>
-                        <PublicationCard
-                            publications={publications || []}
-                            publicationFetchStatus={publicationFetchStatus}
-                            onPublicationSelect={(pub) => {
-                                onSelectedPublicationChanged(pub.id);
-                            }}
-                            onShowPublicationLog={() => setShowPublicationLog(true)}
-                            ratkoStatus={ratkoStatus}
-                        />
-                        <UserCardContainer />
-                    </div>
-                    <div className={styles['frontpage__photo']} />
-                </React.Fragment>
-            )}
-            {!selectedPublication && showPublicationLog && (
-                <PublicationLog onClose={() => setShowPublicationLog(false)} />
-            )}
-            {publication && (
-                <PublicationDetailsView
-                    changeTime={publicationChangeTime}
-                    publication={publication}
-                    onPublicationUnselected={() => onSelectedPublicationChanged(undefined)}
-                    anyFailed={anyFailed}
+            <div className={styles['frontpage']}>
+                <PublicationCard
+                    publications={publications || []}
+                    publicationFetchStatus={publicationFetchStatus}
+                    ratkoStatus={ratkoStatus}
                 />
-            )}
+                <UserCardContainer />
+            </div>
+            <div className={styles['frontpage__photo']} />
         </React.Fragment>
     );
 };

--- a/ui/src/main/main.tsx
+++ b/ui/src/main/main.tsx
@@ -29,6 +29,8 @@ import VerticalGeometryView from 'data-products/vertical-geometry/vertical-geome
 import { commonActionCreators } from 'common/common-slice';
 import { getOwnUser } from 'user/user-api';
 import Licenses from 'licenses/licenses';
+import PublicationLog from 'publication/log/publication-log';
+import { PublicationDetailsContainer } from 'publication/publication-details-container';
 
 type MainProps = {
     layoutMode: LayoutMode;
@@ -46,6 +48,11 @@ const Main: React.FC<MainProps> = (props: MainProps) => {
             <div className={styles.main__content} qa-id="main-content-container">
                 <Routes>
                     <Route path="/" element={<FrontpageContainer />} />
+                    <Route path={'/publication-log'} element={<PublicationLog />} />
+                    <Route
+                        path={'/publication-log/:publicationId'}
+                        element={<PublicationDetailsContainer />}
+                    />
                     <Route
                         path="/track-layout"
                         element={

--- a/ui/src/main/main.tsx
+++ b/ui/src/main/main.tsx
@@ -48,9 +48,9 @@ const Main: React.FC<MainProps> = (props: MainProps) => {
             <div className={styles.main__content} qa-id="main-content-container">
                 <Routes>
                     <Route path="/" element={<FrontpageContainer />} />
-                    <Route path={'/publication-log'} element={<PublicationLog />} />
+                    <Route path={'/publications'} element={<PublicationLog />} />
                     <Route
-                        path={'/publication-log/:publicationId'}
+                        path={'/publications/:publicationId'}
                         element={<PublicationDetailsContainer />}
                     />
                     <Route

--- a/ui/src/publication/card/publication-list.tsx
+++ b/ui/src/publication/card/publication-list.tsx
@@ -9,10 +9,12 @@ import { useTranslation } from 'react-i18next';
 import { ratkoPushFailed, ratkoPushInProgress } from 'ratko/ratko-model';
 import { PublicationDetails } from 'publication/publication-model';
 import { filterUnique } from 'utils/array-utils';
+import { useAppNavigate } from 'common/navigate';
+import { createDelegates } from 'store/store-utils';
+import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 
 type PublicationListProps = {
     publications: PublicationDetails[];
-    onPublicationSelect: (publication: PublicationDetails) => void;
     anyFailed?: boolean;
 };
 
@@ -25,12 +27,15 @@ const getPublicationTrackNumbers = (publication: PublicationDetails) => {
     ].filter(filterUnique);
 };
 
-export const PublicationList: React.FC<PublicationListProps> = ({
-    publications,
-    onPublicationSelect,
-    anyFailed,
-}) => {
+export const PublicationList: React.FC<PublicationListProps> = ({ publications, anyFailed }) => {
     const { t } = useTranslation();
+    const navigate = useAppNavigate();
+
+    const trackLayoutActionDelegates = React.useMemo(
+        () => createDelegates(trackLayoutActionCreators),
+        [],
+    );
+
     //Track numbers rarely change, therefore we can always use the "latest" version
     const trackNumbers = useTrackNumbers('OFFICIAL') || [];
 
@@ -56,7 +61,13 @@ export const PublicationList: React.FC<PublicationListProps> = ({
                             />
                         )}
                         <div className={styles['publication-list-item__text']}>
-                            <Link onClick={() => onPublicationSelect(publication)}>
+                            <Link
+                                onClick={() => {
+                                    trackLayoutActionDelegates.setSelectedPublicationId(
+                                        publication.id,
+                                    );
+                                    navigate('publication-view', publication.id);
+                                }}>
                                 {formatDateFull(publication.publicationTime)}
                             </Link>
                         </div>

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -47,51 +47,6 @@ const PublicationLog: React.FC = () => {
     const [isLoading, setIsLoading] = React.useState(true);
     const [pagedPublications, setPagedPublications] = React.useState<Page<PublicationTableItem>>();
 
-    // TODO Also the URL & redux state should also be updated when the input values are changed
-    // useEffect(() => {
-    //     const queryParams = new URLSearchParams(urlSearchString);
-    //     // const startDate = toDateOrUndefined(queryParams.get('startDate') ?? '');
-    //     // const endDate = toDateOrUndefined(queryParams.get('endDate') ?? '');
-    //
-    //     if (!startDate || !endDate) {
-    //         console.error('Invalid search params, continuing with defaults.');
-    //         navigate(createPublicationLogSearchAddress(defaultPublicationSearch));
-    //     }
-    //
-    //     trackLayoutActionDelegates.setSelectedPublicationSearch({
-    //         startDate: startDate,
-    //         endDate: endDate,
-    //     });
-    //
-    //     setStartDate(startDate);
-    //     setEndDate(endDate);
-    // }, [urlSearchString]);
-
-    // useEffect(() => {
-    //     const newSearch: PublicationSearch = {
-    //         startDate: startDate,
-    //         endDate: endDate,
-    //     };
-    //
-    //     console.log(startDate);
-    //     console.log(endDate);
-    //     // navigate(createPublicationLogSearchAddress(newSearch));
-    // }, [startDate, endDate]);
-
-    // function updateURL(newStartDate: Date | undefined, newEndDate: Date | undefined) {
-    //     const newSearch: PublicationSearch = {
-    //         startDate: newStartDate,
-    //         endDate: newEndDate,
-    //     };
-    //
-    //     trackLayoutActionDelegates.setSelectedPublicationSearch({
-    //         startDate: newStartDate,
-    //         endDate: newEndDate,
-    //     });
-    //
-    //     navigate(createPublicationLogSearchAddress(newSearch));
-    // }
-
     React.useEffect(() => {
         setIsLoading(true);
 

--- a/ui/src/publication/publication-details-container.tsx
+++ b/ui/src/publication/publication-details-container.tsx
@@ -1,0 +1,46 @@
+import PublicationDetailsView from 'publication/publication';
+import { useCommonDataAppSelector } from 'store/hooks';
+import { useLoaderWithStatus } from 'utils/react-utils';
+import { getLatestPublications } from 'publication/publication-api';
+import { MAX_LISTED_PUBLICATIONS } from 'publication/card/publication-card';
+import { useParams } from 'react-router-dom';
+import { PublicationId } from 'preview/preview-table';
+import React from 'react';
+import { ratkoPushFailed } from 'ratko/ratko-model';
+import { createDelegates } from 'store/store-utils';
+import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
+
+export const PublicationDetailsContainer: React.FC = () => {
+    const trackLayoutActionDelegates = React.useMemo(
+        () => createDelegates(trackLayoutActionCreators),
+        [],
+    );
+
+    const selectedPublicationId: PublicationId | undefined = useParams().publicationId;
+
+    const ratkoPushChangeTime = useCommonDataAppSelector((state) => state.changeTimes.ratkoPush);
+    const publicationChangeTime = useCommonDataAppSelector(
+        (state) => state.changeTimes.publication,
+    );
+
+    const [publications, _publicationFetchStatus] = useLoaderWithStatus(
+        () => getLatestPublications(MAX_LISTED_PUBLICATIONS).then((result) => result?.items),
+        [publicationChangeTime, ratkoPushChangeTime],
+    );
+
+    const publication = publications?.find((p) => p.id == selectedPublicationId);
+    const anyFailed = !!publications?.some((p) => ratkoPushFailed(p.ratkoPushStatus));
+
+    if (!selectedPublicationId || !publication) {
+        return <React.Fragment />;
+    }
+
+    return (
+        <PublicationDetailsView
+            publication={publication}
+            setSelectedPublicationId={trackLayoutActionDelegates.setSelectedPublicationId}
+            anyFailed={anyFailed}
+            changeTime={publicationChangeTime}
+        />
+    );
+};

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -280,3 +280,8 @@ export type PublicationTableItem = {
     ratkoPushTime: TimeStamp;
     propChanges: PublicationChange[];
 };
+
+export type PublicationSearch = {
+    startDate: Date | undefined;
+    endDate: Date | undefined;
+};

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -1,5 +1,11 @@
-import { PublishCandidates, PublishRequestIds } from 'publication/publication-model';
+import { subMonths } from 'date-fns';
+import {
+    PublicationSearch,
+    PublishCandidates,
+    PublishRequestIds,
+} from 'publication/publication-model';
 import { filterByIdNotIn, filterIn, filterNotIn } from 'utils/array-utils';
+import { currentDay } from 'utils/date-utils';
 
 export const addPublishRequestIds = (
     a: PublishRequestIds,
@@ -44,3 +50,8 @@ export const dropIdsFromPublishCandidates = (
     ),
     kmPosts: publishCandidates.kmPosts.filter(filterByIdNotIn(ids.kmPosts, ({ id }) => id)),
 });
+
+export const defaultPublicationSearch: PublicationSearch = {
+    startDate: subMonths(currentDay, 1),
+    endDate: currentDay,
+};

--- a/ui/src/publication/publication.tsx
+++ b/ui/src/publication/publication.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import PublicationTable from 'publication/table/publication-table';
-import { PublicationDetails, PublicationTableItem } from 'publication/publication-model';
+import {
+    PublicationDetails,
+    PublicationId,
+    PublicationTableItem,
+} from 'publication/publication-model';
 import styles from './publication.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { useTranslation } from 'react-i18next';
@@ -11,21 +15,23 @@ import { ratkoPushFailed } from 'ratko/ratko-model';
 import { getPublicationAsTableItems } from 'publication/publication-api';
 import { TimeStamp } from 'common/common-model';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
+import { useAppNavigate } from 'common/navigate';
 
 export type PublicationDetailsViewProps = {
     publication: PublicationDetails;
-    onPublicationUnselected: () => void;
+    setSelectedPublicationId: (publicationId: PublicationId | undefined) => void;
     anyFailed: boolean;
     changeTime: TimeStamp;
 };
 
 const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
     publication,
-    onPublicationUnselected,
+    setSelectedPublicationId,
     anyFailed,
     changeTime,
 }) => {
     const { t } = useTranslation();
+    const navigate = useAppNavigate();
 
     const waitingAfterFail = !publication.ratkoPushStatus && anyFailed;
     const [publicationItems, setPublicationItems] = React.useState<PublicationTableItem[]>([]);
@@ -33,6 +39,7 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
 
     React.useEffect(() => {
         setIsLoading(true);
+        setSelectedPublicationId(publication.id);
 
         getPublicationAsTableItems(publication.id).then((p) => {
             p && setPublicationItems(p);
@@ -45,7 +52,8 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
             <div className={styles['publication-details__title']}>
                 <Link
                     onClick={() => {
-                        onPublicationUnselected();
+                        setSelectedPublicationId(undefined);
+                        navigate('frontpage');
                     }}>
                     {t('frontpage.frontpage-link')}
                 </Link>

--- a/ui/src/selection/selection-model.ts
+++ b/ui/src/selection/selection-model.ts
@@ -22,7 +22,7 @@ import {
 } from 'linking/linking-model';
 import { ensureAllKeys } from 'utils/type-utils';
 import { Point } from 'model/geometry';
-import { PublicationId } from 'publication/publication-model';
+import { PublicationId, PublicationSearch } from 'publication/publication-model';
 
 export type SelectionMode = 'alignment' | 'segment' | 'point' | 'switch' | 'trackNumber';
 
@@ -94,7 +94,8 @@ export type Selection = {
     highlightedItems: ItemCollections;
     openPlans: OpenPlanLayout[];
     visiblePlans: VisiblePlanLayout[];
-    publication: PublicationId | undefined;
+    publicationId: PublicationId | undefined;
+    publicationSearch: PublicationSearch | undefined;
 };
 
 export type VisiblePlanLayout = {

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -21,7 +21,8 @@ import {
     GeometryPlanLayoutId,
     GeometrySwitchId,
 } from 'geometry/geometry-model';
-import { PublicationId } from 'publication/publication-model';
+import { PublicationId, PublicationSearch } from 'publication/publication-model';
+import { defaultPublicationSearch } from 'publication/publication-utils';
 
 export function createEmptyItemCollections(): ItemCollections {
     return {
@@ -47,7 +48,8 @@ export const initialSelectionState: Selection = {
     highlightedItems: createEmptyItemCollections(),
     openPlans: [],
     visiblePlans: [],
-    publication: undefined,
+    publicationId: undefined,
+    publicationSearch: undefined,
 };
 
 function getNewIdCollection<TId extends string>(
@@ -311,11 +313,41 @@ export const selectionReducers = {
     ) {
         updateItemCollectionsByUnselecting(state.selectedItems, payload);
     },
-    onSelectedPublicationChanged: (
+    setSelectedPublicationId: (
         state: Selection,
-        { payload: publication }: PayloadAction<PublicationId | undefined>,
+        { payload: publicationId }: PayloadAction<PublicationId | undefined>,
     ) => {
-        state.publication = publication;
+        state.publicationId = publicationId;
+        state.publicationSearch = undefined;
+    },
+    setSelectedPublicationSearch: (
+        state: Selection,
+        { payload: publicationSearch }: PayloadAction<PublicationSearch | undefined>,
+    ) => {
+        state.publicationId = undefined;
+        state.publicationSearch = publicationSearch;
+    },
+    setSelectedPublicationSearchStartDate: (
+        state: Selection,
+        { payload: newStartDate }: PayloadAction<Date | undefined>,
+    ) => {
+        if (!state.publicationSearch) {
+            state.publicationSearch = defaultPublicationSearch;
+        }
+        state.publicationSearch.startDate = newStartDate;
+    },
+    setSelectedPublicationSearchEndDate: (
+        state: Selection,
+        { payload: newEndDate }: PayloadAction<Date | undefined>,
+    ) => {
+        if (!state.publicationSearch) {
+            state.publicationSearch = defaultPublicationSearch;
+        }
+        state.publicationSearch.endDate = newEndDate;
+    },
+    clearPublicationSelection: (state: Selection) => {
+        state.publicationId = undefined;
+        state.publicationSearch = undefined;
     },
     togglePlanVisibility: (
         state: Selection,
@@ -448,6 +480,7 @@ function toggleVisibility(
 function arePlanPartsVisible(plan: VisiblePlanLayout): boolean {
     return plan.kmPosts.length > 0 || plan.switches.length > 0 || plan.alignments.length > 0;
 }
+
 export function wholePlanVisibility(plan: GeometryPlanLayout): VisiblePlanLayout {
     return {
         id: plan.id,

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -297,7 +297,9 @@ export const SwitchEditDialog = ({
     }
 
     const moveToEditLinkText = (s: LayoutSwitch) => {
-        return s.stateCategory === 'NOT_EXISTING' ? t('switch-dialog.move-to-edit-deleted') : t('switch-dialog.move-to-edit', {name: s.name});
+        return s.stateCategory === 'NOT_EXISTING'
+            ? t('switch-dialog.move-to-edit-deleted')
+            : t('switch-dialog.move-to-edit', { name: s.name });
     };
 
     return (
@@ -364,9 +366,13 @@ export const SwitchEditDialog = ({
                             {conflictingSwitch && (
                                 <>
                                     <div className={styles['switch-edit-dialog__alert-color']}>
-                                        {conflictingSwitch.stateCategory === 'NOT_EXISTING' ? t('switch-dialog.name-in-use-deleted') : t('switch-dialog.name-in-use')}
+                                        {conflictingSwitch.stateCategory === 'NOT_EXISTING'
+                                            ? t('switch-dialog.name-in-use-deleted')
+                                            : t('switch-dialog.name-in-use')}
                                     </div>
-                                    <Link className={styles['switch-edit-dialog__alert']} onClick={() => onEdit(conflictingSwitch.id)}>
+                                    <Link
+                                        className={styles['switch-edit-dialog__alert']}
+                                        onClick={() => onEdit(conflictingSwitch.id)}>
                                         {moveToEditLinkText(conflictingSwitch)}
                                     </Link>
                                 </>


### PR DESCRIPTION
GVT-2273: Refactor frontpage & publication log state handling

* Back/front navigation now works properly in the frontpage/publication log.
* Publication log URL was defined for a specific publication.
* Publication log search URL can now be accessed directly.
* Specific publication URL can now be shared and even modified in the address bar to view or share a specific publication.
* Header bar "Frontpage" link is now stateful and depends on the frontpage state. The previous content that was displayed will be shown when the user clicks the "Frontpage" link again from the address bar regardless of the currently viewed page.
* Previously displayed publication log search won't be lost after navigating again to the frontpage/publication-log "tab". While a specific publication was shown correctly even after using the back/front-navigation, the publication log search was not displayed correctly.
* Previously searched dates in publication logs won't be lost. However, the specific date range URL cannot be shared yet.
* The default 1 month publication log search range will be set when the user navigates to the publication log search from the frontpage.
* The currently stored display state of the frontpage/publication log will be updated depending on the URL shown to the user. A user might have navigated to a specific publication by an external link, and this will now change the stored state of the frontpage/publication log.
---
* Known issues: The scroll position and opened items within the publication log won't be stored for now as they are refreshed every time the pages are viewed again. This can be fixed in a new ticket if deemed necessary.