### PR TITLE
GVT-2478: Reference newly created split target location tracks for unused duplicates

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -48,7 +48,14 @@ class SplitFailureException(
     message: String,
     cause: Throwable? = null,
     localizedMessageKey: String = "generic",
-) : ClientException(BAD_REQUEST, "Split failed: $message", cause, "$LOCALIZATION_KEY_BASE.$localizedMessageKey") {
+    localizationParams: LocalizationParams = LocalizationParams.empty,
+) : ClientException(
+    BAD_REQUEST,
+    "Split failed: $message",
+    cause,
+    "$LOCALIZATION_KEY_BASE.$localizedMessageKey",
+    localizationParams,
+) {
     companion object {
         const val LOCALIZATION_KEY_BASE = "error.split"
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -168,6 +168,11 @@ class LocationTrackService(
     }
 
     @Transactional
+    fun fetchDuplicates(id: IntId<LocationTrack>) = dao
+        .fetchDuplicateVersions(id, DRAFT, includeDeleted = true)
+        .map(dao::fetch)
+
+    @Transactional
     fun clearDuplicateReferences(id: IntId<LocationTrack>) = dao
         .fetchDuplicateVersions(id, DRAFT, includeDeleted = true)
         .map(dao::fetch)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -15,7 +15,9 @@
         "split": {
             "segment-allocation-failed": "Jakamista ei voitu suorittaa, koska katkaisukohtien määritys epäonnistui",
             "switch-linking-failed": "Jakamista ei voitu suorittaa, koska vaihteiden uudelleenlinkitys epäonnistui",
-            "no-switch-suggestion": "Jakamista ei voitu suorittaa, koska uudelleenlinkityksen vaihde-ehdotusten muodostus epäonnistui"
+            "no-switch-suggestion": "Jakamista ei voitu suorittaa, koska uudelleenlinkityksen vaihde-ehdotusten muodostus epäonnistui",
+            "geocoding-failed": "Jakamista ei voitu suorittaa, koska jaettavan raiteen {{trackName}} geokoodaus epäonnistui",
+            "new-duplicate-reference-assignment-failed": "Jakamista ei voitu suorittaa, koska käyttämättömälle duplikaattiraiteelle {{duplicate}} ei löydetty päällekkäisyyttä jakamisen seurauksena syntyvistä raiteista"
         },
         "publication": {
             "generic": "Julkaisu epäonnistui",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -89,7 +89,11 @@ class SplitServiceIT @Autowired constructor(
         )
 
         val alignment = alignment(preSwitchSegments + switchSegments + postSwitchSegments)
-        val trackId = insertLocationTrack(locationTrack(insertOfficialTrackNumber()), alignment).id
+
+        val trackNumberId = insertOfficialTrackNumber()
+        insertReferenceLine(referenceLine(trackNumberId), alignment)
+
+        val trackId = insertLocationTrack(locationTrack(trackNumberId), alignment).id
 
         val request = SplitRequest(
             trackId,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -105,13 +105,60 @@ fun segmentsFromSwitchAlignment(
     start: Point,
     switchId: IntId<TrackLayoutSwitch>,
     alignment: SwitchAlignment,
-): List<LayoutSegment> = alignment.elements.mapIndexed { i, e ->
-    segment(
-        points = toSegmentPoints(start + e.start, start + e.end),
-        switchId = switchId,
-        startJointNumber = alignment.jointNumbers[i],
-        endJointNumber = alignment.jointNumbers[i + 1],
-    )
+): List<LayoutSegment> {
+    val jointNumbers = alignment.jointNumbers
+    val elements = alignment.elements
+
+    // There are 5 possibilities of switch line structures at the time of typing:
+    // The start character * means one of the special cases where not every start/end joint number
+    // is defined for all segments.
+    //
+    // 2 joints to one, two (*) or three (*) switch elements;
+    // 3 joints to two elements;
+    // 4 joints to three elements.
+    return when (alignment.jointNumbers.size to alignment.elements.size) {
+        2 to 2 -> listOf(
+            segment(
+                points = toSegmentPoints(start + elements[0].start, start + elements[0].end),
+                switchId = switchId,
+                startJointNumber = jointNumbers[0],
+            ),
+
+            segment(
+                points = toSegmentPoints(start + elements[1].start, start + elements[1].end),
+                switchId = switchId,
+                endJointNumber = jointNumbers[1],
+            ),
+        )
+
+        2 to 3 -> listOf(
+            segment(
+                points = toSegmentPoints(start + elements[0].start, start + elements[0].end),
+                switchId = switchId,
+                startJointNumber = jointNumbers[0],
+            ),
+
+            segment(
+                points = toSegmentPoints(start + elements[1].start, start + elements[1].end),
+                switchId = switchId,
+            ),
+
+            segment(
+                points = toSegmentPoints(start + elements[2].start, start + elements[2].end),
+                switchId = switchId,
+                endJointNumber = jointNumbers[1],
+            ),
+        )
+
+        else -> alignment.elements.mapIndexed { i, e ->
+            segment(
+                points = toSegmentPoints(start + e.start, start + e.end),
+                switchId = switchId,
+                startJointNumber = alignment.jointNumbers[i],
+                endJointNumber = alignment.jointNumbers[i + 1],
+            )
+        }
+    }
 }
 
 fun switchOwnerVayla(): SwitchOwner {


### PR DESCRIPTION
Previously the duplicate references were removed for every duplicate that was part of the split, regardless if the duplicate was used or not.