### PR TITLE
GVT-2423: Koitetaan kääntää TypeScriptin noUncheckedIndexedAccess päälle

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
@@ -126,7 +126,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
     fun getLocationTrackEnds(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") id: IntId<LocationTrack>,
-    ): List<AlignmentPoint> {
+    ): MapAlignmentEndPoints {
         logger.apiCall("getLocationTrackEnds", "publishType" to publishType, "id" to id)
         return mapAlignmentService.getLocationTrackEnds(publishType, id)
     }
@@ -136,7 +136,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
     fun getReferenceLineEnds(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") id: IntId<ReferenceLine>,
-    ): List<AlignmentPoint> {
+    ): MapAlignmentEndPoints {
         logger.apiCall("getReferenceLineEnds", "publishType" to publishType, "id" to id)
         return mapAlignmentService.getReferenceLineEnds(publishType, id)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
@@ -27,6 +27,11 @@ data class MapAlignmentHighlight<T>(
     val ranges: List<Range<Double>>,
 )
 
+data class MapAlignmentEndPoints(
+    val start: List<AlignmentPoint>,
+    val end: List<AlignmentPoint>,
+)
+
 @Service
 class MapAlignmentService(
     private val trackNumberService: LayoutTrackNumberService,
@@ -148,13 +153,13 @@ class MapAlignmentService(
         return getSegmentBorderMValues(alignment)
     }
 
-    fun getLocationTrackEnds(publishType: PublishType, id: IntId<LocationTrack>): List<AlignmentPoint> {
+    fun getLocationTrackEnds(publishType: PublishType, id: IntId<LocationTrack>): MapAlignmentEndPoints {
         logger.serviceCall("getLocationTrackEnds", "publishType" to publishType, "id" to id)
         val (_, alignment) = locationTrackService.getWithAlignmentOrThrow(publishType, id)
         return getEndPoints(alignment)
     }
 
-    fun getReferenceLineEnds(publishType: PublishType, id: IntId<ReferenceLine>): List<AlignmentPoint> {
+    fun getReferenceLineEnds(publishType: PublishType, id: IntId<ReferenceLine>): MapAlignmentEndPoints {
         logger.serviceCall("getReferenceLineEnds", "publishType" to publishType, "id" to id)
         val (_, alignment) = referenceLineService.getWithAlignmentOrThrow(publishType, id)
         return getEndPoints(alignment)
@@ -211,5 +216,5 @@ private fun <T> getMissingLinkings(
 private fun getMissingLinkingRanges(alignment: LayoutAlignment): List<Range<Double>> =
     combineContinuous(alignment.segments.filter { s -> s.sourceId == null }.map { s -> Range(s.startM, s.endM) })
 
-private fun getEndPoints(alignment: LayoutAlignment): List<AlignmentPoint> =
-    alignment.takeFirst(2) + alignment.takeLast(2)
+private fun getEndPoints(alignment: LayoutAlignment): MapAlignmentEndPoints =
+    MapAlignmentEndPoints(alignment.takeFirst(2), alignment.takeLast(2))

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -61,7 +61,7 @@ export const trackMeterIsValid = (trackMeter: string) => TRACK_METER_REGEX.test(
 const splitTrackMeterIntoComponents = (trackMeterString: string) => {
     const components = trackMeterString.match(TRACK_METER_REGEX);
     return {
-        kms: components && components[1].padStart(4, '0'),
+        kms: components && components[1]?.padStart(4, '0'),
         letters: components && components[2],
         meters: components && components[3],
     };

--- a/ui/src/environment/env-restricted.tsx
+++ b/ui/src/environment/env-restricted.tsx
@@ -10,7 +10,7 @@ type EnvRestrictedProps = {
 
 //Local is only shown in local environment,
 //Test is only shown in local, dev and test environment etc.
-const slackRestrictionRules: { [key: string]: Environment[] } = {
+const slackRestrictionRules: { [key in Environment]: Environment[] } = {
     local: ['local'],
     dev: ['local', 'dev'],
     test: ['local', 'dev', 'test'],

--- a/ui/src/infra-model/list/infra-model-load-button.tsx
+++ b/ui/src/infra-model/list/infra-model-load-button.tsx
@@ -17,8 +17,9 @@ const InfraModelLoadButton: React.FC<InframodelLoadButtonProps> = ({
     const navigate = useAppNavigate();
     const { t } = useTranslation();
     async function handleFileInputEvent(e: React.ChangeEvent<HTMLInputElement>) {
-        if (e.target.files) {
-            const serializableFile = await convertToSerializableFile(e.target.files[0]);
+        const file = e.target.files?.[0];
+        if (file) {
+            const serializableFile = await convertToSerializableFile(file);
             onFileSelected(serializableFile);
             navigate('inframodel-upload');
         }

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -1,4 +1,5 @@
 import {
+    AlignmentPoint,
     LayoutKmPostId,
     LayoutState,
     LayoutStateCategory,
@@ -96,6 +97,11 @@ export type LinkInterval = {
     end?: LinkPoint;
 };
 export const emptyLinkInterval = { start: undefined, end: undefined };
+
+export type MapAlignmentEndPoints = {
+    start: AlignmentPoint[];
+    end: AlignmentPoint[];
+};
 
 export type LinkingPhase = 'preliminary' | 'setup' | 'allSet';
 

--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -24,7 +24,7 @@ import {
 } from 'track-layout/track-layout-model';
 import { GeometryKmPostId } from 'geometry/geometry-model';
 import { angleDiffRads, directionBetweenPoints, interpolateXY } from 'utils/math-utils';
-import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { exhaustiveMatchingGuard, getUnsafe } from 'utils/type-utils';
 
 export const linkingReducers = {
     startAlignmentLinking: (
@@ -443,27 +443,27 @@ export function createLinkPoints(
     segmentEndMs: number[],
     points: AlignmentPoint[],
 ): LinkPoint[] {
-    let segmentMIndex = 0;
     return points.flatMap((point, pIdx) => {
         const linkPoints: LinkPoint[] = [];
 
-        // Generate points for segment start/end markers if needed
-        while (segmentMIndex < segmentEndMs.length && segmentEndMs[segmentMIndex] <= point.m) {
-            const newM = segmentEndMs[segmentMIndex];
-            segmentMIndex++;
+        segmentEndMs.every((endM) => {
+            // Generate points for segment start/end markers if needed
+            if (endM <= point.m) return false;
+
             // Only do the interpolated point if it's not in the actual points already
-            if (pIdx > 0 && newM < point.m) {
+            const previousPoint = points[pIdx - 1];
+            if (previousPoint && endM < point.m) {
                 linkPoints.push(
-                    interpolateSegmentEndLinkPoint(type, id, points[pIdx - 1], point, newM),
+                    interpolateSegmentEndLinkPoint(type, id, previousPoint, point, endM),
                 );
             }
-        }
+        });
 
         // Create the linkpoint from layout point
         const direction =
             pIdx === 0
-                ? directionBetweenPoints(point, points[pIdx + 1])
-                : directionBetweenPoints(points[pIdx - 1], point);
+                ? directionBetweenPoints(point, getUnsafe(points[pIdx + 1]))
+                : directionBetweenPoints(getUnsafe(points[pIdx - 1]), point);
         const segmentEnd = segmentEndMs.includes(point.m);
         const alignmentEnd = point.m === 0 || point.m === alignmentLength;
         linkPoints.push(

--- a/ui/src/linking/linking-utils.ts
+++ b/ui/src/linking/linking-utils.ts
@@ -7,6 +7,7 @@ import {
     LocationTrackId,
 } from 'track-layout/track-layout-model';
 import { getLocationTracks } from 'track-layout/layout-location-track-api';
+import { getUnsafe } from 'utils/type-utils';
 
 export enum SwitchTypeMatch {
     Exact,
@@ -55,9 +56,10 @@ export function getMatchingLocationTrackIdsForJoints(
         .flatMap((joint) => joint.accurateMatches.map((m) => m.locationTrackId))
         .filter(filterUnique);
     return locationTrackIds.filter((locationTrackId) => {
-        return [jointsOfAlignment[0], jointsOfAlignment[jointsOfAlignment.length - 1]].every(
-            (joint) => joint.accurateMatches.some((m) => m.locationTrackId == locationTrackId),
-        );
+        return [
+            getUnsafe(jointsOfAlignment[0]),
+            getUnsafe(jointsOfAlignment[jointsOfAlignment.length - 1]),
+        ].every((joint) => joint.accurateMatches.some((m) => m.locationTrackId == locationTrackId));
     });
 }
 
@@ -88,9 +90,8 @@ export function getLocationTracksForJointConnections(
 }
 
 export function getSuggestedSwitchId(suggestedSwitch: SuggestedSwitch): string {
-    return `${suggestedSwitch.geometrySwitchId}_${
-        suggestedSwitch.alignmentEndPoint?.locationTrackId
-    }_${suggestedSwitch.joints.map(
+    return `${suggestedSwitch.geometrySwitchId}_${suggestedSwitch.alignmentEndPoint
+        ?.locationTrackId}_${suggestedSwitch.joints.map(
         (j) => j.number + j.matches.map((m) => m.locationTrackId + m.segmentIndex + m.m),
     )}`;
 }
@@ -119,21 +120,26 @@ export function combineLocationTrackIds(
     }
 
     return Object.values(
-        locationTracks.flat().reduce((acc, locationTrack) => {
-            const jointNumber = locationTrack.jointNumber;
+        locationTracks.flat().reduce(
+            (acc, locationTrack) => {
+                const jointNumber = locationTrack.jointNumber;
 
-            if (acc[jointNumber]) {
-                acc[jointNumber] = {
-                    jointNumber: jointNumber,
-                    locationTrackIds: acc[jointNumber].locationTrackIds
-                        .concat(locationTrack.locationTrackIds)
-                        .filter(filterUnique),
-                };
-            } else {
-                acc[jointNumber] = locationTrack;
-            }
+                if (acc[jointNumber]) {
+                    acc[jointNumber] = {
+                        jointNumber: jointNumber,
+                        locationTrackIds: getUnsafe(
+                            acc[jointNumber]?.locationTrackIds
+                                .concat(locationTrack.locationTrackIds)
+                                .filter(filterUnique),
+                        ),
+                    };
+                } else {
+                    acc[jointNumber] = locationTrack;
+                }
 
-            return acc;
-        }, {} as { [key: JointNumber]: LocationTracksEndingAtJoint }),
+                return acc;
+            },
+            {} as { [key: JointNumber]: LocationTracksEndingAtJoint },
+        ),
     );
 }

--- a/ui/src/linking/switch-suggestion-creator-container.tsx
+++ b/ui/src/linking/switch-suggestion-creator-container.tsx
@@ -25,9 +25,10 @@ export const SwitchSuggestionCreatorContainer: React.FC = () => {
         locationTrackChangeTime: locationTrackChangeTime,
     }));
 
-    const suggestionCreatorData: SuggestionCreatorData = state.locationTrackEndPoint && {
-        locationTrackEndPoint: state.locationTrackEndPoint,
-    };
+    const suggestionCreatorData: SuggestionCreatorData | undefined =
+        state.locationTrackEndPoint && {
+            locationTrackEndPoint: state.locationTrackEndPoint,
+        };
 
     function unselectLocationTrackEndPoint() {
         onSelect({

--- a/ui/src/map/layers/alignment/alignment-linking-layer.ts
+++ b/ui/src/map/layers/alignment/alignment-linking-layer.ts
@@ -924,10 +924,12 @@ export function createAlignmentLinkingLayer(
                             ...selection,
                             highlightedItems: {
                                 ...selection.highlightedItems,
-                                layoutLinkPoints: [getUnsafe(linkPointAddresses.layoutHighlight)],
-                                geometryLinkPoints: [
-                                    getUnsafe(linkPointAddresses.geometryHighlight),
-                                ],
+                                layoutLinkPoints: linkPointAddresses.layoutHighlight
+                                    ? [getUnsafe(linkPointAddresses.layoutHighlight)]
+                                    : [],
+                                geometryLinkPoints: linkPointAddresses.geometryHighlight
+                                    ? [getUnsafe(linkPointAddresses.geometryHighlight)]
+                                    : [],
                             },
                         },
                         {

--- a/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
@@ -31,6 +31,7 @@ import {
     getManyStartsAndEnds,
 } from 'track-layout/layout-location-track-api';
 import { Point } from 'model/geometry';
+import { getCoordsUnsafe, getUnsafe } from 'utils/type-utils';
 
 type EndpointType = 'START' | 'END';
 const BLACK = '#000000';
@@ -67,7 +68,8 @@ function createDuplicateTrackEndpointAddressFeature(
         (endpointType === 'START' && positiveXOffset) ||
         (endpointType === 'END' && !positiveXOffset);
 
-    const renderer = ([x, y]: Coordinate, { pixelRatio, context }: State) => {
+    const renderer = (coord: Coordinate, { pixelRatio, context }: State) => {
+        const [x, y] = getCoordsUnsafe(coord);
         const ctx = context;
 
         ctx.font = `${mapStyles['alignmentBadge-font-weight']} ${
@@ -170,12 +172,12 @@ function createFeatures(
             // The 'points'-array may only include a subset of the actual points of the alignment.
             // Features should only be rendered to the real ends of a given duplicate.
             const startFeature = trackMetersAreApproximatelySame(
-                points[0].m,
+                getUnsafe(points[0]).m,
                 startAndEnd?.start?.point.m,
             )
                 ? createDuplicateTrackEndpointAddressFeature(
-                      points[0],
-                      points[1],
+                      getUnsafe(points[0]),
+                      getUnsafe(points[1]),
                       header.name,
                       startAndEnd?.start?.address,
                       'START',
@@ -186,12 +188,12 @@ function createFeatures(
                 : undefined;
 
             const endFeature = trackMetersAreApproximatelySame(
-                points[points.length - 1].m,
+                getUnsafe(points[points.length - 1]).m,
                 startAndEnd?.end?.point.m,
             )
                 ? createDuplicateTrackEndpointAddressFeature(
-                      points[points.length - 1],
-                      points[points.length - 2],
+                      getUnsafe(points[points.length - 1]),
+                      getUnsafe(points[points.length - 2]),
                       header.name,
                       startAndEnd?.end?.address,
                       'END',

--- a/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
@@ -14,6 +14,7 @@ import { SplittingState } from 'tool-panel/location-track/split-store';
 import { createAlignmentFeature } from '../utils/alignment-layer-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
+import { getUnsafe } from 'utils/type-utils';
 
 let newestLayerId = 0;
 
@@ -66,7 +67,7 @@ export function createLocationTrackSelectedAlignmentLayer(
 
             const showEndPointTicks = resolution <= Limits.SHOW_LOCATION_TRACK_BADGES;
 
-            const track = locationTracks[0];
+            const track = getUnsafe(locationTracks[0]);
             const isSplitting = splittingState?.originLocationTrack.id === track.header.id;
             const alignmentFeatures = createAlignmentFeature(
                 track,

--- a/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
@@ -11,6 +11,7 @@ import { getSelectedReferenceLineMapAlignmentByTiles } from 'track-layout/layout
 import { createAlignmentFeature } from '../utils/alignment-layer-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
+import { getUnsafe } from 'utils/type-utils';
 
 let newestLayerId = 0;
 
@@ -50,7 +51,7 @@ export function createSelectedReferenceLineAlignmentLayer(
             if (layerId !== newestLayerId) return;
 
             const alignmentFeatures = createAlignmentFeature(
-                referenceLines[0],
+                getUnsafe(referenceLines[0]),
                 false,
                 selectedReferenceLineStyle,
             );

--- a/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
+++ b/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
@@ -33,6 +33,7 @@ import {
     indicatorTextBackgroundHeight,
     indicatorTextPadding,
 } from 'map/layers/utils/dashed-line-indicator-utils';
+import { getCoordsUnsafe, getUnsafe } from 'utils/type-utils';
 
 let newestLayerId = 0;
 
@@ -67,7 +68,8 @@ function createAddressFeature(
         pointToCoords(controlPoint),
     );
 
-    const renderer = ([x, y]: Coordinate, { pixelRatio, context }: State) => {
+    const renderer = (coord: Coordinate, { pixelRatio, context }: State) => {
+        const [x, y] = getCoordsUnsafe(coord);
         const ctx = context;
 
         ctx.font = `${mapStyles['alignmentBadge-font-weight']} ${
@@ -134,14 +136,22 @@ function createAddressFeatures(
         const points = referenceLine.points;
 
         if (startAddress && color) {
-            features.push(createAddressFeature(points[0], points[1], startAddress, false, color));
+            features.push(
+                createAddressFeature(
+                    getUnsafe(points[0]),
+                    getUnsafe(points[1]),
+                    startAddress,
+                    false,
+                    color,
+                ),
+            );
         }
 
         if (endAddress && color) {
             const lastIndex = points.length - 1;
             const f = createAddressFeature(
-                points[lastIndex - 1],
-                points[lastIndex],
+                getUnsafe(points[lastIndex - 1]),
+                getUnsafe(points[lastIndex]),
                 endAddress,
                 true,
                 color,

--- a/ui/src/map/layers/utils/badge-layer-utils.ts
+++ b/ui/src/map/layers/utils/badge-layer-utils.ts
@@ -13,6 +13,7 @@ import { Selection } from 'selection/selection-model';
 import { LinkingState } from 'linking/linking-model';
 import { getAlignmentHeaderStates } from 'map/layers/utils/alignment-layer-utils';
 import { BADGE_DRAW_DISTANCES } from 'map/layers/utils/layer-visibility-limits';
+import { getCoordsUnsafe, getUnsafe } from 'utils/type-utils';
 
 type MapAlignmentBadgePoint = {
     point: number[];
@@ -40,7 +41,8 @@ export function createBadgeFeatures(
         const fontSize = 12;
         const badgeNoseWidth = 4;
 
-        const renderer = ([x, y]: Coordinate, state: State) => {
+        const renderer = (coord: Coordinate, state: State) => {
+            const [x, y] = getCoordsUnsafe(coord);
             const ctx = state.context;
             ctx.font = `${mapStyles['alignmentBadge-font-weight']} ${
                 state.pixelRatio * fontSize
@@ -134,9 +136,12 @@ function getBadgeStyle(badgeColor: AlignmentBadgeColor, contrast: boolean) {
     };
 }
 
-function getBadgeRotation(start: Coordinate, end: Coordinate) {
-    const dx = end[0] - start[0];
-    const dy = end[1] - start[1];
+function getBadgeRotation(startCoord: Coordinate, endCoord: Coordinate) {
+    const [startX, startY] = getCoordsUnsafe(startCoord);
+    const [endX, endY] = getCoordsUnsafe(endCoord);
+
+    const dx = endX - startX;
+    const dy = endY - startY;
     const angle = Math.atan2(dy, dx);
     let rotation: number;
     let drawFromEnd = true;
@@ -163,8 +168,8 @@ export function getBadgePoints(
 ): MapAlignmentBadgePoint[] {
     if (points.length < 3) return [];
 
-    const start = Math.ceil(points[1].m / drawDistance);
-    const end = Math.floor(points[points.length - 1].m / drawDistance);
+    const start = Math.ceil(getUnsafe(points[1]).m / drawDistance);
+    const end = Math.floor(getUnsafe(points[points.length - 1]).m / drawDistance);
 
     if (start > end) return [];
 
@@ -185,7 +190,7 @@ export function getBadgePoints(
 }
 
 export function getBadgeDrawDistance(resolution: number): number | undefined {
-    const distance = BADGE_DRAW_DISTANCES.find((d) => resolution < d[0]);
+    const distance = BADGE_DRAW_DISTANCES.find((d) => resolution < getUnsafe(d[0]));
     return distance?.[1];
 }
 

--- a/ui/src/map/layers/utils/dashed-line-indicator-utils.ts
+++ b/ui/src/map/layers/utils/dashed-line-indicator-utils.ts
@@ -1,4 +1,5 @@
 import { Coordinate } from 'ol/coordinate';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 export const DASHED_LINE_INDICATOR_FONT_SIZE = 12;
 export const indicatorLineWidth = (pixelRatio: number) => 120 * pixelRatio;
@@ -11,8 +12,11 @@ export const indicatorLineHeight = (pixelRatio: number) =>
     (DASHED_LINE_INDICATOR_FONT_SIZE + 3) * pixelRatio;
 
 export function getRotation(start: Coordinate, end: Coordinate) {
-    const dx = end[0] - start[0];
-    const dy = end[1] - start[1];
+    const [endX, endY] = getCoordsUnsafe(end);
+    const [startX, startY] = getCoordsUnsafe(start);
+
+    const dx = endX - startX;
+    const dy = endY - startY;
     const angle = Math.atan2(dy, dx);
     const halfPi = Math.PI / 2;
 

--- a/ui/src/map/layers/utils/highlight-layer-utils.ts
+++ b/ui/src/map/layers/utils/highlight-layer-utils.ts
@@ -6,6 +6,7 @@ import { getPartialPolyLine } from 'utils/math-utils';
 import { filterNotEmpty } from 'utils/array-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
+import { getUnsafe } from 'utils/type-utils';
 
 export function createHighlightFeatures(
     alignments: AlignmentDataHolder[],
@@ -17,7 +18,11 @@ export function createHighlightFeatures(
             .filter((h) => h.id === header.id && h.type == header.alignmentType)
             .flatMap(({ ranges }) => {
                 return ranges
-                    .filter((r) => r.max > points[0].m && r.min < points[points.length - 1].m)
+                    .filter(
+                        (r) =>
+                            r.max > getUnsafe(points[0]).m &&
+                            r.min < getUnsafe(points[points.length - 1]).m,
+                    )
                     .map((r) => {
                         const pointsWithinRange = getPartialPolyLine(points, r.min, r.max);
                         return pointsWithinRange.length > 1

--- a/ui/src/map/layers/utils/km-post-layer-utils.ts
+++ b/ui/src/map/layers/utils/km-post-layer-utils.ts
@@ -18,6 +18,7 @@ import { Point as OlPoint, Polygon } from 'ol/geom';
 import { findMatchingEntities, pointToCoords } from 'map/layers/utils/layer-utils';
 import VectorSource from 'ol/source/Vector';
 import { SearchItemsOptions } from 'map/layers/utils/layer-model';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 const kmPostImg: HTMLImageElement = new Image();
 kmPostImg.src = `data:image/svg+xml;utf8,${encodeURIComponent(KmPost)}`;
@@ -119,13 +120,14 @@ function getSelectedKmPostRenderer(
     dFunctions.push(
         (
             _: LayoutKmPost,
-            [x, y]: Coordinate,
+            coord: Coordinate,
             ctx: CanvasRenderingContext2D,
             { pixelRatio }: State,
         ) => {
             ctx.fillStyle = mapStyles['selectedKmPostDot'];
             ctx.strokeStyle = mapStyles['selectedKmPostDotBorder'];
 
+            const [x, y] = getCoordsUnsafe(coord);
             drawCircle(ctx, x, y, iconRadius * pixelRatio);
         },
     );
@@ -133,13 +135,14 @@ function getSelectedKmPostRenderer(
     dFunctions.push(
         (
             { kmNumber }: LayoutKmPost,
-            [x, y]: Coordinate,
+            coord: Coordinate,
             ctx: CanvasRenderingContext2D,
             { pixelRatio }: State,
         ) => {
             ctx.fillStyle = fillColor;
             ctx.strokeStyle = mapStyles['selectedKmPostLabelBorder'];
 
+            const [x, y] = getCoordsUnsafe(coord);
             drawRoundedRect(
                 ctx,
                 x + (iconRadius + 10) * pixelRatio,
@@ -155,10 +158,11 @@ function getSelectedKmPostRenderer(
     dFunctions.push(
         (
             _: LayoutKmPost,
-            [x, y]: Coordinate,
+            coord: Coordinate,
             ctx: CanvasRenderingContext2D,
             { pixelRatio }: State,
         ) => {
+            const [x, y] = getCoordsUnsafe(coord);
             ctx.drawImage(
                 kmPostImg,
                 x + (iconRadius + 10 + paddingRl) * pixelRatio,
@@ -172,7 +176,7 @@ function getSelectedKmPostRenderer(
     dFunctions.push(
         (
             { kmNumber }: LayoutKmPost,
-            [x, y]: Coordinate,
+            coord: Coordinate,
             ctx: CanvasRenderingContext2D,
             state: State,
         ) => {
@@ -180,6 +184,7 @@ function getSelectedKmPostRenderer(
             ctx.textAlign = 'left';
             ctx.textBaseline = 'middle';
 
+            const [x, y] = getCoordsUnsafe(coord);
             const paddingX = iconRadius + 10 + paddingRl + iconSize + textMargin;
             ctx.fillText(kmNumber, x + paddingX * state.pixelRatio, y + 2 * state.pixelRatio);
         },
@@ -203,11 +208,12 @@ function getKmPostRenderer(
     dFunctions.push(
         (
             { kmNumber }: LayoutKmPost,
-            [x, y]: Coordinate,
+            coord: Coordinate,
             ctx: CanvasRenderingContext2D,
             { pixelRatio }: State,
         ) => {
             const textWidth = ctx.measureText(kmNumber).width;
+            const [x, y] = getCoordsUnsafe(coord);
 
             if (kmPostType === 'layoutKmPost') {
                 ctx.fillStyle = mapStyles['kmPostLabel'];
@@ -239,10 +245,11 @@ function getKmPostRenderer(
     dFunctions.push(
         (
             _: LayoutKmPost,
-            [x, y]: Coordinate,
+            coord: Coordinate,
             ctx: CanvasRenderingContext2D,
             { pixelRatio }: State,
         ) => {
+            const [x, y] = getCoordsUnsafe(coord);
             ctx.drawImage(
                 kmPostImg,
                 x - iconRadius * pixelRatio,
@@ -256,7 +263,7 @@ function getKmPostRenderer(
     dFunctions.push(
         (
             { kmNumber }: LayoutKmPost,
-            [x, y]: Coordinate,
+            coord: Coordinate,
             ctx: CanvasRenderingContext2D,
             state: State,
         ) => {
@@ -264,6 +271,7 @@ function getKmPostRenderer(
             ctx.textAlign = 'left';
             ctx.textBaseline = 'middle';
 
+            const [x, y] = getCoordsUnsafe(coord);
             ctx.fillText(
                 kmNumber,
                 x + (iconRadius + textMargin) * state.pixelRatio,

--- a/ui/src/map/layers/utils/switch-layer-utils.ts
+++ b/ui/src/map/layers/utils/switch-layer-utils.ts
@@ -27,6 +27,7 @@ import { Rectangle } from 'model/geometry';
 import { ValidatedAsset } from 'publication/publication-model';
 import { Selection } from 'selection/selection-model';
 import * as Limits from 'map/layers/utils/layer-visibility-limits';
+import { getCoordsUnsafe, getUnsafe } from 'utils/type-utils';
 
 const switchImage: HTMLImageElement = new Image();
 switchImage.src = `data:image/svg+xml;utf8,${encodeURIComponent(SwitchIcon)}`;
@@ -59,7 +60,8 @@ export function getSelectedSwitchLabelRenderer(
             ctx.lineWidth = strokeWidth * pixelRatio;
         },
         [
-            ({ name }, [x, y], ctx, { pixelRatio }) => {
+            ({ name }, coord, ctx, { pixelRatio }) => {
+                const [x, y] = getCoordsUnsafe(coord);
                 ctx.fillStyle = isGeometrySwitch
                     ? linked
                         ? styles.linkedSwitchLabel
@@ -82,7 +84,8 @@ export function getSelectedSwitchLabelRenderer(
                     2 * pixelRatio,
                 );
             },
-            (_, [x, y], ctx, { pixelRatio }) => {
+            (_, coord, ctx, { pixelRatio }) => {
+                const [x, y] = getCoordsUnsafe(coord);
                 ctx.fillStyle = valid ? styles.switchTextColor : styles.errorDefault;
                 ctx.textAlign = 'left';
                 ctx.textBaseline = 'middle';
@@ -96,7 +99,8 @@ export function getSelectedSwitchLabelRenderer(
                 );
             },
 
-            ({ name }, [x, y], ctx, { pixelRatio }) => {
+            ({ name }, coord, ctx, { pixelRatio }) => {
+                const [x, y] = getCoordsUnsafe(coord);
                 ctx.fillStyle = styles.switchTextColor;
                 ctx.fillStyle = valid ? styles.switchTextColor : styles.errorDefault;
                 ctx.textAlign = 'left';
@@ -145,7 +149,7 @@ export function getSwitchRenderer(
                     : styles.errorBright;
                 ctx.lineWidth = (valid ? 1 : 3) * pixelRatio;
 
-                drawCircle(ctx, x, y, circleRadius * pixelRatio);
+                drawCircle(ctx, getUnsafe(x), getUnsafe(y), circleRadius * pixelRatio);
             },
             ({ name }, [x, y], ctx, { pixelRatio }) => {
                 if (showLabel) {
@@ -154,8 +158,8 @@ export function getSwitchRenderer(
                     ctx.textBaseline = 'middle';
 
                     const textWidth = ctx.measureText(name).width;
-                    const textX = x + (circleRadius + textCirclePadding) * pixelRatio;
-                    const textY = y + pixelRatio;
+                    const textX = getUnsafe(x) + (circleRadius + textCirclePadding) * pixelRatio;
+                    const textY = getUnsafe(y) + pixelRatio;
                     const paddingHor = 2;
                     const paddingVer = 1;
                     const contentWidth = textWidth + (valid ? 0 : 15);
@@ -199,7 +203,7 @@ export function getJointRenderer(
                     ? styles.switchMainJointBorder
                     : styles.switchJointBorder;
 
-                drawCircle(ctx, x, y, circleRadius * pixelRatio);
+                drawCircle(ctx, getUnsafe(x), getUnsafe(y), circleRadius * pixelRatio);
             },
 
             ({ number }, [x, y], ctx) => {
@@ -209,7 +213,7 @@ export function getJointRenderer(
                 ctx.textAlign = 'center';
                 ctx.textBaseline = 'middle';
 
-                ctx.fillText(switchJointNumberToString(number), x, y);
+                ctx.fillText(switchJointNumberToString(number), getUnsafe(x), getUnsafe(y));
             },
         ],
     );
@@ -242,7 +246,7 @@ export function getLinkingJointRenderer(
                         : styles.unlinkedSwitchJointBorder
                     : styles.switchJointBorder;
 
-                drawCircle(ctx, x, y, circleRadius * pixelRatio);
+                drawCircle(ctx, getUnsafe(x), getUnsafe(y), circleRadius * pixelRatio);
             },
 
             ({ number }, [x, y], ctx) => {
@@ -250,7 +254,7 @@ export function getLinkingJointRenderer(
                 ctx.textAlign = 'center';
                 ctx.textBaseline = 'middle';
 
-                ctx.fillText(switchJointNumberToString(number), x, y);
+                ctx.fillText(switchJointNumberToString(number), getUnsafe(x), getUnsafe(y));
             },
         ],
     );
@@ -373,7 +377,9 @@ function createSwitchFeature(
     // Use presentation joint as main joint if possible, otherwise use first joint
     const switchFeature = new Feature({
         geometry: new OlPoint(
-            pointToCoords(presentationJoint?.location ?? layoutSwitch.joints[0].location),
+            pointToCoords(
+                presentationJoint?.location ?? getUnsafe(layoutSwitch.joints[0]).location,
+            ),
         ),
     });
     const valid = !validationResult?.errors || validationResult?.errors?.length === 0;

--- a/ui/src/map/location-holder/location-holder-view.tsx
+++ b/ui/src/map/location-holder/location-holder-view.tsx
@@ -88,10 +88,12 @@ export const LocationHolderView: React.FC<LocationHolderProps> = ({
     const debouncedCoordinate = useDebouncedState(hoveredCoordinate, 100);
 
     const hovered = useLoader(() => {
-        if (trackNumbers.length && hoveredCoordinate) {
-            return getReferenceLineHoverLocation(trackNumbers[0], publishType, hoveredCoordinate);
-        } else if (locationTracks.length && hoveredCoordinate) {
-            return getLocationTrackHoverLocation(locationTracks[0], publishType, hoveredCoordinate);
+        const trackNumber = trackNumbers[0];
+        const locationTrack = locationTracks[0];
+        if (trackNumber && hoveredCoordinate) {
+            return getReferenceLineHoverLocation(trackNumber, publishType, hoveredCoordinate);
+        } else if (locationTrack && hoveredCoordinate) {
+            return getLocationTrackHoverLocation(locationTrack, publishType, hoveredCoordinate);
         } else {
             return Promise.resolve(emptyHoveredLocation(hoveredCoordinate));
         }

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -50,7 +50,7 @@ export type MapViewportSource = 'Map';
 
 export type MapViewport = {
     coordinateSystem?: CoordinateSystem;
-    center: Point;
+    center: Point | undefined;
     resolution: number;
 
     /**

--- a/ui/src/map/map-utils.ts
+++ b/ui/src/map/map-utils.ts
@@ -2,6 +2,7 @@ import { MapTile } from 'map/map-model';
 import OlView from 'ol/View';
 import TileGrid from 'ol/tilegrid/TileGrid';
 import { BoundingBox, Point } from 'model/geometry';
+import { getUnsafe } from 'utils/type-utils';
 
 // offset used for defining a suitable boundingBox around a single location (Point)
 export const MAP_POINT_DEFAULT_BBOX_OFFSET = 178;
@@ -16,7 +17,7 @@ for (let i = 0; i < 22; i++) {
 
 export function calculateMapTiles(view: OlView, tileSizePx: number | undefined): MapTile[] {
     // Find a resolution that corresponds to the resolution in the view
-    const actualResolution = view.getResolution() || tileResolutions[0];
+    const actualResolution = view.getResolution() || getUnsafe(tileResolutions[0]);
     const tileResolutionIndex = tileResolutions.findIndex(
         (resolution, index) => resolution < actualResolution || index == tileResolutions.length - 1,
     );
@@ -28,14 +29,19 @@ export function calculateMapTiles(view: OlView, tileSizePx: number | undefined):
     });
     const tiles: MapTile[] = [];
     tileGrid.forEachTileCoord(view.calculateExtent(), tileResolutionIndex, function (tileCoord) {
-        const tileExtent = tileGrid.getTileCoordExtent(tileCoord);
-        const tile = {
+        const tileExtent = tileGrid.getTileCoordExtent(tileCoord) as [
+            number,
+            number,
+            number,
+            number,
+        ];
+        const tile: MapTile = {
             id: tileResolutionIndex + ':' + tileCoord.slice(1).join(':'),
             area: {
                 x: { min: tileExtent[0], max: tileExtent[2] },
                 y: { min: tileExtent[1], max: tileExtent[3] },
             },
-            resolution: tileResolutions[tileResolutionIndex],
+            resolution: getUnsafe(tileResolutions[tileResolutionIndex]),
         };
         tiles.push(tile);
     });
@@ -48,7 +54,7 @@ const tileSizeOptions = [256, 512, 1024, 2048, 4096];
  * Picks a tile size where the given amount of tiles will fill the screen
  */
 export function calculateTileSize(tileCount: number): number {
-    const maxSize = tileSizeOptions[tileSizeOptions.length - 1];
+    const maxSize = getUnsafe(tileSizeOptions[tileSizeOptions.length - 1]);
     if (tileCount >= 1) {
         const optimalTileSize = Math.max(window.screen.width, window.screen.height) / tileCount;
         return tileSizeOptions.find((opt) => opt > optimalTileSize) || maxSize;

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -111,7 +111,7 @@ const defaultScaleLine: ScaleLine = new ScaleLine({
 
 function getOlViewByDomainViewport(viewport: MapViewport): OlView {
     return new OlView({
-        center: [viewport.center.x, viewport.center.y],
+        center: [viewport.center?.x ?? 0, viewport.center?.y ?? 0],
         resolution: viewport.resolution,
         maxZoom: 32,
         minZoom: 6,
@@ -122,13 +122,15 @@ function getOlViewByDomainViewport(viewport: MapViewport): OlView {
 
 function getDomainViewportByOlView(map: OlMap): MapViewport {
     const view = map.getView();
-    const center = view.getCenter() as number[];
-    const extent = map.getView().calculateExtent();
+    const center = view.getCenter() as [number, number] | undefined;
+    const extent = map.getView().calculateExtent() as [number, number, number, number];
     return {
-        center: {
-            x: center[0],
-            y: center[1],
-        },
+        center: center
+            ? {
+                  x: center[0],
+                  y: center[1],
+              }
+            : undefined,
         resolution: view.getResolution() as number,
         area: {
             x: { min: extent[0], max: extent[2] },

--- a/ui/src/map/tools/point-location-tool.ts
+++ b/ui/src/map/tools/point-location-tool.ts
@@ -2,6 +2,7 @@ import OlMap from 'ol/Map';
 import { MapTool, MapToolActivateOptions } from './tool-model';
 import { debounce } from 'ts-debounce';
 import { MapLayer } from 'map/layers/utils/layer-model';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 export const pointLocationTool: MapTool = {
     activate: (map: OlMap, _: MapLayer[], options: MapToolActivateOptions) => {
@@ -18,9 +19,10 @@ export const pointLocationTool: MapTool = {
             },
         );
         const clickEvent = map.on('click', ({ coordinate }) => {
+            const [x, y] = getCoordsUnsafe(coordinate);
             options.onClickLocation({
-                x: coordinate[0],
-                y: coordinate[1],
+                x,
+                y,
             });
         });
         const pointerMoveEvent = map.on('pointermove', debouncedMoveHandlerPointLocation);

--- a/ui/src/map/tools/tool-utils.ts
+++ b/ui/src/map/tools/tool-utils.ts
@@ -1,15 +1,17 @@
-import {Polygon} from 'ol/geom';
+import { Polygon } from 'ol/geom';
 import OlMap from 'ol/Map';
-import {LayerItemSearchResult, MapLayer, SearchItemsOptions} from 'map/layers/utils/layer-model';
-import {mergePartialItemSearchResults} from 'map/layers/utils/layer-utils';
-import {Rectangle} from 'model/geometry';
+import { LayerItemSearchResult, MapLayer, SearchItemsOptions } from 'map/layers/utils/layer-model';
+import { mergePartialItemSearchResults } from 'map/layers/utils/layer-utils';
+import { Rectangle } from 'model/geometry';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 /**
  * Returns a simple shape that has consistent size in pixels and can be used to search items from layers.
  *
  */
 export function getDefaultHitArea(map: OlMap, coordinate: number[], tolerance = 10): Rectangle {
-    const [x, y] = map.getPixelFromCoordinate(coordinate);
+    const pixel = map.getPixelFromCoordinate(coordinate);
+    const [x, y] = getCoordsUnsafe(pixel);
     return new Polygon([
         [
             map.getCoordinateFromPixel([x - tolerance, y - tolerance]),

--- a/ui/src/model/geometry.ts
+++ b/ui/src/model/geometry.ts
@@ -1,5 +1,7 @@
 import { Polygon } from 'ol/geom';
+import { Coordinate } from 'ol/coordinate';
 import { Range } from 'common/common-model';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 export enum CoordinateSystem {
     TM35FIN = 'TM35FIN',
@@ -22,10 +24,11 @@ export type BoundingBox = {
 
 export type Rectangle = Polygon;
 
-export function coordsToPoint(coords: number[]): Point {
+export function coordsToPoint(coords: Coordinate): Point {
+    const [x, y] = getCoordsUnsafe(coords);
     return {
-        x: coords[0],
-        y: coords[1],
+        x,
+        y,
     };
 }
 

--- a/ui/src/preview/calculated-changes-view.tsx
+++ b/ui/src/preview/calculated-changes-view.tsx
@@ -14,6 +14,7 @@ import { getTrackNumbers } from 'track-layout/layout-track-number-api';
 import { getLocationTracks } from 'track-layout/layout-location-track-api';
 import { getSwitches } from 'track-layout/layout-switch-api';
 import { CalculatedChanges } from 'publication/publication-model';
+import { getUnsafe } from 'utils/type-utils';
 
 const calculatedChangesIsEmpty = (calculatedChanges: GroupedCalculatedChanges) => {
     return calculatedChanges.switches.length == 0 && calculatedChanges.locationTracks.length == 0;
@@ -142,7 +143,7 @@ export const CalculatedChangesView: React.FC<CalculatedChangesProps> = ({
                                 disabled: disabledMessage,
                             })}
                             onToggle={() => toggle(trackNumberId)}
-                            open={openTrackNumbers[trackNumberId]}
+                            open={getUnsafe(openTrackNumbers[trackNumberId])}
                             disabled={!hasCalculatedChanges}>
                             <React.Fragment>
                                 <ul

--- a/ui/src/selection-panel/track-number-panel/color-selector/color-selector-utils.ts
+++ b/ui/src/selection-panel/track-number-panel/color-selector/color-selector-utils.ts
@@ -1,4 +1,5 @@
 import { LayoutTrackNumberId } from 'track-layout/track-layout-model';
+import { getUnsafe } from 'utils/type-utils';
 
 export type TrackNumberColorKey = keyof typeof TrackNumberColor;
 export enum TrackNumberColor {
@@ -25,5 +26,5 @@ export const getColors = () => {
 
 export const getDefaultColorKey = (id: LayoutTrackNumberId): TrackNumberColorKey => {
     const colors = getColors();
-    return colors[parseInt(id.replace(/^\D+/g, '')) % colors.length][0];
+    return getUnsafe(colors[parseInt(id.replace(/^\D+/g, '')) % colors.length])[0];
 };

--- a/ui/src/store/store-utils.ts
+++ b/ui/src/store/store-utils.ts
@@ -12,7 +12,9 @@ export type WrappedReducers<TRootState, TState, TReducers> = {
 export function wrapReducers<
     TRootState,
     TState,
-    TReducers extends { [key: string]: ReducerFunc<TState, unknown> },
+    TReducers extends {
+        [key in keyof WrappedReducers<TRootState, TState, TReducers>]: ReducerFunc<TState, unknown>;
+    },
 >(
     getMapFunc: (state: TRootState) => TState,
     reducers: TReducers,
@@ -22,19 +24,19 @@ export function wrapReducers<
     } = {};
     Object.keys(reducers).map((key) => {
         mappedReducers[key] = (state: TRootState, action: unknown) =>
-            reducers[key](getMapFunc(state), action);
+            reducers[key as keyof typeof reducers](getMapFunc(state), action);
     });
     return mappedReducers as WrappedReducers<TRootState, TState, TReducers>;
 }
 
 export function createDelegates<
-    TActionCreators extends { [key: string]: CreateActionFunc<unknown, unknown> },
+    TActionCreators extends { [key in keyof TActionCreators]: CreateActionFunc<unknown, unknown> },
 >(actionCreators: TActionCreators): TActionCreators {
     const delegates: { [key: string]: unknown } = {};
     const dispatch: React.Dispatch<unknown> = appStore.dispatch;
     Object.keys(actionCreators).forEach((key) => {
         delegates[key] = function (payload: unknown) {
-            dispatch(actionCreators[key](payload));
+            dispatch(actionCreators[key as keyof typeof actionCreators](payload));
         };
     });
     return delegates as TActionCreators;
@@ -42,12 +44,12 @@ export function createDelegates<
 
 export function createDelegatesWithDispatcher<
     TDispatch extends React.Dispatch<unknown>,
-    TActionCreators extends { [key: string]: CreateActionFunc<unknown, unknown> },
+    TActionCreators extends { [key in keyof TActionCreators]: CreateActionFunc<unknown, unknown> },
 >(dispatch: TDispatch, actionCreators: TActionCreators): TActionCreators {
     const delegates: { [key: string]: unknown } = {};
     Object.keys(actionCreators).forEach((key) => {
         delegates[key] = function (payload: unknown) {
-            dispatch(actionCreators[key](payload));
+            dispatch(actionCreators[key as keyof typeof actionCreators](payload));
         };
     });
     return delegates as TActionCreators;

--- a/ui/src/tool-panel/infobox/infobox.module.scss
+++ b/ui/src/tool-panel/infobox/infobox.module.scss
@@ -142,7 +142,11 @@
     @include vayla-design.typography-caption;
     display: inline-block;
     padding: 6px 8px 6px 8px;
+    border-top: 0;
+    border-left: 0;
+    border-right: 0;
     border-bottom: 3px solid transparent;
+    background-color: vayla-design.$color-white-default;
     cursor: pointer;
     max-width: 190px;
     box-sizing: border-box;

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -322,7 +322,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     const shortenSwitchName = (name?: string) => {
         const splits = (name && name.split(' ')) ?? '';
         const last = splits.length ? splits[splits.length - 1] : '';
-        const numberPart = last[0] === 'V' ? last.substring(1) : '';
+        const numberPart = last?.[0] === 'V' ? last.substring(1) : '';
         const number = parseInt(numberPart, 10);
         return !isNaN(number) ? `V${number.toString(10).padStart(3, '0')}` : undefined;
     };

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -70,6 +70,7 @@ import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track
 import { EnvRestricted } from 'environment/env-restricted';
 import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
 import { filterNotEmpty } from 'utils/array-utils';
+import { getUnsafe } from 'utils/type-utils';
 
 type LocationTrackInfoboxProps = {
     locationTrack: LayoutLocationTrack;
@@ -133,7 +134,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     const description = useLoader(
         () =>
             getLocationTrackDescriptions([locationTrack.id], publishType).then(
-                (value) => (value && value[0].description) ?? undefined,
+                (value) => (value && getUnsafe(value[0]).description) ?? undefined,
             ),
         [locationTrack?.id, publishType, locationTrackChangeTime],
     );

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -254,8 +254,8 @@ const findRefToFirstErroredField = (
         .sort()[0];
 
     if (minIndex === undefined) return undefined;
-    else if (minIndex === invalidNameIndex) return splitComponents[minIndex].nameRef;
-    else return splitComponents[minIndex].descriptionBaseRef;
+    else if (minIndex === invalidNameIndex) return splitComponents[minIndex]?.nameRef;
+    else return splitComponents[minIndex]?.descriptionBaseRef;
 };
 
 const getSplitAddressPoint = (

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -156,7 +156,7 @@ export const SwitchEditDialog = ({
             setSwitchOwnerId(existingSwitch.ownerId ?? undefined);
         } else if (switchOwners.length > 0) {
             const vayla = switchOwners.find((o) => o.name === 'Väylävirasto');
-            setSwitchOwnerId(vayla ? vayla.id : switchOwners[0].id);
+            setSwitchOwnerId(vayla ? vayla.id : switchOwners[0]?.id);
         }
     }, [switchOwners, existingSwitch]);
 

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -47,8 +47,10 @@ const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({ setHoveredOverI
             getSuggestedSwitchByPoint(linkingState.location, linkingState.layoutSwitch.id).then(
                 (suggestedSwitches) => {
                     delegates.stopLinking();
-                    if (suggestedSwitches.length) {
-                        startSwitchLinking(suggestedSwitches[0], linkingState.layoutSwitch);
+
+                    const suggestedSwitch = suggestedSwitches[0];
+                    if (suggestedSwitch) {
+                        startSwitchLinking(suggestedSwitch, linkingState.layoutSwitch);
                     } else {
                         delegates.hideLayers(['switch-linking-layer']);
                     }

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -548,12 +548,12 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                             selected && 'tool-panel__tab--selected',
                         );
                         return (
-                            <div
+                            <button
                                 className={className}
                                 key={t.asset.type + '_' + t.asset.id}
                                 onClick={() => changeTab(t.asset)}>
                                 {t.title}
-                            </div>
+                            </button>
                         );
                     })}
                 </div>

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -481,11 +481,12 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             (t) => !previousTabs.some((pt) => isSameAsset(t.asset, pt.asset)),
         );
 
-        if (newTabs.length) {
+        const firstTab = newTabs[0];
+        if (firstTab) {
             if (selectedAsset && newTabs.some((nt) => isSameAsset(nt.asset, selectedAsset))) {
                 changeTab(selectedAsset);
             } else {
-                changeTab(tabs[0].asset);
+                changeTab(firstTab.asset);
             }
         }
 

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -22,6 +22,7 @@ import { Result } from 'neverthrow';
 import { TrackLayoutSaveError, TrackLayoutSwitchSaveRequest } from 'linking/linking-model';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
 import { ValidatedAsset } from 'publication/publication-model';
+import { getUnsafe } from 'utils/type-utils';
 
 const switchCache = asyncCache<string, LayoutSwitch | undefined>();
 const switchGroupsCache = asyncCache<string, LayoutSwitch[]>();
@@ -150,7 +151,7 @@ export const getSwitchValidation = async (
     publishType: PublishType,
     id: LayoutSwitchId,
 ): Promise<ValidatedAsset> =>
-    getSwitchesValidation(publishType, [id]).then((switches) => switches[0]);
+    getSwitchesValidation(publishType, [id]).then((switches) => getUnsafe(switches[0]));
 
 export const getSwitchesValidation = async (publishType: PublishType, ids: LayoutSwitchId[]) => {
     const changeTimes = getChangeTimes();

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -300,11 +300,12 @@ const trackLayoutSlice = createSlice({
 
         // Intercept select/highlight reducers to modify options
         onSelect: function (state: TrackLayoutState, action: PayloadAction<OnSelectOptions>): void {
-            if (state.splittingState && action.payload.switches?.length) {
+            const firstSwitchId = action.payload.switches?.[0];
+            if (state.splittingState && firstSwitchId) {
                 if (state.splittingState.state === 'SETUP') {
                     splitReducers.addSplit(state, {
                         ...action,
-                        payload: action.payload.switches[0],
+                        payload: firstSwitchId,
                     });
                 }
                 return;
@@ -317,29 +318,34 @@ const trackLayoutSlice = createSlice({
                 payload: options,
             });
 
+            const onlyLayoutLinkPoint =
+                options.layoutLinkPoints?.length === 1 && options.layoutLinkPoints?.[0];
+            const onlyGeometryLinkPoint =
+                options.geometryLinkPoints?.length === 1 && options.geometryLinkPoints?.[0];
+
             // Set linking information
             switch (state.linkingState?.type) {
                 case LinkingType.LinkingGeometryWithAlignment:
                 case LinkingType.LinkingGeometryWithEmptyAlignment:
-                    if (options.layoutLinkPoints?.length === 1) {
+                    if (onlyLayoutLinkPoint) {
                         linkingReducers.setLayoutLinkPoint(state, {
                             type: '',
-                            payload: options.layoutLinkPoints[0],
+                            payload: onlyLayoutLinkPoint,
                         });
                     }
-                    if (options.geometryLinkPoints?.length === 1) {
+                    if (onlyGeometryLinkPoint) {
                         linkingReducers.setGeometryLinkPoint(state, {
                             type: '',
-                            payload: options.geometryLinkPoints[0],
+                            payload: onlyGeometryLinkPoint,
                         });
                     }
                     break;
 
                 case LinkingType.LinkingAlignment:
-                    if (options.layoutLinkPoints?.length === 1) {
+                    if (onlyLayoutLinkPoint) {
                         linkingReducers.setLayoutLinkPoint(state, {
                             type: '',
-                            payload: options.layoutLinkPoints[0],
+                            payload: onlyLayoutLinkPoint,
                         });
                     }
                     break;

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -1,4 +1,5 @@
 import { TimeStamp } from 'common/common-model';
+import { getUnsafe } from 'utils/type-utils';
 
 export function nonEmptyArray<T>(...values: Array<T | undefined>): T[] {
     return values.filter(filterNotEmpty);
@@ -220,20 +221,6 @@ export function avg(values: number[]): number {
     return values.length > 0 ? sum(values) / values.length : Number.NaN;
 }
 
-export function first<T>(array: T[]): T {
-    return array[0];
-}
-
-export function last<T>(array: T[]): T {
-    return array[array.length - 1];
-}
-
-export function removeIfExists<T>(originalCollection: T[], valueToRemove: T | undefined) {
-    return valueToRemove
-        ? originalCollection.filter((changeId) => changeId != valueToRemove)
-        : originalCollection;
-}
-
 export function addIfExists<T>(originalCollection: T[], newValue: T | undefined): T[] {
     return newValue ? [...originalCollection, newValue] : [...originalCollection];
 }
@@ -247,11 +234,11 @@ export function minimumIndexBy<T, B>(objs: readonly T[], by: (obj: T) => B): num
         return undefined;
     }
     const values = objs.map((obj) => by(obj));
-    let min = values[0];
+    let min = getUnsafe(values[0]);
     let minIndex = 0;
     for (let i = 1; i < values.length; i++) {
-        if (values[i] < min) {
-            min = values[i];
+        if (getUnsafe(values[i]) < min) {
+            min = getUnsafe(values[i]);
             minIndex = i;
         }
     }
@@ -270,7 +257,7 @@ export function partitionBy<T>(list: T[], by: (item: T) => boolean): [T[], T[]] 
 
 export function findLastIndex<T, B>(objs: readonly T[], predicate: (obj: T) => B): number {
     for (let i = objs.length - 1; i >= 0; i--) {
-        if (predicate(objs[i])) return i;
+        if (predicate(getUnsafe(objs[i]))) return i;
     }
     return -1;
 }

--- a/ui/src/utils/file-utils.ts
+++ b/ui/src/utils/file-utils.ts
@@ -1,3 +1,5 @@
+import { getUnsafe } from 'utils/type-utils';
+
 export type SerializableFile = {
     name: string;
     dataUrl: string;
@@ -22,9 +24,9 @@ export function convertToSerializableFile(file: File): Promise<SerializableFile>
 export function convertToNativeFile(serializableFile: SerializableFile): File {
     const dataUrl = serializableFile.dataUrl;
     const arr = dataUrl.split(','),
-        mimeMatch = arr[0].match(/:(.*?);/),
+        mimeMatch = getUnsafe(arr[0]).match(/:(.*?);/),
         mime = mimeMatch && mimeMatch[1],
-        bstr = atob(arr[1]);
+        bstr = atob(getUnsafe(arr[1]));
     if (!mime) {
         throw new Error('Invalid data URL');
     }

--- a/ui/src/utils/type-utils.ts
+++ b/ui/src/utils/type-utils.ts
@@ -1,3 +1,5 @@
+import { Coordinate } from 'ol/coordinate';
+
 export type Override<T1, T2> = Omit<T1, keyof T2> & T2;
 
 export type Prop<TObject, TKey extends keyof TObject> = {
@@ -41,3 +43,19 @@ export function ensureAllKeys<TKey>() {
 export const exhaustiveMatchingGuard = (_: never): never => {
     throw new Error('Should not have reached this code');
 };
+
+export const isNil = <T>(object: T) => object === undefined || object === null;
+
+// Prefer actual nil checks, only use this if you KNOW the index exists
+export const getUnsafe = <T>(thing: T): NonNullable<T> => {
+    if (!isNil(thing)) {
+        return thing!;
+    } else {
+        throw Error('We can has nil!');
+    }
+};
+
+export const getCoordsUnsafe = (coord: Coordinate): [number, number] => [
+    getUnsafe(coord[0]),
+    getUnsafe(coord[1]),
+];

--- a/ui/src/vayla-design-lib/demo/examples/file-input-examples.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/file-input-examples.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { FileInput } from 'vayla-design-lib/file-input/file-input';
 import { Button } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
+import { getUnsafe } from 'utils/type-utils';
 
 export const FileInputExamples: React.FC = () => {
     return (
@@ -10,13 +11,17 @@ export const FileInputExamples: React.FC = () => {
 
             <h3>Text as a visualization</h3>
             <FileInput
-                onChange={(e) => alert(e.target.files ? e.target.files[0].name : 'no file chosen')}>
+                onChange={(e) =>
+                    alert(e.target.files ? getUnsafe(e.target.files[0]).name : 'no file chosen')
+                }>
                 Upload
             </FileInput>
 
             <h3>Button as a visualization</h3>
             <FileInput
-                onChange={(e) => alert(e.target.files ? e.target.files[0].name : 'no file chosen')}>
+                onChange={(e) =>
+                    alert(e.target.files ? getUnsafe(e.target.files[0]).name : 'no file chosen')
+                }>
                 <Button icon={Icons.Download}>Upload a file</Button>
             </FileInput>
         </div>

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -5,6 +5,7 @@ import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { CloseableModal } from 'vayla-design-lib/closeable-modal/closeable-modal';
 import { useImmediateLoader } from 'utils/react-utils';
+import { getUnsafe } from 'utils/type-utils';
 
 export enum DropdownSize {
     SMALL = 'dropdown--small',
@@ -72,7 +73,7 @@ export const Dropdown = function <TItemValue>({
     const { isLoading, load: loadOptions } = useImmediateLoader((options: Item<TItemValue>[]) => {
         const activeOptions = options.filter((option) => !option.disabled);
         if (earlySelect.current && activeOptions.length === 1) {
-            select(activeOptions[0].value);
+            select(getUnsafe(activeOptions[0]).value);
         } else {
             setLoadedOptions(options);
         }

--- a/ui/src/vayla-design-lib/icon/Icon.tsx
+++ b/ui/src/vayla-design-lib/icon/Icon.tsx
@@ -39,6 +39,7 @@ import menuSvg from './glyphs/navigation/menu.svg';
 import positionPinSvg from './glyphs/misc/position-pin.svg';
 import styles from './icon.scss';
 import { createClassName } from 'vayla-design-lib/utils';
+import { getUnsafe } from 'utils/type-utils';
 
 /**
  *
@@ -197,14 +198,14 @@ const SvgIcon: SvgIconComponent = ({
 
 function parseViewBox(svg: string): string {
     const viewBoxMatch = /viewBox="([\s0-9]+)"/.exec(svg);
-    return viewBoxMatch && viewBoxMatch.length >= 2 ? viewBoxMatch[1] : '0 0 24 24';
+    return viewBoxMatch && viewBoxMatch.length >= 2 ? getUnsafe(viewBoxMatch[1]) : '0 0 24 24';
 }
 
 function parseSize(svg: string): number[] | undefined {
     const heightMatch = /height="([0-9]+)"/.exec(svg);
     const widthMatch = /width="([0-9]+)"/.exec(svg);
     if (heightMatch && heightMatch.length >= 2 && widthMatch && widthMatch.length >= 2) {
-        return [parseInt(widthMatch[1]), parseInt(heightMatch[1])];
+        return [parseInt(getUnsafe(widthMatch[1])), parseInt(getUnsafe(heightMatch[1]))];
     } else {
         return undefined;
     }

--- a/ui/src/vertical-geometry/labeled-ticks.tsx
+++ b/ui/src/vertical-geometry/labeled-ticks.tsx
@@ -10,6 +10,7 @@ import {
     minimumLabeledTickDistancePx,
 } from 'vertical-geometry/ticks-at-intervals';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
+import { getUnsafe } from 'utils/type-utils';
 
 export interface LabeledTicksProps {
     trackKmHeights: TrackKmHeights[];
@@ -147,7 +148,11 @@ export const LabeledTicks: React.FC<LabeledTicksProps> = ({
                             const hasSpaceBeforeNextKm =
                                 trackKmIndex === trackKmHeights.length - 1 ||
                                 meterIndex === 0 ||
-                                (trackKmHeights[trackKmIndex + 1].trackMeterHeights[0].m - m) *
+                                (getUnsafe(
+                                    getUnsafe(trackKmHeights[trackKmIndex + 1])
+                                        .trackMeterHeights[0],
+                                ).m -
+                                    m) *
                                     coordinates.mMeterLengthPxOverM >
                                     minimumLabeledTickDistancePx;
                             return (

--- a/ui/src/vertical-geometry/snapped-point.ts
+++ b/ui/src/vertical-geometry/snapped-point.ts
@@ -10,6 +10,7 @@ import { filterNotEmpty, minimumIndexBy } from 'utils/array-utils';
 import { Coordinates, heightToY, mToX, xToM } from 'vertical-geometry/coordinates';
 import { TrackKmHeights } from 'geometry/geometry-api';
 import { approximateHeightAt } from 'vertical-geometry/util';
+import { getUnsafe } from 'utils/type-utils';
 
 export type SnapTarget =
     | 'trackMeterRulerTick'
@@ -218,7 +219,7 @@ function approximateTrackAddressAt(
     kmHeights: TrackKmHeights[],
 ): TrackMeter | undefined {
     const [leftMeter, rightMeter] = getTrackMeterPairAroundIndex(index, kmHeights);
-    const leftKm = kmHeights[index.left.kmIndex];
+    const leftKm = getUnsafe(kmHeights[index.left.kmIndex]);
     const proportion = (m - leftMeter.m) / (rightMeter.m - leftMeter.m);
     return {
         kmNumber: leftKm.kmNumber,

--- a/ui/src/vertical-geometry/ticks-at-intervals.ts
+++ b/ui/src/vertical-geometry/ticks-at-intervals.ts
@@ -1,7 +1,8 @@
 // Interval of 25 pointedly left out to have nicely placed divisors in the sequence. If we had an interval of 25, we'd
 // too easily end up in a situation where we're displaying ticks every 5 meters and labels every 25 meters, but then
 // when we zoom in a bit, the ticks move to being every 2 meters; so the labels at xx25 and xx75 meters disappear!
-const labelIntervalOptions = [1, 2, 5, 10, 50, 100, 250, 500, 1000];
+
+const labelIntervalOptions = [1, 2, 5, 10, 50, 100, 250, 500, 1000] as const;
 
 export const minimumApproximateHorizontalTickWidthPx = 15;
 export const minimumLabeledTickDistancePx = 120;
@@ -14,8 +15,5 @@ export function minimumInterval(itemWidth: number, minimumWidth: number): number
 }
 
 export function minimumIntervalOrLongest(itemWidth: number, minimumWidth: number): number {
-    return (
-        minimumInterval(itemWidth, minimumWidth) ??
-        labelIntervalOptions[labelIntervalOptions.length - 1]
-    );
+    return minimumInterval(itemWidth, minimumWidth) ?? labelIntervalOptions[8];
 }

--- a/ui/src/vertical-geometry/track-address-ruler.tsx
+++ b/ui/src/vertical-geometry/track-address-ruler.tsx
@@ -7,6 +7,7 @@ import {
     minimumRulerHeightLabelDistancePx,
 } from 'vertical-geometry/ticks-at-intervals';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
+import { getUnsafe } from 'utils/type-utils';
 
 export interface TrackAddressRulerProps {
     kmHeights: TrackKmHeights[];
@@ -34,11 +35,11 @@ export const TrackAddressRuler: React.FC<TrackAddressRulerProps> = ({
         return <React.Fragment />;
     }
     const kmPostMarkers = kmHeights
-        .filter(({ trackMeterHeights }) => trackMeterHeights[0].meter === 0)
+        .filter(({ trackMeterHeights }) => trackMeterHeights[0]?.meter === 0)
         .map(({ trackMeterHeights }, kmIndex) => (
             <KmPostMarker
                 key={kmIndex}
-                x={mToX(coordinates, trackMeterHeights[0].m)}
+                x={mToX(coordinates, getUnsafe(trackMeterHeights[0]).m)}
                 heightPx={heightPx}
             />
         ));

--- a/ui/src/vertical-geometry/track-meter-index.ts
+++ b/ui/src/vertical-geometry/track-meter-index.ts
@@ -1,5 +1,6 @@
 import { TrackMeter } from 'common/common-model';
 import { TrackKmHeights, TrackMeterHeight } from 'geometry/geometry-api';
+import { getUnsafe } from 'utils/type-utils';
 
 export interface SingleTrackMeterIndex {
     kmIndex: number;
@@ -17,12 +18,14 @@ export function findTrackMeterIndexContainingM(
     m: number,
     kmHeights: TrackKmHeights[],
 ): TrackMeterIndex | undefined {
-    const nextKmIndex = kmHeights.findIndex(({ trackMeterHeights }) => trackMeterHeights[0].m > m);
+    const nextKmIndex = kmHeights.findIndex(
+        ({ trackMeterHeights }) => trackMeterHeights[0]?.m ?? -1 > m,
+    );
     if (nextKmIndex === 0 || kmHeights.length === 0) {
         return undefined;
     }
     const kmIndex = nextKmIndex === -1 ? kmHeights.length - 1 : nextKmIndex - 1;
-    const km = kmHeights[kmIndex];
+    const km = getUnsafe(kmHeights[kmIndex]);
     const meterIndex = km.trackMeterHeights.findIndex((trackM) => trackM.m >= m);
     // if this the last track km on the alignment, then the last track meter is a sentinel sent by the backend to mark
     // the alignment's end, and can be considered to have zero length; hence, if we're past it, we've fallen past the
@@ -47,7 +50,7 @@ function previousSingleTrackMeterIndex(
     } else if (meterIndex == 0) {
         return {
             kmIndex: kmIndex - 1,
-            meterIndex: kmHeights[kmIndex - 1].trackMeterHeights.length - 1,
+            meterIndex: getUnsafe(kmHeights[kmIndex - 1]).trackMeterHeights.length - 1,
         };
     } else {
         return { kmIndex, meterIndex: meterIndex - 1 };
@@ -58,7 +61,7 @@ export function getTrackAddressAtSingleIndex(
     index: SingleTrackMeterIndex,
     kmHeights: TrackKmHeights[],
 ): TrackMeter {
-    const kmNumber = kmHeights[index.kmIndex].kmNumber;
+    const kmNumber = getUnsafe(kmHeights[index.kmIndex]).kmNumber;
     const meters = getTrackMeterAtSingleIndex(index, kmHeights).meter;
     return { kmNumber, meters };
 }
@@ -67,7 +70,7 @@ export function getTrackMeterAtSingleIndex(
     { kmIndex, meterIndex }: SingleTrackMeterIndex,
     kmHeights: TrackKmHeights[],
 ) {
-    return kmHeights[kmIndex].trackMeterHeights[meterIndex];
+    return getUnsafe(getUnsafe(kmHeights[kmIndex]).trackMeterHeights[meterIndex]);
 }
 
 export function getTrackMeterPairAroundIndex(

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "./dist/",
         "sourceMap": true,
         "noImplicitAny": true,
+        "noUncheckedIndexedAccess": true,
         "module": "commonjs",
         "lib": ["DOM", "ES6", "DOM.Iterable", "ScriptHost", "ES2019.array"],
         "target": "es5",


### PR DESCRIPTION
Älkää antako mun mergata tätä ennen kuin 1.12.0:n koodit on lukittu. Tämä olisi myös syytä testata kunnolla muidenkin puolesta, varmaan ihan jo täällä haarassa ja ennen mergeä. Testasin itsekin tätä jonkin verran, mutta vaikka en mitään tarkoituksella jättänytkään testaamatta, niin tuskin kaikkea tajusin kuitenkaan testatata.

Täällä on siis käytännössä käännetty päälle tsconfigin `noUncheckedIndexedAccess`-propsu, joka vaikuttaa taulukoiden ja objektien indeksointiin (about mikä vaan indeksointi voi palauttaa undefinedin jos tyypitys on yhtään pielessä tai indeksointi sisältää minkäänlaista matematiikkaa.) Tästä aiheutuneet tyypitysvirheet on pyritty ratkaisemaan muutamalla eri tavalla (listattuna alla about prioriteettijärjestyksessä.) Koska korjattavia paikkoja oli _niin_ paljon, niin pyrin parhaani mukaan pysymään poissa logiikan muuttamisesta - nyt on korjattu käännösvirheet, logiikka olkoon joku myöhempi steppi (jota tuskin enää teen tämän tiketin puitteissa.)

* Tyypityksessä nullien salliminen
* Nullish-coalescing-operaattori `?.` (joskus on ihan fine, että juttu on undefined)
* Ehtojen muuttaminen siten, että tarkastellaan suoraan halutun alkion olemassaoloa (esim. `if (arr.length) arr[0].juttu()` -> `const first = arr[0]; if (first) first.juttu()`
* Looppauksen muuttaminen siten, että `for`- ja `while`-looppien sijaan loopataan taulukkoja läpi `.forEach()`:illa (jos käydään kaikki läpi) tai `.every()`:llä (jos halutaan lopettaa kesken)
* Non-nullishnessin tarkastaminen ja nullish-arvoista heittäminen. Tämän myötä tuli demossakin esitelty `getUnsafe()`-funktio, joka ottaa sisäänsä nullish-arvon `T` ja joko heittää tai palauttaa `NonNullable<T>`. Valitettavasti suurin osa korjauksista on näitä, ja lähes aina niiden välttäminen olisi meinannut isompia logiikkamuutoksia. Tästä eteenpäin lienee fiksua, että _aina_ kun koodarille tulee vastaan joku `getUnsafe`-kutsu, niin tutkii voisiko sen kadottaa jotenkin. Aika paljon näitä tulee myös OpenLayersin tyypityksestä, sillä se ei ole meille kauhean suotuisa. Eniten niitä tulee `Coordinate`-tyypistä, jonka tyyppi OpenLayersissa on vain `number[]` (ja vissiin ihan syystä koska pituus ja arvot voivat vaihdella, kuten Ari tiesi kertoa.) Tätä varten tein oman `getCoordUnsafe()`-funktion, joka muuntaa OpenLayersin sisäisen tyypin `[number, number]`:iksi