### PR TITLE
GVT-2390 & GVT-2392: Fix publication view for older publications

### DIFF
--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -47,6 +47,9 @@ export const getLatestPublications = (count: number) => {
     return getNonNull<Page<PublicationDetails>>(`${PUBLICATION_URL}/latest${params}`);
 };
 
+export const getPublication = (id: PublicationId) =>
+    getNonNull<PublicationDetails>(`${PUBLICATION_URL}/${id}`);
+
 export const getPublicationAsTableItems = (id: PublicationId) =>
     getNonNull<PublicationTableItem[]>(
         `${PUBLICATION_URL}/${id}/table-rows${queryParams({ lang: i18next.language })}`,

--- a/ui/src/publication/publication-details-container.tsx
+++ b/ui/src/publication/publication-details-container.tsx
@@ -1,12 +1,10 @@
 import PublicationDetailsView from 'publication/publication';
 import { useCommonDataAppSelector } from 'store/hooks';
 import { useLoaderWithStatus } from 'utils/react-utils';
-import { getLatestPublications } from 'publication/publication-api';
-import { MAX_LISTED_PUBLICATIONS } from 'publication/card/publication-card';
+import { getPublication } from 'publication/publication-api';
 import { useParams } from 'react-router-dom';
 import { PublicationId } from 'preview/preview-table';
 import React from 'react';
-import { ratkoPushFailed } from 'ratko/ratko-model';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 
@@ -17,19 +15,14 @@ export const PublicationDetailsContainer: React.FC = () => {
     );
 
     const selectedPublicationId: PublicationId | undefined = useParams().publicationId;
-
-    const ratkoPushChangeTime = useCommonDataAppSelector((state) => state.changeTimes.ratkoPush);
     const publicationChangeTime = useCommonDataAppSelector(
         (state) => state.changeTimes.publication,
     );
 
-    const [publications, _publicationFetchStatus] = useLoaderWithStatus(
-        () => getLatestPublications(MAX_LISTED_PUBLICATIONS).then((result) => result?.items),
-        [publicationChangeTime, ratkoPushChangeTime],
+    const [publication, _publicationFetchStatus] = useLoaderWithStatus(
+        () => (selectedPublicationId ? getPublication(selectedPublicationId) : undefined),
+        [selectedPublicationId, publicationChangeTime],
     );
-
-    const publication = publications?.find((p) => p.id == selectedPublicationId);
-    const anyFailed = !!publications?.some((p) => ratkoPushFailed(p.ratkoPushStatus));
 
     if (!selectedPublicationId || !publication) {
         return <React.Fragment />;
@@ -39,7 +32,6 @@ export const PublicationDetailsContainer: React.FC = () => {
         <PublicationDetailsView
             publication={publication}
             setSelectedPublicationId={trackLayoutActionDelegates.setSelectedPublicationId}
-            anyFailed={anyFailed}
             changeTime={publicationChangeTime}
         />
     );

--- a/ui/src/publication/publication.tsx
+++ b/ui/src/publication/publication.tsx
@@ -20,20 +20,18 @@ import { useAppNavigate } from 'common/navigate';
 export type PublicationDetailsViewProps = {
     publication: PublicationDetails;
     setSelectedPublicationId: (publicationId: PublicationId | undefined) => void;
-    anyFailed: boolean;
     changeTime: TimeStamp;
 };
 
 const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
     publication,
     setSelectedPublicationId,
-    anyFailed,
     changeTime,
 }) => {
     const { t } = useTranslation();
     const navigate = useAppNavigate();
 
-    const waitingAfterFail = !publication.ratkoPushStatus && anyFailed;
+    const unpublishedToRatko = !publication.ratkoPushStatus;
     const [publicationItems, setPublicationItems] = React.useState<PublicationTableItem[]>([]);
     const [isLoading, setIsLoading] = React.useState(true);
 
@@ -79,7 +77,7 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
                 </div>
                 <PublicationTable isLoading={isLoading} items={publicationItems} />
             </div>
-            {(ratkoPushFailed(publication.ratkoPushStatus) || waitingAfterFail) && (
+            {(ratkoPushFailed(publication.ratkoPushStatus) || unpublishedToRatko) && (
                 <footer className={styles['publication-details__footer']}>
                     {ratkoPushFailed(publication.ratkoPushStatus) && (
                         <div className={styles['publication-details__failure-notification']}>
@@ -100,7 +98,7 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
                             </span>
                         </div>
                     )}
-                    {waitingAfterFail && (
+                    {unpublishedToRatko && (
                         <div className={styles['publication-details__failure-notification']}>
                             <span
                                 className={


### PR DESCRIPTION
Previously the URL & Ratko status display only worked for the most recent publications as the publication view component was trying to find a specific publication id from the list of most recent publications instead of querying the api by it.

Similar issue was fixed for the Ratko publication status. One of the checks to display unpublished or failed status was using the most recent publications list instead of data from the publication that was displayed.