### PR TITLE
General: Some table comments were placed on the wrong table. Fix as repeatable migration

### DIFF
--- a/infra/src/main/resources/db/migration/repeatable/R__08.01_fix_table_comments.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__08.01_fix_table_comments.sql
@@ -1,0 +1,5 @@
+comment on table geometry.plan is 'Geometry Plan: parsed structural data from a plan';
+comment on table geometry.plan_file is 'Original Geometry Plan file contents';
+
+comment on table common.switch_joint is 'Switch structure joint: a joint point of a common.switch_structure';
+comment on table common.switch_owner is 'Switch owners';


### PR DESCRIPTION
Korjaus repeatable migraationa: tuonne voi halutessaan aina lisätä/muokata taulu-kommentteja ilman että joka muutoksesta tarvitsee tehdä oma versioitu migra.