### PR TITLE
GVT-2479: Sijaintiraiteen infoboksin ja sen lasten komponenttirakenteen refaktorointi - Part 1

### DIFF
--- a/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
@@ -1,0 +1,230 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LoaderStatus, useLoader } from 'utils/react-utils';
+import InfoboxContent from 'tool-panel/infobox/infobox-content';
+import InfoboxField from 'tool-panel/infobox/infobox-field';
+import LayoutState from 'geoviite-design-lib/layout-state/layout-state';
+import LocationTrackTypeLabel from 'geoviite-design-lib/alignment/location-track-type-label';
+import { TrackNumberLinkContainer } from 'geoviite-design-lib/track-number/track-number-link';
+import InfoboxText from 'tool-panel/infobox/infobox-text';
+import { LocationTrackInfoboxDuplicateOf } from 'tool-panel/location-track/location-track-infobox-duplicate-of';
+import TopologicalConnectivityLabel from 'tool-panel/location-track/topological-connectivity-label';
+import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import Infobox from 'tool-panel/infobox/infobox';
+import {
+    LayoutLocationTrack,
+    LayoutSwitchIdAndName,
+    LayoutTrackNumber,
+} from 'track-layout/track-layout-model';
+import { ChangeTimes } from 'common/common-slice';
+import { LocationTrackOwnerId, PublishType } from 'common/common-model';
+import {
+    LocationTrackInfoboxVisibilities,
+    trackLayoutActionCreators as TrackLayoutActions,
+} from 'track-layout/track-layout-slice';
+import { Link } from 'vayla-design-lib/link/link';
+import { getLocationTrackOwners } from 'common/common-api';
+import { createDelegates } from 'store/store-utils';
+import { OnSelectOptions } from 'selection/selection-model';
+import { BoundingBox } from 'model/geometry';
+import { useCommonDataAppSelector } from 'store/hooks';
+import { getLocationTrackDescriptions } from 'track-layout/layout-location-track-api';
+import { useLocationTrackInfoboxExtras } from 'track-layout/track-layout-react-utils';
+
+type LocationTrackBasicInfoInfoboxContainerProps = {
+    locationTrack: LayoutLocationTrack;
+    trackNumber?: LayoutTrackNumber;
+    publishType: PublishType;
+    visibilities: LocationTrackInfoboxVisibilities;
+    visibilityChange: (key: keyof LocationTrackInfoboxVisibilities) => void;
+    openEditLocationTrackDialog: () => void;
+    editingDisabled: boolean;
+};
+
+export const LocationTrackBasicInfoInfoboxContainer: React.FC<
+    LocationTrackBasicInfoInfoboxContainerProps
+> = (props: LocationTrackBasicInfoInfoboxContainerProps) => {
+    const delegates = createDelegates(TrackLayoutActions);
+    const changeTimes = useCommonDataAppSelector((state) => state.changeTimes);
+    return (
+        <LocationTrackBasicInfoInfobox
+            {...props}
+            changeTimes={changeTimes}
+            onSelect={delegates.onSelect}
+            showArea={delegates.showArea}
+        />
+    );
+};
+
+type LocationTrackBasicInfoInfoboxProps = LocationTrackBasicInfoInfoboxContainerProps & {
+    onSelect: (items: OnSelectOptions) => void;
+    showArea: (area: BoundingBox) => void;
+    changeTimes: ChangeTimes;
+};
+
+export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfoboxProps> = ({
+    locationTrack,
+    trackNumber,
+    changeTimes,
+    publishType,
+    visibilities,
+    visibilityChange,
+    openEditLocationTrackDialog,
+    editingDisabled,
+    onSelect,
+    showArea,
+}) => {
+    const { t } = useTranslation();
+
+    const locationTrackOwners = useLoader(() => getLocationTrackOwners(), []);
+    function getLocationTrackOwnerName(ownerId: LocationTrackOwnerId) {
+        const name = locationTrackOwners?.find((o) => o.id == ownerId)?.name;
+        return name ?? '-';
+    }
+
+    function getSwitchLink(sw?: LayoutSwitchIdAndName) {
+        if (sw) {
+            const switchId = sw.id;
+            return (
+                <Link
+                    onClick={() =>
+                        onSelect({
+                            switches: [switchId],
+                        })
+                    }>
+                    {sw.name}
+                </Link>
+            );
+        } else {
+            return t('tool-panel.location-track.no-start-or-end-switch');
+        }
+    }
+
+    const description = useLoader(
+        () =>
+            getLocationTrackDescriptions([locationTrack.id], publishType).then(
+                (value) => (value && value[0].description) ?? undefined,
+            ),
+        [locationTrack?.id, publishType, changeTimes.layoutLocationTrack],
+    );
+    const [extraInfo, extraInfoLoadingStatus] = useLocationTrackInfoboxExtras(
+        locationTrack?.id,
+        publishType,
+        changeTimes,
+    );
+
+    return (
+        <Infobox
+            contentVisible={visibilities.basic && extraInfoLoadingStatus != LoaderStatus.Loading}
+            onContentVisibilityChange={() => visibilityChange('basic')}
+            title={t('tool-panel.location-track.basic-info-heading')}
+            qa-id="location-track-infobox">
+            <InfoboxContent>
+                <InfoboxField
+                    qaId="location-track-oid"
+                    label={t('tool-panel.location-track.identifier')}
+                    value={locationTrack.externalId || t('tool-panel.location-track.unpublished')}
+                />
+                <InfoboxField
+                    qaId="location-track-name"
+                    label={t('tool-panel.location-track.track-name')}
+                    value={locationTrack.name}
+                    onEdit={openEditLocationTrackDialog}
+                    iconDisabled={editingDisabled}
+                />
+                <InfoboxField
+                    qaId="location-track-state"
+                    label={t('tool-panel.location-track.state')}
+                    value={<LayoutState state={locationTrack.state} />}
+                    onEdit={openEditLocationTrackDialog}
+                    iconDisabled={editingDisabled}
+                />
+                <InfoboxField
+                    qaId="location-track-type"
+                    label={t('tool-panel.location-track.type')}
+                    value={<LocationTrackTypeLabel type={locationTrack.type} />}
+                    onEdit={openEditLocationTrackDialog}
+                    iconDisabled={editingDisabled}
+                />
+                <InfoboxField
+                    qaId="location-track-description"
+                    label={t('tool-panel.location-track.description')}
+                    value={description}
+                    onEdit={openEditLocationTrackDialog}
+                    iconDisabled={editingDisabled}
+                />
+                <InfoboxField
+                    qaId="location-track-track-number"
+                    label={t('tool-panel.location-track.track-number')}
+                    value={<TrackNumberLinkContainer trackNumberId={trackNumber?.id} />}
+                    onEdit={openEditLocationTrackDialog}
+                    iconDisabled={editingDisabled}
+                />
+                <InfoboxText value={trackNumber?.description} />
+                <InfoboxField
+                    label={
+                        locationTrack.duplicateOf
+                            ? t('tool-panel.location-track.duplicate-of')
+                            : extraInfo?.duplicates?.length ?? 0 > 0
+                            ? t('tool-panel.location-track.has-duplicates')
+                            : t('tool-panel.location-track.not-a-duplicate')
+                    }
+                    value={
+                        <LocationTrackInfoboxDuplicateOf
+                            existingDuplicate={extraInfo?.duplicateOf}
+                            duplicatesOfLocationTrack={extraInfo?.duplicates ?? []}
+                            publishType={publishType}
+                            changeTime={changeTimes.layoutLocationTrack}
+                            currentTrackNumberId={trackNumber?.id}
+                        />
+                    }
+                    onEdit={openEditLocationTrackDialog}
+                    iconDisabled={editingDisabled}
+                    iconHidden={!locationTrack.duplicateOf}
+                />
+                <InfoboxField
+                    label={t('tool-panel.location-track.topological-connectivity')}
+                    value={
+                        <TopologicalConnectivityLabel
+                            topologicalConnectivity={locationTrack.topologicalConnectivity}
+                        />
+                    }
+                    onEdit={openEditLocationTrackDialog}
+                    iconDisabled={editingDisabled}
+                />
+                <InfoboxField
+                    label={t('tool-panel.location-track.owner')}
+                    value={getLocationTrackOwnerName(locationTrack.ownerId)}
+                    onEdit={openEditLocationTrackDialog}
+                    iconDisabled={editingDisabled}
+                />
+                <InfoboxField
+                    label={t('tool-panel.location-track.start-switch')}
+                    value={extraInfo && getSwitchLink(extraInfo.switchAtStart)}
+                />
+                <InfoboxField
+                    label={t('tool-panel.location-track.end-switch')}
+                    value={extraInfo && getSwitchLink(extraInfo.switchAtEnd)}
+                />
+                <InfoboxButtons>
+                    <Button
+                        variant={ButtonVariant.SECONDARY}
+                        size={ButtonSize.SMALL}
+                        qa-id="zoom-to-location-track"
+                        title={
+                            !locationTrack.boundingBox
+                                ? t('tool-panel.location-track.no-geometry')
+                                : ''
+                        }
+                        disabled={!locationTrack.boundingBox}
+                        onClick={() =>
+                            locationTrack.boundingBox && showArea(locationTrack.boundingBox)
+                        }>
+                        {t('tool-panel.location-track.show-on-map')}
+                    </Button>
+                </InfoboxButtons>
+            </InfoboxContent>
+        </Infobox>
+    );
+};

