### PR TITLE
GVT-2501: Dividerit esikatselunäkymän rivikohtaiseen menuun + noUncheckedIndexedAccess tilapäisesti pois päältä

### DIFF
--- a/ui/src/app-bar/app-bar-more-menu.tsx
+++ b/ui/src/app-bar/app-bar-more-menu.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Dialog } from 'geoviite-design-lib/dialog/dialog';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { Menu, MenuSelectOption, menuSelectOption } from 'vayla-design-lib/menu/menu';
 import styles from 'app-bar/app-bar.scss';
 import { useTranslation } from 'react-i18next';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
@@ -15,21 +15,23 @@ const AppBarMoreMenu: React.FC = () => {
     const menuRef = React.useRef(null);
     const navigate = useNavigate();
 
-    const moreActions = [
-        {
-            onSelect: () => {
+    const moreActions: MenuSelectOption[] = [
+        menuSelectOption(
+            () => {
                 setShowMenu(false);
                 navigate('licenses');
             },
-            name: t('app-bar.licenses'),
-        },
-        {
-            onSelect: () => {
+            t('app-bar.licenses'),
+            'licenses',
+        ),
+        menuSelectOption(
+            () => {
                 setShowMenu(false);
                 setShowLogoutConfirmation(true);
             },
-            name: t('app-bar.logout'),
-        },
+            t('app-bar.logout'),
+            'logout',
+        ),
     ];
 
     return (

--- a/ui/src/app-bar/data-products-menu.tsx
+++ b/ui/src/app-bar/data-products-menu.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styles from './app-bar.scss';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { Menu, menuSelectOption } from 'vayla-design-lib/menu/menu';
 import { createClassName } from 'vayla-design-lib/utils';
 
 const DataProductsMenu: React.FC = () => {
@@ -13,30 +13,30 @@ const DataProductsMenu: React.FC = () => {
     const navigate = useNavigate();
 
     const dataProducts = [
-        {
-            onSelect: () => {
+        menuSelectOption(
+            () => {
                 setShowMenu(false);
                 navigate('data-products/element-list');
             },
-            qaId: 'element-list-menu-link',
-            name: t('app-bar.data-products.element-list'),
-        },
-        {
-            onSelect: () => {
+            t('app-bar.data-products.element-list'),
+            'element-list-menu-link',
+        ),
+        menuSelectOption(
+            () => {
                 setShowMenu(false);
                 navigate('data-products/vertical-geometry');
             },
-            qaId: 'vertical-geometry-menu-link',
-            name: t('app-bar.data-products.vertical-geometry'),
-        },
-        {
-            onSelect: () => {
+            t('app-bar.data-products.vertical-geometry'),
+            'vertical-geometry-menu-link',
+        ),
+        menuSelectOption(
+            () => {
                 setShowMenu(false);
                 navigate('data-products/kilometer-lengths');
             },
-            qaId: 'kilometer-length-menu-link',
-            name: t('app-bar.data-products.km-lengths'),
-        },
+            t('app-bar.data-products.km-lengths'),
+            'kilometer-length-menu-link',
+        ),
     ];
 
     return (

--- a/ui/src/infra-model/projektivelho/pv-file-list.tsx
+++ b/ui/src/infra-model/projektivelho/pv-file-list.tsx
@@ -28,7 +28,7 @@ import {
     sortPVTableColumns,
 } from 'infra-model/projektivelho/pv-file-list-utils';
 import { getSortDirectionIcon, SortDirection } from 'utils/table-utils';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { Menu, MenuSelectOption, menuSelectOption } from 'vayla-design-lib/menu/menu';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { PVRedirectLink } from 'infra-model/projektivelho/pv-redirect-link';
 import { PrivilegedLink } from 'user/privileged-link';
@@ -276,10 +276,9 @@ const PVFileListRow = ({
 
     const dialogTranslationPrefix = `confirm-dialog.${suggestedList ? 'reject' : 'restore'}`;
 
-    const fileActions = [
-        {
-            disabled: !item.assignment?.oid,
-            onSelect: () => {
+    const fileActions: MenuSelectOption[] = [
+        menuSelectOption(
+            () => {
                 dialogParams.current = {
                     title: t(`${dialogTranslationPrefix}.by-assignment-title`),
                     message: {
@@ -303,13 +302,14 @@ const PVFileListRow = ({
                 setShowConfirmDialog(true);
                 setFileActionMenuVisible(false);
             },
-            name: t(`${dialogTranslationPrefix}.by-assignment`, {
+            t(`${dialogTranslationPrefix}.by-assignment`, {
                 assignmentCount: itemCounts.assignment ?? '-',
             }),
-        },
-        {
-            disabled: !item.project?.oid,
-            onSelect: () => {
+            'pv-reject-or-restore-by-assignment',
+            !item.assignment?.oid,
+        ),
+        menuSelectOption(
+            () => {
                 dialogParams.current = {
                     title: t(`${dialogTranslationPrefix}.by-project-title`),
                     message: {
@@ -333,13 +333,14 @@ const PVFileListRow = ({
                 setShowConfirmDialog(true);
                 setFileActionMenuVisible(false);
             },
-            name: t(`${dialogTranslationPrefix}.by-project`, {
+            t(`${dialogTranslationPrefix}.by-project`, {
                 projectCount: itemCounts.project ?? '-',
             }),
-        },
-        {
-            disabled: !item.projectGroup?.oid,
-            onSelect: () => {
+            'pv-reject-or-restore-by-project',
+            !item.project?.oid,
+        ),
+        menuSelectOption(
+            () => {
                 dialogParams.current = {
                     title: t(`${dialogTranslationPrefix}.by-project-group-title`),
                     message: {
@@ -363,10 +364,12 @@ const PVFileListRow = ({
                 setShowConfirmDialog(true);
                 setFileActionMenuVisible(false);
             },
-            name: t(`${dialogTranslationPrefix}.by-project-group`, {
+            t(`${dialogTranslationPrefix}.by-project-group`, {
                 groupCount: itemCounts.projectGroup ?? '-',
             }),
-        },
+            'pv-reject-or-restore-by-project-group',
+            !item.projectGroup?.oid,
+        ),
     ];
 
     const confirmDialog = () => {

--- a/ui/src/infra-model/view/dialogs/charset-select-dialog.tsx
+++ b/ui/src/infra-model/view/dialogs/charset-select-dialog.tsx
@@ -6,12 +6,13 @@ import { useTranslation } from 'react-i18next';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Dialog } from 'geoviite-design-lib/dialog/dialog';
 import { Dropdown, Item } from 'vayla-design-lib/dropdown/dropdown';
+import { menuValueOption } from 'vayla-design-lib/menu/menu';
 
 const xmlEncodingOptions: Item<XmlCharset>[] = [
-    { name: 'ISO-8859-1', value: 'ISO_8859_1' },
-    { name: 'UTF-8', value: 'UTF_8' },
-    { name: 'UTF-16', value: 'UTF_16' },
-    { name: 'US ASCII', value: 'US_ASCII' },
+    menuValueOption('ISO_8859_1', 'ISO-8859-1'),
+    menuValueOption('UTF_8', 'UTF-8'),
+    menuValueOption('UTF_16', 'UTF-16'),
+    menuValueOption('US_ASCII', 'US ASCII'),
 ];
 
 export type CharsetSelectDialogProps = {

--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -52,6 +52,7 @@ import FormgroupTextarea from 'infra-model/view/formgroup/formgroup-textarea';
 import { PVRedirectLink } from 'infra-model/projektivelho/pv-redirect-link';
 import { useLoader } from 'utils/react-utils';
 import i18next from 'i18next';
+import { menuValueOption } from 'vayla-design-lib/menu/menu';
 
 type InframodelViewFormContainerProps = {
     changeTimes: ChangeTimes;
@@ -128,14 +129,8 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
     const authors = useLoader(() => fetchAuthors(), [changeTimes.author]) || [];
 
     const planSourceOptions = [
-        {
-            name: t('enum.plan-source.GEOMETRIAPALVELU'),
-            value: 'GEOMETRIAPALVELU' as PlanSource,
-        },
-        {
-            name: t('enum.plan-source.PAIKANNUSPALVELU'),
-            value: 'PAIKANNUSPALVELU' as PlanSource,
-        },
+        menuValueOption('GEOMETRIAPALVELU' as PlanSource, t('enum.plan-source.GEOMETRIAPALVELU')),
+        menuValueOption('PAIKANNUSPALVELU' as PlanSource, t('enum.plan-source.PAIKANNUSPALVELU')),
     ];
 
     function changeInExtraParametersField<
@@ -356,10 +351,9 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                                     <Dropdown
                                         wide
                                         value={geometryPlan.author?.id}
-                                        options={authorsIncludingFromPlan().map((author) => ({
-                                            name: author.companyName,
-                                            value: author.id,
-                                        }))}
+                                        options={authorsIncludingFromPlan().map((author) =>
+                                            menuValueOption(author.id, author.companyName),
+                                        )}
                                         onChange={(authorId) => {
                                             authorId &&
                                                 authorId != geometryPlan.author?.id &&
@@ -403,10 +397,12 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                                             options={
                                                 trackNumberList
                                                     ? trackNumberList
-                                                          .map((tn) => ({
-                                                              name: `${tn.number}`,
-                                                              value: tn.id,
-                                                          }))
+                                                          .map((tn) =>
+                                                              menuValueOption(
+                                                                  tn.id,
+                                                                  `${tn.number}`,
+                                                              ),
+                                                          )
                                                           .sort(compareNamed)
                                                     : []
                                             }
@@ -449,10 +445,12 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                                         options={
                                             sridList
                                                 ? sridList
-                                                      .map((srid) => ({
-                                                          name: `${srid.name} ${srid.srid}`,
-                                                          value: srid.srid,
-                                                      }))
+                                                      .map((srid) =>
+                                                          menuValueOption(
+                                                              srid.srid,
+                                                              `${srid.name} ${srid.srid}`,
+                                                          ),
+                                                      )
                                                       .sort(compareNamed)
                                                 : []
                                         }

--- a/ui/src/infra-model/view/infra-model-toolbar.tsx
+++ b/ui/src/infra-model/view/infra-model-toolbar.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { useAppNavigate } from 'common/navigate';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { Menu, menuValueOption } from 'vayla-design-lib/menu/menu';
 import { Item } from 'vayla-design-lib/dropdown/dropdown';
 
 export type FileMenuOption = 'fix-encoding';
@@ -22,6 +22,10 @@ export const InfraModelToolbar: React.FC<InfraModelToolbarProps> = (
     const { t } = useTranslation();
     const [fileMenuVisible, setFileMenuVisible] = React.useState(false);
     const fileMenuRef = React.useRef(null);
+
+    const items = props.fileMenuItems.map((item) =>
+        menuValueOption(item.value, item.name, item.qaId, item.disabled),
+    );
 
     return (
         <div className="infra-model-upload__tool-bar">
@@ -47,7 +51,7 @@ export const InfraModelToolbar: React.FC<InfraModelToolbarProps> = (
             {fileMenuVisible && (
                 <Menu
                     positionRef={fileMenuRef}
-                    items={props.fileMenuItems}
+                    items={items}
                     onSelect={(item) => {
                         props.fileMenuItemSelected(item);
                         setFileMenuVisible(false);

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -12,7 +12,13 @@ import { createClassName } from 'vayla-design-lib/utils';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { ChangesBeingReverted, PreviewOperations } from 'preview/preview-view';
-import { Menu, MenuSelectOption } from 'vayla-design-lib/menu/menu';
+import {
+    Menu,
+    menuDividerOption,
+    MenuOption,
+    menuSelectOption,
+    MenuSelectOption,
+} from 'vayla-design-lib/menu/menu';
 import { PreviewSelectType, PreviewTableEntry, PublicationId } from 'preview/preview-table';
 import { BoundingBox } from 'model/geometry';
 import { RevertRequestSource } from 'preview/preview-view-revert-request';
@@ -98,20 +104,21 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         setActionMenuVisible(false);
     };
 
-    const menuOptionMoveStageChanges: MenuSelectOption = {
-        onSelect: menuAction(() =>
+    const menuOptionMoveStageChanges: MenuSelectOption = menuSelectOption(
+        menuAction(() =>
             previewOperations.setPublicationStage.forAllStageChanges(
                 displayedPublicationStage,
                 moveTargetStage,
             ),
         ),
-        name: t('publish.move-stage-changes', {
+        t('publish.move-stage-changes', {
             amount: stagePublicationAssetAmount,
         }),
-    };
+        'preview-move-stage-changes',
+    );
 
-    const menuOptionMovePublicationGroupStage: MenuSelectOption = {
-        onSelect: menuAction(() => {
+    const menuOptionMovePublicationGroupStage: MenuSelectOption = menuSelectOption(
+        menuAction(() => {
             if (tableEntry.publicationGroup) {
                 previewOperations.setPublicationStage.forPublicationGroup(
                     tableEntry.publicationGroup,
@@ -119,35 +126,38 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                 );
             }
         }),
-        name: t('publish.move-publication-group', {
+        t('publish.move-publication-group', {
             amount: publicationGroupAssetAmount,
         }),
-    };
+        'preview-move-publication-group',
+    );
 
-    const menuOptionRevertSingleChange: MenuSelectOption = {
-        name: t('publish.revert-change'),
-        onSelect: menuAction(() =>
+    const menuOptionRevertSingleChange: MenuSelectOption = menuSelectOption(
+        menuAction(() =>
             previewOperations.revert.changesWithDependencies(
                 tableEntryAsPublishRequestIds,
                 tableEntryAsRevertRequestSource,
             ),
         ),
-    };
+        t('publish.revert-change'),
+        'preview-revert-change',
+    );
 
-    const menuOptionRevertStageChanges: MenuSelectOption = {
-        onSelect: menuAction(() => {
+    const menuOptionRevertStageChanges: MenuSelectOption = menuSelectOption(
+        menuAction(() => {
             previewOperations.revert.stageChanges(
                 displayedPublicationStage,
                 tableEntryAsRevertRequestSource,
             );
         }),
-        name: t('publish.revert-stage-changes', {
+        t('publish.revert-stage-changes', {
             amount: stagePublicationAssetAmount,
         }),
-    };
+        'preview-revert-stage-changes',
+    );
 
-    const menuOptionPublicationGroupRevert: MenuSelectOption = {
-        onSelect: menuAction(() => {
+    const menuOptionPublicationGroupRevert: MenuSelectOption = menuSelectOption(
+        menuAction(() => {
             if (tableEntry.publicationGroup) {
                 previewOperations.revert.publicationGroup(
                     tableEntry.publicationGroup,
@@ -155,23 +165,27 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                 );
             }
         }),
-        name: t('publish.revert-publication-group', {
+        t('publish.revert-publication-group', {
             amount: publicationGroupAssetAmount,
         }),
-    };
+        'preview-revert-publication-group',
+    );
 
-    const menuOptionShowOnMap: MenuSelectOption = {
-        disabled: !tableEntry.boundingBox,
-        onSelect: menuAction(() => {
+    const menuOptionShowOnMap: MenuSelectOption = menuSelectOption(
+        menuAction(() => {
             tableEntry.boundingBox && onShowOnMap(tableEntry.boundingBox);
         }),
-        name: t('publish.show-on-map'),
-    };
+        t('publish.show-on-map'),
+        'preview-show-on-map',
+        !tableEntry.boundingBox,
+    );
 
-    const menuOptions: MenuSelectOption[] = [
+    const menuOptions: MenuOption<never>[] = [
         ...conditionalMenuOption(tableEntry.publicationGroup, menuOptionMovePublicationGroupStage),
         menuOptionMoveStageChanges,
+        menuDividerOption(),
         menuOptionShowOnMap,
+        menuDividerOption(),
         ...conditionalMenuOption(!tableEntry.publicationGroup, menuOptionRevertSingleChange),
         ...conditionalMenuOption(tableEntry.publicationGroup, menuOptionPublicationGroupRevert),
         menuOptionRevertStageChanges,

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -11,7 +11,7 @@ import { Link } from 'vayla-design-lib/link/link';
 import { formatDateFull } from 'utils/date-utils';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { AppNavigateFunction } from 'common/navigate';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { Menu, menuSelectOption, MenuSelectOption } from 'vayla-design-lib/menu/menu';
 import { SplitDetailsDialog } from 'publication/split/split-details-dialog';
 import { putBulkTransferState } from 'publication/split/split-api';
 import { success } from 'geoviite-design-lib/snackbar/snackbar';
@@ -82,17 +82,17 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
     );
     const menuRef = React.createRef<HTMLDivElement>();
 
-    const actions = [
-        {
-            onSelect: () => {
+    const actions: MenuSelectOption[] = [
+        menuSelectOption(
+            () => {
                 setMenuOpen(false);
                 setSplitDetailsDialogOpen(true);
             },
-            qaId: 'show-split-info-link',
-            name: t('publication-card.show-split-info'),
-        },
-        {
-            onSelect: () => {
+            t('publication-card.show-split-info'),
+            'show-split-info-link',
+        ),
+        menuSelectOption(
+            () => {
                 if (publication.split)
                     putBulkTransferState(publication.split.id, 'DONE')
                         .then(() => {
@@ -101,9 +101,9 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                         .then(() => updateSplitChangeTime());
                 setMenuOpen(false);
             },
-            qaId: 'mark-bulk-transfer-as-finished-link',
-            name: t('publication-card.mark-as-successful'),
-        },
+            t('publication-card.mark-as-successful'),
+            'mark-bulk-transfer-as-finished-link',
+        ),
     ];
 
     return (

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -23,7 +23,7 @@ import { LocationTrackEditDialogContainer } from 'tool-panel/location-track/dial
 import { SwitchEditDialogContainer } from 'tool-panel/switch/dialog/switch-edit-dialog';
 import { KmPostEditDialogContainer } from 'tool-panel/km-post/dialog/km-post-edit-dialog';
 import { TrackNumberEditDialogContainer } from 'tool-panel/track-number/dialog/track-number-edit-dialog';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { Menu, MenuOption, menuValueOption } from 'vayla-design-lib/menu/menu';
 import { WriteAccessRequired } from 'user/write-access-required';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { MapLayerMenu } from 'map/layer-menu/map-layer-menu';
@@ -71,13 +71,13 @@ type TrackNumberItemValue = {
 };
 
 function createTrackNumberItem(layoutTrackNumber: LayoutTrackNumber): Item<TrackNumberItemValue> {
-    return {
-        name: layoutTrackNumber.number,
-        value: {
+    return menuValueOption(
+        {
             type: 'trackNumberSearchItem',
             trackNumber: layoutTrackNumber,
         },
-    };
+        layoutTrackNumber.number,
+    );
 }
 
 type SearchItemValue = LocationTrackItemValue | SwitchItemValue | TrackNumberItemValue;
@@ -98,26 +98,30 @@ async function getOptions(
     );
 
     const locationTracks: Item<LocationTrackItemValue>[] = searchResult.locationTracks.map(
-        (locationTrack) => ({
-            name: `${locationTrack.name}, ${
-                (locationTrackDescriptions &&
-                    locationTrackDescriptions.find((d) => d.id == locationTrack.id)?.description) ??
-                ''
-            }`,
-            value: {
-                type: 'locationTrackSearchItem',
-                locationTrack: locationTrack,
-            },
-        }),
+        (locationTrack) =>
+            menuValueOption(
+                {
+                    type: 'locationTrackSearchItem',
+                    locationTrack: locationTrack,
+                },
+                `${locationTrack.name}, ${
+                    (locationTrackDescriptions &&
+                        locationTrackDescriptions.find((d) => d.id == locationTrack.id)
+                            ?.description) ??
+                    ''
+                }`,
+            ),
     );
 
-    const switches: Item<SwitchItemValue>[] = searchResult.switches.map((layoutSwitch) => ({
-        name: `${layoutSwitch.name}`,
-        value: {
-            type: 'switchSearchItem',
-            layoutSwitch: layoutSwitch,
-        },
-    }));
+    const switches: Item<SwitchItemValue>[] = searchResult.switches.map((layoutSwitch) =>
+        menuValueOption(
+            {
+                type: 'switchSearchItem',
+                layoutSwitch: layoutSwitch,
+            },
+            `${layoutSwitch.name}`,
+        ),
+    );
 
     const trackNumbers: Item<TrackNumberItemValue>[] =
         searchResult.trackNumbers.map(createTrackNumberItem);
@@ -162,15 +166,19 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         'kmPost' = 4,
     }
 
-    const newMenuItems = [
-        { value: NewMenuItems.trackNumber, name: t('tool-bar.new-track-number') },
-        {
-            value: NewMenuItems.locationTrack,
-            name: t('tool-bar.new-location-track'),
-            qaId: 'tool-bar.new-location-track',
-        },
-        { value: NewMenuItems.switch, name: t('tool-bar.new-switch') },
-        { value: NewMenuItems.kmPost, name: t('tool-bar.new-km-post') },
+    const newMenuItems: MenuOption<NewMenuItems>[] = [
+        menuValueOption(
+            NewMenuItems.trackNumber,
+            t('tool-bar.new-track-number'),
+            'tool-bar.new-track-number',
+        ),
+        menuValueOption(
+            NewMenuItems.locationTrack,
+            t('tool-bar.new-location-track'),
+            'tool-bar.new-location-track',
+        ),
+        menuValueOption(NewMenuItems.switch, t('tool-bar.new-switch'), 'tool-bar.new-switch'),
+        menuValueOption(NewMenuItems.kmPost, t('tool-bar.new-km-post'), 'tool-bar.new-km-post'),
     ];
 
     const handleNewMenuItemChange = (item: NewMenuItems) => {

--- a/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
@@ -6,6 +6,7 @@ import { TextField } from 'vayla-design-lib/text-field/text-field';
 import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
 import { ExamplePerson } from 'vayla-design-lib/demo/examples/dropdown-examples';
 import examplePersonsData from 'vayla-design-lib/demo/example-persons.json';
+import { menuValueOption } from 'vayla-design-lib/menu/menu';
 
 export const ButtonExamples: React.FC = () => {
     const [isProcessing, setProcessing] = React.useState(false);
@@ -136,10 +137,9 @@ export const ButtonExamples: React.FC = () => {
                     placeholder="Select person"
                     value={person}
                     onChange={(person) => setPerson(person)}
-                    options={examplePersonsData.map((person) => ({
-                        name: person.name,
-                        value: person,
-                    }))}
+                    options={examplePersonsData.map((person) =>
+                        menuValueOption(person, person.name),
+                    )}
                     attachRight
                 />
                 <Button variant={ButtonVariant.SECONDARY} icon={Icons.Append} attachLeft />

--- a/ui/src/vayla-design-lib/demo/examples/menu-example.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/menu-example.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { Menu } from 'vayla-design-lib/menu/menu';
+import { Menu, menuValueOption } from 'vayla-design-lib/menu/menu';
 import { Button } from 'vayla-design-lib/button/button';
 
 export const MenuExample: React.FC = () => {
     const items = [
-        { value: 'MENU1', name: 'Menu option 1' },
-        { value: 'MENU2', name: 'Menu option 2' },
-        { value: 'MENU3', name: 'Menu option 3' },
+        menuValueOption('MENU1', 'Menu option 1'),
+        menuValueOption('MENU2', 'Menu option 2'),
+        menuValueOption('MENU3', 'Menu option 3'),
     ];
 
     const [chosenItem, setChosenItem] = React.useState<string>('');

--- a/ui/src/vayla-design-lib/menu/menu.scss
+++ b/ui/src/vayla-design-lib/menu/menu.scss
@@ -30,10 +30,6 @@
     cursor: pointer;
     user-select: none;
 
-    &:not(:last-child) {
-        border-bottom: 1px solid colors.$color-white-darker;
-    }
-
     &--disabled {
         color: colors.$color-black-lighter;
         cursor: default;
@@ -42,4 +38,9 @@
     &:hover:not(.menu__item--disabled) {
         background: colors.$color-blue-lighter;
     }
+}
+
+.menu__divider {
+    height: 1px;
+    background-color: colors.$color-white-darker;
 }

--- a/ui/src/vayla-design-lib/menu/menu.tsx
+++ b/ui/src/vayla-design-lib/menu/menu.tsx
@@ -3,23 +3,61 @@ import styles from './menu.scss';
 import { CloseableModal } from 'vayla-design-lib/closeable-modal/closeable-modal';
 import { createClassName } from 'vayla-design-lib/utils';
 
-type MenuOption = { name: string | number; disabled?: boolean; qaId?: string };
+export type MenuOption<TValue> = MenuValueOption<TValue> | MenuSelectOption | MenuDividerOption;
+
+type MenuOptionBase = { name: string; disabled?: boolean; qaId?: string };
 
 export type MenuValueOption<TValue> = {
+    type: 'VALUE';
+    name: string;
     value: TValue;
-    onSelect?: never;
-} & MenuOption;
+} & MenuOptionBase;
 
 export type MenuSelectOption = {
-    value?: never;
+    type: 'SELECT';
+    name: string;
     onSelect: () => void;
-} & MenuOption;
+} & MenuOptionBase;
+
+export type MenuDividerOption = {
+    type: 'DIVIDER';
+};
+
+export const menuValueOption = <TValue,>(
+    value: TValue,
+    name: string,
+    qaId?: string,
+    disabled: boolean = false,
+): MenuValueOption<TValue> => ({
+    type: 'VALUE',
+    name,
+    value,
+    disabled,
+    qaId,
+});
+
+export const menuSelectOption = (
+    onSelect: () => void,
+    name: string,
+    qaId: string,
+    disabled: boolean = false,
+): MenuSelectOption => ({
+    type: 'SELECT',
+    onSelect,
+    name,
+    disabled,
+    qaId,
+});
+
+export const menuDividerOption = (): MenuDividerOption => ({
+    type: 'DIVIDER',
+});
 
 type MenuProps<TValue> = {
     positionRef: React.MutableRefObject<HTMLElement | null>;
     onClickOutside: () => void;
     onSelect?: (item: TValue) => void;
-    items: (MenuValueOption<TValue> | MenuSelectOption)[];
+    items: MenuOption<TValue>[];
 } & Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'>;
 
 export const Menu = function <TValue>({
@@ -40,24 +78,28 @@ export const Menu = function <TValue>({
             offsetY={offsetY + 6}>
             <ol className={styles['menu__items']} {...props}>
                 {items.map((i, index) => {
-                    return (
-                        <li
-                            key={`${index}_${i.name}`}
-                            qa-id={i.qaId}
-                            title={`${i.name}`}
-                            className={createClassName(
-                                styles['menu__item'],
-                                i.disabled && styles['menu__item--disabled'],
-                            )}
-                            onClick={() => {
-                                if (!i.disabled) {
-                                    if (i.onSelect) i.onSelect();
-                                    else if (onSelect) onSelect(i.value);
-                                }
-                            }}>
-                            {i.name}
-                        </li>
-                    );
+                    if (i.type === 'DIVIDER') {
+                        return <div key={`${index}`} className={styles['menu__divider']} />;
+                    } else {
+                        return (
+                            <li
+                                key={`${index}`}
+                                qa-id={i.qaId}
+                                title={`${i.name}`}
+                                className={createClassName(
+                                    styles['menu__item'],
+                                    i.disabled && styles['menu__item--disabled'],
+                                )}
+                                onClick={() => {
+                                    if (!i.disabled) {
+                                        if (i.type === 'SELECT') i.onSelect();
+                                        else if (onSelect) onSelect(i.value);
+                                    }
+                                }}>
+                                {i.name}
+                            </li>
+                        );
+                    }
                 })}
             </ol>
         </CloseableModal>

--- a/ui/src/vayla-design-lib/menu/menu.tsx
+++ b/ui/src/vayla-design-lib/menu/menu.tsx
@@ -5,7 +5,7 @@ import { createClassName } from 'vayla-design-lib/utils';
 
 export type MenuOption<TValue> = MenuValueOption<TValue> | MenuSelectOption | MenuDividerOption;
 
-type MenuOptionBase = { name: string; disabled?: boolean; qaId?: string };
+type MenuOptionBase = { disabled: boolean; qaId?: string };
 
 export type MenuValueOption<TValue> = {
     type: 'VALUE';

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -4,7 +4,8 @@
         "outDir": "./dist/",
         "sourceMap": true,
         "noImplicitAny": true,
-        "noUncheckedIndexedAccess": true,
+        // TODO: Turn this back on in GVT-2510
+        // "noUncheckedIndexedAccess": true,
         "module": "commonjs",
         "lib": ["DOM", "ES6", "DOM.Iterable", "ScriptHost", "ES2019.array"],
         "target": "es5",


### PR DESCRIPTION
Täällä pääasiassa refaktorointia menuihin. Menuihin voi nyt asettaa dividereita, jotka renderöidään aiemman tyylisinä menuitemien välisinä bordereina (jotka on sellaisinaan otettu pois nykyisistä menuista.) Lisäksi refaktoroitu menuitemien luonti ja pakotettu `qaId`:t osalle menuitemeistä (loppujen pakottamisesta on erillinen tiketti.)

Samalla laitettu hetkellisesti taas `noUncheckedIndexedAccess` takaisin pois päältä, että buildit tokenisivat.