### PR TITLE
GVT-2563: Raiteen poistaminen estää toisen raiteen splittauksen (HTTP 400)

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -10,6 +10,8 @@ import fi.fta.geoviite.infra.linking.*
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.publication.PublicationValidationError
+import fi.fta.geoviite.infra.publication.PublicationValidationErrorType
+import fi.fta.geoviite.infra.publication.VALIDATION_SWITCH
 import fi.fta.geoviite.infra.publication.validateSwitchLocationTrackLinkStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
@@ -239,7 +241,18 @@ class SwitchLinkingService @Autowired constructor(
         }
         return switchIds.mapIndexed { index, switchId ->
             val suggestionWithTracks = switchSuggestions[index]
-            if (suggestionWithTracks == null) SwitchRelinkingValidationResult(switchId, null, listOf())
+            if (suggestionWithTracks == null)
+                SwitchRelinkingValidationResult(
+                    switchId,
+                    null,
+                    listOf(
+                        PublicationValidationError(
+                            PublicationValidationErrorType.ERROR,
+                            "$VALIDATION_SWITCH.track-linkage.relinking-failed",
+                            mapOf("switch" to switchService.getOrThrow(DRAFT, switchId).name)
+                        )
+                    )
+                )
             else {
                 val (suggestedSwitch, relevantTracks) = suggestionWithTracks
                 val (validationResults, presentationJointLocation) = validateForSplit(

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -687,6 +687,7 @@
                     "show": "näytä"
                 },
                 "validation-in-progress": "Raiteen vaihteita validoidaan...",
+                "relink-critical-errors": "Raiteen vaihteiden linkityksessä on kriittisiä ongelmia, jotka täytyy korjata ennen raiteen jakamista",
                 "relink-message": "Raiteen vaihteissa on ongelmia, jotka olisi hyödyllistä korjata ennen raiteen jakamista",
                 "cancel-and-relink": "Peruuta ja näytä ongelmalliset vaihteet ({{count}} kpl)"
             },
@@ -695,7 +696,8 @@
                     "title": "Tehtävälista",
                     "validation-errors-message": "Seuraavissa raiteen \"{{locationTrack}}\" vaihteissa on ongelmia",
                     "no-validation-errors-message": "Raiteen \"{{locationTrack}}\" vaihteet ovat kunnossa.",
-                    "close-task-list": "Sulje tehtävälista"
+                    "close-task-list": "Sulje tehtävälista",
+                    "relinking-failed": "Vaihteen automaattinen uudelleenlinkitys epäonnistui"
                 }
             },
             "splitting-blocks-geometry-changes": "Raiteen geometriaa ei voi muokata koska sen jakaminen on kesken",
@@ -1327,7 +1329,8 @@
                     "front-joint-only-duplicate-connected": "Vaihteen etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
                     "switch-alignment-not-connected": "Joitakin vaihteen linjoja ei ole liitetty raiteelle: {{locationTracks}}",
                     "switch-alignment-only-connected-to-duplicate": "Joitakin vaihteen linjoja on liitetty ainoastaan duplikaatiksi merkityille raiteille: {{locationTracks}}",
-                    "multiple-tracks-through-joint": "Joistain vaihteen pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}"
+                    "multiple-tracks-through-joint": "Joistain vaihteen pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}",
+                    "relinking-failed": "Vaihteen {{switch}} uudelleenlinkitys epäonnistui"
                 }
             },
             "geocoding": {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -939,7 +939,13 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 SwitchRelinkingValidationResult(
                     id = unsaveableSwitch.id,
                     successfulSuggestion = null,
-                    validationErrors = listOf(),
+                    validationErrors = listOf(
+                        PublicationValidationError(
+                            type = PublicationValidationErrorType.ERROR,
+                            localizationKey = LocalizationKey("validation.layout.switch.track-linkage.relinking-failed"),
+                            params = LocalizationParams(mapOf("switch" to "unsaveable"))
+                        )
+                    ),
                 ),
             ), validationResult
         )

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list.scss
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list.scss
@@ -69,4 +69,9 @@
         justify-content: center;
         align-items: center;
     }
+
+    &__critical-error {
+        margin-left: 4px;
+        fill: vayla-design.$color-red-dark;
+    }
 }

--- a/ui/src/tool-panel/location-track/splitting/split-utils.ts
+++ b/ui/src/tool-panel/location-track/splitting/split-utils.ts
@@ -22,6 +22,7 @@ import {
     validateLocationTrackName,
 } from 'tool-panel/location-track/dialog/location-track-validation';
 import { isEqualIgnoreCase } from 'utils/string-utils';
+import { SwitchRelinkingValidationResult } from 'linking/linking-model';
 
 export type ValidatedSplit = {
     split: SplitTargetCandidate | FirstSplitTargetCandidate;
@@ -220,6 +221,9 @@ export const getSplitAddressPoint = (
         };
     }
 };
+
+export const hasUnrelinkableSwitches = (switchRelinkingErrors: SwitchRelinkingValidationResult[]) =>
+    switchRelinkingErrors?.some((err) => !err.successfulSuggestion) || false;
 
 export const getOperation = (
     trackId: LocationTrackId,


### PR DESCRIPTION
Tämä tilanne oltiin huomattu jo aiemminkin, sillä kaikki vaihteiden uudelleenlinkityksiä validoidaan jo ennen splittauksen loppua - tältä nimenomaiselta tianteelta puuttui vaan järkevä käsittely. Täällä parannettu asiaa seuraavilla toimenpiteillä:
* Jos vaihde-ehdotusta ei saada muodostettua, ka. tilanteesta palautetaan validaatiovirhe.
* Disabloidaan koko splittaus-UI jos tällainen tilanne ilmestyy (linkitykset validoidaan heti splittauksen alussa, mutta myös aina kun jokin sijaintiraide tai vaihde muuttuu)
* Näytetään tässä tilanteessa operaattorille vahvempi virheilmoitus (punainen pohja ja pelkän kehotuksen sijasta ilmoitetaan että vaihteet pitää korjata)
* Näytetään tehtävälistalla varoituskolmio kriittisen virheen merkkinä mikäli ka. vaihteen automaaginen uudelleenlinkitys epäonnistui