### PR TITLE
General: fix return values in geometryplan insert/update

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
@@ -17,11 +17,6 @@ data class ValidationResponse(
     val source: PlanSource,
 )
 
-data class InsertResponse(
-    val message: String,
-    val planId: IntId<GeometryPlan>,
-)
-
 data class ExtraInfoParameters(
     val planPhase: PlanPhase?,
     val decisionPhase: PlanDecisionPhase?,
@@ -41,18 +36,19 @@ data class OverrideParameters(
     val source: PlanSource?,
 )
 
-fun tryParsing(source: PlanSource?, op: () -> ValidationResponse): ValidationResponse =
-    try {
-        op()
-    } catch (e: Exception) {
-        logger.warn("Failed to parse InfraModel", e)
-        ValidationResponse(
-            validationErrors = listOf(ParsingError(
+fun tryParsing(source: PlanSource?, op: () -> ValidationResponse): ValidationResponse = try {
+    op()
+} catch (e: Exception) {
+    logger.warn("Failed to parse InfraModel", e)
+    ValidationResponse(
+        validationErrors = listOf(
+            ParsingError(
                 if (e is HasLocalizeMessageKey) e.localizedMessageKey
                 else LocalizationKey(INFRAMODEL_PARSING_KEY_GENERIC)
-            )),
-            geometryPlan = null,
-            planLayout = null,
-            source = source ?: PlanSource.GEOMETRIAPALVELU
-        )
-    }
+            ),
+        ),
+        geometryPlan = null,
+        planLayout = null,
+        source = source ?: PlanSource.GEOMETRIAPALVELU,
+    )
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
@@ -1,8 +1,8 @@
 package fi.fta.geoviite.infra.inframodel
 
-import fi.fta.geoviite.infra.authorization.AUTH_UI_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
 import fi.fta.geoviite.infra.authorization.AUTH_INFRAMODEL_DOWNLOAD
+import fi.fta.geoviite.infra.authorization.AUTH_UI_READ
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geometry.GeometryPlan
@@ -20,7 +20,6 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
-
 @RestController
 @RequestMapping("/inframodel")
 class InfraModelController @Autowired constructor(
@@ -37,15 +36,14 @@ class InfraModelController @Autowired constructor(
         @RequestPart(value = "file") file: MultipartFile,
         @RequestPart(value = "override-parameters") overrides: OverrideParameters?,
         @RequestPart(value = "extrainfo-parameters") extraInfo: ExtraInfoParameters?,
-    ): InsertResponse {
+    ): IntId<GeometryPlan> {
         logger.apiCall(
             "saveInfraModel",
             "file.originalFilename" to file.originalFilename,
             "overrides" to overrides,
             "extraInfo" to extraInfo,
         )
-        val id = infraModelService.saveInfraModel(file, overrides, extraInfo).id
-        return InsertResponse("New plan inserted successfully", id)
+        return infraModelService.saveInfraModel(file, overrides, extraInfo).id
     }
 
     @PreAuthorize(AUTH_UI_READ)
@@ -78,9 +76,9 @@ class InfraModelController @Autowired constructor(
         @PathVariable("planId") planId: IntId<GeometryPlan>,
         @RequestPart(value = "override-parameters") overrides: OverrideParameters?,
         @RequestPart(value = "extrainfo-parameters") extraInfo: ExtraInfoParameters?,
-    ): GeometryPlan {
+    ): IntId<GeometryPlan> {
         logger.apiCall("updateInfraModel", "overrides" to overrides, "extraInfo" to extraInfo)
-        return infraModelService.updateInfraModel(planId, overrides, extraInfo)
+        return infraModelService.updateInfraModel(planId, overrides, extraInfo).id
     }
 
     @PreAuthorize(AUTH_ALL_WRITE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -172,7 +172,7 @@ class InfraModelService @Autowired constructor(
         planId: IntId<GeometryPlan>,
         overrideParameters: OverrideParameters?,
         extraInfoParameters: ExtraInfoParameters?,
-    ): GeometryPlan {
+    ): RowVersion<GeometryPlan> {
         logger.serviceCall(
             "updateInfraModel",
             "planId" to planId,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.configuration.USER_HEADER
+import fi.fta.geoviite.infra.geometry.MetaDataName
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.DbTable
 import fi.fta.geoviite.infra.util.getInstant
@@ -102,6 +103,14 @@ abstract class DBTestBase(val testUser: String = TEST_USER) {
     fun getUnusedSwitchName(): SwitchName {
         return SwitchName(getUniqueName(DbTable.LAYOUT_SWITCH, switchNameLength.last))
     }
+
+    fun getUnusedProjectName(): ProjectName = ProjectName(
+        getUniqueName(DbTable.GEOMETRY_PLAN_PROJECT, 100)
+    )
+
+    fun getUnusedAuthorCompanyName(): MetaDataName = MetaDataName(
+        getUniqueName(DbTable.GEOMETRY_PLAN_AUTHOR, 100)
+    )
 
     private fun getUniqueName(table: DbTable, maxLength: Int): String {
         val sql = "select max(id) max_id from ${table.versionTable}"

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -7,7 +7,7 @@ import {
     putNonNull,
     queryParams,
 } from 'api/api-fetch';
-import { GeometryPlan, GeometryPlanId } from 'geometry/geometry-model';
+import { GeometryPlanId } from 'geometry/geometry-model';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { getChangeTimes, updatePlanChangeTime } from 'common/change-time-api';
 import {
@@ -23,11 +23,6 @@ import {
 } from './projektivelho/pv-model';
 import { asyncCache } from 'cache/cache';
 import { Oid, TimeStamp } from 'common/common-model';
-
-export interface InsertResponse {
-    message: string;
-    planId?: number;
-}
 
 export const EMPTY_VALIDATION_RESPONSE: ValidationResponse = {
     validationErrors: [],
@@ -91,9 +86,9 @@ export const saveInfraModelFile = async (
     file?: Blob,
     extraParameters?: ExtraInfraModelParameters,
     overrideParameters?: OverrideInfraModelParameters,
-): Promise<InsertResponse | undefined> => {
+): Promise<GeometryPlanId | undefined> => {
     const formData = createFormData(file, extraParameters, overrideParameters);
-    const response = await postFormNonNullAdt<InsertResponse>(INFRAMODEL_URI, formData);
+    const response = await postFormNonNullAdt<GeometryPlanId>(INFRAMODEL_URI, formData);
 
     if (response.isOk()) {
         Snackbar.success('infra-model.upload.success');
@@ -109,9 +104,12 @@ export async function updateGeometryPlan(
     planId: GeometryPlanId,
     extraParameters?: ExtraInfraModelParameters,
     overrideParameters?: OverrideInfraModelParameters,
-): Promise<GeometryPlan | undefined> {
+): Promise<GeometryPlanId | undefined> {
     const formData = createFormData(undefined, extraParameters, overrideParameters);
-    const response = await putFormNonNullAdt<GeometryPlan>(`${INFRAMODEL_URI}/${planId}`, formData);
+    const response = await putFormNonNullAdt<GeometryPlanId>(
+        `${INFRAMODEL_URI}/${planId}`,
+        formData,
+    );
 
     if (response.isOk()) {
         Snackbar.success('infra-model.edit.success');


### PR DESCRIPTION
Suunnitelmien tallennus-api:n paluuarvot oli vanhaa perua varsin eri näköinen ja kuin muut. Sille ei oikeasti ollut mitään tarvetta, jäänyt vain tuollaiseksi. Bongasin sen aikanaan jonkun isomman rempan yhteydessä mutten halunnut sotkea sen reviewiä joten jätin TODO:n... ja unohdin sen. Nyt korjattu.