### PR TITLE
General: Use less sweat-inducing way to read LocalDates from DB

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -31,7 +31,7 @@ fun ResultSet.getInstantOrNull(name: String): Instant? = getTimestamp(name)?.toI
 
 fun ResultSet.getLocalDate(name: String): LocalDate = verifyNotNull(name, ::getLocalDateOrNull)
 
-fun ResultSet.getLocalDateOrNull(name: String): LocalDate? = getDate(name)?.toLocalDate()
+fun ResultSet.getLocalDateOrNull(name: String): LocalDate? = getString(name)?.let(LocalDate::parse)
 
 fun <T> ResultSet.getIndexedId(parent: String, index: String): IndexedId<T> =
     requireNotNull(getIndexedIdOrNull(parent, index)) {


### PR DESCRIPTION
Tällä tavalla kirjoitettuna LocalDaten lukeminen ei käy lainkaan sellaisen olion kautta, jossa päivämäärä olisi esitetty tarkempana ajanhetkenä (ja jonka kanssa voi miettiä että voikos tämä nyt rikkoa jotain aikavyöhykkeillä), vaan tietokanta antaa päivämäärän ISO-muodossa tekstinä, joka sitten parsitaan.