### PR TITLE
GVT-2602 Ensure fetchSegmentGeometriesAndPlanMetadata runs fast

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -305,7 +305,7 @@ class LayoutAlignmentDao(
                   )
                 group by alignment_id, alignment_version
               ),
-              orig_metadata_plan as (
+              orig_metadata_plan as materialized (
                 select
                   plan.id as plan_id,
                   plan_file.name as file_name


### PR DESCRIPTION
Otetaan erikseen pois päältä tämän CTE:n inlinetys, kts. https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CTE-MATERIALIZATION

Katson vielä ylihuomenna uusilla silmillä, millä tavalla postgres oikeasti saa tämän haun solmuun silloin, kun se keksii inlinettää orig_metadata_planin. Periaatteessa se tekee ihan perinteisen virheen, siis sen, että se luulee, että jossain haussa luotavassa relaatiossa on vain yksi rivi, mutta oikeasti niitä on moniakymmeniä, ja sen perusteella hakuoptimointi menee päin honkia; mutta en saanut vielä haun rakennetta niin kunnolla kiinni, että käsittäisin, mistä virhe alkuaan juontuu, ja että olisiko sitä mitenkään mahdollista korjata jollakin vähemmän hakuoptimointia vääntävällä tavalla.