### PR TITLE
GVT-2207: Pilkoittujen raiteiden näyttämiseen selkeytysparannuksia

### DIFF
--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -367,6 +367,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                         isPostingSplit={splittingState.state === 'POSTING'}
                         startPostingSplit={delegates.startPostingSplit}
                         returnToSplitting={delegates.returnToSplitting}
+                        markSplitOld={delegates.markSplitOld}
                     />
                 </EnvRestricted>
             )}

--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -14,7 +14,7 @@ import { getPlanarDistanceUnwrapped } from 'map/layers/utils/layer-utils';
 
 const DUPLICATE_MAX_DISTANCE = 1.0;
 
-export type InitialSplit = {
+type SplitBase = {
     name: string;
     descriptionBase: string;
     suffixMode: LocationTrackDescriptionSuffixMode;
@@ -23,7 +23,12 @@ export type InitialSplit = {
     new: boolean;
 };
 
-export type Split = InitialSplit & {
+export type InitialSplit = SplitBase & {
+    type: 'INITIAL_SPLIT';
+};
+
+export type Split = SplitBase & {
+    type: 'SPLIT';
     switchId: LayoutSwitchId;
     distance: number;
 };
@@ -102,6 +107,7 @@ export const splitReducers = {
             endLocation: payload.endLocation,
             disabled: payload.locationTrack.draftType !== 'OFFICIAL',
             initialSplit: {
+                type: 'INITIAL_SPLIT',
                 name:
                     duplicateTrackClosestToStart &&
                     duplicateTrackClosestToStart.distance <= DUPLICATE_MAX_DISTANCE
@@ -144,6 +150,7 @@ export const splitReducers = {
             );
             state.splittingState.splits = state.splittingState.splits.concat([
                 {
+                    type: 'SPLIT',
                     switchId: payload,
                     name:
                         closestDupe && closestDupe.distance <= DUPLICATE_MAX_DISTANCE
@@ -191,7 +198,7 @@ export const splitReducers = {
         { payload }: PayloadAction<Split | InitialSplit>,
     ): void => {
         if (state.splittingState) {
-            if ('switchId' in payload) {
+            if (payload.type === 'SPLIT') {
                 state.splittingState.splits = state.splittingState.splits
                     .filter((split) => split.switchId !== payload.switchId)
                     .concat([payload]);

--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -20,6 +20,7 @@ export type InitialSplit = {
     suffixMode: LocationTrackDescriptionSuffixMode;
     duplicateOf?: LocationTrackId;
     location: Point;
+    new: boolean;
 };
 
 export type Split = InitialSplit & {
@@ -114,6 +115,7 @@ export const splitReducers = {
                 descriptionBase: '',
                 suffixMode: 'NONE',
                 location: payload.startLocation,
+                new: true,
             },
         };
     },
@@ -155,8 +157,26 @@ export const splitReducers = {
                     suffixMode: 'NONE',
                     location: allowedSwitch.location,
                     distance: allowedSwitch.distance,
+                    new: true,
                 },
             ]);
+        }
+    },
+    markSplitOld: (
+        state: TrackLayoutState,
+        { payload }: PayloadAction<LayoutSwitchId | undefined>,
+    ): void => {
+        if (state.splittingState) {
+            if (payload) {
+                state.splittingState.splits = state.splittingState.splits.map((split) =>
+                    split.switchId === payload ? { ...split, new: false } : split,
+                );
+            } else {
+                state.splittingState.initialSplit = {
+                    ...state.splittingState.initialSplit,
+                    new: false,
+                };
+            }
         }
     },
     removeSplit: (state: TrackLayoutState, { payload }: PayloadAction<LayoutSwitchId>): void => {

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -82,7 +82,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
     underlyingAssetExists,
 }) => {
     const { t } = useTranslation();
-    const switchId = 'switchId' in split ? split.switchId : undefined;
+    const switchId = split.type === 'SPLIT' ? split.switchId : undefined;
     const [nameCommitted, setNameCommitted] = React.useState(split.name !== '');
     const [descriptionCommitted, setDescriptionCommitted] = React.useState(
         split.descriptionBase !== '',
@@ -122,7 +122,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                     <div className={styles['location-track-infobox__split-row-with-close-button']}>
                         <InfoboxField
                             label={
-                                'switchId' in split
+                                split.type === 'SPLIT'
                                     ? t('tool-panel.location-track.splitting.split-address')
                                     : t('tool-panel.location-track.splitting.start-address')
                             }>

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -63,6 +63,7 @@ type LocationTrackSplittingInfoboxContainerProps = {
     isPostingSplit: boolean;
     returnToSplitting: () => void;
     startPostingSplit: () => void;
+    markSplitOld: (switchId: LayoutSwitchId | undefined) => void;
 };
 
 type LocationTrackSplittingInfoboxProps = {
@@ -82,6 +83,7 @@ type LocationTrackSplittingInfoboxProps = {
     isPostingSplit: boolean;
     returnToSplitting: () => void;
     startPostingSplit: () => void;
+    markSplitOld: (switchId: LayoutSwitchId | undefined) => void;
 };
 
 const validateSplitName = (
@@ -176,6 +178,7 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
     isPostingSplit,
     returnToSplitting,
     startPostingSplit,
+    markSplitOld,
 }) => {
     const locationTrack = useLocationTrack(locationTrackId, 'DRAFT', locationTrackChangeTime);
     const [startAndEnd, _] = useLocationTrackStartAndEnd(
@@ -219,6 +222,7 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
                 isPostingSplit={isPostingSplit}
                 returnToSplitting={returnToSplitting}
                 startPostingSplit={startPostingSplit}
+                markSplitOld={markSplitOld}
             />
         )
     );
@@ -317,6 +321,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
     isPostingSplit,
     returnToSplitting,
     startPostingSplit,
+    markSplitOld,
 }) => {
     const { t } = useTranslation();
 
@@ -416,6 +421,16 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
             .then(() => stopSplitting())
             .catch(() => returnToSplitting());
     };
+
+    React.useEffect(() => {
+        const newSplit = splitComponents.find((s) => s.split.split.new);
+        if (newSplit) {
+            newSplit.nameRef.current?.focus();
+            markSplitOld(
+                'switchId' in newSplit.split.split ? newSplit.split.split.switchId : undefined,
+            );
+        }
+    });
 
     return (
         <React.Fragment>

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -128,15 +128,13 @@ const validateSplitDescription = (
 
 const validateSplitSwitch = (split: Split, switches: LayoutSwitch[]) => {
     const errors: ValidationError<Split>[] = [];
-    if ('switchId' in split) {
-        const switchAtSplit = switches.find((s) => s.id === split.switchId);
-        if (!switchAtSplit || switchAtSplit.stateCategory === 'NOT_EXISTING') {
-            errors.push({
-                field: 'switchId',
-                reason: 'switch-not-found',
-                type: ValidationErrorType.ERROR,
-            });
-        }
+    const switchAtSplit = switches.find((s) => s.id === split.switchId);
+    if (!switchAtSplit || switchAtSplit.stateCategory === 'NOT_EXISTING') {
+        errors.push({
+            field: 'switchId',
+            reason: 'switch-not-found',
+            type: ValidationErrorType.ERROR,
+        });
     }
     return errors;
 };
@@ -261,7 +259,7 @@ const getSplitAddressPoint = (
     startAndEnd: AlignmentStartAndEnd | undefined,
     split: Split | InitialSplit,
 ): AddressPoint | undefined => {
-    if ('switchId' in split) {
+    if (split.type === 'SPLIT') {
         const switchAtSplit = allowedSwitches.find((s) => s.switchId === split.switchId);
 
         if (switchAtSplit?.location && switchAtSplit?.address) {
@@ -301,7 +299,7 @@ const splitToRequestTarget = (
     descriptionBase: (duplicate ? duplicate.descriptionBase : split.descriptionBase) ?? '',
     descriptionSuffix: (duplicate ? duplicate.descriptionSuffix : split.suffixMode) ?? 'NONE',
     duplicateTrackId: split.duplicateOf,
-    startAtSwitchId: 'switchId' in split ? split?.switchId : undefined,
+    startAtSwitchId: split.type === 'SPLIT' ? split?.switchId : undefined,
 });
 
 export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfoboxProps> = ({
@@ -372,7 +370,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
             const switchExists =
                 switches.find(
                     (s) =>
-                        'switchId' in splitValidated.split &&
+                        splitValidated.split.type === 'SPLIT' &&
                         s.id === splitValidated.split.switchId,
                 )?.stateCategory !== 'NOT_EXISTING';
 
@@ -427,7 +425,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
         if (newSplit) {
             newSplit.nameRef.current?.focus();
             markSplitOld(
-                'switchId' in newSplit.split.split ? newSplit.split.split.switchId : undefined,
+                newSplit.split.split.type === 'SPLIT' ? newSplit.split.split.switchId : undefined,
             );
         }
     });


### PR DESCRIPTION
Täällä:
* Jakamisen alussa ja uusia splittejä lisätessä focusoidaan uuden splitin nimikenttä
* En lähtenyt toteuttamaan mitään sen kummempaa highlight-mekanismiä lisätyille spliteille. Ajattelin että focus riittää ainakin alkuun.

Tämän lisäksi turhauduin `InitialSplit`:in ja `Split`:in tyyppien käyttöön, joten muutin ne discriminated type unioniksi