### PR TITLE
GVT-2287 Do switch-location track link topology validation on both sides

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.error
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.inframodel.INFRAMODEL_PARSING_KEY_GENERIC
 import fi.fta.geoviite.infra.localization.LocalizationParams
+import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.util.LocalizationKey
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.*
@@ -105,7 +106,7 @@ class DuplicateNameInPublicationException(
     message = "Duplicate $type in publication: $duplicatedName",
     cause = cause,
     localizedMessageKey = "error.publication.duplicate-name-on.${if (type == DuplicateNameInPublication.SWITCH) "switch" else "track-number"}",
-    localizedMessageParams = LocalizationParams("name" to duplicatedName),
+    localizedMessageParams = localizationParams("name" to duplicatedName),
 )
 
 class DuplicateLocationTrackNameInPublicationException(
@@ -117,7 +118,7 @@ class DuplicateLocationTrackNameInPublicationException(
     message = "Duplicate location track $alignmentName in $trackNumber",
     cause = cause,
     localizedMessageKey = "error.publication.duplicate-name-on.location-track",
-    localizedMessageParams = LocalizationParams(
+    localizedMessageParams = localizationParams(
         "locationTrack" to alignmentName,
         "trackNumber" to trackNumber
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -9,7 +9,7 @@ import fi.fta.geoviite.infra.error.InframodelParsingException
 import fi.fta.geoviite.infra.geography.CoordinateTransformationService
 import fi.fta.geoviite.infra.geography.GeographyService
 import fi.fta.geoviite.infra.geometry.*
-import fi.fta.geoviite.infra.localization.LocalizationParams
+import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
@@ -248,7 +248,7 @@ class InfraModelService @Autowired constructor(
             throw InframodelParsingException(
                 message = "InfraModel file exists already",
                 localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.duplicate-inframodel-file-content",
-                localizedMessageParams = LocalizationParams("fileName" to duplicate.fileName),
+                localizedMessageParams = localizationParams("fileName" to duplicate.fileName),
             )
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
@@ -13,9 +13,7 @@ private val LOCALIZATION_PARAMS_KEY_REGEX = Regex("[a-zA-Z0-9_\\s\\-]*")
 private val LOCALIZATION_PARAMS_PLACEHOLDER_REGEX = Regex("\\{\\{[a-zA-Z0-9_\\s\\-]*\\}\\}")
 
 data class LocalizationParams @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-constructor(@JsonValue val params: Map<String, Any?>) {
-    constructor(vararg params: Pair<String, Any?>) : this(mapOf(*params))
-
+constructor(@JsonValue val params: Map<String, String>) {
     init {
         require(params.none { LOCALIZATION_PARAMS_KEY_REGEX.matchEntire(it.key) == null }) {
             "There are localization keys that do not match with the localization pattern regex. Keys in question are ${
@@ -24,12 +22,17 @@ constructor(@JsonValue val params: Map<String, Any?>) {
         }
     }
 
-    fun get(key: String) = params[key]?.toString() ?: "" //Null values are treated as empty strings instead of "null"
+    fun get(key: String) = params[key] ?: ""
 
     companion object {
-        fun empty() = LocalizationParams()
+        fun empty() = LocalizationParams(mapOf())
     }
 }
+
+fun localizationParams(params: Map<String, Any?>): LocalizationParams =
+    LocalizationParams(params.mapValues { it.value?.toString() ?: "" })
+
+fun localizationParams(vararg params: Pair<String, Any?>): LocalizationParams = localizationParams(mapOf(*params))
 
 data class Translation(val lang: String, val localization: String) {
     private val jsonRoot = JsonMapper().readTree(localization)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -10,6 +10,7 @@ import fi.fta.geoviite.infra.geometry.MetaDataName
 import fi.fta.geoviite.infra.integration.RatkoPushStatus
 import fi.fta.geoviite.infra.integration.SwitchJointChange
 import fi.fta.geoviite.infra.localization.LocalizationParams
+import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
@@ -264,7 +265,7 @@ data class PublishValidationError(
         type: PublishValidationErrorType,
         key: String,
         params: Map<String, Any?> = emptyMap(),
-    ) : this(type, LocalizationKey(key), LocalizationParams(params))
+    ) : this(type, LocalizationKey(key), localizationParams(params))
 }
 
 interface PublishCandidate<T> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -255,9 +255,41 @@ class PublicationDao(
         return publicationId
     }
 
+    fun fetchLinkedSwitchesBeforeOrAfterPublication(
+        ids: List<IntId<LocationTrack>>,
+    ): Map<IntId<LocationTrack>, List<IntId<TrackLayoutSwitch>>> {
+        if (ids.isEmpty()) return mapOf()
+        val sql = """
+            select lt.id, ss.switch_id
+              from layout.location_track lt,
+                lateral (select distinct switch_id
+                           from (
+                             select topology_start_switch_id as switch_id
+                             union all
+                             select topology_end_switch_id
+                             union all
+                             select switch_id
+                               from layout.segment_version sv
+                               where sv.alignment_id = lt.alignment_id and sv.alignment_version = lt.alignment_version
+                           ) ss
+                           where switch_id is not null) ss
+              where lt.id in (:ids)
+        """.trimIndent()
+        return jdbcTemplate.query(sql, mapOf("ids" to ids.map(IntId<*>::intValue))) { rs, _ ->
+            rs.getIntId<LocationTrack>("id") to rs.getIntId<TrackLayoutSwitch>("switch_id")
+        }.groupBy({ it.first }, { it.second })
+    }
+
+    /**
+     * @param switchIds Switches whose linked tracks to find.
+     * @param locationTrackIdsInPublicationUnit Optionally specify the location tracks in the publication unit. Leave
+     * null to have all draft location tracks considered in the publication unit.
+     * @param includeDeleted Filters location tracks, not switches
+     */
     fun fetchLinkedLocationTracks(
         switchIds: List<IntId<TrackLayoutSwitch>>,
-        publicationStatus: PublishType,
+        locationTrackIdsInPublicationUnit: List<IntId<LocationTrack>>? = null,
+        includeDeleted: Boolean = false,
     ): Map<IntId<TrackLayoutSwitch>, Set<RowVersion<LocationTrack>>> {
         if (switchIds.isEmpty()) return mapOf()
         val sql = """
@@ -270,8 +302,13 @@ class PublicationDao(
               from layout.location_track_publication_view lt
                 left join layout.segment_version s on s.alignment_id = lt.alignment_id
                 and s.alignment_version = lt.alignment_version
-              where :publication_status = any(lt.publication_states)
-                and lt.state != 'DELETED'
+              where case
+                when ${if (locationTrackIdsInPublicationUnit == null) "true"
+                       else if (locationTrackIdsInPublicationUnit.isEmpty()) "false"
+                       else ("official_id in (:location_track_ids)")}
+                  then 'DRAFT' ELSE 'OFFICIAL' end
+                  = any(lt.publication_states)
+                and (:include_deleted or lt.state != 'DELETED')
                 and (
                     lt.topology_start_switch_id in (:switch_ids) or
                     lt.topology_end_switch_id in (:switch_ids) or
@@ -283,7 +320,8 @@ class PublicationDao(
         """.trimIndent()
         val params = mapOf(
             "switch_ids" to switchIds.map(IntId<TrackLayoutSwitch>::intValue),
-            "publication_status" to publicationStatus.name,
+            "location_track_ids" to locationTrackIdsInPublicationUnit?.map(IntId<*>::intValue),
+            "include_deleted" to includeDeleted,
         )
         val result = mutableMapOf<IntId<TrackLayoutSwitch>, Set<RowVersion<LocationTrack>>>()
         jdbcTemplate.query(sql, params) { rs, _ ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -14,6 +14,7 @@ import fi.fta.geoviite.infra.integration.*
 import fi.fta.geoviite.infra.linking.*
 import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.Translation
+import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.roundTo1Decimal
 import fi.fta.geoviite.infra.publication.PublishValidationErrorType.ERROR
@@ -163,10 +164,11 @@ class PublicationService @Autowired constructor(
         )
 
         val cacheKeys = collectCacheKeys(versions)
+        val switchTrackLinks = collectSwitchTrackLinks(versions, if (publishType == DRAFT) null else listOf())
 
         return ValidatedAsset(
             validateLocationTrack(
-                version = toValidationVersion(locationTrack), validationVersions = versions, cacheKeys = cacheKeys
+                version = toValidationVersion(locationTrack), validationVersions = versions, cacheKeys = cacheKeys, switchTrackLinks = switchTrackLinks
             ),
             locationTrackId,
         )
@@ -193,8 +195,9 @@ class PublicationService @Autowired constructor(
             switches = switches, locationTracks = (locationTracks + previouslyLinkedTracks).map(locationTrackDao::fetch)
         )
 
-        val linkedTracks =
-            publicationDao.fetchLinkedLocationTracks(switchIds, DRAFT).mapValues { (_, tracks) -> tracks.toSet() }
+        val linkedTracks = publicationDao
+            .fetchLinkedLocationTracks(switchIds, if (publishType == DRAFT) null else listOf())
+            .mapValues { (_, tracks) -> tracks.toSet() }
         val allOfficialSwitches = switchService.list(OFFICIAL)
         return switches.map { switch ->
             ValidatedAsset(
@@ -255,11 +258,7 @@ class PublicationService @Autowired constructor(
         val versions = candidates.getValidationVersions()
         val cacheKeys = collectCacheKeys(versions)
         precacheLocationTrackAlignmentAddresses(candidates, cacheKeys)
-        // TODO: This does not respect the candidate versions
-        val switchTrackLinks = publicationDao.fetchLinkedLocationTracks(
-            candidates.switches.map { s -> s.id },
-            DRAFT,
-        )
+        val switchTrackLinks = collectSwitchTrackLinks(versions, versions.locationTracks.map { v -> v.officialId })
         return PublishCandidates(
             trackNumbers = candidates.trackNumbers.map { candidate ->
                 candidate.copy(errors = validateTrackNumber(candidate.getPublicationVersion(), versions, cacheKeys))
@@ -268,14 +267,21 @@ class PublicationService @Autowired constructor(
                 candidate.copy(errors = validateReferenceLine(candidate.getPublicationVersion(), versions, cacheKeys))
             },
             locationTracks = candidates.locationTracks.map { candidate ->
-                candidate.copy(errors = validateLocationTrack(candidate.getPublicationVersion(), versions, cacheKeys))
+                candidate.copy(
+                    errors = validateLocationTrack(
+                        candidate.getPublicationVersion(),
+                        versions,
+                        cacheKeys,
+                        switchTrackLinks
+                    )
+                )
             },
             switches = candidates.switches.map { candidate ->
                 candidate.copy(
                     errors = validateSwitch(
                         candidate.getPublicationVersion(),
                         versions,
-                        switchTrackLinks.getOrDefault(candidate.id, setOf()),
+                        switchTrackLinks.trackVersionsBySwitchAfterPublication.getOrDefault(candidate.id, setOf()),
                     )
                 )
             },
@@ -300,6 +306,7 @@ class PublicationService @Autowired constructor(
     fun validatePublishRequest(versions: ValidationVersions) {
         logger.serviceCall("validatePublishRequest", "versions" to versions)
         val cacheKeys = collectCacheKeys(versions)
+        val switchTrackLinks = collectSwitchTrackLinks(versions, versions.locationTracks.map { v -> v.officialId })
         versions.trackNumbers.forEach { version ->
             assertNoErrors(version, validateTrackNumber(version, versions, cacheKeys))
         }
@@ -310,17 +317,36 @@ class PublicationService @Autowired constructor(
             assertNoErrors(version, validateReferenceLine(version, versions, cacheKeys))
         }
         versions.locationTracks.forEach { version ->
-            assertNoErrors(version, validateLocationTrack(version, versions, cacheKeys))
+            assertNoErrors(version, validateLocationTrack(version, versions, cacheKeys, switchTrackLinks))
         }
-        // TODO: This does not respect the validation versions
-        val switchTrackLinks =
-            publicationDao.fetchLinkedLocationTracks(versions.switches.map { v -> v.officialId }, DRAFT)
+
         versions.switches.forEach { version ->
             assertNoErrors(
                 version,
-                validateSwitch(version, versions, switchTrackLinks.getOrDefault(version.officialId, setOf())),
+                validateSwitch(
+                    version,
+                    versions,
+                    switchTrackLinks.trackVersionsBySwitchAfterPublication.getOrDefault(version.officialId, setOf())
+                ),
             )
         }
+    }
+
+    data class SwitchTrackLinks(
+        val switchIdsByTrackBeforeOrAfterPublication: Map<IntId<LocationTrack>, List<IntId<TrackLayoutSwitch>>>,
+        val trackVersionsBySwitchAfterPublication:  Map<IntId<TrackLayoutSwitch>, Set<RowVersion<LocationTrack>>>,
+    )
+
+    private fun collectSwitchTrackLinks(
+        versions: ValidationVersions,
+        trackIdsInPublicationUnit: List<IntId<LocationTrack>>?,
+    ): SwitchTrackLinks {
+        val switchIdsInPublicationUnit = versions.switches.map { v -> v.officialId }
+        val linkedSwitchIds =
+            publicationDao.fetchLinkedSwitchesBeforeOrAfterPublication(versions.locationTracks.map { v -> v.officialId })
+        val allSwitchesForValidation = (switchIdsInPublicationUnit + linkedSwitchIds.values.flatten()).distinct()
+        val trackLinks = publicationDao.fetchLinkedLocationTracks(allSwitchesForValidation, trackIdsInPublicationUnit)
+        return SwitchTrackLinks(linkedSwitchIds, trackLinks)
     }
 
     @Transactional(readOnly = true)
@@ -686,6 +712,7 @@ class PublicationService @Autowired constructor(
         version: ValidationVersion<LocationTrack>,
         validationVersions: ValidationVersions,
         cacheKeys: Map<IntId<TrackLayoutTrackNumber>, GeocodingContextCacheKey?>,
+        switchTrackLinks: SwitchTrackLinks,
     ): List<PublishValidationError> {
         val (locationTrack, alignment) = getLocationTrackAndAlignment(version.validatedAssetVersion)
         val trackNumber = getTrackNumber(locationTrack.trackNumberId, validationVersions)
@@ -700,10 +727,12 @@ class PublicationService @Autowired constructor(
             getSegmentSwitches(alignment, validationVersions),
             validationVersions.switches.map { it.officialId },
         )
-        val switchErrorsTopological = validateTopologicallyConnectedSwitchReferences(
+        val topologicallyConnectedSwitchError = validateTopologicallyConnectedSwitchReferences(
             getTopologicallyConnectedSwitches(locationTrack, validationVersions),
             validationVersions.switches.map { it.officialId },
         )
+        val trackNetworkTopologyErrors =
+            validateLocationTrackTopologicalConnectivity(version, validationVersions, switchTrackLinks)
         val duplicateErrors = validateDuplicateOf(version, locationTrack, validationVersions)
         val alignmentErrors = if (locationTrack.exists) validateLocationTrackAlignment(alignment)
         else listOf()
@@ -716,7 +745,29 @@ class PublicationService @Autowired constructor(
             locationTrack, validationVersions
         ) else listOf()
 
-        return fieldErrors + referenceErrors + switchErrorsSegments + switchErrorsTopological + duplicateErrors + alignmentErrors + geocodingErrors + duplicateNameErrors
+        return fieldErrors + referenceErrors + switchErrorsSegments + topologicallyConnectedSwitchError +
+                duplicateErrors + alignmentErrors + geocodingErrors + duplicateNameErrors + trackNetworkTopologyErrors
+    }
+
+    private fun validateLocationTrackTopologicalConnectivity(
+        version: ValidationVersion<LocationTrack>,
+        validationVersions: ValidationVersions,
+        switchTrackLinks: SwitchTrackLinks,
+    ): List<PublishValidationError> {
+        return switchTrackLinks.switchIdsByTrackBeforeOrAfterPublication
+            .getOrDefault(version.officialId, listOf())
+            .map { switchId -> getSwitchForValidation(switchId, validationVersions) }
+            .filter(TrackLayoutSwitch::exists)
+            .flatMap { switch ->
+                val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
+                val locationTracks = switchTrackLinks.trackVersionsBySwitchAfterPublication
+                    .getOrDefault(switch.id, listOf())
+                    .mapNotNull { locationTrackVersion ->
+                        val track = locationTrackDao.fetch(locationTrackVersion)
+                        track.alignmentVersion?.let(alignmentDao::fetch)?.let { track to it }
+                    }
+                validateSwitchTopologicalConnectivity(switch, structure, locationTracks)
+            }
     }
 
     private fun validateDuplicateOf(
@@ -727,7 +778,7 @@ class PublicationService @Autowired constructor(
         val duplicatesAfterPublication = locationTrackDao
             .fetchDuplicates(version.officialId)
             .map(locationTrackDao::fetch)
-            .mapNotNull { duplicate -> fetchRelevantTrackVersionForDuplicateCheck(validationVersions, duplicate) }
+            .mapNotNull { duplicate -> fetchPostPublicationVersion(validationVersions, duplicate) }
             .filter { potentialDuplicate -> potentialDuplicate.duplicateOf == version.officialId }
 
         val duplicateOf = locationTrack.duplicateOf?.let { duplicateId ->
@@ -741,7 +792,7 @@ class PublicationService @Autowired constructor(
         )
     }
 
-    private fun fetchRelevantTrackVersionForDuplicateCheck(
+    private fun fetchPostPublicationVersion(
         validationVersions: ValidationVersions,
         track: LocationTrack,
     ): LocationTrack? {
@@ -1244,7 +1295,7 @@ class PublicationService @Autowired constructor(
                 listOf(joint.point, oldLocation), LAYOUT_SRID
             ) else 0.0
             val jointPropKeyParams =
-                LocalizationParams("trackNumber" to trackNumberCache.findLast { it.id == joint.trackNumberId && it.changeTime <= newTimestamp }?.number?.value,
+                localizationParams("trackNumber" to trackNumberCache.findLast { it.id == joint.trackNumberId && it.changeTime <= newTimestamp }?.number?.value,
                     "switchType" to changes.type.new?.parts?.baseType?.let { switchBaseTypeToProp(translation, it) })
             val oldAddress = oldLocation?.let {
                 geocodingContextGetter(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -12,7 +12,6 @@ import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.integration.*
 import fi.fta.geoviite.infra.linking.*
-import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.Translation
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.logging.serviceCall
@@ -732,7 +731,7 @@ class PublicationService @Autowired constructor(
             validationVersions.switches.map { it.officialId },
         )
         val trackNetworkTopologyErrors =
-            validateLocationTrackTopologicalConnectivity(version, validationVersions, switchTrackLinks)
+            validateLocationTrackTopologicalConnectivity(version, locationTrack, validationVersions, switchTrackLinks)
         val duplicateErrors = validateDuplicateOf(version, locationTrack, validationVersions)
         val alignmentErrors = if (locationTrack.exists) validateLocationTrackAlignment(alignment)
         else listOf()
@@ -751,6 +750,7 @@ class PublicationService @Autowired constructor(
 
     private fun validateLocationTrackTopologicalConnectivity(
         version: ValidationVersion<LocationTrack>,
+        validatingTrack: LocationTrack,
         validationVersions: ValidationVersions,
         switchTrackLinks: SwitchTrackLinks,
     ): List<PublishValidationError> {
@@ -766,7 +766,7 @@ class PublicationService @Autowired constructor(
                         val track = locationTrackDao.fetch(locationTrackVersion)
                         track.alignmentVersion?.let(alignmentDao::fetch)?.let { track to it }
                     }
-                validateSwitchTopologicalConnectivity(switch, structure, locationTracks)
+                validateSwitchTopologicalConnectivity(switch, structure, locationTracks, validatingTrack)
             }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.Translation
+import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.switchLibrary.SwitchBaseType
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
@@ -409,4 +410,4 @@ private fun getChangedAlignmentRanges(old: LayoutAlignment, new: LayoutAlignment
 }
 
 fun publicationChangeRemark(translation: Translation, key: String, value: String?) =
-    translation.t("publication-details-table.remark.$key", LocalizationParams("value" to value))
+    translation.t("publication-details-table.remark.$key", localizationParams("value" to value))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.error.ClientException
 import fi.fta.geoviite.infra.geocoding.*
 import fi.fta.geoviite.infra.localization.LocalizationParams
+import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.math.IntersectType.WITHIN
 import fi.fta.geoviite.infra.math.angleDiffRads
 import fi.fta.geoviite.infra.math.directionBetweenPoints
@@ -46,25 +47,25 @@ fun validateTrackNumberReferences(
     locationTracks.filter(LocationTrack::exists).let { existingTracks ->
         validateWithParams(trackNumber.exists || existingTracks.isEmpty()) {
             val existingNames = existingTracks.joinToString(", ") { track -> track.name }
-            "$VALIDATION_TRACK_NUMBER.location-track.reference-deleted" to LocalizationParams("locationTracks" to existingNames)
+            "$VALIDATION_TRACK_NUMBER.location-track.reference-deleted" to localizationParams("locationTracks" to existingNames)
         }
     },
     locationTracks.filterNot { track -> isPublished(track, publishedTrackIds) }.let { unpublishedTracks ->
         validateWithParams(unpublishedTracks.isEmpty()) {
             val unpublishedNames = unpublishedTracks.joinToString(", ") { track -> track.name }
-            "$VALIDATION_TRACK_NUMBER.location-track.not-published" to LocalizationParams("locationTracks" to unpublishedNames)
+            "$VALIDATION_TRACK_NUMBER.location-track.not-published" to localizationParams("locationTracks" to unpublishedNames)
         }
     },
     kmPosts.filter(TrackLayoutKmPost::exists).let { existingKmPosts ->
         validateWithParams(trackNumber.exists || existingKmPosts.isEmpty()) {
             val existingNames = existingKmPosts.joinToString(", ") { post -> post.kmNumber.toString() }
-            "$VALIDATION_TRACK_NUMBER.km-post.reference-deleted" to LocalizationParams("kmPosts" to existingNames)
+            "$VALIDATION_TRACK_NUMBER.km-post.reference-deleted" to localizationParams("kmPosts" to existingNames)
         }
     },
     kmPosts.filterNot { kmPost -> isPublished(kmPost, publishKmPostIds) }.let { unpublishedKmPosts ->
         validateWithParams(unpublishedKmPosts.isEmpty()) {
             val unpublishedNames = unpublishedKmPosts.joinToString(", ") { post -> post.kmNumber.toString() }
-            "$VALIDATION_TRACK_NUMBER.km-post.not-published" to LocalizationParams("kmPosts" to unpublishedNames)
+            "$VALIDATION_TRACK_NUMBER.km-post.not-published" to localizationParams("kmPosts" to unpublishedNames)
         }
     },
 )
@@ -82,13 +83,13 @@ fun validateKmPostReferences(
     validate(trackNumber != null) { "$VALIDATION_KM_POST.track-number.null" },
     validate(referenceLine != null) { "$VALIDATION_KM_POST.reference-line.null" },
     validateWithParams(!kmPost.exists || trackNumber == null || trackNumber.state.isLinkable()) {
-        "$VALIDATION_KM_POST.track-number.state.${trackNumber?.state}" to LocalizationParams("trackNumber" to trackNumber?.number)
+        "$VALIDATION_KM_POST.track-number.state.${trackNumber?.state}" to localizationParams("trackNumber" to trackNumber?.number)
     },
     validateWithParams(trackNumber == null || kmPost.trackNumberId == trackNumber.id) {
-        "$VALIDATION_KM_POST.track-number.not-official" to LocalizationParams("trackNumber" to trackNumber?.number)
+        "$VALIDATION_KM_POST.track-number.not-official" to localizationParams("trackNumber" to trackNumber?.number)
     },
     validateWithParams(trackNumber == null || isPublished(trackNumber, publishTrackNumberIds)) {
-        "$VALIDATION_KM_POST.track-number.not-published" to LocalizationParams("trackNumber" to trackNumber?.number)
+        "$VALIDATION_KM_POST.track-number.not-published" to localizationParams("trackNumber" to trackNumber?.number)
     },
 )
 
@@ -103,14 +104,14 @@ fun validateSwitchLocationTrackLinkReferences(
 ): List<PublishValidationError> {
     val notPublishedTracks = locationTracks.mapNotNull { locationTrack ->
         validateWithParams(isPublished(locationTrack, publishLocationTrackIds)) {
-            "$VALIDATION_SWITCH.location-track.not-published" to LocalizationParams("locationTrack" to locationTrack.name)
+            "$VALIDATION_SWITCH.location-track.not-published" to localizationParams("locationTrack" to locationTrack.name)
         }
     }
 
     val noReferenceTracks = listOfNotNull(locationTracks.filter(LocationTrack::exists).let { existingTracks ->
         validateWithParams(switch.exists || existingTracks.isEmpty()) {
             val existingNames = existingTracks.joinToString(", ") { track -> track.name }
-            "$VALIDATION_SWITCH.location-track.reference-deleted" to LocalizationParams("locationTracks" to existingNames)
+            "$VALIDATION_SWITCH.location-track.reference-deleted" to localizationParams("locationTracks" to existingNames)
         }
     })
 
@@ -142,31 +143,31 @@ fun validateSwitchLocationTrackLinkStructure(
         segmentGroups.filterNot { (_, group) -> areSegmentsContinuous(group) }.let { errorGroups ->
             validateWithParams(errorGroups.isEmpty()) {
                 val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                "$VALIDATION_SWITCH.location-track.not-continuous" to LocalizationParams("locationTracks" to errorTrackNames)
+                "$VALIDATION_SWITCH.location-track.not-continuous" to localizationParams("locationTracks" to errorTrackNames)
             }
         },
         segmentGroups.filterNot { (_, group) -> segmentAndJointLocationsAgree(switch, group) }.let { errorGroups ->
             validateWithParams(errorGroups.isEmpty(), WARNING) {
                 val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to LocalizationParams("locationTracks" to errorTrackNames)
+                "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to localizationParams("locationTracks" to errorTrackNames)
             }
         },
         topologyLinks.filterNot { (_, group) -> topologyLinkAndJointLocationsAgree(switch, group) }.let { errorGroups ->
             validateWithParams(errorGroups.isEmpty(), WARNING) {
                 val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to LocalizationParams("locationTracks" to errorTrackNames)
+                "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to localizationParams("locationTracks" to errorTrackNames)
             }
         },
         segmentJoints.filterNot { (_, group) -> alignmentJointGroupFound(group, structureJoints) }.let { errorGroups ->
             validateWithParams(errorGroups.isEmpty()) {
                 val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                "$VALIDATION_SWITCH.location-track.wrong-joint-sequence" to LocalizationParams("locationTracks" to errorTrackNames)
+                "$VALIDATION_SWITCH.location-track.wrong-joint-sequence" to localizationParams("locationTracks" to errorTrackNames)
             }
         },
     ) + validateSwitchTopologicalConnectivity(switch, structure, locationTracks) else listOf()
 }
 
-private fun validateSwitchTopologicalConnectivity(
+fun validateSwitchTopologicalConnectivity(
     switch: TrackLayoutSwitch,
     structure: SwitchStructure,
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
@@ -184,9 +185,9 @@ private fun validateSwitchTopologicalConnectivity(
     }
 
     return listOfNotNull(
-        validateFrontJointTopology(switch.id, tracksThroughJoint, connectivityType, locationTracks),
-        validateExcessTracksThroughJoint(connectivityType, tracksThroughJoint),
-        validateSwitchAlignmentTopology(switch.id, connectivityType, nonDuplicateTracks),
+        validateFrontJointTopology(switch.id, tracksThroughJoint, connectivityType, locationTracks, switch.name),
+        validateExcessTracksThroughJoint(connectivityType, tracksThroughJoint, switch.name),
+        validateSwitchAlignmentTopology(switch.id, connectivityType, nonDuplicateTracks, switch.name),
     )
 }
 
@@ -195,6 +196,7 @@ private fun validateFrontJointTopology(
     tracksThroughJoint: Map<JointNumber, List<LocationTrack>>,
     connectivityType: SwitchConnectivityType,
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
+    switchName: SwitchName,
 ): PublishValidationError? {
     val tracksThroughFrontJoint = if (connectivityType.frontJoint == null) {
         listOf()
@@ -220,16 +222,19 @@ private fun validateFrontJointTopology(
             if (okFrontJointLinkInDuplicates) "$VALIDATION_SWITCH.track-linkage.front-joint-only-duplicate-connected"
             else "$VALIDATION_SWITCH.track-linkage.front-joint-not-connected"
 
-        key to LocalizationParams.empty()
+        key to localizationParams("switch" to switchName.toString())
     }
 }
 
 private fun validateExcessTracksThroughJoint(
     connectivityType: SwitchConnectivityType,
     tracksThroughJoint: Map<JointNumber, List<LocationTrack>>,
+    switchName: SwitchName,
 ): PublishValidationError? {
-    val excesses =
-        tracksThroughJoint.filter { (joint, tracks) -> joint != connectivityType.sharedJoint && tracks.size > 1 }
+    val excesses = tracksThroughJoint.filter { (joint, tracks) ->
+        joint != connectivityType.sharedJoint && tracks.count { it.getDraftType() != DraftType.OFFICIAL } > 1
+    }
+
     return validateWithParams(excesses.isEmpty(), WARNING) {
         val trackNames = excesses.entries
             .sortedBy { (jointNumber, _) -> jointNumber.intValue }
@@ -237,14 +242,16 @@ private fun validateExcessTracksThroughJoint(
                 "${jointNumber.intValue} (${tracks.sortedBy { it.name }.joinToString { it.name }})"
             }
 
-        "$VALIDATION_SWITCH.track-linkage.multiple-tracks-through-joint" to LocalizationParams("locationTracks" to trackNames)
+        "$VALIDATION_SWITCH.track-linkage.multiple-tracks-through-joint" to
+                localizationParams("locationTracks" to trackNames, "switch" to switchName.toString())
     }
 }
 
-private fun validateSwitchAlignmentTopology(
+fun validateSwitchAlignmentTopology(
     switchId: DomainId<TrackLayoutSwitch>,
     connectivityType: SwitchConnectivityType,
     nonDuplicateTracks: List<Pair<LocationTrack, LayoutAlignment>>,
+    switchName: SwitchName,
 ): PublishValidationError? {
     val disconnectedAlignments = connectivityType.trackLinkedAlignmentsJoints.filter { switchAlignment ->
         nonDuplicateTracks.none { (_, alignment) ->
@@ -258,7 +265,8 @@ private fun validateSwitchAlignmentTopology(
             alignment.joinToString("-") { joint -> joint.intValue.toString() }
         }
 
-        "$VALIDATION_SWITCH.track-linkage.switch-alignment-not-connected" to LocalizationParams("locationTracks" to alignmentsString)
+        "$VALIDATION_SWITCH.track-linkage.switch-alignment-not-connected" to
+                localizationParams("locationTracks" to alignmentsString, "switch" to switchName.toString())
     }
 }
 
@@ -280,7 +288,7 @@ fun validateDuplicateOfState(
 ): List<PublishValidationError> {
     return if (duplicateOfLocationTrack == null) listOf()
     else {
-        val duplicateNameParams = LocalizationParams("duplicateTrack" to duplicateOfLocationTrack.name)
+        val duplicateNameParams = localizationParams("duplicateTrack" to duplicateOfLocationTrack.name)
 
         listOfNotNull(
             validateWithParams(locationTrack.duplicateOf == duplicateOfLocationTrack.id) {
@@ -297,7 +305,7 @@ fun validateDuplicateOfState(
             },
             validateWithParams(duplicates.isEmpty()) {
                 val suffix = if (duplicates.size > 1) "-multiple" else ""
-                "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-while-duplicated${suffix}" to LocalizationParams(
+                "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-while-duplicated${suffix}" to localizationParams(
                     mapOf("duplicateTrack" to duplicateOfLocationTrack.name,
                         "otherDuplicates" to duplicates.map { track -> track.name }.distinct().joinToString { it })
                 )
@@ -319,7 +327,7 @@ fun validateReferenceLineReference(
         PublishValidationError(ERROR, "$VALIDATION_REFERENCE_LINE.track-number.null")
     )
     else {
-        val numberParams = LocalizationParams("trackNumber" to trackNumber.number)
+        val numberParams = localizationParams("trackNumber" to trackNumber.number)
 
         listOfNotNull(
             validateWithParams(referenceLine.trackNumberId == trackNumber.id) {
@@ -341,7 +349,7 @@ fun validateLocationTrackReference(
         PublishValidationError(ERROR, "$VALIDATION_LOCATION_TRACK.track-number.null")
     )
     else {
-        val numberParams = LocalizationParams("trackNumber" to trackNumber.number)
+        val numberParams = localizationParams("trackNumber" to trackNumber.number)
 
         listOfNotNull(
             validateWithParams(locationTrack.trackNumberId == trackNumber.id) {
@@ -372,7 +380,7 @@ fun validateSegmentSwitchReferences(
         val switch = segmentSwitch.switch
         val segments = segmentSwitch.segments
 
-        val nameLocalizationParams = LocalizationParams("switch" to switch.name)
+        val nameLocalizationParams = localizationParams("switch" to switch.name)
 
         val stateErrors: List<PublishValidationError> = listOfNotNull(
             validateWithParams(segments.all { segment -> switch.id == segment.switchId }) {
@@ -397,7 +405,7 @@ fun validateSegmentSwitchReferences(
                     "$VALIDATION_LOCATION_TRACK.switch.joint-location-mismatch" to nameLocalizationParams
                 },
                 validateWithParams(alignmentJointGroupFound(segmentJoints, structureJoints)) {
-                    "$VALIDATION_LOCATION_TRACK.switch.wrong-joint-sequence" to LocalizationParams(
+                    "$VALIDATION_LOCATION_TRACK.switch.wrong-joint-sequence" to localizationParams(
                         "switch" to switch.name,
                         "switchType" to segmentSwitch.switchStructure.baseType.name,
                         "switchJoints" to jointSequence(segmentJoints),
@@ -418,7 +426,7 @@ fun validateTopologicallyConnectedSwitchReferences(
     publishSwitchIds: List<IntId<TrackLayoutSwitch>>,
 ) = topologicallyConnectedSwitches.mapNotNull { switch ->
     validateWithParams(isPublished(switch, publishSwitchIds)) {
-        "$VALIDATION_LOCATION_TRACK.switch.not-published" to LocalizationParams("switch" to switch.name)
+        "$VALIDATION_LOCATION_TRACK.switch.not-published" to localizationParams("switch" to switch.name)
     }
 }
 
@@ -435,7 +443,7 @@ fun validateGeocodingContext(
     val context = contextCreateResult.geocodingContext
 
     val badStartPoint = validateWithParams(contextCreateResult.startPointRejectedReason == null) {
-        "$VALIDATION_GEOCODING.start-km-too-long" to LocalizationParams()
+        "$VALIDATION_GEOCODING.start-km-too-long" to localizationParams()
     }
 
     val kmPostsInWrongOrder =
@@ -445,7 +453,7 @@ fun validateGeocodingContext(
             !isOrderOk(previous, point) || !isOrderOk(point, next)
         }.let { invalidPoints ->
             validateWithParams(invalidPoints.isEmpty()) {
-                "$VALIDATION_GEOCODING.km-posts-invalid" to LocalizationParams(
+                "$VALIDATION_GEOCODING.km-posts-invalid" to localizationParams(
                     "trackNumber" to context.trackNumber.number,
                     "kmNumbers" to invalidPoints.joinToString(", ") { point -> point.kmNumber.toString() },
                 )
@@ -457,7 +465,7 @@ fun validateGeocodingContext(
         .filter { point -> point.kmPostOffset > MAX_KM_POST_OFFSET }
         .let { farAwayPoints ->
             validateWithParams(farAwayPoints.isEmpty(), WARNING) {
-                "$VALIDATION_GEOCODING.km-posts-far-from-line" to LocalizationParams(
+                "$VALIDATION_GEOCODING.km-posts-far-from-line" to localizationParams(
                     "trackNumber" to context.trackNumber.number,
                     "kmNumbers" to farAwayPoints.joinToString(",") { point -> point.kmNumber.toString() },
                 )
@@ -532,33 +540,33 @@ fun validateAddressPoints(
 
     return listOfNotNull(
         validateWithParams(addresses.startIntersect == WITHIN) {
-            "$VALIDATION_GEOCODING.start-outside-reference-line" to LocalizationParams(
+            "$VALIDATION_GEOCODING.start-outside-reference-line" to localizationParams(
                 "referenceLine" to trackNumber.number,
                 "locationTrack" to locationTrack.name,
             )
         },
         validateWithParams(addresses.endIntersect == WITHIN) {
-            "$VALIDATION_GEOCODING.end-outside-reference-line" to LocalizationParams(
+            "$VALIDATION_GEOCODING.end-outside-reference-line" to localizationParams(
                 "referenceLine" to trackNumber.number,
                 "locationTrack" to locationTrack.name,
             )
         },
         validateWithParams(discontinuousDirectionRanges.isEmpty()) {
-            "$VALIDATION_GEOCODING.sharp-angle" to LocalizationParams(
+            "$VALIDATION_GEOCODING.sharp-angle" to localizationParams(
                 "trackNumber" to trackNumber.number,
                 "locationTrack" to locationTrack.name,
                 "kmNumbers" to discontinuousDirectionRanges
             )
         },
         validateWithParams(stretchedMeterRanges.isEmpty()) {
-            "$VALIDATION_GEOCODING.stretched-meters" to LocalizationParams(
+            "$VALIDATION_GEOCODING.stretched-meters" to localizationParams(
                 "trackNumber" to trackNumber.number,
                 "locationTrack" to locationTrack.name,
                 "kmNumbers" to stretchedMeterRanges
             )
         },
         validateWithParams(discontinuousAddressRanges.isEmpty()) {
-            "$VALIDATION_GEOCODING.not-continuous" to LocalizationParams(
+            "$VALIDATION_GEOCODING.not-continuous" to localizationParams(
                 "trackNumber" to trackNumber.number,
                 "locationTrack" to locationTrack.name,
                 "kmNumbers" to discontinuousAddressRanges

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1191,6 +1191,13 @@
                     "wrong-joint-sequence": "Sijaintiraiteen vaihdepisteet ({{switchJoints}}) vaihteella {{switch}} ({{switchType}}) eivät vastaa vaihderakenteen linjoja",
                     "wrong-links": "Vaihteen {{switch}} linkitys on vajavainen ja se täytyy linkittää uudelleen"
                 },
+                "switch-linkage": {
+                    "front-joint-not-connected": "Vaihteen {{switch}} etujatkokselta ei jatku raidetta",
+                    "front-joint-only-duplicate-connected": "Vaihteen {{switch}} etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
+                    "switch-alignment-not-connected": "Joitakin vaihteen {{switch}} linjoja ei ole liitetty raiteelle: {{locationTracks}}",
+                    "switch-alignment-only-connected-to-duplicate": "Joitakin vaihteen {{switch}} linjoja on liitetty ainoastaan duplikaatiksi merkityille raiteille: {{locationTracks}}",
+                    "multiple-tracks-through-joint": "Joistain vaihteen {{switch}} pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}"
+                },
                 "duplicate-name-official": "Sijaintiraiteen nimi {{locationTrack}} on jo käytössä toisella ratanumeron {{trackNumber}} sijaintiraiteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta sijaintiraidetta nimellä {{locationTrack}} ratanumerolla {{trackNumber}}"
             },
@@ -1210,10 +1217,11 @@
                 "duplicate-name-official": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{switch}}",
                 "track-linkage": {
-                    "front-joint-not-connected": "Vaihteen {{switch}} etujatkokselta ei jatku raidetta",
-                    "front-joint-only-duplicate-connected": "Vaihteen {{switch}} etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
-                    "switch-alignment-not-connected": "Joitakin vaihteen {{switch}} linjoja ei ole liitetty raiteelle: {{locationTracks}}",
-                    "multiple-tracks-through-joint": "Joistain vaihteen {{switch}} pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}"
+                    "front-joint-not-connected": "Vaihteen etujatkokselta ei jatku raidetta",
+                    "front-joint-only-duplicate-connected": "Vaihteen etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
+                    "switch-alignment-not-connected": "Joitakin vaihteen linjoja ei ole liitetty raiteelle: {{locationTracks}}",
+                    "switch-alignment-only-connected-to-duplicate": "Joitakin vaihteen linjoja on liitetty ainoastaan duplikaatiksi merkityille raiteille: {{locationTracks}}",
+                    "multiple-tracks-through-joint": "Joistain vaihteen pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}"
                 }
             },
             "geocoding": {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1210,10 +1210,10 @@
                 "duplicate-name-official": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{switch}}",
                 "track-linkage": {
-                    "front-joint-not-connected": "Vaihteen etujatkokselta ei jatku raidetta",
-                    "front-joint-only-duplicate-connected": "Vaihteen etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
-                    "switch-alignment-not-connected": "Joitakin vaihteen linjoja ei ole liitetty raiteelle: {{locationTracks}}",
-                    "multiple-tracks-through-joint": "Joistain vaihteen pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}"
+                    "front-joint-not-connected": "Vaihteen {{switch}} etujatkokselta ei jatku raidetta",
+                    "front-joint-only-duplicate-connected": "Vaihteen {{switch}} etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
+                    "switch-alignment-not-connected": "Joitakin vaihteen {{switch}} linjoja ei ole liitetty raiteelle: {{locationTracks}}",
+                    "multiple-tracks-through-joint": "Joistain vaihteen {{switch}} pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}"
                 }
             },
             "geocoding": {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -12,6 +12,7 @@ import fi.fta.geoviite.infra.integration.CalculatedChangesService
 import fi.fta.geoviite.infra.integration.LocationTrackChange
 import fi.fta.geoviite.infra.integration.TrackNumberChange
 import fi.fta.geoviite.infra.linking.*
+import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
@@ -890,7 +891,7 @@ class PublicationServiceIT @Autowired constructor(
         }
         assertEquals("error.publication.duplicate-name-on.location-track", exception.localizedMessageKey.toString())
         assertEquals(
-            mapOf("locationTrack" to AlignmentName("LT"), "trackNumber" to TrackNumber("TN")),
+            mapOf("locationTrack" to "LT", "trackNumber" to "TN"),
             exception.localizedMessageParams.params
         )
     }
@@ -1767,7 +1768,7 @@ class PublicationServiceIT @Autowired constructor(
 
     private fun getTopologicalSwitchConnectionTestData(): TopologicalSwitchConnectionTestData {
         val topologyStartSwitch = createSwitchWithJoints(
-            name = "Topological switch connection start switch", jointPositions = listOf(
+            name = "Topological switch connection test start switch", jointPositions = listOf(
                 JointNumber(1) to Point(0.0, 0.0),
                 JointNumber(3) to Point(1.0, 0.0),
             )
@@ -1821,81 +1822,143 @@ class PublicationServiceIT @Autowired constructor(
         return validationResult.validatedAsPublicationUnit.locationTracks.find { lt -> lt.id == locationTrackId }
     }
 
+    private fun switchAlignmentNotConnectedTrackValidationError(locationTrackNames: String, switchName: String) =
+        PublishValidationError(
+            PublishValidationErrorType.WARNING,
+            "validation.layout.switch.track-linkage.switch-alignment-not-connected",
+            mapOf("locationTracks" to locationTrackNames, "switch" to switchName)
+        )
+
+    private fun switchNotPublishedError(switchName: String) = PublishValidationError(
+        PublishValidationErrorType.ERROR,
+        "validation.layout.location-track.switch.not-published",
+        mapOf("switch" to switchName)
+    )
+
+    private fun switchFrontJointNotConnectedError(switchName: String) = PublishValidationError(
+        PublishValidationErrorType.WARNING,
+        "validation.layout.switch.track-linkage.front-joint-not-connected",
+        mapOf("switch" to switchName)
+    )
+
+    private fun assertValidationErrorsForEach(
+        expecteds: List<List<PublishValidationError>>,
+        actuals: List<List<PublishValidationError>>,
+    ) {
+        assertEquals(expecteds.size, actuals.size, "size equals")
+        expecteds.forEachIndexed { i, expected ->
+            assertValidationErrorContentEquals(expected, actuals[i], i)
+        }
+    }
+
+    private fun assertValidationErrorContentEquals(expected: List<PublishValidationError>, actual: List<PublishValidationError>, index: Int) {
+        val allKeys = expected.map { it.localizationKey.toString() } + actual.map { it.localizationKey.toString() }
+        val commonPrefix = allKeys.reduce { acc, next -> acc.take(acc.zip(next) { a, b -> a == b }.takeWhile { it }.count()) }
+        fun cleanupKey(key: LocalizationKey) =
+            key.toString().let { key -> if (commonPrefix.length > 3) "...$key" else key }
+
+        assertEquals(
+            expected.map { cleanupKey(it.localizationKey) }.sorted(),
+            actual.map { cleanupKey(it.localizationKey) }.sorted(),
+            "same errors by localization key, index $index, ")
+
+        val expectedByKey = expected.groupBy { it.localizationKey }
+        val actualByKey = actual.groupBy { it.localizationKey }
+        expectedByKey.keys.forEach { key ->
+            assertEquals(expectedByKey[key]!!.map { it.params }, actualByKey[key]!!.map { it.params }, "params for key $key at index $index, ")
+            assertEquals(expectedByKey[key]!!.map { it.type }, actualByKey[key]!!.map { it.type }, "level for key $key at index $index, ")
+        }
+    }
+
+    private val topoTestDataContextOnLocationTrackValidationError = listOf(PublishValidationError(
+        PublishValidationErrorType.ERROR, "validation.layout.location-track.no-context", mapOf()
+    ))
+    private val topoTestDataStartSwitchNotPublishedError =
+        switchNotPublishedError("Topological switch connection test start switch")
+    private val topoTestDataStartSwitchJointsNotConnectedError = switchAlignmentNotConnectedTrackValidationError(
+        "1-5-2, 1-3", "Topological switch connection test start switch"
+    )
+    private val topoTestDataEndSwitchNotPublishedError =
+        switchNotPublishedError("Topological switch connection test end switch")
+    private val topoTestDataEndSwitchJointsNotConnectedError = switchAlignmentNotConnectedTrackValidationError(
+        "1-5-2, 1-3", "Topological switch connection test end switch"
+    )
+    private val topoTestDataEndSwitchFrontJointNotConnectedError =
+        switchFrontJointNotConnectedError("Topological switch connection test end switch")
+
     @Test
     fun `Location track validation should fail for unofficial and unstaged topologically linked switches`() {
         val topologyTestData = getTopologicalSwitchConnectionTestData()
-        val expectedValidationErrors = 1 // Unverified, but expected geocoding error.
-
-        val singleTopologicallyConnectedSwitchValidationErrors = 1
-        val doubleTopologicallyConnectedSwitchValidationErrors = 2
-
-        topologyTestData.locationTracksUnderTest.forEach { (locationTrackId, lt) ->
-            val validationErrorAmount = getLocationTrackValidationResult(locationTrackId)?.errors?.size
-
-            when {
-                lt.topologyStartSwitch == null && lt.topologyEndSwitch == null -> assertEquals(
-                    expectedValidationErrors, validationErrorAmount
-                )
-
-                lt.topologyStartSwitch == null -> assertEquals(
-                    expectedValidationErrors + singleTopologicallyConnectedSwitchValidationErrors, validationErrorAmount
-                )
-
-                lt.topologyEndSwitch == null -> assertEquals(
-                    expectedValidationErrors + singleTopologicallyConnectedSwitchValidationErrors, validationErrorAmount
-                )
-
-                else -> assertEquals(
-                    expectedValidationErrors + doubleTopologicallyConnectedSwitchValidationErrors, validationErrorAmount
-                )
-            }
+        val noStart = listOf(
+            topoTestDataStartSwitchNotPublishedError,
+            topoTestDataStartSwitchJointsNotConnectedError,
+            // no error about no track continuing from the front joint, because a track in fact does continue from it
+        )
+        val noEnd = listOf(
+            topoTestDataEndSwitchNotPublishedError,
+            topoTestDataEndSwitchJointsNotConnectedError,
+            topoTestDataEndSwitchFrontJointNotConnectedError,
+        )
+        val expected = listOf(
+            topoTestDataContextOnLocationTrackValidationError,
+            topoTestDataContextOnLocationTrackValidationError + noStart,
+            topoTestDataContextOnLocationTrackValidationError + noEnd,
+            topoTestDataContextOnLocationTrackValidationError + noStart + noEnd
+        )
+        val actual = topologyTestData.locationTracksUnderTest.map { (locationTrackId) ->
+            getLocationTrackValidationResult(locationTrackId)!!.errors
         }
+        assertValidationErrorsForEach(expected, actual)
     }
 
     @Test
     fun `Location track validation should succeed for unofficial, but staged topologically linked switches`() {
         val topologyTestData = getTopologicalSwitchConnectionTestData()
-        val expectedValidationErrors = 1 // Unverified, but expected geocoding error.
-
-        topologyTestData.locationTracksUnderTest.forEach { (locationTrackId, lt) ->
-            val validationErrorAmount = getLocationTrackValidationResult(
-                locationTrackId,
-                topologyTestData.switchIdsUnderTest,
-            )?.errors?.size
-
-            when {
-                lt.topologyStartSwitch == null && lt.topologyEndSwitch == null -> assertEquals(
-                    expectedValidationErrors, validationErrorAmount
-                )
-
-                lt.topologyStartSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
-                lt.topologyEndSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
-                else -> assertEquals(expectedValidationErrors, validationErrorAmount)
-            }
+        val noStart = listOf(
+            topoTestDataStartSwitchJointsNotConnectedError,
+            // no error about no track continuing from the front joint, because a track in fact does continue from it
+        )
+        val noEnd = listOf(
+            topoTestDataEndSwitchJointsNotConnectedError,
+            topoTestDataEndSwitchFrontJointNotConnectedError,
+        )
+        val expected =  listOf(
+            topoTestDataContextOnLocationTrackValidationError,
+            topoTestDataContextOnLocationTrackValidationError + noStart,
+            topoTestDataContextOnLocationTrackValidationError + noEnd,
+            topoTestDataContextOnLocationTrackValidationError + noStart + noEnd
+        )
+        val actual =  topologyTestData.locationTracksUnderTest.map { (locationTrackId) ->
+            getLocationTrackValidationResult(locationTrackId, topologyTestData.switchIdsUnderTest,)!!.errors
         }
+
+        assertValidationErrorsForEach(expected, actual)
     }
 
     @Test
     fun `Location track validation should succeed for topologically linked official switches`() {
         val topologyTestData = getTopologicalSwitchConnectionTestData()
-        val expectedValidationErrors = 1 // Unverified, but expected geocoding error.
+
+        val noStart = listOf(
+            topoTestDataStartSwitchJointsNotConnectedError,
+            // no error about no track continuing from the front joint, because a track in fact does continue from it
+        )
+        val noEnd = listOf(
+            topoTestDataEndSwitchJointsNotConnectedError,
+            topoTestDataEndSwitchFrontJointNotConnectedError,
+        )
+        val expected = listOf(
+            topoTestDataContextOnLocationTrackValidationError,
+            topoTestDataContextOnLocationTrackValidationError + noStart,
+            topoTestDataContextOnLocationTrackValidationError + noEnd,
+            topoTestDataContextOnLocationTrackValidationError + noStart + noEnd
+        )
 
         publish(publicationService, switches = topologyTestData.switchIdsUnderTest)
-
-        topologyTestData.locationTracksUnderTest.forEach { (locationTrackId, lt) ->
-            val validationErrorAmount = getLocationTrackValidationResult(locationTrackId)?.errors?.size
-
-            when {
-                lt.topologyStartSwitch == null && lt.topologyEndSwitch == null -> assertEquals(
-                    expectedValidationErrors, validationErrorAmount
-                )
-
-                lt.topologyStartSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
-                lt.topologyEndSwitch == null -> assertEquals(expectedValidationErrors, validationErrorAmount)
-
-                else -> assertEquals(expectedValidationErrors, validationErrorAmount)
-            }
+        val actual = topologyTestData.locationTracksUnderTest.map { (locationTrackId) ->
+            getLocationTrackValidationResult(locationTrackId)!!.errors
         }
+        assertValidationErrorsForEach(expected, actual)
     }
 
     @Test
@@ -1949,7 +2012,8 @@ class PublicationServiceIT @Autowired constructor(
             switchValidation, PublishValidationError(
                 PublishValidationErrorType.WARNING,
                 "validation.layout.switch.track-linkage.multiple-tracks-through-joint",
-                mapOf("locationTracks" to "3 (${locationTrack2.name}, ${locationTrack3.name}), 4 (${locationTrack2.name}, ${locationTrack3.name})")
+                mapOf("locationTracks" to "3 (${locationTrack2.name}, ${locationTrack3.name}), 4 (${locationTrack2.name}, ${locationTrack3.name})",
+                    "switch" to "TV123")
             )
         )
     }
@@ -1992,8 +2056,8 @@ class PublicationServiceIT @Autowired constructor(
         assertContains(
             errorsWhenValidatingSwitchWithTracks(trackOn152Alignment, trackOn13Alignment), PublishValidationError(
                 PublishValidationErrorType.WARNING,
-                "validation.layout.switch.track-linkage.front-joint-not-connected",
-                emptyMap()
+                LocalizationKey("validation.layout.switch.track-linkage.front-joint-not-connected"),
+                LocalizationParams(mapOf("switch" to "TV123")),
             )
         )
 
@@ -2008,7 +2072,7 @@ class PublicationServiceIT @Autowired constructor(
             PublishValidationError(
                 PublishValidationErrorType.WARNING,
                 "validation.layout.switch.track-linkage.front-joint-only-duplicate-connected",
-                emptyMap()
+                mapOf("switch" to "TV123")
             )
         )
 
@@ -2022,6 +2086,139 @@ class PublicationServiceIT @Autowired constructor(
             e.localizationKey.contains("validation.layout.switch.track-linkage.front-joint-not-connected") || e.localizationKey.contains(
                 "validation.layout.switch.track-linkage.front-joint-only-duplicate-connected"
             )
+        })
+    }
+
+    @Test
+    fun `Location track validation catches only switch topology errors related to its own changes`() {
+        val trackNumberId = trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).id
+        val switchId = switchService.saveDraft(
+            switch(
+                123,
+                switchStructureYV60_300_1_9().id as IntId,
+            ).copy(stateCategory = LayoutStateCategory.EXISTING)
+        ).id
+        val officialTrackOn152 = locationTrackDao.insert(
+            locationTrack(
+                trackNumberId, alignmentVersion = alignmentDao.insert(
+                    alignment(
+                        segment(Point(0.0, 5.0), Point(0.0, 0.0)),
+                        segment(Point(0.0, 0.0), Point(5.0, 0.0)).copy(
+                            switchId = switchId, startJointNumber = JointNumber(1), endJointNumber = JointNumber(5)
+                        ),
+                        segment(Point(5.0, 0.0), Point(10.0, 0.0)).copy(
+                            switchId = switchId, startJointNumber = JointNumber(5), endJointNumber = JointNumber(2)
+                        ),
+                    )
+                )
+            )
+        )
+        val officialTrackOn13 = locationTrackDao.insert(
+            locationTrack(
+                trackNumberId, alignmentVersion = alignmentDao.insert(
+                    alignment(
+                        segment(Point(0.0, 0.0), Point(10.0, 2.0)).copy(
+                            switchId = switchId, startJointNumber = JointNumber(1), endJointNumber = JointNumber(3)
+                        ),
+                    )
+                )
+            )
+        )
+        locationTrackService.saveDraft(
+            locationTrackDao.fetch(officialTrackOn152.rowVersion).copy(state = LayoutState.DELETED)
+        )
+        locationTrackService.saveDraft(
+            locationTrackDao.fetch(officialTrackOn13.rowVersion).copy(state = LayoutState.DELETED)
+        )
+
+        val errorsWhenDeletingStraightTrack = publicationService.validatePublishCandidates(
+            publicationService.collectPublishCandidates(), publishRequestIds(
+                locationTracks = listOf(officialTrackOn152.id)
+            )
+        ).validatedAsPublicationUnit.locationTracks[0].errors
+        assertTrue(errorsWhenDeletingStraightTrack.any { error ->
+            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-not-connected") &&
+                    error.params.get("locationTracks") == "1-5-2" && error.params.get("switch") == "TV123"
+        })
+        assertTrue(errorsWhenDeletingStraightTrack.any { error ->
+            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.front-joint-not-connected") &&
+                    error.params.get("switch") == "TV123"
+        })
+
+        val errorsWhenDeletingBranchingTrack = publicationService.validatePublishCandidates(
+            publicationService.collectPublishCandidates(), publishRequestIds(
+                locationTracks = listOf(officialTrackOn13.id)
+            )
+        ).validatedAsPublicationUnit.locationTracks[0].errors
+        assertTrue(errorsWhenDeletingBranchingTrack.any { error ->
+            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-not-connected") &&
+                    error.params.get("locationTracks") == "1-3" && error.params.get("switch") == "TV123"
+        })
+        assertFalse(errorsWhenDeletingBranchingTrack.any { error ->
+            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.front-joint-not-connected") })
+    }
+
+    @Test
+    fun `Location track validation catches track removal causing switches to go unlinked`() {
+        val trackNumberId = trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).id
+        val switchId = switchService.saveDraft(
+            switch(
+                123,
+                switchStructureYV60_300_1_9().id as IntId,
+            ).copy(stateCategory = LayoutStateCategory.EXISTING)
+        ).id
+        val officialTrackOn152 = locationTrackDao.insert(
+            locationTrack(
+                trackNumberId, alignmentVersion = alignmentDao.insert(
+                    alignment(
+                        segment(Point(0.0, 0.0), Point(5.0, 0.0)).copy(
+                            switchId = switchId, startJointNumber = JointNumber(1), endJointNumber = JointNumber(5)
+                        ),
+                        segment(Point(5.0, 0.0), Point(10.0, 0.0)).copy(
+                            switchId = switchId, startJointNumber = JointNumber(5), endJointNumber = JointNumber(2)
+                        ),
+                    )
+                )
+            )
+        )
+        locationTrackService.saveDraft(
+            locationTrackDao.fetch(officialTrackOn152.rowVersion).copy(state = LayoutState.DELETED)
+        )
+        locationTrackDao.insert(
+            locationTrack(trackNumberId, alignmentVersion = alignmentDao.insert(alignment(
+                segment(Point(0.0, 0.0), Point(10.0, 2.0)).copy(
+                    switchId = switchId, startJointNumber = JointNumber(1), endJointNumber = JointNumber(3)
+                ),
+            )
+        )))
+
+        val locationTrackDeletionErrors = publicationService.validatePublishCandidates(
+            publicationService.collectPublishCandidates(), publishRequestIds(
+                locationTracks = listOf(officialTrackOn152.id)
+            )
+        ).validatedAsPublicationUnit.locationTracks[0].errors
+        assertTrue(locationTrackDeletionErrors.any { error ->
+            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-not-connected") &&
+                    error.params.get("locationTracks") == "1-5-2" && error.params.get("switch") == "TV123"
+        })
+        // but it's OK if we link a replacement track
+        val replacementTrack = locationTrackService.saveDraft(
+            locationTrack(trackNumberId), alignment(
+                segment(Point(0.0, 0.0), Point(5.0, 0.0)).copy(
+                    switchId = switchId, startJointNumber = JointNumber(1), endJointNumber = JointNumber(5)
+                ),
+                segment(Point(5.0, 0.0), Point(10.0, 0.0)).copy(
+                    switchId = switchId, startJointNumber = JointNumber(5), endJointNumber = JointNumber(2)
+                ),
+            )
+        )
+        val errorsWithReplacementTrackLinked = publicationService.validatePublishCandidates(
+            publicationService.collectPublishCandidates(), publishRequestIds(
+                locationTracks = listOf(officialTrackOn152.id, replacementTrack.id)
+            )
+        ).validatedAsPublicationUnit.locationTracks[0].errors
+        assertFalse(errorsWithReplacementTrackLinked.any { error ->
+            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-not-connected")
         })
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1825,7 +1825,7 @@ class PublicationServiceIT @Autowired constructor(
     private fun switchAlignmentNotConnectedTrackValidationError(locationTrackNames: String, switchName: String) =
         PublishValidationError(
             PublishValidationErrorType.WARNING,
-            "validation.layout.switch.track-linkage.switch-alignment-not-connected",
+            "validation.layout.location-track.switch-linkage.switch-alignment-not-connected",
             mapOf("locationTracks" to locationTrackNames, "switch" to switchName)
         )
 
@@ -1837,7 +1837,7 @@ class PublicationServiceIT @Autowired constructor(
 
     private fun switchFrontJointNotConnectedError(switchName: String) = PublishValidationError(
         PublishValidationErrorType.WARNING,
-        "validation.layout.switch.track-linkage.front-joint-not-connected",
+        "validation.layout.location-track.switch-linkage.front-joint-not-connected",
         mapOf("switch" to switchName)
     )
 
@@ -2137,11 +2137,11 @@ class PublicationServiceIT @Autowired constructor(
             )
         ).validatedAsPublicationUnit.locationTracks[0].errors
         assertTrue(errorsWhenDeletingStraightTrack.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-not-connected") &&
+            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
                     error.params.get("locationTracks") == "1-5-2" && error.params.get("switch") == "TV123"
         })
         assertTrue(errorsWhenDeletingStraightTrack.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.front-joint-not-connected") &&
+            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.front-joint-not-connected") &&
                     error.params.get("switch") == "TV123"
         })
 
@@ -2151,11 +2151,11 @@ class PublicationServiceIT @Autowired constructor(
             )
         ).validatedAsPublicationUnit.locationTracks[0].errors
         assertTrue(errorsWhenDeletingBranchingTrack.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-not-connected") &&
+            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
                     error.params.get("locationTracks") == "1-3" && error.params.get("switch") == "TV123"
         })
         assertFalse(errorsWhenDeletingBranchingTrack.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.front-joint-not-connected") })
+            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.front-joint-not-connected") })
     }
 
     @Test
@@ -2198,7 +2198,7 @@ class PublicationServiceIT @Autowired constructor(
             )
         ).validatedAsPublicationUnit.locationTracks[0].errors
         assertTrue(locationTrackDeletionErrors.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-not-connected") &&
+            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
                     error.params.get("locationTracks") == "1-5-2" && error.params.get("switch") == "TV123"
         })
         // but it's OK if we link a replacement track
@@ -2218,7 +2218,7 @@ class PublicationServiceIT @Autowired constructor(
             )
         ).validatedAsPublicationUnit.locationTracks[0].errors
         assertFalse(errorsWithReplacementTrackLinked.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-not-connected")
+            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected")
         })
     }
 }


### PR DESCRIPTION
Ongelma oli, että jos sijaintiraiteen linkityksen raiteelle rikkoo, validaatio valitti siitä vain vaihteen julkaisun yhteydessä, vaikka linkit on raiteelle liittyviä asioita. Ratkaisu on kaksipuolinen:

- Vaihteiden julkaisu huomioi nyt korrektisti julkaisuyksikön, eli jos raiteen muutos jätetään vaihteen julkaisusta pois, niin vaihteen validointi ei näe sitä lainkaan
- Raiteiden julkaisussa katsotaan, olisiko julkaisu rikkomassa linkityksen johonkin vaihteeseen. Näistä joudutaan luonnostaankin katsomaan, että eihän käy niin, että rikkoutuva linkitys on sellainen, jota ei julkaistavalla raiteella ole enää lainkaan, ja siksi julkaistaviin raiteseen liittyvät vaihteet haetaan niiden julkaisutilasta riippumatta

Topologiatarkistukset jäävät kuitenkin olemaan vaihteidenkin puolelle, koska paikannuspohjassa on olemassa valmiiksi paikkoja, joissa on puuttuvia linkkejä, eli ilman geometrian katsomista ei oikei näe, mihin minkäkin asian *pitäisi* olla linkitetty. Tästä syystä topologiatarkistuksiin liittyvät validointivirheet näkyvät nyt sekä vaihteiden että raiteiden puolella.

Testiärsyttävyyksien välttämiseksi LocalizationParams ei sisällä enää mitään Any-jä, vaan puhtaasti merkkijonoja; tämä aiheutti ongelmia, kun piti muistaa, sattuiko jossain olemaan nyt String vai SwitchName yms.