### PR TITLE
General: Fix invalid Checkbox-component qaId attributes

### DIFF
--- a/ui/src/vayla-design-lib/checkbox/checkbox.tsx
+++ b/ui/src/vayla-design-lib/checkbox/checkbox.tsx
@@ -8,7 +8,7 @@ export type CheckboxProps = {
     qaId?: string;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
-export const Checkbox: React.FC<CheckboxProps> = ({ children, ...props }: CheckboxProps) => {
+export const Checkbox: React.FC<CheckboxProps> = ({ children, qaId, ...props }: CheckboxProps) => {
     const [touched, setTouched] = React.useState(false);
 
     const className = createClassName(styles.checkbox, touched && styles['checkbox--touched']);
@@ -18,7 +18,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({ children, ...props }: Checkb
             onClick={() => {
                 setTouched(true);
             }}
-            {...(props.qaId && { 'qa-id': props.qaId })}>
+            {...(qaId && { 'qa-id': qaId })}>
             <input {...props} type="checkbox" className={styles.checkbox__input} />
             <span className={styles.checkbox__visualization}>
                 <span className={styles['checkbox__checked-icon']}>


### PR DESCRIPTION
The element listing data product page was using JS-style attribute names which React does not recognize. The qaId-attributes were also duplicated due to passing an unmodified props-object to a child element.

These errors were noticed during E2E-test development.

Fixes error resulting in console error such as:
>Warning: React does not recognize the `qaId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `qaid` instead. If you accidentally passed it from a parent component, remove it from the DOM element

