### PR TITLE
GVT-2401 Add branch as required arg on assetService.saveDraft

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.linking
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.error.LinkingFailureException
@@ -269,7 +270,8 @@ class LinkingService @Autowired constructor(
             location = newLocationInLayoutSpace, sourceId = geometryKmPost.id
         )
 
-        return layoutKmPostService.saveDraft(modifiedLayoutKmPost)
+        // TODO: GVT-2401
+        return layoutKmPostService.saveDraft(LayoutBranch.main, modifiedLayoutKmPost)
     }
 
     fun verifyPlanNotHidden(id: IntId<GeometryPlan>) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -436,7 +436,8 @@ class SplitService(
             unusedDuplicates,
             splitTargetLocationTracks,
         ).forEach { updatedDuplicate ->
-            locationTrackService.saveDraft(updatedDuplicate)
+            // TODO: GVT-2399
+            locationTrackService.saveDraft(LayoutBranch.main, updatedDuplicate)
         }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -32,7 +32,8 @@ class LayoutKmPostService(
             // TODO: GVT-2401
             contextData = LayoutContextData.newDraft(LayoutBranch.main),
         )
-        return saveDraftInternal(kmPost).id
+        // TODO: GVT-2401
+        return saveDraftInternal(LayoutBranch.main, kmPost).id
     }
 
     @Transactional
@@ -42,7 +43,8 @@ class LayoutKmPostService(
             kmNumber = kmPost.kmNumber,
             state = kmPost.state,
         )
-        return saveDraftInternal(trackLayoutKmPost).id
+        // TODO: GVT-2401
+        return saveDraftInternal(LayoutBranch.main, trackLayoutKmPost).id
     }
 
     fun list(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -44,7 +44,9 @@ class LayoutSwitchService @Autowired constructor(
             // TODO: GVT-2400
             contextData = LayoutContextData.newDraft(LayoutBranch.main),
         )
-        return saveDraftInternal(switch).id
+
+        // TODO: GVT-2400
+        return saveDraftInternal(LayoutBranch.main, switch).id
     }
 
     @Transactional
@@ -66,7 +68,8 @@ class LayoutSwitchService @Autowired constructor(
             joints = switchJoints,
             ownerId = switch.ownerId,
         )
-        return saveDraftInternal(updatedLayoutSwitch).id
+        // TODO: GVT-2400
+        return saveDraftInternal(LayoutBranch.main, updatedLayoutSwitch).id
     }
 
     @Transactional
