### PR TITLE
General: Korjaa fetch-loopit splittaus-infoboksissa

### DIFF
--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -324,8 +324,11 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
         switchErrors: validateSplitSwitch(s, switches),
     }));
     const allValidated = [initialSplitValidated, ...splitsValidated];
+    const currentlyUsedLocationTracks = allValidated
+        .map((s) => s.split.duplicateOf)
+        .filter(filterNotEmpty);
     const duplicateTracksInCurrentSplits = useLocationTracks(
-        allValidated.map((s) => s.split.duplicateOf).filter(filterNotEmpty),
+        currentlyUsedLocationTracks,
         'DRAFT',
         getChangeTimes().layoutLocationTrack,
     );

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -324,11 +324,8 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
         switchErrors: validateSplitSwitch(s, switches),
     }));
     const allValidated = [initialSplitValidated, ...splitsValidated];
-    const currentlyUsedLocationTracks = allValidated
-        .map((s) => s.split.duplicateOf)
-        .filter(filterNotEmpty);
     const duplicateTracksInCurrentSplits = useLocationTracks(
-        currentlyUsedLocationTracks,
+        allValidated.map((s) => s.split.duplicateOf).filter(filterNotEmpty),
         'DRAFT',
         getChangeTimes().layoutLocationTrack,
     );

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -93,7 +93,7 @@ export function useReferenceLines(
     return (
         useLoader(
             () => (ids ? getReferenceLines(ids, publishType, changeTime) : undefined),
-            [ids, publishType, changeTime],
+            [JSON.stringify(ids), publishType, changeTime],
         ) || []
     );
 }
@@ -117,7 +117,7 @@ export function useLocationTracks(
     return (
         useLoader(
             () => (ids ? getLocationTracks(ids, publishType, changeTime) : undefined),
-            [ids, publishType, changeTime],
+            [JSON.stringify(ids), publishType, changeTime],
         ) || []
     );
 }
@@ -141,7 +141,7 @@ export function useSwitches(
     return (
         useLoader(
             () => (ids ? getSwitches(ids, publishType, changeTime) : undefined),
-            [ids, publishType, changeTime],
+            [JSON.stringify(ids), publishType, changeTime],
         ) || []
     );
 }
@@ -328,7 +328,7 @@ export function useKmPosts(
     return (
         useLoader(
             () => (ids ? getKmPosts(ids, publishType, changeTime) : undefined),
-            [ids, publishType, changeTime],
+            [JSON.stringify(ids), publishType, changeTime],
         ) || []
     );
 }


### PR DESCRIPTION
Fetch-looppeja pääsi syntymään, koska Reactille annettiin `getMany()`:issä arrayllinen id:itä. React tarkistelee niiden yhtäsuuruuden reference-equalsilla, joka altisti kaikki massahaut tällaisille vaaran paikoille. Korjasin massahakuja nyt niin, että massahauissa depsut aina `JSON.stringify()`:ataan, jolloin React vertailee niitä stringeinä.