### PR TITLE
GVT-2426 Remove temp context transitions

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
@@ -75,9 +75,9 @@ abstract class DBTestBase(val testUser: String = TEST_USER) {
         initUser()
         jdbc.setUser()
         op()
-    } ?: throw IllegalStateException("Transaction returned nothing")
+    } ?: error("Transaction returned nothing")
 
-    fun getUnusedTrackNumberId() =
+    fun getUnusedTrackNumberId(): IntId<TrackLayoutTrackNumber> =
         getOrCreateTrackNumber(getUnusedTrackNumber()).id as IntId
 
     fun getOrCreateTrackNumber(trackNumber: TrackNumber): TrackLayoutTrackNumber {
@@ -86,11 +86,11 @@ abstract class DBTestBase(val testUser: String = TEST_USER) {
         return version.let(trackNumberDao::fetch)
     }
 
-    fun insertDraftTrackNumber(): IntId<TrackLayoutTrackNumber> =
-        insertNewTrackNumber(getUnusedTrackNumber(), true).id
+    fun insertDraftTrackNumber(number: TrackNumber = getUnusedTrackNumber()): IntId<TrackLayoutTrackNumber> =
+        insertNewTrackNumber(number, true).id
 
-    fun insertOfficialTrackNumber(): IntId<TrackLayoutTrackNumber> =
-        insertNewTrackNumber(getUnusedTrackNumber(), false).id
+    fun insertOfficialTrackNumber(number: TrackNumber = getUnusedTrackNumber()): IntId<TrackLayoutTrackNumber> =
+        insertNewTrackNumber(number, false).id
 
     fun getDbTime(): Instant = requireNotNull(
         jdbc.queryForObject("select now() as now", mapOf<String, Any>()) { rs, _ -> rs.getInstant("now") }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
@@ -140,10 +140,10 @@ abstract class DBTestBase(val testUser: String = TEST_USER) {
     }
 
     fun insertUniqueSwitch(): DaoResponse<TrackLayoutSwitch> =
-        insertSwitch(switch(name = getUnusedSwitchName().toString()))
+        insertSwitch(switch(name = getUnusedSwitchName().toString(), draft = false))
 
     fun insertUniqueDraftSwitch(): DaoResponse<TrackLayoutSwitch> =
-        insertSwitch(asMainDraft(switch(name = getUnusedSwitchName().toString())))
+        insertSwitch(asMainDraft(switch(name = getUnusedSwitchName().toString(), draft = true)))
 
     fun insertSwitch(switch: TrackLayoutSwitch): DaoResponse<TrackLayoutSwitch> = transactional {
         jdbc.setUser()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
@@ -27,38 +27,40 @@ class GeocodingDaoIT @Autowired constructor(
 
     @Test
     fun trackNumberWithoutReferenceLineHasNoContext() {
-        val id = trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).id
+        val id = trackNumberDao.insert(trackNumber(getUnusedTrackNumber(), draft = false)).id
         assertNull(geocodingDao.getLayoutGeocodingContextCacheKey(DRAFT, id))
         assertNull(geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, id))
     }
 
     @Test
     fun trackNumberWithoutKmPostsHasAContext() {
-        val id = trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).id
+        val id = trackNumberDao.insert(trackNumber(getUnusedTrackNumber(), draft = false)).id
         val alignmentVersion = alignmentDao.insert(alignment())
-        referenceLineDao.insert(referenceLine(id).copy(alignmentVersion = alignmentVersion))
+        referenceLineDao.insert(referenceLine(id, alignmentVersion = alignmentVersion, draft = false))
         assertNotNull(geocodingDao.getLayoutGeocodingContextCacheKey(DRAFT, id))
         assertNotNull(geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, id))
     }
 
     @Test
     fun cacheKeysAreCalculatedCorrectly() {
-        val tnOfficialResponse = trackNumberDao.insert(trackNumber(getUnusedTrackNumber()))
+        val tnOfficialResponse = trackNumberDao.insert(trackNumber(getUnusedTrackNumber(), draft = false))
         val tnId = tnOfficialResponse.id
         val tnOfficialVersion = tnOfficialResponse.rowVersion
         val tnDraftVersion = trackNumberDao.insert(asMainDraft(trackNumberDao.fetch(tnOfficialVersion))).rowVersion
 
         val alignmentVersion = alignmentDao.insert(alignment())
-        val rlOfficialVersion = referenceLineDao.insert(referenceLine(tnId).copy(alignmentVersion = alignmentVersion)).rowVersion
+        val rlOfficialVersion = referenceLineDao.insert(
+            referenceLine(tnId, alignmentVersion = alignmentVersion, draft = false)
+        ).rowVersion
         val rlDraftVersion = createDraftReferenceLine(rlOfficialVersion)
 
-        val kmPostOneOfficialVersion = kmPostDao.insert(kmPost(tnId, KmNumber(1))).rowVersion
+        val kmPostOneOfficialVersion = kmPostDao.insert(kmPost(tnId, KmNumber(1), draft = false)).rowVersion
         val kmPostOneDraftVersion = kmPostDao.insert(asMainDraft(kmPostDao.fetch(kmPostOneOfficialVersion))).rowVersion
-        val kmPostTwoOnlyDraftVersion = kmPostService.saveDraft(kmPost(tnId, KmNumber(2))).rowVersion
-        val kmPostThreeOnlyOfficialVersion = kmPostDao.insert(kmPost(tnId, KmNumber(3))).rowVersion
+        val kmPostTwoOnlyDraftVersion = kmPostService.saveDraft(kmPost(tnId, KmNumber(2), draft = true)).rowVersion
+        val kmPostThreeOnlyOfficialVersion = kmPostDao.insert(kmPost(tnId, KmNumber(3), draft = false)).rowVersion
 
         // Add a deleted post - should not appear in results
-        kmPostDao.insert(kmPost(tnId, KmNumber(4), state = LayoutState.DELETED))
+        kmPostDao.insert(kmPost(tnId, KmNumber(4), state = LayoutState.DELETED, draft = false))
 
         val officialKey = geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, tnId)!!
         assertEquals(
@@ -131,15 +133,17 @@ class GeocodingDaoIT @Autowired constructor(
 
     @Test
     fun cacheKeysAreCorrectlyFetchedByMoment() {
-        val tnOfficialResponse = trackNumberDao.insert(trackNumber(getUnusedTrackNumber()))
+        val tnOfficialResponse = trackNumberDao.insert(trackNumber(getUnusedTrackNumber(), draft = false))
         val tnId = tnOfficialResponse.id
         val tnOfficialVersion = tnOfficialResponse.rowVersion
         val alignmentVersion = alignmentDao.insert(alignment())
-        val rlOfficialVersion = referenceLineDao.insert(referenceLine(tnId).copy(alignmentVersion = alignmentVersion)).rowVersion
-        val kmPostOneOfficialVersion = kmPostDao.insert(kmPost(tnId, KmNumber(1))).rowVersion
+        val rlOfficialVersion = referenceLineDao.insert(
+            referenceLine(tnId, alignmentVersion = alignmentVersion, draft = false)
+        ).rowVersion
+        val kmPostOneOfficialVersion = kmPostDao.insert(kmPost(tnId, KmNumber(1), draft = false)).rowVersion
 
         val originalTime = kmPostDao.fetchChangeTime()
-        Thread.sleep(1)
+        Thread.sleep(1) // Ensure that later objects get a new changetime so that moment-fetch makes sense
 
         val originalKey = geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, tnId)!!
         assertEquals(
@@ -154,15 +158,15 @@ class GeocodingDaoIT @Autowired constructor(
         // Add some draft changes as well. These shouldn't affect the results
         trackNumberDao.insert(asMainDraft(trackNumberDao.fetch(tnOfficialVersion)))
         createDraftReferenceLine(rlOfficialVersion)
-        kmPostService.saveDraft(kmPost(tnId, KmNumber(10)))
+        kmPostService.saveDraft(kmPost(tnId, KmNumber(10), draft = true))
 
         // Update the official stuff
         val updatedTrackNumberVersion = updateTrackNumber(tnOfficialVersion)
         val updatedReferenceLineVersion = updateReferenceLine(rlOfficialVersion)
         val updatedKmPostOneOfficialVersion = updateKmPost(kmPostOneOfficialVersion)
-        val kmPostTwoOfficialVersion = kmPostDao.insert(kmPost(tnId, KmNumber(2))).rowVersion
+        val kmPostTwoOfficialVersion = kmPostDao.insert(kmPost(tnId, KmNumber(2), draft = false)).rowVersion
         // Add a deleted post - should not appear in results
-        kmPostDao.insert(kmPost(tnId, KmNumber(3), state = LayoutState.DELETED))
+        kmPostDao.insert(kmPost(tnId, KmNumber(3), state = LayoutState.DELETED, draft = false))
 
         val updatedTime = kmPostDao.fetchChangeTime()
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingServiceIT.kt
@@ -10,8 +10,6 @@ import fi.fta.geoviite.infra.inframodel.InfraModelFile
 import fi.fta.geoviite.infra.math.AngularUnit
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
-import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.ui.testdata.createGeometryKmPost
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -25,13 +23,12 @@ import java.math.BigDecimal
 @SpringBootTest
 class GeocodingServiceIT @Autowired constructor(
     private val geocodingService: GeocodingService,
-    private val trackNumberDao: LayoutTrackNumberDao,
     private val geometryDao: GeometryDao,
 ) : DBTestBase() {
 
     @Test
     fun `geocoding context can be generated from geometry plan`() {
-        val trackNumberId = trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).id
+        val trackNumberId = insertOfficialTrackNumber()
         val plan = minimalPlan().copy(
             units = GeometryUnits(
                 coordinateSystemSrid = LAYOUT_SRID,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -72,18 +72,18 @@ val addressPoints = listOf(
     GeocodingReferencePoint(KmNumber(5, "A"), BigDecimal.ZERO, 3 * alignment.length / 5, 0.0, WITHIN),
     GeocodingReferencePoint(KmNumber(5, "B"), BigDecimal.ZERO, 4 * alignment.length / 5, 0.0, WITHIN),
 )
-val trackNumber: TrackLayoutTrackNumber = trackNumber(TrackNumber("T001"))
+val trackNumber: TrackLayoutTrackNumber = trackNumber(TrackNumber("T001"), draft = false)
 val kmPostLocations = (0..5).map { i ->
     val alignmentPoint = alignment.getPointAtM(i * alignment.length / 5)
     checkNotNull(alignmentPoint?.toPoint())
 }
 
 val kmPosts = listOf(
-    kmPost(trackNumberId = null, km = startAddress.kmNumber, location = kmPostLocations[0]),
-    kmPost(trackNumberId = null, km = KmNumber(3), location = kmPostLocations[1]),
-    kmPost(trackNumberId = null, km = KmNumber(4), location = kmPostLocations[2]),
-    kmPost(trackNumberId = null, km = KmNumber(5, "A"), location = kmPostLocations[3]),
-    kmPost(trackNumberId = null, km = KmNumber(5, "B"), location = kmPostLocations[4]),
+    kmPost(trackNumberId = null, km = startAddress.kmNumber, location = kmPostLocations[0], draft = false),
+    kmPost(trackNumberId = null, km = KmNumber(3), location = kmPostLocations[1], draft = false),
+    kmPost(trackNumberId = null, km = KmNumber(4), location = kmPostLocations[2], draft = false),
+    kmPost(trackNumberId = null, km = KmNumber(5, "A"), location = kmPostLocations[3], draft = false),
+    kmPost(trackNumberId = null, km = KmNumber(5, "B"), location = kmPostLocations[4], draft = false),
 )
 val context = GeocodingContext(
     trackNumber,
@@ -253,7 +253,7 @@ class GeocodingTest {
         )
         val startAddress = TrackMeter(KmNumber(2), 100)
         val ctx = GeocodingContext.create(
-            trackNumber = trackNumber(TrackNumber("T001")),
+            trackNumber = trackNumber(TrackNumber("T001"), draft = false),
             startAddress = startAddress,
             referenceLineGeometry = alignment(startSegment, connectSegment, endSegment),
             kmPosts = listOf(),
@@ -528,6 +528,7 @@ class GeocodingTest {
             trackNumberId = IntId(1),
             alignment = referenceLineAlignment,
             startAddress = TrackMeter(10, 0),
+            draft = false,
         )
         val testContext = GeocodingContext.create(
             trackNumber = trackNumber,
@@ -583,7 +584,7 @@ class GeocodingTest {
 
         assertThrows<IllegalArgumentException>("Geocoding context was created with empty reference line") {
             GeocodingContext(
-                trackNumber = trackNumber(TrackNumber("T001")),
+                trackNumber = trackNumber(TrackNumber("T001"), draft = false),
                 startAddress = TrackMeter(KmNumber(10), 100),
                 referenceLineGeometry = startAlignment,
                 referencePoints = emptyList(),
@@ -599,7 +600,7 @@ class GeocodingTest {
 
         assertThrows<IllegalArgumentException>("Geocoding context was created without reference points") {
             GeocodingContext(
-                trackNumber = trackNumber(TrackNumber("T001")),
+                trackNumber = trackNumber(TrackNumber("T001"), draft = false),
                 startAddress = TrackMeter(KmNumber(10), 100),
                 referenceLineGeometry = startAlignment,
                 referencePoints = emptyList(),
@@ -609,12 +610,12 @@ class GeocodingTest {
 
     @Test
     fun `should reject km posts without location`() {
-        val trackNumber = trackNumber(TrackNumber("T001"))
+        val trackNumber = trackNumber(TrackNumber("T001"), draft = false)
         val startAlignment = LayoutAlignment(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         )
 
-        val kmPost = kmPost(IntId(1), KmNumber(11), null)
+        val kmPost = kmPost(IntId(1), KmNumber(11), null, draft = false)
 
         val result = GeocodingContext.create(
             trackNumber = trackNumber,
@@ -636,12 +637,12 @@ class GeocodingTest {
 
     @Test
     fun `should reject km posts that are before start address`() {
-        val trackNumber = trackNumber(TrackNumber("T001"))
+        val trackNumber = trackNumber(TrackNumber("T001"), draft = false)
         val startAlignment = LayoutAlignment(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         )
 
-        val kmPost = kmPost(IntId(1), KmNumber(10), Point(5.0, 0.0))
+        val kmPost = kmPost(IntId(1), KmNumber(10), Point(5.0, 0.0), draft = false)
 
         val result = GeocodingContext.create(
             trackNumber = trackNumber,
@@ -659,12 +660,12 @@ class GeocodingTest {
 
     @Test
     fun `should reject km posts that intersects before reference line`() {
-        val trackNumber = trackNumber(TrackNumber("T001"))
+        val trackNumber = trackNumber(TrackNumber("T001"), draft = false)
         val startAlignment = LayoutAlignment(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         )
 
-        val kmPost = kmPost(IntId(1), KmNumber(11), Point(-5.0, 0.0))
+        val kmPost = kmPost(IntId(1), KmNumber(11), Point(-5.0, 0.0), draft = false)
 
         val result = GeocodingContext.create(
             trackNumber = trackNumber,
@@ -682,12 +683,12 @@ class GeocodingTest {
 
     @Test
     fun `should reject km posts that intersects after reference line`() {
-        val trackNumber = trackNumber(TrackNumber("T001"))
+        val trackNumber = trackNumber(TrackNumber("T001"), draft = false)
         val startAlignment = LayoutAlignment(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         )
 
-        val kmPost = kmPost(IntId(1), KmNumber(11), Point(50.0, 0.0))
+        val kmPost = kmPost(IntId(1), KmNumber(11), Point(50.0, 0.0), draft = false)
 
         val result = GeocodingContext.create(
             trackNumber = trackNumber,
@@ -705,12 +706,12 @@ class GeocodingTest {
 
     @Test
     fun `should reject km posts that are too far apart`() {
-        val trackNumber = trackNumber(TrackNumber("T001"))
+        val trackNumber = trackNumber(TrackNumber("T001"), draft = false)
         val startAlignment = LayoutAlignment(
             segments = listOf(segment(Point(0.0, 0.0), Point(40000.0, 0.0)))
         )
 
-        val kmPost = kmPost(IntId(1), KmNumber(11), Point(20000.0, 0.0))
+        val kmPost = kmPost(IntId(1), KmNumber(11), Point(20000.0, 0.0), draft = false)
 
         val result = GeocodingContext.create(
             trackNumber = trackNumber,
@@ -728,11 +729,11 @@ class GeocodingTest {
 
     @Test
     fun `should require start km to have sane length`() {
-        val trackNumber = trackNumber(TrackNumber("T001"))
+        val trackNumber = trackNumber(TrackNumber("T001"), draft = false)
         val startAlignment = LayoutAlignment(
             segments = listOf(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         )
-        val kmPost = kmPost(IntId(1), KmNumber(1), Point(15.0, 0.0))
+        val kmPost = kmPost(IntId(1), KmNumber(1), Point(15.0, 0.0), draft = false)
         val result = GeocodingContext.create(
             trackNumber = trackNumber,
             startAddress = TrackMeter(KmNumber(0), 9990),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
@@ -208,6 +208,7 @@ class GeometryDaoIT @Autowired constructor(
         val track = locationTrackAndAlignment(
             trackNumberId,
             segment(Point(0.0, 0.0), Point(1.0, 1.0)).copy(sourceId = element.id),
+            draft = true,
         )
         val trackVersion = locationTrackService.saveDraft(track.first, track.second)
         locationTrackService.publish(ValidationVersion(trackVersion.id, trackVersion.rowVersion))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
@@ -291,10 +291,10 @@ class AddressChangesServiceIT @Autowired constructor(
         assertEquals(
             setOf(
                 KmNumber(0),
-                KmNumber(3)
+                KmNumber(3),
             ),
             differences,
-            "Contains wrong km numbers"
+            "Contains wrong km numbers",
         )
     }
 
@@ -328,7 +328,7 @@ class AddressChangesServiceIT @Autowired constructor(
                 KmNumber(3),
             ),
             differences,
-            "Contains wrong km numbers"
+            "Contains wrong km numbers",
         )
     }
 
@@ -362,7 +362,7 @@ class AddressChangesServiceIT @Autowired constructor(
                 KmNumber(3),
             ),
             differences,
-            "Contains wrong km numbers"
+            "Contains wrong km numbers",
         )
     }
 
@@ -396,7 +396,7 @@ class AddressChangesServiceIT @Autowired constructor(
                 KmNumber(3),
             ),
             differences,
-            "Contains wrong km numbers"
+            "Contains wrong km numbers",
         )
     }
 
@@ -437,10 +437,10 @@ class AddressChangesServiceIT @Autowired constructor(
         assertEquals(
             setOf(
                 KmNumber(1),
-                KmNumber(2)
+                KmNumber(2),
             ),
             differences,
-            "Contains wrong km numbers"
+            "Contains wrong km numbers",
         )
     }
 
@@ -482,7 +482,7 @@ class AddressChangesServiceIT @Autowired constructor(
                 KmNumber(2),
             ),
             differences,
-            "Contains wrong km numbers"
+            "Contains wrong km numbers",
         )
     }
 
@@ -516,7 +516,7 @@ class AddressChangesServiceIT @Autowired constructor(
                 KmNumber(1),
             ),
             differences,
-            "Contains wrong km numbers"
+            "Contains wrong km numbers",
         )
     }
 
@@ -557,10 +557,10 @@ class AddressChangesServiceIT @Autowired constructor(
         assertEquals(
             setOf(
                 KmNumber(1),
-                KmNumber(3)
+                KmNumber(3),
             ),
             differences,
-            "Contains wrong km numbers"
+            "Contains wrong km numbers",
         )
     }
 
@@ -587,8 +587,9 @@ class AddressChangesServiceIT @Autowired constructor(
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
         assertEquals(
-            differences, emptySet(),
-            "Should not contain differences"
+            differences,
+            emptySet(),
+            "Should not contain differences",
         )
     }
 
@@ -608,7 +609,7 @@ class AddressChangesServiceIT @Autowired constructor(
         assertNotNull(addressChanges)
         assertEquals(
             setOf(KmNumber(1), KmNumber(2)),
-            addressChanges.changedKmNumbers
+            addressChanges.changedKmNumbers,
         )
         assertTrue(addressChanges.startPointChanged)
         assertTrue(addressChanges.endPointChanged)
@@ -627,14 +628,15 @@ class AddressChangesServiceIT @Autowired constructor(
         val sequence = System.currentTimeMillis().toString().takeLast(8)
         val refPoint = Point(370000.0, 7100000.0) // any point in Finland
         val trackNumber = layoutTrackNumberDao.fetch(
-            layoutTrackNumberDao.insert(trackNumber(TrackNumber("TEST TN $sequence"))).rowVersion
+            layoutTrackNumberDao.insert(trackNumber(TrackNumber("TEST TN $sequence"), draft = false)).rowVersion
         )
         val kmPost1 = layoutKmPostDao.fetch(
             layoutKmPostDao.insert(
                 kmPost(
                     trackNumberId = trackNumber.id as IntId,
                     km = KmNumber(1),
-                    location = refPoint + 5.0
+                    location = refPoint + 5.0,
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -643,7 +645,8 @@ class AddressChangesServiceIT @Autowired constructor(
                 kmPost(
                     trackNumberId = trackNumber.id as IntId,
                     km = KmNumber(2),
-                    location = refPoint + 10.0
+                    location = refPoint + 10.0,
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -658,9 +661,9 @@ class AddressChangesServiceIT @Autowired constructor(
             referenceLineDao.insert(
                 referenceLine(
                     trackNumber.id as IntId<TrackLayoutTrackNumber>,
-                    alignment = referenceLineGeometry
-                ).copy(
-                    alignmentVersion = referenceLineGeometryVersion
+                    alignment = referenceLineGeometry,
+                    alignmentVersion = referenceLineGeometryVersion,
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -676,9 +679,9 @@ class AddressChangesServiceIT @Autowired constructor(
                 locationTrack(
                     trackNumberId = trackNumber.id as IntId,
                     alignment = locationTrackGeometry,
-                    name = "TEST LocTr $sequence"
-                ).copy(
-                    alignmentVersion = locationTrackGeometryVersion
+                    name = "TEST LocTr $sequence",
+                    alignmentVersion = locationTrackGeometryVersion,
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -793,7 +796,7 @@ class AddressChangesServiceIT @Autowired constructor(
             endPoint = addressPoints.lastOrNull() ?: someAddressPoint(),
             startIntersect = IntersectType.WITHIN,
             endIntersect = IntersectType.WITHIN,
-            midPoints = addressPoints.slice(1..addressPoints.size-2),
+            midPoints = addressPoints.slice(1..addressPoints.size - 2),
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -84,7 +84,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrack3,
             alignment3,
             { point -> point + 2.0 },
-            locationTrackService = locationTrackService
+            locationTrackService = locationTrackService,
         )
 
         val changes = getCalculatedChanges(
@@ -92,22 +92,23 @@ class CalculatedChangesServiceIT @Autowired constructor(
         )
 
         assertContains(
-            changes.directChanges.locationTrackChanges, LocationTrackChange(
+            changes.directChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack3.id as IntId<LocationTrack>,
                 changedKmNumbers = setOf(
                     KmNumber(6),
                     KmNumber(7),
-                    KmNumber(8)
+                    KmNumber(8),
                 ),
                 isStartChanged = true,
-                isEndChanged = true
-            )
+                isEndChanged = true,
+            ),
         )
 
         assertContainsSwitchJoint152Change(
             changes.indirectChanges.switchChanges,
             testData.switches.first().id,
-            locationTrack3.id
+            locationTrack3.id,
         )
     }
 
@@ -116,7 +117,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val testData = insertTestData(
             kmPostData = listOf(
                 KmNumber(0) to Point(0.0, 0.0),
-                KmNumber(1) to Point(1000.0, 0.0)
+                KmNumber(1) to Point(1000.0, 0.0),
             ),
             locationTrackData = listOf(
                 Line(Point(0.0, 0.0), Point(100.0, 0.0)),
@@ -129,9 +130,9 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 SwitchData(
                     Point(100.0, 0.0),
                     locationTrackIndexA = 1,
-                    locationTrackIndexB = 2
+                    locationTrackIndexB = 2,
                 )
-            )
+            ),
         )
         val (locationTrack1, alignment1) = testData.locationTracksAndAlignments[0]
         val switch = testData.switches[0]
@@ -140,7 +141,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val (updatedLocationTrack, updatedAlignment) = removeTopologySwitchesFromLocationTrackAndUpdate(
             locationTrack1,
             alignment1,
-            locationTrackService
+            locationTrackService,
         ).let { (id, version) ->
             val (_, publishedVersion) = locationTrackService.publish(ValidationVersion(id, version))
             locationTrackService.getWithAlignment(publishedVersion)
@@ -160,12 +161,13 @@ class CalculatedChangesServiceIT @Autowired constructor(
         )
 
         assertContains(
-            changes.directChanges.locationTrackChanges, LocationTrackChange(
+            changes.directChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack1.id as IntId,
                 changedKmNumbers = setOf(KmNumber(0)),
                 isStartChanged = false,
                 isEndChanged = true
-            )
+            ),
         )
 
         assertEquals(1, changes.indirectChanges.switchChanges.size)
@@ -181,19 +183,18 @@ class CalculatedChangesServiceIT @Autowired constructor(
                         address = TrackMeter("0", "100.000"),
                         locationTrackId = locationTrack1.id as IntId,
                     ),
-                    joint
+                    joint,
                 )
             }
         }
     }
-
 
     @Test
     fun addingTopologyStartSwitchGeneratesIndirectlySwitchChanges() {
         val testData = insertTestData(
             kmPostData = listOf(
                 KmNumber(0) to Point(0.0, 0.0),
-                KmNumber(1) to Point(1000.0, 0.0)
+                KmNumber(1) to Point(1000.0, 0.0),
             ),
             locationTrackData = listOf(
                 // NOTICE: This track starts from the switch. It is not aligned properly
@@ -208,9 +209,9 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 SwitchData(
                     Point(100.0, 0.0),
                     locationTrackIndexA = 1,
-                    locationTrackIndexB = 2
+                    locationTrackIndexB = 2,
                 )
-            )
+            ),
         )
         val (locationTrack1, alignment1) = testData.locationTracksAndAlignments[0]
         val switch = testData.switches[0]
@@ -219,7 +220,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val (updatedLocationTrack, updatedAlignment) = removeTopologySwitchesFromLocationTrackAndUpdate(
             locationTrack1,
             alignment1,
-            locationTrackService
+            locationTrackService,
         ).let { (id, version) ->
             val (_, publishedVersion) = locationTrackService.publish(ValidationVersion(id, version))
             locationTrackService.getWithAlignment(publishedVersion)
@@ -239,12 +240,13 @@ class CalculatedChangesServiceIT @Autowired constructor(
         )
 
         assertContains(
-            changes.directChanges.locationTrackChanges, LocationTrackChange(
+            changes.directChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack1.id as IntId,
                 changedKmNumbers = setOf(KmNumber(0)),
                 isStartChanged = true,
                 isEndChanged = false
-            )
+            ),
         )
 
         assertEquals(1, changes.indirectChanges.switchChanges.size)
@@ -260,7 +262,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                         address = TrackMeter("0", "100.000"),
                         locationTrackId = locationTrack1.id as IntId,
                     ),
-                    joint
+                    joint,
                 )
             }
         }
@@ -273,7 +275,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val testData = insertTestData(
             kmPostData = listOf(
                 KmNumber(0) to Point(0.0, 0.0),
-                KmNumber(1) to Point(1000.0, 0.0)
+                KmNumber(1) to Point(1000.0, 0.0),
             ),
             locationTrackData = listOf(
                 // NOTICE: This track does not locate near to the switch
@@ -296,8 +298,8 @@ class CalculatedChangesServiceIT @Autowired constructor(
                     locationTrackIndexA = 1,
                     locationTrackIndexB = 2,
                     name = "switch-B $sequence",
-                )
-            )
+                ),
+            ),
         )
         val (locationTrack1, alignment1) = testData.locationTracksAndAlignments[0]
 
@@ -315,7 +317,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
             updatedAlignment,
             testData.switches[1].id as IntId,
             JointNumber(3), // Use non-presentation joint number
-            locationTrackService = locationTrackService
+            locationTrackService = locationTrackService,
         )
 
         val changes = getCalculatedChanges(
@@ -323,23 +325,23 @@ class CalculatedChangesServiceIT @Autowired constructor(
         )
 
         assertContains(
-            changes.directChanges.locationTrackChanges, LocationTrackChange(
+            changes.directChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack1.id as IntId,
                 changedKmNumbers = setOf(),
                 isStartChanged = false,
-                isEndChanged = false
-            )
+                isEndChanged = false,
+            ),
         )
         assertTrue(changes.indirectChanges.switchChanges.isEmpty())
     }
-
 
     @Test
     fun removingTopologyEndSwitchGeneratesIndirectlySwitchChanges() {
         val testData = insertTestData(
             kmPostData = listOf(
                 KmNumber(0) to Point(0.0, 0.0),
-                KmNumber(1) to Point(1000.0, 0.0)
+                KmNumber(1) to Point(1000.0, 0.0),
             ),
             locationTrackData = listOf(
                 Line(Point(0.0, 0.0), Point(100.0, 0.0)),
@@ -352,9 +354,9 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 SwitchData(
                     Point(100.0, 0.0),
                     locationTrackIndexA = 1,
-                    locationTrackIndexB = 2
+                    locationTrackIndexB = 2,
                 )
-            )
+            ),
         )
         val (locationTrack1, alignment1) = testData.locationTracksAndAlignments[0]
         val switch = testData.switches[0]
@@ -365,7 +367,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
             alignment1,
             switch.id as IntId,
             JointNumber(1),
-            locationTrackService = locationTrackService
+            locationTrackService = locationTrackService,
         ).let { (id, version) ->
             val (_, publishedVersion) = locationTrackService.publish(ValidationVersion(id, version))
             locationTrackService.getWithAlignment(publishedVersion)
@@ -375,7 +377,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         removeTopologySwitchesFromLocationTrackAndUpdate(
             updatedLocationTrack,
             updatedAlignment,
-            locationTrackService = locationTrackService
+            locationTrackService = locationTrackService,
         )
 
         val changes = getCalculatedChanges(
@@ -385,12 +387,13 @@ class CalculatedChangesServiceIT @Autowired constructor(
         )
 
         assertContains(
-            changes.directChanges.locationTrackChanges, LocationTrackChange(
+            changes.directChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack1.id as IntId,
                 changedKmNumbers = setOf(),
                 isStartChanged = false,
                 isEndChanged = false
-            )
+            ),
         )
 
         assertEquals(1, changes.indirectChanges.switchChanges.size)
@@ -406,12 +409,11 @@ class CalculatedChangesServiceIT @Autowired constructor(
                         address = TrackMeter("0", "100.000"),
                         locationTrackId = locationTrack1.id as IntId,
                     ),
-                    joint
+                    joint,
                 )
             }
         }
     }
-
 
     @Test
     fun allChangedLocationTracksExistInIndirectSwitchChange() {
@@ -426,13 +428,13 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrack3,
             alignment3,
             { point -> point + 2.0 },
-            locationTrackService = locationTrackService
+            locationTrackService = locationTrackService,
         )
         moveLocationTrackGeometryPointsAndUpdate(
             locationTrack4,
             alignment4,
             { point -> point + 2.0 },
-            locationTrackService = locationTrackService
+            locationTrackService = locationTrackService,
         )
 
         val changes = getCalculatedChanges(
@@ -440,37 +442,39 @@ class CalculatedChangesServiceIT @Autowired constructor(
         )
 
         assertContains(
-            changes.directChanges.locationTrackChanges, LocationTrackChange(
+            changes.directChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack3.id as IntId<LocationTrack>,
                 changedKmNumbers = setOf(
                     KmNumber(6),
                     KmNumber(7),
-                    KmNumber(8)
+                    KmNumber(8),
                 ),
                 isStartChanged = true,
-                isEndChanged = true
-            )
+                isEndChanged = true,
+            ),
         )
         assertContains(
-            changes.directChanges.locationTrackChanges, LocationTrackChange(
+            changes.directChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack4.id as IntId<LocationTrack>,
                 changedKmNumbers = setOf(
                     KmNumber(7),
                 ),
                 isStartChanged = true,
-                isEndChanged = true
-            )
+                isEndChanged = true,
+            ),
         )
         assertContainsSwitchJoint13Change(
             changes.indirectChanges.switchChanges,
             testData.switches.first().id,
-            locationTrack4.id
+            locationTrack4.id,
         )
 
         assertContainsSwitchJoint152Change(
             changes.indirectChanges.switchChanges,
             testData.switches.first().id,
-            locationTrack3.id
+            locationTrack3.id,
         )
     }
 
@@ -529,23 +533,24 @@ class CalculatedChangesServiceIT @Autowired constructor(
         assertContains(changes.directChanges.referenceLineChanges, referenceLine.id)
 
         assertContains(
-            changes.indirectChanges.trackNumberChanges, TrackNumberChange(
+            changes.indirectChanges.trackNumberChanges,
+            TrackNumberChange(
                 trackNumberId = referenceLine.trackNumberId,
                 changedKmNumbers = setOf(KmNumber(5)),
                 isStartChanged = true,
                 isEndChanged = false
-            )
+            ),
         )
         assertContains(
-            changes.indirectChanges.locationTrackChanges, LocationTrackChange(
+            changes.indirectChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack1.id as IntId<LocationTrack>,
                 changedKmNumbers = setOf(KmNumber(5)),
                 isStartChanged = true,
                 isEndChanged = false
-            )
+            ),
         )
     }
-
 
     @Test
     fun referenceLineChangeGeneratesIndirectlyLocationTrackChangesThatGenerateIndirectlySwitchChanges() {
@@ -563,13 +568,14 @@ class CalculatedChangesServiceIT @Autowired constructor(
             referenceLine,
             referenceLineAlignment,
             { point ->
-                if (point.m > 1000 && point.m < 2900)
-                // make reference line wavy
+                if (point.m > 1000 && point.m < 2900) {
+                    // make reference line wavy
                     point + Point(0.0, cos((point.m - 1000) / (2900 - 1000) * PI) * 5)
-                else
+                } else {
                     point
+                }
             },
-            referenceLineService = referenceLineService
+            referenceLineService = referenceLineService,
         )
 
         val changes = getCalculatedChanges(
@@ -579,58 +585,62 @@ class CalculatedChangesServiceIT @Autowired constructor(
         assertContains(changes.directChanges.referenceLineChanges, referenceLine.id)
 
         assertContains(
-            changes.indirectChanges.trackNumberChanges, TrackNumberChange(
+            changes.indirectChanges.trackNumberChanges,
+            TrackNumberChange(
                 trackNumberId = referenceLine.trackNumberId,
                 changedKmNumbers = setOf(
                     KmNumber(6),
-                    KmNumber(7)
+                    KmNumber(7),
                 ),
                 isStartChanged = false,
                 isEndChanged = false,
-            )
+            ),
         )
         assertContains(
-            changes.indirectChanges.locationTrackChanges, LocationTrackChange(
+            changes.indirectChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack1.id as IntId,
                 changedKmNumbers = setOf(
                     KmNumber(6),
                 ),
                 isStartChanged = false,
-                isEndChanged = true
-            )
+                isEndChanged = true,
+            ),
         )
         assertContains(
-            changes.indirectChanges.locationTrackChanges, LocationTrackChange(
+            changes.indirectChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack3.id as IntId<LocationTrack>,
                 changedKmNumbers = setOf(
                     KmNumber(6),
                     KmNumber(7),
                 ),
                 isStartChanged = true,
-                isEndChanged = false
-            )
+                isEndChanged = false,
+            ),
         )
         assertContains(
-            changes.indirectChanges.locationTrackChanges, LocationTrackChange(
+            changes.indirectChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack4.id as IntId<LocationTrack>,
                 changedKmNumbers = setOf(
                     KmNumber(7),
                 ),
                 isStartChanged = true,
-                isEndChanged = true
-            )
+                isEndChanged = true,
+            ),
         )
 
         assertContainsSwitchJoint13Change(
             changes.indirectChanges.switchChanges,
             testData.switches.first().id,
-            locationTrack4.id
+            locationTrack4.id,
         )
 
         assertContainsSwitchJoint152Change(
             changes.indirectChanges.switchChanges,
             testData.switches.first().id,
-            locationTrack3.id
+            locationTrack3.id,
         )
     }
 
@@ -650,7 +660,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrack3,
             alignment3,
             { point -> point + 2.0 },
-            locationTrackService = locationTrackService
+            locationTrackService = locationTrackService,
         )
 
         val changes = getCalculatedChanges(
@@ -663,7 +673,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         assertContainsSwitchJoint152Change(
             changes.directChanges.switchChanges,
             testData.switches.first().id,
-            locationTrack3.id
+            locationTrack3.id,
         )
     }
 
@@ -797,13 +807,13 @@ class CalculatedChangesServiceIT @Autowired constructor(
         assertContainsSwitchJoint152Change(
             changes = changes.indirectChanges.switchChanges,
             switchId = switch.id,
-            locationTrackId = locationTrack3.id
+            locationTrackId = locationTrack3.id,
         )
 
         assertContainsSwitchJoint13Change(
             changes = changes.indirectChanges.switchChanges,
             switchId = switch.id,
-            locationTrackId = locationTrack4.id
+            locationTrackId = locationTrack4.id,
         )
     }
 
@@ -952,22 +962,23 @@ class CalculatedChangesServiceIT @Autowired constructor(
             referenceLine,
             alignment,
             { point -> if (point.m < 900) point - 2.0 else point },
-            referenceLineService
+            referenceLineService,
         )
 
         val changes = getCalculatedChanges(
             trackNumberIds = listOf(trackNumber.id as IntId),
-            referenceLineIds = listOf(referenceLine.id as IntId)
+            referenceLineIds = listOf(referenceLine.id as IntId),
         )
 
         assertEquals(1, changes.directChanges.trackNumberChanges.size)
         assertContains(
-            changes.directChanges.trackNumberChanges, TrackNumberChange(
+            changes.directChanges.trackNumberChanges,
+            TrackNumberChange(
                 trackNumberId = trackNumber.id as IntId,
                 changedKmNumbers = setOf(KmNumber(5)),
                 isStartChanged = true,
                 isEndChanged = false
-            )
+            ),
         )
 
         assertEquals(0, changes.indirectChanges.trackNumberChanges.size)
@@ -995,17 +1006,18 @@ class CalculatedChangesServiceIT @Autowired constructor(
 
         val changes = getCalculatedChanges(
             locationTrackIds = listOf(locationTrack.id as IntId),
-            referenceLineIds = listOf(referenceLine.id as IntId)
+            referenceLineIds = listOf(referenceLine.id as IntId),
         )
 
         assertEquals(1, changes.directChanges.locationTrackChanges.size)
         assertContains(
-            changes.directChanges.locationTrackChanges, LocationTrackChange(
+            changes.directChanges.locationTrackChanges,
+            LocationTrackChange(
                 locationTrackId = locationTrack.id as IntId,
                 changedKmNumbers = setOf(KmNumber(5), KmNumber(6)),
                 isStartChanged = true,
                 isEndChanged = true
-            )
+            ),
         )
 
         assertEquals(0, changes.indirectChanges.locationTrackChanges.size)
@@ -1032,19 +1044,18 @@ class CalculatedChangesServiceIT @Autowired constructor(
 
         val changes = getCalculatedChanges(
             switchIds = listOf(switch.id as IntId),
-            locationTrackIds = listOf(locationTrack.id as IntId)
+            locationTrackIds = listOf(locationTrack.id as IntId),
         )
 
         assertEquals(1, changes.directChanges.switchChanges.size)
         assertContainsSwitchJoint152Change(
             changes = changes.directChanges.switchChanges,
             switchId = switch.id,
-            locationTrackId = locationTrack.id
+            locationTrackId = locationTrack.id,
         )
 
         assertEquals(0, changes.indirectChanges.switchChanges.size)
     }
-
 
     data class TestData(
         val trackNumber: TrackLayoutTrackNumber,
@@ -1101,9 +1112,9 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 SwitchData(
                     Point(2500.0, 0.0),
                     locationTrackIndexA = 2,
-                    locationTrackIndexB = 3
+                    locationTrackIndexB = 3,
                 )
-            )
+            ),
         )
     }
 
@@ -1117,7 +1128,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
 
         val trackNumber = layoutTrackNumberDao.fetch(
             layoutTrackNumberDao.insert(
-                trackNumber(TrackNumber("TEST TN $sequence"))
+                trackNumber(TrackNumber("TEST TN $sequence"), draft = false)
             ).rowVersion
         )
         val kmPosts = kmPostData.map { (kmNumber, location) ->
@@ -1126,7 +1137,8 @@ class CalculatedChangesServiceIT @Autowired constructor(
                     kmPost(
                         trackNumberId = trackNumber.id as IntId,
                         km = kmNumber,
-                        location = refPoint + location
+                        location = refPoint + location,
+                        draft = false,
                     )
                 ).rowVersion
             )
@@ -1135,7 +1147,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
             alignment(
                 segment(
                     kmPosts.first().location as Point,
-                    kmPosts.last().location as Point
+                    kmPosts.last().location as Point,
                 )
             )
         )
@@ -1148,7 +1160,8 @@ class CalculatedChangesServiceIT @Autowired constructor(
                     startAddress = TrackMeter(
                         kmNumber = kmPosts.first().kmNumber,
                         meters = BigDecimal.ZERO,
-                    )
+                    ),
+                    draft = false,
                 ).copy(
                     alignmentVersion = referenceLineGeometryVersion
                 )
@@ -1162,7 +1175,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                     segments(
                         refPoint + line.start,
                         refPoint + line.end,
-                        10.0
+                        10.0,
                     )
                 )
             )
@@ -1172,9 +1185,9 @@ class CalculatedChangesServiceIT @Autowired constructor(
                     locationTrack(
                         trackNumberId = trackNumber.id as IntId,
                         alignment = locationTrackGeometry,
-                        name = "TEST LocTr $sequence ${locationTrackSequence++}"
-                    ).copy(
-                        alignmentVersion = locationTrackGeometryVersion
+                        name = "TEST LocTr $sequence ${locationTrackSequence++}",
+                        alignmentVersion = locationTrackGeometryVersion,
+                        draft = false
                     )
                 ).rowVersion
             )
@@ -1197,7 +1210,9 @@ class CalculatedChangesServiceIT @Autowired constructor(
             if (edited.isDraft) {
                 val publishResponse = locationTrackService.publish(ValidationVersion(id, rowVersion))
                 locationTrackService.getWithAlignment(publishResponse.rowVersion)
-            } else edited to editedAlignment
+            } else {
+                edited to editedAlignment
+            }
         }
         val publishedSwitches = switches.map { switch ->
             val id = switch.id as IntId
@@ -1206,7 +1221,9 @@ class CalculatedChangesServiceIT @Autowired constructor(
             if (edited.isDraft) {
                 val publishResponse = switchService.publish(ValidationVersion(id, rowVersion))
                 switchDao.fetch(publishResponse.rowVersion)
-            } else edited
+            } else {
+                edited
+            }
         }
 
         return TestData(
@@ -1229,7 +1246,8 @@ class CalculatedChangesServiceIT @Autowired constructor(
             switchDao.insert(
                 switch(
                     name = name ?: "${trackA.first.name}-${trackB.first.name}",
-                    joints = listOf()
+                    joints = listOf(),
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -1250,7 +1268,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                             switchLinkingAtStart(locationTrackA.id, alignmentA, segIndexA),
                             switchLinkingAtStart(locationTrackB.id, alignmentB, segIndexB),
                         ),
-                        locationAccuracy = null
+                        locationAccuracy = null,
                     ),
                     SwitchLinkingJoint(
                         jointNumber = JointNumber(5),
@@ -1258,7 +1276,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                         segments = listOf(
                             switchLinkingAtEnd(locationTrackA.id, alignmentA, segIndexA),
                         ),
-                        locationAccuracy = null
+                        locationAccuracy = null,
                     ),
                     SwitchLinkingJoint(
                         jointNumber = JointNumber(2),
@@ -1266,7 +1284,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                         segments = listOf(
                             switchLinkingAtEnd(locationTrackA.id, alignmentA, segIndexA + 2),
                         ),
-                        locationAccuracy = null
+                        locationAccuracy = null,
                     ),
                     SwitchLinkingJoint(
                         jointNumber = JointNumber(3),
@@ -1274,8 +1292,8 @@ class CalculatedChangesServiceIT @Autowired constructor(
                         segments = listOf(
                             switchLinkingAtEnd(locationTrackB.id, alignmentB, segIndexB + 1),
                         ),
-                        locationAccuracy = null
-                    )
+                        locationAccuracy = null,
+                    ),
                 ),
                 geometrySwitchId = null,
                 switchStructureId = switch.switchStructureId,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDaoIT.kt
@@ -27,7 +27,7 @@ class LinkingDaoIT @Autowired constructor(
 
     @Test
     fun noSwitchBoundsAreFoundWhenNotLinkedToTracks() {
-        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(switch(1)).id)
+        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(switch(1, draft = true)).id)
         assertEquals(null, linkingDao.getSwitchBoundsFromTracks(OFFICIAL, switch.id as IntId))
         assertEquals(null, linkingDao.getSwitchBoundsFromTracks(DRAFT, switch.id as IntId))
     }
@@ -36,7 +36,7 @@ class LinkingDaoIT @Autowired constructor(
     fun switchBoundsAreFoundFromTracks() {
         val trackNumber = getOrCreateTrackNumber(TrackNumber("123"))
         val tnId = trackNumber.id as IntId
-        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(switch(1)).id)
+        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(switch(1, draft = true)).id)
 
         val point1 = Point(10.0, 10.0)
         val point2 = Point(12.0, 10.0)
@@ -45,19 +45,19 @@ class LinkingDaoIT @Autowired constructor(
 
         // Linked from the start only -> second point shouldn't matter
         locationTrackService.saveDraft(
-            locationTrack(tnId, externalId = someOid()).copy(
+            locationTrack(tnId, externalId = someOid(), draft = true).copy(
                 topologyStartSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(1)),
             ), alignment(segment(point1, point1 + Point(5.0, 5.0)))
         )
         // Linked from the end only -> first point shouldn't matter
         locationTrackService.saveDraft(
-            locationTrack(tnId, externalId = null).copy(
+            locationTrack(tnId, externalId = null, draft = true).copy(
                 topologyEndSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
             ), alignment(segment(point2 - Point(5.0, 5.0), point2))
         )
         // Linked by segment ends -> both points matter
         locationTrackService.saveDraft(
-            locationTrack(tnId, externalId = someOid()),
+            locationTrack(tnId, externalId = someOid(), draft = true),
             alignment(
                 segment(point3_1, point3_2).copy(
                     switchId = switch.id as IntId,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LocationTrackEndpointTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LocationTrackEndpointTest.kt
@@ -21,12 +21,12 @@ class LocationTrackEndpointTest {
 
     @Test
     fun shouldFindLocationTrackStartPoint() {
-        val trackWithStartPointInsideBbox =
-            locationTrackAndAlignment(
-                IntId(0),
-                listOf(segment(pointInsideBbox, pointOutsideBbox)),
-                IntId(0)
-            )
+        val trackWithStartPointInsideBbox = locationTrackAndAlignment(
+            trackNumberId = IntId(0),
+            segments = listOf(segment(pointInsideBbox, pointOutsideBbox)),
+            id = IntId(0),
+            draft = false,
+        )
         val alignments = listOf(trackWithStartPointInsideBbox)
 
         val endpoints = getLocationTrackEndpoints(alignments, bbox)
@@ -43,12 +43,12 @@ class LocationTrackEndpointTest {
 
     @Test
     fun shouldFindLocationTrackEndPoint() {
-        val trackWithEndPointInsideBbox =
-            locationTrackAndAlignment(
-                IntId(0),
-                listOf(segment(pointOutsideBbox, otherPointInsideBbox)),
-                IntId(0)
-            )
+        val trackWithEndPointInsideBbox = locationTrackAndAlignment(
+            trackNumberId = IntId(0),
+            segments = listOf(segment(pointOutsideBbox, otherPointInsideBbox)),
+            id = IntId(0),
+            draft = false,
+        )
         val alignments = listOf(trackWithEndPointInsideBbox)
 
         val endpoints = getLocationTrackEndpoints(alignments, bbox)
@@ -65,14 +65,15 @@ class LocationTrackEndpointTest {
 
     @Test
     fun shouldFindBothLocationTrackEndpoints() {
-        val alignmentWithMissingBothEndpointsInsideBbox =
-            locationTrackAndAlignment(
-                IntId(0),
-                listOf(
-                    segment(pointInsideBbox, otherPointInsideBbox),
-                    segment(otherPointInsideBbox, thirdPointInsideBbox),
-                ), id = IntId(1)
-            )
+        val alignmentWithMissingBothEndpointsInsideBbox = locationTrackAndAlignment(
+            trackNumberId = IntId(0),
+            segments = listOf(
+                segment(pointInsideBbox, otherPointInsideBbox),
+                segment(otherPointInsideBbox, thirdPointInsideBbox),
+            ),
+            id = IntId(1),
+            draft = false,
+        )
         val alignments = listOf(alignmentWithMissingBothEndpointsInsideBbox)
 
         val endpoints = getLocationTrackEndpoints(alignments, bbox)
@@ -104,6 +105,7 @@ class LocationTrackEndpointTest {
                 trackNumberId = IntId(0),
                 id = IntId(0),
                 segments = listOf(segment(pointOutsideBbox, otherPointOutsideBbox)),
+                draft = false,
             ),
         )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SuggestedSwitchTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SuggestedSwitchTest.kt
@@ -15,7 +15,7 @@ class SuggestedSwitchTest {
     private val switchStructure = switchStructureYV60_300_1_9()
     private val switchAlignment_1_5_2 = switchStructure.alignments.find { alignment ->
         alignment.jointNumbers.contains(JointNumber(5))
-    } ?: throw IllegalStateException("Invalid switch structure")
+    } ?: error { "Invalid switch structure" }
 
     private fun transformPoint(
         point: IPoint,
@@ -41,25 +41,24 @@ class SuggestedSwitchTest {
             segments = (0 until transformedPoints.lastIndex).map { index ->
                 segment(
                     transformedPoints[index],
-                    transformedPoints[index + 1]
+                    transformedPoints[index + 1],
                 )
-            }
+            },
         )
     }
 
     @Test
     fun shouldInferSwitchTransformation() {
-        val rotation = degreesToRads(45.0);
+        val rotation = degreesToRads(45.0)
         val translation = Point(2000.0, 3000.0)
 
         val alignmentContainingSwitchSegments = createAlignmentBySwitchAlignment(
             switchAlignment_1_5_2,
             translation = translation,
-            rotation = rotation
+            rotation = rotation,
         )
 
-        val presentationJointLocation =
-            alignmentContainingSwitchSegments.segments[1].alignmentPoints.first()
+        val presentationJointLocation = alignmentContainingSwitchSegments.segments[1].alignmentPoints.first()
         val switchTransformation = inferSwitchTransformation(
             presentationJointLocation,
             switchStructure,
@@ -79,19 +78,18 @@ class SuggestedSwitchTest {
 
     @Test
     fun shouldInferSwitchTransformationFromReversedAlignment() {
-        val rotation = degreesToRads(45.0);
+        val rotation = degreesToRads(45.0)
         val translation = Point(2000.0, 3000.0)
 
         val reversedAlignmentContainingSwitchSegments = reverseAlignment(
             createAlignmentBySwitchAlignment(
                 switchAlignment_1_5_2,
                 translation = translation,
-                rotation = rotation
+                rotation = rotation,
             )
         )
 
-        val presentationJointLocation =
-            reversedAlignmentContainingSwitchSegments.segments[2].alignmentPoints.last()
+        val presentationJointLocation = reversedAlignmentContainingSwitchSegments.segments[2].alignmentPoints.last()
         val switchTransformation = inferSwitchTransformation(
             presentationJointLocation,
             switchStructure,
@@ -138,8 +136,7 @@ class SuggestedSwitchTest {
         val joint = suggestedSwitch.joints.find { joint -> joint.number == jointNumber }
             ?: throw Exception("Switch structure does not contain joint ${jointNumber.intValue}")
         if (!joint.matches.any { match ->
-                match.locationTrackId == alignmentId &&
-                        (m - match.m).absoluteValue < 0.01
+                match.locationTrackId == alignmentId && (m - match.m).absoluteValue < 0.01
             }) {
             fail("Didn't found a match from joint ${jointNumber.intValue}: alignmentId $alignmentId, m $m, $endPoint")
         }
@@ -147,22 +144,22 @@ class SuggestedSwitchTest {
 
     @Test
     fun shouldCreateSuggestedSwitch() {
-        val rotation = degreesToRads(45.0);
+        val rotation = degreesToRads(45.0)
         val translation = Point(2000.0, 3000.0)
 
         val trackId: IntId<LocationTrack> = IntId(1)
         val alignmentContainingSwitchSegments = createAlignmentBySwitchAlignment(
             switchAlignment_1_5_2,
             translation = translation,
-            rotation = rotation
+            rotation = rotation,
         )
-        val locationTrack = locationTrack(IntId(0), alignmentContainingSwitchSegments, trackId)
+        val locationTrack = locationTrack(IntId(0), alignmentContainingSwitchSegments, trackId, draft = false)
         val presentationJointLocation = alignmentContainingSwitchSegments.segments[1].alignmentPoints.first()
 
         val missingLocationTrackEndpoint = LocationTrackEndpoint(
             trackId,
             Point(presentationJointLocation),
-            LocationTrackPointUpdateType.START_POINT
+            LocationTrackPointUpdateType.START_POINT,
         )
 
         val suggestedSwitch = createSuggestedSwitch(
@@ -185,7 +182,7 @@ class SuggestedSwitchTest {
                 JointNumber(1),
                 alignmentId = IntId(1),
                 m = 300.0,
-                SegmentEndPoint.START
+                SegmentEndPoint.START,
             )
 
             assertSuggestedSwitchContainsMatch(
@@ -193,7 +190,7 @@ class SuggestedSwitchTest {
                 JointNumber(5),
                 alignmentId = IntId(1),
                 m = 316.615,
-                SegmentEndPoint.END
+                SegmentEndPoint.END,
             )
 
             assertSuggestedSwitchContainsMatch(
@@ -201,7 +198,7 @@ class SuggestedSwitchTest {
                 JointNumber(2),
                 alignmentId = IntId(1),
                 m = 334.43,
-                SegmentEndPoint.END
+                SegmentEndPoint.END,
             )
         } else {
             fail("Should be able to create suggested switch")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
@@ -38,11 +38,16 @@ class SwitchLinkingTest {
     fun adjacentSegmentsShouldHaveSameJointNumber() {
         var startLength = 0.0
         val locationTrackId = IntId<LocationTrack>(0)
-        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..5).map { num ->
-            val start = (num - 1).toDouble() * 10.0
-            val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-        }, locationTrackId)
+        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(
+            trackNumberId = IntId(0),
+            segments = (1..5).map { num ->
+                val start = (num - 1).toDouble() * 10.0
+                val end = start + 10.0
+                segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
+            },
+            id = locationTrackId,
+            draft = false,
+        )
 
         val joint1 = SwitchLinkingJoint(
             JointNumber(1),
@@ -103,11 +108,16 @@ class SwitchLinkingTest {
     fun shouldSortLinkingJointsInSegmentOrder() {
         var startLength = 0.0
         val locationTrackId = IntId<LocationTrack>(0)
-        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..5).map { num ->
-            val start = (num - 1).toDouble() * 10.0
-            val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-        }, locationTrackId)
+        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(
+            trackNumberId = IntId(0),
+            segments = (1..5).map { num ->
+                val start = (num - 1).toDouble() * 10.0
+                val end = start + 10.0
+                segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
+            },
+            id = locationTrackId,
+            draft = false,
+        )
 
         val joint1 = SwitchLinkingJoint(
             JointNumber(2),
@@ -168,11 +178,16 @@ class SwitchLinkingTest {
     fun shouldSnapToSegmentsFirstAndLastPoint() {
         var startLength = 0.0
         val locationTrackId = IntId<LocationTrack>(0)
-        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..5).map { num ->
-            val start = (num - 1).toDouble() * 10.0
-            val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-        }, locationTrackId)
+        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(
+            trackNumberId = IntId(0),
+            segments = (1..5).map { num ->
+                val start = (num - 1).toDouble() * 10.0
+                val end = start + 10.0
+                segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
+            },
+            id = locationTrackId,
+            draft = false,
+        )
 
         val linkingJoints = listOf(
             SwitchLinkingJoint(
@@ -212,11 +227,16 @@ class SwitchLinkingTest {
     fun shouldSplitSegmentsToSwitchGeometry() {
         var startLength = 0.0
         val locationTrackId = IntId<LocationTrack>(0)
-        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..5).map { num ->
-            val start = (num - 1).toDouble() * 10.0
-            val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-        }, locationTrackId)
+        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(
+            trackNumberId = IntId(0),
+            segments = (1..5).map { num ->
+                val start = (num - 1).toDouble() * 10.0
+                val end = start + 10.0
+                segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
+            },
+            id = locationTrackId,
+            draft = false,
+        )
 
         val splitSegmentIndex = 1
         val splitPointM = origAlignmentNoSwitchInfo.segments[splitSegmentIndex]
@@ -265,11 +285,16 @@ class SwitchLinkingTest {
     fun shouldUpdateSwitchLinkingIntoAlignment() {
         var startLength = 0.0
         val locationTrackId = IntId<LocationTrack>(0)
-        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(IntId(0), (1..3).map { num ->
-            val start = (num - 1).toDouble() * 10.0
-            val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-        }, locationTrackId)
+        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(
+            trackNumberId = IntId(0),
+            segments = (1..3).map { num ->
+                val start = (num - 1).toDouble() * 10.0
+                val end = start + 10.0
+                segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
+            },
+            id = locationTrackId,
+            draft = false,
+        )
 
         val linkingJoints = listOf(
             SwitchLinkingJoint(
@@ -321,9 +346,11 @@ class SwitchLinkingTest {
 
     @Test
     fun shouldClearSwitchTopologyLinkingFromLocationTrackStart() {
-        val locationTrackWithStartLink = locationTrack(IntId(1)).copy(
+        val locationTrackWithStartLink = locationTrack(
+            trackNumberId = IntId(1),
             topologyStartSwitch = TopologyLocationTrackSwitch(testLayoutSwitchId, JointNumber(2)),
             topologyEndSwitch = TopologyLocationTrackSwitch(otherLayoutSwitchId, JointNumber(1)),
+            draft = false,
         )
         val (locationTrackWithStartLinkCleared, _) = clearLinksToSwitch(
             locationTrackWithStartLink,
@@ -336,9 +363,11 @@ class SwitchLinkingTest {
 
     @Test
     fun shouldClearSwitchTopologyLinkingFromLocationTrackEnd() {
-        val locationTrackWithEndLink = locationTrack(IntId(1)).copy(
+        val locationTrackWithEndLink = locationTrack(
+            trackNumberId = IntId(1),
             topologyStartSwitch = TopologyLocationTrackSwitch(otherLayoutSwitchId, JointNumber(2)),
             topologyEndSwitch = TopologyLocationTrackSwitch(testLayoutSwitchId, JointNumber(1)),
+            draft = false,
         )
         val (locationTrackWithEndLinkCleared, _) = clearLinksToSwitch(
             locationTrackWithEndLink,
@@ -352,7 +381,11 @@ class SwitchLinkingTest {
     @Test
     fun shouldClearSwitchLinkingInfoFromAlignment() {
         val (origLocationTrack, origAlignment) = locationTrackWithTwoSwitches(
-            IntId(0), testLayoutSwitchId, otherLayoutSwitchId, locationTrackId = IntId(0)
+            trackNumberId = IntId(0),
+            layoutSwitchId = testLayoutSwitchId,
+            otherLayoutSwitchId = otherLayoutSwitchId,
+            locationTrackId = IntId(0),
+            draft = false,
         )
 
         val (_, clearedAlignment) = clearLinksToSwitch(
@@ -403,7 +436,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack1 = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack1 = locationTrack(IntId(1), id = IntId(1), draft = false)
         val alignment1 = LayoutAlignment(
             segments = listOf(
                 segment(
@@ -414,7 +447,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack2 = locationTrack(IntId(1), id = IntId(2))
+        val locationTrack2 = locationTrack(IntId(1), id = IntId(2), draft = false)
         val alignment2 = LayoutAlignment(
             segments = listOf(
                 segment(
@@ -467,7 +500,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
         val alignment = LayoutAlignment(
             segments = listOf(
@@ -527,7 +560,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
         val alignment = LayoutAlignment(
             segments = listOf(
@@ -587,7 +620,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
         val alignment = LayoutAlignment(
             segments = listOf(
@@ -646,7 +679,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
         val alignment = LayoutAlignment(
             segments = listOf(
@@ -694,7 +727,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
         val alignment = LayoutAlignment(
             segments = listOf(
@@ -740,7 +773,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
         val alignment = LayoutAlignment(
             segments = listOf(
@@ -791,7 +824,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack1 = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack1 = locationTrack(IntId(1), id = IntId(1), draft = false)
         val alignment1 = LayoutAlignment(
             segments = listOf(
                 segment(
@@ -831,7 +864,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack2 = locationTrack(IntId(1), id = IntId(2))
+        val locationTrack2 = locationTrack(IntId(1), id = IntId(2), draft = false)
         val alignment2 = LayoutAlignment(
             segments = listOf(
                 segment(
@@ -913,7 +946,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
         val alignment = LayoutAlignment(
             segments = listOf(
@@ -966,7 +999,7 @@ class SwitchLinkingTest {
             ),
         )
 
-        val locationTrack = locationTrack(IntId(1), id = IntId(1))
+        val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
         val alignment = LayoutAlignment(
             segments = listOf(
@@ -1005,7 +1038,11 @@ class SwitchLinkingTest {
     @Test
     fun `should remove layout switches from all segments that are overridden by switch linking`() {
         val (origLocationTrack, origAlignment) = locationTrackWithTwoSwitches(
-            IntId(0), testLayoutSwitchId, otherLayoutSwitchId, locationTrackId = IntId(0)
+            trackNumberId = IntId(0),
+            layoutSwitchId = testLayoutSwitchId,
+            otherLayoutSwitchId = otherLayoutSwitchId,
+            locationTrackId = IntId(0),
+            draft = false,
         )
 
         val linkingJoints = listOf(
@@ -1061,6 +1098,7 @@ class SwitchLinkingTest {
                 Point(4.0, 0.0),
                 Point(5.0, 0.0),
             ),
+            draft = false,
         )
         val croppedAlignment = cropPoints(locationTrackInArea.second, bbox)
 
@@ -1095,6 +1133,7 @@ class SwitchLinkingTest {
                     Point(5.0, 5.0),
                 )
             ),
+            draft = false,
         )
         val croppedAlignment = cropPoints(locationTrack.second, bbox)
 
@@ -1108,10 +1147,12 @@ class SwitchLinkingTest {
         val switchStructure = YV60_300_1_9_O()
         val locationTrack152 = locationTrackAndAlignment(
             segment(from = segmentPoint(-200.0, 0.0), to = Point(-100.0, 0.0)),
-            segment(from = Point(-100.0, 0.0), to = Point(100.0, 0.0))
+            segment(from = Point(-100.0, 0.0), to = Point(100.0, 0.0)),
+            draft = false,
         )
         val locationTrack13 = locationTrackAndAlignment(
-            segment(from = Point(0.0, 0.0), to = Point(100.0, -100.0 * yvTurnRatio))
+            segment(from = Point(0.0, 0.0), to = Point(100.0, -100.0 * yvTurnRatio)),
+            draft = false,
         )
         val nearbyPoint = Point(10.0, -1.0)
 
@@ -1127,7 +1168,9 @@ class SwitchLinkingTest {
     @Test
     fun `getSwitchBoundsFromTracks handles topology and segment points`() {
         val topoLinkedTrack = locationTrack(
-            IntId(1), topologyEndSwitch = TopologyLocationTrackSwitch(IntId(1), JointNumber(1))
+            trackNumberId = IntId(1),
+            topologyEndSwitch = TopologyLocationTrackSwitch(IntId(1), JointNumber(1)),
+            draft = false,
         )
         // let's say the switch's main joint is at (5.0, 5.0), this geometry incidentally doesn't *quite* come to the
         // front joint, but close enough to link anyway
@@ -1148,7 +1191,7 @@ class SwitchLinkingTest {
                 startJointNumber = JointNumber(5),
                 endJointNumber = JointNumber(2)
             ),
-            segment(Point(7.0, 5.0), Point(8.0, 5.0))
+            segment(Point(7.0, 5.0), Point(8.0, 5.0)),
         )
         val alignmentOn13 = alignment(
             segment(
@@ -1161,8 +1204,8 @@ class SwitchLinkingTest {
         )
         val tracks = listOf(
             topoLinkedTrack to topoAlignment,
-            locationTrack(IntId(1)) to alignmentOn152,
-            locationTrack(IntId(1)) to alignmentOn13
+            locationTrack(IntId(1), draft = false) to alignmentOn152,
+            locationTrack(IntId(1), draft = false) to alignmentOn13,
         )
         assertEquals(
             boundingBoxAroundPoints(listOf(Point(4.9, 5.0), Point(7.0, 6.0))), getSwitchBoundsFromTracks(
@@ -1204,7 +1247,7 @@ private fun assertJointMatchExists(
     if (matchType != null) assertEquals(
         matchType,
         match.matchType,
-        "match type for joint $jointNumber on track $locationTrackId"
+        "match type for joint $jointNumber on track $locationTrackId",
     )
 
     val linkingParametersJoint = switchLinkingParams.joints.find { it.jointNumber.intValue == jointNumber }!!
@@ -1212,6 +1255,6 @@ private fun assertJointMatchExists(
     if (segmentIndex != null) assertEquals(
         segmentIndex,
         linkingParametersMatch.segmentIndex,
-        "segment index for joint $jointNumber on track $locationTrackId"
+        "segment index for joint $jointNumber on track $locationTrackId",
     )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -56,11 +56,11 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun referenceLinePublishCandidatesAreFound() {
-        val trackNumberId = insertAndCheck(trackNumber(getUnusedTrackNumber())).first.id
-        val (_, line) = insertAndCheck(referenceLine(trackNumberId))
-        val (_, draft) = insertAndCheck(asMainDraft(line).copy(
-            startAddress = TrackMeter("0123", 658.321, 3),
-        ))
+        val trackNumberId = insertAndCheck(trackNumber(getUnusedTrackNumber(), draft = false)).first.id
+        val (_, line) = insertAndCheck(referenceLine(trackNumberId, draft = false))
+        val (_, draft) = insertAndCheck(
+            asMainDraft(line).copy(startAddress = TrackMeter("0123", 658.321, 3))
+        )
         val candidates = publicationDao.fetchReferenceLinePublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(line.id, candidates.first().id)
@@ -71,10 +71,10 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun locationTrackPublishCandidatesAreFound() {
-        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
-        val (_, draft) = insertAndCheck(asMainDraft(track).copy(
-            name = AlignmentName("${track.name} DRAFT"),
-        ))
+        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber(), draft = false))
+        val (_, draft) = insertAndCheck(
+            asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT"))
+        )
         val candidates = publicationDao.fetchLocationTrackPublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -86,7 +86,7 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun switchPublishCandidatesAreFound() {
-        val (_, switch) = insertAndCheck(switch(987))
+        val (_, switch) = insertAndCheck(switch(987, draft = false))
         val (_, draft) = insertAndCheck(asMainDraft(switch).copy(name = SwitchName("${switch.name} DRAFT")))
         val candidates = publicationDao.fetchSwitchPublishCandidates()
         assertEquals(1, candidates.size)
@@ -98,7 +98,7 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun createOperationIsInferredCorrectly() {
-        val (_, track) = insertAndCheck(asMainDraft(locationTrack(insertOfficialTrackNumber())))
+        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber(), draft = true))
         val candidates = publicationDao.fetchLocationTrackPublishCandidates()
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -107,7 +107,7 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun modifyOperationIsInferredCorrectly() {
-        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
+        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber(), draft = false))
         val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
         publishAndCheck(version)
         locationTrackService.saveDraft(
@@ -123,7 +123,7 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun deleteOperationIsInferredCorrectly() {
-        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
+        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber(), draft = false))
         val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
         publishAndCheck(version)
         locationTrackService.saveDraft(
@@ -139,11 +139,13 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun restoreOperationIsInferredCorrectly() {
-        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber()))
-        val (version, draft) = insertAndCheck(asMainDraft(track).copy(
-            name = AlignmentName("${track.name} DRAFT"),
-            state = LayoutState.DELETED,
-        ))
+        val (_, track) = insertAndCheck(locationTrack(insertOfficialTrackNumber(), draft = false))
+        val (version, draft) = insertAndCheck(
+            asMainDraft(track).copy(
+                name = AlignmentName("${track.name} DRAFT"),
+                state = LayoutState.DELETED,
+            )
+        )
         publishAndCheck(version)
         locationTrackService.saveDraft(asMainDraft(locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId).copy(
             state = LayoutState.IN_USE,
@@ -157,8 +159,8 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun allCalculatedChangesAreRecorded() {
         val trackNumberId = insertOfficialTrackNumber()
-        val locationTrackId = insertAndCheck(locationTrack(trackNumberId)).first.id
-        val switchId = insertAndCheck(switch(234)).first.id
+        val locationTrackId = insertAndCheck(locationTrack(trackNumberId, draft = false)).first.id
+        val switchId = insertAndCheck(switch(234, draft = false)).first.id
 
         val switchJointChange = SwitchJointChange(
             JointNumber(1),
@@ -179,7 +181,7 @@ class PublicationDaoIT @Autowired constructor(
                         setOf(KmNumber(1234), KmNumber(45, "AB")),
                         isStartChanged = true,
                         isEndChanged = false
-                    )
+                    ),
                 ),
                 kmPostChanges = emptyList(),
                 referenceLineChanges = emptyList(),
@@ -188,14 +190,14 @@ class PublicationDaoIT @Autowired constructor(
                         locationTrackId,
                         setOf(KmNumber(456)),
                         isStartChanged = false,
-                        isEndChanged = true
-                    )
+                        isEndChanged = true,
+                    ),
                 ),
                 switchChanges = listOf(
-                    SwitchChange(switchId, listOf(switchJointChange))
-                )
+                    SwitchChange(switchId, listOf(switchJointChange)),
+                ),
             ),
-            indirectChanges = IndirectChanges(emptyList(), emptyList(), emptyList())
+            indirectChanges = IndirectChanges(emptyList(), emptyList(), emptyList()),
         )
         val publicationId = publicationDao.createPublication("")
         publicationDao.insertCalculatedChanges(publicationId, changes)
@@ -206,13 +208,13 @@ class PublicationDaoIT @Autowired constructor(
         assertTrue(publishedTrackNumbers.directChanges.all { it.version.id == trackNumberId })
         assertEquals(
             changes.directChanges.trackNumberChanges.flatMap { it.changedKmNumbers }.sorted(),
-            publishedTrackNumbers.directChanges.flatMap { it.changedKmNumbers }.sorted()
+            publishedTrackNumbers.directChanges.flatMap { it.changedKmNumbers }.sorted(),
         )
 
         assertTrue(publishedLocationTracks.directChanges.all { it.version.id == locationTrackId })
         assertEquals(
             changes.directChanges.locationTrackChanges.flatMap { it.changedKmNumbers }.sorted(),
-            publishedLocationTracks.directChanges.flatMap { it.changedKmNumbers }.sorted()
+            publishedLocationTracks.directChanges.flatMap { it.changedKmNumbers }.sorted(),
         )
 
         assertTrue(publishedSwitches.directChanges.all { it.version.id == switchId })
@@ -229,10 +231,10 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun fetchOfficialSwitchTrackNumbers() {
         val trackNumberId = insertOfficialTrackNumber()
-        val (_, switch) = insertAndCheck(switch(234, name = "Foo"))
+        val (_, switch) = insertAndCheck(switch(234, name = "Foo", draft = false))
         val switchId = switch.id as IntId
         insertAndCheck(
-            locationTrack(trackNumberId).copy(
+            locationTrack(trackNumberId, draft = false).copy(
                 topologyEndSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(1))
             )
         )
@@ -246,15 +248,13 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun fetchDraftOnlySwitchTrackNumbers() {
         val trackNumberId = insertOfficialTrackNumber()
-        val (_, switch) = insertAndCheck(asMainDraft(switch(345, name = "Foo")))
+        val (_, switch) = insertAndCheck(switch(345, name = "Foo", draft = true))
         val switchId = switch.id as IntId
         insertAndCheck(
-            asMainDraft(
-                locationTrack(trackNumberId).copy(
-                    topologyEndSwitch = TopologyLocationTrackSwitch(
-                        switchId,
-                        JointNumber(1)
-                    )
+            locationTrack(trackNumberId, draft = true).copy(
+                topologyEndSwitch = TopologyLocationTrackSwitch(
+                    switchId,
+                    JointNumber(1),
                 )
             )
         )
@@ -266,28 +266,29 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun `fetchLinkedLocationTracks works on publication units`() {
         val trackNumberId = insertOfficialTrackNumber()
-        val switchByAlignment = switchDao.insert(switch(1)).id
-        val switchByTopo = switchDao.insert(switch(2)).id
+        val switchByAlignment = switchDao.insert(switch(1, draft = false)).id
+        val switchByTopo = switchDao.insert(switch(2, draft = false)).id
         val dummyAlignment = alignmentDao.insert(alignment())
         val officialLinkedTopo = locationTrackDao.insert(
             locationTrack(
                 trackNumberId,
                 topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(1)),
                 alignmentVersion = dummyAlignment,
+                draft = false,
             )
         )
         val draftLinkedTopo = locationTrackDao.insert(
-            asMainDraft(
-                locationTrack(
-                    trackNumberId,
-                    topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(3)),
-                    alignmentVersion = dummyAlignment,
-                )
+            locationTrack(
+                trackNumberId,
+                topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(3)),
+                alignmentVersion = dummyAlignment,
+                draft = true,
             )
         )
         val officialLinkedAlignment = locationTrackDao.insert(
             locationTrack(
-                trackNumberId, alignmentVersion = alignmentDao.insert(
+                trackNumberId = trackNumberId,
+                alignmentVersion = alignmentDao.insert(
                     alignment(
                         segment(
                             Point(0.0, 0.0),
@@ -296,40 +297,50 @@ class PublicationDaoIT @Autowired constructor(
                             startJointNumber = JointNumber(1)
                         )
                     )
-                )
+                ),
+                draft = false,
             )
         )
         val draftLinkedAlignment = locationTrackDao.insert(
-            asMainDraft(
-                locationTrack(
-                    trackNumberId, alignmentVersion = alignmentDao.insert(
-                        alignment(
-                            segment(
-                                Point(2.0, 2.0),
-                                Point(3.0, 3.0),
-                                switchId = switchByAlignment,
-                                startJointNumber = JointNumber(3)
-                            )
+            locationTrack(
+                trackNumberId = trackNumberId,
+                alignmentVersion = alignmentDao.insert(
+                    alignment(
+                        segment(
+                            Point(2.0, 2.0),
+                            Point(3.0, 3.0),
+                            switchId = switchByAlignment,
+                            startJointNumber = JointNumber(3)
                         )
                     )
-                )
+                ),
+                draft = true,
             )
         )
         assertEquals(
-            setOf(daoResponseToValidationVersion(officialLinkedAlignment), daoResponseToValidationVersion(draftLinkedAlignment)),
-            publicationDao.fetchLinkedLocationTracks(listOf(switchByAlignment))[switchByAlignment]
+            setOf(
+                daoResponseToValidationVersion(officialLinkedAlignment),
+                daoResponseToValidationVersion(draftLinkedAlignment),
+            ),
+            publicationDao.fetchLinkedLocationTracks(listOf(switchByAlignment))[switchByAlignment],
         )
         assertEquals(
             setOf(daoResponseToValidationVersion(officialLinkedAlignment)),
             publicationDao.fetchLinkedLocationTracks(listOf(switchByAlignment), listOf())[switchByAlignment]
         )
         assertEquals(
-            setOf(daoResponseToValidationVersion(officialLinkedAlignment), daoResponseToValidationVersion(draftLinkedAlignment)),
+            setOf(
+                daoResponseToValidationVersion(officialLinkedAlignment),
+                daoResponseToValidationVersion(draftLinkedAlignment),
+            ),
             publicationDao.fetchLinkedLocationTracks(listOf(switchByAlignment), listOf(draftLinkedAlignment.id))[switchByAlignment]
         )
         assertEquals(
-            setOf(daoResponseToValidationVersion(officialLinkedTopo), daoResponseToValidationVersion(draftLinkedTopo)),
-            publicationDao.fetchLinkedLocationTracks(listOf(switchByTopo))[switchByTopo]
+            setOf(
+                daoResponseToValidationVersion(officialLinkedTopo),
+                daoResponseToValidationVersion(draftLinkedTopo),
+            ),
+            publicationDao.fetchLinkedLocationTracks(listOf(switchByTopo))[switchByTopo],
         )
         assertEquals(
             setOf(daoResponseToValidationVersion(officialLinkedTopo)),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -959,7 +959,13 @@ class PublicationServiceIT @Autowired constructor(
             asMainDraft(locationTrackDao.fetch(lt1OriginalVersion).copy(name = AlignmentName("LT2")))
         )
 
-        val lt2 = locationTrack(trackNumberId, name = "LT2", alignmentVersion = someAlignment, externalId = null, draft = false)
+        val lt2 = locationTrack(
+            trackNumberId = trackNumberId,
+            name = "LT2",
+            alignmentVersion = someAlignment,
+            externalId = null,
+            draft = false,
+        )
         val lt2OriginalVersion = locationTrackDao.insert(lt2).rowVersion
         val lt2RenamedDraft = locationTrackDao.insert(
             asMainDraft(locationTrackDao.fetch(lt2OriginalVersion).copy(name = AlignmentName("LT1")))
@@ -1008,7 +1014,9 @@ class PublicationServiceIT @Autowired constructor(
         // In new draft, middle wants to duplicate big (leading to: small->middle->big)
         locationTrackService.saveDraft(locationTrackDao.fetch(middleTrack.rowVersion).copy(duplicateOf = bigTrack.id))
 
-        fun getPublishingDuplicateWhileDuplicatedValidationError(vararg publishableTracks: IntId<LocationTrack>): PublishValidationError? {
+        fun getPublishingDuplicateWhileDuplicatedValidationError(
+            vararg publishableTracks: IntId<LocationTrack>,
+        ): PublishValidationError? {
             val validation = publicationService.validatePublishCandidates(
                 publicationService.collectPublishCandidates(),
                 PublishRequestIds(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationUtilsTest.kt
@@ -125,6 +125,8 @@ class PublicationUtilsTest {
         assertEquals(12.0, result[1].changedLengthM)
     }
 
-    private fun xAxisGeocodingContext() = geocodingContext((0..60).map { x -> Point(x.toDouble(), 0.0)})
+    private fun xAxisGeocodingContext() = geocodingContext(
+        (0..60).map { x -> Point(x.toDouble(), 0.0)},
+        draft = false,
+    )
 }
-

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
@@ -44,11 +44,11 @@ class ValidationContextIT @Autowired constructor(
 
     @Test
     fun `ValidationContext returns correct versions for TrackNumber`() {
-        val trackNumber1 = trackNumber(getUnusedTrackNumber())
+        val trackNumber1 = trackNumber(getUnusedTrackNumber(), draft = false)
         val (tn1Id, tn1OfficialVersion) = trackNumberDao.insert(trackNumber1)
         val (_, tn1DraftVersion) = trackNumberDao.insert(asMainDraft(trackNumberDao.fetch(tn1OfficialVersion)))
-        val trackNumber2 = trackNumber(getUnusedTrackNumber())
-        val (tn2Id, tn2DraftVersion) = trackNumberDao.insert(asMainDraft(trackNumber2))
+        val trackNumber2 = trackNumber(getUnusedTrackNumber(), draft = true)
+        val (tn2Id, tn2DraftVersion) = trackNumberDao.insert(trackNumber2)
         assertEquals(
             trackNumberDao.fetch(tn1OfficialVersion),
             validationContext().getTrackNumber(tn1Id),
@@ -85,11 +85,9 @@ class ValidationContextIT @Autowired constructor(
     @Test
     fun `ValidationContext returns correct versions for LocationTrack`() {
         val trackNumberId = getUnusedTrackNumberId()
-        val (lt1Id, lt1OfficialVersion) = insertLocationTrack(locationTrackAndAlignment(trackNumberId))
+        val (lt1Id, lt1OfficialVersion) = insertLocationTrack(locationTrackAndAlignment(trackNumberId, draft = false))
         val (_, lt1DraftVersion) = locationTrackDao.insert(asMainDraft(locationTrackDao.fetch(lt1OfficialVersion)))
-        val (lt2Id, lt2DraftVersion) = insertLocationTrack(
-            locationTrackAndAlignment(trackNumberId).let { (t, a) -> asMainDraft(t) to a }
-        )
+        val (lt2Id, lt2DraftVersion) = insertLocationTrack(locationTrackAndAlignment(trackNumberId, draft = true))
 
         assertEquals(
             locationTrackDao.fetch(lt1OfficialVersion),
@@ -109,10 +107,10 @@ class ValidationContextIT @Autowired constructor(
     @Test
     fun `ValidationContext returns correct versions for Switch`() {
         val switchName1 = getUnusedSwitchName()
-        val (s1Id, s1OfficialVersion) = switchDao.insert(switch(name = switchName1.toString()))
+        val (s1Id, s1OfficialVersion) = switchDao.insert(switch(name = switchName1.toString(), draft = false))
         val (_, s1DraftVersion) = switchDao.insert(asMainDraft(switchDao.fetch(s1OfficialVersion)))
         val switchName2 = getUnusedSwitchName()
-        val (s2Id, s2DraftVersion) = switchDao.insert(asMainDraft(switch(name = switchName2.toString())))
+        val (s2Id, s2DraftVersion) = switchDao.insert(switch(name = switchName2.toString(), draft = true))
 
         assertEquals(
             switchDao.fetch(s1OfficialVersion),
@@ -146,9 +144,9 @@ class ValidationContextIT @Autowired constructor(
     @Test
     fun `ValidationContext returns correct versions for KM-Post`() {
         val trackNumberId = getUnusedTrackNumberId()
-        val (kmp1Id, kmp1OfficialVersion) = kmPostDao.insert(kmPost(trackNumberId, KmNumber(1)))
+        val (kmp1Id, kmp1OfficialVersion) = kmPostDao.insert(kmPost(trackNumberId, KmNumber(1), draft = false))
         val (_, kmp1DraftVersion) = kmPostDao.insert(asMainDraft(kmPostDao.fetch(kmp1OfficialVersion)))
-        val (kmp2Id, kmp2DraftVersion) = kmPostDao.insert(asMainDraft(kmPost(trackNumberId, KmNumber(2))))
+        val (kmp2Id, kmp2DraftVersion) = kmPostDao.insert(kmPost(trackNumberId, KmNumber(2), draft = true))
         assertEquals(
             kmPostDao.fetch(kmp1OfficialVersion),
             validationContext().getKmPost(kmp1Id),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
@@ -1,10 +1,12 @@
 package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.*
-import fi.fta.geoviite.infra.ratko.model.*
+import fi.fta.geoviite.infra.ratko.model.RatkoOid
+import fi.fta.geoviite.infra.ratko.model.RatkoSwitchAsset
+import fi.fta.geoviite.infra.ratko.model.convertToRatkoSwitch
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.switch
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -56,7 +58,7 @@ class RatkoClientIT @Autowired constructor(
     fun shouldUpdateRatkoSwitchProperties() {
         val oid = "1.2.3.4.5"
         fakeRatko.hasSwitch(ratkoSwitch(oid))
-        val layoutSwitch = switch(123).copy(externalId = Oid(oid))
+        val layoutSwitch = switch(123, externalId = oid, draft = false)
         val basicUpdateSwitch = createRatkoBasicUpdateSwitch(layoutSwitch)
         ratkoClient.updateAssetProperties(RatkoOid(oid), basicUpdateSwitch.properties)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -79,11 +79,21 @@ class RatkoServiceIT @Autowired constructor(
     fun testChangeSet() {
         val referenceLineAlignmentVersion = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
         val locationTrackAlignmentVersion = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        val trackNumber = trackNumber(getUnusedTrackNumber())
+        val trackNumber = trackNumber(getUnusedTrackNumber(), draft = false)
         val trackNumberId = layoutTrackNumberDao.insert(trackNumber).id
-        referenceLineDao.insert(referenceLine(trackNumberId).copy(alignmentVersion = referenceLineAlignmentVersion))
+        referenceLineDao.insert(
+            referenceLine(
+                trackNumberId = trackNumberId,
+                alignmentVersion = referenceLineAlignmentVersion,
+                draft = false,
+            )
+        )
         val officialVersion = locationTrackDao.insert(
-            locationTrack(trackNumberId = trackNumberId).copy(alignmentVersion = locationTrackAlignmentVersion)
+            locationTrack(
+                trackNumberId = trackNumberId,
+                alignmentVersion = locationTrackAlignmentVersion,
+                draft = false,
+            )
         )
         val draft = locationTrackService.get(DRAFT, officialVersion.id)!!.let { orig ->
             orig.copy(name = AlignmentName("${orig.name}-draft"))
@@ -96,8 +106,9 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun pushNewTrackNumber() {
         val trackNumber = getUnusedTrackNumber()
-        val originalTrackNumberVersion =
-            layoutTrackNumberDao.insert(trackNumber(trackNumber, description = "augh", externalId = null)).rowVersion
+        val originalTrackNumberVersion = layoutTrackNumberDao.insert(
+            trackNumber(trackNumber, description = "augh", externalId = null, draft = false)
+        ).rowVersion
         insertSomeOfficialReferenceLineFor(originalTrackNumberVersion.id)
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
@@ -145,16 +156,20 @@ class RatkoServiceIT @Autowired constructor(
     fun pushAndDeleteLocationTrack() {
         val trackNumber = getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.insert(
-            trackNumber(
-                trackNumber, description = "augh", externalId = Oid("1.2.3.4.5")
-            )
+            trackNumber(trackNumber, description = "augh", externalId = Oid("1.2.3.4.5"), draft = false)
         ).id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
         val locationTrackOriginalVersion = locationTrackService.saveDraft(
             locationTrack(
-                trackNumberId, name = "abcde", description = "cdefg", type = LocationTrackType.CHORD, externalId = null
-            ), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
+                trackNumberId,
+                name = "abcde",
+                description = "cdefg",
+                type = LocationTrackType.CHORD,
+                externalId = null,
+                draft = true,
+            ),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         ).rowVersion
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(locationTracks = listOf(locationTrackOriginalVersion))
@@ -179,15 +194,24 @@ class RatkoServiceIT @Autowired constructor(
         val trackNumber = getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.insert(
             trackNumber(
-                trackNumber, description = "augh", externalId = Oid("1.2.3.4.5")
+                trackNumber,
+                description = "augh",
+                externalId = Oid("1.2.3.4.5"),
+                draft = false,
             )
         ).id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
         val locationTrackOriginalVersion = locationTrackService.saveDraft(
             locationTrack(
-                trackNumberId, name = "abcde", description = "cdefg", type = LocationTrackType.CHORD, externalId = null
-            ), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
+                trackNumberId,
+                name = "abcde",
+                description = "cdefg",
+                type = LocationTrackType.CHORD,
+                externalId = null,
+                draft = true,
+            ),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         ).rowVersion
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(locationTracks = listOf(locationTrackOriginalVersion))
@@ -221,15 +245,24 @@ class RatkoServiceIT @Autowired constructor(
         val trackNumber = getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.insert(
             trackNumber(
-                trackNumber, description = "augh", externalId = Oid("1.2.3.4.5")
+                trackNumber,
+                description = "augh",
+                externalId = Oid("1.2.3.4.5"),
+                draft = false,
             )
         ).id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
         val locationTrackOriginalVersion = locationTrackService.saveDraft(
             locationTrack(
-                trackNumberId, name = "abcde", description = "cdefg", type = LocationTrackType.CHORD, externalId = null
-            ), alignment(segment(Point(4.0, 0.0), Point(6.0, 0.0)))
+                trackNumberId,
+                name = "abcde",
+                description = "cdefg",
+                type = LocationTrackType.CHORD,
+                externalId = null,
+                draft = true,
+            ),
+            alignment(segment(Point(4.0, 0.0), Point(6.0, 0.0))),
         ).rowVersion
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(locationTracks = listOf(locationTrackOriginalVersion))
@@ -254,14 +287,22 @@ class RatkoServiceIT @Autowired constructor(
         val trackNumber = getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.insert(
             trackNumber(
-                trackNumber, description = "augh", externalId = Oid("1.2.3.4.5")
+                trackNumber,
+                description = "augh",
+                externalId = Oid("1.2.3.4.5"),
+                draft = false,
             )
         ).id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
         val locationTrackOriginalVersion = locationTrackService.saveDraft(
             locationTrack(
-                trackNumberId, name = "abcde", description = "cdefg", type = LocationTrackType.CHORD, externalId = null
+                trackNumberId,
+                name = "abcde",
+                description = "cdefg",
+                type = LocationTrackType.CHORD,
+                externalId = null,
+                draft = true,
             ), alignment(segment(Point(2.0, 0.0), Point(8.0, 0.0)))
         ).rowVersion
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
@@ -287,14 +328,22 @@ class RatkoServiceIT @Autowired constructor(
         val trackNumber = getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.insert(
             trackNumber(
-                trackNumber, description = "augh", externalId = Oid("1.2.3.4.5")
+                trackNumber,
+                description = "augh",
+                externalId = Oid("1.2.3.4.5"),
+                draft = false,
             )
         ).id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
         val locationTrackOriginalVersion = locationTrackService.saveDraft(
             locationTrack(
-                trackNumberId, name = "abcde", description = "cdefg", type = LocationTrackType.CHORD, externalId = null
+                trackNumberId,
+                name = "abcde",
+                description = "cdefg",
+                type = LocationTrackType.CHORD,
+                externalId = null,
+                draft = true,
             ), alignment(segment(Point(0.0, 0.0), Point(1.0, 0.0), Point(5.0, 3.0), Point(9.0, 0.0), Point(10.0, 0.0)))
         ).rowVersion
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
@@ -326,7 +375,10 @@ class RatkoServiceIT @Autowired constructor(
         val trackNumber = getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.insert(
             trackNumber(
-                trackNumber, description = "augh", externalId = Oid("1.2.3.4.5")
+                trackNumber,
+                description = "augh",
+                externalId = Oid("1.2.3.4.5"),
+                draft = false,
             )
         ).id
         insertSomeOfficialReferenceLineFor(trackNumberId)
@@ -349,7 +401,12 @@ class RatkoServiceIT @Autowired constructor(
 
         val locationTrack = locationTrackService.saveDraft(
             locationTrack(
-                trackNumberId, name = "abcde", description = "cdefg", type = LocationTrackType.CHORD, externalId = null
+                trackNumberId,
+                name = "abcde",
+                description = "cdefg",
+                type = LocationTrackType.CHORD,
+                externalId = null,
+                draft = true,
             ), alignment(segment(Point(2.0, 0.0), Point(8.0, 0.0)).copy(sourceId = plan.alignments[0].elements[0].id))
         ).rowVersion
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
@@ -370,10 +427,14 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun pushTwoTrackNumbers() {
         val trackNumber1 = getUnusedTrackNumber()
-        val trackNumber1Version = trackNumberService.saveDraft(trackNumber(trackNumber1, externalId = null))
+        val trackNumber1Version = trackNumberService.saveDraft(
+            trackNumber(trackNumber1, externalId = null, draft = true)
+        )
         insertSomeOfficialReferenceLineFor(trackNumber1Version.id)
         val trackNumber2 = getUnusedTrackNumber()
-        val trackNumber2Version = trackNumberService.saveDraft(trackNumber(trackNumber2, externalId = null))
+        val trackNumber2Version = trackNumberService.saveDraft(
+            trackNumber(trackNumber2, externalId = null, draft = true)
+        )
         insertSomeOfficialReferenceLineFor(trackNumber2Version.id)
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("2.3.4.5.6", "3.4.5.6.7"))
@@ -387,8 +448,9 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun lengthenReferenceLine() {
         val trackNumber = getUnusedTrackNumber()
-        val originalTrackNumberVersion =
-            layoutTrackNumberDao.insert(trackNumber(trackNumber, description = "augh", externalId = null)).rowVersion
+        val originalTrackNumberVersion = layoutTrackNumberDao.insert(
+            trackNumber(trackNumber, description = "augh", externalId = null, draft = false)
+        ).rowVersion
         val originalReferenceLineDaoResponse = insertSomeOfficialReferenceLineFor(originalTrackNumberVersion.id)
         val originalReferenceLine = referenceLineDao.fetch(originalReferenceLineDaoResponse.rowVersion)
 
@@ -409,10 +471,11 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun shortenReferenceLine() {
         val trackNumber = getUnusedTrackNumber()
-        val originalTrackNumberVersion =
-            trackNumberService.saveDraft(trackNumber(trackNumber, description = "augh", externalId = null)).rowVersion
+        val originalTrackNumberVersion = trackNumberService.saveDraft(
+            trackNumber(trackNumber, description = "augh", externalId = null, draft = true)
+        ).rowVersion
         val originalReferenceLineDaoResponse = referenceLineService.saveDraft(
-            referenceLine(originalTrackNumberVersion.id), alignment(
+            referenceLine(originalTrackNumberVersion.id, draft = true), alignment(
                 segment(
                     Point(0.0, 0.0), Point(10.0, 0.0)
                 )
@@ -450,10 +513,11 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun changeReferenceLineGeometry() {
         val trackNumber = getUnusedTrackNumber()
-        val originalTrackNumberVersion =
-            trackNumberService.saveDraft(trackNumber(trackNumber, description = "augh", externalId = null)).rowVersion
+        val originalTrackNumberVersion = trackNumberService.saveDraft(
+            trackNumber(trackNumber, description = "augh", externalId = null, draft = true)
+        ).rowVersion
         val originalReferenceLineDaoResponse = referenceLineService.saveDraft(
-            referenceLine(originalTrackNumberVersion.id), alignment(
+            referenceLine(originalTrackNumberVersion.id, draft = true), alignment(
                 segment(
                     Point(0.0, 0.0),
                     Point(10.0, 0.0),
@@ -464,7 +528,7 @@ class RatkoServiceIT @Autowired constructor(
             )
         )
         val locationTrackDaoResponse = locationTrackService.saveDraft(
-            locationTrack(originalTrackNumberVersion.id, externalId = null),
+            locationTrack(originalTrackNumberVersion.id, externalId = null, draft = true),
             alignment(segment(Point(0.0, 0.0), Point(40.0, 0.0)))
         )
 
@@ -512,11 +576,15 @@ class RatkoServiceIT @Autowired constructor(
     fun removeKmPostBeforeSwitch() {
         val trackNumber = getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.insert(
-            trackNumber(trackNumber, description = "augh", externalId = Oid("1.1.1.1.1"))
+            trackNumber(trackNumber, description = "augh", externalId = Oid("1.1.1.1.1"), draft = false)
         ).rowVersion.id
         insertSomeOfficialReferenceLineFor(trackNumberId)
-        val kmPost1 = kmPostService.saveDraft(kmPost(trackNumberId, KmNumber(1), Point(2.0, 0.0)))
-        val kmPost2 = kmPostService.saveDraft(kmPost(trackNumberId, KmNumber(2), Point(4.0, 0.0)))
+        val kmPost1 = kmPostService.saveDraft(
+            kmPost(trackNumberId, KmNumber(1), Point(2.0, 0.0), draft = true)
+        )
+        val kmPost2 = kmPostService.saveDraft(
+            kmPost(trackNumberId, KmNumber(2), Point(4.0, 0.0), draft = true)
+        )
 
         val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumberId)
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
@@ -550,8 +618,12 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun removeLocationTrackWithSwitch() {
         val trackNumber = establishedTrackNumber()
-        val kmPost1 = kmPostService.saveDraft(kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0)))
-        val kmPost2 = kmPostService.saveDraft(kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0)))
+        val kmPost1 = kmPostService.saveDraft(
+            kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true)
+        )
+        val kmPost2 = kmPostService.saveDraft(
+            kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true)
+        )
 
         val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
@@ -584,8 +656,12 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun modifySwitchJointPositionAccuracy() {
         val trackNumber = establishedTrackNumber()
-        val kmPost1 = kmPostService.saveDraft(kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0)))
-        val kmPost2 = kmPostService.saveDraft(kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0)))
+        val kmPost1 = kmPostService.saveDraft(
+            kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true)
+        )
+        val kmPost2 = kmPostService.saveDraft(
+            kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true)
+        )
 
         val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
@@ -601,7 +677,13 @@ class RatkoServiceIT @Autowired constructor(
 
         val officialSwitchVersion = switchDao.fetchVersion(switch.id, PublishType.OFFICIAL)!!
         val officialSwitch = switchDao.fetch(officialSwitchVersion)
-        switchService.saveDraft(officialSwitch.copy(joints = officialSwitch.joints.map { j -> j.copy(locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED) }))
+        switchService.saveDraft(
+            officialSwitch.copy(
+                joints = officialSwitch.joints.map { j ->
+                    j.copy(locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED)
+                },
+            )
+        )
         publishAndPush(switches = listOf(officialSwitchVersion))
         val pushedSwitchGeoms = fakeRatko.getPushedSwitchGeometries("3.4.5.6.7")
         assertEquals(listOf("OFFICIALLY MEASURED GEODETICALLY", "OFFICIALLY MEASURED GEODETICALLY"),
@@ -661,16 +743,18 @@ class RatkoServiceIT @Autowired constructor(
         detachSwitchesFromTrack(branchingTrack.id)
 
         val differentThroughTrack = locationTrackService.saveDraft(
-            locationTrack(trackNumber.id, externalId = null), alignment(
+            locationTrack(trackNumber.id, externalId = null, draft = true),
+            alignment(
                 segment(Point(0.0, 10.0), Point(5.0, 10.0), switchId = switch.id, endJointNumber = JointNumber(1)),
                 segment(Point(5.0, 10.0), Point(10.0, 10.0), switchId = switch.id, startJointNumber = JointNumber(3)),
-            )
+            ),
         )
         val differentBranchingTrack = locationTrackService.saveDraft(
-            locationTrack(trackNumber.id, externalId = null), alignment(
+            locationTrack(trackNumber.id, externalId = null, draft = true),
+            alignment(
                 segment(Point(5.0, 10.0), Point(7.5, 10.5), switchId = switch.id, endJointNumber = JointNumber(3)),
                 segment(Point(7.5, 10.5), Point(10.0, 11.0), switchId = switch.id, startJointNumber = JointNumber(3))
-            )
+            ),
         )
         listOf("4.4.4.4.4", "5.5.5.5.5").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
         publishAndPush(locationTracks = listOf(differentThroughTrack.rowVersion, differentBranchingTrack.rowVersion))
@@ -692,8 +776,12 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun changeSwitchStateCategory() {
         val trackNumber = establishedTrackNumber()
-        val kmPost1 = kmPostService.saveDraft(kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0)))
-        val kmPost2 = kmPostService.saveDraft(kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0)))
+        val kmPost1 = kmPostService.saveDraft(
+            kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true)
+        )
+        val kmPost2 = kmPostService.saveDraft(
+            kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true)
+        )
 
         val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
@@ -721,24 +809,26 @@ class RatkoServiceIT @Autowired constructor(
     private fun setupDraftSwitchAndLocationTracks(trackNumberId: IntId<TrackLayoutTrackNumber>): Triple<DaoResponse<TrackLayoutSwitch>, DaoResponse<LocationTrack>, DaoResponse<LocationTrack>> {
         val switch = switchService.saveDraft(
             switch(
-                123, joints = listOf(
+                seed = 123,
+                joints = listOf(
                     switchJoint(124).copy(
                         number = JointNumber(1), locationAccuracy = LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY
                     ),
                     switchJoint(125).copy(
                         number = JointNumber(3), locationAccuracy = LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY
                     ),
-                )
+                ),
+                draft = true,
             )
         )
         val throughTrack = locationTrackService.saveDraft(
-            locationTrack(trackNumberId, externalId = null), alignment(
+            locationTrack(trackNumberId, externalId = null, draft = true), alignment(
                 segment(Point(0.0, 0.0), Point(5.0, 0.0), switchId = switch.id, endJointNumber = JointNumber(1)),
                 segment(Point(5.0, 0.0), Point(10.0, 0.0), switchId = switch.id, startJointNumber = JointNumber(3)),
             )
         )
         val branchingTrack = locationTrackService.saveDraft(
-            locationTrack(trackNumberId, externalId = null), alignment(
+            locationTrack(trackNumberId, externalId = null, draft = true), alignment(
                 segment(Point(5.0, 0.0), Point(7.5, 0.5), switchId = switch.id, endJointNumber = JointNumber(3)),
                 segment(Point(7.5, 0.5), Point(10.0, 1.0), switchId = switch.id, startJointNumber = JointNumber(3)),
             )
@@ -749,14 +839,18 @@ class RatkoServiceIT @Autowired constructor(
 
     @Test
     fun linkKmPost() {
-        val trackNumber = layoutTrackNumberDao.insert(trackNumber(getUnusedTrackNumber(), externalId = null))
+        val trackNumber = layoutTrackNumberDao.insert(
+            trackNumber(getUnusedTrackNumber(), externalId = null, draft = false)
+        )
         insertSomeOfficialReferenceLineFor(trackNumber.id)
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
         publishAndPush(trackNumbers = listOf(trackNumber.rowVersion))
         fakeRatko.hasRouteNumber(ratkoRouteNumber(id = "1.2.3.4.5"))
         val pushedPoints = fakeRatko.getCreatedRouteNumberPoints("1.2.3.4.5")
 
-        val kmPost = kmPostService.saveDraft(kmPost(trackNumber.id, KmNumber(1), Point(5.0, 0.0)))
+        val kmPost = kmPostService.saveDraft(
+            kmPost(trackNumber.id, KmNumber(1), Point(5.0, 0.0), draft = true)
+        )
         publishAndPush(kmPosts = listOf(kmPost.rowVersion))
         val deletions = fakeRatko.getRouteNumberPointDeletions("1.2.3.4.5")
         val updatedPoints = fakeRatko.getUpdatedRouteNumberPoints("1.2.3.4.5")
@@ -774,7 +868,8 @@ class RatkoServiceIT @Autowired constructor(
         trackNumberService.saveDraft(trackNumber.trackNumberObject.copy(state = LayoutState.DELETED))
 
         val originalLocationTrackVersion = locationTrackService.saveDraft(
-            locationTrack(trackNumber.id), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
+            locationTrack(trackNumber.id, draft = true),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         ).rowVersion
         val locationTrack = locationTrackDao.fetch(originalLocationTrackVersion)
         locationTrackService.saveDraft(locationTrack.copy(state = LayoutState.DELETED))
@@ -803,7 +898,7 @@ class RatkoServiceIT @Autowired constructor(
         val planAlignments = geometryDao.fetchPlan(planVersion).alignments
 
         val locationTrack = locationTrackService.saveDraft(
-            locationTrack(trackNumber.id, externalId = null), alignment(
+            locationTrack(trackNumber.id, externalId = null, draft = true), alignment(
                 segment(Point(0.0, 0.0), Point(5.0, 0.0), sourceId = planAlignments[0].elements[0].id),
                 segment(Point(5.0, 0.0), Point(5.6, 0.0), sourceId = planAlignments[1].elements[0].id),
             )
@@ -821,9 +916,9 @@ class RatkoServiceIT @Autowired constructor(
     private fun insertSomeOfficialReferenceLineFor(trackNumberId: IntId<TrackLayoutTrackNumber>): DaoResponse<ReferenceLine> {
         return insertOfficialReferenceLineFromPair(
             referenceLineAndAlignment(
-                trackNumberId, segment(
-                    Point(0.0, 0.0), Point(10.0, 0.0)
-                )
+                trackNumberId,
+                segment(Point(0.0, 0.0), Point(10.0, 0.0)),
+                draft = false,
             )
         )
     }
@@ -876,7 +971,9 @@ class RatkoServiceIT @Autowired constructor(
     private fun establishedTrackNumber(oidString: String = "1.1.1.1.1"): EstablishedTrackNumber {
         val oid = Oid<TrackLayoutTrackNumber>(oidString)
         val trackNumber = getUnusedTrackNumber()
-        val trackNumberDaoResponse = layoutTrackNumberDao.insert(trackNumber(trackNumber, externalId = oid))
+        val trackNumberDaoResponse = layoutTrackNumberDao.insert(
+            trackNumber(trackNumber, externalId = oid, draft = false)
+        )
         insertSomeOfficialReferenceLineFor(trackNumberDaoResponse.id)
         fakeRatko.hasRouteNumber(ratkoRouteNumber(oidString))
         return EstablishedTrackNumber(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -6,7 +6,6 @@ import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.PublicationDao
 import fi.fta.geoviite.infra.tracklayout.alignment
-import fi.fta.geoviite.infra.tracklayout.asMainDraft
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.segment
 import org.junit.jupiter.api.Test
@@ -30,11 +29,11 @@ class SplitDaoIT @Autowired constructor(
         val trackNumberId = insertOfficialTrackNumber()
         val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val sourceTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = false) to alignment
         )
 
         val targetTrack = insertLocationTrack(
-            asMainDraft(locationTrack(trackNumberId = trackNumberId)) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = true) to alignment
         )
 
         val relinkedSwitchId = insertUniqueSwitch().id
@@ -58,11 +57,11 @@ class SplitDaoIT @Autowired constructor(
         val trackNumberId = insertOfficialTrackNumber()
         val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val sourceTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = false) to alignment
         )
 
         val targetTrack = insertLocationTrack(
-            asMainDraft(locationTrack(trackNumberId = trackNumberId)) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = true) to alignment
         )
 
         val relinkedSwitchId = insertUniqueSwitch().id
@@ -91,15 +90,15 @@ class SplitDaoIT @Autowired constructor(
         val trackNumberId = insertOfficialTrackNumber()
         val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val sourceTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = false) to alignment
         )
 
         val targetTrack1 = insertLocationTrack(
-            asMainDraft(locationTrack(trackNumberId = trackNumberId)) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = true) to alignment
         )
 
         val targetTrack2 = insertLocationTrack(
-            asMainDraft(locationTrack(trackNumberId = trackNumberId)) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = true) to alignment
         )
 
         val relinkedSwitchId1 = insertUniqueSwitch().id
@@ -133,15 +132,15 @@ class SplitDaoIT @Autowired constructor(
         val trackNumberId = insertOfficialTrackNumber()
         val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val sourceTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = false) to alignment
         )
 
         val someDuplicateTrack = insertLocationTrack(
-            asMainDraft(locationTrack(trackNumberId = trackNumberId)) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = true) to alignment
         )
 
         val targetTrack1 = insertLocationTrack(
-            asMainDraft(locationTrack(trackNumberId = trackNumberId)) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = true) to alignment
         )
 
         val relinkedSwitchId = insertUniqueSwitch().id
@@ -165,11 +164,11 @@ class SplitDaoIT @Autowired constructor(
         val trackNumberId = insertOfficialTrackNumber()
         val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val sourceTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = false) to alignment
         )
 
         val targetTrack1 = insertLocationTrack(
-            asMainDraft(locationTrack(trackNumberId = trackNumberId)) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = true) to alignment
         )
 
         val relinkedSwitchId = insertUniqueSwitch().id
@@ -203,15 +202,15 @@ class SplitDaoIT @Autowired constructor(
         val trackNumberId = insertOfficialTrackNumber()
         val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val sourceTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = false) to alignment
         )
 
         val someDuplicateTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = false) to alignment
         )
 
         val targetTrack = insertLocationTrack(
-            asMainDraft(locationTrack(trackNumberId = trackNumberId)) to alignment
+            locationTrack(trackNumberId = trackNumberId, draft = true) to alignment
         )
 
         val relinkedSwitchId = insertUniqueSwitch().id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -50,7 +50,7 @@ class SplitServiceIT @Autowired constructor(
                 "track_number_version",
                 "segment_version",
                 "segment_geometry",
-            )
+            ),
         )
 
         deleteFromTables(
@@ -62,7 +62,7 @@ class SplitServiceIT @Autowired constructor(
                 "split_relinked_switch_version",
                 "split_target_location_track",
                 "split_Target_location_track_version",
-            )
+            ),
         )
     }
 
@@ -70,7 +70,9 @@ class SplitServiceIT @Autowired constructor(
     fun `location track split should work based on request`() {
         val switchStart = Point(0.0, 0.0)
         val structure = getYvStructure()
-        val switchId = insertSwitch(switchFromDbStructure(getUnusedSwitchName().toString(), switchStart, structure)).id
+        val switchId = insertSwitch(
+            switchFromDbStructure(getUnusedSwitchName().toString(), switchStart, structure, draft = false)
+        ).id
 
         // Some segments in the beginning
         val preSwitchSegments = listOf(
@@ -91,9 +93,9 @@ class SplitServiceIT @Autowired constructor(
         val alignment = alignment(preSwitchSegments + switchSegments + postSwitchSegments)
 
         val trackNumberId = insertOfficialTrackNumber()
-        insertReferenceLine(referenceLine(trackNumberId), alignment)
+        insertReferenceLine(referenceLine(trackNumberId, draft = false), alignment)
 
-        val trackId = insertLocationTrack(locationTrack(trackNumberId), alignment).id
+        val trackId = insertLocationTrack(locationTrack(trackNumberId, draft = false), alignment).id
 
         val request = SplitRequest(
             trackId,
@@ -147,7 +149,9 @@ class SplitServiceIT @Autowired constructor(
         val splitId = insertSplitWithTwoTracks()
         val split = splitDao.getOrThrow(splitId)
 
-        val foundSplits = splitService.findUnfinishedSplitsForLocationTracks(listOf(split.targetLocationTracks.first().locationTrackId))
+        val foundSplits = splitService.findUnfinishedSplitsForLocationTracks(
+            listOf(split.targetLocationTracks.first().locationTrackId)
+        )
 
         assertEquals(splitId, foundSplits.first().id)
     }
@@ -166,7 +170,7 @@ class SplitServiceIT @Autowired constructor(
     fun `Duplicate tracks should be reassigned to most overlapping tracks if left unused`() {
         val trackNumberId = insertOfficialTrackNumber()
         insertReferenceLine(
-            referenceLine(trackNumberId = trackNumberId),
+            referenceLine(trackNumberId = trackNumberId, draft = false),
             alignment(segment(Point(-1000.0, 0.0), Point(1000.0, 0.0))),
         )
 
@@ -184,7 +188,7 @@ class SplitServiceIT @Autowired constructor(
         ) = alignmentWithMultipleSwitches(switchStartPoints)
 
         val sourceTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId),
+            locationTrack(trackNumberId = trackNumberId, draft = false),
             alignment,
         )
 
@@ -194,6 +198,7 @@ class SplitServiceIT @Autowired constructor(
                     name = "Used duplicate between first and second switch",
                     trackNumberId = trackNumberId,
                     duplicateOf = sourceTrack.id,
+                    draft = false,
                 ),
                 alignment(segment(Point(100.0, 0.0), Point(200.0, 0.0))),
             ),
@@ -203,6 +208,7 @@ class SplitServiceIT @Autowired constructor(
                     name = "Unused dupe with full overlap",
                     trackNumberId = trackNumberId,
                     duplicateOf = sourceTrack.id,
+                    draft = false,
                 ),
                 alignment(segment(Point(250.0, 0.0), Point(275.0, 0.0))),
             ),
@@ -212,6 +218,7 @@ class SplitServiceIT @Autowired constructor(
                     name = "Unused dupe with partial overlap of two new tracks",
                     trackNumberId = trackNumberId,
                     duplicateOf = sourceTrack.id,
+                    draft = false,
                 ),
                 alignment(segment(Point(275.0, 0.0), Point(350.0, 0.0))),
             ),
@@ -221,6 +228,7 @@ class SplitServiceIT @Autowired constructor(
                     name = "Unused dupe with flipped partial overlap",
                     trackNumberId = trackNumberId,
                     duplicateOf = sourceTrack.id,
+                    draft = false,
                 ),
                 alignment(segment(Point(370.0, 0.0), Point(410.0, 0.0))),
             ),
@@ -231,12 +239,12 @@ class SplitServiceIT @Autowired constructor(
             listOf(
                 targetRequest(
                     null,
-                    "track start"
+                    "track start",
                 ),
                 targetRequest(
                     switchesAndSegments.switchIds[0],
                     "used dupe track between switch 0 and 1",
-                    duplicateTrackId = duplicateIds[0]
+                    duplicateTrackId = duplicateIds[0],
                 ),
                 targetRequest(
                     switchesAndSegments.switchIds[1],
@@ -267,18 +275,18 @@ class SplitServiceIT @Autowired constructor(
 
         assertEquals(
             splitResult.targetLocationTracks[2].locationTrackId,
-            unusedDuplicateFullyOverlappingNewTrack.duplicateOf
+            unusedDuplicateFullyOverlappingNewTrack.duplicateOf,
         )
 
         assertEquals(
             splitResult.targetLocationTracks[3].locationTrackId,
-            unusedDuplicatePartiallyOverlappingNewTrack.duplicateOf
+            unusedDuplicatePartiallyOverlappingNewTrack.duplicateOf,
         )
 
         assertEquals(
             // Same target location track index as above on purpose.
             splitResult.targetLocationTracks[3].locationTrackId,
-            unusedDuplicateWithFlippedPartialOverlap.duplicateOf
+            unusedDuplicateWithFlippedPartialOverlap.duplicateOf,
         )
     }
 
@@ -290,7 +298,7 @@ class SplitServiceIT @Autowired constructor(
     ): IntId<LocationTrack> {
         val alignment = alignment(segmentsFromSwitchStructure(start, switchId, structure, line))
         val trackNumberId = insertOfficialTrackNumber()
-        return insertLocationTrack(locationTrack(trackNumberId), alignment).id
+        return insertLocationTrack(locationTrack(trackNumberId, draft = false), alignment).id
     }
 
     private fun getYvStructure(): SwitchStructure =
@@ -299,17 +307,17 @@ class SplitServiceIT @Autowired constructor(
     private fun insertSplitWithTwoTracks(): IntId<Split> {
         val trackNumberId = insertOfficialTrackNumber()
         insertReferenceLine(
-            referenceLine(trackNumberId = trackNumberId),
+            referenceLine(trackNumberId = trackNumberId, draft = false),
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
         val sourceTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId),
+            locationTrack(trackNumberId = trackNumberId, draft = false),
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
         val endTrack = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId),
+            locationTrack(trackNumberId = trackNumberId, draft = false),
             alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
         )
 
@@ -341,8 +349,8 @@ class SplitServiceIT @Autowired constructor(
                 ),
                 segment(
                     Point(firstSwitchStart.x - 10.0, firstSwitchStart.y),
-                    Point(firstSwitchStart.x, firstSwitchStart.y)
-                )
+                    Point(firstSwitchStart.x, firstSwitchStart.y),
+                ),
             )
         }
 
@@ -354,7 +362,7 @@ class SplitServiceIT @Autowired constructor(
             startPoints.drop(1) + null
         ).fold(initialSwitchesAndSegments) { switchesAndSegments, (startPoint, nextStartPoint) ->
             val switchId = insertSwitch(
-                switchFromDbStructure(getUnusedSwitchName().toString(), startPoint, structure)
+                switchFromDbStructure(getUnusedSwitchName().toString(), startPoint, structure, draft = false)
             ).id
 
             val switchSegments = segmentsFromSwitchStructure(startPoint, switchId, structure, listOf(1, 5, 2))
@@ -369,11 +377,11 @@ class SplitServiceIT @Autowired constructor(
             val postSwitchSegments = nextStartPoint?.let { actualNextStartPoint ->
                 listOf(
                     segmentAfterSwitch,
-                    segment(pointAfterSwitch, actualNextStartPoint)
+                    segment(pointAfterSwitch, actualNextStartPoint),
                 )
             } ?: listOf(
                 segmentAfterSwitch,
-                segment(pointAfterSwitch, Point(pointAfterSwitch.x + 10.0, pointAfterSwitch.y))
+                segment(pointAfterSwitch, Point(pointAfterSwitch.x + 10.0, pointAfterSwitch.y)),
             )
 
             SwitchesAndSegments(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
@@ -14,7 +14,7 @@ class SplitTest {
 
     @Test
     fun `minimal location track split works`() {
-        val track = locationTrack(trackNumberId = IntId(123))
+        val track = locationTrack(trackNumberId = IntId(123), draft = false)
         val alignment = alignment(
             linearSegment(0..1, switchId = null, startJoint = null, endJoint = null),
             linearSegment(1..2, switchId = IntId(1), startJoint = 1, endJoint = 2),
@@ -32,12 +32,12 @@ class SplitTest {
 
     @Test
     fun `location track split works when overriding existing duplicate`() {
-        val track = locationTrack(trackNumberId = IntId(123))
+        val track = locationTrack(trackNumberId = IntId(123), draft = false)
         val alignment = alignment(
             linearSegment(0..1, switchId = null, startJoint = null, endJoint = null),
             linearSegment(1..2, switchId = IntId(1), startJoint = 1, endJoint = 2),
         )
-        val dupTrack = locationTrack(trackNumberId = IntId(123))
+        val dupTrack = locationTrack(trackNumberId = IntId(123), draft = false)
         // over-large duplicate, but the geometry should be overridden anyhow, so just make it different
         val dupAlignment = alignment(linearSegment(-1..5))
         val targets = listOf(
@@ -55,7 +55,7 @@ class SplitTest {
 
     @Test
     fun `complex location track split works`() {
-        val track = locationTrack(trackNumberId = IntId(123))
+        val track = locationTrack(trackNumberId = IntId(123), draft = false)
         val alignment = alignment(
             linearSegment(0..2, switchId = null, startJoint = null, endJoint = null),
             linearSegment(2..5, switchId = IntId(1), startJoint = 5, endJoint = 4),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
@@ -98,11 +98,21 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         val orphanAlignmentVersion = alignmentDao.insert(alignmentOrphan)
         val locationTrackAlignmentVersion = alignmentDao.insert(alignmentLocationTrack)
         locationTrackDao.insert(
-            locationTrack(trackNumberId, alignmentLocationTrack).copy(alignmentVersion = locationTrackAlignmentVersion)
+            locationTrack(
+                trackNumberId = trackNumberId,
+                alignment = alignmentLocationTrack,
+                alignmentVersion = locationTrackAlignmentVersion,
+                draft = false,
+            )
         )
         val referenceLineAlignmentVersion = alignmentDao.insert(alignmentReferenceLine)
         referenceLineDao.insert(
-            referenceLine(trackNumberId, alignmentReferenceLine).copy(alignmentVersion = referenceLineAlignmentVersion)
+            referenceLine(
+                trackNumberId = trackNumberId,
+                alignment = alignmentReferenceLine,
+                alignmentVersion = referenceLineAlignmentVersion,
+                draft = false,
+            )
         )
 
         val orphanAlignmentBeforeDelete = alignmentDao.fetch(orphanAlignmentVersion)
@@ -286,7 +296,7 @@ class LayoutAlignmentDaoIT @Autowired constructor(
             segment(points = points5, source = GeometrySource.PLAN, sourceId = geometryElement.id),
         )
         val version = alignmentDao.insert(alignment)
-        locationTrackDao.insert(locationTrack(trackNumberId, alignmentVersion = version))
+        locationTrackDao.insert(locationTrack(trackNumberId, alignmentVersion = version, draft = false))
 
         val profileInfo = alignmentDao.fetchProfileInfoForSegmentsInBoundingBox<LocationTrack>(
             PublishType.OFFICIAL, boundingBoxAroundPoints((points + points2 + points3 + points4 + points5).toList())

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
@@ -35,46 +35,6 @@ class LayoutContextDataIT @Autowired constructor(
     }
 
     @Test
-    fun tempReferenceLineDraftDoesntChangeId() {
-        val (track, _) = createReferenceLineAndAlignment(draft = false)
-        val draft = asMainDraft(track)
-        assertEquals(track.id, draft.id)
-        assertFalse(track.isDraft)
-        assertTrue(draft.isDraft)
-        assertEquals(draft.id, draft.contextData.rowId)
-    }
-
-    @Test
-    fun tempLocationTrackDraftDoesntChangeId() {
-        val (track, _) = createLocationTrackAndAlignment(draft = false)
-        val draft = asMainDraft(track)
-        assertEquals(track.id, draft.id)
-        assertFalse(track.isDraft)
-        assertTrue(draft.isDraft)
-        assertEquals(draft.id, draft.contextData.rowId)
-    }
-
-    @Test
-    fun tempSwitchDraftDoesntChangeId() {
-        val switch = switch(987, draft = false)
-        val draft = asMainDraft(switch)
-        assertEquals(switch.id, draft.id)
-        assertFalse(switch.isDraft)
-        assertTrue(draft.isDraft)
-        assertEquals(draft.id, draft.contextData.rowId)
-    }
-
-    @Test
-    fun tempKmPostDraftDoesntChangeId() {
-        val kmPost = kmPost(null, someKmNumber(), draft = false)
-        val draft = asMainDraft(kmPost)
-        assertEquals(kmPost.id, draft.id)
-        assertFalse(kmPost.isDraft)
-        assertTrue(draft.isDraft)
-        assertEquals(kmPost.id, draft.contextData.rowId)
-    }
-
-    @Test
     fun draftAndOfficialReferenceLinesAreFoundWithEachOthersIds() {
         val dbLineAndAlignment = insertAndVerifyLine(createReferenceLineAndAlignment(false))
         val dbDraft = insertAndVerifyLine(alterLine(createAndVerifyDraftLine(dbLineAndAlignment)))
@@ -124,7 +84,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun draftAndOfficialSwitchesAreFoundWithEachOthersIds() {
-        val dbSwitch = insertAndVerify(switch(123))
+        val dbSwitch = insertAndVerify(switch(123, draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbSwitch)))
         assertNotEquals(dbSwitch, dbDraft)
 
@@ -137,7 +97,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun draftAndOfficialKmPostsAreFoundWithEachOthersIds() {
-        val dbKmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber()))
+        val dbKmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber(), draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbKmPost)))
         assertNotEquals(dbKmPost, dbDraft)
 
@@ -174,7 +134,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun draftAndOfficialSwitchesHaveSameOfficialId() {
-        val dbSwitch = insertAndVerify(switch(123))
+        val dbSwitch = insertAndVerify(switch(123, draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbSwitch)))
 
         assertNotEquals(dbSwitch, dbDraft)
@@ -186,7 +146,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun draftAndOfficialKmPostsHaveSameOfficialId() {
-        val dbKmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber()))
+        val dbKmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber(), draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbKmPost)))
 
         assertNotEquals(dbKmPost, dbDraft)
@@ -228,7 +188,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun draftSwitchesAreIncludedInDraftListingsOnly() {
-        val dbSwitch = insertAndVerify(switch(456))
+        val dbSwitch = insertAndVerify(switch(456, draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbSwitch)))
 
         val officials = switchService.list(OFFICIAL)
@@ -243,7 +203,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun draftKmPostsAreIncludedInDraftListingsOnly() {
-        val dbKmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber()))
+        val dbKmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber(), draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbKmPost)))
 
         val officials = kmPostService.list(OFFICIAL)
@@ -280,7 +240,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun switchCanOnlyHaveOneDraft() {
-        val switch = insertAndVerify(switch(9))
+        val switch = insertAndVerify(switch(9, draft = false))
 
         val draft1 = asMainDraft(switch)
         val draft2 = asMainDraft(switch)
@@ -291,7 +251,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun kmPostCanOnlyHaveOneDraft() {
-        val kmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber()))
+        val kmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber(), draft = false))
 
         val draft1 = asMainDraft(kmPost)
         val draft2 = asMainDraft(kmPost)
@@ -302,7 +262,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun trackNumberCanOnlyHaveOneDraft() {
-        val trackNumber = insertAndVerify(trackNumber(getUnusedTrackNumber()))
+        val trackNumber = insertAndVerify(trackNumber(getUnusedTrackNumber(), draft = false))
 
         val draft1 = asMainDraft(trackNumber)
         val draft2 = asMainDraft(trackNumber)
@@ -313,7 +273,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun editStateOfNewDraftIsReturnedCorrectly() {
-        val draft = asMainDraft(kmPost(null, someKmNumber()))
+        val draft = kmPost(null, someKmNumber(), draft = true)
         assertEquals(draft.editState, EditState.CREATED)
         assertFalse(draft.isOfficial)
         assertTrue(draft.isDraft)
@@ -321,7 +281,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun editStateOfOfficialIsReturnedCorrectly() {
-        val official = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber()))
+        val official = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber(), draft = false))
         assertEquals(official.editState, EditState.UNEDITED)
         assertTrue(official.isOfficial)
         assertFalse(official.isDraft)
@@ -329,7 +289,7 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun editStateOfChangedDraftIsReturnedCorrectly() {
-        val edited = asMainDraft(insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber())))
+        val edited = asMainDraft(insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber(), draft = false)))
         assertEquals(edited.editState, EditState.EDITED)
         assertFalse(edited.isOfficial)
         assertTrue(edited.isDraft)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDaoIT.kt
@@ -31,18 +31,21 @@ class LayoutKmPostDaoIT @Autowired constructor(
             km = KmNumber(123),
             location = Point(123.4, 234.5),
             state = IN_USE,
+            draft = false,
         )
         val post2 = kmPost(
             trackNumberId = trackNumberId,
             km = KmNumber(125),
             location = Point(125.6, 236.7),
             state = NOT_IN_USE,
+            draft = false,
         )
         val post3 = kmPost(
             trackNumberId = trackNumberId,
             km = KmNumber(124),
             location = Point(124.5, 235.6),
             state = PLANNED,
+            draft = false,
         )
         insertAndVerify(post1)
         insertAndVerify(post2)
@@ -68,7 +71,7 @@ class LayoutKmPostDaoIT @Autowired constructor(
     @Test
     fun kmPostVersioningWorks() {
         val trackNumberId = insertOfficialTrackNumber()
-        val tempPost = kmPost(trackNumberId, KmNumber(1), Point(1.0, 1.0))
+        val tempPost = kmPost(trackNumberId, KmNumber(1), Point(1.0, 1.0), draft = false)
         val insertVersion = kmPostDao.insert(tempPost).rowVersion
         val inserted = kmPostDao.fetch(insertVersion)
         assertMatches(tempPost, inserted, contextMatch = false)
@@ -98,12 +101,12 @@ class LayoutKmPostDaoIT @Autowired constructor(
     @Test
     fun fetchVersionsForPublicationReturnsDraftsOnlyForPublishableSet() {
         val trackNumberId = insertOfficialTrackNumber()
-        val postOneOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(1)))
+        val postOneOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(1), draft = false))
         val postOneDraft = kmPostDao.insert(asMainDraft(kmPostDao.fetch(postOneOfficial.rowVersion)))
-        val postTwoOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(2)))
+        val postTwoOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(2), draft = false))
         kmPostDao.insert(asMainDraft(kmPostDao.fetch(postTwoOfficial.rowVersion)))
-        val postThreeOnlyDraft = kmPostDao.insert(asMainDraft(kmPost(trackNumberId, KmNumber(3))))
-        val postFourOnlyOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(4)))
+        val postThreeOnlyDraft = kmPostDao.insert(kmPost(trackNumberId, KmNumber(3), draft = true))
+        val postFourOnlyOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(4), draft = false))
 
         val versionsEmpty = kmPostDao.fetchVersionsForPublication(listOf(trackNumberId), listOf())[trackNumberId]!!
         val versionsOnlyOne = kmPostDao.fetchVersionsForPublication(listOf(trackNumberId), listOf(postOneOfficial.id))[trackNumberId]!!
@@ -219,8 +222,7 @@ class LayoutKmPostDaoIT @Autowired constructor(
         kmNumber: Int,
         state: LayoutState = IN_USE,
     ): DaoResponse<TrackLayoutKmPost> {
-        val post = kmPost(tnId, KmNumber(kmNumber))
-        return kmPostDao.insert(asMainDraft(post).copy(state = state))
+        return kmPostDao.insert(kmPost(tnId, KmNumber(kmNumber), state = state, draft = true))
     }
 
     private fun createDraftWithNewTrackNumber(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -34,6 +34,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                     trackNumberId = trackNumberId,
                     km = KmNumber(1),
                     location = Point(1.0, 1.0),
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -43,6 +44,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                     trackNumberId = trackNumberId,
                     km = KmNumber(2),
                     location = Point(2.0, 1.0),
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -52,6 +54,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                     trackNumberId = trackNumberId,
                     km = KmNumber(3),
                     location = null,
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -61,6 +64,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                 trackNumberId = insertOfficialTrackNumber(),
                 km = KmNumber(4),
                 location = null,
+                draft = false,
             )
         )
 
@@ -80,6 +84,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                     trackNumberId = trackNumberId,
                     km = KmNumber(1),
                     location = Point(1.0, 1.0),
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -97,6 +102,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                 trackNumberId = trackNumberId,
                 km = KmNumber(1),
                 location = Point(1.0, 1.0),
+                draft = false,
             )
         )
 
@@ -113,6 +119,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                     trackNumberId = trackNumber1Id,
                     km = KmNumber(1),
                     location = Point(1.0, 1.0),
+                    draft = false,
                 )
             ).rowVersion
         )
@@ -158,20 +165,20 @@ class LayoutKmPostServiceIT @Autowired constructor(
     fun kmPostLengthMatchesTrackNumberService() {
         val trackNumberId = insertDraftTrackNumber()
         referenceLineService.saveDraft(
-            referenceLine(trackNumberId), alignment(
+            referenceLine(trackNumberId, draft = true), alignment(
                 segment(
                     Point(0.0, 0.0), Point(0.0, 5.0), Point(1.0, 10.0), Point(3.0, 15.0), Point(4.0, 20.0)
                 )
             )
         )
         val kmPosts = listOf(
-            kmPost(trackNumberId, KmNumber(1), Point(0.0, 3.0)),
-            kmPost(trackNumberId, KmNumber(2), Point(0.0, 5.0)),
-            kmPost(trackNumberId, KmNumber(3), null),
-            kmPost(trackNumberId, KmNumber(4), Point(0.0, 6.0), state = LayoutState.NOT_IN_USE),
-            kmPost(trackNumberId, KmNumber(5), Point(0.0, 10.0), state = LayoutState.PLANNED),
-            kmPost(trackNumberId, KmNumber(6, "A"), Point(3.0, 14.0)),
-            kmPost(trackNumberId, KmNumber(6, "AA"), Point(6.0, 18.0)),
+            kmPost(trackNumberId, KmNumber(1), Point(0.0, 3.0), draft = true),
+            kmPost(trackNumberId, KmNumber(2), Point(0.0, 5.0), draft = true),
+            kmPost(trackNumberId, KmNumber(3), null, draft = true),
+            kmPost(trackNumberId, KmNumber(4), Point(0.0, 6.0), state = LayoutState.NOT_IN_USE, draft = true),
+            kmPost(trackNumberId, KmNumber(5), Point(0.0, 10.0), state = LayoutState.PLANNED, draft = true),
+            kmPost(trackNumberId, KmNumber(6, "A"), Point(3.0, 14.0), draft = true),
+            kmPost(trackNumberId, KmNumber(6, "AA"), Point(6.0, 18.0), draft = true),
         ).map(kmPostService::saveDraft).map(DaoResponse<TrackLayoutKmPost>::id)
         // drop(1) because the track number km lengths include the section before the first km post
         val expected = trackNumberService.getKmLengths(DRAFT, trackNumberId)!!.drop(1)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
@@ -40,15 +40,15 @@ class LayoutSwitchDaoIT @Autowired constructor(
             jdbc.update(deleteSql, mapOf("external_id" to oid))
         }
 
-        val switch1 = switch(5).copy(externalId = oid)
-        val switch2 = switch(6).copy(externalId = oid)
+        val switch1 = switch(5, externalId = oid.toString(), draft = false)
+        val switch2 = switch(6, externalId = oid.toString(), draft = false)
         switchDao.insert(switch1)
         assertThrows<DuplicateKeyException> { switchDao.insert(switch2) }
     }
 
     @Test
     fun switchesAreStoredAndLoadedOk() {
-        (1..10).map { seed -> switch(seed) }.forEach { switch ->
+        (1..10).map { seed -> switch(seed, draft = false) }.forEach { switch ->
             val rowVersion = switchDao.insert(switch).rowVersion
             assertMatches(switch, switchDao.fetch(rowVersion))
         }
@@ -56,7 +56,7 @@ class LayoutSwitchDaoIT @Autowired constructor(
 
     @Test
     fun switchVersioningWorks() {
-        val tempSwitch = switch(2, name = "TST001", joints = joints(3, 5))
+        val tempSwitch = switch(2, name = "TST001", joints = joints(3, 5), draft = false)
         val (insertId, insertVersion) = switchDao.insert(tempSwitch)
         val inserted = switchDao.fetch(insertVersion)
         assertMatches(tempSwitch, inserted)
@@ -85,7 +85,7 @@ class LayoutSwitchDaoIT @Autowired constructor(
 
     @Test
     fun shouldSuccessfullyDeleteDraftSwitches() {
-        val draftSwitch = asMainDraft(switch(0))
+        val draftSwitch = switch(0, draft = true)
         val (insertedId, insertedVersion) = switchDao.insert(draftSwitch)
         val insertedSwitch = switchDao.fetch(insertedVersion)
 
@@ -99,7 +99,7 @@ class LayoutSwitchDaoIT @Autowired constructor(
 
     @Test
     fun shouldThrowExceptionWhenDeletingNormalSwitch() {
-        val switch = switch(1)
+        val switch = switch(1, draft = false)
         val insertedSwitch = switchDao.insert(switch)
 
         assertThrows<DeletingFailureException> {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import java.time.Instant
-import kotlin.random.Random
 
 
 @ActiveProfiles("dev", "test")
@@ -42,76 +41,94 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun switchOwnerIsReturned() {
-        val dummyOwner = SwitchOwner(id = IntId(4), name = MetaDataName("Cinia"))
+        val owner = SwitchOwner(id = IntId(4), name = MetaDataName("Cinia"))
 
-        switchDao.insert(
-            generateDummySwitch().copy(
-                ownerId = dummyOwner.id
-            )
-        )
+        switchDao.insert(switch(ownerId = owner.id, draft = false))
 
-        assertEquals(dummyOwner, switchLibraryService.getSwitchOwners().first { o -> o.id == dummyOwner.id })
+        assertEquals(owner, switchLibraryService.getSwitchOwners().first { o -> o.id == owner.id })
     }
 
     @Test
     fun whenAddingSwitchShouldReturnIt() {
-        val dummySwitch = generateDummySwitch()
-        val id = switchDao.insert(dummySwitch).id
+        val switch = switch(draft = false)
+        val id = switchDao.insert(switch).id
 
-        assertEquals(dummySwitch.externalId, switchService.get(OFFICIAL, id)!!.externalId)
+        val fetched = switchService.get(OFFICIAL, id)!!
+        assertMatches(switch, fetched, contextMatch = false)
+        assertEquals(id, fetched.id)
     }
 
     @Test
     fun someSwitchesAreReturnedEvenWithoutParameters() {
-        switchDao.insert(generateDummySwitch())
+        switchDao.insert(switch(draft = false))
         assertTrue(switchService.list(OFFICIAL).isNotEmpty())
     }
 
     @Test
     fun switchIsReturnedByBoundingBox() {
-        val dummySwitch = generateDummySwitch()
-        switchDao.insert(dummySwitch)
+        val switch = switch(
+            joints = listOf(
+                switchJoint(1, Point(428423.66891764296, 7210292.096537605)),
+                switchJoint(5, Point(428412.6499928745, 7210278.867815434)),
+            ),
+            draft = false,
+        )
+        val id = switchDao.insert(switch).id
 
         val bbox = BoundingBox(428125.0..428906.25, 7210156.25..7210937.5)
         val switches = getSwitches(switchFilter(bbox = bbox))
 
         assertTrue(switches.isNotEmpty())
-        assertTrue(switches.any { s -> s.externalId == dummySwitch.externalId })
+        assertTrue(switches.any { s -> s.id == id })
     }
 
     @Test
     fun switchOutsideBoundingBoxIsNotReturned() {
-        val oid = Oid<TrackLayoutSwitch>(generateDummyExternalId())
+        val switchOutsideBoundingBox = switch(
+            joints = listOf(
+                switchJoint(1, Point(428423.66891764296, 7210292.096537605)),
+                switchJoint(5, Point(428412.6499928745, 7210278.867815434)),
+            ),
+            draft = false,
+        )
 
-        val switchOutsideBoundingBox = generateDummySwitch()
-
-        switchDao.insert(switchOutsideBoundingBox)
+        val id = switchDao.insert(switchOutsideBoundingBox).id
 
         val bbox = BoundingBox(428125.0..431250.0, 7196875.0..7200000.0)
         val switches = getSwitches(switchFilter(bbox = bbox))
 
-        assertFalse(switches.any { s -> s.externalId == oid })
+        assertFalse(switches.any { s -> s.id == id })
     }
 
     @Test
     fun switchIsReturnedByName() {
-        val dummySwitch = generateDummySwitch()
-        switchDao.insert(dummySwitch)
+        val name = getUnusedSwitchName()
+        val switch = switch(name = name.toString(), draft = false)
 
-        val switchesCompleteName = getSwitches(switchFilter(namePart = dummySwitch.name.toString()))
-        val switchesPartialName = getSwitches(switchFilter(namePart = dummySwitch.name.substring(2)))
+        val id = switchDao.insert(switch).id
+
+        val switchesCompleteName = getSwitches(switchFilter(namePart = name.toString()))
+        val switchesPartialName = getSwitches(switchFilter(namePart = name.substring(2)))
 
         assertTrue(switchesCompleteName.isNotEmpty())
         assertTrue(switchesPartialName.isNotEmpty())
         assertTrue(getSwitches().size >= switchesCompleteName.size)
-        assertTrue(switchesCompleteName.any { s -> s.externalId == dummySwitch.externalId })
-        assertTrue(switchesPartialName.any { s -> s.externalId == dummySwitch.externalId })
+        assertTrue(switchesCompleteName.any { s -> s.id == id })
+        assertTrue(switchesPartialName.any { s -> s.id == id })
     }
 
     @Test
     fun returnsOnlySwitchesThatAreNotDeleted() {
-        val inUseSwitch = generateDummySwitch().copy(stateCategory = LayoutStateCategory.EXISTING)
-        val deletedSwitch = generateDummySwitch().copy(stateCategory = LayoutStateCategory.NOT_EXISTING)
+        val inUseSwitch = switch(
+            name = getUnusedSwitchName().toString(),
+            stateCategory = LayoutStateCategory.EXISTING,
+            draft = false,
+        )
+        val deletedSwitch = switch(
+            name = getUnusedSwitchName().toString(),
+            stateCategory = LayoutStateCategory.NOT_EXISTING,
+            draft = false,
+        )
         val inUseSwitchId = switchDao.insert(inUseSwitch)
         val deletedSwitchId = switchDao.insert(deletedSwitch)
 
@@ -128,9 +145,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun numberOfSwitchesIsReturnedCorrectlyByGivenOffset() {
-        repeat(2) {
-            switchDao.insert(generateDummySwitch())
-        }
+        repeat(2) { switchDao.insert(switch(name = getUnusedSwitchName().toString(), draft = false)) }
         val switches = getSwitches()
 
         assertEquals(switches.size, getSwitches(switchFilter()).size)
@@ -142,9 +157,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun numberOfSwitchesIsReturnedCorrectlyByGivenLimit() {
-        repeat(2) {
-            switchDao.insert(generateDummySwitch())
-        }
+        repeat(2) { switchDao.insert(switch(name = getUnusedSwitchName().toString(), draft = false)) }
         val switches = getSwitches()
 
         assertEquals(switches.size, pageSwitches(switches, 0, null, null).items.size)
@@ -157,8 +170,19 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun switchWithNoJointsIsReturnedFirst() {
-        val idOfSwitchWithNoJoints = switchDao.insert(generateDummySwitch().copy(joints = listOf())).id
-        val idOfRandomSwitch = switchDao.insert(generateDummySwitch()).id
+        val idOfSwitchWithNoJoints = switchDao.insert(
+            switch(
+                name = getUnusedSwitchName().toString(),
+                joints = listOf(),
+                draft = false,
+            )
+        ).id
+        val idOfRandomSwitch = switchDao.insert(
+            switch(
+                name = getUnusedSwitchName().toString(),
+                draft = false,
+            )
+        ).id
 
         val switches = pageSwitches(getSwitches(), 0, null, Point(422222.2, 7222222.2)).items
 
@@ -172,10 +196,11 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun switchesAreSortedByComparisonPoint() {
-        val idOfRandomSwitch = switchDao.insert(generateDummySwitch()).id
+        val idOfRandomSwitch = switchDao.insert(switch(name = getUnusedSwitchName().toString(), draft = false)).id
 
         val idOfSwitchLocatedAtComparisonPoint = switchDao.insert(
-            generateDummySwitch().copy(
+            switch(
+                name = getUnusedSwitchName().toString(),
                 joints = listOf(
                     TrackLayoutSwitchJoint(
                         JointNumber(1),
@@ -187,6 +212,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
                         locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED
                     )
                 ),
+                draft = false,
             )
         ).id
 
@@ -203,21 +229,20 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun switchIsReturnedBySwitchType() {
-        val dummySwitch = generateDummySwitch()
-        val dummySwitchStructure = switchLibraryService.getSwitchStructure(dummySwitch.switchStructureId)
-        val typeName = dummySwitchStructure.type.typeName
+        val switch = switch(draft = false)
+        val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
+        val typeName = structure.type.typeName
 
-        switchDao.insert(dummySwitch)
+        switchDao.insert(switch)
 
         val switchesCompleteTypeName = getSwitches(switchFilter(switchType = typeName))
         val switchesPartialTypeName = getSwitches(switchFilter(switchType = typeName.substring(2)))
 
         assertTrue(switchesCompleteTypeName.isNotEmpty())
         assertTrue(switchesPartialTypeName.isNotEmpty())
-        assertTrue(switchesCompleteTypeName.any { s -> s.externalId == dummySwitch.externalId })
-        assertTrue(switchesPartialTypeName.any { s -> s.externalId == dummySwitch.externalId })
+        assertTrue(switchesCompleteTypeName.any { s -> s.externalId == switch.externalId })
+        assertTrue(switchesPartialTypeName.any { s -> s.externalId == switch.externalId })
     }
-
 
     @Test
     fun noSwitchesReturnedWithNonExistingTypeName() {
@@ -226,15 +251,13 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun returnsNullIfFetchingDraftOnlySwitchUsingOfficialFetch() {
-        val draftSwitch = switchService.saveDraft(generateDummySwitch())
-
+        val draftSwitch = switchService.saveDraft(switch(draft = true))
         assertNull(switchService.get(OFFICIAL, draftSwitch.id))
     }
 
     @Test
     fun throwsIfFetchingOfficialVersionOfDraftOnlySwitchUsingGetOrThrow() {
-        val draftSwitch = switchService.saveDraft(generateDummySwitch())
-
+        val draftSwitch = switchService.saveDraft(switch(draft = true))
         assertThrows<NoSuchEntityException> { switchService.getOrThrow(OFFICIAL, draftSwitch.id) }
     }
 
@@ -242,19 +265,19 @@ class LayoutSwitchServiceIT @Autowired constructor(
     fun switchConnectedLocationTracksFound() {
         val trackNumber = getOrCreateTrackNumber(TrackNumber("123"))
         val tnId = trackNumber.id as IntId
-        val switch = switchService.get(DRAFT, switchService.saveDraft(switch(1)).id)!!
-        val (_, withStartLink) = insert(
-            locationTrack(tnId, externalId = someOid()).copy(
+        val switch = switchService.get(DRAFT, switchService.saveDraft(switch(1, draft = true)).id)!!
+        val (_, withStartLink) = insertDraft(
+            locationTrack(tnId, externalId = someOid(), draft = true).copy(
                 topologyStartSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(1)),
             ), alignment(someSegment())
         )
-        val (_, withEndLink) = insert(
-            locationTrack(tnId, externalId = null).copy(
+        val (_, withEndLink) = insertDraft(
+            locationTrack(tnId, externalId = null, draft = true).copy(
                 topologyEndSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
             ), alignment(someSegment())
         )
-        val (_, withSegmentLink) = insert(
-            locationTrack(tnId, externalId = someOid()),
+        val (_, withSegmentLink) = insertDraft(
+            locationTrack(tnId, externalId = someOid(), draft = true),
             alignment(
                 someSegment().copy(
                     switchId = switch.id as IntId,
@@ -283,7 +306,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
     fun shouldReturnLocationTracksThatAreLinkedToSwitchAtMoment() {
         val trackNumber = getOrCreateTrackNumber(TrackNumber("123"))
         val trackNumberId = trackNumber.id as IntId
-        val switch = switchDao.fetch(switchDao.insert(switch(1)).rowVersion)
+        val switch = switchDao.fetch(switchDao.insert(switch(1, draft = false)).rowVersion)
 
         val locationTrack1Oid = someOid<LocationTrack>()
         val alignment1Version = alignmentDao.insert(alignment(someSegment()))
@@ -294,6 +317,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
                 externalId = locationTrack1Oid,
                 alignmentVersion = alignment1Version,
                 name = "LT 1",
+                draft = false,
             ).copy(
                 topologyStartSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(1)),
             )
@@ -306,6 +330,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
                 trackNumberId = trackNumberId,
                 alignmentVersion = alignment2Version,
                 name = "LT 2",
+                draft = false,
             ).copy(
                 topologyEndSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
             )
@@ -329,6 +354,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
                 externalId = locationTrack3Oid,
                 alignmentVersion = alignment3Version,
                 name = "LT 3",
+                draft = false,
             ).copy(
                 topologyEndSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
             )
@@ -362,11 +388,11 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun getSwitchLinksTopologicalConnections() {
-        val switch = switch(123, IntId(1))
+        val switch = switch(123, IntId(1), draft = false)
         val switchVersion = switchDao.insert(switch)
         val joint1Point = switch.getJoint(JointNumber(1))!!.location
         val (locationTrack, alignment) = locationTrackAndAlignment(
-            getUnusedTrackNumberId(), segment(joint1Point - 1.0, joint1Point)
+            getUnusedTrackNumberId(), segment(joint1Point - 1.0, joint1Point), draft = true
         )
         val locationTrackVersion = locationTrackService.saveDraft(
             locationTrack.copy(topologyEndSwitch = TopologyLocationTrackSwitch(switchVersion.id, JointNumber(1))),
@@ -399,46 +425,12 @@ class LayoutSwitchServiceIT @Autowired constructor(
         assertEquals(switch.switchStructureId, fetchedSwitch.switchStructureId)
     }
 
-    private fun insert(
+    private fun insertDraft(
         locationTrack: LocationTrack,
         alignment: LayoutAlignment,
     ): Pair<LocationTrack, LocationTrackIdentifiers> {
         val (id, version) = locationTrackService.saveDraft(locationTrack, alignment)
         return locationTrackService.get(DRAFT, id)!! to LocationTrackIdentifiers(version, locationTrack.externalId)
-    }
-
-    private fun generateDummyExternalId(): String {
-        val first = Random.nextInt(10, 999999999)
-        val second = Random.nextInt(10, 999999999)
-        val third = Random.nextInt(10, 999999999)
-
-        return "$first.$second.$third"
-    }
-
-    private var dummySwitchNameSequence = 0
-    private fun generateDummySwitch(): TrackLayoutSwitch {
-        return TrackLayoutSwitch(
-            name = SwitchName("ABC123 ${dummySwitchNameSequence++}"),
-            switchStructureId = switchStructureYV60_300_1_9().id as IntId,
-            stateCategory = LayoutStateCategory.EXISTING,
-            joints = listOf(
-                TrackLayoutSwitchJoint(
-                    number = JointNumber(1),
-                    location = Point(428423.66891764296, 7210292.096537605),
-                    locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED
-                ), TrackLayoutSwitchJoint(
-                    number = JointNumber(5),
-                    location = Point(428412.6499928745, 7210278.867815434),
-                    locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED
-                )
-            ),
-            externalId = Oid(generateDummyExternalId()),
-            sourceId = null,
-            trapPoint = true,
-            ownerId = switchOwnerVayla().id,
-            source = GeometrySource.GENERATED,
-            contextData = LayoutContextData.newOfficial(),
-        )
     }
 
     private fun getSwitches(filter: (Pair<TrackLayoutSwitch, SwitchStructure>) -> Boolean): List<TrackLayoutSwitch> =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDaoIT.kt
@@ -52,15 +52,15 @@ class LayoutTrackNumberDaoIT @Autowired constructor(
             jdbc.update(deleteSql, mapOf("external_id" to oid))
         }
 
-        val tn1 = trackNumber(getUnusedTrackNumber()).copy(externalId = oid)
-        val tn2 = trackNumber(getUnusedTrackNumber()).copy(externalId = oid)
+        val tn1 = trackNumber(getUnusedTrackNumber(), externalId = oid, draft = false)
+        val tn2 = trackNumber(getUnusedTrackNumber(), externalId = oid, draft = false)
         trackNumberDao.insert(tn1)
         assertThrows<DuplicateKeyException> { trackNumberDao.insert(tn2) }
     }
 
     @Test
     fun trackNumberVersioningWorks() {
-        val tempTrackNumber = trackNumber(getUnusedTrackNumber(), description = "test 1")
+        val tempTrackNumber = trackNumber(getUnusedTrackNumber(), description = "test 1", draft = false)
         val (id, insertVersion) = trackNumberDao.insert(tempTrackNumber)
         val inserted = trackNumberDao.fetch(insertVersion)
         assertMatches(tempTrackNumber, inserted, contextMatch = false)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -86,7 +86,9 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
 
     @Test
     fun `should return correct lengths for km posts`() {
-        val trackNumber = trackNumberDao.fetch(trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).rowVersion)
+        val trackNumber = trackNumberDao.fetch(
+            trackNumberDao.insert(trackNumber(getUnusedTrackNumber(), draft = false)).rowVersion
+        )
         referenceLineAndAlignment(
             trackNumberId = trackNumber.id as IntId, segments = listOf(
                 segment(
@@ -96,7 +98,9 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
                     Point(3.0, 0.0),
                     Point(4.0, 0.0),
                 )
-            ), startAddress = TrackMeter(KmNumber(1), BigDecimal(0.5))
+            ),
+            startAddress = TrackMeter(KmNumber(1), BigDecimal(0.5)),
+            draft = false,
         ).let { (referenceLine, alignment) ->
             val referenceLineVersion =
                 referenceLineDao.insert(referenceLine.copy(alignmentVersion = alignmentDao.insert(alignment)))
@@ -104,8 +108,18 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
         }
 
         listOf(
-            kmPost(trackNumberId = trackNumber.id as IntId, km = KmNumber(2), location = Point(1.0, 0.0)),
-            kmPost(trackNumberId = trackNumber.id as IntId, km = KmNumber(3), location = Point(3.0, 0.0))
+            kmPost(
+                trackNumberId = trackNumber.id as IntId,
+                km = KmNumber(2),
+                location = Point(1.0, 0.0),
+                draft = false,
+            ),
+            kmPost(
+                trackNumberId = trackNumber.id as IntId,
+                km = KmNumber(3),
+                location = Point(3.0, 0.0),
+                draft = false,
+            ),
         ).map(kmPostDao::insert)
 
         val kmLengths = trackNumberService.getKmLengths(OFFICIAL, trackNumber.id as IntId)
@@ -148,7 +162,9 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
 
     @Test
     fun `should ignore km posts without location when calculating lengths lengths between km posts`() {
-        val trackNumber = trackNumberDao.fetch(trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).rowVersion)
+        val trackNumber = trackNumberDao.fetch(
+            trackNumberDao.insert(trackNumber(getUnusedTrackNumber(), draft = false)).rowVersion
+        )
 
         referenceLineAndAlignment(
             trackNumberId = trackNumber.id as IntId,
@@ -161,7 +177,8 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
                     Point(4.0, 0.0),
                 )
             ),
-            startAddress = TrackMeter(KmNumber(1), BigDecimal(0.5))
+            startAddress = TrackMeter(KmNumber(1), BigDecimal(0.5)),
+            draft = false,
         ).let { (referenceLine, alignment) ->
             val referenceLineVersion = referenceLineDao
                 .insert(referenceLine.copy(alignmentVersion = alignmentDao.insert(alignment)))
@@ -173,13 +190,15 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
             kmPost(
                 trackNumberId = trackNumber.id as IntId,
                 km = KmNumber(2),
-                location = Point(1.0, 0.0)
+                location = Point(1.0, 0.0),
+                draft = false,
             ),
             kmPost(
                 trackNumberId = trackNumber.id as IntId,
                 km = KmNumber(3),
-                location = null
-            )
+                location = null,
+                draft = false,
+            ),
         ).map(kmPostDao::insert)
 
         val kmLengths = trackNumberService.getKmLengths(OFFICIAL, trackNumber.id as IntId)
@@ -195,7 +214,7 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
                 locationSource = GeometrySource.GENERATED,
                 location = Point(0.0, 0.0)
             ),
-            kmLengths.first()
+            kmLengths.first(),
         )
 
         assertEquals(
@@ -206,7 +225,8 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
                 endM = BigDecimal(4).setScale(3),
                 locationSource = GeometrySource.IMPORTED,
                 location = Point(1.0, 0.0)
-            ), kmLengths.last()
+            ),
+            kmLengths.last(),
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
@@ -35,7 +35,7 @@ class LocationTrackDaoIT @Autowired constructor(
     fun locationTrackSaveAndLoadWorks() {
         val alignment = alignment()
         val alignmentVersion = alignmentDao.insert(alignment)
-        val locationTrack = locationTrack(insertOfficialTrackNumber(), alignment).copy(
+        val locationTrack = locationTrack(insertOfficialTrackNumber(), alignment, draft = false).copy(
             name = AlignmentName("ORIG"),
             descriptionBase = FreeText("Oridinal location track"),
             type = MAIN,
@@ -79,9 +79,19 @@ class LocationTrackDaoIT @Autowired constructor(
 
         val trackNumberId = insertOfficialTrackNumber()
         val alignmentVersion1 = alignmentDao.insert(alignment())
-        val locationTrack1 = locationTrack(trackNumberId).copy(externalId = oid, alignmentVersion = alignmentVersion1)
+        val locationTrack1 = locationTrack(
+            trackNumberId = trackNumberId,
+            externalId = oid,
+            alignmentVersion = alignmentVersion1,
+            draft = false,
+        )
         val alignmentVersion2 = alignmentDao.insert(alignment())
-        val locationTrack2 = locationTrack(trackNumberId).copy(externalId = oid, alignmentVersion = alignmentVersion2)
+        val locationTrack2 = locationTrack(
+            trackNumberId = trackNumberId,
+            externalId = oid,
+            alignmentVersion = alignmentVersion2,
+            draft = false,
+        )
 
         locationTrackDao.insert(locationTrack1)
         assertThrows<DuplicateKeyException> { locationTrackDao.insert(locationTrack2) }
@@ -97,6 +107,7 @@ class LocationTrackDaoIT @Autowired constructor(
             name = "test1",
             alignment = tempAlignment,
             alignmentVersion = alignmentVersion,
+            draft = false,
         )
         val (id, insertVersion) = locationTrackDao.insert(tempTrack)
         val inserted = locationTrackDao.fetch(insertVersion)
@@ -283,9 +294,13 @@ class LocationTrackDaoIT @Autowired constructor(
         tnId: IntId<TrackLayoutTrackNumber>,
         state: LayoutState = IN_USE,
     ): DaoResponse<LocationTrack> {
-        val (track, alignment) = locationTrackAndAlignment(tnId)
+        val (track, alignment) = locationTrackAndAlignment(
+            trackNumberId = tnId,
+            state = state,
+            draft = true,
+        )
         val alignmentVersion = alignmentDao.insert(alignment)
-        return locationTrackDao.insert(asMainDraft(track).copy(state = state, alignmentVersion = alignmentVersion))
+        return locationTrackDao.insert(track.copy(alignmentVersion = alignmentVersion))
     }
 
     private fun createDraftWithNewTrackNumber(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -23,7 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import kotlin.test.assertContains
 
-
 @ActiveProfiles("dev", "test")
 @SpringBootTest
 class LocationTrackServiceIT @Autowired constructor(
@@ -44,7 +43,7 @@ class LocationTrackServiceIT @Autowired constructor(
 
     @Test
     fun creatingAndDeletingUnpublishedTrackWithAlignmentWorks() {
-        val (track, alignment) = locationTrackAndAlignment(insertDraftTrackNumber(), someSegment())
+        val (track, alignment) = locationTrackAndAlignment(insertDraftTrackNumber(), someSegment(), draft = true)
         val (id, version) = locationTrackService.saveDraft(track, alignment)
         val (savedTrack, savedAlignment) = locationTrackService.getWithAlignment(version)
         assertTrue(alignmentExists(savedTrack.alignmentVersion!!.id))
@@ -56,7 +55,7 @@ class LocationTrackServiceIT @Autowired constructor(
 
     @Test
     fun deletingOfficialLocationTrackThrowsException() {
-        val (track, alignment) = locationTrackAndAlignment(insertOfficialTrackNumber(), someSegment())
+        val (track, alignment) = locationTrackAndAlignment(insertOfficialTrackNumber(), someSegment(), draft = true)
         val version = locationTrackService.saveDraft(track, alignment)
         publish(version.id)
         assertThrows<DeletingFailureException> { locationTrackService.deleteDraft(version.id) }
@@ -66,18 +65,22 @@ class LocationTrackServiceIT @Autowired constructor(
     fun nearbyLocationTracksAreFoundWithBbox() {
         val trackNumberId = insertDraftTrackNumber()
         val (trackInside, alignmentInside) = locationTrackAndAlignment(
-            trackNumberId, segment(
+            trackNumberId,
+            segment(
                 Point(x = 0.0, y = 0.0),
                 Point(x = 5.0, y = 0.0),
                 startM = 5.0,
-            )
+            ),
+            draft = true,
         )
         val (trackOutside, alignmentOutside) = locationTrackAndAlignment(
-            trackNumberId, segment(
+            trackNumberId,
+            segment(
                 Point(x = 20.0, y = 20.0),
                 Point(x = 30.0, y = 20.0),
                 startM = 10.0,
-            )
+            ),
+            draft = true,
         )
 
         val alignmentIdInBbox = locationTrackService.saveDraft(trackInside, alignmentInside).id
@@ -90,7 +93,6 @@ class LocationTrackServiceIT @Autowired constructor(
         assertTrue(tracksAndAlignments.any { (t, _) -> t.id == alignmentIdInBbox })
         assertTrue(tracksAndAlignments.none { (t, _) -> t.id == alignmentIdOutsideBbox })
     }
-
 
     @Test
     fun locationTrackInsertAndUpdateWorks() {
@@ -208,10 +210,11 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun updateTopologyFindsSwitchStartConnectionInTheMiddleOfAlignment() {
         val trackNumberId = getUnusedTrackNumberId()
-        val switchId = insertAndFetch(switch()).id as IntId
+        val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
+        val (_, _) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(
                 segment(Point(0.0, 0.0), Point(10.0, 0.0)),
                 segment(Point(10.0, 0.0), Point(20.0, 0.0)).copy(
                     switchId = switchId,
@@ -219,13 +222,12 @@ class LocationTrackServiceIT @Autowired constructor(
                     endJointNumber = JointNumber(2),
                 ),
                 segment(Point(20.0, 0.0), Point(30.0, 0.0)),
-            )
+            ),
         )
 
-        val (track, alignment) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
-                segment(Point(10.2, 0.0), Point(10.2, 20.2))
-            )
+        val (track, alignment) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(segment(Point(10.2, 0.0), Point(10.2, 20.2))),
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
@@ -237,10 +239,11 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun updateTopologyFindsSwitchEndConnectionInTheMiddleOfAlignment() {
         val trackNumberId = getUnusedTrackNumberId()
-        val switchId = insertAndFetch(switch()).id as IntId
+        val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
+        val (_, _) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(
                 segment(Point(0.0, 0.0), Point(10.0, 0.0)),
                 segment(Point(10.0, 0.0), Point(20.0, 0.0)).copy(
                     switchId = switchId,
@@ -248,13 +251,12 @@ class LocationTrackServiceIT @Autowired constructor(
                     endJointNumber = JointNumber(2),
                 ),
                 segment(Point(20.0, 0.0), Point(30.0, 0.0)),
-            )
+            ),
         )
 
-        val (track, alignment) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
-                segment(Point(20.2, -20.0), Point(20.2, 0.2))
-            )
+        val (track, alignment) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(segment(Point(20.2, -20.0), Point(20.2, 0.2))),
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
@@ -266,10 +268,11 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun updateTopologyDoesntFindSwitchConnectionForTrackCrossingOverSwitch() {
         val trackNumberId = getUnusedTrackNumberId()
-        val switchId = insertAndFetch(switch()).id as IntId
+        val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
+        val (_, _) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(
                 segment(Point(1000.0, 1000.0), Point(1010.0, 1000.0)),
                 segment(Point(1010.0, 1000.0), Point(1020.0, 1000.0)).copy(
                     switchId = switchId,
@@ -277,13 +280,12 @@ class LocationTrackServiceIT @Autowired constructor(
                     endJointNumber = JointNumber(2),
                 ),
                 segment(Point(1020.0, 1000.0), Point(1030.0, 1000.0)),
-            )
+            ),
         )
 
-        val (track, alignment) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
-                segment(Point(1010.0, 990.0), Point(1010.0, 1000.0), Point(1010.0, 1010.0))
-            )
+        val (track, alignment) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(segment(Point(1010.0, 990.0), Point(1010.0, 1000.0), Point(1010.0, 1010.0)))
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
@@ -295,10 +297,11 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun updateTopologyDoesntFindSwitchConnectionForTrackFartherAway() {
         val trackNumberId = getUnusedTrackNumberId()
-        val switchId = insertAndFetch(switch()).id as IntId
+        val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
+        val (_, _) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(
                 segment(Point(0.0, 0.0), Point(10.0, 0.0)),
                 segment(Point(10.0, 0.0), Point(20.0, 0.0)).copy(
                     switchId = switchId,
@@ -306,13 +309,12 @@ class LocationTrackServiceIT @Autowired constructor(
                     endJointNumber = JointNumber(2),
                 ),
                 segment(Point(20.0, 0.0), Point(30.0, 0.0)),
-            )
+            ),
         )
 
-        val (track, alignment) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
-                segment(Point(12.0, 0.0), Point(22.0, 0.0))
-            )
+        val (track, alignment) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(segment(Point(12.0, 0.0), Point(22.0, 0.0))),
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
@@ -324,21 +326,22 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun updateTopologyFindsSwitchConnectionFromOtherTopology() {
         val trackNumberId = getUnusedTrackNumberId()
-        val switchId1 = insertAndFetch(switch()).id as IntId
-        val switchId2 = insertAndFetch(switch()).id as IntId
+        val switchId1 = insertAndFetchDraft(switch(draft = true)).id as IntId
+        val switchId2 = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetch(
-            locationTrack(trackNumberId).copy(
+        val (_, _) = insertAndFetchDraft(
+            locationTrack(
+                trackNumberId = trackNumberId,
                 topologyStartSwitch = TopologyLocationTrackSwitch(switchId1, JointNumber(3)),
                 topologyEndSwitch = TopologyLocationTrackSwitch(switchId2, JointNumber(5)),
+                draft = true,
             ),
             alignment(segment(Point(2000.0, 2000.0), Point(2010.0, 2010.0))),
         )
 
-        val (track1, alignment1) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
-                segment(Point(2000.0, 2000.0), Point(2022.0, 2000.0))
-            )
+        val (track1, alignment1) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(segment(Point(2000.0, 2000.0), Point(2022.0, 2000.0))),
         )
         assertEquals(null, track1.topologyStartSwitch)
         assertEquals(null, track1.topologyEndSwitch)
@@ -347,10 +350,9 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack1.topologyStartSwitch)
         assertEquals(null, updatedTrack1.topologyEndSwitch)
 
-        val (track2, alignment2) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
-                segment(Point(2009.9, 2010.0), Point(1990.0, 1990.0))
-            )
+        val (track2, alignment2) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(segment(Point(2009.9, 2010.0), Point(1990.0, 1990.0))),
         )
         assertEquals(null, track2.topologyStartSwitch)
         assertEquals(null, track2.topologyEndSwitch)
@@ -359,10 +361,9 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack2.topologyStartSwitch)
         assertEquals(null, updatedTrack2.topologyEndSwitch)
 
-        val (track3, alignment3) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
-                segment(Point(1990.0, 1990.0), Point(1999.9, 2000.0))
-            )
+        val (track3, alignment3) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(segment(Point(1990.0, 1990.0), Point(1999.9, 2000.0))),
         )
         assertEquals(null, track3.topologyStartSwitch)
         assertEquals(null, track3.topologyEndSwitch)
@@ -371,10 +372,9 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, updatedTrack3.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack3.topologyEndSwitch)
 
-        val (track4, alignment4) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
-                segment(Point(2020.0, 2020.0), Point(2010.1, 2009.9))
-            )
+        val (track4, alignment4) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(segment(Point(2020.0, 2020.0), Point(2010.1, 2009.9))),
         )
         assertEquals(null, track4.topologyStartSwitch)
         assertEquals(null, track4.topologyEndSwitch)
@@ -387,13 +387,15 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun updateTopologyDoesntLoseCurrentConnectionIfNothingIsFound() {
         val trackNumberId = getUnusedTrackNumberId()
-        val switchId1 = insertAndFetch(switch()).id as IntId
-        val switchId2 = insertAndFetch(switch()).id as IntId
+        val switchId1 = insertAndFetchDraft(switch(draft = true)).id as IntId
+        val switchId2 = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (track, alignment) = insertAndFetch(
-            locationTrack(trackNumberId).copy(
+        val (track, alignment) = insertAndFetchDraft(
+            locationTrack(
+                trackNumberId = trackNumberId,
                 topologyStartSwitch = TopologyLocationTrackSwitch(switchId1, JointNumber(3)),
                 topologyEndSwitch = TopologyLocationTrackSwitch(switchId2, JointNumber(5)),
+                draft = true,
             ),
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
@@ -405,19 +407,20 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun updateTopologyFindsSwitchConnectionFromOtherTopologyEnd() {
         val trackNumberId = getUnusedTrackNumberId()
-        val switchId = insertAndFetch(switch()).id as IntId
+        val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetch(
-            locationTrack(trackNumberId).copy(
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(3))
+        val (_, _) = insertAndFetchDraft(
+            locationTrack(
+                trackNumberId = trackNumberId,
+                topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(3)),
+                draft = true,
             ),
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val (track, alignment) = insertAndFetch(
-            locationTrack(trackNumberId), alignment(
-                segment(Point(0.0, 0.0), Point(22.0, 0.0))
-            )
+        val (track, alignment) = insertAndFetchDraft(
+            locationTrack(trackNumberId, draft = true),
+            alignment(segment(Point(0.0, 0.0), Point(22.0, 0.0))),
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
@@ -429,14 +432,16 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun `getLocationTrackSwitches finds both topology and segment switches`() {
         val trackNumberId = getUnusedTrackNumberId()
-        val topologyStartSwitchId = insertAndFetch(switch()).id as IntId
-        val topologyEndSwitchId = insertAndFetch(switch()).id as IntId
-        val segmentSwitchId = insertAndFetch(switch()).id as IntId
+        val topologyStartSwitchId = insertAndFetchDraft(switch(draft = true)).id as IntId
+        val topologyEndSwitchId = insertAndFetchDraft(switch(draft = true)).id as IntId
+        val segmentSwitchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (track, _) = insertAndFetch(
-            locationTrack(trackNumberId).copy(
+        val (track, _) = insertAndFetchDraft(
+            locationTrack(
+                trackNumberId = trackNumberId,
                 topologyStartSwitch = TopologyLocationTrackSwitch(topologyStartSwitchId, JointNumber(3)),
                 topologyEndSwitch = TopologyLocationTrackSwitch(topologyEndSwitchId, JointNumber(5)),
+                draft = true,
             ),
             alignment(
                 segment(
@@ -444,7 +449,7 @@ class LocationTrackServiceIT @Autowired constructor(
                     Point(10.0, 0.0),
                     switchId = segmentSwitchId,
                     startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(2)
+                    endJointNumber = JointNumber(2),
                 )
             ),
         )
@@ -460,8 +465,9 @@ class LocationTrackServiceIT @Autowired constructor(
         val trackNumberId = getUnusedTrackNumberId()
         val originalLocationTrackId = locationTrackService.insert(saveRequest(trackNumberId, 1)).id
         publish(originalLocationTrackId)
-        val officialCopy = insertAndFetch(
-            locationTrack(getUnusedTrackNumberId()).copy(duplicateOf = originalLocationTrackId), alignment()
+        val officialCopy = insertAndFetchDraft(
+            locationTrack(getUnusedTrackNumberId(), duplicateOf = originalLocationTrackId, draft = true),
+            alignment(),
         )
         publish(officialCopy.first.id as IntId<LocationTrack>)
 
@@ -483,16 +489,24 @@ class LocationTrackServiceIT @Autowired constructor(
     fun fetchDuplicatesIsOrderedByTrackAddress() {
         val trackNumberId = getUnusedTrackNumberId()
         val fullAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(100.0, 0.0))))
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = fullAlignment))
+        referenceLineDao.insert(
+            referenceLine(trackNumberId, alignmentVersion = fullAlignment, draft = false)
+        )
 
-        val fullTrack = locationTrackDao.insert(locationTrack(trackNumberId, alignmentVersion = fullAlignment))
+        val fullTrack = locationTrackDao.insert(
+            locationTrack(trackNumberId, alignmentVersion = fullAlignment, draft = false)
+        )
 
         fun makeDuplicateAt(xCoord: Double, name: String) {
             val duplicateAlignment =
                 alignmentDao.insert(alignment(segment(Point(xCoord, 0.0), Point(xCoord + 10.0, 0.0))))
             locationTrackDao.insert(
                 locationTrack(
-                    trackNumberId, name = name, alignmentVersion = duplicateAlignment, duplicateOf = fullTrack.id
+                    trackNumberId,
+                    name = name,
+                    alignmentVersion = duplicateAlignment,
+                    duplicateOf = fullTrack.id,
+                    draft = false
                 )
             )
         }
@@ -510,35 +524,39 @@ class LocationTrackServiceIT @Autowired constructor(
     fun `Splitting initialization parameters are fetched properly`() {
         val trackNumberId = getUnusedTrackNumberId()
         val rlAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(100.0, 0.0))))
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = rlAlignment))
+        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = rlAlignment, draft = false))
 
-        val switch = insertAndFetch(
+        val switch = insertAndFetchDraft(
             switch(
                 joints = listOf(
                     TrackLayoutSwitchJoint(
                         JointNumber(1),
                         Point(100.0, 0.0),
-                        LocationAccuracy.DIGITIZED_AERIAL_IMAGE
+                        LocationAccuracy.DIGITIZED_AERIAL_IMAGE,
                     )
-                )
+                ),
+                draft = true,
             )
         ).id as IntId
         val locationTrack = locationTrackDao.insert(
             locationTrack(
-                trackNumberId,
+                trackNumberId = trackNumberId,
                 alignmentVersion = alignmentDao.insert(
                     alignment(
                         segment(
                             Point(50.0, 0.0),
                             Point(100.0, 0.0),
                             switchId = switch,
-                            startJointNumber = JointNumber(1)
+                            startJointNumber = JointNumber(1),
                         )
                     )
-                )
+                ),
+                draft = false,
             )
         )
-        val duplicateLocationTrack = locationTrackDao.insert(locationTrack(trackNumberId, alignmentVersion = rlAlignment, duplicateOf = locationTrack.id))
+        val duplicateLocationTrack = locationTrackDao.insert(
+            locationTrack(trackNumberId, alignmentVersion = rlAlignment, duplicateOf = locationTrack.id, draft = false)
+        )
 
         val splittingParams = locationTrackService.getSplittingInitializationParameters(locationTrack.id, DRAFT)
         assertNotNull(splittingParams)
@@ -550,12 +568,17 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(50.0, splittingParams?.switches?.first()?.distance ?: 0.0, 0.01)
     }
 
-    private fun asLocationTrackDuplicate(locationTrack: LocationTrack) =
-        LocationTrackDuplicate(locationTrack.id as IntId, locationTrack.trackNumberId, locationTrack.name, locationTrack.externalId)
+    private fun asLocationTrackDuplicate(locationTrack: LocationTrack): LocationTrackDuplicate = LocationTrackDuplicate(
+        locationTrack.id as IntId,
+        locationTrack.trackNumberId,
+        locationTrack.name,
+        locationTrack.externalId,
+    )
 
-    private fun insertAndFetch(switch: TrackLayoutSwitch) = switchDao.fetch(switchService.saveDraft(switch).rowVersion)
+    private fun insertAndFetchDraft(switch: TrackLayoutSwitch): TrackLayoutSwitch =
+        switchDao.fetch(switchService.saveDraft(switch).rowVersion)
 
-    private fun insertAndFetch(
+    private fun insertAndFetchDraft(
         locationTrack: LocationTrack,
         alignment: LayoutAlignment,
     ): Pair<LocationTrack, LayoutAlignment> =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDaoIT.kt
@@ -27,7 +27,7 @@ class ReferenceLineDaoIT @Autowired constructor(
         val trackNumberId = insertOfficialTrackNumber()
         val alignment = alignment()
         val alignmentVersion = alignmentDao.insert(alignment)
-        val referenceLine = referenceLine(trackNumberId, alignment).copy(
+        val referenceLine = referenceLine(trackNumberId, alignment, draft = false).copy(
             startAddress = TrackMeter(KmNumber(10), 125.5, 3),
             alignmentVersion = alignmentVersion,
         )
@@ -63,6 +63,7 @@ class ReferenceLineDaoIT @Autowired constructor(
             startAddress = TrackMeter(12, 13),
             alignment = tempAlignment,
             alignmentVersion = alignmentVersion,
+            draft = false,
         )
         val (id, insertVersion) = referenceLineDao.insert(tempTrack)
         val inserted = referenceLineDao.fetch(insertVersion)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
@@ -172,14 +172,16 @@ class ReferenceLineServiceIT @Autowired constructor(
 
     @Test
     fun `should throw exception when there are switches linked to reference line`() {
-        val trackNumberId = trackNumberDao.insert(trackNumber(getUnusedTrackNumber())).id
+        val trackNumberId = getUnusedTrackNumberId()
 
         val (referenceLine, alignment) = referenceLineAndAlignment(
-            trackNumberId = trackNumberId, segments = listOf(
+            trackNumberId = trackNumberId,
+            segments = listOf(
                 segment(
                     Point(0.0, 0.0), Point(1.0, 1.0), switchId = IntId(100), startJointNumber = JointNumber(1)
                 ),
-            )
+            ),
+            draft = false,
         )
 
         assertThrows<IllegalArgumentException> {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -100,6 +100,7 @@ fun locationTrack(
     basePoint: Point,
     incrementPoints: List<Point>,
     description: String = "$name location track description",
+    draft: Boolean,
 ): Pair<LocationTrack, LayoutAlignment> {
     val alignment = alignmentFromPointIncrementList(basePoint, incrementPoints)
     val track = locationTrack(
@@ -109,6 +110,7 @@ fun locationTrack(
         description = description,
         type = layoutAlignmentType,
         state = LayoutState.IN_USE,
+        draft = draft,
     )
     return track to alignment
 }
@@ -117,11 +119,13 @@ fun referenceLine(
     trackNumber: IntId<TrackLayoutTrackNumber>,
     basePoint: Point,
     incrementPoints: List<Point>,
+    draft: Boolean,
 ): Pair<ReferenceLine, LayoutAlignment> {
     val alignment = alignmentFromPointIncrementList(basePoint, incrementPoints)
     val line = referenceLine(
         trackNumberId = trackNumber,
         alignment = alignment,
+        draft = draft,
     )
     return line to alignment
 }
@@ -176,6 +180,7 @@ fun locationTrackAndAlignmentForGeometryAlignment(
     ykjToEtrsTriangulationNetwork: RTree<KkjTm35finTriangle, Rectangle>,
     etrsToYkjTriangulationNetwork: RTree<KkjTm35finTriangle, Rectangle>,
     planSrid: Srid = LAYOUT_SRID,
+    draft: Boolean,
 ): Pair<LocationTrack, LayoutAlignment> {
     val transformation = Transformation.possiblyTriangulableTransform(
         planSrid,
@@ -204,7 +209,7 @@ fun locationTrackAndAlignmentForGeometryAlignment(
             switchId = null,
         ).also { startM += it.length }
     }
-    return locationTrackAndAlignment(trackNumberId, segments)
+    return locationTrackAndAlignment(trackNumberId, segments, draft = draft)
 }
 
 fun createSwitchAndAlignments(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -22,15 +22,6 @@ import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.logger
 import java.math.BigDecimal
 
-fun createTrackLayoutTrackNumber(number: String, description: String = "description for $number") =
-    TrackLayoutTrackNumber(
-        number = TrackNumber(number),
-        description = FreeText(description),
-        state = LayoutState.IN_USE,
-        externalId = null,
-        contextData = LayoutContextData.newOfficial(),
-    )
-
 fun createGeometryKmPost(
     location: Point?,
     kmNumber: String,
@@ -43,15 +34,6 @@ fun createGeometryKmPost(
     description = PlanElementName("0"),
     state = PlanState.PROPOSED,
     location = location,
-)
-
-fun trackLayoutKmPost(kmNumber: String, trackNumberId: IntId<TrackLayoutTrackNumber>, point: Point) = TrackLayoutKmPost(
-    kmNumber = KmNumber(kmNumber),
-    location = point,
-    trackNumberId = trackNumberId,
-    sourceId = null,
-    state = LayoutState.IN_USE,
-    contextData = LayoutContextData.newOfficial(),
 )
 
 fun createGeometryAlignment(
@@ -320,7 +302,6 @@ fun getTransformedPoint(
     val jointPointOrig = structureJointsByNumber[number]!!.location
     return rotateAroundOrigin(switchAngle, jointPointOrig) + orig
 }
-
 
 data class SwitchJointData(
     val switchId: DomainId<GeometrySwitch>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.util.FreeText
 import java.math.BigDecimal
 import java.time.Instant
 
-class HelsinkiTestData {
+class HelsinkiTestData private constructor() {
     companion object {
         const val GEOMETRY_PLAN_NAME = "Helsinki test project"
         var WEST_LT_NAME = "lt-west"
@@ -84,6 +84,7 @@ class HelsinkiTestData {
                 trackNumber = trackNumber,
                 basePoint = HKI_BASE_POINT + Point(x = 675.0, y = 410.0),
                 incrementPoints = listOf(Point(x = 15.0, y = 90.0), Point(x = 5.0, y = 60.0)),
+                draft = false,
             )
         }
 
@@ -98,6 +99,7 @@ class HelsinkiTestData {
                 alignment = alignment,
                 trackNumberId = trackNumber,
                 startAddress = TrackMeter(KmNumber(2), 150),
+                draft = false,
             ) to alignment
         }
 
@@ -112,6 +114,7 @@ class HelsinkiTestData {
                 alignment = alignment,
                 trackNumberId = trackNumber,
                 startAddress = TrackMeter(KmNumber(2), 150),
+                draft = false,
             ) to alignment
         }
 
@@ -121,6 +124,7 @@ class HelsinkiTestData {
                 trackNumber = trackNumberId,
                 basePoint = HKI_BASE_POINT + Point(x = 752.0, y = 410.0),
                 incrementPoints = listOf(Point(x = 0.0, y = 150.0)),
+                draft = false,
             )
         }
 
@@ -134,7 +138,6 @@ class HelsinkiTestData {
                 trackLayoutKmPost("0002we", trackNumber, point2),
                 trackLayoutKmPost("0003we", trackNumber, point3)
             )
-
         }
 
         fun eastTrackLayoutKmPosts(trackNumberId: IntId<TrackLayoutTrackNumber>): List<TrackLayoutKmPost> {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
@@ -14,14 +14,14 @@ import java.time.Instant
 class HelsinkiTestData private constructor() {
     companion object {
         const val GEOMETRY_PLAN_NAME = "Helsinki test project"
-        var WEST_LT_NAME = "lt-west"
-        var EAST_LT_NAME = "lt-east"
+        val WEST_LT_NAME = AlignmentName("lt-west")
+        val EAST_LT_NAME = AlignmentName("lt-east")
 
         const val HKI_BASE_POINT_X = 385000.00
         const val HKI_BASE_POINT_Y = 6672000.00
 
-        const val HKI_TRACK_NUMBER_1 = "HKI1"
-        const val HKI_TRACK_NUMBER_2 = "HKI2"
+        val HKI_TRACK_NUMBER_1 = TrackNumber("HKI1")
+        val HKI_TRACK_NUMBER_2 = TrackNumber("HKI2")
 
         val HKI_BASE_POINT = Point(HKI_BASE_POINT_X, HKI_BASE_POINT_Y)
 
@@ -128,15 +128,15 @@ class HelsinkiTestData private constructor() {
             )
         }
 
-        fun westTrackLayoutKmPosts(trackNumber: IntId<TrackLayoutTrackNumber>): List<TrackLayoutKmPost> {
+        fun westTrackLayoutKmPosts(trackNumberId: IntId<TrackLayoutTrackNumber>): List<TrackLayoutKmPost> {
             val point1 = HKI_BASE_POINT + Point(x = 690.00, y = 410.00)
             val point2 = HKI_BASE_POINT + Point(x = 690.00, y = 485.00)
             val point3 = HKI_BASE_POINT + Point(x = 690.00, y = 560.00)
 
             return arrayListOf(
-                trackLayoutKmPost("0001we", trackNumber, point1),
-                trackLayoutKmPost("0002we", trackNumber, point2),
-                trackLayoutKmPost("0003we", trackNumber, point3)
+                kmPost(trackNumberId = trackNumberId, km = KmNumber("0001we"), location = point1, draft = false),
+                kmPost(trackNumberId = trackNumberId, km = KmNumber("0002we"), location = point2, draft = false),
+                kmPost(trackNumberId = trackNumberId, km = KmNumber("0003we"), location = point3, draft = false),
             )
         }
 
@@ -146,9 +146,9 @@ class HelsinkiTestData private constructor() {
             val point3 = HKI_BASE_POINT + Point(x = 752.00, y = 560.00)
 
             return arrayListOf(
-                trackLayoutKmPost("0001es", trackNumberId, point1),
-                trackLayoutKmPost("0002es", trackNumberId, point2),
-                trackLayoutKmPost("0003es", trackNumberId, point3)
+                kmPost(trackNumberId = trackNumberId, km = KmNumber("0001es"), location = point1, draft = false),
+                kmPost(trackNumberId = trackNumberId, km = KmNumber("0002es"), location = point2, draft = false),
+                kmPost(trackNumberId = trackNumberId, km = KmNumber("0003es"), location = point3, draft = false),
             )
         }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
@@ -20,14 +20,12 @@ import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData.Companion.westMainLoca
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData.Companion.westReferenceLine
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData.Companion.westTrackLayoutKmPosts
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData.Companion.westTrackLayoutSwitch
-import fi.fta.geoviite.infra.ui.testdata.createTrackLayoutTrackNumber
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
@@ -50,8 +48,8 @@ class BasicMapTestUI @Autowired constructor(
         clearAllTestData()
 
         // TODO: GVT-1945  Don't use shared test data - init the data in the test as is needed, so it's clear what is expected
-        TRACK_NUMBER_WEST = createTrackLayoutTrackNumber(HKI_TRACK_NUMBER_1)
-        val trackNumberEast = createTrackLayoutTrackNumber(HKI_TRACK_NUMBER_2)
+        TRACK_NUMBER_WEST = trackNumber(HKI_TRACK_NUMBER_1, draft = false)
+        val trackNumberEast = trackNumber(HKI_TRACK_NUMBER_2, draft = false)
         val trackNumberWestId = trackNumberDao.insert(TRACK_NUMBER_WEST)
         val trackNumberEastId = trackNumberDao.insert(trackNumberEast)
 
@@ -60,7 +58,6 @@ class BasicMapTestUI @Autowired constructor(
         WEST_REFERENCE_LINE = westReferenceLine(trackNumberWestId.id)
         val eastReferenceLine = eastReferenceLine(trackNumberEastId.id)
         val eastLocationTrack = eastLocationTrack(trackNumberEastId.id)
-
 
         insertLocationTrack(WEST_LT)
         insertLocationTrack(eastLocationTrack)
@@ -83,7 +80,7 @@ class BasicMapTestUI @Autowired constructor(
 
     @Test
     fun `Edit and discard location track changes`() {
-        val locationTrackToBeEdited = EAST_LT_NAME
+        val locationTrackToBeEdited = EAST_LT_NAME.toString()
         val trackLayoutPage = goToMap().switchToDraftMode()
         val selectionPanel = trackLayoutPage.selectionPanel
         val toolPanel = trackLayoutPage.toolPanel
@@ -136,7 +133,7 @@ class BasicMapTestUI @Autowired constructor(
 
     @Test
     fun `Edit and save location track changes`() {
-        val locationTrackToBeEdited = WEST_LT_NAME
+        val locationTrackToBeEdited = WEST_LT_NAME.toString()
         val trackLayoutPage = goToMap().switchToDraftMode()
         val selectionPanel = trackLayoutPage.selectionPanel
         val toolPanel = trackLayoutPage.toolPanel

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -12,7 +12,6 @@ import fi.fta.geoviite.infra.ratko.ratkoRouteNumber
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.frontpage.E2EFrontPage
-import fi.fta.geoviite.infra.ui.testdata.createTrackLayoutTrackNumber
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -41,7 +40,7 @@ class FrontPageTestUI @Autowired constructor(
     @Test
     fun `Retry failed publication`() {
         val originalTrackNumberVersion = trackNumberDao.insert(
-            createTrackLayoutTrackNumber("original name").copy(externalId = Oid("1.2.3.4.5"))
+            trackNumber(TrackNumber("original name"), externalId = Oid("1.2.3.4.5"), draft = false)
         ).rowVersion
         val trackNumberId = originalTrackNumberVersion.id
         val alignmentVersion = alignmentDao.insert(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -40,12 +40,14 @@ class FrontPageTestUI @Autowired constructor(
 
     @Test
     fun `Retry failed publication`() {
-        val originalTrackNumberVersion =
-            trackNumberDao.insert(createTrackLayoutTrackNumber("original name").copy(externalId = Oid("1.2.3.4.5"))).rowVersion
+        val originalTrackNumberVersion = trackNumberDao.insert(
+            createTrackLayoutTrackNumber("original name").copy(externalId = Oid("1.2.3.4.5"))
+        ).rowVersion
         val trackNumberId = originalTrackNumberVersion.id
-        val alignmentVersion =
-            alignmentDao.insert(alignment(segment(toSegmentPoints(Point(0.0, 0.0), Point(10.0, 0.0)))))
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = alignmentVersion))
+        val alignmentVersion = alignmentDao.insert(
+            alignment(segment(toSegmentPoints(Point(0.0, 0.0), Point(10.0, 0.0))))
+        )
+        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = alignmentVersion, draft = false))
 
         val successfulPublicationId = publicationDao.createPublication("successful")
         publicationDao.insertCalculatedChanges(successfulPublicationId, changesTouchingTrackNumber(trackNumberId))
@@ -100,7 +102,7 @@ class FrontPageTestUI @Autowired constructor(
                         trackNumberId,
                         changedKmNumbers = setOf(),
                         isStartChanged = false,
-                        isEndChanged = false
+                        isEndChanged = false,
                     )
                 ),
                 kmPostChanges = listOf(),
@@ -111,7 +113,7 @@ class FrontPageTestUI @Autowired constructor(
             IndirectChanges(
                 trackNumberChanges = listOf(),
                 switchChanges = listOf(),
-                locationTrackChanges = listOf()
-            )
+                locationTrackChanges = listOf(),
+            ),
         )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SearchTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SearchTestUI.kt
@@ -28,7 +28,14 @@ class SearchTestUI @Autowired constructor() : SeleniumTest() {
             "test-lt B3" to "test-desc-3",
         )
         ltNames.forEach { (name, desc) ->
-            locationTrackAndAlignment(trackNumberId = tnId, name = name, description = desc).let(::insertLocationTrack)
+            insertLocationTrack(
+                locationTrackAndAlignment(
+                    trackNumberId = tnId,
+                    name = name,
+                    description = desc,
+                    draft = false,
+                )
+            )
         }
 
         startGeoviite()
@@ -50,7 +57,8 @@ class SearchTestUI @Autowired constructor() : SeleniumTest() {
         val (track, alignment) = locationTrackAndAlignment(
             trackNumberId = trackNumber.id as IntId,
             name = "test-lt specific 001",
-            description = "specific track selection test track 001"
+            description = "specific track selection test track 001",
+            draft = false,
         )
         insertLocationTrack(track, alignment)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/GeometryElementListTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/GeometryElementListTestUI.kt
@@ -141,7 +141,12 @@ class GeometryElementListTestUI @Autowired constructor(
             )
         )
         locationTrackDao.insert(
-            locationTrack(trackNumberId, name = "foo test track").copy(alignmentVersion = locationTrackAlignment)
+            locationTrack(
+                trackNumberId = trackNumberId,
+                name = "foo test track",
+                alignmentVersion = locationTrackAlignment,
+                draft = false,
+            )
         )
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/GeometryElementListTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/GeometryElementListTestUI.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.ui.testgroup2
 
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
 import fi.fta.geoviite.infra.geography.CoordinateSystemName
 import fi.fta.geoviite.infra.geometry.*
@@ -9,7 +10,6 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.ui.LocalHostWebClient
 import fi.fta.geoviite.infra.ui.SeleniumTest
-import fi.fta.geoviite.infra.ui.testdata.createTrackLayoutTrackNumber
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -23,7 +23,6 @@ import kotlin.test.assertNotNull
 @SpringBootTest
 class GeometryElementListTestUI @Autowired constructor(
     private val geometryDao: GeometryDao,
-    private val trackNumberDao: LayoutTrackNumberDao,
     private val locationTrackDao: LocationTrackDao,
     private val alignmentDao: LayoutAlignmentDao,
     private val geometryService: GeometryService,
@@ -37,7 +36,7 @@ class GeometryElementListTestUI @Autowired constructor(
 
     @Test
     fun `List layout geometry`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber(TrackNumber("foo"))
         val planVersion = insertSomePlan(trackNumberId)
         linkPlanToSomeLocationTrack(planVersion, trackNumberId)
 
@@ -64,7 +63,7 @@ class GeometryElementListTestUI @Autowired constructor(
 
     @Test
     fun `List plan geometry`() {
-        insertSomePlan(trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id)
+        insertSomePlan(insertOfficialTrackNumber())
         startGeoviite()
         val planListPage = navigationBar.goToElementListPage().planListPage()
         planListPage.selectPlan("testfile")
@@ -89,7 +88,7 @@ class GeometryElementListTestUI @Autowired constructor(
 
     @Test
     fun `List whole network geometry`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber()
         val planVersion = insertSomePlan(trackNumberId)
         linkPlanToSomeLocationTrack(planVersion, trackNumberId)
         geometryService.makeElementListingCsv()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/KilometerLengthsTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/KilometerLengthsTestUI.kt
@@ -30,14 +30,21 @@ class KilometerLengthsTestUI @Autowired constructor(
     fun cleanup() {
         clearAllTestData()
 
-        val trackNumberId = trackNumberDao.insert(trackNumber(TrackNumber("foo"))).id
+        val trackNumberId = trackNumberDao.insert(trackNumber(TrackNumber("foo"), draft = false)).id
 
         val alignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(4000.0, 0.0))))
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = alignment))
-        locationTrackDao.insert(locationTrack(trackNumberId, name = "foo bar", alignmentVersion = alignment))
-        kmPostDao.insert(kmPost(trackNumberId, KmNumber(1), Point(900.0, 1.0)))
-        kmPostDao.insert(kmPost(trackNumberId, KmNumber(2), Point(2000.0, -1.0)))
-        kmPostDao.insert(kmPost(trackNumberId, KmNumber(3), Point(3000.0, 0.0)))
+        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = alignment, draft = false))
+        locationTrackDao.insert(
+            locationTrack(
+                trackNumberId = trackNumberId,
+                name = "foo bar",
+                alignmentVersion = alignment,
+                draft = false,
+            )
+        )
+        kmPostDao.insert(kmPost(trackNumberId, KmNumber(1), Point(900.0, 1.0), draft = false))
+        kmPostDao.insert(kmPost(trackNumberId, KmNumber(2), Point(2000.0, -1.0), draft = false))
+        kmPostDao.insert(kmPost(trackNumberId, KmNumber(3), Point(3000.0, 0.0), draft = false))
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
@@ -12,7 +12,6 @@ import fi.fta.geoviite.infra.ui.pagemodel.map.E2EKmPostEditDialog
 import fi.fta.geoviite.infra.ui.pagemodel.map.E2ELayoutSwitchEditDialog
 import fi.fta.geoviite.infra.ui.pagemodel.map.E2ELocationTrackEditDialog
 import fi.fta.geoviite.infra.ui.pagemodel.map.E2ETrackLayoutPage
-import fi.fta.geoviite.infra.ui.testdata.createTrackLayoutTrackNumber
 import fi.fta.geoviite.infra.ui.testdata.locationTrack
 import fi.fta.geoviite.infra.ui.testdata.pointsFromIncrementList
 import fi.fta.geoviite.infra.ui.testdata.referenceLine
@@ -39,7 +38,6 @@ const val LINKING_TEST_PLAN_NAME = "Linking test plan"
 class LinkingTestUI @Autowired constructor(
     private val testGeometryPlanService: TestGeometryPlanService,
     private val switchDao: LayoutSwitchDao,
-    private val trackNumberDao: LayoutTrackNumberDao,
     private val kmPostDao: LayoutKmPostDao,
     private val referenceLineDao: ReferenceLineDao,
     private val locationTrackDao: LocationTrackDao,
@@ -57,7 +55,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Create a new location track and link geometry`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber(TrackNumber("foo"))
         createAndInsertCommonReferenceLine(trackNumberId)
         val geometryPlan = testGeometryPlanService.buildPlan(trackNumberId).alignment(
             "geo-alignment-a", Point(50.0, 25.0),
@@ -96,7 +94,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Replace existing location track geometry with new geometry`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber()
         createAndInsertCommonReferenceLine(trackNumberId)
         val originalLocationTrack = saveLocationTrackWithAlignment(
             locationTrack(
@@ -164,7 +162,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Edit location track end coordinate`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber()
         createAndInsertCommonReferenceLine(trackNumberId)
         val originalLocationTrack = saveLocationTrackWithAlignment(
             locationTrack(
@@ -202,7 +200,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Edit location track start coordinate`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber()
         createAndInsertCommonReferenceLine(trackNumberId)
         val originalLocationTrack = saveLocationTrackWithAlignment(
             locationTrack(
@@ -239,7 +237,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Link geometry KM-Post to nearest track layout KM-post`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber()
         kmPostDao.insert(
             kmPost(
                 trackNumberId,
@@ -292,7 +290,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Link geometry KM-post to new KM-post`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber()
         val lastKmPostLocation = Point(34.0, 30.0)
 
         testGeometryPlanService
@@ -336,7 +334,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Link geometry switch to new location tracks and layout switch`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo tracknumber")).id
+        val trackNumberId = insertOfficialTrackNumber(TrackNumber("foo tracknumber"))
         val plan = testGeometryPlanService
             .buildPlan(trackNumberId)
             .switch("switch to link", "YV54-200N-1:9-O", Point(5.0, 5.0))
@@ -411,7 +409,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Continue location track using geometry`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo tracknumber")).id
+        val trackNumberId = insertOfficialTrackNumber()
         createAndInsertCommonReferenceLine(trackNumberId)
         val plan = testGeometryPlanService
             .buildPlan(trackNumberId)
@@ -481,7 +479,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Continue and replace location track using geometry`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo tracknumber")).id
+        val trackNumberId = insertOfficialTrackNumber()
         createAndInsertCommonReferenceLine(trackNumberId)
         val plan = testGeometryPlanService
             .buildPlan(trackNumberId)
@@ -550,7 +548,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `link track to a reference line`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo tracknumber")).id
+        val trackNumberId = insertOfficialTrackNumber(TrackNumber("foo tracknumber"))
 
         val originalReferenceLine = referenceLine(
             trackNumber = trackNumberId,
@@ -610,7 +608,7 @@ class LinkingTestUI @Autowired constructor(
 
     @Test
     fun `Delete location track`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo tracknumber")).id
+        val trackNumberId = insertOfficialTrackNumber()
         createAndInsertCommonReferenceLine(trackNumberId)
 
         val originalLocationTrack = locationTrack(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
@@ -33,16 +33,22 @@ class VerticalGeometryDiagramTestUI @Autowired constructor(
 
     @Test
     fun `Vertical geometry diagram for location track loads`() {
-        val trackNumber = insertOfficialTrackNumber()
+        val trackNumberId = insertOfficialTrackNumber()
         referenceLineService.saveDraft(
-            referenceLine(trackNumber),
+            referenceLine(trackNumberId, draft = true),
             alignment(segment(DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0)))
         )
-        kmPostDao.insert(kmPost(trackNumber, km = KmNumber(0), location = DEFAULT_BASE_POINT + Point(0.0, 0.0)))
+        kmPostDao.insert(
+            kmPost(
+                trackNumberId = trackNumberId,
+                km = KmNumber(0), location = DEFAULT_BASE_POINT + Point(0.0, 0.0),
+                draft = false,
+            )
+        )
         val plan = geometryDao.fetchPlan(
             geometryDao.insertPlan(
                 plan(
-                    trackNumber, units = GeometryUnits(
+                    trackNumberId, units = GeometryUnits(
                         coordinateSystemSrid = LAYOUT_SRID,
                         coordinateSystemName = null,
                         verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
@@ -73,12 +79,13 @@ class VerticalGeometryDiagramTestUI @Autowired constructor(
             )
         )
         locationTrackService.saveDraft(
-            locationTrack(trackNumber, name = "foo bar"), alignment(
+            locationTrack(trackNumberId = trackNumberId, name = "foo bar", draft = true),
+            alignment(
                 segment(DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0)).copy(
                     sourceId = plan.alignments[0].elements[0].id,
                     sourceStart = 0.0,
                 )
-            )
+            ),
         )
         startGeoviite()
         val page = goToMap().switchToDraftMode().zoomToScale(E2ETrackLayoutPage.MapScale.M_500)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
@@ -11,7 +11,6 @@ import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.ui.LocalHostWebClient
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.testdata.createGeometryKmPost
-import fi.fta.geoviite.infra.ui.testdata.createTrackLayoutTrackNumber
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -28,7 +27,6 @@ class VerticalGeometryElementListTestUI
 @Autowired constructor(
     private val geometryDao: GeometryDao,
     private val geometryService: GeometryService,
-    private val trackNumberDao: LayoutTrackNumberDao,
     private val locationTrackDao: LocationTrackDao,
     private val alignmentDao: LayoutAlignmentDao,
     private val webClient: LocalHostWebClient,
@@ -41,7 +39,7 @@ class VerticalGeometryElementListTestUI
 
     @Test
     fun `List plan vertical geometry`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber()
         insertGoodPlan(trackNumberId)
         insertMinimalPlan(trackNumberId)
         startGeoviite()
@@ -61,7 +59,7 @@ class VerticalGeometryElementListTestUI
 
     @Test
     fun `List layout vertical geometry`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber()
         val goodPlan = insertGoodPlan(trackNumberId)
         insertMinimalPlan(trackNumberId)
 
@@ -83,7 +81,7 @@ class VerticalGeometryElementListTestUI
 
     @Test
     fun `List entire track vertical geometry`() {
-        val trackNumberId = trackNumberDao.insert(createTrackLayoutTrackNumber("foo")).id
+        val trackNumberId = insertOfficialTrackNumber()
         val goodPlan = insertGoodPlan(trackNumberId)
         insertMinimalPlan(trackNumberId)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
@@ -124,7 +124,7 @@ class VerticalGeometryElementListTestUI
                 alignments = listOf(
                     geometryAlignment(
                         name = "test-alignment-name",
-                        profile = someGeometryProfile()
+                        profile = someGeometryProfile(),
                     )
                 ),
                 coordinateSystemName = CoordinateSystemName("testcrs"),
@@ -177,7 +177,12 @@ class VerticalGeometryElementListTestUI
             )
         )
         locationTrackDao.insert(
-            locationTrack(trackNumberId, name = "foo test track").copy(alignmentVersion = locationTrackAlignment)
+            locationTrack(
+                trackNumberId = trackNumberId,
+                name = "foo test track",
+                alignmentVersion = locationTrackAlignment,
+                draft = false,
+            )
         )
     }
 }


### PR DESCRIPTION
This removes a feature that was never needed in production code and made it unnecessarily complex: transitioning from (some) TEMP-state contexts to other ones. The production code change is trivial but a number of tests relied on this, creating data as OFFICIAL by default and then having it saved as DRAFT. It's now an explicit requirement in the data creation to decide what context the data is created in -> plenty of changed tests. 