### PR TITLE
GVT-2432: Ratanumerokaavion välivalinta -popup ei aukea

### DIFF
--- a/ui/src/selection-panel/track-number-panel/color-selector/color-selector.tsx
+++ b/ui/src/selection-panel/track-number-panel/color-selector/color-selector.tsx
@@ -31,7 +31,6 @@ const ColorSelector: React.FC<ColorSelectorProps> = ({ color, onSelectColor }) =
     );
     const colorSelectorModalOffsetX = 32;
     const colorSelectorModalOffsetY = 0;
-    console.log(showSelector);
 
     return (
         <React.Fragment>

--- a/ui/src/selection-panel/track-number-panel/color-selector/color-selector.tsx
+++ b/ui/src/selection-panel/track-number-panel/color-selector/color-selector.tsx
@@ -31,6 +31,7 @@ const ColorSelector: React.FC<ColorSelectorProps> = ({ color, onSelectColor }) =
     );
     const colorSelectorModalOffsetX = 32;
     const colorSelectorModalOffsetY = 0;
+    console.log(showSelector);
 
     return (
         <React.Fragment>
@@ -45,31 +46,30 @@ const ColorSelector: React.FC<ColorSelectorProps> = ({ color, onSelectColor }) =
                 <CloseableModal
                     positionRef={ref}
                     onClickOutside={() => setShowSelector(false)}
+                    className={styles['color-selector-menu']}
                     offsetX={colorSelectorModalOffsetX}
                     offsetY={colorSelectorModalOffsetY}>
-                    <div className={styles['color-selector-menu']}>
-                        <ol>
+                    <ol>
+                        <li
+                            className={`${styles['color-square']} ${styles['color-square--transparent']}`}
+                            onClick={() => {
+                                setShowSelector(false);
+                                onSelectColor(TrackNumberColor.TRANSPARENT);
+                            }}
+                            title={t('selection-panel.color-selector.transparent')}
+                        />
+                        {getColors().map(([key, value]) => (
                             <li
-                                className={`${styles['color-square']} ${styles['color-square--transparent']}`}
+                                className={styles['color-square']}
+                                key={key}
                                 onClick={() => {
                                     setShowSelector(false);
-                                    onSelectColor(TrackNumberColor.TRANSPARENT);
+                                    onSelectColor(key);
                                 }}
-                                title={t('selection-panel.color-selector.transparent')}
+                                style={{ backgroundColor: value + colorOpacity }}
                             />
-                            {getColors().map(([key, value]) => (
-                                <li
-                                    className={styles['color-square']}
-                                    key={key}
-                                    onClick={() => {
-                                        setShowSelector(false);
-                                        onSelectColor(key);
-                                    }}
-                                    style={{ backgroundColor: value + colorOpacity }}
-                                />
-                            ))}
-                        </ol>
-                    </div>
+                        ))}
+                    </ol>
                 </CloseableModal>
             )}
         </React.Fragment>


### PR DESCRIPTION
Täällä ongelmana oli se, että `CloseableModal`:in refaktoroinnin jäljiltä oli unohtunut siirtää divin CSS-class modaalille itselleen, ja sen vuoksi colorpicker rendautui 0px korkuisena