### PR TITLE
GVT-832 Ilmakuvataso

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1065,6 +1065,7 @@
         "geometry-title": "Geometriat",
         "debug-title": "Debug-työkalut",
         "map": "Taustakartta",
+        "orthographic-background-map": "Ilmakuva",
         "location-track": "Sijaintiraiteet",
         "reference-line": "Pituusmittauslinjat",
         "track-number-diagram": "Pituusmittausraidekaavio",

--- a/ui/src/map/layers/background-map-layer.ts
+++ b/ui/src/map/layers/background-map-layer.ts
@@ -36,14 +36,14 @@ const makeMMLTileSourcePromise = (sourceType: BackgroundMapLayerSourceType) =>
 
 export type BackgroundMapLayerSourceType = 'taustakartta' | 'ortokuva';
 
-function createLayer(sourceType: BackgroundMapLayerSourceType) {
-    const layer = new Tile({ opacity: sourceType === 'taustakartta' ? 0.5 : 1.0 });
+function createLayer(sourceType: BackgroundMapLayerSourceType, opacity: number) {
+    const layer = new Tile({ opacity });
     makeMMLTileSourcePromise(sourceType).then((source) => source && layer.setSource(source));
     return layer;
 }
 
 export function createBackgroundMapLayer(existingOlLayer: Tile<TileSource>): MapLayer {
-    const layer = existingOlLayer || createLayer('taustakartta');
+    const layer = existingOlLayer || createLayer('taustakartta', 0.5);
     return {
         name: 'background-map-layer',
         layer: layer,
@@ -51,7 +51,7 @@ export function createBackgroundMapLayer(existingOlLayer: Tile<TileSource>): Map
 }
 
 export function createOrthographicMapLayer(existingOlLayer: Tile<TileSource>): MapLayer {
-    const layer = existingOlLayer || createLayer('ortokuva');
+    const layer = existingOlLayer || createLayer('ortokuva', 1.0);
     return {
         name: 'orthographic-background-map-layer',
         layer: layer,

--- a/ui/src/map/layers/background-map-layer.ts
+++ b/ui/src/map/layers/background-map-layer.ts
@@ -37,7 +37,7 @@ const makeMMLTileSourcePromise = (sourceType: BackgroundMapLayerSourceType) =>
 export type BackgroundMapLayerSourceType = 'taustakartta' | 'ortokuva';
 
 function createLayer(sourceType: BackgroundMapLayerSourceType) {
-    const layer = new Tile({ opacity: 0.5 });
+    const layer = new Tile({ opacity: sourceType === 'taustakartta' ? 0.5 : 1.0 });
     makeMMLTileSourcePromise(sourceType).then((source) => source && layer.setSource(source));
     return layer;
 }

--- a/ui/src/map/layers/utils/switch-layer-utils.ts
+++ b/ui/src/map/layers/utils/switch-layer-utils.ts
@@ -169,7 +169,7 @@ export function getSwitchRenderer(
                     const textY = y + pixelRatio;
                     const paddingHor = 2;
                     const paddingVer = 1;
-                    const contentWidth = textWidth + (valid ? 0 : 15);
+                    const contentWidth = textWidth + (valid ? 0 : 1);
                     const backgroundX = textX - paddingHor * pixelRatio - pixelRatio;
                     const backgroundY =
                         textY - (fontSize * pixelRatio) / 2 - paddingVer * pixelRatio;

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -16,6 +16,7 @@ import {
 
 export type MapLayerName =
     | 'background-map-layer'
+    | 'orthographic-background-map-layer'
     | 'location-track-background-layer'
     | 'reference-line-background-layer'
     | 'track-number-diagram-layer'
@@ -91,6 +92,7 @@ export type MapLayerMenuItem = {
 
 export type MapLayerMenuItemName =
     | 'map'
+    | 'orthographic-background-map'
     | 'location-track'
     | 'reference-line'
     | 'missing-vertical-geometry'

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -83,6 +83,7 @@ export const layersToHideByProxy: LayerCollection = {
 
 const layerMenuItemMapLayers: Record<MapLayerMenuItemName, MapLayerName[]> = {
     'map': ['background-map-layer'],
+    'orthographic-background-map': ['orthographic-background-map-layer'],
     'location-track': ['location-track-alignment-layer', 'location-track-badge-layer'],
     'reference-line': ['reference-line-alignment-layer', 'reference-line-badge-layer'],
     'missing-vertical-geometry': ['missing-profile-highlight-layer'],
@@ -120,7 +121,18 @@ export const initialMapState: Map = {
     ],
     layerMenu: {
         layout: [
-            { name: 'map', visible: true, qaId: 'background-nap-layer' },
+            {
+                name: 'map',
+                visible: true,
+                qaId: 'background-map-layer',
+                subMenu: [
+                    {
+                        name: 'orthographic-background-map',
+                        visible: false,
+                        qaId: 'orthographic-background-map-layer',
+                    },
+                ],
+            },
             { name: 'reference-line', visible: true, qaId: 'reference-line-layer' },
             {
                 name: 'location-track',

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -81,6 +81,12 @@ export const layersToHideByProxy: LayerCollection = {
     ],
 };
 
+// like hiding by proxy, except with no effect on the displayed layer list, only covering the given layers right at
+// the end
+export const layersCoveringLayers: LayerCollection = {
+    'orthographic-background-map-layer': ['background-map-layer'],
+};
+
 const layerMenuItemMapLayers: Record<MapLayerMenuItemName, MapLayerName[]> = {
     'map': ['background-map-layer'],
     'orthographic-background-map': ['orthographic-background-map-layer'],

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -50,7 +50,10 @@ import { createPlanAreaLayer } from 'map/layers/geometry/plan-area-layer';
 import { pointToCoords } from 'map/layers/utils/layer-utils';
 import { createGeometrySwitchLayer } from 'map/layers/geometry/geometry-switch-layer';
 import { createSwitchLayer } from 'map/layers/switch/switch-layer';
-import { createBackgroundMapLayer } from 'map/layers/background-map-layer';
+import {
+    createBackgroundMapLayer,
+    createOrthographicMapLayer,
+} from 'map/layers/background-map-layer';
 import TileSource from 'ol/source/Tile';
 import TileLayer from 'ol/layer/Tile';
 import { MapLayer } from 'map/layers/utils/layer-model';
@@ -313,6 +316,8 @@ const MapView: React.FC<MapViewProps> = ({
                 switch (layerName) {
                     case 'background-map-layer':
                         return createBackgroundMapLayer(existingOlLayer as TileLayer<TileSource>);
+                    case 'orthographic-background-map-layer':
+                        return createOrthographicMapLayer(existingOlLayer as TileLayer<TileSource>);
                     case 'track-number-diagram-layer':
                         return createTrackNumberDiagramLayer(
                             mapTiles,

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -57,7 +57,7 @@ import {
 import TileSource from 'ol/source/Tile';
 import TileLayer from 'ol/layer/Tile';
 import { MapLayer } from 'map/layers/utils/layer-model';
-import { filterNotEmpty, first } from 'utils/array-utils';
+import { filterNotEmpty, first, objectEntries } from 'utils/array-utils';
 import { mapLayerZIndexes } from 'map/layers/utils/layer-visibility-limits';
 import { createLocationTrackAlignmentLayer } from 'map/layers/alignment/location-track-alignment-layer';
 import { createReferenceLineAlignmentLayer } from 'map/layers/alignment/reference-line-alignment-layer';
@@ -82,6 +82,7 @@ import { createLocationTrackSelectedAlignmentLayer } from 'map/layers/alignment/
 import { createLocationTrackSplitBadgeLayer } from 'map/layers/alignment/location-track-split-badge-layer';
 import { createSelectedReferenceLineAlignmentLayer } from './layers/alignment/reference-line-selected-alignment-layer';
 import { createOperatingPointLayer } from 'map/layers/operating-point/operating-points-layer';
+import { layersCoveringLayers } from 'map/map-store';
 
 declare global {
     interface Window {
@@ -303,8 +304,15 @@ const MapView: React.FC<MapViewProps> = ({
         const olView = olMap.getView();
         const resolution = olView.getResolution() || 0;
 
+        const layerIsCovered = (layer: MapLayerName) =>
+            objectEntries(layersCoveringLayers).some(
+                ([coveringLayer, covers]) =>
+                    map.visibleLayers.includes(coveringLayer) && covers?.includes(layer),
+            );
+
         // Create OpenLayers objects by domain layers
         const updatedLayers = map.visibleLayers
+            .filter((layer) => !layerIsCovered(layer))
             .map((layerName) => {
                 const mapTiles = calculateMapTiles(olView, undefined);
 

--- a/ui/src/map/map.module.scss
+++ b/ui/src/map/map.module.scss
@@ -36,7 +36,7 @@
     linkedGeometryAlignment: geoviite-design.$color-geoviite-green-default;
     selectedLinkedGeometryAlignment: geoviite-design.$color-geoviite-green-dark;
 
-    alignmentBackground: vayla-design.$color-white-default;
+    alignmentBackground: rgba(vayla-design.$color-white-default, 0.6);
 
     alignmentLine: rgba(vayla-design.$color-black-default, 0.8);
     selectedAlignmentLine: geoviite-design.$color-geoviite-blue;


### PR DESCRIPTION
- Päädyin näkemään parhaaksi, että ilmakuvataso piilottaa tavallisen taustakartan kokonaan taakseen, muuten ilmakuvat näyttävät oudon haalistuneilta
- Samalla säädetty myös virheellisten vaihteiden kylttien taustojen koot oikeiksi (ainakin Firefoxilla ja Chromella), ja säädetty raiteiden taustat läpinäkyviksi, jotta ilmakuva ei jää ihan kokonaan niiden taakse