### PR TITLE
GVT-2460: Restrict height of publication change revert dialog

### DIFF
--- a/ui/src/geoviite-design-lib/dialog/dialog.scss
+++ b/ui/src/geoviite-design-lib/dialog/dialog.scss
@@ -47,6 +47,10 @@ $dialog-padding: $dialog-padding-vertical $dialog-padding-horizontal;
         max-width: 1040px;
     }
 
+    &--height-restricted-to-half {
+        max-height: 50%;
+    }
+
     &--dark {
         background: colors.$color-blue-darker;
         color: colors.$color-white-default;

--- a/ui/src/geoviite-design-lib/dialog/dialog.tsx
+++ b/ui/src/geoviite-design-lib/dialog/dialog.tsx
@@ -15,6 +15,10 @@ export enum DialogWidth {
     THREE_COLUMNS = 'dialog__popup--three-columns',
 }
 
+export enum DialogHeight {
+    RESTRICTED_TO_HALF_OF_VIEWPORT = 'dialog__popup--height-restricted-to-half',
+}
+
 export type DialogProps = {
     title?: string;
     children?: React.ReactNode;
@@ -23,6 +27,7 @@ export type DialogProps = {
     onClose?: () => void;
     variant?: DialogVariant;
     width?: DialogWidth;
+    height?: DialogHeight;
     allowClose?: boolean;
     className?: string;
 } & Pick<React.HTMLProps<HTMLElement>, 'style'>;
@@ -73,6 +78,7 @@ export const Dialog: React.FC<DialogProps> = ({
                 className={createClassName(
                     styles['dialog__popup'],
                     styles[width],
+                    props.height && styles[props.height],
                     props.className,
                     props.variant && styles[props.variant],
                     dialogDragParams && styles['dialog__popup--moving'],

--- a/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
+++ b/ui/src/preview/preview-confirm-revert-changes-dialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
+import { Dialog, DialogHeight, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import * as React from 'react';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
@@ -83,6 +83,7 @@ export const PreviewConfirmRevertChangesDialog: React.FC<PreviewRejectConfirmDia
         <Dialog
             title={dialogTitle()}
             variant={DialogVariant.LIGHT}
+            height={DialogHeight.RESTRICTED_TO_HALF_OF_VIEWPORT}
             allowClose={!isReverting}
             onClose={cancelRevertChanges}
             footerContent={

--- a/ui/src/preview/preview-view.scss
+++ b/ui/src/preview/preview-view.scss
@@ -192,7 +192,3 @@ $-color-warning: vayla-design.$color-lemon-dark;
 .preview-confirm__description {
     margin-bottom: 20px;
 }
-
-.preview-confirm__dependency-list {
-    max-height: 50%;
-}


### PR DESCRIPTION
Previously the dialog scaled to the entire viewport height when there were many changes which was unexpected/unwanted behavior.