### PR TITLE
GVT-2575: Bäkkärin kielen enumisointi - Part Deux

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationLanguage.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationLanguage.kt
@@ -1,3 +1,8 @@
 package fi.fta.geoviite.infra.localization
 
-enum class LocalizationLanguage { FI, EN }
+enum class LocalizationLanguage {
+    FI,
+    EN;
+
+    fun lowercase() = name.lowercase()
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
@@ -60,7 +60,7 @@ data class Translation(val lang: LocalizationLanguage, val localization: String)
 class TranslationCache {
     private val translations = ConcurrentHashMap<LocalizationLanguage, Translation>()
     fun getOrLoadTranslation(lang: LocalizationLanguage): Translation = translations.getOrPut(lang) {
-        this::class.java.classLoader.getResource("i18n/translations.${lang}.json")
+        this::class.java.classLoader.getResource("i18n/translations.${lang.lowercase()}.json")
             .let { Translation(lang, it?.readText() ?: "") }
     }
 }
@@ -70,7 +70,7 @@ class LocalizationService(@Value("\${geoviite.i18n.override-path:}") val overrid
     val translationCache = TranslationCache()
 
     fun getLocalization(language: LocalizationLanguage): Translation = if (overridePath.isNotEmpty()) {
-        Translation(language, File("${overridePath}translations.${language}.json").readText())
+        Translation(language, File("${overridePath}translations.${language.lowercase()}.json").readText())
     } else {
         translationCache.getOrLoadTranslation(language)
     }


### PR DESCRIPTION
... Turns out että kielten nimethän pitää kirjoittaa pienellä kun haetaan käännöstiedostoa. En tosin tiedä yhtään miksi kaikki toimi mulla lokaalisti ilman tuotakin 🤷 GitHub ja AWS tuohon räjähtivät.