### PR TITLE
GVT-2570 Retain split list order in updateSplit

### DIFF
--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -246,9 +246,9 @@ export const splitReducers = {
     ): void => {
         if (state.splittingState) {
             if (payload.type === 'SPLIT') {
-                state.splittingState.splits = state.splittingState.splits
-                    .filter((split) => split.switchId !== payload.switchId)
-                    .concat([payload]);
+                state.splittingState.splits = state.splittingState.splits.map((split) =>
+                    split.switchId === payload.switchId ? payload : split,
+                );
             } else {
                 state.splittingState.firstSplit = payload;
             }


### PR DESCRIPTION
Liikennepaikkatiedon hyödyntämisen perua: Tarvitsin splittilistan järjestyksessä, ja näytti loogisemmalta vaan ylläpitää sitä järjestyksessä sen sijaan että sorttaisi sen vasta juuri ennen käyttöä, mutta jätin sitten ottamatta sen tässä kohti huomioon.