### PR TITLE
GVT-2599: Add support for searching operating points

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -18,6 +18,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.logger
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
@@ -61,5 +62,14 @@ class RatkoLocalService @Autowired constructor(
 
     fun getOperatingPoints(bbox: BoundingBox): List<RatkoOperatingPoint> {
         return ratkoOperatingPointDao.getOperatingPoints(bbox)
+    }
+
+    fun searchOperatingPoints(searchTerm: FreeText, resultLimit: Int = 10): List<RatkoOperatingPoint> {
+        logger.serviceCall(
+            "searchOperatingPoints",
+            "searchTerm" to searchTerm,
+            "resultLimit" to resultLimit,
+        )
+        return ratkoOperatingPointDao.searchOperatingPoints(searchTerm, resultLimit)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
@@ -136,11 +136,11 @@ class RatkoOperatingPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : D
               postgis.st_x(location) as x,
               postgis.st_y(location) as y,
               track_number_id
-              from layout.operating_point
-              where name ilike :searchPattern
+            from layout.operating_point
+              where name ilike :searchPattern 
               or abbreviation ilike :searchPattern
-              order by name
-              limit :resultLimit
+            order by name
+            limit :resultLimit
         """.trimIndent()
 
         return jdbcTemplate.query(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
@@ -9,7 +9,20 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.sql.ResultSet
 import java.time.Instant
+
+fun toRatkoOperatingPoint(rs: ResultSet): RatkoOperatingPoint {
+    return RatkoOperatingPoint(
+        externalId = rs.getOid("external_id"),
+        name = rs.getString("name"),
+        abbreviation = rs.getString("abbreviation"),
+        uicCode = rs.getString("uic_code"),
+        type = rs.getEnum("type"),
+        location = rs.getPoint("x", "y"),
+        trackNumberId = rs.getIntId("track_number_id"),
+    )
+}
 
 @Service
 @Component
@@ -107,15 +120,37 @@ class RatkoOperatingPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : D
                 "layout_srid" to LAYOUT_SRID.code
             )
         ) { rs, _ ->
-            RatkoOperatingPoint(
-                rs.getOid("external_id"),
-                rs.getString("name"),
-                rs.getString("abbreviation"),
-                rs.getString("uic_code"),
-                rs.getEnum("type"),
-                rs.getPoint("x", "y"),
-                rs.getIntId("track_number_id"),
+            toRatkoOperatingPoint(rs)
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun searchOperatingPoints(searchTerm: FreeText, resultLimit: Int): List<RatkoOperatingPoint> {
+        val sql = """
+            select
+              external_id,
+              name,
+              abbreviation,
+              uic_code,
+              type,
+              postgis.st_x(location) as x,
+              postgis.st_y(location) as y,
+              track_number_id
+              from layout.operating_point
+              where name ilike :searchPattern
+              or abbreviation ilike :searchPattern
+              order by name
+              limit :resultLimit
+        """.trimIndent()
+
+        return jdbcTemplate.query(
+            sql,
+            mapOf(
+                "searchPattern" to "%$searchTerm%",
+                "resultLimit" to resultLimit,
             )
+        ) { rs, _ ->
+            toRatkoOperatingPoint(rs)
         }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
@@ -5,7 +5,13 @@ import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 
-enum class OperationalPointType { LP, LPO, OLP, SEIS, LVH; }
+enum class OperationalPointType {
+    LP, // Liikennepaikka
+    LPO, // Liikennepaikan osa
+    OLP, // Osiin jaettu liikennepaikka
+    SEIS, // Seisake
+    LVH; // Linjavaihde
+}
 
 abstract class AbstractRatkoOperatingPoint(
     open val name: String,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
@@ -8,6 +8,7 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.logging.apiCall
+import fi.fta.geoviite.infra.ratko.model.RatkoOperatingPoint
 import fi.fta.geoviite.infra.util.FreeText
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -22,6 +23,7 @@ data class TrackLayoutSearchResult(
     val locationTracks: List<LocationTrack>,
     val switches: List<TrackLayoutSwitch>,
     val trackNumbers: List<TrackLayoutTrackNumber>,
+    val operatingPoints: List<RatkoOperatingPoint>,
 )
 
 @RestController

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.logging.serviceCall
+import fi.fta.geoviite.infra.ratko.RatkoLocalService
 import fi.fta.geoviite.infra.util.FreeText
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -14,6 +15,7 @@ class LayoutSearchService @Autowired constructor(
     private val switchService: LayoutSwitchService,
     private val locationTrackService: LocationTrackService,
     private val trackNumberService: LayoutTrackNumberService,
+    private val ratkoLocalService: RatkoLocalService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -92,6 +94,7 @@ class LayoutSearchService @Autowired constructor(
         switches = searchAllSwitches(layoutContext, searchTerm, limitPerResultType),
         locationTracks = searchAllLocationTracks(layoutContext, searchTerm, limitPerResultType),
         trackNumbers = searchAllTrackNumbers(layoutContext, searchTerm, limitPerResultType),
+        operatingPoints = ratkoLocalService.searchOperatingPoints(searchTerm, limitPerResultType),
     )
 
     private fun searchByLocationTrackSearchScope(
@@ -115,7 +118,8 @@ class LayoutSearchService @Autowired constructor(
                 .take(limit),
             trackNumbers = trackNumbers
                 .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
-                .take(limit)
+                .take(limit),
+            operatingPoints = ratkoLocalService.searchOperatingPoints(searchTerm, limit)
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalServiceIT.kt
@@ -188,7 +188,7 @@ class RatkoLocalServiceIT @Autowired constructor(
     }
 
     @Test
-    fun `Operating points search only matches name or abbreviation, not both`() {
+    fun `Operating points search matching both name and abbreviation returns the result only once`() {
         listOf(
             createTestOperatingPoint(
                 name = "AAA",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalServiceIT.kt
@@ -1,0 +1,287 @@
+package fi.fta.geoviite.infra.ratko
+
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.ratko.model.OperationalPointType
+import fi.fta.geoviite.infra.ratko.model.RatkoOperatingPointParse
+import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumber
+import fi.fta.geoviite.infra.tracklayout.someOid
+import fi.fta.geoviite.infra.util.FreeText
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class RatkoLocalServiceIT @Autowired constructor(
+    private val ratkoLocalService: RatkoLocalService,
+    private val operatingPointDao: RatkoOperatingPointDao,
+) : DBTestBase() {
+
+    @BeforeEach
+    fun clearOperatingPoints() {
+        val sql = """
+            truncate layout.operating_point cascade;
+            truncate layout.operating_point_version cascade;
+        """.trimIndent()
+        jdbc.execute(sql) { it.execute() }
+    }
+
+    @Test
+    fun `Operating points can be found by exact name`() {
+        val operatingPointNames = listOf(
+            "Some operating point",
+            "Foo",
+            "Bar",
+        )
+
+        operatingPointNames.map { name ->
+            createTestOperatingPoint(
+                name = name,
+                abbreviation = "Unused",
+            )
+        }.let(operatingPointDao::updateOperatingPoints)
+
+        operatingPointNames
+            .forEach { operatingPointName ->
+                val result = ratkoLocalService.searchOperatingPoints(
+                    FreeText(operatingPointName)
+                )
+
+                assertEquals(1, result.size)
+                assertEquals(operatingPointName, result[0].name)
+            }
+    }
+
+    @Test
+    fun `Operating points can be found by partial name`() {
+        val operatingPointNames = listOf(
+            "Some operating point",
+            "Foo",
+            "Bar",
+        )
+
+        operatingPointNames.map { name ->
+            createTestOperatingPoint(
+                name = name,
+                abbreviation = "Unused",
+            )
+        }.let(operatingPointDao::updateOperatingPoints)
+
+        operatingPointNames
+            .forEach { operatingPointName ->
+                val result = ratkoLocalService.searchOperatingPoints(
+                    FreeText(operatingPointName.takeLast(2))
+                )
+
+                assertEquals(1, result.size)
+                assertEquals(operatingPointName, result[0].name)
+            }
+    }
+
+    @Test
+    fun `Multiple operating points can be found in same search`() {
+        val operatingPointNames = listOf(
+            "FOO AAA BBB",
+            "AAA FOO BBB",
+            "BBB AAA",
+        )
+
+        operatingPointNames.map { name ->
+            createTestOperatingPoint(
+                name = name,
+                abbreviation = "Unused",
+            )
+        }.let(operatingPointDao::updateOperatingPoints)
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("FOO"))
+            .let { result -> assertEquals(2, result.size) }
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("AAA"))
+            .let { result -> assertEquals(3, result.size) }
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("BBB"))
+            .let { result -> assertEquals(3, result.size) }
+    }
+
+    @Test
+    fun `Operating points can be found by abbreviation`() {
+        val operatingPointAbbreviations = listOf(
+            "BBB",
+            "AAA",
+        )
+
+        operatingPointAbbreviations.map { abbreviation ->
+            createTestOperatingPoint(
+                name = "unused",
+                abbreviation = abbreviation,
+            )
+        }.let(operatingPointDao::updateOperatingPoints)
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("BBB"))
+            .let { result -> assertEquals(1, result.size) }
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("AAA"))
+            .let { result -> assertEquals(1, result.size) }
+    }
+
+
+    @Test
+    fun `Operating points search limit restricts the amount of results`() {
+        val stringThatMatchesAll = "Operating point"
+
+        (1..20).map { index ->
+            "$stringThatMatchesAll $index"
+        }.map { name ->
+            createTestOperatingPoint(
+                name = name,
+                abbreviation = "unused",
+            )
+        }.let(operatingPointDao::updateOperatingPoints)
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText(stringThatMatchesAll)) // Limit should be 10 by default.
+            .let { result -> assertEquals(10, result.size) }
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText(stringThatMatchesAll), resultLimit = 5)
+            .let { result -> assertEquals(5, result.size) }
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText(stringThatMatchesAll), resultLimit = 30)
+            .let { result -> assertEquals(20, result.size) }
+    }
+
+    @Test
+    fun `Operating points search results are sorted by name`() {
+        val operatingPointNames = listOf(
+            "BBB 1",
+            "CCC 1",
+            "AAA 1",
+        )
+
+        operatingPointNames.map { name ->
+            createTestOperatingPoint(
+                name = name,
+                abbreviation = "unused",
+            )
+        }.let(operatingPointDao::updateOperatingPoints)
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("1"))
+            .let { result ->
+                assertEquals(3, result.size)
+
+                assertEquals(operatingPointNames[2], result[0].name)
+                assertEquals(operatingPointNames[0], result[1].name)
+                assertEquals(operatingPointNames[1], result[2].name)
+            }
+    }
+
+    @Test
+    fun `Operating points search only matches name or abbreviation, not both`() {
+        listOf(
+            createTestOperatingPoint(
+                name = "AAA",
+                abbreviation = "AAA",
+            )
+        ).let(operatingPointDao::updateOperatingPoints)
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("A"))
+            .let { result ->
+                assertEquals(1, result.size)
+
+                assertEquals("AAA", result[0].name)
+                assertEquals("AAA", result[0].abbreviation)
+            }
+    }
+
+    @Test
+    fun `Operating points search finds mixed results (match by name or abbreviation)`() {
+        listOf(
+            createTestOperatingPoint(
+                name = "AAA",
+                abbreviation = "BBB",
+            ),
+
+            createTestOperatingPoint(
+                name = "BBB",
+                abbreviation = "AAA",
+            ),
+        ).let(operatingPointDao::updateOperatingPoints)
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("A"))
+            .let { result ->
+                assertEquals(2, result.size)
+            }
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("B"))
+            .let { result ->
+                assertEquals(2, result.size)
+            }
+    }
+
+    @Test
+    fun `Operating points search finds matches case-insensitively`() {
+        listOf(
+            createTestOperatingPoint(
+                name = "AAA",
+                abbreviation = "unused",
+            ),
+
+            createTestOperatingPoint(
+                name = "unused",
+                abbreviation = "bbb",
+            ),
+        ).let(operatingPointDao::updateOperatingPoints)
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("a"))
+            .let { result ->
+                assertEquals(1, result.size)
+                assertEquals("AAA", result[0].name)
+            }
+
+        ratkoLocalService
+            .searchOperatingPoints(FreeText("B"))
+            .let { result ->
+                assertEquals(1, result.size)
+                assertEquals("bbb", result[0].abbreviation)
+            }
+    }
+
+    private fun createTestOperatingPoint(
+        name: String,
+        abbreviation: String,
+        ratkoRouteNumberOid: Oid<RatkoRouteNumber>? = null,
+    ): RatkoOperatingPointParse {
+
+        val trackNumberExternalId: Oid<RatkoRouteNumber> = when {
+            ratkoRouteNumberOid != null -> ratkoRouteNumberOid
+            else -> Oid(getOrCreateTrackNumber(getUnusedTrackNumber()).externalId!!.toString())
+        }
+
+        return RatkoOperatingPointParse(
+            externalId = someOid(),
+            name = name,
+            abbreviation = abbreviation,
+            uicCode = "",
+            type = OperationalPointType.LP,
+            location = Point(0.0, 0.0),
+            trackNumberExternalId = trackNumberExternalId,
+        )
+    }
+}
+

--- a/ui/src/map/map-utils.ts
+++ b/ui/src/map/map-utils.ts
@@ -9,6 +9,8 @@ import { first } from 'utils/array-utils';
 export const MAP_POINT_DEFAULT_BBOX_OFFSET = 178;
 export const MAP_POINT_NEAR_BBOX_OFFSET = 78;
 export const MAP_POINT_CLOSEUP_BBOX_OFFSET = 38;
+export const MAP_POINT_OPERATING_POINT_BBOX_OFFSET = 500;
+
 const LAST_RESOLUTION_INDEX = 21;
 
 // Resolutions to use to load stuff from backend

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -45,7 +45,10 @@ import { TabHeader } from 'geoviite-design-lib/tab-header/tab-header';
 import { createClassName } from 'vayla-design-lib/utils';
 import { WorkspaceDialog } from 'tool-bar/workspace-dialog';
 import { EnvRestricted } from 'environment/env-restricted';
-import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
+import {
+    calculateBoundingBoxToShowAroundLocation,
+    MAP_POINT_OPERATING_POINT_BBOX_OFFSET,
+} from 'map/map-utils';
 
 export type ToolbarParams = {
     onSelect: OnSelectFunction;
@@ -251,6 +254,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
             case 'operatingPointSearchItem': {
                 const operatingPointArea = calculateBoundingBoxToShowAroundLocation(
                     item.operatingPoint.location,
+                    MAP_POINT_OPERATING_POINT_BBOX_OFFSET,
                 );
 
                 showArea(operatingPointArea);

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -8,6 +8,7 @@ import {
     LayoutSwitch,
     LayoutTrackNumber,
     LocationTrackId,
+    OperatingPoint,
 } from 'track-layout/track-layout-model';
 import { debounceAsync } from 'utils/async-utils';
 import { isNilOrBlank } from 'utils/string-utils';
@@ -44,6 +45,7 @@ import { TabHeader } from 'geoviite-design-lib/tab-header/tab-header';
 import { createClassName } from 'vayla-design-lib/utils';
 import { WorkspaceDialog } from 'tool-bar/workspace-dialog';
 import { EnvRestricted } from 'environment/env-restricted';
+import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
 
 export type ToolbarParams = {
     onSelect: OnSelectFunction;
@@ -67,17 +69,44 @@ type LocationTrackItemValue = {
     type: 'locationTrackSearchItem';
 };
 
+function createLocationTrackOptionItem(
+    locationTrack: LayoutLocationTrack,
+    description: string,
+): Item<LocationTrackItemValue> {
+    return menuValueOption(
+        {
+            type: 'locationTrackSearchItem',
+            locationTrack: locationTrack,
+        } as const,
+        `${locationTrack.name}, ${description}`,
+        `location-track-${locationTrack.id}`,
+    );
+}
+
 type SwitchItemValue = {
     layoutSwitch: LayoutSwitch;
     type: 'switchSearchItem';
 };
+
+function createSwitchOptionItem(layoutSwitch: LayoutSwitch): Item<SwitchItemValue> {
+    return menuValueOption(
+        {
+            type: 'switchSearchItem',
+            layoutSwitch: layoutSwitch,
+        } as const,
+        layoutSwitch.name,
+        `switch-${layoutSwitch.id}`,
+    );
+}
 
 type TrackNumberItemValue = {
     trackNumber: LayoutTrackNumber;
     type: 'trackNumberSearchItem';
 };
 
-function createTrackNumberItem(layoutTrackNumber: LayoutTrackNumber): Item<TrackNumberItemValue> {
+function createTrackNumberOptionItem(
+    layoutTrackNumber: LayoutTrackNumber,
+): Item<TrackNumberItemValue> {
     return menuValueOption(
         {
             type: 'trackNumberSearchItem',
@@ -88,7 +117,29 @@ function createTrackNumberItem(layoutTrackNumber: LayoutTrackNumber): Item<Track
     );
 }
 
-type SearchItemValue = LocationTrackItemValue | SwitchItemValue | TrackNumberItemValue;
+type OperatingPointItemValue = {
+    operatingPoint: OperatingPoint;
+    type: 'operatingPointSearchItem';
+};
+
+function createOperatingPointOptionItem(
+    operatingPoint: OperatingPoint,
+): Item<OperatingPointItemValue> {
+    return menuValueOption(
+        {
+            operatingPoint: operatingPoint,
+            type: 'operatingPointSearchItem',
+        } as const,
+        `${operatingPoint.name}, ${operatingPoint.abbreviation}`,
+        `operating-point-${operatingPoint.name}`,
+    );
+}
+
+type SearchItemValue =
+    | LocationTrackItemValue
+    | SwitchItemValue
+    | TrackNumberItemValue
+    | OperatingPointItemValue;
 
 async function getOptions(
     layoutContext: LayoutContext,
@@ -106,40 +157,19 @@ async function getOptions(
         layoutContext,
     );
 
-    const locationTracks: Item<LocationTrackItemValue>[] = searchResult.locationTracks.map(
-        (locationTrack) =>
-            menuValueOption(
-                {
-                    type: 'locationTrackSearchItem',
-                    locationTrack: locationTrack,
-                } as const,
-                `${locationTrack.name}, ${
-                    (locationTrackDescriptions &&
-                        locationTrackDescriptions.find((d) => d.id == locationTrack.id)
-                            ?.description) ??
-                    ''
-                }`,
-                `location-track-${locationTrack.id}`,
-            ),
-    );
+    const locationTrackOptions = searchResult.locationTracks.map((locationTrack) => {
+        const description =
+            locationTrackDescriptions?.find((d) => d.id == locationTrack.id)?.description ?? '';
 
-    const switches: Item<SwitchItemValue>[] = searchResult.switches.map((layoutSwitch) =>
-        menuValueOption(
-            {
-                type: 'switchSearchItem',
-                layoutSwitch: layoutSwitch,
-            } as const,
-            layoutSwitch.name,
-            `switch-${layoutSwitch.id}`,
-        ),
-    );
+        return createLocationTrackOptionItem(locationTrack, description);
+    });
 
-    const trackNumbers: Item<TrackNumberItemValue>[] =
-        searchResult.trackNumbers.map(createTrackNumberItem);
-
-    return await Promise.all([locationTracks, switches, trackNumbers]).then((results) =>
-        results.flat(),
-    );
+    return [
+        searchResult.operatingPoints.map(createOperatingPointOptionItem),
+        locationTrackOptions,
+        searchResult.switches.map(createSwitchOptionItem),
+        searchResult.trackNumbers.map(createTrackNumberOptionItem),
+    ].flat();
 }
 
 export const ToolBar: React.FC<ToolbarParams> = ({
@@ -213,7 +243,20 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     );
 
     function onItemSelected(item: SearchItemValue | undefined) {
-        switch (item?.type) {
+        if (!item) {
+            return;
+        }
+
+        switch (item.type) {
+            case 'operatingPointSearchItem': {
+                const operatingPointArea = calculateBoundingBoxToShowAroundLocation(
+                    item.operatingPoint.location,
+                );
+
+                showArea(operatingPointArea);
+                return;
+            }
+
             case 'locationTrackSearchItem':
                 item.locationTrack.boundingBox && showArea(item.locationTrack.boundingBox);
                 return onSelect({
@@ -256,7 +299,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                 });
 
             default:
-                return;
+                return exhaustiveMatchingGuard(item);
         }
     }
 

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -301,9 +301,19 @@ export type SwitchJointTrackMeter = {
     location: Point;
 };
 
+export type OperationalPointType =
+    | 'LP' // Liikennepaikka
+    | 'LPO' // Liikennepaikan osa
+    | 'OLP' // Osiin jaettu liikennepaikka
+    | 'SEIS' // Seisake
+    | 'LVH'; // Linjavaihde
+
 export type OperatingPoint = {
+    externalId: Oid;
     name: string;
     abbreviation: string;
+    uicCode: string;
+    type: OperationalPointType;
     location: Point;
 };
 

--- a/ui/src/track-layout/track-layout-search-api.ts
+++ b/ui/src/track-layout/track-layout-search-api.ts
@@ -3,6 +3,7 @@ import {
     LayoutSwitch,
     LayoutTrackNumber,
     LocationTrackId,
+    OperatingPoint,
 } from 'track-layout/track-layout-model';
 import { getNonNull, queryParams } from 'api/api-fetch';
 import { TRACK_LAYOUT_URI, contextInUri } from 'track-layout/track-layout-api';
@@ -12,6 +13,7 @@ export interface LayoutSearchResult {
     switches: LayoutSwitch[];
     locationTracks: LayoutLocationTrack[];
     trackNumbers: LayoutTrackNumber[];
+    operatingPoints: OperatingPoint[];
 }
 
 export async function getBySearchTerm(


### PR DESCRIPTION
Previously track numbers, location tracks and switches could be searched in the map view. As operating points are now also available in the database of Geoviite, it seemed useful for the user to be able to also search for operating points.