### PR TITLE
GVT-2526 Frontin rakenteettomien tyyppien brändääminen

### DIFF
--- a/ui/src/common/brand.ts
+++ b/ui/src/common/brand.ts
@@ -14,5 +14,5 @@ export function brand<B>(thing: string | undefined): Brand<string, B> | undefine
 export function brand<T, B>(thing: T): Brand<T, B>;
 
 export function brand<T, B>(thing: T): Brand<T, B> {
-    return thing as unknown as Brand<T, B>;
+    return thing as Brand<T, B>;
 }

--- a/ui/src/common/brand.ts
+++ b/ui/src/common/brand.ts
@@ -1,6 +1,18 @@
 export type Brand<T, B> = T & { __brand: B };
 
-export function brand<B>(thing: string): B;
-export function brand<T, B>(thing: T): B {
-    return thing as unknown as B;
+/**
+ * Assert that the given string is in fact the branded kind of thing. This is always a downcast.
+ */
+export function brand<B>(thing: string): Brand<string, B>;
+/**
+ * Assert that the given optional string is in fact the branded kind of thing. This is always a downcast.
+ */
+export function brand<B>(thing: string | undefined): Brand<string, B> | undefined;
+/**
+ * Assert that the given thing is in fact the branded kind of thing. This is always a downcast.
+ */
+export function brand<T, B>(thing: T): Brand<T, B>;
+
+export function brand<T, B>(thing: T): Brand<T, B> {
+    return thing as unknown as Brand<T, B>;
 }

--- a/ui/src/common/brand.ts
+++ b/ui/src/common/brand.ts
@@ -1,0 +1,6 @@
+export type Brand<T, B> = T & { __brand: B };
+
+export function brand<B>(thing: string): B;
+export function brand<T, B>(thing: T): B {
+    return thing as unknown as B;
+}

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -9,6 +9,7 @@ import {
 } from 'track-layout/track-layout-model';
 import { compare } from 'utils/array-utils';
 import i18next from 'i18next';
+import { Brand } from 'common/brand';
 
 export type RotationDirection = 'CW' | 'CCW';
 export type LinearUnit = 'MILLIMETER' | 'CENTIMETER' | 'METER' | 'KILOMETER';
@@ -69,7 +70,7 @@ export type MeasurementMethod =
 
 export type ElevationMeasurementMethod = 'TOP_OF_SLEEPER' | 'TOP_OF_RAIL';
 
-export type TrackNumber = string;
+export type TrackNumber = Brand<string, 'TrackNumber'>;
 
 export type KmNumber = string;
 export const ZERO_TRACK_METER: TrackMeter = {

--- a/ui/src/common/navigate.ts
+++ b/ui/src/common/navigate.ts
@@ -1,7 +1,7 @@
 import { GeometryPlanId } from 'geometry/geometry-model';
 import { PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { useNavigate } from 'react-router-dom';
-import { PublicationId } from 'preview/preview-table';
+import { PublicationId } from 'publication/publication-model';
 
 const appPath = {
     'frontpage': '/',

--- a/ui/src/geometry/geometry-model.ts
+++ b/ui/src/geometry/geometry-model.ts
@@ -21,7 +21,6 @@ import { PVDocumentId } from 'infra-model/projektivelho/pv-model';
 
 export type GeometryPlanLayoutId = string;
 export type GeometryPlanId = string;
-export type GeometryTrackNumberId = string;
 export type GeometryAlignmentId = string;
 export type GeometryElementId = string;
 export type GeometrySwitchId = string;

--- a/ui/src/geoviite-design-lib/demo/examples/badge-examples.tsx
+++ b/ui/src/geoviite-design-lib/demo/examples/badge-examples.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
     LayoutAssetFields,
+    LayoutKmPost,
     LayoutLocationTrack,
     LayoutState,
     LayoutSwitch,
@@ -11,6 +12,7 @@ import {
     LocationTrackBadge,
     LocationTrackBadgeStatus,
 } from 'geoviite-design-lib/alignment/location-track-badge';
+import { brand } from 'common/brand';
 
 const layoutAssetFields: LayoutAssetFields = {
     version: 'version',
@@ -20,14 +22,14 @@ const layoutAssetFields: LayoutAssetFields = {
 
 const layoutLocationTrack: LayoutLocationTrack = {
     ...layoutAssetFields,
-    id: '',
+    id: brand(''),
     name: 'name',
     descriptionBase: 'description',
     state: 'IN_USE' as LayoutState,
     length: 123,
     segmentCount: 0,
     boundingBox: { x: { min: 0, max: 0 }, y: { min: 0, max: 0 } },
-    trackNumberId: '',
+    trackNumberId: brand(''),
     sourceId: '',
     type: undefined,
     externalId: undefined,
@@ -37,17 +39,17 @@ const layoutLocationTrack: LayoutLocationTrack = {
     topologyEndSwitch: undefined,
     ownerId: '',
 };
-const kmPost = {
+const kmPost: LayoutKmPost = {
     ...layoutAssetFields,
-    id: '',
+    id: brand(''),
     kmNumber: '123',
     location: { x: 0, y: 0 },
     state: 'IN_USE' as LayoutState,
-    trackNumberId: '',
+    trackNumberId: brand(''),
 };
 const layoutSwitch: LayoutSwitch = {
     ...layoutAssetFields,
-    id: '',
+    id: brand(''),
     name: 'V1234',
     switchStructureId: '',
     stateCategory: 'EXISTING',

--- a/ui/src/infra-model/list/infra-model-search-form.tsx
+++ b/ui/src/infra-model/list/infra-model-search-form.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { GeometryPlanSearchParams, PlanSource } from 'geometry/geometry-model';
-import { LayoutTrackNumber } from 'track-layout/track-layout-model';
+import { LayoutTrackNumber, LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import { deduplicate, filterNotEmpty } from 'utils/array-utils';
 import { InfraModelLoadButtonContainer } from 'infra-model/list/infra-model-load-button-container';
 import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
@@ -15,7 +15,7 @@ export type InframodelSearchFormProps = {
 };
 
 type TrackNumberOption = {
-    id?: string;
+    id?: LayoutTrackNumberId;
     typeLabel: string;
     label: string;
     number: string;

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -117,34 +117,34 @@ export type GeometryPreliminaryLinkingParameters = {
 };
 
 export type GeometryLinkingAlignmentLockParameters = {
-    alignmentId: LocationTrackId | ReferenceLineId;
-    alignmentType: MapAlignmentType;
+    alignment: LayoutAlignmentTypeAndId;
     type: LinkingType.LinkingGeometryWithAlignment | LinkingType.LinkingGeometryWithEmptyAlignment;
 };
 
+export type LayoutAlignmentTypeAndId =
+    | { type: 'LOCATION_TRACK'; id: LocationTrackId }
+    | { type: 'REFERENCE_LINE'; id: ReferenceLineId };
+
 export type LinkingGeometryWithAlignment = LinkingBaseType & {
     type: LinkingType.LinkingGeometryWithAlignment;
-    layoutAlignmentType: MapAlignmentType;
     geometryPlanId: GeometryPlanId;
+    layoutAlignment: LayoutAlignmentTypeAndId;
     geometryAlignmentId: GeometryAlignmentId;
-    layoutAlignmentId: LocationTrackId | ReferenceLineId;
     geometryAlignmentInterval: LinkInterval;
     layoutAlignmentInterval: LinkInterval;
 };
 
 export type LinkingAlignment = LinkingBaseType & {
     type: LinkingType.LinkingAlignment;
-    layoutAlignmentType: MapAlignmentType;
-    layoutAlignmentId: LocationTrackId | ReferenceLineId;
+    layoutAlignment: LayoutAlignmentTypeAndId;
     layoutAlignmentInterval: LinkInterval;
 };
 
 export type LinkingGeometryWithEmptyAlignment = LinkingBaseType & {
     type: LinkingType.LinkingGeometryWithEmptyAlignment;
-    layoutAlignmentType: MapAlignmentType;
     geometryPlanId: GeometryPlanId;
     geometryAlignmentId: GeometryAlignmentId;
-    layoutAlignmentId: LocationTrackId | ReferenceLineId;
+    layoutAlignment: LayoutAlignmentTypeAndId;
     geometryAlignmentInterval: LinkInterval;
 };
 
@@ -300,7 +300,7 @@ export type SuggestedSwitch = {
     id: SuggestedSwitchId;
     switchStructureId: SwitchStructureId;
     joints: TrackLayoutSwitchJoint[];
-    trackLinks: { [k: LocationTrackId]: SwitchLinkingTrackLinks };
+    trackLinks: Record<LocationTrackId, SwitchLinkingTrackLinks>;
     geometryPlanId?: GeometryPlanId;
     geometrySwitchId?: GeometrySwitchId;
     alignmentEndPoint?: LocationTrackEndpoint;

--- a/ui/src/linking/linking-status.tsx
+++ b/ui/src/linking/linking-status.tsx
@@ -4,13 +4,12 @@ import styles from 'tool-panel/switch/switch-infobox.scss';
 import { useTranslation } from 'react-i18next';
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { getPlanLinkStatus } from 'linking/linking-api';
-import { GeometryPlanId } from 'geometry/geometry-model';
+import { GeometryPlanId, GeometrySwitchId } from 'geometry/geometry-model';
 import { LayoutContext, TimeStamp } from 'common/common-model';
-import { LayoutSwitchId } from 'track-layout/track-layout-model';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 
 type LinkingStatusProps = {
-    switchId: LayoutSwitchId;
+    switchId: GeometrySwitchId;
     planId: GeometryPlanId;
     layoutContext: LayoutContext;
     switchChangeTime: TimeStamp;

--- a/ui/src/linking/linking-utils.ts
+++ b/ui/src/linking/linking-utils.ts
@@ -1,4 +1,4 @@
-import { filterNotEmpty, filterUnique, first, last } from 'utils/array-utils';
+import { filterNotEmpty, filterUnique, first, last, objectEntries } from 'utils/array-utils';
 import {
     SuggestedSwitch,
     SuggestedSwitchJoint,
@@ -124,7 +124,7 @@ export function asTrackLayoutSwitchJointConnection({
 export function suggestedSwitchJointsAsLayoutSwitchJointConnections(
     ss: SuggestedSwitch,
 ): LayoutSwitchJointConnection[] {
-    const tracks = Object.entries(ss.trackLinks).flatMap(([locationTrackId, links]) =>
+    const tracks = objectEntries(ss.trackLinks).flatMap(([locationTrackId, links]) =>
         links.segmentJoints.map((sj) => ({
             number: sj.number,
             locationTrackId,
@@ -146,9 +146,9 @@ export function suggestedSwitchJointsAsLayoutSwitchJointConnections(
 export function suggestedSwitchTopoLinksAsTopologicalJointConnections(
     ss: SuggestedSwitch,
 ): TopologicalJointConnection[] {
-    return Object.entries(
-        Object.entries(ss.trackLinks)
-            .map(([id, link]) => link.topologyJoint && [link.topologyJoint.number, id])
+    return objectEntries(
+        objectEntries(ss.trackLinks)
+            .map(([id, link]) => link.topologyJoint && ([link.topologyJoint.number, id] as const))
             .filter(filterNotEmpty)
             .reduce<{ [key in JointNumber]: LocationTrackId[] }>((acc, [jointNumber, id]) => {
                 acc[jointNumber] ||= [];

--- a/ui/src/map/layers/alignment/location-track-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-alignment-layer.ts
@@ -18,12 +18,13 @@ import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import {
-    AlignmentDataHolder,
     getLocationTrackMapAlignmentsByTiles,
+    LocationTrackAlignmentDataHolder,
 } from 'track-layout/layout-map-api';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
 import { LayoutContext } from 'common/common-model';
+import { brand } from 'common/brand';
 
 let shownLocationTracksCompare = '';
 
@@ -78,7 +79,7 @@ export function createLocationTrackAlignmentLayer(
             ? getLocationTrackMapAlignmentsByTiles(changeTimes, mapTiles, layoutContext)
             : Promise.resolve([]);
 
-    const createFeatures = (locationTracks: AlignmentDataHolder[]) => {
+    const createFeatures = (locationTracks: LocationTrackAlignmentDataHolder[]) => {
         const showEndPointTicks = resolution <= Limits.SHOW_LOCATION_TRACK_BADGES;
 
         return createAlignmentFeatures(
@@ -92,7 +93,7 @@ export function createLocationTrackAlignmentLayer(
 
     const onLoadingChange = (
         loading: boolean,
-        locationTracks: AlignmentDataHolder[] | undefined,
+        locationTracks: LocationTrackAlignmentDataHolder[] | undefined,
     ) => {
         if (!loading) {
             updateShownLocationTracks(locationTracks?.map(({ header }) => header.id) ?? []);
@@ -106,8 +107,8 @@ export function createLocationTrackAlignmentLayer(
         name: layerName,
         layer: layer,
         searchItems: (hitArea: Rectangle, options: SearchItemsOptions): LayerItemSearchResult => ({
-            locationTracks: findMatchingAlignments(hitArea, source, options).map(
-                ({ header }) => header.id,
+            locationTracks: findMatchingAlignments(hitArea, source, options).map(({ header }) =>
+                brand(header.id),
             ),
         }),
         onRemove: () => updateShownLocationTracks([]),

--- a/ui/src/map/layers/alignment/location-track-badge-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-badge-layer.ts
@@ -13,8 +13,8 @@ import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
 import {
-    AlignmentDataHolder,
     getLocationTrackMapAlignmentsByTiles,
+    LocationTrackAlignmentDataHolder,
 } from 'track-layout/layout-map-api';
 import { LayoutContext } from 'common/common-model';
 
@@ -32,12 +32,12 @@ export function createLocationTrackBadgeLayer(
 ): MapLayer {
     const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const dataPromise: Promise<AlignmentDataHolder[]> =
+    const dataPromise: Promise<LocationTrackAlignmentDataHolder[]> =
         resolution <= Limits.SHOW_LOCATION_TRACK_BADGES
             ? getLocationTrackMapAlignmentsByTiles(changeTimes, mapTiles, layoutContext)
             : Promise.resolve([]);
 
-    const createFeatures = (locationTracks: AlignmentDataHolder[]) => {
+    const createFeatures = (locationTracks: LocationTrackAlignmentDataHolder[]) => {
         const badgeDrawDistance = getBadgeDrawDistance(resolution) || 0;
         return createAlignmentBadgeFeatures(
             locationTracks,

--- a/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
@@ -32,6 +32,7 @@ import {
 } from 'track-layout/layout-location-track-api';
 import { Point } from 'model/geometry';
 import { expectCoordinate } from 'utils/type-utils';
+import { brand } from 'common/brand';
 
 type EndpointType = 'START' | 'END';
 const BLACK = '#000000';
@@ -161,7 +162,7 @@ function createFeatures(
     return alignments
         .filter(
             (alignment) =>
-                duplicates.map((d) => d.id).includes(alignment.header.id) &&
+                duplicates.map((d) => d.id).includes(brand(alignment.header.id)) &&
                 alignment.points.length >= 2,
         )
         .flatMap(({ points, header }) => {

--- a/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
@@ -7,8 +7,8 @@ import { MapLayer, SearchItemsOptions } from 'map/layers/utils/layer-model';
 import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import { deduplicate, filterNotEmpty } from 'utils/array-utils';
 import {
-    AlignmentDataHolder,
     getReferenceLineMapAlignmentsByTiles,
+    ReferenceLineAlignmentDataHolder,
 } from 'track-layout/layout-map-api';
 import {
     createAlignmentFeatures,
@@ -68,13 +68,10 @@ export function createReferenceLineAlignmentLayer(
         }
     }
 
-    const dataPromise: Promise<AlignmentDataHolder[]> = getReferenceLineMapAlignmentsByTiles(
-        changeTimes,
-        mapTiles,
-        layoutContext,
-    );
+    const dataPromise: Promise<ReferenceLineAlignmentDataHolder[]> =
+        getReferenceLineMapAlignmentsByTiles(changeTimes, mapTiles, layoutContext);
 
-    const createFeatures = (referenceLines: AlignmentDataHolder[]) =>
+    const createFeatures = (referenceLines: ReferenceLineAlignmentDataHolder[]) =>
         createAlignmentFeatures(
             referenceLines,
             selection,
@@ -85,7 +82,7 @@ export function createReferenceLineAlignmentLayer(
 
     const onLoadingChange = (
         loading: boolean,
-        referenceLines: AlignmentDataHolder[] | undefined,
+        referenceLines: ReferenceLineAlignmentDataHolder[] | undefined,
     ) => {
         if (!loading) {
             updateShownReferenceLines(referenceLines?.map(({ header }) => header.id) ?? []);

--- a/ui/src/map/layers/alignment/reference-line-badge-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-badge-layer.ts
@@ -2,8 +2,8 @@ import { Point as OlPoint } from 'ol/geom';
 import { MapLayerName, MapTile } from 'map/map-model';
 import { Selection } from 'selection/selection-model';
 import {
-    AlignmentDataHolder,
     getReferenceLineMapAlignmentsByTiles,
+    ReferenceLineAlignmentDataHolder,
 } from 'track-layout/layout-map-api';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { LinkingState } from 'linking/linking-model';
@@ -31,13 +31,10 @@ export function createReferenceLineBadgeLayer(
 ): MapLayer {
     const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
 
-    const dataPromise: Promise<AlignmentDataHolder[]> = getReferenceLineMapAlignmentsByTiles(
-        changeTimes,
-        mapTiles,
-        layoutContext,
-    );
+    const dataPromise: Promise<ReferenceLineAlignmentDataHolder[]> =
+        getReferenceLineMapAlignmentsByTiles(changeTimes, mapTiles, layoutContext);
 
-    const createFeatures = (referenceLines: AlignmentDataHolder[]) => {
+    const createFeatures = (referenceLines: ReferenceLineAlignmentDataHolder[]) => {
         const badgeDrawDistance = getBadgeDrawDistance(resolution) || 0;
         return createAlignmentBadgeFeatures(
             referenceLines,

--- a/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
@@ -2,7 +2,10 @@ import { MapLayerName, MapTile } from 'map/map-model';
 import { ChangeTimes } from 'common/common-slice';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { HIGHLIGHTS_SHOW } from 'map/layers/utils/layer-visibility-limits';
-import { AlignmentDataHolder, getMapAlignmentsByTiles } from 'track-layout/layout-map-api';
+import {
+    getLocationTrackMapAlignmentsByTiles,
+    LocationTrackAlignmentDataHolder,
+} from 'track-layout/layout-map-api';
 import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
@@ -19,7 +22,7 @@ import { filterNotEmpty } from 'utils/array-utils';
 import { LayoutContext } from 'common/common-model';
 
 function createFeatures(
-    alignments: AlignmentDataHolder[],
+    alignments: LocationTrackAlignmentDataHolder[],
     duplicateIds: LocationTrackId[],
     linkedDuplicates: LocationTrackId[],
 ): Feature<LineString>[] {
@@ -43,7 +46,7 @@ function createFeatures(
 type DuplicateSplitSectionData = {
     linkedDuplicates: LocationTrackId[];
     duplicates: LocationTrackId[];
-    alignments: AlignmentDataHolder[];
+    alignments: LocationTrackAlignmentDataHolder[];
 };
 
 async function getDuplicateSplitSectionData(
@@ -60,7 +63,7 @@ async function getDuplicateSplitSectionData(
             .filter(filterNotEmpty);
 
         const [alignments, extras] = await Promise.all([
-            getMapAlignmentsByTiles(changeTimes, mapTiles, layoutContext),
+            getLocationTrackMapAlignmentsByTiles(changeTimes, mapTiles, layoutContext),
             getLocationTrackInfoboxExtras(
                 splittingState.originLocationTrack.id,
                 layoutContext,

--- a/ui/src/map/layers/highlight/plan-section-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/plan-section-highlight-layer.ts
@@ -17,10 +17,10 @@ import Feature from 'ol/Feature';
 import { blueHighlightStyle } from 'map/layers/utils/highlight-layer-utils';
 import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
 import { getPartialPolyLine } from 'utils/math-utils';
-import { ReferenceLineId } from 'track-layout/track-layout-model';
+import { LayoutTrackNumberId } from 'track-layout/track-layout-model';
 
-const isReferenceLine = (header: AlignmentHeader, referenceLineId: ReferenceLineId) =>
-    header.trackNumberId === referenceLineId && header.alignmentType === 'REFERENCE_LINE';
+const isReferenceLine = (header: AlignmentHeader, trackNumberId: LayoutTrackNumberId) =>
+    header.trackNumberId === trackNumberId && header.alignmentType === 'REFERENCE_LINE';
 
 function createFeatures(
     alignments: AlignmentDataHolder[],

--- a/ui/src/map/layers/highlight/track-number-diagram-layer.ts
+++ b/ui/src/map/layers/highlight/track-number-diagram-layer.ts
@@ -8,7 +8,7 @@ import {
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { LayoutContext } from 'common/common-model';
 import { ChangeTimes } from 'common/common-slice';
-import { groupBy } from 'utils/array-utils';
+import { groupBy, objectEntries } from 'utils/array-utils';
 import * as Limits from 'map/layers/utils/layer-visibility-limits';
 import Feature from 'ol/Feature';
 import { Stroke, Style } from 'ol/style';
@@ -40,7 +40,10 @@ function createDiagramFeatures(
         (a) => a.header.trackNumberId || a.trackNumber?.id || '',
     );
 
-    return Object.entries(perTrackNumber).flatMap(([trackNumberId, alignments]) => {
+    return objectEntries(perTrackNumber).flatMap(([trackNumberId, alignments]) => {
+        if (trackNumberId === '') {
+            return [];
+        }
         const style = new Style({
             stroke: new Stroke({
                 color: getColorForTrackNumber(trackNumberId, layerSettings),

--- a/ui/src/map/layers/switch/switch-layer.ts
+++ b/ui/src/map/layers/switch/switch-layer.ts
@@ -26,7 +26,7 @@ import VectorSource from 'ol/source/Vector';
 import { fromExtent } from 'ol/geom/Polygon';
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { getMaxTimestamp } from 'utils/date-utils';
-import { ValidatedAsset } from 'publication/publication-model';
+import { ValidatedSwitch } from 'publication/publication-model';
 
 let shownSwitchesCompare: string;
 
@@ -42,7 +42,7 @@ const getTiledSwitchValidation = (
 type SwitchLayerData = {
     switches: LayoutSwitch[];
     structures: SwitchStructure[];
-    validationResult: ValidatedAsset[];
+    validationResult: ValidatedSwitch[];
 };
 
 const layerName: MapLayerName = 'switch-layer';

--- a/ui/src/map/layers/utils/alignment-layer-utils.ts
+++ b/ui/src/map/layers/utils/alignment-layer-utils.ts
@@ -1,5 +1,9 @@
 import { RegularShape, Style } from 'ol/style';
-import { AlignmentDataHolder, AlignmentHeader } from 'track-layout/layout-map-api';
+import {
+    AlignmentDataHolder,
+    LayoutAlignmentDataHolder,
+    LayoutAlignmentHeader,
+} from 'track-layout/layout-map-api';
 import { ItemCollections, Selection } from 'selection/selection-model';
 import { LinkingState, LinkingType } from 'linking/linking-model';
 import Feature from 'ol/Feature';
@@ -120,7 +124,7 @@ export function createAlignmentFeature(
 }
 
 export function createAlignmentFeatures(
-    alignments: AlignmentDataHolder[],
+    alignments: LayoutAlignmentDataHolder[],
     selection: Selection,
     showEndTicks: boolean,
     style: Style,
@@ -135,8 +139,9 @@ export function createAlignmentFeatures(
     );
 }
 
-function includes(selection: ItemCollections, alignment: AlignmentHeader): boolean {
-    switch (alignment.alignmentType) {
+function includes(selection: ItemCollections, alignment: LayoutAlignmentHeader): boolean {
+    const type = alignment.alignmentType;
+    switch (type) {
         case 'REFERENCE_LINE': {
             const tnId = alignment.trackNumberId;
             return tnId != undefined && selection.trackNumbers.includes(tnId);
@@ -145,15 +150,15 @@ function includes(selection: ItemCollections, alignment: AlignmentHeader): boole
             return selection.locationTracks.includes(alignment.id);
         }
         default:
-            return exhaustiveMatchingGuard(alignment.alignmentType);
+            return exhaustiveMatchingGuard(type);
     }
 }
 
-export const isHighlighted = (selection: Selection, header: AlignmentHeader) =>
+export const isHighlighted = (selection: Selection, header: LayoutAlignmentHeader) =>
     includes(selection.highlightedItems, header);
 
 export function getAlignmentHeaderStates(
-    { header }: AlignmentDataHolder,
+    { header }: LayoutAlignmentDataHolder,
     selection: Selection,
     linkingState: LinkingState | undefined,
 ) {
@@ -162,7 +167,7 @@ export function getAlignmentHeaderStates(
     const isLinking = linkingState
         ? (linkingState.type == LinkingType.LinkingGeometryWithAlignment ||
               linkingState.type == LinkingType.LinkingAlignment) &&
-          linkingState.layoutAlignmentType == header.alignmentType &&
+          linkingState.layoutAlignment.type == header.alignmentType &&
           linkingState.layoutAlignmentInterval.start?.alignmentId === header.id
         : false;
 

--- a/ui/src/map/layers/utils/badge-layer-utils.ts
+++ b/ui/src/map/layers/utils/badge-layer-utils.ts
@@ -8,7 +8,7 @@ import { AlignmentPoint } from 'track-layout/track-layout-model';
 import { findOrInterpolateXY } from 'utils/math-utils';
 import { pointToCoords } from 'map/layers/utils/layer-utils';
 import { filterNotEmpty, last } from 'utils/array-utils';
-import { AlignmentDataHolder } from 'track-layout/layout-map-api';
+import { LayoutAlignmentDataHolder } from 'track-layout/layout-map-api';
 import { Selection } from 'selection/selection-model';
 import { LinkingState } from 'linking/linking-model';
 import { getAlignmentHeaderStates } from 'map/layers/utils/alignment-layer-utils';
@@ -196,7 +196,7 @@ export function getBadgeDrawDistance(resolution: number): number | undefined {
 }
 
 export function createAlignmentBadgeFeatures(
-    alignments: AlignmentDataHolder[],
+    alignments: LayoutAlignmentDataHolder[],
     selection: Selection,
     linkingState: LinkingState | undefined,
     badgeDrawDistance: number,

--- a/ui/src/map/layers/utils/switch-layer-utils.ts
+++ b/ui/src/map/layers/utils/switch-layer-utils.ts
@@ -28,7 +28,7 @@ import { findMatchingEntities, pointToCoords } from 'map/layers/utils/layer-util
 import { SearchItemsOptions } from 'map/layers/utils/layer-model';
 import VectorSource from 'ol/source/Vector';
 import { Rectangle } from 'model/geometry';
-import { ValidatedAsset } from 'publication/publication-model';
+import { ValidatedSwitch } from 'publication/publication-model';
 import { Selection } from 'selection/selection-model';
 import * as Limits from 'map/layers/utils/layer-visibility-limits';
 import { expectCoordinate, expectDefined } from 'utils/type-utils';
@@ -320,7 +320,7 @@ export const createLayoutSwitchFeatures = (
     selection: Selection,
     switches: LayoutSwitch[],
     switchStructures: SwitchStructure[],
-    validationResult: ValidatedAsset[],
+    validationResult: ValidatedSwitch[],
 ) => {
     const largeSymbols = resolution <= Limits.SWITCH_LARGE_SYMBOLS;
     const showLabels = resolution <= Limits.SWITCH_LABELS;
@@ -354,7 +354,7 @@ function createSwitchFeatures(
     showLabels: boolean,
     planId?: GeometryPlanId,
     switchStructures?: SwitchStructure[],
-    validationResult?: ValidatedAsset[],
+    validationResult?: ValidatedSwitch[],
 ): Feature<OlPoint>[] {
     return layoutSwitches
         .filter((s) => s.joints.length > 0)
@@ -390,7 +390,7 @@ function createSwitchFeature(
     showLabel: boolean,
     planId?: GeometryPlanId,
     presentationJointNumber?: string | undefined,
-    validationResult?: ValidatedAsset | undefined,
+    validationResult?: ValidatedSwitch | undefined,
 ): Feature<OlPoint>[] {
     const firstJoint = expectDefined(first(layoutSwitch.joints));
 

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -19,20 +19,21 @@ import {
     menuSelectOption,
     MenuSelectOption,
 } from 'vayla-design-lib/menu/menu';
-import { PreviewSelectType, PreviewTableEntry, PublicationId } from 'preview/preview-table';
+import { PreviewSelectType, PreviewTableEntry, PublishableObjectId } from 'preview/preview-table';
 import { BoundingBox } from 'model/geometry';
 import { RevertRequestSource } from 'preview/preview-view-revert-request';
 import { PublicationAssetChangeAmounts } from 'preview/preview-view-data';
+import { brand } from 'common/brand';
 
 const createPublishRequestIdsFromTableEntry = (
-    id: PublicationId,
+    id: PublishableObjectId,
     type: PreviewSelectType,
 ): PublishRequestIds => ({
-    trackNumbers: type === PreviewSelectType.trackNumber ? [id] : [],
-    referenceLines: type === PreviewSelectType.referenceLine ? [id] : [],
-    locationTracks: type === PreviewSelectType.locationTrack ? [id] : [],
-    switches: type === PreviewSelectType.switch ? [id] : [],
-    kmPosts: type === PreviewSelectType.kmPost ? [id] : [],
+    trackNumbers: type === PreviewSelectType.trackNumber ? [brand(id)] : [],
+    referenceLines: type === PreviewSelectType.referenceLine ? [brand(id)] : [],
+    locationTracks: type === PreviewSelectType.locationTrack ? [brand(id)] : [],
+    switches: type === PreviewSelectType.switch ? [brand(id)] : [],
+    kmPosts: type === PreviewSelectType.kmPost ? [brand(id)] : [],
 });
 
 const conditionalMenuOption = (

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -36,7 +36,7 @@ import { ChangeTimes } from 'common/common-slice';
 import { PreviewCandidates, PublicationAssetChangeAmounts } from 'preview/preview-view-data';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
 
-export type PublicationId =
+export type PublishableObjectId =
     | LayoutTrackNumberId
     | ReferenceLineId
     | LocationTrackId

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -93,55 +93,49 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
 
     const [sortInfo, setSortInfo] = React.useState<SortInformation>(InitiallyUnsorted);
 
-    const changesToPublicationEntries = (previewChanges: PreviewCandidates): PreviewTableEntry[] =>
-        previewChanges.trackNumbers
-            .map((trackNumberCandidate) => ({
-                ...trackNumberToChangeTableEntry(trackNumberCandidate),
-                errors: trackNumberCandidate.errors,
-                type: PreviewSelectType.trackNumber,
-                pendingValidation: trackNumberCandidate.pendingValidation,
-                boundingBox: trackNumberCandidate.boundingBox,
-            }))
-            .concat(
-                previewChanges.referenceLines.map((referenceLineCandidate) => ({
-                    ...referenceLineToChangeTableEntry(referenceLineCandidate, trackNumbers),
-                    errors: referenceLineCandidate.errors,
-                    type: PreviewSelectType.referenceLine,
-                    pendingValidation: referenceLineCandidate.pendingValidation,
-                    boundingBox: referenceLineCandidate.boundingBox,
-                })),
-            )
-            .concat(
-                previewChanges.locationTracks.map((locationTrackCandidate) => ({
-                    ...locationTrackToChangeTableEntry(locationTrackCandidate, trackNumbers),
-                    errors: locationTrackCandidate.errors,
-                    type: PreviewSelectType.locationTrack,
-                    pendingValidation: locationTrackCandidate.pendingValidation,
-                    boundingBox: locationTrackCandidate.boundingBox,
-                })),
-            )
-            .concat(
-                previewChanges.switches.map((switchCandidate) => ({
-                    ...switchToChangeTableEntry(switchCandidate, trackNumbers),
-                    errors: switchCandidate.errors,
-                    type: PreviewSelectType.switch,
-                    pendingValidation: switchCandidate.pendingValidation,
-                    boundingBox: switchCandidate.location
-                        ? calculateBoundingBoxToShowAroundLocation(switchCandidate.location)
-                        : undefined,
-                })),
-            )
-            .concat(
-                previewChanges.kmPosts.map((kmPostCandidate) => ({
-                    ...kmPostChangeTableEntry(kmPostCandidate, trackNumbers),
-                    errors: kmPostCandidate.errors,
-                    type: PreviewSelectType.kmPost,
-                    pendingValidation: kmPostCandidate.pendingValidation,
-                    boundingBox: kmPostCandidate.location
-                        ? calculateBoundingBoxToShowAroundLocation(kmPostCandidate.location)
-                        : undefined,
-                })),
-            );
+    const changesToPublicationEntries = (
+        previewChanges: PreviewCandidates,
+    ): PreviewTableEntry[] => [
+        ...previewChanges.trackNumbers.map((trackNumberCandidate) => ({
+            ...trackNumberToChangeTableEntry(trackNumberCandidate),
+            errors: trackNumberCandidate.errors,
+            type: PreviewSelectType.trackNumber,
+            pendingValidation: trackNumberCandidate.pendingValidation,
+            boundingBox: trackNumberCandidate.boundingBox,
+        })),
+        ...previewChanges.referenceLines.map((referenceLineCandidate) => ({
+            ...referenceLineToChangeTableEntry(referenceLineCandidate, trackNumbers),
+            errors: referenceLineCandidate.errors,
+            type: PreviewSelectType.referenceLine,
+            pendingValidation: referenceLineCandidate.pendingValidation,
+            boundingBox: referenceLineCandidate.boundingBox,
+        })),
+        ...previewChanges.locationTracks.map((locationTrackCandidate) => ({
+            ...locationTrackToChangeTableEntry(locationTrackCandidate, trackNumbers),
+            errors: locationTrackCandidate.errors,
+            type: PreviewSelectType.locationTrack,
+            pendingValidation: locationTrackCandidate.pendingValidation,
+            boundingBox: locationTrackCandidate.boundingBox,
+        })),
+        ...previewChanges.switches.map((switchCandidate) => ({
+            ...switchToChangeTableEntry(switchCandidate, trackNumbers),
+            errors: switchCandidate.errors,
+            type: PreviewSelectType.switch,
+            pendingValidation: switchCandidate.pendingValidation,
+            boundingBox: switchCandidate.location
+                ? calculateBoundingBoxToShowAroundLocation(switchCandidate.location)
+                : undefined,
+        })),
+        ...previewChanges.kmPosts.map((kmPostCandidate) => ({
+            ...kmPostChangeTableEntry(kmPostCandidate, trackNumbers),
+            errors: kmPostCandidate.errors,
+            type: PreviewSelectType.kmPost,
+            pendingValidation: kmPostCandidate.pendingValidation,
+            boundingBox: kmPostCandidate.location
+                ? calculateBoundingBoxToShowAroundLocation(kmPostCandidate.location)
+                : undefined,
+        })),
+    ];
 
     const publicationEntries: PreviewTableEntry[] = changesToPublicationEntries(previewChanges);
 

--- a/ui/src/preview/preview-view-filters.ts
+++ b/ui/src/preview/preview-view-filters.ts
@@ -1,6 +1,7 @@
 import {
     PublicationGroup,
     PublishCandidate,
+    PublishCandidateId,
     PublishCandidates,
     PublishRequestIds,
     WithId,
@@ -154,13 +155,13 @@ export const previewCandidatesByUser = (
     kmPosts: filterPreviewCandidateArrayByUser(user, previewCandidates.kmPosts),
 });
 
-export const filterByPublicationGroup = (
-    candidates: (PublishCandidate & WithId)[],
+export const filterByPublicationGroup = <Id extends PublishCandidateId>(
+    candidates: (PublishCandidate & WithId<Id>)[],
     publicationGroup: PublicationGroup,
 ) => candidates.filter((candidate) => candidate.publicationGroup?.id === publicationGroup.id);
 
-export const assetIdsByPublicationGroup = (
-    candidates: (PublishCandidate & WithId)[],
+export const assetIdsByPublicationGroup = <Id extends PublishCandidateId>(
+    candidates: (PublishCandidate & WithId<Id>)[],
     publicationGroup: PublicationGroup,
 ) => {
     return filterByPublicationGroup(candidates, publicationGroup).map((candidate) => candidate.id);

--- a/ui/src/preview/preview-view-revert-request.ts
+++ b/ui/src/preview/preview-view-revert-request.ts
@@ -1,5 +1,5 @@
-import { PublicationGroup, PublicationId, PublicationStage } from 'publication/publication-model';
-import { PreviewSelectType } from 'preview/preview-table';
+import { PublicationGroup, PublicationStage } from 'publication/publication-model';
+import { PreviewSelectType, PublishableObjectId } from 'preview/preview-table';
 
 export enum RevertRequestType {
     STAGE_CHANGES,
@@ -13,7 +13,7 @@ export type RevertRequest =
     | RevertPublicationGroup;
 
 export type RevertRequestSource = {
-    id: PublicationId;
+    id: PublishableObjectId;
     type: PreviewSelectType;
     name: string;
 };

--- a/ui/src/publication/publication-details-container.tsx
+++ b/ui/src/publication/publication-details-container.tsx
@@ -3,10 +3,10 @@ import { useCommonDataAppSelector } from 'store/hooks';
 import { useLoader } from 'utils/react-utils';
 import { getPublication } from 'publication/publication-api';
 import { useParams } from 'react-router-dom';
-import { PublicationId } from 'preview/preview-table';
 import React from 'react';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
+import { PublicationId } from 'publication/publication-model';
 
 export const PublicationDetailsContainer: React.FC = () => {
     const trackLayoutActionDelegates = React.useMemo(

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -72,8 +72,8 @@ export type WithLocation = {
     location?: Point;
 };
 
-export type WithId = {
-    id: PublishCandidateId;
+export type WithId<Id extends PublishCandidateId> = {
+    id: Id;
 };
 
 export type TrackNumberPublishCandidate = PublishCandidate &
@@ -237,10 +237,15 @@ export type PublicationChange = {
     enumKey?: string;
 };
 
-export type ValidatedAsset = {
-    id: AssetId;
+export type ValidatedAsset<Id extends AssetId> = {
+    id: Id;
     errors: PublishValidationError[];
 };
+export type ValidatedTrackNumber = ValidatedAsset<LayoutTrackNumberId>;
+export type ValidatedLocationTrack = ValidatedAsset<LocationTrackId>;
+export type ValidatedReferenceLine = ValidatedAsset<ReferenceLineId>;
+export type ValidatedSwitch = ValidatedAsset<LayoutSwitchId>;
+export type ValidatedKmPost = ValidatedAsset<LayoutKmPostId>;
 
 export type PublishRequest = {
     content: PublishRequestIds;

--- a/ui/src/publication/split/split-details-dialog.tsx
+++ b/ui/src/publication/split/split-details-dialog.tsx
@@ -6,7 +6,7 @@ import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { Table, Th } from 'vayla-design-lib/table/table';
 import { getSplitDetails, splitDetailsCsvUri } from 'publication/publication-api';
 import { formatTrackMeter } from 'utils/geography-utils';
-import { PublicationId } from 'preview/preview-table';
+import { PublicationId } from 'publication/publication-model';
 import {
     ProgressIndicatorType,
     ProgressIndicatorWrapper,

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -47,6 +47,7 @@ import { TrackNumberColorKey } from 'selection-panel/track-number-panel/color-se
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { VIEW_GEOMETRY } from 'user/user-model';
+import { objectEntries } from 'utils/array-utils';
 
 type SelectionPanelProps = {
     changeTimes: ChangeTimes;
@@ -109,7 +110,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
     const diagramLayerSettings = mapLayerSettings['track-number-diagram-layer'];
     const diagramLayerMenuItem = mapLayoutMenu.find((i) => i.name === 'track-number-diagram');
 
-    const selectedTrackNumberIds: LayoutTrackNumberId[] = Object.entries(diagramLayerSettings)
+    const selectedTrackNumberIds: LayoutTrackNumberId[] = objectEntries(diagramLayerSettings)
         .filter(([_, setting]) => setting.selected)
         .map(([id]) => id);
 

--- a/ui/src/selection/selection-model.ts
+++ b/ui/src/selection/selection-model.ts
@@ -49,7 +49,7 @@ export type UnselectableItemCollections = {
     kmPosts: LayoutKmPostId[];
     geometryKmPosts: LayoutKmPostId[];
     switches: LayoutSwitchId[];
-    geometrySwitches: LayoutSwitchId[];
+    geometrySwitches: GeometrySwitchId[];
     trackNumbers: LayoutTrackNumberId[];
     geometryAlignments: LocationTrackId[];
     geometrySegments: LayoutSegmentId[];

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -86,8 +86,8 @@ function filterIdCollection<T extends string>(
     if (unselectItemIds === undefined) {
         return ids;
     }
-
-    return ids.filter((i) => !unselectItemIds.includes(i));
+    const unselect: string[] = unselectItemIds;
+    return ids.filter((i) => !unselect.includes(i));
 }
 
 function filterItemCollection<T extends { id: unknown }>(

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -16,28 +16,28 @@ type HighlightedItemBase = {
     endM: number;
 };
 
-type HighlightedLocationTrack = {
+export type HighlightedLocationTrack = {
     type: 'LOCATION_TRACK';
     id: LocationTrackId;
 } & HighlightedItemBase;
 
-type HighlightedReferenceLine = {
+export type HighlightedReferenceLine = {
     type: 'REFERENCE_LINE';
     id: LayoutTrackNumberId;
 } & HighlightedItemBase;
 
 export type HighlightedAlignment = HighlightedLocationTrack | HighlightedReferenceLine;
 
+export type OnHighlightSection = (section: undefined | { startM: number; endM: number }) => void;
+
 type AlignmentPlanSectionInfoboxContentProps = {
     sections: AlignmentPlanSection[];
-    onHighlightItem: (item: HighlightedAlignment | undefined) => void;
-    id: LocationTrackId | LayoutTrackNumberId;
-    type: 'LOCATION_TRACK' | 'REFERENCE_LINE';
+    onHighlightSection: OnHighlightSection;
 };
 
 export const AlignmentPlanSectionInfoboxContent: React.FC<
     AlignmentPlanSectionInfoboxContentProps
-> = ({ sections, type, id, onHighlightItem }) => {
+> = ({ sections, onHighlightSection }) => {
     const { t } = useTranslation();
 
     const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
@@ -77,15 +77,13 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
                         onMouseOver={() => {
                             section.start &&
                                 section.end &&
-                                onHighlightItem({
-                                    id,
-                                    type,
-                                    startM: section.start?.m,
-                                    endM: section.end?.m,
+                                onHighlightSection({
+                                    startM: section.start.m,
+                                    endM: section.end.m,
                                 });
                         }}
                         onMouseOut={() => {
-                            onHighlightItem(undefined);
+                            onHighlightSection(undefined);
                         }}>
                         {section.planName && !section.isLinked && (
                             <div className="infobox__list-cell">{errorFragment()}</div>

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-candidates.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-candidates.tsx
@@ -222,7 +222,7 @@ export const GeometryAlignmentLinkingReferenceLineCandidates: React.FC<
                             : ReferenceLineBadgeStatus.DEFAULT
                     }
                 />
-                {linkingInProgress && linkingState.layoutAlignmentId === line.id && (
+                {linkingInProgress && linkingState.layoutAlignment.id === line.id && (
                     <Icons.Lock size={IconSize.SMALL} color={IconColor.INHERIT} />
                 )}
             </li>
@@ -376,7 +376,7 @@ export const GeometryAlignmentLinkingLocationTrackCandidates: React.FC<
                             : LocationTrackBadgeStatus.DEFAULT
                     }
                 />
-                {linkingInProgress && linkingState.layoutAlignmentId === track.id && (
+                {linkingInProgress && linkingState.layoutAlignment.id === track.id && (
                     <Icons.Lock size={IconSize.SMALL} color={IconColor.INHERIT} />
                 )}
                 <span>

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -25,8 +25,7 @@ import {
     updateKmPost,
 } from 'track-layout/layout-km-post-api';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
-import { LayoutKmPost, LayoutKmPostId } from 'track-layout/track-layout-model';
-import { GeometryTrackNumberId } from 'geometry/geometry-model';
+import { LayoutKmPost, LayoutKmPostId, LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import { useDebouncedState } from 'utils/react-utils';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
@@ -43,7 +42,7 @@ type KmPostEditDialogContainerProps = {
     kmPostId?: LayoutKmPostId;
     onClose: () => void;
     onSave?: (kmPostId: LayoutKmPostId) => void;
-    prefilledTrackNumberId?: GeometryTrackNumberId;
+    prefilledTrackNumberId?: LayoutTrackNumberId;
 };
 
 type KmPostEditDialogProps = {
@@ -51,7 +50,7 @@ type KmPostEditDialogProps = {
     kmPostId?: LayoutKmPostId;
     onClose: () => void;
     onSave?: (kmPostId: LayoutKmPostId) => void;
-    prefilledTrackNumberId?: GeometryTrackNumberId;
+    prefilledTrackNumberId?: LayoutTrackNumberId;
     onEditKmPost: (id?: LayoutKmPostId) => void;
 };
 

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
@@ -1,7 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { KmPostSaveRequest } from 'linking/linking-model';
-import { LayoutKmPost } from 'track-layout/track-layout-model';
-import { GeometryTrackNumberId } from 'geometry/geometry-model';
+import { LayoutKmPost, LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import {
     isPropEditFieldCommitted,
     PropEdit,
@@ -34,7 +33,7 @@ export const initialKmPostEditState: KmPostEditState = {
     allFieldsCommitted: false,
 };
 
-function newLinkingKmPost(trackNumberId: GeometryTrackNumberId | undefined): KmPostSaveRequest {
+function newLinkingKmPost(trackNumberId: LayoutTrackNumberId | undefined): KmPostSaveRequest {
     return {
         kmNumber: '',
         state: undefined,
@@ -99,7 +98,7 @@ const kmPostEditSlice = createSlice({
         init: (): KmPostEditState => initialKmPostEditState,
         initWithNewKmPost: (
             state: KmPostEditState,
-            { payload: trackNumberId }: PayloadAction<GeometryTrackNumberId | undefined>,
+            { payload: trackNumberId }: PayloadAction<LayoutTrackNumberId | undefined>,
         ): void => {
             state.isNewKmPost = true;
             state.kmPost = newLinkingKmPost(trackNumberId);

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -174,8 +174,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
             <AssetValidationInfoboxContainer
                 contentVisible={visibilities.validation}
                 onContentVisibilityChange={() => visibilityChange('validation')}
-                id={kmPost.id}
-                type={'KM_POST'}
+                idAndType={{ id: kmPost.id, type: 'KM_POST' }}
                 layoutContext={layoutContext}
                 changeTime={kmPostChangeTime}
             />

--- a/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
@@ -9,7 +9,8 @@ import { getLocationTrackSectionsByPlan } from 'track-layout/layout-location-tra
 import { MapViewport } from 'map/map-model';
 import {
     AlignmentPlanSectionInfoboxContent,
-    HighlightedAlignment,
+    HighlightedLocationTrack,
+    OnHighlightSection,
 } from 'tool-panel/alignment-plan-section-infobox-content';
 import { useTranslation } from 'react-i18next';
 import {
@@ -24,7 +25,7 @@ type LocationTrackGeometryInfoboxProps = {
     viewport: MapViewport;
     contentVisible: boolean;
     onContentVisibilityChange: () => void;
-    onHighlightItem: (item: HighlightedAlignment | undefined) => void;
+    onHighlightItem: (item: HighlightedLocationTrack | undefined) => void;
 };
 
 export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfoboxProps> = ({
@@ -48,6 +49,16 @@ export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfobox
         1000,
         [locationTrackId, layoutContext.publicationState, layoutContext.designId, viewportDep],
     );
+    const onHighlightSection: OnHighlightSection = (section) =>
+        onHighlightItem(
+            section === undefined
+                ? undefined
+                : {
+                      ...section,
+                      id: locationTrackId,
+                      type: 'LOCATION_TRACK',
+                  },
+        );
 
     return (
         <Infobox
@@ -76,10 +87,8 @@ export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfobox
                         </p>
                     ) : (
                         <AlignmentPlanSectionInfoboxContent
-                            id={locationTrackId}
+                            onHighlightSection={onHighlightSection}
                             sections={sections || []}
-                            onHighlightItem={onHighlightItem}
-                            type={'LOCATION_TRACK'}
                         />
                     )}
                 </ProgressIndicatorWrapper>

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -186,11 +186,11 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                     duplicateTracks: splitInitializationParameters?.duplicates || [],
                     startLocation: startAndEndPoints.start.point,
                     endLocation: startAndEndPoints.end.point,
-                        trackNumber: trackNumber.number,
-                        nearestOperatingPointToStart:
-                            splitInitializationParameters.nearestOperatingPointToStart,
-                        nearestOperatingPointToEnd:
-                            splitInitializationParameters.nearestOperatingPointToEnd,
+                    trackNumber: trackNumber.number,
+                    nearestOperatingPointToStart:
+                        splitInitializationParameters.nearestOperatingPointToStart,
+                    nearestOperatingPointToEnd:
+                        splitInitializationParameters.nearestOperatingPointToEnd,
                 });
                 showLayers(['location-track-split-location-layer']);
             }
@@ -198,9 +198,14 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
     };
 
     const updateAlignment = (state: LinkingAlignment) => {
-        if (canUpdate && state.layoutAlignmentInterval.start && state.layoutAlignmentInterval.end) {
+        if (
+            canUpdate &&
+            state.layoutAlignmentInterval.start &&
+            state.layoutAlignmentInterval.end &&
+            state.layoutAlignment.type === 'LOCATION_TRACK'
+        ) {
             setUpdatingLength(true);
-            updateLocationTrackGeometry(state.layoutAlignmentId, {
+            updateLocationTrackGeometry(state.layoutAlignment.id, {
                 min: state.layoutAlignmentInterval.start.m,
                 max: state.layoutAlignmentInterval.end.m,
             })

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -373,8 +373,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                 <AssetValidationInfoboxContainer
                     contentVisible={visibilities.validation}
                     onContentVisibilityChange={() => visibilityChange('validation')}
-                    id={layoutSwitch.id}
-                    type={'SWITCH'}
+                    idAndType={{ id: layoutSwitch.id, type: 'SWITCH' }}
                     layoutContext={layoutContext}
                     changeTime={changeTimes.layoutSwitch}
                 />

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -429,7 +429,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             lockToAsset = tabs.find(
                 (t) =>
                     t.asset.type === 'LOCATION_TRACK' &&
-                    t.asset.id === linkingState.layoutAlignmentId,
+                    t.asset.id === linkingState.layoutAlignment.id,
             )?.asset;
         } else if (
             linkingState?.type === LinkingType.LinkingGeometryWithEmptyAlignment ||

--- a/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
@@ -10,6 +10,7 @@ import { revertCandidates } from 'publication/publication-api';
 import { getChangeTimes } from 'common/change-time-api';
 import { ChangesBeingReverted } from 'preview/preview-view';
 import { LayoutContext } from 'common/common-model';
+import { brand } from 'common/brand';
 
 type TrackNumberDeleteConfirmationDialogProps = {
     layoutContext: LayoutContext;
@@ -31,7 +32,7 @@ const TrackNumberDeleteConfirmationDialog: React.FC<TrackNumberDeleteConfirmatio
             result
                 .map(() => {
                     Snackbar.success('tool-panel.track-number.delete-dialog.delete-succeeded');
-                    onSave && onSave(changesBeingReverted.requestedRevertChange.source.id);
+                    onSave && onSave(brand(changesBeingReverted.requestedRevertChange.source.id));
                     onClose();
                 })
                 .mapErr(() => {

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-store.ts
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-store.ts
@@ -12,7 +12,7 @@ import {
     ValidationError,
     ValidationErrorType,
 } from 'utils/validation-utils';
-import { TrackNumber, ZERO_TRACK_METER } from 'common/common-model';
+import { ZERO_TRACK_METER } from 'common/common-model';
 import { formatTrackMeter } from 'utils/geography-utils';
 
 const TRACK_NUMBER_REGEX = /^[äÄöÖåÅA-Za-z0-9 ]{2,20}$/g;
@@ -29,7 +29,7 @@ const REGEX_VALIDATIONS: RegexValidation[] = [
 ];
 
 export type TrackNumberSaveRequest = {
-    number: TrackNumber;
+    number: string;
     description: string;
     state: LayoutState;
     startAddress: string;

--- a/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
@@ -9,7 +9,8 @@ import { LayoutContext, TimeStamp } from 'common/common-model';
 import { MapViewport } from 'map/map-model';
 import {
     AlignmentPlanSectionInfoboxContent,
-    HighlightedAlignment,
+    HighlightedReferenceLine,
+    OnHighlightSection,
 } from 'tool-panel/alignment-plan-section-infobox-content';
 import { useTranslation } from 'react-i18next';
 import {
@@ -24,7 +25,7 @@ type TrackNumberGeometryInfoboxProps = {
     viewport: MapViewport;
     contentVisible: boolean;
     onContentVisibilityChange: () => void;
-    onHighlightItem: (item: HighlightedAlignment | undefined) => void;
+    onHighlightItem: (item: HighlightedReferenceLine | undefined) => void;
     changeTime: TimeStamp;
 };
 
@@ -56,7 +57,16 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
             changeTime,
         ],
     );
-
+    const onHighlightSection: OnHighlightSection = (section) =>
+        onHighlightItem(
+            section === undefined
+                ? undefined
+                : {
+                      ...section,
+                      id: trackNumberId,
+                      type: 'REFERENCE_LINE',
+                  },
+        );
     return (
         <Infobox
             title={t('tool-panel.alignment-plan-sections.reference-line-geometries')}
@@ -84,10 +94,8 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
                         </p>
                     ) : (
                         <AlignmentPlanSectionInfoboxContent
-                            id={trackNumberId}
+                            onHighlightSection={onHighlightSection}
                             sections={sections || []}
-                            onHighlightItem={onHighlightItem}
-                            type={'REFERENCE_LINE'}
                         />
                     )}
                 </ProgressIndicatorWrapper>

--- a/ui/src/tool-panel/track-number/track-number-infobox-linking-container.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox-linking-container.tsx
@@ -7,14 +7,14 @@ import {
 } from 'track-layout/track-layout-slice';
 import { useTrackNumberReferenceLine } from 'track-layout/track-layout-react-utils';
 import TrackNumberInfobox from 'tool-panel/track-number/track-number-infobox';
-import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-content';
+import { HighlightedReferenceLine } from 'tool-panel/alignment-plan-section-infobox-content';
 import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
 
 type TrackNumberInfoboxLinkingContainerProps = {
     trackNumber: LayoutTrackNumber;
     visibilities: TrackNumberInfoboxVisibilities;
     onVisibilityChange: (visibilities: TrackNumberInfoboxVisibilities) => void;
-    setHoveredOverItem: (item: HighlightedAlignment | undefined) => void;
+    setHoveredOverItem: (item: HighlightedReferenceLine | undefined) => void;
 };
 
 const TrackNumberInfoboxLinkingContainer: React.FC<TrackNumberInfoboxLinkingContainerProps> = ({

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -118,9 +118,14 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
     }, [linkingState]);
 
     const updateAlignment = (state: LinkingAlignment) => {
-        if (canUpdate && state.layoutAlignmentInterval.start && state.layoutAlignmentInterval.end) {
+        if (
+            canUpdate &&
+            state.layoutAlignmentInterval.start &&
+            state.layoutAlignmentInterval.end &&
+            state.layoutAlignment.type === 'REFERENCE_LINE'
+        ) {
             setUpdatingLength(true);
-            updateReferenceLineGeometry(state.layoutAlignmentId, {
+            updateReferenceLineGeometry(state.layoutAlignment.id, {
                 min: state.layoutAlignmentInterval.start.m,
                 max: state.layoutAlignmentInterval.end.m,
             })
@@ -326,8 +331,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
             <AssetValidationInfoboxContainer
                 contentVisible={visibilities.validation}
                 onContentVisibilityChange={() => visibilityChange('validation')}
-                id={trackNumber.id}
-                type={'TRACK_NUMBER'}
+                idAndType={{ id: trackNumber.id, type: 'TRACK_NUMBER' }}
                 layoutContext={layoutContext}
                 changeTime={trackNumberChangeTime}
             />

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -26,7 +26,7 @@ import { BoundingBox, Point } from 'model/geometry';
 import { bboxString, pointString } from 'common/common-api';
 import { KmPostSaveError, KmPostSaveRequest } from 'linking/linking-model';
 import { Result } from 'neverthrow';
-import { ValidatedAsset } from 'publication/publication-model';
+import { ValidatedKmPost } from 'publication/publication-model';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
 
 const kmPostListCache = asyncCache<string, LayoutKmPost[]>();
@@ -173,8 +173,8 @@ export const deleteDraftKmPost = async (
 export async function getKmPostValidation(
     layoutContext: LayoutContext,
     id: LayoutKmPostId,
-): Promise<ValidatedAsset | undefined> {
-    return getNullable<ValidatedAsset>(`${layoutUri('km-posts', layoutContext, id)}/validation`);
+): Promise<ValidatedKmPost | undefined> {
+    return getNullable<ValidatedKmPost>(`${layoutUri('km-posts', layoutContext, id)}/validation`);
 }
 
 export async function getKmPostsOnTrackNumber(

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -1,8 +1,8 @@
 import {
     AddressPoint,
+    AlignmentPoint,
     AlignmentStartAndEnd,
     LayoutLocationTrack,
-    AlignmentPoint,
     LayoutTrackNumberId,
     LocationTrackDescription,
     LocationTrackId,
@@ -33,7 +33,7 @@ import { Result } from 'neverthrow';
 import { getChangeTimes, updateLocationTrackChangeTime } from 'common/change-time-api';
 import { isNilOrBlank } from 'utils/string-utils';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
-import { ValidatedAsset } from 'publication/publication-model';
+import { ValidatedLocationTrack } from 'publication/publication-model';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import i18next from 'i18next';
 import { getMaxTimestamp } from 'utils/date-utils';
@@ -321,8 +321,8 @@ export const getSplittingInitializationParameters = async (
 export async function getLocationTrackValidation(
     layoutContext: LayoutContext,
     id: LocationTrackId,
-): Promise<ValidatedAsset | undefined> {
-    return getNullable<ValidatedAsset>(
+): Promise<ValidatedLocationTrack | undefined> {
+    return getNullable<ValidatedLocationTrack>(
         `${layoutUri('location-tracks', layoutContext, id)}/validation`,
     );
 }

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -1,9 +1,5 @@
 import { asyncCache } from 'cache/cache';
-import {
-    LayoutTrackNumber,
-    LayoutTrackNumberId,
-    LocationTrackId,
-} from 'track-layout/track-layout-model';
+import { LayoutTrackNumber, LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import {
     DraftableChangeInfo,
     draftLayoutContext,
@@ -27,7 +23,7 @@ import {
 } from 'common/change-time-api';
 import { LocationTrackSaveError } from 'linking/linking-model';
 import { Result } from 'neverthrow';
-import { ValidatedAsset } from 'publication/publication-model';
+import { ValidatedTrackNumber } from 'publication/publication-model';
 import { AlignmentPlanSection } from 'track-layout/layout-location-track-api';
 import { bboxString } from 'common/common-api';
 import { BoundingBox } from 'model/geometry';
@@ -81,7 +77,7 @@ export async function createTrackNumber(
 export async function deleteTrackNumber(
     layoutContext: LayoutContext,
     trackNumberId: LayoutTrackNumberId,
-): Promise<Result<LocationTrackId, LocationTrackSaveError>> {
+): Promise<Result<LayoutTrackNumberId, LocationTrackSaveError>> {
     const path = layoutUri('track-numbers', draftLayoutContext(layoutContext), trackNumberId);
     const apiResult = await deleteNonNullAdt<undefined, LayoutTrackNumberId>(path, undefined);
 
@@ -97,8 +93,8 @@ export async function deleteTrackNumber(
 export async function getTrackNumberValidation(
     layoutContext: LayoutContext,
     id: LayoutTrackNumberId,
-): Promise<ValidatedAsset | undefined> {
-    return getNullable<ValidatedAsset>(
+): Promise<ValidatedTrackNumber | undefined> {
+    return getNullable<ValidatedTrackNumber>(
         `${layoutUri('track-numbers', layoutContext, id)}/validation`,
     );
 }

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -4,7 +4,6 @@ import {
     GeometryPlanId,
     GeometryPlanLayoutId,
     GeometrySwitchId,
-    GeometryTrackNumberId,
 } from 'geometry/geometry-model';
 import { BoundingBox, Point } from 'model/geometry';
 import {
@@ -25,6 +24,7 @@ import { deduplicateById } from 'utils/array-utils';
 import { AlignmentHeader, AlignmentPolyLine } from './layout-map-api';
 import { GeometryPlanLinkStatus } from 'linking/linking-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { Brand } from 'common/brand';
 
 export type LayoutState = 'IN_USE' | 'NOT_IN_USE' | 'PLANNED' | 'DELETED';
 export type LayoutStateCategory = 'EXISTING' | 'NOT_EXISTING' | 'FUTURE_EXISTING';
@@ -55,8 +55,8 @@ export function filterAlignmentPoints(
     });
 }
 
-export type ReferenceLineId = string;
-export type LocationTrackId = string;
+export type ReferenceLineId = Brand<string, 'ReferenceLineId'>;
+export type LocationTrackId = Brand<string, 'LocationTrackId'>;
 export type LocationTrackType = 'MAIN' | 'SIDE' | 'TRAP' | 'CHORD';
 export type MapAlignmentSource = 'LAYOUT' | 'GEOMETRY';
 export type MapAlignmentType = 'LOCATION_TRACK' | 'REFERENCE_LINE';
@@ -171,7 +171,7 @@ export function trapPointToBoolean(trapPoint: TrapPoint): boolean | undefined {
     }
 }
 
-export type LayoutSwitchId = string;
+export type LayoutSwitchId = Brand<string, 'LayoutSwitchId'>;
 
 export type LayoutSwitch = {
     id: LayoutSwitchId;
@@ -191,7 +191,7 @@ export type LayoutSwitchJoint = {
     locationAccuracy: LocationAccuracy;
 };
 
-export type LayoutKmPostId = string;
+export type LayoutKmPostId = Brand<string, 'LayoutKmPostId'>;
 
 export type LayoutKmPost = {
     id: LayoutKmPostId;
@@ -240,7 +240,7 @@ export type PlanLayoutAlignment = {
     segmentMValues: number[];
 };
 
-export type LayoutTrackNumberId = string;
+export type LayoutTrackNumberId = Brand<string, 'LayoutTrackNumberId'>;
 
 export type LayoutTrackNumber = {
     id: LayoutTrackNumberId;
@@ -248,7 +248,7 @@ export type LayoutTrackNumber = {
     description: string;
     number: TrackNumber;
     state: LayoutState;
-    sourceId?: GeometryTrackNumberId;
+    sourceId?: LayoutTrackNumberId;
 } & LayoutAssetFields;
 
 export type AddressPoint = {

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -277,3 +277,8 @@ export function insertAtIndex<T>(things: readonly T[], thing: T, index: number):
 
 export const findById = <T extends { id: string }>(objs: T[], id: string): T | undefined =>
     objs.find((obj) => obj.id == id);
+
+export const objectEntries = <T extends object>(obj: T) =>
+    Object.entries(obj) as {
+        [K in keyof T]-?: [K, T[K]];
+    }[keyof T][];

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -278,6 +278,10 @@ export function insertAtIndex<T>(things: readonly T[], thing: T, index: number):
 export const findById = <T extends { id: string }>(objs: T[], id: string): T | undefined =>
     objs.find((obj) => obj.id == id);
 
+/**
+ * Like Object.entries, but with the assumption that the argument doesn't contain any fields not mentioned in its
+ * type (they are still output, but the output type doesn't know about them).
+ */
 export const objectEntries = <T extends object>(obj: T) =>
     Object.entries(obj) as {
         [K in keyof T]-?: [K, T[K]];


### PR DESCRIPTION
Tyyppitiedon lisäämisessä koodiin, jossa aiemmin sitä ei ole ollut, on paljon vapautta mennä suuntaan tai toiseen sen kanssa, kuinka paljon tyyppeihin lisätään tarkkuutta ja kuinka paljon tehdään uusia ajonaikaisia tarkistuksia. Menin tässä siihen, että ei lisätä kovin paljoa kumpaakaan, vaan oletetaan vaan, että bäkkäriltä tulee kyllä sitä tavaraa mitä oletetaan tulevan, ja että tehdään vielä aika raa'asti downcasteja sen mukaan kuin kääntäjä kaipaa.

Osa muutoksista konfliktoi varmasti Markuksen preview-näkymän kanssa. Päädyin siihen, että odotan mieluiten sen mainiin, mutta että tuon nyt tämän pullarin kuitenkin näkyville, vaikka mainiin menevään versioon pitää tehdä vielä jonkin verran muutoksia.

Iso osa muutoksista tulee siitä, että tyyppejä ja iideitä liitetään yhteen samaan olioon:

TypeScript pystyy rajaamaan olion tyypin sen perusteella, kun katsotaan sen kenttiä, mutta ei sen perusteella, että yhtä oliota tarkastamalla pystyisi päättelemään toisen tyypin, vaikka funktion tyypistä voisi moisen yhteyden päätellä, siis esim.

```
function test<A extends 'foo' | 'bar'>(
    a: A,
    b: A extends 'foo' ? 'spam' : A extends 'bar' ? 'eggs' : never,
) {
    switch (a) {
        case 'foo': {
            const r = b === 'eggs';
        }
    }
}
```

Tällaisen funktion kanssa TypeScript osaa kyllä tarkistaa kutsujista, etteivät kutsu `test('foo', 'eggs')`, mutta funktion sisällä se ei osaa käyttää hyväksi tietoa tuosta yhteydestä, vaan `r`:n tyyppi tässä on boolean. Mutta tällaisen se osaa käsitellä oikein:

```
function test2(v: { a: 'foo'; b: 'spam' } | { a: 'bar'; b: 'eggs' }) {
    switch (v.a) {
        case 'foo': {
            const r = v.b === 'eggs';
        }
    }
}
```