### PR TITLE
GVT-2428 Optimize switch duplicate-name validation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -220,6 +220,7 @@ data class ValidationVersions(
 ) {
     fun containsLocationTrack(id: IntId<LocationTrack>) = locationTracks.any { it.officialId == id }
     fun containsKmPost(id: IntId<TrackLayoutKmPost>) = kmPosts.any { it.officialId == id }
+    fun containsSwitch(id: IntId<TrackLayoutSwitch>) = switches.any { it.officialId == id }
 
     fun findTrackNumber(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.find { it.officialId == id }
     fun findLocationTrack(id: IntId<LocationTrack>) = locationTracks.find { it.officialId == id }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -661,7 +661,8 @@ class PublicationService @Autowired constructor(
     private fun validateSwitchNameDuplication(
         switch: TrackLayoutSwitch,
         versions: ValidationVersions,
-        allOfficialSwitches: List<TrackLayoutSwitch> = switchService.list(OFFICIAL),
+//        allOfficialSwitches: List<TrackLayoutSwitch> = switchService.list(OFFICIAL),
+        officialNameDuplicates: Map<SwitchName, List<RowVersion<TrackLayoutSwitch>>>,
     ): List<PublishValidationError> {
         val drafts = versions.switches.map { it.officialId to switchDao.fetch(it.validatedAssetVersion) }
         val officials = allOfficialSwitches.filterNot { official ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -197,6 +197,7 @@ class PublicationService @Autowired constructor(
         val validationVersions = toValidationVersions(
             switches = switches, locationTracks = (locationTracks + previouslyLinkedTracks).map(locationTrackDao::fetch)
         )
+        val nameDuplicates = collectPotentialSwitchNameDuplicates(validationVersions)
 
         val linkedTracks = publicationDao
             .fetchLinkedLocationTracks(switchIds, if (publishType == DRAFT) null else listOf())
@@ -207,7 +208,7 @@ class PublicationService @Autowired constructor(
                     version = toValidationVersion(switch),
                     validationVersions = validationVersions,
                     linkedTracks = linkedTracks.getOrDefault(switch.id, setOf()),
-                    nameDuplicates = collectPotentialSwitchNameDuplicates(validationVersions),
+                    nameDuplicates = nameDuplicates,
                 ),
                 switch.id as IntId,
             )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -123,6 +123,28 @@ fun validateSwitchLocation(switch: TrackLayoutSwitch): List<PublishValidationErr
         "$VALIDATION_SWITCH.no-location"
     })
 
+fun validateSwitchNameDuplication(
+    switch: TrackLayoutSwitch,
+    draftsBySameName: List<TrackLayoutSwitch>,
+    officialsBySameName: List<TrackLayoutSwitch>,
+): List<PublishValidationError> {
+    return if (switch.exists) {
+        val officialDuplicateExists = officialsBySameName.any { official -> official.id != switch.id }
+        val stagedDuplicateExists = draftsBySameName.any { draft -> draft.id != switch.id }
+
+        listOfNotNull(
+            validateWithParams(stagedDuplicateExists || !officialDuplicateExists) {
+                "$VALIDATION_SWITCH.duplicate-name-official" to localizationParams("switch" to switch.name)
+            },
+            validateWithParams(!stagedDuplicateExists) {
+                "$VALIDATION_SWITCH.duplicate-name-draft" to localizationParams("switch" to switch.name)
+            },
+        )
+    } else {
+        emptyList()
+    }
+}
+
 fun validateSwitchLocationTrackLinkStructure(
     switch: TrackLayoutSwitch,
     structure: SwitchStructure,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -487,18 +487,22 @@ class LayoutSwitchDao(
     }
 
     fun findOfficialNameDuplicates(names: List<SwitchName>): Map<SwitchName, List<RowVersion<TrackLayoutSwitch>>> {
-        val sql = """
-            select id, version, name
-            from layout.switch
-            where name in (:names)
-              and draft = false
-              and state_category != 'NOT_EXISTING'
-        """.trimIndent()
-        val params = mapOf("names" to names)
-        return jdbcTemplate.query<Pair<SwitchName, RowVersion<TrackLayoutSwitch>>>(sql, params) { rs, _ ->
-            val version = rs.getRowVersion<TrackLayoutSwitch>("id", "version")
-            val name = rs.getString("name").let(::SwitchName)
-            name to version
-        }.groupBy({ (name, _) -> name }, { (_, version) -> version })
+        return if (names.isEmpty()) {
+            emptyMap()
+        } else {
+            val sql = """
+                select id, version, name
+                from layout.switch
+                where name in (:names)
+                  and draft = false
+                  and state_category != 'NOT_EXISTING'
+            """.trimIndent()
+            val params = mapOf("names" to names)
+            return jdbcTemplate.query<Pair<SwitchName, RowVersion<TrackLayoutSwitch>>>(sql, params) { rs, _ ->
+                val version = rs.getRowVersion<TrackLayoutSwitch>("id", "version")
+                val name = rs.getString("name").let(::SwitchName)
+                name to version
+            }.groupBy({ (name, _) -> name }, { (_, version) -> version })
+        }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -485,4 +485,20 @@ class LayoutSwitchDao(
             )
         }
     }
+
+    fun findOfficialNameDuplicates(names: List<SwitchName>): Map<SwitchName, List<RowVersion<TrackLayoutSwitch>>> {
+        val sql = """
+            select id, version, name
+            from layout.switch
+            where name in (:names)
+              and draft = false
+              and state_category != 'NOT_EXISTING'
+        """.trimIndent()
+        val params = mapOf("names" to names)
+        return jdbcTemplate.query<Pair<SwitchName, RowVersion<TrackLayoutSwitch>>>(sql, params) { rs, _ ->
+            val version = rs.getRowVersion<TrackLayoutSwitch>("id", "version")
+            val name = rs.getString("name").let(::SwitchName)
+            name to version
+        }.groupBy({ (name, _) -> name }, { (_, version) -> version })
+    }
 }


### PR DESCRIPTION
Vaihteiden validointi päätyi monissa tilanteissa tekemään hyvin agressiivista datan uudelleenhakua jotta se pystyi varmistamaan ettei virallisella puolella ole duplikaattinimeä. Muutettu niin että viralliset haetaan vain kerran ja niistäkin vain ne rivit jotka ovat duplikaatteja.