### PR TITLE
General: Clean up detekt warnings: there's no need to string-template a variable that is a string

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
@@ -17,7 +17,11 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/geocoding")
@@ -30,7 +34,7 @@ class GeocodingController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/address/{trackNumberId}")
     fun getTrackAddress(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>,
         @RequestParam("coordinate") coordinate: Point,
     ): ResponseEntity<TrackMeter> {
@@ -52,7 +56,7 @@ class GeocodingController(
     @GetMapping("/{$PUBLICATION_STATE}/address-pointlist/{alignmentId}")
     fun getAlignmentAddressPoints(
         @PathVariable("alignmentId") locationTrackId: IntId<LocationTrack>,
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
     ): ResponseEntity<AlignmentAddresses> {
         logger.apiCall("getAlignmentAddressPoints", "locationTrackId" to locationTrackId)
         return toResponse(geocodingService.getAddressPoints(locationTrackId, publicationState))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -1,26 +1,44 @@
 package fi.fta.geoviite.infra.geometry
 
-import fi.fta.geoviite.infra.authorization.*
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.authorization.AUTH_DOWNLOAD_GEOMETRY
+import fi.fta.geoviite.infra.authorization.AUTH_EDIT_GEOMETRY_FILE
+import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
+import fi.fta.geoviite.infra.authorization.AUTH_VIEW_GEOMETRY
+import fi.fta.geoviite.infra.authorization.AUTH_VIEW_GEOMETRY_FILE
+import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
+import fi.fta.geoviite.infra.common.IndexedId
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geocoding.AlignmentStartAndEnd
 import fi.fta.geoviite.infra.geometry.GeometryPlanSortField.ID
-import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
-import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
-import fi.fta.geoviite.infra.util.*
+import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.KnownFileSuffix.CSV
+import fi.fta.geoviite.infra.util.SortOrder
 import fi.fta.geoviite.infra.util.SortOrder.ASCENDING
+import fi.fta.geoviite.infra.util.logger
+import fi.fta.geoviite.infra.util.pageAndRest
+import fi.fta.geoviite.infra.util.toFileDownloadResponse
+import fi.fta.geoviite.infra.util.toResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/geometry")
@@ -351,17 +369,17 @@ class GeometryController @Autowired constructor(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("{$PUBLICATION_STATE}/layout/location-tracks/{id}/linking-summary")
     fun getLocationTrackLinkingSummary(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
     ): List<PlanLinkingSummaryItem>? {
-        logger.apiCall("getLocationTrackLinkingSummary", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getLocationTrackLinkingSummary", PUBLICATION_STATE to publicationState, "id" to id)
         return geometryService.getLocationTrackGeometryLinkingSummary(id, publicationState)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/layout/location-tracks/{id}/alignment-heights")
     fun getLayoutAlignmentHeights(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
         @RequestParam("startDistance") startDistance: Double,
         @RequestParam("endDistance") endDistance: Double,
@@ -369,7 +387,7 @@ class GeometryController @Autowired constructor(
     ): List<KmHeights>? {
         logger.apiCall(
             "getLayoutAlignmentHeights",
-            "$PUBLICATION_STATE" to publicationState,
+            PUBLICATION_STATE to publicationState,
             "id" to id,
             "startDistance" to startDistance,
             "endDistance" to endDistance,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
@@ -21,8 +21,14 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
-
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/linking")
@@ -93,9 +99,9 @@ class LinkingController @Autowired constructor(
     @GetMapping("{$PUBLICATION_STATE}/plans/{id}/status")
     fun getPlanLinkStatus(
         @PathVariable("id") planId: IntId<GeometryPlan>,
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
     ): GeometryPlanLinkStatus {
-        logger.apiCall("getPlanLinkStatus", "planId" to planId, "$PUBLICATION_STATE" to publicationState)
+        logger.apiCall("getPlanLinkStatus", "planId" to planId, PUBLICATION_STATE to publicationState)
         return linkingService.getGeometryPlanLinkStatus(planId = planId, publicationState = publicationState)
     }
 
@@ -103,9 +109,9 @@ class LinkingController @Autowired constructor(
     @GetMapping("{$PUBLICATION_STATE}/plans/status")
     fun getManyPlanLinkStatuses(
         @RequestParam("ids") planIds: List<IntId<GeometryPlan>>,
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
     ): List<GeometryPlanLinkStatus> {
-        logger.apiCall("getManyPlanLinkStatuses", "$PUBLICATION_STATE" to publicationState)
+        logger.apiCall("getManyPlanLinkStatuses", PUBLICATION_STATE to publicationState)
         return linkingService.getGeometryPlanLinkStatuses(planIds = planIds, publicationState = publicationState)
     }
 
@@ -158,8 +164,15 @@ class LinkingController @Autowired constructor(
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
     @PostMapping("/switches/{switchId}/geometry")
-    fun saveSwitchLinking(@RequestBody suggestedSwitch: SuggestedSwitch, @PathVariable switchId: IntId<TrackLayoutSwitch>): IntId<TrackLayoutSwitch> {
-        logger.apiCall("saveSwitchLinking", "switchLinkingParameters" to suggestedSwitch, "switchId" to switchId)
+    fun saveSwitchLinking(
+        @RequestBody suggestedSwitch: SuggestedSwitch,
+        @PathVariable switchId: IntId<TrackLayoutSwitch>,
+    ): IntId<TrackLayoutSwitch> {
+        logger.apiCall(
+            "saveSwitchLinking",
+            "switchLinkingParameters" to suggestedSwitch,
+            "switchId" to switchId,
+        )
         return switchLinkingService.saveSwitchLinking(suggestedSwitch, switchId).id
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -17,7 +17,15 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/track-layout/km-posts")
@@ -31,48 +39,48 @@ class LayoutKmPostController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/{id}")
     fun getKmPost(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutKmPost>,
     ): ResponseEntity<TrackLayoutKmPost> {
-        logger.apiCall("getKmPost", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getKmPost", PUBLICATION_STATE to publicationState, "id" to id)
         return toResponse(kmPostService.get(publicationState, id))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}", params = ["ids"])
     fun getKmPosts(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids", required = true) ids: List<IntId<TrackLayoutKmPost>>,
     ): List<TrackLayoutKmPost> {
-        logger.apiCall("getKmPost", "$PUBLICATION_STATE" to publicationState, "ids" to ids)
+        logger.apiCall("getKmPost", PUBLICATION_STATE to publicationState, "ids" to ids)
         return kmPostService.getMany(publicationState, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/on-track-number/{trackNumberId}")
     fun getKmPostsOnTrackNumber(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("trackNumberId") id: IntId<TrackLayoutTrackNumber>,
     ): List<TrackLayoutKmPost> {
-        logger.apiCall("getKmPostsOnTrackNumber", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getKmPostsOnTrackNumber", PUBLICATION_STATE to publicationState, "id" to id)
         return kmPostService.list(publicationState, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}", params = ["bbox", "step"])
     fun findKmPosts(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("step") step: Int,
     ): List<TrackLayoutKmPost> {
-        logger.apiCall("getKmPosts", "$PUBLICATION_STATE" to publicationState, "bbox" to bbox, "step" to step)
+        logger.apiCall("getKmPosts", PUBLICATION_STATE to publicationState, "bbox" to bbox, "step" to step)
         return kmPostService.list(publicationState, bbox, step)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}", params = ["location", "offset", "limit"])
     fun findKmPosts(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>?,
         @RequestParam("location") location: Point,
         @RequestParam("offset") offset: Int,
@@ -80,7 +88,7 @@ class LayoutKmPostController(
     ): List<TrackLayoutKmPost> {
         logger.apiCall(
             "getNearbyKmPostsOnTrack",
-            "$PUBLICATION_STATE" to publicationState,
+            PUBLICATION_STATE to publicationState,
             "trackNumberId" to trackNumberId,
             "location" to location,
             "offset" to offset,
@@ -98,14 +106,14 @@ class LayoutKmPostController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}", params = ["trackNumberId", "kmNumber"])
     fun getKmPost(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>,
         @RequestParam("kmNumber") kmNumber: KmNumber,
         @RequestParam("includeDeleted") includeDeleted: Boolean,
     ): ResponseEntity<TrackLayoutKmPost> {
         logger.apiCall(
             "getKmPostOnTrack",
-            "$PUBLICATION_STATE" to publicationState,
+            PUBLICATION_STATE to publicationState,
             "trackNumberId" to trackNumberId,
             "kmNumber" to kmNumber,
             "includeDeleted" to includeDeleted,
@@ -116,10 +124,10 @@ class LayoutKmPostController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("{$PUBLICATION_STATE}/{id}/validation")
     fun validateKmPost(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutKmPost>,
     ): ResponseEntity<ValidatedAsset<TrackLayoutKmPost>> {
-        logger.apiCall("validateKmPost", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("validateKmPost", PUBLICATION_STATE to publicationState, "id" to id)
         return publicationService.validateKmPosts(listOf(id), publicationState).firstOrNull().let(::toResponse)
     }
 
@@ -151,7 +159,7 @@ class LayoutKmPostController(
     @GetMapping("/{$PUBLICATION_STATE}/{id}/change-times")
     fun getKmPostChangeInfo(
         @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
     ): ResponseEntity<LayoutAssetChangeInfo> {
         logger.apiCall("getKmPostChangeInfo", "id" to kmPostId, "publicationState" to publicationState)
         return toResponse(kmPostService.getLayoutAssetChangeInfo(kmPostId, publicationState))
@@ -160,10 +168,10 @@ class LayoutKmPostController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/{id}/km-length")
     fun getKmLength(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
     ): ResponseEntity<Double> {
-        logger.apiCall("getKmLength", "id" to kmPostId, "$PUBLICATION_STATE" to publicationState)
+        logger.apiCall("getKmLength", "id" to kmPostId, PUBLICATION_STATE to publicationState)
         return toResponse(kmPostService.getSingleKmPostLength(publicationState, kmPostId))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -17,7 +17,15 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/track-layout/switches")
@@ -30,7 +38,7 @@ class LayoutSwitchController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}")
     fun getTrackLayoutSwitches(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox?,
         @RequestParam("namePart") namePart: String?,
         @RequestParam("exactName") exactName: SwitchName?,
@@ -43,7 +51,7 @@ class LayoutSwitchController(
     ): List<TrackLayoutSwitch> {
         logger.apiCall(
             "getTrackLayoutSwitches",
-            "$PUBLICATION_STATE" to publicationState,
+            PUBLICATION_STATE to publicationState,
             "bbox" to bbox,
             "namePart" to namePart,
             "exactName" to exactName,
@@ -61,41 +69,41 @@ class LayoutSwitchController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/{id}")
     fun getTrackLayoutSwitch(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutSwitch>,
     ): ResponseEntity<TrackLayoutSwitch> {
-        logger.apiCall("getTrackLayoutSwitch", "id" to id, "$PUBLICATION_STATE" to publicationState)
+        logger.apiCall("getTrackLayoutSwitch", "id" to id, PUBLICATION_STATE to publicationState)
         return toResponse(switchService.get(publicationState, id))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}", params = ["ids"])
     fun getTrackLayoutSwitches(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids", required = true) ids: List<IntId<TrackLayoutSwitch>>,
     ): List<TrackLayoutSwitch> {
-        logger.apiCall("getTrackLayoutSwitches", "ids" to ids, "$PUBLICATION_STATE" to publicationState)
+        logger.apiCall("getTrackLayoutSwitches", "ids" to ids, PUBLICATION_STATE to publicationState)
         return switchService.getMany(publicationState, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/{id}/joint-connections")
     fun getSwitchJointConnections(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutSwitch>,
     ): List<TrackLayoutSwitchJointConnection> {
-        logger.apiCall("getSwitchJointConnections", "switchId" to id, "$PUBLICATION_STATE" to publicationState)
+        logger.apiCall("getSwitchJointConnections", "switchId" to id, PUBLICATION_STATE to publicationState)
         return switchService.getSwitchJointConnections(publicationState, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("{$PUBLICATION_STATE}/validation")
     fun validateSwitches(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids") ids: List<IntId<TrackLayoutSwitch>>?,
         @RequestParam("bbox") bbox: BoundingBox?,
     ): List<ValidatedAsset<TrackLayoutSwitch>> {
-        logger.apiCall("validateSwitches", "$PUBLICATION_STATE" to publicationState, "ids" to ids, "bbox" to bbox)
+        logger.apiCall("validateSwitches", PUBLICATION_STATE to publicationState, "ids" to ids, "bbox" to bbox)
         val switches = if (ids != null) {
             switchService.getMany(publicationState, ids)
         } else {
@@ -135,9 +143,9 @@ class LayoutSwitchController(
     @GetMapping("/{$PUBLICATION_STATE}/{id}/change-times")
     fun getSwitchChangeInfo(
         @PathVariable("id") switchId: IntId<TrackLayoutSwitch>,
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
     ): ResponseEntity<LayoutAssetChangeInfo> {
-        logger.apiCall("getSwitchChangeInfo", "id" to switchId, "$PUBLICATION_STATE" to publicationState)
+        logger.apiCall("getSwitchChangeInfo", "id" to switchId, PUBLICATION_STATE to publicationState)
         return toResponse(switchService.getLayoutAssetChangeInfo(switchId, publicationState))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -48,30 +48,30 @@ class LayoutTrackNumberController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}")
     fun getTrackNumbers(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("includeDeleted", defaultValue = "false") includeDeleted: Boolean,
     ): List<TrackLayoutTrackNumber> {
-        logger.apiCall("getTrackNumbers", "$PUBLICATION_STATE" to publicationState)
+        logger.apiCall("getTrackNumbers", PUBLICATION_STATE to publicationState)
         return trackNumberService.list(publicationState, includeDeleted)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/{id}")
     fun getTrackNumber(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
     ): ResponseEntity<TrackLayoutTrackNumber> {
-        logger.apiCall("getTrackNumber", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getTrackNumber", PUBLICATION_STATE to publicationState, "id" to id)
         return toResponse(trackNumberService.get(publicationState, id))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("{$PUBLICATION_STATE}/{id}/validation")
     fun validateTrackNumberAndReferenceLine(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
     ): ResponseEntity<ValidatedAsset<TrackLayoutTrackNumber>> {
-        logger.apiCall("validateTrackNumberAndReferenceLine", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("validateTrackNumberAndReferenceLine", PUBLICATION_STATE to publicationState, "id" to id)
         return publicationService
             .validateTrackNumbersAndReferenceLines(listOf(id), publicationState)
             .firstOrNull()
@@ -106,12 +106,12 @@ class LayoutTrackNumberController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/{id}/plan-geometry")
     fun getTrackSectionsByPlan(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
         @RequestParam("bbox") boundingBox: BoundingBox? = null,
     ): List<AlignmentPlanSection> {
         logger.apiCall(
-            "getTrackSectionsByPlan", "$PUBLICATION_STATE" to publicationState, "id" to id, "bbox" to boundingBox
+            "getTrackSectionsByPlan", PUBLICATION_STATE to publicationState, "id" to id, "bbox" to boundingBox
         )
         return trackNumberService.getMetadataSections(id, publicationState, boundingBox)
     }
@@ -119,11 +119,11 @@ class LayoutTrackNumberController(
     @PreAuthorize(AUTH_VIEW_GEOMETRY)
     @GetMapping("/{$PUBLICATION_STATE}/{id}/km-lengths")
     fun getTrackNumberKmLengths(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
     ): List<TrackLayoutKmLengthDetails> {
         logger.apiCall(
-            "getTrackNumberKmLengths", "$PUBLICATION_STATE" to publicationState, "id" to id
+            "getTrackNumberKmLengths", PUBLICATION_STATE to publicationState, "id" to id
         )
 
         return trackNumberService.getKmLengths(publicationState, id) ?: emptyList()
@@ -132,7 +132,7 @@ class LayoutTrackNumberController(
     @PreAuthorize(AUTH_DOWNLOAD_GEOMETRY)
     @GetMapping("/{$PUBLICATION_STATE}/{id}/km-lengths/as-csv")
     fun getTrackNumberKmLengthsAsCsv(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
         @RequestParam("startKmNumber") startKmNumber: KmNumber? = null,
         @RequestParam("endKmNumber") endKmNumber: KmNumber? = null,
@@ -140,7 +140,7 @@ class LayoutTrackNumberController(
     ): ResponseEntity<ByteArray> {
         logger.apiCall(
             "getTrackNumberKmLengthsAsCsv",
-            "$PUBLICATION_STATE" to publicationState,
+            PUBLICATION_STATE to publicationState,
             "id" to id,
             "startKmNumber" to startKmNumber,
             "endKmNumber" to endKmNumber,
@@ -184,9 +184,9 @@ class LayoutTrackNumberController(
     @GetMapping("/{$PUBLICATION_STATE}/{id}/change-times")
     fun getTrackNumberChangeInfo(
         @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
     ): ResponseEntity<LayoutAssetChangeInfo> {
-        logger.apiCall("getTrackNumberChangeInfo", "id" to id, "$PUBLICATION_STATE" to publicationState)
+        logger.apiCall("getTrackNumberChangeInfo", "id" to id, PUBLICATION_STATE to publicationState)
         return toResponse(trackNumberService.getLayoutAssetChangeInfo(id, publicationState))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
@@ -12,7 +12,11 @@ import fi.fta.geoviite.infra.tracklayout.AlignmentFetchType.ALL
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/track-layout/map")
@@ -22,14 +26,14 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/alignment-polylines")
     fun getAlignmentPolyLines(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("resolution") resolution: Int,
         @RequestParam("type") type: AlignmentFetchType? = null,
     ): List<AlignmentPolyLine<*>> {
         logger.apiCall(
             "getAlignmentPolyLines",
-            "$PUBLICATION_STATE" to publicationState,
+            PUBLICATION_STATE to publicationState,
             "bbox" to bbox,
             "resolution" to resolution,
             "type" to type,
@@ -40,14 +44,14 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/location-track/{id}/alignment-polyline")
     fun getLocationTrackPolyline(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") locationTrackId: IntId<LocationTrack>,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("resolution") resolution: Int,
     ): AlignmentPolyLine<LocationTrack>? {
         logger.apiCall(
             "getLocationTrackPolyline",
-            "$PUBLICATION_STATE" to publicationState,
+            PUBLICATION_STATE to publicationState,
             "id" to locationTrackId,
             "bbox" to bbox,
             "resolution" to resolution
@@ -59,54 +63,54 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/location-track/alignment-headers")
     fun getLocationTrackHeaders(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids") ids: List<IntId<LocationTrack>>,
     ): List<AlignmentHeader<LocationTrack, LocationTrackState>> {
-        logger.apiCall("getReferenceLineHeaders", "$PUBLICATION_STATE" to publicationState, "ids" to ids)
+        logger.apiCall("getReferenceLineHeaders", PUBLICATION_STATE to publicationState, "ids" to ids)
         return mapAlignmentService.getLocationTrackHeaders(publicationState, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/reference-line/alignment-headers")
     fun getReferenceLineHeaders(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids") ids: List<IntId<ReferenceLine>>,
     ): List<AlignmentHeader<ReferenceLine, LayoutState>> {
-        logger.apiCall("getReferenceLineHeaders", "$PUBLICATION_STATE" to publicationState, "ids" to ids)
+        logger.apiCall("getReferenceLineHeaders", PUBLICATION_STATE to publicationState, "ids" to ids)
         return mapAlignmentService.getReferenceLineHeaders(publicationState, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/location-track/{id}/segment-m")
     fun getLocationTrackSegmentMValues(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
     ): List<Double> {
-        logger.apiCall("getLocationTrackSegmentMValues", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getLocationTrackSegmentMValues", PUBLICATION_STATE to publicationState, "id" to id)
         return mapAlignmentService.getLocationTrackSegmentMValues(publicationState, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/alignment/without-linking")
     fun getSectionsWithoutLinking(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("type") type: AlignmentFetchType,
     ): List<MapAlignmentHighlight<*>> {
         logger.apiCall("getSectionsWithoutLinking",
-            "$PUBLICATION_STATE" to publicationState, "bbox" to bbox, "type" to type)
+            PUBLICATION_STATE to publicationState, "bbox" to bbox, "type" to type)
         return mapAlignmentService.getSectionsWithoutLinking(publicationState, bbox, type)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/location-track/without-profile")
     fun getSectionsWithoutProfile(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
     ): List<MapAlignmentHighlight<LocationTrack>> {
         logger.apiCall(
             "getSectionsWithoutProfile",
-            "$PUBLICATION_STATE" to publicationState,
+            PUBLICATION_STATE to publicationState,
             "bbox" to bbox,
         )
         return mapAlignmentService.getSectionsWithoutProfile(publicationState, bbox)
@@ -115,30 +119,30 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/reference-line/{id}/segment-m")
     fun getReferenceLineSegmentMValues(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): List<Double> {
-        logger.apiCall("getReferenceLineSegmentMValues", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getReferenceLineSegmentMValues", PUBLICATION_STATE to publicationState, "id" to id)
         return mapAlignmentService.getReferenceLineSegmentMValues(publicationState, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/location-track/{id}/ends")
     fun getLocationTrackEnds(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
     ): MapAlignmentEndPoints {
-        logger.apiCall("getLocationTrackEnds", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getLocationTrackEnds", PUBLICATION_STATE to publicationState, "id" to id)
         return mapAlignmentService.getLocationTrackEnds(publicationState, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/reference-line/{id}/ends")
     fun getReferenceLineEnds(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): MapAlignmentEndPoints {
-        logger.apiCall("getReferenceLineEnds", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getReferenceLineEnds", PUBLICATION_STATE to publicationState, "id" to id)
         return mapAlignmentService.getReferenceLineEnds(publicationState, id)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
@@ -14,7 +14,11 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/track-layout/reference-lines")
@@ -27,31 +31,31 @@ class ReferenceLineController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/{id}")
     fun getReferenceLine(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): ResponseEntity<ReferenceLine> {
-        logger.apiCall("getReferenceLine", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getReferenceLine", PUBLICATION_STATE to publicationState, "id" to id)
         return toResponse(referenceLineService.get(publicationState, id))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}", params = ["ids"])
     fun getReferenceLines(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids", required = true) ids: List<IntId<ReferenceLine>>,
     ): List<ReferenceLine> {
-        logger.apiCall("getReferenceLines", "$PUBLICATION_STATE" to publicationState, "ids" to ids)
+        logger.apiCall("getReferenceLines", PUBLICATION_STATE to publicationState, "ids" to ids)
         return referenceLineService.getMany(publicationState, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/by-track-number/{trackNumberId}")
     fun getTrackNumberReferenceLine(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): ResponseEntity<ReferenceLine> {
         logger.apiCall(
-            "getTrackNumberReferenceLine", "$PUBLICATION_STATE" to publicationState, "trackNumberId" to trackNumberId
+            "getTrackNumberReferenceLine", PUBLICATION_STATE to publicationState, "trackNumberId" to trackNumberId
         )
         return toResponse(referenceLineService.getByTrackNumber(publicationState, trackNumberId))
     }
@@ -59,20 +63,20 @@ class ReferenceLineController(
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}", params = ["bbox"])
     fun getReferenceLinesNear(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
     ): List<ReferenceLine> {
-        logger.apiCall("getReferenceLinesNear", "$PUBLICATION_STATE" to publicationState, "bbox" to bbox)
+        logger.apiCall("getReferenceLinesNear", PUBLICATION_STATE to publicationState, "bbox" to bbox)
         return referenceLineService.listNear(publicationState, bbox)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/{$PUBLICATION_STATE}/{id}/start-and-end")
     fun getReferenceLineStartAndEnd(
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): ResponseEntity<AlignmentStartAndEnd> {
-        logger.apiCall("getReferenceLineStartAndEnd", "$PUBLICATION_STATE" to publicationState, "id" to id)
+        logger.apiCall("getReferenceLineStartAndEnd", PUBLICATION_STATE to publicationState, "id" to id)
         return toResponse(referenceLineService.getWithAlignment(publicationState, id)?.let { (referenceLine, alignment) ->
             geocodingService.getReferenceLineStartAndEnd(publicationState, referenceLine, alignment)
         })
@@ -89,7 +93,7 @@ class ReferenceLineController(
     @GetMapping("/{$PUBLICATION_STATE}/{id}/change-times")
     fun getReferenceLineChangeInfo(
         @PathVariable("id") id: IntId<ReferenceLine>,
-        @PathVariable("$PUBLICATION_STATE") publicationState: PublicationState,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
     ): ResponseEntity<LayoutAssetChangeInfo> {
         logger.apiCall("getReferenceLineChangeInfo", "id" to id, "publicationState" to publicationState)
         return toResponse(referenceLineService.getLayoutAssetChangeInfo(id, publicationState))


### PR DESCRIPTION
Tein näitä aina muun koodin ohessa, mutta irrotin koko setin nyt vain omaksi pullarikseen. Eli sisältää pelkkää turhan quotetuksen poistoa, ei mitään toiminnallista muutosta.