### PR TITLE
GVT-2564 fix source location track version to split

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
@@ -90,6 +90,22 @@ data class TrackMeter @JsonCreator(mode = DISABLED) constructor(
     override val kmNumber: KmNumber,
     override val meters: BigDecimal,
 ) : ITrackMeter {
+    /**
+     * Returns true if the meters value has no decimals.
+     * TrackMeter("1234+1234.1234").metersHaveIntegerPrecision() == false
+     * TrackMeter("1234+1234.0000").metersHaveIntegerPrecision() == false
+     * TrackMeter("1234+1234").metersHaveIntegerPrecision() == true
+     */
+    fun metersHaveIntegerPrecision() = meters.scale() <= 0
+
+    /**
+     * Returns true if any decimals on the meters value are zeroes (or there are none)
+     * TrackMeter("1234+1234.1234").metersMatchIntegerValue() == false
+     * TrackMeter("1234+1234.0000").metersMatchIntegerValue() == true
+     * TrackMeter("1234+1234").metersMatchIntegerValue() == true
+     */
+    fun metersMatchIntegerValue() = meters.stripTrailingZeros().scale() <= 0
+
     private constructor(values: Pair<KmNumber, BigDecimal>) : this(values.first, values.second)
 
     @JsonCreator(mode = DELEGATING)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
@@ -92,19 +92,19 @@ data class TrackMeter @JsonCreator(mode = DISABLED) constructor(
 ) : ITrackMeter {
     /**
      * Returns true if the meters value has no decimals.
-     * TrackMeter("1234+1234.1234").metersHaveIntegerPrecision() == false
-     * TrackMeter("1234+1234.0000").metersHaveIntegerPrecision() == false
-     * TrackMeter("1234+1234").metersHaveIntegerPrecision() == true
+     * TrackMeter("1234+1234.1234").hasIntegerPrecision() == false
+     * TrackMeter("1234+1234.0000").hasIntegerPrecision() == false
+     * TrackMeter("1234+1234").hasIntegerPrecision() == true
      */
-    fun metersHaveIntegerPrecision() = meters.scale() <= 0
+    fun hasIntegerPrecision() = meters.scale() <= 0
 
     /**
      * Returns true if any decimals on the meters value are zeroes (or there are none)
-     * TrackMeter("1234+1234.1234").metersMatchIntegerValue() == false
-     * TrackMeter("1234+1234.0000").metersMatchIntegerValue() == true
-     * TrackMeter("1234+1234").metersMatchIntegerValue() == true
+     * TrackMeter("1234+1234.1234").matchesIntegerValue() == false
+     * TrackMeter("1234+1234.0000").matchesIntegerValue() == true
+     * TrackMeter("1234+1234").matchesIntegerValue() == true
      */
-    fun metersMatchIntegerValue() = meters.stripTrailingZeros().scale() <= 0
+    fun matchesIntegerValue() = meters.stripTrailingZeros().scale() <= 0
 
     private constructor(values: Pair<KmNumber, BigDecimal>) : this(values.first, values.second)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -41,10 +41,10 @@ import kotlin.math.abs
 
 data class AddressPoint(val point: AlignmentPoint, val address: TrackMeter) {
     fun isSame(other: AddressPoint) = address.isSame(other.address) && point.isSame(other.point)
-    fun asExactMeter(): AddressPoint? =
-        if (address.metersHaveIntegerPrecision()) {
+    fun withIntegerPrecision(): AddressPoint? =
+        if (address.hasIntegerPrecision()) {
             this
-        } else if (address.metersMatchIntegerValue()) {
+        } else if (address.matchesIntegerValue()) {
             AddressPoint(point = point, address = address.floor())
         } else {
             null
@@ -66,7 +66,7 @@ data class AlignmentAddresses(
     @get:JsonIgnore
     val exactMeterPoints: List<AddressPoint> by lazy {
         // midPoints are even anyhow, so just transform start/end
-        listOfNotNull(startPoint.asExactMeter()) + midPoints + listOfNotNull(endPoint.asExactMeter())
+        listOfNotNull(startPoint.withIntegerPrecision()) + midPoints + listOfNotNull(endPoint.withIntegerPrecision())
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -1,11 +1,37 @@
 package fi.fta.geoviite.infra.geocoding
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.DEFAULT_TRACK_METER_DECIMALS
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.error.GeocodingFailureException
-import fi.fta.geoviite.infra.math.*
-import fi.fta.geoviite.infra.math.IntersectType.*
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.math.IPoint
+import fi.fta.geoviite.infra.math.IntersectType
+import fi.fta.geoviite.infra.math.IntersectType.AFTER
+import fi.fta.geoviite.infra.math.IntersectType.BEFORE
+import fi.fta.geoviite.infra.math.IntersectType.WITHIN
+import fi.fta.geoviite.infra.math.Intersection
+import fi.fta.geoviite.infra.math.Line
+import fi.fta.geoviite.infra.math.angleAvgRads
+import fi.fta.geoviite.infra.math.angleDiffRads
+import fi.fta.geoviite.infra.math.directionBetweenPoints
+import fi.fta.geoviite.infra.math.interpolate
+import fi.fta.geoviite.infra.math.isSame
+import fi.fta.geoviite.infra.math.lineIntersection
+import fi.fta.geoviite.infra.math.lineLength
+import fi.fta.geoviite.infra.math.pointInDirection
+import fi.fta.geoviite.infra.math.round
+import fi.fta.geoviite.infra.math.roundTo3Decimals
+import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
+import fi.fta.geoviite.infra.tracklayout.GeometrySource
+import fi.fta.geoviite.infra.tracklayout.IAlignment
+import fi.fta.geoviite.infra.tracklayout.ISegment
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_M_DELTA
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.SegmentPoint
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.math.BigDecimal
@@ -15,6 +41,14 @@ import kotlin.math.abs
 
 data class AddressPoint(val point: AlignmentPoint, val address: TrackMeter) {
     fun isSame(other: AddressPoint) = address.isSame(other.address) && point.isSame(other.point)
+    fun asExactMeter(): AddressPoint? =
+        if (address.metersHaveIntegerPrecision()) {
+            this
+        } else if (address.metersMatchIntegerValue()) {
+            AddressPoint(point = point, address = address.floor())
+        } else {
+            null
+        }
 }
 
 data class AlignmentAddresses(
@@ -27,6 +61,12 @@ data class AlignmentAddresses(
     @get:JsonIgnore
     val allPoints: List<AddressPoint> by lazy {
         emptyList<AddressPoint>() + startPoint + midPoints + endPoint
+    }
+
+    @get:JsonIgnore
+    val exactMeterPoints: List<AddressPoint> by lazy {
+        // midPoints are even anyhow, so just transform start/end
+        listOfNotNull(startPoint.asExactMeter()) + midPoints + listOfNotNull(endPoint.asExactMeter())
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -537,13 +537,12 @@ class PublicationService @Autowired constructor(
         val kmPosts = versions.kmPosts.map(kmPostService::publish).map { r -> r.rowVersion }
         val switches = versions.switches.map(switchService::publish).map { r -> r.rowVersion }
         val referenceLines = versions.referenceLines.map(referenceLineService::publish).map { r -> r.rowVersion }
-        val locationTracks = versions.locationTracks.map(locationTrackService::publish).map { r -> r.rowVersion }
+        val locationTracks = versions.locationTracks.map(locationTrackService::publish)
         val publicationId = publicationDao.createPublication(message)
         publicationDao.insertCalculatedChanges(publicationId, calculatedChanges)
         publicationGeometryChangeRemarksUpdateService.processPublication(publicationId)
 
-        // TODO: GVT-2564 update split to match new source location track version, or the publication will fail
-        splitService.publishSplit(versions.locationTracks.map { it.officialId }, publicationId)
+        splitService.publishSplit(locationTracks, publicationId)
 
         return PublicationResult(
             publicationId = publicationId,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -841,11 +841,7 @@ class PublicationService @Autowired constructor(
         return publicationDao.getPublication(id).let { publication ->
             splitService.getSplitIdByPublicationId(id)?.let { splitId ->
                 val split = splitService.getOrThrow(splitId)
-                val sourceLocationTrack = locationTrackService.getOfficialAtMoment(
-                    split.locationTrackId,
-                    publication.publicationTime,
-                )
-                requireNotNull(sourceLocationTrack) { "Source location track not found" }
+                val sourceLocationTrack = locationTrackDao.fetch(split.sourceLocationTrackVersion)
                 val targetLocationTracks = publicationDao
                     .fetchPublishedLocationTracks(id)
                     .let { changes -> (changes.indirectChanges + changes.directChanges).map { c -> c.version } }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -542,6 +542,7 @@ class PublicationService @Autowired constructor(
         publicationDao.insertCalculatedChanges(publicationId, calculatedChanges)
         publicationGeometryChangeRemarksUpdateService.processPublication(publicationId)
 
+        // TODO: GVT-2564 update split to match new source location track version, or the publication will fail
         splitService.publishSplit(versions.locationTracks.map { it.officialId }, publicationId)
 
         return PublicationResult(
@@ -670,10 +671,11 @@ class PublicationService @Autowired constructor(
                         val switchTracks = validationContext.getSwitchTracksWithAlignments(switch.id as IntId)
                         validateSwitchTopologicalConnectivity(switch, structure, switchTracks, track)
                     }
-                val switchConnectivityErrors = if (track.exists) validateLocationTrackSwitchConnectivity(
-                        track,
-                        alignment
-                    ) else emptyList()
+                val switchConnectivityErrors = if (track.exists) {
+                    validateLocationTrackSwitchConnectivity(track, alignment)
+                } else {
+                    emptyList()
+                }
 
                 val duplicatesAfterPublication = validationContext.getDuplicateTracks(id)
                 val duplicateOf = track.duplicateOf?.let(validationContext::getLocationTrack)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.split
 import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationValidationError
 import fi.fta.geoviite.infra.tracklayout.DescriptionSuffixType
@@ -29,7 +30,7 @@ data class SplitHeader(
 ) {
     constructor(split: Split) : this(
         id = split.id,
-        locationTrackId = split.locationTrackId,
+        locationTrackId = split.sourceLocationTrackId,
         bulkTransferState = split.bulkTransferState,
         publicationId = split.publicationId,
     )
@@ -37,7 +38,8 @@ data class SplitHeader(
 
 data class Split(
     val id: IntId<Split>,
-    val locationTrackId: IntId<LocationTrack>,
+    val sourceLocationTrackId: IntId<LocationTrack>,
+    val sourceLocationTrackVersion: RowVersion<LocationTrack>,
     val bulkTransferState: BulkTransferState,
     val publicationId: IntId<Publication>?,
     val targetLocationTracks: List<SplitTarget>,
@@ -45,7 +47,7 @@ data class Split(
     val updatedDuplicates: List<IntId<LocationTrack>>,
 ) {
     @get:JsonIgnore
-    val locationTracks by lazy { targetLocationTracks.map { it.locationTrackId } + locationTrackId }
+    val locationTracks by lazy { targetLocationTracks.map { it.locationTrackId } + sourceLocationTrackId }
 
     @JsonIgnore
     val isPending: Boolean = bulkTransferState == BulkTransferState.PENDING && publicationId == null

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
@@ -6,7 +6,13 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.util.toResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/location-track-split")
@@ -26,5 +32,5 @@ class SplitController(val splitService: SplitService) {
     fun updateSplitTransferState(
         @PathVariable("id") id: IntId<Split>,
         @RequestBody state: BulkTransferState,
-    ): IntId<Split> = splitService.updateSplitState(id, state)
+    ): IntId<Split> = splitService.updateSplitState(id, state).id
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -217,7 +217,7 @@ class SplitDao(
     }
 
     @Transactional
-    fun updateSplitState(
+    fun updateSplit(
         splitId: IntId<Split>,
         bulkTransferState: BulkTransferState? = null,
         publicationId: IntId<Publication>? = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -487,11 +487,11 @@ fun splitLocationTrack(
         val connectivityType = calculateTopologicalConnectivity(track, alignment.segments.size, segmentIndices)
         val (newTrack, newAlignment) = target.duplicate?.let { d ->
             when (d.operation) {
-                SplitTargetDuplicateOperation.TRANSFER -> updateTransferAssetsSplitTarget(
+                SplitTargetDuplicateOperation.TRANSFER -> updateSplitTargetForTransferAssets(
                     duplicateTrack = d.track,
                     topologicalConnectivityType = connectivityType,
                 ) to d.alignment
-                SplitTargetDuplicateOperation.OVERWRITE -> updateDuplicateToSplitTarget(
+                SplitTargetDuplicateOperation.OVERWRITE -> updateSplitTargetForOverwriteDuplicate(
                     sourceTrack = track,
                     duplicateTrack = d.track,
                     duplicateAlignment = d.alignment,
@@ -535,7 +535,7 @@ fun validateSplitResult(results: List<SplitTargetResult>, alignment: LayoutAlign
     }
 }
 
-private fun updateTransferAssetsSplitTarget(
+private fun updateSplitTargetForTransferAssets(
     duplicateTrack: LocationTrack,
     topologicalConnectivityType: TopologicalConnectivityType,
 ): LocationTrack {
@@ -549,7 +549,7 @@ private fun updateTransferAssetsSplitTarget(
     )
 }
 
-private fun updateDuplicateToSplitTarget(
+private fun updateSplitTargetForOverwriteDuplicate(
     sourceTrack: LocationTrack,
     duplicateTrack: LocationTrack,
     duplicateAlignment: LayoutAlignment,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -270,7 +270,7 @@ class SplitService(
             // TODO: Perhaps we should here compare in-context sources to in-context targets. In source-validation we compare in-context sources to official sources
             geocodingService.getGeocodingContextCacheKey(locationTrack.trackNumberId, OFFICIAL)
                 ?.let { key -> geocodingService.getAddressPoints(key, locationTrack.getAlignmentVersionOrThrow()) }
-                ?.midPoints
+                ?.exactMeterPoints
                 ?.filter { p -> p.point.m in sourceMRange }
         } else {
             null
@@ -280,7 +280,7 @@ class SplitService(
         val targetAddressEnd = sourceAddresses?.lastOrNull()?.address
         val targetAddresses = if (targetAddressStart != null && targetAddressEnd != null) {
             geocodingService.getAddressPoints(target.locationTrackId, DRAFT)
-                ?.midPoints
+                ?.exactMeterPoints
                 ?.let { points ->
                     if (target.operation == SplitTargetOperation.TRANSFER) {
                         points.filter { p -> p.address in targetAddressStart..targetAddressEnd }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -99,7 +99,7 @@ class SplitService(
         return findPendingSplitsForLocationTracks(locationTracks.map { v -> v.id }.distinct())
             .map { split ->
                 val track = locationTracks.find { t -> t.id == split.sourceLocationTrackId }
-                splitDao.updateSplitState(
+                splitDao.updateSplit(
                     splitId = split.id,
                     publicationId = publicationId,
                     sourceTrackVersion = track?.rowVersion,
@@ -326,7 +326,7 @@ class SplitService(
         logger.serviceCall("updateSplitState", "splitId" to splitId)
 
         return splitDao.getOrThrow(splitId).let { split ->
-            splitDao.updateSplitState(split.id, bulkTransferState = state)
+            splitDao.updateSplit(split.id, bulkTransferState = state)
         }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -12,7 +12,6 @@ import fi.fta.geoviite.infra.publication.validate
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.util.LocalizationKey
-import kotlin.math.max
 import kotlin.math.min
 
 const val VALIDATION_SPLIT = "$VALIDATION.split"
@@ -88,14 +87,12 @@ internal fun validateTargetGeometry(
     return if (targetPoints == null || sourcePoints == null) {
         PublicationValidationError(ERROR, "$VALIDATION_SPLIT.no-geometry")
     } else {
-        // Geocoding mid-points are the even meter-points, but assert just in case
-        val startIndex = max(0, sourcePoints.indexOfFirst { s -> s.address == targetPoints.first().address })
-
         targetPoints
             .withIndex()
             .firstNotNullOfOrNull { (targetIndex, targetPoint) ->
-                val sourcePoint = sourcePoints.getOrNull(startIndex + targetIndex)
+                val sourcePoint = sourcePoints.getOrNull(targetIndex)
                 if (sourcePoint?.address != targetPoint.address) {
+                    println("sourcePoint=$sourcePoint targetPoint=$targetPoint")
                     PublicationValidationError(ERROR, "$VALIDATION_SPLIT.trackmeters-changed")
                 } else if (operation != SplitTargetOperation.TRANSFER && !targetPoint.point.isSame(sourcePoint.point)) {
                     PublicationValidationError(ERROR, "$VALIDATION_SPLIT.geometry-changed")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -60,7 +60,7 @@ internal fun validateSplitContent(
     val contentErrors = splits
         .filter { it.isPending }
         .flatMap { split ->
-            val containsSource = trackVersions.any { it.officialId == split.locationTrackId }
+            val containsSource = trackVersions.any { it.officialId == split.sourceLocationTrackId }
             val containsTargets = split.targetLocationTracks.all { tlt ->
                 trackVersions.any { it.officialId == tlt.locationTrackId }
             }

--- a/infra/src/main/resources/db/migration/prod/V74__fix_split_source_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V74__fix_split_source_version.sql
@@ -7,18 +7,21 @@ alter table publication.split disable trigger version_row_trigger;
 -- The migration is breaking if there is data in the table, as there should not be at this point
 alter table publication.split
   drop constraint split_source_location_track_fkey,
-  add column source_location_track_id int not null,
-  add column source_location_track_version int not null,
+  add column source_location_track_row_id int not null,
+  add column source_location_track_row_version int not null,
+  drop column source_location_track_id,
   -- This fixes the split to a particular row version of the source location track
   -- By referencing the main table with version, we ensure that the track cannot be changed without updating the split
   add constraint split_source_location_track_fkey
-    foreign key (source_location_track_id, source_location_track_version)
+    foreign key (source_location_track_row_id, source_location_track_row_version)
       references layout.location_track(id, version)
       -- Constraint checked at end of transaction to make it possible to update split after changing track:
       deferrable initially deferred;
 
 alter table publication.split_version
-  add column source_location_track_version int not null;
+  add column source_location_track_row_id int not null,
+  add column source_location_track_row_version int not null,
+  drop column source_location_track_id;
 
 alter table publication.split enable trigger version_row_trigger;
 alter table publication.split enable trigger version_update_trigger;

--- a/infra/src/main/resources/db/migration/prod/V74__fix_split_source_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V74__fix_split_source_version.sql
@@ -1,0 +1,24 @@
+alter table layout.location_track
+  add constraint location_track_id_version_unique unique (id, version);
+
+alter table publication.split disable trigger version_update_trigger;
+alter table publication.split disable trigger version_row_trigger;
+
+-- The migration is breaking if there is data in the table, as there should not be at this point
+alter table publication.split
+  drop constraint split_source_location_track_fkey,
+  add column source_location_track_id int not null,
+  add column source_location_track_version int not null,
+  -- This fixes the split to a particular row version of the source location track
+  -- By referencing the main table with version, we ensure that the track cannot be changed without updating the split
+  add constraint split_source_location_track_fkey
+    foreign key (source_location_track_id, source_location_track_version)
+      references layout.location_track(id, version)
+      -- Constraint checked at end of transaction to make it possible to update split after changing track:
+      deferrable initially deferred;
+
+alter table publication.split_version
+  add column source_location_track_version int not null;
+
+alter table publication.split enable trigger version_row_trigger;
+alter table publication.split enable trigger version_update_trigger;

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -652,9 +652,11 @@
                 "start-address": "Alkusijainti (km + m)",
                 "split-address": "Katkaisukohta (km + m)",
                 "end-address": "Loppusijainti (km + m)",
-                "OVERWRITE": "Korvaa duplikaattiraiteen",
-                "TRANSFER": "Siirretään vain ratakohteet",
-                "NEW": "Luodaan uusi raide",
+                "operation": {
+                    "OVERWRITE": "Korvaa duplikaattiraiteen",
+                    "TRANSFER": "Siirretään vain ratakohteet",
+                    "CREATE": "Luodaan uusi raide"
+                },
                 "description-base": "Kuvauksen perusosa",
                 "description-suffix": "Kuvauksen lisäosa",
                 "exit-title": "Lopeta raiteen jakaminen",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/KmNumberTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/KmNumberTest.kt
@@ -7,7 +7,6 @@ import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-
 class KmNumberTest {
 
     @Test
@@ -149,5 +148,19 @@ class KmNumberTest {
         assertNotEquals(TrackMeter(123, 321), TrackMeter(123, 321.000, 3))
         assertEquals(TrackMeter(123, 321), TrackMeter(123, 321.000, 3).stripTrailingZeroes())
         assertEquals(TrackMeter(123, 300), TrackMeter(123, 300.000, 3).stripTrailingZeroes())
+    }
+
+    @Test
+    fun `metersHaveIntegerPrecision works`() {
+        assertFalse(TrackMeter("1234+1234.1234").metersHaveIntegerPrecision())
+        assertFalse(TrackMeter("1234+1234.0000").metersHaveIntegerPrecision())
+        assertTrue(TrackMeter("1234+1234").metersHaveIntegerPrecision())
+    }
+
+    @Test
+    fun `metersMatchIntegerValue works`() {
+        assertFalse(TrackMeter("1234+1234.1234").metersMatchIntegerValue())
+        assertTrue(TrackMeter("1234+1234.0000").metersMatchIntegerValue())
+        assertTrue(TrackMeter("1234+1234").metersMatchIntegerValue())
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/KmNumberTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/KmNumberTest.kt
@@ -151,16 +151,16 @@ class KmNumberTest {
     }
 
     @Test
-    fun `metersHaveIntegerPrecision works`() {
-        assertFalse(TrackMeter("1234+1234.1234").metersHaveIntegerPrecision())
-        assertFalse(TrackMeter("1234+1234.0000").metersHaveIntegerPrecision())
-        assertTrue(TrackMeter("1234+1234").metersHaveIntegerPrecision())
+    fun `hasIntegerPrecision works`() {
+        assertFalse(TrackMeter("1234+1234.1234").hasIntegerPrecision())
+        assertFalse(TrackMeter("1234+1234.0000").hasIntegerPrecision())
+        assertTrue(TrackMeter("1234+1234").hasIntegerPrecision())
     }
 
     @Test
-    fun `metersMatchIntegerValue works`() {
-        assertFalse(TrackMeter("1234+1234.1234").metersMatchIntegerValue())
-        assertTrue(TrackMeter("1234+1234.0000").metersMatchIntegerValue())
-        assertTrue(TrackMeter("1234+1234").metersMatchIntegerValue())
+    fun `matchesIntegerValue works`() {
+        assertFalse(TrackMeter("1234+1234.1234").matchesIntegerValue())
+        assertTrue(TrackMeter("1234+1234.0000").matchesIntegerValue())
+        assertTrue(TrackMeter("1234+1234").matchesIntegerValue())
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -1,11 +1,31 @@
 package fi.fta.geoviite.infra.geocoding
 
-import fi.fta.geoviite.infra.common.*
-import fi.fta.geoviite.infra.math.*
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.TrackNumber
+import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType.WITHIN
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.math.Line
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.math.Point3DM
+import fi.fta.geoviite.infra.math.assertApproximatelyEquals
+import fi.fta.geoviite.infra.math.directionBetweenPoints
+import fi.fta.geoviite.infra.math.linePointAtDistance
+import fi.fta.geoviite.infra.math.pointInDirection
+import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.GeometrySource.GENERATED
 import fi.fta.geoviite.infra.tracklayout.GeometrySource.PLAN
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.SegmentPoint
+import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.alignmentFromPoints
+import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.referenceLine
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
@@ -743,6 +763,20 @@ class GeocodingTest {
 
         assertEquals(null, result.geocodingContext.getAddress(Point(14.0, 0.0)))
         assertEquals(StartPointRejectedReason.TOO_LONG, result.startPointRejectedReason)
+    }
+
+    @Test
+    fun `AddressPoint withIntegerPrecision works`() {
+        val point = AlignmentPoint(0.0, 0.0, 0.0, 0.0, null)
+        assertEquals(
+            AddressPoint(point, TrackMeter("1234+1234")),
+            AddressPoint(point, TrackMeter("1234+1234")).withIntegerPrecision(),
+        )
+        assertEquals(
+            AddressPoint(point, TrackMeter("1234+1234")),
+            AddressPoint(point, TrackMeter("1234+1234.000")).withIntegerPrecision(),
+        )
+        assertNull(AddressPoint(point, TrackMeter("1234+1234.123")).withIntegerPrecision())
     }
 
     private fun assertProjectionLinesMatch(result: List<ProjectionLine>, vararg expected: Pair<TrackMeter, Line>) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ElementListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ElementListingTest.kt
@@ -1,17 +1,33 @@
 package fi.fta.geoviite.infra.geometry
 
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.IndexedId
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.RotationDirection.CW
+import fi.fta.geoviite.infra.common.Srid
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geography.CoordinateSystemName
 import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
-import fi.fta.geoviite.infra.geometry.TrackGeometryElementType.*
+import fi.fta.geoviite.infra.geometry.TrackGeometryElementType.CLOTHOID
+import fi.fta.geoviite.infra.geometry.TrackGeometryElementType.CURVE
+import fi.fta.geoviite.infra.geometry.TrackGeometryElementType.LINE
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.roundTo3Decimals
-import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.tracklayout.GeometrySource.PLAN
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.geocodingContext
+import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
+import fi.fta.geoviite.infra.tracklayout.referenceLineAndAlignment
+import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.util.FileName
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -265,7 +281,6 @@ class ElementListingTest {
         val context = geocodingContext(
             referenceLinePoints = listOf(Point(0.0, 0.0), Point(100.0, 0.0)),
             trackNumber = trackNumber,
-            draft = false,
         )
         val listing = toElementListing(
             context,
@@ -309,7 +324,6 @@ class ElementListingTest {
         val context = geocodingContext(
             referenceLinePoints = listOf(Point(0.0, 0.0), Point(100.0, 0.0)),
             trackNumber = trackNumber,
-            draft = false,
         )
         val listing = toElementListing(
             context,
@@ -355,7 +369,6 @@ class ElementListingTest {
         val context = geocodingContext(
             referenceLinePoints = listOf(Point(0.0, 0.0), Point(100.0, 0.0)),
             trackNumber = trackNumber,
-            draft = false,
         )
         val listing = toElementListing(
             context,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -316,7 +316,7 @@ class LinkingServiceIT @Autowired constructor(
                 updatedDuplicates = emptyList(),
             )
         )
-        splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.DONE)
+        splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
 
         assertDoesNotThrow {
             linkingService.saveLocationTrackLinking(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -679,13 +679,13 @@ class PublicationServiceIT @Autowired constructor(
         saveSplit(sourceTrack.id, startTargetTrack.id, endTargetTrack.id)
 
         assertTrue {
-            splitDao.fetchUnfinishedSplits().any { split -> split.locationTrackId == sourceTrack.id }
+            splitDao.fetchUnfinishedSplits().any { split -> split.sourceLocationTrackId == sourceTrack.id }
         }
 
         publicationService.revertPublicationCandidates(publicationRequest(locationTracks = listOf(sourceTrack.id)))
 
         assertTrue {
-            splitDao.fetchUnfinishedSplits().none { split -> split.locationTrackId == sourceTrack.id }
+            splitDao.fetchUnfinishedSplits().none { split -> split.sourceLocationTrackId == sourceTrack.id }
         }
     }
 
@@ -711,7 +711,7 @@ class PublicationServiceIT @Autowired constructor(
         saveSplit(sourceTrack.id, startTargetTrack.id, endTargetTrack.id)
 
         val splitBeforePublish = splitDao.fetchUnfinishedSplits().first { split ->
-            split.locationTrackId == sourceTrack.id
+            split.sourceLocationTrackId == sourceTrack.id
         }
 
         assertNull(splitBeforePublish.publicationId)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -2483,7 +2483,7 @@ class PublicationServiceIT @Autowired constructor(
         val splitSetup = simpleSplitSetup()
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.IN_PROGRESS)
+            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.IN_PROGRESS)
         }
 
         val errors = validateLocationTracks(splitSetup.trackIds)
@@ -2496,7 +2496,7 @@ class PublicationServiceIT @Autowired constructor(
 
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.FAILED)
+            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.FAILED)
         }
 
         val errors = validateLocationTracks(splitSetup.trackIds)
@@ -2509,7 +2509,7 @@ class PublicationServiceIT @Autowired constructor(
 
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.DONE)
+            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
         }
 
         val errors = validateLocationTracks(splitSetup.trackIds)
@@ -2522,7 +2522,7 @@ class PublicationServiceIT @Autowired constructor(
 
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.IN_PROGRESS)
+            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.IN_PROGRESS)
         }
 
         val errors = validateLocationTracks(splitSetup.trackIds)
@@ -2535,7 +2535,7 @@ class PublicationServiceIT @Autowired constructor(
 
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.FAILED)
+            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.FAILED)
         }
 
         val errors = validateLocationTracks(splitSetup.trackIds)
@@ -2548,7 +2548,7 @@ class PublicationServiceIT @Autowired constructor(
 
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.DONE)
+            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
         }
 
         val errors = validateLocationTracks(splitSetup.trackIds)
@@ -2660,7 +2660,7 @@ class PublicationServiceIT @Autowired constructor(
 
         saveSplit(locationTrackResponse.rowVersion).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.FAILED)
+            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.FAILED)
         }
 
         val validation = publicationService.validatePublicationCandidates(
@@ -2691,7 +2691,7 @@ class PublicationServiceIT @Autowired constructor(
 
         saveSplit(locationTrackResponse.rowVersion).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.DONE)
+            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
         }
 
         val validation = publicationService.validatePublicationCandidates(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationUtilsTest.kt
@@ -1,8 +1,15 @@
 package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.tracklayout.*
-import org.junit.jupiter.api.Assertions.*
+import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.geocodingContext
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.singleSegmentWithInterpolatedPoints
+import fi.fta.geoviite.infra.tracklayout.to3DMPoints
+import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class PublicationUtilsTest {
@@ -127,6 +134,5 @@ class PublicationUtilsTest {
 
     private fun xAxisGeocodingContext() = geocodingContext(
         (0..60).map { x -> Point(x.toDouble(), 0.0)},
-        draft = false,
     )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -24,6 +24,9 @@ class SplitDaoIT @Autowired constructor(
     val splitDao: SplitDao,
     val publicationDao: PublicationDao,
 ) : DBTestBase() {
+    j
+    // TODO: GVT-2564 fix...
+
     @Test
     fun `should save split in pending state`() {
         val trackNumberId = insertOfficialTrackNumber()
@@ -39,7 +42,7 @@ class SplitDaoIT @Autowired constructor(
         val relinkedSwitchId = insertUniqueSwitch().id
 
         val split = splitDao.saveSplit(
-            sourceTrack.id,
+            sourceTrack.rowVersion,
             listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
             listOf(relinkedSwitchId),
             updatedDuplicates = emptyList(),
@@ -47,7 +50,8 @@ class SplitDaoIT @Autowired constructor(
 
         assertTrue { split.bulkTransferState == BulkTransferState.PENDING }
         assertNull(split.publicationId)
-        assertEquals(sourceTrack.id, split.locationTrackId)
+        assertEquals(sourceTrack.id, split.sourceLocationTrackId)
+        assertEquals(sourceTrack.rowVersion, split.sourceLocationTrackVersion)
         assertContains(
             split.targetLocationTracks,
             SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -79,7 +79,7 @@ class SplitDaoIT @Autowired constructor(
         ).let(splitDao::getOrThrow)
 
         val publicationId = publicationDao.createPublication("SPLIT PUBLICATION")
-        val updatedSplit = splitDao.updateSplitState(
+        val updatedSplit = splitDao.updateSplit(
             splitId = split.id,
             bulkTransferState = BulkTransferState.FAILED,
             publicationId = publicationId,
@@ -116,7 +116,7 @@ class SplitDaoIT @Autowired constructor(
             updatedDuplicates = emptyList(),
         ).also { splitId ->
             val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplitState(split.id, bulkTransferState = BulkTransferState.DONE)
+            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
         }
 
         val pendingSplitId = splitDao.saveSplit(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -24,8 +24,6 @@ class SplitDaoIT @Autowired constructor(
     val splitDao: SplitDao,
     val publicationDao: PublicationDao,
 ) : DBTestBase() {
-    j
-    // TODO: GVT-2564 fix...
 
     @Test
     fun `should save split in pending state`() {
@@ -74,7 +72,7 @@ class SplitDaoIT @Autowired constructor(
         val relinkedSwitchId = insertUniqueSwitch().id
 
         val split = splitDao.saveSplit(
-            sourceTrack.id,
+            sourceTrack.rowVersion,
             listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
             listOf(relinkedSwitchId),
             updatedDuplicates = emptyList(),
@@ -85,7 +83,7 @@ class SplitDaoIT @Autowired constructor(
             splitId = split.id,
             bulkTransferState = BulkTransferState.FAILED,
             publicationId = publicationId,
-        ).let(splitDao::getOrThrow)
+        ).id.let(splitDao::getOrThrow)
 
         assertEquals(BulkTransferState.FAILED, updatedSplit.bulkTransferState)
         assertEquals(publicationId, updatedSplit.publicationId)
@@ -112,7 +110,7 @@ class SplitDaoIT @Autowired constructor(
         val relinkedSwitchId2 = insertUniqueSwitch().id
 
         val doneSplit = splitDao.saveSplit(
-            sourceTrack.id,
+            sourceTrack.rowVersion,
             listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.CREATE)),
             listOf(relinkedSwitchId1),
             updatedDuplicates = emptyList(),
@@ -122,7 +120,7 @@ class SplitDaoIT @Autowired constructor(
         }
 
         val pendingSplitId = splitDao.saveSplit(
-            sourceTrack.id,
+            sourceTrack.rowVersion,
             listOf(SplitTarget(targetTrack2.id, 0..0, SplitTargetOperation.CREATE)),
             listOf(relinkedSwitchId2),
             updatedDuplicates = emptyList(),
@@ -153,7 +151,7 @@ class SplitDaoIT @Autowired constructor(
         val relinkedSwitchId = insertUniqueSwitch().id
 
         val splitId = splitDao.saveSplit(
-            sourceTrack.id,
+            sourceTrack.rowVersion,
             listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.OVERWRITE)),
             listOf(relinkedSwitchId),
             updatedDuplicates = listOf(someDuplicateTrack.id)
@@ -181,7 +179,7 @@ class SplitDaoIT @Autowired constructor(
         val relinkedSwitchId = insertUniqueSwitch().id
 
         val splitId = splitDao.saveSplit(
-            sourceTrack.id,
+            sourceTrack.rowVersion,
             listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.CREATE)),
             listOf(relinkedSwitchId),
             updatedDuplicates = emptyList(),
@@ -223,7 +221,7 @@ class SplitDaoIT @Autowired constructor(
         val relinkedSwitchId = insertUniqueSwitch().id
 
         return splitDao.saveSplit(
-            sourceTrack.id,
+            sourceTrack.rowVersion,
             listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.OVERWRITE)),
             listOf(relinkedSwitchId),
             updatedDuplicates = listOf(someDuplicateTrack.id),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -506,16 +506,6 @@ class SplitServiceIT @Autowired constructor(
         val trackNumberId = insertOfficialTrackNumber()
         return insertLocationTrack(locationTrack(trackNumberId, draft = false, duplicateOf = duplicateOf), alignment).id
     }
-//    private fun insertBranchingSwitchAlignment(
-//        start: Point,
-//        switchId: IntId<TrackLayoutSwitch>,
-//        structure: SwitchStructure,
-//        line: List<Int>,
-//    ): IntId<LocationTrack> {
-//        val alignment = alignment(segmentsFromSwitchStructure(start, switchId, structure, line))
-//        val trackNumberId = insertOfficialTrackNumber()
-//        return insertLocationTrack(locationTrack(trackNumberId, draft = false), alignment).id
-//    }
 
     private fun getYvStructure(): SwitchStructure =
         requireNotNull(switchStructureDao.fetchSwitchStructures().find { s -> s.type.typeName == "YV60-300-1:9-O" })

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -46,8 +46,6 @@ class SplitServiceIT @Autowired constructor(
     val switchStructureDao: SwitchStructureDao,
     val locationTrackService: LocationTrackService,
 ) : DBTestBase() {
-    // TODO: GVT-2564 fix...
-
     // The run order of the tests in this test suite matters if the database is not cleaned before each test.
     // This gave false positive results for tests.
     //
@@ -346,7 +344,7 @@ class SplitServiceIT @Autowired constructor(
         val splitId = insertSplitWithTwoTracks()
         val split = splitDao.getOrThrow(splitId)
 
-        val foundSplits = splitService.findUnfinishedSplitsForLocationTracks(listOf(split.sourceLocationTrackVersion))
+        val foundSplits = splitService.findUnfinishedSplitsForLocationTracks(listOf(split.sourceLocationTrackId))
 
         assertEquals(splitId, foundSplits.first().id)
     }
@@ -542,7 +540,7 @@ class SplitServiceIT @Autowired constructor(
         val relinkedSwitchId = insertUniqueSwitch().id
 
         return splitDao.saveSplit(
-            sourceTrack.id,
+            sourceTrack.rowVersion,
             listOf(SplitTarget(endTrack.id, 0..0, SplitTargetOperation.CREATE)),
             listOf(relinkedSwitchId),
             updatedDuplicates = emptyList(),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -46,6 +46,7 @@ class SplitServiceIT @Autowired constructor(
     val switchStructureDao: SwitchStructureDao,
     val locationTrackService: LocationTrackService,
 ) : DBTestBase() {
+    // TODO: GVT-2564 fix...
 
     // The run order of the tests in this test suite matters if the database is not cleaned before each test.
     // This gave false positive results for tests.
@@ -247,7 +248,7 @@ class SplitServiceIT @Autowired constructor(
     private fun lastPoint(segments: List<LayoutSegment>): IPoint = segments.last().segmentPoints.last()
 
     private fun assertSplitMatchesRequest(request: SplitRequest, split: Split) {
-        assertEquals(request.sourceTrackId, split.locationTrackId)
+        assertEquals(request.sourceTrackId, split.sourceLocationTrackId)
         request.targetTracks.forEach { targetRequest ->
             if (targetRequest.startAtSwitchId != null) {
                 assertTrue(split.relinkedSwitches.contains(targetRequest.startAtSwitchId))
@@ -345,7 +346,7 @@ class SplitServiceIT @Autowired constructor(
         val splitId = insertSplitWithTwoTracks()
         val split = splitDao.getOrThrow(splitId)
 
-        val foundSplits = splitService.findUnfinishedSplitsForLocationTracks(listOf(split.locationTrackId))
+        val foundSplits = splitService.findUnfinishedSplitsForLocationTracks(listOf(split.sourceLocationTrackVersion))
 
         assertEquals(splitId, foundSplits.first().id)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -578,21 +578,24 @@ fun attachSwitchToIndex(
     switch: TrackLayoutSwitch,
     segmentIndex: Int,
 ): LayoutAlignment {
-    if (alignment.segments.count() < segmentIndex + 3) throw IllegalArgumentException("Alignment must contain at least ${segmentIndex + 3} segments")
-
+    if (alignment.segments.count() < segmentIndex + 3) {
+        throw IllegalArgumentException("Alignment must contain at least ${segmentIndex + 3} segments")
+    }
 
     return alignment.copy(segments = alignment.segments.mapIndexed { index, segment ->
         when (index) {
             segmentIndex -> segment.copy(
-                switchId = switch.id, startJointNumber = JointNumber(1)
+                switchId = switch.id,
+                startJointNumber = JointNumber(1),
             )
 
             segmentIndex + 1 -> segment.copy(
-                switchId = switch.id
+                switchId = switch.id,
             )
 
             segmentIndex + 2 -> segment.copy(
-                switchId = switch.id, endJointNumber = JointNumber(2)
+                switchId = switch.id,
+                endJointNumber = JointNumber(2),
             )
 
             else -> segment
@@ -605,7 +608,6 @@ fun geocodingContext(
     trackNumber: TrackNumber = TrackNumber("001"),
     startAddress: TrackMeter = TrackMeter.ZERO,
     kmPosts: List<TrackLayoutKmPost> = listOf(),
-    draft: Boolean,
 ) = alignment(segment(*referenceLinePoints.toTypedArray())).let { alignment ->
     GeocodingContext.create(
         trackNumber = trackNumber,

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -209,7 +209,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                             {!nameErrorsVisible && (
                                 <InfoboxText
                                     value={t(
-                                        `tool-panel.location-track.splitting.${split.operation}`,
+                                        `tool-panel.location-track.splitting.operation.${split.operation}`,
                                     )}
                                 />
                             )}


### PR DESCRIPTION
Pullarin targettina tuo toinen branch (josta on oma reviewinsä) jotta näkyy vain mikä oikeasti muuttuu tässä. Käytännössä molemmat kannattaa mergetä mainiin kerralla koska kumpikin edellyttää dev/test ympäristöjen kannan resettiä.

Tässä pointtina kiinnittää source locationtrackin rowversio splittiin, jolloin:
- Splittiin voi joinata suoraan versiotaulun rivin ja tietää saavansa aina juuri sen mikä oli splitin hetkellä oikea versio
- Source trackia ei voi muuttaa ilman että päivittää splittiä -> ei voi vahingossa mennä palauttamaan sitä delete-merkattujen limbosta tai muokata muutoin