### PR TITLE
GVT-2407 front-end draftable & publishtype renames

### DIFF
--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -130,7 +130,7 @@ export type ElementLocation = {
     cant?: number;
 };
 
-export type DraftableChangeInfo = {
+export type LayoutAssetChangeInfo = {
     created: TimeStamp;
     changed: TimeStamp | undefined;
 };

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -264,7 +264,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         setShowNewAssetMenu(false);
     }
 
-    function moveToOfficialPublishType() {
+    function switchToOfficialContext() {
         onPublicationStateChange('OFFICIAL');
         setShowNewAssetMenu(false);
     }
@@ -357,7 +357,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                             }
                             variant={ButtonVariant.SECONDARY}
                             title={modeNavigationButtonsDisabledReason()}
-                            onClick={() => moveToOfficialPublishType()}>
+                            onClick={() => switchToOfficialContext()}>
                             {t('tool-bar.draft-mode.disable')}
                         </Button>
                         <Button

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -119,7 +119,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         changeTimes,
     );
 
-    const publishTypeIsDraft = layoutContext.publicationState === 'DRAFT';
+    const isDraft = layoutContext.publicationState === 'DRAFT';
     const locationTrackIsDraft = locationTrack.editState !== 'UNEDITED';
     const duplicatesOnOtherTrackNumbers = extraInfo?.duplicates?.some(
         (duplicate) => duplicate.trackNumberId !== trackNumber?.id,
@@ -128,7 +128,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
     const getSplittingDisabledReasonsTranslated = () => {
         const reasons: string[] = [];
 
-        if (!publishTypeIsDraft) {
+        if (!isDraft) {
             return t('tool-panel.disabled.activity-disabled-in-official-mode');
         }
 
@@ -153,7 +153,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
     };
 
     const getModifyStartOrEndDisabledReasonTranslated = () => {
-        if (!publishTypeIsDraft) {
+        if (!isDraft) {
             return t('tool-panel.disabled.activity-disabled-in-official-mode');
         } else if (splittingState || extraInfo?.partOfUnfinishedSplit) {
             return t('tool-panel.location-track.splitting-blocks-geometry-changes');
@@ -261,7 +261,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
 
                             {linkingState === undefined && (
                                 <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                                    {publishTypeIsDraft && extraInfo?.partOfUnfinishedSplit && (
+                                    {isDraft && extraInfo?.partOfUnfinishedSplit && (
                                         <InfoboxContentSpread>
                                             <MessageBox>
                                                 {t(
@@ -330,7 +330,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                             )}
                             <EnvRestricted restrictTo="test">
                                 <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                                    {publishTypeIsDraft &&
+                                    {isDraft &&
                                         locationTrackIsDraft &&
                                         !extraInfo?.partOfUnfinishedSplit && (
                                             <InfoboxContentSpread>
@@ -341,7 +341,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                                 </MessageBox>
                                             </InfoboxContentSpread>
                                         )}
-                                    {publishTypeIsDraft &&
+                                    {isDraft &&
                                         duplicatesOnOtherTrackNumbers &&
                                         !extraInfo?.partOfUnfinishedSplit && (
                                             <InfoboxContentSpread>
@@ -359,7 +359,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                                 size={ButtonSize.SMALL}
                                                 disabled={
                                                     locationTrack.state !== 'IN_USE' ||
-                                                    !publishTypeIsDraft ||
+                                                    !isDraft ||
                                                     locationTrackIsDraft ||
                                                     duplicatesOnOtherTrackNumbers ||
                                                     extraInfo?.partOfUnfinishedSplit

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -187,7 +187,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     };
 
     // Draft-only entities should be hidden when viewing in official mode. Show everything in draft mode
-    const visibleByTypeAndPublishType = ({ editState }: { editState: EditState }) =>
+    const visibleByContextAndState = ({ editState }: { editState: EditState }) =>
         layoutContext.publicationState === 'DRAFT' || editState !== 'CREATED';
 
     React.useEffect(() => {
@@ -214,7 +214,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         const trackNumberTabs = trackNumberIds
             .map((tnId) => trackNumbers?.find((tn) => tn.id === tnId))
             .filter(filterNotEmpty)
-            .filter(visibleByTypeAndPublishType)
+            .filter(visibleByContextAndState)
             .map((t) => {
                 return {
                     asset: { type: 'TRACK_NUMBER', id: t.id },
@@ -232,7 +232,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                 } as ToolPanelTab;
             });
 
-        const layoutKmPostTabs = kmPosts.filter(visibleByTypeAndPublishType).map((k) => {
+        const layoutKmPostTabs = kmPosts.filter(visibleByContextAndState).map((k) => {
             return {
                 asset: { type: 'KM_POST', id: k.id },
                 title: k.kmNumber,
@@ -271,7 +271,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             },
         );
 
-        const switchTabs = switches.filter(visibleByTypeAndPublishType).map((s) => {
+        const switchTabs = switches.filter(visibleByContextAndState).map((s) => {
             return {
                 asset: { type: 'SWITCH', id: s.id },
                 title: s.name,
@@ -327,25 +327,23 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                 };
             });
 
-        const locationTrackTabs = locationTracks
-            .filter(visibleByTypeAndPublishType)
-            .map((track) => {
-                return {
-                    asset: { type: 'LOCATION_TRACK', id: track.id },
-                    title: track.name,
-                    element: (
-                        <LocationTrackInfoboxLinkingContainer
-                            visibilities={infoboxVisibilities.locationTrack}
-                            onVisibilityChange={(visibilities) =>
-                                infoboxVisibilityChange('locationTrack', visibilities)
-                            }
-                            locationTrackId={track.id}
-                            onDataChange={onDataChange}
-                            onHoverOverPlanSection={onHoverOverPlanSection}
-                        />
-                    ),
-                } as ToolPanelTab;
-            });
+        const locationTrackTabs = locationTracks.filter(visibleByContextAndState).map((track) => {
+            return {
+                asset: { type: 'LOCATION_TRACK', id: track.id },
+                title: track.name,
+                element: (
+                    <LocationTrackInfoboxLinkingContainer
+                        visibilities={infoboxVisibilities.locationTrack}
+                        onVisibilityChange={(visibilities) =>
+                            infoboxVisibilityChange('locationTrack', visibilities)
+                        }
+                        locationTrackId={track.id}
+                        onDataChange={onDataChange}
+                        onHoverOverPlanSection={onHoverOverPlanSection}
+                    />
+                ),
+            } as ToolPanelTab;
+        });
 
         const geometryAlignmentTabs = geometryAlignmentIds.map((aId) => {
             const header = getPlan(aId.planId)?.alignments?.find(

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -90,7 +90,6 @@ export async function getKmPostsByTile(
     const params = queryParams({
         bbox: bboxString(bbox),
         step: Math.ceil(step),
-        publishType: layoutContext.publicationState,
     });
     return kmPostListCache.get(
         changeTime,

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -6,7 +6,7 @@ import {
     LayoutTrackNumberId,
 } from 'track-layout/track-layout-model';
 import {
-    DraftableChangeInfo,
+    LayoutAssetChangeInfo,
     draftLayoutContext,
     KmNumber,
     LayoutContext,
@@ -217,7 +217,7 @@ export const getKmLengthsAsCsv = (
 };
 
 export const getKmPostChangeTimes = (id: LayoutKmPostId, layoutContext: LayoutContext) =>
-    getNullable<DraftableChangeInfo>(changeTimeUri('km-posts', id, layoutContext));
+    getNullable<LayoutAssetChangeInfo>(changeTimeUri('km-posts', id, layoutContext));
 
 export const getEntireRailNetworkKmLengthsCsvUrl = () =>
     `${TRACK_LAYOUT_URI}/track-numbers/rail-network/km-lengths/file`;

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -10,7 +10,7 @@ import {
     OperatingPoint,
 } from 'track-layout/track-layout-model';
 import {
-    DraftableChangeInfo,
+    LayoutAssetChangeInfo,
     draftLayoutContext,
     LayoutContext,
     TimeStamp,
@@ -294,8 +294,8 @@ export async function getNonLinkedLocationTracks(
 export const getLocationTrackChangeTimes = (
     id: LocationTrackId,
     layoutContext: LayoutContext,
-): Promise<DraftableChangeInfo | undefined> => {
-    return getNullable<DraftableChangeInfo>(changeTimeUri('location-tracks', id, layoutContext));
+): Promise<LayoutAssetChangeInfo | undefined> => {
+    return getNullable<LayoutAssetChangeInfo>(changeTimeUri('location-tracks', id, layoutContext));
 };
 
 export const getLocationTrackSectionsByPlan = async (

--- a/ui/src/track-layout/layout-reference-line-api.ts
+++ b/ui/src/track-layout/layout-reference-line-api.ts
@@ -5,7 +5,7 @@ import {
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import {
-    DraftableChangeInfo,
+    LayoutAssetChangeInfo,
     draftLayoutContext,
     LayoutContext,
     TimeStamp,
@@ -98,6 +98,6 @@ export async function getNonLinkedReferenceLines(
 export const getReferenceLineChangeTimes = (
     id: ReferenceLineId,
     layoutContext: LayoutContext,
-): Promise<DraftableChangeInfo | undefined> => {
-    return getNullable<DraftableChangeInfo>(changeTimeUri('reference-lines', id, layoutContext));
+): Promise<LayoutAssetChangeInfo | undefined> => {
+    return getNullable<LayoutAssetChangeInfo>(changeTimeUri('reference-lines', id, layoutContext));
 };

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -1,6 +1,6 @@
 import { BoundingBox, Point } from 'model/geometry';
 import {
-    DraftableChangeInfo,
+    LayoutAssetChangeInfo,
     draftLayoutContext,
     LayoutContext,
     TimeStamp,
@@ -199,6 +199,6 @@ export const getSwitchesValidationByTile = async (
 export const getSwitchChangeTimes = (
     id: LayoutSwitchId,
     layoutContext: LayoutContext,
-): Promise<DraftableChangeInfo | undefined> => {
-    return getNonNull<DraftableChangeInfo>(changeTimeUri('switches', id, layoutContext));
+): Promise<LayoutAssetChangeInfo | undefined> => {
+    return getNonNull<LayoutAssetChangeInfo>(changeTimeUri('switches', id, layoutContext));
 };

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -1,7 +1,7 @@
 import { asyncCache } from 'cache/cache';
 import { LayoutTrackNumber, LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import {
-    DraftableChangeInfo,
+    LayoutAssetChangeInfo,
     draftLayoutContext,
     LayoutContext,
     TimeStamp,
@@ -113,6 +113,6 @@ export const getTrackNumberReferenceLineSectionsByPlan = async (
 export const getTrackNumberChangeTimes = (
     id: LayoutTrackNumberId,
     layoutContext: LayoutContext,
-): Promise<DraftableChangeInfo | undefined> => {
-    return getNullable<DraftableChangeInfo>(changeTimeUri('track-numbers', id, layoutContext));
+): Promise<LayoutAssetChangeInfo | undefined> => {
+    return getNullable<LayoutAssetChangeInfo>(changeTimeUri('track-numbers', id, layoutContext));
 };

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -15,7 +15,7 @@ import {
 import { LoaderStatus, useLoader, useLoaderWithStatus, useOptionalLoader } from 'utils/react-utils';
 import {
     CoordinateSystem,
-    DraftableChangeInfo,
+    LayoutAssetChangeInfo,
     LayoutContext,
     Srid,
     SwitchStructure,
@@ -283,7 +283,7 @@ export function usePlanHeader(id: GeometryPlanId | undefined): GeometryPlanHeade
 export function useTrackNumberChangeTimes(
     id: LayoutTrackNumberId | undefined,
     layoutContext: LayoutContext,
-): DraftableChangeInfo | undefined {
+): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getTrackNumberChangeTimes(id, layoutContext) : undefined),
         [id, layoutContext.designId, layoutContext.publicationState],
@@ -293,7 +293,7 @@ export function useTrackNumberChangeTimes(
 export function useReferenceLineChangeTimes(
     id: ReferenceLineId | undefined,
     layoutContext: LayoutContext,
-): DraftableChangeInfo | undefined {
+): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getReferenceLineChangeTimes(id, layoutContext) : undefined),
         [id, layoutContext.designId, layoutContext.publicationState],
@@ -303,7 +303,7 @@ export function useReferenceLineChangeTimes(
 export function useLocationTrackChangeTimes(
     id: LocationTrackId | undefined,
     layoutContext: LayoutContext,
-): DraftableChangeInfo | undefined {
+): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getLocationTrackChangeTimes(id, layoutContext) : undefined),
         [id, layoutContext.designId, layoutContext.publicationState],
@@ -313,7 +313,7 @@ export function useLocationTrackChangeTimes(
 export function useSwitchChangeTimes(
     id: LayoutSwitchId | undefined,
     layoutContext: LayoutContext,
-): DraftableChangeInfo | undefined {
+): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getSwitchChangeTimes(id, layoutContext) : undefined),
         [id, layoutContext.designId, layoutContext.publicationState],
@@ -323,7 +323,7 @@ export function useSwitchChangeTimes(
 export function useKmPostChangeTimes(
     id: LayoutKmPostId | undefined,
     layoutContext: LayoutContext,
-): DraftableChangeInfo | undefined {
+): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getKmPostChangeTimes(id, layoutContext) : undefined),
         [id, layoutContext.designId, layoutContext.publicationState],


### PR DESCRIPTION
Loput renamet. Tämä branchi oli ollut roikkumassa että saadaan preview muutokset ensin mergettyä ja meinasi unothua. Onneksi Jira-tiketti roikkui muistutuksena. Kyseessä muuttujien/luokkien renameja uuteen termistöön.