### PR TITLE
GVT-1807 & GVT-2339: Tasakilometriä linkittäessä ei näe mille ratanumerolle se kuuluu + EnvRestrict raiteiden splittaukselle

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -412,7 +412,8 @@
                     "choose-km-post-msg": "Valitse tasakilometripiste, johon linkitetään",
                     "start-linking-command": "Aloita linkitys",
                     "link-command": "Linkitä",
-                    "linking-succeed-msg": "Tasakilometripiste linkitetty onnistuneesti"
+                    "linking-succeed-msg": "Tasakilometripiste linkitetty onnistuneesti",
+                    "track-number": "Ratanumerolla {{trackNumber}}"
                 }
             }
         },

--- a/ui/src/geoviite-design-lib/km-post/km-post-badge.tsx
+++ b/ui/src/geoviite-design-lib/km-post/km-post-badge.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import styles from './km-post-badge.scss';
-import { LayoutKmPost } from 'track-layout/track-layout-model';
+import { LayoutKmPost, LayoutTrackNumber } from 'track-layout/track-layout-model';
 import { createClassName } from 'vayla-design-lib/utils';
 
 type KmPostBadgeProps = {
     kmPost: LayoutKmPost;
+    trackNumber?: LayoutTrackNumber;
+    showTrackNumberInBadge?: boolean;
     status?: KmPostBadgeStatus;
     onClick?: () => void;
 };
