### PR TITLE
GVT-2423: Part 2 - Begone, `getUnsafe()`, ja muita kovimpia hittejä

### DIFF
--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -34,7 +34,7 @@ import InfraModelFormChosenDateDropDowns from 'infra-model/view/form/fields/infr
 import FormgroupField from 'infra-model/view/formgroup/formgroup-field';
 import { formatDateShort } from 'utils/date-utils';
 import CoordinateSystemView from 'geoviite-design-lib/coordinate-system/coordinate-system-view';
-import { filterNotEmpty } from 'utils/array-utils';
+import { filterNotEmpty, first, last } from 'utils/array-utils';
 import { getTrackNumbers } from 'track-layout/layout-track-number-api';
 import { TrackNumberEditDialogContainer } from 'tool-panel/track-number/dialog/track-number-edit-dialog';
 import {
@@ -93,7 +93,7 @@ function getKmRangePresentation(kmPosts: GeometryKmPost[]): string {
         .filter(filterNotEmpty)
         .sort((a, b) => a.localeCompare(b));
     if (sorted.length == 0) return '';
-    else return `${sorted[0]} - ${sorted[sorted.length - 1]}`;
+    else return `${first(sorted)} - ${last(sorted)}`;
 }
 
 function profileInformationAvailable(alignments: GeometryAlignment[]): boolean {

--- a/ui/src/linking/linking-api.ts
+++ b/ui/src/linking/linking-api.ts
@@ -39,7 +39,7 @@ import { getMaxTimestamp } from 'utils/date-utils';
 import { getSuggestedSwitchId } from 'linking/linking-utils';
 import { bboxString, pointString } from 'common/common-api';
 import { BoundingBox, Point } from 'model/geometry';
-import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
+import { filterNotEmpty, head, indexIntoMap } from 'utils/array-utils';
 
 const LINKING_URI = `${API_URI}/linking`;
 
@@ -268,7 +268,7 @@ export async function createSuggestedSwitch(
         linkingUri('switches', 'suggested'),
         params,
     ).then((switches) => {
-        const s = switches[0];
+        const s = head(switches);
         return s ? { ...s, id: getSuggestedSwitchId(s) } : undefined;
     });
 }

--- a/ui/src/linking/linking-api.ts
+++ b/ui/src/linking/linking-api.ts
@@ -39,7 +39,7 @@ import { getMaxTimestamp } from 'utils/date-utils';
 import { getSuggestedSwitchId } from 'linking/linking-utils';
 import { bboxString, pointString } from 'common/common-api';
 import { BoundingBox, Point } from 'model/geometry';
-import { filterNotEmpty, head, indexIntoMap } from 'utils/array-utils';
+import { filterNotEmpty, first, indexIntoMap } from 'utils/array-utils';
 
 const LINKING_URI = `${API_URI}/linking`;
 
@@ -268,7 +268,7 @@ export async function createSuggestedSwitch(
         linkingUri('switches', 'suggested'),
         params,
     ).then((switches) => {
-        const s = head(switches);
+        const s = first(switches);
         return s ? { ...s, id: getSuggestedSwitchId(s) } : undefined;
     });
 }

--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -1,6 +1,6 @@
 import { TrackLayoutState } from 'track-layout/track-layout-slice';
 import { PayloadAction } from '@reduxjs/toolkit';
-import { fieldComparator, filterNotEmpty } from 'utils/array-utils';
+import { fieldComparator, filterNotEmpty, first, last } from 'utils/array-utils';
 import {
     emptyLinkInterval,
     GeometryLinkingAlignmentLockParameters,
@@ -275,8 +275,8 @@ export function createUpdatedInterval(
             .filter(filterNotEmpty)
             .sort(fieldComparator((p) => p.m));
         return {
-            start: points.length > 0 ? points[0] : undefined,
-            end: points.length > 0 ? points[points.length - 1] : undefined,
+            start: points.length > 0 ? first(points) : undefined,
+            end: points.length > 0 ? last(points) : undefined,
         };
     }
 }

--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -24,7 +24,7 @@ import {
 } from 'track-layout/track-layout-model';
 import { GeometryKmPostId } from 'geometry/geometry-model';
 import { angleDiffRads, directionBetweenPoints, interpolateXY } from 'utils/math-utils';
