### PR TITLE
GVT-2602 Collect more detailed statistics on layout.segment_version

### DIFF
--- a/infra/src/main/resources/db/migration/prod/V77__add_layout_segment_version_statistics.sql
+++ b/infra/src/main/resources/db/migration/prod/V77__add_layout_segment_version_statistics.sql
@@ -1,0 +1,3 @@
+create statistics layout.segment_version_alignment_stats on alignment_id, alignment_version from layout.segment_version;
+alter statistics layout.segment_version_alignment_stats set statistics 1000;
+analyze layout.segment_version;


### PR DESCRIPTION
Runoilin tästä släkkiin pitemminkin, lyhyesti siis: Postgres pitää oletuksena kirjaa vain sarakekohtaisista tilastoista, ja olettaa kaikkien hakuehtojen olevan tilastollisesti toisistaan itsenäisiä; mutta segment_version-taulussa isosta osasta raiteita on vain yksi versio, mutta joistakin voi olla kymmeniä, mistä syystä postgres aliarvioi pahasti löytyvien segmenttien määrän, jos haussa on suht iso alignment_version hakuperusteena.

Vähennetään vaaraa, että possu keksii päin honkia meneviä hakusuunnitelmia, käskemällä sitä keräämään tarkempia tilastotietoja näistä sarakkeista (ja juuri tästä sarakeyhdistelmästä).