### PR TITLE
GVT-2461: Store preview view 'show only own changes' filter state in Redux

### DIFF
--- a/ui/src/preview/preview-container.tsx
+++ b/ui/src/preview/preview-container.tsx
@@ -12,6 +12,8 @@ export const PreviewContainer: React.FC = () => {
     const props: PreviewProps = {
         changeTimes: changeTimes,
         selectedPublishCandidateIds: trackLayoutState.stagedPublicationRequestIds,
+        showOnlyOwnUnstagedChanges: trackLayoutState.previewState.showOnlyOwnUnstagedChanges,
+        setShowOnlyOwnUnstagedChanges: delegates.setShowOnlyOwnUnstagedChanges,
         onSelect: delegates.onSelect,
         onClosePreview: () => delegates.onLayoutModeChange('DEFAULT'),
         onPublish: delegates.onPublish,

--- a/ui/src/preview/preview-store.tsx
+++ b/ui/src/preview/preview-store.tsx
@@ -1,0 +1,14 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+export type PreviewState = {
+    showOnlyOwnUnstagedChanges: boolean;
+};
+
+export const previewReducers = {
+    setShowOnlyOwnUnstagedChanges: function (
+        state: PreviewState,
+        action: PayloadAction<boolean>,
+    ): void {
+        state.showOnlyOwnUnstagedChanges = action.payload;
+    },
+};

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -73,6 +73,8 @@ export type ChangesBeingReverted = {
 export type PreviewProps = {
     changeTimes: ChangeTimes;
     selectedPublishCandidateIds: PublishRequestIds;
+    showOnlyOwnUnstagedChanges: boolean;
+    setShowOnlyOwnUnstagedChanges: (checked: boolean) => void;
     onSelect: OnSelectFunction;
     onPublish: () => void;
     onClosePreview: () => void;
@@ -275,8 +277,6 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const { t } = useTranslation();
 
     const revertedCandidatesSoFar = useRef(publishCandidateIds(emptyChanges));
-
-    const [onlyShowMine, setOnlyShowMine] = React.useState(false);
     const user = useLoader(getOwnUser, []);
 
     const entireChangeset = useLoader(() => getPublishCandidates(), [props.changeTimes]);
@@ -324,7 +324,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                   kmPosts: unstagedChanges.kmPosts.map(nonPendingCandidate),
               }
             : emptyChanges;
-        return user && onlyShowMine
+        return user && props.showOnlyOwnUnstagedChanges
             ? previewCandidatesByUser(user, allUnstagedChangesValidated)
             : allUnstagedChangesValidated;
     })();
@@ -403,9 +403,9 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                 <div className={styles['preview-view__changes-title']}>
                                     <h3>{t('preview-view.unstaged-changes-title')}</h3>
                                     <Checkbox
-                                        checked={onlyShowMine}
+                                        checked={props.showOnlyOwnUnstagedChanges}
                                         onChange={(e) => {
-                                            setOnlyShowMine(e.target.checked);
+                                            props.setShowOnlyOwnUnstagedChanges(e.target.checked);
                                         }}>
                                         {t('preview-view.show-only-mine')}
                                     </Checkbox>

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -35,6 +35,7 @@ import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { splitReducers, SplittingState } from 'tool-panel/location-track/split-store';
 import { subtractPublishRequestIds } from 'publication/publication-utils';
 import { PURGE } from 'redux-persist';
+import { previewReducers, PreviewState } from 'preview/preview-store';
 
 export type SelectedPublishChange = {
     trackNumber: LayoutTrackNumberId | undefined;
@@ -196,6 +197,7 @@ export type TrackLayoutState = {
     switchLinkingSelectedBeforeLinking: boolean;
     selectedToolPanelTab: ToolPanelAsset | undefined;
     infoboxVisibilities: InfoboxVisibilities;
+    previewState: PreviewState;
 };
 
 export const initialTrackLayoutState: TrackLayoutState = {
@@ -208,6 +210,9 @@ export const initialTrackLayoutState: TrackLayoutState = {
     switchLinkingSelectedBeforeLinking: false,
     selectedToolPanelTab: undefined,
     infoboxVisibilities: initialInfoboxVisibilities,
+    previewState: {
+        showOnlyOwnUnstagedChanges: false,
+    },
 };
 
 export function getSelectableItemTypes(
@@ -276,6 +281,7 @@ const trackLayoutSlice = createSlice({
         ...wrapReducers((state: TrackLayoutState) => state.selection, selectionReducers),
         ...wrapReducers((state: TrackLayoutState) => state, linkingReducers),
         ...wrapReducers((state: TrackLayoutState) => state, splitReducers),
+        ...wrapReducers((state: TrackLayoutState) => state.previewState, previewReducers),
 
         onInfoboxVisibilityChange: (
             state: TrackLayoutState,


### PR DESCRIPTION
Previously the user had to re-enable the filter if they only wanted to view their own unstaged changes.

---

Loin näitä varten uuden tiedoston jo vähän jatkoa ajatellen. Esikatselunäkymään liittyvät asiat- ja tilankäsittely voisivat elää ihan omassa paikassaan (en vielä kuitenkaan siirrellyt tässä yhteydessä nykyisiä esikatseluun & Reduksiin liittyviä asioita uuteen paikkaan).