### PR TITLE
GVT-2325 Fix test that only incidentally worked

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -366,7 +366,10 @@ class CalculatedChangesServiceIT @Autowired constructor(
             switch.id as IntId,
             JointNumber(1),
             locationTrackService = locationTrackService
-        ).let { locationTrackService.getWithAlignment(it.rowVersion) }
+        ).let { (id, version) ->
+            val (_, publishedVersion) = locationTrackService.publish(ValidationVersion(id, version))
+            locationTrackService.getWithAlignment(publishedVersion)
+        }
 
         // Then remove the topology switch info
         removeTopologySwitchesFromLocationTrackAndUpdate(


### PR DESCRIPTION
Testi luo vaihteen ja raiteet, lisää topologialinkin, ja poistaa sen; ja tarkistaa lopulta, että näkyihän poisto muutoksena. Mutta oikeasti se toimi vain sattumalta: Koska testi ei julkaissut topologialinkillistä välitilaa, se vertaisi oikeasti lopputilaa tuon alun testidatan generoinnin luomaan tilaan.

Samassa kohdassa (siis tasan samassa kohdassa (100.0, 0.0)) voi olla monien testiajojen jälkeen satoja vaihdepisteitä, joista nykyinen linkityskoodi "lähimpää" etsiessä sattuu tuurilla valitsemaan uusimman ja sattumalta siksi oikean. Jos linkityskoodia muuttaa sellaisella tavalla, että se muuttaa jotenkin näiden vaihtoehtojen järjestystä, se rikkoo myös tämän testin alkutilan luonnin, vaikka muutoksessa ei oikeasti olisi mitään vikaa.