### PR TITLE
GVT-2380 Fix remaining oddity with topological links, improve tests

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -26,7 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
@@ -945,38 +944,97 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
         val newBranchingTrack = locationTrackService.saveDraft(
             locationTrack(trackNumberId, name = "new branching track"),
-            alignment(shiftTrack(branchingTrackSegments, switch.id, Point(100.0, 0.0)))
+            alignment(shiftTrack(branchingTrackSegments, switch.id, Point(134.321, 0.0)))
         )
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(Point(100.0, 0.0), templateSwitch.switchStructureId)!!
+        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(Point(134.321, 0.0), templateSwitch.switchStructureId)!!
         switchLinkingService.saveSwitchLinking(createSwitchLinkingParameters(suggestedSwitch, switch.id))
-        assertTrackDraftVersionSwitchLinks(originallyLinkedBranchingTrack.id, null, null, listOf(null))
+        assertTrackDraftVersionSwitchLinks(originallyLinkedBranchingTrack.id, null, null, listOf(0.0..34.3 to null))
         assertTrackDraftVersionSwitchLinks(
             newBranchingTrack.id,
             null,
             null,
-            listOf(switch.id)
+            listOf(0.0..34.3 to switch.id)
         )
         assertTrackDraftVersionSwitchLinks(
             throughTrack.id,
             null,
             null,
-            listOf(null, null, null, switch.id, switch.id, null, null, null)
+            listOf(0.0..134.4 to null, 134.5 .. 168.8 to switch.id, 168.9 .. 268.86 to null)
         )
+    }
+
+    @Test
+    fun `re-linking switch cleans up topological connections`() {
+        val trackNumberId = getUnusedTrackNumberId()
+        referenceLineDao.insert(
+            referenceLine(
+                trackNumberId,
+                alignmentVersion = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
+            )
+        )
+        val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "RR54-4x1:9" }!!
+        val (templateSwitch, templateTrackSections) = switchAndMatchingAlignments(trackNumberId, switchStructure)
+        val templateOneTwoTrackSegments = templateTrackSections[0].second.segments
+        val templateFourThreeTrackSegments = templateTrackSections[1].second.segments
+        val oneFive = templateOneTwoTrackSegments[0]
+        val fiveTwo = templateOneTwoTrackSegments[1]
+        val switch = switchDao.insert(templateSwitch.copy(id = StringId()))
+
+        val oneFiveTrack = locationTrackService.saveDraft(
+            locationTrack(
+                trackNumberId,
+                name = "one-five with topo link",
+                topologyEndSwitch = TopologyLocationTrackSwitch(switch.id, JointNumber(5))
+            ), alignment(
+                setSwitchId(listOf(oneFive), null)
+            )
+        )
+
+        val fiveTwoTrack = locationTrackService.saveDraft(
+            locationTrack(
+                trackNumberId,
+                name = "five-two with topo link",
+                topologyStartSwitch = TopologyLocationTrackSwitch(switch.id, JointNumber(5))
+            ), alignment(
+                setSwitchId(listOf(fiveTwo), null)
+            )
+        )
+        val threeFourTrack = locationTrackService.saveDraft(
+            locationTrack(trackNumberId, name = "three-four"),
+            alignment(setSwitchId(templateFourThreeTrackSegments, switch.id))
+        )
+
+        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(Point(0.0, 0.0), templateSwitch.switchStructureId)!!
+        switchLinkingService.saveSwitchLinking(createSwitchLinkingParameters(suggestedSwitch, switch.id))
+
+        assertTrackDraftVersionSwitchLinks(oneFiveTrack.id, null, null, listOf(0.0..5.2 to switch.id))
+        assertTrackDraftVersionSwitchLinks(fiveTwoTrack.id, null, null, listOf(0.0..5.2 to switch.id))
+        assertTrackDraftVersionSwitchLinks(threeFourTrack.id, null, null, listOf(0.0..10.4 to switch.id))
     }
 
     private fun assertTrackDraftVersionSwitchLinks(
         trackId: IntId<LocationTrack>,
         topologyStartSwitchId: IntId<TrackLayoutSwitch>?,
         topologyEndSwitchId: IntId<TrackLayoutSwitch>?,
-        segmentSwitches: List<IntId<TrackLayoutSwitch>?>,
+        segmentSwitchesByMRange: List<Pair<ClosedRange<Double>, IntId<TrackLayoutSwitch>?>>,
     ) {
         val track = locationTrackService.get(PublishType.DRAFT, trackId)!!
         val (_, alignment) = locationTrackService.getWithAlignment(track.version!!)
         assertEquals(topologyStartSwitchId, track.topologyStartSwitch?.switchId)
         assertEquals(topologyEndSwitchId, track.topologyEndSwitch?.switchId)
-        assertEquals(segmentSwitches.size, alignment.segments.size)
-        alignment.segments.forEachIndexed { index, segment ->
-            assertEquals(segmentSwitches[index], segment.switchId)
+        assertEquals(segmentSwitchesByMRange.last().first.endInclusive, alignment.end!!.m, 0.1)
+        segmentSwitchesByMRange.forEach { (range, switchId) ->
+            val rangeStartSegmentIndex = alignment.getSegmentIndexAtM(range.start)
+            val rangeEndSegmentIndex = alignment.getSegmentIndexAtM(range.endInclusive)
+            assertEquals(range.start, alignment.segments[rangeStartSegmentIndex].startM, 0.1, "segment range starts at given m-value")
+            assertEquals(range.endInclusive, alignment.segments[rangeEndSegmentIndex].endM, 0.1, "segment range ends at given m-value")
+            (rangeStartSegmentIndex..rangeEndSegmentIndex).forEach { i ->
+                assertEquals(
+                    switchId,
+                    alignment.segments[i].switchId,
+                    "switch at segment index $i (asserted m-range ${range.start}..${range.endInclusive}, segment m-range ${alignment.segments[i].startM}..${alignment.segments[i].endM}"
+                )
+            }
         }
     }
 
@@ -991,7 +1049,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
                     })
                 )
             }
