### PR TITLE
General: Sijaintiraiteen tilan erottaminen kunnolla LayoutState:sta

### DIFF
--- a/doc/tietomalli.md
+++ b/doc/tietomalli.md
@@ -276,7 +276,7 @@ classDiagram
         name: String
         description: String
         type: MAIN/SIDE/TRAP/CHORD
-        state: IN_USE/NOT_IN_USE/PLANNED/DELETED
+        state: IN_USE/NOT_IN_USE/PLANNED/DELETED/BUILT
     }
     class LayoutAlignment {
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
@@ -43,7 +43,7 @@ data class LocationTrackSaveRequest(
     val descriptionBase: FreeText,
     val descriptionSuffix: DescriptionSuffixType,
     val type: LocationTrackType,
-    val state: LocationTrackLayoutState,
+    val state: LocationTrackState,
     val trackNumberId: IntId<TrackLayoutTrackNumber>,
     val duplicateOf: IntId<LocationTrack>?,
     val topologicalConnectivity: TopologicalConnectivityType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -392,7 +392,7 @@ data class LocationTrackChanges(
     val name: Change<AlignmentName>,
     val descriptionBase: Change<FreeText>,
     val descriptionSuffix: Change<DescriptionSuffixType>,
-    val state: Change<LocationTrackLayoutState>,
+    val state: Change<LocationTrackState>,
     val duplicateOf: Change<IntId<LocationTrack>>,
     val type: Change<LocationTrackType>,
     val length: Change<Double>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -710,7 +710,7 @@ class PublicationDao(
                 },
                 endPoint = rs.getChangePoint("end_x", "end_y"),
                 startPoint = rs.getChangePoint("start_x", "start_y"),
-                state = rs.getChange("state", { rs.getEnumOrNull<LocationTrackLayoutState>(it) }),
+                state = rs.getChange("state", { rs.getEnumOrNull<LocationTrackState>(it) }),
                 duplicateOf = rs.getChange("duplicate_of_location_track_id", rs::getIntIdOrNull),
                 type = rs.getChange("type", { rs.getEnumOrNull<LocationTrackType>(it) }),
                 length = rs.getChange("length", rs::getDoubleOrNull),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -1014,7 +1014,7 @@ class PublicationService @Autowired constructor(
                 { it },
                 PropKey("state"),
                 null,
-                "layout-state",
+                "location-track-state",
             ),
             compareChangeValues(
                 locationTrackChanges.type,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -44,7 +44,7 @@ class RatkoLocationTrackService @Autowired constructor(
                 requireNotNull(layoutLocationTrack.externalId) { "OID required for location track, lt=${layoutLocationTrack.id}" }
             try {
                 ratkoClient.getLocationTrack(RatkoOid(externalId))?.let { existingLocationTrack ->
-                    if (layoutLocationTrack.state == LocationTrackLayoutState.DELETED) {
+                    if (layoutLocationTrack.state == LocationTrackState.DELETED) {
                         deleteLocationTrack(
                             layoutLocationTrack = layoutLocationTrack,
                             existingRatkoLocationTrack = existingLocationTrack,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtils.kt
@@ -9,7 +9,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import fi.fta.geoviite.infra.tracklayout.LocationTrackLayoutState
+import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 
 fun getEndPointNodeCollection(
     alignmentAddresses: AlignmentAddresses,
@@ -60,8 +60,8 @@ fun asSwitchTypeString(switchType: SwitchType): String {
 }
 
 fun sortByDeletedStateFirst(layoutState: LayoutState) = if (layoutState == LayoutState.DELETED) 0 else 1
-fun sortByDeletedStateFirst(locationTrackLayoutState: LocationTrackLayoutState) =
-    if (locationTrackLayoutState == LocationTrackLayoutState.DELETED) 0 else 1
+fun sortByDeletedStateFirst(locationTrackState: LocationTrackState) =
+    if (locationTrackState == LocationTrackState.DELETED) 0 else 1
 
 fun sortByNullDuplicateOfFirst(duplicateOf: IntId<LocationTrack>?) = if (duplicateOf == null) 0 else 1
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
@@ -12,12 +12,12 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.*
 import java.time.ZoneId
 
-fun mapToRatkoLocationTrackState(layoutState: LocationTrackLayoutState) = when (layoutState) {
-    LocationTrackLayoutState.BUILT -> RatkoLocationTrackState.BUILT
-    LocationTrackLayoutState.DELETED -> RatkoLocationTrackState.DELETED
-    LocationTrackLayoutState.NOT_IN_USE -> RatkoLocationTrackState.NOT_IN_USE
-    LocationTrackLayoutState.PLANNED -> RatkoLocationTrackState.PLANNED
-    LocationTrackLayoutState.IN_USE -> RatkoLocationTrackState.IN_USE
+fun mapToRatkoLocationTrackState(layoutState: LocationTrackState) = when (layoutState) {
+    LocationTrackState.BUILT -> RatkoLocationTrackState.BUILT
+    LocationTrackState.DELETED -> RatkoLocationTrackState.DELETED
+    LocationTrackState.NOT_IN_USE -> RatkoLocationTrackState.NOT_IN_USE
+    LocationTrackState.PLANNED -> RatkoLocationTrackState.PLANNED
+    LocationTrackState.IN_USE -> RatkoLocationTrackState.IN_USE
 }
 
 fun mapToRatkoRouteNumberState(layoutState: LayoutState) = when (layoutState) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -290,7 +290,7 @@ class SplitService(
             .map { duplicateTrack -> duplicateTrack.id as IntId }
 
         val sourceTrack = locationTrackDao.getOrThrow(DRAFT, request.sourceTrackId)
-        if (sourceTrack.state != LocationTrackLayoutState.IN_USE) throw SplitFailureException(
+        if (sourceTrack.state != LocationTrackState.IN_USE) throw SplitFailureException(
             message = "Source track state is not IN_USE: id=${sourceTrack.id}",
             localizedMessageKey = "source-track-state-not-in-use",
         )
@@ -328,7 +328,7 @@ class SplitService(
             localizationParams = localizationParams("trackName" to sourceTrack.name)
         )
 
-        locationTrackService.updateState(request.sourceTrackId, LocationTrackLayoutState.DELETED)
+        locationTrackService.updateState(request.sourceTrackId, LocationTrackState.DELETED)
 
         return savedSplitTargetLocationTracks.map { splitTargetResult ->
             SplitTarget(splitTargetResult.locationTrack.id as IntId, splitTargetResult.indices)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -95,7 +95,7 @@ class LocationTrackService(
             ownerId = request.ownerId,
         )
 
-        return if (locationTrack.state != LocationTrackLayoutState.DELETED) {
+        return if (locationTrack.state != LocationTrackState.DELETED) {
             saveDraft(fetchNearbyTracksAndCalculateLocationTrackTopology(locationTrack, originalAlignment))
         } else {
             clearDuplicateReferences(id)
@@ -106,12 +106,12 @@ class LocationTrackService(
     }
 
     @Transactional
-    fun updateState(id: IntId<LocationTrack>, state: LocationTrackLayoutState): DaoResponse<LocationTrack> {
+    fun updateState(id: IntId<LocationTrack>, state: LocationTrackState): DaoResponse<LocationTrack> {
         logger.serviceCall("update", "id" to id, "state" to state)
         val (originalTrack, originalAlignment) = getWithAlignmentInternalOrThrow(DRAFT, id)
         val locationTrack = originalTrack.copy(state = state)
 
-        return if (locationTrack.state != LocationTrackLayoutState.DELETED) {
+        return if (locationTrack.state != LocationTrackState.DELETED) {
             saveDraft(locationTrack)
         } else {
             clearDuplicateReferences(id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
@@ -61,7 +61,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
     fun getLocationTrackHeaders(
         @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
         @RequestParam("ids") ids: List<IntId<LocationTrack>>,
-    ): List<AlignmentHeader<LocationTrack, LocationTrackLayoutState>> {
+    ): List<AlignmentHeader<LocationTrack, LocationTrackState>> {
         logger.apiCall("getReferenceLineHeaders", "$PUBLICATION_STATE" to publicationState, "ids" to ids)
         return mapAlignmentService.getLocationTrackHeaders(publicationState, ids)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
@@ -72,7 +72,7 @@ class MapAlignmentService(
     ): AlignmentPolyLine<LocationTrack>? {
         return locationTrackService
             .getWithAlignment(publicationState, id)
-            ?.takeIf { (t, _) -> t.state != LocationTrackLayoutState.DELETED }
+            ?.takeIf { (t, _) -> t.state != LocationTrackState.DELETED }
             ?.let { (track, alignment) -> toAlignmentPolyLine(track.id, LOCATION_TRACK, alignment, resolution, bbox) }
     }
 
@@ -135,7 +135,7 @@ class MapAlignmentService(
     fun getLocationTrackHeaders(
         publicationState: PublicationState,
         locationTrackIds: List<IntId<LocationTrack>>,
-    ): List<AlignmentHeader<LocationTrack, LocationTrackLayoutState>> {
+    ): List<AlignmentHeader<LocationTrack, LocationTrackState>> {
         return locationTrackService
             .getManyWithAlignments(publicationState, locationTrackIds)
             .map { (track, alignment) -> toAlignmentHeader(track, alignment) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -33,7 +33,7 @@ import java.time.Instant
 val LAYOUT_SRID = Srid(3067)
 val LAYOUT_CRS = crs(LAYOUT_SRID)
 
-enum class LocationTrackLayoutState(val category: LayoutStateCategory) {
+enum class LocationTrackState(val category: LayoutStateCategory) {
     BUILT(LayoutStateCategory.EXISTING),
     IN_USE(LayoutStateCategory.EXISTING),
     NOT_IN_USE(LayoutStateCategory.EXISTING),
@@ -226,7 +226,7 @@ data class LocationTrack(
     val descriptionBase: FreeText,
     val descriptionSuffix: DescriptionSuffixType,
     val type: LocationTrackType,
-    val state: LocationTrackLayoutState,
+    val state: LocationTrackState,
     val externalId: Oid<LocationTrack>?,
     val trackNumberId: IntId<TrackLayoutTrackNumber>,
     val sourceId: IntId<GeometryAlignment>?,

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -211,8 +211,14 @@
             "ENDPOINT": "Raide päättyy",
             "UNKNOWN": "Ei asetettu"
         },
-        "layout-state": {
+        "location-track-state": {
             "BUILT": "Rakennettu",
+            "IN_USE": "Käytössä",
+            "NOT_IN_USE": "Käytöstä poistettu",
+            "PLANNED": "Suunniteltu",
+            "DELETED": "Poistettu"
+        },
+        "layout-state": {
             "IN_USE": "Käytössä",
             "NOT_IN_USE": "Käytöstä poistettu",
             "PLANNED": "Suunniteltu",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
@@ -92,7 +92,7 @@ class AddressChangesServiceIT @Autowired constructor(
         val setupData = createAndInsertTrackNumberAndLocationTrack()
         val contextKey = geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, setupData.locationTrack.trackNumberId)!!
         val changes = addressChangesService.getAddressChanges(
-            beforeTrack = setupData.locationTrack.copy(state = LocationTrackLayoutState.DELETED),
+            beforeTrack = setupData.locationTrack.copy(state = LocationTrackState.DELETED),
             afterTrack = setupData.locationTrack,
             beforeContextKey = contextKey,
             afterContextKey = contextKey,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -169,7 +169,7 @@ class LinkingServiceIT @Autowired constructor(
 
         val (locationTrack, alignment) = locationTrackAndAlignment(
             trackNumberId = insertOfficialTrackNumber(),
-            state = LocationTrackLayoutState.DELETED,
+            state = LocationTrackState.DELETED,
             draft = true,
         )
         val (locationTrackId, locationTrackVersion) = locationTrackService.saveDraft(locationTrack, alignment)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -127,7 +127,7 @@ class PublicationDaoIT @Autowired constructor(
         val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
         publishAndCheck(version)
         locationTrackService.saveDraft(
-            locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId).copy(state = LocationTrackLayoutState.DELETED)
+            locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId).copy(state = LocationTrackState.DELETED)
         )
         val candidates = publicationDao.fetchLocationTrackPublicationCandidates()
         assertEquals(1, candidates.size)
@@ -141,12 +141,12 @@ class PublicationDaoIT @Autowired constructor(
         val (version, draft) = insertAndCheck(
             asMainDraft(track).copy(
                 name = AlignmentName("${track.name} DRAFT"),
-                state = LocationTrackLayoutState.DELETED,
+                state = LocationTrackState.DELETED,
             )
         )
         publishAndCheck(version)
         locationTrackService.saveDraft(
-            locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId).copy(state = LocationTrackLayoutState.IN_USE)
+            locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId).copy(state = LocationTrackState.IN_USE)
         )
         val candidates = publicationDao.fetchLocationTrackPublicationCandidates()
         assertEquals(1, candidates.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1236,7 +1236,7 @@ class PublicationServiceIT @Autowired constructor(
                     FreeText("Test"),
                     DescriptionSuffixType.NONE,
                     LocationTrackType.MAIN,
-                    LocationTrackLayoutState.IN_USE,
+                    LocationTrackState.IN_USE,
                     getUnusedTrackNumberId(),
                     null,
                     TopologicalConnectivityType.NONE,
@@ -1252,7 +1252,7 @@ class PublicationServiceIT @Autowired constructor(
                     FreeText("Test"),
                     DescriptionSuffixType.NONE,
                     LocationTrackType.MAIN,
-                    LocationTrackLayoutState.IN_USE,
+                    LocationTrackState.IN_USE,
                     getUnusedTrackNumberId(),
                     null,
                     TopologicalConnectivityType.NONE,
@@ -1268,7 +1268,7 @@ class PublicationServiceIT @Autowired constructor(
                     FreeText("Test"),
                     DescriptionSuffixType.NONE,
                     LocationTrackType.MAIN,
-                    LocationTrackLayoutState.IN_USE,
+                    LocationTrackState.IN_USE,
                     getUnusedTrackNumberId(),
                     duplicate.id as IntId<LocationTrack>,
                     TopologicalConnectivityType.NONE,
@@ -1294,7 +1294,7 @@ class PublicationServiceIT @Autowired constructor(
                     descriptionBase = FreeText("Test2"),
                     descriptionSuffix = DescriptionSuffixType.SWITCH_TO_BUFFER,
                     type = LocationTrackType.SIDE,
-                    state = LocationTrackLayoutState.NOT_IN_USE,
+                    state = LocationTrackState.NOT_IN_USE,
                     trackNumberId = locationTrack.trackNumberId,
                     duplicate2.id as IntId<LocationTrack>,
                     topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
@@ -1391,7 +1391,7 @@ class PublicationServiceIT @Autowired constructor(
             FreeText("Test"),
             DescriptionSuffixType.NONE,
             LocationTrackType.MAIN,
-            LocationTrackLayoutState.IN_USE,
+            LocationTrackState.IN_USE,
             getUnusedTrackNumberId(),
             null,
             TopologicalConnectivityType.NONE,
@@ -2500,7 +2500,7 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `split source location track validation should fail if source location track isn't deleted`() {
-        val (sourceTrack, startTargetTrack, endTargetTrack) = simpleSplitSetup(LocationTrackLayoutState.IN_USE)
+        val (sourceTrack, startTargetTrack, endTargetTrack) = simpleSplitSetup(LocationTrackState.IN_USE)
 
         saveSplit(sourceTrack.id, startTargetTrack.id, endTargetTrack.id).also(splitDao::get)
 
@@ -2665,7 +2665,7 @@ class PublicationServiceIT @Autowired constructor(
             .insert(alignment(segment(Point(0.0, 0.0), Point(5.0, 5.0), Point(10.0, 0.0))))
             .also { newAlignment ->
                 val lt = locationTrackDao.fetch(sourceTrackVersion).copy(
-                    state = LocationTrackLayoutState.DELETED,
+                    state = LocationTrackState.DELETED,
                     alignmentVersion = newAlignment,
                 )
 
@@ -2707,7 +2707,7 @@ class PublicationServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         ).rowVersion.also { version ->
             val lt = locationTrackDao.fetch(version).copy(
-                state = LocationTrackLayoutState.DELETED
+                state = LocationTrackState.DELETED
             )
 
             locationTrackService.saveDraft(lt)
@@ -2890,7 +2890,7 @@ class PublicationServiceIT @Autowired constructor(
     }
 
     private fun simpleSplitSetup(
-        sourceLocationTrackState: LocationTrackLayoutState = LocationTrackLayoutState.DELETED,
+        sourceLocationTrackState: LocationTrackState = LocationTrackState.DELETED,
     ): Triple<DaoResponse<LocationTrack>, DaoResponse<LocationTrack>, DaoResponse<LocationTrack>> {
         val trackNumberId = insertOfficialTrackNumber()
         insertReferenceLine(
@@ -2966,10 +2966,10 @@ class PublicationServiceIT @Autowired constructor(
             )
         )
         locationTrackService.saveDraft(
-            locationTrackDao.fetch(officialTrackOn152.rowVersion).copy(state = LocationTrackLayoutState.DELETED)
+            locationTrackDao.fetch(officialTrackOn152.rowVersion).copy(state = LocationTrackState.DELETED)
         )
         locationTrackService.saveDraft(
-            locationTrackDao.fetch(officialTrackOn13.rowVersion).copy(state = LocationTrackLayoutState.DELETED)
+            locationTrackDao.fetch(officialTrackOn13.rowVersion).copy(state = LocationTrackState.DELETED)
         )
 
         val errorsWhenDeletingStraightTrack = getLocationTrackValidationResult(officialTrackOn152.id).errors
@@ -3027,7 +3027,7 @@ class PublicationServiceIT @Autowired constructor(
             )
         )
         locationTrackService.saveDraft(
-            locationTrackDao.fetch(officialTrackOn152.rowVersion).copy(state = LocationTrackLayoutState.DELETED)
+            locationTrackDao.fetch(officialTrackOn152.rowVersion).copy(state = LocationTrackState.DELETED)
         )
         locationTrackDao.insert(
             locationTrack(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -41,21 +41,21 @@ class PublicationValidationTest {
             true,
             trackNumber.copy(state = LayoutState.DELETED),
             referenceLine,
-            locationTrack(IntId(0), draft = true).copy(state = LocationTrackLayoutState.IN_USE),
+            locationTrack(IntId(0), draft = true).copy(state = LocationTrackState.IN_USE),
             "$VALIDATION_TRACK_NUMBER.location-track.reference-deleted",
         )
         assertTrackNumberReferenceError(
             false,
             trackNumber.copy(state = LayoutState.DELETED),
             referenceLine,
-            alignment.copy(state = LocationTrackLayoutState.DELETED),
+            alignment.copy(state = LocationTrackState.DELETED),
             "$VALIDATION_TRACK_NUMBER.location-track.reference-deleted",
         )
         assertTrackNumberReferenceError(
             false,
             trackNumber.copy(state = LayoutState.IN_USE),
             referenceLine,
-            alignment.copy(state = LocationTrackLayoutState.IN_USE),
+            alignment.copy(state = LocationTrackState.IN_USE),
             "$VALIDATION_TRACK_NUMBER.location-track.reference-deleted",
         )
     }
@@ -218,12 +218,12 @@ class PublicationValidationTest {
     fun alignmentFieldValidationCatchesPublishingPlanned() {
         assertFieldError(
             true,
-            locationTrack(IntId(0), draft = true).copy(state = LocationTrackLayoutState.PLANNED),
+            locationTrack(IntId(0), draft = true).copy(state = LocationTrackState.PLANNED),
             "$VALIDATION_LOCATION_TRACK.state.PLANNED",
         )
         assertFieldError(
             false,
-            locationTrack(IntId(0), draft = true).copy(state = LocationTrackLayoutState.IN_USE),
+            locationTrack(IntId(0), draft = true).copy(state = LocationTrackState.IN_USE),
             "$VALIDATION_LOCATION_TRACK.state.PLANNED",
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoConversionTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoConversionTest.kt
@@ -10,8 +10,7 @@ import fi.fta.geoviite.infra.ratko.model.convertToRatkoAssetLocations
 import fi.fta.geoviite.infra.ratko.model.mapToRatkoLocationTrackState
 import fi.fta.geoviite.infra.ratko.model.mapToRatkoLocationTrackType
 import fi.fta.geoviite.infra.switchLibrary.SwitchBaseType
-import fi.fta.geoviite.infra.tracklayout.LayoutState
-import fi.fta.geoviite.infra.tracklayout.LocationTrackLayoutState
+import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -36,9 +35,9 @@ class RatkoConversionTest {
 
     @Test
     fun shouldMapToRatkoStateType() {
-        val convertedLayoutBuilt = mapToRatkoLocationTrackState(LocationTrackLayoutState.BUILT)
-        val convertedLayoutNotInUse = mapToRatkoLocationTrackState(LocationTrackLayoutState.NOT_IN_USE)
-        val convertedLayoutInUse = mapToRatkoLocationTrackState(LocationTrackLayoutState.IN_USE)
+        val convertedLayoutBuilt = mapToRatkoLocationTrackState(LocationTrackState.BUILT)
+        val convertedLayoutNotInUse = mapToRatkoLocationTrackState(LocationTrackState.NOT_IN_USE)
+        val convertedLayoutInUse = mapToRatkoLocationTrackState(LocationTrackState.IN_USE)
 
         assertEquals("BUILT", convertedLayoutBuilt.value)
         assertEquals("NOT IN USE", convertedLayoutNotInUse.value)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -172,7 +172,7 @@ class RatkoServiceIT @Autowired constructor(
                 name = "abcde",
                 description = "cdefg",
                 type = LocationTrackType.CHORD,
-                state = LocationTrackLayoutState.BUILT,
+                state = LocationTrackState.BUILT,
                 externalId = null,
                 draft = true,
             ),
@@ -188,7 +188,7 @@ class RatkoServiceIT @Autowired constructor(
         assertEquals(RatkoAssetState.BUILT.name, createdPush.state.name)
         assertEquals(RatkoLocationTrackType.CHORD.name, createdPush.type.name)
 
-        locationTrackService.saveDraft(locationTrackDao.fetch(officialVersion).copy(state = LocationTrackLayoutState.DELETED))
+        locationTrackService.saveDraft(locationTrackDao.fetch(officialVersion).copy(state = LocationTrackState.DELETED))
         publishAndPush(locationTracks = listOf(officialVersion))
 
         assertEquals(listOf(""), fakeRatko.getLocationTrackPointDeletions("2.3.4.5.6"))
@@ -644,7 +644,7 @@ class RatkoServiceIT @Autowired constructor(
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::hostPushedLocationTrack)
         val officialThroughTrackVersion = locationTrackDao.fetchVersion(throughTrack.id, PublicationState.OFFICIAL)!!
         locationTrackService.saveDraft(
-            locationTrackDao.fetch(officialThroughTrackVersion).copy(state = LocationTrackLayoutState.DELETED)
+            locationTrackDao.fetch(officialThroughTrackVersion).copy(state = LocationTrackState.DELETED)
         )
         publishAndPush(locationTracks = listOf(officialThroughTrackVersion))
         val pushedSwitchLocations = fakeRatko.getPushedSwitchLocations("3.4.5.6.7")
@@ -879,7 +879,7 @@ class RatkoServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         ).rowVersion
         val locationTrack = locationTrackDao.fetch(originalLocationTrackVersion)
-        locationTrackService.saveDraft(locationTrack.copy(state = LocationTrackLayoutState.DELETED))
+        locationTrackService.saveDraft(locationTrack.copy(state = LocationTrackState.DELETED))
 
         fakeRatko.hasLocationTrack(ratkoLocationTrack(id = locationTrack.externalId.toString()))
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -115,7 +115,7 @@ class SplitServiceIT @Autowired constructor(
         assertTargetTrack(alignment, request.targetTracks[1], result.targetLocationTracks[1])
 
         // Verify that the old track got deleted
-        assertEquals(LocationTrackLayoutState.DELETED, locationTrackService.get(DRAFT, trackId)?.state)
+        assertEquals(LocationTrackState.DELETED, locationTrackService.get(DRAFT, trackId)?.state)
     }
 
     private fun assertTargetTrack(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
@@ -38,7 +38,7 @@ class LocationTrackDaoIT @Autowired constructor(
             name = AlignmentName("ORIG"),
             descriptionBase = FreeText("Oridinal location track"),
             type = MAIN,
-            state = LocationTrackLayoutState.IN_USE,
+            state = LocationTrackState.IN_USE,
             alignmentVersion = alignmentVersion,
         )
 
@@ -53,7 +53,7 @@ class LocationTrackDaoIT @Autowired constructor(
             name = AlignmentName("UPD"),
             descriptionBase = FreeText("Updated location track"),
             type = SIDE,
-            state = LocationTrackLayoutState.NOT_IN_USE,
+            state = LocationTrackState.NOT_IN_USE,
             topologicalConnectivity = TopologicalConnectivityType.END
         )
         val (updatedId, updatedVersion) = locationTrackDao.update(updatedTrack)
@@ -145,7 +145,7 @@ class LocationTrackDaoIT @Autowired constructor(
         val tnId = insertOfficialTrackNumber()
         val officialVersion = insertOfficialLocationTrack(tnId).rowVersion
         val undeletedDraftVersion = insertDraftLocationTrack(tnId).rowVersion
-        val deleteStateDraftVersion = insertDraftLocationTrack(tnId, LocationTrackLayoutState.DELETED).rowVersion
+        val deleteStateDraftVersion = insertDraftLocationTrack(tnId, LocationTrackState.DELETED).rowVersion
         val (deletedDraftId, deletedDraftVersion) = insertDraftLocationTrack(tnId)
         locationTrackDao.deleteDraft(deletedDraftId)
 
@@ -206,7 +206,7 @@ class LocationTrackDaoIT @Autowired constructor(
         val tnId = insertOfficialTrackNumber()
         val tnId2 = insertOfficialTrackNumber()
         val undeletedDraftVersion = insertDraftLocationTrack(tnId).rowVersion
-        val deleteStateDraftVersion = insertDraftLocationTrack(tnId, LocationTrackLayoutState.DELETED).rowVersion
+        val deleteStateDraftVersion = insertDraftLocationTrack(tnId, LocationTrackState.DELETED).rowVersion
         val changeTrackNumberOriginal = insertOfficialLocationTrack(tnId).rowVersion
         val changeTrackNumberChanged = createDraftWithNewTrackNumber(changeTrackNumberOriginal, tnId2).rowVersion
         val deletedDraftId = insertDraftLocationTrack(tnId).id
@@ -291,7 +291,7 @@ class LocationTrackDaoIT @Autowired constructor(
 
     private fun insertDraftLocationTrack(
         tnId: IntId<TrackLayoutTrackNumber>,
-        state: LocationTrackLayoutState = LocationTrackLayoutState.IN_USE,
+        state: LocationTrackState = LocationTrackState.IN_USE,
     ): DaoResponse<LocationTrack> {
         val (track, alignment) = locationTrackAndAlignment(
             trackNumberId = tnId,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -285,7 +285,7 @@ fun locationTrackAndAlignment(
     name: String = "T001 ${locationTrackNameCounter++}",
     description: String = "test-alignment 001",
     duplicateOf: IntId<LocationTrack>? = null,
-    state: LocationTrackLayoutState = LocationTrackLayoutState.IN_USE,
+    state: LocationTrackState = LocationTrackState.IN_USE,
     id: IntId<LocationTrack>? = null,
     draft: Boolean,
 ): Pair<LocationTrack, LayoutAlignment> = locationTrackAndAlignment(
@@ -307,7 +307,7 @@ fun locationTrackAndAlignment(
     name: String = "T001 ${locationTrackNameCounter++}",
     description: String = "test-alignment 001",
     duplicateOf: IntId<LocationTrack>? = null,
-    state: LocationTrackLayoutState = LocationTrackLayoutState.IN_USE,
+    state: LocationTrackState = LocationTrackState.IN_USE,
 ): Pair<LocationTrack, LayoutAlignment> {
     val alignment = alignment(segments)
     val locationTrack = locationTrack(
@@ -331,7 +331,7 @@ fun locationTrack(
     name: String = "T001 ${locationTrackNameCounter++}",
     description: String = "test-alignment 001",
     type: LocationTrackType = LocationTrackType.SIDE,
-    state: LocationTrackLayoutState = LocationTrackLayoutState.IN_USE,
+    state: LocationTrackState = LocationTrackState.IN_USE,
     externalId: Oid<LocationTrack>? = someOid(),
     alignmentVersion: RowVersion<LayoutAlignment>? = null,
     topologicalConnectivity: TopologicalConnectivityType = TopologicalConnectivityType.NONE,
@@ -363,7 +363,7 @@ fun locationTrack(
     name: String = "T001 ${locationTrackNameCounter++}",
     description: String = "test-alignment 001",
     type: LocationTrackType = LocationTrackType.SIDE,
-    state: LocationTrackLayoutState = LocationTrackLayoutState.IN_USE,
+    state: LocationTrackState = LocationTrackState.IN_USE,
     externalId: Oid<LocationTrack>? = someOid(),
     alignmentVersion: RowVersion<LayoutAlignment>? = null,
     topologicalConnectivity: TopologicalConnectivityType = TopologicalConnectivityType.NONE,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -91,7 +91,7 @@ fun locationTrack(
         name = "lt-$name",
         description = description,
         type = layoutAlignmentType,
-        state = LocationTrackLayoutState.IN_USE,
+        state = LocationTrackState.IN_USE,
         draft = draft,
     )
     return track to alignment

--- a/ui/src/geoviite-design-lib/layout-state/layout-state.tsx
+++ b/ui/src/geoviite-design-lib/layout-state/layout-state.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-    LayoutState as LayoutStateModel,
-    LocationTrackLayoutState,
-} from 'track-layout/track-layout-model';
+import { LayoutState as LayoutStateModel } from 'track-layout/track-layout-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 
 type LayoutStateProps = {
-    state: LayoutStateModel | LocationTrackLayoutState;
+    state: LayoutStateModel;
 };
 
-function getTranslationKey(layoutState: LayoutStateModel | LocationTrackLayoutState) {
+function getTranslationKey(layoutState: LayoutStateModel) {
     switch (layoutState) {
-        case 'BUILT':
         case 'IN_USE':
         case 'NOT_IN_USE':
         case 'PLANNED':

--- a/ui/src/geoviite-design-lib/location-track-state/location-track-state.tsx
+++ b/ui/src/geoviite-design-lib/location-track-state/location-track-state.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LocationTrackState as LocationTrackStateModel } from '../../track-layout/track-layout-model';
+import { exhaustiveMatchingGuard } from 'utils/type-utils';
+
+type LocationTrackStateProps = {
+    state: LocationTrackStateModel;
+};
+
+function getTranslationKey(layoutState: LocationTrackStateModel) {
+    switch (layoutState) {
+        case 'BUILT':
+        case 'IN_USE':
+        case 'NOT_IN_USE':
+        case 'PLANNED':
+        case 'DELETED':
+            return layoutState;
+        default:
+            return exhaustiveMatchingGuard(layoutState);
+    }
+}
+
+export const LocationTrackState: React.FC<LocationTrackStateProps> = ({
+    state,
+}: LocationTrackStateProps) => {
+    const { t } = useTranslation();
+
+    return <span qa-id={state}>{t(`enum.location-track-state.${getTranslationKey(state)}`)}</span>;
+};

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -8,7 +8,7 @@ import {
     LayoutTrackNumberId,
     LocationTrackDescriptionSuffixMode,
     LocationTrackId,
-    LocationTrackLayoutState,
+    LocationTrackState,
     LocationTrackType,
     MapAlignmentType,
     ReferenceLineId,
@@ -41,7 +41,7 @@ export type LocationTrackSaveRequest = {
     descriptionBase?: string;
     descriptionSuffix?: LocationTrackDescriptionSuffixMode;
     type?: LocationTrackType;
-    state?: LocationTrackLayoutState;
+    state?: LocationTrackState;
     trackNumberId?: LayoutTrackNumberId;
     duplicateOf?: string;
     topologicalConnectivity?: TopologicalConnectivityType;

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -29,7 +29,7 @@ import {
 import { createDelegatesWithDispatcher } from 'store/store-utils';
 import { Dropdown, Item } from 'vayla-design-lib/dropdown/dropdown';
 import {
-    locationTrackLayoutStates,
+    locationTrackStates,
     locationTrackTypes,
     topologicalConnectivityTypes,
 } from 'utils/enum-localization-utils';
@@ -139,7 +139,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         props.changeTimes,
     );
 
-    const stateOptions = locationTrackLayoutStates
+    const stateOptions = locationTrackStates
         .filter((ls) => !state.isNewLocationTrack || ls.value != 'DELETED')
         .map((ls) => ({ ...ls, disabled: ls.value == 'PLANNED', qaId: ls.value }));
 
@@ -348,7 +348,8 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
             (tn) => tn.id === state.existingLocationTrack?.trackNumberId || tn.state !== 'DELETED',
         )
         .map((tn) => {
-            const note = tn.state === 'DELETED' ? ` (${t('enum.layout-state.DELETED')})` : '';
+            const note =
+                tn.state === 'DELETED' ? ` (${t('enum.location-track-state.DELETED')})` : '';
             return { name: tn.number + note, value: tn.id, qaId: `track-number-${tn.id}` };
         });
 

--- a/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { LoaderStatus, useLoader } from 'utils/react-utils';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
-import LayoutState from 'geoviite-design-lib/layout-state/layout-state';
 import LocationTrackTypeLabel from 'geoviite-design-lib/alignment/location-track-type-label';
 import { TrackNumberLinkContainer } from 'geoviite-design-lib/track-number/track-number-link';
 import InfoboxText from 'tool-panel/infobox/infobox-text';
@@ -32,6 +31,7 @@ import { useCommonDataAppSelector } from 'store/hooks';
 import { getLocationTrackDescriptions } from 'track-layout/layout-location-track-api';
 import { useLocationTrackInfoboxExtras } from 'track-layout/track-layout-react-utils';
 import { first } from 'utils/array-utils';
+import { LocationTrackState } from 'geoviite-design-lib/location-track-state/location-track-state';
 
 type LocationTrackBasicInfoInfoboxContainerProps = {
     locationTrack: LayoutLocationTrack;
@@ -142,7 +142,7 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
                 <InfoboxField
                     qaId="location-track-state"
                     label={t('tool-panel.location-track.state')}
-                    value={<LayoutState state={locationTrack.state} />}
+                    value={<LocationTrackState state={locationTrack.state} />}
                     onEdit={openEditLocationTrackDialog}
                     iconDisabled={editingDisabled}
                 />

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -7,7 +7,7 @@ import {
     LayoutTrackNumber,
     LayoutTrackNumberId,
     LocationTrackId,
-    LocationTrackLayoutState,
+    LocationTrackState,
     LocationTrackType,
     MapAlignmentType,
     ReferenceLineId,
@@ -64,7 +64,7 @@ export type AlignmentDataHolder = {
 
 export type LocationTrackAlignmentHeader = LayoutAlignmentHeader & {
     id: LocationTrackId;
-    state: LocationTrackLayoutState;
+    state: LocationTrackState;
 };
 export type ReferenceLineAlignmentHeader = LayoutAlignmentHeader & {
     id: ReferenceLineId;

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -27,7 +27,7 @@ import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { Brand } from 'common/brand';
 
 export type LayoutState = 'IN_USE' | 'NOT_IN_USE' | 'PLANNED' | 'DELETED';
-export type LocationTrackLayoutState = 'BUILT' | LayoutState;
+export type LocationTrackState = 'BUILT' | 'IN_USE' | 'NOT_IN_USE' | 'PLANNED' | 'DELETED';
 export type LayoutStateCategory = 'EXISTING' | 'NOT_EXISTING' | 'FUTURE_EXISTING';
 
 export const LAYOUT_SRID: Srid = 'EPSG:3067';
@@ -107,7 +107,7 @@ export type LayoutLocationTrack = {
     descriptionBase?: string;
     descriptionSuffix?: LocationTrackDescriptionSuffixMode;
     type?: LocationTrackType;
-    state: LocationTrackLayoutState;
+    state: LocationTrackState;
     externalId?: Oid;
     trackNumberId: LayoutTrackNumberId;
     sourceId?: GeometryAlignmentId;

--- a/ui/src/utils/enum-localization-utils.ts
+++ b/ui/src/utils/enum-localization-utils.ts
@@ -3,7 +3,7 @@ import {
     LayoutState,
     LayoutStateCategory,
     LocationTrackDescriptionSuffixMode,
-    LocationTrackLayoutState,
+    LocationTrackState,
     LocationTrackType,
     TopologicalConnectivityType,
     TrapPoint,
@@ -46,8 +46,8 @@ export const layoutStates: LocalizedEnum<LayoutState>[] = values('layout-state',
     'DELETED',
 ]);
 
-export const locationTrackLayoutStates: LocalizedEnum<LocationTrackLayoutState>[] = values(
-    'layout-state',
+export const locationTrackStates: LocalizedEnum<LocationTrackState>[] = values(
+    'location-track-state',
     ['PLANNED', 'BUILT', 'IN_USE', 'NOT_IN_USE', 'DELETED'],
 );
 


### PR DESCRIPTION
Muutettu nyt edeltävä `LocationTrackLayoutState`-käsite nimelle `LocationTrackState` ja erotettu ne myös frontissa paremmin toisistaan.