@@ -133,7 +136,8 @@ class LayoutSwitchService @Autowired constructor(
     ): DaoResponse<TrackLayoutSwitch> {
         logger.serviceCall("updateExternalIdForSwitch", "id" to id, "oid" to oid)
         val original = dao.getOrThrow(DRAFT, id)
-        return saveDraft(original.copy(externalId = oid))
+        // TODO: GVT-2400
+        return saveDraft(LayoutBranch.main, original.copy(externalId = oid))
     }
 
     private fun withStructure(switch: TrackLayoutSwitch): Pair<TrackLayoutSwitch, SwitchStructure> =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -37,7 +37,9 @@ class LayoutTrackNumberService(
     @Transactional
     fun insert(saveRequest: TrackNumberSaveRequest): IntId<TrackLayoutTrackNumber> {
         logger.serviceCall("insert", "trackNumber" to saveRequest)
+        // TODO: GVT-2397
         val draftSaveResponse = saveDraftInternal(
+            LayoutBranch.main,
             TrackLayoutTrackNumber(
                 number = saveRequest.number,
                 description = saveRequest.description,
@@ -58,7 +60,9 @@ class LayoutTrackNumberService(
     ): IntId<TrackLayoutTrackNumber> {
         logger.serviceCall("update", "trackNumber" to saveRequest)
         val original = dao.getOrThrow(DRAFT, id)
+        // TODO: GVT-2397
         val draftSaveResponse = saveDraftInternal(
+            LayoutBranch.main,
             original.copy(
                 number = saveRequest.number,
                 description = saveRequest.description,
@@ -79,7 +83,8 @@ class LayoutTrackNumberService(
         val original = dao.getOrThrow(DRAFT, id)
         val trackLayoutTrackNumber = original.copy(externalId = oid)
 
-        return saveDraftInternal(trackLayoutTrackNumber)
+        // TODO: GVT-2397
+        return saveDraftInternal(LayoutBranch.main, trackLayoutTrackNumber)
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -77,7 +77,8 @@ class LocationTrackService(
             // TODO: GVT-2399
             contextData = LayoutContextData.newDraft(LayoutBranch.main),
         )
-        return saveDraftInternal(locationTrack)
+        // TODO: GVT-2399
+        return saveDraftInternal(LayoutBranch.main, locationTrack)
     }
 
     @Transactional
@@ -97,7 +98,8 @@ class LocationTrackService(
         )
 
         return if (locationTrack.state != LocationTrackState.DELETED) {
-            saveDraft(fetchNearbyTracksAndCalculateLocationTrackTopology(locationTrack, originalAlignment))
+            // TODO: GVT-2399
+            saveDraft(LayoutBranch.main, fetchNearbyTracksAndCalculateLocationTrackTopology(locationTrack, originalAlignment))
         } else {
             clearDuplicateReferences(id)
             val segmentsWithoutSwitch = originalAlignment.segments.map(LayoutSegment::withoutSwitch)
@@ -113,7 +115,8 @@ class LocationTrackService(
         val locationTrack = originalTrack.copy(state = state)
 
         return if (locationTrack.state != LocationTrackState.DELETED) {
-            saveDraft(locationTrack)
+            // TODO: GVT-2399
+            saveDraft(LayoutBranch.main, locationTrack)
         } else {
             clearDuplicateReferences(id)
             val segmentsWithoutSwitch = originalAlignment.segments.map(LayoutSegment::withoutSwitch)
@@ -123,8 +126,8 @@ class LocationTrackService(
     }
 
     @Transactional
-    override fun saveDraft(draft: LocationTrack): DaoResponse<LocationTrack> =
-        super.saveDraft(draft.copy(alignmentVersion = updatedAlignmentVersion(draft)))
+    override fun saveDraft(branch: LayoutBranch, draftItem: LocationTrack): DaoResponse<LocationTrack> =
+        super.saveDraft(branch, draftItem.copy(alignmentVersion = updatedAlignmentVersion(draftItem)))
 
     private fun updatedAlignmentVersion(track: LocationTrack): RowVersion<LayoutAlignment>? =
         // If we're creating a new row or starting a draft, we duplicate the alignment to not edit any original
@@ -145,14 +148,16 @@ class LocationTrackService(
             } else {
                 alignmentService.save(alignment)
             }
-        return saveDraftInternal(draft.copy(alignmentVersion = alignmentVersion))
+        return saveDraftInternal(LayoutBranch.main, draft.copy(alignmentVersion = alignmentVersion))
     }
 
     @Transactional
     fun updateExternalId(id: IntId<LocationTrack>, oid: Oid<LocationTrack>): DaoResponse<LocationTrack> {
         logger.serviceCall("updateExternalIdForLocationTrack", "id" to id, "oid" to oid)
         val original = dao.getOrThrow(DRAFT, id)
+        // TODO: GVT-2399
         return saveDraftInternal(
+            LayoutBranch.main,
             original.copy(
                 externalId = oid,
                 alignmentVersion = updatedAlignmentVersion(original),
@@ -201,7 +206,10 @@ class LocationTrackService(
         .fetchDuplicateVersions(id, DRAFT, includeDeleted = true)
         .map(dao::fetch)
         .map(::asMainDraft)
-        .forEach { duplicate -> saveDraft(duplicate.copy(duplicateOf = null)) }
+        .forEach { duplicate ->
+            // TODO: GVT-2399
+            saveDraft(LayoutBranch.main, duplicate.copy(duplicateOf = null))
+        }
 
     fun listNonLinked(): List<LocationTrack> {
         logger.serviceCall("listNonLinked")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -55,19 +55,22 @@ class ReferenceLineService(
             ?: throw IllegalStateException("Track number should have a reference line")
         val original = dao.fetch(originalVersion)
         return if (original.startAddress != startAddress) {
-            saveDraftInternal(original.copy(
-                startAddress = startAddress,
-                alignmentVersion = updatedAlignmentVersion(original),
-            ))
+            // TODO: GVT-2398
+            saveDraftInternal(
+                LayoutBranch.main,
+                original.copy(
+                    startAddress = startAddress,
+                    alignmentVersion = updatedAlignmentVersion(original),
+                )
+            )
         } else {
             null
         }
     }
 
     @Transactional
-    override fun saveDraft(draft: ReferenceLine): DaoResponse<ReferenceLine> = super.saveDraft(
-        draft.copy(alignmentVersion = updatedAlignmentVersion(draft))
-    )
+    override fun saveDraft(branch: LayoutBranch, draftItem: ReferenceLine): DaoResponse<ReferenceLine> =
+        super.saveDraft(branch, draftItem.copy(alignmentVersion = updatedAlignmentVersion(draftItem)))
 
     @Transactional
     fun saveDraft(draft: ReferenceLine, alignment: LayoutAlignment): DaoResponse<ReferenceLine> {
@@ -90,7 +93,8 @@ class ReferenceLineService(
             } else {
                 alignmentService.save(alignment)
             }
-        return saveDraftInternal(draft.copy(alignmentVersion = alignmentVersion))
+        // TODO: GVT-2398
+        return saveDraftInternal(LayoutBranch.main, draft.copy(alignmentVersion = alignmentVersion))
     }
 
     private fun updatedAlignmentVersion(line: ReferenceLine) =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
@@ -766,6 +767,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val testData = insertTestData()
         val kmPost = testData.kmPosts.first()
         kmPostService.saveDraft(
+            LayoutBranch.main,
             kmPost.copy(
                 kmNumber = KmNumber(kmPost.kmNumber.number, "A")
             )
@@ -861,6 +863,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val testData = insertTestData()
         val (referenceLine, _) = testData.referenceLineAndAlignment
         referenceLineService.saveDraft(
+            LayoutBranch.main,
             referenceLine.copy(
                 startAddress = TrackMeter(0, 500)
             )
@@ -917,6 +920,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val testData = insertTestData()
         val trackNumber = testData.trackNumber
         trackNumberservice.saveDraft(
+            LayoutBranch.main,
             trackNumber.copy(
                 description = FreeText(UUID.randomUUID().toString())
             )
@@ -974,6 +978,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val testData = insertTestData()
         val switch = testData.switches.first()
         switchService.saveDraft(
+            LayoutBranch.main,
             switch.copy(
                 name = SwitchName(UUID.randomUUID().toString())
             )
@@ -992,6 +997,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
 
         val trackNumber = testData.trackNumber
         trackNumberservice.saveDraft(
+            LayoutBranch.main,
             trackNumber.copy(
                 description = FreeText(UUID.randomUUID().toString())
             )
@@ -1069,6 +1075,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val switch = testData.switches.first()
 
         switchService.saveDraft(
+            LayoutBranch.main,
             switch.copy(
                 name = SwitchName(UUID.randomUUID().toString())
             )
@@ -1102,7 +1109,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val referenceLineId = referenceLineService.saveDraft(
             referenceLine(trackNumberId, draft = true), alignment(segment(Point(0.0, 0.0), Point(0.0, 20.0)))
         ).id
-        val switch = switchService.saveDraft(switch(123, draft = true)).id
+        val switch = switchService.saveDraft(LayoutBranch.main, switch(123, draft = true)).id
         val wibblyTrack = locationTrackService.saveDraft(
             locationTrack(trackNumberId, draft = true), alignment(
                 segment(Point(0.0, 0.0), Point(0.0, 10.0)).copy(switchId = switch, endJointNumber = JointNumber(5)),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDaoIT.kt
@@ -4,12 +4,20 @@ package fi.fta.geoviite.infra.linking
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoints
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.TopologyLocationTrackSwitch
+import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.someOid
+import fi.fta.geoviite.infra.tracklayout.switch
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -24,10 +32,9 @@ class LinkingDaoIT @Autowired constructor(
     private val locationTrackService: LocationTrackService,
 ) : DBTestBase() {
 
-
     @Test
     fun noSwitchBoundsAreFoundWhenNotLinkedToTracks() {
-        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(switch(1, draft = true)).id)
+        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id)
         assertEquals(null, linkingDao.getSwitchBoundsFromTracks(OFFICIAL, switch.id as IntId))
         assertEquals(null, linkingDao.getSwitchBoundsFromTracks(DRAFT, switch.id as IntId))
     }
@@ -36,7 +43,7 @@ class LinkingDaoIT @Autowired constructor(
     fun switchBoundsAreFoundFromTracks() {
         val trackNumber = getOrCreateTrackNumber(TrackNumber("123"))
         val tnId = trackNumber.id as IntId
-        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(switch(1, draft = true)).id)
+        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id)
 
         val point1 = Point(10.0, 10.0)
         val point2 = Point(12.0, 10.0)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -4,11 +4,46 @@ import daoResponseToValidationVersion
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.TEST_USER
 import fi.fta.geoviite.infra.authorization.UserName
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.DataType
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
-import fi.fta.geoviite.infra.integration.*
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.integration.CalculatedChanges
+import fi.fta.geoviite.infra.integration.DirectChanges
+import fi.fta.geoviite.infra.integration.IndirectChanges
+import fi.fta.geoviite.infra.integration.LocationTrackChange
+import fi.fta.geoviite.infra.integration.SwitchChange
+import fi.fta.geoviite.infra.integration.SwitchJointChange
+import fi.fta.geoviite.infra.integration.TrackNumberChange
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.LocationTrackState
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.tracklayout.TopologyLocationTrackSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.asMainDraft
+import fi.fta.geoviite.infra.tracklayout.assertMatches
+import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.referenceLine
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.switch
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -111,6 +146,7 @@ class PublicationDaoIT @Autowired constructor(
         val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
         publishAndCheck(version)
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId).let { lt ->
                 lt.copy(name = AlignmentName("${lt.name} TEST"))
             },
@@ -127,6 +163,7 @@ class PublicationDaoIT @Autowired constructor(
         val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
         publishAndCheck(version)
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId).copy(state = LocationTrackState.DELETED)
         )
         val candidates = publicationDao.fetchLocationTrackPublicationCandidates()
@@ -146,6 +183,7 @@ class PublicationDaoIT @Autowired constructor(
         )
         publishAndCheck(version)
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrackService.getOrThrow(OFFICIAL, draft.id as IntId).copy(state = LocationTrackState.IN_USE)
         )
         val candidates = publicationDao.fetchLocationTrackPublicationCandidates()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -109,15 +110,15 @@ class LayoutSearchServiceIT @Autowired constructor(
 
         // Search scope origin track's start switch, should be included
         val topologyStartSwitchId =
-            switchDao.fetch(switchService.saveDraft(switch(name = "blaa V0001", draft = true)).rowVersion).id as IntId
+            switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch(name = "blaa V0001", draft = true)).rowVersion).id as IntId
         // Search scope origin track's end switch, should be included
         val topologyEndSwitchId =
-            switchDao.fetch(switchService.saveDraft(switch(name = "blee V0002", draft = true)).rowVersion).id as IntId
+            switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch(name = "blee V0002", draft = true)).rowVersion).id as IntId
         // Related to duplicate but not in search scope, should be left out of search results
         val duplicateStartSwitchId =
-            switchDao.fetch(switchService.saveDraft(switch(name = "bluu V0003", draft = true)).rowVersion).id as IntId
+            switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true)).rowVersion).id as IntId
         // Entirely unrelated, should be left out of search results
-        switchDao.fetch(switchService.saveDraft(switch(name = "bluu V0003", draft = true)).rowVersion).id as IntId
+        switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true)).rowVersion).id as IntId
 
         val lt1 = insertLocationTrack( // Location track search scope origin, should be included
             locationTrack(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -1,9 +1,15 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.DataType
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LocationAccuracy
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geometry.MetaDataName
 import fi.fta.geoviite.infra.linking.TrackLayoutSwitchSaveRequest
@@ -13,7 +19,10 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao.LocationTrackIdentifiers
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -21,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import java.time.Instant
-
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -251,13 +259,13 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun returnsNullIfFetchingDraftOnlySwitchUsingOfficialFetch() {
-        val draftSwitch = switchService.saveDraft(switch(draft = true))
+        val draftSwitch = switchService.saveDraft(LayoutBranch.main, switch(draft = true))
         assertNull(switchService.get(OFFICIAL, draftSwitch.id))
     }
 
     @Test
     fun throwsIfFetchingOfficialVersionOfDraftOnlySwitchUsingGetOrThrow() {
-        val draftSwitch = switchService.saveDraft(switch(draft = true))
+        val draftSwitch = switchService.saveDraft(LayoutBranch.main, switch(draft = true))
         assertThrows<NoSuchEntityException> { switchService.getOrThrow(OFFICIAL, draftSwitch.id) }
     }
 
@@ -265,7 +273,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
     fun switchConnectedLocationTracksFound() {
         val trackNumber = getOrCreateTrackNumber(TrackNumber("123"))
         val tnId = trackNumber.id as IntId
-        val switch = switchService.get(DRAFT, switchService.saveDraft(switch(1, draft = true)).id)!!
+        val switch = switchService.get(DRAFT, switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id)!!
         val (_, withStartLink) = insertDraft(
             locationTrack(tnId, externalId = someOid(), draft = true).copy(
                 topologyStartSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(1)),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LocationAccuracy
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
@@ -126,7 +127,7 @@ class LocationTrackServiceIT @Autowired constructor(
     fun savingCreatesDraft() {
         val (publicationResponse, published) = createPublishedLocationTrack(1)
 
-        val editedVersion = locationTrackService.saveDraft(published.copy(name = AlignmentName("EDITED1")))
+        val editedVersion = locationTrackService.saveDraft(LayoutBranch.main, published.copy(name = AlignmentName("EDITED1")))
         assertEquals(publicationResponse.id, editedVersion.id)
         assertNotEquals(publicationResponse.rowVersion.id, editedVersion.rowVersion.id)
 
@@ -135,7 +136,7 @@ class LocationTrackServiceIT @Autowired constructor(
         // Creating a draft should duplicate the alignment
         assertNotEquals(published.alignmentVersion!!.id, editedDraft.alignmentVersion!!.id)
 
-        val editedVersion2 = locationTrackService.saveDraft(editedDraft.copy(name = AlignmentName("EDITED2")))
+        val editedVersion2 = locationTrackService.saveDraft(LayoutBranch.main, editedDraft.copy(name = AlignmentName("EDITED2")))
         assertEquals(publicationResponse.id, editedVersion2.id)
         assertNotEquals(publicationResponse.rowVersion.id, editedVersion2.rowVersion.id)
 
@@ -548,7 +549,7 @@ class LocationTrackServiceIT @Autowired constructor(
     )
 
     private fun insertAndFetchDraft(switch: TrackLayoutSwitch): TrackLayoutSwitch =
-        switchDao.fetch(switchService.saveDraft(switch).rowVersion)
+        switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch).rowVersion)
 
     private fun insertAndFetchDraft(
         locationTrack: LocationTrack,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -12,7 +13,13 @@ import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.util.FreeText
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -113,7 +120,9 @@ class ReferenceLineServiceIT @Autowired constructor(
         val referenceLineId = referenceLineService.getByTrackNumber(DRAFT, trackNumberId)!!.id as IntId
         val (publishResponse, published) = publishAndVerify(trackNumberId, referenceLineId)
 
-        val editedVersion = referenceLineService.saveDraft(published.copy(startAddress = TrackMeter(1, 1)))
+        val editedVersion = referenceLineService.saveDraft(
+            LayoutBranch.main, published.copy(startAddress = TrackMeter(1, 1)),
+        )
         assertEquals(publishResponse.id, editedVersion.id)
         assertNotEquals(publishResponse.rowVersion.id, editedVersion.rowVersion.id)
 
@@ -122,7 +131,10 @@ class ReferenceLineServiceIT @Autowired constructor(
         // Creating a draft should duplicate the alignment
         assertNotEquals(published.alignmentVersion!!.id, editedDraft.alignmentVersion!!.id)
 
-        val editedVersion2 = referenceLineService.saveDraft(editedDraft.copy(startAddress = TrackMeter(2, 2)))
+        val editedVersion2 = referenceLineService.saveDraft(
+            LayoutBranch.main,
+            editedDraft.copy(startAddress = TrackMeter(2, 2)),
+        )
         assertEquals(publishResponse.id, editedVersion2.id)
         assertNotEquals(publishResponse.rowVersion.id, editedVersion2.rowVersion.id)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IPoint3DM
 import fi.fta.geoviite.infra.math.Point
@@ -12,6 +13,7 @@ fun moveKmPostLocation(
     location: Point,
     kmPostService: LayoutKmPostService,
 ) = kmPostService.saveDraft(
+    LayoutBranch.main,
     kmPost.copy(location = location)
 )
 
@@ -100,7 +102,7 @@ fun moveSwitchPoints(
     switch: TrackLayoutSwitch,
     moveFunc: (point: IPoint) -> IPoint,
     switchService: LayoutSwitchService,
-) = switchService.saveDraft(moveSwitchPoints(switch, moveFunc))
+) = switchService.saveDraft(LayoutBranch.main, moveSwitchPoints(switch, moveFunc))
 
 fun moveSwitchPoints(
     switch: TrackLayoutSwitch,


### PR DESCRIPTION
Joukon isoin muutos: kaikki draft-muutokset tallennetaan saman palvelukutsun läpi ja sen täytyy jatkossa huomioida branch. Tässä toteutettu tuo huomiointi + korjattu käyttävät asettamalla branchiksi LayoutBranch.main kovakoodatusti. Muutoksia on moneen tiedostoon, mutta nyt tässä pullarissa ei pitäisi olla mitään muuta kuin tätä samaa aihetta. Tuon päälle pitäisi olla selkeämmin tehtävissä tikettikohtaiset featuret (suunnitelmat asseteille x), joita olen puolestaan merkkaillut todo-kommenteilla vaikka detekt niistä nillittääkin.