### PR TITLE
GVT-2360: Poistettu olio revertin riippuvuuslistalla näkyy tyhjänä

### DIFF
--- a/ui/src/preview/publication-request-dependency-list.tsx
+++ b/ui/src/preview/publication-request-dependency-list.tsx
@@ -14,7 +14,6 @@ import {
     useLocationTrack,
     useReferenceLine,
     useSwitch,
-    useTrackNumbers,
     useTrackNumbersIncludingDeleted,
 } from 'track-layout/track-layout-react-utils';
 import { ChangeTimes } from 'common/common-slice';
@@ -32,7 +31,7 @@ const TrackNumberItem: React.FC<{ trackNumberId: LayoutTrackNumberId; changeTime
     props,
 ) => {
     const { t } = useTranslation();
-    const trackNumbers = useTrackNumbers('DRAFT', props.changeTime);
+    const trackNumbers = useTrackNumbersIncludingDeleted('DRAFT', props.changeTime);
     const trackNumber = trackNumbers && trackNumbers.find((tn) => tn.id === props.trackNumberId);
     return trackNumber === undefined ? (
         <li />


### PR DESCRIPTION
Kyseessä oli ratanumerospesifinen ongelma. Ratanumeroita ei haeta yksittäin, vaan ne haetaan aina yhtenä massana -> olisi pitänyt käyttää sitä hakua joka hakee myös deletedit, niinkuin muissa dialogeissa tehtiin.

Tämän yhteydessä käyty läpi myös muiden asset-tyyppien revertit ja vaikuttaisi siltä että tämä oli ainoa joka bugasi.