### PR TITLE
GVT-2442 Publication validation context refactor

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -165,8 +165,8 @@ data class ValidatedPublishCandidates(
 )
 
 data class ValidatedAsset<T>(
-    val errors: List<PublishValidationError>,
     val id: IntId<T>,
+    val errors: List<PublishValidationError>,
 )
 
 data class PublishCandidates(
@@ -225,13 +225,21 @@ data class ValidationVersions(
     fun findTrackNumber(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.find { it.officialId == id }
     fun findLocationTrack(id: IntId<LocationTrack>) = locationTracks.find { it.officialId == id }
     fun findSwitch(id: IntId<TrackLayoutSwitch>) = switches.find { it.officialId == id }
+
+    fun getTrackNumberIds() = trackNumbers.map { v -> v.officialId }
+    fun getReferenceLineIds() = referenceLines.map { v -> v.officialId }
+    fun getLocationTrackIds() = locationTracks.map { v -> v.officialId }
+    fun getSwitchIds() = switches.map { v -> v.officialId }
+    fun getKmPostIds() = kmPosts.map { v -> v.officialId }
 }
 
 data class PublicationGroup(
     val id: IntId<Split>,
 )
 
-data class ValidationVersion<T>(val officialId: IntId<T>, val validatedAssetVersion: RowVersion<T>)
+data class ValidationVersion<T>(val officialId: IntId<T>, val validatedAssetVersion: RowVersion<T>) {
+    fun isOfficial() = officialId == validatedAssetVersion.id
+}
 
 data class PublishRequestIds(
     val trackNumbers: List<IntId<TrackLayoutTrackNumber>>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -237,9 +237,7 @@ data class PublicationGroup(
     val id: IntId<Split>,
 )
 
-data class ValidationVersion<T>(val officialId: IntId<T>, val validatedAssetVersion: RowVersion<T>) {
-    fun isOfficial() = officialId == validatedAssetVersion.id
-}
+data class ValidationVersion<T>(val officialId: IntId<T>, val validatedAssetVersion: RowVersion<T>)
 
 data class PublishRequestIds(
     val trackNumbers: List<IntId<TrackLayoutTrackNumber>>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -276,7 +276,6 @@ class PublicationDao(
      * null to have all draft location tracks considered in the publication unit.
      * @param includeDeleted Filters location tracks, not switches
      */
-    // TODO: GVT-2442 This can probably be simplified now (only one use-place)
     fun fetchLinkedLocationTracks(
         switchIds: List<IntId<TrackLayoutSwitch>>,
         locationTrackIdsInPublicationUnit: List<IntId<LocationTrack>>? = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -589,7 +589,6 @@ class PublicationService @Autowired constructor(
         context: ValidationContext,
     ): List<PublishValidationError>? = context.getKmPost(id)?.let { kmPost ->
         val trackNumber = kmPost.trackNumberId?.let(context::getTrackNumber)
-        // TODO: GVT-2442 This needs to be cached
         val trackNumberNumber = (trackNumber ?: kmPost.trackNumberId?.let(context::getDraftTrackNumber))?.number
         val referenceLine = trackNumber?.referenceLineId?.let(context::getReferenceLine)
 
@@ -1219,7 +1218,7 @@ class PublicationService @Autowired constructor(
             list
         }.sortedBy { it.propKey.key }
 
-        val oldLinkedTrackNames = oldLinkedLocationTracks.values.mapNotNull { it.first.name?.toString() }.sorted()
+        val oldLinkedTrackNames = oldLinkedLocationTracks.values.mapNotNull { it.first.name.toString() }.sorted()
         val newLinkedTrackNames = changes.locationTracks.map { it.name.toString() }.sorted()
 
         return listOfNotNull(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -158,94 +158,74 @@ class PublicationService @Autowired constructor(
     }
 
     @Transactional(readOnly = true)
-    fun validateTrackNumberAndReferenceLine(
-        trackNumberId: IntId<TrackLayoutTrackNumber>,
+    fun validateTrackNumbersAndReferenceLines(
+        trackNumberIds: List<IntId<TrackLayoutTrackNumber>>,
         publishType: PublishType,
-    ): ValidatedAsset<TrackLayoutTrackNumber> {
+    ): List<ValidatedAsset<TrackLayoutTrackNumber>> {
         logger.serviceCall(
-            "validateTrackNumberAndReferenceLine", "trackNumberId" to trackNumberId, "publishType" to publishType
+            "validateTrackNumbersAndReferenceLines",
+            "trackNumberIds" to trackNumberIds,
+             "publishType" to publishType,
         )
 
-        val trackNumber = trackNumberService.getOrThrow(publishType, trackNumberId)
-        val referenceLine = referenceLineService.getByTrackNumber(publishType, trackNumberId)
-
-        val locationTracks = if (publishType == DRAFT) locationTrackDao
-            .fetchVersions(DRAFT, false, trackNumberId)
-            .map(locationTrackDao::fetch)
-        else emptyList()
-
-        val kmPosts =
-            if (publishType == DRAFT) kmPostDao.fetchVersions(DRAFT, false, trackNumberId).map(kmPostDao::fetch)
-            else emptyList()
-
-        val versions = toValidationVersions(
-            trackNumbers = listOf(trackNumber),
-            referenceLines = listOfNotNull(referenceLine),
-            kmPosts = kmPosts,
-            locationTracks = locationTracks,
-        )
-
-        val cacheKeys = collectCacheKeys(versions)
-
-        val trackNumberValidation = validateTrackNumber(
-            version = toValidationVersion(trackNumber), validationVersions = versions, cacheKeys = cacheKeys
-        )
-
-        val referenceLineValidation = versions.referenceLines.flatMap { rl ->
-            validateReferenceLine(
-                version = rl,
-                validationVersions = versions,
-                cacheKeys = cacheKeys,
+        // Switches don't affect tracknumber validity, so they are ignored
+        val validationContext = when (publishType) {
+            DRAFT -> createValidationContext(
+                locationTracks = locationTrackDao.fetchPublicationVersions(),
+                kmPosts = kmPostDao.fetchPublicationVersions(),
+                trackNumbers = trackNumberDao.fetchPublicationVersions(),
+                referenceLines = referenceLineDao.fetchPublicationVersions(),
             )
-        }
 
-        return ValidatedAsset(
-            errors = (trackNumberValidation + referenceLineValidation).distinct(),
-            id = trackNumberId,
-        )
+            OFFICIAL -> createValidationContext()
+        }
+        validationContext.preloadTrackNumberAndReferenceLineVersions(trackNumberIds)
+        validationContext.preloadTrackNumbersByNumber(trackNumberIds)
+        validationContext.preloadKmPostsByTrackNumbers(trackNumberIds)
+        validationContext.preloadLocationTracksByTrackNumbers(trackNumberIds)
+
+        return trackNumberIds.mapNotNull { id ->
+            val trackNumberErrors = validateTrackNumber(id, validationContext)
+            val referenceLineId = validationContext.getReferenceLineIdByTrackNumber(id)
+            val referenceLineErrors = referenceLineId?.let { rlId -> validateReferenceLine(rlId, validationContext) }
+            if (trackNumberErrors != null || referenceLineErrors != null) {
+                val allErrors = ((trackNumberErrors ?: emptyList()) + (referenceLineErrors ?: emptyList())).distinct()
+                ValidatedAsset(id, allErrors)
+            } else null
+        }
     }
 
     @Transactional(readOnly = true)
-    fun validateLocationTrack(
-        locationTrackId: IntId<LocationTrack>,
+    fun validateLocationTracks(
+        trackIds: List<IntId<LocationTrack>>,
         publishType: PublishType,
-    ): ValidatedAsset<LocationTrack> {
+    ): List<ValidatedAsset<LocationTrack>> {
         logger.serviceCall(
-            "validateLocationTrack", "locationTrackId" to locationTrackId, "publishType" to publishType
+            "validateLocationTrack", "locationTrackId" to trackIds, "publishType" to publishType
         )
 
-        val (locationTrack, alignment) = locationTrackService.getWithAlignmentOrThrow(publishType, locationTrackId)
+        val validationContext = when (publishType) {
+            DRAFT -> createValidationContext(
+                switches = switchDao.fetchPublicationVersions(),
+                locationTracks = locationTrackDao.fetchPublicationVersions(),
+                kmPosts = kmPostDao.fetchPublicationVersions(),
+                trackNumbers = trackNumberDao.fetchPublicationVersions(),
+                referenceLines = referenceLineDao.fetchPublicationVersions(),
+            )
 
-        val duplicateTrack = locationTrack.duplicateOf?.let { duplicateId ->
-            locationTrackService.getOrThrow(publishType, duplicateId)
+            OFFICIAL -> createValidationContext()
         }
+        validationContext.preloadLocationTrackVersions(trackIds)
+        validationContext.preloadLocationTracksByName(trackIds)
+        validationContext.preloadTrackDuplicates(trackIds)
+        validationContext.preloadAssociatedTrackNumberAndReferenceLineVersions(trackIds = trackIds)
+        val linkedSwitchIds = trackIds.flatMap(validationContext::getPotentiallyAffectedSwitchIds).distinct()
+        validationContext.preloadSwitchVersions(linkedSwitchIds)
+        validationContext.preloadSwitchTrackLinks(linkedSwitchIds)
 
-        val trackNumber = trackNumberService.getOrThrow(publishType, locationTrack.trackNumberId)
-        val referenceLine = referenceLineService.getByTrackNumber(publishType, trackNumber.id as IntId)
-
-        val switches = getConnectedSwitchIds(locationTrack, alignment).map { switchId ->
-            switchService.getOrThrow(publishType, switchId)
+        return trackIds.mapNotNull { id ->
+            validateLocationTrack(id, validationContext)?.let { errors -> ValidatedAsset(id, errors) }
         }
-
-        val versions = toValidationVersions(
-            locationTracks = listOfNotNull(locationTrack, duplicateTrack),
-            switches = switches,
-            trackNumbers = listOf(trackNumber),
-            referenceLines = listOfNotNull(referenceLine)
-        )
-
-        val cacheKeys = collectCacheKeys(versions)
-        val switchTrackLinks = collectSwitchTrackLinks(versions, if (publishType == DRAFT) null else listOf())
-
-        return ValidatedAsset(
-            validateLocationTrack(
-                version = toValidationVersion(locationTrack),
-                validationVersions = versions,
-                cacheKeys = cacheKeys,
-                switchTrackLinks = switchTrackLinks,
-            ),
-            locationTrackId,
-        )
     }
 
     @Transactional(readOnly = true)
@@ -255,189 +235,139 @@ class PublicationService @Autowired constructor(
     ): List<ValidatedAsset<TrackLayoutSwitch>> {
         logger.serviceCall("validateSwitches", "switchIds" to switchIds, "publishType" to publishType)
 
-        val switches = switchService.getMany(publishType, switchIds)
-        val locationTracks =
-            switchDao.findLocationTracksLinkedToSwitches(publishType, switchIds).map { it.rowVersion }.distinct()
-
-        val previouslyLinkedTracks = if (publishType == DRAFT) switchDao
-            .findLocationTracksLinkedToSwitches(OFFICIAL, switchIds)
-            .mapNotNull { lt -> locationTrackDao.fetchDraftVersion(lt.rowVersion.id) }
-            .distinct()
-            .filterNot(locationTracks::contains) else emptyList()
-
-        val validationVersions = toValidationVersions(
-            switches = switches, locationTracks = (locationTracks + previouslyLinkedTracks).map(locationTrackDao::fetch)
-        )
-        val nameDuplicates = collectPotentialSwitchNameDuplicates(validationVersions)
-
-        val linkedTracks = publicationDao
-            .fetchLinkedLocationTracks(switchIds, if (publishType == DRAFT) null else listOf())
-            .mapValues { (_, tracks) -> tracks.toSet() }
-        return switches.map { switch ->
-            ValidatedAsset(
-                validateSwitch(
-                    version = toValidationVersion(switch),
-                    validationVersions = validationVersions,
-                    linkedTracks = linkedTracks.getOrDefault(switch.id, setOf()),
-                    nameDuplicates = nameDuplicates,
-                ),
-                switch.id as IntId,
+        // Only tracks and switches affect switch validation, so we can ignore the other types in the publication unit
+        val validationContext = when (publishType) {
+            DRAFT -> createValidationContext(
+                switches = switchDao.fetchPublicationVersions(),
+                locationTracks = locationTrackDao.fetchPublicationVersions(),
             )
+
+            OFFICIAL -> createValidationContext()
+        }
+        validationContext.preloadSwitchVersions(switchIds)
+        validationContext.preloadSwitchTrackLinks(switchIds)
+        validationContext.preloadSwitchesByName(switchIds)
+
+        return switchIds.mapNotNull { id ->
+            validateSwitch(id, validationContext)?.let { errors -> ValidatedAsset(id, errors) }
         }
     }
 
     @Transactional(readOnly = true)
-    fun validateKmPost(
-        kmPostId: IntId<TrackLayoutKmPost>,
+    fun validateKmPosts(
+        kmPostIds: List<IntId<TrackLayoutKmPost>>,
         publishType: PublishType,
-    ): ValidatedAsset<TrackLayoutKmPost> {
-        logger.serviceCall("validateKmPost", "kmPostId" to kmPostId, "publishType" to publishType)
+    ): List<ValidatedAsset<TrackLayoutKmPost>> {
+        logger.serviceCall("validateKmPost", "kmPostIds" to kmPostIds, "publishType" to publishType)
 
-        val kmPost = kmPostService.getOrThrow(publishType, kmPostId)
-        val trackNumber = kmPost.trackNumberId?.let { trackNumberId ->
-            trackNumberService.getOrThrow(publishType, trackNumberId)
+        // We can ignore switches and locationtracks, as they don't affect km-post validity
+        val validationContext = when (publishType) {
+            DRAFT -> createValidationContext(
+                kmPosts = kmPostDao.fetchPublicationVersions(),
+                trackNumbers = trackNumberDao.fetchPublicationVersions(),
+                referenceLines = referenceLineDao.fetchPublicationVersions(),
+            )
+
+            OFFICIAL -> createValidationContext()
         }
 
-        val referenceLine = trackNumber?.let {
-            referenceLineService.getByTrackNumber(publishType, trackNumber.id as IntId)
+        validationContext.preloadKmPostVersions(kmPostIds)
+        validationContext.preloadTrackNumberAndReferenceLineVersions(
+            validationContext.collectAssociatedTrackNumberIds(kmPostIds = kmPostIds)
+        )
+
+        return kmPostIds.mapNotNull { id ->
+            validateKmPost(id, validationContext)?.let { errors -> ValidatedAsset(id, errors) }
         }
-
-        val versions = toValidationVersions(
-            trackNumbers = listOfNotNull(trackNumber),
-            referenceLines = listOfNotNull(referenceLine),
-            kmPosts = listOf(kmPost)
-        )
-
-        val cacheKeys = collectCacheKeys(versions)
-
-        return ValidatedAsset(
-            validateKmPost(
-                version = toValidationVersion(kmPost), validationVersions = versions, cacheKeys = cacheKeys
-            ), kmPostId
-        )
     }
+
+    private fun createValidationContext(
+        trackNumbers: List<ValidationVersion<TrackLayoutTrackNumber>> = listOf(),
+        locationTracks: List<ValidationVersion<LocationTrack>> = listOf(),
+        referenceLines: List<ValidationVersion<ReferenceLine>> = listOf(),
+        switches: List<ValidationVersion<TrackLayoutSwitch>> = listOf(),
+        kmPosts: List<ValidationVersion<TrackLayoutKmPost>> = listOf(),
+    ): ValidationContext = createValidationContext(
+        ValidationVersions(trackNumbers, locationTracks, referenceLines, switches, kmPosts)
+    )
+
+    private fun createValidationContext(publicationSet: ValidationVersions): ValidationContext = ValidationContext(
+        trackNumberDao = trackNumberDao,
+        referenceLineDao = referenceLineDao,
+        kmPostDao = kmPostDao,
+        locationTrackDao = locationTrackDao,
+        switchDao = switchDao,
+        geocodingService = geocodingService,
+        alignmentDao = alignmentDao,
+        publicationDao = publicationDao,
+        switchLibraryService = switchLibraryService,
+        publicationSet = publicationSet,
+    )
 
     fun getChangeTime(): Instant {
         logger.serviceCall("getChangeTime")
         return publicationDao.fetchChangeTime()
     }
 
-    private fun validateAsPublicationUnit(candidates: PublishCandidates, allowMultipleSplits: Boolean): PublishCandidates {
+    @Transactional(readOnly = true)
+    fun validateAsPublicationUnit(candidates: PublishCandidates, allowMultipleSplits: Boolean): PublishCandidates {
         val versions = candidates.getValidationVersions()
-        val cacheKeys = collectCacheKeys(versions)
-        precacheLocationTrackAlignmentAddresses(candidates, cacheKeys)
-        val switchTrackLinks = collectSwitchTrackLinks(versions, versions.locationTracks.map { v -> v.officialId })
-        val nameDuplicates = collectPotentialSwitchNameDuplicates(versions)
+
+        val validationContext = createValidationContext(versions).also { ctx -> ctx.preloadByPublicationSet() }
+        // TODO: GVT-2442 split validation could (should) also use the validation context
         val splitErrors = splitService.validateSplit(versions, allowMultipleSplits)
 
         return PublishCandidates(
             trackNumbers = candidates.trackNumbers.map { candidate ->
                 val trackNumberSplitErrors = splitErrors.trackNumbers[candidate.id] ?: emptyList()
-                val validationErrors = validateTrackNumber(candidate.getPublicationVersion(), versions, cacheKeys)
-
+                val validationErrors = validateTrackNumber(candidate.id, validationContext) ?: emptyList()
                 candidate.copy(errors = trackNumberSplitErrors + validationErrors)
             },
             referenceLines = candidates.referenceLines.map { candidate ->
                 val referenceLineSplitErrors = splitErrors.referenceLines[candidate.id] ?: emptyList()
-                val validationErrors = validateReferenceLine(candidate.getPublicationVersion(), versions, cacheKeys)
-
+                val validationErrors = validateReferenceLine(candidate.id, validationContext) ?: emptyList()
                 candidate.copy(errors = referenceLineSplitErrors + validationErrors)
             },
             locationTracks = candidates.locationTracks.map { candidate ->
                 val locationTrackSplitErrors = splitErrors.locationTracks[candidate.id] ?: emptyList()
-
-                val validationErrors = validateLocationTrack(
-                    version = candidate.getPublicationVersion(),
-                    validationVersions = versions,
-                    cacheKeys = cacheKeys,
-                    switchTrackLinks = switchTrackLinks,
-                )
-
+                val validationErrors = validateLocationTrack(candidate.id, validationContext) ?: emptyList()
                 candidate.copy(errors = validationErrors + locationTrackSplitErrors)
             },
             switches = candidates.switches.map { candidate ->
                 val switchSplitErrors = splitErrors.switches[candidate.id] ?: emptyList()
-
-                val validationErrors = validateSwitch(
-                    candidate.getPublicationVersion(),
-                    versions,
-                    switchTrackLinks.trackVersionsBySwitchAfterPublication.getOrDefault(candidate.id, setOf()),
-                    nameDuplicates,
-                )
-
+                val validationErrors = validateSwitch(candidate.id, validationContext) ?: emptyList()
                 candidate.copy(errors = validationErrors + switchSplitErrors)
             },
             kmPosts = candidates.kmPosts.map { candidate ->
                 val kmPostSplitErrors = splitErrors.kmPosts[candidate.id] ?: emptyList()
-                val validationErrors = validateKmPost(candidate.getPublicationVersion(), versions, cacheKeys)
-
+                val validationErrors = validateKmPost(candidate.id, validationContext) ?: emptyList()
                 candidate.copy(errors = validationErrors + kmPostSplitErrors)
             },
         )
     }
 
-    private fun precacheLocationTrackAlignmentAddresses(
-        candidates: PublishCandidates,
-        cacheKeys: Map<IntId<TrackLayoutTrackNumber>, GeocodingContextCacheKey?>,
-    ) = candidates.locationTracks.mapNotNull { candidate ->
-        val track = locationTrackDao.fetch(candidate.getPublicationVersion().validatedAssetVersion)
-        val alignmentVersion = track.alignmentVersion
-        val geocodingContextKey = cacheKeys[track.trackNumberId]
-        if (alignmentVersion == null || geocodingContextKey == null) null
-        else geocodingService.collectDataForGetAddressPoints(geocodingContextKey, alignmentVersion)
-    }.parallelStream().forEach { run -> run() }
-
     @Transactional(readOnly = true)
     fun validatePublishRequest(versions: ValidationVersions) {
         logger.serviceCall("validatePublishRequest", "versions" to versions)
-        val cacheKeys = collectCacheKeys(versions)
-        val switchTrackLinks = collectSwitchTrackLinks(versions, versions.locationTracks.map { v -> v.officialId })
-        val splitErrors = splitService.validateSplit(versions, allowMultipleSplits = false)
-        val nameDuplicates = collectPotentialSwitchNameDuplicates(versions)
-
-        assertNoSplitErrors(splitErrors)
+        // TODO: GVT-2442 split validation could (should) also use the validation context
+        splitService.validateSplit(versions, allowMultipleSplits = false).also(::assertNoSplitErrors)
+        val validationContext = createValidationContext(versions).also { ctx -> ctx.preloadByPublicationSet() }
 
         versions.trackNumbers.forEach { version ->
-            assertNoErrors(version, validateTrackNumber(version, versions, cacheKeys))
+            assertNoErrors(version, requireNotNull(validateTrackNumber(version.officialId, validationContext)))
         }
         versions.kmPosts.forEach { version ->
-            assertNoErrors(version, validateKmPost(version, versions, cacheKeys))
+            assertNoErrors(version, requireNotNull(validateKmPost(version.officialId, validationContext)))
         }
         versions.referenceLines.forEach { version ->
-            assertNoErrors(version, validateReferenceLine(version, versions, cacheKeys))
+            assertNoErrors(version, requireNotNull(validateReferenceLine(version.officialId, validationContext)))
         }
         versions.locationTracks.forEach { version ->
-            assertNoErrors(version, validateLocationTrack(version, versions, cacheKeys, switchTrackLinks))
+            assertNoErrors(version, requireNotNull(validateLocationTrack(version.officialId, validationContext)))
         }
-
         versions.switches.forEach { version ->
-            assertNoErrors(
-                version,
-                validateSwitch(
-                    version,
-                    versions,
-                    switchTrackLinks.trackVersionsBySwitchAfterPublication.getOrDefault(version.officialId, setOf()),
-                    nameDuplicates,
-                ),
-            )
+            assertNoErrors(version, requireNotNull(validateSwitch(version.officialId, validationContext)))
         }
-    }
-
-    data class SwitchTrackLinks(
-        val switchIdsByTrackBeforeOrAfterPublication: Map<IntId<LocationTrack>, List<IntId<TrackLayoutSwitch>>>,
-        val trackVersionsBySwitchAfterPublication:  Map<IntId<TrackLayoutSwitch>, Set<RowVersion<LocationTrack>>>,
-    )
-
-    private fun collectSwitchTrackLinks(
-        versions: ValidationVersions,
-        trackIdsInPublicationUnit: List<IntId<LocationTrack>>?,
-    ): SwitchTrackLinks {
-        val switchIdsInPublicationUnit = versions.switches.map { v -> v.officialId }
-        val linkedSwitchIds =
-            publicationDao.fetchLinkedSwitchesBeforeOrAfterPublication(versions.locationTracks.map { v -> v.officialId })
-        val allSwitchesForValidation = (switchIdsInPublicationUnit + linkedSwitchIds.values.flatten()).distinct()
-        val trackLinks = publicationDao.fetchLinkedLocationTracks(allSwitchesForValidation, trackIdsInPublicationUnit)
-        return SwitchTrackLinks(linkedSwitchIds, trackLinks)
     }
 
     @Transactional(readOnly = true)
@@ -635,190 +565,133 @@ class PublicationService @Autowired constructor(
     }
 
     private fun validateTrackNumber(
-        version: ValidationVersion<TrackLayoutTrackNumber>,
-        validationVersions: ValidationVersions,
-        cacheKeys: Map<IntId<TrackLayoutTrackNumber>, GeocodingContextCacheKey?>,
-    ): List<PublishValidationError> {
-        val trackNumber = trackNumberDao.fetch(version.validatedAssetVersion)
-        val kmPosts = getKmPostsByTrackNumber(version.officialId, validationVersions)
-        val referenceLine = getReferenceLineByTrackNumber(version.officialId, validationVersions)
-        val locationTracks = getLocationTracksByTrackNumber(version.officialId, validationVersions)
+        id: IntId<TrackLayoutTrackNumber>,
+        validationContext: ValidationContext,
+    ): List<PublishValidationError>? = validationContext.getTrackNumber(id)?.let { trackNumber ->
+        val kmPosts = validationContext.getKmPostsByTrackNumber(id)
+        val referenceLine = validationContext.getReferenceLineByTrackNumber(id)
+        val locationTracks = validationContext.getLocationTracksByTrackNumber(id)
         val fieldErrors = validateDraftTrackNumberFields(trackNumber)
-        val referenceErrors = validateTrackNumberReferences(
-            trackNumber,
-            referenceLine,
-            kmPosts,
-            locationTracks,
-            validationVersions.kmPosts.map { it.officialId },
-            validationVersions.locationTracks.map { it.officialId },
-        )
+        val referenceErrors = validateTrackNumberReferences(trackNumber, referenceLine, kmPosts, locationTracks)
         val geocodingErrors = if (trackNumber.exists && referenceLine != null) {
-            validateGeocodingContext(cacheKeys[version.officialId], VALIDATION_TRACK_NUMBER, trackNumber.number)
+            val geocodingContextCacheKey = validationContext.getGeocodingContextCacheKey(id)
+            validateGeocodingContext(geocodingContextCacheKey, VALIDATION_TRACK_NUMBER, trackNumber.number)
         } else listOf()
-        val duplicateNameErrors = validateTrackNumberNumberDuplication(trackNumber, validationVersions)
+        val duplicateNameErrors = validateTrackNumberNumberDuplication(
+            trackNumber = trackNumber,
+            duplicates = validationContext.getTrackNumbersByNumber(trackNumber.number),
+        )
         return fieldErrors + referenceErrors + geocodingErrors + duplicateNameErrors
     }
 
-    private fun validateTrackNumberNumberDuplication(
-        trackNumber: TrackLayoutTrackNumber,
-        versions: ValidationVersions,
-    ): List<PublishValidationError> {
-        val drafts = versions.trackNumbers.map { it.officialId to trackNumberDao.fetch(it.validatedAssetVersion) }
-        val officials = trackNumberDao.fetchVersions(OFFICIAL, false).map(trackNumberDao::fetch).filterNot { official ->
-            drafts.map { draft -> draft.first }.contains(official.id)
-        }
-        val officialDuplicateExists =
-            officials.any { official -> official.id != trackNumber.id && official.number == trackNumber.number }
-        val stagedDuplicateExists =
-            drafts.any { (_, draft) -> draft.number == trackNumber.number && draft.id != trackNumber.id && draft.state != LayoutState.DELETED }
-
-        return listOfNotNull(
-            if (!stagedDuplicateExists && officialDuplicateExists) PublishValidationError(
-                ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-official", mapOf("trackNumber" to trackNumber.number)
-            ) else null,
-            if (stagedDuplicateExists) PublishValidationError(
-                ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-draft", mapOf("trackNumber" to trackNumber.number)
-            ) else null,
-        )
-    }
-
     private fun validateKmPost(
-        version: ValidationVersion<TrackLayoutKmPost>,
-        validationVersions: ValidationVersions,
-        cacheKeys: Map<IntId<TrackLayoutTrackNumber>, GeocodingContextCacheKey?>,
-    ): List<PublishValidationError> {
-        val kmPost = kmPostDao.fetch(version.validatedAssetVersion)
-        val trackNumber = kmPost.trackNumberId?.let { id -> getTrackNumber(id, validationVersions) }
-        val referenceLine = kmPost.trackNumberId?.let { id -> getReferenceLineByTrackNumber(id, validationVersions) }
-        val fieldErrors = validateDraftKmPostFields(kmPost)
-        val referenceErrors = validateKmPostReferences(
-            kmPost,
-            trackNumber,
-            referenceLine,
-            validationVersions.trackNumbers.map { it.officialId },
-        )
-        val geocodingErrors = if (kmPost.exists && trackNumber?.exists == true && referenceLine != null) {
-            validateGeocodingContext(cacheKeys[kmPost.trackNumberId], VALIDATION_KM_POST, trackNumber.number)
-        } else listOf()
+        id: IntId<TrackLayoutKmPost>,
+        context: ValidationContext,
+    ): List<PublishValidationError>? = context.getKmPost(id)?.let { kmPost ->
+        val trackNumber = kmPost.trackNumberId?.let(context::getTrackNumber)
+        // TODO: GVT-2442 This needs to be cached
+        val trackNumberNumber = (trackNumber ?: kmPost.trackNumberId?.let(context::getTrackNumber))?.number
+        val referenceLine = trackNumber?.referenceLineId?.let(context::getReferenceLine)
 
-        return fieldErrors + referenceErrors + geocodingErrors
+        val fieldErrors = validateDraftKmPostFields(kmPost)
+        val referenceErrors = validateKmPostReferences(kmPost, trackNumber, referenceLine, trackNumberNumber)
+
+        val geocodingErrors = if (kmPost.exists && trackNumber?.exists == true && referenceLine != null) {
+            validateGeocodingContext(context.getGeocodingContextCacheKey(kmPost.trackNumberId), VALIDATION_KM_POST, trackNumber.number)
+        } else listOf()
+        fieldErrors + referenceErrors + geocodingErrors
     }
 
     private fun validateSwitch(
-        version: ValidationVersion<TrackLayoutSwitch>,
-        validationVersions: ValidationVersions,
-        linkedTracks: Set<RowVersion<LocationTrack>>,
-        nameDuplicates: Map<SwitchName, PotentialDuplicates>,
-    ): List<PublishValidationError> {
-        val switch = switchDao.fetch(version.validatedAssetVersion)
+        id: IntId<TrackLayoutSwitch>,
+        validationContext: ValidationContext,
+    ): List<PublishValidationError>? = validationContext.getSwitch(id)?.let { switch ->
         val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
-        val linkedTracksAndAlignments = linkedTracks.map(locationTrackService::getWithAlignment)
+        val linkedTracksAndAlignments = validationContext.getSwitchTracksWithAlignments(id)
+        val linkedTracks = linkedTracksAndAlignments.map(Pair<LocationTrack, *>::first)
+
         val fieldErrors = validateDraftSwitchFields(switch)
-        val referenceErrors = validateSwitchLocationTrackLinkReferences(
-            switch,
-            linkedTracksAndAlignments.map(Pair<LocationTrack, *>::first),
-            validationVersions.locationTracks.map { it.officialId },
-        )
+        val referenceErrors = validateSwitchLocationTrackLinkReferences(switch, linkedTracks)
+
         val locationErrors = if (switch.exists) validateSwitchLocation(switch) else emptyList()
         val structureErrors = locationErrors.ifEmpty {
             validateSwitchLocationTrackLinkStructure(switch, structure, linkedTracksAndAlignments)
         }
 
-        val duplicationErrors = validateSwitchNameDuplication(
-            switch = switch,
-            draftsBySameName = nameDuplicates[switch.name]?.draft ?: emptyList(),
-            officialsBySameName = nameDuplicates[switch.name]?.official ?: emptyList(),
-        )
+        val duplicationErrors = validateSwitchNameDuplication(switch, validationContext.getSwitchesByName(switch.name))
         return fieldErrors + referenceErrors + structureErrors + duplicationErrors
     }
 
-    data class PotentialDuplicates(val draft: List<TrackLayoutSwitch>, val official: List<TrackLayoutSwitch>)
-
-    private fun collectPotentialSwitchNameDuplicates(
-        versions: ValidationVersions,
-    ): Map<SwitchName, PotentialDuplicates> {
-        val drafts = versions.switches.map { sv -> sv.validatedAssetVersion }.map(switchDao::fetch)
-        val draftNamesToCheck = drafts.filter(TrackLayoutSwitch::exists).map(TrackLayoutSwitch::name).distinct()
-        val officialVersions = switchDao.findOfficialNameDuplicates(draftNamesToCheck)
-        val officials = officialVersions.mapValues { (_, officials) ->
-            officials.mapNotNull { v -> if (versions.containsSwitch(v.id)) null else switchDao.fetch(v) }
-        }
-        return draftNamesToCheck.associate { name ->
-            name to PotentialDuplicates(
-                draft = drafts.filter { d -> d.name == name && d.exists },
-                official = officials[name] ?: listOf(),
-            )
-        }
-    }
-
     private fun validateReferenceLine(
-        version: ValidationVersion<ReferenceLine>,
-        validationVersions: ValidationVersions,
-        cacheKeys: Map<IntId<TrackLayoutTrackNumber>, GeocodingContextCacheKey?>,
-    ): List<PublishValidationError> {
-        val (referenceLine, alignment) = getReferenceLineAndAlignment(version.validatedAssetVersion)
-        val trackNumber = getTrackNumber(referenceLine.trackNumberId, validationVersions)
-        val referenceErrors = validateReferenceLineReference(
-            referenceLine,
-            trackNumber,
-            validationVersions.trackNumbers.map { it.officialId },
-        )
-        val alignmentErrors = if (trackNumber?.exists == true) validateReferenceLineAlignment(alignment) else listOf()
-        val geocodingErrors: List<PublishValidationError> = if (trackNumber?.exists == true) {
-            val contextKey = cacheKeys[referenceLine.trackNumberId]
-            val contextErrors = validateGeocodingContext(contextKey, VALIDATION_REFERENCE_LINE, trackNumber.number)
-            val addressErrors = contextKey?.let { key ->
-                val locationTracks = getLocationTracksByTrackNumber(trackNumber.id as IntId, validationVersions)
-                locationTracks.flatMap { track ->
-                    validateAddressPoints(trackNumber, key, track, VALIDATION_REFERENCE_LINE)
-                }
-            } ?: listOf()
-            contextErrors + addressErrors
-        } else listOf()
+        id: IntId<ReferenceLine>,
+        validationContext: ValidationContext,
+    ): List<PublishValidationError>? =
+        validationContext.getReferenceLineWithAlignment(id)?.let { (referenceLine, alignment) ->
+            val trackNumber = validationContext.getTrackNumber(referenceLine.trackNumberId)
+            val referenceErrors = validateReferenceLineReference(
+                referenceLine = referenceLine,
+                trackNumber = trackNumber,
+                trackNumberNumber = validationContext.getDraftTrackNumber(referenceLine.trackNumberId).number,
+            )
+            val alignmentErrors = if (trackNumber?.exists == true) validateReferenceLineAlignment(alignment) else listOf()
+            val geocodingErrors: List<PublishValidationError> = if (trackNumber?.exists == true) {
+                val contextKey = validationContext.getGeocodingContextCacheKey(referenceLine.trackNumberId)
+                val contextErrors = validateGeocodingContext(contextKey, VALIDATION_REFERENCE_LINE, trackNumber.number)
+                val addressErrors = contextKey?.let { key ->
+                    val locationTracks = validationContext.getLocationTracksByTrackNumber(referenceLine.trackNumberId)
+                    locationTracks.flatMap { track ->
+                        validateAddressPoints(trackNumber, key, track, VALIDATION_REFERENCE_LINE)
+                    }
+                } ?: listOf()
+                contextErrors + addressErrors
+            } else listOf()
 
-        return referenceErrors + alignmentErrors + geocodingErrors
-    }
+            return referenceErrors + alignmentErrors + geocodingErrors
+        }
 
     private fun validateLocationTrack(
-        version: ValidationVersion<LocationTrack>,
-        validationVersions: ValidationVersions,
-        cacheKeys: Map<IntId<TrackLayoutTrackNumber>, GeocodingContextCacheKey?>,
-        switchTrackLinks: SwitchTrackLinks,
-    ): List<PublishValidationError> {
-        val (locationTrack, alignment) = getLocationTrackAndAlignment(version.validatedAssetVersion)
-        val trackNumber = getTrackNumber(locationTrack.trackNumberId, validationVersions)
-        val fieldErrors = validateDraftLocationTrackFields(locationTrack)
-        val referenceErrors = validateLocationTrackReference(
-            locationTrack,
-            trackNumber,
-            validationVersions.trackNumbers.map { it.officialId },
-        )
-        val switchErrorsSegments = validateSegmentSwitchReferences(
-            locationTrack,
-            getSegmentSwitches(alignment, validationVersions),
-            validationVersions.switches.map { it.officialId },
-        )
+        id: IntId<LocationTrack>,
+        validationContext: ValidationContext,
+    ): List<PublishValidationError>? = validationContext.getLocationTrackWithAlignment(id)?.let { (track, alignment) ->
+        val trackNumber = validationContext.getTrackNumber(track.trackNumberId)
+        val trackNumberName = (trackNumber ?: validationContext.getDraftTrackNumber(track.trackNumberId)).number
+        val fieldErrors = validateDraftLocationTrackFields(track)
+
+        val referenceErrors = validateLocationTrackReference(track, trackNumber, trackNumberName)
+        val segmentSwitches = validationContext.getSegmentSwitches(alignment)
+        val switchSegmentErrors = validateSegmentSwitchReferences(track, segmentSwitches)
         val topologicallyConnectedSwitchError = validateTopologicallyConnectedSwitchReferences(
-            getTopologicallyConnectedSwitches(locationTrack, validationVersions),
-            validationVersions.switches.map { it.officialId },
+            track,
+            validationContext.getTopologicallyConnectedSwitches(track),
         )
-        val trackNetworkTopologyErrors =
-            validateLocationTrackTopologicalConnectivity(version, locationTrack, validationVersions, switchTrackLinks)
-        val duplicateErrors = validateDuplicateOf(version, locationTrack, validationVersions)
-        val alignmentErrors = if (locationTrack.exists) validateLocationTrackAlignment(alignment)
-        else listOf()
-        val geocodingErrors = if (locationTrack.exists && trackNumber != null) {
-            cacheKeys[locationTrack.trackNumberId]?.let { key ->
-                validateAddressPoints(trackNumber, key, locationTrack, VALIDATION_LOCATION_TRACK)
+        val trackNetworkTopologyErrors = validationContext
+            .getPotentiallyAffectedSwitches(id)
+            .filter(TrackLayoutSwitch::exists)
+            .flatMap { switch ->
+                val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
+                val switchTracks = validationContext.getSwitchTracksWithAlignments(switch.id as IntId)
+                validateSwitchTopologicalConnectivity(switch, structure, switchTracks, track)
+            }
+
+        val duplicatesAfterPublication = validationContext.getDuplicateTracks(id)
+        val duplicateOf = track.duplicateOf?.let(validationContext::getLocationTrack)
+        // Draft-only won't be found if it's not in the publication set -> get name from draft for validation errors
+        val duplicateOfName = track.duplicateOf?.let(validationContext::getDraftLocationTrack)?.name
+        val duplicateErrors = validateDuplicateOfState(track, duplicateOf, duplicateOfName, duplicatesAfterPublication)
+
+        val alignmentErrors = if (track.exists) validateLocationTrackAlignment(alignment) else listOf()
+        val geocodingErrors = if (track.exists && trackNumber != null) {
+            validationContext.getGeocodingContextCacheKey(track.trackNumberId)?.let { key ->
+                validateAddressPoints(trackNumber, key, track, VALIDATION_REFERENCE_LINE)
             } ?: listOf(noGeocodingContext(VALIDATION_LOCATION_TRACK))
         } else listOf()
-        val duplicateNameErrors = if (locationTrack.exists) validateLocationTrackNameDuplication(
-            locationTrack, validationVersions
-        ) else listOf()
 
-        return (fieldErrors +
+        val tracksWithSameName = validationContext.getLocationTracksByName(track.name)
+        val duplicateNameErrors = validateLocationTrackNameDuplication(track, trackNumberName, tracksWithSameName)
+
+        (fieldErrors +
                 referenceErrors +
-                switchErrorsSegments +
+                switchSegmentErrors +
                 topologicallyConnectedSwitchError +
                 duplicateErrors +
                 alignmentErrors +
@@ -826,121 +699,6 @@ class PublicationService @Autowired constructor(
                 duplicateNameErrors +
                 trackNetworkTopologyErrors)
     }
-
-    private fun validateLocationTrackTopologicalConnectivity(
-        version: ValidationVersion<LocationTrack>,
-        validatingTrack: LocationTrack,
-        validationVersions: ValidationVersions,
-        switchTrackLinks: SwitchTrackLinks,
-    ): List<PublishValidationError> {
-        return switchTrackLinks.switchIdsByTrackBeforeOrAfterPublication
-            .getOrDefault(version.officialId, listOf())
-            .map { switchId -> getSwitchForValidation(switchId, validationVersions) }
-            .filter(TrackLayoutSwitch::exists)
-            .flatMap { switch ->
-                val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
-                val locationTracks = switchTrackLinks.trackVersionsBySwitchAfterPublication
-                    .getOrDefault(switch.id, listOf())
-                    .mapNotNull { locationTrackVersion ->
-                        val track = locationTrackDao.fetch(locationTrackVersion)
-                        track.alignmentVersion?.let(alignmentDao::fetch)?.let { track to it }
-                    }
-                validateSwitchTopologicalConnectivity(switch, structure, locationTracks, validatingTrack)
-            }
-    }
-
-    @Transactional(readOnly = true)
-    fun validateDuplicateOf(
-        version: ValidationVersion<LocationTrack>,
-        track: LocationTrack,
-        validationVersions: ValidationVersions,
-    ): List<PublishValidationError> {
-        // Find the versions in validation set context. These can be null (draft-only that's not included)
-        val duplicatesAfterPublication = locationTrackDao
-            .fetchDuplicateIdsInAnyLayoutContext(version.officialId)
-            .mapNotNull { id -> getLocationTrack(id, validationVersions) }
-            .filter { potentialDuplicate -> potentialDuplicate.duplicateOf == version.officialId }
-
-        val duplicateOf = track.duplicateOf?.let { id -> getLocationTrack(id, validationVersions) }
-        // Draft-only won't be found if it's not in the publication set -> get name from draft for validation errors
-        val duplicateOfDraftName = track.duplicateOf?.let { id -> locationTrackDao.getOrThrow(DRAFT, id).name }
-        return validateDuplicateOfState(track, duplicateOf, duplicateOfDraftName, duplicatesAfterPublication)
-    }
-
-    private fun validateLocationTrackNameDuplication(
-        locationTrack: LocationTrack,
-        versions: ValidationVersions,
-    ): List<PublishValidationError> {
-        val drafts = versions.locationTracks
-            .map { it.officialId to locationTrackDao.fetch(it.validatedAssetVersion) }
-            .filter { (_, lt) -> lt.trackNumberId == locationTrack.trackNumberId }
-        val officials = locationTrackDao
-            .list(OFFICIAL, false, locationTrack.trackNumberId)
-            .filterNot { official -> drafts.map { draft -> draft.first }.contains(official.id) }
-        val officialDuplicateExists = officials.any { official ->
-            official.id != locationTrack.id && official.name == locationTrack.name
-        }
-        val stagedDuplicateExists = drafts.any { (_, draft) ->
-            draft.name == locationTrack.name && draft.id != locationTrack.id && draft.state != LayoutState.DELETED
-        }
-        val trackNumberName = locationTrack.trackNumberId.let { trackNumberService.get(DRAFT, it)?.number }
-
-        return listOfNotNull(
-            if (stagedDuplicateExists) PublishValidationError(
-                ERROR,
-                "$VALIDATION_LOCATION_TRACK.duplicate-name-draft",
-                mapOf("locationTrack" to locationTrack.name, "trackNumber" to trackNumberName)
-            ) else null, if (!stagedDuplicateExists && officialDuplicateExists) PublishValidationError(
-                ERROR,
-                "$VALIDATION_LOCATION_TRACK.duplicate-name-official",
-                mapOf("locationTrack" to locationTrack.name, "trackNumber" to trackNumberName)
-            ) else null
-        )
-    }
-
-    private fun getTrackNumber(
-        id: IntId<TrackLayoutTrackNumber>,
-        versions: ValidationVersions,
-    ): TrackLayoutTrackNumber? {
-        val version = versions.findTrackNumber(id)?.validatedAssetVersion ?: trackNumberDao.fetchOfficialVersion(id)
-        return version?.let(trackNumberDao::fetch)
-    }
-
-    private fun getLocationTrack(id: IntId<LocationTrack>, versions: ValidationVersions): LocationTrack? {
-        val version = versions.findLocationTrack(id)?.validatedAssetVersion ?: locationTrackDao.fetchOfficialVersion(id)
-        return version?.let(locationTrackDao::fetch)
-    }
-
-    private fun getReferenceLineByTrackNumber(
-        trackNumberId: IntId<TrackLayoutTrackNumber>,
-        versions: ValidationVersions,
-    ) = versions.referenceLines
-        .map { v -> referenceLineDao.fetch(v.validatedAssetVersion) }
-        .find { line -> line.trackNumberId == trackNumberId } ?: referenceLineDao
-        .fetchVersionByTrackNumberId(OFFICIAL, trackNumberId)
-        ?.let(referenceLineDao::fetch)
-
-    private fun getKmPostsByTrackNumber(
-        trackNumberId: IntId<TrackLayoutTrackNumber>,
-        versions: ValidationVersions,
-    ) = combineVersions(
-        officials = kmPostDao.fetchVersions(OFFICIAL, false, trackNumberId),
-        validations = versions.kmPosts,
-    ).map(kmPostDao::fetch).filter { km -> km.trackNumberId == trackNumberId }
-
-    private fun getLocationTracksByTrackNumber(
-        trackNumberId: IntId<TrackLayoutTrackNumber>,
-        versions: ValidationVersions,
-    ) = combineVersions(
-        officials = locationTrackDao.fetchVersions(OFFICIAL, false, trackNumberId),
-        validations = versions.locationTracks
-    ).map(locationTrackDao::fetch).filter { lt -> lt.trackNumberId == trackNumberId }
-
-    private fun getReferenceLineAndAlignment(version: RowVersion<ReferenceLine>) =
-        referenceLineWithAlignment(referenceLineDao, alignmentDao, version)
-
-    private fun getLocationTrackAndAlignment(version: RowVersion<LocationTrack>) =
-        locationTrackWithAlignment(locationTrackDao, alignmentDao, version)
 
     @Transactional(readOnly = true)
     fun getPublicationDetails(id: IntId<Publication>): PublicationDetails {
@@ -1511,60 +1269,14 @@ class PublicationService @Autowired constructor(
         contextKey: GeocodingContextCacheKey,
         track: LocationTrack,
         validationTargetLocalizationPrefix: String,
-    ) = if (!track.exists || track.alignmentVersion == null) listOf()
-    else {
+    ): List<PublishValidationError> = if (!track.exists) {
+        listOf()
+    } else if (track.alignmentVersion == null) {
+        throw IllegalStateException("LocationTrack in DB should have an alignment: track=$track")
+    } else {
         validateAddressPoints(trackNumber, track, validationTargetLocalizationPrefix) {
             geocodingService.getAddressPoints(contextKey, track.alignmentVersion)
         }
-    }
-
-    private fun getSwitchForValidation(
-        switchId: IntId<TrackLayoutSwitch>,
-        versions: ValidationVersions,
-    ): TrackLayoutSwitch {
-        val version =
-            versions.findSwitch(switchId)?.validatedAssetVersion ?: switchDao.fetchVersionPair(switchId).let { (o, d) ->
-                o ?: checkNotNull(d) {
-                    "Fetched switch is neither official nor draft, switchId=$switchId"
-                }
-            }
-
-        return switchDao.fetch(version)
-    }
-
-    private fun getSegmentSwitches(alignment: LayoutAlignment, versions: ValidationVersions): List<SegmentSwitch> {
-        val segmentsBySwitch = alignment.segments
-            .mapNotNull { segment -> segment.switchId?.let { id -> id as IntId to segment } }
-            .groupBy({ (switchId, _) -> switchId }, { (_, segment) -> segment })
-            .mapKeys { (switchId, _) -> getSwitchForValidation(switchId, versions) }
-
-        return segmentsBySwitch.entries.map { (switch, segments) ->
-            SegmentSwitch(
-                switch = switch,
-                switchStructure = switchLibraryService.getSwitchStructure(switch.switchStructureId),
-                segments = segments,
-            )
-        }
-    }
-
-    private fun getTopologicallyConnectedSwitches(
-        locationTrack: LocationTrack,
-        versions: ValidationVersions,
-    ): List<TrackLayoutSwitch> {
-        return listOfNotNull(
-            locationTrack.topologyStartSwitch?.switchId,
-            locationTrack.topologyEndSwitch?.switchId,
-        ).map { switchId -> getSwitchForValidation(switchId, versions) }
-    }
-
-    private fun collectCacheKeys(versions: ValidationVersions): Map<IntId<TrackLayoutTrackNumber>, GeocodingContextCacheKey?> {
-        val trackNumberIds = listOf(
-            versions.trackNumbers.map { version -> version.officialId },
-            versions.kmPosts.mapNotNull { v -> kmPostDao.fetch(v.validatedAssetVersion).trackNumberId },
-            versions.locationTracks.map { v -> locationTrackDao.fetch(v.validatedAssetVersion).trackNumberId },
-            versions.referenceLines.map { v -> referenceLineDao.fetch(v.validatedAssetVersion).trackNumberId },
-        ).flatten().toSet()
-        return trackNumberIds.associateWith { tnId -> geocodingService.getGeocodingContextCacheKey(tnId, versions) }
     }
 
     private fun latestTrackNumberNamesAtMoment(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -576,7 +576,9 @@ class PublicationService @Autowired constructor(
         val geocodingErrors = if (trackNumber.exists && referenceLine != null) {
             val geocodingContextCacheKey = validationContext.getGeocodingContextCacheKey(id)
             validateGeocodingContext(geocodingContextCacheKey, VALIDATION_TRACK_NUMBER, trackNumber.number)
-        } else listOf()
+        } else {
+            listOf()
+        }
         val duplicateNameErrors = validateTrackNumberNumberDuplication(
             trackNumber = trackNumber,
             duplicates = validationContext.getTrackNumbersByNumber(trackNumber.number),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -590,7 +590,7 @@ class PublicationService @Autowired constructor(
     ): List<PublishValidationError>? = context.getKmPost(id)?.let { kmPost ->
         val trackNumber = kmPost.trackNumberId?.let(context::getTrackNumber)
         // TODO: GVT-2442 This needs to be cached
-        val trackNumberNumber = (trackNumber ?: kmPost.trackNumberId?.let(context::getTrackNumber))?.number
+        val trackNumberNumber = (trackNumber ?: kmPost.trackNumberId?.let(context::getDraftTrackNumber))?.number
         val referenceLine = trackNumber?.referenceLineId?.let(context::getReferenceLine)
 
         val fieldErrors = validateDraftKmPostFields(kmPost)
@@ -631,7 +631,7 @@ class PublicationService @Autowired constructor(
             val referenceErrors = validateReferenceLineReference(
                 referenceLine = referenceLine,
                 trackNumber = trackNumber,
-                trackNumberNumber = validationContext.getDraftTrackNumber(referenceLine.trackNumberId).number,
+                trackNumberNumber = validationContext.getDraftTrackNumber(referenceLine.trackNumberId)?.number,
             )
             val alignmentErrors = if (trackNumber?.exists == true) validateReferenceLineAlignment(alignment) else listOf()
             val geocodingErrors: List<PublishValidationError> = if (trackNumber?.exists == true) {
@@ -654,7 +654,7 @@ class PublicationService @Autowired constructor(
         validationContext: ValidationContext,
     ): List<PublishValidationError>? = validationContext.getLocationTrackWithAlignment(id)?.let { (track, alignment) ->
         val trackNumber = validationContext.getTrackNumber(track.trackNumberId)
-        val trackNumberName = (trackNumber ?: validationContext.getDraftTrackNumber(track.trackNumberId)).number
+        val trackNumberName = (trackNumber ?: validationContext.getDraftTrackNumber(track.trackNumberId))?.number
         val fieldErrors = validateDraftLocationTrackFields(track)
 
         val referenceErrors = validateLocationTrackReference(track, trackNumber, trackNumberName)
@@ -1219,7 +1219,7 @@ class PublicationService @Autowired constructor(
             list
         }.sortedBy { it.propKey.key }
 
-        val oldLinkedTrackNames = oldLinkedLocationTracks.values.mapNotNull { it?.first?.name?.toString() }.sorted()
+        val oldLinkedTrackNames = oldLinkedLocationTracks.values.mapNotNull { it.first.name?.toString() }.sorted()
         val newLinkedTrackNames = changes.locationTracks.map { it.name.toString() }.sorted()
 
         return listOfNotNull(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -145,7 +145,7 @@ fun validateSwitchNameDuplication(
 
 fun validateLocationTrackNameDuplication(
     track: LocationTrack,
-    trackNumber: TrackNumber,
+    trackNumber: TrackNumber?,
     duplicates: List<LocationTrack>,
 ): List<PublishValidationError> {
     return if (track.exists && duplicates.any { d -> d.id != track.id }) {
@@ -416,7 +416,7 @@ fun validateDraftLocationTrackFields(locationTrack: LocationTrack): List<Publish
 
 fun validateReferenceLineReference(
     referenceLine: ReferenceLine,
-    trackNumberNumber: TrackNumber,
+    trackNumberNumber: TrackNumber?,
     trackNumber: TrackLayoutTrackNumber?,
 ): List<PublishValidationError> {
     val numberParams = localizationParams("trackNumber" to trackNumberNumber)
@@ -433,7 +433,7 @@ fun validateReferenceLineReference(
 fun validateLocationTrackReference(
     locationTrack: LocationTrack,
     trackNumber: TrackLayoutTrackNumber?,
-    trackNumberName: TrackNumber,
+    trackNumberName: TrackNumber?,
 ): List<PublishValidationError> {
     return if (trackNumber == null) listOf(
         validationError("$VALIDATION_LOCATION_TRACK.track-number.not-published", "trackNumber" to trackNumberName),
@@ -453,7 +453,7 @@ fun validateLocationTrackReference(
 
 data class SegmentSwitch(
     val switchId: IntId<TrackLayoutSwitch>,
-    val switchName: SwitchName,
+    val switchName: SwitchName?,
     val switch: TrackLayoutSwitch?,
     val switchStructure: SwitchStructure?,
     val segments: List<LayoutSegment>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -62,13 +62,13 @@ fun validateTrackNumberNumberDuplication(
 ): List<PublishValidationError> {
     return if (trackNumber.exists) {
         val officialDuplicateExists = duplicates.any { d -> d.id != trackNumber.id && d.isOfficial() }
-        val stagedDuplicateExists = duplicates.any { d -> d.id != trackNumber.id && d.isDraft() }
+        val draftDuplicateExists = duplicates.any { d -> d.id != trackNumber.id && d.isDraft() }
 
         listOfNotNull(
-            if (!stagedDuplicateExists && officialDuplicateExists) PublishValidationError(
+            if (!draftDuplicateExists && officialDuplicateExists) PublishValidationError(
                 ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-official", mapOf("trackNumber" to trackNumber.number)
             ) else null,
-            if (stagedDuplicateExists) PublishValidationError(
+            if (draftDuplicateExists) PublishValidationError(
                 ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-draft", mapOf("trackNumber" to trackNumber.number)
             ) else null,
         )
@@ -128,13 +128,13 @@ fun validateSwitchNameDuplication(
 ): List<PublishValidationError> {
     return if (switch.exists) {
         val officialDuplicateExists = duplicates.any { d -> d.id != switch.id && d.isOfficial() }
-        val stagedDuplicateExists = duplicates.any { d -> d.id != switch.id && d.isDraft() }
+        val draftDuplicateExists = duplicates.any { d -> d.id != switch.id && d.isDraft() }
 
         listOfNotNull(
-            validateWithParams(stagedDuplicateExists || !officialDuplicateExists) {
+            validateWithParams(draftDuplicateExists || !officialDuplicateExists) {
                 "$VALIDATION_SWITCH.duplicate-name-official" to localizationParams("switch" to switch.name)
             },
-            validateWithParams(!stagedDuplicateExists) {
+            validateWithParams(!draftDuplicateExists) {
                 "$VALIDATION_SWITCH.duplicate-name-draft" to localizationParams("switch" to switch.name)
             },
         )
@@ -150,16 +150,16 @@ fun validateLocationTrackNameDuplication(
 ): List<PublishValidationError> {
     return if (track.exists && duplicates.any { d -> d.id != track.id }) {
         val officialDuplicateExists = duplicates.any { d -> d.id != track.id && d.isOfficial() }
-        val stagedDuplicateExists = duplicates.any { d -> d.id != track.id && d.isDraft() }
+        val draftDuplicateExists = duplicates.any { d -> d.id != track.id && d.isDraft() }
         val localizationParams = localizationParams(
             "locationTrack" to track.name,
             "trackNumber" to trackNumber,
         )
         return listOfNotNull(
-            validateWithParams(stagedDuplicateExists || !officialDuplicateExists) {
+            validateWithParams(draftDuplicateExists || !officialDuplicateExists) {
                 "$VALIDATION_LOCATION_TRACK.duplicate-name-official" to localizationParams
             },
-            validateWithParams(!stagedDuplicateExists) {
+            validateWithParams(!draftDuplicateExists) {
                 "$VALIDATION_LOCATION_TRACK.duplicate-name-draft" to localizationParams
             },
         )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -1,0 +1,406 @@
+package fi.fta.geoviite.infra.publication
+
+import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.PublishType.DRAFT
+import fi.fta.geoviite.infra.common.PublishType.OFFICIAL
+import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
+import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
+import fi.fta.geoviite.infra.tracklayout.*
+import java.util.concurrent.ConcurrentHashMap
+
+class NullableCache<K, V> {
+    val map: ConcurrentHashMap<K, NullableValue<V>> = ConcurrentHashMap()
+
+    fun get(key: K, getter: (K) -> V?): V? = map.computeIfAbsent(key) { k -> NullableValue(getter(k)) }.value
+
+    fun preload(keys: List<K>, getter: (List<K>) -> Map<K, V?>) {
+        val missingKeys = keys.filterNot(map::containsKey)
+        val preloaded = if (missingKeys.isNotEmpty()) getter(missingKeys) else mapOf()
+        // TODO: GVT-2442 test that this actually works
+        // Also cache the "not found" results
+        val notFound = missingKeys.filterNot(preloaded::containsKey)
+        putAll(preloaded + notFound.associateWith { null })
+    }
+
+    fun putAll(values: Map<K, V?>): Unit = map.putAll(values.mapValues { (_, v) -> NullableValue(v) })
+
+    fun contains(key: K): Boolean = map.containsKey(key)
+
+    // Holder for nullable value so computeIfAbsent doesn't re-resolve a missing result
+    data class NullableValue<T>(val value: T?)
+}
+
+typealias RowVersionCache<T> = NullableCache<IntId<T>, RowVersion<T>>
+
+/**
+ * Validation context provides a layout world-view that combines the drafts of a publication set (selected drafts) to
+ * the baseline of official layout. Each object only has one version that can exist in this context:
+ *
+ * In addition, it caches the validation data for quicker access.
+ */
+class ValidationContext(
+    val trackNumberDao: LayoutTrackNumberDao,
+    val referenceLineDao: ReferenceLineDao,
+    val kmPostDao: LayoutKmPostDao,
+    val locationTrackDao: LocationTrackDao,
+    val alignmentDao: LayoutAlignmentDao,
+    val switchDao: LayoutSwitchDao,
+    val switchLibraryService: SwitchLibraryService,
+    val publicationDao: PublicationDao,
+    val geocodingService: GeocodingService,
+    val publicationSet: ValidationVersions,
+) {
+    private val trackNumberVersionCache: RowVersionCache<TrackLayoutTrackNumber> = RowVersionCache()
+    private val referenceLineVersionCache: RowVersionCache<ReferenceLine> = RowVersionCache()
+    private val kmPostVersionCache: RowVersionCache<TrackLayoutKmPost> = RowVersionCache()
+    private val locationTrackVersionCache: RowVersionCache<LocationTrack> = RowVersionCache()
+    private val switchVersionCache: RowVersionCache<TrackLayoutSwitch> = RowVersionCache()
+
+    private val trackNumberKmPosts: NullableCache<IntId<TrackLayoutTrackNumber>, List<IntId<TrackLayoutKmPost>>> = NullableCache()
+    private val trackNumberLocationTracks: NullableCache<IntId<TrackLayoutTrackNumber>, List<IntId<LocationTrack>>> = NullableCache()
+
+    private val switchTrackLinks: NullableCache<IntId<TrackLayoutSwitch>, List<IntId<LocationTrack>>> = NullableCache()
+    private val trackDuplicateLinks: NullableCache<IntId<LocationTrack>, List<IntId<LocationTrack>>> = NullableCache()
+    private val geocodingContextKeys: NullableCache<IntId<TrackLayoutTrackNumber>, GeocodingContextCacheKey> = NullableCache()
+
+    val switchNameCache: NullableCache<SwitchName, List<IntId<TrackLayoutSwitch>>> = NullableCache()
+    val trackNameCache: NullableCache<AlignmentName, List<IntId<LocationTrack>>> = NullableCache()
+    val trackNumberNumberCache: NullableCache<TrackNumber, List<IntId<TrackLayoutTrackNumber>>> = NullableCache()
+
+    fun getTrackNumber(id: IntId<TrackLayoutTrackNumber>): TrackLayoutTrackNumber? =
+        getObject(id, publicationSet.trackNumbers, trackNumberDao, trackNumberVersionCache)
+
+    fun getTrackNumbersByNumber(number: TrackNumber): List<TrackLayoutTrackNumber> =
+        trackNumberNumberCache.get(number) { n ->
+            throw IllegalStateException("TrackNumber numbers should have been preloaded before use: number=$n")
+        }?.mapNotNull(::getTrackNumber) ?: emptyList()
+
+    fun getReferenceLine(id: IntId<ReferenceLine>): ReferenceLine? =
+        getObject(id, publicationSet.referenceLines, referenceLineDao, referenceLineVersionCache)
+
+    fun getReferenceLineWithAlignment(id: IntId<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment>? =
+        getObject(id, publicationSet.referenceLines, referenceLineDao, referenceLineVersionCache)?.let { rl ->
+            rl to alignmentDao.fetch(requireNotNull(rl.alignmentVersion) {
+                "Reference line in DB should have an alignment: id=$id"
+            })
+        }
+
+    fun getKmPost(id: IntId<TrackLayoutKmPost>): TrackLayoutKmPost? =
+        getObject(id, publicationSet.kmPosts, kmPostDao, kmPostVersionCache)
+
+    fun getLocationTrack(id: IntId<LocationTrack>): LocationTrack? =
+        getObject(id, publicationSet.locationTracks, locationTrackDao, locationTrackVersionCache)
+
+    fun getLocationTrackWithAlignment(id: IntId<LocationTrack>): Pair<LocationTrack, LayoutAlignment>? =
+        getLocationTrack(id)?.let { track ->
+            track to requireNotNull(track.alignmentVersion?.let(alignmentDao::fetch)) {
+                "LocationTrack in DB needs to have an alignment: id=$id"
+            }
+        }
+
+    fun getSwitch(id: IntId<TrackLayoutSwitch>): TrackLayoutSwitch? =
+        getObject(id, publicationSet.switches, switchDao, switchVersionCache)
+
+    fun getReferenceLineByTrackNumber(trackNumberId: IntId<TrackLayoutTrackNumber>): ReferenceLine? =
+        getReferenceLineIdByTrackNumber(trackNumberId)?.let(::getReferenceLine)
+
+    fun getReferenceLineIdByTrackNumber(trackNumberId: IntId<TrackLayoutTrackNumber>): IntId<ReferenceLine>? =
+        getTrackNumber(trackNumberId)?.referenceLineId
+
+    fun getKmPostsByTrackNumber(trackNumberId: IntId<TrackLayoutTrackNumber>): List<TrackLayoutKmPost> =
+        trackNumberKmPosts
+            .get(trackNumberId) { id -> fetchKmPostIdsByTrackNumbers(listOf(id))[id] }
+            ?.mapNotNull(::getKmPost) ?: emptyList()
+
+    fun getLocationTracksByTrackNumber(trackNumberId: IntId<TrackLayoutTrackNumber>): List<LocationTrack> =
+        trackNumberLocationTracks
+            .get(trackNumberId) { id -> fetchLocationTrackIdsByTrackNumbers(listOf(id))[id] }
+            ?.mapNotNull(::getLocationTrack) ?: emptyList()
+
+    fun getSwitchTrackLinks(switchId: IntId<TrackLayoutSwitch>): List<IntId<LocationTrack>>? =
+        switchTrackLinks.get(switchId) { id -> fetchSwitchTrackLinks(listOf(id))[id] }
+
+    fun getSwitchTracksWithAlignments(id: IntId<TrackLayoutSwitch>): List<Pair<LocationTrack, LayoutAlignment>> =
+        getSwitchTrackLinks(id)?.mapNotNull(::getLocationTrackWithAlignment) ?: emptyList()
+
+    fun getPotentiallyAffectedSwitchIds(trackId: IntId<LocationTrack>): List<IntId<TrackLayoutSwitch>> {
+        val track = getLocationTrack(trackId)
+        val draftLinks = track?.switchIds ?: emptyList()
+        val officialLinks = if (track == null || track.isDraft()) {
+            getOfficialLocationTrack(trackId)?.switchIds ?: emptyList()
+        } else emptyList()
+        return (officialLinks + draftLinks).distinct()
+    }
+
+    fun getPotentiallyAffectedSwitches(trackId: IntId<LocationTrack>): List<TrackLayoutSwitch> =
+        getPotentiallyAffectedSwitchIds(trackId).mapNotNull(::getSwitch)
+
+    fun getSwitchesByName(name: SwitchName): List<TrackLayoutSwitch> = switchNameCache.get(name) { n ->
+        throw IllegalStateException("Switch names should have been preloaded before use: name=$n")
+    }?.mapNotNull(::getSwitch) ?: emptyList()
+
+    fun getSegmentSwitches(alignment: LayoutAlignment): List<SegmentSwitch> = alignment.segments
+        .mapNotNull { segment -> segment.switchId?.let { id -> id as IntId to segment } }
+        .groupBy({ (switchId, _) -> switchId }, { (_, segment) -> segment })
+        .map { (switchId, segments) ->
+            val switch = getSwitch(switchId)
+            val name = switch?.name ?: getDraftSwitch(switchId).name
+            val structure = switch?.switchStructureId?.let(switchLibraryService::getSwitchStructure)
+            SegmentSwitch(switchId, name, switch, structure, segments)
+        }
+
+    fun getTopologicallyConnectedSwitches(track: LocationTrack): List<Pair<SwitchName, TrackLayoutSwitch?>> =
+        listOfNotNull(track.topologyStartSwitch?.switchId, track.topologyEndSwitch?.switchId).map { switchId ->
+            val switch = getSwitch(switchId)
+            val name = switch?.name ?: getDraftSwitch(switchId).name
+            name to switch
+        }
+
+    fun getLocationTracksByName(name: AlignmentName): List<LocationTrack> = trackNameCache.get(name) { n ->
+        throw IllegalStateException("Track names should have been preloaded before use: name=$n")
+    }?.mapNotNull(::getLocationTrack) ?: emptyList()
+
+    fun getDuplicateTrackIds(trackId: IntId<LocationTrack>): List<IntId<LocationTrack>>? =
+        trackDuplicateLinks.get(trackId) { id -> fetchLocationTrackDuplicateLinks(listOf(id))[id] }
+
+    fun getDuplicateTracks(id: IntId<LocationTrack>): List<LocationTrack> =
+        (getDuplicateTrackIds(id) ?: emptyList()).mapNotNull(::getLocationTrack)
+
+    fun getGeocodingContext(trackNumberId: IntId<TrackLayoutTrackNumber>) =
+        getGeocodingContextCacheKey(trackNumberId)?.let { key ->
+            geocodingService.getGeocodingContext(key)
+        }
+
+    fun getGeocodingContextCacheKey(trackNumberId: IntId<TrackLayoutTrackNumber>) =
+        geocodingContextKeys.get(trackNumberId) { tnId ->
+            geocodingService.getGeocodingContextCacheKey(tnId, publicationSet)
+        }
+
+    // TODO: GVT-2442 track-switch validation wants the official ones to validate that no switch was left trackless. Include caching?
+    fun getOfficialLocationTrack(id: IntId<LocationTrack>) = locationTrackDao.get(OFFICIAL, id)
+
+    // TODO: GVT-2442 Draft searches that ignore context, for logging reference errors when the item doesn't exist in the context. Include caching?
+    fun getDraftTrackNumber(id: IntId<TrackLayoutTrackNumber>) = trackNumberDao.getOrThrow(DRAFT, id)
+    fun getDraftSwitch(id: IntId<TrackLayoutSwitch>) = switchDao.getOrThrow(DRAFT, id)
+    fun getDraftLocationTrack(id: IntId<LocationTrack>) = locationTrackDao.getOrThrow(DRAFT, id)
+
+    fun preloadByPublicationSet() {
+        preloadAssociatedTrackNumberAndReferenceLineVersions(publicationSet)
+
+        val trackNumberIds = publicationSet.getTrackNumberIds()
+        preloadTrackNumbersByNumber(trackNumberIds)
+
+        val locationTrackIds = publicationSet.getLocationTrackIds()
+        preloadLocationTrackVersions(locationTrackIds)
+        preloadLocationTracksByTrackNumbers(trackNumberIds)
+        preloadTrackDuplicates(locationTrackIds)
+        preloadLocationTracksByName(locationTrackIds)
+
+        preloadKmPostVersions(publicationSet.getKmPostIds())
+        preloadKmPostsByTrackNumbers(trackNumberIds)
+
+        val linkedSwitchIds = locationTrackIds.flatMap(::getPotentiallyAffectedSwitchIds)
+        val allSwitchIds = (publicationSet.getSwitchIds() + linkedSwitchIds).distinct()
+        preloadSwitchVersions(allSwitchIds)
+        preloadSwitchesByName(publicationSet.switches.map { v -> v.officialId })
+        preloadSwitchTrackLinks(allSwitchIds)
+    }
+
+    fun preloadTrackNumberVersions(ids: List<IntId<TrackLayoutTrackNumber>>) =
+        preloadOfficialVersions(ids, publicationSet.trackNumbers, trackNumberDao, trackNumberVersionCache)
+
+    fun preloadKmPostsByTrackNumbers(tnIds: List<IntId<TrackLayoutTrackNumber>>) =
+        trackNumberKmPosts.preload(tnIds, ::fetchKmPostIdsByTrackNumbers)
+
+    fun preloadLocationTracksByTrackNumbers(tnIds: List<IntId<TrackLayoutTrackNumber>>) =
+        trackNumberLocationTracks.preload(tnIds, ::fetchLocationTrackIdsByTrackNumbers)
+
+    fun preloadAssociatedTrackNumberAndReferenceLineVersions(versions: ValidationVersions) =
+        preloadAssociatedTrackNumberAndReferenceLineVersions(
+            trackNumberIds = versions.trackNumbers.map { v -> v.officialId },
+            referenceLineIds = versions.referenceLines.map { v -> v.officialId },
+            kmPostIds = versions.kmPosts.map { v -> v.officialId },
+            trackIds = versions.locationTracks.map { v -> v.officialId },
+        )
+
+    fun preloadAssociatedTrackNumberAndReferenceLineVersions(
+        trackNumberIds: List<IntId<TrackLayoutTrackNumber>> = emptyList(),
+        referenceLineIds: List<IntId<ReferenceLine>> = emptyList(),
+        kmPostIds: List<IntId<TrackLayoutKmPost>> = emptyList(),
+        trackIds: List<IntId<LocationTrack>> = emptyList(),
+    ): Unit = preloadTrackNumberAndReferenceLineVersions(
+        collectAssociatedTrackNumberIds(trackNumberIds, referenceLineIds, kmPostIds, trackIds)
+    )
+
+    fun preloadTrackNumberAndReferenceLineVersions(ids: List<IntId<TrackLayoutTrackNumber>>) =
+        preloadTrackNumberVersions(ids).also {
+            val referenceLineIds = ids.mapNotNull(::getTrackNumber).mapNotNull(TrackLayoutTrackNumber::referenceLineId)
+            preloadReferenceLineVersions(referenceLineIds)
+        }
+
+    fun preloadReferenceLineVersions(ids: List<IntId<ReferenceLine>>) =
+        preloadOfficialVersions(ids, publicationSet.referenceLines, referenceLineDao, referenceLineVersionCache)
+
+    fun preloadKmPostVersions(ids: List<IntId<TrackLayoutKmPost>>) =
+        preloadOfficialVersions(ids, publicationSet.kmPosts, kmPostDao, kmPostVersionCache)
+
+    fun preloadLocationTrackVersions(ids: List<IntId<LocationTrack>>) =
+        preloadOfficialVersions(ids, publicationSet.locationTracks, locationTrackDao, locationTrackVersionCache)
+
+    fun preloadSwitchVersions(ids: List<IntId<TrackLayoutSwitch>>) =
+        preloadOfficialVersions(ids, publicationSet.switches, switchDao, switchVersionCache)
+
+    fun preloadSwitchTrackLinks(switchIds: List<IntId<TrackLayoutSwitch>>): Unit =
+        switchTrackLinks.preload(switchIds, ::fetchSwitchTrackLinks)
+
+    fun preloadTrackDuplicates(trackIds: List<IntId<LocationTrack>>): Unit =
+        trackDuplicateLinks.preload(trackIds, ::fetchLocationTrackDuplicateLinks)
+
+    fun preloadSwitchesByName(comparedSwitchIds: List<IntId<TrackLayoutSwitch>>) {
+        val names = comparedSwitchIds.mapNotNull(::getSwitch).map(TrackLayoutSwitch::name).distinct()
+        val officialVersions = switchDao.findOfficialNameDuplicates(names)
+        cacheOfficialVersions(officialVersions.values.flatten(), switchVersionCache)
+        val nameIndex = mapIdsByField(names, { s -> s.name }, publicationSet.switches, officialVersions, switchDao)
+        switchNameCache.putAll(nameIndex)
+    }
+
+    fun preloadLocationTracksByName(comparedTrackIds: List<IntId<LocationTrack>>) {
+        val names = comparedTrackIds.mapNotNull(::getLocationTrack).map(LocationTrack::name).distinct()
+        val officialVersions = locationTrackDao.findOfficialNameDuplicates(names)
+        cacheOfficialVersions(officialVersions.values.flatten(), locationTrackVersionCache)
+        val nameIndex = mapIdsByField(names, { t -> t.name }, publicationSet.locationTracks, officialVersions, locationTrackDao)
+        trackNameCache.putAll(nameIndex)
+    }
+
+    fun preloadTrackNumbersByNumber(comparedTrackNumberIds: List<IntId<TrackLayoutTrackNumber>>) {
+        val names = comparedTrackNumberIds.mapNotNull(::getTrackNumber).map(TrackLayoutTrackNumber::number).distinct()
+        val officialVersions = trackNumberDao.findOfficialNumberDuplicates(names)
+        cacheOfficialVersions(officialVersions.values.flatten(), trackNumberVersionCache)
+        val nameIndex = mapIdsByField(names, { t -> t.number }, publicationSet.trackNumbers, officialVersions, trackNumberDao)
+        trackNumberNumberCache.putAll(nameIndex)
+    }
+
+    private fun fetchKmPostIdsByTrackNumbers(
+        tnIds: List<IntId<TrackLayoutTrackNumber>>,
+    ): Map<IntId<TrackLayoutTrackNumber>, List<IntId<TrackLayoutKmPost>>> = kmPostDao
+        // TODO: GVT-2442 The sql behind this could be simplified at the cost of making this more complex:
+        //  - fetch the official version with links
+        //  - override by publication set, noting their respective links
+        .fetchVersionsForPublication(tnIds, publicationSet.kmPosts.map { v -> v.officialId })
+        .mapValues { (_, versions) ->
+            cacheOfficialValidationVersions(versions, kmPostVersionCache)
+            versions.map { v -> v.officialId }
+        }
+
+    private fun fetchLocationTrackIdsByTrackNumbers(
+        tnIds: List<IntId<TrackLayoutTrackNumber>>,
+    ): Map<IntId<TrackLayoutTrackNumber>, List<IntId<LocationTrack>>> = locationTrackDao
+        // TODO: GVT-2442 The sql behind this could be simplified at the cost of making this more complex:
+        //  - fetch the official version with links
+        //  - override by publication set, noting their respective links
+        .fetchVersionsForPublication(tnIds, publicationSet.locationTracks.map { v -> v.officialId })
+        .mapValues { (_, versions) ->
+            cacheOfficialValidationVersions(versions, locationTrackVersionCache)
+            versions.map { v -> v.officialId }
+        }
+
+    fun collectAssociatedTrackNumberIds(
+        trackNumberIds: List<IntId<TrackLayoutTrackNumber>> = emptyList(),
+        referenceLineIds: List<IntId<ReferenceLine>> = emptyList(),
+        kmPostIds: List<IntId<TrackLayoutKmPost>> = emptyList(),
+        trackIds: List<IntId<LocationTrack>> = emptyList(),
+    ): List<IntId<TrackLayoutTrackNumber>> = listOf(
+        trackNumberIds,
+        referenceLineIds.mapNotNull { id -> getReferenceLine(id)?.trackNumberId },
+        kmPostIds.mapNotNull { id -> getKmPost(id)?.trackNumberId },
+        trackIds.mapNotNull { id -> getLocationTrack(id)?.trackNumberId },
+    ).flatten().distinct()
+
+    private fun fetchSwitchTrackLinks(
+        ids: List<IntId<TrackLayoutSwitch>>,
+    ): Map<IntId<TrackLayoutSwitch>, List<IntId<LocationTrack>>> {
+        val draftTrackIds = publicationSet.locationTracks.map { v -> v.officialId }
+        // TODO: GVT-2442 The sql behind this could be simplified at the cost of making this more complex:
+        //  - fetch the official version with links
+        //  - override by publication set
+        //  - filter (using LocationTrack.switchIds) to drop tracks where links are removed in draft
+        return publicationDao.fetchLinkedLocationTracks(ids, draftTrackIds).mapValues { (_, trackVersions) ->
+            // We get the versions on the same fetch, so cache those as well
+            val firstSeenVersions = trackVersions
+                .filterNot { v -> publicationSet.containsLocationTrack(v.officialId) || locationTrackVersionCache.contains(v.officialId) }
+                .associate { v -> v.officialId to v.validatedAssetVersion }
+            locationTrackVersionCache.putAll(firstSeenVersions)
+            trackVersions.map { v -> v.officialId }
+        }
+    }
+
+    private fun fetchLocationTrackDuplicateLinks(
+        ids: List<IntId<LocationTrack>>
+    ): Map<IntId<LocationTrack>, List<IntId<LocationTrack>>> {
+        val officialVersions = publicationDao
+            .fetchOfficialDuplicateTrackVersions(ids)
+            .mapValues { (_, versions) -> versions.filterNot { v -> publicationSet.containsLocationTrack(v.id) } }
+            .also { duplicateMap -> cacheOfficialVersions(duplicateMap.values.flatten(), locationTrackVersionCache) }
+        val draftTracks = publicationSet.locationTracks.map { v -> locationTrackDao.fetch(v.validatedAssetVersion) }
+        return ids.associateWith { id ->
+            val draft = draftTracks.filter { t -> t.duplicateOf == id }.map { t -> t.id as IntId }
+            val official = officialVersions[id]?.map { v -> v.id } ?: emptyList()
+            draft + official
+        }
+    }
+
+    private fun <T : Draftable<T>> getObject(
+        id: IntId<T>,
+        publicationVersions: List<ValidationVersion<T>>,
+        dao: IDraftableObjectDao<T>,
+        versionCache: RowVersionCache<T>,
+    ): T? {
+        val version = publicationVersions.find { v -> v.officialId == id }?.validatedAssetVersion
+            ?: versionCache.get(id, dao::fetchOfficialVersion)
+        return version?.let(dao::fetch)
+    }
+
+    private fun <T : Draftable<T>> preloadOfficialVersions(
+        ids: List<IntId<T>>,
+        publicationVersions: List<ValidationVersion<T>>,
+        dao: IDraftableObjectDao<T>,
+        versionCache: RowVersionCache<T>,
+    ) {
+        val missingIds = ids.filterNot { id ->
+            publicationVersions.any { v -> v.officialId == id } || versionCache.contains(id)
+        }
+        cacheOfficialVersions(dao.fetchOfficialVersions(missingIds), versionCache)
+    }
+
+    private fun <T : Draftable<T>> cacheOfficialValidationVersions(
+        versions: List<ValidationVersion<T>>,
+        cache: RowVersionCache<T>,
+    ) = cacheOfficialVersions(
+        versions = versions.filter { v -> v.isOfficial() }.map { v -> v.validatedAssetVersion },
+        cache = cache,
+    )
+
+    private fun <T : Draftable<T>> cacheOfficialVersions(versions: List<RowVersion<T>>, cache: RowVersionCache<T>) {
+        cache.putAll(versions.filterNot { (id) -> cache.contains(id) }.distinct().associateBy { v -> v.id })
+    }
+
+    private fun <T : Draftable<T>, Field> mapIdsByField(
+        fields: List<Field>,
+        getField: (T) -> Field,
+        publicationVersions: List<ValidationVersion<T>>,
+        matchingOfficialVersions: Map<Field, List<RowVersion<T>>>,
+        dao: IDraftableObjectDao<T>,
+    ): Map<Field, List<IntId<T>>> {
+        return fields.associateWith { field ->
+            val draftMatches = publicationVersions.mapNotNull { v ->
+                val draftObject = dao.fetch(v.validatedAssetVersion)
+                if (getField(draftObject) == field) draftObject.id as IntId else null
+            }
+            val officialMatches = matchingOfficialVersions[field]
+                ?.filterNot { ov -> publicationVersions.any { pv -> pv.officialId == ov.id } }
+                ?.map { v -> v.id } ?: emptyList()
+            (draftMatches + officialMatches).distinct()
+        }
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -33,7 +33,10 @@ class NameCache<Field, T : Draftable<T>>(val fetch: (List<Field>) -> Map<Field, 
 
     fun get(name: Field) = map.computeIfAbsent(name) { n -> fetch(listOf(n))[n] ?: emptyList() }
 
-    fun preload(names: List<Field>) = map.putAll(fetch(names))
+    fun preload(names: List<Field>) {
+        val missing = names.filterNot(map::containsKey)
+        if (missing.isNotEmpty()) map.putAll(fetch(missing))
+    }
 }
 
 typealias RowVersionCache<T> = NullableCache<IntId<T>, RowVersion<T>>
@@ -376,7 +379,7 @@ private fun <T : Draftable<T>> preloadOfficialVersions(
 ) = cacheOfficialVersions(dao.fetchOfficialVersions(ids), versionCache)
 
 private fun <T : Draftable<T>> cacheOfficialVersions(versions: List<RowVersion<T>>, cache: RowVersionCache<T>) {
-    cache.putAll(versions.filterNot { (id) -> cache.contains(id) }.distinct().associateBy { v -> v.id })
+    cache.putAll(versions.filterNot { (id) -> cache.contains(id) }.associateBy { v -> v.id })
 }
 
 private fun <T : Draftable<T>, Field> mapIdsByField(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -1,7 +1,7 @@
 package fi.fta.geoviite.infra.tracklayout
 
-import fi.fta.geoviite.infra.authorization.AUTH_UI_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
+import fi.fta.geoviite.infra.authorization.AUTH_UI_READ
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.PublishType
@@ -117,9 +117,9 @@ class LayoutKmPostController(
     fun validateKmPost(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") id: IntId<TrackLayoutKmPost>,
-    ): ValidatedAsset<TrackLayoutKmPost> {
+    ): ResponseEntity<ValidatedAsset<TrackLayoutKmPost>> {
         logger.apiCall("validateKmPost", "publishType" to publishType, "id" to id)
-        return publicationService.validateKmPost(id, publishType)
+        return publicationService.validateKmPosts(listOf(id), publishType).firstOrNull().let(::toResponse)
     }
 
     @PreAuthorize(AUTH_ALL_WRITE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -95,15 +95,16 @@ class LayoutSwitchController(
         @RequestParam("bbox") bbox: BoundingBox?,
     ): List<ValidatedAsset<TrackLayoutSwitch>> {
         logger.apiCall("validateSwitches", "publishType" to publishType, "ids" to ids)
-        val switches = if (ids != null) switchService.getMany(publishType, ids) else switchService.list(
-            publishType,
-            false
-        )
-        return publicationService.validateSwitches(
-            switches
-                .filter { switch -> switchMatchesBbox(switch, bbox, false) }
-                .map { sw -> sw.id as IntId }, publishType
-        )
+        // TODO: GVT-2442 This could be a dao-fetch for ids with list+bbox (we only need ids)
+        val switches = if (ids != null) {
+            switchService.getMany(publishType, ids)
+        } else {
+            switchService.list(publishType, false)
+        }
+        val switchIds = switches
+            .filter { switch -> switchMatchesBbox(switch, bbox, false) }
+            .map { sw -> sw.id as IntId }
+        return publicationService.validateSwitches(switchIds, publishType)
     }
 
     @PreAuthorize(AUTH_ALL_WRITE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -94,8 +94,7 @@ class LayoutSwitchController(
         @RequestParam("ids") ids: List<IntId<TrackLayoutSwitch>>?,
         @RequestParam("bbox") bbox: BoundingBox?,
     ): List<ValidatedAsset<TrackLayoutSwitch>> {
-        logger.apiCall("validateSwitches", "publishType" to publishType, "ids" to ids)
-        // TODO: GVT-2442 This could be a dao-fetch for ids with list+bbox (we only need ids)
+        logger.apiCall("validateSwitches", "publishType" to publishType, "ids" to ids, "bbox" to bbox)
         val switches = if (ids != null) {
             switchService.getMany(publishType, ids)
         } else {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -1,8 +1,8 @@
 package fi.fta.geoviite.infra.tracklayout
 
-import fi.fta.geoviite.infra.authorization.AUTH_UI_READ
 import fi.fta.geoviite.infra.authorization.AUTH_ALL_WRITE
 import fi.fta.geoviite.infra.authorization.AUTH_DATAPRODUCT_DOWNLOAD
+import fi.fta.geoviite.infra.authorization.AUTH_UI_READ
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.PublishType
@@ -60,9 +60,12 @@ class LayoutTrackNumberController(
     fun validateTrackNumberAndReferenceLine(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
-    ): ValidatedAsset<TrackLayoutTrackNumber> {
+    ): ResponseEntity<ValidatedAsset<TrackLayoutTrackNumber>> {
         logger.apiCall("validateTrackNumberAndReferenceLine", "publishType" to publishType, "id" to id)
-        return publicationService.validateTrackNumberAndReferenceLine(id, publishType)
+        return publicationService
+            .validateTrackNumbersAndReferenceLines(listOf(id), publishType)
+            .firstOrNull()
+            .let(::toResponse)
     }
 
     @PreAuthorize(AUTH_ALL_WRITE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -148,9 +148,9 @@ class LocationTrackController(
     fun validateLocationTrack(
         @PathVariable("publishType") publishType: PublishType,
         @PathVariable("id") id: IntId<LocationTrack>,
-    ): ValidatedAsset<LocationTrack> {
+    ): ResponseEntity<ValidatedAsset<LocationTrack>> {
         logger.apiCall("validateLocationTrack", "publishType" to publishType, "id" to id)
-        return publicationService.validateLocationTrack(id, publishType)
+        return publicationService.validateLocationTracks(listOf(id), publishType).firstOrNull().let(::toResponse)
     }
 
     @PreAuthorize(AUTH_UI_READ)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -71,7 +71,8 @@ class ReferenceLineDao(
               left join layout.alignment_version av on rl.alignment_id = av.id and rl.alignment_version = av.version
         """.trimIndent()
 
-        val referenceLines = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ -> getReferenceLine(rs) }
+        val referenceLines = jdbcTemplate
+            .query(sql, mapOf<String, Any>()) { rs, _ -> getReferenceLine(rs) }
             .associateBy(ReferenceLine::version)
         logger.daoAccess(AccessType.FETCH, ReferenceLine::class, referenceLines.keys)
         cache.putAll(referenceLines)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -74,6 +74,7 @@ data class TrackLayoutTrackNumber(
     override val dataType: DataType = DataType.TEMP,
     override val version: RowVersion<TrackLayoutTrackNumber>? = null,
     @JsonIgnore override val draft: Draft<TrackLayoutTrackNumber>? = null,
+    @JsonIgnore val referenceLineId: IntId<ReferenceLine>? = null
 ) : Draftable<TrackLayoutTrackNumber> {
     @JsonIgnore
     val exists = !state.isRemoved()
@@ -194,10 +195,16 @@ data class LocationTrack(
     val ownerId: IntId<LocationTrackOwner>,
     @JsonIgnore val alignmentVersion: RowVersion<LayoutAlignment>? = null,
     @JsonIgnore override val draft: Draft<LocationTrack>? = null,
+    @JsonIgnore val segmentSwitchIds: List<IntId<TrackLayoutSwitch>> = listOf(),
 ) : Draftable<LocationTrack> {
 
     @JsonIgnore
     val exists = !state.isRemoved()
+
+    @get:JsonIgnore
+    val switchIds: List<IntId<TrackLayoutSwitch>> by lazy {
+        (segmentSwitchIds + listOfNotNull(topologyStartSwitch?.switchId, topologyEndSwitch?.switchId)).distinct()
+    }
 
     init {
         require(descriptionBase.length in locationTrackDescriptionLength) {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1212,6 +1212,7 @@
                     "publishing-duplicate-while-duplicated": "Raide on merkitty duplikaatiksi, mutta raide {{otherDuplicates}} on tämän raiteen duplikaatti",
                     "publishing-duplicate-while-duplicated-multiple": "Raide on merkitty duplikaatiksi, mutta raiteet {{otherDuplicates}} ovat tämän raiteen duplikaatteja"
                 },
+                "deleted-duplicated-by-existing": "Poistettavaan raiteeseen viittaa edelleen poistamattomia duplikaattiraiteita: {{duplicates}}",
                 "empty-segments": "Sijaintiraiteella ei ole geometriaa",
                 "points": {
                     "not-continuous": "Sijaintiraiteen pisteet eivät ole jatkuvia (kulma on liian suuri pisteiden välillä)"

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1156,15 +1156,13 @@
                     "PLANNED": "Ratanumero on tilassa \"Suunniteltu\""
                 },
                 "reference-line": {
-                    "null": "Ratanumeron pituusmittauslinja ei ole mukana julkaisussa"
+                    "not-published": "Ratanumeron pituusmittauslinja ei ole mukana julkaisussa"
                 },
                 "location-track": {
-                    "reference-deleted": "Poistettavaan ratanumeroon viittaa edelleen poistamattomia raiteita: {{locationTracks}}",
-                    "not-published": "Ratanumeron sijaintiraiteilla ({{locationTracks}}) on julkaisemattomia muutoksia"
+                    "reference-deleted": "Poistettavaan ratanumeroon viittaa edelleen poistamattomia raiteita: {{locationTracks}}"
                 },
                 "km-post": {
-                    "reference-deleted": "Poistettavaan ratanumeroon viittaa edelleen poistamattomia tasakilometripisteitä: {{kmPosts}}",
-                    "not-published": "Ratanumeron tasakilometripisteillä ({{kmPosts}}) on julkaisemattomia muutoksia"
+                    "reference-deleted": "Poistettavaan ratanumeroon viittaa edelleen poistamattomia tasakilometripisteitä: {{kmPosts}}"
                 },
                 "duplicate-name-official": "Ratanumeron numero {{trackNumber}} on jo käytössä",
                 "duplicate-name-draft": "Muutosjoukossa on monta ratanumeroa nimellä {{trackNumber}}"
@@ -1193,7 +1191,6 @@
                 "no-context": "Pituusmittauslinjalle ei voida laskea tasametripisteitä koska siltä puuttuu tietoja",
                 "not-draft": "Virhe julkaisun sisällössä: julkaistava pituusmittauslinja ei ole luonnos",
                 "track-number": {
-                    "null": "Pituusmittauslinjan ratanumero ei ole mukana julkaisussa",
                     "not-official": "Pituusmittauslinja viittaa ratanumeron {{trackNumber}} luonnosriviin",
                     "not-published": "Pituusmittauslinja viittaa julkaisemattomaan ratanumeroon {{trackNumber}}"
                 },
@@ -1224,9 +1221,8 @@
                     "PLANNED": "Sijaintiraide on tilassa \"Suunniteltu\""
                 },
                 "track-number": {
-                    "null": "Sijaintiraiteelle ei ole asetettu ratanumeroa tai se ei ole mukana julkaisussa",
                     "not-official": "Sijaintiraide viittaa ratanumeron {{trackNumber}} luonnosriviin",
-                    "not-published": "Sijaintiraide viittaa julkaisemattomaan ratanumeroon {{trackNumber}}",
+                    "not-published": "Sijaintiraide viittaa ratanumeroon {{trackNumber}}, joka ei ole mukana julkaisussa",
                     "state": {
                         "PLANNED": "Sijaintiraide viittaa ratanumeroon {{trackNumber}} joka on tilassa \"Suunniteltu\"",
                         "DELETED": "Sijaintiraide viittaa ratanumeroon {{trackNumber}} joka on tilassa \"Poistettu\""

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -1,11 +1,7 @@
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.RowVersion
-import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.publication.*
-import fi.fta.geoviite.infra.publication.PublishValidationErrorType.ERROR
-import fi.fta.geoviite.infra.publication.PublishValidationErrorType.WARNING
 import fi.fta.geoviite.infra.tracklayout.*
-import fi.fta.geoviite.infra.util.LocalizationKey
 
 fun publishRequest(
     trackNumbers: List<IntId<TrackLayoutTrackNumber>> = listOf(),
@@ -50,12 +46,4 @@ fun publish(publicationService: PublicationService, request: PublishRequestIds):
     return publicationService.publishChanges(versions, calculatedChanges, "Test")
 }
 
-fun validationError(
-    localizationKey: String,
-    vararg params: Pair<String, Any?>,
-) = PublishValidationError(ERROR, localizationKey, params.associate { it })
-
-fun validationWarning(
-    localizationKey: String,
-    vararg params: Pair<String, Any?>,
-) = PublishValidationError(WARNING, localizationKey, params.associate { it })
+fun <T> daoResponseToValidationVersion(response: DaoResponse<T>) = ValidationVersion<T>(response.id, response.rowVersion)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.publication
 
+import daoResponseToValidationVersion
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.TEST_USER
 import fi.fta.geoviite.infra.authorization.UserName
@@ -274,14 +275,16 @@ class PublicationDaoIT @Autowired constructor(
                 topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(1)),
                 alignmentVersion = dummyAlignment,
             )
-        ).rowVersion
-        val draftLinkedTopo = locationTrackDao.insert(draft(
-            locationTrack(
-                trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(3)),
-                alignmentVersion = dummyAlignment,
+        )
+        val draftLinkedTopo = locationTrackDao.insert(
+            draft(
+                locationTrack(
+                    trackNumberId,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(3)),
+                    alignmentVersion = dummyAlignment,
+                )
             )
-        )).rowVersion
+        )
         val officialLinkedAlignment = locationTrackDao.insert(
             locationTrack(
                 trackNumberId, alignmentVersion = alignmentDao.insert(
@@ -295,7 +298,7 @@ class PublicationDaoIT @Autowired constructor(
                     )
                 )
             )
-        ).rowVersion
+        )
         val draftLinkedAlignment = locationTrackDao.insert(
             draft(
                 locationTrack(
@@ -311,29 +314,29 @@ class PublicationDaoIT @Autowired constructor(
                     )
                 )
             )
-        ).rowVersion
+        )
         assertEquals(
-            setOf(officialLinkedAlignment, draftLinkedAlignment),
+            setOf(daoResponseToValidationVersion(officialLinkedAlignment), daoResponseToValidationVersion(draftLinkedAlignment)),
             publicationDao.fetchLinkedLocationTracks(listOf(switchByAlignment))[switchByAlignment]
         )
         assertEquals(
-            setOf(officialLinkedAlignment),
+            setOf(daoResponseToValidationVersion(officialLinkedAlignment)),
             publicationDao.fetchLinkedLocationTracks(listOf(switchByAlignment), listOf())[switchByAlignment]
         )
         assertEquals(
-            setOf(officialLinkedAlignment, draftLinkedAlignment),
+            setOf(daoResponseToValidationVersion(officialLinkedAlignment), daoResponseToValidationVersion(draftLinkedAlignment)),
             publicationDao.fetchLinkedLocationTracks(listOf(switchByAlignment), listOf(draftLinkedAlignment.id))[switchByAlignment]
         )
         assertEquals(
-            setOf(officialLinkedTopo, draftLinkedTopo),
+            setOf(daoResponseToValidationVersion(officialLinkedTopo), daoResponseToValidationVersion(draftLinkedTopo)),
             publicationDao.fetchLinkedLocationTracks(listOf(switchByTopo))[switchByTopo]
         )
         assertEquals(
-            setOf(officialLinkedTopo),
+            setOf(daoResponseToValidationVersion(officialLinkedTopo)),
             publicationDao.fetchLinkedLocationTracks(listOf(switchByTopo), listOf())[switchByTopo]
         )
         assertEquals(
-            setOf(officialLinkedTopo, draftLinkedTopo),
+            setOf(daoResponseToValidationVersion(officialLinkedTopo), daoResponseToValidationVersion(draftLinkedTopo)),
             publicationDao.fetchLinkedLocationTracks(listOf(switchByTopo), listOf(draftLinkedTopo.id))[switchByTopo]
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -16,7 +16,6 @@ import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.split.*
-import fi.fta.geoviite.infra.split.validateSplitContent
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.FreeText
@@ -1892,7 +1891,7 @@ class PublicationServiceIT @Autowired constructor(
 
         val diff = publicationService.diffSwitch(
             localizationService.getLocalization("fi"),
-            changes.getValue(switch.id as IntId),
+            changes.getValue(switch.id),
             latestPub.publicationTime,
             previousPub.publicationTime,
             Operation.MODIFY,
@@ -1964,7 +1963,8 @@ class PublicationServiceIT @Autowired constructor(
         )
 
         val validationResult = publicationService.validateAsPublicationUnit(
-            publicationService.collectPublishCandidates().filter(publishRequestIds)
+            publicationService.collectPublishCandidates().filter(publishRequestIds),
+            allowMultipleSplits = false,
         )
 
         return validationResult.locationTracks.find { lt -> lt.id == locationTrackId }!!
@@ -2591,7 +2591,7 @@ class PublicationServiceIT @Autowired constructor(
             ValidationVersion(startTargetTrack2.id, startTargetTrack2.rowVersion),
             ValidationVersion(endTargetTrack.id, endTargetTrack.rowVersion),
             ValidationVersion(endTargetTrack2.id, endTargetTrack2.rowVersion)
-        );
+        )
 
         assertContains(validateSplitContent(
             locationTrackValidationVersions,
@@ -2617,7 +2617,7 @@ class PublicationServiceIT @Autowired constructor(
             ValidationVersion(sourceTrack.id, sourceTrack.rowVersion),
             ValidationVersion(startTargetTrack.id, startTargetTrack.rowVersion),
             ValidationVersion(endTargetTrack.id, endTargetTrack.rowVersion),
-        );
+        )
 
         assertContains(validateSplitContent(
             locationTrackValidationVersions,
@@ -2653,7 +2653,7 @@ class PublicationServiceIT @Autowired constructor(
             ValidationVersion(sourceTrack.id, sourceTrack.rowVersion),
             ValidationVersion(startTargetTrack.id, startTargetTrack.rowVersion),
             ValidationVersion(endTargetTrack.id, endTargetTrack.rowVersion),
-        );
+        )
 
         assertEquals(0, validateSplitContent(
             locationTrackValidationVersions,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1281,56 +1281,55 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals("duplicate-of", diff[5].propKey.key.toString())
     }
 
-    // TODO: GVT-2442 Fix this or just do the unit-test part?
-//    @Test
-//    fun `Don't allow publishing a track that is a duplicate of an unpublished draft-only one`() {
-//        val trackNumberId = getUnusedTrackNumberId()
-//        val (draftOnlyTrack, draftOnlyAlignment) = locationTrackAndAlignment(
-//            trackNumberId = trackNumberId,
-//            segments = listOf(someSegment()),
-//            duplicateOf = null,
-//        )
-//        val draftOnlyId = locationTrackService.saveDraft(draft(draftOnlyTrack), draftOnlyAlignment).id
-//
-//        val (duplicateTrack, duplicateAlignment) = locationTrackAndAlignment(
-//            trackNumberId = trackNumberId,
-//            segments = listOf(someSegment()),
-//            duplicateOf = draftOnlyId,
-//        )
-//        val duplicateId = locationTrackService.saveDraft(draft(duplicateTrack), duplicateAlignment).id
-//
-//        // Both tracks in validation set: this is fine
-//        assertEquals(listOf(), validateDuplicateOf(toValidate = duplicateId, duplicateId, draftOnlyId))
-//        // Only the target (main) track in set: this is also fine
-//        assertEquals(listOf(), validateDuplicateOf(toValidate = draftOnlyId, draftOnlyId))
-//        // Only the duplicate track in set: this would result in official referring to draft through duplicateOf
-//        assertEquals(
-//            listOf(
-//                validationError(
-//                    "validation.layout.location-track.duplicate-of.not-published",
-//                    "duplicateTrack" to draftOnlyTrack.name.toString(),
-//                ),
-//            ),
-//            validateDuplicateOf(toValidate = duplicateId, duplicateId),
-//        )
-//    }
-//
-//    private fun validateDuplicateOf(
-//        toValidate: IntId<LocationTrack>,
-//        vararg publicationSet: IntId<LocationTrack>,
-//    ): List<PublishValidationError> {
-//        val validationVersions = publicationService.getValidationVersions(
-//            publishRequest(locationTracks = publicationSet.toList())
-//        )
-//        val validationVersion = requireNotNull(validationVersions.findLocationTrack(toValidate)) {
-//            "Track $toValidate should be in validation set: $validationVersions"
-//        }
-//        return publicationService.validateDuplicateOf(
-//            validationVersion,
-//            locationTrackDao.fetch(validationVersion.validatedAssetVersion),
-//            validationVersions,
-//        )
-//    }
+    @Test
+    fun `Don't allow publishing a track that is a duplicate of an unpublished draft-only one`() {
+        val trackNumberId = getUnusedTrackNumberId()
+        val (draftOnlyTrack, draftOnlyAlignment) = locationTrackAndAlignment(
+            trackNumberId = trackNumberId,
+            segments = listOf(someSegment()),
+            duplicateOf = null,
+        )
+        val draftOnlyId = locationTrackService.saveDraft(draft(draftOnlyTrack), draftOnlyAlignment).id
+
+        val (duplicateTrack, duplicateAlignment) = locationTrackAndAlignment(
+            trackNumberId = trackNumberId,
+            segments = listOf(someSegment()),
+            duplicateOf = draftOnlyId,
+        )
+        val duplicateId = locationTrackService.saveDraft(draft(duplicateTrack), duplicateAlignment).id
+
+        // Both tracks in validation set: this is fine
+        assertFalse(containsDuplicateOfNotPublishedError(
+            validateLocationTrack(toValidate = duplicateId, duplicateId, draftOnlyId)
+        ))
+        // Only the target (main) track in set: this is also fine
+        assertFalse(containsDuplicateOfNotPublishedError(
+            validateLocationTrack(toValidate = draftOnlyId, draftOnlyId)
+        ))
+        // Only the duplicate track in set: this would result in official referring to draft through duplicateOf
+        assertTrue(containsDuplicateOfNotPublishedError(
+            validateLocationTrack(toValidate = duplicateId, duplicateId)
+        ))
+    }
+
+    private fun containsDuplicateOfNotPublishedError(errors: List<PublishValidationError>) =
+        containsError(errors, "validation.layout.location-track.duplicate-of.not-published")
+
+    private fun containsError(errors: List<PublishValidationError>, key: String) =
+        errors.any { e -> e.localizationKey.toString() == key }
+
+    private fun validateLocationTrack(
+        toValidate: IntId<LocationTrack>,
+        vararg publicationSet: IntId<LocationTrack>,
+    ): List<PublishValidationError> {
+        val candidates = publicationService
+            .collectPublishCandidates()
+            .filter(publishRequest(locationTracks = publicationSet.toList()))
+        return publicationService
+            .validateAsPublicationUnit(candidates, false)
+            .locationTracks.find { c -> c.id == toValidate }!!
+            .errors
+    }
 
     @Test
     fun `Changing specific Location Track field returns only that field`() {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
@@ -1,0 +1,191 @@
+package fi.fta.geoviite.infra.publication
+
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
+import fi.fta.geoviite.infra.tracklayout.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class ValidationContextIT @Autowired constructor(
+    val trackNumberDao: LayoutTrackNumberDao,
+    val referenceLineDao: ReferenceLineDao,
+    val kmPostDao: LayoutKmPostDao,
+    val locationTrackDao: LocationTrackDao,
+    val alignmentDao: LayoutAlignmentDao,
+    val switchDao: LayoutSwitchDao,
+    val switchLibraryService: SwitchLibraryService,
+    val publicationDao: PublicationDao,
+    val geocodingService: GeocodingService,
+) : DBTestBase() {
+
+    @Test
+    fun `NullableCache caches both real and null values`() {
+        val cache = NullableCache<Int, String>()
+        cache.get(1) { "one" }
+        cache.get(2) { null }
+        cache.preload(listOf(1, 2, 3, 4, 5)) { missing ->
+            assertEquals(listOf(3, 4, 5), missing)
+            missing.associateWith { n -> if (n == 5) null else "$n" }
+        }
+        assertEquals("one", cache.get(1) { "second fetch should not happen" })
+        assertEquals(null, cache.get(2) { "second fetch should not happen" })
+        assertEquals("3", cache.get(3) { "second fetch should not happen" })
+        assertEquals("4", cache.get(4) { "second fetch should not happen" })
+        assertEquals(null, cache.get(5) { "second fetch should not happen" })
+    }
+
+    @Test
+    fun `ValidationContext returns correct versions for TrackNumber`() {
+        val trackNumber1 = trackNumber(getUnusedTrackNumber())
+        val (tn1Id, tn1OfficialVersion) = trackNumberDao.insert(trackNumber1)
+        val (_, tn1DraftVersion) = trackNumberDao.insert(draft(trackNumberDao.fetch(tn1OfficialVersion)))
+        val trackNumber2 = trackNumber(getUnusedTrackNumber())
+        val (tn2Id, tn2DraftVersion) = trackNumberDao.insert(draft(trackNumber2))
+        assertEquals(
+            trackNumberDao.fetch(tn1OfficialVersion),
+            validationContext().getTrackNumber(tn1Id),
+        )
+        assertEquals(
+            trackNumberDao.fetch(tn1DraftVersion),
+            validationContext(trackNumbers = listOf(tn1Id)).getTrackNumber(tn1Id),
+        )
+        assertEquals(null, validationContext().getTrackNumber(tn2Id))
+        assertEquals(
+            trackNumberDao.fetch(tn2DraftVersion),
+            validationContext(trackNumbers = listOf(tn2Id)).getTrackNumber(tn2Id),
+        )
+
+        assertEquals(
+            listOf(trackNumberDao.fetch(tn1OfficialVersion)),
+            validationContext().getTrackNumbersByNumber(trackNumber1.number),
+        )
+        assertEquals(
+            listOf(trackNumberDao.fetch(tn1DraftVersion)),
+            validationContext(trackNumbers = listOf(tn1Id)).getTrackNumbersByNumber(trackNumber1.number),
+        )
+
+        assertEquals(
+            emptyList<TrackLayoutTrackNumber>(),
+            validationContext().getTrackNumbersByNumber(trackNumber2.number),
+        )
+        assertEquals(
+            listOf(trackNumberDao.fetch(tn2DraftVersion)),
+            validationContext(trackNumbers = listOf(tn2Id)).getTrackNumbersByNumber(trackNumber2.number),
+        )
+    }
+
+    @Test
+    fun `ValidationContext returns correct versions for LocationTrack`() {
+        val trackNumberId = getUnusedTrackNumberId()
+        val (lt1Id, lt1OfficialVersion) = insertLocationTrack(locationTrackAndAlignment(trackNumberId))
+        val (_, lt1DraftVersion) = locationTrackDao.insert(draft(locationTrackDao.fetch(lt1OfficialVersion)))
+        val (lt2Id, lt2DraftVersion) = insertLocationTrack(
+            locationTrackAndAlignment(trackNumberId).let { (t, a) -> draft(t) to a }
+        )
+
+        assertEquals(
+            locationTrackDao.fetch(lt1OfficialVersion),
+            validationContext().getLocationTrack(lt1Id),
+        )
+        assertEquals(
+            locationTrackDao.fetch(lt1DraftVersion),
+            validationContext(locationTracks = listOf(lt1Id)).getLocationTrack(lt1Id),
+        )
+        assertEquals(null, validationContext().getLocationTrack(lt2Id))
+        assertEquals(
+            locationTrackDao.fetch(lt2DraftVersion),
+            validationContext(locationTracks = listOf(lt2Id)).getLocationTrack(lt2Id),
+        )
+    }
+
+    @Test
+    fun `ValidationContext returns correct versions for Switch`() {
+        val switchName1 = getUnusedSwitchName()
+        val (s1Id, s1OfficialVersion) = switchDao.insert(switch(name = switchName1.toString()))
+        val (_, s1DraftVersion) = switchDao.insert(draft(switchDao.fetch(s1OfficialVersion)))
+        val switchName2 = getUnusedSwitchName()
+        val (s2Id, s2DraftVersion) = switchDao.insert(draft(switch(name = switchName2.toString())))
+
+        assertEquals(
+            switchDao.fetch(s1OfficialVersion),
+            validationContext().getSwitch(s1Id),
+        )
+        assertEquals(
+            switchDao.fetch(s1DraftVersion),
+            validationContext(switches = listOf(s1Id)).getSwitch(s1Id),
+        )
+        assertEquals(null, validationContext().getSwitch(s2Id))
+        assertEquals(
+            switchDao.fetch(s2DraftVersion),
+            validationContext(switches = listOf(s2Id)).getSwitch(s2Id),
+        )
+
+        assertEquals(
+            listOf(switchDao.fetch(s1OfficialVersion)),
+            validationContext().getSwitchesByName(switchName1),
+        )
+        assertEquals(
+            listOf(switchDao.fetch(s1DraftVersion)),
+            validationContext(switches = listOf(s1Id)).getSwitchesByName(switchName1),
+        )
+        assertEquals(emptyList<TrackLayoutSwitch>(), validationContext().getSwitchesByName(switchName2))
+        assertEquals(
+            listOf(switchDao.fetch(s2DraftVersion)),
+            validationContext(switches = listOf(s2Id)).getSwitchesByName(switchName2),
+        )
+    }
+
+    @Test
+    fun `ValidationContext returns correct versions for KM-Post`() {
+        val trackNumberId = getUnusedTrackNumberId()
+        val (kmp1Id, kmp1OfficialVersion) = kmPostDao.insert(kmPost(trackNumberId, KmNumber(1)))
+        val (_, kmp1DraftVersion) = kmPostDao.insert(draft(kmPostDao.fetch(kmp1OfficialVersion)))
+        val (kmp2Id, kmp2DraftVersion) = kmPostDao.insert(draft(kmPost(trackNumberId, KmNumber(2))))
+        assertEquals(
+            kmPostDao.fetch(kmp1OfficialVersion),
+            validationContext().getKmPost(kmp1Id),
+        )
+        assertEquals(
+            kmPostDao.fetch(kmp1DraftVersion),
+            validationContext(kmPosts = listOf(kmp1Id)).getKmPost(kmp1Id),
+        )
+        assertEquals(null, validationContext().getKmPost(kmp2Id))
+        assertEquals(
+            kmPostDao.fetch(kmp2DraftVersion),
+            validationContext(kmPosts = listOf(kmp2Id)).getKmPost(kmp2Id),
+        )
+    }
+
+    private fun validationContext(
+        trackNumbers: List<IntId<TrackLayoutTrackNumber>> = listOf(),
+        locationTracks: List<IntId<LocationTrack>> = listOf(),
+        referenceLines: List<IntId<ReferenceLine>> = listOf(),
+        switches: List<IntId<TrackLayoutSwitch>> = listOf(),
+        kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
+    ): ValidationContext = ValidationContext(
+        trackNumberDao = trackNumberDao,
+        referenceLineDao = referenceLineDao,
+        kmPostDao = kmPostDao,
+        locationTrackDao = locationTrackDao,
+        switchDao = switchDao,
+        geocodingService = geocodingService,
+        alignmentDao = alignmentDao,
+        publicationDao = publicationDao,
+        switchLibraryService = switchLibraryService,
+        publicationSet = ValidationVersions(
+            trackNumbers = trackNumberDao.fetchPublicationVersions(trackNumbers),
+            referenceLines = referenceLineDao.fetchPublicationVersions(referenceLines),
+            kmPosts = kmPostDao.fetchPublicationVersions(kmPosts),
+            locationTracks = locationTrackDao.fetchPublicationVersions(locationTracks),
+            switches = switchDao.fetchPublicationVersions(switches),
+        )
+    )
+}

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -161,8 +161,8 @@ export const deleteDraftKmPost = async (
 export async function getKmPostValidation(
     publishType: PublishType,
     id: LayoutKmPostId,
-): Promise<ValidatedAsset> {
-    return getNonNull<ValidatedAsset>(`${layoutUri('km-posts', publishType, id)}/validation`);
+): Promise<ValidatedAsset | undefined> {
+    return getNullable<ValidatedAsset>(`${layoutUri('km-posts', publishType, id)}/validation`);
 }
 
 export async function getKmPostsOnTrackNumber(

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -292,8 +292,8 @@ export const getSplittingInitializationParameters = async (
 export async function getLocationTrackValidation(
     publishType: PublishType,
     id: LocationTrackId,
-): Promise<ValidatedAsset> {
-    return getNonNull<ValidatedAsset>(
+): Promise<ValidatedAsset | undefined> {
+    return getNullable<ValidatedAsset>(
         `${layoutUri('location-tracks', publishType, id)}/validation`,
     );
 }

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -158,7 +158,7 @@ export const getSwitchValidation = async (
 export const getSwitchesValidation = async (publishType: PublishType, ids: LayoutSwitchId[]) => {
     const changeTimes = getChangeTimes();
     const maxTime = getMaxTimestamp(changeTimes.layoutLocationTrack, changeTimes.layoutSwitch);
-    const fetch = (fetchIds: LayoutSwitchId[]) =>
+    const fetchOperation = (fetchIds: LayoutSwitchId[]) =>
         getNonNull<ValidatedAsset[]>(
             `${layoutUri('switches', publishType)}/validation?ids=${fetchIds}`,
         ).then((switches) => {
@@ -166,7 +166,7 @@ export const getSwitchesValidation = async (publishType: PublishType, ids: Layou
             return (id: LayoutSwitchId) => switchValidationMap.get(id) as ValidatedAsset;
         });
     return switchValidationCache
-        .getMany(maxTime, ids, (id) => id, fetch)
+        .getMany(maxTime, ids, (id) => id, fetchOperation)
         .then((switches) => switches.filter(filterNotEmpty));
 };
 

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -22,6 +22,7 @@ import { Result } from 'neverthrow';
 import { TrackLayoutSaveError, TrackLayoutSwitchSaveRequest } from 'linking/linking-model';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
 import { ValidatedAsset } from 'publication/publication-model';
+import { getMaxTimestamp } from 'utils/date-utils';
 
 const switchCache = asyncCache<string, LayoutSwitch | undefined>();
 const switchGroupsCache = asyncCache<string, LayoutSwitch[]>();
@@ -149,30 +150,23 @@ export async function deleteDraftSwitch(
 export const getSwitchValidation = async (
     publishType: PublishType,
     id: LayoutSwitchId,
-): Promise<ValidatedAsset> =>
-    getSwitchesValidation(publishType, [id]).then((switches) => switches[0]);
+): Promise<ValidatedAsset | undefined> =>
+    getSwitchesValidation(publishType, [id]).then((switches) =>
+        switches.length > 0 ? switches[0] : undefined,
+    );
 
 export const getSwitchesValidation = async (publishType: PublishType, ids: LayoutSwitchId[]) => {
     const changeTimes = getChangeTimes();
-    const maxTime =
-        changeTimes.layoutSwitch > changeTimes.layoutLocationTrack
-            ? changeTimes.layoutSwitch
-            : changeTimes.layoutLocationTrack;
+    const maxTime = getMaxTimestamp(changeTimes.layoutLocationTrack, changeTimes.layoutSwitch);
+    const fetch = (fetchIds: LayoutSwitchId[]) =>
+        getNonNull<ValidatedAsset[]>(
+            `${layoutUri('switches', publishType)}/validation?ids=${fetchIds}`,
+        ).then((switches) => {
+            const switchValidationMap = indexIntoMap<LayoutSwitchId, ValidatedAsset>(switches);
+            return (id: LayoutSwitchId) => switchValidationMap.get(id) as ValidatedAsset;
+        });
     return switchValidationCache
-        .getMany(
-            maxTime,
-            ids,
-            (id) => id,
-            (fetchIds) =>
-                getNonNull<ValidatedAsset[]>(
-                    `${layoutUri('switches', publishType)}/validation?ids=${fetchIds}`,
-                ).then((switches) => {
-                    const switchValidationMap = indexIntoMap<LayoutSwitchId, ValidatedAsset>(
-                        switches,
-                    );
-                    return (id) => switchValidationMap.get(id) as ValidatedAsset;
-                }),
-        )
+        .getMany(maxTime, ids, (id) => id, fetch)
         .then((switches) => switches.filter(filterNotEmpty));
 };
 

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -89,8 +89,8 @@ export async function deleteTrackNumber(
 export async function getTrackNumberValidation(
     publishType: PublishType,
     id: LayoutTrackNumberId,
-): Promise<ValidatedAsset> {
-    return getNonNull<ValidatedAsset>(`${layoutUri('track-numbers', publishType, id)}/validation`);
+): Promise<ValidatedAsset | undefined> {
+    return getNullable<ValidatedAsset>(`${layoutUri('track-numbers', publishType, id)}/validation`);
 }
 
 export const getTrackNumberReferenceLineSectionsByPlan = async (


### PR DESCRIPTION
Alunperin aloitin tutkimaan bugia, jossa väärät versiot päätyivät validointiin ja totesin että siinä on useassa paikkaa vähän erikoisuuksia. Korjattu luomalla erillinen validointikonteksti joka tarjoaa validointilogiikalle yhtenäisen "universumin jota validoidaan" ja hoitaa samalla hakutulosten kakutuksia sekä preloadeja.

Pahoittelut isosta pullarista, mutta tämä vaikuttaa vähän kaikkeen :see_no_evil: 