### PR TITLE
GVT-2469 Joukko fiksejä liikennepaikoille

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -392,10 +392,10 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                     "secondarySortOrder" to "ASC"
                 )
             ))
-            pagePoints = ((ratkoJsonMapper.readValue(body, RatkoOperatingPointAssetsResponse::class.java)?.assets)
+            pagePoints = (ratkoJsonMapper.readValue(body, RatkoOperatingPointAssetsResponse::class.java)?.assets
                 ?: listOf()).mapNotNull(::parseAsset)
             allPoints.addAll(pagePoints)
-        } while (pagePoints.isNotEmpty())
+        } while (pagePoints.size == 100)
         return allPoints
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/ratko")
 class RatkoController(
     private val ratkoServiceParam: RatkoService?,
-    private val ratkoStatusService: RatkoStatusService,
+    private val ratkoLocalService: RatkoLocalService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -55,29 +55,29 @@ class RatkoController(
         @PathVariable("publicationId") publicationId: IntId<Publication>,
     ): ResponseEntity<RatkoPushErrorWithAsset> {
         logger.apiCall("getRatkoPushErrors", "publicationId" to publicationId)
-        return toResponse(ratkoStatusService.getRatkoPushError(publicationId))
+        return toResponse(ratkoLocalService.getRatkoPushError(publicationId))
     }
 
     @PreAuthorize(AUTH_BASIC)
     @GetMapping("/is-online")
     fun getRatkoOnlineStatus(): RatkoClient.RatkoStatus {
         logger.apiCall("ratkoIsOnline")
-        return ratkoStatusService.getRatkoOnlineStatus()
+        return ratkoLocalService.getRatkoOnlineStatus()
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/fetch-operating-points-from-ratko")
-    fun fetchOperatingPointsFromRatko(): HttpStatus {
-        logger.apiCall("fetchOperatingPointsFromRatko")
-        ratkoService.fetchOperatingPointsFromRatko()
+    @PostMapping("/update-operating-points-from-ratko")
+    fun updateOperatingPointsFromRatko(): HttpStatus {
+        logger.apiCall("updateOperatingPointsFromRatko")
+        ratkoService.updateOperatingPointsFromRatko()
 
         return HttpStatus.NO_CONTENT
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT)
     @GetMapping("/operating-points")
-    fun getOperatingPoints(bbox: BoundingBox): List<RatkoOperatingPoint> {
-        return ratkoService.getOperatingPoints(bbox);
+    fun getOperatingPoints(@RequestParam bbox: BoundingBox): List<RatkoOperatingPoint> {
+        return ratkoLocalService.getOperatingPoints(bbox)
     }
 
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -6,8 +6,10 @@ import fi.fta.geoviite.infra.configuration.CACHE_RATKO_HEALTH_STATUS
 import fi.fta.geoviite.infra.integration.RatkoAssetType.*
 import fi.fta.geoviite.infra.integration.RatkoPushErrorWithAsset
 import fi.fta.geoviite.infra.logging.serviceCall
+import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.ratko.RatkoClient.RatkoStatus
+import fi.fta.geoviite.infra.ratko.model.RatkoOperatingPoint
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.logger
 import org.springframework.beans.factory.annotation.Autowired
@@ -15,9 +17,10 @@ import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 
 @Service
-class RatkoStatusService @Autowired constructor(
+class RatkoLocalService @Autowired constructor(
     private val ratkoClient: RatkoClient?,
     private val ratkoPushDao: RatkoPushDao,
+    private val ratkoOperatingPointDao: RatkoOperatingPointDao,
     private val trackNumberService: LayoutTrackNumberService,
     private val locationTrackService: LocationTrackService,
     private val switchService: LayoutSwitchService,
@@ -47,5 +50,9 @@ class RatkoStatusService @Autowired constructor(
                 asset
             )
         }
+    }
+
+    fun getOperatingPoints(bbox: BoundingBox): List<RatkoOperatingPoint> {
+        return ratkoOperatingPointDao.getOperatingPoints(bbox)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
@@ -1,17 +1,10 @@
 package fi.fta.geoviite.infra.ratko
 
-import fi.fta.geoviite.infra.integration.RatkoPush
-import fi.fta.geoviite.infra.logging.AccessType
-import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.BoundingBox
-import fi.fta.geoviite.infra.ratko.model.RatkoOid
 import fi.fta.geoviite.infra.ratko.model.RatkoOperatingPoint
 import fi.fta.geoviite.infra.ratko.model.RatkoOperatingPointParse
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.util.*
-import fi.fta.geoviite.infra.util.batchUpdate
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import withUser
 import java.time.Duration
 import java.time.Instant
@@ -69,20 +68,16 @@ class RatkoService @Autowired constructor(
 
     @Scheduled(cron = "0 30 3 * * *")
     fun scheduledRatkoOperatingPointsFetch() {
-        withUser(ratkoSchedulerUserName, ::fetchOperatingPointsFromRatko)
+        withUser(ratkoSchedulerUserName, ::updateOperatingPointsFromRatko)
     }
 
-    fun fetchOperatingPointsFromRatko() {
+    fun updateOperatingPointsFromRatko() {
         lockDao.runWithLock(
             DatabaseLock.RATKO_OPERATING_POINTS_FETCH, databaseLockDuration
         ) {
             val points = ratkoClient.fetchOperatingPoints()
             ratkoOperatingPointDao.writeOperatingPoints(points)
         }
-    }
-
-    fun getOperatingPoints(bbox: BoundingBox): List<RatkoOperatingPoint> {
-        return ratkoOperatingPointDao.getOperatingPoints(bbox)
     }
 
     fun pushChangesToRatko(retryFailed: Boolean = true) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
@@ -45,7 +45,7 @@ fun parseAsset(asset: RatkoOperatingPointAsset): RatkoOperatingPointParse? {
         node.nodeType == RatkoNodeType.MIDDLE_POINT
     }?.point
     val location = middlePoint?.geometry?.coordinates?.let { cs -> Point(cs[0], cs[1])}
-    val trackNumberExternalId = middlePoint?.routenumber?.toString()?.let { Oid<RatkoRouteNumber>(it) }
+    val trackNumberExternalId: Oid<RatkoRouteNumber>? = middlePoint?.routenumber?.toString()?.let(::Oid)
     return if (type == null || location == null || trackNumberExternalId == null) null else RatkoOperatingPointParse(
         externalId = externalId,
         name = asset.getStringProperty("name") ?: "",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -946,7 +946,7 @@ class RatkoServiceIT @Autowired constructor(
                 kannustamoOperatingPoint
             )
         )
-        ratkoService.fetchOperatingPointsFromRatko()
+        ratkoService.updateOperatingPointsFromRatko()
         val pointsFromDatabase = ratkoService.getOperatingPoints(boundingBoxAroundPoint(Point(95.0, 95.0), 10.0))
         assertEquals(1, pointsFromDatabase.size)
         val point = pointsFromDatabase[0]

--- a/ui/src/map/layers/operating-point/operating-points-layer.ts
+++ b/ui/src/map/layers/operating-point/operating-points-layer.ts
@@ -56,7 +56,8 @@ function renderPoint(point: OperatingPoint): Feature<OlPoint> {
         text: new Text({
             text: point.name,
             fill: new Fill({ color: 'black' }),
-            offsetX: 30,
+            offsetX: 10,
+            textAlign: 'left',
             backgroundFill: new Fill({ color: 'rgba(255, 255, 255, 0.85)' }),
         }),
     });

--- a/ui/src/map/layers/operating-point/operating-points-layer.ts
+++ b/ui/src/map/layers/operating-point/operating-points-layer.ts
@@ -10,6 +10,7 @@ import { OperatingPoint } from 'track-layout/track-layout-model';
 import Style from 'ol/style/Style';
 import { Circle, Fill, Stroke, Text } from 'ol/style';
 import OlView from 'ol/View';
+import { ChangeTimes } from 'common/common-slice';
 
 const layerName: MapLayerName = 'operating-points-layer';
 
@@ -19,12 +20,17 @@ export function createOperatingPointLayer(
     mapTiles: MapTile[],
     existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
     olView: OlView,
+    changeTimes: ChangeTimes,
 ): MapLayer {
     const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
     const resolution = olView.getResolution() || 0;
 
     const getOperatingPointsFromApi = async () => {
-        return (await Promise.all(mapTiles.map((tile) => getOperatingPoints(tile)))).flat();
+        return (
+            await Promise.all(
+                mapTiles.map((tile) => getOperatingPoints(tile, changeTimes.operatingPoints)),
+            )
+        ).flat();
     };
     const onLoadingChange = () => {};
     const createFeatures = (points: OperatingPoint[]) =>

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -117,7 +117,6 @@ export const initialMapState: Map = {
         'geometry-km-post-layer',
         'location-track-selected-alignment-layer',
         'reference-line-selected-alignment-layer',
-        'operating-points-layer',
     ],
     layerMenu: {
         layout: [

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -578,6 +578,7 @@ const MapView: React.FC<MapViewProps> = ({
                             mapTiles,
                             existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
                             olView,
+                            changeTimes,
                         );
                     case 'debug-1m-points-layer':
                         return createDebug1mPointsLayer(

--- a/ui/src/track-layout/layout-operating-point-api.ts
+++ b/ui/src/track-layout/layout-operating-point-api.ts
@@ -3,11 +3,15 @@ import { getNonNull, queryParams } from 'api/api-fetch';
 import { asyncCache } from 'cache/cache';
 import { MapTile } from 'map/map-model';
 import { bboxString } from 'common/common-api';
+import { TimeStamp } from 'common/common-model';
 
 const operatingPointCache = asyncCache<string, OperatingPoint[]>();
 
-export async function getOperatingPoints(mapTile: MapTile): Promise<OperatingPoint[]> {
-    return operatingPointCache.get('2000-01-01 00:00:00', mapTile.id, () => {
+export async function getOperatingPoints(
+    mapTile: MapTile,
+    changeTime: TimeStamp,
+): Promise<OperatingPoint[]> {
+    return operatingPointCache.get(changeTime, mapTile.id, () => {
         const params = queryParams({ boundingBox: bboxString(mapTile.area) });
         return getNonNull<OperatingPoint[]>(`api/ratko/operating-points${params}`);
     });

--- a/ui/src/track-layout/layout-operating-point-api.ts
+++ b/ui/src/track-layout/layout-operating-point-api.ts
@@ -12,7 +12,7 @@ export async function getOperatingPoints(
     changeTime: TimeStamp,
 ): Promise<OperatingPoint[]> {
     return operatingPointCache.get(changeTime, mapTile.id, () => {
-        const params = queryParams({ boundingBox: bboxString(mapTile.area) });
+        const params = queryParams({ bbox: bboxString(mapTile.area) });
         return getNonNull<OperatingPoint[]>(`api/ratko/operating-points${params}`);
     });
 }


### PR DESCRIPTION
Oleellisia bugifiksejä: ChangeTime-passaaminen, joka oli jäänyt kokonaan pois; ja getOperatingPoints-metodin siirtäminen palveluun, jonka olemassaolo ei riipu siitä, että RatkoClient-bean on konffattu. Muuten pienempiä bugifiksejä ja putsauksia.