### PR TITLE
GVT-2559: Splittiin ei tulisi syntyä katkaisukohtaa valittaessa vaihde haun kautta + muita hakuparannuksia

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
@@ -35,12 +35,10 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
             "limit" to limit,
         )
 
-        return searchTerm.toString().trim().takeIf(String::isNotEmpty)?.let { term ->
-            dao.list(publicationState, true)
-                .filter { item -> idMatches(term, item) || contentMatches(term, item) }
-                .let { list -> sortSearchResult(list) }
-                .let { list -> if (limit != null) list.take(limit) else list }
-        } ?: listOf()
+        return dao.list(publicationState, true)
+            .let { list -> filterBySearchTerm(list, searchTerm) }
+            .let { list -> sortSearchResult(list) }
+            .let { list -> if (limit != null) list.take(limit) else list }
     }
 
     fun get(publicationState: PublicationState, id: IntId<ObjectType>): ObjectType? {
@@ -76,6 +74,11 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
         )
         return dao.fetchLayoutAssetChangeInfo(id, publicationState)
     }
+
+    fun filterBySearchTerm(list: List<ObjectType>, searchTerm: FreeText): List<ObjectType> =
+        searchTerm.toString().trim().takeIf(String::isNotEmpty)?.let { term ->
+            list.filter { item -> idMatches(term, item) || contentMatches(term, item) }
+        } ?: listOf()
 
     protected open fun sortSearchResult(list: List<ObjectType>): List<ObjectType> = list
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
+import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.util.FreeText
@@ -19,9 +20,7 @@ data class TrackLayoutSearchResult(
 @RestController
 @RequestMapping("/track-layout/search")
 class LayoutSearchController(
-    private val switchService: LayoutSwitchService,
-    private val locationTrackService: LocationTrackService,
-    private val trackNumberService: LayoutTrackNumberService,
+    private val searchService: LayoutSearchService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -31,18 +30,16 @@ class LayoutSearchController(
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("searchTerm", required = true) searchTerm: FreeText,
         @RequestParam("limitPerResultType", required = true) limitPerResultType: Int,
+        @RequestParam("contextLocationTrackId", required = false) contextLocationTrackId: IntId<LocationTrack>?,
     ): TrackLayoutSearchResult {
         logger.apiCall(
             "searchAssets",
             PUBLICATION_STATE to publicationState,
             "searchTerm" to searchTerm,
             "limitPerResultType" to limitPerResultType,
+            "contextLocationTrackId" to contextLocationTrackId,
         )
 
-        return TrackLayoutSearchResult(
-            switches = switchService.list(publicationState, searchTerm, limitPerResultType),
-            locationTracks = locationTrackService.list(publicationState, searchTerm, limitPerResultType),
-            trackNumbers = trackNumberService.list(publicationState, searchTerm, limitPerResultType),
-        )
+        return searchService.searchAssets(publicationState, searchTerm, limitPerResultType, contextLocationTrackId)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
@@ -1,0 +1,69 @@
+package fi.fta.geoviite.infra.tracklayout
+
+import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.logging.serviceCall
+import fi.fta.geoviite.infra.util.FreeText
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class LayoutSearchService @Autowired constructor(
+    private val switchService: LayoutSwitchService,
+    private val locationTrackService: LocationTrackService,
+    private val trackNumberService: LayoutTrackNumberService,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    fun searchAssets(
+        publicationState: PublicationState,
+        searchTerm: FreeText,
+        limitPerResultType: Int,
+        contextLocationTrackId: IntId<LocationTrack>?,
+    ): TrackLayoutSearchResult {
+        logger.serviceCall(
+            "searchAssets",
+            PUBLICATION_STATE to publicationState,
+            "searchTerm" to searchTerm,
+            "limitPerResultType" to limitPerResultType,
+            "contextLocationTrackId" to contextLocationTrackId,
+        )
+
+        return if (contextLocationTrackId != null) {
+            val switches = locationTrackService.getSwitchesForLocationTrack(contextLocationTrackId, publicationState)
+                .let { ids -> switchService.getMany(publicationState, ids) }
+            val locationTracks = locationTrackService
+                .getWithAlignmentOrThrow(publicationState, contextLocationTrackId)
+                .let { (lt, alignment) ->
+                    val duplicates = locationTrackService
+                        .getLocationTrackDuplicates(lt, alignment, publicationState)
+                        .map { it.id }
+                        .let { ids -> locationTrackService.getMany(publicationState, ids) }
+
+                    listOf(lt) + duplicates
+                }
+            val trackNumbers = emptyList<TrackLayoutTrackNumber>()
+
+            TrackLayoutSearchResult(
+                switches = switches
+                    .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
+                    .take(limitPerResultType),
+                locationTracks = locationTracks
+                    .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
+                    .take(limitPerResultType),
+                trackNumbers = trackNumbers
+                    .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
+                    .take(limitPerResultType)
+            )
+        } else {
+            TrackLayoutSearchResult(
+                switches = switchService.list(publicationState, searchTerm, limitPerResultType),
+                locationTracks = locationTrackService.list(publicationState, searchTerm, limitPerResultType),
+                trackNumbers = trackNumberService.list(publicationState, searchTerm, limitPerResultType),
+            )
+        }
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -458,7 +458,7 @@ class LocationTrackService(
             locationTrack.topologyEndSwitch?.switchId,
         ) + switchDao.findSwitchesNearAlignment(alignmentVersion)).distinct().size
 
-    private fun getLocationTrackDuplicates(
+    fun getLocationTrackDuplicates(
         track: LocationTrack,
         alignment: LayoutAlignment,
         publicationState: PublicationState,

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1515,7 +1515,8 @@
         }
     },
     "tool-bar": {
-        "search": "Hae...",
+        "search-from-whole-network": "Hae koko rataverkolta...",
+        "search-from-track": "Hae raiteelta {{track}}...",
         "new": "Luo uusi",
         "draft-mode": {
             "title": "LUONNOSTILA",

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -7,6 +7,7 @@ import {
     LayoutLocationTrack,
     LayoutSwitch,
     LayoutTrackNumber,
+    LocationTrackId,
 } from 'track-layout/track-layout-model';
 import { debounceAsync } from 'utils/async-utils';
 import { isNilOrBlank } from 'utils/string-utils';
@@ -87,12 +88,13 @@ type SearchItemValue = LocationTrackItemValue | SwitchItemValue | TrackNumberIte
 async function getOptions(
     layoutContext: LayoutContext,
     searchTerm: string,
+    contextLocationTrackId: LocationTrackId | undefined,
 ): Promise<Item<SearchItemValue>[]> {
     if (isNilOrBlank(searchTerm)) {
         return Promise.resolve([]);
     }
 
-    const searchResult = await getBySearchTerm(searchTerm, layoutContext);
+    const searchResult = await getBySearchTerm(searchTerm, layoutContext, contextLocationTrackId);
 
     const locationTrackDescriptions = await getLocationTrackDescriptions(
         searchResult.locationTracks.map((lt) => lt.id),
@@ -193,8 +195,9 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     const debouncedGetOptions = debounceAsync(getOptions, 250);
     // Use memoized function to make debouncing functionality to work when re-rendering
     const memoizedDebouncedGetOptions = React.useCallback(
-        (searchTerm: string) => debouncedGetOptions(layoutContext, searchTerm),
-        [layoutContext],
+        (searchTerm: string) =>
+            debouncedGetOptions(layoutContext, searchTerm, splittingState?.originLocationTrack?.id),
+        [layoutContext, splittingState],
     );
 
     function onItemSelected(item: SearchItemValue | undefined) {
@@ -217,11 +220,13 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                     const bbox = expandBoundingBox(boundingBoxAroundPoints([center]), 200);
                     showArea(bbox);
                 }
-                return onSelect({
-                    switches: [item.layoutSwitch.id],
-                    locationTracks: [],
-                    trackNumbers: [],
-                });
+                return !splittingState
+                    ? onSelect({
+                          switches: [item.layoutSwitch.id],
+                          locationTracks: [],
+                          trackNumbers: [],
+                      })
+                    : undefined;
 
             case 'trackNumberSearchItem':
                 getTrackNumberReferenceLine(item.trackNumber.id, layoutContext).then(
@@ -302,7 +307,13 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         <div className={`tool-bar tool-bar--${layoutContext.publicationState.toLowerCase()}`}>
             <div className={styles['tool-bar__left-section']}>
                 <Dropdown
-                    placeholder={t('tool-bar.search')}
+                    placeholder={
+                        splittingState
+                            ? t('tool-bar.search-from-track', {
+                                  track: splittingState.originLocationTrack.name,
+                              })
+                            : t('tool-bar.search-from-whole-network')
+                    }
                     options={memoizedDebouncedGetOptions}
                     searchable
                     onChange={onItemSelected}

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -112,7 +112,7 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
         () =>
             splittingState
                 ? validateLocationTrackSwitchRelinking(splittingState.originLocationTrack.id).then(
-                      (t) => t.filter((t) => t.validationErrors.length > 0),
+                      (results) => results.filter((res) => res.validationErrors.length > 0),
                   )
                 : Promise.resolve([]),
         [changeTimes.layoutLocationTrack, changeTimes.layoutSwitch],

--- a/ui/src/track-layout/track-layout-search-api.ts
+++ b/ui/src/track-layout/track-layout-search-api.ts
@@ -2,6 +2,7 @@ import {
     LayoutLocationTrack,
     LayoutSwitch,
     LayoutTrackNumber,
+    LocationTrackId,
 } from 'track-layout/track-layout-model';
 import { getNonNull, queryParams } from 'api/api-fetch';
 import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
@@ -16,12 +17,14 @@ export interface LayoutSearchResult {
 export async function getBySearchTerm(
     searchTerm: string,
     layoutContext: LayoutContext,
+    contextLocationTrackId?: LocationTrackId,
     limitPerResultType: number = 10,
 ): Promise<LayoutSearchResult> {
     const uri = `${TRACK_LAYOUT_URI}/search/${layoutContext.publicationState.toLowerCase()}`;
 
     const params = queryParams({
         searchTerm: searchTerm,
+        contextLocationTrackId: contextLocationTrackId,
         limitPerResultType: limitPerResultType,
     });
 


### PR DESCRIPTION
Tiketin varsinaisen asian lisäksi täällä siis muokattu hakulaatikon toimintaa siten, että splittauksen ollessa aktiivinen haku palauttaa ainoastaan splittaukseen liittyvää tavaraa (splitattava raide, sen duplikaattiraiteet, raiteen vaihteet)