### PR TITLE
GVT-2273 (part 2): Fix publication log rendering failure due to invalid redux state

### DIFF
--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -282,6 +282,6 @@ export type PublicationTableItem = {
 };
 
 export type PublicationSearch = {
-    startDate: Date | undefined;
-    endDate: Date | undefined;
+    startDate: TimeStamp | undefined;
+    endDate: TimeStamp | undefined;
 };

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -52,6 +52,6 @@ export const dropIdsFromPublishCandidates = (
 });
 
 export const defaultPublicationSearch: PublicationSearch = {
-    startDate: subMonths(currentDay, 1),
-    endDate: currentDay,
+    startDate: subMonths(currentDay, 1).toISOString(),
+    endDate: currentDay.toISOString(),
 };

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -23,6 +23,7 @@ import {
 } from 'geometry/geometry-model';
 import { PublicationId, PublicationSearch } from 'publication/publication-model';
 import { defaultPublicationSearch } from 'publication/publication-utils';
+import { TimeStamp } from 'common/common-model';
 
 export function createEmptyItemCollections(): ItemCollections {
     return {
@@ -329,7 +330,7 @@ export const selectionReducers = {
     },
     setSelectedPublicationSearchStartDate: (
         state: Selection,
-        { payload: newStartDate }: PayloadAction<Date | undefined>,
+        { payload: newStartDate }: PayloadAction<TimeStamp | undefined>,
     ) => {
         if (!state.publicationSearch) {
             state.publicationSearch = defaultPublicationSearch;
@@ -338,7 +339,7 @@ export const selectionReducers = {
     },
     setSelectedPublicationSearchEndDate: (
         state: Selection,
-        { payload: newEndDate }: PayloadAction<Date | undefined>,
+        { payload: newEndDate }: PayloadAction<TimeStamp | undefined>,
     ) => {
         if (!state.publicationSearch) {
             state.publicationSearch = defaultPublicationSearch;

--- a/ui/src/utils/date-utils.ts
+++ b/ui/src/utils/date-utils.ts
@@ -1,6 +1,6 @@
 import { TimeStamp } from 'common/common-model';
 import { maxOf, minOf } from 'utils/array-utils';
-import { format, getYear, startOfToday } from 'date-fns';
+import { format, getYear, parseISO, startOfToday } from 'date-fns';
 
 export const currentDay = startOfToday();
 
@@ -87,4 +87,12 @@ export function createYearRange(fromYear: number, toYear: number): number[] {
 
 export function createYearRangeFromCurrentYear(backwards: number, forwards: number): number[] {
     return createYearRange(currentYear - backwards, currentYear + forwards);
+}
+
+export function parseISOOrUndefined(timestamp: TimeStamp | undefined): Date | undefined {
+    if (!timestamp || timestamp.length === 0) {
+        return undefined;
+    }
+
+    return parseISO(timestamp);
 }


### PR DESCRIPTION
Ongelmanahan oli, että jos käyttäjä oli käynyt julkaisulokihakusivulla ja sen jälkeen vaikkapa päivittänyt selaimen sivun, niin julkaisulokihakukomponentti ei enää renderöitynyt lainkaan (`Can't perform a React state update on a component that hasn't mounted yet...`)

Julkaisulokikomponentti käytti aiemmin kahta eri tilaa, joiden synkkaus osoittautui hieman ongelmalliseksi. Tässä pullarissa tuo aiemmin jaettu tila (päivämääräväli) muutetaan pelkästään Reduxissa tallennetuksi tilaksi.

Julkaisulokikomponentti käytti myös aiemmin useEffectiä päätelläkseen milloin näytettyä lokitaulukkoa tulee päivittää. Tämä aiheutti vielä lisää tilasynkkausprobleemaa. Tämän pullarin jälkeen taulukko päivitetään vain komponentin mounttaamisen yhteydessä ja silloin, kun käyttäjä päivittää valittuja päivämääräarvoja (eikä hookattuna muuttujien päivittymisen yhteydessä)