### PR TITLE
GVT-2576: Fix staging/reverting only own changes when only own changes are displayed

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1197,8 +1197,8 @@
         "switches": "Vaihteita",
         "move-publication-group": "Siirrä kokonaisuus ({{amount}} kpl)",
         "revert-publication-group": "Hylkää kokonaisuus  ({{amount}} kpl)",
-        "move-stage-changes": "Siirrä kaikki listan muutokset ({{amount}} kpl)",
-        "revert-stage-changes": "Hylkää kaikki listan muutokset ({{amount}} kpl)"
+        "move-all-shown-changes": "Siirrä kaikki listan muutokset ({{amount}} kpl)",
+        "revert-all-shown-changes": "Hylkää kaikki listan muutokset ({{amount}} kpl)"
     },
     "validation": {
         "layout": {

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -18,7 +18,7 @@ import {
 import { PreviewTableEntry } from 'preview/preview-table';
 import { BoundingBox } from 'model/geometry';
 import { RevertRequestSource } from 'preview/preview-view-revert-request';
-import { PublicationAssetChangeAmounts } from 'publication/publication-utils';
+import { PublicationGroupAmounts } from 'publication/publication-utils';
 
 const conditionalMenuOption = (
     condition: unknown | undefined,
@@ -30,7 +30,8 @@ export type PreviewTableItemProps = {
     publish?: boolean;
     changesBeingReverted: ChangesBeingReverted | undefined;
     previewOperations: PreviewOperations;
-    publicationAssetChangeAmounts: PublicationAssetChangeAmounts;
+    publicationGroupAmounts: PublicationGroupAmounts;
+    displayedTotalPublicationAssetAmount: number;
     onShowOnMap: (bbox: BoundingBox) => void;
 };
 
@@ -39,7 +40,8 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     publish = false,
     changesBeingReverted,
     previewOperations,
-    publicationAssetChangeAmounts,
+    publicationGroupAmounts,
+    displayedTotalPublicationAssetAmount,
     onShowOnMap,
 }) => {
     const { t } = useTranslation();
@@ -62,16 +64,12 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     const actionMenuRef = React.useRef(null);
 
     const publicationGroupAssetAmount = tableEntry.publicationGroup
-        ? publicationAssetChangeAmounts.groupAmounts[tableEntry.publicationGroup?.id]
+        ? publicationGroupAmounts[tableEntry.publicationGroup?.id]
         : undefined;
 
     const [displayedPublicationStage, moveTargetStage] = publish
         ? [PublicationStage.STAGED, PublicationStage.UNSTAGED]
         : [PublicationStage.UNSTAGED, PublicationStage.STAGED];
-
-    const stagePublicationAssetAmount = publish
-        ? publicationAssetChangeAmounts.staged
-        : publicationAssetChangeAmounts.unstaged;
 
     const tableEntryAsRevertRequestSource: RevertRequestSource = {
         id: tableEntry.id,
@@ -86,13 +84,13 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
 
     const menuOptionMoveStageChanges: MenuSelectOption = menuSelectOption(
         menuAction(() =>
-            previewOperations.setPublicationStage.forAllStageChanges(
+            previewOperations.setPublicationStage.forAllShownChanges(
                 displayedPublicationStage,
                 moveTargetStage,
             ),
         ),
         t('publish.move-stage-changes', {
-            amount: stagePublicationAssetAmount,
+            amount: displayedTotalPublicationAssetAmount,
         }),
         'preview-move-stage-changes',
     );
@@ -131,7 +129,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
             );
         }),
         t('publish.revert-stage-changes', {
-            amount: stagePublicationAssetAmount,
+            amount: displayedTotalPublicationAssetAmount,
         }),
         'preview-revert-stage-changes',
     );

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -82,17 +82,17 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         setActionMenuVisible(false);
     };
 
