### PR TITLE
GVT-2377: "Kohdista kartalla" -nappia pystyy painamaan vaikka raiteella ei ole geometriaa

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -401,7 +401,8 @@
                 "coordinates": "Koordinaatit (TM35FIN)",
                 "change-info-heading": "Lokitiedot",
                 "no-kilometer-length": "Pituutta ei voida laskea",
-                "negative-kilometer-length": "Virheellinen sijainti"
+                "negative-kilometer-length": "Virheellinen sijainti",
+                "no-location": "Ei sijaintia"
             },
             "geometry": {
                 "general-title": "Raidegeometria: Tasakilometripiste",
@@ -489,7 +490,8 @@
             "end-coordinates": "Loppukoordinaatit",
             "end-points-updated": "Pituusmittauslinjan päätepisteet päivitetty",
             "reference-line-singular": "Pituusmittauslinja",
-            "reference-line-plural": "Pituusmittauslinjat"
+            "reference-line-plural": "Pituusmittauslinjat",
+            "no-geometry": "Pituusmittauslinjalla ei ole geometriaa"
         },
         "alignment": {
             "geometry": {
@@ -563,6 +565,7 @@
             "show-on-map": "Kohdista kartalla",
             "unpublished": "Julkaisematon",
             "modify-start-or-end": "Lyhennä alkua ja/tai loppua",
+            "no-geometry": "Sijaintiraiteella ei ole geometriaa",
             "ready": "Valmis",
             "location-track-endpoints-updated": "Raiteen päätepisteet päivitetty",
             "choose-start-and-end-points": "Valitse kartalta alku- ja loppusijainti",

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -137,6 +137,9 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                     <InfoboxButtons>
                         <Button
                             size={ButtonSize.SMALL}
+                            title={
+                                !kmPost.location ? t('tool-panel.km-post.layout.no-location') : ''
+                            }
                             disabled={!kmPost.location}
                             variant={ButtonVariant.SECONDARY}
                             qa-id="zoom-to-km-post"

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -326,6 +326,12 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                             variant={ButtonVariant.SECONDARY}
                             size={ButtonSize.SMALL}
                             qa-id="zoom-to-location-track"
+                            title={
+                                !locationTrack.boundingBox
+                                    ? t('tool-panel.location-track.no-geometry')
+                                    : ''
+                            }
+                            disabled={!locationTrack.boundingBox}
                             onClick={() =>
                                 locationTrack.boundingBox && showArea(locationTrack.boundingBox)
                             }>

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -244,6 +244,9 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                         <InfoboxButtons>
                             <Button
                                 size={ButtonSize.SMALL}
+                                title={
+                                    !switchLocation ? t('tool-panel.switch.layout.no-location') : ''
+                                }
                                 disabled={!switchLocation}
                                 variant={ButtonVariant.SECONDARY}
                                 qa-id="zoom-to-switch"

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -289,6 +289,12 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                                 variant={ButtonVariant.SECONDARY}
                                 size={ButtonSize.SMALL}
                                 qa-id="zoom-to-track-number"
+                                title={
+                                    !referenceLine?.boundingBox
+                                        ? t('tool-panel.reference-line.layout.no-geometry')
+                                        : ''
+                                }
+                                disabled={!referenceLine?.boundingBox}
                                 onClick={() =>
                                     referenceLine?.boundingBox &&
                                     showArea(referenceLine.boundingBox)


### PR DESCRIPTION
KM-pylväälle ja vaihteelle tämä olikin jo disabloituna. Samalla lisätty kaikille tooltip, joka kertoo miksi nappi on disabloitu