### PR TITLE
GVT-2513: Lisenssi- ja uloskirjautumisvalikko piirtyy osittain ruudun ulkopuolelle

### DIFF
--- a/ui/src/app-bar/app-bar-more-menu.tsx
+++ b/ui/src/app-bar/app-bar-more-menu.tsx
@@ -50,6 +50,7 @@ const AppBarMoreMenu: React.FC = () => {
                     items={moreActions}
                     className={styles['app-bar__more-menu']}
                     onClickOutside={() => setShowMenu(false)}
+                    opensTowardsLeft={true}
                 />
             )}
 

--- a/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
+++ b/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
@@ -60,6 +60,7 @@ export const CloseableModal: React.FC<CloseableModalProps> = ({
 
     React.useEffect(() => {
         if (refPosition && modalRef.current) {
+            console.log(modalSize);
             const windowHeight = window.innerHeight;
             const windowWidth = window.innerWidth;
 
@@ -76,7 +77,7 @@ export const CloseableModal: React.FC<CloseableModalProps> = ({
             const newPosition: ModalPosition = { left: x, top: y };
 
             setModalSize({
-                ...modalSize,
+                width: modalWidth,
                 maxHeight:
                     maxHeight === undefined || maxHeight <= calculatedMaxHeight
                         ? maxHeight

--- a/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
+++ b/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
@@ -60,7 +60,6 @@ export const CloseableModal: React.FC<CloseableModalProps> = ({
 
     React.useEffect(() => {
         if (refPosition && modalRef.current) {
-            console.log(modalSize);
             const windowHeight = window.innerHeight;
             const windowWidth = window.innerWidth;
 

--- a/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
+++ b/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
@@ -12,6 +12,7 @@ type CloseableModalProps = {
     useRefWidth?: boolean;
     refWidthOffset?: number;
     maxHeight?: number;
+    openTowardsLeft?: boolean;
 };
 
 const WINDOW_MARGIN = 6;
@@ -36,6 +37,7 @@ export const CloseableModal: React.FC<CloseableModalProps> = ({
     offsetY = 0,
     refWidthOffset = 0,
     useRefWidth = false,
+    openTowardsLeft = false,
 }: CloseableModalProps) => {
     const [modalPosition, setModalPosition] = React.useState<ModalPosition>();
     const [modalSize, setModalSize] = React.useState<ModalSize>();
@@ -61,12 +63,14 @@ export const CloseableModal: React.FC<CloseableModalProps> = ({
             const windowHeight = window.innerHeight;
             const windowWidth = window.innerWidth;
 
-            const x = refPosition.left + offsetX;
+            const parentWidth = positionRef.current?.getBoundingClientRect().width ?? 0;
+            const modalWidth = modalRef.current.getBoundingClientRect().width ?? 0;
+            const x = openTowardsLeft
+                ? refPosition.left + parentWidth + offsetX - modalWidth
+                : refPosition.left + offsetX;
             const y = refPosition.top + offsetY;
 
             const calculatedMaxHeight = windowHeight - y - WINDOW_MARGIN;
-
-            const modalWidth = modalSize?.width ?? 0;
             const widthOverflow = x + modalWidth + WINDOW_MARGIN - windowWidth;
 
             const newPosition: ModalPosition = { left: x, top: y };

--- a/ui/src/vayla-design-lib/menu/menu.tsx
+++ b/ui/src/vayla-design-lib/menu/menu.tsx
@@ -58,6 +58,7 @@ type MenuProps<TValue> = {
     onClickOutside: () => void;
     onSelect?: (item: TValue) => void;
     items: MenuOption<TValue>[];
+    opensTowardsLeft?: boolean;
 } & Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'>;
 
 export const Menu = function <TValue>({
@@ -66,6 +67,7 @@ export const Menu = function <TValue>({
     items,
     onSelect,
     className,
+    opensTowardsLeft,
     ...props
 }: MenuProps<TValue>) {
     const { height: offsetY } = positionRef.current?.getBoundingClientRect() ?? { height: 0 };
@@ -75,6 +77,7 @@ export const Menu = function <TValue>({
             className={createClassName(styles['menu'], className)}
             onClickOutside={onClickOutside}
             positionRef={positionRef}
+            openTowardsLeft={opensTowardsLeft}
             offsetY={offsetY + 6}>
             <ol className={styles['menu__items']} {...props}>
                 {items.map((i, index) => {


### PR DESCRIPTION
`CloseableModal` ei ollut ottanut huomioon tilannetta, jossa menu haluttiin avata kohti vasenta. Ne otetaan nyt huomioon, ja se on parametrisoitavissa `CloseableModal`:ille ja `Menu`:lle. Varmaan olisi ollut jotenkin mahdollista laskeakin meneekö menun toinen reuna ruudusta yli ja päätellä siitä kumpaan suuntaan menu pitää avata, mutta kun meillä on tällä hetkellä tasan tuo yksi vasemmalle aukeava menu, niin en katsonut vaivan arvoiseksi (plus jotain menuja saatettaisiin muutenkin haluta joskus avata vasemmalle riippumatta siitä ovatko ne näytön oikeassa reunassa vai eivät)