### PR TITLE
GVT-2373: Vaihteen linkitysinfoboksin messagebox ei ole koko infoboksin levyinen

### DIFF
--- a/ui/src/map/layers/switch/switch-linking-layer.ts
+++ b/ui/src/map/layers/switch/switch-linking-layer.ts
@@ -7,17 +7,12 @@ import { LinkingSwitch, SuggestedSwitch } from 'linking/linking-model';
 import { getSuggestedSwitchesByTile } from 'linking/linking-api';
 import { clearFeatures, findMatchingEntities, pointToCoords } from 'map/layers/utils/layer-utils';
 import { Selection } from 'selection/selection-model';
-import { endPointStyle, getLinkingJointRenderer } from 'map/layers/utils/switch-layer-utils';
+import { getLinkingJointRenderer } from 'map/layers/utils/switch-layer-utils';
 import { SUGGESTED_SWITCH_SHOW } from 'map/layers/utils/layer-visibility-limits';
 import { filterNotEmpty } from 'utils/array-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-
-// The older switch linking joint layer (red circles with crosses)
-// should no longer be displayed, but the code regarding it is not
-// yet determined to be removed completely (see GVT-2176).
-const DISPLAY_DEPRECATED_SWITCH_LINKING_JOINTS = false;
 
 let newestLayerId = 0;
 
@@ -42,21 +37,6 @@ function createSwitchFeatures(
             setSuggestedSwitchFeatureProperty(f, suggestedSwitch);
             features.push(f);
         });
-    } else if (DISPLAY_DEPRECATED_SWITCH_LINKING_JOINTS) {
-        const presentationJoint = suggestedSwitch.joints.find(
-            (joint) => joint.number == suggestedSwitch.switchStructure.presentationJointNumber,
-        );
-
-        if (presentationJoint) {
-            const f = new Feature({
-                geometry: new OlPoint(pointToCoords(presentationJoint.location)),
-            });
-
-            f.setStyle(endPointStyle);
-            setSuggestedSwitchFeatureProperty(f, suggestedSwitch);
-
-            features.push(f);
-        }
     }
 
     return features;

--- a/ui/src/map/layers/utils/switch-layer-utils.ts
+++ b/ui/src/map/layers/utils/switch-layer-utils.ts
@@ -11,8 +11,6 @@ import { GeometryPlanId } from 'geometry/geometry-model';
 import Feature from 'ol/Feature';
 import { Point as OlPoint } from 'ol/geom';
 import { findMatchingEntities, pointToCoords } from 'map/layers/utils/layer-utils';
-import { Circle, Fill, RegularShape, Stroke } from 'ol/style';
-import mapStyles from 'map/map.module.scss';
 import { SearchItemsOptions } from 'map/layers/utils/layer-model';
 import VectorSource from 'ol/source/Vector';
 import { Rectangle } from 'model/geometry';
@@ -356,24 +354,3 @@ export function findMatchingSwitches(
 function setSwitchFeatureProperty(feature: Feature<OlPoint>, data: SwitchFeatureProperty) {
     feature.set(SWITCH_FEATURE_DATA_PROPERTY, data);
 }
-
-export const endPointStyle = [
-    new Style({
-        image: new Circle({
-            radius: 6,
-            fill: new Fill({ color: mapStyles.locationTrackEndPoint }),
-            stroke: new Stroke({ color: mapStyles.locationTrackEndPointBorder }),
-        }),
-        zIndex: 4,
-    }),
-    new Style({
-        image: new RegularShape({
-            stroke: new Stroke({ color: mapStyles.locationTrackEndPointCross }),
-            points: 4,
-            radius: 4,
-            radius2: 0,
-            angle: 0,
-        }),
-        zIndex: 4,
-    }),
-];

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -10,7 +10,7 @@ import {
     SwitchJointTrackMeter,
 } from 'track-layout/track-layout-model';
 import Infobox from 'tool-panel/infobox/infobox';
-import InfoboxContent from 'tool-panel/infobox/infobox-content';
+import InfoboxContent, { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { makeSwitchImage } from 'geoviite-design-lib/switch/switch-icons';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
@@ -324,7 +324,11 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                         </InfoboxButtons>
                     </WriteAccessRequired>
                     {placingSwitchLinkingState && (
-                        <MessageBox>{t('tool-panel.switch.layout.switch-placing-help')}</MessageBox>
+                        <InfoboxContentSpread>
+                            <MessageBox>
+                                {t('tool-panel.switch.layout.switch-placing-help')}
+                            </MessageBox>
+                        </InfoboxContentSpread>
                     )}
                 </InfoboxContent>
             </Infobox>


### PR DESCRIPTION
Tätä ei vaan oltu wräpätty `InfoboxContentSpread`:iin. Samalla käyty läpi muut `MessageBox`:in käyttökohdat ja varmistettu että ne toimivat