### PR TITLE
GVT-2359 Don't remove geometry tracknumber links on all reverts

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
@@ -7,7 +7,6 @@ import fi.fta.geoviite.infra.common.FeatureTypeCode
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.boundingBoxAroundPointsOrNull
-import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.FreeText
 import java.math.BigDecimal
 
@@ -27,7 +26,6 @@ data class GeometryAlignment(
     val elements: List<GeometryElement>,
     val profile: GeometryProfile? = null,
     val cant: GeometryCant? = null,
-    val trackNumberId: DomainId<TrackLayoutTrackNumber>?,
     val id: DomainId<GeometryAlignment> = StringId(),
 ) : Loggable {
     @get:JsonIgnore

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -20,9 +20,7 @@ import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Range
 import fi.fta.geoviite.infra.math.toAngle
-import fi.fta.geoviite.infra.publication.RemovedTrackNumberReferenceIds
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
-import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.*
 import fi.fta.geoviite.infra.util.DbTable.*
 import org.springframework.beans.factory.annotation.Autowired
@@ -1347,58 +1345,6 @@ class GeometryDao @Autowired constructor(
                 )
             }
         }
-    }
-
-    @Transactional
-    fun removeReferencesToTrackNumber(id: IntId<TrackLayoutTrackNumber>): RemovedTrackNumberReferenceIds {
-        return RemovedTrackNumberReferenceIds(
-            kmPostIds = removeKmPostReferenceToTrackNumber(id),
-            alignmentIds = removeAlignmentReferenceToTrackNumber(id),
-            planIds = removePlanReferenceToTrackNumber(id)
-        )
-    }
-
-    private fun removeKmPostReferenceToTrackNumber(id: IntId<TrackLayoutTrackNumber>): List<IntId<GeometryKmPost>> {
-        val sql = """
-          update geometry.km_post
-          set track_number_id = null 
-          where track_number_id = :id
-          returning id as km_post_id
-        """.trimIndent()
-
-        return jdbcTemplate.query<IntId<GeometryKmPost>>(
-            sql, mapOf("id" to id.intValue)
-        ) { rs, _ -> IntId(rs.getInt("km_post_id")) }
-            .also { ids -> logger.daoAccess(UPDATE, GeometryKmPost::class, ids) }
-    }
-
-
-    private fun removeAlignmentReferenceToTrackNumber(id: IntId<TrackLayoutTrackNumber>): List<IntId<GeometryAlignment>> {
-        val sql = """
-          update geometry.alignment
-          set track_number_id = null 
-          where track_number_id = :id
-          returning id as alignment_id
-        """.trimIndent()
-
-        return jdbcTemplate.query<IntId<GeometryAlignment>>(
-            sql, mapOf("id" to id.intValue)
-        ) { rs, _ -> IntId(rs.getInt("alignment_id")) }
-            .also { ids -> logger.daoAccess(UPDATE, GeometryAlignment::class, ids) }
-
-    }
-
-    private fun removePlanReferenceToTrackNumber(id: IntId<TrackLayoutTrackNumber>): List<IntId<GeometryPlan>> {
-        val sql = """
-          update geometry.plan
-          set track_number_id = null 
-          where track_number_id = :id
-          returning id as plan_id
-        """.trimIndent()
-
-        return jdbcTemplate.query<IntId<GeometryPlan>>(
-            sql, mapOf("id" to id.intValue)
-        ) { rs, _ -> IntId(rs.getInt("plan_id")) }.also { ids -> logger.daoAccess(UPDATE, GeometryPlan::class, ids) }
     }
 
     private fun getElementData(rs: ResultSet): ElementData {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -536,27 +536,27 @@ class GeometryDao @Autowired constructor(
     private fun insertKmPosts(kmPostParams: List<Map<String, Any?>>) {
         val sql = """
             insert into geometry.km_post(
-              track_number_id, 
               km_post_index,
               plan_id,
-              sta_back, 
-              sta_ahead, 
-              sta_internal, 
-              km_number, 
+              sta_back,
+              sta_ahead,
+              sta_internal,
+              km_number,
               description,
               location,
-              state)
+              state
+            )
             values (
-             :track_number_id, 
-             :km_post_index, 
-             :plan_id,
-             :sta_back, 
-             :sta_ahead, 
-             :sta_internal, 
-             :km_number, 
-             :description,
-             postgis.st_point(:x, :y),
-             :state::geometry.plan_state)
+              :km_post_index,
+              :plan_id,
+              :sta_back,
+              :sta_ahead,
+              :sta_internal,
+              :km_number,
+              :description,
+              postgis.st_point(:x, :y),
+              :state::geometry.plan_state
+            )
             """
         jdbcTemplate.batchUpdate(sql, kmPostParams.toTypedArray())
     }
@@ -567,7 +567,6 @@ class GeometryDao @Autowired constructor(
     ): List<Map<String, Any?>> {
         return kmPosts.mapIndexed { index, kmPost ->
             mapOf(
-                "track_number_id" to kmPost.trackNumberId?.intValue,
                 "km_post_index" to index,
                 "plan_id" to planId.intValue,
                 "sta_back" to kmPost.staBack,
@@ -1074,7 +1073,7 @@ class GeometryDao @Autowired constructor(
     ): List<GeometryAlignment> {
         val sql = """
             select 
-              alignment.id, alignment.track_number_id, alignment.oid_part, 
+              alignment.id, alignment.oid_part, 
               alignment.name, alignment.state, alignment.description,
               alignment.sta_start,
               alignment.profile_name,
@@ -1084,7 +1083,7 @@ class GeometryDao @Autowired constructor(
             from geometry.alignment 
             where (:plan_id::int is null or alignment.plan_id = :plan_id)
               and (:alignment_id::int is null or alignment.id = :alignment_id)
-            order by alignment.track_number_id, alignment.id
+            order by alignment.id
         """.trimIndent()
         return jdbcTemplate.query(
             sql, mapOf("plan_id" to planId?.intValue, "alignment_id" to geometryAlignmentId?.intValue)
@@ -1095,7 +1094,6 @@ class GeometryDao @Autowired constructor(
             val featureTypeCode = rs.getFeatureTypeCodeOrNull("feature_type_code")
             GeometryAlignment(
                 id = alignmentId,
-                trackNumberId = rs.getIntIdOrNull("track_number_id"),
                 name = AlignmentName(rs.getString("name")),
                 description = rs.getFreeTextOrNull("description"),
                 oidPart = rs.getFreeTextOrNull("oid_part"),
@@ -1190,7 +1188,6 @@ class GeometryDao @Autowired constructor(
         val sql = """
             select
               km_post.id,
-              km_post.track_number_id, 
               km_post.km_post_index, 
               km_post.sta_back, 
               km_post.sta_ahead,
@@ -1210,7 +1207,6 @@ class GeometryDao @Autowired constructor(
         return jdbcTemplate.query(sql, params) { rs, _ ->
             GeometryKmPost(
                 id = rs.getIntId("id"),
-                trackNumberId = rs.getIntIdOrNull("track_number_id"),
                 staBack = rs.getBigDecimal("sta_back"),
                 staAhead = rs.getBigDecimal("sta_ahead"),
                 staInternal = rs.getBigDecimal("sta_internal"),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryKmPost.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryKmPost.kt
@@ -2,13 +2,11 @@ package fi.fta.geoviite.infra.geometry
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.common.DomainId
-import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import java.math.BigDecimal
 
 data class GeometryKmPost(
@@ -19,8 +17,7 @@ data class GeometryKmPost(
     val description: PlanElementName,
     val state: PlanState?,
     val location: Point?,
-    val trackNumberId: IntId<TrackLayoutTrackNumber>?,
     val id: DomainId<GeometryKmPost> = StringId(),
 ) : Loggable {
-    override fun toLog(): String = logFormat("id" to id, "trackNumber" to trackNumberId, "kmNumber" to kmNumber)
+    override fun toLog(): String = logFormat("id" to id, "kmNumber" to kmNumber)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -521,7 +521,7 @@ class GeometryService @Autowired constructor(
                     alignment.segments[lastPlanEndIndex + 1].startM,
                     alignment.segments[thisPlanEndIndex].endM,
                     segmentSources[thisPlanEndIndex].plan?.fileName,
-                    segmentSources[thisPlanEndIndex].alignment?.let(::toAlignmentHeader),
+                    segmentSources[thisPlanEndIndex].alignment?.let { toAlignmentHeader(null, it) },
                     segmentSources[thisPlanEndIndex].plan?.id,
                     segmentSources[thisPlanEndIndex].plan?.units?.verticalCoordinateSystem,
                     segmentSources[thisPlanEndIndex].plan?.elevationMeasurementMethod,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
@@ -81,20 +81,14 @@ fun toGvtPlan(
         }
 
         alignments.addAll(group.alignments.map { xmlAlignment ->
-            toGvtAlignment(
-                layoutTrackNumberId,
-                xmlAlignment,
-                units,
-                gvtSwitches,
-                trackNumberState,
-            )
+            toGvtAlignment(xmlAlignment, units, gvtSwitches, trackNumberState)
         })
         kmPosts.addAll(group.alignments.flatMap { alignment ->
             val alignmentState = alignment.state?.let { stateString ->
                 tryParsePlanState("Alignment ${alignment.name} state", stateString)
             }
             alignment.staEquations.map { s ->
-                toGvtKmPost(layoutTrackNumberId, s, alignmentState ?: trackNumberState)
+                toGvtKmPost(s, alignmentState ?: trackNumberState)
             }
         })
     }
@@ -184,7 +178,6 @@ fun toVerticalCoordinateSystem(name: String): VerticalCoordinateSystem? = if (na
 } else null
 
 fun toGvtAlignment(
-    trackNumberId: DomainId<TrackLayoutTrackNumber>?,
     alignment: InfraModelAlignment,
     units: GeometryUnits,
     switches: Map<SwitchKey, GeometrySwitch>,
@@ -207,7 +200,6 @@ fun toGvtAlignment(
         },
         profile = profile,
         cant = cant,
-        trackNumberId = trackNumberId,
     )
 }
 
@@ -217,7 +209,6 @@ private fun getAlignmentImCodingFeatureType(features: List<InfraModelFeature>): 
         ?.let(::tryParseFeatureTypeCode)
 
 fun toGvtKmPost(
-    trackNumberId: IntId<TrackLayoutTrackNumber>?,
     staEquation: InfraModelStaEquation,
     state: PlanState?,
 ): GeometryKmPost {
@@ -235,7 +226,6 @@ fun toGvtKmPost(
         description = PlanElementName(description),
         location = location,
         state = state,
-        trackNumberId = trackNumberId,
     )
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -401,10 +401,7 @@ class PublicationService @Autowired constructor(
         alignmentDao.deleteOrphanedAlignments()
         val switchCount = toDelete.switches.map { id -> switchService.deleteDraft(id) }.size
         val kmPostCount = toDelete.kmPosts.map { id -> kmPostService.deleteDraft(id) }.size
-        val trackNumberCount = toDelete.trackNumbers.map { id ->
-            geometryDao.removeReferencesToTrackNumber(id)
-            trackNumberService.deleteDraft(id)
-        }.size
+        val trackNumberCount = toDelete.trackNumbers.map { id -> trackNumberService.deleteDraft(id) }.size
 
         return PublishResult(
             publishId = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -27,6 +27,7 @@ fun toTrackLayout(
     val switches = toTrackLayoutSwitches(geometryPlan.switches, planToLayout)
 
     val alignments: List<PlanLayoutAlignment> = toMapAlignments(
+        geometryPlan.trackNumberId,
         geometryPlan.alignments,
         planToLayout,
         pointListStepLength,
@@ -35,7 +36,7 @@ fun toTrackLayout(
         includeGeometryData
     )
 
-    val kmPosts = toTrackLayoutKmPosts(geometryPlan.kmPosts, planToLayout)
+    val kmPosts = toTrackLayoutKmPosts(geometryPlan.trackNumberId, geometryPlan.kmPosts, planToLayout)
     val startAddress = getPlanStartAddress(geometryPlan.kmPosts)
 
     return GeometryPlanLayout(
@@ -51,6 +52,7 @@ fun toTrackLayout(
 }
 
 fun toTrackLayoutKmPosts(
+    trackNumberId: IntId<TrackLayoutTrackNumber>?,
     kmPosts: List<GeometryKmPost>,
     planToLayout: Transformation,
 ): List<TrackLayoutKmPost> {
@@ -62,7 +64,7 @@ fun toTrackLayoutKmPosts(
                 location = planToLayout.transform(kmPost.location),
                 state = getLayoutStateOrDefault(kmPost.state),
                 sourceId = kmPost.id,
-                trackNumberId = kmPost.trackNumberId,
+                trackNumberId = trackNumberId,
             )
         } else null
     }
@@ -95,6 +97,7 @@ fun toTrackLayoutSwitches(
     geometrySwitches.mapNotNull { s -> toTrackLayoutSwitch(s, planToLayout)?.let { s.id to it } }.associate { it }
 
 fun toMapAlignments(
+    trackNumberId: IntId<TrackLayoutTrackNumber>?,
     geometryAlignments: List<GeometryAlignment>,
     planToLayout: Transformation,
     pointListStepLength: Int,
@@ -118,13 +121,14 @@ fun toMapAlignments(
         }
 
         PlanLayoutAlignment(
-            header = toAlignmentHeader(alignment, boundingBoxInLayoutSpace),
+            header = toAlignmentHeader(trackNumberId, alignment, boundingBoxInLayoutSpace),
             segments = mapSegments,
         )
     }
 }
 
 fun toAlignmentHeader(
+    trackNumberId: IntId<TrackLayoutTrackNumber>?,
     alignment: GeometryAlignment,
     boundingBoxInLayoutSpace: BoundingBox? = null,
 ) = AlignmentHeader(
@@ -133,7 +137,7 @@ fun toAlignmentHeader(
     alignmentSource = MapAlignmentSource.GEOMETRY,
     alignmentType = getAlignmentType(alignment.featureTypeCode),
     state = getLayoutStateOrDefault(alignment.state),
-    trackNumberId = alignment.trackNumberId,
+    trackNumberId = trackNumberId,
     boundingBox = boundingBoxInLayoutSpace,
     length = alignment.elements.sumOf(GeometryElement::calculatedLength),
     segmentCount = alignment.elements.size,

--- a/infra/src/main/resources/db/migration/prod/V59__set_geometry_track_number_fkey_to_null_on_delete.sql
+++ b/infra/src/main/resources/db/migration/prod/V59__set_geometry_track_number_fkey_to_null_on_delete.sql
@@ -1,0 +1,17 @@
+alter table geometry.plan
+  drop constraint plan_track_number_id_fkey;
+alter table geometry.plan
+  add constraint plan_track_number_id_fkey foreign key (track_number_id)
+    references layout.track_number (id) on delete set null;
+
+alter table geometry.alignment
+  drop constraint alignment_track_number_id_fkey;
+alter table geometry.alignment
+  add constraint alignment_track_number_id_fkey foreign key (track_number_id)
+    references layout.track_number (id) on delete set null;
+
+alter table geometry.km_post
+  drop constraint km_post_track_number_id_fkey;
+alter table geometry.km_post
+  add constraint km_post_track_number_id_fkey foreign key (track_number_id)
+    references layout.track_number (id) on delete set null;

--- a/infra/src/main/resources/db/migration/prod/V59__set_geometry_track_number_fkey_to_null_on_delete.sql
+++ b/infra/src/main/resources/db/migration/prod/V59__set_geometry_track_number_fkey_to_null_on_delete.sql
@@ -4,14 +4,8 @@ alter table geometry.plan
   add constraint plan_track_number_id_fkey foreign key (track_number_id)
     references layout.track_number (id) on delete set null;
 
+-- Remove these columns entirely, since they currently only carry duplicate data from the plan track_number
 alter table geometry.alignment
-  drop constraint alignment_track_number_id_fkey;
-alter table geometry.alignment
-  add constraint alignment_track_number_id_fkey foreign key (track_number_id)
-    references layout.track_number (id) on delete set null;
-
+  drop column track_number_id;
 alter table geometry.km_post
-  drop constraint km_post_track_number_id_fkey;
-alter table geometry.km_post
-  add constraint km_post_track_number_id_fkey foreign key (track_number_id)
-    references layout.track_number (id) on delete set null;
+  drop column track_number_id;

--- a/infra/src/main/resources/db/migration/prod/V60__fix_lost_geometry_tracknumber_refs.sql
+++ b/infra/src/main/resources/db/migration/prod/V60__fix_lost_geometry_tracknumber_refs.sql
@@ -1,0 +1,20 @@
+with plan_with_lost_tracknumber as (
+  select
+    plan.id,
+    max(intact.version) as last_intact_version
+    from geometry.plan left join geometry.plan_version intact on intact.id = plan.id
+    where plan.track_number_id is null
+      and intact.track_number_id is not null
+      and exists(select 1 from layout.track_number where id = intact.track_number_id)
+    group by plan.id
+)
+update geometry.plan
+set track_number_id = last_known_data.track_number_id
+  from (
+    select
+      plan.id,
+      intact.track_number_id
+      from plan_with_lost_tracknumber plan
+        left join geometry.plan_version intact on intact.id = plan.id and intact.version = plan.last_intact_version
+  ) as last_known_data
+  where plan.id = last_known_data.id;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingServiceIT.kt
@@ -32,38 +32,35 @@ class GeocodingServiceIT @Autowired constructor(
     @Test
     fun `geocoding context can be generated from geometry plan`() {
         val trackNumberId = trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).id
-        val plan = minimalPlan()
-            .copy(
-                units = GeometryUnits(
-                    coordinateSystemSrid = LAYOUT_SRID,
-                    coordinateSystemName = null,
-                    verticalCoordinateSystem = null,
-                    directionUnit = AngularUnit.GRADS,
-                    linearUnit = LinearUnit.METER,
-                ),
-                alignments = listOf(
-                    geometryAlignment(
-                        trackNumberId,
-                        listOf(
-                            // reference line goes straight up
-                            line(Point(450000.0, 7000000.0), Point(450000.0, 7000020.0)),
-                        ),
-                        featureTypeCode = FeatureTypeCode("111")
+        val plan = minimalPlan().copy(
+            units = GeometryUnits(
+                coordinateSystemSrid = LAYOUT_SRID,
+                coordinateSystemName = null,
+                verticalCoordinateSystem = null,
+                directionUnit = AngularUnit.GRADS,
+                linearUnit = LinearUnit.METER,
+            ),
+            alignments = listOf(
+                geometryAlignment(
+                    listOf(
+                        // reference line goes straight up
+                        line(Point(450000.0, 7000000.0), Point(450000.0, 7000020.0)),
                     ),
-                    geometryAlignment(
-                        trackNumberId,
-                        listOf(
-                            // location track goes somewhere that doesn't matter (but actually just goes diagonally)
-                            line(Point(450000.0, 7000000.0), Point(450020.0, 7000020.0)),
-                        ),
-                        featureTypeCode = FeatureTypeCode("121")
-                    )
+                    featureTypeCode = FeatureTypeCode("111"),
                 ),
-                kmPosts = listOf(
-                    createGeometryKmPost(trackNumberId, null, "0140", staInternal = BigDecimal.valueOf(-100L)),
-                    createGeometryKmPost(trackNumberId, Point(450000.0, 7000010.0), "0141")
-                )
-            )
+                geometryAlignment(
+                    listOf(
+                        // location track goes somewhere that doesn't matter (but actually just goes diagonally)
+                        line(Point(450000.0, 7000000.0), Point(450020.0, 7000020.0)),
+                    ),
+                    featureTypeCode = FeatureTypeCode("121"),
+                ),
+            ),
+            kmPosts = listOf(
+                createGeometryKmPost(null, "0140", staInternal = BigDecimal.valueOf(-100L)),
+                createGeometryKmPost(Point(450000.0, 7000010.0), "0141")
+            ),
+        )
         val planVersion = geometryDao.insertPlan(
             plan, InfraModelFile(plan.fileName, "<plan />"),
             listOf(
@@ -72,7 +69,7 @@ class GeocodingServiceIT @Autowired constructor(
                 Point(460000.0, 7100000.0),
                 Point(450000.0, 7100000.0),
                 Point(450000.0, 7000000.0),
-            )
+            ),
         )
         val context = geocodingService.getGeocodingContext(trackNumberId, planVersion)
         assertNotNull(context)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/DataProductsTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/DataProductsTestData.kt
@@ -3,14 +3,11 @@ package fi.fta.geoviite.infra.geometry
 import fi.fta.geoviite.infra.common.IndexedId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 
 fun createAlignment(
-    trackNumberId: IntId<TrackLayoutTrackNumber>,
     vararg elementTypes: GeometryElementType,
 ) = geometryAlignment(
     id = IntId(1),
-    trackNumberId = trackNumberId,
     elements = createElements(1, *elementTypes),
 )
 
@@ -19,18 +16,21 @@ fun createElements(parentId: Int, vararg types: GeometryElementType) = types.map
         GeometryElementType.LINE -> minimalLine(
             id = IndexedId(parentId, index),
             start = Point(index.toDouble(), index.toDouble()),
-            end = Point((index+1).toDouble(), (index+1).toDouble()),
+            end = Point((index + 1).toDouble(), (index + 1).toDouble()),
         )
+
         GeometryElementType.CURVE -> minimalCurve(
             id = IndexedId(parentId, index),
             start = Point(index.toDouble(), index.toDouble()),
-            end = Point((index+1).toDouble(), (index+1).toDouble()),
+            end = Point((index + 1).toDouble(), (index + 1).toDouble()),
         )
+
         GeometryElementType.CLOTHOID -> minimalClothoid(
             id = IndexedId(parentId, index),
             start = Point(index.toDouble(), index.toDouble()),
-            end = Point((index+1).toDouble(), (index+1).toDouble()),
+            end = Point((index + 1).toDouble(), (index + 1).toDouble()),
         )
+
         else -> throw IllegalStateException("element $t not supported by this test method")
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ElementListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ElementListingTest.kt
@@ -28,7 +28,6 @@ class ElementListingTest {
     fun `Basic info is filled from LocationTrack & GeometryPlanHeader`() {
         val trackNumberId = IntId<TrackLayoutTrackNumber>(1)
         val alignment = geometryAlignment(
-            trackNumberId = trackNumberId,
             id = IntId(1),
             elements = createElements(
                 1,
@@ -72,7 +71,6 @@ class ElementListingTest {
     fun `Basic info is filled from GeometryPlan`() {
         val trackNumberId = IntId<TrackLayoutTrackNumber>(1)
         val alignment = geometryAlignment(
-            trackNumberId = trackNumberId,
             elements = listOf(minimalLine(), minimalCurve(), minimalClothoid()),
             name = "TSTTrack001",
         )
@@ -167,7 +165,6 @@ class ElementListingTest {
     fun `Plan element listing is filtered by types`() {
         val trackNumberId = IntId<TrackLayoutTrackNumber>(1)
         val geometryAlignment = createAlignment(
-            trackNumberId,
             GeometryElementType.LINE,
             GeometryElementType.CURVE,
             GeometryElementType.CLOTHOID,
@@ -195,7 +192,6 @@ class ElementListingTest {
         val trackNumberId = IntId<TrackLayoutTrackNumber>(1)
         val plan = planHeader(trackNumberId = trackNumberId)
         val geometryAlignment = createAlignment(
-            trackNumberId,
             GeometryElementType.LINE,
             GeometryElementType.CURVE,
             GeometryElementType.CLOTHOID,
@@ -231,7 +227,6 @@ class ElementListingTest {
         val trackNumberId = IntId<TrackLayoutTrackNumber>(1)
         val alignment1 = geometryAlignment(
             id = IntId(1),
-            trackNumberId = trackNumberId,
             elements = listOf(
                 minimalLine(id = IndexedId(1,1)),
                 minimalCurve(id = IndexedId(1,2)),
@@ -240,7 +235,6 @@ class ElementListingTest {
         )
         val alignment2 = geometryAlignment(
             id = IntId(2),
-            trackNumberId = trackNumberId,
             elements = listOf(
                 minimalCurve(id = IndexedId(2,1)),
                 minimalClothoid(id = IndexedId(2,2)),
@@ -269,7 +263,7 @@ class ElementListingTest {
             TrackMeter(KmNumber.ZERO, 25),
             TrackMeter(KmNumber.ZERO, 35),
             { id -> alignments.find { a -> a.second.id == id }!! },
-            { _ -> SwitchName("Test") }
+            { _ -> SwitchName("Test") },
         )
 
         // Linked: alignment1 elements 1 & 2 (not 0) + alignment2 elements 0 & 1 (not 2)
@@ -283,7 +277,6 @@ class ElementListingTest {
         val trackNumberId = IntId<TrackLayoutTrackNumber>(1)
         val alignment = geometryAlignment(
             id = IntId(1),
-            trackNumberId = trackNumberId,
             elements = listOf(
                 minimalLine(id = IndexedId(1,1)),
                 minimalLine(id = IndexedId(1,2)),
@@ -310,7 +303,7 @@ class ElementListingTest {
             null,
             null,
             { id -> alignments.find { a -> a.second.id == id }!! },
-            { _ -> SwitchName("Test") }
+            { _ -> SwitchName("Test") },
         )
 
         assertNull(listing[0].connectedSwitchName)
@@ -322,7 +315,6 @@ class ElementListingTest {
         val trackNumberId = IntId<TrackLayoutTrackNumber>(1)
         val alignment = geometryAlignment(
             id = IntId(1),
-            trackNumberId = trackNumberId,
             elements = listOf(
                 minimalLine(id = IndexedId(1,1)),
                 minimalLine(id = IndexedId(1,2)),
@@ -353,7 +345,7 @@ class ElementListingTest {
             null,
             null,
             { id -> alignments.find { a -> a.second.id == id }!! },
-            { _ -> SwitchName("Test") }
+            { _ -> SwitchName("Test") },
         )
         assertEquals(3, listing.size)
         assertEquals(listOf(3, 1, 2), listing.map { l -> (l.elementId as IndexedId).index })

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
@@ -367,13 +367,13 @@ fun infraModelFile(name: String = "test_file.xml") = InfraModelFile(
 fun plan(
     trackNumberId: IntId<TrackLayoutTrackNumber> = IntId(1),
     srid: Srid = Srid(3879),
-    vararg alignments: GeometryAlignment = arrayOf(geometryAlignment(trackNumberId)),
+    vararg alignments: GeometryAlignment = arrayOf(geometryAlignment()),
 ): GeometryPlan = plan(trackNumberId, srid, alignments.toList())
 
 fun plan(
     trackNumberId: IntId<TrackLayoutTrackNumber> = IntId(1),
     srid: Srid = Srid(3879),
-    alignments: List<GeometryAlignment> = listOf(geometryAlignment(trackNumberId)),
+    alignments: List<GeometryAlignment> = listOf(geometryAlignment()),
     switches: List<GeometrySwitch> = listOf(),
     measurementMethod: MeasurementMethod? = MeasurementMethod.VERIFIED_DESIGNED_GEOMETRY,
     elevationMeasurementMethod: ElevationMeasurementMethod? = ElevationMeasurementMethod.TOP_OF_SLEEPER,
@@ -383,7 +383,7 @@ fun plan(
     verticalCoordinateSystem: VerticalCoordinateSystem? = null,
     source: PlanSource = PlanSource.GEOMETRIAPALVELU,
     planTime: Instant = Instant.EPOCH,
-    kmPosts: List<GeometryKmPost> = kmPosts(trackNumberId),
+    kmPosts: List<GeometryKmPost> = kmPosts(),
     project: Project = project(),
     units: GeometryUnits = geometryUnits(srid, coordinateSystemName, verticalCoordinateSystem),
 ): GeometryPlan {
@@ -518,19 +518,17 @@ fun geometryElements(): List<GeometryElement> {
 }
 
 fun geometryAlignment(
-    trackNumberId: DomainId<TrackLayoutTrackNumber>,
     vararg elements: GeometryElement = geometryElements().toTypedArray(),
-) = geometryAlignment(trackNumberId, elements.toList())
+): GeometryAlignment = geometryAlignment(elements.toList())
 
 fun geometryAlignment(
-    trackNumberId: DomainId<TrackLayoutTrackNumber>? = null,
     elements: List<GeometryElement> = geometryElements(),
     profile: GeometryProfile? = null,
     cant: GeometryCant? = null,
     name: String = "001",
     id: DomainId<GeometryAlignment> = StringId(),
     featureTypeCode: FeatureTypeCode = FeatureTypeCode("111"),
-) = GeometryAlignment(
+): GeometryAlignment = GeometryAlignment(
     id = id,
     name = AlignmentName(name),
     description = FreeText("test-alignment 001"),
@@ -541,7 +539,6 @@ fun geometryAlignment(
     elements = elements,
     profile = profile,
     cant = cant,
-    trackNumberId = trackNumberId,
 )
 
 fun linearCant(startDistance: Double, endDistance: Double, startValue: Double, endValue: Double): GeometryCant {
@@ -568,7 +565,7 @@ fun geometryCant(points: List<GeometryCantPoint>) = GeometryCant(
     points = points,
 )
 
-fun kmPosts(trackNumberId: IntId<TrackLayoutTrackNumber>) = listOf(
+fun kmPosts() = listOf(
     GeometryKmPost(
         staBack = null,
         staAhead = BigDecimal("-148.729000"),
@@ -577,7 +574,6 @@ fun kmPosts(trackNumberId: IntId<TrackLayoutTrackNumber>) = listOf(
         description = PlanElementName("0"),
         state = PlanState.PROPOSED,
         location = null,
-        trackNumberId = trackNumberId,
     ), GeometryKmPost(
         staBack = BigDecimal("1003.440894"),
         staAhead = BigDecimal("854.711894"),
@@ -586,7 +582,6 @@ fun kmPosts(trackNumberId: IntId<TrackLayoutTrackNumber>) = listOf(
         description = PlanElementName("1"),
         state = PlanState.PROPOSED,
         location = Point(x = 2.5496599876E7, y = 6674007.758),
-        trackNumberId = trackNumberId,
     )
 )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -230,7 +230,7 @@ class GeometryServiceIT @Autowired constructor(
             locationTrack(trackNumberId),
             alignment(
                 segment(yRangeToSegmentPoints(0..10)),
-            )
+            ),
         ).id
         kmPostService.saveDraft(kmPost(trackNumberId, KmNumber("0155"), Point(0.0, 8.0)))
         kmPostService.saveDraft(kmPost(trackNumberId, KmNumber("0156"), Point(0.0, 9.0)))
@@ -257,7 +257,6 @@ class GeometryServiceIT @Autowired constructor(
         verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
         alignments = listOf(
             geometryAlignment(
-                trackNumberId,
                 elements = listOf(lineFromOrigin(1.0)),
                 name = "foo",
                 profile = GeometryProfile(
@@ -273,9 +272,9 @@ class GeometryServiceIT @Autowired constructor(
                             BigDecimal(155),
                         ),
                         VIPoint(PlanElementName("endpoint"), Point(600.0, 51.0)),
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ),
     )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TestGeometryPlanService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TestGeometryPlanService.kt
@@ -54,7 +54,7 @@ class TestGeometryPlanService @Autowired constructor(
 
 
         fun kmPost(name: String, location: Point): BuildGeometryPlan {
-            kmPosts.add(createGeometryKmPost(trackNumberId, DEFAULT_BASE_POINT + location, name))
+            kmPosts.add(createGeometryKmPost(DEFAULT_BASE_POINT + location, name))
             return this
         }
 
@@ -82,7 +82,6 @@ class TestGeometryPlanService @Autowired constructor(
             val builtAlignments = alignments.map { build ->
                 createGeometryAlignment(
                     alignmentName = build.name,
-                    trackNumberId = trackNumberId,
                     basePoint = DEFAULT_BASE_POINT + build.firstPoint,
                     incrementPoints = build.incrementPoints,
                     switchData = build.switchData,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
@@ -292,9 +292,8 @@ class ValidationTest {
         structure: SwitchStructure,
     ) = structure.alignments.map { structureAlignment ->
         geometryAlignment(
-            trackNumberId = null,
             elements = structureAlignment.jointNumbers.mapIndexedNotNull { index, jointNumber ->
-                structureAlignment.jointNumbers.getOrNull(index+1)?.let { nextJointNumber ->
+                structureAlignment.jointNumbers.getOrNull(index + 1)?.let { nextJointNumber ->
                     val startPoint = switch.getJoint(jointNumber)!!.location
                     val endPoint = switch.getJoint(nextJointNumber)!!.location
                     line(
@@ -305,7 +304,7 @@ class ValidationTest {
                             switchId = switch.id,
                             startJointNumber = jointNumber,
                             endJointNumber = null,
-                        )
+                        ),
                     )
                 }
             },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
@@ -209,7 +209,6 @@ class VerticalGeometryListingTest() {
                 featureTypeCode = FeatureTypeCode("111"),
                 oidPart = FreeText("123"),
                 state = PlanState.EXISTING,
-                trackNumberId = IntId(1)
             ),
             null,
             null,
@@ -239,7 +238,6 @@ class VerticalGeometryListingTest() {
     @Test
     fun `Returns right coordinate at the intersection of elements`() {
         val alignment = createAlignment(
-            IntId(1),
             GeometryElementType.LINE,
             GeometryElementType.LINE,
         )
@@ -252,7 +250,6 @@ class VerticalGeometryListingTest() {
     @Test
     fun `Returns right coordinate at the beginning of alignment`() {
         val alignment = createAlignment(
-            IntId(1),
             GeometryElementType.LINE,
         )
         val element = alignment.elements.get(0)
@@ -264,7 +261,6 @@ class VerticalGeometryListingTest() {
     @Test
     fun `Returns right coordinate mid-element`() {
         val alignment = createAlignment(
-            IntId(1),
             GeometryElementType.LINE,
             GeometryElementType.LINE,
         )
@@ -279,7 +275,6 @@ class VerticalGeometryListingTest() {
     @Test
     fun `Returns right coordinate at the end of alignment`() {
         val alignment = createAlignment(
-            IntId(1),
             GeometryElementType.LINE,
         )
         val coordinate = alignment.getCoordinateAt(alignment.elements.first().calculatedLength)!!
@@ -290,7 +285,6 @@ class VerticalGeometryListingTest() {
     @Test
     fun `Throws if distance is past the end of alignment`() {
         val alignment = createAlignment(
-            IntId(1),
             GeometryElementType.LINE,
         )
         assertNull(alignment.getCoordinateAt(alignment.elements.first().calculatedLength + 0.5))
@@ -302,7 +296,7 @@ class VerticalGeometryListingTest() {
             start,
             end,
             center,
-            radius
+            radius,
         )
 
     private fun linearSegment(start: Point, end: Point) =
@@ -310,6 +304,6 @@ class VerticalGeometryListingTest() {
             PlanElementName(""),
             start,
             end,
-            true
+            true,
         )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -44,7 +44,6 @@ class LinkingServiceIT @Autowired constructor(
         val geometryEnd = geometrySegmentChange + Point(3.0, 2.5)
         val plan = plan(
             trackNumberId.id, Srid(3067), geometryAlignment(
-                trackNumberId.id,
                 line(geometryStart, geometrySegmentChange),
                 line(geometrySegmentChange, geometryEnd),
             )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -832,30 +832,30 @@ class SwitchLinkingServiceIT @Autowired constructor(
             switchStructure,
             0.01, // avoid plan1's bounding box becoming degenerate by slightly rotating the main track
             Point(50.0, 50.0),
-            trackNumberId
         )
 
         val plan1 = makeAndSavePlan(
-            trackNumberId, MeasurementMethod.DIGITIZED_AERIAL_IMAGE,
+            trackNumberId,
+            MeasurementMethod.DIGITIZED_AERIAL_IMAGE,
             switches = listOf(switch),
             alignments = listOf(switchAlignments[0])
         )
 
         val plan2 = makeAndSavePlan(
-            trackNumberId, null,
-            alignments = listOf(switchAlignments[1])
+            trackNumberId,
+            measurementMethod = null,
+            alignments = listOf(switchAlignments[1]),
         )
 
-        val trackNumberIds =
-            (plan1.alignments + plan2.alignments).map { a ->
-                val (locationTrack, alignment) = locationTrackAndAlignmentForGeometryAlignment(
-                    trackNumberId,
-                    a,
-                    kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.KKJ_TO_TM35FIN),
-                    kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.TM35FIN_TO_KKJ)
-                )
-                locationTrackService.saveDraft(locationTrack, alignment)
-            }
+        val trackNumberIds = (plan1.alignments + plan2.alignments).map { a ->
+            val (locationTrack, alignment) = locationTrackAndAlignmentForGeometryAlignment(
+                trackNumberId,
+                a,
+                kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.KKJ_TO_TM35FIN),
+                kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.TM35FIN_TO_KKJ)
+            )
+            locationTrackService.saveDraft(locationTrack, alignment)
+        }
         val mainLocationTrackId = trackNumberIds[0].id
 
         return SuggestedSwitchCreateParams(
@@ -869,9 +869,9 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 SuggestedSwitchCreateParamsAlignmentMapping(
                     switchAlignment_1_5_2.id as StringId,
                     mainLocationTrackId,
-                    true
-                )
-            )
+                    true,
+                ),
+            ),
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -339,7 +339,8 @@ class RatkoServiceIT @Autowired constructor(
                 planTime = Instant.parse("2018-11-30T18:35:24.00Z"),
                 alignments = listOf(
                     geometryAlignment(
-                        trackNumberId, name = "geo name", elements = listOf(lineFromOrigin(1.0))
+                        name = "geo name",
+                        elements = listOf(lineFromOrigin(1.0)),
                     )
                 ),
             ), InfraModelFile(FileName("foobar"), "<a></a>"), null
@@ -794,8 +795,8 @@ class RatkoServiceIT @Autowired constructor(
             trackNumber.id,
             LAYOUT_SRID,
             // elements don't matter, only the names being different matters since that makes the metadatas distinct
-            geometryAlignment(trackNumber.id, elements = listOf(lineFromOrigin(1.0)), name = "foo"),
-            geometryAlignment(trackNumber.id, elements = listOf(lineFromOrigin(1.0)), name = "bar"),
+            geometryAlignment(elements = listOf(lineFromOrigin(1.0)), name = "foo"),
+            geometryAlignment(elements = listOf(lineFromOrigin(1.0)), name = "bar"),
         )
         val fileContent = "<a></a>"
         val planVersion = geometryDao.insertPlan(plan, InfraModelFile(plan.fileName, fileContent), null)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -31,7 +31,8 @@ fun createTrackLayoutTrackNumber(number: String, description: String = "descript
     )
 
 fun createGeometryKmPost(
-    trackNumberId: IntId<TrackLayoutTrackNumber>, location: Point?, kmNumber: String,
+    location: Point?,
+    kmNumber: String,
     staInternal: BigDecimal = BigDecimal("-148.729000"),
 ) = GeometryKmPost(
     staBack = null,
@@ -41,7 +42,6 @@ fun createGeometryKmPost(
     description = PlanElementName("0"),
     state = PlanState.PROPOSED,
     location = location,
-    trackNumberId = trackNumberId,
 )
 
 fun trackLayoutKmPost(kmNumber: String, trackNumberId: IntId<TrackLayoutTrackNumber>, point: Point) = TrackLayoutKmPost(
@@ -54,7 +54,6 @@ fun trackLayoutKmPost(kmNumber: String, trackNumberId: IntId<TrackLayoutTrackNum
 
 fun createGeometryAlignment(
     alignmentName: String,
-    trackNumberId: DomainId<TrackLayoutTrackNumber>,
     basePoint: Point,
     incrementPoints: List<Point>,
     switchData: List<SwitchData?> = emptyList(),
@@ -62,14 +61,13 @@ fun createGeometryAlignment(
     val points = pointsFromIncrementList(basePoint, incrementPoints)
 
     return createGeometryAlignment(
-        alignmentName = alignmentName, trackNumberId = trackNumberId, locationPoints = points, switchData = switchData
+        alignmentName = alignmentName, locationPoints = points, switchData = switchData
     )
 }
 
 fun createGeometryAlignment(
     alignmentName: String,
     elementNamePrefix: String = "elm",
-    trackNumberId: DomainId<TrackLayoutTrackNumber>,
     locationPoints: List<Point>,
     switchData: List<SwitchData?> = emptyList(),
 ): GeometryAlignment {
@@ -90,7 +88,6 @@ fun createGeometryAlignment(
         staStart = BigDecimal("0.000000"),
         elements = elements,
         profile = null,
-        trackNumberId = trackNumberId,
     )
 }
 
@@ -212,7 +209,6 @@ fun createSwitchAndAlignments(
     switchStructure: SwitchStructure,
     switchAngle: Double,
     switchOrig: Point,
-    trackNumberId: IntId<TrackLayoutTrackNumber>,
 ): Pair<GeometrySwitch, List<GeometryAlignment>> {
     val jointNumbers = switchStructure.joints.map { switchJoint -> switchJoint.number }
     logger.info("Switch structure id ${switchStructure.id}")
@@ -233,7 +229,6 @@ fun createSwitchAndAlignments(
         switchAngle,
         switchOrig,
         geometrySwitch,
-        trackNumberId,
     )
     return Pair(geometrySwitch, geometryAlignments)
 }
@@ -244,7 +239,6 @@ fun switchStructureToGeometryAlignment(
     switchAngle: Double,
     switchOrig: Point,
     geometrySwitch: GeometrySwitch,
-    trackNumberId: IntId<TrackLayoutTrackNumber>,
 ): List<GeometryAlignment> {
     return switchStructure.alignments.mapIndexed { index, switchAlignment ->
         GeometryAlignment(
@@ -262,7 +256,6 @@ fun switchStructureToGeometryAlignment(
                 switchStructure.joints,
             ),
             profile = null,
-            trackNumberId = trackNumberId,
         )
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
@@ -35,9 +35,9 @@ class HelsinkiTestData {
                 units = tmi35GeometryUnit(),
                 trackNumberId = trackLayoutTrackNumberId,
                 trackNumberDescription = PlanElementName(""),
-                alignments = listOf(westGeometryAlignment(trackLayoutTrackNumberId)),
+                alignments = listOf(westGeometryAlignment()),
                 switches = listOf(),
-                kmPosts = listOf(westGeometryKmPost(trackLayoutTrackNumberId)),
+                kmPosts = listOf(westGeometryKmPost()),
                 fileName = FileName("ratapiha.xml"),
                 pvDocumentId = null,
                 planPhase = PlanPhase.RAILWAY_PLAN,
@@ -45,16 +45,16 @@ class HelsinkiTestData {
                 measurementMethod = MeasurementMethod.VERIFIED_DESIGNED_GEOMETRY,
                 elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_SLEEPER,
                 message = null,
-                uploadTime = Instant.now()
+                uploadTime = Instant.now(),
             )
         }
 
-        fun westGeometryKmPost(trackNumberId: IntId<TrackLayoutTrackNumber>): GeometryKmPost {
+        fun westGeometryKmPost(): GeometryKmPost {
             val location = HKI_BASE_POINT + Point(x = 710.00, y = 550.00)
-            return createGeometryKmPost(trackNumberId, location, "0001")
+            return createGeometryKmPost(location, "0001")
         }
 
-        fun westGeometryAlignment(trackNumberId: DomainId<TrackLayoutTrackNumber>): GeometryAlignment {
+        fun westGeometryAlignment(): GeometryAlignment {
             val point1 = Point(x = HKI_BASE_POINT_X + 680.00, y = HKI_BASE_POINT_Y + 410.00) //etelä
             val point2 = Point(x = HKI_BASE_POINT_X + 695.00, y = HKI_BASE_POINT_Y + 500.00)
             val point3 = Point(x = HKI_BASE_POINT_X + 700.00, y = HKI_BASE_POINT_Y + 560.00) //pohjoinen
@@ -75,7 +75,6 @@ class HelsinkiTestData {
                     geometryLine("north", "2", point2, point3, staStart, length2)
                 ),
                 profile = null,
-                trackNumberId = trackNumberId,
             )
         }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
@@ -50,7 +50,7 @@ class VerticalGeometryDiagramTestUI @Autowired constructor(
                         linearUnit = LinearUnit.METER,
                     ), alignments = listOf(
                         geometryAlignment(
-                            trackNumber, elements = listOf(
+                            elements = listOf(
                                 line(
                                     DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0)
                                 )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
@@ -141,7 +141,7 @@ class VerticalGeometryElementListTestUI
                 srid = LAYOUT_SRID,
                 kmPosts = listOf(
                     createGeometryKmPost(
-                        trackNumberId, staInternal = BigDecimal(-10), location = DEFAULT_BASE_POINT, kmNumber = "0045"
+                        staInternal = BigDecimal(-10), location = DEFAULT_BASE_POINT, kmNumber = "0045"
                     )
                 ),
                 alignments = listOf(
@@ -151,7 +151,7 @@ class VerticalGeometryElementListTestUI
                             lineAtBasePoint(Point(1.0, 1.0), Point(150.0, 100.0)),
                             lineAtBasePoint(Point(150.0, 100.0), Point(300.0, 300.0))
                         ),
-                        profile = someGeometryProfile()
+                        profile = someGeometryProfile(),
                     )
                 ),
                 coordinateSystemName = CoordinateSystemName("testcrs"),

--- a/ui/src/geometry/geometry-model.ts
+++ b/ui/src/geometry/geometry-model.ts
@@ -162,7 +162,6 @@ export type GeometryAlignment = {
     elements: GeometryElement[];
     profile?: GeometryProfile;
     cant?: GeometryCant;
-    trackNumberId: GeometryTrackNumberId;
 };
 
 export type GeometryProfile = {
@@ -201,7 +200,6 @@ export type GeometryKmPost = {
     description: string;
     state?: PlanState;
     location?: Point;
-    trackNumberId: GeometryTrackNumberId;
 };
 
 export type GeometrySwitch = {


### PR DESCRIPTION
The point of the logic was to avoid reference errors when reverting a new draft tracknumber that is referred to by a geometry plan. The bug is that it's done on all reverts, not just new-draft reverts. Replaced the logic by simply making the foreign key references "on delete set null".

Also fixed links that has already been removed due to the bug.

Also removed tracknumber links from geometry.alignment & geometry.km_post, as those only duplicate their plan's data. The columns existed because originally, it was possible to have multiple tracknumbers in a single plan, but that is no longer the case.

Changed file-count is somewhat large but the majority of that is removing the tracknumber-links from test data generation. It was not relevant to the tests themselves and was only there because the object needed the field.