### PR TITLE
GVT-2425 Korjauksia julkaisulokin vaihdemuutoksiin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -365,7 +365,11 @@ data class RemovedTrackNumberReferenceIds(
     val planIds: List<IntId<GeometryPlan>>,
 )
 
-data class SwitchLocationTrack(val name: AlignmentName, val trackNumberId: IntId<TrackLayoutTrackNumber>)
+data class SwitchLocationTrack(
+    val name: AlignmentName,
+    val trackNumberId: IntId<TrackLayoutTrackNumber>,
+    val oldVersion: RowVersion<LocationTrack>,
+)
 
 data class Change<T>(
     val old: T?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -962,9 +962,18 @@ class PublicationDao(
             location_tracks as (
               select switch_id,
                 array_agg(lt.track_number_id order by location_track_id) as lt_track_number_ids,
-                array_agg(lt.name order by location_track_id) as lt_names
+                array_agg(lt.name order by location_track_id) as lt_names,
+                array_agg(lt.id order by location_track_id) as lt_location_track_ids,
+                array_agg(
+                  lt.version - case when plt.direct_change is true then 1 else 0 end order by location_track_id
+                ) as lt_location_track_old_versions
                 from publication.switch_location_tracks
                   left join layout.location_track_version lt on lt.id = location_track_id and lt.version = location_track_version
+                  left join lateral
+                    (select direct_change
+                    from publication.location_track plt
+                    where plt.publication_id = :publication_id
+                      and plt.location_track_id = switch_location_tracks.location_track_id) plt on (true)
                 where publication_id = :publication_id
                 group by switch_id
             )
@@ -991,7 +1000,9 @@ class PublicationDao(
               joints.track_number_ids,
               switch_structure.presentation_joint_number,
               location_tracks.lt_track_number_ids,
-              location_tracks.lt_names
+              location_tracks.lt_names,
+              location_tracks.lt_location_track_ids,
+              location_tracks.lt_location_track_old_versions
               from publication.switch
                 left join layout.switch_version switch_version
                           on switch.switch_id = switch_version.id and switch.switch_version = switch_version.version
@@ -1051,10 +1062,14 @@ class PublicationDao(
             val locationTrackNames = rs.getListOrNull<String>("lt_names")?.map(::AlignmentName) ?: emptyList()
             val trackNumberIds =
                 rs.getListOrNull<Int>("lt_track_number_ids")?.map { IntId<TrackLayoutTrackNumber>(it) } ?: emptyList()
+            val locationTrackIds =
+                rs.getListOrNull<Int>("lt_location_track_ids")?.map { IntId<LocationTrack>(it) } ?: emptyList()
+            val locationTrackOldVersions = rs.getListOrNull<Int>("lt_location_track_old_versions") ?: emptyList()
             val lts = locationTrackNames.indices.map { index ->
                 SwitchLocationTrack(
                     trackNumberId = trackNumberIds[index],
                     name = locationTrackNames[index],
+                    oldVersion = RowVersion(locationTrackIds[index], locationTrackOldVersions[index]),
                 )
             }
             val id = rs.getIntId<TrackLayoutSwitch>("switch_id")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -1358,9 +1358,11 @@ class PublicationService @Autowired constructor(
     ): List<PublicationChange<*>> {
         val relatedJoints = changes.joints.filterNot { it.removed }.distinctBy { it.trackNumberId }
 
+        val oldLinkedLocationTracks = changes.locationTracks.associate { lt ->
+            lt.oldVersion.id to locationTrackService.getWithAlignment(lt.oldVersion)
+        }
         val jointLocationChanges = relatedJoints.flatMap { joint ->
-            val oldLocationTrack = locationTrackService.getOfficialWithAlignmentAtMoment(joint.locationTrackId, oldTimestamp)
-            val oldLocation = oldLocationTrack?.let { (track, alignment) ->
+            val oldLocation = oldLinkedLocationTracks[joint.locationTrackId]?.let { (track, alignment) ->
                 findJointPoint(
                     track,
                     alignment,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -1401,6 +1401,10 @@ class PublicationService @Autowired constructor(
             )
             list
         }.sortedBy { it.propKey.key }
+
+        val oldLinkedTrackNames = oldLinkedLocationTracks.values.mapNotNull { it?.first?.name?.toString() }.sorted()
+        val newLinkedTrackNames = changes.locationTracks.map { it.name.toString() }.sorted()
+
         return listOfNotNull(
             compareChangeValues(changes.name, { it }, PropKey("switch")),
             compareChangeValues(changes.state, { it }, PropKey("state-category"), null, "layout-state-category"),
@@ -1410,11 +1414,9 @@ class PublicationService @Autowired constructor(
             ),
             compareChangeValues(changes.owner, { it }, PropKey("owner")),
             compareChange(
-                { changes.locationTracks.any() },
-                if (operation != Operation.CREATE) listOf(
-                    translation.t("publication-details-table.not-calculated")
-                ) else null,
-                changes.locationTracks.map { it.name },
+                { oldLinkedTrackNames != newLinkedTrackNames },
+                oldLinkedTrackNames,
+                newLinkedTrackNames,
                 { list -> list.joinToString(", ") { it } },
                 PropKey("location-track-connectivity"),
             ),


### PR DESCRIPTION
Pääkorjaus on, että käytetään yhdenmukaisesti segmenttipistettä vaihteen pisteen sijaintina raiteella. Ja kun kerran tämän tiedon hakemisen takia pitää joka tapauksessa hakea vanhoja alignmentteja ja raiteita, samalla kerkesi korjaamaan hyvin myös entiset linkitettyjen raiteiden nimet, jotta niistä ei tule muutoslokiin noisea.