### PR TITLE
GVT-2338: Validoi jaettavan raiteen ratanumero - Part 1

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -394,7 +394,7 @@ class LocationTrackService(
             compareValues(
                 duplicateMValues[a.first], duplicateMValues[b.first]
             )
-        }.map { (_, track) -> LocationTrackDuplicate(track.id as IntId, track.name, track.externalId) }
+        }.map { (_, track) -> LocationTrackDuplicate(track.id as IntId, track.trackNumberId, track.name, track.externalId) }
     }
 
     private fun getDuplicateOf(
@@ -403,7 +403,7 @@ class LocationTrackService(
     ) = locationTrack.duplicateOf?.let { duplicateId ->
         get(publishType, duplicateId)?.let { dup ->
             LocationTrackDuplicate(
-                duplicateId, dup.name, dup.externalId
+                duplicateId, dup.trackNumberId, dup.name, dup.externalId
             )
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -45,6 +45,7 @@ enum class TopologicalConnectivityType {
 
 data class LocationTrackDuplicate(
     val id: IntId<LocationTrack>,
+    val trackNumberId: IntId<TrackLayoutTrackNumber>,
     val name: AlignmentName,
     val externalId: Oid<LocationTrack>?,
 )

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -568,6 +568,7 @@
             "end-location": "Loppusijainti (km + m)",
             "true-length": "Todellinen pituus (m)",
             "owner": "Omistaja",
+            "duplicate-on-different-track-number": "Raide on eri ratanumerolla ({{trackNumber}})",
             "delete-dialog": {
                 "delete-draft-confirm": "Poistetaanko luonnos?",
                 "can-be-deleted": "Tätä sijaintiraidetta ei ole vielä julkaistu Ratkoon, joten voit poistaa sen kokonaan. Poiston jälkeen et voi enää palauttaa sijaintiraidetta.",
@@ -606,6 +607,7 @@
                 "description-base": "Kuvauksen perusosa",
                 "description-suffix": "Kuvauksen lisäosa",
                 "validation": {
+                    "duplicates-on-different-track-number": "Raiteen jakamista ei voi suorittaa, koska osa tämän raiteen duplikaattiraiteista sijaitsee eri ratanumerolla.",
                     "track-draft-exists": "Muokattua sijaintiraidetta ei voi jakaa. Julkaise tai kumoa muutokset.",
                     "conflicts-with-split": "Tunnus on jo käytössä toisella katkaisukohdalla",
                     "conflicts-with-track": "Tunnus on jo käytössä toisella raiteella",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -552,7 +552,7 @@ class LocationTrackServiceIT @Autowired constructor(
     }
 
     private fun asLocationTrackDuplicate(locationTrack: LocationTrack) =
-        LocationTrackDuplicate(locationTrack.id as IntId, locationTrack.name, locationTrack.externalId)
+        LocationTrackDuplicate(locationTrack.id as IntId, locationTrack.trackNumberId, locationTrack.name, locationTrack.externalId)
 
     private fun insertAndFetch(switch: TrackLayoutSwitch) = switchDao.fetch(switchService.saveDraft(switch).rowVersion)
 

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
@@ -19,10 +19,29 @@ export type LocationTrackInfoboxDuplicateOfProps = {
     currentTrackNumberId: LayoutTrackNumberId | undefined;
 };
 
-const findTrackNumber = (
+const getTrackNumberName = (
     trackNumbers: LayoutTrackNumber[] | undefined,
     trackNumberId: LayoutTrackNumberId,
-) => trackNumbers?.find((tn) => tn.id === trackNumberId)?.number;
+) => trackNumbers?.find((tn) => tn.id === trackNumberId)?.number || '';
+
+type LocationTrackDuplicateTrackNumberWarningProps = {
+    differingTrackNumberName: string;
+};
+
+const LocationTrackDuplicateTrackNumberWarning: React.FC<
+    LocationTrackDuplicateTrackNumberWarningProps
+> = ({ differingTrackNumberName }) => {
+    const { t } = useTranslation();
+    return (
+        <span
+            title={t('tool-panel.location-track.duplicate-on-different-track-number', {
+                trackNumber: differingTrackNumberName,
+            })}
+            className={styles['location-track-infobox-duplicate-of__on-different-track']}>
+            <Icons.StatusError color={IconColor.INHERIT} size={IconSize.SMALL} />
+        </span>
+    );
+};
 
 export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDuplicateOfProps> = ({
     existingDuplicate,
@@ -30,7 +49,6 @@ export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDupli
     currentTrackNumberId,
     publishType,
 }: LocationTrackInfoboxDuplicateOfProps) => {
-    const { t } = useTranslation();
     const trackNumbers = useTrackNumbers(publishType);
     return existingDuplicate ? (
         <React.Fragment>
@@ -38,15 +56,14 @@ export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDupli
                 locationTrackId={existingDuplicate.id}
                 locationTrackName={existingDuplicate.name}
             />
+            &nbsp;
             {currentTrackNumberId !== existingDuplicate.trackNumberId && (
-                <span
-                    className={styles['location-track-infobox-duplicate-of__on-different-track']}
-                    title={t('tool-panel.location-track.duplicate-on-different-track-number', {
-                        trackNumber: findTrackNumber(trackNumbers, existingDuplicate.trackNumberId),
-                    })}>
-                    &nbsp;
-                    <Icons.StatusError color={IconColor.INHERIT} size={IconSize.SMALL} />
-                </span>
+                <LocationTrackDuplicateTrackNumberWarning
+                    differingTrackNumberName={getTrackNumberName(
+                        trackNumbers,
+                        existingDuplicate.trackNumberId,
+                    )}
+                />
             )}
         </React.Fragment>
     ) : duplicatesOfLocationTrack ? (
@@ -56,24 +73,15 @@ export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDupli
                     <LocationTrackLink
                         locationTrackId={duplicate.id}
                         locationTrackName={duplicate.name}
-                    />{' '}
+                    />
+                    &nbsp;
                     {currentTrackNumberId !== duplicate.trackNumberId && (
-                        <span
-                            className={
-                                styles['location-track-infobox-duplicate-of__on-different-track']
-                            }
-                            title={t(
-                                'tool-panel.location-track.duplicate-on-different-track-number',
-                                {
-                                    trackNumber: findTrackNumber(
-                                        trackNumbers,
-                                        duplicate.trackNumberId,
-                                    ),
-                                },
-                            )}>
-                            &nbsp;
-                            <Icons.StatusError color={IconColor.INHERIT} size={IconSize.SMALL} />
-                        </span>
+                        <LocationTrackDuplicateTrackNumberWarning
+                            differingTrackNumberName={getTrackNumberName(
+                                trackNumbers,
+                                duplicate.trackNumberId,
+                            )}
+                        />
                     )}
                 </li>
             ))}

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
@@ -1,25 +1,54 @@
 import * as React from 'react';
-import { LocationTrackDuplicate } from 'track-layout/track-layout-model';
+import { useTranslation } from 'react-i18next';
+import {
+    LayoutTrackNumber,
+    LayoutTrackNumberId,
+    LocationTrackDuplicate,
+} from 'track-layout/track-layout-model';
 import { LocationTrackLink } from 'tool-panel/location-track/location-track-link';
 import styles from './location-track-infobox.scss';
 import { PublishType, TimeStamp } from 'common/common-model';
+import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
+import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 
 export type LocationTrackInfoboxDuplicateOfProps = {
     publishType: PublishType;
     changeTime: TimeStamp;
     existingDuplicate: LocationTrackDuplicate | undefined;
     duplicatesOfLocationTrack: LocationTrackDuplicate[] | undefined;
+    currentTrackNumberId: LayoutTrackNumberId | undefined;
 };
+
+const findTrackNumber = (
+    trackNumbers: LayoutTrackNumber[] | undefined,
+    trackNumberId: LayoutTrackNumberId,
+) => trackNumbers?.find((tn) => tn.id === trackNumberId)?.number;
 
 export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDuplicateOfProps> = ({
     existingDuplicate,
     duplicatesOfLocationTrack,
+    currentTrackNumberId,
+    publishType,
 }: LocationTrackInfoboxDuplicateOfProps) => {
+    const { t } = useTranslation();
+    const trackNumbers = useTrackNumbers(publishType);
     return existingDuplicate ? (
-        <LocationTrackLink
-            locationTrackId={existingDuplicate.id}
-            locationTrackName={existingDuplicate.name}
-        />
+        <React.Fragment>
+            <LocationTrackLink
+                locationTrackId={existingDuplicate.id}
+                locationTrackName={existingDuplicate.name}
+            />
+            {currentTrackNumberId !== existingDuplicate.trackNumberId && (
+                <span
+                    className={styles['location-track-infobox-duplicate-of__on-different-track']}
+                    title={t('tool-panel.location-track.duplicate-on-different-track-number', {
+                        trackNumber: findTrackNumber(trackNumbers, existingDuplicate.trackNumberId),
+                    })}>
+                    &nbsp;
+                    <Icons.StatusError color={IconColor.INHERIT} size={IconSize.SMALL} />
+                </span>
+            )}
+        </React.Fragment>
     ) : duplicatesOfLocationTrack ? (
         <ul className={styles['location-track-infobox-duplicate-of__ul']}>
             {duplicatesOfLocationTrack.map((duplicate) => (
@@ -27,7 +56,25 @@ export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDupli
                     <LocationTrackLink
                         locationTrackId={duplicate.id}
                         locationTrackName={duplicate.name}
-                    />
+                    />{' '}
+                    {currentTrackNumberId !== duplicate.trackNumberId && (
+                        <span
+                            className={
+                                styles['location-track-infobox-duplicate-of__on-different-track']
+                            }
+                            title={t(
+                                'tool-panel.location-track.duplicate-on-different-track-number',
+                                {
+                                    trackNumber: findTrackNumber(
+                                        trackNumbers,
+                                        duplicate.trackNumberId,
+                                    ),
+                                },
+                            )}>
+                            &nbsp;
+                            <Icons.StatusError color={IconColor.INHERIT} size={IconSize.SMALL} />
+                        </span>
+                    )}
                 </li>
             ))}
         </ul>

--- a/ui/src/tool-panel/location-track/location-track-infobox.scss
+++ b/ui/src/tool-panel/location-track/location-track-infobox.scss
@@ -13,6 +13,12 @@
     margin: 0; /* Remove margins */
 }
 
+.location-track-infobox-duplicate-of__on-different-track {
+    .icon {
+        fill: vayla-design.$color-red-dark;
+    }
+}
+
 .location-track-infobox__split {
     padding-left: 11px;
 

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -110,6 +110,7 @@ export type LayoutLocationTrack = {
 
 export type LocationTrackDuplicate = {
     id: LocationTrackId;
+    trackNumberId: LayoutTrackNumberId;
     name: string;
     externalId: Oid;
 };


### PR DESCRIPTION
Alkuperäisen tiketin descriptionissa puhuttiin pelkästään duplikaattiraiteiden ratanumeroiden validoinnista, joten täällä tehty se. Tämän lisäksi lienee järkevää validoida myös ratanumeron draftius (tai ainakin se, että sillä ei ole julkaisemattomia geometriamuutoksia.) Tätä ei ole kuitenkaan vielä speksattu ihan loppuun, joten jätetään se myöhemmäksi.