### PR TITLE
GVT-2415: Raiteen jakamisen tiedot -dialogi

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
@@ -19,7 +19,9 @@ const val DEFAULT_TRACK_METER_DECIMALS = 3
 private val extensionLength = 1..2
 private val extensionRegex = Regex("^[A-Z]*\$")
 
-data class KmNumber @JsonCreator(mode = DISABLED) constructor(
+data class KmNumber
+@JsonCreator(mode = DISABLED)
+constructor(
     val number: Int,
     val extension: String? = null,
 ) : Comparable<KmNumber> {
@@ -53,9 +55,13 @@ data class KmNumber @JsonCreator(mode = DISABLED) constructor(
 private const val METERS_MAX_INTEGER_DIGITS = 4
 private const val METERS_MAX_DECIMAL_DIGITS = 6
 private fun limitScale(meters: BigDecimal) =
-    if (meters.scale() < 0) meters.setScale(0)
-    else if (meters.scale() > METERS_MAX_DECIMAL_DIGITS) meters.setScale(METERS_MAX_DECIMAL_DIGITS, HALF_UP)
-    else meters
+    if (meters.scale() < 0) {
+        meters.setScale(0)
+    } else if (meters.scale() > METERS_MAX_DECIMAL_DIGITS) {
+        meters.setScale(METERS_MAX_DECIMAL_DIGITS, HALF_UP)
+    } else {
+        meters
+    }
 
 private val maxMeter = BigDecimal.valueOf(10.0.pow(METERS_MAX_INTEGER_DIGITS))
 private val metersDecimalsValidRange = 0..METERS_MAX_DECIMAL_DIGITS
@@ -80,7 +86,9 @@ interface ITrackMeter : Comparable<ITrackMeter> {
     override operator fun compareTo(other: ITrackMeter): Int = compare(this, other)
 }
 
-data class TrackMeter @JsonCreator(mode = DISABLED) constructor(
+data class TrackMeter
+@JsonCreator(mode = DISABLED)
+constructor(
     override val kmNumber: KmNumber,
     override val meters: BigDecimal,
 ) : ITrackMeter {
@@ -187,4 +195,11 @@ fun compare(trackMeter1: ITrackMeter, trackMeter2: ITrackMeter): Int {
 
 fun compare(trackMeter1: ITrackMeter, trackMeter2: ITrackMeter, decimals: Int): Int {
     return compareValuesBy(trackMeter1, trackMeter2, { tm -> tm.kmNumber }, { tm -> tm.metersRound(decimals) })
+}
+
+fun compareOptional(trackMeter1: ITrackMeter?, trackMeter2: ITrackMeter?): Int {
+    return if (trackMeter1 == null && trackMeter2 == null) 0
+    else if (trackMeter1 == null) -1
+    else if (trackMeter2 == null) 1
+    else compare(trackMeter1, trackMeter2)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
@@ -19,9 +19,7 @@ const val DEFAULT_TRACK_METER_DECIMALS = 3
 private val extensionLength = 1..2
 private val extensionRegex = Regex("^[A-Z]*\$")
 
-data class KmNumber
-@JsonCreator(mode = DISABLED)
-constructor(
+data class KmNumber @JsonCreator(mode = DISABLED) constructor(
     val number: Int,
     val extension: String? = null,
 ) : Comparable<KmNumber> {
@@ -86,9 +84,7 @@ interface ITrackMeter : Comparable<ITrackMeter> {
     override operator fun compareTo(other: ITrackMeter): Int = compare(this, other)
 }
 
-data class TrackMeter
-@JsonCreator(mode = DISABLED)
-constructor(
+data class TrackMeter @JsonCreator(mode = DISABLED) constructor(
     override val kmNumber: KmNumber,
     override val meters: BigDecimal,
 ) : ITrackMeter {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/CsvTranslations.kt
@@ -141,6 +141,27 @@ fun translateVerticalGeometryListingHeader(header: VerticalGeometryListingHeader
         VerticalGeometryListingHeader.LOCATION_N_POINT -> "Taitepisteen sijainti N"
     }
 
+enum class SplitTargetListingHeader {
+    SOURCE_NAME,
+    SOURCE_OID,
+    TARGET_NAME,
+    TARGET_OID,
+    OPERATION,
+    START_ADDRESS,
+    END_ADDRESS,
+}
+
+fun translateSplitTargetListingHeader(header: SplitTargetListingHeader) =
+    when (header) {
+        SplitTargetListingHeader.SOURCE_NAME -> "Alkuperäinen raide"
+        SplitTargetListingHeader.SOURCE_OID -> "Alkuperäisen raiteen OID"
+        SplitTargetListingHeader.TARGET_NAME -> "Kohderaide"
+        SplitTargetListingHeader.TARGET_OID -> "Kohderaiteen OID"
+        SplitTargetListingHeader.OPERATION -> "Toimenpide"
+        SplitTargetListingHeader.START_ADDRESS -> "Alkuosoite"
+        SplitTargetListingHeader.END_ADDRESS -> "Loppuosoite"
+    }
+
 fun translateElevationMeasurementMethod(elevationMeasurementMethod: ElevationMeasurementMethod?) =
     when (elevationMeasurementMethod) {
         ElevationMeasurementMethod.TOP_OF_SLEEPER -> "Korkeusviiva"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -455,3 +455,19 @@ data class LocationTrackPublicationSwitchLinkChanges(
     val old: Map<IntId<TrackLayoutSwitch>, SwitchChangeIds>,
     val new: Map<IntId<TrackLayoutSwitch>, SwitchChangeIds>,
 )
+
+data class SplitInPublication(
+    val id: IntId<Publication>,
+    val splitId: IntId<Split>,
+    val locationTrack: LocationTrack,
+    val targetLocationTracks: List<SplitTargetInPublication>,
+)
+
+data class SplitTargetInPublication(
+    val id: IntId<LocationTrack>,
+    val name: AlignmentName,
+    val oid: Oid<LocationTrack>?,
+    val startAddress: TrackMeter?,
+    val endAddress: TrackMeter?,
+    val newlyCreated: Boolean,
+)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -14,6 +14,7 @@ import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.Page
 import fi.fta.geoviite.infra.util.SortOrder
+import fi.fta.geoviite.infra.util.toResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -202,5 +203,23 @@ class PublicationController @Autowired constructor(
     fun getPublicationDetails(@PathVariable("id") id: IntId<Publication>): PublicationDetails {
         logger.apiCall("getPublicationDetails", "id" to id)
         return publicationService.getPublicationDetails(id)
+    }
+
+    @PreAuthorize(AUTH_UI_READ)
+    @GetMapping("/{id}/split-details")
+    fun getSplitDetails(@PathVariable("id") id: IntId<Publication>): ResponseEntity<SplitInPublication> {
+        logger.apiCall("getLocationTrackDetails", "id" to id)
+        return publicationService.getSplitInPublication(id).let(::toResponse)
+    }
+
+    @PreAuthorize(AUTH_UI_READ)
+    @GetMapping("/{id}/split-details/csv")
+    fun getSplitDetailsAsCsv(@PathVariable("id") id: IntId<Publication>): ResponseEntity<ByteArray> {
+        logger.apiCall("getSplitDetailsAsCsv", "id" to id)
+        return publicationService
+            .getSplitInPublicationCsv(id)
+            .let { (csv, ltName) ->
+                getCsvResponseEntity(csv, FileName("Raiteen jakaminen $ltName.csv"))
+            }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.split
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.publication.Publication
@@ -37,8 +38,10 @@ data class Split(
     val targetLocationTracks: List<SplitTarget>,
     val relinkedSwitches: List<IntId<TrackLayoutSwitch>>,
 ) {
+    @get:JsonIgnore
     val locationTracks by lazy { targetLocationTracks.map { it.locationTrackId } + locationTrackId }
 
+    @JsonIgnore
     val isPending: Boolean = bulkTransferState == BulkTransferState.PENDING && publicationId == null
 
     fun containsLocationTrack(trackId: IntId<LocationTrack>): Boolean = locationTracks.contains(trackId)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
@@ -1,12 +1,12 @@
 package fi.fta.geoviite.infra.split
 
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
+import fi.fta.geoviite.infra.authorization.AUTH_UI_READ
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.util.toResponse
+import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/location-track-split")
@@ -16,4 +16,15 @@ class SplitController(val splitService: SplitService) {
     fun splitLocationTrack(@RequestBody request: SplitRequest): IntId<Split> {
         return splitService.split(request)
     }
+
+    @PreAuthorize(AUTH_UI_READ)
+    @GetMapping("/{id}")
+    fun getSplit(@PathVariable("id") id: IntId<Split>): ResponseEntity<Split> = toResponse(splitService.get(id))
+
+    @PreAuthorize(AUTH_ALL_WRITE)
+    @PutMapping("/{id}/bulk-transfer-state")
+    fun updateSplitTransferState(
+        @PathVariable("id") id: IntId<Split>,
+        @RequestBody state: BulkTransferState,
+    ): ResponseEntity<Unit> = splitService.updateSplitState(id, state).let(::toResponse)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
@@ -26,5 +26,5 @@ class SplitController(val splitService: SplitService) {
     fun updateSplitTransferState(
         @PathVariable("id") id: IntId<Split>,
         @RequestBody state: BulkTransferState,
-    ): ResponseEntity<Unit> = splitService.updateSplitState(id, state).let(::toResponse)
+    ): IntId<Split> = splitService.updateSplitState(id, state)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -261,7 +261,6 @@ class SplitDao(
         }
     }
 
-    // TODO add proper tests once splits can be properly linked to publications
     fun fetchSplitIdByPublication(publicationId: IntId<Publication>): IntId<Split>? {
         val sql = """
             select id from publication.split where publication_id = :publication_id

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -11,10 +11,7 @@ import fi.fta.geoviite.infra.linking.SwitchLinkingService
 import fi.fta.geoviite.infra.linking.createSwitchLinkingParameters
 import fi.fta.geoviite.infra.linking.fixSegmentStarts
 import fi.fta.geoviite.infra.logging.serviceCall
-import fi.fta.geoviite.infra.publication.Publication
-import fi.fta.geoviite.infra.publication.PublishValidationError
-import fi.fta.geoviite.infra.publication.PublishValidationErrorType
-import fi.fta.geoviite.infra.publication.ValidationVersions
+import fi.fta.geoviite.infra.publication.*
 import fi.fta.geoviite.infra.tracklayout.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -127,11 +124,29 @@ class SplitService(
 
     fun getSplitHeaderByPublicationId(publicationId: IntId<Publication>): SplitHeader? {
         logger.serviceCall(
-            "getSplitByPublicationId",
+            "getSplitHeaderByPublicationId",
             "publicationId" to publicationId,
         )
 
         return splitDao.fetchSplitIdByPublication(publicationId)?.let(splitDao::getSplitHeader)
+    }
+
+    fun get(splitId: IntId<Split>): Split? {
+        logger.serviceCall(
+            "getOrThrow",
+            "splitId" to splitId,
+        )
+
+        return splitDao.get(splitId)
+    }
+
+    fun getOrThrow(splitId: IntId<Split>): Split {
+        logger.serviceCall(
+            "getOrThrow",
+            "splitId" to splitId,
+        )
+
+        return splitDao.getOrThrow(splitId)
     }
 
     private fun validateSplitForLocationTrack(
@@ -196,6 +211,17 @@ class SplitService(
                 "$VALIDATION_SPLIT.split-in-progress",
             )
         else null
+    }
+
+    fun updateSplitState(splitId: IntId<Split>, state: BulkTransferState) {
+        logger.serviceCall(
+            "updateSplitState",
+            "splitId" to splitId,
+        )
+
+        splitDao.getOrThrow(splitId).let { split ->
+            splitDao.updateSplitState(split.copy(bulkTransferState = state))
+        }
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -124,7 +124,7 @@ class SplitService(
 
     fun getSplitIdByPublicationId(publicationId: IntId<Publication>): IntId<Split>? {
         logger.serviceCall(
-            "getSplitHeaderByPublicationId",
+            "getSplitIdByPublicationId",
             "publicationId" to publicationId,
         )
 
@@ -133,7 +133,7 @@ class SplitService(
 
     fun get(splitId: IntId<Split>): Split? {
         logger.serviceCall(
-            "getOrThrow",
+            "get",
             "splitId" to splitId,
         )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -122,13 +122,13 @@ class SplitService(
         )
     }
 
-    fun getSplitHeaderByPublicationId(publicationId: IntId<Publication>): SplitHeader? {
+    fun getSplitIdByPublicationId(publicationId: IntId<Publication>): IntId<Split>? {
         logger.serviceCall(
             "getSplitHeaderByPublicationId",
             "publicationId" to publicationId,
         )
 
-        return splitDao.fetchSplitIdByPublication(publicationId)?.let(splitDao::getSplitHeader)
+        return splitDao.fetchSplitIdByPublication(publicationId)
     }
 
     fun get(splitId: IntId<Split>): Split? {
@@ -213,13 +213,13 @@ class SplitService(
         else null
     }
 
-    fun updateSplitState(splitId: IntId<Split>, state: BulkTransferState) {
+    fun updateSplitState(splitId: IntId<Split>, state: BulkTransferState): IntId<Split> {
         logger.serviceCall(
             "updateSplitState",
             "splitId" to splitId,
         )
 
-        splitDao.getOrThrow(splitId).let { split ->
+        return splitDao.getOrThrow(splitId).let { split ->
             splitDao.updateSplitState(split.copy(bulkTransferState = state))
         }
     }

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1375,8 +1375,24 @@
         "publication-status": "Raiteiden ja vaihteiden vienti",
         "bulk-transfer-status": "Kohteiden siirto jaetulta raiteelta",
         "actions": "Toiminnot",
-        "mark-as-successful": "Merkitse siirto onnistuneeksi",
-        "transfer-starts-shortly": "Vienti käynnistyy automaattisesti hetken kuluttua"
+        "show-split-info": "Näytä raiteen jakamisen tiedot",
+        "mark-as-successful": "Merkitse kohteiden siirto onnistuneeksi",
+        "transfer-starts-shortly": "Vienti käynnistyy automaattisesti hetken kuluttua",
+        "bulk-transfer-marked-as-successful": "Kohteiden siirto merkitty onnistuneeksi"
+    },
+    "split-details-dialog": {
+        "title": "Raiteen jakamisen tiedot",
+        "source-name": "Alkuperäisen raiteen tunnus",
+        "source-oid": "Alkuperäisen raiteen OID",
+        "download-csv": "Lataa CSV",
+        "targets": "Jakamisessa syntyneet/muokatut raiteet ({{trackCount}} kpl)",
+        "target-name": "Raiteen tunnus",
+        "target-oid": "Raiteen OID",
+        "operation": "Toimenpide",
+        "start-address": "Rataosoite alku",
+        "end-address": "Rataosoite loppu",
+        "newly-created": "Uusi kohde",
+        "replaces-duplicate": "Duplikaatti korvattu"
     },
     "error-in-ratko-connection": {
         "connection-error-status-code": "Ratkoon ei saada yhteyttä. Virhe Ratko-yhteydessä ({{code}}). ",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -290,7 +290,7 @@ class LinkingServiceIT @Autowired constructor(
             ),
         )
 
-        val split = splitDao.getSplit(
+        val split = splitDao.getOrThrow(
             splitDao.saveSplit(
                 locationTrackId,
                 listOf(SplitTargetSaveRequest(locationTrackId, 0..1))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -51,7 +51,7 @@ class SplitServiceIT @Autowired constructor(
             trackId,
             listOf(targetRequest(null, "part1"), targetRequest(switchId, "part2")),
         )
-        val result = splitDao.getSplit(splitService.split(request))
+        val result = splitDao.getOrThrow(splitService.split(request))
 
         // Verify split result data
         assertEquals(trackId, result.locationTrackId)
@@ -87,7 +87,7 @@ class SplitServiceIT @Autowired constructor(
     @Test
     fun `should find splits by source location track`() {
         val splitId = insertSplitWithTwoTracks()
-        val split = splitDao.getSplit(splitId)
+        val split = splitDao.getOrThrow(splitId)
 
         val foundSplits = splitService.findUnfinishedSplits(listOf(split.locationTrackId))
 
@@ -97,7 +97,7 @@ class SplitServiceIT @Autowired constructor(
     @Test
     fun `should find splits by target location track`() {
         val splitId = insertSplitWithTwoTracks()
-        val split = splitDao.getSplit(splitId)
+        val split = splitDao.getOrThrow(splitId)
 
         val foundSplits = splitService.findUnfinishedSplits(listOf(split.targetLocationTracks.first().locationTrackId))
 

--- a/ui/src/geoviite-design-lib/dialog/dialog.scss
+++ b/ui/src/geoviite-design-lib/dialog/dialog.scss
@@ -42,6 +42,11 @@ $dialog-padding: $dialog-padding-vertical $dialog-padding-horizontal;
         max-width: 780px;
     }
 
+    &--three-columns {
+        min-width: 1040px;
+        max-width: 1040px;
+    }
+
     &--dark {
         background: colors.$color-blue-darker;
         color: colors.$color-white-default;

--- a/ui/src/geoviite-design-lib/dialog/dialog.tsx
+++ b/ui/src/geoviite-design-lib/dialog/dialog.tsx
@@ -12,6 +12,7 @@ export enum DialogVariant {
 export enum DialogWidth {
     NORMAL = 'dialog__popup--normal',
     TWO_COLUMNS = 'dialog__popup--two-columns',
+    THREE_COLUMNS = 'dialog__popup--three-columns',
 }
 
 export type DialogProps = {

--- a/ui/src/map/layers/alignment/location-track-split-badge-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-badge-layer.ts
@@ -52,7 +52,7 @@ const calculateSplitBounds = (
         {
             start: originalStartAndEnd.start?.point.m || 0,
             end: splitsSorted[0]?.distance || originalStartAndEnd.end?.point?.m || 0,
-            name: splittingState.initialSplit.name,
+            name: splittingState.firstSplit.name,
         },
         ...splitsSorted.map((split, index) => ({
             start: split.distance,

--- a/ui/src/map/layers/alignment/location-track-split-location-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-location-layer.ts
@@ -51,7 +51,7 @@ export const createLocationTrackSplitLocationLayer = (
             if (layerId !== newestLayerId) return;
 
             const firstAndLast: SwitchIdAndLocation[] = [
-                { location: splittingState.initialSplit.location, switchId: undefined },
+                { location: splittingState.firstSplit.location, switchId: undefined },
                 { location: splittingState.endLocation, switchId: undefined },
             ];
             const splits: SwitchIdAndLocation[] = splittingState.splits.map((split) => ({

--- a/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
@@ -59,7 +59,7 @@ export function createDuplicateSplitSectionHighlightLayer(
         inFlight = true;
         const linkedDuplicates = splittingState.splits
             .map((split) => split.duplicateOf)
-            .concat(splittingState.initialSplit.duplicateOf);
+            .concat(splittingState.firstSplit.duplicateOf);
         getLocationTrackInfoboxExtras(splittingState.originLocationTrack.id, publishType)
             .then((extras) => {
                 getMapAlignmentsByTiles(changeTimes, mapTiles, publishType).then((alignments) => {

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -74,19 +74,18 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
 }) => {
     const { t } = useTranslation();
 
-    const [open, setOpen] = React.useState(false);
-    const [dialogOpen, setDialogOpen] = React.useState(false);
+    const [menuOpen, setMenuOpen] = React.useState(false);
+    const [splitDetailsDialogOpen, setSplitDetailsDialogOpen] = React.useState(false);
     const buttonClassNames = createClassName(
-        styles['publication-list-item__split-action-button'],
-        open && styles['publication-list-item__split-action-button--open'],
+        menuOpen && styles['publication-list-item__split-action-button--open'],
     );
     const menuRef = React.createRef<HTMLDivElement>();
 
     const actions = [
         {
             onSelect: () => {
-                setOpen(false);
-                setDialogOpen(true);
+                setMenuOpen(false);
+                setSplitDetailsDialogOpen(true);
             },
             qaId: 'show-split-info-link',
             name: t('publication-card.show-split-info'),
@@ -97,7 +96,7 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                     putBulkTransferState(publication.split.id, 'DONE').then(() => {
                         success(t('publication-card.bulk-transfer-marked-as-successful'));
                     });
-                setOpen(false);
+                setMenuOpen(false);
             },
             qaId: 'mark-bulk-transfer-as-finished-link',
             name: t('publication-card.mark-as-successful'),
@@ -142,20 +141,20 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                             <span>{t('publication-card.bulk-transfer-status')}</span>
                         </div>
                     </div>
-                    <div>
+                    <div className={styles['publication-list-item__split-action-button-container']}>
                         <Button
                             className={buttonClassNames}
                             size={ButtonSize.SMALL}
                             variant={ButtonVariant.SECONDARY}
-                            onClick={() => setOpen(!open)}
+                            onClick={() => setMenuOpen(!menuOpen)}
                             icon={Icons.Down}>
                             {t('publication-card.actions')}
                         </Button>
-                        {open && (
+                        {menuOpen && (
                             <div ref={menuRef}>
                                 <Menu
                                     positionRef={menuRef}
-                                    onClickOutside={() => setOpen(true)}
+                                    onClickOutside={() => setMenuOpen(true)}
                                     items={actions}
                                 />
                             </div>
@@ -163,10 +162,10 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                     </div>
                 </div>
             )}
-            {dialogOpen && (
+            {splitDetailsDialogOpen && (
                 <SplitDetailsDialog
                     publicationId={publication.id}
-                    onClose={() => setDialogOpen(false)}
+                    onClose={() => setSplitDetailsDialogOpen(false)}
                 />
             )}
         </div>

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { BulkTransferState, PublicationDetails } from 'publication/publication-model';
-import { ratkoPushFailed, ratkoPushInProgress } from 'ratko/ratko-model';
+import { ratkoPushFailed, ratkoPushInProgress, ratkoPushSucceeded } from 'ratko/ratko-model';
 import styles from 'publication/card/publication-list.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { Spinner, SpinnerSize } from 'vayla-design-lib/spinner/spinner';
@@ -10,8 +10,11 @@ import { createClassName } from 'vayla-design-lib/utils';
 import { Link } from 'vayla-design-lib/link/link';
 import { formatDateFull } from 'utils/date-utils';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
-import RatkoPublishButton from 'ratko/ratko-publish-button';
 import { AppNavigateFunction } from 'common/navigate';
+import { Menu } from 'vayla-design-lib/menu/menu';
+import { SplitDetailsDialog } from 'publication/split/split-details-dialog';
+import { putBulkTransferState } from 'publication/split/split-api';
+import { success } from 'geoviite-design-lib/snackbar/snackbar';
 
 type PublicationListRowProps = {
     publication: PublicationDetails;
@@ -20,7 +23,13 @@ type PublicationListRowProps = {
 };
 
 const publicationStateIcon: React.FC<PublicationDetails> = (publication) => {
-    if (ratkoPushFailed(publication.ratkoPushStatus)) {
+    if (ratkoPushSucceeded(publication.ratkoPushStatus)) {
+        return (
+            <span className={styles['publication-list-item--success']}>
+                <Icons.Tick size={IconSize.SMALL} color={IconColor.INHERIT} />
+            </span>
+        );
+    } else if (ratkoPushFailed(publication.ratkoPushStatus)) {
         return (
             <span className={styles['publication-list-item--error']}>
                 <Icons.StatusError size={IconSize.SMALL} color={IconColor.INHERIT} />
@@ -35,10 +44,15 @@ const publicationStateIcon: React.FC<PublicationDetails> = (publication) => {
 
 const bulkTransferStateIcon = (bulkTransferState: BulkTransferState | undefined) => {
     switch (bulkTransferState) {
-        case 'DONE':
         case 'PENDING':
         case undefined:
             return <span className={styles['publication-list-item__split-detail-no-icon']} />;
+        case 'DONE':
+            return (
+                <span className={styles['publication-list-item--success']}>
+                    <Icons.Tick size={IconSize.SMALL} color={IconColor.INHERIT} />
+                </span>
+            );
         case 'FAILED':
         case 'TEMPORARY_FAILURE':
             return (
@@ -61,10 +75,35 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
     const { t } = useTranslation();
 
     const [open, setOpen] = React.useState(false);
+    const [dialogOpen, setDialogOpen] = React.useState(false);
     const buttonClassNames = createClassName(
         styles['publication-list-item__split-action-button'],
         open && styles['publication-list-item__split-action-button--open'],
     );
+    const menuRef = React.createRef<HTMLDivElement>();
+
+    const actions = [
+        {
+            onSelect: () => {
+                setOpen(false);
+                setDialogOpen(true);
+            },
+            qaId: 'show-split-info-link',
+            name: t('publication-card.show-split-info'),
+        },
+        {
+            onSelect: () => {
+                if (publication.split)
+                    putBulkTransferState(publication.split.id, 'DONE').then(() => {
+                        success(t('publication-card.bulk-transfer-marked-as-successful'));
+                    });
+                setOpen(false);
+            },
+            qaId: 'mark-bulk-transfer-as-finished-link',
+            name: t('publication-card.mark-as-successful'),
+        },
+    ];
+
     return (
         <div className={styles['publication-list-item-container']}>
             <div className={styles['publication-list-item']}>
@@ -98,28 +137,37 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                         </div>
                         <div className={styles['publication-list-item__split-detail-row']}>
                             <span>
-                                {bulkTransferStateIcon(publication.split.bulkTransferState)}
+                                {bulkTransferStateIcon(publication.split?.bulkTransferState)}
                             </span>
                             <span>{t('publication-card.bulk-transfer-status')}</span>
                         </div>
                     </div>
-                    <Button
-                        className={buttonClassNames}
-                        size={ButtonSize.SMALL}
-                        variant={ButtonVariant.SECONDARY}
-                        onClick={() => setOpen(!open)}
-                        icon={Icons.Down}>
-                        {t('publication-card.actions')}
-                    </Button>
+                    <div>
+                        <Button
+                            className={buttonClassNames}
+                            size={ButtonSize.SMALL}
+                            variant={ButtonVariant.SECONDARY}
+                            onClick={() => setOpen(!open)}
+                            icon={Icons.Down}>
+                            {t('publication-card.actions')}
+                        </Button>
+                        {open && (
+                            <div ref={menuRef}>
+                                <Menu
+                                    positionRef={menuRef}
+                                    onClickOutside={() => setOpen(true)}
+                                    items={actions}
+                                />
+                            </div>
+                        )}
+                    </div>
                 </div>
             )}
-            {open && (
-                <div className={styles['publication-list-item__split-actions']}>
-                    <RatkoPublishButton />
-                    <Button variant={ButtonVariant.SECONDARY}>
-                        {t('publication-card.mark-as-successful')}
-                    </Button>
-                </div>
+            {dialogOpen && (
+                <SplitDetailsDialog
+                    publicationId={publication.id}
+                    onClose={() => setDialogOpen(false)}
+                />
             )}
         </div>
     );

--- a/ui/src/publication/card/publication-list.scss
+++ b/ui/src/publication/card/publication-list.scss
@@ -77,6 +77,10 @@
         fill: vayla-design.$color-red-default;
     }
 
+    &--success {
+        fill: vayla-design.$color-green-dark;
+    }
+
     &__split-action-button {
         margin-left: 18px;
         margin-bottom: 22px;

--- a/ui/src/publication/card/publication-list.scss
+++ b/ui/src/publication/card/publication-list.scss
@@ -81,14 +81,14 @@
         fill: vayla-design.$color-green-dark;
     }
 
-    &__split-action-button {
+    &__split-action-button-container {
         margin-left: 18px;
         margin-bottom: 22px;
+    }
 
-        &--open {
-            .icon {
-                transform: rotate(180deg);
-            }
+    &__split-action-button--open {
+        .icon {
+            transform: rotate(180deg);
         }
     }
 

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -15,6 +15,7 @@ import {
     PublishRequest,
     PublishRequestIds,
     PublishResult,
+    SplitInPublication,
     ValidatedPublishCandidates,
 } from 'publication/publication-model';
 import i18next from 'i18next';
@@ -107,3 +108,8 @@ export const getRevertRequestDependencies = (request: PublishRequestIds) =>
         `${PUBLICATION_URL}/candidates/revert-request-dependencies`,
         request,
     );
+
+export const getSplitDetails = (id: string) =>
+    getNonNull<SplitInPublication>(`${PUBLICATION_URL}/${id}/split-details`);
+
+export const splitDetailsCsvUri = (id: string) => `${PUBLICATION_URL}/${id}/split-details/csv`;

--- a/ui/src/publication/publication-details-container.tsx
+++ b/ui/src/publication/publication-details-container.tsx
@@ -1,6 +1,6 @@
 import PublicationDetailsView from 'publication/publication';
 import { useCommonDataAppSelector } from 'store/hooks';
-import { useLoaderWithStatus } from 'utils/react-utils';
+import { useLoader } from 'utils/react-utils';
 import { getPublication } from 'publication/publication-api';
 import { useParams } from 'react-router-dom';
 import { PublicationId } from 'preview/preview-table';
@@ -19,7 +19,7 @@ export const PublicationDetailsContainer: React.FC = () => {
         (state) => state.changeTimes.publication,
     );
 
-    const [publication, _publicationFetchStatus] = useLoaderWithStatus(
+    const publication = useLoader(
         () => (selectedPublicationId ? getPublication(selectedPublicationId) : undefined),
         [selectedPublicationId, publicationChangeTime],
     );

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -11,6 +11,7 @@ import {
 } from 'common/common-model';
 import {
     LayoutKmPostId,
+    LayoutLocationTrack,
     LayoutSwitchId,
     LayoutTrackNumberId,
     LocationTrackId,
@@ -116,6 +117,15 @@ export type PublishedSplitHeader = {
     locationTrackId: LocationTrackId;
     bulkTransferState: BulkTransferState;
     publicationId?: PublicationId;
+};
+
+export type SplitTarget = {
+    locationTrackId: LocationTrackId;
+};
+
+export type Split = PublishedSplitHeader & {
+    targetLocationTracks: SplitTarget[];
+    relinkedSwitches: LayoutSwitchId[];
 };
 
 export type PublicationDetails = {
@@ -294,4 +304,20 @@ export type PublicationTableItem = {
 export type PublicationSearch = {
     startDate: TimeStamp | undefined;
     endDate: TimeStamp | undefined;
+};
+
+export type SplitInPublication = {
+    id: PublicationId;
+    splitId: string;
+    locationTrack: LayoutLocationTrack;
+    targetLocationTracks: SplitTargetInPublication[];
+};
+
+export type SplitTargetInPublication = {
+    id: LocationTrackId;
+    name: string;
+    oid: Oid;
+    startAddress: TrackMeter;
+    endAddress: TrackMeter;
+    newlyCreated: boolean;
 };

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -112,7 +112,7 @@ export type ValidatedPublishCandidates = {
 
 export type BulkTransferState = 'PENDING' | 'IN_PROGRESS' | 'DONE' | 'FAILED' | 'TEMPORARY_FAILURE';
 
-export type PublishedSplitHeader = {
+export type SplitHeader = {
     id: string;
     locationTrackId: LocationTrackId;
     bulkTransferState: BulkTransferState;
@@ -123,7 +123,7 @@ export type SplitTarget = {
     locationTrackId: LocationTrackId;
 };
 
-export type Split = PublishedSplitHeader & {
+export type Split = SplitHeader & {
     targetLocationTracks: SplitTarget[];
     relinkedSwitches: LayoutSwitchId[];
 };
@@ -141,7 +141,7 @@ export type PublicationDetails = {
     ratkoPushTime?: TimeStamp;
     calculatedChanges: PublishedCalculatedChanges;
     message?: string;
-    split?: PublishedSplitHeader;
+    split?: SplitHeader;
 };
 
 export type PublishedTrackNumber = {

--- a/ui/src/publication/split/split-api.ts
+++ b/ui/src/publication/split/split-api.ts
@@ -1,0 +1,16 @@
+import { SplitRequest } from 'tool-panel/location-track/split-store';
+import { API_URI, getNullable, postNonNull, putNullable } from 'api/api-fetch';
+import { Split } from 'publication/publication-model';
+
+const SPLIT_URI = `${API_URI}/location-track-split`;
+
+export const postSplitLocationTrack = async (request: SplitRequest): Promise<string> => {
+    return postNonNull<SplitRequest, string>(SPLIT_URI, request);
+};
+
+export const getSplit = async (id: string): Promise<Split | undefined> =>
+    getNullable<Split>(`${SPLIT_URI}/${id}`);
+
+export const putBulkTransferState = async (id: string, state: string): Promise<void> => {
+    await putNullable<string, void>(`${SPLIT_URI}/${id}/bulk-transfer-state`, state);
+};

--- a/ui/src/publication/split/split-api.ts
+++ b/ui/src/publication/split/split-api.ts
@@ -1,5 +1,5 @@
 import { SplitRequest } from 'tool-panel/location-track/split-store';
-import { API_URI, getNullable, postNonNull, putNullable } from 'api/api-fetch';
+import { API_URI, getNullable, postNonNull, putNonNull } from 'api/api-fetch';
 import { Split } from 'publication/publication-model';
 
 const SPLIT_URI = `${API_URI}/location-track-split`;
@@ -11,6 +11,6 @@ export const postSplitLocationTrack = async (request: SplitRequest): Promise<str
 export const getSplit = async (id: string): Promise<Split | undefined> =>
     getNullable<Split>(`${SPLIT_URI}/${id}`);
 
-export const putBulkTransferState = async (id: string, state: string): Promise<void> => {
-    await putNullable<string, void>(`${SPLIT_URI}/${id}/bulk-transfer-state`, state);
+export const putBulkTransferState = async (id: string, state: string): Promise<string> => {
+    return putNonNull<string, string>(`${SPLIT_URI}/${id}/bulk-transfer-state`, state);
 };

--- a/ui/src/publication/split/split-details-dialog.tsx
+++ b/ui/src/publication/split/split-details-dialog.tsx
@@ -40,7 +40,7 @@ export const SplitDetailsDialog: React.FC<SplitDetailsViewProps> = ({ publicatio
                         </Button>
                     </a>
                     <Button variant={ButtonVariant.PRIMARY} onClick={onClose}>
-                        Sulje
+                        {t('button.close')}
                     </Button>
                 </div>
             }

--- a/ui/src/publication/split/split-details-dialog.tsx
+++ b/ui/src/publication/split/split-details-dialog.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
+import { Dialog, DialogWidth } from 'geoviite-design-lib/dialog/dialog';
+import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
+import { Table, Th } from 'vayla-design-lib/table/table';
+import { getSplitDetails, splitDetailsCsvUri } from 'publication/publication-api';
+import { formatTrackMeter } from 'utils/geography-utils';
+import { PublicationId } from 'preview/preview-table';
+import {
+    ProgressIndicatorType,
+    ProgressIndicatorWrapper,
+} from 'vayla-design-lib/progress/progress-indicator-wrapper';
+import styles from './split-details-dialog.scss';
+import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+
+export type SplitDetailsViewProps = {
+    publicationId: PublicationId;
+    onClose: () => void;
+};
+
+export const SplitDetailsDialog: React.FC<SplitDetailsViewProps> = ({ publicationId, onClose }) => {
+    const { t } = useTranslation();
+    const [splitDetails, splitDetailsStatus] = useLoaderWithStatus(
+        () => getSplitDetails(publicationId),
+        [publicationId],
+    );
+
+    return (
+        <Dialog
+            width={DialogWidth.THREE_COLUMNS}
+            onClose={onClose}
+            footerContent={
+                <div className={dialogStyles['dialog__footer-content--centered']}>
+                    <a href={splitDetailsCsvUri(publicationId)}>
+                        <Button variant={ButtonVariant.SECONDARY} icon={Icons.Download}>
+                            {t(`split-details-dialog.download-csv`)}
+                        </Button>
+                    </a>
+                    <Button variant={ButtonVariant.PRIMARY} onClick={onClose}>
+                        Sulje
+                    </Button>
+                </div>
+            }
+            title={t('split-details-dialog.title')}>
+            <ProgressIndicatorWrapper
+                inline={false}
+                indicator={ProgressIndicatorType.Area}
+                inProgress={splitDetailsStatus !== LoaderStatus.Ready}>
+                <div>
+                    <FieldLayout label={t('split-details-dialog.source-name')}>
+                        <div>{splitDetails?.locationTrack?.name}</div>
+                    </FieldLayout>
+                    <FieldLayout label={t('split-details-dialog.source-oid')}>
+                        <div>{splitDetails?.locationTrack?.externalId}</div>
+                    </FieldLayout>
+                    <FieldLayout
+                        label={t('split-details-dialog.targets', {
+                            trackCount: splitDetails?.targetLocationTracks?.length,
+                        })}>
+                        <div className={styles['split-details-dialog__table']}>
+                            <Table wide>
+                                <thead className={styles['split-details-dialog__table-header']}>
+                                    <tr>
+                                        <Th>{t('split-details-dialog.target-name')}</Th>
+                                        <Th>{t('split-details-dialog.target-oid')}</Th>
+                                        <Th>{t('split-details-dialog.operation')}</Th>
+                                        <Th>{t('split-details-dialog.start-address')}</Th>
+                                        <Th>{t('split-details-dialog.end-address')}</Th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {splitDetails?.targetLocationTracks.map((target) => {
+                                        return (
+                                            <tr key={target.id}>
+                                                <td>{target.name}</td>
+                                                <td>{target.oid}</td>
+                                                <td>
+                                                    {target.newlyCreated
+                                                        ? t('split-details-dialog.newly-created')
+                                                        : t(
+                                                              'split-details-dialog.replaces-duplicate',
+                                                          )}
+                                                </td>
+                                                <td>
+                                                    {target.startAddress
+                                                        ? formatTrackMeter(target.startAddress)
+                                                        : undefined}
+                                                </td>
+                                                <td>
+                                                    {target.endAddress
+                                                        ? formatTrackMeter(target.endAddress)
+                                                        : undefined}
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </Table>
+                        </div>
+                    </FieldLayout>
+                </div>
+            </ProgressIndicatorWrapper>
+        </Dialog>
+    );
+};

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -350,7 +350,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     <LocationTrackSplittingInfoboxContainer
                         visibilities={visibilities}
                         visibilityChange={visibilityChange}
-                        initialSplit={splittingState.initialSplit}
+                        firstSplit={splittingState.firstSplit}
                         splits={splittingState.splits || []}
                         locationTrackId={splittingState.originLocationTrack.id}
                         locationTrackChangeTime={locationTrackChangeTime}

--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -24,7 +24,7 @@ type SplitTargetCandidateBase = {
 };
 
 export type FirstSplitTargetCandidate = SplitTargetCandidateBase & {
-    type: 'INITIAL_SPLIT';
+    type: 'FIRST_SPLIT';
 };
 
 export type SplitTargetCandidate = SplitTargetCandidateBase & {
@@ -40,7 +40,7 @@ export type SplittingState = {
     allowedSwitches: SwitchOnLocationTrack[];
     startAndEndSwitches: LayoutSwitchId[];
     duplicateTracks: SplitDuplicate[];
-    initialSplit: FirstSplitTargetCandidate;
+    firstSplit: FirstSplitTargetCandidate;
     splits: SplitTargetCandidate[];
     disabled: boolean;
 };
@@ -106,8 +106,8 @@ export const splitReducers = {
             splits: [],
             endLocation: payload.endLocation,
             disabled: payload.locationTrack.draftType !== 'OFFICIAL',
-            initialSplit: {
-                type: 'INITIAL_SPLIT',
+            firstSplit: {
+                type: 'FIRST_SPLIT',
                 name:
                     duplicateTrackClosestToStart &&
                     duplicateTrackClosestToStart.distance <= DUPLICATE_MAX_DISTANCE
@@ -179,8 +179,8 @@ export const splitReducers = {
                     split.switchId === payload ? { ...split, new: false } : split,
                 );
             } else {
-                state.splittingState.initialSplit = {
-                    ...state.splittingState.initialSplit,
+                state.splittingState.firstSplit = {
+                    ...state.splittingState.firstSplit,
                     new: false,
                 };
             }
@@ -203,7 +203,7 @@ export const splitReducers = {
                     .filter((split) => split.switchId !== payload.switchId)
                     .concat([payload]);
             } else {
-                state.splittingState.initialSplit = payload;
+                state.splittingState.firstSplit = payload;
             }
         }
     },

--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -14,7 +14,7 @@ import { getPlanarDistanceUnwrapped } from 'map/layers/utils/layer-utils';
 
 const DUPLICATE_MAX_DISTANCE = 1.0;
 
-type SplitBase = {
+type SplitTargetCandidateBase = {
     name: string;
     descriptionBase: string;
     suffixMode: LocationTrackDescriptionSuffixMode;
@@ -23,11 +23,11 @@ type SplitBase = {
     new: boolean;
 };
 
-export type InitialSplit = SplitBase & {
+export type FirstSplitTargetCandidate = SplitTargetCandidateBase & {
     type: 'INITIAL_SPLIT';
 };
 
-export type Split = SplitBase & {
+export type SplitTargetCandidate = SplitTargetCandidateBase & {
     type: 'SPLIT';
     switchId: LayoutSwitchId;
     distance: number;
@@ -40,8 +40,8 @@ export type SplittingState = {
     allowedSwitches: SwitchOnLocationTrack[];
     startAndEndSwitches: LayoutSwitchId[];
     duplicateTracks: SplitDuplicate[];
-    initialSplit: InitialSplit;
-    splits: Split[];
+    initialSplit: FirstSplitTargetCandidate;
+    splits: SplitTargetCandidate[];
     disabled: boolean;
 };
 
@@ -74,7 +74,7 @@ export type SplitRequestTarget = {
     descriptionSuffix: LocationTrackDescriptionSuffixMode;
 };
 
-export const sortSplitsByDistance = (splits: Split[]) =>
+export const sortSplitsByDistance = (splits: SplitTargetCandidate[]) =>
     [...splits].sort((a, b) => a.distance - b.distance);
 
 const findClosestDuplicate = (duplicates: SplitDuplicate[], otherPoint: Point) =>
@@ -195,7 +195,7 @@ export const splitReducers = {
     },
     updateSplit: (
         state: TrackLayoutState,
-        { payload }: PayloadAction<Split | InitialSplit>,
+        { payload }: PayloadAction<SplitTargetCandidate | FirstSplitTargetCandidate>,
     ): void => {
         if (state.splittingState) {
             if (payload.type === 'SPLIT') {

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -15,7 +15,10 @@ import {
     LocationTrackDuplicate,
     LocationTrackId,
 } from 'track-layout/track-layout-model';
-import { InitialSplit, Split } from 'tool-panel/location-track/split-store';
+import {
+    FirstSplitTargetCandidate,
+    SplitTargetCandidate,
+} from 'tool-panel/location-track/split-store';
 import { MAP_POINT_NEAR_BBOX_OFFSET } from 'map/map-utils';
 import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
 
@@ -25,13 +28,13 @@ type EndpointProps = {
 };
 
 type SplitProps = EndpointProps & {
-    split: Split | InitialSplit;
+    split: SplitTargetCandidate | FirstSplitTargetCandidate;
     onRemove?: (switchId: LayoutSwitchId) => void;
-    updateSplit: (updateSplit: Split | InitialSplit) => void;
+    updateSplit: (updateSplit: SplitTargetCandidate | FirstSplitTargetCandidate) => void;
     duplicateOf: LocationTrackId | undefined;
-    nameErrors: ValidationError<Split>[];
-    descriptionErrors: ValidationError<Split>[];
-    switchErrors: ValidationError<Split>[];
+    nameErrors: ValidationError<SplitTargetCandidate>[];
+    descriptionErrors: ValidationError<SplitTargetCandidate>[];
+    switchErrors: ValidationError<SplitTargetCandidate>[];
     nameRef: React.RefObject<HTMLInputElement>;
     descriptionBaseRef: React.RefObject<HTMLInputElement>;
     deletingDisabled: boolean;

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -51,7 +51,7 @@ import { postSplitLocationTrack } from 'publication/split/split-api';
 type LocationTrackSplittingInfoboxContainerProps = {
     visibilities: LocationTrackInfoboxVisibilities;
     visibilityChange: (key: keyof LocationTrackInfoboxVisibilities) => void;
-    initialSplit: FirstSplitTargetCandidate;
+    firstSplit: FirstSplitTargetCandidate;
     splits: SplitTargetCandidate[];
     allowedSwitches: SwitchOnLocationTrack[];
     switchChangeTime: TimeStamp;
@@ -71,7 +71,7 @@ type LocationTrackSplittingInfoboxContainerProps = {
 type LocationTrackSplittingInfoboxProps = {
     visibilities: LocationTrackInfoboxVisibilities;
     visibilityChange: (key: keyof LocationTrackInfoboxVisibilities) => void;
-    initialSplit: FirstSplitTargetCandidate;
+    firstSplit: FirstSplitTargetCandidate;
     splits: SplitTargetCandidate[];
     allowedSwitches: SwitchOnLocationTrack[];
     switches: LayoutSwitch[];
@@ -165,7 +165,7 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
 > = ({
     locationTrackId,
     locationTrackChangeTime,
-    initialSplit,
+    firstSplit,
     splits,
     visibilities,
     visibilityChange,
@@ -189,8 +189,8 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
     );
     const conflictingTracks = useConflictingTracks(
         locationTrack?.trackNumberId,
-        [initialSplit, ...splits].map((s) => s.name),
-        [initialSplit, ...splits].map((s) => s.duplicateOf).filter(filterNotEmpty),
+        [firstSplit, ...splits].map((s) => s.name),
+        [firstSplit, ...splits].map((s) => s.duplicateOf).filter(filterNotEmpty),
         'DRAFT',
     );
     const allowedSwitchIds = React.useMemo(
@@ -209,7 +209,7 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
             <LocationTrackSplittingInfobox
                 visibilities={visibilities}
                 visibilityChange={visibilityChange}
-                initialSplit={initialSplit}
+                firstSplit={firstSplit}
                 splits={splits}
                 allowedSwitches={allowedSwitches}
                 switches={switches}
@@ -283,12 +283,12 @@ const getSplitAddressPoint = (
 
 const splitRequest = (
     sourceTrackId: LocationTrackId,
-    initialSplit: FirstSplitTargetCandidate,
+    firstSplit: FirstSplitTargetCandidate,
     splits: SplitTargetCandidate[],
     allDuplicates: LayoutLocationTrack[],
 ): SplitRequest => ({
     sourceTrackId,
-    targetTracks: [initialSplit, ...splits].map((s) => {
+    targetTracks: [firstSplit, ...splits].map((s) => {
         const dupe = s.duplicateOf ? findById(allDuplicates, s.duplicateOf) : undefined;
         return splitToRequestTarget(s, dupe);
     }),
@@ -308,7 +308,7 @@ const splitToRequestTarget = (
 export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfoboxProps> = ({
     visibilities,
     visibilityChange,
-    initialSplit,
+    firstSplit,
     splits,
     allowedSwitches,
     switches,
@@ -328,14 +328,14 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
     const [confirmExit, setConfirmExit] = React.useState(false);
 
     const sortedSplits = sortSplitsByDistance(splits);
-    const allSplitNames = [initialSplit, ...splits].map((s) => s.name);
+    const allSplitNames = [firstSplit, ...splits].map((s) => s.name);
 
-    const initialSplitValidated = {
-        split: initialSplit,
-        nameErrors: validateSplitName(initialSplit.name, allSplitNames, conflictingLocationTracks),
+    const firstSplitValidated = {
+        split: firstSplit,
+        nameErrors: validateSplitName(firstSplit.name, allSplitNames, conflictingLocationTracks),
         descriptionErrors: validateSplitDescription(
-            initialSplit.descriptionBase,
-            initialSplit.duplicateOf,
+            firstSplit.descriptionBase,
+            firstSplit.duplicateOf,
         ),
         switchErrors: [],
     };
@@ -345,7 +345,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
         descriptionErrors: validateSplitDescription(s.descriptionBase, s.duplicateOf),
         switchErrors: validateSplitSwitch(s, switches),
     }));
-    const allValidated = [initialSplitValidated, ...splitsValidated];
+    const allValidated = [firstSplitValidated, ...splitsValidated];
     const duplicateTracksInCurrentSplits = useLocationTracks(
         allValidated.map((s) => s.split.duplicateOf).filter(filterNotEmpty),
         'DRAFT',
@@ -420,7 +420,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
         postSplitLocationTrack(
             splitRequest(
                 locationTrack.id,
-                initialSplit,
+                firstSplit,
                 sortSplitsByDistance(splits),
                 duplicateTracksInCurrentSplits,
             ),

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -10,11 +10,9 @@ import {
 } from 'track-layout/track-layout-model';
 import { DraftableChangeInfo, PublishType, TimeStamp, TrackMeter } from 'common/common-model';
 import {
-    API_URI,
     deleteNonNullAdt,
     getNonNull,
     getNullable,
-    postNonNull,
     postNonNullAdt,
     putNonNullAdt,
     queryParams,
@@ -32,7 +30,7 @@ import { ValidatedAsset } from 'publication/publication-model';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import i18next from 'i18next';
 import { getMaxTimestamp } from 'utils/date-utils';
-import { SplitRequest, SwitchOnLocationTrack } from 'tool-panel/location-track/split-store';
+import { SwitchOnLocationTrack } from 'tool-panel/location-track/split-store';
 
 const locationTrackCache = asyncCache<string, LayoutLocationTrack | undefined>();
 const locationTrackInfoboxExtrasCache = asyncCache<
@@ -299,7 +297,3 @@ export async function getLocationTrackValidation(
         `${layoutUri('location-tracks', publishType, id)}/validation`,
     );
 }
-
-export const postSplitLocationTrack = async (request: SplitRequest): Promise<string> => {
-    return postNonNull<SplitRequest, string>(`${API_URI}/location-track-split`, request);
-};


### PR DESCRIPTION
Pahoittelut taas todella massiivisesta reviewistä 🙈 Täällä tehtyä:
* Muutettu etusivun splittijulkaisujen toiminnot menuksi
* Luotu dialogi, johon splittausjulkaisun detaljit saa näkymään ja josta ne saa ladattua CSV:nä
* Luotu bäkkäripuolelle endpointit edellämainittujen kyselemiseen
* Luotu myös endpointti julkaisun massasiirron merkkaamiseen valmiiksi
* Yhtenäistetty tyypityksiä frontin ja bäkkärin välillä
* Yleistä refaktorointia ja satunnaisia bugikorjauksia, esim. lisätty ikoni DONE-tilaisille splittijulkaisuille