### PR TITLE
GVT-2410: Virhetoasteihin korrelaatio-id tai timestamp näkyviin/kopioitavaksi

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -84,8 +84,10 @@
             }
         },
         "entity-not-found": "Tietoa ei löydy",
-        "entity-not-found-on-path": "Tietoa ei löytynyt kutsussa polkuun {{path}}",
-        "request-failed": "Pyyntö epäonnistui kutsussa polkuun {{path}}"
+        "entity-not-found-on-path": "Tietoa ei löytynyt: {{path}}",
+        "request-failed": "Pyyntö epäonnistui: {{path}}",
+        "copied-to-clipboard": "Kopioitu leikepöydälle",
+        "copy-details-to-clipboard": "Kopioi tiedot leikepöydälle"
     },
     "unauthorized-request": {
         "title": "Istunto on vanhentunut.",

--- a/ui/src/api/api-fetch.ts
+++ b/ui/src/api/api-fetch.ts
@@ -242,7 +242,7 @@ async function fetchNonNullAdt<Input, Output>(
     const result = await fetchNullableAdt<Input, Output>(path, method, body);
 
     if (result.isOk() && result.value === undefined) {
-        Snackbar.error('Expected non-null result but got null', `${method} ${path}`);
+        Snackbar.error('Expected non-null result but got null');
 
         return err(undefined);
     } else {
@@ -261,7 +261,7 @@ export async function fetchFormNonNullAdt<Output>(
     );
 
     if (r.isOk() && r.value === undefined) {
-        Snackbar.error('Expected non-null result but got null', `${method} ${path}`);
+        Snackbar.error('Expected non-null result but got null');
 
         return err(undefined);
     } else {
@@ -368,11 +368,5 @@ async function tryToReadText(response: Response): Promise<string | undefined> {
 }
 
 const showHttpError = (path: string, response: ApiErrorResponse) => {
-    const msg =
-        response.localizedMessageKey &&
-        i18n.t(response.localizedMessageKey, response.localizedMessageParams);
-
-    const content = msg || response.messageRows.map((r) => `${r}`).join('\n');
-
-    Snackbar.error(i18n.t('error.request-failed', { path }), content);
+    Snackbar.error(i18n.t('error.request-failed', { path }), response);
 };

--- a/ui/src/geoviite-design-lib/demo/examples/snackbar-examples.tsx
+++ b/ui/src/geoviite-design-lib/demo/examples/snackbar-examples.tsx
@@ -4,8 +4,8 @@ import { Button } from 'vayla-design-lib/button/button';
 import { TextField } from 'vayla-design-lib/text-field/text-field';
 
 export const SnackbarExamples: React.FC = () => {
-    const [header, setHeader] = React.useState<string>('Tetson stetson');
-    const [body, setBody] = React.useState<string>('balleballe');
+    const [header, setHeader] = React.useState<string>('');
+    const [body, setBody] = React.useState<string>('');
 
     const infoSnackbar = () => {
         Snackbar.info(header, body);

--- a/ui/src/geoviite-design-lib/demo/examples/snackbar-examples.tsx
+++ b/ui/src/geoviite-design-lib/demo/examples/snackbar-examples.tsx
@@ -4,8 +4,8 @@ import { Button } from 'vayla-design-lib/button/button';
 import { TextField } from 'vayla-design-lib/text-field/text-field';
 
 export const SnackbarExamples: React.FC = () => {
-    const [header, setHeader] = React.useState<string>('');
-    const [body, setBody] = React.useState<string>('');
+    const [header, setHeader] = React.useState<string>('Tetson stetson');
+    const [body, setBody] = React.useState<string>('balleballe');
 
     const infoSnackbar = () => {
         Snackbar.info(header, body);
@@ -16,7 +16,7 @@ export const SnackbarExamples: React.FC = () => {
     };
 
     const errorSnackbar = () => {
-        Snackbar.error(header, body);
+        Snackbar.error(header);
     };
 
     return (

--- a/ui/src/geoviite-design-lib/snackbar/snackbar.scss
+++ b/ui/src/geoviite-design-lib/snackbar/snackbar.scss
@@ -25,6 +25,23 @@
         font-weight: 600;
         line-height: 20px;
         white-space: nowrap;
+        overflow: hidden;
+    }
+
+    &__toast-header-container {
+        display: flex;
+        align-items: center;
+        flex: 1;
+    }
+
+    &__toast-body-content {
+        display: flex;
+    }
+
+    &__toast-footer {
+        margin-top: 4px;
+        font-weight: 600;
+        font-size: 12px;
     }
 
     &__toast-text-body {

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -148,7 +148,7 @@ export async function getSwitchValidation(
     publishType: PublishType,
     id: LayoutSwitchId,
 ): Promise<ValidatedAsset> {
-    return getNonNull<ValidatedAsset>(`${layoutUri('switches', publishType, id)}/validation`);
+    return getNonNull<ValidatedAsset>(`${layoutUri('switches', publishType, id)}/validations`);
 }
 
 export const getSwitchChangeTimes = (

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -148,7 +148,7 @@ export async function getSwitchValidation(
     publishType: PublishType,
     id: LayoutSwitchId,
 ): Promise<ValidatedAsset> {
-    return getNonNull<ValidatedAsset>(`${layoutUri('switches', publishType, id)}/validations`);
+    return getNonNull<ValidatedAsset>(`${layoutUri('switches', publishType, id)}/validation`);
 }
 
 export const getSwitchChangeTimes = (


### PR DESCRIPTION
Tässä tuli tehtyä yleisön pyynnöstä vähän muitakin asioita kuin pelkkä kopiointinappi, timestamp ja correlationId. Täällä tehtyä kokonaisuudessaan:
- Virhetoasteilta otettu bodyn näyttämien pois. Aiemmin tätä käytettiinkin ainoastaan siihen, että siinä näytettiin bäkkäriltä tullut ihmisluettava virheviesti, joka monesti oli vielä englanniksi
- Virhetoasteille voi nyt antaa `ApiErrorResponse`-tyyppiä olevan virheolion, jonka olemassaolon perusteella toastissa näytetään a) kopiointinappi virheviestin oikealla puolella (tästä lisää myöhemmin), b) pohjalla aikaleima (bäkkäriltä, mutta käännetty lokaaliin aikaan) ja c) bäkkärin correlationId. Jos errorResponsea ei anneta (esim. puhtaasti frontin sisäisissä virheissä), nappia, aikaleimaa ja correlationId:tä ei näytetä
- Bäkkärivirheet voi nyt kopioida leikepöydälle edesmainitulla napilla. Käytännössä tämä kopioi annetun `ApiErrorResponse`-JSON:in leikepöydälle stringinä. Vasteena kopioinnista näytetään pikaisesti katoava success-toast.