### PR TITLE
GVT-2378: Splittauksessa alkuperäisen raiteen loppupään vaihteen voi lisätä katkaisukohdaksi

### DIFF
--- a/ui/src/map/layers/switch/switch-layer.ts
+++ b/ui/src/map/layers/switch/switch-layer.ts
@@ -34,11 +34,14 @@ export function createSwitchLayer(
     const layerId = ++newestLayerId;
     const getSwitchesFromApi = () => {
         if (resolution <= Limits.SWITCH_SHOW) {
+            const switchIds =
+                splittingState?.allowedSwitches
+                    .map((sw) => sw.switchId)
+                    .concat(splittingState?.startAndEndSwitches) || [];
             return splittingState
-                ? getSwitches(
-                      splittingState.allowedSwitches.map((sw) => sw.switchId),
-                      publishType,
-                  ).then((switches) => switches.filter((sw) => sw.stateCategory !== 'NOT_EXISTING'))
+                ? getSwitches(switchIds, publishType).then((switches) =>
+                      switches.filter((sw) => sw.stateCategory !== 'NOT_EXISTING'),
+                  )
                 : Promise.all(
                       mapTiles.map((t) =>
                           getSwitchesByTile(changeTimes.layoutSwitch, t, publishType),

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -4,6 +4,7 @@ import Infobox from 'tool-panel/infobox/infobox';
 import {
     LAYOUT_SRID,
     LayoutLocationTrack,
+    LayoutSwitchId,
     LayoutSwitchIdAndName,
 } from 'track-layout/track-layout-model';
 import InfoboxContent, { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
@@ -68,6 +69,7 @@ import { getLocationTrackOwners } from 'common/common-api';
 import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
 import { EnvRestricted } from 'environment/env-restricted';
 import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import { filterNotEmpty } from 'utils/array-utils';
 
 type LocationTrackInfoboxProps = {
     locationTrack: LayoutLocationTrack;
@@ -223,6 +225,9 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
             return 'tool-panel.location-track.splitting.validation.duplicates-on-different-track-number';
         return '';
     };
+
+    const isStartOrEndSwitch = (switchId: LayoutSwitchId) =>
+        switchId === extraInfo?.switchAtStart?.id || switchId === extraInfo?.switchAtEnd?.id;
 
     return (
         <React.Fragment>
@@ -482,8 +487,16 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                                             delegates.onStartSplitting({
                                                                 locationTrack: locationTrack,
                                                                 allowedSwitches:
-                                                                    splitInitializationParameters?.switches ||
-                                                                    [],
+                                                                    splitInitializationParameters?.switches.filter(
+                                                                        (sw) =>
+                                                                            !isStartOrEndSwitch(
+                                                                                sw.switchId,
+                                                                            ),
+                                                                    ) || [],
+                                                                startAndEndSwitches: [
+                                                                    extraInfo?.switchAtStart?.id,
+                                                                    extraInfo?.switchAtEnd?.id,
+                                                                ].filter(filterNotEmpty),
                                                                 duplicateTracks:
                                                                     splitInitializationParameters?.duplicates ||
                                                                     [],

--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -31,6 +31,7 @@ export type SplittingState = {
     endLocation: AlignmentPoint;
     originLocationTrack: LayoutLocationTrack;
     allowedSwitches: SwitchOnLocationTrack[];
+    startAndEndSwitches: LayoutSwitchId[];
     duplicateTracks: SplitDuplicate[];
     initialSplit: InitialSplit;
     splits: Split[];
@@ -40,6 +41,7 @@ export type SplittingState = {
 type SplitStart = {
     locationTrack: LayoutLocationTrack;
     allowedSwitches: SwitchOnLocationTrack[];
+    startAndEndSwitches: LayoutSwitchId[];
     duplicateTracks: SplitDuplicate[];
     startLocation: AlignmentPoint;
     endLocation: AlignmentPoint;
@@ -78,6 +80,7 @@ export const splitReducers = {
         state.splittingState = {
             originLocationTrack: payload.locationTrack,
             allowedSwitches: payload.allowedSwitches,
+            startAndEndSwitches: payload.startAndEndSwitches,
             duplicateTracks: payload.duplicateTracks,
             splits: [],
             endLocation: payload.endLocation,


### PR DESCRIPTION
Täällä ongelmana oli, että alku- ja loppuvaihteita ei oltu mitenkään eroteltu muista vaihteista. Täten niihinkin pystyi luomaan katkaisukohtia. Tein tälle tarkastelun joka on ainakin toistaiseksi puhtaasti fronttipohjainen, sillä en katsonut tämän olevan niin bäkkärin asiaa, varsinkin kun varsinainen splittaustyö tehdään muutenkin puhtaasti fronttipäässä.