### PR TITLE
GVT-2558 Slightly straighten out duplicate parent/child reference directions

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -422,7 +422,7 @@ class LocationTrackService(
     fun getInfoboxExtras(publicationState: PublicationState, id: IntId<LocationTrack>): LocationTrackInfoboxExtras? {
         val locationTrackAndAlignment = getWithAlignment(publicationState, id)
         return locationTrackAndAlignment?.let { (locationTrack, alignment) ->
-            val duplicateOf = getDuplicateOf(locationTrack, publicationState)
+            val duplicateOf = getDuplicateTrackParent(locationTrack, publicationState)
             val sortedDuplicates = getLocationTrackDuplicates(locationTrack, alignment, publicationState)
             val startSwitch = (alignment.segments.firstOrNull()?.switchId as IntId?
                 ?: locationTrack.topologyStartSwitch?.switchId)?.let { id -> fetchSwitchAtEndById(id, publicationState) }
@@ -474,13 +474,13 @@ class LocationTrackService(
         return getLocationTrackDuplicatesByJoint(track, alignment, duplicateTracksAndAlignments)
     }
 
-    private fun getDuplicateOf(
-        locationTrack: LocationTrack,
+    private fun getDuplicateTrackParent(
+        childTrack: LocationTrack,
         publicationState: PublicationState,
-    ): LocationTrackDuplicate? = locationTrack.duplicateOf?.let { duplicateOfId ->
-        getWithAlignment(publicationState, duplicateOfId)?.let { (duplicateOfTrack, duplicateOfAlignment) ->
-            val alignment = alignmentDao.fetch(locationTrack.getAlignmentVersionOrThrow())
-            getLocationTrackDuplicateOfStatus(locationTrack, alignment, duplicateOfTrack, duplicateOfAlignment)
+    ): LocationTrackDuplicate? = childTrack.duplicateOf?.let { parentId ->
+        getWithAlignment(publicationState, parentId)?.let { (parentTrack, parentTrackAlignment) ->
+            val childAlignment = alignmentDao.fetch(childTrack.getAlignmentVersionOrThrow())
+            getDuplicateTrackParentStatus(parentTrack, parentTrackAlignment, childTrack, childAlignment)
         }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLink.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLink.kt
@@ -4,26 +4,26 @@ import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 
-fun getLocationTrackDuplicateOfStatus(
-    mainTrack: LocationTrack,
-    mainAlignment: LayoutAlignment,
-    duplicatedTrack: LocationTrack,
-    duplicatedAlignment: LayoutAlignment,
+fun getDuplicateTrackParentStatus(
+    parentTrack: LocationTrack,
+    parentAlignment: LayoutAlignment,
+    childTrack: LocationTrack,
+    childAlignment: LayoutAlignment,
 ): LocationTrackDuplicate {
-    val mainTrackJoints = collectSwitchJoints(mainTrack, mainAlignment)
-    val duplicatedTrackJoints = collectSwitchJoints(duplicatedTrack, duplicatedAlignment)
+    val parentTrackJoints = collectSwitchJoints(parentTrack, parentAlignment)
+    val childTrackJoints = collectSwitchJoints(childTrack, childAlignment)
     val statuses = getDuplicateMatches(
-        duplicatedTrackJoints,
-        mainTrackJoints,
-        duplicatedTrack.id,
-        duplicatedTrack.duplicateOf,
+        parentTrackJoints,
+        childTrackJoints,
+        parentTrack.id,
+        childTrack.duplicateOf,
     )
     return statuses.map { (jointIndex, status) ->
         jointIndex to LocationTrackDuplicate(
-            duplicatedTrack.id as IntId,
-            duplicatedTrack.trackNumberId,
-            duplicatedTrack.name,
-            duplicatedTrack.externalId,
+            parentTrack.id as IntId,
+            parentTrack.trackNumberId,
+            parentTrack.name,
+            parentTrack.externalId,
             status,
         )
     }.first().second // There has to at least one found, since we know the duplicateOf is set


### PR DESCRIPTION
Teoriassa varsinaisesta bugista itsestään selviäisi pienemmälläkin muutoksella. Käytännössä tuossa sai miettiä kuin peukkuileva Timo Soini konsanaan, että mitähän tässä nyt oli tarkoitettu tehdä kummalla raiteella, ja ajattelin, että kyllä asia voisi olla selkeämminkin sanottu.

En lähtenyt tekemään muutoksia isompaan määrään koodia, jonka kanssa Jyrki on juuri hääräämässä, mutta kun duplikaattien kanssa pitää varmasti vielä jonkin verran ährätä, niin voisi ährätä vaikka tällä käsitteistöllä.