-            shift = acc.last().last().segmentEnd.toPoint()
+            shift += segments.last().segmentEnd.toPoint() - segments.first().segmentStart.toPoint()
             acc += listOf(segment(shift, shift + spacerVector))
             shift += spacerVector
         }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -889,7 +889,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
             alignment(shiftTrack(templateBranchingTrackSegments, null, shift1))
         )
         val validationResult = switchLinkingService.validateRelinkingTrack(throughTrack.id)
-        assertEquals(
+        assertEqualsRounded(
             listOf(
                 SwitchRelinkingResult(
                     id = okSwitch.id,
@@ -913,6 +913,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
             ), validationResult
         )
     }
+
     @Test
     fun `re-linking switch cleans up previous references consistently`() {
         val trackNumberId = getUnusedTrackNumberId()
@@ -1153,4 +1154,13 @@ class SwitchLinkingServiceIT @Autowired constructor(
         locationAccuracy: LocationAccuracy?,
     ) = assertEquals(locationAccuracy, switch.joints.find { j -> j.number == jointNumber }!!.locationAccuracy)
 
+    private fun assertEqualsRounded(expected: List<SwitchRelinkingResult>, actual: List<SwitchRelinkingResult>) =
+        assertEquals(roundRelinkingResult(expected), roundRelinkingResult(actual))
+
+    private fun roundRelinkingResult(r: List<SwitchRelinkingResult>) =
+        r.map { one ->
+            one.copy(successfulSuggestion = one.successfulSuggestion?.copy(
+                location = one.successfulSuggestion!!.location.round(1).toPoint()
+            ))
+        }
 }


### PR DESCRIPTION
Olihan siinä linkityskoodissa vielä parikin bugia, ja kirjoitan vielä pari testiä näidenkin jälkeen. Oleellisin vika oli, että originalTracks käytti tarkkoja locationTrackService.getWithAlignment()in palauttamia iideitä, jotka sitten meni vikaan, koska muu koodi osasi käyttää oikein virallisia, mutta nämä saattoi olla drafti-iideitä; ja että topologialinkkejä ilmestyi vain uusina.