@@ -20,9 +23,12 @@ export enum KmPostBadgeStatus {
 
 export const KmPostBadge: React.FC<KmPostBadgeProps> = ({
     kmPost,
+    trackNumber,
     status = KmPostBadgeStatus.DEFAULT,
+    showTrackNumberInBadge,
     onClick,
 }: KmPostBadgeProps) => {
+    const { t } = useTranslation();
     const classes = createClassName(
         styles['km-post-badge'],
         status,
@@ -31,9 +37,20 @@ export const KmPostBadge: React.FC<KmPostBadgeProps> = ({
 
     const Icon = status == KmPostBadgeStatus.SELECTED ? Icons.KmPostSelected : Icons.KmPost;
     return (
-        <div className={classes} onClick={onClick}>
+        <div
+            className={classes}
+            title={
+                trackNumber
+                    ? t('tool-panel.km-post.geometry.linking.track-number', {
+                          trackNumber: trackNumber.number,
+                      })
+                    : ''
+            }
+            onClick={onClick}>
             <Icon size={IconSize.SMALL} />
-            <span>{kmPost.kmNumber}</span>
+            <span>{`${kmPost.kmNumber} ${
+                showTrackNumberInBadge ? `/ ${trackNumber?.number}` : ''
+            }`}</span>
         </div>
     );
 };

--- a/ui/src/geoviite-design-lib/km-post/km-post-badge.tsx
+++ b/ui/src/geoviite-design-lib/km-post/km-post-badge.tsx
@@ -36,20 +36,17 @@ export const KmPostBadge: React.FC<KmPostBadgeProps> = ({
     );
 
     const Icon = status == KmPostBadgeStatus.SELECTED ? Icons.KmPostSelected : Icons.KmPost;
+    const onTrackNumberTranslation = t('tool-panel.km-post.geometry.linking.track-number', {
+        trackNumber: trackNumber?.number,
+    });
     return (
         <div
             className={classes}
-            title={
-                trackNumber
-                    ? t('tool-panel.km-post.geometry.linking.track-number', {
-                          trackNumber: trackNumber.number,
-                      })
-                    : ''
-            }
+            title={trackNumber ? onTrackNumberTranslation : ''}
             onClick={onClick}>
             <Icon size={IconSize.SMALL} />
             <span>{`${kmPost.kmNumber} ${
-                showTrackNumberInBadge ? `/ ${trackNumber?.number}` : ''
+                showTrackNumberInBadge && trackNumber ? `/ ${onTrackNumberTranslation}` : ''
             }`}</span>
         </div>
     );

--- a/ui/src/selection-panel/km-posts-panel/km-posts-panel.tsx
+++ b/ui/src/selection-panel/km-posts-panel/km-posts-panel.tsx
@@ -3,9 +3,12 @@ import { LayoutKmPost, LayoutKmPostId } from 'track-layout/track-layout-model';
 import { KmPostBadge, KmPostBadgeStatus } from 'geoviite-design-lib/km-post/km-post-badge';
 import styles from './km-posts-panel.scss';
 import { useTranslation } from 'react-i18next';
+import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
+import { PublishType } from 'common/common-model';
 
 type KmPostsPanelProps = {
     kmPosts: LayoutKmPost[];
+    publishType: PublishType;
     onToggleKmPostSelection: (kmPost: LayoutKmPost) => void;
     selectedKmPosts?: LayoutKmPostId[];
     max?: number;
@@ -13,11 +16,13 @@ type KmPostsPanelProps = {
 
 export const KmPostsPanel: React.FC<KmPostsPanelProps> = ({
     kmPosts,
+    publishType,
     onToggleKmPostSelection,
     selectedKmPosts,
     max = 16,
 }: KmPostsPanelProps) => {
     const { t } = useTranslation();
+    const trackNumbers = useTrackNumbers(publishType);
 
     const [kmPostsCount, setKmPostsCount] = React.useState(0);
     const [visibleKmPosts, setVisibleKmPosts] = React.useState([] as LayoutKmPost[]);
@@ -48,6 +53,9 @@ export const KmPostsPanel: React.FC<KmPostsPanelProps> = ({
                                 kmPost={kmPost}
                                 onClick={() => onToggleKmPostSelection(kmPost)}
                                 status={isSelected ? KmPostBadgeStatus.SELECTED : undefined}
+                                trackNumber={trackNumbers?.find(
+                                    (tn) => tn.id === kmPost.trackNumberId,
+                                )}
                             />
                         </li>
                     );

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -250,6 +250,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                 <div className={styles['selection-panel__content']}>
                     <KmPostsPanel
                         kmPosts={filteredKmPosts}
+                        publishType={publishType}
                         selectedKmPosts={selectedItems.kmPosts}
                         onToggleKmPostSelection={(kmPost) =>
                             onSelect({

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
@@ -28,6 +28,9 @@
 
 .geometry-km-post-linking-infobox__layout-km-post {
     padding: 4px 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
 
     .km-post-badge {
         cursor: pointer;

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
@@ -28,9 +28,6 @@
 
 .geometry-km-post-linking-infobox__layout-km-post {
     padding: 4px 0;
-    display: flex;
-    align-items: center;
-    gap: 6px;
 
     .km-post-badge {
         cursor: pointer;

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -23,7 +23,7 @@ import { KmPostEditDialogContainer } from 'tool-panel/km-post/dialog/km-post-edi
 import { filterNotEmpty } from 'utils/array-utils';
 import { WriteAccessRequired } from 'user/write-access-required';
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
-import { refereshKmPostSelection } from 'track-layout/track-layout-react-utils';
+import { refereshKmPostSelection, useTrackNumbers } from 'track-layout/track-layout-react-utils';
 
 type GeometryKmPostLinkingInfoboxProps = {
     geometryKmPost: LayoutKmPost;
@@ -84,6 +84,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                 : [];
         }, [publishType, geometryKmPost.trackNumberId, geometryKmPost.location, layoutKmPost]) ||
         [];
+    const trackNumbers = useTrackNumbers(publishType);
 
     const [linkingCallInProgress, setLinkingCallInProgress] = React.useState(false);
     const canLink = !linkingCallInProgress && linkingState && geometryKmPost && layoutKmPost;
@@ -138,6 +139,9 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                             linkedLayoutKmPosts.map((kmPost) => (
                                 <KmPostBadge
                                     key={kmPost.id}
+                                    trackNumber={trackNumbers?.find(
+                                        (tn) => tn.id === kmPost.trackNumberId,
+                                    )}
                                     kmPost={kmPost}
                                     status={KmPostBadgeStatus.DEFAULT}
                                 />
@@ -197,27 +201,35 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                                     className={
                                         styles['geometry-km-post-linking-infobox__layout-km-posts']
                                     }>
-                                    {kmPosts.map((layoutKmPostOption) => (
-                                        <li
-                                            key={layoutKmPostOption.id}
-                                            className={
-                                                styles[
-                                                    'geometry-km-post-linking-infobox__layout-km-post'
-                                                ]
-                                            }
-                                            onClick={() =>
-                                                onSelect({ kmPosts: [layoutKmPostOption.id] })
-                                            }>
-                                            <KmPostBadge
-                                                kmPost={layoutKmPostOption}
-                                                status={
-                                                    layoutKmPostOption.id == layoutKmPost?.id
-                                                        ? KmPostBadgeStatus.SELECTED
-                                                        : KmPostBadgeStatus.DEFAULT
+                                    {kmPosts.map((layoutKmPostOption) => {
+                                        return (
+                                            <li
+                                                key={layoutKmPostOption.id}
+                                                className={
+                                                    styles[
+                                                        'geometry-km-post-linking-infobox__layout-km-post'
+                                                    ]
                                                 }
-                                            />
-                                        </li>
-                                    ))}
+                                                onClick={() =>
+                                                    onSelect({ kmPosts: [layoutKmPostOption.id] })
+                                                }>
+                                                <KmPostBadge
+                                                    kmPost={layoutKmPostOption}
+                                                    trackNumber={trackNumbers?.find(
+                                                        (tn) =>
+                                                            tn.id ==
+                                                            layoutKmPostOption.trackNumberId,
+                                                    )}
+                                                    showTrackNumberInBadge={true}
+                                                    status={
+                                                        layoutKmPostOption.id == layoutKmPost?.id
+                                                            ? KmPostBadgeStatus.SELECTED
+                                                            : KmPostBadgeStatus.DEFAULT
+                                                    }
+                                                />
+                                            </li>
+                                        );
+                                    })}
                                 </ul>
                             </div>
 

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -201,35 +201,32 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                                     className={
                                         styles['geometry-km-post-linking-infobox__layout-km-posts']
                                     }>
-                                    {kmPosts.map((layoutKmPostOption) => {
-                                        return (
-                                            <li
-                                                key={layoutKmPostOption.id}
-                                                className={
-                                                    styles[
-                                                        'geometry-km-post-linking-infobox__layout-km-post'
-                                                    ]
+                                    {kmPosts.map((layoutKmPostOption) => (
+                                        <li
+                                            key={layoutKmPostOption.id}
+                                            className={
+                                                styles[
+                                                    'geometry-km-post-linking-infobox__layout-km-post'
+                                                ]
+                                            }
+                                            onClick={() =>
+                                                onSelect({ kmPosts: [layoutKmPostOption.id] })
+                                            }>
+                                            <KmPostBadge
+                                                kmPost={layoutKmPostOption}
+                                                trackNumber={trackNumbers?.find(
+                                                    (tn) =>
+                                                        tn.id == layoutKmPostOption.trackNumberId,
+                                                )}
+                                                showTrackNumberInBadge={true}
+                                                status={
+                                                    layoutKmPostOption.id == layoutKmPost?.id
+                                                        ? KmPostBadgeStatus.SELECTED
+                                                        : KmPostBadgeStatus.DEFAULT
                                                 }
-                                                onClick={() =>
-                                                    onSelect({ kmPosts: [layoutKmPostOption.id] })
-                                                }>
-                                                <KmPostBadge
-                                                    kmPost={layoutKmPostOption}
-                                                    trackNumber={trackNumbers?.find(
-                                                        (tn) =>
-                                                            tn.id ==
-                                                            layoutKmPostOption.trackNumberId,
-                                                    )}
-                                                    showTrackNumberInBadge={true}
-                                                    status={
-                                                        layoutKmPostOption.id == layoutKmPost?.id
-                                                            ? KmPostBadgeStatus.SELECTED
-                                                            : KmPostBadgeStatus.DEFAULT
-                                                    }
-                                                />
-                                            </li>
-                                        );
-                                    })}
+                                            />
+                                        </li>
+                                    ))}
                                 </ul>
                             </div>
 

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -66,6 +66,7 @@ import { LocationTrackSplittingInfoboxContainer } from 'tool-panel/location-trac
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { getLocationTrackOwners } from 'common/common-api';
 import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
+import { EnvRestricted } from 'environment/env-restricted';
 
 type LocationTrackInfoboxProps = {
     locationTrack: LayoutLocationTrack;
@@ -320,25 +321,27 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 </InfoboxContent>
             </Infobox>
             {splittingState && (
-                <LocationTrackSplittingInfoboxContainer
-                    visibilities={visibilities}
-                    visibilityChange={visibilityChange}
-                    initialSplit={splittingState.initialSplit}
-                    splits={splittingState.splits || []}
-                    locationTrackId={splittingState.originLocationTrack.id}
-                    locationTrackChangeTime={locationTrackChangeTime}
-                    removeSplit={delegates.removeSplit}
-                    cancelSplitting={() => {
-                        delegates.cancelSplitting();
-                        delegates.hideLayers(['location-track-split-location-layer']);
-                    }}
-                    allowedSwitches={splittingState.allowedSwitches}
-                    switchChangeTime={switchChangeTime}
-                    duplicateLocationTracks={extraInfo?.duplicates || []}
-                    updateSplit={delegates.updateSplit}
-                    setSplittingDisabled={delegates.setDisabled}
-                    disabled={splittingState.disabled}
-                />
+                <EnvRestricted restrictTo={'dev'}>
+                    <LocationTrackSplittingInfoboxContainer
+                        visibilities={visibilities}
+                        visibilityChange={visibilityChange}
+                        initialSplit={splittingState.initialSplit}
+                        splits={splittingState.splits || []}
+                        locationTrackId={splittingState.originLocationTrack.id}
+                        locationTrackChangeTime={locationTrackChangeTime}
+                        removeSplit={delegates.removeSplit}
+                        cancelSplitting={() => {
+                            delegates.cancelSplitting();
+                            delegates.hideLayers(['location-track-split-location-layer']);
+                        }}
+                        allowedSwitches={splittingState.allowedSwitches}
+                        switchChangeTime={switchChangeTime}
+                        duplicateLocationTracks={extraInfo?.duplicates || []}
+                        updateSplit={delegates.updateSplit}
+                        setSplittingDisabled={delegates.setDisabled}
+                        disabled={splittingState.disabled}
+                    />
+                </EnvRestricted>
             )}
             {startAndEndPoints && coordinateSystem && (
                 <Infobox
@@ -435,47 +438,49 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                 )}
                                 <InfoboxButtons>
                                     {!linkingState && !splittingState && (
-                                        <Button
-                                            variant={ButtonVariant.SECONDARY}
-                                            size={ButtonSize.SMALL}
-                                            disabled={locationTrack.draftType !== 'OFFICIAL'}
-                                            title={
-                                                locationTrack.draftType !== 'OFFICIAL'
-                                                    ? t(
-                                                          'tool-panel.location-track.splitting.validation.track-draft-exists',
-                                                      )
-                                                    : undefined
-                                            }
-                                            onClick={() => {
-                                                getSplittingInitializationParameters(
-                                                    'DRAFT',
-                                                    locationTrack.id,
-                                                ).then((splitInitializationParameters) => {
-                                                    if (
-                                                        startAndEndPoints?.start &&
-                                                        startAndEndPoints?.end
-                                                    ) {
-                                                        delegates.onStartSplitting({
-                                                            locationTrack: locationTrack,
-                                                            allowedSwitches:
-                                                                splitInitializationParameters?.switches ||
-                                                                [],
-                                                            duplicateTracks:
-                                                                splitInitializationParameters?.duplicates ||
-                                                                [],
-                                                            startLocation:
-                                                                startAndEndPoints.start.point,
-                                                            endLocation:
-                                                                startAndEndPoints.end.point,
-                                                        });
-                                                        delegates.showLayers([
-                                                            'location-track-split-location-layer',
-                                                        ]);
-                                                    }
-                                                });
-                                            }}>
-                                            {t('tool-panel.location-track.start-splitting')}
-                                        </Button>
+                                        <EnvRestricted restrictTo={'dev'}>
+                                            <Button
+                                                variant={ButtonVariant.SECONDARY}
+                                                size={ButtonSize.SMALL}
+                                                disabled={locationTrack.draftType !== 'OFFICIAL'}
+                                                title={
+                                                    locationTrack.draftType !== 'OFFICIAL'
+                                                        ? t(
+                                                              'tool-panel.location-track.splitting.validation.track-draft-exists',
+                                                          )
+                                                        : undefined
+                                                }
+                                                onClick={() => {
+                                                    getSplittingInitializationParameters(
+                                                        'DRAFT',
+                                                        locationTrack.id,
+                                                    ).then((splitInitializationParameters) => {
+                                                        if (
+                                                            startAndEndPoints?.start &&
+                                                            startAndEndPoints?.end
+                                                        ) {
+                                                            delegates.onStartSplitting({
+                                                                locationTrack: locationTrack,
+                                                                allowedSwitches:
+                                                                    splitInitializationParameters?.switches ||
+                                                                    [],
+                                                                duplicateTracks:
+                                                                    splitInitializationParameters?.duplicates ||
+                                                                    [],
+                                                                startLocation:
+                                                                    startAndEndPoints.start.point,
+                                                                endLocation:
+                                                                    startAndEndPoints.end.point,
+                                                            });
+                                                            delegates.showLayers([
+                                                                'location-track-split-location-layer',
+                                                            ]);
+                                                        }
+                                                    });
+                                                }}>
+                                                {t('tool-panel.location-track.start-splitting')}
+                                            </Button>
+                                        </EnvRestricted>
                                     )}
                                 </InfoboxButtons>
 


### PR DESCRIPTION
Kilometripylväille lisätty tooltip, jossa lukee mille kilometripylväälle ne kuuluvat. Samalla lisätty KM-pylväiden linkityslistauksessa näytettäviin badgeihin ratanumero, jotta niistä olisi helpompi nähdä mille ratanumerolle ne kuuluvat.

Näiden lisäksi lisätty EnvRestricted splittauksen ympärille