### PR TITLE
GVT-2350 Fix render loop

### DIFF
--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -178,11 +178,11 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
         [initialSplit, ...splits].map((s) => s.duplicateOf).filter(filterNotEmpty),
         'DRAFT',
     );
-    const switches = useSwitches(
-        allowedSwitches.map((sw) => sw.switchId),
-        'DRAFT',
-        switchChangeTime,
+    const allowedSwitchIds = React.useMemo(
+        () => allowedSwitches.map((sw) => sw.switchId),
+        [allowedSwitches],
     );
+    const switches = useSwitches(allowedSwitchIds, 'DRAFT', switchChangeTime);
 
     React.useEffect(() => {
         locationTrack && setSplittingDisabled(locationTrack?.draftType !== 'OFFICIAL');


### PR DESCRIPTION
Bugi oli pieni kompastuskohta massa-fetchejä tekevissä koukuissa, ehkä sellainen, jota voisi miettiä enemmänkin. Haettava id-lista on joka renderillä uusi, ja koska se on uusi, niin koukun useLoader kutsuu lataajafunktiota, joka taas käy poimimassa cachesta pyydetyt id:t, eli vaikka mitään ei varsinaisesti haeta (kaikki on jo cachessa), niin palautettava lista on myös uusi. Tällöin siis komponentti luulee joka renderillä listan muuttuneen, ja renderöityy jatkuvasti uusiksi.

Periaatteessahan useSwitches voisi itsekin tukea alkuperäistä käyttötapaa "suoraan", mutta ilmaista se ei olisi, eli tein tässä tapauksessa perffin suhteen korrektimman paikallisratkaisun.