### PR TITLE
GVT-2311 Julkaisulokin geometriamuutosten tunnistuksen korjauksia

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -363,7 +363,7 @@ fun getKmNumbersChangedRemarkOrNull(
             mapOf(
                 "changedLengthM" to roundTo1Decimal(summary.changedLengthM).toString(),
                 "maxDistance" to roundTo1Decimal(summary.maxDistance).toString(),
-                "addressRange" to "${summary.startAddress}-${summary.endAddress}"
+                "addressRange" to "${summary.startAddress.round(0)}-${summary.endAddress.round(0)}"
             )
         )
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -357,7 +357,7 @@ fun getKmNumbersChangedRemarkOrNull(
         if (changedKmNumbers.size > 1) "changed-km-numbers" else "changed-km-number",
         formatChangedKmNumbers(changedKmNumbers.toList())
     )
-} else summaries.joinToString(".") { summary ->
+} else summaries.joinToString(". ") { summary ->
     translation.t(
         "publication-details-table.remark.geometry-changed", LocalizationParams(
             mapOf(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1700,7 +1700,7 @@ class PublicationServiceIT @Autowired constructor(
         print(diff)
         assertEquals(1, diff.size)
         assertEquals(
-            "Muutos välillä 0000+0001.000-0000+0009.000, sivusuuntainen muutos 10.0 m",
+            "Muutos välillä 0000+0001-0000+0009, sivusuuntainen muutos 10.0 m",
             diff[0].remark
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -660,15 +660,24 @@ fun someSegment() = segment(3, 10.0, 20.0, 10.0, 20.0)
 fun segment(points: Int, minX: Double, maxX: Double, minY: Double, maxY: Double) =
     segment(points = rawPoints(points, minX, maxX, minY, maxY))
 
+fun segment(points: Int, start: Point, end: Point) =
+    segment(points, start.x, end.x, start.y, end.y)
+
 fun segment(from: IPoint, to: IPoint): LayoutSegment {
-    val middlePoints =
-        (1 until lineLength(from, to).toInt()).map { i -> (from + (to - from).normalized() * i.toDouble()) }
-    return segment(toSegmentPoints(to3DMPoints((listOf(from) + middlePoints + listOf(to)).distinct())))
+    return segment(toSegmentPoints(to3DMPoints((listOf(from) + middlePoints(from, to) + listOf(to)).distinct())))
 }
+
+private fun middlePoints(from: IPoint, to: IPoint) =
+    (1 until lineLength(from, to).toInt()).map { i -> (from + (to - from).normalized() * i.toDouble()) }
 
 fun segments(from: IPoint, to: IPoint, segmentCount: Int): List<LayoutSegment> {
     return segments(from, to, lineLength(from, to) / segmentCount)
 }
+
+fun singleSegmentWithInterpolatedPoints(vararg points: IPoint): LayoutSegment =
+    segment(toSegmentPoints(to3DMPoints(points.toList().zipWithNext { a, b ->
+        listOf(a) + middlePoints(a, b)
+    }.flatten() + points.last())))
 
 fun segments(from: IPoint, to: IPoint, segmentLength: Double): List<LayoutSegment> {
     val dir = (to - from).normalized()


### PR DESCRIPTION
Isoin ja oleellisin muutos tietenkin tuo, että geometriamuutokselliset välit tunnistetaan nyt oikeasti geometriasta eikä ainoastaan siitä, että koko segmentti on joko uusi tai ei. Tällä logiikalla löytyi joulukuiselta dumpilta seitsemän tapausta, joissa samalla sijaintiraiteella samassa julkaisussa on useampi muutos.