--- a/ui/src/tool-panel/location-track/location-track-change-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-change-info-infobox.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import InfoboxContent from 'tool-panel/infobox/infobox-content';
+import InfoboxField from 'tool-panel/infobox/infobox-field';
+import { formatDateShort } from 'utils/date-utils';
+import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+import Infobox from 'tool-panel/infobox/infobox';
+import {
+    useLocationTrack,
+    useLocationTrackChangeTimes,
+} from 'track-layout/track-layout-react-utils';
+import { LocationTrackId } from 'track-layout/track-layout-model';
+import { PublishType } from 'common/common-model';
+import { LocationTrackInfoboxVisibilities } from 'track-layout/track-layout-slice';
+import { useCommonDataAppSelector } from 'store/hooks';
+
+type LocationTrackChangeInfoInfoboxProps = {
+    locationTrackId: LocationTrackId;
+    publishType: PublishType;
+    visibilities: LocationTrackInfoboxVisibilities;
+    visibilityChange: (key: keyof LocationTrackInfoboxVisibilities) => void;
+    setConfirmingDraftDelete: (value: boolean) => void;
+};
+
+export const LocationTrackChangeInfoInfobox: React.FC<LocationTrackChangeInfoInfoboxProps> = ({
+    locationTrackId,
+    publishType,
+    visibilities,
+    visibilityChange,
+    setConfirmingDraftDelete,
+}) => {
+    const { t } = useTranslation();
+    const changeTimes = useCommonDataAppSelector((state) => state.changeTimes);
+
+    const locationTrackChangeInfo = useLocationTrackChangeTimes(locationTrackId, publishType);
+    const officialLocationTrack = useLocationTrack(
+        locationTrackId,
+        'OFFICIAL',
+        changeTimes.layoutLocationTrack,
+    );
+
+    return (
+        locationTrackChangeInfo && (
+            <Infobox
+                contentVisible={visibilities.log}
+                onContentVisibilityChange={() => visibilityChange('log')}
+                title={t('tool-panel.location-track.change-info-heading')}
+                qa-id="location-track-log-infobox">
+                <InfoboxContent>
+                    <InfoboxField
+                        qaId="location-track-created-date"
+                        label={t('tool-panel.created')}
+                        value={formatDateShort(locationTrackChangeInfo.created)}
+                    />
+                    <InfoboxField
+                        qaId="location-track-changed-date"
+                        label={t('tool-panel.changed')}
+                        value={
+                            locationTrackChangeInfo.changed &&
+                            formatDateShort(locationTrackChangeInfo.changed)
+                        }
+                    />
+                    {officialLocationTrack === undefined && (
+                        <InfoboxButtons>
+                            <Button
+                                onClick={() => setConfirmingDraftDelete(true)}
+                                icon={Icons.Delete}
+                                variant={ButtonVariant.WARNING}
+                                size={ButtonSize.SMALL}>
+                                {t('button.delete-draft')}
+                            </Button>
+                        </InfoboxButtons>
+                    )}
+                </InfoboxContent>
+            </Infobox>
+        )
+    );
+};

--- a/ui/src/tool-panel/location-track/location-track-infobox-linking-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-linking-container.tsx
@@ -44,14 +44,6 @@ const LocationTrackInfoboxLinkingContainer: React.FC<LocationTrackInfoboxLinking
                 linkingState={trackLayoutState.linkingState}
                 splittingState={trackLayoutState.splittingState}
                 onDataChange={onDataChange}
-                onStartLocationTrackGeometryChange={(interval) => {
-                    delegates.showLayers(['alignment-linking-layer']);
-                    delegates.startAlignmentGeometryChange(interval);
-                }}
-                onEndLocationTrackGeometryChange={() => {
-                    delegates.hideLayers(['alignment-linking-layer']);
-                    delegates.stopLinking();
-                }}
                 showArea={delegates.showArea}
                 publishType={trackLayoutState.publishType}
                 changeTimes={changeTimes}
@@ -65,7 +57,6 @@ const LocationTrackInfoboxLinkingContainer: React.FC<LocationTrackInfoboxLinking
                     trackLayoutState.map.verticalGeometryDiagramState.visible
                 }
                 onHighlightItem={onHoverOverPlanSection}
-                showLocationTrackTaskList={delegates.showLocationTrackTaskList}
             />
         );
 };

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -1,83 +1,39 @@
 import * as React from 'react';
