### PR TITLE
GVT-2441: Pilkkomiseen liittyvän raiteen lyhentämisen ei pitäisi onnistua

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -206,6 +206,7 @@ class LinkingService @Autowired constructor(
             "updateLocationTrackGeometry", "locationTrackId" to locationTrackId, "mRange" to mRange
         )
 
+        verifyAllSplitsDone(locationTrackId)
         val (locationTrack, alignment) = locationTrackService.getWithAlignmentOrThrow(DRAFT, locationTrackId)
         val updatedAlignment = cutLayoutGeometry(alignment, mRange)
         val updatedLocationTrack = updateTopology(locationTrack, alignment, updatedAlignment)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -274,4 +274,9 @@ class SplitDao(
             logger.daoAccess(AccessType.FETCH, Split::class, "publicationId" to publicationId)
         }
     }
+
+    fun locationTracksPartOfAnyUnfinishedSplit(locationTrackIds: Collection<IntId<LocationTrack>>) =
+        fetchUnfinishedSplits().filter { split ->
+            locationTrackIds.any { lt -> split.containsLocationTrack(lt) }
+        }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -54,9 +54,7 @@ class SplitService(
     fun findUnfinishedSplitsForLocationTracks(locationTracks: Collection<IntId<LocationTrack>>): List<Split> {
         logger.serviceCall("findUnfinishedSplitsForLocationTracks", "locationTracks" to locationTracks)
 
-        return splitDao.fetchUnfinishedSplits().filter { split ->
-            locationTracks.any { lt -> split.containsLocationTrack(lt) }
-        }
+        return splitDao.locationTracksPartOfAnyUnfinishedSplit(locationTracks)
     }
 
     fun findUnfinishedSplitsForSwitches(switches: Collection<IntId<TrackLayoutSwitch>>): List<Split> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.linking.LocationTrackSaveRequest
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.publication.ValidationVersion
+import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.util.FreeText
 import org.springframework.stereotype.Service
@@ -32,6 +33,7 @@ class LocationTrackService(
     private val geocodingService: GeocodingService,
     private val switchDao: LayoutSwitchDao,
     private val switchLibraryService: SwitchLibraryService,
+    private val splitDao: SplitDao,
 ) : DraftableObjectService<LocationTrack, LocationTrackDao>(locationTrackDao) {
 
     @Transactional
@@ -393,7 +395,9 @@ class LocationTrackService(
                 ?: locationTrack.topologyStartSwitch?.switchId)?.let { id -> fetchSwitchAtEndById(id, publishType) }
             val endSwitch = (alignment.segments.lastOrNull()?.switchId as IntId?
                 ?: locationTrack.topologyEndSwitch?.switchId)?.let { id -> fetchSwitchAtEndById(id, publishType) }
-            LocationTrackInfoboxExtras(duplicateOf, sortedDuplicates, startSwitch, endSwitch)
+            val partOfUnfinishedSplit = splitDao.locationTracksPartOfAnyUnfinishedSplit(listOf(id)).isNotEmpty()
+
+            LocationTrackInfoboxExtras(duplicateOf, sortedDuplicates, startSwitch, endSwitch, partOfUnfinishedSplit)
         }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -142,6 +142,7 @@ data class LocationTrackInfoboxExtras(
     val duplicates: List<LocationTrackDuplicate>,
     val switchAtStart: LayoutSwitchIdAndName?,
     val switchAtEnd: LayoutSwitchIdAndName?,
+    val partOfUnfinishedSplit: Boolean?,
 )
 
 data class SwitchValidationWithSuggestedSwitch(

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -235,6 +235,30 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     const isStartOrEndSwitch = (switchId: LayoutSwitchId) =>
         switchId === extraInfo?.switchAtStart?.id || switchId === extraInfo?.switchAtEnd?.id;
 
+    const onStartSplitting = () => {
+        getSplittingInitializationParameters('DRAFT', locationTrack.id).then(
+            (splitInitializationParameters) => {
+                if (startAndEndPoints?.start && startAndEndPoints?.end) {
+                    delegates.onStartSplitting({
+                        locationTrack: locationTrack,
+                        allowedSwitches:
+                            splitInitializationParameters?.switches.filter(
+                                (sw) => !isStartOrEndSwitch(sw.switchId),
+                            ) || [],
+                        startAndEndSwitches: [
+                            extraInfo?.switchAtStart?.id,
+                            extraInfo?.switchAtEnd?.id,
+                        ].filter(filterNotEmpty),
+                        duplicateTracks: splitInitializationParameters?.duplicates || [],
+                        startLocation: startAndEndPoints.start.point,
+                        endLocation: startAndEndPoints.end.point,
+                    });
+                    delegates.showLayers(['location-track-split-location-layer']);
+                }
+            },
+        );
+    };
+
     return (
         <React.Fragment>
             <Infobox
@@ -421,7 +445,8 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                                 size={ButtonSize.SMALL}
                                                 qa-id="modify-start-or-end"
                                                 title={
-                                                    splittingState
+                                                    splittingState ||
+                                                    extraInfo?.partOfUnfinishedSplit
                                                         ? t(
                                                               'tool-panel.location-track.splitting-blocks-geometry-changes',
                                                           )
@@ -429,6 +454,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                                 }
                                                 disabled={
                                                     !!splittingState ||
+                                                    extraInfo?.partOfUnfinishedSplit ||
                                                     !startAndEndPoints.start?.point ||
                                                     !startAndEndPoints.end?.point
                                                 }
@@ -507,42 +533,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                                                     duplicatesOnOtherTracks
                                                 }
                                                 title={getSplittingDisabledReasonsTranslated()}
-                                                onClick={() => {
-                                                    getSplittingInitializationParameters(
-                                                        'DRAFT',
-                                                        locationTrack.id,
-                                                    ).then((splitInitializationParameters) => {
-                                                        if (
-                                                            startAndEndPoints?.start &&
-                                                            startAndEndPoints?.end
-                                                        ) {
-                                                            delegates.onStartSplitting({
-                                                                locationTrack: locationTrack,
-                                                                allowedSwitches:
-                                                                    splitInitializationParameters?.switches.filter(
-                                                                        (sw) =>
-                                                                            !isStartOrEndSwitch(
-                                                                                sw.switchId,
-                                                                            ),
-                                                                    ) || [],
-                                                                startAndEndSwitches: [
-                                                                    extraInfo?.switchAtStart?.id,
-                                                                    extraInfo?.switchAtEnd?.id,
-                                                                ].filter(filterNotEmpty),
-                                                                duplicateTracks:
-                                                                    splitInitializationParameters?.duplicates ||
-                                                                    [],
-                                                                startLocation:
-                                                                    startAndEndPoints.start.point,
-                                                                endLocation:
-                                                                    startAndEndPoints.end.point,
-                                                            });
-                                                            delegates.showLayers([
-                                                                'location-track-split-location-layer',
-                                                            ]);
-                                                        }
-                                                    });
-                                                }}>
+                                                onClick={onStartSplitting}>
                                                 {t('tool-panel.location-track.start-splitting')}
                                             </Button>
                                         )}

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -125,6 +125,7 @@ export type LocationTrackInfoboxExtras = {
     duplicates: LocationTrackDuplicate[];
     switchAtStart?: LayoutSwitchIdAndName;
     switchAtEnd?: LayoutSwitchIdAndName;
+    partOfUnfinishedSplit?: boolean;
 };
 
 export type AlignmentId = LocationTrackId | ReferenceLineId | GeometryAlignmentId;


### PR DESCRIPTION
Täällä estetty tämä kaksivaiheisesti:
- Disabloidaan "Lyhennä alkua ja/tai loppua" -nappi sijaintiraiteen infoboksista, tooltippinä tieto siitä että geometriamuutoksia ei sallita kun splitti on kesken
- Jos joku nyt kuitenkin on päässyt lyhennystilaan (esim. operaattori A on lyhentämässä raidetta ja operaattori B ehtii ottaa tämän raiteen mukaan splittiin ennen kuin A on valmis,) niin bäkkäri heittää virheen kun jakamista yritetään tallentaa.

Tuo suora bäkkärivirheen esittäminen on sinällään hieman meidän nykyisiä suuntaviivoja vastaan, mutta nykyään tuosta bäkkärivirheestä tulee oikeasti jopa luettava virheilmoitus, jossa lukee selkeästi suomeksi mikä meni vikaan. Näiden käytön suuntaviivoista voidaan jutella myöhemminkin, mutta omasta mielestäni niitä voidaan alkaa suosimaan enemmänkin nykyään (samasta syystä kuin miksi käytin niitä tässäkin.)