### PR TITLE
GVT-2094: Clarify automatically calculated changes in publication log

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -1678,7 +1678,22 @@ class PublicationService @Autowired constructor(
             )
         }
 
-        return (trackNumbers + referenceLines + locationTracks + switches + kmPosts + calculatedLocationTracks + calculatedSwitches)
+        return listOf(
+            trackNumbers,
+            referenceLines,
+            locationTracks,
+            switches,
+            kmPosts,
+            calculatedLocationTracks,
+            calculatedSwitches,
+        )
+            .flatten()
+            .map { publicationTableItem ->
+                addOperationClarificationsToPublicationTableItem(
+                    translation,
+                    publicationTableItem,
+                )
+            }
     }
 
     private fun mapToPublicationTableItem(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -444,7 +444,8 @@ fun addOperationClarificationsToPublicationTableItem(
             propChanges = publicationTableItem.propChanges.map { publicationChange ->
                 addChangeClarification(
                     publicationChange,
-                    translation.t("publication-table.calculated-change")
+                    translation.t("publication-table.calculated-change"),
+                    translation.t("publication-table.calculated-change-lowercase")
                 )
             }
         )
@@ -456,14 +457,19 @@ fun addOperationClarificationsToPublicationTableItem(
 fun addChangeClarification(
     publicationChange: PublicationChange<*>,
     clarification: String,
+    clarificationInSentenceBody: String? = null,
 ): PublicationChange<*> {
     return when (publicationChange.remark) {
         null -> publicationChange.copy(
             remark = clarification
         )
 
-        else -> publicationChange.copy(
-            remark = "${publicationChange.remark}, ${clarification.replaceFirstChar(Char::lowercase)}"
-        )
+        else -> {
+            val displayedClarification = clarificationInSentenceBody ?: clarification
+
+            publicationChange.copy(
+                remark = "${publicationChange.remark}, $displayedClarification"
+            )
+        }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -432,5 +432,38 @@ private fun getChangedAlignmentRanges(old: LayoutAlignment, new: LayoutAlignment
     }
 }
 
-fun publicationChangeRemark(translation: Translation, key: String, value: String?) =
+fun publicationChangeRemark(translation: Translation, key: String, value: String? = null) =
     translation.t("publication-details-table.remark.$key", localizationParams("value" to value))
+
+fun addOperationClarificationsToPublicationTableItem(
+    translation: Translation,
+    publicationTableItem: PublicationTableItem,
+): PublicationTableItem {
+    return when (publicationTableItem.operation) {
+        Operation.CALCULATED -> publicationTableItem.copy(
+            propChanges = publicationTableItem.propChanges.map { publicationChange ->
+                addChangeClarification(
+                    publicationChange,
+                    translation.t("publication-table.calculated-change")
+                )
+            }
+        )
+
+        else -> publicationTableItem
+    }
+}
+
+fun addChangeClarification(
+    publicationChange: PublicationChange<*>,
+    clarification: String,
+): PublicationChange<*> {
+    return when (publicationChange.remark) {
+        null -> publicationChange.copy(
+            remark = clarification
+        )
+
+        else -> publicationChange.copy(
+            remark = "${publicationChange.remark}, ${clarification.replaceFirstChar(Char::lowercase)}"
+        )
+    }
+}

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1308,6 +1308,7 @@
         "count-header-loading": "Julkaistut muutokset",
         "count-header": "Julkaistut muutokset ({{number}}{{truncated}} kpl)",
         "calculated-change": "Laskennallinen muutos",
+        "calculated-change-lowercase": "laskennallinen muutos",
         "truncated": "Käyttöliittymässä näytetään {{number}} ensimmäistä muutosta",
         "changes": "Muutokset"
     },

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -193,7 +193,7 @@
             "DELETE": "Poisto",
             "MODIFY": "Muokkaus",
             "RESTORE": "Palautus",
-            "CALCULATED": "Laskettu muutos"
+            "CALCULATED": "Laskennallinen muutos"
         },
         "topological-connectivity-type": {
             "NONE": "Ei kytketty",
@@ -1307,7 +1307,7 @@
         "km-post": "Tasakilometripiste",
         "count-header-loading": "Julkaistut muutokset",
         "count-header": "Julkaistut muutokset ({{number}}{{truncated}} kpl)",
-        "calculated-change": "Laskettu muutos",
+        "calculated-change": "Laskennallinen muutos",
         "truncated": "Käyttöliittymässä näytetään {{number}} ensimmäistä muutosta",
         "changes": "Muutokset"
     },


### PR DESCRIPTION
Previously it was possible for a user of the publication log to be confused about a change that was not manually made.