### PR TITLE
GVT-2418: Implement move and revert operations for groups of changes in preview view

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -227,7 +227,7 @@ data class ValidationVersions(
     fun findSwitch(id: IntId<TrackLayoutSwitch>) = switches.find { it.officialId == id }
 }
 
-data class SplitPublishGroup(
+data class PublicationGroup(
     val id: IntId<Split>,
 )
 
@@ -284,6 +284,7 @@ interface PublishCandidate<T> {
     val userName: UserName
     val errors: List<PublishValidationError>
     val operation: Operation?
+    val publicationGroup: PublicationGroup?
 
     fun getPublicationVersion() = ValidationVersion(id, rowVersion)
 }
@@ -296,6 +297,7 @@ data class TrackNumberPublishCandidate(
     override val userName: UserName,
     override val errors: List<PublishValidationError> = listOf(),
     override val operation: Operation,
+    override val publicationGroup: PublicationGroup? = null,
     val boundingBox: BoundingBox?,
 ) : PublishCandidate<TrackLayoutTrackNumber> {
     override val type = DraftChangeType.TRACK_NUMBER
@@ -310,6 +312,7 @@ data class ReferenceLinePublishCandidate(
     override val userName: UserName,
     override val errors: List<PublishValidationError> = listOf(),
     override val operation: Operation?,
+    override val publicationGroup: PublicationGroup? = null,
     val boundingBox: BoundingBox?,
 ) : PublishCandidate<ReferenceLine> {
     override val type = DraftChangeType.REFERENCE_LINE
@@ -325,7 +328,7 @@ data class LocationTrackPublishCandidate(
     override val userName: UserName,
     override val errors: List<PublishValidationError> = listOf(),
     override val operation: Operation,
-    val group: SplitPublishGroup?,
+    override val publicationGroup: PublicationGroup? = null,
     val boundingBox: BoundingBox?,
 ) : PublishCandidate<LocationTrack> {
     override val type = DraftChangeType.LOCATION_TRACK
@@ -340,6 +343,7 @@ data class SwitchPublishCandidate(
     override val userName: UserName,
     override val errors: List<PublishValidationError> = listOf(),
     override val operation: Operation,
+    override val publicationGroup: PublicationGroup? = null,
     val location: Point?,
 ) : PublishCandidate<TrackLayoutSwitch> {
     override val type = DraftChangeType.SWITCH
@@ -354,6 +358,7 @@ data class KmPostPublishCandidate(
     override val userName: UserName,
     override val errors: List<PublishValidationError> = listOf(),
     override val operation: Operation,
+    override val publicationGroup: PublicationGroup? = null,
     val location: Point?,
 ) : PublishCandidate<TrackLayoutKmPost> {
     override val type = DraftChangeType.KM_POST

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -157,7 +157,7 @@ class PublicationDao(
                 userName = UserName(rs.getString("change_user")),
                 operation = rs.getEnum("operation"),
                 boundingBox = rs.getBboxOrNull("bounding_box"),
-                group = rs.getIntIdOrNull<Split>("split_id")?.let(::SplitPublishGroup)
+                publicationGroup = rs.getIntIdOrNull<Split>("split_id")?.let(::PublicationGroup)
             )
         }
         logger.daoAccess(FETCH, LocationTrackPublishCandidate::class, candidates.map(LocationTrackPublishCandidate::id))

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1062,9 +1062,9 @@
         "cluster-overlay-choose-layout": "Valitse paikannuspohjan piste"
     },
     "preview-view": {
-        "unstaged-changes-title": "Muutokset",
-        "staged-changes-title": "Julkaistavat muutokset",
-        "show-only-mine": "Näytä vain omat muutokset",
+        "unstaged-changes-title": "Muutokset ({{amount}} kpl)",
+        "staged-changes-title": "Julkaistavat muutokset ({{amount}} kpl)",
+        "show-only-mine": "Näytä vain omat muutokset ({{amount}} kpl)",
         "map-crop": "Rajaa kartalta",
         "track-address-changes": "Rataosoitemuutokset",
         "track-number": "Ratanumero {{number}} {{disabled}}",
@@ -1105,8 +1105,16 @@
             "confirm": "Julkaise muutokset ({{candidates}} kpl)"
         },
         "revert-confirm": {
-            "title": "Muutoksen hylkääminen",
-            "description": "Haluatko hylätä muutoksen",
+            "title": {
+                "stage-changes": "Kaikkien listan muutosten hylkääminen",
+                "changes-with-dependencies": "Muutoksen hylkääminen",
+                "publication-group": "Kokonaisuuden hylkääminen"
+            },
+            "description": {
+                "stage-changes": "Haluatko hylätä kaikki listatut muutokset ({{amount}} kpl)?",
+                "changes-with-dependencies": "Haluatko hylätä muutoksen",
+                "publication-group": "Haluatko hylätä kokonaisuuden ({{amount}} kpl)?"
+            },
             "dependencies": "Tämän muutoksen hylkääminen aiheuttaa myös seuraavien riippuvien muutosten hylkäämisen:",
             "cancel": "Peruuta",
             "confirm": "Hylkää",
@@ -1133,7 +1141,11 @@
         "km-posts": "Tasakilometripisteitä",
         "reference-lines": "Pituusmittauslinjoja",
         "location-tracks": "Sijaintiraiteita",
-        "switches": "Vaihteita"
+        "switches": "Vaihteita",
+        "move-publication-group": "Siirrä kokonaisuus ({{amount}} kpl)",
+        "revert-publication-group": "Hylkää kokonaisuus  ({{amount}} kpl)",
+        "move-stage-changes": "Siirrä kaikki listan muutokset ({{amount}} kpl)",
+        "revert-stage-changes": "Hylkää kaikki listan muutokset ({{amount}} kpl)"
     },
     "validation": {
         "layout": {

--- a/ui/src/preview/change-table-entry-mapping.ts
+++ b/ui/src/preview/change-table-entry-mapping.ts
@@ -2,6 +2,7 @@ import {
     KmPostPublishCandidate,
     LocationTrackPublishCandidate,
     Operation,
+    PublicationGroup,
     ReferenceLinePublishCandidate,
     SwitchPublishCandidate,
     TrackNumberPublishCandidate,
@@ -32,6 +33,7 @@ export type ChangeTableEntry = {
     changeTime: string;
     userName: string;
     operation: Operation;
+    publicationGroup?: PublicationGroup;
 };
 
 const changeTableEntryCommonFields = (
@@ -46,6 +48,7 @@ const changeTableEntryCommonFields = (
     userName: candidate.userName,
     changeTime: candidate.draftChangeTime,
     operation: candidate.operation,
+    publicationGroup: candidate.publicationGroup,
 });
 
 export function getTrackNumberUiName(trackNumber: TrackNumber | undefined) {

--- a/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
+++ b/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
@@ -4,13 +4,14 @@ import * as React from 'react';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { useTranslation } from 'react-i18next';
-import { ChangesBeingReverted, RevertRequestType } from 'preview/preview-view';
+import { ChangesBeingReverted } from 'preview/preview-view';
 import {
     PublicationRequestDependencyList,
     publicationRequestTypeTranslationKey,
 } from 'preview/publication-request-dependency-list';
 import { getChangeTimes } from 'common/change-time-api';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { RevertRequestType } from 'preview/preview-view-revert-request';
 
 export interface PreviewRejectConfirmDialogProps {
     changesBeingReverted: ChangesBeingReverted;

--- a/ui/src/preview/preview-container.tsx
+++ b/ui/src/preview/preview-container.tsx
@@ -17,7 +17,7 @@ export const PreviewContainer: React.FC = () => {
         onSelect: delegates.onSelect,
         onClosePreview: () => delegates.onLayoutModeChange('DEFAULT'),
         onPublish: delegates.onPublish,
-        onPreviewSelect: delegates.onPreviewSelect,
+        onPublishPreviewSelect: delegates.onPublishPreviewSelect,
         onPublishPreviewRemove: delegates.onPublishPreviewRemove,
         onShowOnMap: delegates.showArea,
     };

--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -23,9 +23,9 @@ import {
     PublishValidationError,
 } from 'publication/publication-model';
 import { OnSelectFunction } from 'selection/selection-model';
-import { PreviewCandidates } from 'preview/preview-view';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { TextArea } from 'vayla-design-lib/text-area/text-area';
+import { PreviewCandidates } from 'preview/preview-view-data';
 
 type PreviewFooterProps = {
     onSelect: OnSelectFunction;

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -11,15 +11,12 @@ import {
 import { createClassName } from 'vayla-design-lib/utils';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
-import {
-    ChangesBeingReverted,
-    PreviewOperations,
-    PublicationAssetChangeAmounts,
-    RevertRequestSource,
-} from 'preview/preview-view';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { ChangesBeingReverted, PreviewOperations } from 'preview/preview-view';
+import { Menu, MenuSelectOption } from 'vayla-design-lib/menu/menu';
 import { PreviewSelectType, PreviewTableEntry, PublicationId } from 'preview/preview-table';
 import { BoundingBox } from 'model/geometry';
+import { RevertRequestSource } from 'preview/preview-view-revert-request';
+import { PublicationAssetChangeAmounts } from 'preview/preview-view-data';
 
 const createPublishRequestIdsFromTableEntry = (
     id: PublicationId,

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -32,6 +32,11 @@ const createPublishRequestIdsFromTableEntry = (
     kmPosts: type === PreviewSelectType.kmPost ? [id] : [],
 });
 
+const conditionalMenuOption = (
+    condition: unknown | undefined,
+    menuOption: MenuSelectOption,
+): MenuSelectOption[] => (condition ? [menuOption] : []);
+
 export type PreviewTableItemProps = {
     tableEntry: PreviewTableEntry;
     publish?: boolean;
@@ -105,7 +110,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         setActionMenuVisible(false);
     };
 
-    const menuOptionMoveStageChanges = {
+    const menuOptionMoveStageChanges: MenuSelectOption = {
         onSelect: menuAction(() =>
             previewOperations.setPublicationStage.forAllStageChanges(
                 displayedPublicationStage,
@@ -117,7 +122,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         }),
     };
 
-    const menuOptionMovePublicationGroupStage = {
+    const menuOptionMovePublicationGroupStage: MenuSelectOption = {
         onSelect: menuAction(() => {
             if (tableEntry.publicationGroup) {
                 previewOperations.setPublicationStage.forPublicationGroup(
@@ -131,7 +136,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         }),
     };
 
-    const menuOptionRevertSingleChange = {
+    const menuOptionRevertSingleChange: MenuSelectOption = {
         name: t('publish.revert-change'),
         onSelect: menuAction(() =>
             previewOperations.revert.changesWithDependencies(
@@ -141,7 +146,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         ),
     };
 
-    const menuOptionRevertStageChanges = {
+    const menuOptionRevertStageChanges: MenuSelectOption = {
         onSelect: menuAction(() => {
             previewOperations.revert.stageChanges(
                 displayedPublicationStage,
@@ -153,7 +158,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         }),
     };
 
-    const menuOptionPublicationGroupRevert = {
+    const menuOptionPublicationGroupRevert: MenuSelectOption = {
         onSelect: menuAction(() => {
             if (tableEntry.publicationGroup) {
                 previewOperations.revert.publicationGroup(
@@ -167,7 +172,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         }),
     };
 
-    const menuOptionShowOnMap = {
+    const menuOptionShowOnMap: MenuSelectOption = {
         disabled: !tableEntry.boundingBox,
         onSelect: menuAction(() => {
             tableEntry.boundingBox && onShowOnMap(tableEntry.boundingBox);
@@ -175,12 +180,12 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         name: t('publish.show-on-map'),
     };
 
-    const menuOptions = [
-        ...(tableEntry.publicationGroup ? [menuOptionMovePublicationGroupStage] : []),
+    const menuOptions: MenuSelectOption[] = [
+        ...conditionalMenuOption(tableEntry.publicationGroup, menuOptionMovePublicationGroupStage),
         menuOptionMoveStageChanges,
         menuOptionShowOnMap,
-        ...(!tableEntry.publicationGroup ? [menuOptionRevertSingleChange] : []),
-        ...(tableEntry.publicationGroup ? [menuOptionPublicationGroupRevert] : []),
+        ...conditionalMenuOption(!tableEntry.publicationGroup, menuOptionRevertSingleChange),
+        ...conditionalMenuOption(tableEntry.publicationGroup, menuOptionPublicationGroupRevert),
         menuOptionRevertStageChanges,
     ];
 

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -96,15 +96,6 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         name: tableEntry.name,
     };
 
-    const changeItemPublicationStage = () => {
-        const newStage = publish ? PublicationStage.UNSTAGED : PublicationStage.STAGED;
-
-        previewOperations.setPublicationStage.forSpecificChanges(
-            tableEntryAsPublishRequestIds,
-            newStage,
-        );
-    };
-
     const menuAction = (menuActionFunction: () => void) => (): void => {
         menuActionFunction();
         setActionMenuVisible(false);
@@ -234,7 +225,12 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                     <Button
                         qa-id={'stage-change-button'}
                         variant={ButtonVariant.GHOST}
-                        onClick={changeItemPublicationStage}
+                        onClick={() =>
+                            previewOperations.setPublicationStage.forSpecificChanges(
+                                tableEntryAsPublishRequestIds,
+                                moveTargetStage,
+                            )
+                        }
                         icon={publish ? Icons.Ascending : Icons.Descending}
                     />
                     <React.Fragment>

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -10,7 +10,6 @@ import {
 } from 'track-layout/track-layout-model';
 import { getTrackNumbers } from 'track-layout/layout-track-number-api';
 import styles from './preview-view.scss';
-import { SelectedPublishChange } from 'track-layout/track-layout-slice';
 import { negComparator } from 'utils/array-utils';
 import {
     getSortInfoForProp,
@@ -28,7 +27,12 @@ import {
 } from 'preview/change-table-entry-mapping';
 import { PreviewTableItem } from 'preview/preview-table-item';
 import { PublishValidationError } from 'publication/publication-model';
-import { ChangesBeingReverted, PreviewCandidates } from 'preview/preview-view';
+import {
+    ChangesBeingReverted,
+    PreviewCandidates,
+    PreviewOperations,
+    PublicationAssetChangeAmounts,
+} from 'preview/preview-view';
 import { BoundingBox } from 'model/geometry';
 import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
 import { getSortDirectionIcon, SortDirection } from 'utils/table-utils';
@@ -59,22 +63,22 @@ export enum PreviewSelectType {
 
 type PreviewTableProps = {
     previewChanges: PreviewCandidates;
-    onPreviewSelect: (selectedChanges: SelectedPublishChange) => void;
-    onRevert: (entry: PreviewTableEntry) => void;
     staged: boolean;
     changesBeingReverted?: ChangesBeingReverted;
     onShowOnMap: (bbox: BoundingBox) => void;
     changeTimes: ChangeTimes;
+    publicationAssetChangeAmounts: PublicationAssetChangeAmounts;
+    previewOperations: PreviewOperations;
 };
 
 const PreviewTable: React.FC<PreviewTableProps> = ({
     previewChanges,
-    onPreviewSelect,
-    onRevert,
     staged,
     changesBeingReverted,
-    onShowOnMap,
     changeTimes,
+    publicationAssetChangeAmounts,
+    previewOperations,
+    onShowOnMap,
 }) => {
     const { t } = useTranslation();
     const trackNumbers =
@@ -84,39 +88,6 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
         ) || [];
 
     const [sortInfo, setSortInfo] = React.useState<SortInformation>(InitiallyUnsorted);
-
-    const defaultSelectedPublishChange: SelectedPublishChange = {
-        trackNumber: undefined,
-        referenceLine: undefined,
-        locationTrack: undefined,
-        switch: undefined,
-        kmPost: undefined,
-    };
-
-    function handlePreviewSelect<T>(id: PublicationId, type: T) {
-        switch (type) {
-            case PreviewSelectType.trackNumber:
-                onPreviewSelect &&
-                    onPreviewSelect({ ...defaultSelectedPublishChange, trackNumber: id });
-                break;
-            case PreviewSelectType.referenceLine:
-                onPreviewSelect &&
-                    onPreviewSelect({ ...defaultSelectedPublishChange, referenceLine: id });
-                break;
-            case PreviewSelectType.locationTrack:
-                onPreviewSelect &&
-                    onPreviewSelect({ ...defaultSelectedPublishChange, locationTrack: id });
-                break;
-            case PreviewSelectType.switch:
-                onPreviewSelect && onPreviewSelect({ ...defaultSelectedPublishChange, switch: id });
-                break;
-            case PreviewSelectType.kmPost:
-                onPreviewSelect && onPreviewSelect({ ...defaultSelectedPublishChange, kmPost: id });
-                break;
-            default:
-                onPreviewSelect && onPreviewSelect(defaultSelectedPublishChange);
-        }
-    }
 
     const changesToPublicationEntries = (previewChanges: PreviewCandidates): PreviewTableEntry[] =>
         previewChanges.trackNumbers
@@ -220,21 +191,12 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
                         <React.Fragment key={`${entry.type}_${entry.id}`}>
                             {
                                 <PreviewTableItem
-                                    onPublishItemSelect={() =>
-                                        handlePreviewSelect(entry.id, entry.type)
-                                    }
-                                    onRevert={() => onRevert(entry)}
-                                    itemName={entry.uiName}
-                                    trackNumber={entry.trackNumber}
-                                    errors={entry.errors}
-                                    changeTime={entry.changeTime}
-                                    userName={entry.userName}
-                                    pendingValidation={entry.pendingValidation}
-                                    operation={entry.operation}
+                                    tableEntry={entry}
                                     publish={staged}
                                     changesBeingReverted={changesBeingReverted}
-                                    boundingBox={entry.boundingBox}
                                     onShowOnMap={onShowOnMap}
+                                    previewOperations={previewOperations}
+                                    publicationAssetChangeAmounts={publicationAssetChangeAmounts}
                                 />
                             }
                         </React.Fragment>

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -27,17 +27,13 @@ import {
 } from 'preview/change-table-entry-mapping';
 import { PreviewTableItem } from 'preview/preview-table-item';
 import { PublishValidationError } from 'publication/publication-model';
-import {
-    ChangesBeingReverted,
-    PreviewCandidates,
-    PreviewOperations,
-    PublicationAssetChangeAmounts,
-} from 'preview/preview-view';
+import { ChangesBeingReverted, PreviewOperations } from 'preview/preview-view';
 import { BoundingBox } from 'model/geometry';
 import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
 import { getSortDirectionIcon, SortDirection } from 'utils/table-utils';
 import { useLoader } from 'utils/react-utils';
 import { ChangeTimes } from 'common/common-slice';
+import { PreviewCandidates, PublicationAssetChangeAmounts } from 'preview/preview-view-data';
 
 export type PublicationId =
     | LayoutTrackNumberId

--- a/ui/src/preview/preview-view-data.ts
+++ b/ui/src/preview/preview-view-data.ts
@@ -1,0 +1,96 @@
+import {
+    KmPostPublishCandidate,
+    LocationTrackPublishCandidate,
+    PublicationGroupId,
+    PublishCandidate,
+    PublishCandidates,
+    PublishRequestIds,
+    ReferenceLinePublishCandidate,
+    SwitchPublishCandidate,
+    TrackNumberPublishCandidate,
+} from 'publication/publication-model';
+import { AssetId } from 'common/common-model';
+
+export type Candidate = {
+    id: AssetId;
+};
+
+export type PreviewCandidate = PublishCandidate & PendingValidation;
+
+export type PreviewCandidates = {
+    trackNumbers: (TrackNumberPublishCandidate & PendingValidation)[];
+    referenceLines: (ReferenceLinePublishCandidate & PendingValidation)[];
+    locationTracks: (LocationTrackPublishCandidate & PendingValidation)[];
+    switches: (SwitchPublishCandidate & PendingValidation)[];
+    kmPosts: (KmPostPublishCandidate & PendingValidation)[];
+};
+
+export type PendingValidation = {
+    pendingValidation: boolean;
+};
+
+export const emptyChanges = {
+    trackNumbers: [],
+    locationTracks: [],
+    referenceLines: [],
+    switches: [],
+    kmPosts: [],
+} satisfies PreviewCandidates | PublishRequestIds;
+
+export const nonPendingCandidate = <T extends PublishCandidate>(candidate: T) => ({
+    ...candidate,
+    pendingValidation: false,
+});
+export const pendingCandidate = <T extends PublishCandidate>(candidate: T) => ({
+    ...candidate,
+    pendingValidation: true,
+});
+
+// Validating the change set takes time. After a change is staged, it should be regarded as staged, but pending
+// validation until validation is complete
+export const pendingValidation = (allStaged: AssetId[], allValidated: AssetId[], id: AssetId) =>
+    allStaged.includes(id) && !allValidated.includes(id);
+
+export type PublicationAssetChangeAmounts = {
+    total: number;
+    staged: number;
+    unstaged: number;
+    groupAmounts: Record<PublicationGroupId, number>;
+    ownUnstaged: number;
+};
+
+export const countPublishCandidates = (
+    publishCandidates: PublishCandidates | undefined,
+): number => {
+    if (!publishCandidates) {
+        return 0;
+    }
+
+    return Object.values(publishCandidates)
+        .filter((maybeAssetArray) => Array.isArray(maybeAssetArray))
+        .reduce((amount, assetArray) => amount + assetArray.length, 0);
+};
+
+export const countPublicationGroupAmounts = (
+    changeSet: PublishCandidates | undefined,
+): Record<PublicationGroupId, number> => {
+    if (!changeSet) {
+        return {};
+    }
+
+    return Object.values(changeSet)
+        .filter((maybeAssetArray) => Array.isArray(maybeAssetArray))
+        .flatMap((assetArray) => {
+            return assetArray.map((asset) => asset.publicationGroup?.id);
+        })
+        .filter(
+            (publicationGroupId): publicationGroupId is PublicationGroupId => !!publicationGroupId,
+        )
+        .reduce((groupSizes, publicationGroup) => {
+            publicationGroup in groupSizes
+                ? (groupSizes[publicationGroup] += 1)
+                : (groupSizes[publicationGroup] = 1);
+
+            return groupSizes;
+        }, {} as Record<PublicationGroupId, number>);
+};

--- a/ui/src/preview/preview-view-filters.ts
+++ b/ui/src/preview/preview-view-filters.ts
@@ -1,0 +1,178 @@
+import {
+    PublicationGroup,
+    PublishCandidate,
+    PublishCandidates,
+    PublishRequestIds,
+    WithId,
+} from 'publication/publication-model';
+import { AssetId } from 'common/common-model';
+import { User } from 'user/user-model';
+import {
+    Candidate,
+    nonPendingCandidate,
+    pendingCandidate,
+    pendingValidation,
+    PreviewCandidate,
+    PreviewCandidates,
+} from 'preview/preview-view-data';
+
+export const publishCandidateIds = (candidates: PublishCandidates): PublishRequestIds => ({
+    trackNumbers: candidates.trackNumbers.map((tn) => tn.id),
+    locationTracks: candidates.locationTracks.map((lt) => lt.id),
+    referenceLines: candidates.referenceLines.map((rl) => rl.id),
+    switches: candidates.switches.map((s) => s.id),
+    kmPosts: candidates.kmPosts.map((s) => s.id),
+});
+
+const filterStaged = (stagedIds: AssetId[], candidate: Candidate) =>
+    stagedIds.includes(candidate.id);
+const filterUnstaged = (stagedIds: AssetId[], candidate: Candidate) =>
+    !stagedIds.includes(candidate.id);
+
+const filterPreviewCandidateArrayByUser = <T extends PreviewCandidate>(
+    user: User,
+    candidates: T[],
+) => candidates.filter((candidate) => candidate.userName === user.details.userName);
+
+export const getStagedChanges = (
+    publishCandidates: PublishCandidates,
+    stagedChangeIds: PublishRequestIds,
+): PublishCandidates => ({
+    trackNumbers: publishCandidates.trackNumbers.filter((trackNumber) =>
+        filterStaged(stagedChangeIds.trackNumbers, trackNumber),
+    ),
+    locationTracks: publishCandidates.locationTracks.filter((locationTrack) =>
+        filterStaged(stagedChangeIds.locationTracks, locationTrack),
+    ),
+    switches: publishCandidates.switches.filter((layoutSwitch) =>
+        filterStaged(stagedChangeIds.switches, layoutSwitch),
+    ),
+    kmPosts: publishCandidates.kmPosts.filter((kmPost) =>
+        filterStaged(stagedChangeIds.kmPosts, kmPost),
+    ),
+    referenceLines: publishCandidates.referenceLines.filter((referenceLine) =>
+        filterStaged(stagedChangeIds.referenceLines, referenceLine),
+    ),
+});
+
+export const getUnstagedChanges = (
+    publishCandidates: PublishCandidates,
+    stagedChangeIds: PublishRequestIds,
+): PublishCandidates => ({
+    trackNumbers: publishCandidates.trackNumbers.filter((trackNumber) =>
+        filterUnstaged(stagedChangeIds.trackNumbers, trackNumber),
+    ),
+    locationTracks: publishCandidates.locationTracks.filter((locationTrack) =>
+        filterUnstaged(stagedChangeIds.locationTracks, locationTrack),
+    ),
+    switches: publishCandidates.switches.filter((layoutSwitch) =>
+        filterUnstaged(stagedChangeIds.switches, layoutSwitch),
+    ),
+    kmPosts: publishCandidates.kmPosts.filter((kmPost) =>
+        filterUnstaged(stagedChangeIds.kmPosts, kmPost),
+    ),
+    referenceLines: publishCandidates.referenceLines.filter((referenceLine) =>
+        filterUnstaged(stagedChangeIds.referenceLines, referenceLine),
+    ),
+});
+
+export const previewChanges = (
+    stagedValidatedChanges: PublishCandidates,
+    allSelectedChanges: PublishRequestIds,
+    entireChangeset: PublishCandidates,
+): PreviewCandidates => {
+    const validatedIds = publishCandidateIds(stagedValidatedChanges);
+
+    return {
+        trackNumbers: [
+            ...stagedValidatedChanges.trackNumbers.map(nonPendingCandidate),
+            ...entireChangeset.trackNumbers
+                .filter((change) =>
+                    pendingValidation(
+                        allSelectedChanges.trackNumbers,
+                        validatedIds.trackNumbers,
+                        change.id,
+                    ),
+                )
+                .map(pendingCandidate),
+        ],
+        referenceLines: [
+            ...stagedValidatedChanges.referenceLines.map(nonPendingCandidate),
+            ...entireChangeset.referenceLines
+                .filter((change) =>
+                    pendingValidation(
+                        allSelectedChanges.referenceLines,
+                        validatedIds.referenceLines,
+                        change.id,
+                    ),
+                )
+                .map(pendingCandidate),
+        ],
+        locationTracks: [
+            ...stagedValidatedChanges.locationTracks.map(nonPendingCandidate),
+            ...entireChangeset.locationTracks
+                .filter((change) =>
+                    pendingValidation(
+                        allSelectedChanges.locationTracks,
+                        validatedIds.locationTracks,
+                        change.id,
+                    ),
+                )
+                .map(pendingCandidate),
+        ],
+        switches: [
+            ...stagedValidatedChanges.switches.map(nonPendingCandidate),
+            ...entireChangeset.switches
+                .filter((change) =>
+                    pendingValidation(
+                        allSelectedChanges.switches,
+                        validatedIds.switches,
+                        change.id,
+                    ),
+                )
+                .map(pendingCandidate),
+        ],
+        kmPosts: [
+            ...stagedValidatedChanges.kmPosts.map(nonPendingCandidate),
+            ...entireChangeset.kmPosts
+                .filter((change) =>
+                    pendingValidation(allSelectedChanges.kmPosts, validatedIds.kmPosts, change.id),
+                )
+                .map(pendingCandidate),
+        ],
+    };
+};
+
+export const previewCandidatesByUser = (
+    user: User,
+    previewCandidates: PreviewCandidates,
+): PreviewCandidates => ({
+    trackNumbers: filterPreviewCandidateArrayByUser(user, previewCandidates.trackNumbers),
+    referenceLines: filterPreviewCandidateArrayByUser(user, previewCandidates.referenceLines),
+    locationTracks: filterPreviewCandidateArrayByUser(user, previewCandidates.locationTracks),
+    switches: filterPreviewCandidateArrayByUser(user, previewCandidates.switches),
+    kmPosts: filterPreviewCandidateArrayByUser(user, previewCandidates.kmPosts),
+});
+
+export const filterByPublicationGroup = (
+    candidates: (PublishCandidate & WithId)[],
+    publicationGroup: PublicationGroup,
+) => candidates.filter((candidate) => candidate.publicationGroup?.id === publicationGroup.id);
+
+export const assetIdsByPublicationGroup = (
+    candidates: (PublishCandidate & WithId)[],
+    publicationGroup: PublicationGroup,
+) => {
+    return filterByPublicationGroup(candidates, publicationGroup).map((candidate) => candidate.id);
+};
+
+export const idsByPublicationGroup = (
+    candidates: PublishCandidates,
+    publicationGroup: PublicationGroup,
+): PublishRequestIds => ({
+    trackNumbers: assetIdsByPublicationGroup(candidates.trackNumbers, publicationGroup),
+    referenceLines: assetIdsByPublicationGroup(candidates.referenceLines, publicationGroup),
+    locationTracks: assetIdsByPublicationGroup(candidates.locationTracks, publicationGroup),
+    switches: assetIdsByPublicationGroup(candidates.switches, publicationGroup),
+    kmPosts: assetIdsByPublicationGroup(candidates.kmPosts, publicationGroup),
+});

--- a/ui/src/preview/preview-view-revert-request.ts
+++ b/ui/src/preview/preview-view-revert-request.ts
@@ -1,0 +1,35 @@
+import { PublicationGroup, PublicationId, PublicationStage } from 'publication/publication-model';
+import { PreviewSelectType } from 'preview/preview-table';
+
+export enum RevertRequestType {
+    STAGE_CHANGES,
+    CHANGES_WITH_DEPENDENCIES,
+    PUBLICATION_GROUP,
+}
+
+export type RevertRequest =
+    | RevertStageChanges
+    | RevertChangesWithDependencies
+    | RevertPublicationGroup;
+
+export type RevertRequestSource = {
+    id: PublicationId;
+    type: PreviewSelectType;
+    name: string;
+};
+
+export type RevertStageChanges = {
+    type: RevertRequestType.STAGE_CHANGES;
+    amount: number;
+    stage: PublicationStage;
+};
+
+export type RevertChangesWithDependencies = {
+    type: RevertRequestType.CHANGES_WITH_DEPENDENCIES;
+};
+
+export type RevertPublicationGroup = {
+    type: RevertRequestType.PUBLICATION_GROUP;
+    amount: number;
+    publicationGroup: PublicationGroup;
+};

--- a/ui/src/preview/preview-view.scss
+++ b/ui/src/preview/preview-view.scss
@@ -153,6 +153,7 @@ $-color-warning: vayla-design.$color-lemon-dark;
 
 .preview-table-item__actions--cell {
     padding: 2px 8px 0 8px;
+
     > div {
         display: inline-flex;
     }
@@ -190,4 +191,8 @@ $-color-warning: vayla-design.$color-lemon-dark;
 
 .preview-confirm__description {
     margin-bottom: 20px;
+}
+
+.preview-confirm__dependency-list {
+    max-height: 50%;
 }

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -14,22 +14,25 @@ import {
 import { PreviewFooter } from 'preview/preview-footer';
 import { PreviewToolBar } from 'preview/preview-tool-bar';
 import { OnSelectFunction } from 'selection/selection-model';
-import { SelectedPublishChange } from 'track-layout/track-layout-slice';
 import { AssetId, PublishType } from 'common/common-model';
 import { CalculatedChangesView } from './calculated-changes-view';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import {
     KmPostPublishCandidate,
     LocationTrackPublishCandidate,
+    PublicationGroup,
+    PublicationGroupId,
     PublicationId,
+    PublicationStage,
     PublishCandidate,
     PublishCandidates,
     PublishRequestIds,
     ReferenceLinePublishCandidate,
     SwitchPublishCandidate,
     TrackNumberPublishCandidate,
+    WithId,
 } from 'publication/publication-model';
-import PreviewTable, { PreviewSelectType, PreviewTableEntry } from 'preview/preview-table';
+import PreviewTable, { PreviewSelectType } from 'preview/preview-table';
 import { updateAllChangeTimes } from 'common/change-time-api';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { PreviewConfirmRevertChangesDialog } from 'preview/preview-confirm-revert-changes-dialog';
@@ -46,6 +49,7 @@ import {
     dropIdsFromPublishCandidates,
     intersectPublishRequestIds,
 } from 'publication/publication-utils';
+import { exhaustiveMatchingGuard } from 'utils/type-utils';
 
 type Candidate = {
     id: AssetId;
@@ -65,8 +69,41 @@ export type PreviewCandidates = {
     kmPosts: (KmPostPublishCandidate & PendingValidation)[];
 };
 
+export type RevertRequestSource = {
+    id: PublicationId;
+    type: PreviewSelectType;
+    name: string;
+};
+
+export enum RevertRequestType {
+    STAGE_CHANGES,
+    CHANGES_WITH_DEPENDENCIES,
+    PUBLICATION_GROUP,
+}
+
+export type RevertRequest =
+    | RevertStageChanges
+    | RevertChangesWithDependencies
+    | RevertPublicationGroup;
+
+export type RevertStageChanges = {
+    type: RevertRequestType.STAGE_CHANGES;
+    amount: number;
+    stage: PublicationStage;
+};
+
+export type RevertChangesWithDependencies = {
+    type: RevertRequestType.CHANGES_WITH_DEPENDENCIES;
+};
+
+export type RevertPublicationGroup = {
+    type: RevertRequestType.PUBLICATION_GROUP;
+    amount: number;
+    publicationGroup: PublicationGroup;
+};
+
 export type ChangesBeingReverted = {
-    requestedRevertChange: { type: PreviewSelectType; name: string; id: string };
+    requestedRevertChange: { source: RevertRequestSource } & RevertRequest;
     changeIncludingDependencies: PublishRequestIds;
 };
 
@@ -78,9 +115,35 @@ export type PreviewProps = {
     onSelect: OnSelectFunction;
     onPublish: () => void;
     onClosePreview: () => void;
-    onPreviewSelect: (selectedChange: SelectedPublishChange) => void;
+    onPublishPreviewSelect: (selectedChanges: PublishRequestIds) => void;
     onPublishPreviewRemove: (selectedChangesWithDependencies: PublishRequestIds) => void;
     onShowOnMap: (bbox: BoundingBox) => void;
+};
+
+export type PreviewOperations = {
+    setPublicationStage: {
+        forSpecificChanges: (
+            publishRequestIds: PublishRequestIds,
+            newStage: PublicationStage,
+        ) => void;
+        forAllStageChanges: (currentStage: PublicationStage, newStage: PublicationStage) => void;
+        forPublicationGroup: (
+            publicationGroup: PublicationGroup,
+            newStage: PublicationStage,
+        ) => void;
+    };
+
+    revert: {
+        stageChanges: (stage: PublicationStage, revertRequestSource: RevertRequestSource) => void;
+        changesWithDependencies: (
+            publishRequestIds: PublishRequestIds,
+            revertRequestSource: RevertRequestSource,
+        ) => void;
+        publicationGroup: (
+            publicationGroup: PublicationGroup,
+            revertRequestSource: RevertRequestSource,
+        ) => void;
+    };
 };
 
 const publishCandidateIds = (candidates: PublishCandidates): PublishRequestIds => ({
@@ -97,7 +160,7 @@ const emptyChanges = {
     referenceLines: [],
     switches: [],
     kmPosts: [],
-};
+} satisfies PreviewCandidates | PublishRequestIds;
 
 const filterStaged = (stagedIds: AssetId[], candidate: Candidate) =>
     stagedIds.includes(candidate.id);
@@ -107,7 +170,7 @@ const filterUnstaged = (stagedIds: AssetId[], candidate: Candidate) =>
 const getStagedChanges = (
     publishCandidates: PublishCandidates,
     stagedChangeIds: PublishRequestIds,
-) => ({
+): PublishCandidates => ({
     trackNumbers: publishCandidates.trackNumbers.filter((trackNumber) =>
         filterStaged(stagedChangeIds.trackNumbers, trackNumber),
     ),
@@ -128,7 +191,7 @@ const getStagedChanges = (
 const getUnstagedChanges = (
     publishCandidates: PublishCandidates,
     stagedChangeIds: PublishRequestIds,
-) => ({
+): PublishCandidates => ({
     trackNumbers: publishCandidates.trackNumbers.filter((trackNumber) =>
         filterUnstaged(stagedChangeIds.trackNumbers, trackNumber),
     ),
@@ -155,7 +218,7 @@ const previewChanges = (
     stagedValidatedChanges: PublishCandidates,
     allSelectedChanges: PublishRequestIds,
     entireChangeset: PublishCandidates,
-) => {
+): PreviewCandidates => {
     const validatedIds = publishCandidateIds(stagedValidatedChanges);
 
     return {
@@ -227,27 +290,6 @@ const pendingCandidate = <T extends PublishCandidate>(candidate: T) => ({
     pendingValidation: true,
 });
 
-const singleRowPublishRequestOfPreviewTableEntry = (
-    id: PublicationId,
-    type: PreviewSelectType,
-): PublishRequestIds => ({
-    trackNumbers: type === 'trackNumber' ? [id] : [],
-    referenceLines: type === 'referenceLine' ? [id] : [],
-    locationTracks: type === 'locationTrack' ? [id] : [],
-    switches: type === 'switch' ? [id] : [],
-    kmPosts: type === 'kmPost' ? [id] : [],
-});
-
-const singleRowPublishRequestOfSelectedPublishChange = (
-    change: SelectedPublishChange,
-): PublishRequestIds => ({
-    trackNumbers: change.trackNumber ? [change.trackNumber] : [],
-    referenceLines: change.referenceLine ? [change.referenceLine] : [],
-    locationTracks: change.locationTrack ? [change.locationTrack] : [],
-    switches: change.switch ? [change.switch] : [],
-    kmPosts: change.kmPost ? [change.kmPost] : [],
-});
-
 const filterPreviewCandidateArrayByUser = <T extends PreviewCandidate>(
     user: User,
     candidates: T[],
@@ -255,13 +297,13 @@ const filterPreviewCandidateArrayByUser = <T extends PreviewCandidate>(
 
 const previewCandidatesByUser = (
     user: User,
-    publishCandidates: PreviewCandidates,
+    previewCandidates: PreviewCandidates,
 ): PreviewCandidates => ({
-    trackNumbers: filterPreviewCandidateArrayByUser(user, publishCandidates.trackNumbers),
-    referenceLines: filterPreviewCandidateArrayByUser(user, publishCandidates.referenceLines),
-    locationTracks: filterPreviewCandidateArrayByUser(user, publishCandidates.locationTracks),
-    switches: filterPreviewCandidateArrayByUser(user, publishCandidates.switches),
-    kmPosts: filterPreviewCandidateArrayByUser(user, publishCandidates.kmPosts),
+    trackNumbers: filterPreviewCandidateArrayByUser(user, previewCandidates.trackNumbers),
+    referenceLines: filterPreviewCandidateArrayByUser(user, previewCandidates.referenceLines),
+    locationTracks: filterPreviewCandidateArrayByUser(user, previewCandidates.locationTracks),
+    switches: filterPreviewCandidateArrayByUser(user, previewCandidates.switches),
+    kmPosts: filterPreviewCandidateArrayByUser(user, previewCandidates.kmPosts),
 });
 
 const validateDebounced = debounceAsync(
@@ -272,6 +314,71 @@ const getCalculatedChangesDebounced = debounceAsync(
     (request: PublishRequestIds) => getCalculatedChanges(request),
     1000,
 );
+
+const filterByPublicationGroup = (
+    candidates: (PublishCandidate & WithId)[],
+    publicationGroup: PublicationGroup,
+) => candidates.filter((candidate) => candidate.publicationGroup?.id === publicationGroup.id);
+
+const assetIdsByPublicationGroup = (
+    candidates: (PublishCandidate & WithId)[],
+    publicationGroup: PublicationGroup,
+) => {
+    return filterByPublicationGroup(candidates, publicationGroup).map((candidate) => candidate.id);
+};
+
+const idsByPublicationGroup = (
+    candidates: PublishCandidates,
+    publicationGroup: PublicationGroup,
+): PublishRequestIds => ({
+    trackNumbers: assetIdsByPublicationGroup(candidates.trackNumbers, publicationGroup),
+    referenceLines: assetIdsByPublicationGroup(candidates.referenceLines, publicationGroup),
+    locationTracks: assetIdsByPublicationGroup(candidates.locationTracks, publicationGroup),
+    switches: assetIdsByPublicationGroup(candidates.switches, publicationGroup),
+    kmPosts: assetIdsByPublicationGroup(candidates.kmPosts, publicationGroup),
+});
+
+export type PublicationAssetChangeAmounts = {
+    total: number;
+    staged: number;
+    unstaged: number;
+    groupAmounts: Record<PublicationGroupId, number>;
+    ownUnstaged: number;
+};
+
+const countPublishCandidates = (publishCandidates: PublishCandidates | undefined): number => {
+    if (!publishCandidates) {
+        return 0;
+    }
+
+    return Object.values(publishCandidates)
+        .filter((maybeAssetArray) => Array.isArray(maybeAssetArray))
+        .reduce((amount, assetArray) => amount + assetArray.length, 0);
+};
+
+const countPublicationGroupAmounts = (
+    changeSet: PublishCandidates | undefined,
+): Record<PublicationGroupId, number> => {
+    if (!changeSet) {
+        return {};
+    }
+
+    return Object.values(changeSet)
+        .filter((maybeAssetArray) => Array.isArray(maybeAssetArray))
+        .flatMap((assetArray) => {
+            return assetArray.map((asset) => asset.publicationGroup?.id);
+        })
+        .filter(
+            (publicationGroupId): publicationGroupId is PublicationGroupId => !!publicationGroupId,
+        )
+        .reduce((groupSizes, publicationGroup) => {
+            publicationGroup in groupSizes
+                ? (groupSizes[publicationGroup] += 1)
+                : (groupSizes[publicationGroup] = 1);
+
+            return groupSizes;
+        }, {} as Record<PublicationGroupId, number>);
+};
 
 export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const { t } = useTranslation();
@@ -314,7 +421,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
           )
         : undefined;
 
-    const unstagedPreviewChanges: PreviewCandidates = (() => {
+    const unstagedPreviewChanges = ((): PreviewCandidates => {
         const allUnstagedChangesValidated = unstagedChanges
             ? {
                   trackNumbers: unstagedChanges.trackNumbers.map(nonPendingCandidate),
@@ -345,24 +452,22 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const [mapMode, setMapMode] = React.useState<PublishType>('DRAFT');
     const [changesBeingReverted, setChangesBeingReverted] = React.useState<ChangesBeingReverted>();
 
-    const onRequestRevert = (requestedRevertChange: PreviewTableEntry) => {
-        getRevertRequestDependencies(
-            singleRowPublishRequestOfPreviewTableEntry(
-                requestedRevertChange.id,
-                requestedRevertChange.type,
-            ),
-        ).then((changeIncludingDependencies) => {
-            setChangesBeingReverted({
-                requestedRevertChange,
-                changeIncludingDependencies,
-            });
-        });
+    const publicationAssetChangeAmounts: PublicationAssetChangeAmounts = {
+        total: countPublishCandidates(entireChangeset),
+        staged: countPublishCandidates(stagedPreviewChanges),
+        unstaged: countPublishCandidates(unstagedPreviewChanges),
+        groupAmounts: countPublicationGroupAmounts(entireChangeset),
+        ownUnstaged:
+            user && entireChangeset
+                ? countPublishCandidates(previewCandidatesByUser(user, unstagedPreviewChanges))
+                : 0,
     };
 
     const onConfirmRevert = () => {
         if (changesBeingReverted === undefined) {
             return;
         }
+
         revertCandidates(changesBeingReverted.changeIncludingDependencies)
             .then((r) => {
                 if (r.isOk()) {
@@ -380,14 +485,136 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
             });
     };
 
-    const onPublishPreviewRemove = (selectedChange: SelectedPublishChange): void => {
-        props.onPublishPreviewRemove(
-            singleRowPublishRequestOfSelectedPublishChange(selectedChange),
-        );
+    const setStageForSpecificChanges = (
+        publishRequestIds: PublishRequestIds,
+        publicationStage: PublicationStage,
+    ) => {
+        switch (publicationStage) {
+            case PublicationStage.STAGED:
+                return props.onPublishPreviewSelect(publishRequestIds);
+
+            case PublicationStage.UNSTAGED:
+                return props.onPublishPreviewRemove(publishRequestIds);
+
+            default:
+                exhaustiveMatchingGuard(publicationStage);
+        }
     };
 
-    const onPreviewSelect = (selectedChange: SelectedPublishChange): void => {
-        props.onPreviewSelect(selectedChange);
+    const setPublicationGroupStage = (
+        publicationGroup: PublicationGroup,
+        stage: PublicationStage,
+    ) => {
+        if (!entireChangeset) {
+            return;
+        }
+
+        const groupedChanges = idsByPublicationGroup(entireChangeset, publicationGroup);
+        setStageForSpecificChanges(groupedChanges, stage);
+    };
+
+    const revertChangesWithDependencies = (
+        publishRequestIds: PublishRequestIds,
+        revertRequestSource: RevertRequestSource,
+    ) => {
+        getRevertRequestDependencies(publishRequestIds).then((changeIncludingDependencies) => {
+            setChangesBeingReverted({
+                requestedRevertChange: {
+                    type: RevertRequestType.CHANGES_WITH_DEPENDENCIES,
+                    source: revertRequestSource,
+                },
+                changeIncludingDependencies,
+            });
+        });
+    };
+
+    const getStageCandidates = (stage: PublicationStage): [PreviewCandidates, number] => {
+        switch (stage) {
+            case PublicationStage.UNSTAGED:
+                return [unstagedPreviewChanges, publicationAssetChangeAmounts.unstaged];
+
+            case PublicationStage.STAGED:
+                return [stagedPreviewChanges, publicationAssetChangeAmounts.staged];
+
+            default: {
+                return exhaustiveMatchingGuard(stage);
+            }
+        }
+    };
+
+    const revertStageChanges = (
+        stage: PublicationStage,
+        revertRequestSource: RevertRequestSource,
+    ) => {
+        const [stageCandidates, amountOfCandidates] = getStageCandidates(stage);
+        if (!stageCandidates) {
+            return;
+        }
+
+        setChangesBeingReverted({
+            requestedRevertChange: {
+                type: RevertRequestType.STAGE_CHANGES,
+                source: revertRequestSource,
+                amount: amountOfCandidates,
+                stage: stage,
+            },
+            changeIncludingDependencies: publishCandidateIds(stageCandidates),
+        });
+    };
+
+    const revertPublicationGroup = (
+        publicationGroup: PublicationGroup,
+        revertRequestSource: RevertRequestSource,
+    ) => {
+        if (!entireChangeset) {
+            return;
+        }
+
+        setChangesBeingReverted({
+            requestedRevertChange: {
+                type: RevertRequestType.PUBLICATION_GROUP,
+                source: revertRequestSource,
+                amount: publicationAssetChangeAmounts.groupAmounts[publicationGroup.id],
+                publicationGroup: publicationGroup,
+            },
+            changeIncludingDependencies: idsByPublicationGroup(entireChangeset, publicationGroup),
+        });
+    };
+
+    const setNewStageForStageChanges = (
+        currentStage: PublicationStage,
+        newStage: PublicationStage,
+    ) => {
+        switch (currentStage) {
+            case PublicationStage.STAGED:
+                return setStageForSpecificChanges(
+                    publishCandidateIds(stagedPreviewChanges),
+                    newStage,
+                );
+
+            case PublicationStage.UNSTAGED:
+                return setStageForSpecificChanges(
+                    publishCandidateIds(unstagedPreviewChanges),
+                    newStage,
+                );
+
+            default:
+                exhaustiveMatchingGuard(currentStage);
+        }
+    };
+
+    const previewOperations: PreviewOperations = {
+        setPublicationStage: {
+            forSpecificChanges: setStageForSpecificChanges,
+            forAllStageChanges: setNewStageForStageChanges,
+            forPublicationGroup: setPublicationGroupStage,
+        },
+
+        revert: {
+            stageChanges: revertStageChanges,
+            changesWithDependencies: revertChangesWithDependencies,
+            publicationGroup: revertPublicationGroup,
+        },
     };
 
     return (
@@ -401,38 +628,48 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 qa-id={'unstaged-changes'}
                                 className={styles['preview-section']}>
                                 <div className={styles['preview-view__changes-title']}>
-                                    <h3>{t('preview-view.unstaged-changes-title')}</h3>
+                                    <h3>
+                                        {t('preview-view.unstaged-changes-title', {
+                                            amount: publicationAssetChangeAmounts.unstaged,
+                                        })}
+                                    </h3>
                                     <Checkbox
                                         checked={props.showOnlyOwnUnstagedChanges}
                                         onChange={(e) => {
                                             props.setShowOnlyOwnUnstagedChanges(e.target.checked);
                                         }}>
-                                        {t('preview-view.show-only-mine')}
+                                        {t('preview-view.show-only-mine', {
+                                            amount: publicationAssetChangeAmounts.ownUnstaged,
+                                        })}
                                     </Checkbox>
                                 </div>
                                 <PreviewTable
-                                    onPreviewSelect={onPreviewSelect}
-                                    onRevert={onRequestRevert}
                                     changesBeingReverted={changesBeingReverted}
                                     previewChanges={unstagedPreviewChanges}
                                     staged={false}
                                     onShowOnMap={props.onShowOnMap}
                                     changeTimes={props.changeTimes}
+                                    publicationAssetChangeAmounts={publicationAssetChangeAmounts}
+                                    previewOperations={previewOperations}
                                 />
                             </section>
 
                             <section qa-id={'staged-changes'} className={styles['preview-section']}>
                                 <div className={styles['preview-view__changes-title']}>
-                                    <h3>{t('preview-view.staged-changes-title')}</h3>
+                                    <h3>
+                                        {t('preview-view.staged-changes-title', {
+                                            amount: publicationAssetChangeAmounts.staged,
+                                        })}
+                                    </h3>
                                 </div>
                                 <PreviewTable
-                                    onPreviewSelect={onPublishPreviewRemove}
-                                    onRevert={onRequestRevert}
                                     changesBeingReverted={changesBeingReverted}
                                     previewChanges={stagedPreviewChanges}
                                     staged={true}
                                     onShowOnMap={props.onShowOnMap}
                                     changeTimes={props.changeTimes}
+                                    publicationAssetChangeAmounts={publicationAssetChangeAmounts}
+                                    previewOperations={previewOperations}
                                 />
                             </section>
 

--- a/ui/src/preview/publication-request-dependency-list.tsx
+++ b/ui/src/preview/publication-request-dependency-list.tsx
@@ -18,8 +18,9 @@ import {
 } from 'track-layout/track-layout-react-utils';
 import { ChangeTimes } from 'common/common-slice';
 import { PreviewSelectType } from 'preview/preview-table';
-import { ChangesBeingReverted, RevertRequestType } from 'preview/preview-view';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { RevertRequestType } from 'preview/preview-view-revert-request';
+import { ChangesBeingReverted } from 'preview/preview-view';
 
 const publicationRequestSize = (req: PublishRequestIds): number =>
     req.switches.length +

--- a/ui/src/preview/publication-request-dependency-list.tsx
+++ b/ui/src/preview/publication-request-dependency-list.tsx
@@ -18,7 +18,8 @@ import {
 } from 'track-layout/track-layout-react-utils';
 import { ChangeTimes } from 'common/common-slice';
 import { PreviewSelectType } from 'preview/preview-table';
-import { ChangesBeingReverted } from 'preview/preview-view';
+import { ChangesBeingReverted, RevertRequestType } from 'preview/preview-view';
+import { exhaustiveMatchingGuard } from 'utils/type-utils';
 
 const publicationRequestSize = (req: PublishRequestIds): number =>
     req.switches.length +
@@ -124,8 +125,8 @@ export const publicationRequestTypeTranslationKey = (type: PreviewSelectType) =>
 
 export const onlyDependencies = (changesBeingReverted: ChangesBeingReverted): PublishRequestIds => {
     const allChanges = changesBeingReverted.changeIncludingDependencies;
-    const reqType = changesBeingReverted.requestedRevertChange.type;
-    const reqId = changesBeingReverted.requestedRevertChange.id;
+    const reqType = changesBeingReverted.requestedRevertChange.source.type;
+    const reqId = changesBeingReverted.requestedRevertChange.source.id;
     return {
         trackNumbers: allChanges.trackNumbers.filter(
             (tn) => reqType != PreviewSelectType.trackNumber || tn !== reqId,
@@ -145,20 +146,46 @@ export const onlyDependencies = (changesBeingReverted: ChangesBeingReverted): Pu
     };
 };
 
+const filterDisplayedDependencies = (
+    changesBeingReverted: ChangesBeingReverted,
+): PublishRequestIds => {
+    const revertRequestType = changesBeingReverted.requestedRevertChange.type;
+
+    switch (revertRequestType) {
+        case RevertRequestType.STAGE_CHANGES:
+        case RevertRequestType.PUBLICATION_GROUP:
+            return changesBeingReverted.changeIncludingDependencies;
+
+        case RevertRequestType.CHANGES_WITH_DEPENDENCIES:
+            return onlyDependencies(changesBeingReverted);
+
+        default:
+            return exhaustiveMatchingGuard(revertRequestType);
+    }
+};
+
 export interface PublicationRequestDependencyListProps {
-    dependencies: PublishRequestIds;
+    changesBeingReverted: ChangesBeingReverted;
     changeTimes: ChangeTimes;
 }
 
 export const PublicationRequestDependencyList: React.FC<PublicationRequestDependencyListProps> = ({
-    dependencies,
+    changesBeingReverted,
     changeTimes,
 }) => {
     const { t } = useTranslation();
+    const dependencies = filterDisplayedDependencies(changesBeingReverted);
+
+    const displayExtraDependencyInformation =
+        changesBeingReverted.requestedRevertChange.type ===
+        RevertRequestType.CHANGES_WITH_DEPENDENCIES;
+
     return (
         publicationRequestSize(dependencies) > 0 && (
             <>
-                <div>{t(`publish.revert-confirm.dependencies`)}</div>
+                <div>
+                    {displayExtraDependencyInformation && t(`publish.revert-confirm.dependencies`)}
+                </div>
                 <ul>
                     {dependencies.trackNumbers.map((tn) => (
                         <TrackNumberItem

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -37,12 +37,30 @@ export enum DraftChangeType {
 
 export type Operation = 'CREATE' | 'DELETE' | 'MODIFY' | 'RESTORE' | 'CALCULATED';
 
+export type PublicationGroupId = string;
+export type PublicationGroup = {
+    id: PublicationGroupId;
+};
+
+export enum PublicationStage {
+    UNSTAGED = 'UNSTAGED',
+    STAGED = 'STAGED',
+}
+
 export type PublicationId = string;
+
+export type PublishCandidateId =
+    | LayoutTrackNumberId
+    | ReferenceLineId
+    | LocationTrackId
+    | LayoutSwitchId
+    | LayoutKmPostId;
 
 export type PublishCandidate = {
     draftChangeTime: TimeStamp;
     userName: string;
     operation: Operation;
+    publicationGroup?: PublicationGroup;
     errors: PublishValidationError[];
 };
 
@@ -52,6 +70,10 @@ export type WithBoundingBox = {
 
 export type WithLocation = {
     location?: Point;
+};
+
+export type WithId = {
+    id: PublishCandidateId;
 };
 
 export type TrackNumberPublishCandidate = PublishCandidate &

--- a/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
@@ -6,10 +6,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { ChangesBeingReverted } from 'preview/preview-view';
-import {
-    onlyDependencies,
-    PublicationRequestDependencyList,
-} from 'preview/publication-request-dependency-list';
+import { PublicationRequestDependencyList } from 'preview/publication-request-dependency-list';
 import { ChangeTimes } from 'common/common-slice';
 import { revertCandidates } from 'publication/publication-api';
 import { getChangeTimes } from 'common/change-time-api';
@@ -33,7 +30,7 @@ const TrackNumberDeleteConfirmationDialog: React.FC<TrackNumberDeleteConfirmatio
             result
                 .map(() => {
                     Snackbar.success('tool-panel.track-number.delete-dialog.delete-succeeded');
-                    onSave && onSave(changesBeingReverted.requestedRevertChange.id);
+                    onSave && onSave(changesBeingReverted.requestedRevertChange.source.id);
                     onClose();
                 })
                 .mapErr(() => {
@@ -62,7 +59,7 @@ const TrackNumberDeleteConfirmationDialog: React.FC<TrackNumberDeleteConfirmatio
             <p>{t('tool-panel.track-number.delete-dialog.can-be-deleted')}</p>
             <PublicationRequestDependencyList
                 changeTimes={getChangeTimes()}
-                dependencies={onlyDependencies(changesBeingReverted)}
+                changesBeingReverted={changesBeingReverted}
             />
         </Dialog>
     );

--- a/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
@@ -5,11 +5,11 @@ import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
-import { ChangesBeingReverted } from 'preview/preview-view';
 import { PublicationRequestDependencyList } from 'preview/publication-request-dependency-list';
 import { ChangeTimes } from 'common/common-slice';
 import { revertCandidates } from 'publication/publication-api';
 import { getChangeTimes } from 'common/change-time-api';
+import { ChangesBeingReverted } from 'preview/preview-view';
 
 type TrackNumberDeleteConfirmationDialogProps = {
     changesBeingReverted: ChangesBeingReverted;

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -37,9 +37,9 @@ import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import TrackNumberDeleteConfirmationDialog from 'tool-panel/track-number/dialog/track-number-delete-confirmation-dialog';
 import { Link } from 'vayla-design-lib/link/link';
-import { ChangesBeingReverted } from 'preview/preview-view';
 import { onRequestDeleteTrackNumber } from 'tool-panel/track-number/track-number-deletion';
 import { getChangeTimes } from 'common/change-time-api';
+import { ChangesBeingReverted } from 'preview/preview-view';
 
 type TrackNumberEditDialogContainerProps = {
     editTrackNumberId?: LayoutTrackNumberId;
@@ -246,7 +246,9 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
                             }
                             errors={numberErrors.map(({ reason }) => t(mapError(reason)))}>
                             {otherTrackNumber && (
-                                <Link className={dialogStyles['dialog__alert']} onClick={() => onEditTrackNumber(otherTrackNumber.id)}>
+                                <Link
+                                    className={dialogStyles['dialog__alert']}
+                                    onClick={() => onEditTrackNumber(otherTrackNumber.id)}>
                                     {moveToEditLinkText(otherTrackNumber)}
                                 </Link>
                             )}

--- a/ui/src/tool-panel/track-number/track-number-deletion.ts
+++ b/ui/src/tool-panel/track-number/track-number-deletion.ts
@@ -2,7 +2,7 @@ import { getRevertRequestDependencies } from 'publication/publication-api';
 import { publishNothing } from 'publication/publication-model';
 import { PreviewSelectType } from 'preview/preview-table';
 import { LayoutTrackNumber } from 'track-layout/track-layout-model';
-import { ChangesBeingReverted } from 'preview/preview-view';
+import { ChangesBeingReverted, RevertRequestType } from 'preview/preview-view';
 
 export const onRequestDeleteTrackNumber = (
     trackNumber: LayoutTrackNumber,
@@ -12,9 +12,12 @@ export const onRequestDeleteTrackNumber = (
         (changeIncludingDependencies) =>
             setChangesBeingReverted({
                 requestedRevertChange: {
-                    type: PreviewSelectType.trackNumber,
-                    name: trackNumber.number,
-                    id: trackNumber.id,
+                    type: RevertRequestType.CHANGES_WITH_DEPENDENCIES,
+                    source: {
+                        type: PreviewSelectType.trackNumber,
+                        name: trackNumber.number,
+                        id: trackNumber.id,
+                    },
                 },
                 changeIncludingDependencies,
             }),

--- a/ui/src/tool-panel/track-number/track-number-deletion.ts
+++ b/ui/src/tool-panel/track-number/track-number-deletion.ts
@@ -2,7 +2,8 @@ import { getRevertRequestDependencies } from 'publication/publication-api';
 import { publishNothing } from 'publication/publication-model';
 import { PreviewSelectType } from 'preview/preview-table';
 import { LayoutTrackNumber } from 'track-layout/track-layout-model';
-import { ChangesBeingReverted, RevertRequestType } from 'preview/preview-view';
+import { RevertRequestType } from 'preview/preview-view-revert-request';
+import { ChangesBeingReverted } from 'preview/preview-view';
 
 export const onRequestDeleteTrackNumber = (
     trackNumber: LayoutTrackNumber,

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -40,9 +40,9 @@ import { getEndLinkPoints } from 'track-layout/layout-map-api';
 import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
 import { ChangeTimes } from 'common/common-slice';
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
-import { ChangesBeingReverted } from 'preview/preview-view';
 import { onRequestDeleteTrackNumber } from 'tool-panel/track-number/track-number-deletion';
 import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
+import { ChangesBeingReverted } from 'preview/preview-view';
 
 type TrackNumberInfoboxProps = {
     trackNumber: LayoutTrackNumber;

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -28,12 +28,11 @@ import {
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import { Point } from 'model/geometry';
-import { addIfExists } from 'utils/array-utils';
 import { PublishRequestIds } from 'publication/publication-model';
 import { ToolPanelAsset } from 'tool-panel/tool-panel';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { splitReducers, SplittingState } from 'tool-panel/location-track/split-store';
-import { subtractPublishRequestIds } from 'publication/publication-utils';
+import { addPublishRequestIds, subtractPublishRequestIds } from 'publication/publication-utils';
 import { PURGE } from 'redux-persist';
 import { previewReducers, PreviewState } from 'preview/preview-store';
 
@@ -353,38 +352,15 @@ const trackLayoutSlice = createSlice({
                 }
             }
         },
-        onPreviewSelect: function (
-            state: TrackLayoutState,
-            action: PayloadAction<SelectedPublishChange>,
-        ): void {
-            const trackNumbers = addIfExists(
-                state.stagedPublicationRequestIds.trackNumbers,
-                action.payload.trackNumber,
-            );
-            const referenceLines = addIfExists(
-                state.stagedPublicationRequestIds.referenceLines,
-                action.payload.referenceLine,
-            );
-            const locationTracks = addIfExists(
-                state.stagedPublicationRequestIds.locationTracks,
-                action.payload.locationTrack,
-            );
-            const switches = addIfExists(
-                state.stagedPublicationRequestIds.switches,
-                action.payload.switch,
-            );
-            const kmPosts = addIfExists(
-                state.stagedPublicationRequestIds.kmPosts,
-                action.payload.kmPost,
-            );
 
-            state.stagedPublicationRequestIds = {
-                trackNumbers: trackNumbers,
-                referenceLines: referenceLines,
-                locationTracks: locationTracks,
-                switches: switches,
-                kmPosts: kmPosts,
-            };
+        onPublishPreviewSelect: function (
+            state: TrackLayoutState,
+            action: PayloadAction<PublishRequestIds>,
+        ): void {
+            const stateCandidates = state.stagedPublicationRequestIds;
+            const toAdd = action.payload;
+
+            state.stagedPublicationRequestIds = addPublishRequestIds(stateCandidates, toAdd);
         },
 
         onPublishPreviewRemove: function (

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -153,13 +153,10 @@ export function groupBy<T, K extends string | number>(
     array: T[],
     getKey: (item: T) => K,
 ): Record<K, T[]> {
-    return array.reduce(
-        (acc, item) => {
-            (acc[getKey(item)] ||= []).push(item);
-            return acc;
-        },
-        {} as Record<K, T[]>,
-    );
+    return array.reduce((acc, item) => {
+        (acc[getKey(item)] ||= []).push(item);
+        return acc;
+    }, {} as Record<K, T[]>);
 }
 
 /**


### PR DESCRIPTION
Previously it was time consuming to move each change to the staged publications individually as well as to revert multiple changes as it also had to be done individually in most cases.

Additionally the concept of "publication group" was added. It will initially be used for location track split groups.

---

Luokittelisin tämän megapullariksi, sorgen. Laitoin kuitenkin runsaasti mainintoja.