### PR TITLE
GVT-2493: Fix split location track geometry validation during track number mismatch

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -9,7 +9,6 @@ import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.linking.SuggestedSwitch
 import fi.fta.geoviite.infra.linking.SwitchLinkingService
-import fi.fta.geoviite.infra.linking.createSwitchLinkingParameters
 import fi.fta.geoviite.infra.linking.fixSegmentStarts
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.logging.serviceCall
@@ -187,6 +186,54 @@ class SplitService(
     ): List<PublishValidationError> {
         val pendingSplits = splits.filter { it.isPending }
 
+        val trackNumberMismatchErrors = splits
+            .firstOrNull { it.targetLocationTracks.any { tlt -> tlt.locationTrackId == trackId } }
+            ?.let { split ->
+                val sourceLocationTrack = locationTrackDao.getOrThrow(OFFICIAL, split.locationTrackId)
+                split.targetLocationTracks.mapNotNull { targetLt ->
+                    val targetLocationTrack = locationTrackService.getOrThrow(DRAFT, targetLt.locationTrackId)
+                    validateTargetTrackNumber(sourceLocationTrack, targetLocationTrack)
+                }
+            } ?: emptyList()
+
+        // As an optimization, geometry error checking is skipped if the track numbers are different
+        // between any source & target location tracks. The geometry check will rarely if ever succeed
+        // for differing track numbers on source & target tracks, and differing track number for any
+        // source & target track is already a considered a publication-blocking error.
+        val splitGeometryErrors = when {
+            trackNumberMismatchErrors.isEmpty() -> validateSplitGeometries(trackId, pendingSplits)
+            else -> emptyList()
+        }
+
+        val splitSourceLocationTrackError = splits
+            .firstOrNull { it.locationTrackId == trackId }
+            ?.let {
+                validateSplitSourceLocationTrack(locationTrackService.getOrThrow(DRAFT, trackId))
+            }
+
+        val statusError = splits
+            .firstOrNull { !it.isPending }
+            ?.let {
+                PublishValidationError(
+                    PublishValidationErrorType.ERROR,
+                    "$VALIDATION_SPLIT.split-in-progress",
+                )
+            }
+
+        return listOf(
+            listOfNotNull(
+                statusError,
+                splitSourceLocationTrackError,
+            ),
+            trackNumberMismatchErrors,
+            splitGeometryErrors,
+        ).flatten()
+    }
+
+    fun validateSplitGeometries(
+        trackId: IntId<LocationTrack>,
+        pendingSplits: Collection<Split>,
+    ): List<PublishValidationError> {
         val targetGeometryError = pendingSplits
             .firstOrNull { it.targetLocationTracks.any { tlt -> tlt.locationTrackId == trackId } }
             ?.let { split ->
@@ -204,33 +251,10 @@ class SplitService(
                 validateSourceGeometry(draftAddresses, officialAddresses)
             }
 
-        val splitSourceLocationTrackErrors = splits
-            .firstOrNull { it.locationTrackId == trackId }
-            ?.let {
-                validateSplitSourceLocationTrack(locationTrackService.getOrThrow(DRAFT, trackId))
-            }
-
-        val sourceDuplicateTrackErrors = splits
-            .firstOrNull { it.targetLocationTracks.any { tlt -> tlt.locationTrackId == trackId } }
-            ?.let { split ->
-                val sourceLocationTrack = locationTrackDao.getOrThrow(DRAFT, split.locationTrackId)
-                split.targetLocationTracks.mapNotNull { targetLt ->
-                    val targetLocationTrack = locationTrackService.getOrThrow(DRAFT, targetLt.locationTrackId)
-                    validateTargetTrackNumber(sourceLocationTrack, targetLocationTrack)
-                }
-            } ?: emptyList()
-
-        val statusError = splits
-            .firstOrNull { !it.isPending }
-            ?.let {
-                PublishValidationError(
-                    PublishValidationErrorType.ERROR,
-                    "$VALIDATION_SPLIT.split-in-progress",
-                )
-            }
-
-        return sourceDuplicateTrackErrors +
-                listOfNotNull(targetGeometryError, sourceGeometryErrors, splitSourceLocationTrackErrors, statusError)
+        return listOfNotNull(
+            targetGeometryError,
+            sourceGeometryErrors,
+        )
     }
 
     fun validateSplitReferencesByTrackNumber(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.split
 
 import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
+import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.publication.PublishValidationError
 import fi.fta.geoviite.infra.publication.PublishValidationErrorType.ERROR
 import fi.fta.geoviite.infra.publication.VALIDATION
@@ -8,6 +9,7 @@ import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.publication.validate
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.util.LocalizationKey
 import kotlin.math.max
 import kotlin.math.min
 
@@ -103,8 +105,8 @@ internal fun validateTargetTrackNumber(
 ) = if (sourceLocationTrack.trackNumberId != targetLocationTrack.trackNumberId) {
     PublishValidationError(
         ERROR,
-        "$VALIDATION_SPLIT.duplicate-on-different-track-number",
-        mapOf("duplicateTrack" to targetLocationTrack.name)
+        LocalizationKey("$VALIDATION_SPLIT.source-and-target-track-numbers-are-different"),
+        localizationParams("trackName" to targetLocationTrack.name),
     )
 } else {
     null

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1323,6 +1323,7 @@
             },
             "split": {
                 "source-not-deleted": "Jaettava raide ei ole Poistettu-tilassa",
+                "source-and-target-track-numbers-are-different": "Jakamisessa syntynyt raide {{trackName}} on eri ratanumerolla on kuin alkuperäinen jaettu raide",
                 "duplicate-on-different-track-number": "Duplikaattiraide {{duplicateTrack}} on eri ratanumerolla kuin jaettava raide",
                 "split-missing-location-tracks": "Kaikki jakoon liittyvät sijaintiraiteet eivät ole mukana julkaisussa",
                 "split-missing-switches": "Kaikki jakoon liittyvät vaihteet eivät ole mukana julkaisussa",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -2369,8 +2369,8 @@ class PublicationServiceIT @Autowired constructor(
             errors,
             PublishValidationError(
                 PublishValidationErrorType.ERROR,
-                LocalizationKey("validation.layout.split.duplicate-on-different-track-number"),
-                LocalizationParams(mapOf("duplicateTrack" to startTarget.name.toString())),
+                LocalizationKey("validation.layout.split.source-and-target-track-numbers-are-different"),
+                LocalizationParams(mapOf("trackName" to startTarget.name.toString())),
             ),
         )
     }


### PR DESCRIPTION
Previously if the track number of a resulting track was changed, the geometry validation did not work properly and through a HTTP 500 error.