### PR TITLE
GVT-2524 Use validation context for split validation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -1,13 +1,20 @@
 package fi.fta.geoviite.infra.error
 
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.DomainId
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.common.TrackNumber
+import fi.fta.geoviite.infra.common.idToString
 import fi.fta.geoviite.infra.inframodel.INFRAMODEL_PARSING_KEY_GENERIC
 import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.util.LocalizationKey
 import fi.fta.geoviite.infra.util.formatForException
 import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatus.*
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE
+import org.springframework.http.HttpStatus.UNAUTHORIZED
 import kotlin.reflect.KClass
 
 interface HasLocalizedMessage {
@@ -65,7 +72,8 @@ class PublicationFailureException(
     message: String,
     cause: Throwable? = null,
     localizedMessageKey: String = "generic",
-) : ClientException(BAD_REQUEST, "Publishing failed: $message", cause, "$LOCALIZATION_KEY_BASE.$localizedMessageKey") {
+    status: HttpStatus = BAD_REQUEST,
+) : ClientException(status, "Publishing failed: $message", cause, "$LOCALIZATION_KEY_BASE.$localizedMessageKey") {
     companion object {
         const val LOCALIZATION_KEY_BASE = "error.publication"
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -64,7 +64,7 @@ data class AlignmentAddresses(
     }
 
     @get:JsonIgnore
-    val exactMeterPoints: List<AddressPoint> by lazy {
+    val integerPrecisionPoints: List<AddressPoint> by lazy {
         // midPoints are even anyhow, so just transform start/end
         listOfNotNull(startPoint.withIntegerPrecision()) + midPoints + listOfNotNull(endPoint.withIntegerPrecision())
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingCacheService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingCacheService.kt
@@ -11,7 +11,15 @@ import fi.fta.geoviite.infra.geometry.PlanLayoutService
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.map.MapAlignmentType
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -80,8 +88,7 @@ class GeocodingCacheService(
         logger.daoAccess(AccessType.FETCH, GeocodingContext::class, "cacheKey" to key)
         val trackNumber = trackNumberDao.fetch(key.trackNumberVersion)
         val referenceLine = referenceLineDao.fetch(key.referenceLineVersion)
-        val alignment = referenceLine.alignmentVersion?.let(alignmentDao::fetch)
-            ?: throw IllegalStateException("DB ReferenceLine should have an alignment")
+        val alignment = referenceLine.getAlignmentVersionOrThrow().let(alignmentDao::fetch)
         // If the track number is deleted or reference line has no geometry, we cannot geocode.
         if (!trackNumber.exists || alignment.segments.isEmpty()) return null
         val kmPosts = key.kmPostVersions.map(kmPostDao::fetch).sortedBy { post -> post.kmNumber }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -6,7 +6,11 @@ import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.error.LinkingFailureException
 import fi.fta.geoviite.infra.geography.CoordinateTransformationService
 import fi.fta.geoviite.infra.geography.calculateDistance
-import fi.fta.geoviite.infra.geometry.*
+import fi.fta.geoviite.infra.geometry.GeometryAlignment
+import fi.fta.geoviite.infra.geometry.GeometryPlan
+import fi.fta.geoviite.infra.geometry.GeometryPlanLinkStatus
+import fi.fta.geoviite.infra.geometry.GeometryService
+import fi.fta.geoviite.infra.geometry.PlanLayoutService
 import fi.fta.geoviite.infra.linking.LocationTrackPointUpdateType.END_POINT
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.BoundingBox
@@ -14,7 +18,16 @@ import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Range
 import fi.fta.geoviite.infra.split.SplitService
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.DaoResponse
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostService
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -266,7 +279,7 @@ class LinkingService @Autowired constructor(
     }
 
     fun verifyAllSplitsDone(id: IntId<LocationTrack>) {
-        if (splitService.findUnfinishedSplitsForLocationTracks(listOf(id)).isNotEmpty()) {
+        if (splitService.findUnfinishedSplits(locationTrackIds = listOf(id)).isNotEmpty()) {
             throw LinkingFailureException(
                 message = "Cannot link a location track that has unfinished splits",
                 localizedMessageKey = "unfinished-splits",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDao.kt
@@ -4,11 +4,36 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.inframodel.InfraModelFile
-import fi.fta.geoviite.infra.logging.AccessType.*
+import fi.fta.geoviite.infra.logging.AccessType.FETCH
+import fi.fta.geoviite.infra.logging.AccessType.INSERT
+import fi.fta.geoviite.infra.logging.AccessType.UPDATE
+import fi.fta.geoviite.infra.logging.AccessType.UPSERT
 import fi.fta.geoviite.infra.logging.daoAccess
-import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.*
+import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.DOCUMENT_TYPE
+import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.MATERIAL_CATEGORY
+import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.MATERIAL_GROUP
+import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.MATERIAL_STATE
+import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.PROJECT_STATE
+import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.TECHNICS_FIELD
 import fi.fta.geoviite.infra.projektivelho.PVFetchStatus.WAITING
-import fi.fta.geoviite.infra.util.*
+import fi.fta.geoviite.infra.util.DaoBase
+import fi.fta.geoviite.infra.util.DbTable
+import fi.fta.geoviite.infra.util.LocalizationKey
+import fi.fta.geoviite.infra.util.getEnum
+import fi.fta.geoviite.infra.util.getFileName
+import fi.fta.geoviite.infra.util.getFreeTextOrNull
+import fi.fta.geoviite.infra.util.getInstant
+import fi.fta.geoviite.infra.util.getIntId
+import fi.fta.geoviite.infra.util.getOid
+import fi.fta.geoviite.infra.util.getOidOrNull
+import fi.fta.geoviite.infra.util.getOne
+import fi.fta.geoviite.infra.util.getOptional
+import fi.fta.geoviite.infra.util.getPVDictionaryCode
+import fi.fta.geoviite.infra.util.getPVDictionaryName
+import fi.fta.geoviite.infra.util.getPVId
+import fi.fta.geoviite.infra.util.getPVProjectName
+import fi.fta.geoviite.infra.util.getRowVersion
+import fi.fta.geoviite.infra.util.setUser
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -308,7 +333,7 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
             "reason" to reason,
         )
         jdbcTemplate.setUser()
-        return getOne<PVDocument, IntId<PVDocumentRejection>?>(
+        return getOne<PVDocument, IntId<PVDocumentRejection>>(
             documentRowVersion.id,
             jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId("id") },
         ).also { id -> logger.daoAccess(INSERT, PVDocumentRejection::class, id) }
@@ -326,13 +351,16 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
             "document_version" to documentRowVersion.version,
         )
         jdbcTemplate.setUser()
-        return getOne<PVDocument, PVDocumentRejection>(documentRowVersion.id, jdbcTemplate.query(sql, params) { rs, _ ->
-            PVDocumentRejection(
-                id = rs.getIntId("id"),
-                documentVersion = rs.getRowVersion("document_id", "document_version"),
-                reason = LocalizationKey(rs.getString("reason")),
-            )
-        })
+        return getOne<PVDocument, PVDocumentRejection>(
+            documentRowVersion.id,
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                PVDocumentRejection(
+                    id = rs.getIntId("id"),
+                    documentVersion = rs.getRowVersion("document_id", "document_version"),
+                    reason = LocalizationKey(rs.getString("reason")),
+                )
+            }
+        )
     }
 
     fun getDocumentHeader(id: IntId<PVDocument>) = getDocumentHeaders(id = id).single()
@@ -483,5 +511,4 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
             PROJECT_STATE -> "project_state"
         }
     }"
-
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -218,6 +218,8 @@ data class ValidationVersions(
     val referenceLines: List<ValidationVersion<ReferenceLine>>,
     val switches: List<ValidationVersion<TrackLayoutSwitch>>,
     val kmPosts: List<ValidationVersion<TrackLayoutKmPost>>,
+    // TODO: GVT-2524 do we actually need these here? Maybe it's just stuff to fetch from context?
+    val splits: List<ValidationVersion<Split>>,
 ) {
     fun containsLocationTrack(id: IntId<LocationTrack>) = locationTracks.any { it.officialId == id }
     fun containsKmPost(id: IntId<TrackLayoutKmPost>) = kmPosts.any { it.officialId == id }
@@ -232,6 +234,7 @@ data class ValidationVersions(
     fun getLocationTrackIds() = locationTracks.map { v -> v.officialId }
     fun getSwitchIds() = switches.map { v -> v.officialId }
     fun getKmPostIds() = kmPosts.map { v -> v.officialId }
+    fun getSplitIds() = splits.map { v -> v.officialId }
 }
 
 data class PublicationGroup(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -185,12 +185,13 @@ data class PublicationCandidates(
         kmPosts.map { candidate -> candidate.id },
     )
 
-    fun getValidationVersions() = ValidationVersions(
+    fun getValidationVersions(splitVersions: List<ValidationVersion<Split>>) = ValidationVersions(
         trackNumbers = trackNumbers.map(TrackNumberPublicationCandidate::getPublicationVersion),
         referenceLines = referenceLines.map(ReferenceLinePublicationCandidate::getPublicationVersion),
         locationTracks = locationTracks.map(LocationTrackPublicationCandidate::getPublicationVersion),
         switches = switches.map(SwitchPublicationCandidate::getPublicationVersion),
         kmPosts = kmPosts.map(KmPostPublicationCandidate::getPublicationVersion),
+        splits = splitVersions,
     )
 
     fun filter(request: PublicationRequestIds) = PublicationCandidates(
@@ -218,12 +219,12 @@ data class ValidationVersions(
     val referenceLines: List<ValidationVersion<ReferenceLine>>,
     val switches: List<ValidationVersion<TrackLayoutSwitch>>,
     val kmPosts: List<ValidationVersion<TrackLayoutKmPost>>,
-    // TODO: GVT-2524 do we actually need these here? Maybe it's just stuff to fetch from context?
     val splits: List<ValidationVersion<Split>>,
 ) {
     fun containsLocationTrack(id: IntId<LocationTrack>) = locationTracks.any { it.officialId == id }
     fun containsKmPost(id: IntId<TrackLayoutKmPost>) = kmPosts.any { it.officialId == id }
     fun containsSwitch(id: IntId<TrackLayoutSwitch>) = switches.any { it.officialId == id }
+    fun containsSplit(id: IntId<Split>): Boolean = splits.any { it.officialId == id }
 
     fun findTrackNumber(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.find { it.officialId == id }
     fun findLocationTrack(id: IntId<LocationTrack>) = locationTracks.find { it.officialId == id }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -542,7 +542,7 @@ class PublicationService @Autowired constructor(
         publicationDao.insertCalculatedChanges(publicationId, calculatedChanges)
         publicationGeometryChangeRemarksUpdateService.processPublication(publicationId)
 
-        splitService.publishSplit(locationTracks, publicationId, versions.splits)
+        splitService.publishSplit(versions.splits, locationTracks, publicationId)
 
         return PublicationResult(
             publicationId = publicationId,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -1,10 +1,29 @@
 package fi.fta.geoviite.infra.publication
 
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackNumber
+import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
 import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.ILayoutAssetDao
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutAsset
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import java.util.concurrent.ConcurrentHashMap
 
 class NullableCache<K, V> {
@@ -184,6 +203,14 @@ class ValidationContext(
             geocodingService.getGeocodingContextCacheKey(tnId, publicationSet)
         }
 
+    fun getAddressPoints(trackId: IntId<LocationTrack>): AlignmentAddresses? =
+        getLocationTrack(trackId)?.let(::getAddressPoints)
+
+    fun getAddressPoints(track: LocationTrack): AlignmentAddresses? =
+        getGeocodingContextCacheKey(track.trackNumberId)?.let { key ->
+            geocodingService.getAddressPoints(key, track.getAlignmentVersionOrThrow())
+        }
+
     fun preloadByPublicationSet() {
         preloadAssociatedTrackNumberAndReferenceLineVersions(publicationSet)
 
@@ -358,6 +385,11 @@ class ValidationContext(
             val official = officialVersions[id]?.map { v -> v.id } ?: emptyList()
             draft + official
         }
+    }
+
+    fun getUnfinishedSplits(): List<Split> {
+        // TODO: GVT-2524
+TODO("Not implemented yet")
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -38,6 +38,7 @@ data class SplitHeader(
 
 data class Split(
     val id: IntId<Split>,
+    val rowVersion: RowVersion<Split>,
     val sourceLocationTrackId: IntId<LocationTrack>,
     val sourceLocationTrackVersion: RowVersion<LocationTrack>,
     val bulkTransferState: BulkTransferState,
@@ -52,6 +53,11 @@ data class Split(
     @JsonIgnore
     val isPending: Boolean = bulkTransferState == BulkTransferState.PENDING && publicationId == null
 
+    @JsonIgnore
+    val isPublishedAndWaitingTransfer: Boolean = bulkTransferState != BulkTransferState.DONE && publicationId != null
+
+    fun containsTargetTrack(trackId: IntId<LocationTrack>): Boolean =
+        targetLocationTracks.any { tlt -> tlt.locationTrackId == trackId }
     fun containsLocationTrack(trackId: IntId<LocationTrack>): Boolean = locationTracks.contains(trackId)
     fun getTargetLocationTrack(trackId: IntId<LocationTrack>): SplitTarget? =
         targetLocationTracks.find { track -> track.locationTrackId == trackId }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -47,11 +47,17 @@ data class Split(
     val relinkedSwitches: List<IntId<TrackLayoutSwitch>>,
     val updatedDuplicates: List<IntId<LocationTrack>>,
 ) {
+    init {
+        if (publicationId != null) {
+            require(id == rowVersion.id) { "Split source row version must refer to official row, once published" }
+        }
+        if (publicationId == null) {
+            require(bulkTransferState == BulkTransferState.PENDING) { "Split must be pending if not published" }
+        }
+    }
+
     @get:JsonIgnore
     val locationTracks by lazy { targetLocationTracks.map { it.locationTrackId } + sourceLocationTrackId }
-
-    @JsonIgnore
-    val isPending: Boolean = bulkTransferState == BulkTransferState.PENDING && publicationId == null
 
     @JsonIgnore
     val isPublishedAndWaitingTransfer: Boolean = bulkTransferState != BulkTransferState.DONE && publicationId != null

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.util.DaoBase
+import fi.fta.geoviite.infra.util.DbTable
 import fi.fta.geoviite.infra.util.getEnum
 import fi.fta.geoviite.infra.util.getIntId
 import fi.fta.geoviite.infra.util.getIntIdArray
@@ -294,6 +295,8 @@ class SplitDao(
             logger.daoAccess(AccessType.FETCH, SplitTarget::class, ids.map { it.id })
         }
     }
+
+    fun fetchChangeTime() = fetchLatestChangeTime(DbTable.PUBLICATION_SPLIT)
 
     fun fetchSplitIdByPublication(publicationId: IntId<Publication>): IntId<Split>? {
         val sql = "select id from publication.split where publication_id = :publication_id"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -192,38 +192,39 @@ class SplitDao(
         ).also { logger.daoAccess(AccessType.FETCH, Split::class, splitId) }
     }
 
-    fun get(splitVersion: RowVersion<Split>): Split {
-        val sql = """
-          select
-              split.id,
-              split.version,
-              split.bulk_transfer_state,
-              split.publication_id,
-              coalesce(source_track.official_row_id, source_track.id) as source_location_track_official_id,
-              split.source_location_track_row_id,
-              split.source_location_track_row_version,
-              array_agg(split_relinked_switch.switch_id) as switch_ids,
-              array_agg(split_updated_duplicate.duplicate_location_track_id) as updated_duplicate_ids
-          from publication.split_version split
-              inner join layout.location_track_version source_track 
-                  on split.source_location_track_row_id = source_track.id
-                   and split.source_location_track_row_version = source_track.version
-              left join publication.split_relinked_switch on split.id = split_relinked_switch.split_id
-              left join publication.split_updated_duplicate on split.id = split_updated_duplicate.split_id
-          -- Note: split content tables are never edited -> only the main split is fetched by id and version
-          where split.id = :id and split.version = :version
-          group by split.id, split.version, source_track.official_row_id, source_track.id
-        """.trimIndent()
-
-        val params = mapOf(
-            "id" to splitVersion.id.intValue,
-            "version" to splitVersion.version,
-        )
-        return getOne(
-            splitVersion,
-            jdbcTemplate.query(sql, params) { rs, _ -> toSplit(rs, getSplitTargets(splitVersion.id)) },
-        ).also { logger.daoAccess(AccessType.FETCH, Split::class, splitVersion) }
-    }
+    // TODO: GVT-2524 cleanup
+//    fun get(splitVersion: RowVersion<Split>): Split {
+//        val sql = """
+//          select
+//              split.id,
+//              split.version,
+//              split.bulk_transfer_state,
+//              split.publication_id,
+//              coalesce(source_track.official_row_id, source_track.id) as source_location_track_official_id,
+//              split.source_location_track_row_id,
+//              split.source_location_track_row_version,
+//              array_agg(split_relinked_switch.switch_id) as switch_ids,
+//              array_agg(split_updated_duplicate.duplicate_location_track_id) as updated_duplicate_ids
+//          from publication.split_version split
+//              inner join layout.location_track_version source_track
+//                  on split.source_location_track_row_id = source_track.id
+//                   and split.source_location_track_row_version = source_track.version
+//              left join publication.split_relinked_switch on split.id = split_relinked_switch.split_id
+//              left join publication.split_updated_duplicate on split.id = split_updated_duplicate.split_id
+//          -- Note: split content tables are never edited -> only the main split is fetched by id and version
+//          where split.id = :id and split.version = :version
+//          group by split.id, split.version, source_track.official_row_id, source_track.id
+//        """.trimIndent()
+//
+//        val params = mapOf(
+//            "id" to splitVersion.id.intValue,
+//            "version" to splitVersion.version,
+//        )
+//        return getOne(
+//            splitVersion,
+//            jdbcTemplate.query(sql, params) { rs, _ -> toSplit(rs, getSplitTargets(splitVersion.id)) },
+//        ).also { logger.daoAccess(AccessType.FETCH, Split::class, splitVersion) }
+//    }
 
     fun getSplitHeader(splitId: IntId<Split>): SplitHeader {
         val sql = """
@@ -333,6 +334,7 @@ class SplitDao(
         }
     }
 
+    // TODO: GVT-2524 cleanup
 //    fun fetchUnfinishedSplitIdsByTrackNumber(trackNumberId: IntId<TrackLayoutTrackNumber>): List<IntId<Split>> {
 //        val sql = """
 //            select distinct split.id

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -57,7 +57,7 @@ internal fun validateSplitContent(
     }
 
     val contentErrors = splits
-        .filter { it.isPending }
+        .filter { split -> split.publicationId == null }
         .flatMap { split ->
             val containsSource = trackVersions.any { it.officialId == split.sourceLocationTrackId }
             val containsTargets = split.targetLocationTracks.all { tlt ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -6,8 +6,20 @@ import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
-import fi.fta.geoviite.infra.util.*
 import fi.fta.geoviite.infra.util.DbTable.LAYOUT_TRACK_NUMBER
+import fi.fta.geoviite.infra.util.getDaoResponse
+import fi.fta.geoviite.infra.util.getEnum
+import fi.fta.geoviite.infra.util.getFreeText
+import fi.fta.geoviite.infra.util.getInstant
+import fi.fta.geoviite.infra.util.getIntId
+import fi.fta.geoviite.infra.util.getIntIdOrNull
+import fi.fta.geoviite.infra.util.getLayoutContextData
+import fi.fta.geoviite.infra.util.getOidOrNull
+import fi.fta.geoviite.infra.util.getOne
+import fi.fta.geoviite.infra.util.getRowVersion
+import fi.fta.geoviite.infra.util.getTrackNumber
+import fi.fta.geoviite.infra.util.setUser
+import fi.fta.geoviite.infra.util.toDbId
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
@@ -127,7 +139,7 @@ class LayoutTrackNumberDao(
         state = rs.getEnum("state"),
         externalId = rs.getOidOrNull("external_id"),
         version = rs.getRowVersion("row_id", "row_version"),
-        // TODO: GVT-2442 This should be non-null but we have a lot of tests that produce broken data
+        // TODO: GVT-2524 This should be non-null but we have a lot of tests that produce broken data
         referenceLineId = rs.getIntIdOrNull("reference_line_id"),
         contextData = rs.getLayoutContextData("official_row_id", "row_id", "draft"),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -139,7 +139,7 @@ class LayoutTrackNumberDao(
         state = rs.getEnum("state"),
         externalId = rs.getOidOrNull("external_id"),
         version = rs.getRowVersion("row_id", "row_version"),
-        // TODO: GVT-2524 This should be non-null but we have a lot of tests that produce broken data
+        // TODO: GVT-2442 This should be non-null but we have a lot of tests that produce broken data
         referenceLineId = rs.getIntIdOrNull("reference_line_id"),
         contextData = rs.getLayoutContextData("official_row_id", "row_id", "draft"),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Functional.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Functional.kt
@@ -1,0 +1,7 @@
+package fi.fta.geoviite.infra.util
+
+fun <T> produceIfNot(condition: Boolean, producer: () -> T): T? =
+    if (!condition) producer() else null
+
+fun <T> produceIf(condition: Boolean, producer: () -> T): T? =
+    if (condition) producer() else null

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -685,7 +685,8 @@
                     "duplicate-not-published": "Duplikaattiraiteen {{duplicateName}} muutoksia ei ole julkaistu Ratkoon. Poikkeavat tiedot Geoviitteen ja Ratkon välillä voivat aiheuttaa ongelmia kohteiden massasiirrossa Ratkossa.",
                     "publish-duplicate": "Julkaise tai hylkää duplikaattiraiteen muutokset ja yritä jakamista sitten uudestaan.",
                     "has-errors": "Tiedoissa on virheitä",
-                    "show": "näytä"
+                    "show": "näytä",
+                    "split-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteella, jonka jakamista ei ole vielä viety ratkoon"
                 },
                 "validation-in-progress": "Raiteen vaihteita validoidaan...",
                 "relink-critical-errors": "Raiteen vaihteiden linkityksessä on kriittisiä ongelmia, jotka täytyy korjata ennen raiteen jakamista",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -686,7 +686,8 @@
                     "publish-duplicate": "Julkaise tai hylkää duplikaattiraiteen muutokset ja yritä jakamista sitten uudestaan.",
                     "has-errors": "Tiedoissa on virheitä",
                     "show": "näytä",
-                    "split-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteella, jonka jakamista ei ole vielä viety ratkoon"
+                    "affected-split-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteella, jonka jakamista ({{sourceName}}) ei ole vielä viety ratkoon",
+                    "track-split-in-progress": "Raidetta ei voida muuttaa, koska sen jakamista ({{sourceName}}) ei ole vielä viety ratkoon"
                 },
                 "validation-in-progress": "Raiteen vaihteita validoidaan...",
                 "relink-critical-errors": "Raiteen vaihteiden linkityksessä on kriittisiä ongelmia, jotka täytyy korjata ennen raiteen jakamista",
@@ -1352,8 +1353,9 @@
                 "start-km-too-long": "Alkukilometri ottaen huomioon alkupisteen metrit on liian pitkä"
             },
             "split": {
-                "source-not-deleted": "Jaettava raide ei ole Poistettu-tilassa",
-                "source-and-target-track-numbers-are-different": "Jakamisessa syntynyt raide {{trackName}} on eri ratanumerolla on kuin alkuperäinen jaettu raide",
+                "source-not-deleted": "Jaettava raide {{sourceName}} ei ole Poistettu-tilassa",
+                "source-edited-after-split": "Jaettavaa raidetta {{sourceName}} on muokattu vaikka jako on vielä kesken",
+                "source-and-target-track-numbers-are-different": "Jakamisessa syntynyt raide {{trackName}} on eri ratanumerolla on kuin alkuperäinen jaettu raide {{sourceName}}",
                 "duplicate-on-different-track-number": "Duplikaattiraide {{duplicateTrack}} on eri ratanumerolla kuin jaettava raide",
                 "split-missing-location-tracks": "Kaikki jakoon liittyvät sijaintiraiteet eivät ole mukana julkaisussa",
                 "split-missing-switches": "Kaikki jakoon liittyvät vaihteet eivät ole mukana julkaisussa",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1364,7 +1364,7 @@
                 "geometry-changed": "Jaettavan raiteen geometria on muuttunut",
                 "transfer-geometry-changed": "Säilytettävän osittaisen duplikaatin osoitteisto eroaa yli metrin jaettavasta raiteesta",
                 "trackmeters-changed": "Jaetun raiteen geometria ei sisällä samoja tasametripisteitä",
-                "no-geometry": "Raiteella ei ole geometriaa",
+                "no-geometry": "Raiteella ei ole geometriaa"
             }
         }
     },

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -29,7 +29,8 @@
                 "location-track": "Julkaisussa on useammalla sijaintiraiteella sama nimi {{locationTrack}} (ratanumerolla {{trackNumber}})",
                 "switch": "Julkaisussa on useammalla vaihteella sama nimi {{name}}",
                 "track-number": "Julkaisussa on useammalla radalla sama ratanumero {{name}}"
-            }
+            },
+            "split-version-changed": "Raiteen jakamista ei voitu julkaista, koska sitä muokattiin yhtä aikaa"
         },
         "input": {
             "generic": "Tarkasta syötekentät ja yritä uudestaan",
@@ -1363,7 +1364,7 @@
                 "geometry-changed": "Jaettavan raiteen geometria on muuttunut",
                 "transfer-geometry-changed": "Säilytettävän osittaisen duplikaatin osoitteisto eroaa yli metrin jaettavasta raiteesta",
                 "trackmeters-changed": "Jaetun raiteen geometria ei sisällä samoja tasametripisteitä",
-                "no-geometry": "Raiteella ei ole geometriaa"
+                "no-geometry": "Raiteella ei ole geometriaa",
             }
         }
     },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -1,7 +1,13 @@
 package fi.fta.geoviite.infra.integration
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.DomainId
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.linking.FittedSwitch
 import fi.fta.geoviite.infra.linking.FittedSwitchJoint
 import fi.fta.geoviite.infra.linking.switches.SwitchLinkingService
@@ -10,7 +16,40 @@ import fi.fta.geoviite.infra.math.Line
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.publication.ValidationVersions
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostService
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.addTopologyEndSwitchIntoLocationTrackAndUpdate
+import fi.fta.geoviite.infra.tracklayout.addTopologyStartSwitchIntoLocationTrackAndUpdate
+import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.moveKmPostLocation
+import fi.fta.geoviite.infra.tracklayout.moveLocationTrackGeometryPointsAndUpdate
+import fi.fta.geoviite.infra.tracklayout.moveReferenceLineGeometryPointsAndUpdate
+import fi.fta.geoviite.infra.tracklayout.moveSwitchPoints
+import fi.fta.geoviite.infra.tracklayout.referenceLine
+import fi.fta.geoviite.infra.tracklayout.removeTopologySwitchesFromLocationTrackAndUpdate
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.segments
+import fi.fta.geoviite.infra.tracklayout.switch
+import fi.fta.geoviite.infra.tracklayout.switchLinkingAtEnd
+import fi.fta.geoviite.infra.tracklayout.switchLinkingAtStart
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FreeText
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -1381,6 +1420,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
             referenceLines = referenceLineDao.fetchPublicationVersions(referenceLineIds),
             switches = switchDao.fetchPublicationVersions(switchIds),
             trackNumbers = layoutTrackNumberDao.fetchPublicationVersions(trackNumberIds),
+            splits = listOf(),
         )
 
         return calculatedChangesService.getCalculatedChanges(publicationVersions)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -1,7 +1,16 @@
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.RowVersion
-import fi.fta.geoviite.infra.publication.*
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.publication.PublicationRequestIds
+import fi.fta.geoviite.infra.publication.PublicationResult
+import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.publication.ValidationVersion
+import fi.fta.geoviite.infra.publication.ValidationVersions
+import fi.fta.geoviite.infra.tracklayout.DaoResponse
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 
 fun publicationRequest(
     trackNumbers: List<IntId<TrackLayoutTrackNumber>> = listOf(),
@@ -29,6 +38,7 @@ fun validationVersions(
     kmPosts = kmPosts.map { (id,version) -> ValidationVersion(id, version) },
     locationTracks = locationTracks.map { (id,version) -> ValidationVersion(id, version) },
     switches = switches.map { (id,version) -> ValidationVersion(id, version) },
+    splits = listOf(),
 )
 
 fun publish(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -26,6 +26,7 @@ import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.linking.fixSegmentStarts
 import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.LocalizationService
+import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.split.Split
@@ -2470,88 +2471,74 @@ class PublicationServiceIT @Autowired constructor(
     }
 
     @Test
-    fun `split target location track validation should not fail when the split is still pending`() {
+    fun `split target location track validation should fail if it's part of a published split`() {
         val splitSetup = simpleSplitSetup()
+
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
+        publish(publicationService, locationTracks = splitSetup.trackIds)
 
-        val errors = validateLocationTracks(splitSetup.trackIds)
-        assertTrue(errors.isEmpty(), "Expected no errors: actual=$errors")
-    }
+        val draft = locationTrackService.saveDraft(
+            locationTrackDao.getOrThrow(DRAFT, splitSetup.targetTracks.first().first.id)
+        )
 
-    @Test
-    fun `split target location track validation should fail when the split is still in progress`() {
-        val splitSetup = simpleSplitSetup()
-        saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
-            val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.IN_PROGRESS)
-        }
-
-        val errors = validateLocationTracks(splitSetup.trackIds)
-        assertContains(errors, validationError("validation.layout.split.split-in-progress"))
-    }
-
-    @Test
-    fun `split target location track validation should fail on failed split`() {
-        val splitSetup = simpleSplitSetup()
-
-        saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
-            val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.FAILED)
-        }
-
-        val errors = validateLocationTracks(splitSetup.trackIds)
-        assertContains(errors, validationError("validation.layout.split.split-in-progress"))
+        val errors = validateLocationTracks(listOf(draft.id))
+        assertContains(
+            errors,
+            validationError(
+                "validation.layout.split.track-split-in-progress",
+                "sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack.rowVersion).name
+            ),
+        )
     }
 
     @Test
     fun `split target location track validation should not fail on finished split`() {
         val splitSetup = simpleSplitSetup()
 
-        saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
-            val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
-        }
+        val splitId = saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
+        publish(publicationService, locationTracks = splitSetup.trackIds)
 
-        val errors = validateLocationTracks(splitSetup.trackIds)
+        splitDao.updateSplit(splitId, bulkTransferState = BulkTransferState.DONE)
+
+        val draft = locationTrackService.saveDraft(
+            locationTrackDao.getOrThrow(DRAFT, splitSetup.targetTracks.first().first.id)
+        )
+
+        val errors = validateLocationTracks(listOf(draft.id))
         assertTrue { errors.isEmpty() }
     }
 
     @Test
-    fun `split source location track validation should fail when the split is still in progress`() {
+    fun `split source location track validation should fail if it's part of a published split`() {
         val splitSetup = simpleSplitSetup()
 
-        saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
-            val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.IN_PROGRESS)
-        }
+        saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
+        publish(publicationService, locationTracks = splitSetup.trackIds)
 
-        val errors = validateLocationTracks(splitSetup.trackIds)
-        assertContains(errors, validationError("validation.layout.split.split-in-progress"))
-    }
+        val draft = locationTrackService.saveDraft(locationTrackDao.getOrThrow(DRAFT, splitSetup.sourceTrack.id))
 
-    @Test
-    fun `split source location track validation should fail on failed split`() {
-        val splitSetup = simpleSplitSetup()
-
-        saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
-            val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.FAILED)
-        }
-
-        val errors = validateLocationTracks(splitSetup.trackIds)
-        assertContains(errors, validationError("validation.layout.split.split-in-progress"))
+        val errors = validateLocationTracks(listOf(draft.id))
+        assertContains(
+            errors,
+            validationError(
+                "validation.layout.split.track-split-in-progress",
+                "sourceName" to locationTrackDao.fetch(draft.rowVersion).name
+            ),
+        )
     }
 
     @Test
     fun `split source location track validation should not fail on finished split`() {
         val splitSetup = simpleSplitSetup()
 
-        saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also { splitId ->
-            val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
-        }
+        val splitId = saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
+        publish(publicationService, locationTracks = splitSetup.trackIds)
 
-        val errors = validateLocationTracks(splitSetup.trackIds)
+        splitDao.updateSplit(splitId, bulkTransferState = BulkTransferState.DONE)
+
+        val draft = locationTrackService.saveDraft(locationTrackDao.getOrThrow(DRAFT, splitSetup.sourceTrack.id))
+
+        val errors = validateLocationTracks(listOf(draft.id))
         assertTrue { errors.isEmpty() }
     }
 
@@ -2567,7 +2554,9 @@ class PublicationServiceIT @Autowired constructor(
             PublicationValidationError(
                 PublicationValidationErrorType.ERROR,
                 LocalizationKey("validation.layout.split.source-not-deleted"),
-                LocalizationParams.empty,
+                localizationParams(
+                    "sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack.rowVersion).name
+                ),
             ),
         )
     }
@@ -2580,7 +2569,7 @@ class PublicationServiceIT @Autowired constructor(
             startTarget.copy(trackNumberId = getUnusedTrackNumberId())
         )
 
-        saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams).also(splitDao::get)
+        saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
 
         val errors = validateLocationTracks(splitSetup.trackIds)
         assertContains(
@@ -2588,7 +2577,10 @@ class PublicationServiceIT @Autowired constructor(
             PublicationValidationError(
                 PublicationValidationErrorType.ERROR,
                 LocalizationKey("validation.layout.split.source-and-target-track-numbers-are-different"),
-                LocalizationParams(mapOf("trackName" to startTarget.name.toString())),
+                localizationParams(
+                    "trackName" to startTarget.name,
+                    "sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack.rowVersion).name,
+                ),
             ),
         )
     }
@@ -2598,7 +2590,7 @@ class PublicationServiceIT @Autowired constructor(
         val trackNumberId = insertOfficialTrackNumber()
         val kmPostId = kmPostDao.insert(kmPost(trackNumberId = trackNumberId, km = KmNumber.ZERO, draft = true)).id
         val locationTrackResponse = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId, draft = false),
+            locationTrack(trackNumberId = trackNumberId, draft = true),
             alignment(),
         )
 
@@ -2606,12 +2598,18 @@ class PublicationServiceIT @Autowired constructor(
 
         val validation = publicationService.validatePublicationCandidates(
             publicationService.collectPublicationCandidates(),
-            publicationRequestIds(kmPosts = listOf(kmPostId)),
+            publicationRequestIds(locationTracks = listOf(locationTrackResponse.id), kmPosts = listOf(kmPostId)),
         )
 
         val errors = validation.validatedAsPublicationUnit.kmPosts.flatMap { it.errors }
 
-        assertContains(errors, validationError("validation.layout.split.split-in-progress"))
+        assertContains(
+            errors,
+            validationError(
+                "validation.layout.split.affected-split-in-progress",
+                "sourceName" to locationTrackDao.fetch(locationTrackResponse.rowVersion).name
+            ),
+        )
     }
 
     @Test
@@ -2621,9 +2619,7 @@ class PublicationServiceIT @Autowired constructor(
         val referenceLineVersion = insertReferenceLine(
             referenceLine(trackNumberId = trackNumberId, draft = false),
             alignment,
-        ).rowVersion
-
-        referenceLineDao.fetch(referenceLineVersion).also(referenceLineService::saveDraft)
+        ).let { v -> referenceLineService.saveDraft(referenceLineDao.fetch(v.rowVersion)) }
 
         val locationTrackResponse = insertLocationTrack(
             locationTrack(trackNumberId = trackNumberId, draft = true),
@@ -2634,43 +2630,21 @@ class PublicationServiceIT @Autowired constructor(
 
         val validation = publicationService.validatePublicationCandidates(
             publicationService.collectPublicationCandidates(),
-            publicationRequestIds(referenceLines = listOf(referenceLineVersion.id))
+            publicationRequestIds(
+                locationTracks = listOf(locationTrackResponse.id),
+                referenceLines = listOf(referenceLineVersion.id),
+            )
         )
 
         val errors = validation.validatedAsPublicationUnit.referenceLines.flatMap { it.errors }
 
-        assertContains(errors, validationError("validation.layout.split.split-in-progress"))
-    }
-
-    @Test
-    fun `reference line split validation should fail on failed splitting`() {
-        val trackNumberId = insertOfficialTrackNumber()
-        val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-
-        val referenceLineVersion = insertReferenceLine(
-            referenceLine(trackNumberId = trackNumberId, draft = false),
-            alignment,
-        ).rowVersion
-        val locationTrackResponse = insertLocationTrack(
-            locationTrack(trackNumberId = trackNumberId, draft = true),
-            alignment,
+        assertContains(
+            errors,
+            validationError(
+                "validation.layout.split.affected-split-in-progress",
+                "sourceName" to locationTrackDao.fetch(locationTrackResponse.rowVersion).name
+            ),
         )
-
-        referenceLineDao.fetch(referenceLineVersion).also(referenceLineService::saveDraft)
-
-        saveSplit(locationTrackResponse.rowVersion).also { splitId ->
-            val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.FAILED)
-        }
-
-        val validation = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(),
-            publicationRequestIds(referenceLines = listOf(referenceLineVersion.id))
-        )
-
-        val errors = validation.validatedAsPublicationUnit.referenceLines.flatMap { it.errors }
-
-        assertContains(errors, validationError("validation.layout.split.split-in-progress"))
     }
 
     @Test
@@ -2972,10 +2946,10 @@ class PublicationServiceIT @Autowired constructor(
             alignment(startSegment, endSegment),
         )
 
-        locationTrackDao
+        val draftSource = locationTrackDao
             .fetch(sourceTrack.rowVersion)
             .copy(state = sourceLocationTrackState)
-            .also(locationTrackService::saveDraft)
+            .let(locationTrackService::saveDraft)
 
         val startTrack = insertLocationTrack(
             locationTrack(trackNumberId = trackNumberId, draft = true),
@@ -2987,7 +2961,7 @@ class PublicationServiceIT @Autowired constructor(
             alignment(endSegment),
         )
 
-        return SplitSetup(sourceTrack, listOf(startTrack to 0..0, endTrack to 1..1))
+        return SplitSetup(draftSource, listOf(startTrack to 0..0, endTrack to 1..1))
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -2842,7 +2842,8 @@ class PublicationServiceIT @Autowired constructor(
         val trackValidationVersions = splitSetup.trackValidationVersions + splitSetup2.trackValidationVersions
 
         assertContains(
-            validateSplitContent(trackValidationVersions, emptyList(), listOf(split, split2), false).map { it.second },
+            validateSplitContent(trackValidationVersions, emptyList(), listOf(split, split2), false)
+                .map { it.second },
             validationError("validation.layout.split.multiple-splits-not-allowed"),
         )
         assertTrue(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -3220,8 +3220,8 @@ class PublicationServiceIT @Autowired constructor(
     fun `Publication group should be set for assets related to a split`() {
         (1..4).forEach { testIndex ->
             val testData = insertPublicationGroupTestData()
-            val splits = splitService.findUnfinishedSplitsForLocationTracks(
-                listOf(testData.sourceLocationTrackId)
+            val splits = splitService.findUnfinishedSplits(
+                locationTrackIds = listOf(testData.sourceLocationTrackId)
             )
 
             assertEquals(1, splits.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
@@ -4,8 +4,24 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.asMainDraft
+import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
+import fi.fta.geoviite.infra.tracklayout.switch
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -24,6 +40,7 @@ class ValidationContextIT @Autowired constructor(
     val switchLibraryService: SwitchLibraryService,
     val publicationDao: PublicationDao,
     val geocodingService: GeocodingService,
+    val splitService: SplitService,
 ) : DBTestBase() {
 
     @Test
@@ -178,12 +195,14 @@ class ValidationContextIT @Autowired constructor(
         alignmentDao = alignmentDao,
         publicationDao = publicationDao,
         switchLibraryService = switchLibraryService,
+        splitService = splitService,
         publicationSet = ValidationVersions(
             trackNumbers = trackNumberDao.fetchPublicationVersions(trackNumbers),
             referenceLines = referenceLineDao.fetchPublicationVersions(referenceLines),
             kmPosts = kmPostDao.fetchPublicationVersions(kmPosts),
             locationTracks = locationTrackDao.fetchPublicationVersions(locationTracks),
             switches = switchDao.fetchPublicationVersions(switches),
+            splits = splitService.fetchPublicationVersions(locationTracks, switches),
         )
     )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -342,7 +342,7 @@ class SplitServiceIT @Autowired constructor(
         val splitId = insertSplitWithTwoTracks()
         val split = splitDao.getOrThrow(splitId)
 
-        val foundSplits = splitService.findUnfinishedSplitsForLocationTracks(listOf(split.sourceLocationTrackId))
+        val foundSplits = splitService.findUnfinishedSplits(locationTrackIds = listOf(split.sourceLocationTrackId))
 
         assertEquals(splitId, foundSplits.first().id)
     }
@@ -352,8 +352,8 @@ class SplitServiceIT @Autowired constructor(
         val splitId = insertSplitWithTwoTracks()
         val split = splitDao.getOrThrow(splitId)
 
-        val foundSplits = splitService.findUnfinishedSplitsForLocationTracks(
-            listOf(split.targetLocationTracks.first().locationTrackId)
+        val foundSplits = splitService.findUnfinishedSplits(
+            locationTrackIds = listOf(split.targetLocationTracks.first().locationTrackId)
         )
 
         assertEquals(splitId, foundSplits.first().id)
@@ -364,7 +364,7 @@ class SplitServiceIT @Autowired constructor(
         val splitId = insertSplitWithTwoTracks()
         val split = splitDao.getOrThrow(splitId)
 
-        val foundSplits = splitService.findUnfinishedSplitsForSwitches(split.relinkedSwitches)
+        val foundSplits = splitService.findUnfinishedSplits(switchIds = split.relinkedSwitches)
 
         assertEquals(splitId, foundSplits.first().id)
     }


### PR DESCRIPTION
Pääpointit:
- Kiinnitetään myös splitin versio ennen validointia ja varmistetaan että julkaisussa ei mikään muuttunut alta
- Käytetään split-validoinnissa validointikontekstia, mikä takaa että julkaisujoukon validoinnissa ei välitetä ei-valituista drafteista (vaikka ne olisivat split-juttuja) ja että kaikista olioista haetaan vain yksi versio (vähemmän kannassa ramppaamista + validointi on jotain versiota vasten)

Splitin kanssa tuo ei ollut kaikilta osin aivan ilmeistä miten sen pitäisi mennä, mutta pyrin samaan kuin muussakin, eli validointi näkee julkaisujoukossa mukana olevat splitit + jo julkaistut splitit ja varmistaa että se on kaikki bueno.