-    const menuOptionMoveStageChanges: MenuSelectOption = menuSelectOption(
+    const menuOptionMoveAllShownChanges: MenuSelectOption = menuSelectOption(
         menuAction(() =>
             previewOperations.setPublicationStage.forAllShownChanges(
                 displayedPublicationStage,
                 moveTargetStage,
             ),
         ),
-        t('publish.move-stage-changes', {
+        t('publish.move-all-shown-changes', {
             amount: displayedTotalPublicationAssetAmount,
         }),
-        'preview-move-stage-changes',
+        'preview-move-all-shown-changes',
     );
 
     const menuOptionMovePublicationGroupStage: MenuSelectOption = menuSelectOption(
@@ -121,17 +121,17 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         'preview-revert-change',
     );
 
-    const menuOptionRevertStageChanges: MenuSelectOption = menuSelectOption(
+    const menuOptionRevertAllShownChanges: MenuSelectOption = menuSelectOption(
         menuAction(() => {
             previewOperations.revert.stageChanges(
                 displayedPublicationStage,
                 tableEntryAsRevertRequestSource,
             );
         }),
-        t('publish.revert-stage-changes', {
+        t('publish.revert-all-shown-changes', {
             amount: displayedTotalPublicationAssetAmount,
         }),
-        'preview-revert-stage-changes',
+        'preview-revert-all-shown-changes',
     );
 
     const menuOptionPublicationGroupRevert: MenuSelectOption = menuSelectOption(
@@ -160,13 +160,13 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
 
     const menuOptions: MenuOption<never>[] = [
         ...conditionalMenuOption(tableEntry.publicationGroup, menuOptionMovePublicationGroupStage),
-        menuOptionMoveStageChanges,
+        menuOptionMoveAllShownChanges,
         menuDividerOption(),
         menuOptionShowOnMap,
         menuDividerOption(),
         ...conditionalMenuOption(!tableEntry.publicationGroup, menuOptionRevertSingleChange),
         ...conditionalMenuOption(tableEntry.publicationGroup, menuOptionPublicationGroupRevert),
-        menuOptionRevertStageChanges,
+        menuOptionRevertAllShownChanges,
     ];
 
     return (

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -38,7 +38,7 @@ import { useLoader } from 'utils/react-utils';
 import { ChangeTimes } from 'common/common-slice';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
-import { PublicationAssetChangeAmounts } from 'publication/publication-utils';
+import { PublicationGroupAmounts } from 'publication/publication-utils';
 import { Spinner, SpinnerSize } from 'vayla-design-lib/spinner/spinner';
 import styles from './preview-view.scss';
 import { PreviewTableItem } from 'preview/preview-table-item';
@@ -65,7 +65,8 @@ type PreviewTableProps = {
     changesBeingReverted?: ChangesBeingReverted;
     onShowOnMap: (bbox: BoundingBox) => void;
     changeTimes: ChangeTimes;
-    publicationAssetChangeAmounts: PublicationAssetChangeAmounts;
+    publicationGroupAmounts: PublicationGroupAmounts;
+    displayedTotalPublicationAssetAmount: number;
     previewOperations: PreviewOperations;
     showStatusSpinner: boolean;
 };
@@ -76,7 +77,8 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
     staged,
     changesBeingReverted,
     changeTimes,
-    publicationAssetChangeAmounts,
+    publicationGroupAmounts,
+    displayedTotalPublicationAssetAmount,
     previewOperations,
     onShowOnMap,
     showStatusSpinner,
@@ -216,7 +218,10 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
                                     changesBeingReverted={changesBeingReverted}
                                     onShowOnMap={onShowOnMap}
                                     previewOperations={previewOperations}
-                                    publicationAssetChangeAmounts={publicationAssetChangeAmounts}
+                                    publicationGroupAmounts={publicationGroupAmounts}
+                                    displayedTotalPublicationAssetAmount={
+                                        displayedTotalPublicationAssetAmount
+                                    }
                                 />
                             }
                         </React.Fragment>

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -42,9 +42,11 @@ export type PublicationAssetChangeAmounts = {
     total: number;
     staged: number;
     unstaged: number;
-    groupAmounts: Record<PublicationGroupId, number>;
+    groupAmounts: PublicationGroupAmounts;
     ownUnstaged: number;
 };
+
+export type PublicationGroupAmounts = Record<PublicationGroupId, number>;
 
 export const countPublicationGroupAmounts = (
     publicationCandidates: PublicationCandidate[],
@@ -59,7 +61,7 @@ export const countPublicationGroupAmounts = (
         }
 
         return groupSizes;
-    }, {} as Record<PublicationGroupId, number>);
+    }, {} as PublicationGroupAmounts);
 };
 
 export const createPublicationCandidateReference = (


### PR DESCRIPTION
Previously the "Revert all/Move all" operations moved performed the action to literally all changes, even though the user had selected the "Display only my changes" option. This was unintuitive, and it was possible for users to accidentally stage/revert changes that were not their own.