-import styles from './location-track-infobox.scss';
-import Infobox from 'tool-panel/infobox/infobox';
-import {
-    LAYOUT_SRID,
-    LayoutLocationTrack,
-    LayoutSwitchId,
-    LayoutSwitchIdAndName,
-} from 'track-layout/track-layout-model';
-import InfoboxContent, { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
-import InfoboxField from 'tool-panel/infobox/infobox-field';
-import { Precision, roundToPrecision } from 'utils/rounding';
-import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
-import { LinkingAlignment, LinkingState, LinkingType, LinkInterval } from 'linking/linking-model';
-import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
-import { updateLocationTrackGeometry } from 'linking/linking-api';
+import { LayoutLocationTrack } from 'track-layout/track-layout-model';
+import { LinkingState } from 'linking/linking-model';
 import {
     refreshLocationTrackSelection,
-    useCoordinateSystem,
-    useLocationTrack,
-    useLocationTrackChangeTimes,
-    useLocationTrackInfoboxExtras,
-    useLocationTrackStartAndEnd,
     useTrackNumber,
 } from 'track-layout/track-layout-react-utils';
-import InfoboxText from 'tool-panel/infobox/infobox-text';
-import { formatToTM35FINString } from 'utils/geography-utils';
-import { formatDateShort } from 'utils/date-utils';
 import { LocationTrackEditDialogContainer } from 'tool-panel/location-track/dialog/location-track-edit-dialog';
 import { BoundingBox } from 'model/geometry';
 import 'i18n/config';
-import { useTranslation } from 'react-i18next';
-import LayoutState from 'geoviite-design-lib/layout-state/layout-state';
-import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
-import { LocationTrackOwnerId, PublishType } from 'common/common-model';
-import { Icons } from 'vayla-design-lib/icon/Icon';
-import { TrackNumberLinkContainer } from 'geoviite-design-lib/track-number/track-number-link';
+import { PublishType } from 'common/common-model';
 import LocationTrackDeleteConfirmationDialog from 'tool-panel/location-track/location-track-delete-confirmation-dialog';
-import {
-    getLocationTrackDescriptions,
-    getSplittingInitializationParameters,
-} from 'track-layout/layout-location-track-api';
-import LocationTrackTypeLabel from 'geoviite-design-lib/alignment/location-track-type-label';
-import { LoaderStatus, useLoader } from 'utils/react-utils';
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
-import { LocationTrackInfoboxDuplicateOf } from 'tool-panel/location-track/location-track-infobox-duplicate-of';
-import TopologicalConnectivityLabel from 'tool-panel/location-track/topological-connectivity-label';
 import { LocationTrackRatkoPushDialog } from 'tool-panel/location-track/dialog/location-track-ratko-push-dialog';
 import { LocationTrackGeometryInfobox } from 'tool-panel/location-track/location-track-geometry-infobox';
 import { MapViewport } from 'map/map-model';
-import { getEndLinkPoints } from 'track-layout/layout-map-api';
 import {
     LocationTrackInfoboxVisibilities,
-    SwitchRelinkingValidationTaskList,
     trackLayoutActionCreators as TrackLayoutActions,
 } from 'track-layout/track-layout-slice';
-import { WriteAccessRequired } from 'user/write-access-required';
 import { LocationTrackVerticalGeometryInfobox } from 'tool-panel/location-track/location-track-vertical-geometry-infobox';
 import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
-import {
-    ProgressIndicatorType,
-    ProgressIndicatorWrapper,
-} from 'vayla-design-lib/progress/progress-indicator-wrapper';
-import { Link } from 'vayla-design-lib/link/link';
 import { createDelegates } from 'store/store-utils';
 import { LocationTrackSplittingInfoboxContainer } from 'tool-panel/location-track/splitting/location-track-splitting-infobox';
 import { SplittingState } from 'tool-panel/location-track/split-store';
-import { getLocationTrackOwners } from 'common/common-api';
-import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
 import { EnvRestricted } from 'environment/env-restricted';
-import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
-import { filterNotEmpty } from 'utils/array-utils';
 import { ChangeTimes } from 'common/common-slice';
 import { LocationTrackValidationInfoboxContainer } from 'tool-panel/location-track/location-track-validation-infobox-container';
-import { LocationTrackSwitchRelinkingDialog } from 'tool-panel/location-track/dialog/location-track-switch-relinking-dialog';
+import { LocationTrackSwitchRelinkingDialogContainer } from 'tool-panel/location-track/dialog/location-track-switch-relinking-dialog';
+import { LocationTrackBasicInfoInfoboxContainer } from 'tool-panel/location-track/location-track-basic-info-infobox';
+import { LocationTrackLocationInfoboxContainer } from 'tool-panel/location-track/location-track-location-infobox';
+import { LocationTrackChangeInfoInfobox } from 'tool-panel/location-track/location-track-change-info-infobox';
+import { LocationTrackRatkoSyncInfobox } from 'tool-panel/location-track/location-track-ratko-sync-infobox';
 
 type LocationTrackInfoboxProps = {
     locationTrack: LayoutLocationTrack;
-    onStartLocationTrackGeometryChange: (linkInterval: LinkInterval) => void;
-    onEndLocationTrackGeometryChange: () => void;
     linkingState?: LinkingState;
     splittingState?: SplittingState;
     showArea: (area: BoundingBox) => void;
@@ -92,14 +48,10 @@ type LocationTrackInfoboxProps = {
     onVerticalGeometryDiagramVisibilityChange: (visibility: boolean) => void;
     verticalGeometryDiagramVisible: boolean;
     onHighlightItem: (item: HighlightedAlignment | undefined) => void;
-    showLocationTrackTaskList: (taskList: SwitchRelinkingValidationTaskList | undefined) => void;
 };
 
 const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     locationTrack,
-    onStartLocationTrackGeometryChange,
-    onEndLocationTrackGeometryChange,
-    showArea,
     linkingState,
     splittingState,
     onDataChange,
@@ -113,35 +65,11 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     verticalGeometryDiagramVisible,
     onVerticalGeometryDiagramVisibilityChange,
     onHighlightItem,
-    showLocationTrackTaskList,
 }: LocationTrackInfoboxProps) => {
-    const { t } = useTranslation();
     const delegates = createDelegates(TrackLayoutActions);
     const trackNumber = useTrackNumber(publishType, locationTrack?.trackNumberId);
-    const [startAndEndPoints, startAndEndPointFetchStatus] = useLocationTrackStartAndEnd(
-        locationTrack?.id,
-        publishType,
-        changeTimes,
-    );
-    const locationTrackChangeInfo = useLocationTrackChangeTimes(locationTrack?.id, publishType);
-    const coordinateSystem = useCoordinateSystem(LAYOUT_SRID);
-    const officialLocationTrack = useLocationTrack(
-        locationTrack.id,
-        'OFFICIAL',
-        changeTimes.layoutLocationTrack,
-    );
-    const description = useLoader(
-        () =>
-            getLocationTrackDescriptions([locationTrack.id], publishType).then(
-                (value) => (value && value[0].description) ?? undefined,
-            ),
-        [locationTrack?.id, publishType, changeTimes.layoutLocationTrack],
-    );
-    const locationTrackOwners = useLoader(() => getLocationTrackOwners(), []);
 
     const [showEditDialog, setShowEditDialog] = React.useState(false);
-    const [updatingLength, setUpdatingLength] = React.useState<boolean>(false);
-    const [canUpdate, setCanUpdate] = React.useState<boolean>();
     const [confirmingDraftDelete, setConfirmingDraftDelete] = React.useState<boolean>();
     const [showRatkoPushDialog, setShowRatkoPushDialog] = React.useState<boolean>(false);
     const [confirmingSwitchRelinking, setConfirmingSwitchRelinking] = React.useState(false);
@@ -152,7 +80,6 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
         setShowEditDialog(true);
         onDataChange();
     }
