### PR TITLE
GVT-2476: Add duplicates related to a split to publication groups

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -113,9 +113,12 @@ class PublicationDao(
                 select
                     split.id as split_id,
                     split.source_location_track_id as source_track_id,
-                    array_agg(stlt.location_track_id) as target_track_ids
+                    array_agg(stlt.location_track_id) as target_track_ids,
+                    array_agg(split_updated_duplicates.duplicate_id) as split_updated_duplicate_ids
                 from publication.split
                     inner join publication.split_target_location_track stlt on stlt.split_id = split.id
+                    left join publication.split_updated_duplicate split_updated_duplicates 
+                        on split_updated_duplicates.split_id = split.id
                 where split.bulk_transfer_state = 'PENDING' and split.publication_id is null
                 group by split.id, split.source_location_track_id
             )
@@ -144,6 +147,7 @@ class PublicationDao(
                 left join splits 
                     on splits.source_track_id = draft_location_track.official_id 
                         or draft_location_track.official_id = any(splits.target_track_ids)
+                        or draft_location_track.official_id = any(splits.split_updated_duplicate_ids)
             where draft_location_track.draft = true
         """.trimIndent()
         val candidates = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
@@ -166,6 +170,16 @@ class PublicationDao(
 
     fun fetchSwitchPublishCandidates(): List<SwitchPublishCandidate> {
         val sql = """
+            with splits as (
+                select
+                    split.id as split_id,
+                    array_agg(split_relinked_switches.switch_id) as split_relinked_switch_ids
+                from publication.split
+                    inner join publication.split_relinked_switch split_relinked_switches 
+                        on split_relinked_switches.split_id = split.id
+                where split.bulk_transfer_state = 'PENDING' and split.publication_id is null
+                group by split.id, split.source_location_track_id
+            )
             select 
               draft_switch.row_id,
               draft_switch.row_version,
@@ -181,7 +195,8 @@ class PublicationDao(
                 draft_switch.state_category
               ) as operation,
               postgis.st_x(switch_joint_version.location) as point_x, 
-              postgis.st_y(switch_joint_version.location) as point_y
+              postgis.st_y(switch_joint_version.location) as point_y,
+              splits.split_id
             from layout.switch_publication_view draft_switch
               left join layout.switch_publication_view official_switch
                 on official_switch.official_id = draft_switch.official_id
@@ -192,6 +207,8 @@ class PublicationDao(
                 on switch_joint_version.switch_id = coalesce(draft_switch.draft_id, draft_switch.official_id)
                   and switch_joint_version.switch_version = coalesce(draft_switch.draft_version, draft_switch.official_id)
                   and switch_joint_version.number = switch_structure.presentation_joint_number
+             left join splits 
+                on draft_switch.official_id = any(splits.split_relinked_switch_ids)
             where draft_switch.draft = true
         """.trimIndent()
         val candidates = jdbcTemplate.query(
@@ -208,6 +225,7 @@ class PublicationDao(
                 operation = rs.getEnum("operation"),
                 trackNumberIds = rs.getIntIdArray("track_numbers"),
                 location = rs.getPointOrNull("point_x", "point_y"),
+                publicationGroup = rs.getIntIdOrNull<Split>("split_id")?.let(::PublicationGroup)
             )
         }
         logger.daoAccess(FETCH, SwitchPublishCandidate::class, candidates.map(SwitchPublishCandidate::id))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -102,46 +102,6 @@ class PublicationService @Autowired constructor(
             referenceLines = publicationDao.fetchReferenceLinePublishCandidates(),
             switches = publicationDao.fetchSwitchPublishCandidates(),
             kmPosts = publicationDao.fetchKmPostPublishCandidates(),
-        ).let(::assignPublicationGroups)
-    }
-
-    fun assignPublicationGroups(
-        publishCandidates: PublishCandidates,
-    ): PublishCandidates {
-        val locationTrackIdToPublicationGroup = mutableMapOf<IntId<LocationTrack>, PublicationGroup>()
-        val switchIdToPublicationGroup = mutableMapOf<IntId<TrackLayoutSwitch>, PublicationGroup>()
-
-        publishCandidates.locationTracks
-            .map { locationTrack -> locationTrack.id }
-            .let { locationTrackIds -> splitService.findUnfinishedSplitsForLocationTracks(locationTrackIds) }
-            .map { unfinishedSplit ->
-                val publicationGroup = PublicationGroup(unfinishedSplit.id)
-
-                unfinishedSplit.locationTracks.forEach { locationTrackId ->
-                    locationTrackIdToPublicationGroup[locationTrackId] = publicationGroup
-                }
-
-                unfinishedSplit.relinkedSwitches.forEach { switchId ->
-                    switchIdToPublicationGroup[switchId] = publicationGroup
-                }
-            }
-
-        return publishCandidates.copy(
-            locationTracks = publishCandidates.locationTracks.map { locationTrackPublishCandidate ->
-                locationTrackIdToPublicationGroup[locationTrackPublishCandidate.id]?.let { assignedPublicationGroup ->
-                    locationTrackPublishCandidate.copy(
-                        publicationGroup = assignedPublicationGroup
-                    )
-                } ?: locationTrackPublishCandidate
-            },
-
-            switches = publishCandidates.switches.map { switchPublishCandidate ->
-                switchIdToPublicationGroup[switchPublishCandidate.id]?.let { assignedPublicationGroup ->
-                    switchPublishCandidate.copy(
-                        publicationGroup = assignedPublicationGroup
-                    )
-                } ?: switchPublishCandidate
-            },
         )
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -349,7 +349,8 @@ class PublicationService @Autowired constructor(
             locationTrackDao.fetchOnlyDraftVersions(includeDeleted = true, tnId)
         }.map(RowVersion<LocationTrack>::id)
 
-        val revertSplitTracks = splitService.findUnfinishedSplitsForLocationTracks(revertLocationTrackIds).flatMap { it.locationTracks }
+        val revertSplitTracks = splitService.findUnpublishedSplitsForLocationTracks(revertLocationTrackIds)
+            .flatMap { split -> split.locationTracks }
 
         val revertKmPostIds = requestIds.kmPosts.toSet() + draftOnlyTrackNumberIds.flatMap { tnId ->
             kmPostDao.fetchOnlyDraftVersions(includeDeleted = true, tnId)
@@ -372,8 +373,8 @@ class PublicationService @Autowired constructor(
     fun revertPublishCandidates(toDelete: PublishRequestIds): PublishResult {
         logger.serviceCall("revertPublishCandidates", "toDelete" to toDelete)
 
-        splitService.findUnfinishedSplitsForLocationTracks(toDelete.locationTracks)
-            .map { it.id }
+        splitService.findUnpublishedSplitsForLocationTracks(toDelete.locationTracks)
+            .map { split -> split.id }
             .distinct()
             .forEach(splitService::deleteSplit)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -37,6 +37,7 @@ data class Split(
     val publicationId: IntId<Publication>?,
     val targetLocationTracks: List<SplitTarget>,
     val relinkedSwitches: List<IntId<TrackLayoutSwitch>>,
+    val updatedDuplicates: List<IntId<LocationTrack>>,
 ) {
     @get:JsonIgnore
     val locationTracks by lazy { targetLocationTracks.map { it.locationTrackId } + locationTrackId }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -1,6 +1,8 @@
 package fi.fta.geoviite.infra.split
 
+import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.publication.Publication

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -14,6 +14,7 @@ import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.split.SplitDao
+import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.util.FreeText
 import org.springframework.stereotype.Service

--- a/infra/src/main/resources/db/migration/prod/V66__add_split_updated_duplicates_table.sql
+++ b/infra/src/main/resources/db/migration/prod/V66__add_split_updated_duplicates_table.sql
@@ -1,0 +1,15 @@
+create table publication.split_updated_duplicate
+(
+  split_id     int not null,
+  duplicate_id int not null,
+
+  primary key (split_id, duplicate_id),
+
+  constraint split_fkey foreign key (split_id) references publication.split (id) on delete cascade,
+  constraint split_duplicate_fkey foreign key (duplicate_id) references layout.location_track (id)
+);
+
+comment on table publication.split_relinked_switch is 'Duplicate location tracks that were updated during a location track split';
+
+select common.add_metadata_columns('publication', 'split_updated_duplicate');
+select common.add_table_versioning('publication', 'split_updated_duplicate');

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
@@ -142,6 +142,9 @@ abstract class DBTestBase(val testUser: String = TEST_USER) {
     fun insertUniqueSwitch(): DaoResponse<TrackLayoutSwitch> =
         insertSwitch(switch(name = getUnusedSwitchName().toString()))
 
+    fun insertUniqueDraftSwitch(): DaoResponse<TrackLayoutSwitch> =
+        insertSwitch(draft(switch(name = getUnusedSwitchName().toString())))
+
     fun insertSwitch(switch: TrackLayoutSwitch): DaoResponse<TrackLayoutSwitch> = transactional {
         jdbc.setUser()
         switchDao.insert(switch)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -222,7 +222,12 @@ class LinkingServiceIT @Autowired constructor(
             mRange = Range(0.0, 0.0),
         )
 
-        splitDao.saveSplit(locationTrackId, listOf(SplitTarget(locationTrackId, 0..1)), emptyList())
+        splitDao.saveSplit(
+            locationTrackId,
+            listOf(SplitTarget(locationTrackId, 0..1)),
+            relinkedSwitches = emptyList(),
+            updatedDuplicates = emptyList(),
+        )
 
         val ex = assertThrows<LinkingFailureException> {
             linkingService.saveLocationTrackLinking(
@@ -290,7 +295,8 @@ class LinkingServiceIT @Autowired constructor(
             splitDao.saveSplit(
                 locationTrackId,
                 listOf(SplitTarget(locationTrackId, 0..1)),
-                emptyList(),
+                relinkedSwitches = emptyList(),
+                updatedDuplicates = emptyList(),
             )
         )
         splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.DONE)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -54,6 +54,7 @@ class PublicationServiceIT @Autowired constructor(
     val localizationService: LocalizationService,
     val switchStructureDao: SwitchStructureDao,
     val splitDao: SplitDao,
+    val splitService: SplitService,
 ) : DBTestBase() {
 
     @BeforeEach
@@ -2682,6 +2683,7 @@ class PublicationServiceIT @Autowired constructor(
             sourceTrackId,
             targetTrackIds.map { id -> SplitTarget(id, 0..0) },
             listOf(),
+            updatedDuplicates = emptyList(),
         )
     }
 
@@ -2694,6 +2696,7 @@ class PublicationServiceIT @Autowired constructor(
             sourceTrackId,
             targetTrackIds.map { id -> SplitTarget(id, 0..0) },
             switches,
+            updatedDuplicates = emptyList(),
         )
     }
 
@@ -2876,6 +2879,187 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals(true, splitInPublication.targetLocationTracks[0].newlyCreated)
         assertEquals(endTargetTrack.id, splitInPublication.targetLocationTracks[1].id)
         assertEquals(true, splitInPublication.targetLocationTracks[1].newlyCreated)
+    }
+
+    @Test
+    fun `Publication group should not be set for assets unrelated to a split`() {
+        // Add some additional assets as "noise", other assets should not have publication
+        // groups even if there are unpublished splits.
+        insertPublicationGroupTestData()
+
+        val trackNumberId = insertOfficialTrackNumber()
+        insertReferenceLine(
+            referenceLine(trackNumberId = trackNumberId),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+        )
+
+        val someTrack = insertLocationTrack(
+            draft(locationTrack(trackNumberId = trackNumberId)),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+        )
+
+        val someDuplicateTrack = insertLocationTrack(
+            draft(locationTrack(
+                trackNumberId = trackNumberId,
+                duplicateOf = someTrack.id,
+            )),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+        )
+
+        val someTrackIds = listOf(
+            someTrack.id,
+            someDuplicateTrack.id,
+        )
+
+        val someSwitchId = insertUniqueDraftSwitch().id
+
+        val publishCandidates = publicationService.collectPublishCandidates()
+
+        publishCandidates.locationTracks
+            .filter { locationTrackPublishCandidate ->
+                locationTrackPublishCandidate.id in someTrackIds
+            }
+            .also { filteredLocationTrackPublishCandidates ->
+                assertEquals(2, filteredLocationTrackPublishCandidates.size)
+            }
+            .forEach { locationTrackPublishCandidate ->
+                assertEquals(null, locationTrackPublishCandidate.publicationGroup)
+            }
+
+        publishCandidates.switches
+            .filter { switchPublishCandidate ->
+                switchPublishCandidate.id == someSwitchId
+            }
+            .also { filteredLocationTracks ->
+                assertEquals(1, filteredLocationTracks.size)
+            }
+            .forEach { switchPublishCandidate ->
+                assertEquals(null, switchPublishCandidate.publicationGroup)
+            }
+    }
+
+    @Test
+    fun `Publication group should be set for assets related to a split`() {
+        (1..4).forEach { testIndex ->
+            val testData = insertPublicationGroupTestData()
+            val splits = splitService.findUnfinishedSplitsForLocationTracks(
+                listOf(testData.sourceLocationTrackId)
+            )
+
+            assertEquals(1, splits.size)
+            val splitId = splits[0].id
+
+            val publishCandidates = publicationService.collectPublishCandidates()
+
+            val amountOfNonDuplicatesInCurrentTest = 3
+            val amountOfDuplicatesInCurrentTest = 5
+            val expectedTotalUnpublishedLocationTrackAmount =
+                testIndex * (amountOfNonDuplicatesInCurrentTest + amountOfDuplicatesInCurrentTest)
+
+            assertEquals(expectedTotalUnpublishedLocationTrackAmount, publishCandidates.locationTracks.size)
+
+            publishCandidates.locationTracks
+                .filter { locationTrackPublishCandidate ->
+                    locationTrackPublishCandidate.id in testData.allLocationTrackIds
+                }
+                .also { filteredLocationTrackPublishCandidates ->
+                    assertEquals(
+                        amountOfNonDuplicatesInCurrentTest + amountOfDuplicatesInCurrentTest,
+                        filteredLocationTrackPublishCandidates.size
+                    )
+                }
+                .forEach { locationTrackPublishCandidate ->
+                    assertEquals(splitId, locationTrackPublishCandidate.publicationGroup?.id)
+                }
+
+            val amountOfSwitchesInCurrentTest = 6
+            val expectedTotalUnpublishedSwitchAmount = testIndex * amountOfSwitchesInCurrentTest
+            assertEquals(expectedTotalUnpublishedSwitchAmount, publishCandidates.switches.size)
+
+            publishCandidates.switches
+                .filter { switchPublishCandidate ->
+                    switchPublishCandidate.id in testData.switchIds
+                }
+                .also { filteredLocationTracks ->
+                    assertEquals(
+                        amountOfSwitchesInCurrentTest,
+                        filteredLocationTracks.size
+                    )
+                }
+                .forEach { switchPublishCandidate ->
+                    assertEquals(splitId, switchPublishCandidate.publicationGroup?.id)
+                }
+        }
+    }
+
+    data class PublicationGroupTestData(
+        val sourceLocationTrackId: IntId<LocationTrack>,
+        val allLocationTrackIds: List<IntId<LocationTrack>>,
+        val duplicateLocationTrackIds: List<IntId<LocationTrack>>,
+        val switchIds: List<IntId<TrackLayoutSwitch>>,
+    )
+
+    private fun insertPublicationGroupTestData(): PublicationGroupTestData {
+        val trackNumberId = insertOfficialTrackNumber()
+        insertReferenceLine(
+            referenceLine(trackNumberId = trackNumberId),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+        )
+
+        // Due to using splitDao.saveSplit and not actually running a split,
+        // the sourceTrack is created as a draft as well.
+        val sourceTrack = insertLocationTrack(
+            draft(locationTrack(trackNumberId = trackNumberId)),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+        )
+
+        val middleTrack = insertLocationTrack(
+            draft(locationTrack(trackNumberId = trackNumberId)),
+            alignment(segment(Point(2.0, 0.0), Point(3.0, 0.0))),
+        )
+
+        val endTrack = insertLocationTrack(
+            draft(locationTrack(trackNumberId = trackNumberId)),
+            alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
+        )
+
+        val someSwitches = (0..5).map {
+            insertUniqueDraftSwitch().id
+        }
+
+        val someDuplicates = (0..4).map { i ->
+            insertLocationTrack(
+                draft(locationTrack(
+                    trackNumberId = trackNumberId,
+                    duplicateOf = sourceTrack.id,
+                )),
+                alignment(segment(Point(i.toDouble(), 0.0), Point(i + 0.75, 0.0))),
+            ).id
+        }
+
+        splitDao.saveSplit(
+            sourceTrack.id,
+            listOf(
+                SplitTarget(middleTrack.id, 0..0),
+                SplitTarget(endTrack.id, 0..0)
+            ),
+            relinkedSwitches = someSwitches,
+            updatedDuplicates = someDuplicates,
+        )
+
+        return PublicationGroupTestData(
+            sourceLocationTrackId = sourceTrack.id,
+            allLocationTrackIds = listOf(
+                listOf(
+                    sourceTrack.id,
+                    middleTrack.id,
+                    endTrack.id,
+                ),
+                someDuplicates
+            ).flatten(),
+            switchIds = someSwitches,
+            duplicateLocationTrackIds = someDuplicates,
+        )
     }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -43,6 +43,7 @@ class SplitDaoIT @Autowired constructor(
             sourceTrack.id,
             listOf(SplitTarget(targetTrack.id, 0..0)),
             listOf(relinkedSwitchId),
+            updatedDuplicates = emptyList(),
         ).let(splitDao::getOrThrow)
 
         assertTrue { split.bulkTransferState == BulkTransferState.PENDING }
@@ -70,6 +71,7 @@ class SplitDaoIT @Autowired constructor(
             sourceTrack.id,
             listOf(SplitTarget(targetTrack.id, 0..0)),
             listOf(relinkedSwitchId),
+            updatedDuplicates = emptyList(),
         ).let(splitDao::getOrThrow)
 
         val publicationId = publicationDao.createPublication("SPLIT PUBLICATION")
@@ -107,6 +109,7 @@ class SplitDaoIT @Autowired constructor(
             sourceTrack.id,
             listOf(SplitTarget(targetTrack1.id, 0..0)),
             listOf(relinkedSwitchId1),
+            updatedDuplicates = emptyList(),
         ).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
             splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.DONE)
@@ -116,6 +119,7 @@ class SplitDaoIT @Autowired constructor(
             sourceTrack.id,
             listOf(SplitTarget(targetTrack2.id, 0..0)),
             listOf(relinkedSwitchId2),
+            updatedDuplicates = emptyList(),
         )
 
         val splits = splitDao.fetchUnfinishedSplits()
@@ -132,6 +136,10 @@ class SplitDaoIT @Autowired constructor(
             locationTrack(trackNumberId = trackNumberId) to alignment
         )
 
+        val someDuplicateTrack = insertLocationTrack(
+            draft(locationTrack(trackNumberId = trackNumberId)) to alignment
+        )
+
         val targetTrack1 = insertLocationTrack(
             draft(locationTrack(trackNumberId = trackNumberId)) to alignment
         )
@@ -142,6 +150,7 @@ class SplitDaoIT @Autowired constructor(
             sourceTrack.id,
             listOf(SplitTarget(targetTrack1.id, 0..0)),
             listOf(relinkedSwitchId),
+            updatedDuplicates = listOf(someDuplicateTrack.id)
         )
 
         assertTrue { splitDao.fetchUnfinishedSplits().any { it.id == splitId } }
@@ -169,6 +178,7 @@ class SplitDaoIT @Autowired constructor(
             sourceTrack.id,
             listOf(SplitTarget(targetTrack1.id, 0..0)),
             listOf(relinkedSwitchId),
+            updatedDuplicates = emptyList(),
         )
 
         val splitHeader = splitDao.getSplitHeader(splitId)
@@ -196,6 +206,10 @@ class SplitDaoIT @Autowired constructor(
             locationTrack(trackNumberId = trackNumberId) to alignment
         )
 
+        val someDuplicateTrack = insertLocationTrack(
+            locationTrack(trackNumberId = trackNumberId) to alignment
+        )
+
         val targetTrack = insertLocationTrack(
             draft(locationTrack(trackNumberId = trackNumberId)) to alignment
         )
@@ -206,6 +220,7 @@ class SplitDaoIT @Autowired constructor(
             sourceTrack.id,
             listOf(SplitTarget(targetTrack.id, 0..0)),
             listOf(relinkedSwitchId),
+            updatedDuplicates = listOf(someDuplicateTrack.id),
         )
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -319,6 +319,7 @@ class SplitServiceIT @Autowired constructor(
             sourceTrack.id,
             listOf(SplitTarget(endTrack.id, 0..0)),
             listOf(relinkedSwitchId),
+            updatedDuplicates = emptyList(),
         )
     }
 


### PR DESCRIPTION
Previously the publication groups did not include the duplicates that were removed or modified during a location track split.

Additionally as an optimization, publication groups are now queried directly in SQL instead of setting them individually for each unpublished asset within Kotlin code.

--

Target-haara on hassu: Tässä on pohjana toisen pullarin haara, ja tuon toisen pullarin haaran tunnus on väärin (pitäisi olla GVT-2478). Targettina se, että näkyy ainoastaan tähän pullariin liittyviä muutoksia. Laitan tuon toisen haaran ennen tätä pullaria mainiin, jolloin tämänkin targetiksi muuttuu maini.