### PR TITLE
GVT-2497: Hide edit icon from the list of duplicates of a location track

### DIFF
--- a/ui/src/tool-panel/infobox/infobox-field.tsx
+++ b/ui/src/tool-panel/infobox/infobox-field.tsx
@@ -14,6 +14,7 @@ type InfoboxFieldProps = {
     onEdit?: () => void;
     className?: string;
     iconDisabled?: boolean;
+    iconHidden?: boolean;
     hasErrors?: boolean;
 };
 
@@ -25,6 +26,7 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
     qaId,
     inEditMode = false,
     iconDisabled = false,
+    iconHidden = false,
     hasErrors = false,
     ...props
 }: InfoboxFieldProps) => {
@@ -47,14 +49,14 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
                 )}>
                 {children || value}
             </div>
-            {!inEditMode && props.onEdit && !iconDisabled && (
+            {!inEditMode && props.onEdit && !iconDisabled && !iconHidden && (
                 <div
                     className={styles['infobox__edit-icon']}
                     onClick={() => props.onEdit && props.onEdit()}>
                     <Icons.Edit size={IconSize.SMALL} />
                 </div>
             )}
-            {iconDisabled && (
+            {iconDisabled && !iconHidden && (
                 <WriteAccessRequired>
                     <div className={styles['infobox__edit-icon']}>
                         <span title={t('tool-panel.disabled.activity-disabled-in-official-mode')}>

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -336,6 +336,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                         }
                         onEdit={openEditLocationTrackDialog}
                         iconDisabled={editingDisabled}
+                        iconHidden={!locationTrack.duplicateOf}
                     />
                     <InfoboxField
                         label={t('tool-panel.location-track.topological-connectivity')}


### PR DESCRIPTION
The edit icon displayed next to the list of duplicates can be confusing to a user: Clicking this edit icon will not lead the user to edit the actual duplicates of a given location track, but instead opens the location track edit dialog where changes to the duplicates of the track cannot be made.