### PR TITLE
GVT-2503 refactor maplayer load indicator + fix e2e test random fails

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelElement.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelElement.kt
@@ -103,7 +103,7 @@ internal class E2EFormGroupField(by: By) : E2EViewFragment(by) {
         toggleEdit()
     }
 
-    fun selectNewValue(newValues: List<String>, toastId: String) = apply {
+    fun createAndSelectNewValue(newValues: List<String>, toastId: String) = apply {
         logger.info("Create new dropdown option with values $newValues")
 
         toggleEdit()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelElement.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelElement.kt
@@ -103,7 +103,7 @@ internal class E2EFormGroupField(by: By) : E2EViewFragment(by) {
         toggleEdit()
     }
 
-    fun selectNewValue(newValues: List<String>) = apply {
+    fun selectNewValue(newValues: List<String>, toastId: String) = apply {
         logger.info("Create new dropdown option with values $newValues")
 
         toggleEdit()
@@ -115,6 +115,7 @@ internal class E2EFormGroupField(by: By) : E2EViewFragment(by) {
         E2EDialogWithTextField()
             .inputValues(newValues)
             .clickPrimaryButton()
+            .also { waitAndClearToast(toastId) }
 
         toggleEdit()
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelForm.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelForm.kt
@@ -55,7 +55,7 @@ class E2EMetaFormGroup(formBy: By) : E2EFormGroup(formBy) {
         logger.info("Select new project $newProject")
 
         projectField
-            .selectNewValue(listOf(newProject), "new-project-created")
+            .createAndSelectNewValue(listOf(newProject), "new-project-created")
             .waitUntilFieldIs(newProject)
     }
 
@@ -63,7 +63,7 @@ class E2EMetaFormGroup(formBy: By) : E2EFormGroup(formBy) {
         logger.info("Select new author $newAuthor")
 
         authorField
-            .selectNewValue(listOf(newAuthor), "new-author-created")
+            .createAndSelectNewValue(listOf(newAuthor), "new-author-created")
             .waitUntilFieldIs(newAuthor)
     }
 }
@@ -86,11 +86,11 @@ class E2ELocationFormGroup(formBy: By) : E2EFormGroup(formBy) {
         trackNumberField.selectValue(trackNumber)
     }
 
-    fun selectNewTrackNumber(trackNumber: String, description: String): E2ELocationFormGroup = apply {
+    fun createAndSelectNewTrackNumber(trackNumber: String, description: String): E2ELocationFormGroup = apply {
         logger.info("Select new track number $trackNumber with description $description")
 
         trackNumberField
-            .selectNewValue(listOf(trackNumber, description), "track-number-edit.result.succeeded")
+            .createAndSelectNewValue(listOf(trackNumber, description), "track-number-edit.result.succeeded")
             .waitUntilFieldIs(trackNumber)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelForm.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelForm.kt
@@ -55,8 +55,7 @@ class E2EMetaFormGroup(formBy: By) : E2EFormGroup(formBy) {
         logger.info("Select new project $newProject")
 
         projectField
-            .selectNewValue(listOf(newProject))
-            .also { waitAndClearToast("new-project-created") }
+            .selectNewValue(listOf(newProject), "new-project-created")
             .waitUntilFieldIs(newProject)
     }
 
@@ -64,8 +63,7 @@ class E2EMetaFormGroup(formBy: By) : E2EFormGroup(formBy) {
         logger.info("Select new author $newAuthor")
 
         authorField
-            .selectNewValue(listOf(newAuthor))
-            .also { waitAndClearToast("new-author-created") }
+            .selectNewValue(listOf(newAuthor), "new-author-created")
             .waitUntilFieldIs(newAuthor)
     }
 }
@@ -92,8 +90,7 @@ class E2ELocationFormGroup(formBy: By) : E2EFormGroup(formBy) {
         logger.info("Select new track number $trackNumber with description $description")
 
         trackNumberField
-            .selectNewValue(listOf(trackNumber, description))
-            .also { waitAndClearToast("track-number-edit.result.succeeded") }
+            .selectNewValue(listOf(trackNumber, description), "track-number-edit.result.succeeded")
             .waitUntilFieldIs(trackNumber)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelPage.kt
@@ -32,6 +32,8 @@ class E2EInfraModelPage : E2EViewFragment(By.className("infra-model-main")) {
 
         waitUntilChildVisible(By.className("infra-model-list-search-result__table"))
         childTextInput(By.cssSelector(".infra-model-search-form__auto-complete input")).replaceValue(query)
+
+        infraModelsList.waitUntilReady()
     }
 
     fun openVelhoWaitingForApprovalList(): E2EProjektiVelhoPage {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/TrackLayoutPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/TrackLayoutPage.kt
@@ -109,28 +109,27 @@ class E2ETrackLayoutPage : E2EViewFragment(byQaId("track-layout-content")) {
     fun zoomToScale(targetScale: MapScale): E2ETrackLayoutPage = apply {
         logger.info("Zoom map to scale $targetScale")
 
-        if (targetScale.ordinal >= mapScale.ordinal) {
-            while (targetScale != mapScale) zoomOut()
-        } else {
-            while (targetScale != mapScale) zoomIn()
+        var oldResolution = resolution
+        while (targetScale != mapScale) {
+            if (targetScale.ordinal > mapScale.ordinal) zoomOut(oldResolution)
+            if (targetScale.ordinal < mapScale.ordinal) zoomIn(oldResolution)
+            oldResolution = resolution
         }
 
         finishLoading()
     }
 
-    private fun zoomOut() {
-        val oldScale = resolution
+    private fun zoomOut(oldResolution: Double) {
         clickChild(By.className("ol-zoom-out"))
-        waitUntilScaleChanges(oldScale)
+        waitUntilResolutionChanges(oldResolution)
     }
 
-    private fun zoomIn() {
-        val oldScale = resolution
+    private fun zoomIn(oldResolution: Double) {
         clickChild(By.className("ol-zoom-in"))
-        waitUntilScaleChanges(oldScale)
+        waitUntilResolutionChanges(oldResolution)
     }
 
-    private fun waitUntilScaleChanges(oldScale: Double) {
-        tryWait({ resolution != oldScale }) { "Map scale did not change from $oldScale" }
+    private fun waitUntilResolutionChanges(oldResolution: Double) {
+        tryWait({ resolution != oldResolution }) { "Map scale did not change from $oldResolution" }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/InfraModelTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/InfraModelTestUI.kt
@@ -121,7 +121,7 @@ class InfraModelTestUI @Autowired constructor(
         //Sijaintitiedot
         val sijaintitiedot = uploadForm.locationFormGroup
         val ratanumero = "123E2E"
-        sijaintitiedot.selectNewTrackNumber(ratanumero, "kaunis kuvaus")
+        sijaintitiedot.createAndSelectNewTrackNumber(ratanumero, "kaunis kuvaus")
         assertEquals(ratanumero, sijaintitiedot.trackNumber)
 
         //Tilanne ja laatutiedot

--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -59,7 +59,6 @@ export const linkingReducers = {
                 errors: [],
             };
         }
-        state.map.loadingIndicatorVisible = true;
     },
     stopLinking: function (state: TrackLayoutState): void {
         state.linkingState = undefined;

--- a/ui/src/map/layers/alignment/alignment-linking-layer.ts
+++ b/ui/src/map/layers/alignment/alignment-linking-layer.ts
@@ -4,13 +4,14 @@ import { LineString, Point as OlPoint } from 'ol/geom';
 import { Circle, Fill, Stroke, Style, Text } from 'ol/style';
 import { Coordinate } from 'ol/coordinate';
 import { State } from 'ol/render';
-import { MapTile } from 'map/map-model';
+import { MapLayerName, MapTile } from 'map/map-model';
 import { Selection } from 'selection/selection-model';
 import {
     centroid,
-    clearFeatures,
+    createLayer,
     findIntersectingFeatures,
     getPlanarDistanceUnwrapped,
+    loadLayerData,
     pointToCoords,
     sortFeaturesByDistance,
 } from 'map/layers/utils/layer-utils';
@@ -18,6 +19,9 @@ import { LayerItemSearchResult, MapLayer, SearchItemsOptions } from 'map/layers/
 import { LINKING_DOTS } from 'map/layers/utils/layer-visibility-limits';
 import {
     ClusterPoint,
+    LinkingAlignment,
+    LinkingGeometryWithAlignment,
+    LinkingGeometryWithEmptyAlignment,
     LinkingState,
     LinkingType,
     LinkInterval,
@@ -754,7 +758,261 @@ async function getLinkPointsWithAddresses<
     });
 }
 
-let newestLayerId = 0;
+type LayoutSection = {
+    layoutStart: LinkPoint | undefined;
+    layoutEnd: LinkPoint | undefined;
+    layoutHighlight: LinkPoint;
+};
+
+type GeometrySection = {
+    geometryStart: LinkPoint | undefined;
+    geometryEnd: LinkPoint | undefined;
+    geometryHighlight: LinkPoint;
+};
+
+type AlignmentLinkingData = {
+    type: LinkingType.LinkingAlignment;
+    state: LinkingAlignment;
+    points: LinkPoint[];
+    pointAddresses: LayoutSection;
+};
+
+type GeometryWithEmptyAlignmentLinkingData = {
+    type: LinkingType.LinkingGeometryWithEmptyAlignment;
+    state: LinkingGeometryWithEmptyAlignment;
+    points: LinkPoint[];
+    pointAddresses: GeometrySection;
+};
+
+type GeometryWithAlignmentLinkingData = {
+    type: LinkingType.LinkingGeometryWithAlignment;
+    state: LinkingGeometryWithAlignment;
+    layoutPoints: LinkPoint[];
+    geometryPoints: LinkPoint[];
+    pointAddresses: GeometrySection & LayoutSection;
+};
+
+type EmptyData = {
+    type: 'empty';
+};
+
+type LinkingData =
+    | AlignmentLinkingData
+    | GeometryWithEmptyAlignmentLinkingData
+    | GeometryWithAlignmentLinkingData
+    | EmptyData;
+
+async function getLinkingData(
+    mapTiles: MapTile[],
+    selection: Selection,
+    state: LinkingState | undefined,
+    changeTimes: ChangeTimes,
+): Promise<LinkingData> {
+    if (state?.state === 'setup' || state?.state === 'allSet') {
+        const changeTime = getMaxTimestamp(
+            changeTimes.layoutReferenceLine,
+            changeTimes.layoutLocationTrack,
+        );
+        const { highlightedItems } = selection;
+
+        if (state.type === LinkingType.LinkingAlignment) {
+            const [points, pointAddresses] = await Promise.all([
+                getLinkPointsByTiles(
+                    changeTime,
+                    mapTiles,
+                    state.layoutAlignmentId,
+                    state.layoutAlignmentType,
+                ),
+                getLinkPointsWithAddresses(state.layoutAlignmentType, state.layoutAlignmentId, {
+                    layoutStart: state.layoutAlignmentInterval.start,
+                    layoutEnd: state.layoutAlignmentInterval.end,
+                    layoutHighlight: highlightedItems.layoutLinkPoints[0],
+                }),
+            ]);
+            return { type: LinkingType.LinkingAlignment, state, points, pointAddresses };
+        } else if (state.type === LinkingType.LinkingGeometryWithEmptyAlignment) {
+            const [points, pointAddresses] = await Promise.all([
+                getGeometryLinkPointsByTiles(
+                    state.geometryPlanId,
+                    state.geometryAlignmentId,
+                    mapTiles,
+                    [
+                        state.geometryAlignmentInterval.start,
+                        state.geometryAlignmentInterval.end,
+                    ].filter(filterNotEmpty),
+                ),
+                getLinkPointsWithAddresses(state.layoutAlignmentType, state.layoutAlignmentId, {
+                    geometryStart: state.geometryAlignmentInterval.start,
+                    geometryEnd: state.geometryAlignmentInterval.end,
+                    geometryHighlight: highlightedItems.geometryLinkPoints[0],
+                }),
+            ]);
+            return {
+                type: LinkingType.LinkingGeometryWithEmptyAlignment,
+                state,
+                points,
+                pointAddresses,
+            };
+        } else if (state?.type === LinkingType.LinkingGeometryWithAlignment) {
+            const [layoutPoints, geometryPoints, pointAddresses] = await Promise.all([
+                getGeometryLinkPointsByTiles(
+                    state.geometryPlanId,
+                    state.geometryAlignmentId,
+                    mapTiles,
+                    [
+                        state.geometryAlignmentInterval.start,
+                        state.geometryAlignmentInterval.end,
+                        state.layoutAlignmentInterval.start,
+                        state.layoutAlignmentInterval.end,
+                    ].filter(filterNotEmpty),
+                ),
+                getLinkPointsByTiles(
+                    changeTime,
+                    mapTiles,
+                    state.layoutAlignmentId,
+                    state.layoutAlignmentType,
+                ),
+                getLinkPointsWithAddresses(state.layoutAlignmentType, state.layoutAlignmentId, {
+                    layoutStart: state.layoutAlignmentInterval.start,
+                    layoutEnd: state.layoutAlignmentInterval.end,
+                    layoutHighlight: highlightedItems.layoutLinkPoints[0],
+                    geometryStart: state.geometryAlignmentInterval.start,
+                    geometryEnd: state.geometryAlignmentInterval.end,
+                    geometryHighlight: highlightedItems.geometryLinkPoints[0],
+                }),
+            ]);
+            return {
+                type: LinkingType.LinkingGeometryWithAlignment,
+                state: state,
+                layoutPoints,
+                geometryPoints,
+                pointAddresses,
+            };
+        } else {
+            return { type: 'empty' };
+        }
+    } else {
+        return { type: 'empty' };
+    }
+}
+
+const createFeatures = (
+    data: LinkingData,
+    selection: Selection,
+    drawLinkingDots: boolean,
+): Feature<LineString | OlPoint>[] => {
+    switch (data.type) {
+        case LinkingType.LinkingAlignment:
+            return createLinkingAlignmentFeatures(
+                data.points,
+                {
+                    ...data.state.layoutAlignmentInterval,
+                    start: data.pointAddresses.layoutStart,
+                    end: data.pointAddresses.layoutEnd,
+                },
+                data.pointAddresses.layoutHighlight,
+                drawLinkingDots,
+            );
+
+        case LinkingType.LinkingGeometryWithEmptyAlignment:
+            return createAlignmentFeatures(
+                data.points,
+                data.pointAddresses.geometryHighlight,
+                [],
+                {
+                    ...data.state.geometryAlignmentInterval,
+                    start: data.pointAddresses.geometryStart,
+                    end: data.pointAddresses.geometryEnd,
+                },
+                drawLinkingDots,
+                true,
+                geometryPointStyle,
+                geometryAlignmentStyle,
+                geometryPointSelectedStyle,
+                geometryPointSelectedLargeStyle,
+                geometryAlignmentSelectedStyle,
+            );
+
+        case LinkingType.LinkingGeometryWithAlignment:
+            return createLinkingGeometryWithAlignmentFeatures(
+                {
+                    ...selection,
+                    highlightedItems: {
+                        ...selection.highlightedItems,
+                        layoutLinkPoints: [data.pointAddresses.layoutHighlight],
+                        geometryLinkPoints: [data.pointAddresses.geometryHighlight],
+                    },
+                },
+                {
+                    ...data.state.layoutAlignmentInterval,
+                    start: data.pointAddresses.layoutStart,
+                    end: data.pointAddresses.layoutEnd,
+                },
+                {
+                    ...data.state.geometryAlignmentInterval,
+                    start: data.pointAddresses.geometryStart,
+                    end: data.pointAddresses.geometryEnd,
+                },
+                drawLinkingDots,
+                data.layoutPoints,
+                data.geometryPoints,
+            );
+
+        case 'empty':
+            return [];
+    }
+};
+
+const emptySearchResult = {
+    layoutLinkPoints: [],
+    geometryLinkPoints: [],
+    clusterPoints: [],
+};
+
+const searchItems = (source: VectorSource, hitArea: Rectangle): LayerItemSearchResult => {
+    const features = findIntersectingFeatures<OlPoint | LineString>(hitArea, source);
+
+    const clusterPoint: ClusterPoint | undefined = findFirstOfType<ClusterPoint>(
+        features,
+        FeatureType.ClusterPoint,
+    );
+
+    let layoutLinkPoint: LinkPoint | undefined;
+    let geometryLinkPoint: LinkPoint | undefined;
+
+    if (!clusterPoint) {
+        const linkPointFeatures = getSortedLinkPointFeatures(
+            source.getFeatures(),
+            centroid(hitArea),
+        );
+
+        const onLayoutLine = containsType(features, FeatureType.LayoutLine);
+        const onGeometryLine = containsType(features, FeatureType.GeometryLine);
+
+        if (onLayoutLine && onGeometryLine) {
+            const closestPoint = linkPointFeatures[0];
+            const closestPointType = getFeatureType(closestPoint);
+
+            if (closestPointType === FeatureType.GeometryPoint) {
+                geometryLinkPoint = getFeatureData(closestPoint);
+            } else if (closestPointType === FeatureType.LayoutPoint) {
+                layoutLinkPoint = getFeatureData(closestPoint);
+            }
+        } else if (onGeometryLine) {
+            geometryLinkPoint = findFirstOfType(linkPointFeatures, FeatureType.GeometryPoint);
+        } else if (onLayoutLine) {
+            layoutLinkPoint = findFirstOfType(linkPointFeatures, FeatureType.LayoutPoint);
+        }
+    }
+
+    return {
+        layoutLinkPoints: layoutLinkPoint ? [layoutLinkPoint] : [],
+        geometryLinkPoints: geometryLinkPoint ? [geometryLinkPoint] : [],
+        clusterPoints: clusterPoint ? [clusterPoint] : [],
+    };
+};
+
+const layerName: MapLayerName = 'alignment-linking-layer';
 
 export function createAlignmentLinkingLayer(
     mapTiles: MapTile[],
@@ -763,254 +1021,29 @@ export function createAlignmentLinkingLayer(
     linkingState: LinkingState | undefined,
     changeTimes: ChangeTimes,
     resolution: number,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
     const drawLinkingDots = resolution <= LINKING_DOTS;
 
-    let inFlight = false;
-    if (linkingState?.state === 'setup' || linkingState?.state === 'allSet') {
-        if (linkingState.type === LinkingType.LinkingAlignment) {
-            const changeTime = getMaxTimestamp(
-                changeTimes.layoutReferenceLine,
-                changeTimes.layoutLocationTrack,
-            );
+    const dataPromise = getLinkingData(mapTiles, selection, linkingState, changeTimes);
 
-            inFlight = true;
-            Promise.all([
-                getLinkPointsByTiles(
-                    changeTime,
-                    mapTiles,
-                    linkingState.layoutAlignmentId,
-                    linkingState.layoutAlignmentType,
-                ),
-                getLinkPointsWithAddresses(
-                    linkingState.layoutAlignmentType,
-                    linkingState.layoutAlignmentId,
-                    {
-                        layoutStart: linkingState.layoutAlignmentInterval.start,
-                        layoutEnd: linkingState.layoutAlignmentInterval.end,
-                        layoutHighlight: selection.highlightedItems.layoutLinkPoints[0],
-                    },
-                ),
-            ])
-                .then(([points, linkPointAddresses]) => {
-                    if (layerId !== newestLayerId) return;
-                    const features = createLinkingAlignmentFeatures(
-                        points,
-                        {
-                            ...linkingState.layoutAlignmentInterval,
-                            start: linkPointAddresses.layoutStart,
-                            end: linkPointAddresses.layoutEnd,
-                        },
-                        linkPointAddresses.layoutHighlight,
-                        drawLinkingDots,
-                    );
-
-                    clearFeatures(vectorSource);
-                    vectorSource.addFeatures(features);
-                })
-                .catch(() => {
-                    if (layerId === newestLayerId) clearFeatures(vectorSource);
-                })
-                .finally(() => {
-                    inFlight = false;
-                });
-        } else if (linkingState.type === LinkingType.LinkingGeometryWithEmptyAlignment) {
-            inFlight = true;
-            Promise.all([
-                getGeometryLinkPointsByTiles(
-                    linkingState.geometryPlanId,
-                    linkingState.geometryAlignmentId,
-                    mapTiles,
-                    [
-                        linkingState.geometryAlignmentInterval.start,
-                        linkingState.geometryAlignmentInterval.end,
-                    ].filter(filterNotEmpty),
-                ),
-                getLinkPointsWithAddresses(
-                    linkingState.layoutAlignmentType,
-                    linkingState.layoutAlignmentId,
-                    {
-                        geometryStart: linkingState.geometryAlignmentInterval.start,
-                        geometryEnd: linkingState.geometryAlignmentInterval.end,
-                        geometryHighlight: selection.highlightedItems.geometryLinkPoints[0],
-                    },
-                ),
-            ])
-                .then(([points, linkPointAddresses]) => {
-                    if (layerId !== newestLayerId) return;
-
-                    const features = createAlignmentFeatures(
-                        points,
-                        linkPointAddresses.geometryHighlight,
-                        [],
-                        {
-                            ...linkingState.geometryAlignmentInterval,
-                            start: linkPointAddresses.geometryStart,
-                            end: linkPointAddresses.geometryEnd,
-                        },
-                        drawLinkingDots,
-                        true,
-                        geometryPointStyle,
-                        geometryAlignmentStyle,
-                        geometryPointSelectedStyle,
-                        geometryPointSelectedLargeStyle,
-                        geometryAlignmentSelectedStyle,
-                    );
-
-                    clearFeatures(vectorSource);
-                    vectorSource.addFeatures(features);
-                })
-                .catch(() => {
-                    if (layerId === newestLayerId) clearFeatures(vectorSource);
-                })
-                .finally(() => {
-                    inFlight = false;
-                });
-        } else if (linkingState?.type === LinkingType.LinkingGeometryWithAlignment) {
-            inFlight = true;
-            const geometryPointsPromise = getGeometryLinkPointsByTiles(
-                linkingState.geometryPlanId,
-                linkingState.geometryAlignmentId,
-                mapTiles,
-                [
-                    linkingState.geometryAlignmentInterval.start,
-                    linkingState.geometryAlignmentInterval.end,
-                    linkingState.layoutAlignmentInterval.start,
-                    linkingState.layoutAlignmentInterval.end,
-                ].filter(filterNotEmpty),
-            );
-
-            const changeTime = getMaxTimestamp(
-                changeTimes.layoutReferenceLine,
-                changeTimes.layoutLocationTrack,
-            );
-
-            const layoutPointsPromise = getLinkPointsByTiles(
-                changeTime,
-                mapTiles,
-                linkingState.layoutAlignmentId,
-                linkingState.layoutAlignmentType,
-            );
-
-            const linkPointAddressesPromise = getLinkPointsWithAddresses(
-                linkingState.layoutAlignmentType,
-                linkingState.layoutAlignmentId,
-                {
-                    layoutStart: linkingState.layoutAlignmentInterval.start,
-                    layoutEnd: linkingState.layoutAlignmentInterval.end,
-                    layoutHighlight: selection.highlightedItems.layoutLinkPoints[0],
-                    geometryStart: linkingState.geometryAlignmentInterval.start,
-                    geometryEnd: linkingState.geometryAlignmentInterval.end,
-                    geometryHighlight: selection.highlightedItems.geometryLinkPoints[0],
-                },
-            );
-
-            Promise.all([layoutPointsPromise, geometryPointsPromise, linkPointAddressesPromise])
-                .then(([layoutPoints, geometryPoints, linkPointAddresses]) => {
-                    if (layerId !== newestLayerId) return;
-
-                    const features = createLinkingGeometryWithAlignmentFeatures(
-                        {
-                            ...selection,
-                            highlightedItems: {
-                                ...selection.highlightedItems,
-                                layoutLinkPoints: [linkPointAddresses.layoutHighlight],
-                                geometryLinkPoints: [linkPointAddresses.geometryHighlight],
-                            },
-                        },
-                        {
-                            ...linkingState.layoutAlignmentInterval,
-                            start: linkPointAddresses.layoutStart,
-                            end: linkPointAddresses.layoutEnd,
-                        },
-                        {
-                            ...linkingState.geometryAlignmentInterval,
-                            start: linkPointAddresses.geometryStart,
-                            end: linkPointAddresses.geometryEnd,
-                        },
-                        drawLinkingDots,
-                        layoutPoints,
-                        geometryPoints,
-                    );
-
-                    clearFeatures(vectorSource);
-                    vectorSource.addFeatures(features);
-                })
-                .catch(() => {
-                    if (layerId === newestLayerId) clearFeatures(vectorSource);
-                })
-                .finally(() => {
-                    inFlight = false;
-                });
-        } else {
-            clearFeatures(vectorSource);
-        }
-    } else {
-        clearFeatures(vectorSource);
-    }
+    loadLayerData(source, isLatest, onLoadingData, dataPromise, (data) =>
+        createFeatures(data, selection, drawLinkingDots),
+    );
 
     return {
-        name: 'alignment-linking-layer',
+        name: layerName,
         layer: layer,
         searchItems: (hitArea: Rectangle, _options: SearchItemsOptions): LayerItemSearchResult => {
-            //If dots are not drawn, do not select anything
             if (!drawLinkingDots) {
-                return {
-                    layoutLinkPoints: [],
-                    geometryLinkPoints: [],
-                    clusterPoints: [],
-                };
+                //If dots are not drawn, do not select anything
+                return emptySearchResult;
+            } else {
+                return searchItems(source, hitArea);
             }
-
-            const features = findIntersectingFeatures<OlPoint | LineString>(hitArea, vectorSource);
-
-            const clusterPoint: ClusterPoint | undefined = findFirstOfType<ClusterPoint>(
-                features,
-                FeatureType.ClusterPoint,
-            );
-
-            let layoutLinkPoint: LinkPoint | undefined;
-            let geometryLinkPoint: LinkPoint | undefined;
-
-            if (!clusterPoint) {
-                const linkPointFeatures = getSortedLinkPointFeatures(
-                    vectorSource.getFeatures(),
-                    centroid(hitArea),
-                );
-
-                const onLayoutLine = containsType(features, FeatureType.LayoutLine);
-                const onGeometryLine = containsType(features, FeatureType.GeometryLine);
-
-                if (onLayoutLine && onGeometryLine) {
-                    const closestPoint = linkPointFeatures[0];
-                    const closestPointType = getFeatureType(closestPoint);
-
-                    if (closestPointType === FeatureType.GeometryPoint) {
-                        geometryLinkPoint = getFeatureData(closestPoint);
-                    } else if (closestPointType === FeatureType.LayoutPoint) {
-                        layoutLinkPoint = getFeatureData(closestPoint);
-                    }
-                } else if (onGeometryLine) {
-                    geometryLinkPoint = findFirstOfType(
-                        linkPointFeatures,
-                        FeatureType.GeometryPoint,
-                    );
-                } else if (onLayoutLine) {
-                    layoutLinkPoint = findFirstOfType(linkPointFeatures, FeatureType.LayoutPoint);
-                }
-            }
-
-            return {
-                layoutLinkPoints: layoutLinkPoint ? [layoutLinkPoint] : [],
-                geometryLinkPoints: geometryLinkPoint ? [geometryLinkPoint] : [],
-                clusterPoints: clusterPoint ? [clusterPoint] : [],
-            };
         },
-        requestInFlight: () => inFlight,
     };
 }
 

--- a/ui/src/map/layers/alignment/alignment-linking-layer.ts
+++ b/ui/src/map/layers/alignment/alignment-linking-layer.ts
@@ -854,7 +854,7 @@ async function getLinkingData(
                 pointAddresses,
             };
         } else if (state?.type === LinkingType.LinkingGeometryWithAlignment) {
-            const [layoutPoints, geometryPoints, pointAddresses] = await Promise.all([
+            const [geometryPoints, layoutPoints, pointAddresses] = await Promise.all([
                 getGeometryLinkPointsByTiles(
                     state.geometryPlanId,
                     state.geometryAlignmentId,

--- a/ui/src/map/layers/alignment/location-track-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-alignment-layer.ts
@@ -1,8 +1,8 @@
 import { LineString, Point as OlPoint } from 'ol/geom';
 import OlView from 'ol/View';
-import { MapTile, OptionalShownItems } from 'map/map-model';
+import { MapLayerName, MapTile, OptionalShownItems } from 'map/map-model';
 import { Selection } from 'selection/selection-model';
-import { clearFeatures } from 'map/layers/utils/layer-utils';
+import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import { LayerItemSearchResult, MapLayer, SearchItemsOptions } from 'map/layers/utils/layer-model';
 import * as Limits from 'map/layers/utils/layer-visibility-limits';
 import { ALL_ALIGNMENTS } from 'map/layers/utils/layer-visibility-limits';
@@ -18,12 +18,14 @@ import { LocationTrackId } from 'track-layout/track-layout-model';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-import { getLocationTrackMapAlignmentsByTiles } from 'track-layout/layout-map-api';
+import {
+    AlignmentDataHolder,
+    getLocationTrackMapAlignmentsByTiles,
+} from 'track-layout/layout-map-api';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
 
 let shownLocationTracksCompare = '';
-let newestLayerId = 0;
 
 const highlightedLocationTrackStyle = new Style({
     stroke: new Stroke({
@@ -41,6 +43,8 @@ const locationTrackStyle = new Style({
     zIndex: 0,
 });
 
+const layerName: MapLayerName = 'location-track-alignment-layer';
+
 export function createLocationTrackAlignmentLayer(
     mapTiles: MapTile[],
     existingOlLayer: VectorLayer<VectorSource<LineString | OlPoint>> | undefined,
@@ -50,11 +54,10 @@ export function createLocationTrackAlignmentLayer(
     changeTimes: ChangeTimes,
     olView: OlView,
     onViewContentChanged: (items: OptionalShownItems) => void,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
     layer.setOpacity(
         isSplitting ? OTHER_ALIGNMENTS_OPACITY_WHILE_SPLITTING : NORMAL_ALIGNMENT_OPACITY,
     );
@@ -70,52 +73,43 @@ export function createLocationTrackAlignmentLayer(
         }
     }
 
-    let inFlight = true;
     const alignmentPromise =
         resolution <= ALL_ALIGNMENTS
             ? getLocationTrackMapAlignmentsByTiles(changeTimes, mapTiles, publishType)
             : Promise.resolve([]);
 
-    alignmentPromise
-        .then((locationTracks) => {
-            if (layerId !== newestLayerId) return;
+    const createFeatures = (locationTracks: AlignmentDataHolder[]) => {
+        const showEndPointTicks = resolution <= Limits.SHOW_LOCATION_TRACK_BADGES;
 
-            const showEndPointTicks = resolution <= Limits.SHOW_LOCATION_TRACK_BADGES;
+        return createAlignmentFeatures(
+            locationTracks,
+            selection,
+            showEndPointTicks,
+            locationTrackStyle,
+            highlightedLocationTrackStyle,
+        );
+    };
 
-            const features = createAlignmentFeatures(
-                locationTracks,
-                selection,
-                showEndPointTicks,
-                locationTrackStyle,
-                highlightedLocationTrackStyle,
-            );
+    const onLoadingChange = (
+        loading: boolean,
+        locationTracks: AlignmentDataHolder[] | undefined,
+    ) => {
+        if (!loading) {
+            updateShownLocationTracks(locationTracks?.map(({ header }) => header.id) ?? []);
+        }
+        onLoadingData(loading);
+    };
 
-            clearFeatures(vectorSource);
-            vectorSource.addFeatures(features);
-
-            updateShownLocationTracks(locationTracks.map(({ header }) => header.id));
-        })
-        .catch(() => {
-            if (layerId === newestLayerId) {
-                clearFeatures(vectorSource);
-                updateShownLocationTracks([]);
-            }
-        })
-        .finally(() => {
-            inFlight = false;
-        });
+    loadLayerData(source, isLatest, onLoadingChange, alignmentPromise, createFeatures);
 
     return {
-        name: 'location-track-alignment-layer',
+        name: layerName,
         layer: layer,
-        searchItems: (hitArea: Rectangle, options: SearchItemsOptions): LayerItemSearchResult => {
-            return {
-                locationTracks: findMatchingAlignments(hitArea, vectorSource, options).map(
-                    ({ header }) => header.id,
-                ),
-            };
-        },
+        searchItems: (hitArea: Rectangle, options: SearchItemsOptions): LayerItemSearchResult => ({
+            locationTracks: findMatchingAlignments(hitArea, source, options).map(
+                ({ header }) => header.id,
+            ),
+        }),
         onRemove: () => updateShownLocationTracks([]),
-        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/alignment/location-track-background-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-background-layer.ts
@@ -1,5 +1,5 @@
 import { LineString } from 'ol/geom';
-import { MapTile } from 'map/map-model';
+import { MapLayerName, MapTile } from 'map/map-model';
 import {
     AlignmentDataHolder,
     getLocationTrackMapAlignmentsByTiles,
@@ -10,7 +10,7 @@ import { ALL_ALIGNMENTS } from 'map/layers/utils/layer-visibility-limits';
 import { PublishType } from 'common/common-model';
 import { ChangeTimes } from 'common/common-slice';
 import { createAlignmentBackgroundFeatures } from 'map/layers/utils/background-layer-utils';
-import { clearFeatures } from 'map/layers/utils/layer-utils';
+import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { Selection } from 'selection/selection-model';
@@ -20,7 +20,7 @@ import {
 } from 'map/layers/utils/alignment-layer-utils';
 import { LocationTrackId } from 'track-layout/track-layout-model';
 
-let newestLayerId = 0;
+const layerName: MapLayerName = 'location-track-background-layer';
 
 export function createLocationTrackBackgroundLayer(
     mapTiles: MapTile[],
@@ -30,19 +30,17 @@ export function createLocationTrackBackgroundLayer(
     resolution: number,
     selection: Selection,
     isSplitting: boolean,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
     layer.setOpacity(
         isSplitting ? OTHER_ALIGNMENTS_OPACITY_WHILE_SPLITTING : NORMAL_ALIGNMENT_OPACITY,
     );
 
-    let inFlight = true;
     const selectedTrack = selection.selectedItems.locationTracks[0];
 
-    const alignmentPromise = getMapAlignments(
+    const alignmentPromise: Promise<AlignmentDataHolder[]> = getMapAlignments(
         changeTimes,
         mapTiles,
         resolution,
@@ -50,27 +48,12 @@ export function createLocationTrackBackgroundLayer(
         selectedTrack,
     );
 
-    alignmentPromise
-        .then((locationTracks) => {
-            if (layerId === newestLayerId) {
-                const features = createAlignmentBackgroundFeatures(locationTracks);
+    const createFeatures = (locationTracks: AlignmentDataHolder[]) =>
+        createAlignmentBackgroundFeatures(locationTracks);
 
-                clearFeatures(vectorSource);
-                vectorSource.addFeatures(features);
-            }
-        })
-        .catch(() => {
-            if (layerId === newestLayerId) clearFeatures(vectorSource);
-        })
-        .finally(() => {
-            inFlight = false;
-        });
+    loadLayerData(source, isLatest, onLoadingData, alignmentPromise, createFeatures);
 
-    return {
-        name: 'location-track-background-layer',
-        layer: layer,
-        requestInFlight: () => inFlight,
-    };
+    return { name: layerName, layer: layer };
 }
 
 function getMapAlignments(

--- a/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
@@ -1,18 +1,19 @@
 import { LineString, Point as OlPoint } from 'ol/geom';
-import { MapTile } from 'map/map-model';
+import { MapLayerName, MapTile } from 'map/map-model';
 import { Selection } from 'selection/selection-model';
-import { clearFeatures } from 'map/layers/utils/layer-utils';
+import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { PublishType } from 'common/common-model';
 import { ChangeTimes } from 'common/common-slice';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-import { getSelectedReferenceLineMapAlignmentByTiles } from 'track-layout/layout-map-api';
+import {
+    AlignmentDataHolder,
+    getSelectedReferenceLineMapAlignmentByTiles,
+} from 'track-layout/layout-map-api';
 import { createAlignmentFeature } from '../utils/alignment-layer-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
-
-let newestLayerId = 0;
 
 const selectedReferenceLineStyle = new Style({
     stroke: new Stroke({
@@ -22,21 +23,20 @@ const selectedReferenceLineStyle = new Style({
     zIndex: 1,
 });
 
+const layerName: MapLayerName = 'reference-line-selected-alignment-layer';
+
 export function createSelectedReferenceLineAlignmentLayer(
     mapTiles: MapTile[],
     existingOlLayer: VectorLayer<VectorSource<LineString | OlPoint>> | undefined,
     selection: Selection,
     publishType: PublishType,
     changeTimes: ChangeTimes,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
-
-    let inFlight = true;
     const selectedTrackNumber = selection.selectedItems.trackNumbers[0];
-    const alignmentPromise = selectedTrackNumber
+    const dataPromise: Promise<AlignmentDataHolder[]> = selectedTrackNumber
         ? getSelectedReferenceLineMapAlignmentByTiles(
               changeTimes,
               mapTiles,
@@ -45,31 +45,10 @@ export function createSelectedReferenceLineAlignmentLayer(
           )
         : Promise.resolve([]);
 
-    alignmentPromise
-        .then((referenceLines) => {
-            if (layerId !== newestLayerId) return;
+    const createFeatures = (referenceLines: AlignmentDataHolder[]) =>
+        createAlignmentFeature(referenceLines[0], false, selectedReferenceLineStyle);
 
-            const alignmentFeatures = createAlignmentFeature(
-                referenceLines[0],
-                false,
-                selectedReferenceLineStyle,
-            );
+    loadLayerData(source, isLatest, onLoadingData, dataPromise, createFeatures);
 
-            clearFeatures(vectorSource);
-            vectorSource.addFeatures(alignmentFeatures);
-        })
-        .catch(() => {
-            if (layerId === newestLayerId) {
-                clearFeatures(vectorSource);
-            }
-        })
-        .finally(() => {
-            inFlight = false;
-        });
-
-    return {
-        name: 'reference-line-selected-alignment-layer',
-        layer: layer,
-        requestInFlight: () => inFlight,
-    };
+    return { name: layerName, layer };
 }

--- a/ui/src/map/layers/background-map-layer.ts
+++ b/ui/src/map/layers/background-map-layer.ts
@@ -40,7 +40,5 @@ export function createBackgroundMapLayer(existingOlLayer: Tile<TileSource>): Map
     return {
         name: 'background-map-layer',
         layer: layer,
-        // the background map uses OL's native loading, so we don't need to worry about it
-        requestInFlight: () => false,
     };
 }

--- a/ui/src/map/layers/debug/debug-layer.ts
+++ b/ui/src/map/layers/debug/debug-layer.ts
@@ -3,9 +3,10 @@ import { Point as OlPoint } from 'ol/geom';
 import { filterNotEmpty } from 'utils/array-utils';
 import { Circle, Fill, Stroke, Style, Text } from 'ol/style';
 import { MapLayer } from 'map/layers/utils/layer-model';
-import { clearFeatures, pointToCoords } from 'map/layers/utils/layer-utils';
+import { clearFeatures, createLayer, pointToCoords } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
+import { MapLayerName } from 'map/map-model';
 
 type DebugLayerPoint = {
     type: 'point';
@@ -66,15 +67,16 @@ function createDebugFeatures(points: DebugLayerPoint[]): Feature<OlPoint>[] {
         .filter(filterNotEmpty);
 }
 
+const layerName: MapLayerName = 'debug-layer';
+
 export function createDebugLayer(
     existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
 ): MapLayer {
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
+    const { layer, source } = createLayer(layerName, existingOlLayer);
 
     function updateFeatures(features: Feature<OlPoint>[]) {
-        clearFeatures(vectorSource);
-        vectorSource.addFeatures(features);
+        clearFeatures(source);
+        source.addFeatures(features);
     }
 
     updateLayerFunc = () => {
@@ -83,9 +85,5 @@ export function createDebugLayer(
 
     updateLayerFunc();
 
-    return {
-        name: 'debug-layer',
-        layer: layer,
-        requestInFlight: () => false,
-    };
+    return { name: layerName, layer: layer };
 }

--- a/ui/src/map/layers/geometry/geometry-km-post-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-km-post-layer.ts
@@ -33,7 +33,7 @@ export function createGeometryKmPostLayer(
     manuallySetPlan: GeometryPlanLayout | undefined,
     onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer, false);
 
     const step = getKmPostStepByResolution(resolution);
 

--- a/ui/src/map/layers/geometry/geometry-km-post-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-km-post-layer.ts
@@ -3,9 +3,10 @@ import { Selection } from 'selection/selection-model';
 import { GeometryPlanLayout, LayoutKmPost, PlanAndStatus } from 'track-layout/track-layout-model';
 import { LayerItemSearchResult, MapLayer, SearchItemsOptions } from 'map/layers/utils/layer-model';
 import {
-    clearFeatures,
+    createLayer,
     getManualPlanWithStatus,
     getVisiblePlansWithStatus,
+    loadLayerData,
 } from 'map/layers/utils/layer-utils';
 import { PublishType } from 'common/common-model';
 import {
@@ -18,9 +19,9 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { filterNotEmpty } from 'utils/array-utils';
 import { ChangeTimes } from 'common/common-slice';
-import { MapTile } from 'map/map-model';
+import { MapLayerName, MapTile } from 'map/map-model';
 
-let newestLayerId = 0;
+const layerName: MapLayerName = 'geometry-km-post-layer';
 
 export function createGeometryKmPostLayer(
     mapTiles: MapTile[],
@@ -29,18 +30,20 @@ export function createGeometryKmPostLayer(
     selection: Selection,
     publishType: PublishType,
     changeTimes: ChangeTimes,
-    manuallySetPlan?: GeometryPlanLayout,
+    manuallySetPlan: GeometryPlanLayout | undefined,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
-
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource, style: null });
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
     const step = getKmPostStepByResolution(resolution);
 
-    let inFlight = false;
-    if (step) {
-        inFlight = true;
+    const dataPromise = step
+        ? manuallySetPlan
+            ? getManualPlanWithStatus(manuallySetPlan, publishType)
+            : getVisiblePlansWithStatus(selection.visiblePlans, mapTiles, publishType, changeTimes)
+        : Promise.resolve([]);
+
+    const createFeatures = (planStatuses: PlanAndStatus[]) => {
         const isSelected = (kmPost: LayoutKmPost) => {
             return selection.selectedItems.geometryKmPostIds.some(
                 ({ geometryId }) => geometryId === kmPost.sourceId,
@@ -51,72 +54,51 @@ export function createGeometryKmPostLayer(
             ? manuallySetPlan.kmPosts.map((p) => p.sourceId)
             : selection.visiblePlans.flatMap((p) => p.kmPosts);
 
-        const plansPromise: Promise<PlanAndStatus[]> = manuallySetPlan
-            ? getManualPlanWithStatus(manuallySetPlan, publishType)
-            : getVisiblePlansWithStatus(selection.visiblePlans, mapTiles, publishType, changeTimes);
+        return planStatuses.flatMap(({ plan, status }) => {
+            const kmPosts: LayoutKmPost[] = plan.kmPosts.filter(
+                ({ sourceId, kmNumber }) =>
+                    sourceId &&
+                    visibleKmPosts.includes(sourceId) &&
+                    Number.parseInt(kmNumber) % step === 0,
+            );
 
-        plansPromise
-            .then((planStatuses) => {
-                if (layerId !== newestLayerId) return;
+            const kmPostLinkedStatus = status
+                ? new Map(
+                      status.kmPosts.map((kmPosts) => [
+                          kmPosts.id,
+                          kmPosts.linkedKmPosts?.length > 0,
+                      ]),
+                  )
+                : undefined;
 
-                const features = planStatuses.flatMap(({ plan, status }) => {
-                    const kmPosts: LayoutKmPost[] = plan.kmPosts.filter(
-                        ({ sourceId, kmNumber }) =>
-                            sourceId &&
-                            visibleKmPosts.includes(sourceId) &&
-                            Number.parseInt(kmNumber) % step === 0,
-                    );
-
-                    const kmPostLinkedStatus = status
-                        ? new Map(
-                              status.kmPosts.map((kmPosts) => [
-                                  kmPosts.id,
-                                  kmPosts.linkedKmPosts?.length > 0,
-                              ]),
-                          )
-                        : undefined;
-
-                    return createKmPostFeatures(
-                        kmPosts,
-                        isSelected,
-                        'geometryKmPost',
-                        resolution,
-                        plan.id,
-                        (kmPost) =>
-                            (kmPost.sourceId && kmPostLinkedStatus?.get(kmPost.sourceId)) || false,
-                    );
-                });
-
-                clearFeatures(vectorSource);
-                vectorSource.addFeatures(features);
-            })
-            .catch(() => {
-                if (layerId === newestLayerId) clearFeatures(vectorSource);
-            })
-            .finally(() => {
-                inFlight = false;
-            });
-    } else {
-        clearFeatures(vectorSource);
-    }
-
-    return {
-        name: 'geometry-km-post-layer',
-        layer: layer,
-        searchItems: (hitArea: Rectangle, options: SearchItemsOptions): LayerItemSearchResult => {
-            return {
-                geometryKmPostIds: findMatchingKmPosts(hitArea, vectorSource, options)
-                    .map((kp) =>
-                        kp.kmPost.sourceId && kp.planId
-                            ? {
-                                  geometryId: kp.kmPost.sourceId,
-                                  planId: kp.planId,
-                              }
-                            : undefined,
-                    )
-                    .filter(filterNotEmpty),
-            };
-        },
-        requestInFlight: () => inFlight,
+            return createKmPostFeatures(
+                kmPosts,
+                isSelected,
+                'geometryKmPost',
+                resolution,
+                plan.id,
+                (kmPost) => (kmPost.sourceId && kmPostLinkedStatus?.get(kmPost.sourceId)) || false,
+            );
+        });
     };
+
+    loadLayerData(source, isLatest, onLoadingData, dataPromise, createFeatures);
+
+    const searchItems = (
+        hitArea: Rectangle,
+        options: SearchItemsOptions,
+    ): LayerItemSearchResult => ({
+        geometryKmPostIds: findMatchingKmPosts(hitArea, source, options)
+            .map((kp) =>
+                kp.kmPost.sourceId && kp.planId
+                    ? {
+                          geometryId: kp.kmPost.sourceId,
+                          planId: kp.planId,
+                      }
+                    : undefined,
+            )
+            .filter(filterNotEmpty),
+    });
+
+    return { name: layerName, layer: layer, searchItems: searchItems };
 }

--- a/ui/src/map/layers/geometry/plan-area-layer.ts
+++ b/ui/src/map/layers/geometry/plan-area-layer.ts
@@ -2,11 +2,11 @@ import mapStyles from 'map/map.module.scss';
 import Feature from 'ol/Feature';
 import { Polygon } from 'ol/geom';
 import { Stroke, Style, Text } from 'ol/style';
-import { MapTile } from 'map/map-model';
+import { MapLayerName, MapTile } from 'map/map-model';
 import { PlanArea } from 'track-layout/track-layout-model';
 import { getPlanAreasByTile } from 'geometry/geometry-api';
 import { ChangeTimes } from 'common/common-slice';
-import { clearFeatures, pointToCoords } from 'map/layers/utils/layer-utils';
+import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
@@ -40,41 +40,27 @@ function createPlanFeature(planArea: PlanArea): Feature<Polygon> {
     return feature;
 }
 
-let newestLayerId = 0;
+const layerName: MapLayerName = 'plan-area-layer';
 
 export function createPlanAreaLayer(
     mapTiles: MapTile[],
     existingOlLayer: VectorLayer<VectorSource<Polygon>> | undefined,
     changeTimes: ChangeTimes,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
-
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
     const planAreaPromises = mapTiles.map((tile) =>
         getPlanAreasByTile(tile, changeTimes.geometryPlan),
     );
+    const dataPromise: Promise<PlanArea[]> = Promise.all(planAreaPromises).then((planAreas) =>
+        deduplicatePlanAreas(planAreas.flat()),
+    );
 
-    let inFlight = true;
-    Promise.all(planAreaPromises)
-        .then((planAreas) => deduplicatePlanAreas(planAreas.flat()))
-        .then((planAreas) => {
-            if (layerId === newestLayerId) {
-                const features = planAreas.flatMap((planArea) => createPlanFeature(planArea));
+    const createFeatures = (planAreas: PlanArea[]) =>
+        planAreas.flatMap((planArea) => createPlanFeature(planArea));
 
-                clearFeatures(vectorSource);
-                vectorSource.addFeatures(features);
-            }
-        })
-        .catch(() => {
-            if (layerId === newestLayerId) clearFeatures(vectorSource);
-        })
-        .finally(() => (inFlight = false));
+    loadLayerData(source, isLatest, onLoadingData, dataPromise, createFeatures);
 
-    return {
-        name: 'plan-area-layer',
-        layer: layer,
-        requestInFlight: () => inFlight,
-    };
+    return { name: layerName, layer: layer };
 }

--- a/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
@@ -1,10 +1,10 @@
-import { MapTile } from 'map/map-model';
+import { MapLayerName, MapTile } from 'map/map-model';
 import { PublishType } from 'common/common-model';
 import { ChangeTimes } from 'common/common-slice';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { HIGHLIGHTS_SHOW } from 'map/layers/utils/layer-visibility-limits';
 import { AlignmentDataHolder, getMapAlignmentsByTiles } from 'track-layout/layout-map-api';
-import { clearFeatures, pointToCoords } from 'map/layers/utils/layer-utils';
+import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { LineString } from 'ol/geom';
@@ -16,11 +16,12 @@ import {
 import { LocationTrackId } from 'track-layout/track-layout-model';
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { getLocationTrackInfoboxExtras } from 'track-layout/layout-location-track-api';
+import { filterNotEmpty } from 'utils/array-utils';
 
 function createFeatures(
     alignments: AlignmentDataHolder[],
     duplicateIds: LocationTrackId[],
-    linkedDuplicates: (LocationTrackId | undefined)[],
+    linkedDuplicates: LocationTrackId[],
 ): Feature<LineString>[] {
     return alignments
         .filter((alignment) => duplicateIds.includes(alignment.header.id))
@@ -39,7 +40,38 @@ function createFeatures(
         });
 }
 
-let newestLayerId = 0;
+type DuplicateSplitSectionData = {
+    linkedDuplicates: LocationTrackId[];
+    duplicates: LocationTrackId[];
+    alignments: AlignmentDataHolder[];
+};
+
+async function getDuplicateSplitSectionData(
+    splittingState: SplittingState | undefined,
+    publishType: PublishType,
+    changeTimes: ChangeTimes,
+    mapTiles: MapTile[],
+    resolution: number,
+): Promise<DuplicateSplitSectionData> {
+    if (resolution <= HIGHLIGHTS_SHOW && splittingState) {
+        const linkedDuplicates = splittingState.splits
+            .map((split) => split.duplicateOf)
+            .concat(splittingState.firstSplit.duplicateOf)
+            .filter(filterNotEmpty);
+
+        const [alignments, extras] = await Promise.all([
+            getMapAlignmentsByTiles(changeTimes, mapTiles, publishType),
+            getLocationTrackInfoboxExtras(splittingState.originLocationTrack.id, publishType, changeTimes),
+        ]);
+        const duplicates = extras?.duplicates?.map((dupe) => dupe.id) || [];
+
+        return { linkedDuplicates, duplicates, alignments };
+    } else {
+        return { linkedDuplicates: [], duplicates: [], alignments: [] };
+    }
+}
+
+const layerName: MapLayerName = 'duplicate-split-section-highlight-layer';
 
 export function createDuplicateSplitSectionHighlightLayer(
     mapTiles: MapTile[],
@@ -48,50 +80,22 @@ export function createDuplicateSplitSectionHighlightLayer(
     changeTimes: ChangeTimes,
     resolution: number,
     splittingState: SplittingState | undefined,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
+    const dataPromise: Promise<DuplicateSplitSectionData> = getDuplicateSplitSectionData(
+        splittingState,
+        publishType,
+        changeTimes,
+        mapTiles,
+        resolution,
+    );
 
-    let inFlight = false;
-    if (resolution <= HIGHLIGHTS_SHOW && splittingState) {
-        inFlight = true;
-        const linkedDuplicates = splittingState.splits
-            .map((split) => split.duplicateOf)
-            .concat(splittingState.firstSplit.duplicateOf);
-        getLocationTrackInfoboxExtras(
-            splittingState.originLocationTrack.id,
-            publishType,
-            changeTimes,
-        )
-            .then((extras) => {
-                getMapAlignmentsByTiles(changeTimes, mapTiles, publishType).then((alignments) => {
-                    if (layerId === newestLayerId) {
-                        const features = createFeatures(
-                            alignments,
-                            extras?.duplicates.map((dupe) => dupe.id) || [],
-                            linkedDuplicates,
-                        );
+    const createOlFeatures = (data: DuplicateSplitSectionData) =>
+        createFeatures(data.alignments, data.duplicates, data.linkedDuplicates);
 
-                        clearFeatures(vectorSource);
-                        vectorSource.addFeatures(features);
-                    }
-                });
-            })
-            .catch(() => {
-                if (layerId === newestLayerId) clearFeatures(vectorSource);
-            })
-            .finally(() => {
-                inFlight = false;
-            });
-    } else {
-        clearFeatures(vectorSource);
-    }
+    loadLayerData(source, isLatest, onLoadingData, dataPromise, createOlFeatures);
 
-    return {
-        name: 'duplicate-split-section-highlight-layer',
-        layer: layer,
-        requestInFlight: () => inFlight,
-    };
+    return { name: layerName, layer: layer };
 }

--- a/ui/src/map/layers/highlight/missing-profile-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/missing-profile-highlight-layer.ts
@@ -1,8 +1,9 @@
 import mapStyles from 'map/map.module.scss';
 import { LineString } from 'ol/geom';
 import { Stroke, Style } from 'ol/style';
-import { MapTile } from 'map/map-model';
+import { AlignmentHighlight, MapLayerName, MapTile } from 'map/map-model';
 import {
+    AlignmentDataHolder,
     getLocationTrackMapAlignmentsByTiles,
     getLocationTrackSectionsWithoutProfileByTiles,
 } from 'track-layout/layout-map-api';
@@ -11,7 +12,7 @@ import { PublishType } from 'common/common-model';
 import { ChangeTimes } from 'common/common-slice';
 import { HIGHLIGHTS_SHOW } from 'map/layers/utils/layer-visibility-limits';
 import { createHighlightFeatures } from 'map/layers/utils/highlight-layer-utils';
-import { clearFeatures } from 'map/layers/utils/layer-utils';
+import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
 
@@ -22,7 +23,7 @@ const highlightBackgroundStyle = new Style({
     }),
 });
 
-let newestLayerId = 0;
+const layerName: MapLayerName = 'missing-profile-highlight-layer';
 
 export function createMissingProfileHighlightLayer(
     mapTiles: MapTile[],
@@ -30,53 +31,28 @@ export function createMissingProfileHighlightLayer(
     publishType: PublishType,
     changeTimes: ChangeTimes,
     resolution: number,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
+    const dataPromise: Promise<[AlignmentDataHolder[], AlignmentHighlight[]]> =
+        resolution <= HIGHLIGHTS_SHOW
+            ? Promise.all([
+                  getLocationTrackMapAlignmentsByTiles(changeTimes, mapTiles, publishType),
+                  getLocationTrackSectionsWithoutProfileByTiles(
+                      changeTimes.layoutLocationTrack,
+                      publishType,
+                      mapTiles,
+                  ),
+              ])
+            : Promise.resolve([[], []]);
 
-    let inFlight = false;
-    if (resolution <= HIGHLIGHTS_SHOW) {
-        inFlight = true;
-        const locationTracksPromise = getLocationTrackMapAlignmentsByTiles(
-            changeTimes,
-            mapTiles,
-            publishType,
-        );
+    const createFeatures = ([locationTracks, sections]: [
+        AlignmentDataHolder[],
+        AlignmentHighlight[],
+    ]) => createHighlightFeatures(locationTracks, sections, highlightBackgroundStyle);
 
-        const profilePromise = getLocationTrackSectionsWithoutProfileByTiles(
-            changeTimes.layoutLocationTrack,
-            publishType,
-            mapTiles,
-        );
+    loadLayerData(source, isLatest, onLoadingData, dataPromise, createFeatures);
 
-        Promise.all([locationTracksPromise, profilePromise])
-            .then(([locationTracks, sections]) => {
-                if (layerId !== newestLayerId) return;
-
-                const features = createHighlightFeatures(
-                    locationTracks,
-                    sections,
-                    highlightBackgroundStyle,
-                );
-
-                clearFeatures(vectorSource);
-                vectorSource.addFeatures(features);
-            })
-            .catch(() => {
-                if (layerId === newestLayerId) clearFeatures(vectorSource);
-            })
-            .finally(() => {
-                inFlight = false;
-            });
-    } else {
-        clearFeatures(vectorSource);
-    }
-
-    return {
-        name: 'missing-profile-highlight-layer',
-        layer: layer,
-        requestInFlight: () => inFlight,
-    };
+    return { name: layerName, layer: layer };
 }

--- a/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
+++ b/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
@@ -1,5 +1,5 @@
 import { Point as OlPoint } from 'ol/geom';
-import { MapTile, TrackNumberDiagramLayerSetting } from 'map/map-model';
+import { MapLayerName, MapTile, TrackNumberDiagramLayerSetting } from 'map/map-model';
 import {
     AlignmentDataHolder,
     getReferenceLineMapAlignmentsByTiles,
@@ -12,7 +12,7 @@ import * as Limits from 'map/layers/utils/layer-visibility-limits';
 import Feature from 'ol/Feature';
 import { Style } from 'ol/style';
 import { AlignmentPoint, LayoutTrackNumberId } from 'track-layout/track-layout-model';
-import { clearFeatures, pointToCoords } from 'map/layers/utils/layer-utils';
+import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
 import {
     getColor,
     getDefaultColorKey,
@@ -33,8 +33,6 @@ import {
     indicatorTextBackgroundHeight,
     indicatorTextPadding,
 } from 'map/layers/utils/dashed-line-indicator-utils';
-
-let newestLayerId = 0;
 
 type AlignmentDataHolderWithAddresses = {
     data: AlignmentDataHolder;
@@ -154,6 +152,8 @@ function createAddressFeatures(
     });
 }
 
+const layerName: MapLayerName = 'track-number-addresses-layer';
+
 export function createTrackNumberEndPointAddressesLayer(
     mapTiles: MapTile[],
     existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
@@ -161,58 +161,51 @@ export function createTrackNumberEndPointAddressesLayer(
     publishType: PublishType,
     resolution: number,
     layerSettings: TrackNumberDiagramLayerSetting,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
+    const dataPromise: Promise<AlignmentDataHolderWithAddresses[]> =
+        resolution <= Limits.ALL_ALIGNMENTS
+            ? getTrackNumberEndPointData(mapTiles, changeTimes, publishType, layerSettings)
+            : Promise.resolve([]);
 
-    let inFlight = false;
-    if (resolution <= Limits.ALL_ALIGNMENTS) {
-        inFlight = true;
-        getReferenceLineMapAlignmentsByTiles(changeTimes, mapTiles, publishType)
-            .then((referenceLines) => {
-                const showAll = Object.values(layerSettings).every((s) => !s.selected);
-                const filteredReferenceLines = showAll
-                    ? referenceLines
-                    : referenceLines.filter((r) => {
-                          const trackNumberId = r.trackNumber?.id;
-                          return trackNumberId ? !!layerSettings[trackNumberId]?.selected : false;
-                      });
+    const createFeatures = (referenceLines: AlignmentDataHolderWithAddresses[]) =>
+        createAddressFeatures(referenceLines, layerSettings);
 
-                return filteredReferenceLines.filter((r) => {
-                    const trackNumberId = r.trackNumber?.id;
-                    return trackNumberId
-                        ? layerSettings[trackNumberId]?.color !== TrackNumberColor.TRANSPARENT
-                        : false;
-                });
-            })
-            .then((referenceLines) =>
-                getEndPointAddresses(referenceLines, publishType, changeTimes.layoutTrackNumber),
-            )
-            .then((referenceLines) => {
-                if (layerId === newestLayerId) {
-                    const features = createAddressFeatures(referenceLines, layerSettings);
+    loadLayerData(source, isLatest, onLoadingData, dataPromise, createFeatures);
 
-                    clearFeatures(vectorSource);
-                    vectorSource.addFeatures(features);
-                }
-            })
-            .catch(() => {
-                if (layerId === newestLayerId) clearFeatures(vectorSource);
-            })
-            .finally(() => {
-                inFlight = false;
-            });
-    } else {
-        clearFeatures(vectorSource);
-    }
+    return { name: layerName, layer: layer };
+}
 
-    return {
-        name: 'track-number-addresses-layer',
-        layer: layer,
-        requestInFlight: () => inFlight,
-    };
+async function getTrackNumberEndPointData(
+    mapTiles: MapTile[],
+    changeTimes: ChangeTimes,
+    publishType: PublishType,
+    layerSettings: TrackNumberDiagramLayerSetting,
+): Promise<AlignmentDataHolderWithAddresses[]> {
+    const referenceLines = await getReferenceLineMapAlignmentsByTiles(
+        changeTimes,
+        mapTiles,
+        publishType,
+    );
+
+    const showAll = Object.values(layerSettings).every((s) => !s.selected);
+    const shownReferenceLines = showAll
+        ? referenceLines
+        : referenceLines.filter((r) => {
+              const trackNumberId = r.trackNumber?.id;
+              return trackNumberId ? !!layerSettings[trackNumberId]?.selected : false;
+          });
+
+    const filteredReferenceLines = shownReferenceLines.filter((r) => {
+        const trackNumberId = r.trackNumber?.id;
+        return trackNumberId
+            ? layerSettings[trackNumberId]?.color !== TrackNumberColor.TRANSPARENT
+            : false;
+    });
+
+    return getEndPointAddresses(filteredReferenceLines, publishType, changeTimes.layoutTrackNumber);
 }
 
 const getEndPointAddresses = (

--- a/ui/src/map/layers/km-post/km-post-layer.ts
+++ b/ui/src/map/layers/km-post/km-post-layer.ts
@@ -32,7 +32,7 @@ export function createKmPostLayer(
     onViewContentChanged: (items: OptionalShownItems) => void,
     onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer, false);
 
     const resolution = olView.getResolution() || 0;
     const getKmPostsFromApi = (step: number) =>

--- a/ui/src/map/layers/km-post/km-post-layer.ts
+++ b/ui/src/map/layers/km-post/km-post-layer.ts
@@ -1,11 +1,11 @@
 import { Point as OlPoint } from 'ol/geom';
 import OlView from 'ol/View';
-import { MapTile, OptionalShownItems } from 'map/map-model';
+import { MapLayerName, MapTile, OptionalShownItems } from 'map/map-model';
 import { Selection } from 'selection/selection-model';
 import { LayoutKmPost, LayoutKmPostId } from 'track-layout/track-layout-model';
 import { getKmPostsByTile } from 'track-layout/layout-km-post-api';
 import { LayerItemSearchResult, MapLayer, SearchItemsOptions } from 'map/layers/utils/layer-model';
-import { clearFeatures } from 'map/layers/utils/layer-utils';
+import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import { PublishType } from 'common/common-model';
 import { ChangeTimes } from 'common/common-slice';
 import {
@@ -19,7 +19,8 @@ import VectorSource from 'ol/source/Vector';
 import { filterUniqueById } from 'utils/array-utils';
 
 let shownKmPostsCompare: string;
-let newestLayerId = 0;
+
+const layerName: MapLayerName = 'km-post-layer';
 
 export function createKmPostLayer(
     mapTiles: MapTile[],
@@ -29,20 +30,22 @@ export function createKmPostLayer(
     changeTimes: ChangeTimes,
     olView: OlView,
     onViewContentChanged: (items: OptionalShownItems) => void,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
+
     const resolution = olView.getResolution() || 0;
     const getKmPostsFromApi = (step: number) =>
-        Promise.all(
-            mapTiles.map(({ area }) =>
-                getKmPostsByTile(publishType, changeTimes.layoutKmPost, area, step),
-            ),
-        ).then((kmPostGroups) =>
-            kmPostGroups.flat().filter(filterUniqueById((kmPost) => kmPost.id)),
-        );
-
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource, style: null });
+        // Fetch every nth
+        step === 0
+            ? Promise.resolve([])
+            : Promise.all(
+                  mapTiles.map(({ area }) =>
+                      getKmPostsByTile(publishType, changeTimes.layoutKmPost, area, step),
+                  ),
+              ).then((kmPostGroups) =>
+                  kmPostGroups.flat().filter(filterUniqueById((kmPost) => kmPost.id)),
+              );
 
     function updateShownKmPosts(kmPostIds: LayoutKmPostId[]) {
         const compare = kmPostIds.sort().join();
@@ -53,57 +56,31 @@ export function createKmPostLayer(
         }
     }
 
-    let inFlight = false;
     const step = getKmPostStepByResolution(resolution);
-    if (step == 0) {
-        clearFeatures(vectorSource);
-        updateShownKmPosts([]);
-    } else {
-        inFlight = true;
-        // Fetch every nth
-        getKmPostsFromApi(step)
-            .then((kmPosts) => {
-                // Handle latest fetch only
-                if (layerId !== newestLayerId) return;
+    const dataPromise: Promise<LayoutKmPost[]> = getKmPostsFromApi(step);
 
-                const isSelected = (kmPost: LayoutKmPost) => {
-                    return selection.selectedItems.kmPosts.some((k) => k === kmPost.id);
-                };
+    const createFeatures = (kmPosts: LayoutKmPost[]) => {
+        const isSelected = (kmPost: LayoutKmPost) => {
+            return selection.selectedItems.kmPosts.some((k) => k === kmPost.id);
+        };
+        return createKmPostFeatures(kmPosts, isSelected, 'layoutKmPost', resolution);
+    };
 
-                const features = createKmPostFeatures(
-                    kmPosts,
-                    isSelected,
-                    'layoutKmPost',
-                    resolution,
-                );
+    const onLoadingChange = (loading: boolean, kmPosts: LayoutKmPost[] | undefined) => {
+        if (!loading) {
+            updateShownKmPosts(kmPosts?.map((kmp) => kmp.id) ?? []);
+        }
+        onLoadingData(loading);
+    };
 
-                clearFeatures(vectorSource);
-                vectorSource.addFeatures(features);
-
-                updateShownKmPosts(kmPosts.map((k) => k.id));
-            })
-            .catch(() => {
-                if (layerId === newestLayerId) {
-                    clearFeatures(vectorSource);
-                    updateShownKmPosts([]);
-                }
-            })
-            .finally(() => {
-                inFlight = false;
-            });
-    }
+    loadLayerData(source, isLatest, onLoadingChange, dataPromise, createFeatures);
 
     return {
-        name: 'km-post-layer',
+        name: layerName,
         layer: layer,
-        searchItems: (hitArea: Rectangle, options: SearchItemsOptions): LayerItemSearchResult => {
-            return {
-                kmPosts: findMatchingKmPosts(hitArea, vectorSource, options).map(
-                    ({ kmPost }) => kmPost.id,
-                ),
-            };
-        },
+        searchItems: (hitArea: Rectangle, options: SearchItemsOptions): LayerItemSearchResult => ({
+            kmPosts: findMatchingKmPosts(hitArea, source, options).map(({ kmPost }) => kmPost.id),
+        }),
         onRemove: () => updateShownKmPosts([]),
-        requestInFlight: () => inFlight,
     };
 }

--- a/ui/src/map/layers/switch/switch-linking-layer.ts
+++ b/ui/src/map/layers/switch/switch-linking-layer.ts
@@ -1,11 +1,16 @@
 import Feature from 'ol/Feature';
 import { Style } from 'ol/style';
 import { Point as OlPoint } from 'ol/geom';
-import { MapTile } from 'map/map-model';
+import { MapLayerName, MapTile } from 'map/map-model';
 import { LayerItemSearchResult, MapLayer, SearchItemsOptions } from 'map/layers/utils/layer-model';
 import { LinkingSwitch, SuggestedSwitch } from 'linking/linking-model';
 import { getSuggestedSwitchesByTile } from 'linking/linking-api';
-import { clearFeatures, findMatchingEntities, pointToCoords } from 'map/layers/utils/layer-utils';
+import {
+    createLayer,
+    findMatchingEntities,
+    loadLayerData,
+    pointToCoords,
+} from 'map/layers/utils/layer-utils';
 import { Selection } from 'selection/selection-model';
 import { getLinkingJointRenderer } from 'map/layers/utils/switch-layer-utils';
 import { SUGGESTED_SWITCH_SHOW } from 'map/layers/utils/layer-visibility-limits';
@@ -13,8 +18,6 @@ import { filterNotEmpty } from 'utils/array-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-
-let newestLayerId = 0;
 
 function createSwitchFeatures(
     suggestedSwitch: SuggestedSwitch,
@@ -42,69 +45,49 @@ function createSwitchFeatures(
     return features;
 }
 
+const layerName: MapLayerName = 'switch-linking-layer';
+
 export function createSwitchLinkingLayer(
     mapTiles: MapTile[],
     resolution: number,
     existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
     selection: Selection,
     linkingState: LinkingSwitch | undefined,
+    onLoadingData: (loading: boolean) => void,
 ): MapLayer {
-    const layerId = ++newestLayerId;
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const vectorSource = existingOlLayer?.getSource() || new VectorSource();
-    const layer = existingOlLayer || new VectorLayer({ source: vectorSource });
+    const selectedSwitches = selection.selectedItems.suggestedSwitches;
 
-    let inFlight = false;
-    if (resolution <= SUGGESTED_SWITCH_SHOW) {
-        inFlight = true;
-        const selectedSwitches = selection.selectedItems.suggestedSwitches;
-
-        const getSuggestedSwitchesPromises = linkingState
+    const getSuggestedSwitchesPromises =
+        resolution <= SUGGESTED_SWITCH_SHOW && linkingState
             ? []
             : mapTiles.map((tile) => getSuggestedSwitchesByTile(tile));
 
-        Promise.all(getSuggestedSwitchesPromises)
-            .then((suggestedSwitches) =>
-                [
-                    ...suggestedSwitches.flat(),
-                    selectedSwitches[0], // add selected suggested switch into collection
-                ].filter(filterNotEmpty),
-            )
-            .then((suggestedSwitches) => {
-                // Handle latest fetch only
-                if (layerId !== newestLayerId) return;
+    const dataPromise: Promise<SuggestedSwitch[]> = Promise.all(getSuggestedSwitchesPromises).then(
+        (suggestedSwitches) =>
+            [
+                ...suggestedSwitches.flat(),
+                selectedSwitches[0], // add selected suggested switch into collection
+            ].filter(filterNotEmpty),
+    );
 
-                const features = suggestedSwitches.flatMap((suggestedSwitch) =>
-                    createSwitchFeatures(
-                        suggestedSwitch,
-                        selectedSwitches.some(
-                            (switchToCheck) => switchToCheck.id == suggestedSwitch.id,
-                        ),
-                    ),
-                );
+    const createFeatures = (suggestedSwitches: SuggestedSwitch[]) =>
+        suggestedSwitches.flatMap((suggestedSwitch) =>
+            createSwitchFeatures(
+                suggestedSwitch,
+                selectedSwitches.some((switchToCheck) => switchToCheck.id == suggestedSwitch.id),
+            ),
+        );
 
-                clearFeatures(vectorSource);
-                vectorSource.addFeatures(features);
-            })
-            .catch(() => {
-                if (layerId === newestLayerId) clearFeatures(vectorSource);
-            })
-            .finally(() => {
-                inFlight = false;
-            });
-    } else {
-        clearFeatures(vectorSource);
-    }
+    loadLayerData(source, isLatest, onLoadingData, dataPromise, createFeatures);
 
     return {
-        name: 'switch-linking-layer',
-        layer: layer,
-        searchItems: (hitArea: Rectangle, options: SearchItemsOptions): LayerItemSearchResult => {
-            return {
-                suggestedSwitches: findMatchingSwitches(hitArea, vectorSource, options),
-            };
-        },
-        requestInFlight: () => inFlight,
+        name: layerName,
+        layer,
+        searchItems: (hitArea: Rectangle, options: SearchItemsOptions): LayerItemSearchResult => ({
+            suggestedSwitches: findMatchingSwitches(hitArea, source, options),
+        }),
     };
 }
 

--- a/ui/src/map/layers/utils/layer-model.ts
+++ b/ui/src/map/layers/utils/layer-model.ts
@@ -14,5 +14,4 @@ export type MapLayer = {
     layer: BaseLayer;
     searchItems?: (hitArea: Rectangle, options: SearchItemsOptions) => LayerItemSearchResult;
     onRemove?: () => void;
-    requestInFlight: () => boolean;
 };

--- a/ui/src/map/layers/utils/layer-utils.ts
+++ b/ui/src/map/layers/utils/layer-utils.ts
@@ -166,10 +166,12 @@ export type LayerResult<FeatureType extends Geometry> = {
 export function createLayer<FeatureType extends Geometry>(
     name: MapLayerName,
     existingLayer: VectorLayer<VectorSource<FeatureType>> | undefined,
+    allowDefaultStyle: boolean = true,
 ): LayerResult<FeatureType> {
     const id = getId(name);
     const source = existingLayer?.getSource() || new VectorSource();
-    const layer = existingLayer || new VectorLayer({ source: source });
+    const options = allowDefaultStyle ? { source: source } : { source: source, style: null };
+    const layer = existingLayer || new VectorLayer(options);
     return {
         layer,
         source,

--- a/ui/src/map/layers/utils/layer-utils.ts
+++ b/ui/src/map/layers/utils/layer-utils.ts
@@ -14,7 +14,9 @@ import { getPlanLinkStatus, getPlanLinkStatuses } from 'linking/linking-api';
 import { PublishType } from 'common/common-model';
 import { getPlanAreasByTile, getTrackLayoutPlans } from 'geometry/geometry-api';
 import { ChangeTimes } from 'common/common-slice';
-import { MapTile } from 'map/map-model';
+import { MapLayerName, MapTile } from 'map/map-model';
+import VectorLayer from 'ol/layer/Vector';
+import BaseLayer from 'ol/layer/Base';
 
 proj4.defs(LAYOUT_SRID, '+proj=utm +zone=35 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 register(proj4);
@@ -145,6 +147,59 @@ export function sortFeaturesByDistance<T extends Geometry>(features: Feature<T>[
         else if (geometryB) return 1;
         else return 0;
     });
+}
+
+const latestLayerIds: Map<MapLayerName, number> = new Map();
+const getId = (name: MapLayerName) => {
+    const id = (latestLayerIds.get(name) ?? 0) + 1;
+    latestLayerIds.set(name, id);
+    return id;
+};
+const isLatestLayerId = (name: MapLayerName, id: number) => latestLayerIds.get(name) === id;
+
+export type LayerResult<FeatureType extends Geometry> = {
+    layer: BaseLayer;
+    source: VectorSource<FeatureType>;
+    isLatest: () => boolean;
+};
+
+export function createLayer<FeatureType extends Geometry>(
+    name: MapLayerName,
+    existingLayer: VectorLayer<VectorSource<FeatureType>> | undefined,
+): LayerResult<FeatureType> {
+    const id = getId(name);
+    const source = existingLayer?.getSource() || new VectorSource();
+    const layer = existingLayer || new VectorLayer({ source: source });
+    return {
+        layer,
+        source,
+        isLatest: () => isLatestLayerId(name, id),
+    };
+}
+
+export function loadLayerData<Data, FeatureType extends Geometry>(
+    source: VectorSource<FeatureType>,
+    isLatest: () => boolean,
+    onLoadingData: (loading: boolean, loadedData: Data | undefined) => void,
+    dataPromise: Promise<Data>,
+    createFeatures: (data: Data) => Feature<FeatureType>[],
+) {
+    onLoadingData(true, undefined);
+    dataPromise
+        .then((data) => {
+            if (isLatest()) {
+                clearFeatures(source);
+                const features = createFeatures(data);
+                if (features.length > 0) source.addFeatures(features);
+                onLoadingData(false, data);
+            }
+        })
+        .catch(() => {
+            if (isLatest()) {
+                clearFeatures(source);
+                onLoadingData(false, undefined);
+            }
+        });
 }
 
 export const clearFeatures = (vectorSource: VectorSource) => vectorSource.clear();

--- a/ui/src/map/layers/utils/layer-utils.ts
+++ b/ui/src/map/layers/utils/layer-utils.ts
@@ -150,7 +150,7 @@ export function sortFeaturesByDistance<T extends Geometry>(features: Feature<T>[
 }
 
 const latestLayerIds: Map<MapLayerName, number> = new Map();
-const getId = (name: MapLayerName) => {
+const incrementAndGetLayerId = (name: MapLayerName) => {
     const id = (latestLayerIds.get(name) ?? 0) + 1;
     latestLayerIds.set(name, id);
     return id;
@@ -168,7 +168,7 @@ export function createLayer<FeatureType extends Geometry>(
     existingLayer: VectorLayer<VectorSource<FeatureType>> | undefined,
     allowDefaultStyle: boolean = true,
 ): LayerResult<FeatureType> {
-    const id = getId(name);
+    const id = incrementAndGetLayerId(name);
     const source = existingLayer?.getSource() || new VectorSource();
     const options = allowDefaultStyle ? { source: source } : { source: source, style: null };
     const layer = existingLayer || new VectorLayer(options);

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -134,7 +134,6 @@ export type Map = {
     shownItems: ShownItems;
     clickLocation?: Point;
     verticalGeometryDiagramState: VerticalGeometryDiagramState;
-    loadingIndicatorVisible: boolean;
 };
 
 export type MapTile = {

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -31,11 +31,10 @@ export const isLayerInProxyLayerCollection = (
     proxyLayerCollection: LayerCollection,
 ): boolean => {
     const layersFromMenuItem = layerMenuItemMapLayers[menuItemName];
-    const key = Object.keys(proxyLayerCollection).find(
-        (key) =>
-            proxyLayerCollection[key as MapLayerName]?.find((layer) =>
-                layersFromMenuItem.includes(layer),
-            ),
+    const key = Object.keys(proxyLayerCollection).find((key) =>
+        proxyLayerCollection[key as MapLayerName]?.find((layer) =>
+            layersFromMenuItem.includes(layer),
+        ),
     );
     return visibleLayers.some((layer) => layer === key);
 };
@@ -156,7 +155,6 @@ export const initialMapState: Map = {
         resolution: 20,
     },
     verticalGeometryDiagramState: initialVerticalGeometryDiagramState,
-    loadingIndicatorVisible: false,
 };
 
 export const mapReducers = {
@@ -180,7 +178,6 @@ export const mapReducers = {
                   1.2
                 : state.viewport.resolution,
         };
-        state.loadingIndicatorVisible = true;
     },
     showLayers(state: Map, { payload: layers }: PayloadAction<MapLayerName[]>) {
         const newVisibleLayers = deduplicate([
@@ -193,7 +190,6 @@ export const mapReducers = {
         state.visibleLayers = newVisibleLayers.filter(
             (layer) => !layersHiddenByProxy.includes(layer),
         );
-        state.loadingIndicatorVisible = true;
     },
     hideLayers(state: Map, { payload: layers }: PayloadAction<MapLayerName[]>) {
         const relatedLayers = collectRelatedLayers(layers);
@@ -260,9 +256,6 @@ export const mapReducers = {
                 action.alignmentId.locationTrackId
             ] = action.extent;
         }
-    },
-    onDoneLoading: (state: Map): void => {
-        state.loadingIndicatorVisible = false;
     },
 };
 

--- a/ui/src/map/map-view-container.tsx
+++ b/ui/src/map/map-view-container.tsx
@@ -38,7 +38,6 @@ const getTrackLayoutProps = (): MapViewProps => {
         onViewportUpdate: delegates.onViewportChange,
         publishType: store.publishType,
         selection: store.selection,
-        onDoneLoading: delegates.onDoneLoading,
     };
 };
 
@@ -65,7 +64,6 @@ const getInfraModelProps = (): MapViewProps => {
         onViewportUpdate: delegates.onViewportChange,
         publishType: 'OFFICIAL',
         selection: store.selection,
-        onDoneLoading: emptyFn,
     };
 };
 

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -166,15 +166,20 @@ const MapView: React.FC<MapViewProps> = ({
     const [hoveredLocation, setHoveredLocation] = React.useState<Point>();
 
     const [layersLoadingData, setLayersLoadingData] = React.useState<MapLayerName[]>([]);
+
     const onLayerLoading = (name: MapLayerName, isLoading: boolean) => {
-        if (isLoading && !layersLoadingData.includes(name)) {
-            setLayersLoadingData(layersLoadingData.concat(name));
-        } else if (!isLoading && layersLoadingData.includes(name)) {
-            setLayersLoadingData(layersLoadingData.filter((n) => n !== name));
-        }
+        setLayersLoadingData((prevLoadingLayers) => {
+            if (isLoading && !prevLoadingLayers.includes(name)) {
+                return [...prevLoadingLayers, name];
+            } else if (!isLoading && prevLoadingLayers.includes(name)) {
+                return prevLoadingLayers.filter((n) => n !== name);
+            } else {
+                return prevLoadingLayers;
+            }
+        });
     };
     const isLoading = () => [...map.visibleLayers].some((l) => layersLoadingData.includes(l));
-    console.log('loading', isLoading());
+
     const mapLayers = [...map.visibleLayers].sort().join();
 
     const handleClusterPointClick = (clickType: ClickType) => {

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -161,7 +161,7 @@ const MapView: React.FC<MapViewProps> = ({
     // State to store OpenLayers map object between renders
     const [olMap, setOlMap] = React.useState<OlMap>();
     const olMapContainer = React.useRef<HTMLDivElement>(null);
-    const visibleLayers = React.useRef<MapLayer[]>([]);
+    const [visibleLayers, setVisibleLayers] = React.useState<MapLayer[]>([]);
     const [measurementToolActive, setMeasurementToolActive] = React.useState(false);
     const [hoveredLocation, setHoveredLocation] = React.useState<Point>();
 
@@ -297,9 +297,7 @@ const MapView: React.FC<MapViewProps> = ({
                 // Step 2. create the layer
                 // In some cases an adapter wants to reuse existing OL layer,
                 // e.g. tile layers cause flickering if recreated every time
-                const existingOlLayer = visibleLayers.current.find(
-                    (l) => l.name === layerName,
-                )?.layer;
+                const existingOlLayer = visibleLayers.find((l) => l.name === layerName)?.layer;
 
                 switch (layerName) {
                     case 'background-map-layer':
@@ -586,11 +584,11 @@ const MapView: React.FC<MapViewProps> = ({
 
         updatedLayers.forEach((l) => l.layer.setZIndex(mapLayerZIndexes[l.name]));
 
-        visibleLayers.current
+        visibleLayers
             .filter((vl) => !updatedLayers.some((ul) => ul.name === vl.name))
             .forEach((l) => l.onRemove && l.onRemove());
 
-        visibleLayers.current = updatedLayers;
+        setVisibleLayers(updatedLayers);
 
         // Set converted layers into map object
         const olLayers = updatedLayers.map((l) => l.layer);
@@ -621,16 +619,16 @@ const MapView: React.FC<MapViewProps> = ({
         };
 
         const deactivateCallbacks = [
-            pointLocationTool.activate(olMap, visibleLayers.current, toolActivateOptions),
+            pointLocationTool.activate(olMap, visibleLayers, toolActivateOptions),
         ];
 
         if (!measurementToolActive) {
             deactivateCallbacks.push(
-                selectTool.activate(olMap, visibleLayers.current, toolActivateOptions),
+                selectTool.activate(olMap, visibleLayers, toolActivateOptions),
             );
 
             deactivateCallbacks.push(
-                highlightTool.activate(olMap, visibleLayers.current, toolActivateOptions),
+                highlightTool.activate(olMap, visibleLayers, toolActivateOptions),
             );
         }
 
@@ -638,7 +636,7 @@ const MapView: React.FC<MapViewProps> = ({
         return () => {
             deactivateCallbacks.forEach((f) => f());
         };
-    }, [olMap, visibleLayers.current, measurementToolActive]);
+    }, [olMap, visibleLayers, measurementToolActive]);
 
     React.useEffect(() => {
         if (measurementToolActive && olMap) {

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -125,7 +125,7 @@ type GeometryAlignmentLinkingInfoboxProps = {
     onContentVisibilityChange: () => void;
 };
 
-const isNotPreliminary = (state: LinkingPhase) => state === 'allSet' || state === 'setup';
+const isNotPreliminary = (state: LinkingPhase) => state !== 'preliminary';
 
 const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxProps> = ({
     onSelect,

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -103,7 +103,7 @@ export async function getMapAlignmentsByTiles(
     changeTimes: ChangeTimes,
     mapTiles: MapTile[],
     publishType: PublishType,
-) {
+): Promise<AlignmentDataHolder[]> {
     const polyLines = await Promise.all(
         mapTiles.map((tile) =>
             getPolyLines(tile, changeTimes.layoutReferenceLine, publishType, 'ALL'),
@@ -126,7 +126,7 @@ export async function getSelectedReferenceLineMapAlignmentByTiles(
     mapTiles: MapTile[],
     publishType: PublishType,
     trackNumberId: LayoutTrackNumberId,
-) {
+): Promise<AlignmentDataHolder[]> {
     return getReferenceLineMapAlignmentsByTiles(changeTimes, mapTiles, publishType).then(
         (alignments) => {
             const alignment = alignments.find(
@@ -143,7 +143,7 @@ export async function getReferenceLineMapAlignmentsByTiles(
     changeTimes: ChangeTimes,
     mapTiles: MapTile[],
     publishType: PublishType,
-) {
+): Promise<AlignmentDataHolder[]> {
     const changeTime = getMaxTimestamp(
         changeTimes.layoutReferenceLine,
         changeTimes.layoutTrackNumber,


### PR DESCRIPTION
Paljon muutoksia refaktoroinnista mutta samankaltaisia keskenään. Kommentoin tärkeimmät kohdat. Pääajatus on koittaa eristää yhteinen logiikka (layerin luonti, async-datan haku + päivitys sourceen, loading-statuksen seuranta) yleiseen funkkariin. Parhaimmillaan se voisi olla niin geneeristä että mapview voisi hoitaa nuo kutsut ja pyytää layereiltä vain datan (async) ja featuret (sync), mutta se on vähän vielä kauempi maali. Tässä ekassa versiossa funktioitu nuo 2 osiota mutta olemassaolevat create-funkkarit käyttää niitä jotta rajapinta ulospäin on melko pitkälti sama.

Lisäksi joitain randomilla failaavia e2e-testejä paikailtu.