### PR TITLE
GVT-2559: Review-korjauksia

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
@@ -23,24 +23,6 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
         return dao.list(publicationState, includeDeleted)
     }
 
-    fun list(
-        publicationState: PublicationState,
-        searchTerm: FreeText,
-        limit: Int?,
-    ): List<ObjectType> {
-        logger.serviceCall(
-            "list",
-            "publicationState" to publicationState,
-            "searchTerm" to searchTerm,
-            "limit" to limit,
-        )
-
-        return dao.list(publicationState, true)
-            .let { list -> filterBySearchTerm(list, searchTerm) }
-            .let { list -> sortSearchResult(list) }
-            .let { list -> if (limit != null) list.take(limit) else list }
-    }
-
     fun get(publicationState: PublicationState, id: IntId<ObjectType>): ObjectType? {
         logger.serviceCall("get", "publicationState" to publicationState, "id" to id)
         return dao.get(publicationState, id)
@@ -80,7 +62,7 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
             list.filter { item -> idMatches(term, item) || contentMatches(term, item) }
         } ?: listOf()
 
-    protected open fun sortSearchResult(list: List<ObjectType>): List<ObjectType> = list
+    //abstract fun sortSearchResult(list: List<ObjectType>): List<ObjectType>
 
     protected open fun idMatches(term: String, item: ObjectType): Boolean = false
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
@@ -62,8 +62,6 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
             list.filter { item -> idMatches(term, item) || contentMatches(term, item) }
         } ?: listOf()
 
