### PR TITLE
General: Fix flaky E2E test by waiting for change validations to complete in preview view

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/PreviewChangesPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/PreviewChangesPage.kt
@@ -64,6 +64,12 @@ class E2EPreviewChangesPage : E2EViewFragment(byQaId("preview-content")) {
             .also { map -> map.scrollMap(1, 1) }
             .also { map -> map.scrollMap(-1, -1) }
     }
+
+    fun waitForAllTableValidationsToComplete() {
+        logger.info("Waiting for table validations to begin & complete")
+        waitUntilChildVisible(byQaId("table-validation-in-progress"))
+        waitUntilChildInvisible(byQaId("table-validation-in-progress"))
+    }
 }
 
 class E2EPreviewChangesSaveOrDiscardDialog : E2EDialog() {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
@@ -112,6 +112,8 @@ class BasicMapTestUI @Autowired constructor(
         assertEquals(E2ELocationTrackEditDialog.State.NOT_IN_USE.name, locationTrackInfobox.state)
 
         val previewChangesPage = trackLayoutPage.goToPreview()
+        previewChangesPage.waitForAllTableValidationsToComplete()
+
         val changePreviewTable = previewChangesPage.changesTable
 
         assertTrue(changePreviewTable.rows.isNotEmpty())

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -171,7 +171,14 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
             icon={sortInfo.propName === prop ? getSortDirectionIcon(sortInfo.direction) : undefined}
             contentAlignment={showSpinner ? ThContentAlignment.VERTICALLY_ALIGNED : undefined}>
             {t(translationKey)}
-            {showSpinner && <Spinner inline={true} size={SpinnerSize.SMALL} tableHeader={true} />}
+            {showSpinner && (
+                <Spinner
+                    inline={true}
+                    size={SpinnerSize.SMALL}
+                    tableHeader={true}
+                    qaId={'table-validation-in-progress'}
+                />
+            )}
         </Th>
     );
 

--- a/ui/src/vayla-design-lib/spinner/spinner.tsx
+++ b/ui/src/vayla-design-lib/spinner/spinner.tsx
@@ -11,12 +11,14 @@ export type SpinnerProps = {
     size?: SpinnerSize;
     inline?: boolean;
     tableHeader?: boolean;
+    qaId?: string;
 };
 
 export const Spinner: React.FC<SpinnerProps> = ({
     size = SpinnerSize.NORMAL,
     inline = false,
     tableHeader = false,
+    qaId,
 }: SpinnerProps) => {
     const className = createClassName(
         styles.spinner,
@@ -25,5 +27,5 @@ export const Spinner: React.FC<SpinnerProps> = ({
         size === SpinnerSize.SMALL && styles['spinner--small'],
     );
 
-    return <div className={className} />;
+    return <div className={className} {...(qaId && { 'qa-id': qaId })} />;
 };


### PR DESCRIPTION
After the preview view has opened, it fetches the currently unpublished changes from the API. After this fetch call, it sends another validation api call based on the changes it received.

Usually the UI operations accomplished by an E2E test trying to revert a change were accomplished before the ongoing validation api call managed to finish. Sometimes it was possible for the asynchronous validation call of the preview view component to finish before the ongoing revert operation of the E2E test, leading to an update of the preview view component and further causing the test code to no longer finding the element that it was looking for during the .revertChange()-call.

This PR provides functionality to synchronize E2E tests for the validation state of the preview view component and enables the synchronization for the (rarely) flaky `Edit and discard location track changes` E2E-test.