### PR TITLE
General: Splittien järjestäminen splittauksen tekemisen bäkkärikutsussa

### DIFF
--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -417,7 +417,12 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
     const postSplit = () => {
         startPostingSplit();
         postSplitLocationTrack(
-            splitRequest(locationTrack.id, initialSplit, splits, duplicateTracksInCurrentSplits),
+            splitRequest(
+                locationTrack.id,
+                initialSplit,
+                sortSplitsByDistance(splits),
+                duplicateTracksInCurrentSplits,
+            ),
         )
             .then(() => stopSplitting())
             .catch(() => returnToSplitting());


### PR DESCRIPTION
Aiemmin frontti luotti että bäkkäri saa splitit järjestettyä oikein eikä miettinyt niiden järjestystä sen kummemmin, but as it turns out, bäkkäri tarvitseekin splitit järjestyksessä