### PR TITLE
GVT-2462: Massasiirron tila tulisi näyttää heti suoritetuksi merkitsemisen jälkeen

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.projektivelho.PVDocumentService
 import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.ratko.RatkoPushDao
+import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.tracklayout.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -28,6 +29,7 @@ data class CollectedChangeTimes(
     val publication: Instant,
     val ratkoPush: Instant,
     val pvDocument: Instant,
+    val split: Instant,
 )
 
 @RestController
@@ -42,6 +44,7 @@ class ChangeTimeController(
     private val publicationService: PublicationService,
     private val ratkoPushDao: RatkoPushDao,
     private val pvDocumentService: PVDocumentService,
+    private val splitService: SplitService,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -63,6 +66,7 @@ class ChangeTimeController(
             publication = publicationService.getChangeTime(),
             ratkoPush = ratkoPushDao.getRatkoPushChangeTime(),
             pvDocument = pvDocumentService.getDocumentChangeTime(),
+            split = splitService.getChangeTime(),
         )
     }
 
@@ -134,5 +138,12 @@ class ChangeTimeController(
     fun getPVDocumentChangeTime(): Instant {
         logger.apiCall("getPVDocumentChangeTime")
         return pvDocumentService.getDocumentChangeTime()
+    }
+
+    @PreAuthorize(AUTH_UI_READ)
+    @GetMapping("/splits")
+    fun getSplitChangeTime(): Instant {
+        logger.apiCall("getSplitChangeTime")
+        return splitService.getChangeTime()
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -263,6 +263,8 @@ class SplitDao(
         }
     }
 
+    fun fetchChangeTime() = fetchLatestChangeTime(DbTable.PUBLICATION_SPLIT)
+
     fun fetchSplitIdByPublication(publicationId: IntId<Publication>): IntId<Split>? {
         val sql = """
             select id from publication.split where publication_id = :publication_id

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -19,6 +19,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 
 @Service
 class SplitService(
@@ -46,6 +47,11 @@ class SplitService(
         )
 
         return splitDao.saveSplit(locationTrackId, splitTargets, relinkedSwitches)
+    }
+
+    fun getChangeTime(): Instant {
+        logger.serviceCall("getChangeTime")
+        return splitDao.fetchChangeTime()
     }
 
     fun findPendingSplitsForLocationTracks(locationTracks: Collection<IntId<LocationTrack>>) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -41,7 +41,9 @@ enum class DbTable(schema: String, table: String, sortColumns: List<String> = li
     GEOMETRY_KM_POST("geometry", "km_post", listOf("track_number_id", "km_number")),
     GEOMETRY_TRACK_NUMBER("geometry", "track_number"),
 
-    PROJEKTIVELHO_DOCUMENT("projektivelho", "document");
+    PROJEKTIVELHO_DOCUMENT("projektivelho", "document"),
+
+    PUBLICATION_SPLIT("publication", "split");
 
     val fullName: String = "$schema.$table"
     val versionTable = "$schema.${table}_version"

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -630,6 +630,7 @@
             "splitting": {
                 "title": "Raiteen jakaminen osiin",
                 "confirm-split": "Suorita jako",
+                "splitting-success": "Sijaintiraide {{locationTrackName}} jaettu {{count}} osaan",
                 "splitting-guide": "Valitse kartalta vaihteet, joiden kohdalta raide katkaistaan.",
                 "start-address": "Alkusijainti (km + m)",
                 "split-address": "Katkaisukohta (km + m)",

--- a/ui/src/common/change-time-api.ts
+++ b/ui/src/common/change-time-api.ts
@@ -100,6 +100,14 @@ export function updatePVDocumentsChangeTime(): Promise<TimeStamp> {
     );
 }
 
+export function updateSplitChangeTime(): Promise<TimeStamp> {
+    return updateChangeTime(
+        `${CHANGES_API}/splits`,
+        delegates.setSplitChangeTime,
+        getChangeTimes().split,
+    );
+}
+
 function updateChangeTime(
     url: string,
     storeUpdate: (ts: TimeStamp) => void,

--- a/ui/src/common/common-slice.ts
+++ b/ui/src/common/common-slice.ts
@@ -16,6 +16,7 @@ export type ChangeTimes = {
     publication: TimeStamp;
     ratkoPush: TimeStamp;
     pvDocument: TimeStamp;
+    split: TimeStamp;
 };
 
 export const initialChangeTime: TimeStamp = '1970-01-01T00:00:00.000Z';
@@ -31,6 +32,7 @@ export const initialChangeTimes: ChangeTimes = {
     publication: initialChangeTime,
     ratkoPush: initialChangeTime,
     pvDocument: initialChangeTime,
+    split: initialChangeTime,
 };
 
 export type CommonState = {
@@ -128,6 +130,9 @@ const commonSlice = createSlice({
             { payload }: PayloadAction<TimeStamp>,
         ) {
             if (toDate(changeTimes.ratkoPush) < toDate(payload)) changeTimes.ratkoPush = payload;
+        },
+        setSplitChangeTime: function ({ changeTimes }, { payload }) {
+            updateChangeTime(changeTimes, 'split', payload);
         },
         setUserPrivileges: (
             state: CommonState,

--- a/ui/src/frontpage/frontpage-container.tsx
+++ b/ui/src/frontpage/frontpage-container.tsx
@@ -7,11 +7,13 @@ export const FrontpageContainer: React.FC = () => {
         (state) => state.changeTimes.publication,
     );
     const ratkoPushChangeTime = useCommonDataAppSelector((state) => state.changeTimes.ratkoPush);
+    const splitChangeTime = useCommonDataAppSelector((state) => state.changeTimes.split);
 
     return (
         <Frontpage
             publicationChangeTime={publicationChangeTime}
             ratkoPushChangeTime={ratkoPushChangeTime}
+            splitChangeTime={splitChangeTime}
         />
     );
 };

--- a/ui/src/frontpage/frontpage.tsx
+++ b/ui/src/frontpage/frontpage.tsx
@@ -11,9 +11,14 @@ import { TimeStamp } from 'common/common-model';
 type FrontPageProps = {
     publicationChangeTime: TimeStamp;
     ratkoPushChangeTime: TimeStamp;
+    splitChangeTime: TimeStamp;
 };
 
-const Frontpage: React.FC<FrontPageProps> = ({ publicationChangeTime, ratkoPushChangeTime }) => {
+const Frontpage: React.FC<FrontPageProps> = ({
+    publicationChangeTime,
+    ratkoPushChangeTime,
+    splitChangeTime,
+}) => {
     const [ratkoStatus, setRatkoStatus] = React.useState<RatkoStatus | undefined>();
 
     useLoaderWithTimer(setRatkoStatus, getRatkoStatus, [], 30000);
@@ -24,6 +29,7 @@ const Frontpage: React.FC<FrontPageProps> = ({ publicationChangeTime, ratkoPushC
                 <PublicationCard
                     publicationChangeTime={publicationChangeTime}
                     ratkoPushChangeTime={ratkoPushChangeTime}
+                    splitChangeTime={splitChangeTime}
                     ratkoStatus={ratkoStatus}
                 />
                 <UserCardContainer />

--- a/ui/src/publication/card/publication-card.tsx
+++ b/ui/src/publication/card/publication-card.tsx
@@ -27,6 +27,7 @@ import {
 type PublishListProps = {
     publicationChangeTime: TimeStamp;
     ratkoPushChangeTime: TimeStamp;
+    splitChangeTime: TimeStamp;
     ratkoStatus: RatkoStatus | undefined;
 };
 
@@ -73,6 +74,7 @@ export const MAX_LISTED_PUBLICATIONS = 8;
 const PublicationCard: React.FC<PublishListProps> = ({
     publicationChangeTime,
     ratkoPushChangeTime,
+    splitChangeTime,
     ratkoStatus,
 }) => {
     const { t } = useTranslation();
@@ -90,7 +92,7 @@ const PublicationCard: React.FC<PublishListProps> = ({
     const [pageCount, setPageCount] = React.useState(1);
     const [publications, publicationFetchStatus] = useLoaderWithStatus(
         () => getLatestPublications(MAX_LISTED_PUBLICATIONS * pageCount),
-        [publicationChangeTime, ratkoPushChangeTime, pageCount],
+        [publicationChangeTime, ratkoPushChangeTime, splitChangeTime, pageCount],
     );
 
     const allPublications =

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -15,6 +15,7 @@ import { Menu } from 'vayla-design-lib/menu/menu';
 import { SplitDetailsDialog } from 'publication/split/split-details-dialog';
 import { putBulkTransferState } from 'publication/split/split-api';
 import { success } from 'geoviite-design-lib/snackbar/snackbar';
+import { updateSplitChangeTime } from 'common/change-time-api';
 
 type PublicationListRowProps = {
     publication: PublicationDetails;
@@ -93,9 +94,11 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
         {
             onSelect: () => {
                 if (publication.split)
-                    putBulkTransferState(publication.split.id, 'DONE').then(() => {
-                        success(t('publication-card.bulk-transfer-marked-as-successful'));
-                    });
+                    putBulkTransferState(publication.split.id, 'DONE')
+                        .then(() => {
+                            success(t('publication-card.bulk-transfer-marked-as-successful'));
+                        })
+                        .then(() => updateSplitChangeTime());
                 setMenuOpen(false);
             },
             qaId: 'mark-bulk-transfer-as-finished-link',

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -47,6 +47,7 @@ import { getChangeTimes } from 'common/change-time-api';
 import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { postSplitLocationTrack } from 'publication/split/split-api';
+import { success } from 'geoviite-design-lib/snackbar/snackbar';
 
 type LocationTrackSplittingInfoboxContainerProps = {
     visibilities: LocationTrackInfoboxVisibilities;
@@ -425,7 +426,15 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                 duplicateTracksInCurrentSplits,
             ),
         )
-            .then(() => stopSplitting())
+            .then(() => {
+                stopSplitting();
+                success(
+                    t('tool-panel.location-track.splitting.splitting-success', {
+                        locationTrackName: locationTrack.name,
+                        count: allValidated.length,
+                    }),
+                );
+            })
             .catch(() => returnToSplitting());
     };
 


### PR DESCRIPTION
Massasiirron tilan muuttaminen ei muuta itse julkaisua -> siihen liittyvä aikaleima ei muutu. Täten lisätty spliteille oma aikaleima, jonka perusteella julkaisut haetaan uudelleen.