### PR TITLE
GVT-2329: Linkityksen estäminen pilkonnan ajaksi (fronttipääty)

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -619,7 +619,8 @@
                     "has-errors": "Tiedoissa on virheitä",
                     "show": "näytä"
                 }
-            }
+            },
+            "splitting-blocks-geometry-changes": "Raiteen geometriaa ei voi muokata koska sen jakaminen on kesken"
         },
         "disabled": {
             "activity-disabled-in-official-mode": "Toiminto on aktiivinen vain luonnostilassa."

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -400,7 +400,15 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                                 variant={ButtonVariant.SECONDARY}
                                                 size={ButtonSize.SMALL}
                                                 qa-id="modify-start-or-end"
+                                                title={
+                                                    splittingState
+                                                        ? t(
+                                                              'tool-panel.location-track.splitting-blocks-geometry-changes',
+                                                          )
+                                                        : ''
+                                                }
                                                 disabled={
+                                                    !!splittingState ||
                                                     !startAndEndPoints.start?.point ||
                                                     !startAndEndPoints.end?.point
                                                 }


### PR DESCRIPTION
Koitin käydä läpi eri tapoja siirtyä linkitystilaan frontissa splittauksen ollessa päällä ja löysin ainoastaan raiteen lyhennysnappulan. Se disabloituu nyt splittaustilassa olemisen mukaan.