### PR TITLE
GVT-2310: Show directionality of track/refline length change in publication log

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -191,13 +191,29 @@ fun pointsAreSame(point1: IPoint?, point2: IPoint?) =
     point1 == point2 || point1 != null && point2 != null && point1.isSame(point2, DISTANCE_CHANGE_THRESHOLD)
 
 fun getLengthChangedRemarkOrNull(translation: Translation, length1: Double?, length2: Double?) =
-    if (length1 != null && length2 != null) lengthDifference(length1, length2).let { lengthDifference ->
-        if (lengthDifference > DISTANCE_CHANGE_THRESHOLD) publicationChangeRemark(
-            translation, "changed-x-meters", formatDistance(lengthDifference)
-        )
-        else null
+    if (length1 == null || length2 == null) {
+        null
+    } else {
+        (length2 - length1).let { directionalLengthDifference ->
+            when {
+                abs(directionalLengthDifference) <= DISTANCE_CHANGE_THRESHOLD -> null
+
+                (directionalLengthDifference < 0) -> publicationChangeRemark(
+                    translation,
+                    "shortened-x-meters",
+                    formatDistance(abs(directionalLengthDifference))
+                )
+
+                (directionalLengthDifference > 0) -> publicationChangeRemark(
+                    translation,
+                    "lengthened-x-meters",
+                    formatDistance(abs(directionalLengthDifference))
+                )
+
+                else -> null
+            }
+        }
     }
-    else null
 
 fun getPointMovedRemarkOrNull(translation: Translation, oldPoint: Point?, newPoint: Point?) = oldPoint?.let { p1 ->
     newPoint?.let { p2 ->

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1273,6 +1273,8 @@
         "not-calculated": "Ei laskettu",
         "remark": {
             "changed-x-meters": "Muutos {{value}} m",
+            "shortened-x-meters": "Lyhentynyt {{value}} m",
+            "lengthened-x-meters": "Pidentynyt {{value}} m",
             "moved-x-meters": "Siirtynyt {{value}} m",
             "geometry-change-info-not-calculated": "Geometriamuutostietoja ei vielä laskettu",
             "changed-km-number": "Muuttunut kilometriltä {{value}}",


### PR DESCRIPTION
Previously the user reading the publication log had to figure out the directionality of the length change by themselves.