-    //abstract fun sortSearchResult(list: List<ObjectType>): List<ObjectType>
-
     protected open fun idMatches(term: String, item: ObjectType): Boolean = false
 
     protected open fun contentMatches(term: String, item: ObjectType): Boolean = false

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
@@ -30,16 +30,16 @@ class LayoutSearchController(
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("searchTerm", required = true) searchTerm: FreeText,
         @RequestParam("limitPerResultType", required = true) limitPerResultType: Int,
-        @RequestParam("contextLocationTrackId", required = false) contextLocationTrackId: IntId<LocationTrack>?,
+        @RequestParam("locationTrackSearchScope", required = false) locationTrackSearchScope: IntId<LocationTrack>?,
     ): TrackLayoutSearchResult {
         logger.apiCall(
             "searchAssets",
             PUBLICATION_STATE to publicationState,
             "searchTerm" to searchTerm,
             "limitPerResultType" to limitPerResultType,
-            "contextLocationTrackId" to contextLocationTrackId,
+            "locationTrackSearchScope" to locationTrackSearchScope,
         )
 
-        return searchService.searchAssets(publicationState, searchTerm, limitPerResultType, contextLocationTrackId)
+        return searchService.searchAssets(publicationState, searchTerm, limitPerResultType, locationTrackSearchScope)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
@@ -22,48 +22,116 @@ class LayoutSearchService @Autowired constructor(
         publicationState: PublicationState,
         searchTerm: FreeText,
         limitPerResultType: Int,
-        contextLocationTrackId: IntId<LocationTrack>?,
+        locationTrackSearchScope: IntId<LocationTrack>?,
     ): TrackLayoutSearchResult {
         logger.serviceCall(
             "searchAssets",
             PUBLICATION_STATE to publicationState,
             "searchTerm" to searchTerm,
             "limitPerResultType" to limitPerResultType,
-            "contextLocationTrackId" to contextLocationTrackId,
+            "locationTrackSearchScope" to locationTrackSearchScope,
         )
 
-        return if (contextLocationTrackId != null) {
-            val switches = locationTrackService.getSwitchesForLocationTrack(contextLocationTrackId, publicationState)
-                .let { ids -> switchService.getMany(publicationState, ids) }
-            val locationTracks = locationTrackService
-                .getWithAlignmentOrThrow(publicationState, contextLocationTrackId)
-                .let { (lt, alignment) ->
-                    val duplicates = locationTrackService
-                        .getLocationTrackDuplicates(lt, alignment, publicationState)
-                        .map { it.id }
-                        .let { ids -> locationTrackService.getMany(publicationState, ids) }
-
-                    listOf(lt) + duplicates
-                }
-            val trackNumbers = emptyList<TrackLayoutTrackNumber>()
-
-            TrackLayoutSearchResult(
-                switches = switches
-                    .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
-                    .take(limitPerResultType),
-                locationTracks = locationTracks
-                    .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
-                    .take(limitPerResultType),
-                trackNumbers = trackNumbers
-                    .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
-                    .take(limitPerResultType)
-            )
+        return if (locationTrackSearchScope != null) {
+            searchByLocationTrackSearchScope(locationTrackSearchScope, publicationState, searchTerm, limitPerResultType)
         } else {
-            TrackLayoutSearchResult(
-                switches = switchService.list(publicationState, searchTerm, limitPerResultType),
-                locationTracks = locationTrackService.list(publicationState, searchTerm, limitPerResultType),
-                trackNumbers = trackNumberService.list(publicationState, searchTerm, limitPerResultType),
-            )
+            searchFromEntireRailwayNetwork(publicationState, searchTerm, limitPerResultType)
         }
+    }
+
+    private fun searchFromEntireRailwayNetwork(
+        publicationState: PublicationState,
+        searchTerm: FreeText,
+        limitPerResultType: Int,
+    ) = TrackLayoutSearchResult(
+        switches = searchAllSwitches(publicationState, searchTerm, limitPerResultType),
+        locationTracks = searchAllLocationTracks(publicationState, searchTerm, limitPerResultType),
+        trackNumbers = searchAllTrackNumbers(publicationState, searchTerm, limitPerResultType),
+    )
+
+    private fun searchByLocationTrackSearchScope(
+        locationTrackSearchScope: IntId<LocationTrack>,
+        publicationState: PublicationState,
+        searchTerm: FreeText,
+        limitPerResultType: Int,
+    ): TrackLayoutSearchResult {
+        val switches = locationTrackService
+            .getSwitchesForLocationTrack(locationTrackSearchScope, publicationState)
+            .let { ids -> switchService.getMany(publicationState, ids) }
+        val locationTracks = locationTrackService.getWithAlignmentOrThrow(publicationState, locationTrackSearchScope).let { (lt, alignment) ->
+                val duplicates = locationTrackService
+                    .getLocationTrackDuplicates(lt, alignment, publicationState)
+                    .map { it.id }
+                    .let { ids -> locationTrackService.getMany(publicationState, ids) }
+
+                listOf(lt) + duplicates
+            }
+        val trackNumbers = emptyList<TrackLayoutTrackNumber>()
+
+        return TrackLayoutSearchResult(
+            switches = switches
+                .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
+                .take(limitPerResultType),
+            locationTracks = locationTracks
+                .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
+                .take(limitPerResultType),
+            trackNumbers = trackNumbers
+                .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
+                .take(limitPerResultType)
+        )
+    }
+
+    fun searchAllLocationTracks(
+        publicationState: PublicationState,
+        searchTerm: FreeText,
+        limit: Int?,
+    ): List<LocationTrack> {
+        logger.serviceCall(
+            "searchAllLocationTracks",
+            "publicationState" to publicationState,
+            "searchTerm" to searchTerm,
+            "limit" to limit,
+        )
+
+        return locationTrackService.list(publicationState, true)
+            .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
+            .let { list -> locationTrackService.sortSearchResult(list) }
+            .let { list -> if (limit != null) list.take(limit) else list }
+    }
+
+    fun searchAllSwitches(
+        publicationState: PublicationState,
+        searchTerm: FreeText,
+        limit: Int?,
+    ): List<TrackLayoutSwitch> {
+        logger.serviceCall(
+            "searchAllLayoutSwitches",
+            "publicationState" to publicationState,
+            "searchTerm" to searchTerm,
+            "limit" to limit,
+        )
+
+        return switchService.list(publicationState, true)
+            .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
+            .let { list -> switchService.sortSearchResult(list) }
+            .let { list -> if (limit != null) list.take(limit) else list }
+    }
+
+    fun searchAllTrackNumbers(
+        publicationState: PublicationState,
+        searchTerm: FreeText,
+        limit: Int?,
+    ): List<TrackLayoutTrackNumber> {
+        logger.serviceCall(
+            "searchAllTrackNumbers",
+            "publicationState" to publicationState,
+            "searchTerm" to searchTerm,
+            "limit" to limit,
+        )
+
+        return trackNumberService.list(publicationState, true)
+            .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
+            .let { list -> trackNumberService.sortSearchResult(list) }
+            .let { list -> if (limit != null) list.take(limit) else list }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
@@ -39,6 +39,60 @@ class LayoutSearchService @Autowired constructor(
         }
     }
 
+    fun searchAllLocationTracks(
+        publicationState: PublicationState,
+        searchTerm: FreeText,
+        limit: Int,
+    ): List<LocationTrack> {
+        logger.serviceCall(
+            "searchAllLocationTracks",
+            "publicationState" to publicationState,
+            "searchTerm" to searchTerm,
+            "limit" to limit,
+        )
+
+        return locationTrackService.list(publicationState, true)
+            .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
+            .sortedBy(LocationTrack::name)
+            .take(limit)
+    }
+
+    fun searchAllSwitches(
+        publicationState: PublicationState,
+        searchTerm: FreeText,
+        limit: Int,
+    ): List<TrackLayoutSwitch> {
+        logger.serviceCall(
+            "searchAllLayoutSwitches",
+            "publicationState" to publicationState,
+            "searchTerm" to searchTerm,
+            "limit" to limit,
+        )
+
+        return switchService.list(publicationState, true)
+            .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
+            .sortedBy(TrackLayoutSwitch::name)
+            .take(limit)
+    }
+
+    fun searchAllTrackNumbers(
+        publicationState: PublicationState,
+        searchTerm: FreeText,
+        limit: Int,
+    ): List<TrackLayoutTrackNumber> {
+        logger.serviceCall(
+            "searchAllTrackNumbers",
+            "publicationState" to publicationState,
+            "searchTerm" to searchTerm,
+            "limit" to limit,
+        )
+
+        return trackNumberService.list(publicationState, true)
+            .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
+            .sortedBy(TrackLayoutTrackNumber::number)
+            .take(limit)
+    }
+
     private fun searchFromEntireRailwayNetwork(
         publicationState: PublicationState,
         searchTerm: FreeText,
@@ -53,85 +107,42 @@ class LayoutSearchService @Autowired constructor(
         locationTrackSearchScope: IntId<LocationTrack>,
         publicationState: PublicationState,
         searchTerm: FreeText,
-        limitPerResultType: Int,
+        limit: Int,
     ): TrackLayoutSearchResult {
         val switches = locationTrackService
             .getSwitchesForLocationTrack(locationTrackSearchScope, publicationState)
             .let { ids -> switchService.getMany(publicationState, ids) }
-        val locationTracks = locationTrackService.getWithAlignmentOrThrow(publicationState, locationTrackSearchScope).let { (lt, alignment) ->
-                val duplicates = locationTrackService
-                    .getLocationTrackDuplicates(lt, alignment, publicationState)
-                    .map { it.id }
-                    .let { ids -> locationTrackService.getMany(publicationState, ids) }
-
-                listOf(lt) + duplicates
-            }
+        val locationTracks = getLocationTrackAndDuplicatesByScope(locationTrackSearchScope, publicationState)
         val trackNumbers = emptyList<TrackLayoutTrackNumber>()
 
         return TrackLayoutSearchResult(
             switches = switches
                 .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
-                .take(limitPerResultType),
+                .take(limit),
             locationTracks = locationTracks
                 .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
-                .take(limitPerResultType),
+                .take(limit),
             trackNumbers = trackNumbers
                 .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
-                .take(limitPerResultType)
+                .take(limit)
         )
     }
 
-    fun searchAllLocationTracks(
+    private fun getLocationTrackAndDuplicatesByScope(
+        locationTrackSearchScope: IntId<LocationTrack>,
         publicationState: PublicationState,
-        searchTerm: FreeText,
-        limit: Int?,
-    ): List<LocationTrack> {
-        logger.serviceCall(
-            "searchAllLocationTracks",
-            "publicationState" to publicationState,
-            "searchTerm" to searchTerm,
-            "limit" to limit,
-        )
-
-        return locationTrackService.list(publicationState, true)
-            .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
-            .let { list -> locationTrackService.sortSearchResult(list) }
-            .let { list -> if (limit != null) list.take(limit) else list }
-    }
-
-    fun searchAllSwitches(
-        publicationState: PublicationState,
-        searchTerm: FreeText,
-        limit: Int?,
-    ): List<TrackLayoutSwitch> {
-        logger.serviceCall(
-            "searchAllLayoutSwitches",
-            "publicationState" to publicationState,
-            "searchTerm" to searchTerm,
-            "limit" to limit,
-        )
-
-        return switchService.list(publicationState, true)
-            .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
-            .let { list -> switchService.sortSearchResult(list) }
-            .let { list -> if (limit != null) list.take(limit) else list }
-    }
-
-    fun searchAllTrackNumbers(
-        publicationState: PublicationState,
-        searchTerm: FreeText,
-        limit: Int?,
-    ): List<TrackLayoutTrackNumber> {
-        logger.serviceCall(
-            "searchAllTrackNumbers",
-            "publicationState" to publicationState,
-            "searchTerm" to searchTerm,
-            "limit" to limit,
-        )
-
-        return trackNumberService.list(publicationState, true)
-            .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
-            .let { list -> trackNumberService.sortSearchResult(list) }
-            .let { list -> if (limit != null) list.take(limit) else list }
-    }
+    ): List<LocationTrack> = locationTrackService
+        .getWithAlignmentOrThrow(publicationState, locationTrackSearchScope)
+        .let { (lt, alignment) ->
+            lt to locationTrackService.getLocationTrackDuplicates(
+                lt,
+                alignment,
+                publicationState
+            )
+        }
+        .let { (locationTrack, duplicates) ->
+            listOf(locationTrack) + locationTrackService.getMany(
+                publicationState,
+                duplicates.map { d -> d.id })
+        }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -118,8 +118,6 @@ class LayoutSwitchService @Autowired constructor(
         return dao.list(publicationState, includeDeleted).map(::withStructure)
     }
 
-    fun sortSearchResult(list: List<TrackLayoutSwitch>) = list.sortedBy(TrackLayoutSwitch::name)
-
     override fun idMatches(term: String, item: TrackLayoutSwitch) =
         item.externalId.toString() == term || item.id.toString() == term
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -118,7 +118,7 @@ class LayoutSwitchService @Autowired constructor(
         return dao.list(publicationState, includeDeleted).map(::withStructure)
     }
 
-    override fun sortSearchResult(list: List<TrackLayoutSwitch>) = list.sortedBy(TrackLayoutSwitch::name)
+    fun sortSearchResult(list: List<TrackLayoutSwitch>) = list.sortedBy(TrackLayoutSwitch::name)
 
     override fun idMatches(term: String, item: TrackLayoutSwitch) =
         item.externalId.toString() == term || item.id.toString() == term

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -78,7 +78,7 @@ class LayoutTrackNumberService(
         return deleteDraft(id).id
     }
 
-    override fun sortSearchResult(list: List<TrackLayoutTrackNumber>) = list.sortedBy(TrackLayoutTrackNumber::number)
+    fun sortSearchResult(list: List<TrackLayoutTrackNumber>) = list.sortedBy(TrackLayoutTrackNumber::number)
 
     override fun idMatches(term: String, item: TrackLayoutTrackNumber) =
         item.externalId.toString() == term || item.id.toString() == term

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -78,8 +78,6 @@ class LayoutTrackNumberService(
         return deleteDraft(id).id
     }
 
-    fun sortSearchResult(list: List<TrackLayoutTrackNumber>) = list.sortedBy(TrackLayoutTrackNumber::number)
-
     override fun idMatches(term: String, item: TrackLayoutTrackNumber) =
         item.externalId.toString() == term || item.id.toString() == term
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -37,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/track-layout")
 class LocationTrackController(
     private val locationTrackService: LocationTrackService,
+    private val searchService: LayoutSearchService,
     private val geocodingService: GeocodingService,
     private val publicationService: PublicationService,
     private val switchLinkingService: SwitchLinkingService,
@@ -61,7 +62,7 @@ class LocationTrackController(
         @RequestParam("limit", required = true) limit: Int,
     ): List<LocationTrack> {
         logger.apiCall("searchLocationTracks", PUBLICATION_STATE to publicationState, "searchTerm" to searchTerm, "limit" to limit)
-        return locationTrackService.list(publicationState, searchTerm, limit)
+        return searchService.searchAllLocationTracks(publicationState, searchTerm, limit)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -212,7 +212,7 @@ class LocationTrackService(
         return dao.list(publicationState, false).filter { tn -> bbox.intersects(tn.boundingBox) }
     }
 
-    override fun sortSearchResult(list: List<LocationTrack>): List<LocationTrack> = list.sortedBy(LocationTrack::name)
+    fun sortSearchResult(list: List<LocationTrack>): List<LocationTrack> = list.sortedBy(LocationTrack::name)
 
     fun list(
         publicationState: PublicationState,
@@ -458,6 +458,7 @@ class LocationTrackService(
             locationTrack.topologyEndSwitch?.switchId,
         ) + switchDao.findSwitchesNearAlignment(alignmentVersion)).distinct().size
 
+    @Transactional(readOnly = true)
     fun getLocationTrackDuplicates(
         track: LocationTrack,
         alignment: LayoutAlignment,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -212,8 +212,6 @@ class LocationTrackService(
         return dao.list(publicationState, false).filter { tn -> bbox.intersects(tn.boundingBox) }
     }
 
-    fun sortSearchResult(list: List<LocationTrack>): List<LocationTrack> = list.sortedBy(LocationTrack::name)
-
     fun list(
         publicationState: PublicationState,
         trackNumberId: IntId<TrackLayoutTrackNumber>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
@@ -1,0 +1,112 @@
+package fi.fta.geoviite.infra.tracklayout
+
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.TrackNumber
+import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
+import fi.fta.geoviite.infra.util.FreeText
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class LayoutSearchServiceIT @Autowired constructor(
+    val searchService: LayoutSearchService,
+    val trackNumberService: LayoutTrackNumberService,
+): DBTestBase() {
+    @BeforeEach
+    fun cleanup() {
+        deleteFromTables("layout", "track_number", "reference_line")
+    }
+
+    @Test
+    fun `free text search should find multiple matching track numbers, and not the ones that did not match`() {
+        val trackNumbers = listOf(
+            TrackNumber("track number 1"),
+            TrackNumber("track number 11"),
+            TrackNumber("number 111"),
+            TrackNumber("number111 111")
+        )
+
+        saveTrackNumbersWithSaveRequests(
+            trackNumbers,
+            LayoutState.IN_USE,
+        )
+
+        assertEquals(2, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), null).size)
+        assertEquals(3, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("11"), null).size)
+        assertEquals(4, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("1"), null).size)
+    }
+
+    @Test
+    fun `free text search should limit the amount of returned track numbers as specified`() {
+        val trackNumbers = (0..15).map { number ->
+            TrackNumber("some track $number")
+        }
+
+        saveTrackNumbersWithSaveRequests(
+            trackNumbers,
+            LayoutState.IN_USE,
+        )
+
+        assertEquals(5, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("some track"), 5).size)
+        assertEquals(10, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("some track"), 10).size)
+        assertEquals(15, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("some track"), 15).size)
+    }
+
+    @Test
+    fun `free text search should not return deleted track numbers when its domain id or external id does not match the search term`() {
+        val trackNumbers = listOf(
+            TrackNumber("track number 1"),
+            TrackNumber("track number 11"),
+        )
+
+        saveTrackNumbersWithSaveRequests(trackNumbers, LayoutState.DELETED)
+        assertEquals(0, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), null).size)
+    }
+
+    @Test
+    fun `free text search should return deleted track number when its domain id or external id matches`() {
+        val trackNumbers = listOf(
+            TrackNumber("track number 1"),
+            TrackNumber("track number 11"),
+        )
+
+        saveTrackNumbersWithSaveRequests(
+            trackNumbers,
+            LayoutState.DELETED,
+        ).forEachIndexed { index, trackNumberId ->
+            val oid = Oid<TrackLayoutTrackNumber>("1.2.3.4.5.6.$index")
+            trackNumberService.updateExternalId(trackNumberId, oid)
+
+            assertEquals(1, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText(oid.toString()), null).size)
+            assertEquals(1, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText(trackNumberId.toString()), null).size)
+        }
+
+        // LayoutState was set to DELETED, meaning that these track numbers should not be found by free text.
+        assertEquals(0, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), null).size)
+    }
+
+    private fun saveTrackNumbersWithSaveRequests(
+        trackNumbers: List<TrackNumber>,
+        layoutState: LayoutState,
+    ): List<IntId<TrackLayoutTrackNumber>> {
+        return trackNumbers.map { trackNumber ->
+            TrackNumberSaveRequest(
+                trackNumber, FreeText("some description"), layoutState, TrackMeter(
+                    KmNumber(5555), 5.5, 1
+                )
+            )
+        }.map { saveRequest ->
+            trackNumberService.insert(saveRequest)
+        }
+    }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
@@ -41,9 +41,9 @@ class LayoutSearchServiceIT @Autowired constructor(
             LayoutState.IN_USE,
         )
 
