### PR TITLE
GVT-2437 & GVT-2438: Splittauksen julkaisuvalidointijuttuja

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -110,8 +110,8 @@ class PublicationService @Autowired constructor(
     ): ValidatedPublishCandidates {
         logger.serviceCall("validatePublishCandidates", "candidates" to candidates, "request" to request)
         return ValidatedPublishCandidates(
-            validatedAsPublicationUnit = validateAsPublicationUnit(candidates.filter(request), true),
-            allChangesValidated = validateAsPublicationUnit(candidates, false),
+            validatedAsPublicationUnit = validateAsPublicationUnit(candidates.filter(request), allowMultipleSplits = false),
+            allChangesValidated = validateAsPublicationUnit(candidates, allowMultipleSplits = true),
         )
     }
 
@@ -280,12 +280,12 @@ class PublicationService @Autowired constructor(
         return publicationDao.fetchChangeTime()
     }
 
-    private fun validateAsPublicationUnit(candidates: PublishCandidates, validatingStagedChanges: Boolean): PublishCandidates {
+    private fun validateAsPublicationUnit(candidates: PublishCandidates, allowMultipleSplits: Boolean): PublishCandidates {
         val versions = candidates.getValidationVersions()
         val cacheKeys = collectCacheKeys(versions)
         precacheLocationTrackAlignmentAddresses(candidates, cacheKeys)
         val switchTrackLinks = collectSwitchTrackLinks(versions, versions.locationTracks.map { v -> v.officialId })
-        val splitErrors = splitService.validateSplit(versions, validatingStagedChanges)
+        val splitErrors = splitService.validateSplit(versions, allowMultipleSplits)
 
         return PublishCandidates(
             trackNumbers = candidates.trackNumbers.map { candidate ->
@@ -348,7 +348,7 @@ class PublicationService @Autowired constructor(
         logger.serviceCall("validatePublishRequest", "versions" to versions)
         val cacheKeys = collectCacheKeys(versions)
         val switchTrackLinks = collectSwitchTrackLinks(versions, versions.locationTracks.map { v -> v.officialId })
-        val splitErrors = splitService.validateSplit(versions, validatingStagedChanges = true)
+        val splitErrors = splitService.validateSplit(versions, allowMultipleSplits = false)
 
         assertNoSplitErrors(splitErrors)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -76,9 +76,9 @@ class SplitService(
         splitDao.deleteSplit(splitId)
     }
 
-    fun validateSplit(candidates: ValidationVersions): SplitPublishValidationErrors {
+    fun validateSplit(candidates: ValidationVersions, validatingStagedChanges: Boolean): SplitPublishValidationErrors {
         val splits = findUnfinishedSplits(candidates.locationTracks.map { it.officialId })
-        val splitErrors = validateSplitContent(candidates.locationTracks, candidates.switches, splits)
+        val splitErrors = validateSplitContent(candidates.locationTracks, candidates.switches, splits, validatingStagedChanges)
 
         val tnSplitErrors = candidates.trackNumbers.associate { (id, _) ->
             id to listOfNotNull(validateSplitReferencesByTrackNumber(id))
@@ -193,7 +193,8 @@ class SplitService(
             }
 
         return sourceDuplicateTrackErrors +
-                listOfNotNull(targetGeometryError, sourceGeometryErrors, splitSourceLocationTrackErrors, statusError)
+                listOfNotNull(//targetGeometryError,
+                    sourceGeometryErrors, splitSourceLocationTrackErrors, statusError)
     }
 
     fun validateSplitReferencesByTrackNumber(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -196,8 +196,7 @@ class SplitService(
             }
 
         return sourceDuplicateTrackErrors +
-                listOfNotNull(//targetGeometryError,
-                    sourceGeometryErrors, splitSourceLocationTrackErrors, statusError)
+                listOfNotNull(targetGeometryError, sourceGeometryErrors, splitSourceLocationTrackErrors, statusError)
     }
 
     fun validateSplitReferencesByTrackNumber(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -79,9 +79,9 @@ class SplitService(
         splitDao.deleteSplit(splitId)
     }
 
-    fun validateSplit(candidates: ValidationVersions, validatingStagedChanges: Boolean): SplitPublishValidationErrors {
+    fun validateSplit(candidates: ValidationVersions, allowMultipleSplits: Boolean): SplitPublishValidationErrors {
         val splits = findUnfinishedSplits(candidates.locationTracks.map { it.officialId })
-        val splitErrors = validateSplitContent(candidates.locationTracks, candidates.switches, splits, validatingStagedChanges)
+        val splitErrors = validateSplitContent(candidates.locationTracks, candidates.switches, splits, allowMultipleSplits)
 
         val tnSplitErrors = candidates.trackNumbers.associate { (id, _) ->
             id to listOfNotNull(validateSplitReferencesByTrackNumber(id))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -42,10 +42,10 @@ internal fun validateSplitContent(
     trackVersions: List<ValidationVersion<LocationTrack>>,
     switchVersions: List<ValidationVersion<TrackLayoutSwitch>>,
     splits: Collection<Split>,
-    validatingStagedChanges: Boolean,
+    allowMultipleSplits: Boolean,
 ): List<Pair<Split, PublishValidationError>> {
-    val multipleSplitsStagedErrors = if (validatingStagedChanges && splits.size > 1) {
-        splits.map { split -> split to PublishValidationError(ERROR, "$VALIDATION_SPLIT.multiple-staged-splits")}
+    val multipleSplitsStagedErrors = if (!allowMultipleSplits && splits.size > 1) {
+        splits.map { split -> split to PublishValidationError(ERROR, "$VALIDATION_SPLIT.multiple-splits-not-allowed")}
     } else {
         emptyList()
     }

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1281,7 +1281,12 @@
             },
             "split": {
                 "source-not-deleted": "Jaettava raide ei ole Poistettu-tilassa",
-                "duplicate-on-different-track-number": "Duplikaattiraide {{duplicateTrack}} on eri ratanumerolla kuin jaettava raide"
+                "duplicate-on-different-track-number": "Duplikaattiraide {{duplicateTrack}} on eri ratanumerolla kuin jaettava raide",
+                "split-missing-location-tracks": "Kaikki jakoon liittyvät sijaintiraiteet eivät ole mukana julkaisussa",
+                "split-missing-switches": "Kaikki jakoon liittyvät vaihteet eivät ole mukana julkaisussa",
+                "multiple-staged-splits": "Julkaisussa on mukana useampi jaettu raide",
+                "geometry-changed": "Raiteen geometria on muuttunut",
+                "no-geometry": "Raiteella ei ole geometriaa"
             }
         }
     },

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1284,7 +1284,7 @@
                 "duplicate-on-different-track-number": "Duplikaattiraide {{duplicateTrack}} on eri ratanumerolla kuin jaettava raide",
                 "split-missing-location-tracks": "Kaikki jakoon liittyvät sijaintiraiteet eivät ole mukana julkaisussa",
                 "split-missing-switches": "Kaikki jakoon liittyvät vaihteet eivät ole mukana julkaisussa",
-                "multiple-staged-splits": "Julkaisussa on mukana useampi jaettu raide",
+                "multiple-splits-not-allowed": "Julkaisussa on mukana useampi jaettu raide",
                 "geometry-changed": "Raiteen geometria on muuttunut",
                 "no-geometry": "Raiteella ei ole geometriaa"
             }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -2449,7 +2449,7 @@ class PublicationServiceIT @Autowired constructor(
 
         assertTrue {
             errors.any {
-                it.localizationKey == LocalizationKey("validation.layout.split.source-geometry-changed")
+                it.localizationKey == LocalizationKey("validation.layout.split.geometry-changed")
             }
         }
     }
@@ -2489,7 +2489,7 @@ class PublicationServiceIT @Autowired constructor(
         val errors = validateLocationTracks(sourceTrackVersion.id, startTargetTrackId, endTargetTrackId)
         assertTrue {
             errors.any {
-                it.localizationKey == LocalizationKey("validation.layout.split.target-geometry-changed")
+                it.localizationKey == LocalizationKey("validation.layout.split.geometry-changed")
             }
         }
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -4,7 +4,6 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.publication.ValidationVersions
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
 import fi.fta.geoviite.infra.tracklayout.*

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublishType.DRAFT
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.publication.ValidationVersions
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
 import fi.fta.geoviite.infra.tracklayout.*


### PR DESCRIPTION
Täällä tehty:
- Mekanismi, jolla erotetaan ollaanko tekemässä validointia stagetetuille (tai julkaistaville) muutoksille
- Validaatio tilanteelle, jossa koitetaan stagettaa useampi erillinen raiteen jako
- Lisätty käännöksiä puuttuneille jakamisen validaatiovirheille
- Yhdistelty jakamisen lähtö- ja lopputulosraiteita jos käännöksissä ei ole ollut järkeä erottaa näitä toisistaan