### PR TITLE
GVT-2375 Simplify hiding all geometry plans in view

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -46,12 +46,16 @@ class GeometryController @Autowired constructor(
         @RequestParam("sortField") sortField: GeometryPlanSortField?,
         @RequestParam("sortOrder") sortOrder: SortOrder?,
         @RequestParam("lang") lang: String,
-    ): Page<GeometryPlanHeader> {
+    ): GeometryPlanHeadersSearchResult {
         log.apiCall("getPlanHeaders", "sources" to sources)
         val filter = geometryService.getFilter(freeText, trackNumberIds ?: listOf())
         val headers = geometryService.getPlanHeaders(sources, bbox, filter)
         val comparator = geometryService.getComparator(sortField ?: ID, sortOrder ?: ASCENDING, lang)
-        return page(items = headers, offset = offset ?: 0, limit = limit ?: 50, comparator = comparator)
+        val results = pageAndRest(items = headers, offset = offset ?: 0, limit = limit ?: 50, comparator = comparator)
+        return GeometryPlanHeadersSearchResult(
+            planHeaders = results.page,
+            remainingIds = results.rest.map { plan -> plan.id },
+        )
     }
 
     @PreAuthorize(AUTH_UI_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
@@ -17,6 +17,7 @@ import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
+import fi.fta.geoviite.infra.util.Page
 import java.time.Instant
 
 
@@ -132,3 +133,8 @@ data class GeometryPlanLinkedItems(
 ) {
     val isEmpty = locationTracks.isEmpty() && switches.isEmpty() && kmPosts.isEmpty()
 }
+
+data class GeometryPlanHeadersSearchResult(
+    val planHeaders: Page<GeometryPlanHeader>,
+    val remainingIds: List<IntId<GeometryPlan>>,
+)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Paging.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Paging.kt
@@ -12,10 +12,27 @@ data class Page<T>(
     fun <S> map(mapper: (T) -> S) = Page(totalCount, items.map(mapper), start)
 }
 
+data class PageAndRest<T>(
+    val page: Page<T>,
+    val rest: List<T>,
+)
+
 fun <T> page(items: List<T>, offset: Int, limit: Int?, comparator: Comparator<T>): Page<T> =
     Page(totalCount = items.size, items = pageToList(items, offset, limit, comparator), start = offset)
 
 fun <T> pageToList(items: List<T>, offset: Int, limit: Int?, comparator: Comparator<T>): List<T> {
-    val endIndex = limit?.let { lim -> minOf(offset + lim - 1, items.lastIndex) } ?: items.lastIndex
+    val endIndex = getEndIndex(limit, offset, items)
     return items.sortedWith(comparator).slice(offset..endIndex)
+}
+
+private fun getEndIndex(limit: Int?, offset: Int, items: List<*>) =
+    limit?.let { lim -> minOf(offset + lim - 1, items.lastIndex) } ?: items.lastIndex
+
+fun <T> pageAndRest(items: List<T>, offset: Int, limit: Int?, comparator: Comparator<T>): PageAndRest<T> {
+    val endIndex = getEndIndex(limit, offset, items)
+    val sorted = items.sortedWith(comparator)
+    return PageAndRest(
+        Page(totalCount = items.size, items = sorted.slice(offset..endIndex), start = offset),
+        sorted.slice(0 until offset) + sorted.slice(endIndex + 1 until sorted.size)
+    )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/PagingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/PagingTest.kt
@@ -1,0 +1,33 @@
+package fi.fta.geoviite.infra.util
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class PagingTest {
+    @Test
+    fun `page limit and offset are sensible`() {
+        val items = (0..10).toList().reversed()
+        val order: Comparator<Int> = Comparator.naturalOrder()
+        assertEquals((0..3).toList(), page(items, 0, 4, order).items)
+        assertEquals((4..7).toList(), page(items, 4, 4, order).items)
+        assertEquals((8..10).toList(), page(items, 8, 4, order).items)
+    }
+
+    @Test
+    fun `pageAndRest limit and offset are sensible`() {
+        val items = (0..10).toList().reversed()
+        val order: Comparator<Int> = Comparator.naturalOrder()
+        assertEquals(
+            PageAndRest(Page(11, (0..3).toList(), 0), (4..10).toList()),
+            pageAndRest(items, 0, 4, order)
+        )
+        assertEquals(
+            PageAndRest(Page(11, (4..7).toList(), 4), (0..3).toList() + (8..10).toList()),
+            pageAndRest(items, 4, 4, order)
+        )
+        assertEquals(
+            PageAndRest(Page(11, (8..10).toList(), 8), (0..7).toList()),
+            pageAndRest(items, 8, 4, order)
+        )
+    }
+}

--- a/ui/src/data-products/data-products-utils.ts
+++ b/ui/src/data-products/data-products-utils.ts
@@ -23,7 +23,7 @@ export const searchGeometryPlanHeaders = async (
         [],
         searchTerm,
     );
-    return t.items;
+    return t.planHeaders.items;
 };
 
 export const getGeometryPlanOptions = (

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -85,6 +85,10 @@ async function getPlanAreas(bbox: BoundingBox): Promise<PlanArea[]> {
     const path = `${GEOMETRY_URI}/plans/areas${params}`;
     return getNonNull<PlanArea[]>(path);
 }
+export interface GeometryPlanHeadersSearchResult {
+    planHeaders: Page<GeometryPlanHeader>;
+    remainingIds: GeometryPlanId[];
+}
 
 export async function getGeometryPlanHeadersBySearchTerms(
     limit: number,
@@ -95,7 +99,7 @@ export async function getGeometryPlanHeadersBySearchTerms(
     freeText?: string,
     sortField?: GeometrySortBy,
     sortOrder?: GeometrySortOrder,
-): Promise<Page<GeometryPlanHeader>> {
+): Promise<GeometryPlanHeadersSearchResult> {
     const params = queryParams({
         bbox: bbox ? bboxString(bbox) : undefined,
         sources: sources,
@@ -114,7 +118,7 @@ export async function getGeometryPlanHeadersBySearchTerms(
         lang: i18next.language,
     });
 
-    return getNonNull<Page<GeometryPlanHeader>>(`${GEOMETRY_URI}/plan-headers${params}`);
+    return getNonNull<GeometryPlanHeadersSearchResult>(`${GEOMETRY_URI}/plan-headers${params}`);
 }
 
 export async function getGeometryPlanHeader(planId: GeometryPlanId): Promise<GeometryPlanHeader> {

--- a/ui/src/infra-model/tabs/infra-model-tabs.tsx
+++ b/ui/src/infra-model/tabs/infra-model-tabs.tsx
@@ -45,11 +45,11 @@ const InfraModelTabs: React.FC<TabsProps> = ({ activeTab }) => {
                 state.searchParams.sortBy,
                 state.searchParams.sortOrder,
             )
-                .then((page) => {
+                .then((result) => {
                     infraModelListDelegates.onPlansFetchReady({
-                        plans: page.items,
+                        plans: result.planHeaders.items,
                         searchParams: state.searchParams,
-                        totalCount: page.totalCount,
+                        totalCount: result.planHeaders.totalCount,
                     });
                 })
                 .catch((e) => infraModelListDelegates.onPlanFetchError(e?.toString()));


### PR DESCRIPTION
Valintapaneelin geometrialistan yhteinen silmäikoni tulee nyt näkyviin aina jos näkyvillä on geometrioita, ja toimii kolmella tavalla toisin kuin ennen:

- Näkyy, jos kartalla näkyvällä alueella on suunnitelmia (ennen oli: Näkyi, jos kartalla näkyvällä alueella on enintään 50 suunnitelmaa)
- Näkyy sinisenä, jos kartalla näkyvällä alueella on valittuja suunnitelmia (ennen oli: Näkyi sinisenä, jos missään oli valittu suunnitelma)
- Poistaa valinnan kaikilta kartalta näkyviltä suunnitelmilta aina, jos niitä on (ennen oli: Poisti valinnan suunnitelmilta, jotka näkyivät sekä kartalla että valintapaneelin listassa; eli ei miltään, jos suunnitelmia oli kartalla näkyvällä alueella yli 50)

Näistä viimeinen toteutettu sillä, että getPlanHeaders palauttaa pyydetyn määrän suunnitelmien otsikoita, ja lopuista haettuihin ehtoihin osuvista suunnitelmista vielä ID:t, vaikka määrä olisi yli maksimin. Periaatteessahan tämän voisi tehdä myös lisäämättä tietoliikennettä lainkaan, karttapuolihan pitää jo nyt karttatiileittäin kirjaa siitä, minkä suunnitelman aluetta on missäkin; mutta se ei ole ihan selvää, miten tämän tekisi niin, että tulos olisi luotettavasti oikein.