### PR TITLE
GVT-2573: Raiteen jakamisen kohteiden siirron voi merkata onnistuneeksi monta kertaa

### DIFF
--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -103,6 +103,7 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
             },
             t('publication-card.mark-as-successful'),
             'mark-bulk-transfer-as-finished-link',
+            publication.split?.bulkTransferState === 'DONE',
         ),
     ];
 


### PR DESCRIPTION
Päädyin tekemään tämän pelkästään UI:hin. Tiketillä ehdoteltiin myös tämän estämistä backendillä, mutta en itse nähnyt tätä niin järkeväksi, sillä on mahdollista että useampi operaattori koittaisi syystä tai toisesta tehdä tätä yhtä aikaa, ja Geoviitteessä yleisenä patternina on ollut, että näissä tilanteissa bäkkärin kannalta jälkimmäiselle ei saa lävähtää virhettä ruudulle