### PR TITLE
GVT-2546 Relax joint distinctness requirement in merging switch changes

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -543,7 +543,7 @@ private fun mergeSwitchChanges(
     .flatMap { it }
     .groupBy { it.switchId }
     .map { (switchId, changes) ->
-        val mergedJoints = changes.flatMap { it.changedJoints }.distinct()
+        val mergedJoints = changes.flatMap { it.changedJoints }.distinctBy { joint -> joint.number to joint.locationTrackId }
         SwitchChange(switchId = switchId, changedJoints = mergedJoints)
     }
 


### PR DESCRIPTION
Ongelma oli siis, että tämä osaa yleensä yhdistää eri segmenteiltä tulevat samaan vaihtepisteeseen liittyvät muutokset, mutta eipä osaakaan, jos geometria on sellainen, että segmenttien päätepisteiden välillä on aukkoa.

Periaatteessa tuo aiempi distinct() oli kai siitä hyvä, että siitä tiesi, että se räjäyttää julkaisun, jos yhdistettävissä muutoksissa on mitään vääränlaista eroa => saadaanpahan ainakin sisäisiä virheitä julkaisusta, sen sijaan että tallennettaisiin julkaisuun bugisen muutoslaskennan tulosta. Mutta käytännössä muutoslaskennasta alkaa olla toivottavasti aika hyvin bugit taputeltu, joten ajattelin järkevimmäksi vaan olettaa riittävän, että tehdään nyt vaan ihan raakasti tuo distinct() vain pisteen tunnistetiedoilla.