### PR TITLE
GVT-2380 Vielä vaihdelinkitysfiksejä

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingService.kt
@@ -1047,7 +1047,7 @@ class SwitchLinkingService @Autowired constructor(
         } ?: suggestedSwitch
 
     fun getSuggestedSwitch(location: IPoint, switchStructureId: IntId<SwitchStructure>): SuggestedSwitch? =
-        getSuggestedSwitches(listOf(location to switchStructureId))[0]
+        getSuggestedSwitches(listOf(location to switchStructureId)).getOrNull(0)
 
     private fun assignNewSwitchLinkingToLocationTracksAndAlignments(
         locationTracksAndAlignments: List<Pair<LocationTrack, LayoutAlignment>>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
@@ -960,6 +961,15 @@ class SwitchLinkingServiceIT @Autowired constructor(
             null,
             null,
             listOf(0.0..134.4 to null, 134.5 .. 168.8 to switch.id, 168.9 .. 268.86 to null)
+        )
+    }
+
+    @Test
+    fun `null is suggested when no switch is applicable`() {
+        assertNull(
+            switchLinkingService.getSuggestedSwitch(
+                Point(123.0, 456.0), switchLibraryService.getSwitchStructuresById().keys.first()
+            )
         )
     }
 


### PR DESCRIPTION
- Hyvin oleellinen fiksi: Jos ehdotuksia ei ole, palautetaan nyt null kuten aiemminkin
- Logiikkamuutos: Jos ollaan korjaamassa tilannetta, jossa oli aiemmin linkitetty vaihde segmentille, mutta uudelleenlinkitys haluaisikin siirtää sen topologialinkitetyksi, niin osataan oikeasti poistaa segmenttilinkki ja lisätä topologialinkki