-        assertEquals(2, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), null).size)
-        assertEquals(3, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("11"), null).size)
-        assertEquals(4, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("1"), null).size)
+        assertEquals(2, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), 100).size)
+        assertEquals(3, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("11"), 100).size)
+        assertEquals(4, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("1"), 100).size)
     }
 
     @Test
@@ -70,7 +70,7 @@ class LayoutSearchServiceIT @Autowired constructor(
         )
 
         saveTrackNumbersWithSaveRequests(trackNumbers, LayoutState.DELETED)
-        assertEquals(0, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), null).size)
+        assertEquals(0, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), 100).size)
     }
 
     @Test
@@ -87,12 +87,12 @@ class LayoutSearchServiceIT @Autowired constructor(
             val oid = Oid<TrackLayoutTrackNumber>("1.2.3.4.5.6.$index")
             trackNumberService.updateExternalId(trackNumberId, oid)
 
-            assertEquals(1, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText(oid.toString()), null).size)
-            assertEquals(1, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText(trackNumberId.toString()), null).size)
+            assertEquals(1, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText(oid.toString()), 100).size)
+            assertEquals(1, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText(trackNumberId.toString()), 100).size)
         }
 
         // LayoutState was set to DELETED, meaning that these track numbers should not be found by free text.
