### PR TITLE
GVT-2376 Save publication log search dates in Redux state as strings

### DIFF
--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'vayla-design-lib/link/link';
 import { DatePicker } from 'vayla-design-lib/datepicker/datepicker';
 import { currentDay } from 'utils/date-utils';
-import { endOfDay, startOfDay, subMonths } from 'date-fns';
+import { endOfDay, parseISO, startOfDay, subMonths } from 'date-fns';
 import { getPublicationsAsTableItems, getPublicationsCsvUri } from 'publication/publication-api';
 import PublicationTable from 'publication/table/publication-table';
 import { Button } from 'vayla-design-lib/button/button';
@@ -39,9 +39,11 @@ const PublicationLog: React.FC = () => {
     );
 
     const [startDate, setStartDate] = React.useState<Date | undefined>(
-        initialStartDate ?? subMonths(currentDay, 1),
+        initialStartDate ? parseISO(initialStartDate) : subMonths(currentDay, 1),
     );
-    const [endDate, setEndDate] = React.useState<Date | undefined>(initialEndDate ?? currentDay);
+    const [endDate, setEndDate] = React.useState<Date | undefined>(
+        initialEndDate ? parseISO(initialEndDate) : currentDay,
+    );
     const [sortInfo, setSortInfo] =
         React.useState<PublicationDetailsTableSortInformation>(InitiallyUnsorted);
     const [isLoading, setIsLoading] = React.useState(true);

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -282,6 +282,6 @@ export type PublicationTableItem = {
 };
 
 export type PublicationSearch = {
-    startDate: Date | undefined;
-    endDate: Date | undefined;
+    startDate: TimeStamp | undefined;
+    endDate: TimeStamp | undefined;
 };

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -52,6 +52,6 @@ export const dropIdsFromPublishCandidates = (
 });
 
 export const defaultPublicationSearch: PublicationSearch = {
-    startDate: subMonths(currentDay, 1),
-    endDate: currentDay,
+    startDate: subMonths(currentDay, 1).toISOString(),
+    endDate: currentDay.toISOString(),
 };

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -334,7 +334,7 @@ export const selectionReducers = {
         if (!state.publicationSearch) {
             state.publicationSearch = defaultPublicationSearch;
         }
-        state.publicationSearch.startDate = newStartDate;
+        state.publicationSearch.startDate = newStartDate?.toISOString();
     },
     setSelectedPublicationSearchEndDate: (
         state: Selection,
@@ -343,7 +343,7 @@ export const selectionReducers = {
         if (!state.publicationSearch) {
             state.publicationSearch = defaultPublicationSearch;
         }
-        state.publicationSearch.endDate = newEndDate;
+        state.publicationSearch.endDate = newEndDate?.toISOString();
     },
     clearPublicationSelection: (state: Selection) => {
         state.publicationId = undefined;


### PR DESCRIPTION
Ongelma oli: https://github.com/rt2zz/redux-persist/issues/82 , ja tämän takia julkaisulokisivu räjähtää, jos yrittää käyttää persistoitua julkaisupäiväväliä.

Ajattelin tässä tapauksessa selkeimmäksi välttää vaan Date-olioiden persistoinnin kokonaan, sen sijaan että lähtisi säätämään tallennuksen/latauksen aikaisia muunnoksia.

TimeStamp-tyypin käytöstä tässä en ole ihan varma, mutta sen varmaan oleellisimman tämän tyypin ominaisuuden, eli että Date.parse osaa parsia sen, ISO-muodossa tallentaminen kyllä toteuttaa.