### PR TITLE
GVT-2584: Esikatselunäkymän "Julkaise"-nappia voi painaa vaikka julkaisuvalidointi on kesken

### DIFF
--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -24,7 +24,6 @@ import { OnSelectFunction } from 'selection/selection-model';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { TextArea } from 'vayla-design-lib/text-area/text-area';
 import { draftLayoutContext, LayoutContext, officialLayoutContext } from 'common/common-model';
-import { pendingValidations } from 'preview/preview-view-filters';
 
 type PreviewFooterProps = {
     onSelect: OnSelectFunction;
@@ -32,6 +31,7 @@ type PreviewFooterProps = {
     layoutContext: LayoutContext;
     onChangeLayoutContext: (context: LayoutContext) => void;
     stagedPublicationCandidates: PublicationCandidate[];
+    validating: boolean;
 };
 
 function previewChangesCanBePublished(publishCandidates: PublicationCandidate[]) {
@@ -103,7 +103,7 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
                     disabled={
                         candidateCount === 0 ||
                         publishConfirmVisible ||
-                        pendingValidations(props.stagedPublicationCandidates) ||
+                        props.validating ||
                         (allPublishErrors && allPublishErrors?.length > 0) ||
                         !publishPreviewChanges
                     }>

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -33,6 +33,7 @@ export type PreviewTableItemProps = {
     publicationGroupAmounts: PublicationGroupAmounts;
     displayedTotalPublicationAssetAmount: number;
     onShowOnMap: (bbox: BoundingBox) => void;
+    isValidating: (item: PreviewTableEntry) => boolean;
 };
 
 export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
@@ -43,6 +44,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     publicationGroupAmounts,
     displayedTotalPublicationAssetAmount,
     onShowOnMap,
+    isValidating,
 }) => {
     const { t } = useTranslation();
     const [isErrorRowExpanded, setIsErrorRowExpanded] = React.useState(false);
@@ -181,7 +183,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                 </td>
                 <td>{formatDateFull(tableEntry.changeTime)}</td>
                 <td>{tableEntry.userName}</td>
-                {tableEntry.pendingValidation ? (
+                {isValidating(tableEntry) ? (
                     <td>
                         <Spinner />
                     </td>

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -67,7 +67,7 @@ type PreviewTableProps = {
     publicationGroupAmounts: PublicationGroupAmounts;
     displayedTotalPublicationAssetAmount: number;
     previewOperations: PreviewOperations;
-    isValidating: (tableEntry: PreviewTableEntry) => boolean;
+    itemIsValidating: (tableEntry: PreviewTableEntry) => boolean;
 };
 
 const PreviewTable: React.FC<PreviewTableProps> = ({
@@ -80,7 +80,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
     displayedTotalPublicationAssetAmount,
     previewOperations,
     onShowOnMap,
-    isValidating,
+    itemIsValidating,
 }) => {
     const { t } = useTranslation();
     const trackNumbers =
@@ -206,7 +206,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
                                     displayedTotalPublicationAssetAmount={
                                         displayedTotalPublicationAssetAmount
                                     }
-                                    isValidating={isValidating}
+                                    isValidating={itemIsValidating}
                                 />
                             }
                         </React.Fragment>

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -1,4 +1,4 @@
-import { Table, Th, ThContentAlignment } from 'vayla-design-lib/table/table';
+import { Table, Th } from 'vayla-design-lib/table/table';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -39,7 +39,6 @@ import { ChangeTimes } from 'common/common-slice';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { PublicationGroupAmounts } from 'publication/publication-utils';
-import { Spinner, SpinnerSize } from 'vayla-design-lib/spinner/spinner';
 import styles from './preview-view.scss';
 import { PreviewTableItem } from 'preview/preview-table-item';
 
@@ -68,7 +67,7 @@ type PreviewTableProps = {
     publicationGroupAmounts: PublicationGroupAmounts;
     displayedTotalPublicationAssetAmount: number;
     previewOperations: PreviewOperations;
-    showStatusSpinner: boolean;
+    isValidating: (tableEntry: PreviewTableEntry) => boolean;
 };
 
 const PreviewTable: React.FC<PreviewTableProps> = ({
@@ -81,7 +80,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
     displayedTotalPublicationAssetAmount,
     previewOperations,
     onShowOnMap,
-    showStatusSpinner,
+    isValidating,
 }) => {
     const { t } = useTranslation();
     const trackNumbers =
@@ -162,25 +161,14 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
         setSortInfo(newSortInfo);
     };
 
-    const sortableTableHeader = (
-        prop: SortProps,
-        translationKey: string,
-        showSpinner: boolean = false,
-    ) => (
+    const sortableTableHeader = (prop: SortProps, translationKey: string) => (
         <Th
             onClick={() => sortByProp(prop)}
             qa-id={translationKey}
-            icon={sortInfo.propName === prop ? getSortDirectionIcon(sortInfo.direction) : undefined}
-            contentAlignment={showSpinner ? ThContentAlignment.VERTICALLY_ALIGNED : undefined}>
+            icon={
+                sortInfo.propName === prop ? getSortDirectionIcon(sortInfo.direction) : undefined
+            }>
             {t(translationKey)}
-            {showSpinner && (
-                <Spinner
-                    inline={true}
-                    size={SpinnerSize.SMALL}
-                    tableHeader={true}
-                    qaId={'table-validation-in-progress'}
-                />
-            )}
         </Th>
     );
 
@@ -200,11 +188,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
                             'preview-table.modified-moment',
                         )}
                         {sortableTableHeader(SortProps.USER_NAME, 'preview-table.user')}
-                        {sortableTableHeader(
-                            SortProps.ERRORS,
-                            'preview-table.status',
-                            showStatusSpinner,
-                        )}
+                        {sortableTableHeader(SortProps.ERRORS, 'preview-table.status')}
                         <Th>{t('preview-table.actions')}</Th>
                     </tr>
                 </thead>
@@ -222,6 +206,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
                                     displayedTotalPublicationAssetAmount={
                                         displayedTotalPublicationAssetAmount
                                     }
+                                    isValidating={isValidating}
                                 />
                             }
                         </React.Fragment>

--- a/ui/src/preview/preview-view-filters.ts
+++ b/ui/src/preview/preview-view-filters.ts
@@ -36,7 +36,3 @@ export const filterByPublicationStage = (
 ): PublicationCandidate[] => {
     return publicationCandidates.filter((candidate) => candidate.stage === publicationStage);
 };
-
-export const pendingValidations = (publicationCandidates: PublicationCandidate[]) => {
-    return publicationCandidates.some((candidate) => candidate.pendingValidation);
-};

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -387,7 +387,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                             : publicationAssetChangeAmounts.unstaged
                                     }
                                     previewOperations={previewOperations}
-                                    isValidating={(item) => item.pendingValidation}
+                                    itemIsValidating={(item) => item.pendingValidation}
                                 />
                             </section>
 
@@ -413,7 +413,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                         publicationAssetChangeAmounts.staged
                                     }
                                     previewOperations={previewOperations}
-                                    isValidating={() => showValidationStatusSpinner}
+                                    itemIsValidating={() => showValidationStatusSpinner}
                                 />
                             </section>
 

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -387,7 +387,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                             : publicationAssetChangeAmounts.unstaged
                                     }
                                     previewOperations={previewOperations}
-                                    showStatusSpinner={showValidationStatusSpinner}
+                                    isValidating={(item) => item.pendingValidation}
                                 />
                             </section>
 
@@ -413,7 +413,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                         publicationAssetChangeAmounts.staged
                                     }
                                     previewOperations={previewOperations}
-                                    showStatusSpinner={showValidationStatusSpinner}
+                                    isValidating={() => showValidationStatusSpinner}
                                 />
                             </section>
 
@@ -446,6 +446,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                         clearStagedCandidates();
                     }}
                     stagedPublicationCandidates={stagedPublicationCandidates}
+                    validating={showValidationStatusSpinner}
                 />
             </div>
             {changesBeingReverted !== undefined && (


### PR DESCRIPTION
Samalla rukattu muutakin spinnerien näyttämistä esikatselunäkymän taulukoissa. Nyt ylemmässä taulukossa näytetään spinnerit aina kun jotain assettia validoidaan, ja alemmassa ylipäätään kun validaatio ajautuu