-        assertEquals(0, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), null).size)
+        assertEquals(0, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), 100).size)
     }
 
     private fun saveTrackNumbersWithSaveRequests(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -423,6 +423,8 @@ fun <T> someOid() = Oid<T>(
     "${nextInt(10, 1000)}.${nextInt(10, 1000)}.${nextInt(10, 1000)}"
 )
 
+fun someAlignment() = alignment(someSegment())
+
 fun alignmentFromPoints(vararg points: Point) = alignment(segment(*points))
 
 fun alignment(vararg segments: LayoutSegment) = alignment(segments.toList())

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -88,13 +88,13 @@ type SearchItemValue = LocationTrackItemValue | SwitchItemValue | TrackNumberIte
 async function getOptions(
     layoutContext: LayoutContext,
     searchTerm: string,
-    contextLocationTrackId: LocationTrackId | undefined,
+    locationTrackSearchScope: LocationTrackId | undefined,
 ): Promise<Item<SearchItemValue>[]> {
     if (isNilOrBlank(searchTerm)) {
         return Promise.resolve([]);
     }
 
-    const searchResult = await getBySearchTerm(searchTerm, layoutContext, contextLocationTrackId);
+    const searchResult = await getBySearchTerm(searchTerm, layoutContext, locationTrackSearchScope);
 
     const locationTrackDescriptions = await getLocationTrackDescriptions(
         searchResult.locationTracks.map((lt) => lt.id),

--- a/ui/src/track-layout/track-layout-search-api.ts
+++ b/ui/src/track-layout/track-layout-search-api.ts
@@ -17,14 +17,14 @@ export interface LayoutSearchResult {
 export async function getBySearchTerm(
     searchTerm: string,
     layoutContext: LayoutContext,
-    contextLocationTrackId?: LocationTrackId,
+    locationTrackSearchScope?: LocationTrackId,
     limitPerResultType: number = 10,
 ): Promise<LayoutSearchResult> {
     const uri = `${TRACK_LAYOUT_URI}/search/${layoutContext.publicationState.toLowerCase()}`;
 
     const params = queryParams({
         searchTerm: searchTerm,
-        contextLocationTrackId: contextLocationTrackId,
+        locationTrackSearchScope: locationTrackSearchScope,
         limitPerResultType: limitPerResultType,
     });
 


### PR DESCRIPTION
Täällä suurimpana juttuna on Jyrkin ehdotuksen mukaisesti hakujuttujen siirtäminen pois kunkin assettityypin omasta servicestä `LayoutSearchService`:en. Myös hakufunktionaalisuuden testit siirtyivät siinä samalla uuteen IT-filuun. Tämän kattauksen lisäksi on tehty muita kovimpia refaktorointihittejä, kuten asioiden splittausta funktioihin ja uudelleennimeämisiä.