### PR TITLE
GVT-2393: Luontimenun ja SelectionPanelin käsitteiden disablointi splittaustilan ollessa aktiivinen

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1402,7 +1402,8 @@
         "new-switch": "Uusi vaihde",
         "new-location-track": "Uusi sijaintiraide",
         "new-km-post": "Uusi tasakilometripiste",
-        "splitting-in-progress": "Raiteen jakaminen on kesken"
+        "splitting-in-progress": "Raiteen jakaminen on kesken",
+        "linking-in-progress": "Linkitys on kesken"
     },
     "user-card": {
         "my-details": "Omat tiedot",

--- a/ui/src/geoviite-design-lib/accordion/accordion.tsx
+++ b/ui/src/geoviite-design-lib/accordion/accordion.tsx
@@ -16,6 +16,7 @@ type AccordionProps = {
     headerSelected?: boolean;
     fetchingContent?: boolean;
     disabled?: boolean;
+    eyeHidden?: boolean;
     qaId?: string;
 };
 
@@ -32,6 +33,7 @@ export const Accordion: React.FC<AccordionProps> = ({
     fetchingContent = false,
     disabled,
     qaId,
+    eyeHidden = false,
 }: AccordionProps) => {
     const accordionClasses = createClassName(
         styles['accordion__header'],
@@ -58,7 +60,7 @@ export const Accordion: React.FC<AccordionProps> = ({
                     {header}
                     {subheader && <div className="accordion__subheader">{subheader}</div>}
                 </span>
-                {onVisibilityToggle && (
+                {onVisibilityToggle && !eyeHidden && (
                     <Eye
                         onVisibilityToggle={onVisibilityToggle}
                         visibility={visibility}

--- a/ui/src/geoviite-design-lib/accordion/accordion.tsx
+++ b/ui/src/geoviite-design-lib/accordion/accordion.tsx
@@ -18,6 +18,7 @@ type AccordionProps = {
     disabled?: boolean;
     eyeHidden?: boolean;
     qaId?: string;
+    className?: string;
 };
 
 export const Accordion: React.FC<AccordionProps> = ({
@@ -34,6 +35,7 @@ export const Accordion: React.FC<AccordionProps> = ({
     disabled,
     qaId,
     eyeHidden = false,
+    className,
 }: AccordionProps) => {
     const accordionClasses = createClassName(
         styles['accordion__header'],
@@ -45,8 +47,10 @@ export const Accordion: React.FC<AccordionProps> = ({
         onHeaderClick && styles['accordion__header-title--clickable'],
     );
 
+    const classes = createClassName('accordion', className);
+
     return (
-        <div className="accordion" qa-id={qaId}>
+        <div className={classes} qa-id={qaId}>
             <h4 className={accordionClasses}>
                 <AccordionToggle
                     onToggle={disabled ? undefined : onToggle}

--- a/ui/src/geoviite-design-lib/km-post/km-post-badge.scss
+++ b/ui/src/geoviite-design-lib/km-post/km-post-badge.scss
@@ -30,9 +30,10 @@
     }
 
     &--disabled {
-        background-color: vayla-design.$color-white-dark;
-        border-color: rgba(vayla-design.$color-black-default, 0.3);
-        color: vayla-design.$color-black-light;
+        pointer-events: none;
+        border-color: vayla-design.$color-black-lighter;
+        fill: vayla-design.$color-black-lighter;
+        color: vayla-design.$color-black-lighter;
     }
 
     &--clickable {

--- a/ui/src/geoviite-design-lib/km-post/km-post-badge.tsx
+++ b/ui/src/geoviite-design-lib/km-post/km-post-badge.tsx
@@ -21,6 +21,12 @@ export enum KmPostBadgeStatus {
     DISABLED = 'km-post-badge--disabled',
 }
 
+const statusToIcon = (status: KmPostBadgeStatus) => {
+    if (status === KmPostBadgeStatus.DISABLED) return Icons.KmPostDisabled;
+    else if (status === KmPostBadgeStatus.SELECTED) return Icons.KmPostSelected;
+    else return Icons.KmPost;
+};
+
 export const KmPostBadge: React.FC<KmPostBadgeProps> = ({
     kmPost,
     trackNumber,
@@ -35,7 +41,7 @@ export const KmPostBadge: React.FC<KmPostBadgeProps> = ({
         onClick && styles['km-post-badge--clickable'],
     );
 
-    const Icon = status == KmPostBadgeStatus.SELECTED ? Icons.KmPostSelected : Icons.KmPost;
+    const Icon = statusToIcon(status);
     const onTrackNumberTranslation = t('tool-panel.km-post.geometry.linking.track-number', {
         trackNumber: trackNumber?.number,
     });

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -64,7 +64,12 @@ const relatedMapLayers: LayerCollection = {
 };
 
 const layersToHideByProxy: LayerCollection = {
-    'location-track-split-location-layer': ['location-track-badge-layer'],
+    'location-track-split-location-layer': [
+        'location-track-badge-layer',
+        'geometry-alignment-layer',
+        'geometry-switch-layer',
+        'geometry-km-post-layer',
+    ],
 };
 
 const layerMenuItemMapLayers: Record<MapLayerMenuItemName, MapLayerName[]> = {

--- a/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.scss
+++ b/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.scss
@@ -64,4 +64,9 @@ $accordion-right-padding: 20px;
         flex: 1;
         cursor: pointer;
     }
+
+    &--disabled {
+        pointer-events: none;
+        color: vayla-design.$color-black-lighter;
+    }
 }

--- a/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
+++ b/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
@@ -58,7 +58,7 @@ type GeometryPlanProps = {
     planLayout?: GeometryPlanLayout;
     linkStatus?: GeometryPlanLinkStatus;
     planBeingLoaded: boolean;
-    canSelect: boolean;
+    disabled: boolean;
 };
 
 type Visibilities = {
@@ -89,7 +89,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
     planLayout,
     linkStatus,
     planBeingLoaded,
-    canSelect,
+    disabled,
 }: GeometryPlanProps) => {
     const { t } = useTranslation();
     const openPlanLayout = openPlans.find((p) => p.id === planHeader.id);
@@ -208,13 +208,15 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                 header={planHeader.project.name}
                 subheader={subHeader}
                 onToggle={onPlanToggle}
-                open={isPlanOpen || openingAccordion}
+                open={!disabled && (isPlanOpen || openingAccordion)}
                 onVisibilityToggle={onPlanVisibilityToggle}
                 visibility={visibilities.planHeader}
                 onHeaderClick={() => onPlanHeaderSelection(planHeader)}
                 headerSelected={selectedItems.geometryPlans?.some((id) => id === planHeader.id)}
                 fetchingContent={openingAccordion || planBeingLoaded}
-                eyeHidden={!canSelect}>
+                eyeHidden={disabled}
+                disabled={disabled}
+                className={disabled ? styles['geometry-plan-panel--disabled'] : ''}>
                 {planLayout && (
                     <div className={styles['geometry-plan-panel__alignments']}>
                         <Accordion
@@ -226,8 +228,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                     isOpen: !isKmPostsOpen,
                                 });
                             }}
-                            open={isKmPostsOpen}
-                            eyeHidden={!canSelect}>
+                            open={isKmPostsOpen}>
                             <ul>
                                 {planLayout.kmPosts.map((planKmPost) =>
                                     createKmPostRow(
@@ -238,7 +239,6 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         linkStatus,
                                         onKmPostSelect,
                                         onToggleKmPostVisibility,
-                                        canSelect,
                                     ),
                                 )}
                                 {planLayout.kmPosts.length == 0 && (
@@ -257,8 +257,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                     isOpen: !isAlignmentsOpen,
                                 });
                             }}
-                            open={isAlignmentsOpen}
-                            eyeHidden={!canSelect}>
+                            open={isAlignmentsOpen}>
                             <ul>
                                 {planLayout.alignments.map((alignment) =>
                                     createAlignmentRow(
@@ -269,7 +268,6 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         linkStatus,
                                         onAlignmentSelect,
                                         onToggleAlignmentVisibility,
-                                        canSelect,
                                     ),
                                 )}
                                 {planLayout.alignments.length == 0 && (
@@ -288,8 +286,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                     isOpen: !isSwitchesOpen,
                                 });
                             }}
-                            open={isSwitchesOpen}
-                            eyeHidden={!canSelect}>
+                            open={isSwitchesOpen}>
                             <ul>
                                 {planLayout.switches.map((planSwitch) =>
                                     createSwitchRow(
@@ -300,7 +297,6 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         linkStatus,
                                         onSwitchSelect,
                                         onToggleSwitchVisibility,
-                                        canSelect,
                                     ),
                                 )}
                                 {planLayout.switches.length == 0 && (
@@ -325,7 +321,6 @@ function createKmPostRow(
     linkStatus: GeometryPlanLinkStatus | undefined,
     onKmPostSelect: (kmPostItem: LayoutKmPost, kmPostStatus: KmPostBadgeStatus) => void,
     onToggleKmPostVisibility: (payload: ToggleKmPostPayload) => void,
-    canSelect: boolean,
 ): React.ReactElement {
     const isKmPostSelected = selectedItems.geometryKmPostIds?.some(
         ({ geometryId }) => geometryId === planKmPost.sourceId,
@@ -351,27 +346,23 @@ function createKmPostRow(
                 onClick={() => onKmPostSelect(planKmPost, kmPostStatus)}>
                 <KmPostBadge kmPost={planKmPost} status={kmPostStatus} />
             </span>
-
-            {canSelect && (
-                <span
-                    className={createClassName(
-                        styles['geometry-plan-panel__kmpost-visibility'],
-                        isKmPostVisible &&
-                            styles['geometry-plan-panel__kmpost-visibility--visible'],
-                    )}>
-                    <Icons.Eye
-                        color={IconColor.INHERIT}
-                        onClick={() =>
-                            isKmPostSelected ||
-                            (planKmPost.sourceId &&
-                                onToggleKmPostVisibility({
-                                    kmPostId: planKmPost.sourceId,
-                                    planId: planLayout.id,
-                                }))
-                        }
-                    />
-                </span>
-            )}
+            <span
+                className={createClassName(
+                    styles['geometry-plan-panel__kmpost-visibility'],
+                    isKmPostVisible && styles['geometry-plan-panel__kmpost-visibility--visible'],
+                )}>
+                <Icons.Eye
+                    color={IconColor.INHERIT}
+                    onClick={() =>
+                        isKmPostSelected ||
+                        (planKmPost.sourceId &&
+                            onToggleKmPostVisibility({
+                                kmPostId: planKmPost.sourceId,
+                                planId: planLayout.id,
+                            }))
+                    }
+                />
+            </span>
         </li>
     );
 }
@@ -384,7 +375,6 @@ function createAlignmentRow(
     linkStatus: GeometryPlanLinkStatus | undefined,
     onAlignmentSelect: (alignment: AlignmentHeader, status: LocationTrackBadgeStatus) => void,
     onToggleAlignmentVisibility: (payload: ToggleAlignmentPayload) => void,
-    canSelect: boolean,
 ): React.ReactElement {
     const alignmentStatus = linkStatus?.alignments?.some(
         (s) => s.id == alignment.header.id && s.isLinked,
@@ -409,26 +399,23 @@ function createAlignmentRow(
                 onClick={() => onAlignmentSelect(alignment.header, alignmentStatus)}>
                 <LocationTrackBadge locationTrack={alignment.header} status={alignmentStatus} />
             </span>
-
-            {canSelect && (
-                <span
-                    className={createClassName(
-                        styles['geometry-plan-panel__alignment-visibility'],
-                        isAlignmentVisible &&
-                            styles['geometry-plan-panel__alignment-visibility--visible'],
-                    )}>
-                    <Icons.Eye
-                        color={IconColor.INHERIT}
-                        onClick={() =>
-                            isAlignmentSelected ||
-                            onToggleAlignmentVisibility({
-                                alignmentId: alignment.header.id,
-                                planId: planLayout.id,
-                            })
-                        }
-                    />
-                </span>
-            )}
+            <span
+                className={createClassName(
+                    styles['geometry-plan-panel__alignment-visibility'],
+                    isAlignmentVisible &&
+                        styles['geometry-plan-panel__alignment-visibility--visible'],
+                )}>
+                <Icons.Eye
+                    color={IconColor.INHERIT}
+                    onClick={() =>
+                        isAlignmentSelected ||
+                        onToggleAlignmentVisibility({
+                            alignmentId: alignment.header.id,
+                            planId: planLayout.id,
+                        })
+                    }
+                />
+            </span>
         </li>
     );
 }
@@ -441,7 +428,6 @@ function createSwitchRow(
     linkStatus: GeometryPlanLinkStatus | undefined,
     onSwitchSelect: (switchItem: LayoutSwitch, switchStatus: SwitchBadgeStatus) => void,
     onToggleSwitchVisibility: (payload: ToggleSwitchPayload) => void,
-    canSelect: boolean,
 ): React.ReactElement {
     const switchStatus = linkStatus?.switches?.some(
         (s) => s.id == planSwitch.sourceId && s.isLinked,
@@ -468,27 +454,23 @@ function createSwitchRow(
                 onClick={() => onSwitchSelect(planSwitch, switchStatus)}>
                 <SwitchBadge switchItem={planSwitch} status={switchStatus} />
             </span>
-
-            {canSelect && (
-                <span
-                    className={createClassName(
-                        styles['geometry-plan-panel__switch-visibility'],
-                        isSwitchVisible &&
-                            styles['geometry-plan-panel__switch-visibility--visible'],
-                    )}>
-                    <Icons.Eye
-                        color={IconColor.INHERIT}
-                        onClick={() =>
-                            isSwitchSelected ||
-                            (planSwitch.sourceId &&
-                                onToggleSwitchVisibility({
-                                    switchId: planSwitch.sourceId,
-                                    planId: planLayout.id,
-                                }))
-                        }
-                    />
-                </span>
-            )}
+            <span
+                className={createClassName(
+                    styles['geometry-plan-panel__switch-visibility'],
+                    isSwitchVisible && styles['geometry-plan-panel__switch-visibility--visible'],
+                )}>
+                <Icons.Eye
+                    color={IconColor.INHERIT}
+                    onClick={() =>
+                        isSwitchSelected ||
+                        (planSwitch.sourceId &&
+                            onToggleSwitchVisibility({
+                                switchId: planSwitch.sourceId,
+                                planId: planLayout.id,
+                            }))
+                    }
+                />
+            </span>
         </li>
     );
 }

--- a/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
+++ b/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
@@ -58,6 +58,7 @@ type GeometryPlanProps = {
     planLayout?: GeometryPlanLayout;
     linkStatus?: GeometryPlanLinkStatus;
     planBeingLoaded: boolean;
+    canSelect: boolean;
 };
 
 type Visibilities = {
@@ -88,6 +89,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
     planLayout,
     linkStatus,
     planBeingLoaded,
+    canSelect,
 }: GeometryPlanProps) => {
     const { t } = useTranslation();
     const openPlanLayout = openPlans.find((p) => p.id === planHeader.id);
@@ -211,7 +213,8 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                 visibility={visibilities.planHeader}
                 onHeaderClick={() => onPlanHeaderSelection(planHeader)}
                 headerSelected={selectedItems.geometryPlans?.some((id) => id === planHeader.id)}
-                fetchingContent={openingAccordion || planBeingLoaded}>
+                fetchingContent={openingAccordion || planBeingLoaded}
+                eyeHidden={!canSelect}>
                 {planLayout && (
                     <div className={styles['geometry-plan-panel__alignments']}>
                         <Accordion
@@ -223,7 +226,8 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                     isOpen: !isKmPostsOpen,
                                 });
                             }}
-                            open={isKmPostsOpen}>
+                            open={isKmPostsOpen}
+                            eyeHidden={!canSelect}>
                             <ul>
                                 {planLayout.kmPosts.map((planKmPost) =>
                                     createKmPostRow(
@@ -234,6 +238,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         linkStatus,
                                         onKmPostSelect,
                                         onToggleKmPostVisibility,
+                                        canSelect,
                                     ),
                                 )}
                                 {planLayout.kmPosts.length == 0 && (
@@ -252,7 +257,8 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                     isOpen: !isAlignmentsOpen,
                                 });
                             }}
-                            open={isAlignmentsOpen}>
+                            open={isAlignmentsOpen}
+                            eyeHidden={!canSelect}>
                             <ul>
                                 {planLayout.alignments.map((alignment) =>
                                     createAlignmentRow(
@@ -263,6 +269,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         linkStatus,
                                         onAlignmentSelect,
                                         onToggleAlignmentVisibility,
+                                        canSelect,
                                     ),
                                 )}
                                 {planLayout.alignments.length == 0 && (
@@ -281,7 +288,8 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                     isOpen: !isSwitchesOpen,
                                 });
                             }}
-                            open={isSwitchesOpen}>
+                            open={isSwitchesOpen}
+                            eyeHidden={!canSelect}>
                             <ul>
                                 {planLayout.switches.map((planSwitch) =>
                                     createSwitchRow(
@@ -292,6 +300,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         linkStatus,
                                         onSwitchSelect,
                                         onToggleSwitchVisibility,
+                                        canSelect,
                                     ),
                                 )}
                                 {planLayout.switches.length == 0 && (
@@ -316,6 +325,7 @@ function createKmPostRow(
     linkStatus: GeometryPlanLinkStatus | undefined,
     onKmPostSelect: (kmPostItem: LayoutKmPost, kmPostStatus: KmPostBadgeStatus) => void,
     onToggleKmPostVisibility: (payload: ToggleKmPostPayload) => void,
+    canSelect: boolean,
 ): React.ReactElement {
     const isKmPostSelected = selectedItems.geometryKmPostIds?.some(
         ({ geometryId }) => geometryId === planKmPost.sourceId,
@@ -342,23 +352,26 @@ function createKmPostRow(
                 <KmPostBadge kmPost={planKmPost} status={kmPostStatus} />
             </span>
 
-            <span
-                className={createClassName(
-                    styles['geometry-plan-panel__kmpost-visibility'],
-                    isKmPostVisible && styles['geometry-plan-panel__kmpost-visibility--visible'],
-                )}>
-                <Icons.Eye
-                    color={IconColor.INHERIT}
-                    onClick={() =>
-                        isKmPostSelected ||
-                        (planKmPost.sourceId &&
-                            onToggleKmPostVisibility({
-                                kmPostId: planKmPost.sourceId,
-                                planId: planLayout.id,
-                            }))
-                    }
-                />
-            </span>
+            {canSelect && (
+                <span
+                    className={createClassName(
+                        styles['geometry-plan-panel__kmpost-visibility'],
+                        isKmPostVisible &&
+                            styles['geometry-plan-panel__kmpost-visibility--visible'],
+                    )}>
+                    <Icons.Eye
+                        color={IconColor.INHERIT}
+                        onClick={() =>
+                            isKmPostSelected ||
+                            (planKmPost.sourceId &&
+                                onToggleKmPostVisibility({
+                                    kmPostId: planKmPost.sourceId,
+                                    planId: planLayout.id,
+                                }))
+                        }
+                    />
+                </span>
+            )}
         </li>
     );
 }
@@ -371,6 +384,7 @@ function createAlignmentRow(
     linkStatus: GeometryPlanLinkStatus | undefined,
     onAlignmentSelect: (alignment: AlignmentHeader, status: LocationTrackBadgeStatus) => void,
     onToggleAlignmentVisibility: (payload: ToggleAlignmentPayload) => void,
+    canSelect: boolean,
 ): React.ReactElement {
     const alignmentStatus = linkStatus?.alignments?.some(
         (s) => s.id == alignment.header.id && s.isLinked,
@@ -396,23 +410,25 @@ function createAlignmentRow(
                 <LocationTrackBadge locationTrack={alignment.header} status={alignmentStatus} />
             </span>
 
-            <span
-                className={createClassName(
-                    styles['geometry-plan-panel__alignment-visibility'],
-                    isAlignmentVisible &&
-                        styles['geometry-plan-panel__alignment-visibility--visible'],
-                )}>
-                <Icons.Eye
-                    color={IconColor.INHERIT}
-                    onClick={() =>
-                        isAlignmentSelected ||
-                        onToggleAlignmentVisibility({
-                            alignmentId: alignment.header.id,
-                            planId: planLayout.id,
-                        })
-                    }
-                />
-            </span>
+            {canSelect && (
+                <span
+                    className={createClassName(
+                        styles['geometry-plan-panel__alignment-visibility'],
+                        isAlignmentVisible &&
+                            styles['geometry-plan-panel__alignment-visibility--visible'],
+                    )}>
+                    <Icons.Eye
+                        color={IconColor.INHERIT}
+                        onClick={() =>
+                            isAlignmentSelected ||
+                            onToggleAlignmentVisibility({
+                                alignmentId: alignment.header.id,
+                                planId: planLayout.id,
+                            })
+                        }
+                    />
+                </span>
+            )}
         </li>
     );
 }
@@ -425,6 +441,7 @@ function createSwitchRow(
     linkStatus: GeometryPlanLinkStatus | undefined,
     onSwitchSelect: (switchItem: LayoutSwitch, switchStatus: SwitchBadgeStatus) => void,
     onToggleSwitchVisibility: (payload: ToggleSwitchPayload) => void,
+    canSelect: boolean,
 ): React.ReactElement {
     const switchStatus = linkStatus?.switches?.some(
         (s) => s.id == planSwitch.sourceId && s.isLinked,
@@ -452,23 +469,26 @@ function createSwitchRow(
                 <SwitchBadge switchItem={planSwitch} status={switchStatus} />
             </span>
 
-            <span
-                className={createClassName(
-                    styles['geometry-plan-panel__switch-visibility'],
-                    isSwitchVisible && styles['geometry-plan-panel__switch-visibility--visible'],
-                )}>
-                <Icons.Eye
-                    color={IconColor.INHERIT}
-                    onClick={() =>
-                        isSwitchSelected ||
-                        (planSwitch.sourceId &&
-                            onToggleSwitchVisibility({
-                                switchId: planSwitch.sourceId,
-                                planId: planLayout.id,
-                            }))
-                    }
-                />
-            </span>
+            {canSelect && (
+                <span
+                    className={createClassName(
+                        styles['geometry-plan-panel__switch-visibility'],
+                        isSwitchVisible &&
+                            styles['geometry-plan-panel__switch-visibility--visible'],
+                    )}>
+                    <Icons.Eye
+                        color={IconColor.INHERIT}
+                        onClick={() =>
+                            isSwitchSelected ||
+                            (planSwitch.sourceId &&
+                                onToggleSwitchVisibility({
+                                    switchId: planSwitch.sourceId,
+                                    planId: planLayout.id,
+                                }))
+                        }
+                    />
+                </span>
+            )}
         </li>
     );
 }

--- a/ui/src/selection-panel/km-posts-panel/km-posts-panel.tsx
+++ b/ui/src/selection-panel/km-posts-panel/km-posts-panel.tsx
@@ -12,6 +12,7 @@ type KmPostsPanelProps = {
     onToggleKmPostSelection: (kmPost: LayoutKmPost) => void;
     selectedKmPosts?: LayoutKmPostId[];
     max?: number;
+    disabled: boolean;
 };
 
 export const KmPostsPanel: React.FC<KmPostsPanelProps> = ({
@@ -20,6 +21,7 @@ export const KmPostsPanel: React.FC<KmPostsPanelProps> = ({
     onToggleKmPostSelection,
     selectedKmPosts,
     max = 16,
+    disabled,
 }: KmPostsPanelProps) => {
     const { t } = useTranslation();
     const trackNumbers = useTrackNumbers(publishType);
@@ -47,12 +49,17 @@ export const KmPostsPanel: React.FC<KmPostsPanelProps> = ({
                     const isSelected = selectedKmPosts?.some(
                         (selectedPost) => selectedPost == kmPost.id,
                     );
+                    const status = () => {
+                        if (disabled) return KmPostBadgeStatus.DISABLED;
+                        else if (isSelected) return KmPostBadgeStatus.SELECTED;
+                        else return undefined;
+                    };
                     return (
                         <li key={kmPost.id}>
                             <KmPostBadge
                                 kmPost={kmPost}
                                 onClick={() => onToggleKmPostSelection(kmPost)}
-                                status={isSelected ? KmPostBadgeStatus.SELECTED : undefined}
+                                status={status()}
                                 trackNumber={trackNumbers?.find(
                                     (tn) => tn.id === kmPost.trackNumberId,
                                 )}

--- a/ui/src/selection-panel/reference-line-panel/reference-line.scss
+++ b/ui/src/selection-panel/reference-line-panel/reference-line.scss
@@ -31,5 +31,10 @@
         &--can-select {
             cursor: pointer;
         }
+
+        &--disabled {
+            pointer-events: none;
+            color: vayla-design.$color-black-lighter;
+        }
     }
 }

--- a/ui/src/selection-panel/reference-line-panel/reference-lines-panel.tsx
+++ b/ui/src/selection-panel/reference-line-panel/reference-lines-panel.tsx
@@ -26,6 +26,7 @@ type ReferenceLinesPanelProps = {
     selectedTrackNumbers?: LayoutTrackNumberId[];
     canSelectReferenceLine: boolean;
     max?: number;
+    disabled: boolean;
 };
 
 const ReferenceLinesPanel: React.FC<ReferenceLinesPanelProps> = ({
@@ -36,6 +37,7 @@ const ReferenceLinesPanel: React.FC<ReferenceLinesPanelProps> = ({
     selectedTrackNumbers,
     canSelectReferenceLine,
     max = 16,
+    disabled,
 }: ReferenceLinesPanelProps) => {
     const { t } = useTranslation();
     const [linesCount, setLinesCount] = React.useState(0);
@@ -70,6 +72,11 @@ const ReferenceLinesPanel: React.FC<ReferenceLinesPanelProps> = ({
                             'reference-lines-panel__reference-line--can-select',
                     );
                     const trackNumber = trackNumbers?.find((tn) => tn.id == line.trackNumberId);
+                    const status = () => {
+                        if (disabled) return ReferenceLineBadgeStatus.DISABLED;
+                        else if (isSelected) return ReferenceLineBadgeStatus.SELECTED;
+                        else return undefined;
+                    };
                     return trackNumber ? (
                         <li
                             key={line.id}
@@ -78,11 +85,15 @@ const ReferenceLinesPanel: React.FC<ReferenceLinesPanelProps> = ({
                                 canSelectReferenceLine &&
                                 onToggleReferenceLineSelection(line.trackNumberId, line.id)
                             }>
-                            <ReferenceLineBadge
-                                trackNumber={trackNumber}
-                                status={isSelected ? ReferenceLineBadgeStatus.SELECTED : undefined}
-                            />
-                            <span>{t('reference-line')}</span>
+                            <ReferenceLineBadge trackNumber={trackNumber} status={status()} />
+                            <span
+                                className={
+                                    disabled
+                                        ? styles['reference-lines-panel__reference-line--disabled']
+                                        : undefined
+                                }>
+                                {t('reference-line')}
+                            </span>
                         </li>
                     ) : (
                         <React.Fragment key={line.id} />

--- a/ui/src/selection-panel/selection-panel-container.tsx
+++ b/ui/src/selection-panel/selection-panel-container.tsx
@@ -65,6 +65,7 @@ export const SelectionPanelContainer: React.FC = () => {
             mapLayerSettings={state.map.layerSettings}
             mapLayoutMenu={state.map.layerMenu.layout}
             onMapLayerMenuItemChange={delegates.onLayerMenuItemChange}
+            splittingState={state.splittingState}
         />
     );
 };

--- a/ui/src/selection-panel/selection-panel-geometry-section.tsx
+++ b/ui/src/selection-panel/selection-panel-geometry-section.tsx
@@ -55,6 +55,7 @@ type GeometryPlansPanelProps = {
     togglePlanAlignmentsOpen: (payload: ToggleAccordionOpenPayload) => void;
     togglePlanSwitchesOpen: (payload: ToggleAccordionOpenPayload) => void;
     onSelect: (options: OnSelectOptions) => void;
+    canSelect?: boolean;
 };
 const MAX_PLAN_HEADERS = 50;
 
@@ -80,6 +81,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
     togglePlanAlignmentsOpen,
     togglePlanSwitchesOpen,
     onSelect,
+    canSelect = true,
 }) => {
     const { t } = useTranslation();
     const [planHeadersDisplayableInPanel, setPlanHeadersDisplayableInPanel] = React.useState<
@@ -191,7 +193,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
                 {`${t('selection-panel.geometries-title')} (${
                     planHeadersDisplayableInPanel.length
                 }/${planHeaderCount})`}{' '}
-                {planHeadersDisplayableInPanel.length > 1 && (
+                {planHeadersDisplayableInPanel.length > 1 && canSelect && (
                     <Eye
                         onVisibilityToggle={toggleAllPlanVisibilities}
                         visibility={visiblePlansInView.length > 0}
@@ -273,6 +275,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
                                 linkStatus={fetchedPlans.get(h.id)?.linkStatus}
                                 planBeingLoaded={plansBeingFetched.has(h.id)}
                                 loadPlanLayout={() => fetchPlanLayout(h.id)}
+                                canSelect={canSelect}
                             />
                         );
                     })}

--- a/ui/src/selection-panel/selection-panel-geometry-section.tsx
+++ b/ui/src/selection-panel/selection-panel-geometry-section.tsx
@@ -55,7 +55,7 @@ type GeometryPlansPanelProps = {
     togglePlanAlignmentsOpen: (payload: ToggleAccordionOpenPayload) => void;
     togglePlanSwitchesOpen: (payload: ToggleAccordionOpenPayload) => void;
     onSelect: (options: OnSelectOptions) => void;
-    canSelect?: boolean;
+    disabled?: boolean;
 };
 const MAX_PLAN_HEADERS = 50;
 
@@ -81,7 +81,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
     togglePlanAlignmentsOpen,
     togglePlanSwitchesOpen,
     onSelect,
-    canSelect = true,
+    disabled = false,
 }) => {
     const { t } = useTranslation();
     const [planHeadersDisplayableInPanel, setPlanHeadersDisplayableInPanel] = React.useState<
@@ -193,7 +193,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
                 {`${t('selection-panel.geometries-title')} (${
                     planHeadersDisplayableInPanel.length
                 }/${planHeaderCount})`}{' '}
-                {planHeadersDisplayableInPanel.length > 1 && canSelect && (
+                {planHeadersDisplayableInPanel.length > 1 && !disabled && (
                     <Eye
                         onVisibilityToggle={toggleAllPlanVisibilities}
                         visibility={visiblePlansInView.length > 0}
@@ -275,7 +275,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
                                 linkStatus={fetchedPlans.get(h.id)?.linkStatus}
                                 planBeingLoaded={plansBeingFetched.has(h.id)}
                                 loadPlanLayout={() => fetchPlanLayout(h.id)}
-                                canSelect={canSelect}
+                                disabled={disabled}
                             />
                         );
                     })}

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -44,6 +44,7 @@ import SelectionPanelGeometrySection from './selection-panel-geometry-section';
 import { ChangeTimes } from 'common/common-slice';
 import { Eye } from 'geoviite-design-lib/eye/eye';
 import { TrackNumberColorKey } from 'selection-panel/track-number-panel/color-selector/color-selector-utils';
+import { SplittingState } from 'tool-panel/location-track/split-store';
 
 type SelectionPanelProps = {
     changeTimes: ChangeTimes;
@@ -70,6 +71,7 @@ type SelectionPanelProps = {
     mapLayerSettings: MapLayerSettings;
     onMapLayerMenuItemChange: (change: MapLayerMenuChange) => void;
     mapLayoutMenu: MapLayerMenuItem[];
+    splittingState: SplittingState | undefined;
 };
 
 const SelectionPanel: React.FC<SelectionPanelProps> = ({
@@ -97,6 +99,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
     mapLayerSettings,
     onMapLayerMenuItemChange,
     mapLayoutMenu,
+    splittingState,
 }: SelectionPanelProps) => {
     const { t } = useTranslation();
     const [visibleTrackNumbers, setVisibleTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
@@ -202,17 +205,19 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
             <section>
                 <h3 className={styles['selection-panel__title']}>
                     {`${t('selection-panel.track-numbers-title')} (${visibleTrackNumbers.length})`}
-                    <Eye
-                        onVisibilityToggle={() => {
-                            if (diagramLayerMenuItem) {
-                                onMapLayerMenuItemChange({
-                                    name: 'track-number-diagram',
-                                    visible: !diagramLayerMenuItem.visible,
-                                });
-                            }
-                        }}
-                        visibility={diagramLayerMenuItem?.visible ?? false}
-                    />
+                    {!splittingState && (
+                        <Eye
+                            onVisibilityToggle={() => {
+                                if (diagramLayerMenuItem) {
+                                    onMapLayerMenuItemChange({
+                                        name: 'track-number-diagram',
+                                        visible: !diagramLayerMenuItem.visible,
+                                    });
+                                }
+                            }}
+                            visibility={diagramLayerMenuItem?.visible ?? false}
+                        />
+                    )}
                 </h3>
                 <div className={styles['selection-panel__content']}>
                     <TrackNumberPanel
@@ -221,6 +226,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         selectedTrackNumbers={selectedTrackNumberIds}
                         onSelectTrackNumber={onTrackNumberSelection}
                         onSelectColor={onTrackNumberColorSelection}
+                        canSelect={!splittingState}
                     />
                 </div>
             </section>
@@ -241,6 +247,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                 selectedTrackNumbers={selectedTrackNumberIds}
                 togglePlanOpen={togglePlanOpen}
                 onSelect={onSelect}
+                canSelect={!splittingState}
             />
             <section>
                 <h3 className={styles['selection-panel__title']}>

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -226,7 +226,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         selectedTrackNumbers={selectedTrackNumberIds}
                         onSelectTrackNumber={onTrackNumberSelection}
                         onSelectColor={onTrackNumberColorSelection}
-                        canSelect={!splittingState}
+                        disabled={!!splittingState}
                     />
                 </div>
             </section>
@@ -247,7 +247,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                 selectedTrackNumbers={selectedTrackNumberIds}
                 togglePlanOpen={togglePlanOpen}
                 onSelect={onSelect}
-                canSelect={!splittingState}
+                disabled={!!splittingState}
             />
             <section>
                 <h3 className={styles['selection-panel__title']}>
@@ -266,6 +266,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                                 isToggle: true,
                             })
                         }
+                        disabled={!!splittingState}
                     />
                 </div>
             </section>
@@ -282,6 +283,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         selectedTrackNumbers={selectedItems.trackNumbers}
                         canSelectReferenceLine={selectableItemTypes.includes('trackNumbers')}
                         onToggleReferenceLineSelection={onToggleReferenceLineSelection}
+                        disabled={!!splittingState}
                     />
                 </div>
             </section>

--- a/ui/src/selection-panel/track-number-panel/track-number-panel.scss
+++ b/ui/src/selection-panel/track-number-panel/track-number-panel.scss
@@ -31,5 +31,10 @@
         .radio {
             margin-right: 8px;
         }
+
+        &--disabled {
+            color: vayla-design.$color-black-lighter;
+            pointer-events: none;
+        }
     }
 }

--- a/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
+++ b/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
@@ -18,6 +18,7 @@ type TrackNumberPanelProps = {
     onSelectColor: (trackNumberId: LayoutTrackNumberId, color: TrackNumberColorKey) => void;
     selectedTrackNumbers: LayoutTrackNumberId[];
     max?: number;
+    canSelect?: boolean;
 };
 
 const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
@@ -27,6 +28,7 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
     onSelectColor,
     selectedTrackNumbers,
     max = 16,
+    canSelect = true,
 }: TrackNumberPanelProps) => {
     const { t } = useTranslation();
     const [sortedTrackNumbers, setSortedTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
@@ -51,8 +53,12 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
                                 className={styles['track-number-panel__track-number']}
                                 key={trackNumber.id}>
                                 <div>
-                                    <span onMouseUp={() => onSelectTrackNumber(trackNumber)}>
+                                    <span
+                                        onMouseUp={() =>
+                                            canSelect && onSelectTrackNumber(trackNumber)
+                                        }>
                                         <Radio
+                                            disabled={!canSelect}
                                             checked={isSelected}
                                             readOnly={true}
                                             name={trackNumber.number}

--- a/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
+++ b/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
@@ -10,6 +10,7 @@ import {
     TrackNumberColorKey,
 } from 'selection-panel/track-number-panel/color-selector/color-selector-utils';
 import ColorSelector from 'selection-panel/track-number-panel/color-selector/color-selector';
+import { createClassName } from 'vayla-design-lib/utils';
 
 type TrackNumberPanelProps = {
     trackNumbers: LayoutTrackNumber[];
@@ -18,7 +19,7 @@ type TrackNumberPanelProps = {
     onSelectColor: (trackNumberId: LayoutTrackNumberId, color: TrackNumberColorKey) => void;
     selectedTrackNumbers: LayoutTrackNumberId[];
     max?: number;
-    canSelect?: boolean;
+    disabled?: boolean;
 };
 
 const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
@@ -28,7 +29,7 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
     onSelectColor,
     selectedTrackNumbers,
     max = 16,
-    canSelect = true,
+    disabled = false,
 }: TrackNumberPanelProps) => {
     const { t } = useTranslation();
     const [sortedTrackNumbers, setSortedTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
@@ -41,6 +42,10 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
 
         setSortedTrackNumbers(visibleTrackNumbers.sort(fieldComparator((tn) => tn.number)));
     }, [trackNumbers, selectedTrackNumbers]);
+    const trackNumberClassNames = createClassName(
+        styles['track-number-panel__track-number'],
+        disabled && styles['track-number-panel__track-number--disabled'],
+    );
 
     return (
         <div>
@@ -49,32 +54,32 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
                     {sortedTrackNumbers.map((trackNumber) => {
                         const isSelected = selectedTrackNumbers?.some((s) => s == trackNumber.id);
                         return (
-                            <li
-                                className={styles['track-number-panel__track-number']}
-                                key={trackNumber.id}>
+                            <li className={trackNumberClassNames} key={trackNumber.id}>
                                 <div>
                                     <span
                                         onMouseUp={() =>
-                                            canSelect && onSelectTrackNumber(trackNumber)
+                                            !disabled && onSelectTrackNumber(trackNumber)
                                         }>
                                         <Radio
-                                            disabled={!canSelect}
+                                            disabled={disabled}
                                             checked={isSelected}
                                             readOnly={true}
                                             name={trackNumber.number}
                                         />
                                         {trackNumber.number}
                                     </span>
-                                    <ColorSelector
-                                        color={
-                                            settings[trackNumber.id]?.color ??
-                                            getDefaultColorKey(trackNumber.id)
-                                        }
-                                        onSelectColor={(color) =>
-                                            onSelectColor(trackNumber.id, color)
-                                        }
-                                        className={'track-number-panel__color-selector'}
-                                    />
+                                    {!disabled && (
+                                        <ColorSelector
+                                            color={
+                                                settings[trackNumber.id]?.color ??
+                                                getDefaultColorKey(trackNumber.id)
+                                            }
+                                            onSelectColor={(color) =>
+                                                onSelectColor(trackNumber.id, color)
+                                            }
+                                            className={'track-number-panel__color-selector'}
+                                        />
+                                    )}
                                 </div>
                             </li>
                         );

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -39,6 +39,7 @@ import {
 } from 'track-layout/track-layout-react-utils';
 import { getBySearchTerm } from 'track-layout/track-layout-search-api';
 import { SplittingState } from 'tool-panel/location-track/split-store';
+import { LinkingState } from 'linking/linking-model';
 
 export type ToolbarParams = {
     onSelect: OnSelectFunction;
@@ -54,6 +55,7 @@ export type ToolbarParams = {
     mapLayerMenuGroups: MapLayerMenuGroups;
     visibleLayers: MapLayerName[];
     splittingState: SplittingState | undefined;
+    linkingState: LinkingState | undefined;
 };
 
 type LocationTrackItemValue = {
@@ -142,6 +144,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     mapLayerMenuGroups,
     visibleLayers,
     splittingState,
+    linkingState,
 }: ToolbarParams) => {
     const { t } = useTranslation();
 
@@ -264,6 +267,16 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     const handleSwitchSave = refreshSwitchSelection('DRAFT', onSelect, onUnselect);
     const handleKmPostSave = refereshKmPostSelection('DRAFT', onSelect, onUnselect);
 
+    const modeNavigationButtonsDisabledReason = () => {
+        if (splittingState) {
+            return t('tool-bar.splitting-in-progress');
+        } else if (linkingState?.state === 'allSet' || linkingState?.state === 'setup') {
+            return t('tool-bar.linking-in-progress');
+        } else {
+            return undefined;
+        }
+    };
+
     return (
         <div className={`tool-bar tool-bar--${publishType.toLowerCase()}`}>
             <div className={styles['tool-bar__left-section']}>
@@ -314,17 +327,25 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                 {publishType === 'DRAFT' && (
                     <React.Fragment>
                         <Button
-                            disabled={!!splittingState}
+                            disabled={
+                                !!splittingState ||
+                                linkingState?.state === 'allSet' ||
+                                linkingState?.state === 'setup'
+                            }
                             variant={ButtonVariant.SECONDARY}
-                            title={t('tool-bar.splitting-in-progress')}
+                            title={modeNavigationButtonsDisabledReason()}
                             onClick={() => moveToOfficialPublishType()}>
                             {t('tool-bar.draft-mode.disable')}
                         </Button>
                         <Button
-                            disabled={!!splittingState}
+                            disabled={
+                                !!splittingState ||
+                                linkingState?.state === 'allSet' ||
+                                linkingState?.state === 'setup'
+                            }
                             icon={Icons.VectorRight}
                             variant={ButtonVariant.PRIMARY}
-                            title={t('tool-bar.splitting-in-progress')}
+                            title={modeNavigationButtonsDisabledReason()}
                             qa-id="open-preview-view"
                             onClick={() => openPreviewAndStopLinking()}>
                             {t('tool-bar.preview-mode.enable')}

--- a/ui/src/track-layout/track-layout-view.tsx
+++ b/ui/src/track-layout/track-layout-view.tsx
@@ -64,7 +64,8 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = ({
             <ToolBar
                 disableNewMenu={
                     linkingState?.type === LinkingType.LinkingGeometryWithAlignment ||
-                    linkingState?.type === LinkingType.LinkingGeometryWithEmptyAlignment
+                    linkingState?.type === LinkingType.LinkingGeometryWithEmptyAlignment ||
+                    !!splittingState
                 }
                 publishType={publishType}
                 showArea={showArea}
@@ -80,6 +81,7 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = ({
                 mapLayerMenuGroups={mapLayerMenuGroups}
                 visibleLayers={visibleMapLayers}
                 splittingState={splittingState}
+                linkingState={linkingState}
             />
 
             <div className={styles['track-layout__main-view']}>

--- a/ui/src/vayla-design-lib/accordion-toggle/accordion-toggle.scss
+++ b/ui/src/vayla-design-lib/accordion-toggle/accordion-toggle.scss
@@ -18,7 +18,7 @@
     }
 
     &--disabled {
-        background-color: colors.$color-white-darker;
+        background-color: colors.$color-white-dark;
         cursor: default;
     }
 }

--- a/ui/src/vayla-design-lib/icon/Icon.tsx
+++ b/ui/src/vayla-design-lib/icon/Icon.tsx
@@ -20,6 +20,7 @@ import navigationDownSvg from './glyphs/navigation/down.svg';
 import statusErrorSvg from './glyphs/status/error.svg';
 import kmPostSvg from './glyphs/misc/kmpost.svg';
 import kmPostSelectedSvg from './glyphs/misc/kmpost-selected.svg';
+import kmPostDisabledSvg from './glyphs/misc/kmpost-disabled.svg';
 import switchSvg from './glyphs/misc/switch.svg';
 import chevronSvg from './glyphs/navigation/chevron.svg';
 import eyeSvg from './glyphs/status/eye.svg';
@@ -115,6 +116,7 @@ const iconNameToSvgMapStaticColor = {
     // Misc
     KmPost: kmPostSvg,
     KmPostSelected: kmPostSelectedSvg,
+    KmPostDisabled: kmPostDisabledSvg,
 };
 
 export enum IconSize {

--- a/ui/src/vayla-design-lib/icon/glyphs/misc/kmpost-disabled.svg
+++ b/ui/src/vayla-design-lib/icon/glyphs/misc/kmpost-disabled.svg
@@ -1,0 +1,11 @@
+<svg width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="5.5" cy="5.5" r="5" fill="white" stroke="#858585"/>
+  <mask id="mask_km_post" maskUnits="userSpaceOnUse" x="0" y="0" width="11" height="11">
+    <circle cx="5.5" cy="5.5" r="5.5" fill="white"/>
+  </mask>
+  <g mask="url(#mask_km_post)">
+    <rect y="5.5" width="5.5" height="5.5" fill="#858585"/>
+    <rect x="5.5" width="5.5" height="5.5" fill="#858585"/>
+  </g>
+  <circle cx="5.5" cy="5.5" r="5" stroke="#858585"/>
+</svg>


### PR DESCRIPTION
Muutettu karttanäkymän toimintaa seuraavasti splittauksen ollessa päällä:
* Luontimenu disabloitu
* Pituusmittausraidekaavion ja suunnitelmien silmäikonit otettu pois näkyvistä
* Disabloitu ratanumeroiden, suunnitelmien, kilometripylväiden sekä pituusmittauslinjojen valinta vasemmasta paneelista (sekä estetty klikkaaminen että tehty visuaaliset tyylit näiden indikoimiselle)

Noiden lisäksi disabloitu tilanvaihtonapit linkityksen ollessa aktiivinen splittaustilan tyyliin.