-import { exhaustiveMatchingGuard, getUnsafe } from 'utils/type-utils';
+import { exhaustiveMatchingGuard, expectDefined } from 'utils/type-utils';
 
 export const linkingReducers = {
     startAlignmentLinking: (
@@ -462,8 +462,8 @@ export function createLinkPoints(
         // Create the linkpoint from layout point
         const direction =
             pIdx === 0
-                ? directionBetweenPoints(point, getUnsafe(points[pIdx + 1]))
-                : directionBetweenPoints(getUnsafe(points[pIdx - 1]), point);
+                ? directionBetweenPoints(point, expectDefined(points[pIdx + 1]))
+                : directionBetweenPoints(expectDefined(points[pIdx - 1]), point);
         const segmentEnd = segmentEndMs.includes(point.m);
         const alignmentEnd = point.m === 0 || point.m === alignmentLength;
         linkPoints.push(

--- a/ui/src/linking/linking-utils.ts
+++ b/ui/src/linking/linking-utils.ts
@@ -56,10 +56,11 @@ export function getMatchingLocationTrackIdsForJoints(
         .flatMap((joint) => joint.accurateMatches.map((m) => m.locationTrackId))
         .filter(filterUnique);
     return locationTrackIds.filter((locationTrackId) => {
-        return [
-            getUnsafe(jointsOfAlignment[0]),
-            getUnsafe(jointsOfAlignment[jointsOfAlignment.length - 1]),
-        ].every((joint) => joint.accurateMatches.some((m) => m.locationTrackId == locationTrackId));
+        return [jointsOfAlignment[0], jointsOfAlignment[jointsOfAlignment.length - 1]]
+            .filter(filterNotEmpty)
+            .every((joint) =>
+                joint.accurateMatches.some((m) => m.locationTrackId == locationTrackId),
+            );
     });
 }
 

--- a/ui/src/linking/linking-utils.ts
+++ b/ui/src/linking/linking-utils.ts
@@ -1,4 +1,4 @@
-import { filterNotEmpty, filterUnique } from 'utils/array-utils';
+import { filterNotEmpty, filterUnique, first, last } from 'utils/array-utils';
 import { SuggestedSwitch, SuggestedSwitchJoint } from 'linking/linking-model';
 import { JointNumber, PublishType } from 'common/common-model';
 import {
@@ -56,7 +56,7 @@ export function getMatchingLocationTrackIdsForJoints(
         .flatMap((joint) => joint.accurateMatches.map((m) => m.locationTrackId))
         .filter(filterUnique);
     return locationTrackIds.filter((locationTrackId) => {
-        return [jointsOfAlignment[0], jointsOfAlignment[jointsOfAlignment.length - 1]]
+        return [first(jointsOfAlignment), last(jointsOfAlignment)]
             .filter(filterNotEmpty)
             .every((joint) =>
                 joint.accurateMatches.some((m) => m.locationTrackId == locationTrackId),

--- a/ui/src/linking/linking-utils.ts
+++ b/ui/src/linking/linking-utils.ts
@@ -7,7 +7,7 @@ import {
     LocationTrackId,
 } from 'track-layout/track-layout-model';
 import { getLocationTracks } from 'track-layout/layout-location-track-api';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 export enum SwitchTypeMatch {
     Exact,
@@ -128,7 +128,7 @@ export function combineLocationTrackIds(
                 if (acc[jointNumber]) {
                     acc[jointNumber] = {
                         jointNumber: jointNumber,
-                        locationTrackIds: getUnsafe(
+                        locationTrackIds: expectDefined(
                             acc[jointNumber]?.locationTrackIds
                                 .concat(locationTrack.locationTrackIds)
                                 .filter(filterUnique),

--- a/ui/src/linking/switch-suggestion-creator-container.tsx
+++ b/ui/src/linking/switch-suggestion-creator-container.tsx
@@ -5,6 +5,7 @@ import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 import { LocationTrackEndpoint, SuggestedSwitch } from 'linking/linking-model';
 import { PublishTypeHandlingDialog } from 'linking/publish-type-handling-dialog';
+import { first } from 'utils/array-utils';
 
 type SuggestionCreatorData = {
     locationTrackEndPoint: LocationTrackEndpoint;
@@ -20,8 +21,8 @@ export const SwitchSuggestionCreatorContainer: React.FC = () => {
     );
     const state = useTrackLayoutAppSelector((state) => ({
         publishType: state.publishType,
-        locationTrackEndPoint: state.selection.selectedItems.locationTrackEndPoints[0],
-        locationTrack: state.selection.selectedItems.locationTracks[0],
+        locationTrackEndPoint: first(state.selection.selectedItems.locationTrackEndPoints),
+        locationTrack: first(state.selection.selectedItems.locationTracks),
         locationTrackChangeTime: locationTrackChangeTime,
     }));
 

--- a/ui/src/linking/switch/switch-suggestion-creator-dialog.tsx
+++ b/ui/src/linking/switch/switch-suggestion-creator-dialog.tsx
@@ -21,7 +21,7 @@ import { switchJointNumberToString } from 'utils/enum-localization-utils';
 import { LocationTrackId } from 'track-layout/track-layout-model';
 import { boundingBoxAroundPoints, expandBoundingBox } from 'model/geometry';
 import { createSuggestedSwitch } from 'linking/linking-api';
-import { filterNotEmpty } from 'utils/array-utils';
+import { filterNotEmpty, first } from 'utils/array-utils';
 import {
     asTrackLayoutSwitchJointConnection,
     getMatchingLocationTrackIdsForJointNumbers,
@@ -94,10 +94,12 @@ export const SwitchSuggestionCreatorDialog: React.FC<SwitchSuggestionCreatorProp
                 const locationTrackId = alignmentConfig
                     ? alignmentConfig.locationTrackId
                     : jointConnections
-                    ? getMatchingLocationTrackIdsForJointNumbers(
-                          switchAlignment.jointNumbers,
-                          jointConnections,
-                      )[0]
+                    ? first(
+                          getMatchingLocationTrackIdsForJointNumbers(
+                              switchAlignment.jointNumbers,
+                              jointConnections,
+                          ),
+                      )
                     : undefined;
 
                 const jointPlainNumbers =

--- a/ui/src/map/layers/alignment/alignment-linking-layer.ts
+++ b/ui/src/map/layers/alignment/alignment-linking-layer.ts
@@ -40,7 +40,7 @@ import { formatTrackMeter } from 'utils/geography-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-import { getCoordsUnsafe, getUnsafe } from 'utils/type-utils';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 const linkPointRadius = 4;
 const linkPointSelectedRadius = 6;
@@ -353,12 +353,11 @@ function getPointsByOrder(
     orderStart?: number,
     orderEnd?: number,
 ): LinkPoint[] {
-    if (points.length === 0 || orderStart === undefined || orderEnd === undefined) return [];
-    else if (
-        orderEnd < getUnsafe(points[0]).m ||
-        orderStart > getUnsafe(points[points.length - 1]).m
-    )
-        return [];
+    const first = points[0];
+    const last = points[points.length - 1];
+
+    if (!first || !last || orderStart === undefined || orderEnd === undefined) return [];
+    else if (orderEnd < first.m || orderStart > last.m) return [];
     else return points.filter((p) => p.m >= orderStart && p.m <= orderEnd);
 }
 
@@ -925,10 +924,10 @@ export function createAlignmentLinkingLayer(
                             highlightedItems: {
                                 ...selection.highlightedItems,
                                 layoutLinkPoints: linkPointAddresses.layoutHighlight
-                                    ? [getUnsafe(linkPointAddresses.layoutHighlight)]
+                                    ? [linkPointAddresses.layoutHighlight]
                                     : [],
                                 geometryLinkPoints: linkPointAddresses.geometryHighlight
-                                    ? [getUnsafe(linkPointAddresses.geometryHighlight)]
+                                    ? [linkPointAddresses.geometryHighlight]
                                     : [],
                             },
                         },
@@ -996,12 +995,12 @@ export function createAlignmentLinkingLayer(
                 const onGeometryLine = containsType(features, FeatureType.GeometryLine);
 
                 if (onLayoutLine && onGeometryLine) {
-                    const closestPoint = getUnsafe(linkPointFeatures[0]);
+                    const closestPoint = linkPointFeatures[0];
                     const closestPointType = getFeatureType(closestPoint);
 
-                    if (closestPointType === FeatureType.GeometryPoint) {
+                    if (closestPoint && closestPointType === FeatureType.GeometryPoint) {
                         geometryLinkPoint = getFeatureData(closestPoint);
-                    } else if (closestPointType === FeatureType.LayoutPoint) {
+                    } else if (closestPoint && closestPointType === FeatureType.LayoutPoint) {
                         layoutLinkPoint = getFeatureData(closestPoint);
                     }
                 } else if (onGeometryLine) {

--- a/ui/src/map/layers/alignment/location-track-background-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-background-layer.ts
@@ -19,6 +19,7 @@ import {
     OTHER_ALIGNMENTS_OPACITY_WHILE_SPLITTING,
 } from 'map/layers/utils/alignment-layer-utils';
 import { LocationTrackId } from 'track-layout/track-layout-model';
+import { first } from 'utils/array-utils';
 
 let newestLayerId = 0;
 
@@ -40,7 +41,7 @@ export function createLocationTrackBackgroundLayer(
     );
 
     let inFlight = true;
-    const selectedTrack = selection.selectedItems.locationTracks[0];
+    const selectedTrack = first(selection.selectedItems.locationTracks);
 
     const alignmentPromise = getMapAlignments(
         changeTimes,

--- a/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
@@ -31,7 +31,7 @@ import {
     getManyStartsAndEnds,
 } from 'track-layout/layout-location-track-api';
 import { Point } from 'model/geometry';
-import { getCoordsUnsafe, getUnsafe } from 'utils/type-utils';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 type EndpointType = 'START' | 'END';
 const BLACK = '#000000';
@@ -171,37 +171,41 @@ function createFeatures(
 
             // The 'points'-array may only include a subset of the actual points of the alignment.
             // Features should only be rendered to the real ends of a given duplicate.
-            const startFeature = trackMetersAreApproximatelySame(
-                getUnsafe(points[0]).m,
-                startAndEnd?.start?.point.m,
-            )
-                ? createDuplicateTrackEndpointAddressFeature(
-                      getUnsafe(points[0]),
-                      getUnsafe(points[1]),
-                      header.name,
-                      startAndEnd?.start?.address,
-                      'START',
-                      startAndEnd?.start?.address
-                          ? calculateZIndexForTrackMeter(startAndEnd.start.address)
-                          : 0,
-                  )
-                : undefined;
+            const startPoint = points[0];
+            const startControlPoint = points[1];
+            const startFeature =
+                startPoint &&
+                startControlPoint &&
+                trackMetersAreApproximatelySame(startPoint.m, startAndEnd?.start?.point.m)
+                    ? createDuplicateTrackEndpointAddressFeature(
+                          startPoint,
+                          startControlPoint,
+                          header.name,
+                          startAndEnd?.start?.address,
+                          'START',
+                          startAndEnd?.start?.address
+                              ? calculateZIndexForTrackMeter(startAndEnd.start.address)
+                              : 0,
+                      )
+                    : undefined;
 
-            const endFeature = trackMetersAreApproximatelySame(
-                getUnsafe(points[points.length - 1]).m,
-                startAndEnd?.end?.point.m,
-            )
-                ? createDuplicateTrackEndpointAddressFeature(
-                      getUnsafe(points[points.length - 1]),
-                      getUnsafe(points[points.length - 2]),
-                      header.name,
-                      startAndEnd?.end?.address,
-                      'END',
-                      startAndEnd?.end?.address
-                          ? calculateZIndexForTrackMeter(startAndEnd.end.address)
-                          : 0,
-                  )
-                : undefined;
+            const endPoint = points[points.length - 1];
+            const endControlPoint = points[points.length - 2];
+            const endFeature =
+                endPoint &&
+                endControlPoint &&
+                trackMetersAreApproximatelySame(endPoint.m, startAndEnd?.end?.point.m)
+                    ? createDuplicateTrackEndpointAddressFeature(
+                          endPoint,
+                          endControlPoint,
+                          header.name,
+                          startAndEnd?.end?.address,
+                          'END',
+                          startAndEnd?.end?.address
+                              ? calculateZIndexForTrackMeter(startAndEnd.end.address)
+                              : 0,
+                      )
+                    : undefined;
 
             return [startFeature, endFeature];
         })

--- a/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
@@ -171,8 +171,7 @@ function createFeatures(
 
             // The 'points'-array may only include a subset of the actual points of the alignment.
             // Features should only be rendered to the real ends of a given duplicate.
-            const startPoint = points[0];
-            const startControlPoint = points[1];
+            const [startPoint, startControlPoint] = [points[0], points[1]];
             const startFeature =
                 startPoint &&
                 startControlPoint &&
@@ -189,8 +188,10 @@ function createFeatures(
                       )
                     : undefined;
 
-            const endPoint = points[points.length - 1];
-            const endControlPoint = points[points.length - 2];
+            const [endPoint, endControlPoint] = [
+                points[points.length - 1],
+                points[points.length - 2],
+            ];
             const endFeature =
                 endPoint &&
                 endControlPoint &&

--- a/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
@@ -14,6 +14,7 @@ import { SplittingState } from 'tool-panel/location-track/split-store';
 import { createAlignmentFeature } from '../utils/alignment-layer-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
+import { first } from 'utils/array-utils';
 
 let newestLayerId = 0;
 
@@ -50,7 +51,7 @@ export function createLocationTrackSelectedAlignmentLayer(
     const resolution = olView.getResolution() || 0;
 
     let inFlight = true;
-    const selectedTrack = selection.selectedItems.locationTracks[0];
+    const selectedTrack = first(selection.selectedItems.locationTracks);
     const alignmentPromise = selectedTrack
         ? getSelectedLocationTrackMapAlignmentByTiles(
               changeTimes,
@@ -62,15 +63,14 @@ export function createLocationTrackSelectedAlignmentLayer(
 
     alignmentPromise
         .then((locationTracks) => {
-            if (!locationTracks[0]) {
+            const selectedTrack = first(locationTracks);
+            if (!selectedTrack) {
                 clearFeatures(vectorSource);
                 return;
             }
             if (layerId !== newestLayerId) return;
 
-            const selectedTrack = locationTracks[0];
             const showEndPointTicks = resolution <= Limits.SHOW_LOCATION_TRACK_BADGES;
-
             const isSplitting = splittingState?.originLocationTrack.id === selectedTrack.header.id;
             const alignmentFeatures = createAlignmentFeature(
                 selectedTrack,

--- a/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
@@ -14,7 +14,6 @@ import { SplittingState } from 'tool-panel/location-track/split-store';
 import { createAlignmentFeature } from '../utils/alignment-layer-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
-import { getUnsafe } from 'utils/type-utils';
 
 let newestLayerId = 0;
 
@@ -63,14 +62,18 @@ export function createLocationTrackSelectedAlignmentLayer(
 
     alignmentPromise
         .then((locationTracks) => {
+            if (!locationTracks[0]) {
+                clearFeatures(vectorSource);
+                return;
+            }
             if (layerId !== newestLayerId) return;
 
+            const selectedTrack = locationTracks[0];
             const showEndPointTicks = resolution <= Limits.SHOW_LOCATION_TRACK_BADGES;
 
-            const track = getUnsafe(locationTracks[0]);
-            const isSplitting = splittingState?.originLocationTrack.id === track.header.id;
+            const isSplitting = splittingState?.originLocationTrack.id === selectedTrack.header.id;
             const alignmentFeatures = createAlignmentFeature(
-                track,
+                selectedTrack,
                 showEndPointTicks,
                 isSplitting ? splittingLocationTrackStyle : selectedLocationTrackStyle,
             );

--- a/ui/src/map/layers/alignment/location-track-split-badge-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-badge-layer.ts
@@ -20,6 +20,7 @@ import {
 import { sortSplitsByDistance, SplittingState } from 'tool-panel/location-track/split-store';
 import { AlignmentStartAndEnd } from 'track-layout/track-layout-model';
 import { getLocationTrackStartAndEnd } from 'track-layout/layout-location-track-api';
+import { first } from 'utils/array-utils';
 
 let newestLayerId = 0;
 
@@ -51,7 +52,7 @@ const calculateSplitBounds = (
     return [
         {
             start: originalStartAndEnd.start?.point.m || 0,
-            end: splitsSorted[0]?.distance || originalStartAndEnd.end?.point?.m || 0,
+            end: first(splitsSorted)?.distance || originalStartAndEnd.end?.point?.m || 0,
             name: splittingState.firstSplit.name,
         },
         ...splitsSorted.map((split, index) => ({

--- a/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
@@ -11,6 +11,7 @@ import { getSelectedReferenceLineMapAlignmentByTiles } from 'track-layout/layout
 import { createAlignmentFeature } from '../utils/alignment-layer-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
+import { first } from 'utils/array-utils';
 
 let newestLayerId = 0;
 
@@ -35,7 +36,7 @@ export function createSelectedReferenceLineAlignmentLayer(
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
     let inFlight = true;
-    const selectedTrackNumber = selection.selectedItems.trackNumbers[0];
+    const selectedTrackNumber = first(selection.selectedItems.trackNumbers);
     const alignmentPromise = selectedTrackNumber
         ? getSelectedReferenceLineMapAlignmentByTiles(
               changeTimes,
@@ -48,13 +49,15 @@ export function createSelectedReferenceLineAlignmentLayer(
     alignmentPromise
         .then((referenceLines) => {
             if (layerId !== newestLayerId) return;
-            if (!referenceLines[0]) {
+
+            const referenceLine = first(referenceLines);
+            if (!referenceLine) {
                 clearFeatures(vectorSource);
                 return;
             }
 
             const alignmentFeatures = createAlignmentFeature(
-                referenceLines[0],
+                referenceLine,
                 false,
                 selectedReferenceLineStyle,
             );

--- a/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
@@ -11,7 +11,6 @@ import { getSelectedReferenceLineMapAlignmentByTiles } from 'track-layout/layout
 import { createAlignmentFeature } from '../utils/alignment-layer-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
-import { getUnsafe } from 'utils/type-utils';
 
 let newestLayerId = 0;
 
@@ -49,9 +48,13 @@ export function createSelectedReferenceLineAlignmentLayer(
     alignmentPromise
         .then((referenceLines) => {
             if (layerId !== newestLayerId) return;
+            if (!referenceLines[0]) {
+                clearFeatures(vectorSource);
+                return;
+            }
 
             const alignmentFeatures = createAlignmentFeature(
-                getUnsafe(referenceLines[0]),
+                referenceLines[0],
                 false,
                 selectedReferenceLineStyle,
             );

--- a/ui/src/map/layers/debug/debug-1m-points-layer.ts
+++ b/ui/src/map/layers/debug/debug-1m-points-layer.ts
@@ -9,6 +9,7 @@ import { MapLayer } from 'map/layers/utils/layer-model';
 import { clearFeatures, pointToCoords } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
+import { first } from 'utils/array-utils';
 
 type DebugLayerPoint = {
     x: number;
@@ -83,7 +84,7 @@ export function createDebug1mPointsLayer(
     const vectorSource = existingOlLayer?.getSource() || new VectorSource();
     const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
 
-    const selected = selection.selectedItems.locationTracks[0];
+    const selected = first(selection.selectedItems.locationTracks);
     let inFlight = false;
     if (selected && resolution <= DEBUG_1M_POINTS) {
         inFlight = true;

--- a/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
+++ b/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
@@ -34,6 +34,7 @@ import {
     indicatorTextPadding,
 } from 'map/layers/utils/dashed-line-indicator-utils';
 import { getCoordsUnsafe } from 'utils/type-utils';
+import { first, last } from 'utils/array-utils';
 
 let newestLayerId = 0;
 
@@ -225,8 +226,8 @@ const getEndPointAddresses = (
             .flatMap((referenceLine) => {
                 const trackNumberId = referenceLine.header.trackNumberId as LayoutTrackNumberId;
 
-                const firstPoint = referenceLine.points[0];
-                const lastPoint = referenceLine.points[referenceLine.points.length - 1];
+                const firstPoint = first(referenceLine.points);
+                const lastPoint = last(referenceLine.points);
 
                 return Promise.all([
                     firstPoint?.m === 0

--- a/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
+++ b/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
@@ -33,7 +33,7 @@ import {
     indicatorTextBackgroundHeight,
     indicatorTextPadding,
 } from 'map/layers/utils/dashed-line-indicator-utils';
-import { getCoordsUnsafe, getUnsafe } from 'utils/type-utils';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 let newestLayerId = 0;
 
@@ -134,28 +134,17 @@ function createAddressFeatures(
 
         const features: Feature<OlPoint>[] = [];
         const points = referenceLine.points;
+        const [startPoint, startControlPoint] = [points[0], points[1]];
 
-        if (startAddress && color) {
+        if (startAddress && startPoint && startControlPoint && color) {
             features.push(
-                createAddressFeature(
-                    getUnsafe(points[0]),
-                    getUnsafe(points[1]),
-                    startAddress,
-                    false,
-                    color,
-                ),
+                createAddressFeature(startPoint, startControlPoint, startAddress, false, color),
             );
         }
 
-        if (endAddress && color) {
-            const lastIndex = points.length - 1;
-            const f = createAddressFeature(
-                getUnsafe(points[lastIndex - 1]),
-                getUnsafe(points[lastIndex]),
-                endAddress,
-                true,
-                color,
-            );
+        const [endPoint, endControlPoint] = [points[points.length - 1], points[points.length - 2]];
+        if (endAddress && endPoint && endControlPoint && color) {
+            const f = createAddressFeature(endPoint, endControlPoint, endAddress, true, color);
 
             features.push(f);
         }

--- a/ui/src/map/layers/switch/switch-linking-layer.ts
+++ b/ui/src/map/layers/switch/switch-linking-layer.ts
@@ -9,7 +9,7 @@ import { clearFeatures, findMatchingEntities, pointToCoords } from 'map/layers/u
 import { Selection } from 'selection/selection-model';
 import { getLinkingJointRenderer } from 'map/layers/utils/switch-layer-utils';
 import { SUGGESTED_SWITCH_SHOW } from 'map/layers/utils/layer-visibility-limits';
-import { filterNotEmpty } from 'utils/array-utils';
+import { filterNotEmpty, first } from 'utils/array-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
@@ -67,7 +67,7 @@ export function createSwitchLinkingLayer(
             .then((suggestedSwitches) =>
                 [
                     ...suggestedSwitches.flat(),
-                    selectedSwitches[0], // add selected suggested switch into collection
+                    first(selectedSwitches), // add selected suggested switch into collection
                 ].filter(filterNotEmpty),
             )
             .then((suggestedSwitches) => {

--- a/ui/src/map/layers/utils/badge-layer-utils.ts
+++ b/ui/src/map/layers/utils/badge-layer-utils.ts
@@ -13,7 +13,7 @@ import { Selection } from 'selection/selection-model';
 import { LinkingState } from 'linking/linking-model';
 import { getAlignmentHeaderStates } from 'map/layers/utils/alignment-layer-utils';
 import { BADGE_DRAW_DISTANCES } from 'map/layers/utils/layer-visibility-limits';
-import { getCoordsUnsafe, getUnsafe } from 'utils/type-utils';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 type MapAlignmentBadgePoint = {
     point: number[];
@@ -166,10 +166,11 @@ export function getBadgePoints(
     points: AlignmentPoint[],
     drawDistance: number,
 ): MapAlignmentBadgePoint[] {
-    if (points.length < 3) return [];
+    const [second, last] = [points[1], points[points.length - 1]];
+    if (!second || !last) return [];
 
-    const start = Math.ceil(getUnsafe(points[1]).m / drawDistance);
-    const end = Math.floor(getUnsafe(points[points.length - 1]).m / drawDistance);
+    const start = Math.ceil(second.m / drawDistance);
+    const end = Math.floor(last.m / drawDistance);
 
     if (start > end) return [];
 
@@ -190,7 +191,7 @@ export function getBadgePoints(
 }
 
 export function getBadgeDrawDistance(resolution: number): number | undefined {
-    const distance = BADGE_DRAW_DISTANCES.find((d) => resolution < getUnsafe(d[0]));
+    const distance = BADGE_DRAW_DISTANCES.find((d) => resolution < d[0]);
     return distance?.[1];
 }
 

--- a/ui/src/map/layers/utils/highlight-layer-utils.ts
+++ b/ui/src/map/layers/utils/highlight-layer-utils.ts
@@ -3,7 +3,7 @@ import { AlignmentHighlight } from 'map/map-model';
 import Feature from 'ol/Feature';
 import { LineString } from 'ol/geom';
 import { getPartialPolyLine } from 'utils/math-utils';
-import { filterNotEmpty, head, last } from 'utils/array-utils';
+import { filterNotEmpty, first, last } from 'utils/array-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
 
@@ -16,9 +16,12 @@ export function createHighlightFeatures(
         return linkingInfo
             .filter((h) => h.id === header.id && h.type == header.alignmentType)
             .flatMap(({ ranges }) => {
-                const [first, lst] = [head(points), last(points)];
+                const [firstPoint, lastPoint] = [first(points), last(points)];
                 return ranges
-                    .filter((r) => first && lst && r.max > first.m && r.min < lst.m)
+                    .filter(
+                        (r) =>
+                            firstPoint && lastPoint && r.max > firstPoint.m && r.min < lastPoint.m,
+                    )
                     .map((r) => {
                         const pointsWithinRange = getPartialPolyLine(points, r.min, r.max);
                         return pointsWithinRange.length > 1

--- a/ui/src/map/layers/utils/highlight-layer-utils.ts
+++ b/ui/src/map/layers/utils/highlight-layer-utils.ts
@@ -3,10 +3,9 @@ import { AlignmentHighlight } from 'map/map-model';
 import Feature from 'ol/Feature';
 import { LineString } from 'ol/geom';
 import { getPartialPolyLine } from 'utils/math-utils';
-import { filterNotEmpty } from 'utils/array-utils';
+import { filterNotEmpty, head, last } from 'utils/array-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
-import { getUnsafe } from 'utils/type-utils';
 
 export function createHighlightFeatures(
     alignments: AlignmentDataHolder[],
@@ -17,12 +16,9 @@ export function createHighlightFeatures(
         return linkingInfo
             .filter((h) => h.id === header.id && h.type == header.alignmentType)
             .flatMap(({ ranges }) => {
+                const [first, lst] = [head(points), last(points)];
                 return ranges
-                    .filter(
-                        (r) =>
-                            r.max > getUnsafe(points[0]).m &&
-                            r.min < getUnsafe(points[points.length - 1]).m,
-                    )
+                    .filter((r) => first && lst && r.max > first.m && r.min < lst.m)
                     .map((r) => {
                         const pointsWithinRange = getPartialPolyLine(points, r.min, r.max);
                         return pointsWithinRange.length > 1

--- a/ui/src/map/layers/utils/layer-utils.ts
+++ b/ui/src/map/layers/utils/layer-utils.ts
@@ -15,7 +15,7 @@ import { PublishType } from 'common/common-model';
 import { getPlanAreasByTile, getTrackLayoutPlans } from 'geometry/geometry-api';
 import { ChangeTimes } from 'common/common-slice';
 import { MapTile } from 'map/map-model';
-import { getCoordsUnsafe, getUnsafe } from 'utils/type-utils';
+import { getCoordsUnsafe } from 'utils/type-utils';
 
 proj4.defs(LAYOUT_SRID, '+proj=utm +zone=35 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 register(proj4);
@@ -72,11 +72,11 @@ export function getDistancePointAndLine(olPoint: OlPoint, line: LineString): num
         .map((coordinate) => coordsToPoint(coordinate))
         .map((point, index, points) => {
             const nextPoint = points[index + 1];
-            return nextPoint ? [point, nextPoint] : undefined;
+            return (nextPoint ? [point, nextPoint] : undefined) as [Point, Point] | undefined;
         })
         .filter(filterNotEmpty);
     const squaredDistances = segments.map((segment) =>
-        distToSegmentSquared(point, getUnsafe(segment[0]), getUnsafe(segment[1])),
+        distToSegmentSquared(point, segment[0], segment[1]),
     );
     const minSquaredDistance = Math.min(...squaredDistances);
     return Math.sqrt(minSquaredDistance);

--- a/ui/src/map/layers/utils/layer-visibility-limits.ts
+++ b/ui/src/map/layers/utils/layer-visibility-limits.ts
@@ -64,7 +64,7 @@ export const BADGE_DRAW_DISTANCES = [
     [11, 2560],
     [16, 5120],
     [24, 10240],
-];
+] as const;
 
 // Switches
 export const SWITCH_SHOW = 3.2;

--- a/ui/src/map/layers/utils/switch-layer-utils.ts
+++ b/ui/src/map/layers/utils/switch-layer-utils.ts
@@ -28,7 +28,7 @@ import { ValidatedAsset } from 'publication/publication-model';
 import { Selection } from 'selection/selection-model';
 import * as Limits from 'map/layers/utils/layer-visibility-limits';
 import { getCoordsUnsafe } from 'utils/type-utils';
-import { head } from 'utils/array-utils';
+import { first } from 'utils/array-utils';
 
 const switchImage: HTMLImageElement = new Image();
 switchImage.src = `data:image/svg+xml;utf8,${encodeURIComponent(SwitchIcon)}`;
@@ -377,7 +377,7 @@ function createSwitchFeature(
     presentationJointNumber?: string | undefined,
     validationResult?: ValidatedAsset | undefined,
 ): Feature<OlPoint>[] {
-    const firstJoint = head(layoutSwitch.joints);
+    const firstJoint = first(layoutSwitch.joints);
     if (!firstJoint) return [];
 
     const presentationJoint = layoutSwitch.joints.find(

--- a/ui/src/map/location-holder/location-holder-view.tsx
+++ b/ui/src/map/location-holder/location-holder-view.tsx
@@ -10,6 +10,7 @@ import TrackMeter from 'geoviite-design-lib/track-meter/track-meter';
 import { getLocationTrack } from 'track-layout/layout-location-track-api';
 import { getTrackNumberById } from 'track-layout/layout-track-number-api';
 import { getTrackNumberReferenceLine } from 'track-layout/layout-reference-line-api';
+import { first } from 'utils/array-utils';
 
 type LocationHolderProps = {
     hoveredCoordinate: Point | undefined;
@@ -86,10 +87,10 @@ export const LocationHolderView: React.FC<LocationHolderProps> = ({
     publishType,
 }: LocationHolderProps) => {
     const debouncedCoordinate = useDebouncedState(hoveredCoordinate, 100);
+    const trackNumber = first(trackNumbers);
+    const locationTrack = first(locationTracks);
 
     const hovered = useLoader(() => {
-        const trackNumber = trackNumbers[0];
-        const locationTrack = locationTracks[0];
         if (trackNumber && hoveredCoordinate) {
             return getReferenceLineHoverLocation(trackNumber, publishType, hoveredCoordinate);
         } else if (locationTrack && hoveredCoordinate) {
@@ -97,7 +98,7 @@ export const LocationHolderView: React.FC<LocationHolderProps> = ({
         } else {
             return Promise.resolve(emptyHoveredLocation(hoveredCoordinate));
         }
-    }, [debouncedCoordinate, trackNumbers[0], locationTracks[0]]);
+    }, [debouncedCoordinate, trackNumber, locationTrack]);
 
     return (
         <div className={styles['location-holder-view']}>

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -159,4 +159,4 @@ export type VerticalAlignmentVisibleExtentChange = {
     extent: [number, number];
 };
 
-export const HELSINKI_COORDS: Point = { x: 385782.89, y: 6672277.83 };
+export const HELSINKI_RAILWAY_STATION_COORDS: Point = { x: 385782.89, y: 6672277.83 };

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -158,3 +158,5 @@ export type VerticalAlignmentVisibleExtentChange = {
     alignmentId: VerticalGeometryDiagramAlignmentId;
     extent: [number, number];
 };
+
+export const HELSINKI_COORDS: Point = { x: 385782.89, y: 6672277.83 };

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -1,5 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import {
+    HELSINKI_COORDS,
     Map,
     MapLayerMenuChange,
     MapLayerMenuItem,
@@ -149,10 +150,7 @@ export const initialMapState: Map = {
     },
     shownItems: getEmptyShownItems(),
     viewport: {
-        center: {
-            x: 385782.89,
-            y: 6672277.83,
-        },
+        center: HELSINKI_COORDS,
         resolution: 20,
     },
     verticalGeometryDiagramState: initialVerticalGeometryDiagramState,

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -1,6 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import {
-    HELSINKI_COORDS,
+    HELSINKI_RAILWAY_STATION_COORDS,
     Map,
     MapLayerMenuChange,
     MapLayerMenuItem,
@@ -150,7 +150,7 @@ export const initialMapState: Map = {
     },
     shownItems: getEmptyShownItems(),
     viewport: {
-        center: HELSINKI_COORDS,
+        center: HELSINKI_RAILWAY_STATION_COORDS,
         resolution: 20,
     },
     verticalGeometryDiagramState: initialVerticalGeometryDiagramState,

--- a/ui/src/map/map-utils.ts
+++ b/ui/src/map/map-utils.ts
@@ -2,7 +2,7 @@ import { MapTile } from 'map/map-model';
 import OlView from 'ol/View';
 import TileGrid from 'ol/tilegrid/TileGrid';
 import { BoundingBox, Point } from 'model/geometry';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 import { first } from 'utils/array-utils';
 
 // offset used for defining a suitable boundingBox around a single location (Point)
@@ -44,7 +44,7 @@ export function calculateMapTiles(view: OlView, tileSizePx: number | undefined):
                 x: { min: tileExtent[0], max: tileExtent[2] },
                 y: { min: tileExtent[1], max: tileExtent[3] },
             },
-            resolution: getUnsafe(tileResolutions[tileResolutionIndex]),
+            resolution: expectDefined(tileResolutions[tileResolutionIndex]),
         };
         tiles.push(tile);
     });
@@ -57,7 +57,7 @@ const tileSizeOptions = [256, 512, 1024, 2048, 4096];
  * Picks a tile size where the given amount of tiles will fill the screen
  */
 export function calculateTileSize(tileCount: number): number {
-    const maxSize = getUnsafe(tileSizeOptions[tileSizeOptions.length - 1]);
+    const maxSize = expectDefined(tileSizeOptions[tileSizeOptions.length - 1]);
     if (tileCount >= 1) {
         const optimalTileSize = Math.max(window.screen.width, window.screen.height) / tileCount;
         return tileSizeOptions.find((opt) => opt > optimalTileSize) || maxSize;

--- a/ui/src/map/map-utils.ts
+++ b/ui/src/map/map-utils.ts
@@ -3,7 +3,7 @@ import OlView from 'ol/View';
 import TileGrid from 'ol/tilegrid/TileGrid';
 import { BoundingBox, Point } from 'model/geometry';
 import { getUnsafe } from 'utils/type-utils';
-import { head } from 'utils/array-utils';
+import { first } from 'utils/array-utils';
 
 // offset used for defining a suitable boundingBox around a single location (Point)
 export const MAP_POINT_DEFAULT_BBOX_OFFSET = 178;
@@ -19,7 +19,7 @@ for (let i = 0; i <= LAST_RESOLUTION_INDEX; i++) {
 
 export function calculateMapTiles(view: OlView, tileSizePx: number | undefined): MapTile[] {
     // Find a resolution that corresponds to the resolution in the view
-    const actualResolution = view.getResolution() || head(tileResolutions);
+    const actualResolution = view.getResolution() || first(tileResolutions);
     const tileResolutionIndex = tileResolutions.findIndex(
         (resolution, index) =>
             (actualResolution && resolution < actualResolution) || index == LAST_RESOLUTION_INDEX,

--- a/ui/src/map/map-utils.ts
+++ b/ui/src/map/map-utils.ts
@@ -3,23 +3,26 @@ import OlView from 'ol/View';
 import TileGrid from 'ol/tilegrid/TileGrid';
 import { BoundingBox, Point } from 'model/geometry';
 import { getUnsafe } from 'utils/type-utils';
+import { head } from 'utils/array-utils';
 
 // offset used for defining a suitable boundingBox around a single location (Point)
 export const MAP_POINT_DEFAULT_BBOX_OFFSET = 178;
 export const MAP_POINT_NEAR_BBOX_OFFSET = 78;
 export const MAP_POINT_CLOSEUP_BBOX_OFFSET = 38;
+const LAST_RESOLUTION_INDEX = 21;
 
 // Resolutions to use to load stuff from backend
 const tileResolutions: number[] = [];
-for (let i = 0; i < 22; i++) {
+for (let i = 0; i <= LAST_RESOLUTION_INDEX; i++) {
     tileResolutions[i] = 200000 / Math.pow(2, i);
 }
 
 export function calculateMapTiles(view: OlView, tileSizePx: number | undefined): MapTile[] {
     // Find a resolution that corresponds to the resolution in the view
-    const actualResolution = view.getResolution() || getUnsafe(tileResolutions[0]);
+    const actualResolution = view.getResolution() || head(tileResolutions);
     const tileResolutionIndex = tileResolutions.findIndex(
-        (resolution, index) => resolution < actualResolution || index == tileResolutions.length - 1,
+        (resolution, index) =>
+            (actualResolution && resolution < actualResolution) || index == LAST_RESOLUTION_INDEX,
     );
     // Use OL tile grid to calc tiles
     const tileGrid = new TileGrid({

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -10,7 +10,7 @@ import { defaults as defaultInteractions } from 'ol/interaction';
 import DragPan from 'ol/interaction/DragPan.js';
 import 'ol/ol.css';
 import OlView from 'ol/View';
-import { Map, MapViewport, OptionalShownItems } from 'map/map-model';
+import { HELSINKI_COORDS, Map, MapViewport, OptionalShownItems } from 'map/map-model';
 import { createSwitchLinkingLayer } from './layers/switch/switch-linking-layer';
 import styles from './map.module.scss';
 import { selectTool } from './tools/select-tool';
@@ -48,7 +48,7 @@ import { createBackgroundMapLayer } from 'map/layers/background-map-layer';
 import TileSource from 'ol/source/Tile';
 import TileLayer from 'ol/layer/Tile';
 import { MapLayer } from 'map/layers/utils/layer-model';
-import { filterNotEmpty } from 'utils/array-utils';
+import { filterNotEmpty, first } from 'utils/array-utils';
 import { mapLayerZIndexes } from 'map/layers/utils/layer-visibility-limits';
 import { createLocationTrackAlignmentLayer } from 'map/layers/alignment/location-track-alignment-layer';
 import { createReferenceLineAlignmentLayer } from 'map/layers/alignment/reference-line-alignment-layer';
@@ -111,7 +111,7 @@ const defaultScaleLine: ScaleLine = new ScaleLine({
 
 function getOlViewByDomainViewport(viewport: MapViewport): OlView {
     return new OlView({
-        center: [viewport.center?.x ?? 0, viewport.center?.y ?? 0],
+        center: [viewport.center?.x ?? HELSINKI_COORDS.x, viewport.center?.y ?? HELSINKI_COORDS.y],
         resolution: viewport.resolution,
         maxZoom: 32,
         minZoom: 6,
@@ -172,7 +172,7 @@ const MapView: React.FC<MapViewProps> = ({
     const mapLayers = [...map.visibleLayers].sort().join();
 
     const handleClusterPointClick = (clickType: ClickType) => {
-        const clusterPoint = selection.selectedItems.clusterPoints[0];
+        const clusterPoint = first(selection.selectedItems.clusterPoints);
         if (clusterPoint) {
             switch (clickType) {
                 case 'all':
@@ -248,11 +248,10 @@ const MapView: React.FC<MapViewProps> = ({
         };
     }, [olMap]);
 
+    const firstClusterPoint = first(selection.selectedItems.clusterPoints);
     React.useEffect(() => {
-        const clusterPoint = selection.selectedItems.clusterPoints[0];
-
-        if (!olMap || !clusterPoint) return;
-        const pos = pointToCoords(clusterPoint);
+        if (!olMap || !firstClusterPoint) return;
+        const pos = pointToCoords(firstClusterPoint);
         const popupElement = document.getElementById('clusteroverlay') || undefined;
         const popup = new Overlay({
             position: pos,
@@ -260,7 +259,7 @@ const MapView: React.FC<MapViewProps> = ({
             element: popupElement,
         });
         olMap.addOverlay(popup);
-    }, [olMap, selection.selectedItems.clusterPoints[0]]);
+    }, [olMap, firstClusterPoint]);
 
     // Update the view"port" of the map
     React.useEffect(() => {
@@ -641,7 +640,7 @@ const MapView: React.FC<MapViewProps> = ({
             />
 
             <div id="clusteroverlay">
-                {selection.selectedItems.clusterPoints[0] && (
+                {first(selection.selectedItems.clusterPoints) && (
                     <div className={styles['map__popup-menu']}>
                         <div
                             className={styles['map__popup-item']}

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -10,7 +10,12 @@ import { defaults as defaultInteractions } from 'ol/interaction';
 import DragPan from 'ol/interaction/DragPan.js';
 import 'ol/ol.css';
 import OlView from 'ol/View';
-import { HELSINKI_COORDS, Map, MapViewport, OptionalShownItems } from 'map/map-model';
+import {
+    HELSINKI_RAILWAY_STATION_COORDS,
+    Map,
+    MapViewport,
+    OptionalShownItems,
+} from 'map/map-model';
 import { createSwitchLinkingLayer } from './layers/switch/switch-linking-layer';
 import styles from './map.module.scss';
 import { selectTool } from './tools/select-tool';
@@ -111,7 +116,10 @@ const defaultScaleLine: ScaleLine = new ScaleLine({
 
 function getOlViewByDomainViewport(viewport: MapViewport): OlView {
     return new OlView({
-        center: [viewport.center?.x ?? HELSINKI_COORDS.x, viewport.center?.y ?? HELSINKI_COORDS.y],
+        center: [
+            viewport.center?.x ?? HELSINKI_RAILWAY_STATION_COORDS.x,
+            viewport.center?.y ?? HELSINKI_RAILWAY_STATION_COORDS.y,
+        ],
         resolution: viewport.resolution,
         maxZoom: 32,
         minZoom: 6,

--- a/ui/src/map/tools/measurement-tool.ts
+++ b/ui/src/map/tools/measurement-tool.ts
@@ -9,7 +9,7 @@ import CircleStyle from 'ol/style/Circle';
 import { LineString } from 'ol/geom';
 import { Coordinate } from 'ol/coordinate';
 import { getPlanarDistanceUnwrapped, pointToCoords } from 'map/layers/utils/layer-utils';
-import { filterNotEmpty, head, last } from 'utils/array-utils';
+import { filterNotEmpty, first, last } from 'utils/array-utils';
 import { AlignmentPoint } from 'track-layout/track-layout-model';
 import { ALIGNMENT_FEATURE_DATA_PROPERTY } from 'map/layers/utils/alignment-layer-utils';
 import { AlignmentDataHolder } from 'track-layout/layout-map-api';
@@ -31,7 +31,7 @@ function findClosestPoints(
     points: AlignmentPoint[],
     targetCoordinate: Coordinate,
 ): AlignmentPoint[] {
-    const firstPoint = head(points);
+    const firstPoint = first(points);
     const lastPoint = last(points);
     if (!firstPoint || !lastPoint || points.length <= MAX_POINTS) {
         return points;

--- a/ui/src/preview/calculated-changes-view.tsx
+++ b/ui/src/preview/calculated-changes-view.tsx
@@ -14,7 +14,6 @@ import { getTrackNumbers } from 'track-layout/layout-track-number-api';
 import { getLocationTracks } from 'track-layout/layout-location-track-api';
 import { getSwitches } from 'track-layout/layout-switch-api';
 import { CalculatedChanges } from 'publication/publication-model';
-import { getUnsafe } from 'utils/type-utils';
 
 const calculatedChangesIsEmpty = (calculatedChanges: GroupedCalculatedChanges) => {
     return calculatedChanges.switches.length == 0 && calculatedChanges.locationTracks.length == 0;
@@ -143,7 +142,7 @@ export const CalculatedChangesView: React.FC<CalculatedChangesProps> = ({
                                 disabled: disabledMessage,
                             })}
                             onToggle={() => toggle(trackNumberId)}
-                            open={getUnsafe(openTrackNumbers[trackNumberId])}
+                            open={openTrackNumbers[trackNumberId] ?? false}
                             disabled={!hasCalculatedChanges}>
                             <React.Fragment>
                                 <ul

--- a/ui/src/publication/card/publication-card.tsx
+++ b/ui/src/publication/card/publication-card.tsx
@@ -23,6 +23,7 @@ import {
     ProgressIndicatorType,
     ProgressIndicatorWrapper,
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
+import { first } from 'utils/array-utils';
 
 type PublishListProps = {
     publicationChangeTime: TimeStamp;
@@ -108,9 +109,9 @@ const PublicationCard: React.FC<PublishListProps> = ({
         ratkoPushSucceeded(publication.ratkoPushStatus),
     );
 
-    const latestFailure = allPublications.filter((publication) =>
-        ratkoPushFailed(publication.ratkoPushStatus),
-    )?.[0];
+    const latestFailure = first(
+        allPublications.filter((publication) => ratkoPushFailed(publication.ratkoPushStatus)),
+    );
 
     const ratkoConnectionError =
         ratkoStatus && !ratkoStatus.isOnline && ratkoStatus.statusCode >= 300;

--- a/ui/src/publication/table/publication-table-row.tsx
+++ b/ui/src/publication/table/publication-table-row.tsx
@@ -8,6 +8,7 @@ import { createClassName } from 'vayla-design-lib/utils';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { AccordionToggle } from 'vayla-design-lib/accordion-toggle/accordion-toggle';
 import { PublicationTableDetails } from 'publication/table/publication-table-details';
+import { first } from 'utils/array-utils';
 
 type PublicationTableRowProps = {
     propChanges: PublicationChange[];
@@ -75,7 +76,7 @@ export const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
                         onClick={() => setMessageExpanded(!messageExpanded)}
                     />
                     <div className={contentClassNames}>
-                        {messageExpanded ? message : messageRows[0]}
+                        {messageExpanded ? message : first(messageRows)}
                     </div>
                 </td>
                 <td>{ratkoPushTime ? formatDateFull(ratkoPushTime) : t('no')}</td>

--- a/ui/src/selection-panel/track-number-panel/color-selector/color-selector-utils.ts
+++ b/ui/src/selection-panel/track-number-panel/color-selector/color-selector-utils.ts
@@ -1,5 +1,5 @@
 import { LayoutTrackNumberId } from 'track-layout/track-layout-model';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 export type TrackNumberColorKey = keyof typeof TrackNumberColor;
 export enum TrackNumberColor {
@@ -26,5 +26,5 @@ export const getColors = () => {
 
 export const getDefaultColorKey = (id: LayoutTrackNumberId): TrackNumberColorKey => {
     const colors = getColors();
-    return getUnsafe(colors[parseInt(id.replace(/^\D+/g, '')) % colors.length])[0];
+    return expectDefined(colors[parseInt(id.replace(/^\D+/g, '')) % colors.length])[0];
 };

--- a/ui/src/tool-panel/km-post/geometry-km-post-infobox-linking-container.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-infobox-linking-container.tsx
@@ -8,6 +8,7 @@ import GeometryKmPostLinkingInfobox from 'tool-panel/km-post/geometry-km-post-li
 import { GeometryPlanId } from 'geometry/geometry-model';
 import { LinkingType } from 'linking/linking-model';
 import { MapLayerName } from 'map/map-model';
+import { first } from 'utils/array-utils';
 
 type GeometryKmPostLinkingContainerProps = {
     geometryKmPost: LayoutKmPost;
@@ -26,7 +27,7 @@ const GeometryKmPostLinkingContainer: React.FC<GeometryKmPostLinkingContainerPro
     const state = useTrackLayoutAppSelector((state) => state);
     const kmPostChangeTime = useCommonDataAppSelector((state) => state.changeTimes.layoutKmPost);
     const selectedLayoutKmPost = useKmPost(
-        state.selection.selectedItems.kmPosts[0],
+        first(state.selection.selectedItems.kmPosts),
         state.publishType,
         kmPostChangeTime,
     );

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -70,7 +70,6 @@ import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track
 import { EnvRestricted } from 'environment/env-restricted';
 import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
 import { filterNotEmpty } from 'utils/array-utils';
-import { getUnsafe } from 'utils/type-utils';
 
 type LocationTrackInfoboxProps = {
     locationTrack: LayoutLocationTrack;
@@ -134,7 +133,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     const description = useLoader(
         () =>
             getLocationTrackDescriptions([locationTrack.id], publishType).then(
-                (value) => (value && getUnsafe(value[0]).description) ?? undefined,
+                (value) => value?.[0]?.description ?? undefined,
             ),
         [locationTrack?.id, publishType, locationTrackChangeTime],
     );

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -40,6 +40,7 @@ import { useLoader } from 'utils/react-utils';
 import { Link } from 'vayla-design-lib/link/link';
 import { getSaveDisabledReasons } from 'track-layout/track-layout-react-utils';
 import SwitchDeleteConfirmationDialog from './switch-delete-confirmation-dialog';
+import { first } from 'utils/array-utils';
 
 const SWITCH_NAME_REGEX = /^[A-ZÄÖÅa-zäöå0-9 \-_/]+$/g;
 
@@ -156,7 +157,7 @@ export const SwitchEditDialog = ({
             setSwitchOwnerId(existingSwitch.ownerId ?? undefined);
         } else if (switchOwners.length > 0) {
             const vayla = switchOwners.find((o) => o.name === 'Väylävirasto');
-            setSwitchOwnerId(vayla ? vayla.id : switchOwners[0]?.id);
+            setSwitchOwnerId(vayla ? vayla.id : first(switchOwners)?.id);
         }
     }, [switchOwners, existingSwitch]);
 

--- a/ui/src/tool-panel/switch/geometry-switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-infobox.tsx
@@ -20,6 +20,7 @@ import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/butto
 import { Point } from 'model/geometry';
 import { getSwitchStructure } from 'common/common-api';
 import { GeometrySwitchInfoboxVisibilities } from 'track-layout/track-layout-slice';
+import { first } from 'utils/array-utils';
 
 type GeometrySwitchInfoboxProps = {
     switchId?: GeometrySwitchId;
@@ -62,7 +63,7 @@ const GeometrySwitchInfobox: React.FC<GeometrySwitchInfoboxProps> = ({
                 : undefined,
         [switchItem],
     );
-    const switchLocation = geometrySwitchLayout && geometrySwitchLayout.joints[0]?.location;
+    const switchLocation = geometrySwitchLayout && first(geometrySwitchLayout.joints)?.location;
 
     const SwitchImage =
         switchStructure && makeSwitchImage(switchStructure.baseType, switchStructure.hand);

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -7,6 +7,7 @@ import { LinkingType, SuggestedSwitch } from 'linking/linking-model';
 import { LayoutSwitch, LocationTrackId } from 'track-layout/track-layout-model';
 import { getSuggestedSwitchByPoint } from 'linking/linking-api';
 import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
+import { first } from 'utils/array-utils';
 
 type ToolPanelContainerProps = {
     setHoveredOverItem: (item: HighlightedAlignment | undefined) => void;
@@ -48,7 +49,7 @@ const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({ setHoveredOverI
                 (suggestedSwitches) => {
                     delegates.stopLinking();
 
-                    const suggestedSwitch = suggestedSwitches[0];
+                    const suggestedSwitch = first(suggestedSwitches);
                     if (suggestedSwitch) {
                         startSwitchLinking(suggestedSwitch, linkingState.layoutSwitch);
                     } else {

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -27,7 +27,7 @@ import {
 import { BoundingBox, Point } from 'model/geometry';
 import GeometryAlignmentLinkingContainer from 'tool-panel/geometry-alignment/geometry-alignment-linking-container';
 import { PublishType } from 'common/common-model';
-import { filterNotEmpty, filterUnique } from 'utils/array-utils';
+import { filterNotEmpty, filterUnique, first } from 'utils/array-utils';
 import LocationTrackInfoboxLinkingContainer from 'tool-panel/location-track/location-track-infobox-linking-container';
 import { getKmPosts } from 'track-layout/layout-km-post-api';
 import TrackNumberInfoboxLinkingContainer from 'tool-panel/track-number/track-number-infobox-linking-container';
@@ -350,7 +350,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                             infoboxVisibilityChange('geometrySwitch', visibilities)
                         }
                         switchId={ss.geometrySwitchId ?? undefined}
-                        layoutSwitch={switches ? switches[0] : undefined}
+                        layoutSwitch={switches ? first(switches) : undefined}
                         suggestedSwitch={ss}
                         linkingState={linkingState}
                         planId={ss.geometryPlanId ?? undefined}
@@ -377,7 +377,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                                 infoboxVisibilityChange('geometrySwitch', visibilities)
                             }
                             switchId={s.geometryId}
-                            layoutSwitch={switches ? switches[0] : undefined}
+                            layoutSwitch={switches ? first(switches) : undefined}
                             suggestedSwitch={undefined}
                             linkingState={linkingState}
                             planId={s.planId ?? undefined}
@@ -431,8 +431,8 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                             infoboxVisibilityChange('geometryAlignment', visibilities)
                         }
                         geometryAlignment={header}
-                        selectedLocationTrackId={locationTrackIds[0]}
-                        selectedTrackNumberId={trackNumberIds[0]}
+                        selectedLocationTrackId={first(locationTrackIds)}
+                        selectedTrackNumberId={first(trackNumberIds)}
                         planId={aId.planId}
                         linkingState={linkingState}
                         publishType={publishType}
@@ -481,7 +481,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             (t) => !previousTabs.some((pt) => isSameAsset(t.asset, pt.asset)),
         );
 
-        const firstTab = newTabs[0];
+        const firstTab = first(newTabs);
         if (firstTab) {
             if (selectedAsset && newTabs.some((nt) => isSameAsset(nt.asset, selectedAsset))) {
                 changeTab(selectedAsset);
@@ -561,7 +561,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             )}
             {anyTabSelected
                 ? tabs.find((t) => isSameAsset(t.asset, selectedAsset))?.element
-                : tabs[0]?.element}
+                : first(tabs)?.element}
         </div>
     );
 };

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -24,12 +24,11 @@ import { getTrackLayoutPlan } from 'geometry/geometry-api';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
 import { createLinkPoints, alignmentPointToLinkPoint } from 'linking/linking-store';
-import { deduplicate, filterNotEmpty, indexIntoMap, partitionBy } from 'utils/array-utils';
+import { deduplicate, filterNotEmpty, indexIntoMap, last, partitionBy } from 'utils/array-utils';
 import { getMaxTimestamp } from 'utils/date-utils';
 import { getTrackNumbers } from './layout-track-number-api';
 import { directionBetweenPoints } from 'utils/math-utils';
 import { ChangeTimes } from 'common/common-slice';
-import { getUnsafe } from 'utils/type-utils';
 
 export type AlignmentDataHolder = {
     trackNumber?: LayoutTrackNumber;
@@ -356,13 +355,10 @@ export async function getLinkPointsByTiles(
         .flat()
         .filter((a) => a.alignmentType === alignmentType && a.id === alignmentId);
     const allPoints = combineAlignmentPoints(allPieces.map((a) => a.points));
-    return createLinkPoints(
-        alignmentType,
-        alignmentId,
-        getUnsafe(segmentEndMs[segmentEndMs.length - 1]),
-        segmentEndMs,
-        allPoints,
-    );
+    const lastSegmentEndM = last(segmentEndMs);
+    return lastSegmentEndM
+        ? createLinkPoints(alignmentType, alignmentId, lastSegmentEndM, segmentEndMs, allPoints)
+        : [];
 }
 
 export async function getGeometryLinkPointsByTiles(

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -24,7 +24,14 @@ import { getTrackLayoutPlan } from 'geometry/geometry-api';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
 import { createLinkPoints, alignmentPointToLinkPoint } from 'linking/linking-store';
-import { deduplicate, filterNotEmpty, indexIntoMap, last, partitionBy } from 'utils/array-utils';
+import {
+    deduplicate,
+    filterNotEmpty,
+    first,
+    indexIntoMap,
+    last,
+    partitionBy,
+} from 'utils/array-utils';
 import { getMaxTimestamp } from 'utils/date-utils';
 import { getTrackNumbers } from './layout-track-number-api';
 import { directionBetweenPoints } from 'utils/math-utils';
@@ -368,9 +375,10 @@ export async function getGeometryLinkPointsByTiles(
     alwaysIncludePoints: LinkPoint[] = [],
     changeTime: TimeStamp = getChangeTimes().geometryPlan,
 ): Promise<LinkPoint[]> {
-    if (!mapTiles[0]) return [];
+    const firstMapTile = first(mapTiles);
+    if (!firstMapTile) return [];
 
-    const resolution = toMapAlignmentResolution(mapTiles[0].resolution);
+    const resolution = toMapAlignmentResolution(firstMapTile.resolution);
     const bounds = combineBoundingBoxes(mapTiles.map((tile) => tile.area));
     const plan = await getTrackLayoutPlan(geometryPlanId, changeTime, true);
     const alignment = plan?.alignments?.find((a) => a.header.id === geometryAlignmentId);

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -20,7 +20,7 @@ import { asyncCache } from 'cache/cache';
 import { MapTile } from 'map/map-model';
 import { Result } from 'neverthrow';
 import { TrackLayoutSaveError, TrackLayoutSwitchSaveRequest } from 'linking/linking-model';
-import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
+import { filterNotEmpty, head, indexIntoMap } from 'utils/array-utils';
 import { ValidatedAsset } from 'publication/publication-model';
 import { getUnsafe } from 'utils/type-utils';
 
@@ -151,7 +151,7 @@ export const getSwitchValidation = async (
     publishType: PublishType,
     id: LayoutSwitchId,
 ): Promise<ValidatedAsset> =>
-    getSwitchesValidation(publishType, [id]).then((switches) => getUnsafe(switches[0]));
+    getSwitchesValidation(publishType, [id]).then((switches) => getUnsafe(head(switches)));
 
 export const getSwitchesValidation = async (publishType: PublishType, ids: LayoutSwitchId[]) => {
     const changeTimes = getChangeTimes();

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -20,7 +20,7 @@ import { asyncCache } from 'cache/cache';
 import { MapTile } from 'map/map-model';
 import { Result } from 'neverthrow';
 import { TrackLayoutSaveError, TrackLayoutSwitchSaveRequest } from 'linking/linking-model';
-import { filterNotEmpty, head, indexIntoMap } from 'utils/array-utils';
+import { filterNotEmpty, first, indexIntoMap } from 'utils/array-utils';
 import { ValidatedAsset } from 'publication/publication-model';
 import { getUnsafe } from 'utils/type-utils';
 
@@ -151,7 +151,7 @@ export const getSwitchValidation = async (
     publishType: PublishType,
     id: LayoutSwitchId,
 ): Promise<ValidatedAsset> =>
-    getSwitchesValidation(publishType, [id]).then((switches) => getUnsafe(head(switches)));
+    getSwitchesValidation(publishType, [id]).then((switches) => getUnsafe(first(switches)));
 
 export const getSwitchesValidation = async (publishType: PublishType, ids: LayoutSwitchId[]) => {
     const changeTimes = getChangeTimes();

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -22,7 +22,7 @@ import { Result } from 'neverthrow';
 import { TrackLayoutSaveError, TrackLayoutSwitchSaveRequest } from 'linking/linking-model';
 import { filterNotEmpty, first, indexIntoMap } from 'utils/array-utils';
 import { ValidatedAsset } from 'publication/publication-model';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 const switchCache = asyncCache<string, LayoutSwitch | undefined>();
 const switchGroupsCache = asyncCache<string, LayoutSwitch[]>();
@@ -151,7 +151,7 @@ export const getSwitchValidation = async (
     publishType: PublishType,
     id: LayoutSwitchId,
 ): Promise<ValidatedAsset> =>
-    getSwitchesValidation(publishType, [id]).then((switches) => getUnsafe(first(switches)));
+    getSwitchesValidation(publishType, [id]).then((switches) => expectDefined(first(switches)));
 
 export const getSwitchesValidation = async (publishType: PublishType, ids: LayoutSwitchId[]) => {
     const changeTimes = getChangeTimes();

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -28,7 +28,7 @@ import {
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import { Point } from 'model/geometry';
-import { addIfExists } from 'utils/array-utils';
+import { addIfExists, first } from 'utils/array-utils';
 import { PublishRequestIds } from 'publication/publication-model';
 import { ToolPanelAsset } from 'tool-panel/tool-panel';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
@@ -350,7 +350,7 @@ const trackLayoutSlice = createSlice({
                     }
                     break;
                 case LinkingType.LinkingSwitch: {
-                    const selectedSwitch = state.selection.selectedItems.switches[0];
+                    const selectedSwitch = first(state.selection.selectedItems.switches);
                     linkingReducers.lockSwitchSelection(state, {
                         type: '',
                         payload: selectedSwitch,

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -1,5 +1,5 @@
 import { TimeStamp } from 'common/common-model';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 export const first = <T>(arr: readonly T[]) => arr[0];
 export const last = <T>(arr: readonly T[]) => arr[arr.length - 1];
@@ -240,7 +240,7 @@ export function minimumIndexBy<T, B>(objs: readonly T[], by: (obj: T) => B): num
     let min = first(values);
     let minIndex = 0;
     values.forEach((value, index) => {
-        if (value < getUnsafe(min)) {
+        if (value < expectDefined(min)) {
             min = value;
             minIndex = index;
         }

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -1,8 +1,8 @@
 import { TimeStamp } from 'common/common-model';
 import { getUnsafe } from 'utils/type-utils';
 
-export const head = <T>(arr: T[]) => arr[0];
-export const last = <T>(arr: T[]) => arr[arr.length - 1];
+export const first = <T>(arr: readonly T[]) => arr[0];
+export const last = <T>(arr: readonly T[]) => arr[arr.length - 1];
 
 export function nonEmptyArray<T>(...values: Array<T | undefined>): T[] {
     return values.filter(filterNotEmpty);
@@ -237,7 +237,7 @@ export function minimumIndexBy<T, B>(objs: readonly T[], by: (obj: T) => B): num
         return undefined;
     }
     const values = objs.map((obj) => by(obj));
-    let min = head(values);
+    let min = first(values);
     let minIndex = 0;
     values.forEach((value, index) => {
         if (value < getUnsafe(min)) {
@@ -259,10 +259,8 @@ export function partitionBy<T>(list: T[], by: (item: T) => boolean): [T[], T[]] 
 }
 
 export function findLastIndex<T, B>(objs: readonly T[], predicate: (obj: T) => B): number {
-    for (let i = objs.length - 1; i >= 0; i--) {
-        if (predicate(getUnsafe(objs[i]))) return i;
-    }
-    return -1;
+    const reverseIndex = [...objs].reverse().findIndex(predicate);
+    return reverseIndex >= 0 ? objs.length - 1 - reverseIndex : -1;
 }
 
 export const findById = <T extends { id: string }>(objs: T[], id: string): T | undefined =>

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -1,6 +1,9 @@
 import { TimeStamp } from 'common/common-model';
 import { getUnsafe } from 'utils/type-utils';
 
+export const head = <T>(arr: T[]) => arr[0];
+export const last = <T>(arr: T[]) => arr[arr.length - 1];
+
 export function nonEmptyArray<T>(...values: Array<T | undefined>): T[] {
     return values.filter(filterNotEmpty);
 }
@@ -234,14 +237,14 @@ export function minimumIndexBy<T, B>(objs: readonly T[], by: (obj: T) => B): num
         return undefined;
     }
     const values = objs.map((obj) => by(obj));
-    let min = getUnsafe(values[0]);
+    let min = head(values);
     let minIndex = 0;
-    for (let i = 1; i < values.length; i++) {
-        if (getUnsafe(values[i]) < min) {
-            min = getUnsafe(values[i]);
-            minIndex = i;
+    values.forEach((value, index) => {
+        if (value < getUnsafe(min)) {
+            min = value;
+            minIndex = index;
         }
-    }
+    });
     return minIndex;
 }
 

--- a/ui/src/utils/file-utils.ts
+++ b/ui/src/utils/file-utils.ts
@@ -24,7 +24,7 @@ export function convertToSerializableFile(file: File): Promise<SerializableFile>
 export function convertToNativeFile(serializableFile: SerializableFile): File {
     const dataUrl = serializableFile.dataUrl;
     const arr = dataUrl.split(','),
-        mimeMatch = getUnsafe(arr[0]).match(/:(.*?);/),
+        mimeMatch = arr[0]?.match(/:(.*?);/),
         mime = mimeMatch && mimeMatch[1],
         bstr = atob(getUnsafe(arr[1]));
     if (!mime) {

--- a/ui/src/utils/file-utils.ts
+++ b/ui/src/utils/file-utils.ts
@@ -1,4 +1,4 @@
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 export type SerializableFile = {
     name: string;
@@ -26,7 +26,7 @@ export function convertToNativeFile(serializableFile: SerializableFile): File {
     const arr = dataUrl.split(','),
         mimeMatch = arr[0]?.match(/:(.*?);/),
         mime = mimeMatch && mimeMatch[1],
-        bstr = atob(getUnsafe(arr[1]));
+        bstr = atob(expectDefined(arr[1]));
     if (!mime) {
         throw new Error('Invalid data URL');
     }

--- a/ui/src/utils/math-utils.ts
+++ b/ui/src/utils/math-utils.ts
@@ -1,6 +1,7 @@
 import { Point } from 'model/geometry';
 import { AlignmentPoint } from 'track-layout/track-layout-model';
 import { getUnsafe } from 'utils/type-utils';
+import { head, last } from 'utils/array-utils';
 
 export function directionBetweenPoints(p1: Point, p2: Point): number {
     return Math.atan2(p2.y - p1.y, p2.x - p1.x);
@@ -53,21 +54,23 @@ export function findOrInterpolateXY(
 ): SeekResult | undefined {
     if (points.length < 2) return undefined;
 
-    const lastIndex = points.length - 1;
-    const first = getUnsafe(points[0]);
-    const last = getUnsafe(points[lastIndex]);
-    if (first.m >= mValue)
+    const first = head(points);
+    if (first && first.m >= mValue)
         return {
             low: 0,
             high: 0,
             point: [first.x, first.y],
         };
-    if (last.m <= mValue)
+
+    const lastIndex = points.length - 1;
+    const lastPoint = last(points);
+    if (lastPoint && lastPoint.m <= mValue)
         return {
             low: lastIndex,
             high: lastIndex,
-            point: [last.x, last.y],
+            point: [lastPoint.x, lastPoint.y],
         };
+
     let low = 0;
     let high = lastIndex;
     while (low < high - 1) {
@@ -82,6 +85,7 @@ export function findOrInterpolateXY(
                 point: [mid.x, mid.y],
             };
     }
+
     return {
         low: low,
         high: high,

--- a/ui/src/utils/math-utils.ts
+++ b/ui/src/utils/math-utils.ts
@@ -1,6 +1,6 @@
 import { Point } from 'model/geometry';
 import { AlignmentPoint } from 'track-layout/track-layout-model';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 import { first, last } from 'utils/array-utils';
 
 export function directionBetweenPoints(p1: Point, p2: Point): number {
@@ -75,7 +75,7 @@ export function findOrInterpolateXY(
     let high = lastIndex;
     while (low < high - 1) {
         const midIndex = Math.floor((low + high) / 2);
-        const mid = getUnsafe(points[midIndex]);
+        const mid = expectDefined(points[midIndex]);
         if (mid.m > mValue) high = midIndex;
         else if (mid.m < mValue) low = midIndex;
         else
@@ -89,7 +89,7 @@ export function findOrInterpolateXY(
     return {
         low: low,
         high: high,
-        point: interpolateXY(getUnsafe(points[low]), getUnsafe(points[high]), mValue),
+        point: interpolateXY(expectDefined(points[low]), expectDefined(points[high]), mValue),
     };
 }
 

--- a/ui/src/utils/math-utils.ts
+++ b/ui/src/utils/math-utils.ts
@@ -1,7 +1,7 @@
 import { Point } from 'model/geometry';
 import { AlignmentPoint } from 'track-layout/track-layout-model';
 import { getUnsafe } from 'utils/type-utils';
-import { head, last } from 'utils/array-utils';
+import { first, last } from 'utils/array-utils';
 
 export function directionBetweenPoints(p1: Point, p2: Point): number {
     return Math.atan2(p2.y - p1.y, p2.x - p1.x);
@@ -54,12 +54,12 @@ export function findOrInterpolateXY(
 ): SeekResult | undefined {
     if (points.length < 2) return undefined;
 
-    const first = head(points);
-    if (first && first.m >= mValue)
+    const firstPoint = first(points);
+    if (firstPoint && firstPoint.m >= mValue)
         return {
             low: 0,
             high: 0,
-            point: [first.x, first.y],
+            point: [firstPoint.x, firstPoint.y],
         };
 
     const lastIndex = points.length - 1;

--- a/ui/src/utils/type-utils.ts
+++ b/ui/src/utils/type-utils.ts
@@ -47,7 +47,7 @@ export const exhaustiveMatchingGuard = (_: never): never => {
 export const isNil = <T>(object: T | undefined | null) => object === undefined || object === null;
 
 // Prefer actual nil checks, only use this if you KNOW the index exists
-export const getUnsafe = <T>(thing: T): NonNullable<T> => {
+export const expectDefined = <T>(thing: T): NonNullable<T> => {
     if (!isNil(thing)) {
         return thing!;
     } else {
@@ -56,6 +56,6 @@ export const getUnsafe = <T>(thing: T): NonNullable<T> => {
 };
 
 export const getCoordsUnsafe = (coord: Coordinate): [number, number] => [
-    getUnsafe(coord[0]),
-    getUnsafe(coord[1]),
+    expectDefined(coord[0]),
+    expectDefined(coord[1]),
 ];

--- a/ui/src/utils/type-utils.ts
+++ b/ui/src/utils/type-utils.ts
@@ -44,7 +44,7 @@ export const exhaustiveMatchingGuard = (_: never): never => {
     throw new Error('Should not have reached this code');
 };
 
-export const isNil = <T>(object: T) => object === undefined || object === null;
+export const isNil = <T>(object: T | undefined | null) => object === undefined || object === null;
 
 // Prefer actual nil checks, only use this if you KNOW the index exists
 export const getUnsafe = <T>(thing: T): NonNullable<T> => {

--- a/ui/src/utils/type-utils.ts
+++ b/ui/src/utils/type-utils.ts
@@ -51,7 +51,7 @@ export const getUnsafe = <T>(thing: T): NonNullable<T> => {
     if (!isNil(thing)) {
         return thing!;
     } else {
-        throw Error('We can has nil!');
+        throw Error('Encountered an unexpected nil!');
     }
 };
 

--- a/ui/src/vayla-design-lib/demo/examples/file-input-examples.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/file-input-examples.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { FileInput } from 'vayla-design-lib/file-input/file-input';
 import { Button } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
-import { getUnsafe } from 'utils/type-utils';
 
 export const FileInputExamples: React.FC = () => {
     return (
@@ -12,7 +11,7 @@ export const FileInputExamples: React.FC = () => {
             <h3>Text as a visualization</h3>
             <FileInput
                 onChange={(e) =>
-                    alert(e.target.files ? getUnsafe(e.target.files[0]).name : 'no file chosen')
+                    alert(e.target.files?.[0] ? e.target.files[0].name : 'no file chosen')
                 }>
                 Upload
             </FileInput>
@@ -20,7 +19,7 @@ export const FileInputExamples: React.FC = () => {
             <h3>Button as a visualization</h3>
             <FileInput
                 onChange={(e) =>
-                    alert(e.target.files ? getUnsafe(e.target.files[0]).name : 'no file chosen')
+                    alert(e.target.files?.[0] ? e.target.files[0].name : 'no file chosen')
                 }>
                 <Button icon={Icons.Download}>Upload a file</Button>
             </FileInput>

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -5,7 +5,7 @@ import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { CloseableModal } from 'vayla-design-lib/closeable-modal/closeable-modal';
 import { useImmediateLoader } from 'utils/react-utils';
-import { getUnsafe } from 'utils/type-utils';
+import { head } from 'utils/array-utils';
 
 export enum DropdownSize {
     SMALL = 'dropdown--small',
@@ -73,7 +73,7 @@ export const Dropdown = function <TItemValue>({
     const { isLoading, load: loadOptions } = useImmediateLoader((options: Item<TItemValue>[]) => {
         const activeOptions = options.filter((option) => !option.disabled);
         if (earlySelect.current && activeOptions.length === 1) {
-            select(getUnsafe(activeOptions[0]).value);
+            select(head(activeOptions)?.value);
         } else {
             setLoadedOptions(options);
         }

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -5,7 +5,7 @@ import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { CloseableModal } from 'vayla-design-lib/closeable-modal/closeable-modal';
 import { useImmediateLoader } from 'utils/react-utils';
-import { head } from 'utils/array-utils';
+import { first } from 'utils/array-utils';
 
 export enum DropdownSize {
     SMALL = 'dropdown--small',
@@ -73,7 +73,7 @@ export const Dropdown = function <TItemValue>({
     const { isLoading, load: loadOptions } = useImmediateLoader((options: Item<TItemValue>[]) => {
         const activeOptions = options.filter((option) => !option.disabled);
         if (earlySelect.current && activeOptions.length === 1) {
-            select(head(activeOptions)?.value);
+            select(first(activeOptions)?.value);
         } else {
             setLoadedOptions(options);
         }

--- a/ui/src/vayla-design-lib/icon/Icon.tsx
+++ b/ui/src/vayla-design-lib/icon/Icon.tsx
@@ -39,7 +39,6 @@ import menuSvg from './glyphs/navigation/menu.svg';
 import positionPinSvg from './glyphs/misc/position-pin.svg';
 import styles from './icon.scss';
 import { createClassName } from 'vayla-design-lib/utils';
-import { getUnsafe } from 'utils/type-utils';
 
 /**
  *
@@ -198,14 +197,18 @@ const SvgIcon: SvgIconComponent = ({
 
 function parseViewBox(svg: string): string {
     const viewBoxMatch = /viewBox="([\s0-9]+)"/.exec(svg);
-    return viewBoxMatch && viewBoxMatch.length >= 2 ? getUnsafe(viewBoxMatch[1]) : '0 0 24 24';
+    const viewBox = viewBoxMatch && viewBoxMatch[1];
+    return viewBox ? viewBox : '0 0 24 24';
 }
 
 function parseSize(svg: string): number[] | undefined {
     const heightMatch = /height="([0-9]+)"/.exec(svg);
     const widthMatch = /width="([0-9]+)"/.exec(svg);
-    if (heightMatch && heightMatch.length >= 2 && widthMatch && widthMatch.length >= 2) {
-        return [parseInt(getUnsafe(widthMatch[1])), parseInt(getUnsafe(heightMatch[1]))];
+
+    const height = heightMatch && heightMatch[1];
+    const width = widthMatch && widthMatch[1];
+    if (height && width) {
+        return [parseInt(width, 10), parseInt(height, 10)];
     } else {
         return undefined;
     }

--- a/ui/src/vertical-geometry/km-heights-fetch.ts
+++ b/ui/src/vertical-geometry/km-heights-fetch.ts
@@ -10,6 +10,7 @@ import { getMaxTimestamp, toDate } from 'utils/date-utils';
 import { VerticalGeometryDiagramAlignmentId } from 'vertical-geometry/store';
 import { TimeStamp } from 'common/common-model';
 import { getUnsafe } from 'utils/type-utils';
+import { head } from 'utils/array-utils';
 
 type HeightCacheKey = string;
 type HeightCacheItem = {
@@ -167,7 +168,7 @@ function getQueryableRange(
     endM: number,
 ): [number, number] | undefined {
     return getMissingCoveringRange(
-        resolved.map((r) => [getUnsafe(r.trackMeterHeights[0]).m, r.endM]),
+        resolved.map((r) => [getUnsafe(head(r.trackMeterHeights)).m, r.endM]),
         startM,
         endM,
     );

--- a/ui/src/vertical-geometry/km-heights-fetch.ts
+++ b/ui/src/vertical-geometry/km-heights-fetch.ts
@@ -10,7 +10,7 @@ import { getMaxTimestamp, toDate } from 'utils/date-utils';
 import { VerticalGeometryDiagramAlignmentId } from 'vertical-geometry/store';
 import { TimeStamp } from 'common/common-model';
 import { getUnsafe } from 'utils/type-utils';
-import { head } from 'utils/array-utils';
+import { first } from 'utils/array-utils';
 
 type HeightCacheKey = string;
 type HeightCacheItem = {
@@ -168,7 +168,7 @@ function getQueryableRange(
     endM: number,
 ): [number, number] | undefined {
     return getMissingCoveringRange(
-        resolved.map((r) => [getUnsafe(head(r.trackMeterHeights)).m, r.endM]),
+        resolved.map((r) => [getUnsafe(first(r.trackMeterHeights)).m, r.endM]),
         startM,
         endM,
     );
@@ -195,7 +195,7 @@ export function useAlignmentHeights(
         if (cacheItem) {
             setLoadedHeights(
                 cacheItem.resolved.filter(
-                    (item) => getUnsafe(item.trackMeterHeights[0]).m <= eM && item.endM >= sM,
+                    (item) => getUnsafe(first(item.trackMeterHeights)).m <= eM && item.endM >= sM,
                 ),
             );
         }
@@ -231,7 +231,7 @@ export function useAlignmentHeights(
                 );
 
                 loadedCacheItem.resolved = weaveKms(
-                    (kms) => getUnsafe(kms.trackMeterHeights[0]).m,
+                    (kms) => getUnsafe(first(kms.trackMeterHeights)).m,
                     loadedCacheItem.resolved,
                     loadedKms,
                 );

--- a/ui/src/vertical-geometry/km-heights-fetch.ts
+++ b/ui/src/vertical-geometry/km-heights-fetch.ts
@@ -9,7 +9,7 @@ import { ChangeTimes } from 'common/common-slice';
 import { getMaxTimestamp, toDate } from 'utils/date-utils';
 import { VerticalGeometryDiagramAlignmentId } from 'vertical-geometry/store';
 import { TimeStamp } from 'common/common-model';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 import { first } from 'utils/array-utils';
 
 type HeightCacheKey = string;
@@ -90,14 +90,14 @@ export function weaveKms<T>(getFirstM: (km: T) => number, left: T[], right: T[])
         rightI = 0;
 
     while (leftI < left.length && rightI < right.length) {
-        const leftM = getFirstM(getUnsafe(left[leftI]));
-        const rightM = getFirstM(getUnsafe(right[rightI]));
+        const leftM = getFirstM(expectDefined(left[leftI]));
+        const rightM = getFirstM(expectDefined(right[rightI]));
         if (leftM < rightM) {
-            rv.push(getUnsafe(left[leftI++]));
+            rv.push(expectDefined(left[leftI++]));
         } else if (rightM < leftM) {
-            rv.push(getUnsafe(right[rightI++]));
+            rv.push(expectDefined(right[rightI++]));
         } else {
-            rv.push(getUnsafe(left[leftI++]));
+            rv.push(expectDefined(left[leftI++]));
             rightI++;
         }
     }
@@ -168,7 +168,7 @@ function getQueryableRange(
     endM: number,
 ): [number, number] | undefined {
     return getMissingCoveringRange(
-        resolved.map((r) => [getUnsafe(first(r.trackMeterHeights)).m, r.endM]),
+        resolved.map((r) => [expectDefined(first(r.trackMeterHeights)).m, r.endM]),
         startM,
         endM,
     );
@@ -195,7 +195,8 @@ export function useAlignmentHeights(
         if (cacheItem) {
             setLoadedHeights(
                 cacheItem.resolved.filter(
-                    (item) => getUnsafe(first(item.trackMeterHeights)).m <= eM && item.endM >= sM,
+                    (item) =>
+                        expectDefined(first(item.trackMeterHeights)).m <= eM && item.endM >= sM,
                 ),
             );
         }
@@ -231,7 +232,7 @@ export function useAlignmentHeights(
                 );
 
                 loadedCacheItem.resolved = weaveKms(
-                    (kms) => getUnsafe(first(kms.trackMeterHeights)).m,
+                    (kms) => expectDefined(first(kms.trackMeterHeights)).m,
                     loadedCacheItem.resolved,
                     loadedKms,
                 );

--- a/ui/src/vertical-geometry/labeled-ticks.tsx
+++ b/ui/src/vertical-geometry/labeled-ticks.tsx
@@ -10,7 +10,6 @@ import {
     minimumLabeledTickDistancePx,
 } from 'vertical-geometry/ticks-at-intervals';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
-import { getUnsafe } from 'utils/type-utils';
 
 export interface LabeledTicksProps {
     trackKmHeights: TrackKmHeights[];
@@ -145,16 +144,15 @@ export const LabeledTicks: React.FC<LabeledTicksProps> = ({
                                 meter === 0 ||
                                 (trackMeterDisplayStep !== undefined &&
                                     meter % trackMeterDisplayStep === 0);
+
+                            const firstTrackMeterHeight =
+                                trackKmHeights[trackKmIndex + 1]?.trackMeterHeights[0];
                             const hasSpaceBeforeNextKm =
                                 trackKmIndex === trackKmHeights.length - 1 ||
                                 meterIndex === 0 ||
-                                (getUnsafe(
-                                    getUnsafe(trackKmHeights[trackKmIndex + 1])
-                                        .trackMeterHeights[0],
-                                ).m -
-                                    m) *
-                                    coordinates.mMeterLengthPxOverM >
-                                    minimumLabeledTickDistancePx;
+                                (firstTrackMeterHeight &&
+                                    firstTrackMeterHeight.m - m * coordinates.mMeterLengthPxOverM >
+                                        minimumLabeledTickDistancePx);
                             return (
                                 ordinaryTick &&
                                 inRenderedRange &&

--- a/ui/src/vertical-geometry/pvi-geometry.tsx
+++ b/ui/src/vertical-geometry/pvi-geometry.tsx
@@ -4,7 +4,7 @@ import { formatTrackMeterWithoutMeters } from 'utils/geography-utils';
 
 import { Coordinates, heightToY, mToX } from 'vertical-geometry/coordinates';
 import { TrackKmHeights } from 'geometry/geometry-api';
-import { filterNotEmpty } from 'utils/array-utils';
+import { filterNotEmpty, first, last } from 'utils/array-utils';
 import { approximateHeightAtM, polylinePoints } from 'vertical-geometry/util';
 import { radsToDegrees } from 'utils/math-utils';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
@@ -305,9 +305,9 @@ export const PviGeometry: React.FC<PviGeometryProps> = ({
     coordinates,
     drawTangentArrows,
 }) => {
-    const first = geometry[0];
-    const last = geometry[geometry.length - 1];
-    if (!first) {
+    const firstItem = first(geometry);
+    const lastItem = last(geometry);
+    if (!firstItem) {
         return <React.Fragment />;
     }
     const pvis: JSX.Element[] = [];
@@ -322,22 +322,22 @@ export const PviGeometry: React.FC<PviGeometryProps> = ({
     );
     const rightPviI = pastRightmostPviInViewR == -1 ? geometry.length - 1 : pastRightmostPviInViewR;
 
-    if (leftPviI === 0 && first.start && first.point) {
+    if (leftPviI === 0 && firstItem.start && firstItem.point) {
         pvis.push(
             <LeftMostStartingLine
                 key={pviKey++}
                 coordinates={coordinates}
-                verticalGeometryItem={first}
+                verticalGeometryItem={firstItem}
             />,
         );
     }
 
-    if (rightPviI == geometry.length - 1 && last) {
+    if (rightPviI == geometry.length - 1 && lastItem) {
         pvis.push(
             <RightMostEndingLine
                 key={pviKey++}
                 coordinates={coordinates}
-                verticalGeometryItem={last}
+                verticalGeometryItem={lastItem}
             />,
         );
     }

--- a/ui/src/vertical-geometry/pvi-geometry.tsx
+++ b/ui/src/vertical-geometry/pvi-geometry.tsx
@@ -9,7 +9,7 @@ import { approximateHeightAtM, polylinePoints } from 'vertical-geometry/util';
 import { radsToDegrees } from 'utils/math-utils';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
 import { TrackMeter } from 'common/common-model';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 const minimumSpacePxForPviPointSideLabels = 14;
 const minimumSpacePxForPviPointTopLabel = 16;
@@ -344,7 +344,7 @@ export const PviGeometry: React.FC<PviGeometryProps> = ({
 
     geometry.every((geo, index) => {
         if (index === geometry.length - 1) return false;
-        const nextGeo = getUnsafe(geometry[index + 1]);
+        const nextGeo = expectDefined(geometry[index + 1]);
 
         if (!geo.point || !geo.end || !nextGeo.point) {
             return true;

--- a/ui/src/vertical-geometry/snapped-point.ts
+++ b/ui/src/vertical-geometry/snapped-point.ts
@@ -10,7 +10,7 @@ import { filterNotEmpty, minimumIndexBy } from 'utils/array-utils';
 import { Coordinates, heightToY, mToX, xToM } from 'vertical-geometry/coordinates';
 import { TrackKmHeights } from 'geometry/geometry-api';
 import { approximateHeightAt } from 'vertical-geometry/util';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 export type SnapTarget =
     | 'trackMeterRulerTick'
@@ -219,7 +219,7 @@ function approximateTrackAddressAt(
     kmHeights: TrackKmHeights[],
 ): TrackMeter | undefined {
     const [leftMeter, rightMeter] = getTrackMeterPairAroundIndex(index, kmHeights);
-    const leftKm = getUnsafe(kmHeights[index.left.kmIndex]);
+    const leftKm = expectDefined(kmHeights[index.left.kmIndex]);
     const proportion = (m - leftMeter.m) / (rightMeter.m - leftMeter.m);
     return {
         kmNumber: leftKm.kmNumber,

--- a/ui/src/vertical-geometry/ticks-at-intervals.ts
+++ b/ui/src/vertical-geometry/ticks-at-intervals.ts
@@ -3,7 +3,7 @@
 // when we zoom in a bit, the ticks move to being every 2 meters; so the labels at xx25 and xx75 meters disappear!
 
 import { last } from 'utils/array-utils';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 const labelIntervalOptions = [1, 2, 5, 10, 50, 100, 250, 500, 1000];
 
@@ -18,5 +18,5 @@ export function minimumInterval(itemWidth: number, minimumWidth: number): number
 }
 
 export function minimumIntervalOrLongest(itemWidth: number, minimumWidth: number): number {
-    return minimumInterval(itemWidth, minimumWidth) ?? getUnsafe(last(labelIntervalOptions));
+    return minimumInterval(itemWidth, minimumWidth) ?? expectDefined(last(labelIntervalOptions));
 }

--- a/ui/src/vertical-geometry/ticks-at-intervals.ts
+++ b/ui/src/vertical-geometry/ticks-at-intervals.ts
@@ -2,7 +2,10 @@
 // too easily end up in a situation where we're displaying ticks every 5 meters and labels every 25 meters, but then
 // when we zoom in a bit, the ticks move to being every 2 meters; so the labels at xx25 and xx75 meters disappear!
 
-const labelIntervalOptions = [1, 2, 5, 10, 50, 100, 250, 500, 1000] as const;
+import { last } from 'utils/array-utils';
+import { getUnsafe } from 'utils/type-utils';
+
+const labelIntervalOptions = [1, 2, 5, 10, 50, 100, 250, 500, 1000];
 
 export const minimumApproximateHorizontalTickWidthPx = 15;
 export const minimumLabeledTickDistancePx = 120;
@@ -15,5 +18,5 @@ export function minimumInterval(itemWidth: number, minimumWidth: number): number
 }
 
 export function minimumIntervalOrLongest(itemWidth: number, minimumWidth: number): number {
-    return minimumInterval(itemWidth, minimumWidth) ?? labelIntervalOptions[8];
+    return minimumInterval(itemWidth, minimumWidth) ?? getUnsafe(last(labelIntervalOptions));
 }

--- a/ui/src/vertical-geometry/track-address-ruler.tsx
+++ b/ui/src/vertical-geometry/track-address-ruler.tsx
@@ -7,7 +7,7 @@ import {
     minimumRulerHeightLabelDistancePx,
 } from 'vertical-geometry/ticks-at-intervals';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 export interface TrackAddressRulerProps {
     kmHeights: TrackKmHeights[];
@@ -39,7 +39,7 @@ export const TrackAddressRuler: React.FC<TrackAddressRulerProps> = ({
         .map(({ trackMeterHeights }, kmIndex) => (
             <KmPostMarker
                 key={kmIndex}
-                x={mToX(coordinates, getUnsafe(trackMeterHeights[0]).m)}
+                x={mToX(coordinates, expectDefined(trackMeterHeights[0]).m)}
                 heightPx={heightPx}
             />
         ));

--- a/ui/src/vertical-geometry/track-meter-index.ts
+++ b/ui/src/vertical-geometry/track-meter-index.ts
@@ -1,6 +1,6 @@
 import { TrackMeter } from 'common/common-model';
 import { TrackKmHeights, TrackMeterHeight } from 'geometry/geometry-api';
-import { getUnsafe } from 'utils/type-utils';
+import { expectDefined } from 'utils/type-utils';
 
 export interface SingleTrackMeterIndex {
     kmIndex: number;
@@ -25,7 +25,7 @@ export function findTrackMeterIndexContainingM(
         return undefined;
     }
     const kmIndex = nextKmIndex === -1 ? kmHeights.length - 1 : nextKmIndex - 1;
-    const km = getUnsafe(kmHeights[kmIndex]);
+    const km = expectDefined(kmHeights[kmIndex]);
     const meterIndex = km.trackMeterHeights.findIndex((trackM) => trackM.m >= m);
     // if this the last track km on the alignment, then the last track meter is a sentinel sent by the backend to mark
     // the alignment's end, and can be considered to have zero length; hence, if we're past it, we've fallen past the
@@ -50,7 +50,7 @@ function previousSingleTrackMeterIndex(
     } else if (meterIndex == 0) {
         return {
             kmIndex: kmIndex - 1,
-            meterIndex: getUnsafe(kmHeights[kmIndex - 1]).trackMeterHeights.length - 1,
+            meterIndex: expectDefined(kmHeights[kmIndex - 1]).trackMeterHeights.length - 1,
         };
     } else {
         return { kmIndex, meterIndex: meterIndex - 1 };
@@ -61,7 +61,7 @@ export function getTrackAddressAtSingleIndex(
     index: SingleTrackMeterIndex,
     kmHeights: TrackKmHeights[],
 ): TrackMeter {
-    const kmNumber = getUnsafe(kmHeights[index.kmIndex]).kmNumber;
+    const kmNumber = expectDefined(kmHeights[index.kmIndex]).kmNumber;
     const meters = getTrackMeterAtSingleIndex(index, kmHeights).meter;
     return { kmNumber, meters };
 }
@@ -70,7 +70,7 @@ export function getTrackMeterAtSingleIndex(
     { kmIndex, meterIndex }: SingleTrackMeterIndex,
     kmHeights: TrackKmHeights[],
 ) {
-    return getUnsafe(getUnsafe(kmHeights[kmIndex]).trackMeterHeights[meterIndex]);
+    return expectDefined(expectDefined(kmHeights[kmIndex]).trackMeterHeights[meterIndex]);
 }
 
 export function getTrackMeterPairAroundIndex(

--- a/ui/src/vertical-geometry/vertical-geometry-diagram-container.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-container.tsx
@@ -6,6 +6,7 @@ import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 import { VerticalGeometryDiagramHolder } from './vertical-geometry-diagram-holder';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
 import { VerticalGeometryDiagramAlignmentId } from 'vertical-geometry/store';
+import { first } from 'utils/array-utils';
 
 export const VerticalGeometryDiagramContainer: React.FC = () => {
     const state = useTrackLayoutAppSelector((s) => s);
@@ -20,8 +21,8 @@ export const VerticalGeometryDiagramContainer: React.FC = () => {
     const [alignmentId, setAlignmentId] = React.useState<VerticalGeometryDiagramAlignmentId>();
 
     React.useEffect(() => {
-        const selectedGeometryAlignment = state.selection.selectedItems.geometryAlignmentIds[0];
-        const selectedLocationTrack = state.selection.selectedItems.locationTracks[0];
+        const selectedGeometryAlignment = first(state.selection.selectedItems.geometryAlignmentIds);
+        const selectedLocationTrack = first(state.selection.selectedItems.locationTracks);
 
         if (
             state.selectedToolPanelTab?.type === 'GEOMETRY_ALIGNMENT' &&


### PR DESCRIPTION
Täällä refaktoroitu suurin osa aiemmassa branchissa esitellyistä `getUnsafe()`-kutsuista toimimaan jotenkin muuten kuin ka. funktiolla. Samalla renamettu `getUnsafe()` nimelle `expectDefined()` Markuksen ehdotuksen mukaan, sillä se on kuvaavampi niin.

Samalla tehty muutakin yleistä taulukkoihin liittyvää refaktorointia, mm. lisätty helpperifunktiot `first()` ja `last()` taulukon ensimmäisen ja viimeisen alkion hakemiseen ja otettu ne käyttöön about kaikkialla missä se on vaikuttanut järkevältä. Vähän tästä muutoksesta:

* Ka. funktiot on tarkoitettu _taulukoille_. Eli siis esim. indeksoitavia olioita (`FileList` ym.) ei voi sillä mennä läpi
* Samoin tällä hetkellä ne eivät hyväksy nullish-taulukkoa (mietin että pitäisikö, mutta jätin ne toistaiseksi näin,) joten `T[] | undefined`-taulukot pitää edelleen hoitaa käsin jotenkin muuten
* Ei varsinaisesti tarkoitettu tuplejen läpikäymiseen. Meillä on muutamassa paikassa käytetty tupleja, joiden tyypit ovat tyyliin `[T, V]`, ja noita nuo eivät osaa. Paluutyyppi on tuolloin `T | V | undefined`
* Ne tekevät sisäisesti vain normaalia indeksointia. Täten ne voivat aina palauttaa `undefined`:in
* Meillä on paljon paikkoja, joissa halutaan indeksoida useita vierekkäisiä indeksejä esim. `const first = arr[0]; const second = arr[1];`. Katsoin että tuollaisissa paikoissa suora indeksointi oli edelleen paljon luettavampi kuin `... first(arr); ... arr[1];`. 