### PR TITLE
GVT-2379 Geometriasuunnitelmien layouttien laskemisen optimointeja

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
@@ -64,7 +64,6 @@ class CacheConfiguration @Autowired constructor(
             manager.registerCustomCache(CACHE_GEOCODING_CONTEXTS, cache(500, layoutCacheDuration))
 
             manager.registerCustomCache(CACHE_GEOMETRY_PLAN, cache(100, planCacheDuration))
-            manager.registerCustomCache(CACHE_GEOMETRY_PLAN_LAYOUT, cache(100, planCacheDuration))
             manager.registerCustomCache(CACHE_GEOMETRY_SWITCH, cache(10000, planCacheDuration))
             manager.registerCustomCache(CACHE_PLAN_GEOCODING_CONTEXTS, cache(50, planCacheDuration))
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationService.kt
@@ -13,6 +13,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem
 import org.opengis.referencing.operation.MathTransform
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
 
 data class Transformation private constructor(
     val sourceSrid: Srid,
@@ -91,12 +92,12 @@ data class Transformation private constructor(
 class CoordinateTransformationService @Autowired constructor(
     private val kkjTm35FinTriangulationDao: KkjTm35finTriangulationDao
 ) {
-    private val transformations = mutableMapOf<Pair<Srid, Srid>, Transformation>()
+    private val transformations = ConcurrentHashMap<Pair<Srid, Srid>, Transformation>()
 
     fun getLayoutTransformation(sourceSrid: Srid) = getTransformation(sourceSrid, LAYOUT_SRID)
 
     fun getTransformation(sourceSrid: Srid, targetSrid: Srid): Transformation =
-        transformations.getOrPut(Pair(sourceSrid, targetSrid)) {
+        transformations.computeIfAbsent(Pair(sourceSrid, targetSrid)) {
             Transformation.possiblyTriangulableTransform(
                 sourceSrid,
                 targetSrid,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
@@ -45,16 +45,16 @@ fun calculateDistance(points: List<IPoint>, ref: CoordinateReferenceSystem): Dou
 private val crsCache: MutableMap<Srid, CoordinateReferenceSystem> = mutableMapOf()
 fun crs(srid: Srid): CoordinateReferenceSystem = crsCache.getOrPut(srid) { CRS.decode(srid.toString()) }
 
+private val geometryFactory = JTSFactoryFinder.getGeometryFactory()
 fun toJtsPolygon(polygonPoints: List<IPoint>, ref: CoordinateReferenceSystem): Polygon? {
     val geometryPointList = polygonPoints.map { point -> toJtsPoint(point, ref) }
-    val geometryFactory = JTSFactoryFinder.getGeometryFactory()
     val geometryCollection = geometryFactory.createGeometryCollection(geometryPointList.toTypedArray()).coordinates
     return geometryFactory.createPolygon(geometryCollection)
 }
 
 fun toJtsPoint(point: IPoint, ref: CoordinateReferenceSystem): org.locationtech.jts.geom.Point {
     val coordinate = toCoordinate(point, ref)
-    return JTSFactoryFinder.getGeometryFactory().createPoint(coordinate)
+    return geometryFactory.createPoint(coordinate)
 }
 
 fun toGvtPoint(point: org.locationtech.jts.geom.Point, ref: CoordinateReferenceSystem): Point {


### PR DESCRIPTION
Pääasiana perffin suhteen tuo rinnakkaistus, mutta nuo getGeometryFactory()-kutsut oli myös vähän turhan kalliita ottaen huomioon sen, että GeometryFactory-luokka on ainakin dokumentaation mukaan säieturvallinen, ja nähdäkseni tilaton -> yksi instanssi riittää.