### PR TITLE
GVT-2325: Raiteen ratanumeron muutos ei näy julkaisulokissa oikein

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -1060,7 +1060,7 @@ class PublicationService @Autowired constructor(
 
         return listOfNotNull(compareChangeValues(
             locationTrackChanges.trackNumberId,
-            { trackNumberCache.findLast { it.id == locationTrackChanges.trackNumberId.new && it.changeTime <= publicationTime }?.number },
+            { tnIdFromChange -> trackNumberCache.findLast { tn -> tn.id == tnIdFromChange && tn.changeTime <= publicationTime }?.number },
             PropKey("track-number"),
         ),
             compareChangeValues(
@@ -1214,7 +1214,7 @@ class PublicationService @Autowired constructor(
     ) = listOfNotNull(
         compareChangeValues(
             changes.trackNumberId,
-            { trackNumberCache.findLast { it.id == changes.trackNumberId.new && it.changeTime <= publicationTime }?.number },
+            { tnIdFromChange -> trackNumberCache.findLast { tn -> tn.id == tnIdFromChange && tn.changeTime <= publicationTime }?.number },
             PropKey("track-number"),
         ),
         compareChangeValues(changes.kmNumber, { it }, PropKey("km-post")),


### PR DESCRIPTION
Huomionarvoista: Jos aiemman ratanumeron nimi muuttuu tässä julkaisussa, Vanha arvo -kentässä näytetään ratanumeron *uusi* nimi. Testailin tätä itse jonkin verran, ja se tuntui olevan ainakin omaan silmään selkeämpi kuin wanhan nimen näyttäminen. Eriäviä mielipiteitä saa toki esittää.