### PR TITLE
GVT-2551 & GVT-2554: Korjauksia linkityksen virheilmoituksiin ja splittaukseen

### DIFF
--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -383,7 +383,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                             )}
                         </React.Fragment>
                     )}
-                    {linkingInProgress && canLink && (
+                    {linkingInProgress && (
                         <React.Fragment>
                             <div
                                 className={styles['geometry-alignment-infobox__connection-points']}>

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -456,6 +456,12 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                     t.asset.id === linkingState.geometryKmPostId
                 );
             })?.asset;
+        } else if (splittingState) {
+            lockToAsset = tabs.find(
+                (t) =>
+                    t.asset.type === 'LOCATION_TRACK' &&
+                    t.asset.id === splittingState.originLocationTrack.id,
+            )?.asset;
         }
 
         setSelectedAsset(lockToAsset ? lockToAsset : tab);


### PR DESCRIPTION
Alkuperäinen tiketti oli se, että linkityksen varoituslaatikot eivät näy. Tätä testatessa huomasin toisenkin ei-toivotun käyttäytymisen (splittauksen ollessa aktiivinen toolpanelissa valittua tabia ei lukita linkitystilan tyyliin, vaan sieltä pääsee esim. linkittämään geometriaraiteita.) Tein omilla valtuuksillani tähänkin korjauksen, sillä mielestäni on paljon järkevämpää että splitatessa voidaan tehdä pelkkää splittausta. 