### PR TITLE
GVT-General: Allow LayoutAlignment#takeFirst and #takeLast to cross segment boundaries

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -63,10 +63,19 @@ interface IAlignment : Loggable {
     val start: AlignmentPoint? get() = segments.firstOrNull()?.alignmentStart
     val end: AlignmentPoint? get() = segments.lastOrNull()?.alignmentEnd
 
-    val allSegmentPoints: Sequence<SegmentPoint> get() = segments.asSequence().flatMapIndexed { index, segment ->
-        if (index == segments.lastIndex) segment.segmentPoints.asSequence()
-        else segment.segmentPoints.asSequence().take(segment.segmentPoints.size - 1)
-    }
+    private fun getSegmentPoints(downward: Boolean): Sequence<Pair<SegmentPoint, ISegment>> =
+        (if (downward) segments.asReversed() else segments).asSequence().flatMapIndexed { index, segment ->
+            (if (downward && index == 0 || !downward && index == segments.lastIndex) segment.segmentPoints
+            else segment.segmentPoints.subList(0, segment.segmentPoints.size - 1))
+                .let { if (downward) it.asReversed() else it }
+                .map { it to segment }
+        }
+
+    val allSegmentPoints: Sequence<SegmentPoint> get() = getSegmentPoints(false).map { (point) -> point }
+    val allAlignmentPoints: Sequence<AlignmentPoint>
+        get() = getSegmentPoints(false).map { (point, segment) -> point.toAlignmentPoint(segment.startM) }
+    val allAlignmentPointsDownward: Sequence<AlignmentPoint>
+        get() = getSegmentPoints(true).map { (point, segment) -> point.toAlignmentPoint(segment.startM) }
 
     fun filterSegmentsByBbox(bbox: BoundingBox): List<ISegment> {
         return if (!bbox.intersects(boundingBox)) {
@@ -212,9 +221,9 @@ data class LayoutAlignment(
 
     fun withSegments(newSegments: List<LayoutSegment>) = copy(segments = newSegments)
 
-    fun takeFirst(count: Int): List<AlignmentPoint> = segments.firstOrNull()?.takeFirst(count) ?: listOf()
+    fun takeFirst(count: Int): List<AlignmentPoint> = allAlignmentPoints.take(count).toList()
 
-    fun takeLast(count: Int): List<AlignmentPoint> = segments.lastOrNull()?.takeLast(count) ?: listOf()
+    fun takeLast(count: Int): List<AlignmentPoint> = allAlignmentPointsDownward.take(count).toList().asReversed()
 }
 
 data class LayoutSegmentMetadata(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometryTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometryTest.kt
@@ -417,4 +417,22 @@ class LayoutGeometryTest {
         )
         assertEquals(0.0, alignment.getMaxDirectionDeltaRads())
     }
+
+    @Test
+    fun `takeLast(n) with smaller last segment than n points`() {
+        val alignment = alignment(
+            segment(Point(0.0, 0.0), Point(3.0, 0.0)),
+            segment(Point(3.0001, 0.0), Point(4.0001, 0.0), Point(5.0001, 0.0))
+        )
+        assertEquals(listOf(1.0, 2.0, 3.0001, 4.0001, 5.0001), alignment.takeLast(5).map { it.x })
+    }
+
+    @Test
+    fun `takeFirst(n) with smaller first segment than n points`() {
+        val alignment = alignment(
+            segment(Point(0.0, 0.0), Point(3.0, 0.0)),
+            segment(Point(3.0001, 0.0), Point(4.0001, 0.0), Point(5.0001, 0.0))
+        )
+        assertEquals(listOf(0.0, 1.0, 2.0, 3.0001, 4.0001), alignment.takeFirst(5).map { it.x })
+    }
 }


### PR DESCRIPTION
GVT-2423:ta toteutettaessa hoksattu juttu, joka näytti kohtuulliselta putsata. En siis tiedä mitään paikkaa, missä tuo yleistys olisi tarpeen juuri tämän hetken kutsujilla, mutta aika ikävää olisi, jos jokin kutsuja haluaisi kolmea pistettä, ja se menisi rikki juuri jos päässä onkin kaksipisteinen segmentti.