### PR TITLE
GVT-2422: Review-korjauksia

### DIFF
--- a/ui/src/tool-panel/infobox/infobox.module.scss
+++ b/ui/src/tool-panel/infobox/infobox.module.scss
@@ -142,7 +142,11 @@
     @include vayla-design.typography-caption;
     display: inline-block;
     padding: 6px 8px 6px 8px;
+    border-top: 0;
+    border-left: 0;
+    border-right: 0;
     border-bottom: 3px solid transparent;
+    background-color: vayla-design.$color-white-default;
     cursor: pointer;
     max-width: 190px;
     box-sizing: border-box;

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -548,12 +548,12 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                             selected && 'tool-panel__tab--selected',
                         );
                         return (
-                            <div
+                            <button
                                 className={className}
                                 key={t.asset.type + '_' + t.asset.id}
                                 onClick={() => changeTab(t.asset)}>
                                 {t.title}
-                            </div>
+                            </button>
                         );
                     })}
                 </div>


### PR DESCRIPTION
Korvattu divit buttoneilla. Meidän `<Button>` ei tuohon käyttöön oikeastaan taipunut, niin käytin sitten ihan vaan HTML:n perus-nappia (ja sitäkin sai säätää hieman lisää että se näytti oikealta.) Jos meillä olisi koskaan tarvetta näyttää tab-headereita muualla, niin tuosta kannattaisi eriyttää oma komponenttinsa, mutta en katsonut sitä tarpeelliseksi pelkästään tälle käyttötapaukselle.