-
     function closeEditLocationTrackDialog() {
         setShowEditDialog(false);
         onDataChange();
@@ -160,224 +87,25 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
 
     const handleLocationTrackSave = refreshLocationTrackSelection('DRAFT', onSelect, onUnselect);
 
-    function getLocationTrackOwnerName(ownerId: LocationTrackOwnerId) {
-        const name = locationTrackOwners?.find((o) => o.id == ownerId)?.name;
-        return name ?? '-';
-    }
-
-    function getSwitchLink(sw?: LayoutSwitchIdAndName) {
-        if (sw) {
-            const switchId = sw.id;
-            return (
-                <Link
-                    onClick={() =>
-                        delegates.onSelect({
-                            switches: [switchId],
-                        })
-                    }>
-                    {sw.name}
-                </Link>
-            );
-        } else {
-            return t('tool-panel.location-track.no-start-or-end-switch');
-        }
-    }
-
-    React.useEffect(() => {
-        setCanUpdate(
-            linkingState?.type === LinkingType.LinkingAlignment && linkingState.state === 'allSet',
-        );
-    }, [linkingState]);
-
-    const updateAlignment = (state: LinkingAlignment) => {
-        if (canUpdate && state.layoutAlignmentInterval.start && state.layoutAlignmentInterval.end) {
-            setUpdatingLength(true);
-            updateLocationTrackGeometry(state.layoutAlignmentId, {
-                min: state.layoutAlignmentInterval.start.m,
-                max: state.layoutAlignmentInterval.end.m,
-            })
-                .then(() => {
-                    Snackbar.success('tool-panel.location-track.location-track-endpoints-updated');
-                    onEndLocationTrackGeometryChange();
-                })
-                .finally(() => setUpdatingLength(false));
-        }
-    };
-
-    const [extraInfo, extraInfoLoadingStatus] = useLocationTrackInfoboxExtras(
-        locationTrack?.id,
-        publishType,
-        changeTimes,
-    );
-
     const visibilityChange = (key: keyof LocationTrackInfoboxVisibilities) => {
         onVisibilityChange({ ...visibilities, [key]: !visibilities[key] });
     };
 
-    const isDraft = locationTrack.draftType !== 'OFFICIAL';
-    const duplicatesOnOtherTracks = extraInfo?.duplicates?.some(
-        (dupe) => dupe.trackNumberId !== trackNumber?.id,
-    );
-
-    const getSplittingDisabledReasonsTranslated = () => {
-        const reasons = [];
-        if (isDraft)
-            reasons.push(t('tool-panel.location-track.splitting.validation.track-draft-exists'));
-        if (duplicatesOnOtherTracks)
-            reasons.push(
-                t(
-                    'tool-panel.location-track.splitting.validation.duplicates-on-different-track-number',
-                ),
-            );
-        return reasons.join('\n\n');
-    };
-
-    const isStartOrEndSwitch = (switchId: LayoutSwitchId) =>
-        switchId === extraInfo?.switchAtStart?.id || switchId === extraInfo?.switchAtEnd?.id;
-
-    const onStartSplitting = () => {
-        getSplittingInitializationParameters('DRAFT', locationTrack.id).then(
-            (splitInitializationParameters) => {
-                if (startAndEndPoints?.start && startAndEndPoints?.end) {
-                    delegates.onStartSplitting({
-                        locationTrack: locationTrack,
-                        allowedSwitches:
-                            splitInitializationParameters?.switches.filter(
-                                (sw) => !isStartOrEndSwitch(sw.switchId),
-                            ) || [],
-                        startAndEndSwitches: [
-                            extraInfo?.switchAtStart?.id,
-                            extraInfo?.switchAtEnd?.id,
-                        ].filter(filterNotEmpty),
-                        duplicateTracks: splitInitializationParameters?.duplicates || [],
-                        startLocation: startAndEndPoints.start.point,
-                        endLocation: startAndEndPoints.end.point,
-                    });
-                    delegates.showLayers(['location-track-split-location-layer']);
-                }
-            },
-        );
-    };
-
     return (
         <React.Fragment>
-            <Infobox
-                contentVisible={
-                    visibilities.basic && extraInfoLoadingStatus != LoaderStatus.Loading
-                }
-                onContentVisibilityChange={() => visibilityChange('basic')}
-                title={t('tool-panel.location-track.basic-info-heading')}
-                qa-id="location-track-infobox">
-                <InfoboxContent>
-                    <InfoboxField
-                        qaId="location-track-oid"
-                        label={t('tool-panel.location-track.identifier')}
-                        value={
-                            locationTrack.externalId || t('tool-panel.location-track.unpublished')
-                        }
-                    />
-                    <InfoboxField
-                        qaId="location-track-name"
-                        label={t('tool-panel.location-track.track-name')}
-                        value={locationTrack.name}
-                        onEdit={openEditLocationTrackDialog}
-                        iconDisabled={editingDisabled}
-                    />
-                    <InfoboxField
-                        qaId="location-track-state"
-                        label={t('tool-panel.location-track.state')}
-                        value={<LayoutState state={locationTrack.state} />}
-                        onEdit={openEditLocationTrackDialog}
-                        iconDisabled={editingDisabled}
-                    />
-                    <InfoboxField
-                        qaId="location-track-type"
-                        label={t('tool-panel.location-track.type')}
-                        value={<LocationTrackTypeLabel type={locationTrack.type} />}
-                        onEdit={openEditLocationTrackDialog}
-                        iconDisabled={editingDisabled}
-                    />
-                    <InfoboxField
-                        qaId="location-track-description"
-                        label={t('tool-panel.location-track.description')}
-                        value={description}
-                        onEdit={openEditLocationTrackDialog}
-                        iconDisabled={editingDisabled}
-                    />
-                    <InfoboxField
-                        qaId="location-track-track-number"
-                        label={t('tool-panel.location-track.track-number')}
-                        value={<TrackNumberLinkContainer trackNumberId={trackNumber?.id} />}
-                        onEdit={openEditLocationTrackDialog}
-                        iconDisabled={editingDisabled}
-                    />
-                    <InfoboxText value={trackNumber?.description} />
-                    <InfoboxField
-                        label={
-                            locationTrack.duplicateOf
-                                ? t('tool-panel.location-track.duplicate-of')
-                                : extraInfo?.duplicates?.length ?? 0 > 0
-                                ? t('tool-panel.location-track.has-duplicates')
-                                : t('tool-panel.location-track.not-a-duplicate')
-                        }
-                        value={
-                            <LocationTrackInfoboxDuplicateOf
-                                existingDuplicate={extraInfo?.duplicateOf}
-                                duplicatesOfLocationTrack={extraInfo?.duplicates ?? []}
-                                publishType={publishType}
-                                changeTime={changeTimes.layoutLocationTrack}
-                                currentTrackNumberId={trackNumber?.id}
-                            />
-                        }
-                        onEdit={openEditLocationTrackDialog}
-                        iconDisabled={editingDisabled}
-                        iconHidden={!locationTrack.duplicateOf}
-                    />
-                    <InfoboxField
-                        label={t('tool-panel.location-track.topological-connectivity')}
-                        value={
-                            <TopologicalConnectivityLabel
-                                topologicalConnectivity={locationTrack.topologicalConnectivity}
-                            />
-                        }
-                        onEdit={openEditLocationTrackDialog}
-                        iconDisabled={editingDisabled}
-                    />
-                    <InfoboxField
-                        label={t('tool-panel.location-track.owner')}
-                        value={getLocationTrackOwnerName(locationTrack.ownerId)}
-                        onEdit={openEditLocationTrackDialog}
-                        iconDisabled={editingDisabled}
-                    />
-                    <InfoboxField
-                        label={t('tool-panel.location-track.start-switch')}
-                        value={extraInfo && getSwitchLink(extraInfo.switchAtStart)}
-                    />
-                    <InfoboxField
-                        label={t('tool-panel.location-track.end-switch')}
-                        value={extraInfo && getSwitchLink(extraInfo.switchAtEnd)}
-                    />
-                    <InfoboxButtons>
-                        <Button
-                            variant={ButtonVariant.SECONDARY}
-                            size={ButtonSize.SMALL}
-                            qa-id="zoom-to-location-track"
-                            title={
-                                !locationTrack.boundingBox
-                                    ? t('tool-panel.location-track.no-geometry')
-                                    : ''
-                            }
-                            disabled={!locationTrack.boundingBox}
-                            onClick={() =>
-                                locationTrack.boundingBox && showArea(locationTrack.boundingBox)
-                            }>
-                            {t('tool-panel.location-track.show-on-map')}
-                        </Button>
-                    </InfoboxButtons>
-                </InfoboxContent>
-            </Infobox>
+            {locationTrack && (
+                <LocationTrackBasicInfoInfoboxContainer
+                    locationTrack={locationTrack}
+                    publishType={publishType}
+                    trackNumber={trackNumber}
+                    editingDisabled={editingDisabled}
+                    visibilities={visibilities}
+                    visibilityChange={visibilityChange}
+                    openEditLocationTrackDialog={openEditLocationTrackDialog}
+                />
+            )}
             {splittingState && (
-                <EnvRestricted restrictTo="dev">
+                <EnvRestricted restrictTo="test">
                     <LocationTrackSplittingInfoboxContainer
                         visibilities={visibilities}
                         visibilityChange={visibilityChange}
@@ -401,197 +129,15 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                     />
                 </EnvRestricted>
             )}
-            {startAndEndPoints && coordinateSystem && (
-                <Infobox
-                    contentVisible={visibilities.location}
-                    onContentVisibilityChange={() => visibilityChange('location')}
-                    title={t('tool-panel.location-track.track-location-heading')}
-                    qa-id="location-track-location-infobox">
-                    <InfoboxContent>
-                        <ProgressIndicatorWrapper
-                            indicator={ProgressIndicatorType.Area}
-                            inProgress={startAndEndPointFetchStatus !== LoaderStatus.Ready}>
-                            <React.Fragment>
-                                <InfoboxField
-                                    qaId="location-track-start-track-meter"
-                                    label={t('tool-panel.location-track.start-location')}>
-                                    {startAndEndPoints?.start?.address ? (
-                                        <NavigableTrackMeter
-                                            trackMeter={startAndEndPoints?.start?.address}
-                                            location={startAndEndPoints?.start?.point}
-                                        />
-                                    ) : (
-                                        t('tool-panel.location-track.unset')
-                                    )}
-                                </InfoboxField>
-                                <InfoboxField
-                                    qaId="location-track-end-track-meter"
-                                    label={t('tool-panel.location-track.end-location')}>
-                                    {startAndEndPoints?.end?.address ? (
-                                        <NavigableTrackMeter
-                                            trackMeter={startAndEndPoints?.end?.address}
-                                            location={startAndEndPoints?.end?.point}
-                                        />
-                                    ) : (
-                                        t('tool-panel.location-track.unset')
-                                    )}
-                                </InfoboxField>
-
-                                {linkingState === undefined && (
-                                    <WriteAccessRequired>
-                                        {extraInfo?.partOfUnfinishedSplit && (
-                                            <InfoboxContentSpread>
-                                                <MessageBox>
-                                                    {t(
-                                                        'tool-panel.alignment.geometry.part-of-unfinished-split',
-                                                        {
-                                                            locationTrackName: locationTrack.name,
-                                                        },
-                                                    )}
-                                                </MessageBox>
-                                            </InfoboxContentSpread>
-                                        )}
-                                        <InfoboxButtons>
-                                            <Button
-                                                variant={ButtonVariant.SECONDARY}
-                                                size={ButtonSize.SMALL}
-                                                qa-id="modify-start-or-end"
-                                                title={
-                                                    splittingState ||
-                                                    extraInfo?.partOfUnfinishedSplit
-                                                        ? t(
-                                                              'tool-panel.location-track.splitting-blocks-geometry-changes',
-                                                          )
-                                                        : ''
-                                                }
-                                                disabled={
-                                                    !!splittingState ||
-                                                    extraInfo?.partOfUnfinishedSplit ||
-                                                    !startAndEndPoints.start?.point ||
-                                                    !startAndEndPoints.end?.point
-                                                }
-                                                onClick={() => {
-                                                    getEndLinkPoints(
-                                                        locationTrack.id,
-                                                        publishType,
-                                                        'LOCATION_TRACK',
-                                                        changeTimes.layoutLocationTrack,
-                                                    ).then(onStartLocationTrackGeometryChange);
-                                                }}>
-                                                {t('tool-panel.location-track.modify-start-or-end')}
-                                            </Button>
-                                        </InfoboxButtons>
-                                    </WriteAccessRequired>
-                                )}
-                                {linkingState?.type === LinkingType.LinkingAlignment && (
-                                    <React.Fragment>
-                                        <p
-                                            className={
-                                                styles[
-                                                    'location-track-infobox__link-alignment-guide'
-                                                ]
-                                            }>
-                                            {t(
-                                                'tool-panel.location-track.choose-start-and-end-points',
-                                            )}
-                                        </p>
-                                        <InfoboxButtons>
-                                            <Button
-                                                variant={ButtonVariant.SECONDARY}
-                                                size={ButtonSize.SMALL}
-                                                disabled={updatingLength}
-                                                onClick={onEndLocationTrackGeometryChange}>
-                                                {t('button.cancel')}
-                                            </Button>
-                                            <Button
-                                                size={ButtonSize.SMALL}
-                                                isProcessing={updatingLength}
-                                                disabled={updatingLength || !canUpdate}
-                                                qa-id="save-start-and-end-changes"
-                                                onClick={() => {
-                                                    updateAlignment(linkingState);
-                                                }}>
-                                                {t('tool-panel.location-track.ready')}
-                                            </Button>
-                                        </InfoboxButtons>
-                                    </React.Fragment>
-                                )}
-                                <EnvRestricted restrictTo="test">
-                                    <WriteAccessRequired>
-                                        {isDraft && !extraInfo?.partOfUnfinishedSplit && (
-                                            <InfoboxContentSpread>
-                                                <MessageBox>
-                                                    {t(
-                                                        'tool-panel.location-track.splitting.validation.track-draft-exists',
-                                                    )}
-                                                </MessageBox>
-                                            </InfoboxContentSpread>
-                                        )}
-                                        {duplicatesOnOtherTracks &&
-                                            !extraInfo?.partOfUnfinishedSplit && (
-                                                <InfoboxContentSpread>
-                                                    <MessageBox>
-                                                        {t(
-                                                            'tool-panel.location-track.splitting.validation.duplicates-on-different-track-number',
-                                                        )}
-                                                    </MessageBox>
-                                                </InfoboxContentSpread>
-                                            )}
-                                        <InfoboxButtons>
-                                            {!linkingState && !splittingState && (
-                                                <Button
-                                                    variant={ButtonVariant.SECONDARY}
-                                                    size={ButtonSize.SMALL}
-                                                    disabled={
-                                                        locationTrack.draftType !== 'OFFICIAL' ||
-                                                        duplicatesOnOtherTracks
-                                                    }
-                                                    title={getSplittingDisabledReasonsTranslated()}
-                                                    onClick={onStartSplitting}>
-                                                    {t('tool-panel.location-track.start-splitting')}
-                                                </Button>
-                                            )}
-                                        </InfoboxButtons>
-                                    </WriteAccessRequired>
-                                </EnvRestricted>
-
-                                <InfoboxField
-                                    qaId="location-track-true-length"
-                                    label={t('tool-panel.location-track.true-length')}
-                                    value={
-                                        roundToPrecision(
-                                            locationTrack.length,
-                                            Precision.alignmentLengthMeters,
-                                        ) + ' m'
-                                    }
-                                />
-                                <InfoboxField
-                                    qaId="location-track-start-coordinates"
-                                    label={`${t('tool-panel.location-track.start-coordinates')} ${
-                                        coordinateSystem.name
-                                    }`}
-                                    value={
-                                        startAndEndPoints?.start
-                                            ? formatToTM35FINString(startAndEndPoints.start.point)
-                                            : t('tool-panel.location-track.unset')
-                                    }
-                                />
-                                <InfoboxField
-                                    qaId="location-track-end-coordinates"
-                                    label={`${t('tool-panel.location-track.end-coordinates')} ${
-                                        coordinateSystem.name
-                                    }`}
-                                    value={
-                                        startAndEndPoints?.end
-                                            ? formatToTM35FINString(startAndEndPoints?.end.point)
-                                            : t('tool-panel.location-track.unset')
-                                    }
-                                />
-                            </React.Fragment>
-                        </ProgressIndicatorWrapper>
-                    </InfoboxContent>
-                </Infobox>
-            )}
+            <LocationTrackLocationInfoboxContainer
+                locationTrack={locationTrack}
+                trackNumber={trackNumber}
+                visibilities={visibilities}
+                visibilityChange={visibilityChange}
+                linkingState={linkingState}
+                splittingState={splittingState}
+                publishType={publishType}
+            />
             <LocationTrackGeometryInfobox
                 contentVisible={visibilities.geometry}
                 onContentVisibilityChange={() => visibilityChange('geometry')}
@@ -608,73 +154,29 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 }
                 verticalGeometryDiagramVisible={verticalGeometryDiagramVisible}
             />
-            {locationTrack.draftType !== 'NEW_DRAFT' && extraInfo !== undefined && (
+            {locationTrack.draftType !== 'NEW_DRAFT' && (
                 <LocationTrackValidationInfoboxContainer
                     contentVisible={visibilities.validation}
                     onContentVisibilityChange={() => visibilityChange('validation')}
                     id={locationTrack.id}
                     publishType={publishType}
-                    changeTime={changeTimes.layoutLocationTrack}
-                    linkedSwitchesCount={extraInfo.linkedSwitchesCount}
                     showLinkedSwitchesRelinkingDialog={() => setConfirmingSwitchRelinking(true)}
                     editingDisabled={editingDisabled}
                 />
             )}
-            {locationTrackChangeInfo && (
-                <Infobox
-                    contentVisible={visibilities.log}
-                    onContentVisibilityChange={() => visibilityChange('log')}
-                    title={t('tool-panel.location-track.change-info-heading')}
-                    qa-id="location-track-log-infobox">
-                    <InfoboxContent>
-                        <InfoboxField
-                            qaId="location-track-created-date"
-                            label={t('tool-panel.created')}
-                            value={formatDateShort(locationTrackChangeInfo.created)}
-                        />
-                        <InfoboxField
-                            qaId="location-track-changed-date"
-                            label={t('tool-panel.changed')}
-                            value={
-                                locationTrackChangeInfo.changed &&
-                                formatDateShort(locationTrackChangeInfo.changed)
-                            }
-                        />
-                        {officialLocationTrack === undefined && (
-                            <InfoboxButtons>
-                                <Button
-                                    onClick={() => setConfirmingDraftDelete(true)}
-                                    icon={Icons.Delete}
-                                    variant={ButtonVariant.WARNING}
-                                    size={ButtonSize.SMALL}>
-                                    {t('button.delete-draft')}
-                                </Button>
-                            </InfoboxButtons>
-                        )}
-                    </InfoboxContent>
-                </Infobox>
-            )}
-
-            {officialLocationTrack && (
-                <WriteAccessRequired>
-                    <Infobox
-                        contentVisible={visibilities.ratkoPush}
-                        onContentVisibilityChange={() => visibilityChange('ratkoPush')}
-                        title={t('tool-panel.location-track.ratko-info-heading')}
-                        qa-id="location-track-ratko-infobox">
-                        <InfoboxContent>
-                            <InfoboxButtons>
-                                <Button
-                                    onClick={() => setShowRatkoPushDialog(true)}
-                                    variant={ButtonVariant.SECONDARY}
-                                    size={ButtonSize.SMALL}>
-                                    {t('tool-panel.location-track.push-to-ratko')}
-                                </Button>
-                            </InfoboxButtons>
-                        </InfoboxContent>
-                    </Infobox>
-                </WriteAccessRequired>
-            )}
+            <LocationTrackChangeInfoInfobox
+                locationTrackId={locationTrack.id}
+                publishType={publishType}
+                visibilities={visibilities}
+                visibilityChange={visibilityChange}
+                setConfirmingDraftDelete={setConfirmingDraftDelete}
+            />
+            <LocationTrackRatkoSyncInfobox
+                locationTrackId={locationTrack.id}
+                visibilities={visibilities}
+                visibilityChange={visibilityChange}
+                setShowRatkoPushDialog={setShowRatkoPushDialog}
+            />
 
             {showRatkoPushDialog && (
                 <LocationTrackRatkoPushDialog
@@ -700,13 +202,12 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 />
             )}
 
-            {confirmingSwitchRelinking && extraInfo && (
-                <LocationTrackSwitchRelinkingDialog
+            {confirmingSwitchRelinking && (
+                <LocationTrackSwitchRelinkingDialogContainer
                     locationTrackId={locationTrack.id}
+                    publishType={publishType}
                     name={locationTrack.name}
-                    linkedSwitchesCount={extraInfo.linkedSwitchesCount}
                     closeDialog={() => setConfirmingSwitchRelinking(false)}
-                    showLocationTrackTaskList={showLocationTrackTaskList}
                 />
             )}
         </React.Fragment>

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -1,0 +1,376 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import InfoboxContent, { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
+import {
+    ProgressIndicatorType,
+    ProgressIndicatorWrapper,
+} from 'vayla-design-lib/progress/progress-indicator-wrapper';
+import { LoaderStatus } from 'utils/react-utils';
+import InfoboxField from 'tool-panel/infobox/infobox-field';
+import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
+import { WriteAccessRequired } from 'user/write-access-required';
+import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import { getEndLinkPoints } from 'track-layout/layout-map-api';
+import { LinkingAlignment, LinkingState, LinkingType, LinkInterval } from 'linking/linking-model';
+import styles from 'tool-panel/location-track/location-track-infobox.scss';
+import { EnvRestricted } from 'environment/env-restricted';
+import { Precision, roundToPrecision } from 'utils/rounding';
+import { formatToTM35FINString } from 'utils/geography-utils';
+import Infobox from 'tool-panel/infobox/infobox';
+import {
+    LAYOUT_SRID,
+    LayoutLocationTrack,
+    LayoutSwitchId,
+    LayoutTrackNumber,
+} from 'track-layout/track-layout-model';
+import {
+    LocationTrackInfoboxVisibilities,
+    trackLayoutActionCreators as TrackLayoutActions,
+} from 'track-layout/track-layout-slice';
+import { SplitStart, SplittingState } from 'tool-panel/location-track/split-store';
+import { ChangeTimes } from 'common/common-slice';
+import { PublishType } from 'common/common-model';
+import { useCommonDataAppSelector } from 'store/hooks';
+import { getSplittingInitializationParameters } from 'track-layout/layout-location-track-api';
+import { filterNotEmpty } from 'utils/array-utils';
+import {
+    useCoordinateSystem,
+    useLocationTrackInfoboxExtras,
+    useLocationTrackStartAndEnd,
+} from 'track-layout/track-layout-react-utils';
+import { createDelegates } from 'store/store-utils';
+import { MapLayerName } from 'map/map-model';
+import { updateLocationTrackGeometry } from 'linking/linking-api';
+import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
+
+type LocationTrackLocationInfoboxContainerProps = {
+    locationTrack: LayoutLocationTrack;
+    trackNumber: LayoutTrackNumber | undefined;
+    visibilities: LocationTrackInfoboxVisibilities;
+    visibilityChange: (key: keyof LocationTrackInfoboxVisibilities) => void;
+    linkingState: LinkingState | undefined;
+    splittingState: SplittingState | undefined;
+    publishType: PublishType;
+};
+
+export const LocationTrackLocationInfoboxContainer: React.FC<
+    LocationTrackLocationInfoboxContainerProps
+> = (props: LocationTrackLocationInfoboxContainerProps) => {
+    const delegates = createDelegates(TrackLayoutActions);
+    const changeTimes = useCommonDataAppSelector((state) => state.changeTimes);
+
+    return (
+        <LocationTrackLocationInfobox
+            {...props}
+            changeTimes={changeTimes}
+            onStartSplitting={delegates.onStartSplitting}
+            onStartLocationTrackGeometryChange={(interval: LinkInterval) => {
+                delegates.showLayers(['alignment-linking-layer']);
+                delegates.startAlignmentGeometryChange(interval);
+            }}
+            onEndLocationTrackGeometryChange={() => {
+                delegates.hideLayers(['alignment-linking-layer']);
+                delegates.stopLinking();
+            }}
+            showLayers={delegates.showLayers}
+        />
+    );
+};
+
+type LocationTrackLocationInfoboxProps = LocationTrackLocationInfoboxContainerProps & {
+    changeTimes: ChangeTimes;
+    onStartLocationTrackGeometryChange: (points: LinkInterval) => void;
+    onEndLocationTrackGeometryChange: () => void;
+    onStartSplitting: (splitStartParams: SplitStart) => void;
+    showLayers: (layers: MapLayerName[]) => void;
+};
+
+export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfoboxProps> = ({
+    locationTrack,
+    trackNumber,
+    visibilities,
+    visibilityChange,
+    onStartLocationTrackGeometryChange,
+    onEndLocationTrackGeometryChange,
+    linkingState,
+    splittingState,
+    changeTimes,
+    publishType,
+    onStartSplitting,
+    showLayers,
+}: LocationTrackLocationInfoboxProps) => {
+    const { t } = useTranslation();
+
+    const isStartOrEndSwitch = (switchId: LayoutSwitchId) =>
+        switchId === extraInfo?.switchAtStart?.id || switchId === extraInfo?.switchAtEnd?.id;
+
+    const [startAndEndPoints, startAndEndPointFetchStatus] = useLocationTrackStartAndEnd(
+        locationTrack?.id,
+        publishType,
+        changeTimes,
+    );
+    const coordinateSystem = useCoordinateSystem(LAYOUT_SRID);
+    const [extraInfo, _] = useLocationTrackInfoboxExtras(
+        locationTrack?.id,
+        publishType,
+        changeTimes,
+    );
+
+    const isDraft = locationTrack.draftType !== 'OFFICIAL';
+    const duplicatesOnOtherTracks = extraInfo?.duplicates?.some(
+        (dupe) => dupe.trackNumberId !== trackNumber?.id,
+    );
+
+    const getSplittingDisabledReasonsTranslated = () => {
+        const reasons = [];
+        if (isDraft)
+            reasons.push(t('tool-panel.location-track.splitting.validation.track-draft-exists'));
+        if (duplicatesOnOtherTracks)
+            reasons.push(
+                t(
+                    'tool-panel.location-track.splitting.validation.duplicates-on-different-track-number',
+                ),
+            );
+        return reasons.join('\n\n');
+    };
+
+    const [updatingLength, setUpdatingLength] = React.useState<boolean>(false);
+    const [canUpdate, setCanUpdate] = React.useState<boolean>();
+
+    React.useEffect(() => {
+        setCanUpdate(
+            linkingState?.type === LinkingType.LinkingAlignment && linkingState.state === 'allSet',
+        );
+    }, [linkingState]);
+
+    const startSplitting = () => {
+        getSplittingInitializationParameters('DRAFT', locationTrack.id).then(
+            (splitInitializationParameters) => {
+                if (startAndEndPoints?.start && startAndEndPoints?.end) {
+                    onStartSplitting({
+                        locationTrack: locationTrack,
+                        allowedSwitches:
+                            splitInitializationParameters?.switches.filter(
+                                (sw) => !isStartOrEndSwitch(sw.switchId),
+                            ) || [],
+                        startAndEndSwitches: [
+                            extraInfo?.switchAtStart?.id,
+                            extraInfo?.switchAtEnd?.id,
+                        ].filter(filterNotEmpty),
+                        duplicateTracks: splitInitializationParameters?.duplicates || [],
+                        startLocation: startAndEndPoints.start.point,
+                        endLocation: startAndEndPoints.end.point,
+                    });
+                    showLayers(['location-track-split-location-layer']);
+                }
+            },
+        );
+    };
+
+    const updateAlignment = (state: LinkingAlignment) => {
+        if (canUpdate && state.layoutAlignmentInterval.start && state.layoutAlignmentInterval.end) {
+            setUpdatingLength(true);
+            updateLocationTrackGeometry(state.layoutAlignmentId, {
+                min: state.layoutAlignmentInterval.start.m,
+                max: state.layoutAlignmentInterval.end.m,
+            })
+                .then(() => {
+                    Snackbar.success('tool-panel.location-track.location-track-endpoints-updated');
+                    onEndLocationTrackGeometryChange();
+                })
+                .finally(() => setUpdatingLength(false));
+        }
+    };
+
+    return (
+        startAndEndPoints &&
+        coordinateSystem && (
+            <Infobox
+                contentVisible={visibilities.location}
+                onContentVisibilityChange={() => visibilityChange('location')}
+                title={t('tool-panel.location-track.track-location-heading')}
+                qa-id="location-track-location-infobox">
+                <InfoboxContent>
+                    <ProgressIndicatorWrapper
+                        indicator={ProgressIndicatorType.Area}
+                        inProgress={startAndEndPointFetchStatus !== LoaderStatus.Ready}>
+                        <React.Fragment>
+                            <InfoboxField
+                                qaId="location-track-start-track-meter"
+                                label={t('tool-panel.location-track.start-location')}>
+                                {startAndEndPoints?.start?.address ? (
+                                    <NavigableTrackMeter
+                                        trackMeter={startAndEndPoints?.start?.address}
+                                        location={startAndEndPoints?.start?.point}
+                                    />
+                                ) : (
+                                    t('tool-panel.location-track.unset')
+                                )}
+                            </InfoboxField>
+                            <InfoboxField
+                                qaId="location-track-end-track-meter"
+                                label={t('tool-panel.location-track.end-location')}>
+                                {startAndEndPoints?.end?.address ? (
+                                    <NavigableTrackMeter
+                                        trackMeter={startAndEndPoints?.end?.address}
+                                        location={startAndEndPoints?.end?.point}
+                                    />
+                                ) : (
+                                    t('tool-panel.location-track.unset')
+                                )}
+                            </InfoboxField>
+
+                            {linkingState === undefined && (
+                                <WriteAccessRequired>
+                                    {extraInfo?.partOfUnfinishedSplit && (
+                                        <InfoboxContentSpread>
+                                            <MessageBox>
+                                                {t(
+                                                    'tool-panel.alignment.geometry.part-of-unfinished-split',
+                                                    {
+                                                        locationTrackName: locationTrack.name,
+                                                    },
+                                                )}
+                                            </MessageBox>
+                                        </InfoboxContentSpread>
+                                    )}
+                                    <InfoboxButtons>
+                                        <Button
+                                            variant={ButtonVariant.SECONDARY}
+                                            size={ButtonSize.SMALL}
+                                            qa-id="modify-start-or-end"
+                                            title={
+                                                splittingState || extraInfo?.partOfUnfinishedSplit
+                                                    ? t(
+                                                          'tool-panel.location-track.splitting-blocks-geometry-changes',
+                                                      )
+                                                    : ''
+                                            }
+                                            disabled={
+                                                !!splittingState ||
+                                                extraInfo?.partOfUnfinishedSplit ||
+                                                !startAndEndPoints.start?.point ||
+                                                !startAndEndPoints.end?.point
+                                            }
+                                            onClick={() => {
+                                                getEndLinkPoints(
+                                                    locationTrack.id,
+                                                    publishType,
+                                                    'LOCATION_TRACK',
+                                                    changeTimes.layoutLocationTrack,
+                                                ).then(onStartLocationTrackGeometryChange);
+                                            }}>
+                                            {t('tool-panel.location-track.modify-start-or-end')}
+                                        </Button>
+                                    </InfoboxButtons>
+                                </WriteAccessRequired>
+                            )}
+                            {linkingState?.type === LinkingType.LinkingAlignment && (
+                                <React.Fragment>
+                                    <p
+                                        className={
+                                            styles['location-track-infobox__link-alignment-guide']
+                                        }>
+                                        {t('tool-panel.location-track.choose-start-and-end-points')}
+                                    </p>
+                                    <InfoboxButtons>
+                                        <Button
+                                            variant={ButtonVariant.SECONDARY}
+                                            size={ButtonSize.SMALL}
+                                            disabled={updatingLength}
+                                            onClick={onEndLocationTrackGeometryChange}>
+                                            {t('button.cancel')}
+                                        </Button>
+                                        <Button
+                                            size={ButtonSize.SMALL}
+                                            isProcessing={updatingLength}
+                                            disabled={updatingLength || !canUpdate}
+                                            qa-id="save-start-and-end-changes"
+                                            onClick={() => {
+                                                updateAlignment(linkingState);
+                                            }}>
+                                            {t('tool-panel.location-track.ready')}
+                                        </Button>
+                                    </InfoboxButtons>
+                                </React.Fragment>
+                            )}
+                            <EnvRestricted restrictTo="test">
+                                <WriteAccessRequired>
+                                    {isDraft && !extraInfo?.partOfUnfinishedSplit && (
+                                        <InfoboxContentSpread>
+                                            <MessageBox>
+                                                {t(
+                                                    'tool-panel.location-track.splitting.validation.track-draft-exists',
+                                                )}
+                                            </MessageBox>
+                                        </InfoboxContentSpread>
+                                    )}
+                                    {duplicatesOnOtherTracks &&
+                                        !extraInfo?.partOfUnfinishedSplit && (
+                                            <InfoboxContentSpread>
+                                                <MessageBox>
+                                                    {t(
+                                                        'tool-panel.location-track.splitting.validation.duplicates-on-different-track-number',
+                                                    )}
+                                                </MessageBox>
+                                            </InfoboxContentSpread>
+                                        )}
+                                    <InfoboxButtons>
+                                        {!linkingState && !splittingState && (
+                                            <Button
+                                                variant={ButtonVariant.SECONDARY}
+                                                size={ButtonSize.SMALL}
+                                                disabled={
+                                                    locationTrack.draftType !== 'OFFICIAL' ||
+                                                    duplicatesOnOtherTracks
+                                                }
+                                                title={getSplittingDisabledReasonsTranslated()}
+                                                onClick={startSplitting}>
+                                                {t('tool-panel.location-track.start-splitting')}
+                                            </Button>
+                                        )}
+                                    </InfoboxButtons>
+                                </WriteAccessRequired>
+                            </EnvRestricted>
+
+                            <InfoboxField
+                                qaId="location-track-true-length"
+                                label={t('tool-panel.location-track.true-length')}
+                                value={
+                                    roundToPrecision(
+                                        locationTrack.length,
+                                        Precision.alignmentLengthMeters,
+                                    ) + ' m'
+                                }
+                            />
+                            <InfoboxField
+                                qaId="location-track-start-coordinates"
+                                label={`${t('tool-panel.location-track.start-coordinates')} ${
+                                    coordinateSystem.name
+                                }`}
+                                value={
+                                    startAndEndPoints.start
+                                        ? formatToTM35FINString(startAndEndPoints.start.point)
+                                        : t('tool-panel.location-track.unset')
+                                }
+                            />
+                            <InfoboxField
+                                qaId="location-track-end-coordinates"
+                                label={`${t('tool-panel.location-track.end-coordinates')} ${
+                                    coordinateSystem.name
+                                }`}
+                                value={
+                                    startAndEndPoints.end
+                                        ? formatToTM35FINString(startAndEndPoints?.end.point)
+                                        : t('tool-panel.location-track.unset')
+                                }
+                            />
+                        </React.Fragment>
+                    </ProgressIndicatorWrapper>
+                </InfoboxContent>
+            </Infobox>
+        )
+    );
+};

--- a/ui/src/tool-panel/location-track/location-track-ratko-sync-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-ratko-sync-infobox.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { WriteAccessRequired } from 'user/write-access-required';
+import Infobox from 'tool-panel/infobox/infobox';
+import InfoboxContent from 'tool-panel/infobox/infobox-content';
+import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import { useLocationTrack } from 'track-layout/track-layout-react-utils';
+import { LocationTrackId } from 'track-layout/track-layout-model';
+import { LocationTrackInfoboxVisibilities } from 'track-layout/track-layout-slice';
+import { useCommonDataAppSelector } from 'store/hooks';
+
+type LocationTrackRatkoSyncInfoboxProps = {
+    locationTrackId: LocationTrackId;
+    visibilities: LocationTrackInfoboxVisibilities;
+    visibilityChange: (key: keyof LocationTrackInfoboxVisibilities) => void;
+    setShowRatkoPushDialog: (showing: boolean) => void;
+};
+
+export const LocationTrackRatkoSyncInfobox: React.FC<LocationTrackRatkoSyncInfoboxProps> = ({
+    locationTrackId,
+    visibilities,
+    visibilityChange,
+    setShowRatkoPushDialog,
+}) => {
+    const { t } = useTranslation();
+    const changeTimes = useCommonDataAppSelector((state) => state.changeTimes);
+
+    const officialLocationTrack = useLocationTrack(
+        locationTrackId,
+        'OFFICIAL',
+        changeTimes.layoutLocationTrack,
+    );
+    return officialLocationTrack ? (
+        <WriteAccessRequired>
+            <Infobox
+                contentVisible={visibilities.ratkoPush}
+                onContentVisibilityChange={() => visibilityChange('ratkoPush')}
+                title={t('tool-panel.location-track.ratko-info-heading')}
+                qa-id="location-track-ratko-infobox">
+                <InfoboxContent>
+                    <InfoboxButtons>
+                        <Button
+                            onClick={() => setShowRatkoPushDialog(true)}
+                            variant={ButtonVariant.SECONDARY}
+                            size={ButtonSize.SMALL}>
+                            {t('tool-panel.location-track.push-to-ratko')}
+                        </Button>
+                    </InfoboxButtons>
+                </InfoboxContent>
+            </Infobox>
+        </WriteAccessRequired>
+    ) : (
+        <React.Fragment />
+    );
+};

--- a/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
@@ -2,18 +2,17 @@ import * as React from 'react';
 import { useLoaderWithStatus } from 'utils/react-utils';
 import { AssetValidationInfobox } from 'tool-panel/asset-validation-infobox';
 import { getLocationTrackValidation } from 'track-layout/layout-location-track-api';
-import { PublishType, TimeStamp } from 'common/common-model';
+import { PublishType } from 'common/common-model';
 import { LocationTrackId } from 'track-layout/track-layout-model';
 import { Button, ButtonSize } from 'vayla-design-lib/button/button';
 import { useTranslation } from 'react-i18next';
+import { useCommonDataAppSelector } from 'store/hooks';
 
 type LocationTrackValidationInfoboxProps = {
     id: LocationTrackId;
     publishType: PublishType;
-    changeTime: TimeStamp;
     contentVisible: boolean;
     onContentVisibilityChange: () => void;
-    linkedSwitchesCount: number;
     showLinkedSwitchesRelinkingDialog: () => void;
     editingDisabled: boolean;
 };
@@ -23,16 +22,17 @@ export const LocationTrackValidationInfoboxContainer: React.FC<
 > = ({
     id,
     publishType,
-    changeTime,
     contentVisible,
     onContentVisibilityChange,
     showLinkedSwitchesRelinkingDialog,
     editingDisabled,
 }) => {
     const { t } = useTranslation();
+    const changeTimes = useCommonDataAppSelector((state) => state.changeTimes);
+
     const [validation, validationLoaderStatus] = useLoaderWithStatus(
         () => getLocationTrackValidation(publishType, id),
-        [id, publishType, changeTime],
+        [id, publishType, changeTimes.layoutLocationTrack],
     );
 
     const errors = validation?.errors.filter((err) => err.type === 'ERROR') || [];

--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -45,7 +45,7 @@ export type SplittingState = {
     disabled: boolean;
 };
 
-type SplitStart = {
+export type SplitStart = {
     locationTrack: LayoutLocationTrack;
     allowedSwitches: SwitchOnLocationTrack[];
     startAndEndSwitches: LayoutSwitchId[];


### PR DESCRIPTION
Tein tämän refakin osissa, tässä niistä ensimmäinen. Täällä käytännössä refaktoroitu varsinainen `LocationTrackInfobox` mm. jakamalla sitä osiin. Uusille ali-infobokseille on about järjestäen myös luotu containerit, jotta dataa ei tarvitse passailla niin paljoa. Täällä ei pitäISI oikeastaan olla logiikkamuutoksia, vaan kaiken pitäisi olla pelkkää datan puljailua ja muuta refaktorointia, mutta kannnattaa silti pitää silmät auki, sillä täällä on kuitenkin paljon massaa.