### PR TITLE
GVT-2397, GVT-2398, GVT.-2399, GVT-2400, GVT-2401 Include layout branch in API, controllers & services

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/Privileges.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/Privileges.kt
@@ -12,5 +12,6 @@ const val AUTH_VIEW_PUBLICATION = "hasAuthority('view-publication')"
 const val AUTH_DOWNLOAD_PUBLICATION = "hasAuthority('download-publication')"
 const val AUTH_VIEW_PV_DOCUMENTS = "hasAuthority('view-pv-documents')"
 
+const val LAYOUT_BRANCH = "layoutBranch"
 const val PUBLICATION_STATE = "publicationState"
 const val AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE = "(#$PUBLICATION_STATE.name() == 'DRAFT' && $AUTH_VIEW_LAYOUT_DRAFT) || (#$PUBLICATION_STATE.name() == 'OFFICIAL' && $AUTH_VIEW_LAYOUT)"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/LayoutContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/LayoutContext.kt
@@ -10,6 +10,11 @@ enum class PublicationState { OFFICIAL, DRAFT }
 
 enum class LayoutBranchType { MAIN, DESIGN }
 
+fun assertMainBranch(branch: LayoutBranch) = require(branch == LayoutBranch.main) {
+    // TODO: GVT-2397, GVT-2398, GVT-2401: DAO support missing for fetching design branch data
+    "Design branch use is not yet supported"
+}
+
 sealed class LayoutBranch {
     companion object {
         @JvmStatic
@@ -26,6 +31,10 @@ sealed class LayoutBranch {
             "Value is not a ${LayoutBranch::class.simpleName}: ${formatForException(value)}"
         }
     }
+
+    val draft by lazy { LayoutContext.of(this, PublicationState.DRAFT) }
+
+    val official by lazy { LayoutContext.of(this, PublicationState.OFFICIAL) }
 
     open val designId: IntId<LayoutDesign>? get() = null
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
@@ -3,7 +3,7 @@ package fi.fta.geoviite.infra.geocoding
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.configuration.layoutCacheDuration
 import fi.fta.geoviite.infra.logging.serviceCall
@@ -42,12 +42,12 @@ class AddressPointsCache(
 
     @Transactional(readOnly = true)
     fun getAddressPointCacheKey(
-        publicationState: PublicationState,
+        layoutContext: LayoutContext,
         locationTrackId: IntId<LocationTrack>,
     ): AddressPointCacheKey? {
-        return locationTrackDao.fetchVersion(locationTrackId, publicationState)?.let { trackVersion ->
+        return locationTrackDao.fetchVersion(layoutContext, locationTrackId)?.let { trackVersion ->
             val track = locationTrackDao.fetch(trackVersion)
-            val contextCacheKey = geocodingDao.getLayoutGeocodingContextCacheKey(publicationState, track.trackNumberId)
+            val contextCacheKey = geocodingDao.getLayoutGeocodingContextCacheKey(layoutContext, track.trackNumberId)
             if (track.alignmentVersion != null && contextCacheKey != null) {
                 AddressPointCacheKey(track.alignmentVersion, contextCacheKey)
             } else {
@@ -56,8 +56,9 @@ class AddressPointsCache(
         }
     }
 
-    /** This is for caching address points. Please don't call this directly if possible, please
-    prefer GeocodingService's getAddressPoints method instead
+    /**
+     * This is for caching address points. Please don't call this directly if possible, please
+     * prefer GeocodingService's getAddressPoints method instead
      **/
     fun getAddressPoints(cacheKey: AddressPointCacheKey): AlignmentAddresses? {
         logger.serviceCall("getAddressPoints", "cacheKey" to cacheKey)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingCacheService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingCacheService.kt
@@ -1,7 +1,7 @@
 package fi.fta.geoviite.infra.geocoding
 
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.configuration.CACHE_GEOCODING_CONTEXTS
@@ -11,7 +11,15 @@ import fi.fta.geoviite.infra.geometry.PlanLayoutService
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.map.MapAlignmentType
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -96,8 +104,11 @@ class GeocodingCacheService(
         val startAddress = plan?.startAddress
         val referenceLine = plan?.let(::getGeometryGeocodingContextReferenceLine)
 
-        return if (startAddress == null || referenceLine == null) null
-        else GeocodingContext.create(key.trackNumber, startAddress, referenceLine, plan.kmPosts)
+        return if (startAddress == null || referenceLine == null) {
+            null
+        } else {
+            GeocodingContext.create(key.trackNumber, startAddress, referenceLine, plan.kmPosts)
+        }
     }
 
     private fun getGeometryGeocodingContextReferenceLine(plan: GeometryPlanLayout): PlanLayoutAlignment? {
@@ -109,10 +120,10 @@ class GeocodingCacheService(
 
     @Transactional(readOnly = true)
     fun getGeocodingContextCreateResult(
-        publicationState: PublicationState,
+        layoutContext: LayoutContext,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): GeocodingContextCreateResult? = geocodingDao
-        .getLayoutGeocodingContextCacheKey(publicationState, trackNumberId)
+        .getLayoutGeocodingContextCacheKey(layoutContext, trackNumberId)
         ?.let(geocodingCacheService::getGeocodingContextWithReasons)
 
     @Transactional(readOnly = true)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -1,8 +1,15 @@
 package fi.fta.geoviite.infra.geometry
 
 import fi.fta.geoviite.infra.authorization.UserName
-import fi.fta.geoviite.infra.common.*
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.IndexedId
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.MainLayoutContext
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.common.Srid
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.error.DeletingFailureException
 import fi.fta.geoviite.infra.geocoding.AlignmentStartAndEnd
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
@@ -20,7 +27,20 @@ import fi.fta.geoviite.infra.localization.LocalizationLanguage
 import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.BoundingBox
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
+import fi.fta.geoviite.infra.tracklayout.ElementListingFile
+import fi.fta.geoviite.infra.tracklayout.ElementListingFileDao
+import fi.fta.geoviite.infra.tracklayout.IAlignment
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.toAlignmentHeader
+import fi.fta.geoviite.infra.tracklayout.toTrackLayoutSwitch
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.SortOrder
@@ -207,27 +227,48 @@ class GeometryService @Autowired constructor(
         return geometryDao.fetchDuplicateGeometryPlanVersion(newFile, source)?.let(geometryDao::getPlanHeader)
     }
 
+    private fun getSwitchName(context: LayoutContext, switchId: IntId<TrackLayoutSwitch>): SwitchName =
+        switchService.get(context, switchId)?.name ?: SwitchName("-")
+
     @Transactional(readOnly = true)
-    fun getElementListing(planId: IntId<GeometryPlan>, elementTypes: List<GeometryElementType>): List<ElementListing> {
-        logger.serviceCall("getElementListing", "planId" to planId, "elementTypes" to elementTypes)
+    fun getElementListing(
+        planId: IntId<GeometryPlan>,
+        elementTypes: List<GeometryElementType>,
+    ): List<ElementListing> {
+        logger.serviceCall(
+            "getElementListing",
+            "planId" to planId,
+            "elementTypes" to elementTypes,
+        )
         val planVersion = geometryDao.fetchPlanVersion(planId)
         val plan = geometryDao.fetchPlan(planVersion)
-        val context = plan.trackNumber?.let { geocodingService.getGeocodingContext(plan.trackNumber, planVersion) }
+        val geocodingContext = plan.trackNumber
+            ?.let { geocodingService.getGeocodingContext(plan.trackNumber, planVersion) }
 
         return toElementListing(
-            context, coordinateTransformationService::getLayoutTransformation, plan, elementTypes
-        ) { switchId -> switchService.getOrThrow(OFFICIAL, switchId).name }
+            geocodingContext,
+            coordinateTransformationService::getLayoutTransformation,
+            plan,
+            elementTypes,
+        ) { id -> getSwitchName(MainLayoutContext.official, id) }
     }
 
     @Transactional(readOnly = true)
-    fun getElementListingCsv(planId: IntId<GeometryPlan>, elementTypes: List<GeometryElementType>, lang: LocalizationLanguage): ElementListingFile {
+    fun getElementListingCsv(
+        planId: IntId<GeometryPlan>,
+        elementTypes: List<GeometryElementType>,
+        lang: LocalizationLanguage,
+    ): ElementListingFile {
         logger.serviceCall("getElementListingCsv", "planId" to planId, "elementTypes" to elementTypes, "lang" to lang)
         val plan = getPlanHeader(planId)
         val elementListing = getElementListing(planId, elementTypes)
         val translation = localizationService.getLocalization(lang)
 
         val csvFileContent = planElementListingToCsv(elementListing, translation)
-        return ElementListingFile(FileName("${translation.t("data-products.element-list.element-list-title")} ${plan.fileName}"), csvFileContent)
+        return ElementListingFile(
+            FileName("${translation.t("data-products.element-list.element-list-title")} ${plan.fileName}"),
+            csvFileContent,
+        )
     }
 
     @Transactional(readOnly = true)
@@ -244,15 +285,16 @@ class GeometryService @Autowired constructor(
             locationTrack,
             alignment,
             trackNumber,
-            TrackGeometryElementType.values().toList(),
+            TrackGeometryElementType.entries,
             null,
             null,
             ::getHeaderAndAlignment,
-        ) { switchId -> switchService.getOrThrow(OFFICIAL, switchId).name }
+        ) { id -> getSwitchName(MainLayoutContext.official, id) }
     }
 
     @Transactional(readOnly = true)
     fun getElementListing(
+        layoutContext: LayoutContext,
         trackId: IntId<LocationTrack>,
         elementTypes: List<TrackGeometryElementType>,
         startAddress: TrackMeter?,
@@ -260,13 +302,16 @@ class GeometryService @Autowired constructor(
     ): List<ElementListing> {
         logger.serviceCall(
             "getElementListing",
-            "trackId" to trackId, "elementTypes" to elementTypes,
-            "startAddress" to startAddress, "endAddress" to endAddress,
+            "layoutContext" to layoutContext,
+            "trackId" to trackId,
+            "elementTypes" to elementTypes,
+            "startAddress" to startAddress,
+            "endAddress" to endAddress,
         )
-        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(OFFICIAL, trackId)
-        val trackNumber = trackNumberService.get(OFFICIAL, track.trackNumberId)?.number
+        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(layoutContext, trackId)
+        val trackNumber = trackNumberService.get(layoutContext, track.trackNumberId)?.number
         return toElementListing(
-            geocodingService.getGeocodingContext(OFFICIAL, track.trackNumberId),
+            geocodingService.getGeocodingContext(layoutContext, track.trackNumberId),
             coordinateTransformationService::getLayoutTransformation,
             track,
             alignment,
@@ -275,11 +320,12 @@ class GeometryService @Autowired constructor(
             startAddress,
             endAddress,
             ::getHeaderAndAlignment,
-        ) { switchId -> switchService.getOrThrow(OFFICIAL, switchId).name }
+        ) { id -> getSwitchName(layoutContext, id) }
     }
 
     @Transactional(readOnly = true)
     fun getElementListingCsv(
+        layoutContext: LayoutContext,
         trackId: IntId<LocationTrack>,
         elementTypes: List<TrackGeometryElementType>,
         startAddress: TrackMeter?,
@@ -288,12 +334,15 @@ class GeometryService @Autowired constructor(
     ): ElementListingFile {
         logger.serviceCall(
             "getElementListing",
-            "trackId" to trackId, "elementTypes" to elementTypes,
-            "startAddress" to startAddress, "endAddress" to endAddress,
+            "layoutContext" to layoutContext,
+            "trackId" to trackId,
+            "elementTypes" to elementTypes,
+            "startAddress" to startAddress,
+            "endAddress" to endAddress,
             "lang" to lang
         )
-        val track = locationTrackService.getOrThrow(OFFICIAL, trackId)
-        val elementListing = getElementListing(trackId, elementTypes, startAddress, endAddress)
+        val track = locationTrackService.getOrThrow(layoutContext, trackId)
+        val elementListing = getElementListing(layoutContext, trackId, elementTypes, startAddress, endAddress)
         val translation = localizationService.getLocalization(lang)
         val csvFileContent = locationTrackElementListingToCsv(elementListing, translation)
         return ElementListingFile(FileName("${translation.t("data-products.element-list.element-list-title")} ${track.name}"), csvFileContent)
@@ -304,15 +353,16 @@ class GeometryService @Autowired constructor(
     fun makeElementListingCsv() = runElementListGeneration {
         logger.serviceCall("makeElementListingCsv")
         val translation = localizationService.getLocalization(LocalizationLanguage.FI)
-        val geocodingContexts = geocodingService.getGeocodingContexts(OFFICIAL)
+        val geocodingContexts = geocodingService.getGeocodingContexts(MainLayoutContext.official)
         val elementListing = locationTrackService
-            .list(OFFICIAL, includeDeleted = false)
-            .sortedBy { locationTrack -> locationTrack.name }
-            .map { locationTrack -> locationTrack to geocodingContexts[locationTrack.trackNumberId]?.trackNumber }
-            .sortedBy { (_, trackNumber) -> trackNumber }
-            .flatMap { (locationTrack, trackNumber) ->
-                val (_, alignment) = locationTrackService.getWithAlignmentOrThrow(OFFICIAL, locationTrack.id as IntId)
-                getElementListing(locationTrack, alignment, trackNumber, geocodingContexts[locationTrack.trackNumberId])
+            .listWithAlignments(MainLayoutContext.official, includeDeleted = false)
+            .sortedBy { (locationTrack, _) -> locationTrack.name }
+            .map { (locationTrack, alignment) ->
+                Triple(locationTrack, alignment, geocodingContexts[locationTrack.trackNumberId]?.trackNumber)
+            }
+            .sortedBy { (_, _, trackNumber) -> trackNumber }
+            .flatMap { (track, alignment, trackNumber) ->
+                getElementListing(track, alignment, trackNumber, geocodingContexts[track.trackNumberId])
             }
         val csvFileContent = locationTrackElementListingToCsv(elementListing, translation)
         val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneId.of("Europe/Helsinki"))
@@ -326,7 +376,6 @@ class GeometryService @Autowired constructor(
     }
 
     fun getElementListingCsv() = elementListingFileDao.getElementListingFile()
-
 
     fun getVerticalGeometryListing(planId: IntId<GeometryPlan>): List<VerticalGeometryListing> {
         logger.serviceCall("getVerticalGeometryListing", "planId" to planId)
@@ -351,7 +400,7 @@ class GeometryService @Autowired constructor(
 
     @Transactional(readOnly = true)
     fun getVerticalGeometryListing(
-        publicationType: PublicationState,
+        layoutContext: LayoutContext,
         locationTrackId: IntId<LocationTrack>,
         startAddress: TrackMeter? = null,
         endAddress: TrackMeter? = null,
@@ -362,8 +411,8 @@ class GeometryService @Autowired constructor(
             "startAddress" to startAddress,
             "endAddress" to endAddress
         )
-        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(publicationType, locationTrackId)
-        val geocodingContext = geocodingService.getGeocodingContext(publicationType, track.trackNumberId)
+        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(layoutContext, locationTrackId)
+        val geocodingContext = geocodingService.getGeocodingContext(layoutContext, track.trackNumberId)
         return toVerticalGeometryListing(
             track,
             alignment,
@@ -385,30 +434,33 @@ class GeometryService @Autowired constructor(
             "getVerticalGeometryListingCsv",
             "trackId" to locationTrackId,
             "startAddress" to startAddress,
-            "endAddress" to endAddress
+            "endAddress" to endAddress,
         )
-        val locationTrack = locationTrackService.getOrThrow(OFFICIAL, locationTrackId)
-        val verticalGeometryListing = getVerticalGeometryListing(OFFICIAL, locationTrackId, startAddress, endAddress)
+        val locationTrack = locationTrackService.getOrThrow(MainLayoutContext.official, locationTrackId)
+        val verticalGeometryListing = getVerticalGeometryListing(MainLayoutContext.official, locationTrackId, startAddress, endAddress)
         val translation = localizationService.getLocalization(lang)
 
         val csvFileContent = locationTrackVerticalGeometryListingToCsv(verticalGeometryListing, translation)
-        return FileName("${translation.t("data-products.vertical-geometry.vertical-geometry-title")} ${locationTrack.name}") to csvFileContent.toByteArray()
+        val name = FileName(
+            "${translation.t("data-products.vertical-geometry.vertical-geometry-title")} ${locationTrack.name}"
+        )
+        return name to csvFileContent.toByteArray()
     }
 
     @Scheduled(cron = "\${geoviite.rail-network-export.vertical-geometry-schedule}")
     @Scheduled(initialDelay = 1000 * 300, fixedDelay = Long.MAX_VALUE)
     fun makeEntireVerticalGeometryListingCsv() = runVerticalGeometryListGeneration {
         logger.serviceCall("makeEntireVerticalGeometryListingCsv")
-        val geocodingContexts = geocodingService.getGeocodingContexts(OFFICIAL)
+        val geocodingContexts = geocodingService.getGeocodingContexts(MainLayoutContext.official)
         val verticalGeometryListingWithTrackNumbers =
-            locationTrackService.list(OFFICIAL, includeDeleted = false).sortedWith(
+            locationTrackService.list(MainLayoutContext.official, includeDeleted = false).sortedWith(
                 compareBy(
                     { locationTrack -> geocodingContexts[locationTrack.trackNumberId]?.trackNumber },
                     { locationTrack -> locationTrack.name },
                 )
             ).flatMap { locationTrack ->
                 val verticalGeometryListingWithoutTrackNumbers =
-                    getVerticalGeometryListing(OFFICIAL, locationTrack.id as IntId)
+                    getVerticalGeometryListing(MainLayoutContext.official, locationTrack.id as IntId)
 
                 verticalGeometryListingWithoutTrackNumbers.map { verticalGeometryListing ->
                     verticalGeometryListing.copy(
@@ -424,7 +476,7 @@ class GeometryService @Autowired constructor(
         verticalGeometryListingFileDao.upsertVerticalGeometryListingFile(
             VerticalGeometryListingFile(
                 name = FileName("${translation.t("data-products.vertical-geometry.vertical-geometry-whole-network-title")} ${dateFormatter.format(Instant.now())}"),
-                content = csvFileContent
+                content = csvFileContent,
             )
         )
     }
@@ -514,10 +566,10 @@ class GeometryService @Autowired constructor(
 
     @Transactional(readOnly = true)
     fun getLocationTrackGeometryLinkingSummary(
+        layoutContext: LayoutContext,
         locationTrackId: IntId<LocationTrack>,
-        publicationState: PublicationState,
     ): List<PlanLinkingSummaryItem>? {
-        val locationTrack = locationTrackService.get(publicationState, locationTrackId) ?: return null
+        val locationTrack = locationTrackService.get(layoutContext, locationTrackId) ?: return null
         val alignment = layoutAlignmentDao.fetch(locationTrack.alignmentVersion ?: return null)
         val segmentSources = collectSegmentSources(alignment)
         val planLinkEndSegmentIndices = segmentSources.zipWithNext { a, b -> a.plan == b.plan }
@@ -538,17 +590,17 @@ class GeometryService @Autowired constructor(
 
     @Transactional(readOnly = true)
     fun getLocationTrackHeights(
+        layoutContext: LayoutContext,
         locationTrackId: IntId<LocationTrack>,
-        publicationState: PublicationState,
         startDistance: Double,
         endDistance: Double,
         tickLength: Int,
     ): List<KmHeights>? {
-        val locationTrack = locationTrackService.get(publicationState, locationTrackId) ?: return null
+        val locationTrack = locationTrackService.get(layoutContext, locationTrackId) ?: return null
         val alignment = layoutAlignmentDao.fetch(locationTrack.alignmentVersion ?: return null)
         val boundingBox = alignment.boundingBox ?: return null
         val geocodingContext =
-            geocodingService.getGeocodingContext(publicationState, locationTrack.trackNumberId) ?: return null
+            geocodingService.getGeocodingContext(layoutContext, locationTrack.trackNumberId) ?: return null
 
         val segmentSources = collectSegmentSources(alignment)
         val alignmentLinkEndSegmentIndices = segmentSources.zipWithNext { a, b -> a.alignment == b.alignment }
@@ -727,17 +779,19 @@ class GeometryService @Autowired constructor(
     }
 
     private fun getLayoutGeocodingContextForPlanTrackNumber(trackNumber: TrackNumber?): GeocodingContext? = trackNumber
-        ?.let { number -> trackNumberService.find(number, OFFICIAL).firstOrNull()?.id }
-        ?.let { trackNumberId -> geocodingService.getGeocodingContext(OFFICIAL, trackNumberId) }
-
+        ?.let { number -> trackNumberService.find(MainLayoutContext.official, number).firstOrNull()?.id }
+        ?.let { trackNumberId -> geocodingService.getGeocodingContext(MainLayoutContext.official, trackNumberId) }
 }
 
 private fun getKmLengthAtReferencePointIndex(
     referencePointIndex: Int,
     geocodingContext: GeocodingContext,
 ) =
-    if (referencePointIndex == geocodingContext.referencePoints.size - 1) geocodingContext.referenceLineGeometry.length - geocodingContext.referencePoints[referencePointIndex].distance
-    else geocodingContext.referencePoints[referencePointIndex + 1].distance - geocodingContext.referencePoints[referencePointIndex].distance
+    if (referencePointIndex == geocodingContext.referencePoints.size - 1) {
+        geocodingContext.referenceLineGeometry.length - geocodingContext.referencePoints[referencePointIndex].distance
+    } else {
+        geocodingContext.referencePoints[referencePointIndex + 1].distance - geocodingContext.referencePoints[referencePointIndex].distance
+    }
 
 private fun trackNumbersMatch(
     header: GeometryPlanHeader,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
@@ -3,12 +3,20 @@ package fi.fta.geoviite.infra.geometry
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.configuration.planCacheDuration
-import fi.fta.geoviite.infra.geography.*
+import fi.fta.geoviite.infra.geography.CoordinateTransformationException
+import fi.fta.geoviite.infra.geography.CoordinateTransformationService
+import fi.fta.geoviite.infra.geography.HeightTriangle
+import fi.fta.geoviite.infra.geography.HeightTriangleDao
+import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.logging.serviceCall
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.toTrackLayout
 import fi.fta.geoviite.infra.util.LocalizationKey
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -99,7 +107,7 @@ class PlanLayoutCache(
         }
         val heightTriangles = heightTriangleDao.fetchTriangles(polygon)
         val trackNumberId = geometryPlan.trackNumber
-            ?.let { trackNumberDao.list(geometryPlan.trackNumber, PublicationState.OFFICIAL) }
+            ?.let { trackNumberDao.list(MainLayoutContext.official, geometryPlan.trackNumber) }
             ?.firstOrNull()
             ?.id as? IntId
 
@@ -144,16 +152,18 @@ private fun transformToLayoutPlan(
         ) to null
     } catch (e: CoordinateTransformationException) {
         logger.warn("Could not convert plan coordinates: " +
-                "id=${geometryPlan.id} " +
-                "srid=${geometryPlan.units.coordinateSystemSrid} " +
-                "file=${geometryPlan.fileName}",
-            e)
+            "id=${geometryPlan.id} " +
+            "srid=${geometryPlan.units.coordinateSystemSrid} " +
+            "file=${geometryPlan.fileName}",
+            e,
+        )
         null to TransformationError("coordinate-transformation-failed", geometryPlan.units)
     } catch (e: Exception) {
         logger.warn("Failed to convert plan to layout form: " +
-                "id=${geometryPlan.id} " +
-                "srid=${geometryPlan.units.coordinateSystemSrid} " +
-                "file=${geometryPlan.fileName}",
-            e)
+            "id=${geometryPlan.id} " +
+            "srid=${geometryPlan.units.coordinateSystemSrid} " +
+            "file=${geometryPlan.fileName}",
+            e,
+        )
         null to TransformationError("plan-transformation-failed", geometryPlan.units)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -3,12 +3,22 @@ package fi.fta.geoviite.infra.inframodel
 import fi.fta.geoviite.infra.codeDictionary.CodeDictionaryService
 import fi.fta.geoviite.infra.codeDictionary.FeatureType
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.error.InframodelParsingException
 import fi.fta.geoviite.infra.geography.CoordinateTransformationService
 import fi.fta.geoviite.infra.geography.GeographyService
-import fi.fta.geoviite.infra.geometry.*
+import fi.fta.geoviite.infra.geometry.Author
+import fi.fta.geoviite.infra.geometry.GeometryDao
+import fi.fta.geoviite.infra.geometry.GeometryPlan
+import fi.fta.geoviite.infra.geometry.GeometryService
+import fi.fta.geoviite.infra.geometry.PlanLayoutCache
+import fi.fta.geoviite.infra.geometry.PlanSource
+import fi.fta.geoviite.infra.geometry.Project
+import fi.fta.geoviite.infra.geometry.TransformationError
+import fi.fta.geoviite.infra.geometry.ValidationError
+import fi.fta.geoviite.infra.geometry.getBoundingPolygonPointsFromAlignments
+import fi.fta.geoviite.infra.geometry.validate
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
@@ -238,7 +248,7 @@ class InfraModelService @Autowired constructor(
             geometryPlan,
             codeDictionaryService.getFeatureTypes(),
             switchLibraryService.getSwitchStructuresById(),
-            trackNumberService.list(OFFICIAL).map { it.number },
+            trackNumberService.list(MainLayoutContext.official).map { it.number },
         )
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/ChangeContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/ChangeContext.kt
@@ -1,11 +1,17 @@
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.publication.ValidationVersion
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutAsset
+import fi.fta.geoviite.infra.tracklayout.LayoutAssetDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import java.time.Instant
 import kotlin.reflect.KClass
 
@@ -36,12 +42,13 @@ class ChangeContext(
 }
 
 inline fun <reified T : LayoutAsset<T>> createTypedContext(
+    branch: LayoutBranch,
     dao: LayoutAssetDao<T>,
     versions: List<ValidationVersion<T>>
 ): TypedChangeContext<T> = createTypedContext(
     dao,
-    { id -> dao.fetchVersion(id, OFFICIAL) },
-    { id -> versions.find { v -> v.officialId == id }?.validatedAssetVersion ?: dao.fetchVersion(id, OFFICIAL) },
+    { id -> dao.fetchVersion(branch.official, id) },
+    { id -> versions.find { v -> v.officialId == id }?.validatedAssetVersion ?: dao.fetchVersion(branch.official, id) },
 )
 
 inline fun <reified T : LayoutAsset<T>> createTypedContext(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
@@ -3,8 +3,11 @@ package fi.fta.geoviite.infra.linking
 import fi.fta.geoviite.infra.authorization.AUTH_EDIT_LAYOUT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT_DRAFT
+import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.geometry.GeometryPlanLinkStatus
@@ -40,84 +43,105 @@ class LinkingController @Autowired constructor(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/reference-lines/geometry")
+    @PostMapping("/{$LAYOUT_BRANCH}/reference-lines/geometry")
     fun saveReferenceLineLinking(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @RequestBody linkingParameters: LinkingParameters<ReferenceLine>,
     ): IntId<ReferenceLine> {
-        logger.apiCall("saveReferenceLineLinking", "linkingParameters" to linkingParameters)
-        return linkingService.saveReferenceLineLinking(linkingParameters)
+        logger.apiCall("saveReferenceLineLinking", "branch" to branch, "linkingParameters" to linkingParameters)
+        return linkingService.saveReferenceLineLinking(branch, linkingParameters)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/location-tracks/geometry")
+    @PostMapping("/{$LAYOUT_BRANCH}/location-tracks/geometry")
     fun saveLocationTrackLinking(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @RequestBody linkingParameters: LinkingParameters<LocationTrack>,
     ): IntId<LocationTrack> {
-        logger.apiCall("saveLocationTrackLinking", "linkingParameters" to linkingParameters)
-        return linkingService.saveLocationTrackLinking(linkingParameters)
+        logger.apiCall("saveLocationTrackLinking", "branch" to branch, "linkingParameters" to linkingParameters)
+        return linkingService.saveLocationTrackLinking(branch, linkingParameters)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/reference-lines/empty-geometry")
+    @PostMapping("/{$LAYOUT_BRANCH}/reference-lines/empty-geometry")
     fun saveEmptyReferenceLineLinking(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @RequestBody linkingParameters: EmptyAlignmentLinkingParameters<ReferenceLine>,
     ): IntId<ReferenceLine> {
-        logger.apiCall("saveEmptyReferenceLineLinking", "linkingParameters" to linkingParameters)
-        return linkingService.saveReferenceLineLinking(linkingParameters)
+        logger.apiCall("saveEmptyReferenceLineLinking", "branch" to branch, "linkingParameters" to linkingParameters)
+        return linkingService.saveReferenceLineLinking(branch, linkingParameters)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/location-tracks/empty-geometry")
+    @PostMapping("/{$LAYOUT_BRANCH}/location-tracks/empty-geometry")
     fun saveEmptyLocationTrackLinking(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @RequestBody linkingParameters: EmptyAlignmentLinkingParameters<LocationTrack>,
     ): IntId<LocationTrack> {
-        logger.apiCall("saveEmptyLocationTrackLinking", "linkingParameters" to linkingParameters)
-        return linkingService.saveLocationTrackLinking(linkingParameters)
+        logger.apiCall("saveEmptyLocationTrackLinking", "branch" to branch, "linkingParameters" to linkingParameters)
+        return linkingService.saveLocationTrackLinking(branch, linkingParameters)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PutMapping("/location-tracks/{id}/geometry")
+    @PutMapping("/{$LAYOUT_BRANCH}/location-tracks/{id}/geometry")
     fun updateLocationTrackGeometry(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable("id") alignmentId: IntId<LocationTrack>,
         @RequestBody mRange: Range<Double>,
     ): IntId<LocationTrack> {
-        logger.apiCall("updateLocationTrackGeometry", "alignmentId" to alignmentId, "mRange" to mRange)
-        return linkingService.updateLocationTrackGeometry(alignmentId, mRange)
+        logger.apiCall(
+            "updateLocationTrackGeometry",
+            "branch" to branch,
+            "alignmentId" to alignmentId,
+            "mRange" to mRange,
+        )
+        return linkingService.updateLocationTrackGeometry(branch, alignmentId, mRange)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PutMapping("/reference-lines/{id}/geometry")
+    @PutMapping("/{$LAYOUT_BRANCH}/reference-lines/{id}/geometry")
     fun updateReferenceLineGeometry(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable("id") alignmentId: IntId<ReferenceLine>,
         @RequestBody mRange: Range<Double>,
     ): IntId<ReferenceLine> {
-        logger.apiCall("updateReferenceLineGeometry", "alignmentId" to alignmentId, "mRange" to mRange)
-        return linkingService.updateReferenceLineGeometry(alignmentId, mRange)
+        logger.apiCall(
+            "updateReferenceLineGeometry",
+            "branch" to branch,
+            "alignmentId" to alignmentId,
+            "mRange" to mRange,
+        )
+        return linkingService.updateReferenceLineGeometry(branch, alignmentId, mRange)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("{$PUBLICATION_STATE}/plans/{id}/status")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/plans/{id}/status")
     fun getPlanLinkStatus(
-        @PathVariable("id") planId: IntId<GeometryPlan>,
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
+        @PathVariable("id") planId: IntId<GeometryPlan>,
     ): GeometryPlanLinkStatus {
-        logger.apiCall("getPlanLinkStatus", "planId" to planId, PUBLICATION_STATE to publicationState)
-        return linkingService.getGeometryPlanLinkStatus(planId = planId, publicationState = publicationState)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getPlanLinkStatus", "layoutContext" to layoutContext, "planId" to planId)
+        return linkingService.getGeometryPlanLinkStatus(layoutContext, planId)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("{$PUBLICATION_STATE}/plans/status")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/plans/status")
     fun getManyPlanLinkStatuses(
-        @RequestParam("ids") planIds: List<IntId<GeometryPlan>>,
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
+        @RequestParam("ids") planIds: List<IntId<GeometryPlan>>,
     ): List<GeometryPlanLinkStatus> {
-        logger.apiCall("getManyPlanLinkStatuses", PUBLICATION_STATE to publicationState)
-        return linkingService.getGeometryPlanLinkStatuses(planIds = planIds, publicationState = publicationState)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getManyPlanLinkStatuses", "layoutContext" to layoutContext)
+        return linkingService.getGeometryPlanLinkStatuses(layoutContext, planIds)
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
-    @GetMapping("/location-tracks/suggested")
+    @GetMapping("/{$LAYOUT_BRANCH}/location-tracks/suggested")
     fun getSuggestedConnectedLocationTracks(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @RequestParam("id") locationTrackId: IntId<LocationTrack>,
         @RequestParam("location") location: Point,
         @RequestParam("locationTrackPointUpdateType") locationTrackPointUpdateType: LocationTrackPointUpdateType,
@@ -125,12 +149,15 @@ class LinkingController @Autowired constructor(
     ): List<LocationTrack> {
         logger.apiCall(
             "getSuggestedConnectedLocationTracks",
+            "branch" to branch,
+            "branch" to branch,
             "locationTrackId" to locationTrackId,
             "location" to location,
             "locationTrackPointUpdateType" to locationTrackPointUpdateType,
             "bbox" to bbox,
         )
         return linkingService.getSuggestedAlignments(
+            branch,
             locationTrackId,
             location,
             locationTrackPointUpdateType,
@@ -139,61 +166,79 @@ class LinkingController @Autowired constructor(
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
-    @GetMapping("/switches/suggested", params = ["bbox"])
-    fun getSuggestedSwitches(@RequestParam("bbox") bbox: BoundingBox): List<SuggestedSwitch> {
-        logger.apiCall("getSuggestedSwitches", "bbox" to bbox)
-        return switchLinkingService.getSuggestedSwitches(bbox)
+    @GetMapping("/{$LAYOUT_BRANCH}/switches/suggested", params = ["bbox"])
+    fun getSuggestedSwitches(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestParam("bbox") bbox: BoundingBox,
+    ): List<SuggestedSwitch> {
+        logger.apiCall("getSuggestedSwitches", "branch" to branch, "bbox" to bbox)
+        return switchLinkingService.getSuggestedSwitches(branch, bbox)
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
-    @GetMapping("/switches/suggested", params = ["location", "switchId"])
+    @GetMapping("/{$LAYOUT_BRANCH}/switches/suggested", params = ["location", "switchId"])
     fun getSuggestedSwitches(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @RequestParam("location") location: Point,
         @RequestParam("switchId") switchId: IntId<TrackLayoutSwitch>,
     ): List<SuggestedSwitch> {
-        logger.apiCall("getSuggestedSwitches", "location" to location, "switchId" to switchId)
-        return listOfNotNull(switchLinkingService.getSuggestedSwitch(location, switchId))
+        logger.apiCall("getSuggestedSwitches", "branch" to branch, "location" to location, "switchId" to switchId)
+        return listOfNotNull(switchLinkingService.getSuggestedSwitch(branch, location, switchId))
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/switches/suggested")
-    fun getSuggestedSwitch(@RequestBody createParams: SuggestedSwitchCreateParams): List<SuggestedSwitch> {
-        logger.apiCall("getSuggestedSwitch", "createParams" to createParams)
-        return listOfNotNull(switchLinkingService.getSuggestedSwitch(createParams))
+    @PostMapping("/{$LAYOUT_BRANCH}/switches/suggested")
+    fun getSuggestedSwitch(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody createParams: SuggestedSwitchCreateParams,
+    ): List<SuggestedSwitch> {
+        logger.apiCall("getSuggestedSwitch", "branch" to branch, "createParams" to createParams)
+        return listOfNotNull(switchLinkingService.getSuggestedSwitch(branch, createParams))
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/switches/{switchId}/geometry")
+    @PostMapping("/{$LAYOUT_BRANCH}/switches/{switchId}/geometry")
     fun saveSwitchLinking(
-        @RequestBody suggestedSwitch: SuggestedSwitch,
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable switchId: IntId<TrackLayoutSwitch>,
+        @RequestBody suggestedSwitch: SuggestedSwitch,
     ): IntId<TrackLayoutSwitch> {
         logger.apiCall(
             "saveSwitchLinking",
+            "branch" to branch,
             "switchLinkingParameters" to suggestedSwitch,
             "switchId" to switchId,
         )
-        return switchLinkingService.saveSwitchLinking(suggestedSwitch, switchId).id
+        return switchLinkingService.saveSwitchLinking(branch, suggestedSwitch, switchId).id
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/km-posts/geometry")
-    fun saveKmPostLinking(@RequestBody linkingParameters: KmPostLinkingParameters): IntId<TrackLayoutKmPost> {
-        logger.apiCall("saveKmPostLinking", "linkingParameters" to linkingParameters)
-        return linkingService.saveKmPostLinking(linkingParameters).id
+    @PostMapping("/{$LAYOUT_BRANCH}/km-posts/geometry")
+    fun saveKmPostLinking(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody linkingParameters: KmPostLinkingParameters,
+    ): IntId<TrackLayoutKmPost> {
+        logger.apiCall("saveKmPostLinking", "branch" to branch, "linkingParameters" to linkingParameters)
+        return linkingService.saveKmPostLinking(branch, linkingParameters).id
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
-    @GetMapping("/validate-relinking-track/{id}")
-    fun validateRelinkingTrack(@PathVariable("id") id: IntId<LocationTrack>): List<SwitchRelinkingValidationResult> {
-        logger.apiCall("validateRelinkingTrack", "id" to id)
-        return switchLinkingService.validateRelinkingTrack(id)
+    @GetMapping("/{$LAYOUT_BRANCH}/location-tracks/{id}/validate-relinking")
+    fun validateRelinkingTrack(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @PathVariable("id") id: IntId<LocationTrack>,
+    ): List<SwitchRelinkingValidationResult> {
+        logger.apiCall("validateRelinkingTrack", "branch" to branch, "id" to id)
+        return switchLinkingService.validateRelinkingTrack(branch, id)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/relink-track-switches/{id}")
-    fun relinkTrackSwitches(@PathVariable("id") id: IntId<LocationTrack>): List<TrackSwitchRelinkingResult> {
-        logger.apiCall("relinkTrackSwitches", "id" to id)
-        return switchLinkingService.relinkTrack(id)
+    @PostMapping("/{$LAYOUT_BRANCH}/location-tracks/{id}/relink-switches")
+    fun relinkTrackSwitches(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @PathVariable("id") id: IntId<LocationTrack>,
+    ): List<TrackSwitchRelinkingResult> {
+        logger.apiCall("relinkTrackSwitches", "branch" to branch, "id" to id)
+        return switchLinkingService.relinkTrack(branch, id)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
@@ -150,7 +150,6 @@ class LinkingController @Autowired constructor(
         logger.apiCall(
             "getSuggestedConnectedLocationTracks",
             "branch" to branch,
-            "branch" to branch,
             "locationTrackId" to locationTrackId,
             "location" to location,
             "locationTrackPointUpdateType" to locationTrackPointUpdateType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -171,6 +171,7 @@ data class ValidatedAsset<T>(
 )
 
 data class PublicationCandidates(
+    val branch: LayoutBranch,
     val trackNumbers: List<TrackNumberPublicationCandidate>,
     val locationTracks: List<LocationTrackPublicationCandidate>,
     val referenceLines: List<ReferenceLinePublicationCandidate>,
@@ -185,7 +186,11 @@ data class PublicationCandidates(
         kmPosts.map { candidate -> candidate.id },
     )
 
-    fun getValidationVersions(splitVersions: List<ValidationVersion<Split>>) = ValidationVersions(
+    fun getValidationVersions(
+        branch: LayoutBranch,
+        splitVersions: List<ValidationVersion<Split>>,
+    ) = ValidationVersions(
+        branch = branch,
         trackNumbers = trackNumbers.map(TrackNumberPublicationCandidate::getPublicationVersion),
         referenceLines = referenceLines.map(ReferenceLinePublicationCandidate::getPublicationVersion),
         locationTracks = locationTracks.map(LocationTrackPublicationCandidate::getPublicationVersion),
@@ -194,7 +199,7 @@ data class PublicationCandidates(
         splits = splitVersions,
     )
 
-    fun filter(request: PublicationRequestIds) = PublicationCandidates(
+    fun filter(request: PublicationRequestIds) = copy(
         trackNumbers = trackNumbers.filter { candidate -> request.trackNumbers.contains(candidate.id) },
         referenceLines = referenceLines.filter { candidate -> request.referenceLines.contains(candidate.id) },
         locationTracks = locationTracks.filter { candidate -> request.locationTracks.contains(candidate.id) },
@@ -214,6 +219,7 @@ data class PublicationCandidates(
 }
 
 data class ValidationVersions(
+    val branch: LayoutBranch,
     val trackNumbers: List<ValidationVersion<TrackLayoutTrackNumber>>,
     val locationTracks: List<ValidationVersion<LocationTrack>>,
     val referenceLines: List<ValidationVersion<ReferenceLine>>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -4,7 +4,9 @@ import fi.fta.geoviite.infra.authorization.AUTH_DOWNLOAD_PUBLICATION
 import fi.fta.geoviite.infra.authorization.AUTH_EDIT_LAYOUT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT_DRAFT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_PUBLICATION
+import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.error.PublicationFailureException
 import fi.fta.geoviite.infra.integration.CalculatedChanges
 import fi.fta.geoviite.infra.integration.CalculatedChangesService
@@ -23,7 +25,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
@@ -42,35 +51,44 @@ class PublicationController @Autowired constructor(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
-    @GetMapping("/candidates")
-    fun getPublicationCandidates(): PublicationCandidates {
-        logger.apiCall("getPublicationCandidates")
-        return publicationService.collectPublicationCandidates()
+    @GetMapping("/{$LAYOUT_BRANCH}/candidates")
+    fun getPublicationCandidates(@PathVariable(LAYOUT_BRANCH) branch: LayoutBranch): PublicationCandidates {
+        logger.apiCall("getPublicationCandidates", "branch" to branch)
+        return publicationService.collectPublicationCandidates(branch)
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
-    @PostMapping("/validate")
-    fun validatePublicationCandidates(@RequestBody request: PublicationRequestIds): ValidatedPublicationCandidates {
-        logger.apiCall("validatePublicationCandidates", "request" to request)
+    @PostMapping("/{$LAYOUT_BRANCH}/validate")
+    fun validatePublicationCandidates(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody request: PublicationRequestIds,
+    ): ValidatedPublicationCandidates {
+        logger.apiCall("validatePublicationCandidates", "branch" to branch, "request" to request)
         return publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(),
+            publicationService.collectPublicationCandidates(branch),
             request,
         )
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
-    @PostMapping("/calculated-changes")
-    fun getCalculatedChanges(@RequestBody request: PublicationRequestIds): CalculatedChanges {
-        logger.apiCall("getCalculatedChanges", "request" to request)
-        return calculatedChangesService.getCalculatedChanges(publicationService.getValidationVersions(request))
+    @PostMapping("/{$LAYOUT_BRANCH}/calculated-changes")
+    fun getCalculatedChanges(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody request: PublicationRequestIds,
+    ): CalculatedChanges {
+        logger.apiCall("getCalculatedChanges", "branch" to branch, "request" to request)
+        return calculatedChangesService.getCalculatedChanges(publicationService.getValidationVersions(branch, request))
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @DeleteMapping("/candidates")
-    fun revertPublicationCandidates(@RequestBody toDelete: PublicationRequestIds): PublicationResult {
-        logger.apiCall("revertPublicationCandidates", "toDelete" to toDelete)
+    @DeleteMapping("/{$LAYOUT_BRANCH}/candidates")
+    fun revertPublicationCandidates(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody toDelete: PublicationRequestIds,
+    ): PublicationResult {
+        logger.apiCall("revertPublicationCandidates", "branch" to branch, "toDelete" to toDelete)
         return lockDao.runWithLock(PUBLICATION, publicationMaxDuration) {
-            publicationService.revertPublicationCandidates(toDelete)
+            publicationService.revertPublicationCandidates(branch, toDelete)
         } ?: throw PublicationFailureException(
             message = "Could not reserve publication lock",
             localizedMessageKey = "lock-obtain-failed",
@@ -78,22 +96,28 @@ class PublicationController @Autowired constructor(
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
-    @PostMapping("/candidates/revert-request-dependencies")
-    fun getRevertRequestDependencies(@RequestBody toDelete: PublicationRequestIds): PublicationRequestIds {
-        logger.apiCall("getRevertRequestDependencies")
-        return publicationService.getRevertRequestDependencies(toDelete)
+    @PostMapping("/{$LAYOUT_BRANCH}/candidates/revert-request-dependencies")
+    fun getRevertRequestDependencies(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody toDelete: PublicationRequestIds,
+    ): PublicationRequestIds {
+        logger.apiCall("getRevertRequestDependencies", "branch" to branch)
+        return publicationService.getRevertRequestDependencies(branch, toDelete)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping
-    fun publishChanges(@RequestBody request: PublicationRequest): PublicationResult {
-        logger.apiCall("publishChanges", "request" to request)
+    @PostMapping("/{$LAYOUT_BRANCH}")
+    fun publishChanges(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody request: PublicationRequest,
+    ): PublicationResult {
+        logger.apiCall("publishChanges", "branch" to branch, "request" to request)
         return lockDao.runWithLock(PUBLICATION, publicationMaxDuration) {
-            publicationService.updateExternalId(request.content)
-            val versions = publicationService.getValidationVersions(request.content)
+            publicationService.updateExternalId(branch, request.content)
+            val versions = publicationService.getValidationVersions(branch, request.content)
             publicationService.validatePublicationRequest(versions)
             val calculatedChanges = publicationService.getCalculatedChanges(versions)
-            publicationService.publishChanges(versions, calculatedChanges, request.message)
+            publicationService.publishChanges(branch, versions, calculatedChanges, request.message)
         } ?: throw PublicationFailureException(
             message = "Could not reserve publication lock",
             localizedMessageKey = "lock-obtain-failed",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -28,7 +28,8 @@ class PublicationDao(
     val alignmentDao: LayoutAlignmentDao,
 ) : DaoBase(jdbcTemplateParam) {
 
-    fun fetchTrackNumberPublicationCandidates(): List<TrackNumberPublicationCandidate> {
+    fun fetchTrackNumberPublicationCandidates(branch: LayoutBranch): List<TrackNumberPublicationCandidate> {
+        assertMainBranch(branch)
         val sql = """
             select
               draft_track_number.row_id,
@@ -55,7 +56,7 @@ class PublicationDao(
                 draftChangeTime = rs.getInstant("change_time"),
                 operation = rs.getEnum("operation"),
                 userName = UserName.of(rs.getString("change_user")),
-                boundingBox = referenceLineDao.fetchVersionByTrackNumberId(PublicationState.DRAFT, id)
+                boundingBox = referenceLineDao.fetchVersionByTrackNumberId(branch.draft, id)
                     ?.let(referenceLineDao::fetch)?.boundingBox
             )
         }
@@ -63,7 +64,8 @@ class PublicationDao(
         return candidates
     }
 
-    fun fetchReferenceLinePublicationCandidates(): List<ReferenceLinePublicationCandidate> {
+    fun fetchReferenceLinePublicationCandidates(branch: LayoutBranch): List<ReferenceLinePublicationCandidate> {
+        assertMainBranch(branch)
         val sql = """
             select 
               draft_reference_line.row_id,
@@ -104,7 +106,8 @@ class PublicationDao(
         return candidates
     }
 
-    fun fetchLocationTrackPublicationCandidates(): List<LocationTrackPublicationCandidate> {
+    fun fetchLocationTrackPublicationCandidates(branch: LayoutBranch): List<LocationTrackPublicationCandidate> {
+        assertMainBranch(branch)
         val sql = """
             with splits as (
                 select
@@ -168,7 +171,8 @@ class PublicationDao(
         return candidates
     }
 
-    fun fetchSwitchPublicationCandidates(): List<SwitchPublicationCandidate> {
+    fun fetchSwitchPublicationCandidates(branch: LayoutBranch): List<SwitchPublicationCandidate> {
+        assertMainBranch(branch)
         val sql = """
             with splits as (
                 select
@@ -233,7 +237,8 @@ class PublicationDao(
         return candidates
     }
 
-    fun fetchKmPostPublicationCandidates(): List<KmPostPublicationCandidate> {
+    fun fetchKmPostPublicationCandidates(branch: LayoutBranch): List<KmPostPublicationCandidate> {
+        assertMainBranch(branch)
         val sql = """
             select
               draft_km_post.row_id,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.authorization.AUTH_BASIC
 import fi.fta.geoviite.infra.authorization.AUTH_EDIT_LAYOUT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.error.Integration
 import fi.fta.geoviite.infra.error.IntegrationNotConfiguredException
 import fi.fta.geoviite.infra.integration.LocationTrackChange
@@ -18,7 +19,13 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/ratko")
@@ -45,7 +52,7 @@ class RatkoController(
     @PostMapping("/push-location-tracks")
     fun pushLocationTracksToRatko(@RequestBody changes: List<LocationTrackChange>): ResponseEntity<String> {
         logger.apiCall("pushLocationTracksToRatko", "changes" to changes)
-        ratkoService.pushLocationTracksToRatko(changes)
+        ratkoService.pushLocationTracksToRatko(LayoutBranch.main, changes)
         return ResponseEntity(HttpStatus.OK)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -1,16 +1,23 @@
 package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.configuration.CACHE_RATKO_HEALTH_STATUS
-import fi.fta.geoviite.infra.integration.RatkoAssetType.*
+import fi.fta.geoviite.infra.integration.RatkoAssetType.LOCATION_TRACK
+import fi.fta.geoviite.infra.integration.RatkoAssetType.SWITCH
+import fi.fta.geoviite.infra.integration.RatkoAssetType.TRACK_NUMBER
 import fi.fta.geoviite.infra.integration.RatkoPushErrorWithAsset
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.ratko.RatkoClient.RatkoStatus
 import fi.fta.geoviite.infra.ratko.model.RatkoOperatingPoint
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.logger
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
@@ -35,9 +42,9 @@ class RatkoLocalService @Autowired constructor(
         logger.serviceCall("getRatkoPushError", "publicationId" to publicationId)
         return ratkoPushDao.getLatestRatkoPushErrorFor(publicationId)?.let { ratkoError ->
             val asset = when (ratkoError.assetType) {
-                TRACK_NUMBER -> trackNumberService.get(OFFICIAL, ratkoError.assetId as IntId<TrackLayoutTrackNumber>)
-                LOCATION_TRACK -> locationTrackService.get(OFFICIAL, ratkoError.assetId as IntId<LocationTrack>)
-                SWITCH -> switchService.get(OFFICIAL, ratkoError.assetId as IntId<TrackLayoutSwitch>)
+                TRACK_NUMBER -> trackNumberService.get(MainLayoutContext.official, ratkoError.assetId as IntId<TrackLayoutTrackNumber>)
+                LOCATION_TRACK -> locationTrackService.get(MainLayoutContext.official, ratkoError.assetId as IntId<LocationTrack>)
+                SWITCH -> switchService.get(MainLayoutContext.official, ratkoError.assetId as IntId<TrackLayoutSwitch>)
             }
             checkNotNull(asset) { "No asset found for id! ${ratkoError.assetType} ${ratkoError.assetId}" }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -1,14 +1,31 @@
 package fi.fta.geoviite.infra.ratko
 
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.localization.LocalizationLanguage
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.publication.PublishedLocationTrack
-import fi.fta.geoviite.infra.ratko.model.*
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrack
+import fi.fta.geoviite.infra.ratko.model.RatkoMetadataAsset
+import fi.fta.geoviite.infra.ratko.model.RatkoNodes
+import fi.fta.geoviite.infra.ratko.model.RatkoOid
+import fi.fta.geoviite.infra.ratko.model.convertToRatkoLocationTrack
+import fi.fta.geoviite.infra.ratko.model.convertToRatkoMetadataAsset
+import fi.fta.geoviite.infra.ratko.model.convertToRatkoNodeCollection
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutSegmentMetadata
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.LocationTrackState
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -30,6 +47,7 @@ class RatkoLocationTrackService @Autowired constructor(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     fun pushLocationTrackChangesToRatko(
+        branch: LayoutBranch,
         publishedLocationTracks: Collection<PublishedLocationTrack>,
         publicationTime: Instant,
     ): List<Oid<LocationTrack>> {
@@ -47,19 +65,21 @@ class RatkoLocationTrackService @Autowired constructor(
                 ratkoClient.getLocationTrack(RatkoOid(externalId))?.let { existingLocationTrack ->
                     if (layoutLocationTrack.state == LocationTrackState.DELETED) {
                         deleteLocationTrack(
+                            branch = branch,
                             layoutLocationTrack = layoutLocationTrack,
                             existingRatkoLocationTrack = existingLocationTrack,
                             moment = publicationTime,
                         )
                     } else {
                         updateLocationTrack(
+                            branch = branch,
                             layoutLocationTrack = layoutLocationTrack,
                             existingRatkoLocationTrack = existingLocationTrack,
                             changedKmNumbers = changedKmNumbers,
                             moment = publicationTime
                         )
                     }
-                } ?: createLocationTrack(layoutLocationTrack, publicationTime)
+                } ?: createLocationTrack(branch, layoutLocationTrack, publicationTime)
             } catch (ex: RatkoPushException) {
                 throw RatkoLocationTrackPushException(ex, layoutLocationTrack)
             }
@@ -92,7 +112,7 @@ class RatkoLocationTrackService @Autowired constructor(
         }
     }
 
-    private fun createLocationTrack(layoutLocationTrack: LocationTrack, moment: Instant) {
+    private fun createLocationTrack(branch: LayoutBranch, layoutLocationTrack: LocationTrack, moment: Instant) {
         logger.serviceCall(
             "createRatkoLocationTrack",
             "layoutLocationTrack" to layoutLocationTrack,
@@ -113,7 +133,7 @@ class RatkoLocationTrackService @Autowired constructor(
             nodeCollection = ratkoNodes,
             duplicateOfOid = duplicateOfOidLocationTrack,
             descriptionGetter = { locationTrack ->
-                locationTrackService.getFullDescription(PublicationState.OFFICIAL, locationTrack, LocalizationLanguage.FI).toString()
+                locationTrackService.getFullDescription(branch.official, locationTrack, LocalizationLanguage.FI).toString()
             })
         val locationTrackOid = ratkoClient.newLocationTrack(ratkoLocationTrack)
         checkNotNull(locationTrackOid) {
@@ -155,13 +175,10 @@ class RatkoLocationTrackService @Autowired constructor(
         requireNotNull(layoutLocationTrack.externalId) {
             "Cannot update location track metadata without location track oid, id=${layoutLocationTrack.id}"
         }
-        requireNotNull(layoutLocationTrack.alignmentVersion) {
-            "Location track is missing geometry, id=${layoutLocationTrack.id}"
-        }
 
         val geocodingContext = geocodingService.getGeocodingContextAtMoment(layoutLocationTrack.trackNumberId, moment)
 
-        alignmentDao.fetchMetadata(layoutLocationTrack.alignmentVersion)
+        alignmentDao.fetchMetadata(layoutLocationTrack.getAlignmentVersionOrThrow())
             .fold(mutableListOf<LayoutSegmentMetadata>()) { acc, metadata ->
                 val previousMetadata = acc.lastOrNull()
 
@@ -229,6 +246,7 @@ class RatkoLocationTrackService @Autowired constructor(
     } ?: error("No address point found: seek=$seek rounding=$rounding")
 
     private fun deleteLocationTrack(
+        branch: LayoutBranch,
         layoutLocationTrack: LocationTrack,
         existingRatkoLocationTrack: RatkoLocationTrack,
         moment: Instant,
@@ -248,6 +266,7 @@ class RatkoLocationTrackService @Autowired constructor(
             existingRatkoLocationTrack.nodecollection?.let(::toNodeCollectionMarkingEndpointsNotInUse)
 
         updateLocationTrackProperties(
+            branch = branch,
             layoutLocationTrack = layoutLocationTrack,
             moment = moment,
             changedNodeCollection = deletedEndsPoints,
@@ -257,6 +276,7 @@ class RatkoLocationTrackService @Autowired constructor(
     }
 
     private fun updateLocationTrack(
+        branch: LayoutBranch,
         layoutLocationTrack: LocationTrack,
         existingRatkoLocationTrack: RatkoLocationTrack,
         changedKmNumbers: Set<KmNumber>,
@@ -298,6 +318,7 @@ class RatkoLocationTrackService @Autowired constructor(
 
         //Update location track end points before deleting anything, otherwise old end points will stay in use
         updateLocationTrackProperties(
+            branch = branch,
             layoutLocationTrack = layoutLocationTrack,
             moment = moment,
             changedNodeCollection = updatedEndPointNodeCollection,
@@ -336,6 +357,7 @@ class RatkoLocationTrackService @Autowired constructor(
     }
 
     private fun updateLocationTrackProperties(
+        branch: LayoutBranch,
         layoutLocationTrack: LocationTrack,
         moment: Instant,
         changedNodeCollection: RatkoNodes? = null,
@@ -350,7 +372,7 @@ class RatkoLocationTrackService @Autowired constructor(
             nodeCollection = changedNodeCollection,
             duplicateOfOid = duplicateOfOidLocationTrack,
             descriptionGetter = { locationTrack ->
-                locationTrackService.getFullDescription(PublicationState.OFFICIAL, locationTrack, LocalizationLanguage.FI).toString()
+                locationTrackService.getFullDescription(branch.official, locationTrack, LocalizationLanguage.FI).toString()
             })
 
         ratkoClient.updateLocationTrackProperties(ratkoLocationTrack)
@@ -360,10 +382,6 @@ class RatkoLocationTrackService @Autowired constructor(
         locationTrack: LocationTrack,
         moment: Instant,
     ): Pair<AlignmentAddresses, List<AddressPoint>> {
-        val alignmentVersion = requireNotNull(locationTrack.alignmentVersion) {
-            "Location track missing alignment, id=${locationTrack.id}"
-        }
-
         val geocodingContext = geocodingService.getGeocodingContextCacheKey(
             locationTrack.trackNumberId,
             moment,
@@ -373,7 +391,7 @@ class RatkoLocationTrackService @Autowired constructor(
             "Missing geocoding context, trackNumberId=${locationTrack.trackNumberId} moment=$moment"
         }
 
-        val alignment = alignmentDao.fetch(alignmentVersion)
+        val alignment = alignmentDao.fetch(locationTrack.getAlignmentVersionOrThrow())
         val addresses = checkNotNull(geocodingContext.getAddressPoints(alignment)) {
             "Cannot calculate addresses for location track, id=${locationTrack.id}"
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -57,10 +57,12 @@ class RatkoLocationTrackService @Autowired constructor(
         }.sortedWith(
             compareBy(
                 { sortByNullDuplicateOfFirst(it.first.duplicateOf) },
-                { sortByDeletedStateFirst(it.first.state) })
+                { sortByDeletedStateFirst(it.first.state) },
+            )
         ).map { (layoutLocationTrack, changedKmNumbers) ->
-            val externalId =
-                requireNotNull(layoutLocationTrack.externalId) { "OID required for location track, lt=${layoutLocationTrack.id}" }
+            val externalId = requireNotNull(layoutLocationTrack.externalId) {
+                "OID required for location track, lt=${layoutLocationTrack.id}"
+            }
             try {
                 ratkoClient.getLocationTrack(RatkoOid(externalId))?.let { existingLocationTrack ->
                     if (layoutLocationTrack.state == LocationTrackState.DELETED) {
@@ -316,7 +318,7 @@ class RatkoLocationTrackService @Autowired constructor(
             (addresses.midPoints + switchPoints).filter { p -> changedKmNumbers.contains(p.address.kmNumber) }
                 .sortedBy { p -> p.address }
 
-        //Update location track end points before deleting anything, otherwise old end points will stay in use
+        // Update location track end points before deleting anything, otherwise old end points will stay in use
         updateLocationTrackProperties(
             branch = branch,
             layoutLocationTrack = layoutLocationTrack,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
@@ -3,13 +3,31 @@ package fi.fta.geoviite.infra.ratko
 import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
-import fi.fta.geoviite.infra.integration.*
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.assertMainBranch
+import fi.fta.geoviite.infra.integration.CalculatedChangesService
+import fi.fta.geoviite.infra.integration.DatabaseLock
+import fi.fta.geoviite.infra.integration.LocationTrackChange
+import fi.fta.geoviite.infra.integration.LockDao
+import fi.fta.geoviite.infra.integration.RatkoAssetType
+import fi.fta.geoviite.infra.integration.RatkoOperation
+import fi.fta.geoviite.infra.integration.RatkoPushErrorType
+import fi.fta.geoviite.infra.integration.RatkoPushStatus
+import fi.fta.geoviite.infra.integration.SwitchChange
 import fi.fta.geoviite.infra.logging.serviceCall
-import fi.fta.geoviite.infra.publication.*
+import fi.fta.geoviite.infra.publication.Operation
+import fi.fta.geoviite.infra.publication.PublicationDetails
+import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.publication.PublishedLocationTrack
+import fi.fta.geoviite.infra.publication.PublishedSwitch
 import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrack
 import fi.fta.geoviite.infra.ratko.model.RatkoOid
 import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumber
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -102,7 +120,8 @@ class RatkoService @Autowired constructor(
         }
     }
 
-    fun pushLocationTracksToRatko(locationTrackChanges: Collection<LocationTrackChange>) {
+    fun pushLocationTracksToRatko(branch: LayoutBranch, locationTrackChanges: Collection<LocationTrackChange>) {
+        assertMainBranch(branch)
         lockDao.runWithLock(DatabaseLock.RATKO, databaseLockDuration) {
             logger.serviceCall("pushLocationTracksToRatko")
 
@@ -149,6 +168,7 @@ class RatkoService @Autowired constructor(
                 }
 
             val pushedLocationTrackOids = ratkoLocationTrackService.pushLocationTrackChangesToRatko(
+                branch,
                 publishedLocationTrackChanges,
                 latestPublicationMoment,
             )
@@ -180,6 +200,7 @@ class RatkoService @Autowired constructor(
             )
 
             val pushedLocationTrackOids = ratkoLocationTrackService.pushLocationTrackChangesToRatko(
+                LayoutBranch.main,
                 publications.flatMap { it.allPublishedLocationTracks },
                 lastPublicationTime
             )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
@@ -2,7 +2,9 @@ package fi.fta.geoviite.infra.split
 
 import fi.fta.geoviite.infra.authorization.AUTH_EDIT_LAYOUT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT_DRAFT
+import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.util.toResponse
 import org.slf4j.Logger
@@ -25,10 +27,13 @@ class SplitController(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping
-    fun splitLocationTrack(@RequestBody request: SplitRequest): IntId<Split> {
-        logger.apiCall("splitLocationTrack", "request" to request)
-        return splitService.split(request)
+    @PostMapping("/{$LAYOUT_BRANCH}")
+    fun splitLocationTrack(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody request: SplitRequest,
+    ): IntId<Split> {
+        logger.apiCall("splitLocationTrack", "branch" to branch, "request" to request)
+        return splitService.split(branch, request)
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -1,7 +1,9 @@
 package fi.fta.geoviite.infra.split
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.common.assertMainBranch
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
@@ -266,7 +268,8 @@ class SplitDao(
         }
     }
 
-    fun fetchUnfinishedSplits(): List<Split> {
+    fun fetchUnfinishedSplits(branch: LayoutBranch): List<Split> {
+        assertMainBranch(branch)
         val sql = """
           select
               split.id,
@@ -306,8 +309,8 @@ class SplitDao(
             .also { _ -> logger.daoAccess(AccessType.FETCH, Split::class, "publicationId" to publicationId) }
     }
 
-    fun locationTracksPartOfAnyUnfinishedSplit(locationTrackIds: Collection<IntId<LocationTrack>>) =
-        fetchUnfinishedSplits().filter { split ->
+    fun locationTracksPartOfAnyUnfinishedSplit(branch: LayoutBranch, locationTrackIds: Collection<IntId<LocationTrack>>) =
+        fetchUnfinishedSplits(branch).filter { split ->
             locationTrackIds.any { lt -> split.containsLocationTrack(lt) }
         }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -198,7 +198,8 @@ class LayoutAlignmentDao(
     }
 
     @Transactional
-    fun deleteOrphanedAlignments(): List<IntId<LayoutAlignment>> {
+    fun deleteOrphanedAlignments(branch: LayoutBranch): List<IntId<LayoutAlignment>> {
+        assertMainBranch(branch)
         val sql = """
            delete
            from layout.alignment alignment
@@ -487,10 +488,9 @@ class LayoutAlignmentDao(
     }
 
     fun <T> fetchProfileInfoForSegmentsInBoundingBox(
-        publicationState: PublicationState,
+        layoutContext: LayoutContext,
         bbox: BoundingBox,
     ): List<MapSegmentProfileInfo<T>> {
-        val layoutContext = MainLayoutContext.of(publicationState)
         //language=SQL
         val sql = """
             select

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -48,11 +48,7 @@ interface LayoutAssetWriter<T : LayoutAsset<T>> {
     fun update(updatedItem: T): DaoResponse<T>
 
     fun deleteDraft(branch: LayoutBranch, id: IntId<T>): DaoResponse<T>
-//     = branch.let { b ->
-//        assertMainBranch(b)
-//        deleteDraft(id)
-//    }
-//    fun deleteDraft(id: IntId<T>): DaoResponse<T>
+
     fun deleteDrafts(branch: LayoutBranch): List<DaoResponse<T>>
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -4,10 +4,12 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.common.assertMainBranch
 import fi.fta.geoviite.infra.configuration.layoutCacheDuration
 import fi.fta.geoviite.infra.error.DeletingFailureException
 import fi.fta.geoviite.infra.error.NoSuchEntityException
@@ -15,9 +17,19 @@ import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.AccessType.DELETE
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.publication.ValidationVersion
-import fi.fta.geoviite.infra.util.*
+import fi.fta.geoviite.infra.util.DaoBase
+import fi.fta.geoviite.infra.util.DbTable
+import fi.fta.geoviite.infra.util.FetchType
 import fi.fta.geoviite.infra.util.FetchType.MULTI
 import fi.fta.geoviite.infra.util.FetchType.SINGLE
+import fi.fta.geoviite.infra.util.getDaoResponse
+import fi.fta.geoviite.infra.util.getInstant
+import fi.fta.geoviite.infra.util.getInstantOrNull
+import fi.fta.geoviite.infra.util.getIntId
+import fi.fta.geoviite.infra.util.getRowVersion
+import fi.fta.geoviite.infra.util.idOrIdsEqualSqlFragment
+import fi.fta.geoviite.infra.util.queryOptional
+import fi.fta.geoviite.infra.util.setUser
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -35,8 +47,13 @@ interface LayoutAssetWriter<T : LayoutAsset<T>> {
 
     fun update(updatedItem: T): DaoResponse<T>
 
-    fun deleteDraft(id: IntId<T>): DaoResponse<T>
-    fun deleteDrafts(): List<DaoResponse<T>>
+    fun deleteDraft(branch: LayoutBranch, id: IntId<T>): DaoResponse<T>
+//     = branch.let { b ->
+//        assertMainBranch(b)
+//        deleteDraft(id)
+//    }
+//    fun deleteDraft(id: IntId<T>): DaoResponse<T>
+    fun deleteDrafts(branch: LayoutBranch): List<DaoResponse<T>>
 }
 
 @Transactional(readOnly = true)
@@ -44,56 +61,54 @@ interface LayoutAssetReader<T : LayoutAsset<T>> {
     fun fetch(version: RowVersion<T>): T
 
     fun fetchChangeTime(): Instant
-    fun fetchLayoutAssetChangeInfo(id: IntId<T>, publicationState: PublicationState): LayoutAssetChangeInfo?
+    fun fetchLayoutAssetChangeInfo(layoutContext: LayoutContext, id: IntId<T>): LayoutAssetChangeInfo?
 
     fun fetchAllVersions(): List<RowVersion<T>>
-    fun fetchVersions(publicationState: PublicationState, includeDeleted: Boolean): List<RowVersion<T>>
+    fun fetchVersions(layoutContext: LayoutContext, includeDeleted: Boolean): List<RowVersion<T>>
 
-    fun fetchPublicationVersions(): List<ValidationVersion<T>>
-    fun fetchPublicationVersions(ids: List<IntId<T>>): List<ValidationVersion<T>>
+    fun fetchPublicationVersions(branch: LayoutBranch): List<ValidationVersion<T>>
+    fun fetchPublicationVersions(branch: LayoutBranch, ids: List<IntId<T>>): List<ValidationVersion<T>>
 
-    fun draftExists(id: IntId<T>): Boolean
-    fun officialExists(id: IntId<T>): Boolean
-
-    fun fetchVersionPair(id: IntId<T>): VersionPair<T>
-    fun fetchDraftVersion(id: IntId<T>): RowVersion<T>?
-    fun fetchDraftVersions(ids: List<IntId<T>>): List<RowVersion<T>>
-    fun fetchDraftVersionOrThrow(id: IntId<T>): RowVersion<T>
-    fun fetchOfficialVersion(id: IntId<T>): RowVersion<T>?
-    fun fetchOfficialVersionOrThrow(id: IntId<T>): RowVersion<T>
-    fun fetchOfficialVersions(ids: List<IntId<T>>): List<RowVersion<T>>
-    fun fetchVersion(id: IntId<T>, publicationState: PublicationState): RowVersion<T>? = when (publicationState) {
-        OFFICIAL -> fetchOfficialVersion(id)
-        DRAFT -> fetchDraftVersion(id)
+    fun fetchVersionPair(branch: LayoutBranch, id: IntId<T>): VersionPair<T>
+    fun fetchDraftVersion(branch: LayoutBranch, id: IntId<T>): RowVersion<T>?
+    fun fetchDraftVersions(branch: LayoutBranch, ids: List<IntId<T>>): List<RowVersion<T>>
+    fun fetchDraftVersionOrThrow(branch: LayoutBranch, id: IntId<T>): RowVersion<T>
+    fun fetchOfficialVersion(branch: LayoutBranch, id: IntId<T>): RowVersion<T>?
+    fun fetchOfficialVersionOrThrow(branch: LayoutBranch, id: IntId<T>): RowVersion<T>
+    fun fetchOfficialVersions(branch: LayoutBranch, ids: List<IntId<T>>): List<RowVersion<T>>
+    fun fetchVersion(layoutContext: LayoutContext, id: IntId<T>): RowVersion<T>? = when (layoutContext.state) {
+        OFFICIAL -> fetchOfficialVersion(layoutContext.branch, id)
+        DRAFT -> fetchDraftVersion(layoutContext.branch, id)
     }
 
     fun fetchOfficialVersionAtMomentOrThrow(id: IntId<T>, moment: Instant): RowVersion<T>
     fun fetchOfficialVersionAtMoment(id: IntId<T>, moment: Instant): RowVersion<T>?
 
-    fun fetchVersionOrThrow(id: IntId<T>, publicationState: PublicationState): RowVersion<T> = when (publicationState) {
-        OFFICIAL -> fetchOfficialVersionOrThrow(id)
-        DRAFT -> fetchDraftVersionOrThrow(id)
+    fun fetchVersionOrThrow(layoutContext: LayoutContext, id: IntId<T>): RowVersion<T> =
+        when (layoutContext.state) {
+            OFFICIAL -> fetchOfficialVersionOrThrow(layoutContext.branch, id)
+            DRAFT -> fetchDraftVersionOrThrow(layoutContext.branch, id)
+        }
+
+    fun get(context: LayoutContext, id: IntId<T>): T? = when (context.state) {
+        DRAFT -> fetchDraftVersion(context.branch, id)?.let(::fetch)
+        OFFICIAL -> fetchOfficialVersion(context.branch, id)?.let(::fetch)
     }
 
-    fun get(publicationState: PublicationState, id: IntId<T>): T? = when (publicationState) {
-        DRAFT -> fetchDraftVersion(id)?.let(::fetch)
-        OFFICIAL -> fetchOfficialVersion(id)?.let(::fetch)
-    }
-
-    fun getOrThrow(publicationState: PublicationState, id: IntId<T>): T = when (publicationState) {
-        DRAFT -> fetch(fetchDraftVersionOrThrow(id))
-        OFFICIAL -> fetch(fetchOfficialVersionOrThrow(id))
+    fun getOrThrow(context: LayoutContext, id: IntId<T>): T = when (context.state) {
+        DRAFT -> fetch(fetchDraftVersionOrThrow(context.branch, id))
+        OFFICIAL -> fetch(fetchOfficialVersionOrThrow(context.branch, id))
     }
 
     fun getOfficialAtMoment(id: IntId<T>, moment: Instant): T? = fetchOfficialVersionAtMoment(id, moment)?.let(::fetch)
 
-    fun getMany(publicationState: PublicationState, ids: List<IntId<T>>): List<T> = when (publicationState) {
-        DRAFT -> fetchDraftVersions(ids)
-        OFFICIAL -> fetchOfficialVersions(ids)
+    fun getMany(context: LayoutContext, ids: List<IntId<T>>): List<T> = when (context.state) {
+        DRAFT -> fetchDraftVersions(context.branch, ids)
+        OFFICIAL -> fetchOfficialVersions(context.branch, ids)
     }.map(::fetch)
 
-    fun list(publicationState: PublicationState, includeDeleted: Boolean): List<T> =
-        fetchVersions(publicationState, includeDeleted).map(::fetch)
+    fun list(context: LayoutContext, includeDeleted: Boolean): List<T> =
+        fetchVersions(context, includeDeleted).map(::fetch)
 }
 
 interface ILayoutAssetDao<T : LayoutAsset<T>> : LayoutAssetReader<T>, LayoutAssetWriter<T>
@@ -139,7 +154,8 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
           and draft = true
     """.trimIndent()
 
-    override fun fetchPublicationVersions(): List<ValidationVersion<T>> {
+    override fun fetchPublicationVersions(branch: LayoutBranch): List<ValidationVersion<T>> {
+        assertMainBranch(branch)
         return jdbcTemplate.query<ValidationVersion<T>>(allPublicationVersionsSql, emptyMap<String, Any>()) { rs, _ ->
             ValidationVersion(
                 rs.getIntId("official_id"),
@@ -148,7 +164,8 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
         }
     }
 
-    override fun fetchPublicationVersions(ids: List<IntId<T>>): List<ValidationVersion<T>> {
+    override fun fetchPublicationVersions(branch: LayoutBranch, ids: List<IntId<T>>): List<ValidationVersion<T>> {
+        assertMainBranch(branch)
         // Empty lists don't play nice in the SQL, but the result would be empty anyhow
         if (ids.isEmpty()) return listOf()
         val distinctIds = ids.distinct()
@@ -199,10 +216,11 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
       where id = :id and version = 1 limit 1
     """.trimIndent()
 
-    override fun fetchLayoutAssetChangeInfo(id: IntId<T>, publicationState: PublicationState): LayoutAssetChangeInfo? {
+    override fun fetchLayoutAssetChangeInfo(layoutContext: LayoutContext, id: IntId<T>): LayoutAssetChangeInfo? {
+        assertMainBranch(layoutContext.branch)
         return jdbcTemplate.query(layoutAssetChangeInfoSql, mapOf("id" to id.intValue)) { rs, _ ->
             val draftDeleted = rs.getBoolean("draft_deleted")
-            if (publicationState == OFFICIAL) {
+            if (layoutContext.state == OFFICIAL) {
                 LayoutAssetChangeInfo(
                     created = rs.getInstant("creation_time"),
                     changed = rs.getInstantOrNull("official_change_time"),
@@ -215,9 +233,6 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
             }
         }.firstOrNull()
     }
-
-    override fun draftExists(id: IntId<T>): Boolean = fetchVersionPair(id).draft != null
-    override fun officialExists(id: IntId<T>): Boolean = fetchVersionPair(id).official != null
 
     override fun fetchAllVersions(): List<RowVersion<T>> = fetchRowVersions(table)
 
@@ -238,7 +253,8 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
                  on not official.draft and direct.official_row_id = official.id;
     """.trimIndent()
 
-    override fun fetchVersionPair(id: IntId<T>): VersionPair<T> {
+    override fun fetchVersionPair(branch: LayoutBranch, id: IntId<T>): VersionPair<T> {
+        assertMainBranch(branch)
         val params = mapOf("id" to id.intValue)
         val versions: List<Pair<Boolean, RowVersion<T>>> = jdbcTemplate.query(versionPairSql, params) { rs, _ ->
             rs.getBoolean("draft") to rs.getRowVersion("id", "version")
@@ -255,22 +271,25 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
     private val singleOfficialVersionSql = officialFetchSql(table, SINGLE)
     private val multiOfficialVersionSql = officialFetchSql(table, MULTI)
 
-    override fun fetchDraftVersion(id: IntId<T>): RowVersion<T>? = fetchDraftRowVersion(id, table)
+    override fun fetchDraftVersion(branch: LayoutBranch, id: IntId<T>): RowVersion<T>? = fetchDraftRowVersion(branch, id, table)
 
-    override fun fetchOfficialVersion(id: IntId<T>): RowVersion<T>? = fetchOfficialRowVersion(id, table)
+    override fun fetchOfficialVersion(branch: LayoutBranch, id: IntId<T>): RowVersion<T>? = fetchOfficialRowVersion(branch, id, table)
 
-    override fun fetchOfficialVersionOrThrow(id: IntId<T>): RowVersion<T> {
+    override fun fetchOfficialVersionOrThrow(branch: LayoutBranch, id: IntId<T>): RowVersion<T> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
+        assertMainBranch(branch)
         return queryRowVersion(singleOfficialVersionSql, id)
     }
 
-    private fun fetchOfficialRowVersion(id: IntId<T>, table: DbTable): RowVersion<T>? {
+    private fun fetchOfficialRowVersion(branch: LayoutBranch, id: IntId<T>, table: DbTable): RowVersion<T>? {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
+        assertMainBranch(branch)
         return queryRowVersionOrNull(singleOfficialVersionSql, id)
     }
 
-    override fun fetchOfficialVersions(ids: List<IntId<T>>): List<RowVersion<T>> {
+    override fun fetchOfficialVersions(branch: LayoutBranch, ids: List<IntId<T>>): List<RowVersion<T>> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.versionTable, ids)
+        assertMainBranch(branch)
         val params = mapOf("ids" to ids.distinct().map { it.intValue })
         val versions: List<RowVersion<T>> = if (ids.isEmpty()) {
             emptyList()
@@ -280,18 +299,21 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
         return versions
     }
 
-    override fun fetchDraftVersionOrThrow(id: IntId<T>): RowVersion<T> {
+    override fun fetchDraftVersionOrThrow(branch: LayoutBranch, id: IntId<T>): RowVersion<T> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
+        assertMainBranch(branch)
         return queryRowVersion(singleDraftVersionSql, id)
     }
 
-    private fun <T> fetchDraftRowVersion(id: IntId<T>, table: DbTable): RowVersion<T>? {
+    private fun <T> fetchDraftRowVersion(branch: LayoutBranch, id: IntId<T>, table: DbTable): RowVersion<T>? {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, id)
+        assertMainBranch(branch)
         return queryRowVersionOrNull(singleDraftVersionSql, id)
     }
 
-    override fun fetchDraftVersions(ids: List<IntId<T>>): List<RowVersion<T>> {
+    override fun fetchDraftVersions(branch: LayoutBranch, ids: List<IntId<T>>): List<RowVersion<T>> {
         logger.daoAccess(AccessType.VERSION_FETCH, table.name, ids)
+        assertMainBranch(branch)
         val params = mapOf("ids" to ids.distinct().map { it.intValue })
         val versions: List<RowVersion<T>> = if (ids.isEmpty()) {
             emptyList()
@@ -319,29 +341,31 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
     """.trimIndent()
 
     override fun fetchOfficialVersionAtMoment(id: IntId<T>, moment: Instant): RowVersion<T>? {
+        logger.daoAccess(AccessType.VERSION_FETCH, LocationTrack::class, id)
         val params = mapOf(
             "id" to id.intValue,
             "moment" to Timestamp.from(moment),
         )
-        logger.daoAccess(AccessType.VERSION_FETCH, LocationTrack::class, id)
         return jdbcTemplate.queryOptional(officialVersionAtMomentSql, params, ::toRowVersion)
     }
 
     @Transactional
-    override fun deleteDraft(id: IntId<T>): DaoResponse<T> = deleteDraftsInternal(id).let { r ->
-        if (r.size > 1) {
-            error { "Multiple rows deleted with one ID: type=${table.name} id=$id" }
-        } else if (r.isEmpty()) {
-            throw DeletingFailureException("Trying to delete a non-existing draft object: type=${table.name} id=$id")
-        } else {
-            r.first()
+    override fun deleteDraft(branch: LayoutBranch, id: IntId<T>): DaoResponse<T> = deleteDraftsInternal(branch, id)
+        .let { r ->
+            if (r.size > 1) {
+                error { "Multiple rows deleted with one ID: type=${table.name} id=$id" }
+            } else if (r.isEmpty()) {
+                throw DeletingFailureException("Trying to delete a non-existing draft object: type=${table.name} id=$id")
+            } else {
+                r.first()
+            }
         }
-    }
 
     @Transactional
-    override fun deleteDrafts(): List<DaoResponse<T>> = deleteDraftsInternal()
+    override fun deleteDrafts(branch: LayoutBranch): List<DaoResponse<T>> = deleteDraftsInternal(branch)
 
-    private fun deleteDraftsInternal(id: IntId<T>? = null): List<DaoResponse<T>> {
+    private fun deleteDraftsInternal(branch: LayoutBranch, id: IntId<T>? = null): List<DaoResponse<T>> {
+        assertMainBranch(branch)
         val sql = """
             delete from ${table.fullName}
             where draft = true 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -226,6 +226,11 @@ fun <T : LayoutAsset<T>> asMainDraft(item: T): T = item.contextData.let { ctx ->
     }
 }
 
+fun <T : LayoutAsset<T>> asOfficial(branch: LayoutBranch, item: T): T = when (branch) {
+    is MainBranch -> asMainOfficial(item)
+    is DesignBranch -> asDesignOfficial(item, branch.designId)
+}
+
 fun <T : LayoutAsset<T>> asMainOfficial(item: T): T =
     item.contextData.let { ctx ->
         when (ctx) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -2,9 +2,12 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.authorization.AUTH_EDIT_LAYOUT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
+import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.linking.TrackLayoutKmPostSaveRequest
 import fi.fta.geoviite.infra.logging.apiCall
@@ -37,65 +40,75 @@ class LayoutKmPostController(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/{id}")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}")
     fun getKmPost(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutKmPost>,
     ): ResponseEntity<TrackLayoutKmPost> {
-        logger.apiCall("getKmPost", PUBLICATION_STATE to publicationState, "id" to id)
-        return toResponse(kmPostService.get(publicationState, id))
+        val context = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getKmPost", "context" to context, "id" to id)
+        return toResponse(kmPostService.get(context, id))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}", params = ["ids"])
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["ids"])
     fun getKmPosts(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids", required = true) ids: List<IntId<TrackLayoutKmPost>>,
     ): List<TrackLayoutKmPost> {
-        logger.apiCall("getKmPost", PUBLICATION_STATE to publicationState, "ids" to ids)
-        return kmPostService.getMany(publicationState, ids)
+        val context = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getKmPost", "context" to context, "ids" to ids)
+        return kmPostService.getMany(context, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/on-track-number/{trackNumberId}")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/on-track-number/{trackNumberId}")
     fun getKmPostsOnTrackNumber(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("trackNumberId") id: IntId<TrackLayoutTrackNumber>,
     ): List<TrackLayoutKmPost> {
-        logger.apiCall("getKmPostsOnTrackNumber", PUBLICATION_STATE to publicationState, "id" to id)
-        return kmPostService.list(publicationState, id)
+        val context = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getKmPostsOnTrackNumber", "context" to context, "id" to id)
+        return kmPostService.list(context, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}", params = ["bbox", "step"])
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["bbox", "step"])
     fun findKmPosts(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("step") step: Int,
     ): List<TrackLayoutKmPost> {
-        logger.apiCall("getKmPosts", PUBLICATION_STATE to publicationState, "bbox" to bbox, "step" to step)
-        return kmPostService.list(publicationState, bbox, step)
+        val context = LayoutContext.of(branch, publicationState)
+        logger.apiCall("findKmPosts", "context" to context, "bbox" to bbox, "step" to step)
+        return kmPostService.list(context, bbox, step)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}", params = ["location", "offset", "limit"])
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["location", "offset", "limit"])
     fun findKmPosts(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>?,
         @RequestParam("location") location: Point,
         @RequestParam("offset") offset: Int,
         @RequestParam("limit") limit: Int,
     ): List<TrackLayoutKmPost> {
+        val context = LayoutContext.of(branch, publicationState)
         logger.apiCall(
             "getNearbyKmPostsOnTrack",
-            PUBLICATION_STATE to publicationState,
+            "context" to context,
             "trackNumberId" to trackNumberId,
             "location" to location,
             "offset" to offset,
             "limit" to limit
         )
         return kmPostService.listNearbyOnTrackPaged(
-            publicationState = publicationState,
+            layoutContext = context,
             location = location,
             trackNumberId = trackNumberId,
             offset = offset,
@@ -104,74 +117,89 @@ class LayoutKmPostController(
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}", params = ["trackNumberId", "kmNumber"])
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["trackNumberId", "kmNumber"])
     fun getKmPost(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>,
         @RequestParam("kmNumber") kmNumber: KmNumber,
         @RequestParam("includeDeleted") includeDeleted: Boolean,
     ): ResponseEntity<TrackLayoutKmPost> {
+        val context = LayoutContext.of(branch, publicationState)
         logger.apiCall(
             "getKmPostOnTrack",
-            PUBLICATION_STATE to publicationState,
+            "context" to context,
             "trackNumberId" to trackNumberId,
             "kmNumber" to kmNumber,
             "includeDeleted" to includeDeleted,
         )
-        return toResponse(kmPostService.getByKmNumber(publicationState, trackNumberId, kmNumber, includeDeleted))
+        return kmPostService.getByKmNumber(context, trackNumberId, kmNumber, includeDeleted).let(::toResponse)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("{$PUBLICATION_STATE}/{id}/validation")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}/validation")
     fun validateKmPost(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutKmPost>,
     ): ResponseEntity<ValidatedAsset<TrackLayoutKmPost>> {
-        logger.apiCall("validateKmPost", PUBLICATION_STATE to publicationState, "id" to id)
-        return publicationService.validateKmPosts(listOf(id), publicationState).firstOrNull().let(::toResponse)
+        val context = LayoutContext.of(branch, publicationState)
+        logger.apiCall("validateKmPost", "context" to context, "id" to id)
+        return publicationService.validateKmPosts(context, listOf(id)).firstOrNull().let(::toResponse)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/draft")
-    fun insertTrackLayoutKmPost(@RequestBody request: TrackLayoutKmPostSaveRequest): IntId<TrackLayoutKmPost> {
-        logger.apiCall("insertTrackLayoutKmPost", "request" to request)
-        return kmPostService.insertKmPost(request)
+    @PostMapping("/{$LAYOUT_BRANCH}/draft")
+    fun insertTrackLayoutKmPost(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody request: TrackLayoutKmPostSaveRequest,
+    ): IntId<TrackLayoutKmPost> {
+        logger.apiCall("insertTrackLayoutKmPost", "branch" to branch, "request" to request)
+        return kmPostService.insertKmPost(branch, request)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PutMapping("/draft/{id}")
+    @PutMapping("/{$LAYOUT_BRANCH}/draft/{id}")
     fun updateKmPost(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
         @RequestBody request: TrackLayoutKmPostSaveRequest,
     ): IntId<TrackLayoutKmPost> {
-        logger.apiCall("updateKmPost", "kmPostId" to kmPostId, "request" to request)
-        return kmPostService.updateKmPost(kmPostId, request)
+        logger.apiCall("updateKmPost", "branch" to branch, "kmPostId" to kmPostId, "request" to request)
+        return kmPostService.updateKmPost(branch, kmPostId, request)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @DeleteMapping("/draft/{id}")
-    fun deleteDraftKmPost(@PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>): IntId<TrackLayoutKmPost> {
-        logger.apiCall("deleteDraftKmPost", "kmPostId" to kmPostId)
-        return kmPostService.deleteDraft(kmPostId).id
+    @DeleteMapping("/{$LAYOUT_BRANCH}/draft/{id}")
+    fun deleteDraftKmPost(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
+    ): IntId<TrackLayoutKmPost> {
+        logger.apiCall("deleteDraftKmPost", "branch" to branch, "kmPostId" to kmPostId)
+        return kmPostService.deleteDraft(branch, kmPostId).id
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/{id}/change-times")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}/change-info")
     fun getKmPostChangeInfo(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
     ): ResponseEntity<LayoutAssetChangeInfo> {
-        logger.apiCall("getKmPostChangeInfo", "id" to kmPostId, "publicationState" to publicationState)
-        return toResponse(kmPostService.getLayoutAssetChangeInfo(kmPostId, publicationState))
+        val context = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getKmPostChangeInfo", "id" to kmPostId, "context" to context)
+        return toResponse(kmPostService.getLayoutAssetChangeInfo(context, kmPostId))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/{id}/km-length")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}/km-length")
     fun getKmLength(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") kmPostId: IntId<TrackLayoutKmPost>,
     ): ResponseEntity<Double> {
-        logger.apiCall("getKmLength", "id" to kmPostId, PUBLICATION_STATE to publicationState)
-        return toResponse(kmPostService.getSingleKmPostLength(publicationState, kmPostId))
+        val context = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getKmLength", "context" to context, "id" to kmPostId)
+        return toResponse(kmPostService.getSingleKmPostLength(context, kmPostId))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -47,7 +47,7 @@ class LayoutKmPostDao(
         includeDeleted: Boolean,
         trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
         bbox: BoundingBox? = null,
-    ): List<TrackLayoutKmPost>  = fetchVersions(layoutContext, includeDeleted, trackNumberId, bbox).map(::fetch)
+    ): List<TrackLayoutKmPost> = fetchVersions(layoutContext, includeDeleted, trackNumberId, bbox).map(::fetch)
 
     fun fetchVersions(
         layoutContext: LayoutContext,
@@ -67,14 +67,15 @@ class LayoutKmPostDao(
             order by km_post.track_number_id, km_post.km_number
         """.trimIndent()
         return jdbcTemplate.query(
-            sql, mapOf(
+            sql,
+            mapOf(
                 "track_number_id" to trackNumberId?.intValue,
                 "publication_state" to layoutContext.state.name,
                 "design_id" to layoutContext.branch.designId?.intValue,
                 "include_deleted" to includeDeleted,
                 "polygon_wkt" to bbox?.let { b -> create2DPolygonString(b.polygonFromCorners) },
                 "map_srid" to LAYOUT_SRID.code,
-            )
+            ),
         ) { rs, _ ->
             rs.getRowVersion("row_id", "row_version")
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -2,8 +2,11 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.authorization.AUTH_EDIT_LAYOUT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
+import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.linking.TrackLayoutSwitchSaveRequest
@@ -36,8 +39,9 @@ class LayoutSwitchController(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}")
+    @GetMapping("/{${LAYOUT_BRANCH}}/{$PUBLICATION_STATE}")
     fun getTrackLayoutSwitches(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox?,
         @RequestParam("namePart") namePart: String?,
@@ -49,9 +53,10 @@ class LayoutSwitchController(
         @RequestParam("includeSwitchesWithNoJoints") includeSwitchesWithNoJoints: Boolean = false,
         @RequestParam("includeDeleted") includeDeleted: Boolean = false,
     ): List<TrackLayoutSwitch> {
+        val layoutContext = LayoutContext.of(branch, publicationState)
         logger.apiCall(
             "getTrackLayoutSwitches",
-            PUBLICATION_STATE to publicationState,
+            "layoutContext" to layoutContext,
             "bbox" to bbox,
             "namePart" to namePart,
             "exactName" to exactName,
@@ -62,90 +67,107 @@ class LayoutSwitchController(
             "includeDeleted" to includeDeleted,
         )
         val filter = switchFilter(namePart, exactName, switchType, bbox, includeSwitchesWithNoJoints)
-        val switches = switchService.listWithStructure(publicationState, includeDeleted).filter(filter)
+        val switches = switchService.listWithStructure(layoutContext, includeDeleted).filter(filter)
         return pageSwitches(switches, offset ?: 0, limit, comparisonPoint).items
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/{id}")
+    @GetMapping("/{${LAYOUT_BRANCH}}/{$PUBLICATION_STATE}/{id}")
     fun getTrackLayoutSwitch(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutSwitch>,
     ): ResponseEntity<TrackLayoutSwitch> {
-        logger.apiCall("getTrackLayoutSwitch", "id" to id, PUBLICATION_STATE to publicationState)
-        return toResponse(switchService.get(publicationState, id))
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getTrackLayoutSwitch", "layoutContext" to layoutContext, "id" to id)
+        return toResponse(switchService.get(layoutContext, id))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}", params = ["ids"])
+    @GetMapping("/{${LAYOUT_BRANCH}}/{$PUBLICATION_STATE}", params = ["ids"])
     fun getTrackLayoutSwitches(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids", required = true) ids: List<IntId<TrackLayoutSwitch>>,
     ): List<TrackLayoutSwitch> {
-        logger.apiCall("getTrackLayoutSwitches", "ids" to ids, PUBLICATION_STATE to publicationState)
-        return switchService.getMany(publicationState, ids)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getTrackLayoutSwitches", "layoutContext" to layoutContext, "ids" to ids)
+        return switchService.getMany(layoutContext, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/{id}/joint-connections")
+    @GetMapping("/{${LAYOUT_BRANCH}}/{$PUBLICATION_STATE}/{id}/joint-connections")
     fun getSwitchJointConnections(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutSwitch>,
     ): List<TrackLayoutSwitchJointConnection> {
-        logger.apiCall("getSwitchJointConnections", "switchId" to id, PUBLICATION_STATE to publicationState)
-        return switchService.getSwitchJointConnections(publicationState, id)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getSwitchJointConnections", "layoutContext" to layoutContext, "switchId" to id)
+        return switchService.getSwitchJointConnections(layoutContext, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("{$PUBLICATION_STATE}/validation")
+    @GetMapping("/{${LAYOUT_BRANCH}}/{$PUBLICATION_STATE}/validation")
     fun validateSwitches(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids") ids: List<IntId<TrackLayoutSwitch>>?,
         @RequestParam("bbox") bbox: BoundingBox?,
     ): List<ValidatedAsset<TrackLayoutSwitch>> {
-        logger.apiCall("validateSwitches", PUBLICATION_STATE to publicationState, "ids" to ids, "bbox" to bbox)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("validateSwitches", "layoutContext" to layoutContext, "ids" to ids, "bbox" to bbox)
         val switches = if (ids != null) {
-            switchService.getMany(publicationState, ids)
+            switchService.getMany(layoutContext, ids)
         } else {
-            switchService.list(publicationState, false)
+            switchService.list(layoutContext, false)
         }
         val switchIds = switches
             .filter { switch -> switchMatchesBbox(switch, bbox, false) }
             .map { sw -> sw.id as IntId }
-        return publicationService.validateSwitches(switchIds, publicationState)
+        return publicationService.validateSwitches(layoutContext, switchIds)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/draft")
-    fun insertTrackLayoutSwitch(@RequestBody request: TrackLayoutSwitchSaveRequest): IntId<TrackLayoutSwitch> {
-        logger.apiCall("insertTrackLayoutSwitch", "request" to request)
-        return switchService.insertSwitch(request)
+    @PostMapping("/{${LAYOUT_BRANCH}}/draft")
+    fun insertTrackLayoutSwitch(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody request: TrackLayoutSwitchSaveRequest,
+    ): IntId<TrackLayoutSwitch> {
+        logger.apiCall("insertTrackLayoutSwitch", "branch" to branch, "request" to request)
+        return switchService.insertSwitch(branch, request)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PutMapping("/draft/{id}")
+    @PutMapping("/{${LAYOUT_BRANCH}}/draft/{id}")
     fun updateSwitch(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable("id") switchId: IntId<TrackLayoutSwitch>,
         @RequestBody switch: TrackLayoutSwitchSaveRequest,
     ): IntId<TrackLayoutSwitch> {
-        logger.apiCall("updateSwitch", "switchId" to switchId, "switch" to switch)
-        return switchService.updateSwitch(switchId, switch)
+        logger.apiCall("updateSwitch", "branch" to branch, "switchId" to switchId, "switch" to switch)
+        return switchService.updateSwitch(branch, switchId, switch)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @DeleteMapping("/draft/{id}")
-    fun deleteDraftSwitch(@PathVariable("id") switchId: IntId<TrackLayoutSwitch>): IntId<TrackLayoutSwitch> {
-        logger.apiCall("deleteDraftSwitch", "switchId" to switchId)
-        return switchService.deleteDraft(switchId).id
+    @DeleteMapping("/{${LAYOUT_BRANCH}}/draft/{id}")
+    fun deleteDraftSwitch(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @PathVariable("id") switchId: IntId<TrackLayoutSwitch>,
+    ): IntId<TrackLayoutSwitch> {
+        logger.apiCall("deleteDraftSwitch", "branch" to branch, "switchId" to switchId)
+        return switchService.deleteDraft(branch, switchId).id
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/{id}/change-times")
+    @GetMapping("/{${LAYOUT_BRANCH}}/{$PUBLICATION_STATE}/{id}/change-info")
     fun getSwitchChangeInfo(
-        @PathVariable("id") switchId: IntId<TrackLayoutSwitch>,
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
+        @PathVariable("id") switchId: IntId<TrackLayoutSwitch>,
     ): ResponseEntity<LayoutAssetChangeInfo> {
-        logger.apiCall("getSwitchChangeInfo", "id" to switchId, PUBLICATION_STATE to publicationState)
-        return toResponse(switchService.getLayoutAssetChangeInfo(switchId, publicationState))
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getSwitchChangeInfo", "layoutContext" to layoutContext, "id" to switchId)
+        return toResponse(switchService.getLayoutAssetChangeInfo(layoutContext, switchId))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
@@ -1,8 +1,11 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
+import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.map.AlignmentHeader
@@ -24,125 +27,145 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/alignment-polylines")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/alignment-polylines")
     fun getAlignmentPolyLines(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("resolution") resolution: Int,
         @RequestParam("type") type: AlignmentFetchType? = null,
     ): List<AlignmentPolyLine<*>> {
+        val layoutContext = LayoutContext.of(branch, publicationState)
         logger.apiCall(
             "getAlignmentPolyLines",
-            PUBLICATION_STATE to publicationState,
+            "layoutContext" to layoutContext,
             "bbox" to bbox,
             "resolution" to resolution,
             "type" to type,
         )
-        return mapAlignmentService.getAlignmentPolyLines(publicationState, bbox, resolution, type ?: ALL)
+        return mapAlignmentService.getAlignmentPolyLines(layoutContext, bbox, resolution, type ?: ALL)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/location-track/{id}/alignment-polyline")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-track/{id}/alignment-polyline")
     fun getLocationTrackPolyline(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") locationTrackId: IntId<LocationTrack>,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("resolution") resolution: Int,
     ): AlignmentPolyLine<LocationTrack>? {
+        val layoutContext = LayoutContext.of(branch, publicationState)
         logger.apiCall(
             "getLocationTrackPolyline",
-            PUBLICATION_STATE to publicationState,
+            "layoutContext" to layoutContext,
             "id" to locationTrackId,
             "bbox" to bbox,
             "resolution" to resolution
         )
 
-        return mapAlignmentService.getAlignmentPolyline(locationTrackId, publicationState, bbox, resolution)
+        return mapAlignmentService.getAlignmentPolyline(layoutContext, locationTrackId, bbox, resolution)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/location-track/alignment-headers")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-track/alignment-headers")
     fun getLocationTrackHeaders(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids") ids: List<IntId<LocationTrack>>,
     ): List<AlignmentHeader<LocationTrack, LocationTrackState>> {
-        logger.apiCall("getReferenceLineHeaders", PUBLICATION_STATE to publicationState, "ids" to ids)
-        return mapAlignmentService.getLocationTrackHeaders(publicationState, ids)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getReferenceLineHeaders", "layoutContext" to layoutContext, "ids" to ids)
+        return mapAlignmentService.getLocationTrackHeaders(layoutContext, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/reference-line/alignment-headers")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/reference-line/alignment-headers")
     fun getReferenceLineHeaders(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids") ids: List<IntId<ReferenceLine>>,
     ): List<AlignmentHeader<ReferenceLine, LayoutState>> {
-        logger.apiCall("getReferenceLineHeaders", PUBLICATION_STATE to publicationState, "ids" to ids)
-        return mapAlignmentService.getReferenceLineHeaders(publicationState, ids)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getReferenceLineHeaders", "layoutContext" to layoutContext, "ids" to ids)
+        return mapAlignmentService.getReferenceLineHeaders(layoutContext, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/location-track/{id}/segment-m")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-track/{id}/segment-m")
     fun getLocationTrackSegmentMValues(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
     ): List<Double> {
-        logger.apiCall("getLocationTrackSegmentMValues", PUBLICATION_STATE to publicationState, "id" to id)
-        return mapAlignmentService.getLocationTrackSegmentMValues(publicationState, id)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getLocationTrackSegmentMValues", "layoutContext" to layoutContext, "id" to id)
+        return mapAlignmentService.getLocationTrackSegmentMValues(layoutContext, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/alignment/without-linking")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/alignment/without-linking")
     fun getSectionsWithoutLinking(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("type") type: AlignmentFetchType,
     ): List<MapAlignmentHighlight<*>> {
+        val layoutContext = LayoutContext.of(branch, publicationState)
         logger.apiCall("getSectionsWithoutLinking",
-            PUBLICATION_STATE to publicationState, "bbox" to bbox, "type" to type)
-        return mapAlignmentService.getSectionsWithoutLinking(publicationState, bbox, type)
+            "layoutContext" to layoutContext, "bbox" to bbox, "type" to type)
+        return mapAlignmentService.getSectionsWithoutLinking(layoutContext, bbox, type)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/location-track/without-profile")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-track/without-profile")
     fun getSectionsWithoutProfile(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
     ): List<MapAlignmentHighlight<LocationTrack>> {
+        val layoutContext = LayoutContext.of(branch, publicationState)
         logger.apiCall(
             "getSectionsWithoutProfile",
-            PUBLICATION_STATE to publicationState,
+            "layoutContext" to layoutContext,
             "bbox" to bbox,
         )
-        return mapAlignmentService.getSectionsWithoutProfile(publicationState, bbox)
+        return mapAlignmentService.getSectionsWithoutProfile(layoutContext, bbox)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/reference-line/{id}/segment-m")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/reference-line/{id}/segment-m")
     fun getReferenceLineSegmentMValues(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): List<Double> {
-        logger.apiCall("getReferenceLineSegmentMValues", PUBLICATION_STATE to publicationState, "id" to id)
-        return mapAlignmentService.getReferenceLineSegmentMValues(publicationState, id)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getReferenceLineSegmentMValues", "layoutContext" to layoutContext, "id" to id)
+        return mapAlignmentService.getReferenceLineSegmentMValues(layoutContext, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/location-track/{id}/ends")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-track/{id}/ends")
     fun getLocationTrackEnds(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
     ): MapAlignmentEndPoints {
-        logger.apiCall("getLocationTrackEnds", PUBLICATION_STATE to publicationState, "id" to id)
-        return mapAlignmentService.getLocationTrackEnds(publicationState, id)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getLocationTrackEnds", "layoutContext" to layoutContext, "id" to id)
+        return mapAlignmentService.getLocationTrackEnds(layoutContext, id)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/reference-line/{id}/ends")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/reference-line/{id}/ends")
     fun getReferenceLineEnds(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): MapAlignmentEndPoints {
-        logger.apiCall("getReferenceLineEnds", PUBLICATION_STATE to publicationState, "id" to id)
-        return mapAlignmentService.getReferenceLineEnds(publicationState, id)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getReferenceLineEnds", "layoutContext" to layoutContext, "id" to id)
+        return mapAlignmentService.getReferenceLineEnds(layoutContext, id)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
@@ -2,8 +2,11 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT_DRAFT
+import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.geocoding.AlignmentStartAndEnd
 import fi.fta.geoviite.infra.geocoding.GeocodingService
@@ -29,73 +32,85 @@ class ReferenceLineController(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/{id}")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}")
     fun getReferenceLine(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): ResponseEntity<ReferenceLine> {
-        logger.apiCall("getReferenceLine", PUBLICATION_STATE to publicationState, "id" to id)
-        return toResponse(referenceLineService.get(publicationState, id))
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getReferenceLine", "layoutContext" to layoutContext, "id" to id)
+        return toResponse(referenceLineService.get(layoutContext, id))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}", params = ["ids"])
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["ids"])
     fun getReferenceLines(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids", required = true) ids: List<IntId<ReferenceLine>>,
     ): List<ReferenceLine> {
-        logger.apiCall("getReferenceLines", PUBLICATION_STATE to publicationState, "ids" to ids)
-        return referenceLineService.getMany(publicationState, ids)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getReferenceLines", "layoutContext" to layoutContext, "ids" to ids)
+        return referenceLineService.getMany(layoutContext, ids)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/by-track-number/{trackNumberId}")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/by-track-number/{trackNumberId}")
     fun getTrackNumberReferenceLine(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("trackNumberId") trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): ResponseEntity<ReferenceLine> {
+        val layoutContext = LayoutContext.of(branch, publicationState)
         logger.apiCall(
-            "getTrackNumberReferenceLine", PUBLICATION_STATE to publicationState, "trackNumberId" to trackNumberId
+            "getTrackNumberReferenceLine", "layoutContext" to layoutContext, "trackNumberId" to trackNumberId
         )
-        return toResponse(referenceLineService.getByTrackNumber(publicationState, trackNumberId))
+        return toResponse(referenceLineService.getByTrackNumber(layoutContext, trackNumberId))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}", params = ["bbox"])
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["bbox"])
     fun getReferenceLinesNear(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
     ): List<ReferenceLine> {
-        logger.apiCall("getReferenceLinesNear", PUBLICATION_STATE to publicationState, "bbox" to bbox)
-        return referenceLineService.listNear(publicationState, bbox)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getReferenceLinesNear", "layoutContext" to layoutContext, "bbox" to bbox)
+        return referenceLineService.listNear(layoutContext, bbox)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/{id}/start-and-end")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}/start-and-end")
     fun getReferenceLineStartAndEnd(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): ResponseEntity<AlignmentStartAndEnd> {
-        logger.apiCall("getReferenceLineStartAndEnd", PUBLICATION_STATE to publicationState, "id" to id)
-        return toResponse(referenceLineService.getWithAlignment(publicationState, id)?.let { (referenceLine, alignment) ->
-            geocodingService.getReferenceLineStartAndEnd(publicationState, referenceLine, alignment)
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getReferenceLineStartAndEnd", "layoutContext" to layoutContext, "id" to id)
+        return toResponse(referenceLineService.getWithAlignment(layoutContext, id)?.let { (referenceLine, alignment) ->
+            geocodingService.getReferenceLineStartAndEnd(layoutContext, referenceLine, alignment)
         })
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
-    @GetMapping("/draft/non-linked")
-    fun getNonLinkedReferenceLines(): List<ReferenceLine> {
-        logger.apiCall("getNonLinkedReferenceLines")
-        return referenceLineService.listNonLinked()
+    @GetMapping("/{$LAYOUT_BRANCH}/draft/non-linked")
+    fun getNonLinkedReferenceLines(@PathVariable(LAYOUT_BRANCH) branch: LayoutBranch): List<ReferenceLine> {
+        logger.apiCall("getNonLinkedReferenceLines", "branch" to branch)
+        return referenceLineService.listNonLinked(branch)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$PUBLICATION_STATE}/{id}/change-times")
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}/change-info")
     fun getReferenceLineChangeInfo(
-        @PathVariable("id") id: IntId<ReferenceLine>,
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
+        @PathVariable("id") id: IntId<ReferenceLine>,
     ): ResponseEntity<LayoutAssetChangeInfo> {
-        logger.apiCall("getReferenceLineChangeInfo", "id" to id, "publicationState" to publicationState)
-        return toResponse(referenceLineService.getLayoutAssetChangeInfo(id, publicationState))
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        logger.apiCall("getReferenceLineChangeInfo", "id" to id, "layoutContext" to layoutContext)
+        return toResponse(referenceLineService.getLayoutAssetChangeInfo(layoutContext, id))
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -4,8 +4,7 @@ import fi.fta.geoviite.infra.common.DataType.STORED
 import fi.fta.geoviite.infra.common.DataType.TEMP
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
-import fi.fta.geoviite.infra.common.PublicationState
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.logging.serviceCall
@@ -24,21 +23,22 @@ class ReferenceLineService(
 
     @Transactional
     fun addTrackNumberReferenceLine(
+        branch: LayoutBranch,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         startAddress: TrackMeter,
     ): DaoResponse<ReferenceLine> {
-        logger.serviceCall(
-            "insertTrackNumberReferenceLine",
+        logger.serviceCall("insertTrackNumberReferenceLine",
+            "branch" to branch,
             "trackNumberId" to trackNumberId,
             "startAddress" to startAddress,
         )
         return saveDraftInternal(
+            branch,
             ReferenceLine(
                 trackNumberId = trackNumberId,
                 startAddress = startAddress,
                 sourceId = null,
-                // TODO: GVT-2398
-                contextData = LayoutContextData.newDraft(LayoutBranch.main),
+                contextData = LayoutContextData.newDraft(branch),
             ),
             emptyAlignment(),
         )
@@ -46,18 +46,22 @@ class ReferenceLineService(
 
     @Transactional
     fun updateTrackNumberReferenceLine(
+        branch: LayoutBranch,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         startAddress: TrackMeter,
     ): DaoResponse<ReferenceLine>? {
         logger.serviceCall("updateTrackNumberStart",
-            "trackNumberId" to trackNumberId, "startAddress" to startAddress)
-        val originalVersion = dao.fetchVersionByTrackNumberId(DRAFT, trackNumberId)
+            "branch" to branch,
+            "trackNumberId" to trackNumberId,
+             "startAddress" to startAddress,
+        )
+
+        val originalVersion = dao.fetchVersionByTrackNumberId(branch.draft, trackNumberId)
             ?: throw IllegalStateException("Track number should have a reference line")
         val original = dao.fetch(originalVersion)
         return if (original.startAddress != startAddress) {
-            // TODO: GVT-2398
             saveDraftInternal(
-                LayoutBranch.main,
+                branch,
                 original.copy(
                     startAddress = startAddress,
                     alignmentVersion = updatedAlignmentVersion(original),
@@ -73,12 +77,16 @@ class ReferenceLineService(
         super.saveDraft(branch, draftItem.copy(alignmentVersion = updatedAlignmentVersion(draftItem)))
 
     @Transactional
-    fun saveDraft(draft: ReferenceLine, alignment: LayoutAlignment): DaoResponse<ReferenceLine> {
-        logger.serviceCall("save", "locationTrack" to draft, "alignment" to alignment)
-        return saveDraftInternal(draft, alignment)
+    fun saveDraft(branch: LayoutBranch, draft: ReferenceLine, alignment: LayoutAlignment): DaoResponse<ReferenceLine> {
+        logger.serviceCall("save", "branch" to branch, "locationTrack" to draft, "alignment" to alignment)
+        return saveDraftInternal(branch, draft, alignment)
     }
 
-    private fun saveDraftInternal(draft: ReferenceLine, alignment: LayoutAlignment): DaoResponse<ReferenceLine> {
+    private fun saveDraftInternal(
+        branch: LayoutBranch,
+        draft: ReferenceLine,
+        alignment: LayoutAlignment,
+    ): DaoResponse<ReferenceLine> {
         require(alignment.segments.all { it.switchId == null }) {
             "Reference line cannot have switches, id=${draft.id} trackNumberId=${draft.trackNumberId}"
         }
@@ -93,8 +101,7 @@ class ReferenceLineService(
             } else {
                 alignmentService.save(alignment)
             }
-        // TODO: GVT-2398
-        return saveDraftInternal(LayoutBranch.main, draft.copy(alignmentVersion = alignmentVersion))
+        return saveDraftInternal(branch, draft.copy(alignmentVersion = alignmentVersion))
     }
 
     private fun updatedAlignmentVersion(line: ReferenceLine) =
@@ -103,12 +110,12 @@ class ReferenceLineService(
         else line.alignmentVersion
 
     @Transactional
-    override fun publish(version: ValidationVersion<ReferenceLine>): DaoResponse<ReferenceLine> {
-        logger.serviceCall("publish", "version" to version)
-        val officialVersion = dao.fetchOfficialVersion(version.officialId)
+    override fun publish(branch: LayoutBranch, version: ValidationVersion<ReferenceLine>): DaoResponse<ReferenceLine> {
+        logger.serviceCall("publish", "branch" to branch, "version" to version)
+        val officialVersion = dao.fetchOfficialVersion(branch, version.officialId)
         val oldDraft = dao.fetch(version.validatedAssetVersion)
         val oldOfficial = officialVersion?.let(dao::fetch)
-        val publishedVersion = publishInternal(VersionPair(officialVersion, version.validatedAssetVersion))
+        val publishedVersion = publishInternal(branch, VersionPair(officialVersion, version.validatedAssetVersion))
         if (oldOfficial != null && oldDraft.alignmentVersion != oldOfficial.alignmentVersion) {
             // The alignment on the draft overrides the one on official -> delete the original, orphaned alignment
             oldOfficial.alignmentVersion?.id?.let(alignmentDao::delete)
@@ -117,48 +124,60 @@ class ReferenceLineService(
     }
 
     @Transactional
-    override fun deleteDraft(id: IntId<ReferenceLine>): DaoResponse<ReferenceLine> {
-        val draft = dao.getOrThrow(DRAFT, id)
-        val deletedVersion = super.deleteDraft(id)
+    override fun deleteDraft(branch: LayoutBranch, id: IntId<ReferenceLine>): DaoResponse<ReferenceLine> {
+        val draft = dao.getOrThrow(branch.draft, id)
+        val deletedVersion = super.deleteDraft(branch, id)
         draft.alignmentVersion?.id?.let(alignmentDao::delete)
         return deletedVersion
     }
 
     @Transactional
-    fun deleteDraftByTrackNumberId(trackNumberId: IntId<TrackLayoutTrackNumber>): DaoResponse<ReferenceLine>? {
-        logger.serviceCall("deleteDraftByTrackNumberId", "trackNumberId" to trackNumberId)
-        val referenceLine = requireNotNull(referenceLineDao.getByTrackNumber(DRAFT, trackNumberId)) {
+    fun deleteDraftByTrackNumberId(
+        branch: LayoutBranch,
+        trackNumberId: IntId<TrackLayoutTrackNumber>,
+    ): DaoResponse<ReferenceLine>? {
+        logger.serviceCall("deleteDraftByTrackNumberId", "branch" to branch, "trackNumberId" to trackNumberId)
+        val referenceLine = requireNotNull(referenceLineDao.getByTrackNumber(branch.draft, trackNumberId)) {
             "Found Track Number without Reference Line $trackNumberId"
         }
-        return if (referenceLine.isDraft) deleteDraft(referenceLine.id as IntId) else null
+        return if (referenceLine.isDraft) deleteDraft(branch, referenceLine.id as IntId) else null
     }
 
-    fun getByTrackNumber(publicationState: PublicationState, trackNumberId: IntId<TrackLayoutTrackNumber>): ReferenceLine? {
-        logger.serviceCall("getByTrackNumber",
-            "publicationState" to publicationState, "trackNumberId" to trackNumberId)
-        return dao.getByTrackNumber(publicationState, trackNumberId)
+    fun getByTrackNumber(layoutContext: LayoutContext, trackNumberId: IntId<TrackLayoutTrackNumber>): ReferenceLine? {
+        logger.serviceCall(
+            "getByTrackNumber",
+             "layoutContext" to layoutContext,
+            "trackNumberId" to trackNumberId,
+        )
+        return dao.getByTrackNumber(layoutContext, trackNumberId)
     }
 
     @Transactional(readOnly = true)
     fun getByTrackNumberWithAlignment(
-        publicationState: PublicationState,
+        layoutContext: LayoutContext,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): Pair<ReferenceLine,LayoutAlignment>? {
-        logger.serviceCall("getByTrackNumberWithAlignment",
-            "publicationState" to publicationState, "trackNumberId" to trackNumberId)
-        return dao.fetchVersionByTrackNumberId(publicationState, trackNumberId)?.let(::getWithAlignmentInternal)
+        logger.serviceCall(
+            "getByTrackNumberWithAlignment",
+            "layoutContext" to layoutContext,
+            "trackNumberId" to trackNumberId,
+        )
+        return dao.fetchVersionByTrackNumberId(layoutContext, trackNumberId)?.let(::getWithAlignmentInternal)
     }
 
     @Transactional(readOnly = true)
-    fun getWithAlignmentOrThrow(publicationState: PublicationState, id: IntId<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment> {
-        logger.serviceCall("getWithAlignment", "publicationState" to publicationState, "id" to id)
-        return getWithAlignmentInternalOrThrow(publicationState, id)
+    fun getWithAlignmentOrThrow(
+        layoutContext: LayoutContext,
+        id: IntId<ReferenceLine>,
+    ): Pair<ReferenceLine, LayoutAlignment> {
+        logger.serviceCall("getWithAlignment", "layoutContext" to layoutContext, "id" to id)
+        return getWithAlignmentInternalOrThrow(layoutContext, id)
     }
 
     @Transactional(readOnly = true)
-    fun getWithAlignment(publicationState: PublicationState, id: IntId<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment>? {
-        logger.serviceCall("getWithAlignment", "publicationState" to publicationState, "id" to id)
-        return getWithAlignmentInternal(publicationState, id)
+    fun getWithAlignment(layoutContext: LayoutContext, id: IntId<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment>? {
+        logger.serviceCall("getWithAlignment", "layoutContext" to layoutContext, "id" to id)
+        return getWithAlignmentInternal(layoutContext, id)
     }
 
     @Transactional(readOnly = true)
@@ -169,35 +188,43 @@ class ReferenceLineService(
 
     @Transactional(readOnly = true)
     fun getManyWithAlignments(
-        publicationState: PublicationState,
+        layoutContext: LayoutContext,
         ids: List<IntId<ReferenceLine>>,
     ): List<Pair<ReferenceLine, LayoutAlignment>> {
-        logger.serviceCall("getManyWithAlignments", "publicationState" to publicationState, "ids" to ids)
-        return dao.getMany(publicationState, ids).let(::associateWithAlignments)
+        logger.serviceCall("getManyWithAlignments", "layoutContext" to layoutContext, "ids" to ids)
+        return dao.getMany(layoutContext, ids).let(::associateWithAlignments)
     }
 
     @Transactional(readOnly = true)
     fun listWithAlignments(
-        publicationState: PublicationState,
+        layoutContext: LayoutContext,
         includeDeleted: Boolean = false,
         boundingBox: BoundingBox? = null,
     ): List<Pair<ReferenceLine, LayoutAlignment>> {
         logger.serviceCall(
             "listWithAlignments",
-            "publicationState" to publicationState,
+            "layoutContext" to layoutContext,
             "includeDeleted" to includeDeleted,
         )
         return dao
-            .list(publicationState, includeDeleted)
+            .list(layoutContext, includeDeleted)
             .let { list -> filterByBoundingBox(list, boundingBox) }
             .let(::associateWithAlignments)
     }
 
-    private fun getWithAlignmentInternalOrThrow(publicationState: PublicationState, id: IntId<ReferenceLine>) =
-        getWithAlignmentInternal(dao.fetchVersionOrThrow(id, publicationState))
+    private fun getWithAlignmentInternalOrThrow(
+        layoutContext: LayoutContext,
+        id: IntId<ReferenceLine>,
+    ): Pair<ReferenceLine, LayoutAlignment> {
+        return getWithAlignmentInternal(dao.fetchVersionOrThrow(layoutContext, id))
+    }
 
-    private fun getWithAlignmentInternal(publicationState: PublicationState, id: IntId<ReferenceLine>) =
-        dao.fetchVersion(id, publicationState)?.let { v -> getWithAlignmentInternal(v) }
+    private fun getWithAlignmentInternal(
+        layoutContext: LayoutContext,
+        id: IntId<ReferenceLine>,
+    ): Pair<ReferenceLine, LayoutAlignment>? {
+        return dao.fetchVersion(layoutContext, id)?.let { v -> getWithAlignmentInternal(v) }
+    }
 
     private fun getWithAlignmentInternal(version: RowVersion<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment> =
         referenceLineWithAlignment(dao, alignmentDao, version)
@@ -208,14 +235,14 @@ class ReferenceLineService(
         return lines.map { line -> line to alignments.getValue(line.getAlignmentVersionOrThrow()) }
     }
 
-    fun listNonLinked(): List<ReferenceLine> {
-        logger.serviceCall("listNonLinked")
-        return dao.fetchVersionsNonLinked(DRAFT).map(dao::fetch)
+    fun listNonLinked(branch: LayoutBranch): List<ReferenceLine> {
+        logger.serviceCall("listNonLinked", "branch" to branch)
+        return dao.fetchVersionsNonLinked(branch.draft).map(dao::fetch)
     }
 
-    fun listNear(publicationState: PublicationState, bbox: BoundingBox): List<ReferenceLine> {
-        logger.serviceCall("listNear", "publicationState" to publicationState, "bbox" to bbox)
-        return dao.fetchVersionsNear(publicationState, bbox).map(dao::fetch)
+    fun listNear(layoutContext: LayoutContext, bbox: BoundingBox): List<ReferenceLine> {
+        logger.serviceCall("listNear", "layoutContext" to layoutContext, "bbox" to bbox)
+        return dao.fetchVersionsNear(layoutContext, bbox).map(dao::fetch)
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLink.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLink.kt
@@ -174,16 +174,12 @@ fun collectSwitchJoints(
 
 fun getSwitchJoints(segment: LayoutSegment): List<SwitchJointOnTrack> {
     val switchId = segment.switchId as IntId?
-    val joints = switchId?.let { switchId ->
+    val joints = switchId?.let { id ->
         val startJoint = segment.startJointNumber?.let { jointNumber ->
-            SwitchJointOnTrack(
-                switchId, jointNumber, segment.alignmentStart
-            )
+            SwitchJointOnTrack(id, jointNumber, segment.alignmentStart)
         }
         val endJoint = segment.endJointNumber?.let { jointNumber ->
-            SwitchJointOnTrack(
-                switchId, jointNumber, segment.alignmentEnd
-            )
+            SwitchJointOnTrack(id, jointNumber, segment.alignmentEnd)
         }
         listOfNotNull(startJoint, endJoint)
     } ?: emptyList()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
@@ -2,10 +2,29 @@ package fi.fta.geoviite.infra
 
 import currentUser
 import fi.fta.geoviite.infra.authorization.UserName
-import fi.fta.geoviite.infra.common.*
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.MainLayoutContext
+import fi.fta.geoviite.infra.common.ProjectName
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackNumber
+import fi.fta.geoviite.infra.common.switchNameLength
+import fi.fta.geoviite.infra.common.trackNumberLength
 import fi.fta.geoviite.infra.geometry.MetaDataName
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.DaoResponse
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutState
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.asMainDraft
+import fi.fta.geoviite.infra.tracklayout.switch
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.DbTable
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.setUser
@@ -81,7 +100,7 @@ abstract class DBTestBase(val testUser: String = TEST_USER) {
         getOrCreateTrackNumber(getUnusedTrackNumber()).id as IntId
 
     fun getOrCreateTrackNumber(trackNumber: TrackNumber): TrackLayoutTrackNumber {
-        val version = trackNumberDao.fetchVersions(DRAFT, false, trackNumber).firstOrNull()
+        val version = trackNumberDao.fetchVersions(MainLayoutContext.draft, false, trackNumber).firstOrNull()
             ?: insertNewTrackNumber(trackNumber, false).rowVersion
         return version.let(trackNumberDao::fetch)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
@@ -3,8 +3,7 @@ package fi.fta.geoviite.infra.geocoding
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentService
@@ -46,8 +45,8 @@ class GeocodingDaoIT @Autowired constructor(
     @Test
     fun trackNumberWithoutReferenceLineHasNoContext() {
         val id = trackNumberDao.insert(trackNumber(getUnusedTrackNumber(), draft = false)).id
-        assertNull(geocodingDao.getLayoutGeocodingContextCacheKey(DRAFT, id))
-        assertNull(geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, id))
+        assertNull(geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.draft, id))
+        assertNull(geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, id))
     }
 
     @Test
@@ -55,8 +54,8 @@ class GeocodingDaoIT @Autowired constructor(
         val id = trackNumberDao.insert(trackNumber(getUnusedTrackNumber(), draft = false)).id
         val alignmentVersion = alignmentDao.insert(alignment())
         referenceLineDao.insert(referenceLine(id, alignmentVersion = alignmentVersion, draft = false))
-        assertNotNull(geocodingDao.getLayoutGeocodingContextCacheKey(DRAFT, id))
-        assertNotNull(geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, id))
+        assertNotNull(geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.draft, id))
+        assertNotNull(geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, id))
     }
 
     @Test
@@ -83,7 +82,7 @@ class GeocodingDaoIT @Autowired constructor(
         // Add a deleted post - should not appear in results
         kmPostDao.insert(kmPost(tnId, KmNumber(4), state = LayoutState.DELETED, draft = false))
 
-        val officialKey = geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, tnId)!!
+        val officialKey = geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId)!!
         assertEquals(
             LayoutGeocodingContextCacheKey(
                 trackNumberVersion = tnOfficialVersion,
@@ -93,7 +92,7 @@ class GeocodingDaoIT @Autowired constructor(
             officialKey,
         )
 
-        val draftKey = geocodingDao.getLayoutGeocodingContextCacheKey(DRAFT, tnId)!!
+        val draftKey = geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.draft, tnId)!!
         assertEquals(
             LayoutGeocodingContextCacheKey(
                 trackNumberVersion = tnDraftVersion,
@@ -166,7 +165,7 @@ class GeocodingDaoIT @Autowired constructor(
         val originalTime = kmPostDao.fetchChangeTime()
         Thread.sleep(1) // Ensure that later objects get a new changetime so that moment-fetch makes sense
 
-        val originalKey = geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, tnId)!!
+        val originalKey = geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId)!!
         assertEquals(
             LayoutGeocodingContextCacheKey(
                 trackNumberVersion = tnOfficialVersion,
@@ -191,7 +190,7 @@ class GeocodingDaoIT @Autowired constructor(
 
         val updatedTime = kmPostDao.fetchChangeTime()
 
-        val updatedKey = geocodingDao.getLayoutGeocodingContextCacheKey(OFFICIAL, tnId)!!
+        val updatedKey = geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId)!!
         assertEquals(
             LayoutGeocodingContextCacheKey(
                 trackNumberVersion = updatedTrackNumberVersion,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
@@ -3,8 +3,9 @@ package fi.fta.geoviite.infra.geometry
 import assertPlansMatch
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.authorization.UserName
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.ProjectName
-import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.inframodel.InfraModelFile
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.ValidationVersion
@@ -215,10 +216,10 @@ class GeometryDaoIT @Autowired constructor(
             segment(Point(0.0, 0.0), Point(1.0, 1.0)).copy(sourceId = element.id),
             draft = true,
         )
-        val trackVersion = locationTrackService.saveDraft(track.first, track.second)
-        locationTrackService.publish(ValidationVersion(trackVersion.id, trackVersion.rowVersion))
+        val trackVersion = locationTrackService.saveDraft(LayoutBranch.main, track.first, track.second)
+        locationTrackService.publish(LayoutBranch.main, ValidationVersion(trackVersion.id, trackVersion.rowVersion))
         val trackChangeTime =
-            locationTrackService.getLayoutAssetChangeInfo(trackVersion.id, PublicationState.OFFICIAL)?.changed
+            locationTrackService.getLayoutAssetChangeInfo(MainLayoutContext.official, trackVersion.id)?.changed
 
         val expectedSummary = GeometryPlanLinkingSummary(trackChangeTime, listOf(UserName.of("TEST_USER")), true)
         val summaries = geometryDao.getLinkingSummaries(listOf(planVersion.id))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
@@ -15,7 +15,7 @@ import kotlin.math.sqrt
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-class VerticalGeometryListingTest() {
+class VerticalGeometryListingTest {
     @Test
     fun `Station point is calculated correctly when other line goes straight up`() {
         val curve = CurvedProfileSegment(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -2,11 +2,20 @@ package fi.fta.geoviite.infra.integration
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationDao
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.ratko.RatkoPushDao
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.DaoResponse
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
 import fi.fta.geoviite.infra.util.getEnum
 import fi.fta.geoviite.infra.util.getInstantOrNull
 import org.junit.jupiter.api.Assertions
@@ -225,8 +234,8 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
     fun insertAndPublishLocationTrack(): DaoResponse<LocationTrack> =
         locationTrackAndAlignment(trackNumberId, draft = true).let { (track, alignment) ->
-            val draftVersion = locationTrackService.saveDraft(track, alignment)
-            locationTrackService.publish(ValidationVersion(draftVersion.id, draftVersion.rowVersion))
+            val draftVersion = locationTrackService.saveDraft(LayoutBranch.main, track, alignment)
+            locationTrackService.publish(LayoutBranch.main, ValidationVersion(draftVersion.id, draftVersion.rowVersion))
         }
 
     fun createPublication(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDaoIT.kt
@@ -1,12 +1,10 @@
 package fi.fta.geoviite.infra.linking
 
-
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoints
@@ -34,16 +32,22 @@ class LinkingDaoIT @Autowired constructor(
 
     @Test
     fun noSwitchBoundsAreFoundWhenNotLinkedToTracks() {
-        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id)
-        assertEquals(null, linkingDao.getSwitchBoundsFromTracks(OFFICIAL, switch.id as IntId))
-        assertEquals(null, linkingDao.getSwitchBoundsFromTracks(DRAFT, switch.id as IntId))
+        val switch = switchService.getOrThrow(
+            MainLayoutContext.draft,
+            switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id,
+        )
+        assertEquals(null, linkingDao.getSwitchBoundsFromTracks(MainLayoutContext.official, switch.id as IntId))
+        assertEquals(null, linkingDao.getSwitchBoundsFromTracks(MainLayoutContext.draft, switch.id as IntId))
     }
 
     @Test
     fun switchBoundsAreFoundFromTracks() {
         val trackNumber = getOrCreateTrackNumber(TrackNumber("123"))
         val tnId = trackNumber.id as IntId
-        val switch = switchService.getOrThrow(DRAFT, switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id)
+        val switch = switchService.getOrThrow(
+            MainLayoutContext.draft,
+            switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id,
+        )
 
         val point1 = Point(10.0, 10.0)
         val point2 = Point(12.0, 10.0)
@@ -52,18 +56,23 @@ class LinkingDaoIT @Autowired constructor(
 
         // Linked from the start only -> second point shouldn't matter
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(tnId, externalId = someOid(), draft = true).copy(
                 topologyStartSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(1)),
-            ), alignment(segment(point1, point1 + Point(5.0, 5.0)))
+            ),
+            alignment(segment(point1, point1 + Point(5.0, 5.0))),
         )
         // Linked from the end only -> first point shouldn't matter
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(tnId, externalId = null, draft = true).copy(
                 topologyEndSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
-            ), alignment(segment(point2 - Point(5.0, 5.0), point2))
+            ),
+            alignment(segment(point2 - Point(5.0, 5.0), point2)),
         )
         // Linked by segment ends -> both points matter
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(tnId, externalId = someOid(), draft = true),
             alignment(
                 segment(point3_1, point3_2).copy(
@@ -73,10 +82,10 @@ class LinkingDaoIT @Autowired constructor(
                 )
             ),
         )
-        assertEquals(null, linkingDao.getSwitchBoundsFromTracks(OFFICIAL, switch.id as IntId))
+        assertEquals(null, linkingDao.getSwitchBoundsFromTracks(MainLayoutContext.official, switch.id as IntId))
         assertEquals(
             boundingBoxAroundPoints(point1, point2, point3_1, point3_2),
-            linkingDao.getSwitchBoundsFromTracks(DRAFT, switch.id as IntId),
+            linkingDao.getSwitchBoundsFromTracks(MainLayoutContext.draft, switch.id as IntId),
         )
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -1,4 +1,5 @@
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.publication.PublicationRequestIds
 import fi.fta.geoviite.infra.publication.PublicationResult
@@ -32,7 +33,9 @@ fun validationVersions(
     kmPosts: List<Pair<IntId<TrackLayoutKmPost>, RowVersion<TrackLayoutKmPost>>> = listOf(),
     locationTracks: List<Pair<IntId<LocationTrack>, RowVersion<LocationTrack>>> = listOf(),
     switches: List<Pair<IntId<TrackLayoutSwitch>, RowVersion<TrackLayoutSwitch>>> = listOf(),
+    branch: LayoutBranch = LayoutBranch.main,
 ) = ValidationVersions(
+    branch = branch,
     trackNumbers = trackNumbers.map { (id,version) -> ValidationVersion(id, version) },
     referenceLines = referenceLines.map { (id,version) -> ValidationVersion(id, version) },
     kmPosts = kmPosts.map { (id,version) -> ValidationVersion(id, version) },
@@ -50,10 +53,14 @@ fun publish(
     locationTracks: List<IntId<LocationTrack>> = listOf(),
 ) = publish(publicationService, publicationRequest(trackNumbers, kmPosts, switches, referenceLines, locationTracks))
 
-fun publish(publicationService: PublicationService, request: PublicationRequestIds): PublicationResult {
-    val versions = publicationService.getValidationVersions(request)
+fun publish(
+    publicationService: PublicationService,
+    request: PublicationRequestIds,
+    branch: LayoutBranch = LayoutBranch.main,
+): PublicationResult {
+    val versions = publicationService.getValidationVersions(branch, request)
     val calculatedChanges = publicationService.getCalculatedChanges(versions)
-    return publicationService.publishChanges(versions, calculatedChanges, "Test")
+    return publicationService.publishChanges(branch, versions, calculatedChanges, "Test")
 }
 
 fun <T> daoResponseToValidationVersion(response: DaoResponse<T>) = ValidationVersion<T>(response.id, response.rowVersion)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -6,8 +6,8 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LocationAccuracy
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.MeasurementMethod
-import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -103,6 +103,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
     @Test()
     fun getSuggestedSwitchesWorks() {
         switchLinkingService.getSuggestedSwitches(
+            LayoutBranch.main,
             BoundingBox(
                 x = Range(500000.0, 600000.0),
                 y = Range(6900000.0, 7000000.0),
@@ -116,6 +117,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
             switchDao.insert(switch(665, draft = false)).rowVersion
         )
         val suggestedSwitch = switchLinkingService.matchFittedSwitch(
+            LayoutBranch.main,
             FittedSwitch(
                 joints = emptyList(),
                 geometrySwitchId = null,
@@ -125,7 +127,9 @@ class SwitchLinkingServiceIT @Autowired constructor(
             ),
             insertedSwitch.id as IntId,
         )
-        val rowVersion = switchLinkingService.saveSwitchLinking(suggestedSwitch, insertedSwitch.id as IntId).rowVersion
+        val rowVersion = switchLinkingService
+            .saveSwitchLinking(LayoutBranch.main, suggestedSwitch, insertedSwitch.id as IntId)
+            .rowVersion
         val switch = switchDao.fetch(rowVersion)
         assertEquals(switch.source, GeometrySource.GENERATED)
     }
@@ -134,6 +138,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
     fun linkingExistingGeometrySwitchGetsSwitchAccuracyForJoints() {
         setupJointLocationAccuracyTest()
         val suggestedSwitch = switchLinkingService.getSuggestedSwitches(
+            LayoutBranch.main,
             BoundingBox(
                 x = Range(0.0, 100.0),
                 y = Range(0.0, 100.0),
@@ -147,7 +152,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
     @Test
     fun linkingManualSwitchGetsGeometryCalculatedAccuracy() {
         val suggestedSwitchCreateParams = setupJointLocationAccuracyTest()
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(suggestedSwitchCreateParams)!!
+        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, suggestedSwitchCreateParams)!!
 
         for (joint in suggestedSwitch.joints.map { j -> j.number }) {
             assertJointPointLocationAccuracy(suggestedSwitch, joint, LocationAccuracy.GEOMETRY_CALCULATED)
@@ -168,7 +173,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
             segments = segments,
             draft = true,
         )
-        val locationTrackId = locationTrackService.saveDraft(locationTrack, locationTrackAlignment)
+        val locationTrackId = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, locationTrackAlignment)
 
         val insertedSwitch = switchDao.fetch(switchDao.insert(switch(665, draft = false)).rowVersion)
 
@@ -212,7 +217,9 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
 
         switchLinkingService.saveSwitchLinking(
+            LayoutBranch.main,
             switchLinkingService.matchFittedSwitch(
+                LayoutBranch.main,
                 suggestedSwitchFitting(
                     joints = linkingJoints,
                     geometrySwitchId = null,
@@ -221,7 +228,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
             ), insertedSwitch.id as IntId,
         )
 
-        val (_, alignment) = locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, locationTrackId.id)
+        val (_, alignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId.id)
         val joint12Segment = alignment.segments[1]
 
         assertEquals(JointNumber(1), joint12Segment.startJointNumber)
@@ -246,7 +253,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
             segments = segments,
             draft = true,
         )
-        val locationTrackId = locationTrackService.saveDraft(locationTrack, locationTrackAlignment)
+        val locationTrackId = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, locationTrackAlignment)
 
         val insertedSwitch = switchDao.fetch(switchDao.insert(switch(665, draft = false)).rowVersion)
 
@@ -290,7 +297,9 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
 
         switchLinkingService.saveSwitchLinking(
+            LayoutBranch.main,
             switchLinkingService.matchFittedSwitch(
+                LayoutBranch.main,
                 suggestedSwitchFitting(
                     joints = linkingJoints,
                     geometrySwitchId = null,
@@ -299,7 +308,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
             ), insertedSwitch.id as IntId,
         )
 
-        val (_, alignment) = locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, locationTrackId.id)
+        val (_, alignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId.id)
         val joint12Segment = alignment.segments[1]
 
         assertEquals(JointNumber(1), joint12Segment.startJointNumber)
@@ -324,7 +333,9 @@ class SwitchLinkingServiceIT @Autowired constructor(
             .let { switchRowVersion -> switchDao.fetch(switchRowVersion) }
             .let { storedSwitch ->
                 switchLinkingService.saveSwitchLinking(
+                    LayoutBranch.main,
                     switchLinkingService.matchFittedSwitch(
+                        LayoutBranch.main,
                         suggestedSwitchFitting(
                             switchStructureId = storedSwitch.switchStructureId,
                             joints = linkedJoints,
@@ -411,10 +422,10 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
 
         val (linkedStraightTrack, linkedStraightTrackAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, straightTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, straightTrack.id as IntId)
 
         val (linkedDivertingTrack, linkedDivertingTrackAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, divertingTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, divertingTrack.id as IntId)
 
         // No segment splits are excepted to have happened.
         assertEquals(straightAlignment.segments.size, linkedStraightTrackAlignment.segments.size)
@@ -514,7 +525,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
 
         val (_, overlapLinkedStraightAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, testLocation.straightTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocation.straightTrack.id as IntId)
 
         // The overlapping segment has not been split, the next segment is used.
         assertEquals(testLocation.straightTrackAlignment.segments.size, overlapLinkedStraightAlignment.segments.size)
@@ -525,12 +536,24 @@ class SwitchLinkingServiceIT @Autowired constructor(
 
         // Previously existing switch segments should stay the same.
         assertEquals(testLocation.linkedSwitch.id, overlapLinkedStraightAlignment.segments[1].switchId)
-        assertEquals(testLocation.straightTrackAlignment.segments[1].startJointNumber, overlapLinkedStraightAlignment.segments[1].startJointNumber)
-        assertEquals(testLocation.straightTrackAlignment.segments[1].endJointNumber, overlapLinkedStraightAlignment.segments[1].endJointNumber)
+        assertEquals(
+            testLocation.straightTrackAlignment.segments[1].startJointNumber,
+            overlapLinkedStraightAlignment.segments[1].startJointNumber,
+        )
+        assertEquals(
+            testLocation.straightTrackAlignment.segments[1].endJointNumber,
+            overlapLinkedStraightAlignment.segments[1].endJointNumber,
+        )
 
         assertEquals(testLocation.linkedSwitch.id, overlapLinkedStraightAlignment.segments[2].switchId)
-        assertEquals(testLocation.straightTrackAlignment.segments[2].startJointNumber, overlapLinkedStraightAlignment.segments[2].startJointNumber)
-        assertEquals(testLocation.straightTrackAlignment.segments[2].endJointNumber, overlapLinkedStraightAlignment.segments[2].endJointNumber)
+        assertEquals(
+            testLocation.straightTrackAlignment.segments[2].startJointNumber,
+            overlapLinkedStraightAlignment.segments[2].startJointNumber,
+        )
+        assertEquals(
+            testLocation.straightTrackAlignment.segments[2].endJointNumber,
+            overlapLinkedStraightAlignment.segments[2].endJointNumber,
+        )
 
         // New switch
         assertEquals(newSwitch.id, overlapLinkedStraightAlignment.segments[3].switchId)
@@ -621,7 +644,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
 
         val (_, linkedTestAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, testLocationTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocationTrack.id as IntId)
 
         assertEquals(testAlignment.segments.size, linkedTestAlignment.segments.size)
 
@@ -742,7 +765,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
             )
 
             val (_, linkedTestAlignment) =
-                locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, testLocationTrack.id as IntId)
+                locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocationTrack.id as IntId)
 
             assertEquals(null, linkedTestAlignment.segments[0].switchId)
             assertEquals(null, linkedTestAlignment.segments[0].startJointNumber)
@@ -815,7 +838,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
 
         val (_, linkedTestAlignmentBeforeTryingOverlap) =
-            locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, testLocationTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocationTrack.id as IntId)
 
         (1..2).forEach { segmentIndex ->
             assertEquals(linkedSwitch.id, linkedTestAlignmentBeforeTryingOverlap.segments[segmentIndex].switchId)
@@ -856,7 +879,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
 
         val (_, linkedTestAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, testLocationTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocationTrack.id as IntId)
 
         // The original alignment is expected to have been split at the desired starting point of the new switch,
         // as it was not possible to snap it to a nearby segment without overlap.
@@ -938,6 +961,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val unsaveableSwitch = switchDao.insert(shiftSwitch(templateSwitch, "unsaveable", shift2))
 
         val throughTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "through track", draft = true), alignment(
                 pasteTrackSegmentsWithSpacers(
                     listOf(
@@ -951,15 +975,17 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
 
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "ok branching track", draft = true),
             alignment(shiftTrack(templateBranchingTrackSegments, null, shift0))
         )
         // linkable, but will cause a validation error due to being wrongly marked as a duplicate
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "bad branching track", duplicateOf = throughTrack.id, draft = true),
             alignment(shiftTrack(templateBranchingTrackSegments, null, shift1))
         )
-        val validationResult = switchLinkingService.validateRelinkingTrack(throughTrack.id)
+        val validationResult = switchLinkingService.validateRelinkingTrack(LayoutBranch.main, throughTrack.id)
         assertEqualsRounded(
             listOf(
                 SwitchRelinkingValidationResult(
@@ -1009,6 +1035,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val templateThroughTrackSegments = templateTrackSections[0].second.segments
         val templateBranchingTrackSegments = templateTrackSections[1].second.segments
         val track152 = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "track152", draft = true), alignment(
                 listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))) + shiftTrack(
                     templateThroughTrackSegments,
@@ -1018,13 +1045,14 @@ class SwitchLinkingServiceIT @Autowired constructor(
             )
         ).id
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "track13", draft = true),
             alignment(shiftTrack(templateBranchingTrackSegments, null, Point(10.0, 0.0)))
         )
         val okSwitch = switchDao.insert(shiftSwitch(templateSwitch, "ok", Point(10.0, 0.0)))
 
-        val validationResult = switchLinkingService.validateRelinkingTrack(track152)
-        val relinkingResult = switchLinkingService.relinkTrack(track152)
+        val validationResult = switchLinkingService.validateRelinkingTrack(LayoutBranch.main, track152)
+        val relinkingResult = switchLinkingService.relinkTrack(LayoutBranch.main, track152)
         assertEquals(
             listOf(
                 SwitchRelinkingValidationResult(
@@ -1066,23 +1094,28 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val okSwitch = switchDao.insert(shiftSwitch(templateSwitch, "ok", basePoint))
         val switchSomewhereElse = switchDao.insert(shiftSwitch(templateSwitch, "somewhere else", somewhereElse))
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "track152", draft = true),
             alignment(shiftTrack(templateThroughTrackSegments, okSwitch.id, basePoint))
         )
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "track13", draft = true),
             alignment(shiftTrack(templateBranchingTrackSegments, okSwitch.id, basePoint))
         )
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "some other track152", draft = true),
             alignment(shiftTrack(templateThroughTrackSegments, null, somewhereElse))
         )
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "some other track13", draft = true),
             alignment(shiftTrack(templateBranchingTrackSegments, okSwitch.id, somewhereElse))
         )
 
         val topoTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(
                 trackNumberId,
                 name = "topoTrack",
@@ -1098,7 +1131,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 segment(Point(5.0, 0.0), basePoint),
             ),
         )
-        val validationResult = switchLinkingService.validateRelinkingTrack(topoTrack.id)
+        val validationResult = switchLinkingService.validateRelinkingTrack(LayoutBranch.main, topoTrack.id)
         assertEqualsRounded(
             listOf(
                 SwitchRelinkingValidationResult(
@@ -1141,6 +1174,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val branchingTrackSegments = templateTrackSections[1].second.segments
         val switch = switchDao.insert(templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
         val throughTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "through track", draft = true),
             alignment(
                 pasteTrackSegmentsWithSpacers(
@@ -1152,15 +1186,17 @@ class SwitchLinkingServiceIT @Autowired constructor(
             ),
         )
         val originallyLinkedBranchingTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "originally linked branching track", draft = true),
             alignment(setSwitchId(branchingTrackSegments, switch.id))
         )
         val newBranchingTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "new branching track", draft = true),
             alignment(shiftTrack(branchingTrackSegments, switch.id, Point(134.321, 0.0)))
         )
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(Point(134.321, 0.0), switch.id)!!
-        switchLinkingService.saveSwitchLinking(suggestedSwitch, switch.id)
+        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(134.321, 0.0), switch.id)!!
+        switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
         assertTrackDraftVersionSwitchLinks(originallyLinkedBranchingTrack.id, null, null, listOf(0.0..34.3 to null))
         assertTrackDraftVersionSwitchLinks(
             newBranchingTrack.id,
@@ -1180,7 +1216,9 @@ class SwitchLinkingServiceIT @Autowired constructor(
     fun `null is suggested when no switch is applicable`() {
         assertNull(
             switchLinkingService.getSuggestedSwitch(
-                Point(123.0, 456.0), switchDao.insert(switch(draft = false)).id
+                LayoutBranch.main,
+                Point(123.0, 456.0),
+                switchDao.insert(switch(draft = false)).id,
             )
         )
     }
@@ -1208,6 +1246,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val switch = switchDao.insert(templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
 
         val oneFiveTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(
                 trackNumberId,
                 name = "one-five with topo link",
@@ -1218,6 +1257,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         )
 
         val fiveTwoTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(
                 trackNumberId,
                 name = "five-two with topo link",
@@ -1227,12 +1267,13 @@ class SwitchLinkingServiceIT @Autowired constructor(
             alignment(setSwitchId(listOf(fiveTwo), null)),
         )
         val threeFourTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "three-four", draft = true),
             alignment(setSwitchId(templateFourThreeTrackSegments, switch.id))
         )
 
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(Point(0.0, 0.0), switch.id)!!
-        switchLinkingService.saveSwitchLinking(suggestedSwitch, switch.id)
+        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(0.0, 0.0), switch.id)!!
+        switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
 
         assertTrackDraftVersionSwitchLinks(oneFiveTrack.id, null, null, listOf(0.0..5.2 to switch.id))
         assertTrackDraftVersionSwitchLinks(fiveTwoTrack.id, null, null, listOf(0.0..5.2 to switch.id))
@@ -1263,26 +1304,30 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val fullShift = shift + Point(100.0, 0.0)
 
         val throughTrackStart = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "through track start", draft = true), alignment(
                 setSwitchId(templateThroughTrackSegments + listOf(segment(shift, fullShift)), switch.id),
             )
         )
         val throughTrackSwitchAndEnd = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "through track switch and end", draft = true), alignment(
                 shiftTrack(templateThroughTrackSegments, switch.id, fullShift)
             )
         )
         val originallyLinkedBranchingTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "originally linked branching track", draft = true),
             alignment(setSwitchId(templateBranchingTrackSegments, switch.id))
         )
         val newBranchingTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "new branching track", draft = true),
             alignment(shiftTrack(templateBranchingTrackSegments, switch.id, fullShift))
         )
 
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(fullShift, switch.id)!!
-        switchLinkingService.saveSwitchLinking(suggestedSwitch, switch.id)
+        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, fullShift, switch.id)!!
+        switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
 
         assertTrackDraftVersionSwitchLinks(
             throughTrackStart.id, null, switch.id, listOf(0.0..134.4 to null)
@@ -1327,6 +1372,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val fullShift = shift + Point(100.0, 0.0)
 
         val throughTrackStart = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(
                 trackNumberId,
                 name = "through track start",
@@ -1337,32 +1383,36 @@ class SwitchLinkingServiceIT @Autowired constructor(
             )
         )
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "through track switch and end", draft = true), alignment(
                 shiftTrack(templateThroughTrackSegments, switch.id, fullShift)
             )
         )
         // confuser branching track is misleadingly placed starting at the origin, while the switch is at x=134.43
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "branching track", draft = true),
             alignment(setSwitchId(templateBranchingTrackSegments, switch.id))
         )
         val uninvolvedTrack = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "uninvolved track", draft = true),
             alignment(shiftTrack(templateThroughTrackSegments, null, fullShift - Point(1.0, 1.0))),
         )
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(fullShift, switch.id)!!
-        switchLinkingService.saveSwitchLinking(suggestedSwitch, switch.id)
+        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, fullShift, switch.id)!!
+        switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
 
         assertTrackDraftVersionSwitchLinks(
             throughTrackStart.id, null, switch.id, listOf(0.0..134.4 to null)
         )
         assertEquals(
             locationTrackDao.fetch(throughTrackStart.rowVersion).alignmentVersion!!,
-            locationTrackDao.fetch(
-                locationTrackDao.fetchVersion(throughTrackStart.id, PublicationState.DRAFT)!!
-            ).alignmentVersion!!,
+            locationTrackDao.getOrThrow(MainLayoutContext.draft, throughTrackStart.id).alignmentVersion!!,
         )
-        assertEquals(uninvolvedTrack.rowVersion, locationTrackDao.fetchVersion(uninvolvedTrack.id, PublicationState.DRAFT))
+        assertEquals(
+            uninvolvedTrack.rowVersion,
+            locationTrackDao.fetchVersion(MainLayoutContext.draft, uninvolvedTrack.id),
+        )
     }
 
     @Test
@@ -1384,11 +1434,13 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val switch = switchDao.insert(templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
         templateTrackSections.forEach { (_, a) ->
             locationTrackService.saveDraft(
+                LayoutBranch.main,
                 locationTrack(trackNumberId, draft = true),
                 alignment(setSwitchId(a.segments, null)),
             )
         }
         val otherLocationTrackWithTopoSwitchLink = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(
                 trackNumberId,
                 name = "unrelated mislinked track",
@@ -1397,8 +1449,8 @@ class SwitchLinkingServiceIT @Autowired constructor(
             ),
             alignment(segment(Point(456.7, 345.5), Point(457.8, 346.9))),
         )
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(Point(0.0, 0.0), switch.id)!!
-        switchLinkingService.saveSwitchLinking(suggestedSwitch, switch.id)
+        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(0.0, 0.0), switch.id)!!
+        switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
         assertTrackDraftVersionSwitchLinks(
             otherLocationTrackWithTopoSwitchLink.id, null, null, listOf(0.0..1.7 to null)
         )
@@ -1408,11 +1460,13 @@ class SwitchLinkingServiceIT @Autowired constructor(
     fun `nearby track end not within bounding box of switch joints still gets topologically connected when linking single switch`() {
         val (_, branchingTrackContinuation, switchId) = setupForLinkingTopoLinkToTrackOutsideSwitchJointBoundingBox()
         switchLinkingService.saveSwitchLinking(
-            switchLinkingService.getSuggestedSwitch(Point(0.0, 0.0), switchId)!!, switchId
+            LayoutBranch.main,
+            switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(0.0, 0.0), switchId)!!,
+            switchId,
         )
         val expected = TopologyLocationTrackSwitch(switchId, JointNumber(3))
         val actual = locationTrackDao.fetch(
-            locationTrackDao.fetchVersion(branchingTrackContinuation, PublicationState.DRAFT)!!
+            locationTrackDao.fetchVersion(MainLayoutContext.draft, branchingTrackContinuation)!!
         ).topologyStartSwitch
         assertEquals(expected, actual)
     }
@@ -1420,10 +1474,10 @@ class SwitchLinkingServiceIT @Autowired constructor(
     @Test
     fun `nearby track end not within bounding box of switch joints still gets topologically connected when linking track`() {
         val (throughTrack, branchingTrackContinuation, switchId) = setupForLinkingTopoLinkToTrackOutsideSwitchJointBoundingBox()
-        switchLinkingService.relinkTrack(throughTrack)
+        switchLinkingService.relinkTrack(LayoutBranch.main, throughTrack)
         val expected = TopologyLocationTrackSwitch(switchId, JointNumber(3))
         val actual = locationTrackDao.fetch(
-            locationTrackDao.fetchVersion(branchingTrackContinuation, PublicationState.DRAFT)!!
+            locationTrackDao.fetchVersion(MainLayoutContext.draft, branchingTrackContinuation)!!
         ).topologyStartSwitch
         assertEquals(expected, actual)
     }
@@ -1454,6 +1508,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
             )
         ).id
         val throughTrackId = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "through track", draft = true),
             alignment(
                 segment(
@@ -1465,10 +1520,12 @@ class SwitchLinkingServiceIT @Autowired constructor(
             ),
         ).id
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "branching track start", draft = true),
             alignment(segment(Point(0.0, 0.0), Point(34.9, -2.0)))
         )
         val branchingTrackContinuationId = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId, name = "branching track continuation", draft = true),
             alignment(segment(Point(35.0, -2.0), Point(50.0, -3.0)))
         ).id
@@ -1481,7 +1538,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
         topologyEndSwitchId: IntId<TrackLayoutSwitch>?,
         segmentSwitchesByMRange: List<Pair<ClosedRange<Double>, IntId<TrackLayoutSwitch>?>>,
     ) {
-        val track = locationTrackService.get(PublicationState.DRAFT, trackId)!!
+        val track = locationTrackService.get(MainLayoutContext.draft, trackId)!!
         val (_, alignment) = locationTrackService.getWithAlignment(track.version!!)
         assertEquals(topologyStartSwitchId, track.topologyStartSwitch?.switchId)
         assertEquals(topologyEndSwitchId, track.topologyEndSwitch?.switchId)
@@ -1548,8 +1605,8 @@ class SwitchLinkingServiceIT @Autowired constructor(
             segments = layoutSegments,
             draft = true,
         )
-        val locationTrackId = locationTrackService.saveDraft(locationTrack, alignment).id
-        return locationTrackService.getWithAlignmentOrThrow(PublicationState.DRAFT, locationTrackId)
+        val locationTrackId = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment).id
+        return locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
     }
 
     private fun setupJointLocationAccuracyTest(): SuggestedSwitchCreateParams {
@@ -1583,7 +1640,7 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.TM35FIN_TO_KKJ),
                 draft = true,
             )
-            locationTrackService.saveDraft(locationTrack, alignment)
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
         }
         val mainLocationTrackId = trackNumberIds[0].id
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.publication
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
@@ -180,6 +181,7 @@ class ValidationContextIT @Autowired constructor(
     }
 
     private fun validationContext(
+        branch: LayoutBranch = LayoutBranch.main,
         trackNumbers: List<IntId<TrackLayoutTrackNumber>> = listOf(),
         locationTracks: List<IntId<LocationTrack>> = listOf(),
         referenceLines: List<IntId<ReferenceLine>> = listOf(),
@@ -197,12 +199,13 @@ class ValidationContextIT @Autowired constructor(
         switchLibraryService = switchLibraryService,
         splitService = splitService,
         publicationSet = ValidationVersions(
-            trackNumbers = trackNumberDao.fetchPublicationVersions(trackNumbers),
-            referenceLines = referenceLineDao.fetchPublicationVersions(referenceLines),
-            kmPosts = kmPostDao.fetchPublicationVersions(kmPosts),
-            locationTracks = locationTrackDao.fetchPublicationVersions(locationTracks),
-            switches = switchDao.fetchPublicationVersions(switches),
-            splits = splitService.fetchPublicationVersions(locationTracks, switches),
+            branch = branch,
+            trackNumbers = trackNumberDao.fetchPublicationVersions(branch, trackNumbers),
+            referenceLines = referenceLineDao.fetchPublicationVersions(branch, referenceLines),
+            kmPosts = kmPostDao.fetchPublicationVersions(branch, kmPosts),
+            locationTracks = locationTrackDao.fetchPublicationVersions(branch, locationTracks),
+            switches = switchDao.fetchPublicationVersions(branch, switches),
+            splits = splitService.fetchPublicationVersions(branch, locationTracks, switches),
         )
     )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.split
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.PublicationDao
@@ -126,7 +127,7 @@ class SplitDaoIT @Autowired constructor(
             updatedDuplicates = emptyList(),
         )
 
-        val splits = splitDao.fetchUnfinishedSplits()
+        val splits = splitDao.fetchUnfinishedSplits(LayoutBranch.main)
 
         assertTrue { splits.any { s -> s.id == pendingSplitId } }
         assertTrue { splits.none { s -> s.id == doneSplit } }
@@ -157,11 +158,11 @@ class SplitDaoIT @Autowired constructor(
             updatedDuplicates = listOf(someDuplicateTrack.id)
         )
 
-        assertTrue { splitDao.fetchUnfinishedSplits().any { it.id == splitId } }
+        assertTrue { splitDao.fetchUnfinishedSplits(LayoutBranch.main).any { it.id == splitId } }
 
         splitDao.deleteSplit(splitId)
 
-        assertTrue { splitDao.fetchUnfinishedSplits().none { it.id == splitId } }
+        assertTrue { splitDao.fetchUnfinishedSplits(LayoutBranch.main).none { it.id == splitId } }
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
@@ -2,18 +2,26 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geography.CoordinateSystemName
-import fi.fta.geoviite.infra.geometry.*
+import fi.fta.geoviite.infra.geometry.GeometryDao
+import fi.fta.geoviite.infra.geometry.geometryAlignment
+import fi.fta.geoviite.infra.geometry.infraModelFile
+import fi.fta.geoviite.infra.geometry.line
+import fi.fta.geoviite.infra.geometry.plan
 import fi.fta.geoviite.infra.linking.fixSegmentStarts
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoints
 import fi.fta.geoviite.infra.util.getIntId
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -120,7 +128,7 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         assertMatches(alignmentLocationTrack, alignmentDao.fetch(locationTrackAlignmentVersion))
         assertMatches(alignmentReferenceLine, alignmentDao.fetch(referenceLineAlignmentVersion))
 
-        alignmentDao.deleteOrphanedAlignments()
+        alignmentDao.deleteOrphanedAlignments(LayoutBranch.main)
 
         assertEquals(orphanAlignmentBeforeDelete, alignmentDao.fetch(orphanAlignmentVersion))
         assertThrows<NoSuchEntityException> { alignmentDao.fetch(orphanAlignmentVersion.next()) }
@@ -194,12 +202,13 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         val trackNumber = getUnusedTrackNumber()
         val planVersion = geometryDao.insertPlan(
             plan = plan(
-                trackNumber = trackNumber, alignments = listOf(
+                trackNumber = trackNumber,
+                alignments = listOf(
                     geometryAlignment(
                         name = "test-alignment-name",
                         elements = listOf(line(Point(1.0, 1.0), Point(3.0, 3.0))),
                     )
-                )
+                ),
             ),
             file = infraModelFile("testfile.xml"),
             boundingBoxInLayoutCoordinates = null,
@@ -300,7 +309,8 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         locationTrackDao.insert(locationTrack(trackNumberId, alignmentVersion = version, draft = false))
 
         val profileInfo = alignmentDao.fetchProfileInfoForSegmentsInBoundingBox<LocationTrack>(
-            PublicationState.OFFICIAL, boundingBoxAroundPoints((points + points2 + points3 + points4 + points5).toList())
+            MainLayoutContext.official,
+            boundingBoxAroundPoints((points + points2 + points3 + points4 + points5).toList()),
         )
         assertEquals(5, profileInfo.size)
         assertTrue(profileInfo[0].hasProfile)
@@ -323,21 +333,23 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         fixSegmentStarts((0..count).map { seed -> segmentWithoutZAndCant(alignmentSeed + seed) })
 
     private fun segmentWithoutZAndCant(segmentSeed: Int) = createSegment(
-        segmentSeed, points(
+        segmentSeed,
+        points(
             count = 10,
             x = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
             y = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
-        )
+        ),
     )
 
     private fun segmentWithZAndCant(segmentSeed: Int) = createSegment(
-        segmentSeed, points(
+        segmentSeed,
+        points(
             count = 20,
             x = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
             y = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
             z = segmentSeed.toDouble()..segmentSeed + 20.0,
             cant = segmentSeed.toDouble()..segmentSeed + 20.0,
-        )
+        ),
     )
 
     private fun createSegment(segmentSeed: Int, points: List<SegmentPoint>) = segment(
@@ -392,5 +404,4 @@ class LayoutAlignmentDaoIT @Autowired constructor(
             "All geometries should have m-values at 0.0-length: violations=$geometriesWithInvalidMValues",
         )
     }
-
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
@@ -1,11 +1,17 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.*
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.DataType
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.MainLayoutContext
+import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.math.Point
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -46,16 +52,26 @@ class LayoutContextDataIT @Autowired constructor(
         assertNotEquals(dbDraft.first.contextData.rowId, dbDraft.first.id)
 
         assertMatches(
-            dbLineAndAlignment.first, referenceLineService.get(OFFICIAL, dbLineAndAlignment.first.id as IntId)!!, true
+            dbLineAndAlignment.first,
+            referenceLineService.getOrThrow(MainLayoutContext.official, dbLineAndAlignment.first.id as IntId),
+            true,
         )
         assertMatches(
             dbLineAndAlignment.first,
-            referenceLineService.get(OFFICIAL, dbDraft.first.contextData.rowId as IntId)!!,
+            referenceLineService.getOrThrow(MainLayoutContext.official, dbDraft.first.contextData.rowId as IntId),
             true
         )
 
-        assertMatches(dbDraft.first, referenceLineService.get(DRAFT, dbDraft.first.id as IntId)!!, true)
-        assertMatches(dbDraft.first, referenceLineService.get(DRAFT, dbDraft.first.contextData.rowId as IntId)!!, true)
+        assertMatches(
+            dbDraft.first,
+            referenceLineService.get(MainLayoutContext.draft, dbDraft.first.id as IntId)!!,
+            true,
+        )
+        assertMatches(
+            dbDraft.first,
+            referenceLineService.get(MainLayoutContext.draft, dbDraft.first.contextData.rowId as IntId)!!,
+            true,
+        )
     }
 
     @Test
@@ -70,16 +86,26 @@ class LayoutContextDataIT @Autowired constructor(
         assertNotEquals(dbDraft.first.contextData.rowId, dbDraft.first.id)
 
         assertMatches(
-            dbTrackAndAlignment.first, locationTrackService.get(OFFICIAL, dbTrackAndAlignment.first.id as IntId)!!, true
+            dbTrackAndAlignment.first,
+            locationTrackService.getOrThrow(MainLayoutContext.official, dbTrackAndAlignment.first.id as IntId),
+            true,
         )
         assertMatches(
             dbTrackAndAlignment.first,
-            locationTrackService.get(OFFICIAL, dbDraft.first.contextData.rowId as IntId)!!,
-            true
+            locationTrackService.getOrThrow(MainLayoutContext.official, dbDraft.first.contextData.rowId as IntId),
+            true,
         )
 
-        assertMatches(dbDraft.first, locationTrackService.get(DRAFT, dbDraft.first.id as IntId)!!, true)
-        assertMatches(dbDraft.first, locationTrackService.get(DRAFT, dbDraft.first.contextData.rowId as IntId)!!, true)
+        assertMatches(
+            dbDraft.first,
+            locationTrackService.getOrThrow(MainLayoutContext.draft, dbDraft.first.id as IntId),
+            true,
+        )
+        assertMatches(
+            dbDraft.first,
+            locationTrackService.getOrThrow(MainLayoutContext.draft, dbDraft.first.contextData.rowId as IntId),
+            true,
+        )
     }
 
     @Test
@@ -88,11 +114,27 @@ class LayoutContextDataIT @Autowired constructor(
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbSwitch)))
         assertNotEquals(dbSwitch, dbDraft)
 
-        assertMatches(dbSwitch, switchService.get(OFFICIAL, dbSwitch.id as IntId)!!, true)
-        assertMatches(dbSwitch, switchService.get(OFFICIAL, dbDraft.contextData.rowId as IntId)!!, true)
+        assertMatches(
+            dbSwitch,
+            switchService.get(MainLayoutContext.official, dbSwitch.id as IntId)!!,
+            true,
+        )
+        assertMatches(
+            dbSwitch,
+            switchService.get(MainLayoutContext.official, dbDraft.contextData.rowId as IntId)!!,
+            true,
+        )
 
-        assertMatches(dbDraft, switchService.get(DRAFT, dbDraft.id as IntId)!!, true)
-        assertMatches(dbDraft, switchService.get(DRAFT, dbDraft.contextData.rowId as IntId)!!, true)
+        assertMatches(
+            dbDraft,
+            switchService.get(MainLayoutContext.draft, dbDraft.id as IntId)!!,
+            true,
+        )
+        assertMatches(
+            dbDraft,
+            switchService.get(MainLayoutContext.draft, dbDraft.contextData.rowId as IntId)!!,
+            true,
+        )
     }
 
     @Test
@@ -101,11 +143,27 @@ class LayoutContextDataIT @Autowired constructor(
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbKmPost)))
         assertNotEquals(dbKmPost, dbDraft)
 
-        assertMatches(dbKmPost, kmPostService.get(OFFICIAL, dbKmPost.id as IntId)!!, true)
-        assertMatches(dbKmPost, kmPostService.get(OFFICIAL, dbDraft.contextData.rowId as IntId)!!, true)
+        assertMatches(
+            dbKmPost,
+            kmPostService.getOrThrow(MainLayoutContext.official, dbKmPost.id as IntId),
+            true,
+        )
+        assertMatches(
+            dbKmPost,
+            kmPostService.getOrThrow(MainLayoutContext.official, dbDraft.contextData.rowId as IntId),
+            true,
+        )
 
-        assertMatches(dbDraft, kmPostService.get(DRAFT, dbDraft.id as IntId)!!, true)
-        assertMatches(dbDraft, kmPostService.get(DRAFT, dbDraft.contextData.rowId as IntId)!!, true)
+        assertMatches(
+            dbDraft,
+            kmPostService.getOrThrow(MainLayoutContext.draft, dbDraft.id as IntId),
+            true,
+        )
+        assertMatches(
+            dbDraft,
+            kmPostService.getOrThrow(MainLayoutContext.draft, dbDraft.contextData.rowId as IntId),
+            true,
+        )
     }
 
     @Test
@@ -161,8 +219,8 @@ class LayoutContextDataIT @Autowired constructor(
         val dbOfficial = insertAndVerifyLine(createReferenceLineAndAlignment(false))
         val dbDraft = insertAndVerifyLine(alterLine(createAndVerifyDraftLine(dbOfficial)))
 
-        val officials = referenceLineService.list(OFFICIAL)
-        val drafts = referenceLineService.list(DRAFT)
+        val officials = referenceLineService.list(MainLayoutContext.official)
+        val drafts = referenceLineService.list(MainLayoutContext.draft)
 
         assertFalse(officials.contains(dbDraft.first))
         assertFalse(drafts.contains(dbOfficial.first))
@@ -176,8 +234,8 @@ class LayoutContextDataIT @Autowired constructor(
         val dbOfficial = insertAndVerifyTrack(createLocationTrackAndAlignment(false))
         val dbDraft = insertAndVerifyTrack(alterTrack(createAndVerifyDraftTrack(dbOfficial)))
 
-        val officials = locationTrackService.list(OFFICIAL)
-        val drafts = locationTrackService.list(DRAFT)
+        val officials = locationTrackService.list(MainLayoutContext.official)
+        val drafts = locationTrackService.list(MainLayoutContext.draft)
 
         assertFalse(officials.contains(dbDraft.first))
         assertFalse(drafts.contains(dbOfficial.first))
@@ -191,8 +249,8 @@ class LayoutContextDataIT @Autowired constructor(
         val dbSwitch = insertAndVerify(switch(456, draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbSwitch)))
 
-        val officials = switchService.list(OFFICIAL)
-        val drafts = switchService.list(DRAFT)
+        val officials = switchService.list(MainLayoutContext.official)
+        val drafts = switchService.list(MainLayoutContext.draft)
 
         assertFalse(officials.contains(dbDraft))
         assertFalse(drafts.contains(dbSwitch))
@@ -206,8 +264,8 @@ class LayoutContextDataIT @Autowired constructor(
         val dbKmPost = insertAndVerify(kmPost(insertOfficialTrackNumber(), someKmNumber(), draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbKmPost)))
 
-        val officials = kmPostService.list(OFFICIAL)
-        val drafts = kmPostService.list(DRAFT)
+        val officials = kmPostService.list(MainLayoutContext.official)
+        val drafts = kmPostService.list(MainLayoutContext.draft)
 
         assertFalse(officials.contains(dbDraft))
         assertFalse(drafts.contains(dbKmPost))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -4,8 +4,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.linking.TrackLayoutKmPostSaveRequest
 import fi.fta.geoviite.infra.math.Point
 import org.junit.jupiter.api.Test
@@ -69,7 +68,11 @@ class LayoutKmPostServiceIT @Autowired constructor(
         )
 
         val actual = kmPostService.listNearbyOnTrackPaged(
-            OFFICIAL, Point(0.0, 0.0), trackNumberId, 0, null
+            MainLayoutContext.official,
+            Point(0.0, 0.0),
+            trackNumberId,
+            0,
+            null,
         )
         val expected = listOf(kmPost3, kmPost1, kmPost2)
         assertEquals(expected, actual)
@@ -89,7 +92,12 @@ class LayoutKmPostServiceIT @Autowired constructor(
             ).rowVersion
         )
 
-        val result = kmPostService.getByKmNumber(OFFICIAL, trackNumberId, kmPost.kmNumber, true)
+        val result = kmPostService.getByKmNumber(
+            MainLayoutContext.official,
+            trackNumberId,
+            kmPost.kmNumber,
+            true,
+        )
         assertNotNull(result)
         assertMatches(kmPost, result)
     }
@@ -106,7 +114,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
             )
         )
 
-        assertNull(kmPostService.getByKmNumber(OFFICIAL, trackNumberId, KmNumber(2), true))
+        assertNull(kmPostService.getByKmNumber(MainLayoutContext.official, trackNumberId, KmNumber(2), true))
     }
 
     @Test
@@ -124,7 +132,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
             ).rowVersion
         )
 
-        assertNull(kmPostService.getByKmNumber(OFFICIAL, trackNumber2Id, kmPost.kmNumber, true))
+        assertNull(kmPostService.getByKmNumber(MainLayoutContext.official, trackNumber2Id, kmPost.kmNumber, true))
     }
 
     @Test
@@ -133,13 +141,13 @@ class LayoutKmPostServiceIT @Autowired constructor(
         val kmPost = kmPost(trackNumberId, KmNumber(7654), draft = true)
 
         val draftId = kmPostService.saveDraft(LayoutBranch.main, asMainDraft(kmPost)).id
-        val draftFromDb = kmPostService.get(DRAFT, draftId)
+        val draftFromDb = kmPostService.get(MainLayoutContext.draft, draftId)
 
-        assertEquals(1, kmPostService.list(DRAFT) { k -> k == draftFromDb }.size)
+        assertEquals(1, kmPostService.list(MainLayoutContext.draft) { k -> k == draftFromDb }.size)
 
-        kmPostService.deleteDraft(draftId)
+        kmPostService.deleteDraft(LayoutBranch.main, draftId)
 
-        assertEquals(0, kmPostService.list(DRAFT) { k -> k == draftFromDb }.size)
+        assertEquals(0, kmPostService.list(MainLayoutContext.draft) { k -> k == draftFromDb }.size)
     }
 
     @Test
@@ -150,10 +158,10 @@ class LayoutKmPostServiceIT @Autowired constructor(
             state = LayoutState.IN_USE,
             trackNumberId = trackNumberId,
         )
-        val kmPostId = kmPostService.insertKmPost(kmPost)
+        val kmPostId = kmPostService.insertKmPost(LayoutBranch.main, kmPost)
 
-        val fetchedKmPost = kmPostService.get(DRAFT, kmPostId)!!
-        assertNull(kmPostService.get(OFFICIAL, kmPostId))
+        val fetchedKmPost = kmPostService.getOrThrow(MainLayoutContext.draft, kmPostId)
+        assertNull(kmPostService.get(MainLayoutContext.official, kmPostId))
 
         assertEquals(DataType.STORED, fetchedKmPost.dataType)
         assertEquals(kmPost.kmNumber, fetchedKmPost.kmNumber)
@@ -165,6 +173,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
     fun kmPostLengthMatchesTrackNumberService() {
         val trackNumberId = insertDraftTrackNumber()
         referenceLineService.saveDraft(
+            LayoutBranch.main,
             referenceLine(trackNumberId, draft = true),
             alignment(
                 segment(
@@ -174,7 +183,7 @@ class LayoutKmPostServiceIT @Autowired constructor(
                     Point(3.0, 15.0),
                     Point(4.0, 20.0),
                 )
-            )
+            ),
         )
         val kmPosts = listOf(
             kmPost(trackNumberId, KmNumber(1), Point(0.0, 3.0), draft = true),
@@ -190,8 +199,10 @@ class LayoutKmPostServiceIT @Autowired constructor(
             .map(DaoResponse<TrackLayoutKmPost>::id)
 
         // drop(1) because the track number km lengths include the section before the first km post
-        val expected = trackNumberService.getKmLengths(DRAFT, trackNumberId)!!.drop(1)
-        val actual = kmPostSaveResults.mapNotNull { kmPost -> kmPostService.getSingleKmPostLength(DRAFT, kmPost) }
+        val expected = trackNumberService.getKmLengths(MainLayoutContext.draft, trackNumberId)!!.drop(1)
+        val actual = kmPostSaveResults.mapNotNull { kmPost ->
+            kmPostService.getSingleKmPostLength(MainLayoutContext.draft, kmPost)
+        }
         assertEquals(expected.size, actual.size)
         expected.zip(actual) { e, a -> assertEquals(e.length.toDouble(), a, 0.001) }
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
@@ -5,8 +5,8 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
-import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
@@ -27,7 +27,7 @@ class LayoutSearchServiceIT @Autowired constructor(
     val locationTrackService: LocationTrackService,
     val switchService: LayoutSwitchService,
     val switchDao: LayoutSwitchDao,
-): DBTestBase() {
+) : DBTestBase() {
     @BeforeEach
     fun cleanup() {
         deleteFromTables("layout", "track_number", "reference_line")
@@ -47,9 +47,18 @@ class LayoutSearchServiceIT @Autowired constructor(
             LayoutState.IN_USE,
         )
 
-        assertEquals(2, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), 100).size)
-        assertEquals(3, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("11"), 100).size)
-        assertEquals(4, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("1"), 100).size)
+        assertEquals(
+            2,
+            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100).size,
+        )
+        assertEquals(
+            3,
+            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("11"), 100).size,
+        )
+        assertEquals(
+            4,
+            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("1"), 100).size,
+        )
     }
 
     @Test
@@ -63,9 +72,18 @@ class LayoutSearchServiceIT @Autowired constructor(
             LayoutState.IN_USE,
         )
 
-        assertEquals(5, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("some track"), 5).size)
-        assertEquals(10, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("some track"), 10).size)
-        assertEquals(15, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("some track"), 15).size)
+        assertEquals(
+            5,
+            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 5).size,
+        )
+        assertEquals(
+            10,
+            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 10).size,
+        )
+        assertEquals(
+            15,
+            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 15).size,
+        )
     }
 
     @Test
@@ -76,7 +94,10 @@ class LayoutSearchServiceIT @Autowired constructor(
         )
 
         saveTrackNumbersWithSaveRequests(trackNumbers, LayoutState.DELETED)
-        assertEquals(0, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), 100).size)
+        assertEquals(
+            0,
+            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100).size,
+        )
     }
 
     @Test
@@ -91,14 +112,14 @@ class LayoutSearchServiceIT @Autowired constructor(
             LayoutState.DELETED,
         ).forEachIndexed { index, trackNumberId ->
             val oid = Oid<TrackLayoutTrackNumber>("1.2.3.4.5.6.$index")
-            trackNumberService.updateExternalId(trackNumberId, oid)
+            trackNumberService.updateExternalId(LayoutBranch.main, trackNumberId, oid)
 
-            assertEquals(1, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText(oid.toString()), 100).size)
-            assertEquals(1, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText(trackNumberId.toString()), 100).size)
+            assertEquals(1, searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText(oid.toString()), 100).size)
+            assertEquals(1, searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText(trackNumberId.toString()), 100).size)
         }
 
         // LayoutState was set to DELETED, meaning that these track numbers should not be found by free text.
-        assertEquals(0, searchService.searchAllTrackNumbers(PublicationState.DRAFT, FreeText("tRaCk number"), 100).size)
+        assertEquals(0, searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100).size)
     }
 
     @Test
@@ -109,16 +130,21 @@ class LayoutSearchServiceIT @Autowired constructor(
         ).first()
 
         // Search scope origin track's start switch, should be included
-        val topologyStartSwitchId =
-            switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch(name = "blaa V0001", draft = true)).rowVersion).id as IntId
+        val topologyStartSwitchId = switchDao.fetch(
+            switchService.saveDraft(LayoutBranch.main, switch(name = "blaa V0001", draft = true)).rowVersion
+        ).id as IntId
         // Search scope origin track's end switch, should be included
-        val topologyEndSwitchId =
-            switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch(name = "blee V0002", draft = true)).rowVersion).id as IntId
+        val topologyEndSwitchId = switchDao.fetch(
+            switchService.saveDraft(LayoutBranch.main, switch(name = "blee V0002", draft = true)).rowVersion
+        ).id as IntId
         // Related to duplicate but not in search scope, should be left out of search results
-        val duplicateStartSwitchId =
-            switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true)).rowVersion).id as IntId
+        val duplicateStartSwitchId = switchDao.fetch(
+            switchService.saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true)).rowVersion
+        ).id as IntId
         // Entirely unrelated, should be left out of search results
-        switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true)).rowVersion).id as IntId
+        switchDao.fetch(
+            switchService.saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true)).rowVersion
+        ).id as IntId
 
         val lt1 = insertLocationTrack( // Location track search scope origin, should be included
             locationTrack(
@@ -159,7 +185,7 @@ class LayoutSearchServiceIT @Autowired constructor(
             someAlignment()
         )
 
-        val searchResults = searchService.searchAssets(PublicationState.DRAFT, FreeText("bl"), 100, lt1.id)
+        val searchResults = searchService.searchAssets(MainLayoutContext.draft, FreeText("bl"), 100, lt1.id)
 
         assertEquals(3, searchResults.locationTracks.size)
         assertContains(searchResults.locationTracks.map { it.id }, lt1.id)
@@ -179,12 +205,13 @@ class LayoutSearchServiceIT @Autowired constructor(
     ): List<IntId<TrackLayoutTrackNumber>> {
         return trackNumbers.map { trackNumber ->
             TrackNumberSaveRequest(
-                trackNumber, FreeText("some description"), layoutState, TrackMeter(
-                    KmNumber(5555), 5.5, 1
-                )
+                trackNumber,
+                FreeText("some description"),
+                layoutState,
+                TrackMeter(KmNumber(5555), 5.5, 1),
             )
         }.map { saveRequest ->
-            trackNumberService.insert(saveRequest)
+            trackNumberService.insert(LayoutBranch.main, saveRequest)
         }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
@@ -1,9 +1,9 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.error.DeletingFailureException
@@ -23,7 +23,7 @@ import kotlin.test.assertContains
 @SpringBootTest
 class LayoutSwitchDaoIT @Autowired constructor(
     private val switchDao: LayoutSwitchDao,
-): DBTestBase() {
+) : DBTestBase() {
 
     @BeforeEach
     fun cleanup() {
@@ -60,22 +60,34 @@ class LayoutSwitchDaoIT @Autowired constructor(
         val (insertId, insertVersion) = switchDao.insert(tempSwitch)
         val inserted = switchDao.fetch(insertVersion)
         assertMatches(tempSwitch, inserted)
-        assertEquals(VersionPair(insertVersion, null), switchDao.fetchVersionPair(insertId))
+        assertEquals(
+            VersionPair(insertVersion, null),
+            switchDao.fetchVersionPair(LayoutBranch.main, insertId),
+        )
 
         val tempDraft1 = asMainDraft(inserted).copy(name = SwitchName("TST002"))
         val draftVersion1 = switchDao.insert(tempDraft1).rowVersion
         val draft1 = switchDao.fetch(draftVersion1)
         assertMatches(tempDraft1, draft1)
-        assertEquals(VersionPair(insertVersion, draftVersion1), switchDao.fetchVersionPair(insertId))
+        assertEquals(
+            VersionPair(insertVersion, draftVersion1),
+            switchDao.fetchVersionPair(LayoutBranch.main, insertId),
+        )
 
         val tempDraft2 = draft1.copy(joints = joints(5, 4))
         val draftVersion2 = switchDao.update(tempDraft2).rowVersion
         val draft2 = switchDao.fetch(draftVersion2)
         assertMatches(tempDraft2, draft2)
-        assertEquals(VersionPair(insertVersion, draftVersion2), switchDao.fetchVersionPair(insertId))
+        assertEquals(
+            VersionPair(insertVersion, draftVersion2),
+            switchDao.fetchVersionPair(LayoutBranch.main, insertId)
+        )
 
-        switchDao.deleteDraft(insertId)
-        assertEquals(VersionPair(insertVersion, null), switchDao.fetchVersionPair(insertId))
+        switchDao.deleteDraft(LayoutBranch.main, insertId)
+        assertEquals(
+            VersionPair(insertVersion, null),
+            switchDao.fetchVersionPair(LayoutBranch.main, insertId)
+        )
 
         assertEquals(inserted, switchDao.fetch(insertVersion))
         assertEquals(draft1, switchDao.fetch(draftVersion1))
@@ -89,7 +101,7 @@ class LayoutSwitchDaoIT @Autowired constructor(
         val (insertedId, insertedVersion) = switchDao.insert(draftSwitch)
         val insertedSwitch = switchDao.fetch(insertedVersion)
 
-        val deletedId = switchDao.deleteDraft(insertedId)
+        val deletedId = switchDao.deleteDraft(LayoutBranch.main, insertedId)
         assertEquals(insertedId, deletedId.id)
         assertFalse(switchDao.fetchAllVersions().any { id -> id == insertedId })
 
@@ -103,7 +115,7 @@ class LayoutSwitchDaoIT @Autowired constructor(
         val insertedSwitch = switchDao.insert(switch)
 
         assertThrows<DeletingFailureException> {
-            switchDao.deleteDraft(insertedSwitch.id)
+            switchDao.deleteDraft(LayoutBranch.main, insertedSwitch.id)
         }
     }
 
@@ -113,20 +125,20 @@ class LayoutSwitchDaoIT @Autowired constructor(
         val undeletedDraftVersion = insertDraft().rowVersion
         val deleteStateDraftVersion = insertDraft(LayoutStateCategory.NOT_EXISTING).rowVersion
         val deletedDraftVersion = insertDraft().rowVersion
-        assertEquals(deletedDraftVersion, switchDao.deleteDraft(deletedDraftVersion.id).rowVersion)
+        assertEquals(deletedDraftVersion, switchDao.deleteDraft(LayoutBranch.main, deletedDraftVersion.id).rowVersion)
 
-        val official = switchDao.fetchVersions(OFFICIAL, false)
+        val official = switchDao.fetchVersions(MainLayoutContext.official, false)
         assertContains(official, officialVersion)
         assertFalse(official.contains(undeletedDraftVersion))
         assertFalse(official.contains(deleteStateDraftVersion))
         assertFalse(official.contains(deletedDraftVersion))
 
-        val draftWithoutDeleted = switchDao.fetchVersions(DRAFT, false)
+        val draftWithoutDeleted = switchDao.fetchVersions(MainLayoutContext.draft, false)
         assertContains(draftWithoutDeleted, undeletedDraftVersion)
         assertFalse(draftWithoutDeleted.contains(deleteStateDraftVersion))
         assertFalse(draftWithoutDeleted.contains(deletedDraftVersion))
 
-        val draftWithDeleted = switchDao.fetchVersions(DRAFT, true)
+        val draftWithDeleted = switchDao.fetchVersions(MainLayoutContext.draft, true)
         assertContains(draftWithDeleted, undeletedDraftVersion)
         assertContains(draftWithDeleted, deleteStateDraftVersion)
         assertFalse(draftWithDeleted.contains(deletedDraftVersion))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -6,8 +6,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LocationAccuracy
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.error.NoSuchEntityException
@@ -61,7 +60,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
         val switch = switch(draft = false)
         val id = switchDao.insert(switch).id
 
-        val fetched = switchService.get(OFFICIAL, id)!!
+        val fetched = switchService.get(MainLayoutContext.official, id)!!
         assertMatches(switch, fetched, contextMatch = false)
         assertEquals(id, fetched.id)
     }
@@ -69,7 +68,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
     @Test
     fun someSwitchesAreReturnedEvenWithoutParameters() {
         switchDao.insert(switch(draft = false))
-        assertTrue(switchService.list(OFFICIAL).isNotEmpty())
+        assertTrue(switchService.list(MainLayoutContext.official).isNotEmpty())
     }
 
     @Test
@@ -140,7 +139,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
         val inUseSwitchId = switchDao.insert(inUseSwitch)
         val deletedSwitchId = switchDao.insert(deletedSwitch)
 
-        val switches = switchService.list(OFFICIAL)
+        val switches = switchService.list(MainLayoutContext.official)
 
         assertTrue(switches.any { it.id == inUseSwitchId.id })
         assertTrue(switches.none { it.id == deletedSwitchId.id })
@@ -172,7 +171,8 @@ class LayoutSwitchServiceIT @Autowired constructor(
         assertEquals(0, pageSwitches(switches, 0, 0, null).items.size)
         assertEquals(1, pageSwitches(switches, 0, 1, null).items.size)
         assertEquals(
-            switches.size, pageSwitches(switches, 0, switches.lastIndex + 10, null).items.size
+            switches.size,
+            pageSwitches(switches, 0, switches.lastIndex + 10, null).items.size,
         )
     }
 
@@ -214,7 +214,8 @@ class LayoutSwitchServiceIT @Autowired constructor(
                         JointNumber(1),
                         location = Point(422222.2, 7222222.2),
                         locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED
-                    ), TrackLayoutSwitchJoint(
+                    ),
+                    TrackLayoutSwitchJoint(
                         JointNumber(5),
                         location = Point(428305.33617941965, 7210146.458099049),
                         locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED
@@ -260,29 +261,34 @@ class LayoutSwitchServiceIT @Autowired constructor(
     @Test
     fun returnsNullIfFetchingDraftOnlySwitchUsingOfficialFetch() {
         val draftSwitch = switchService.saveDraft(LayoutBranch.main, switch(draft = true))
-        assertNull(switchService.get(OFFICIAL, draftSwitch.id))
+        assertNull(switchService.get(MainLayoutContext.official, draftSwitch.id))
     }
 
     @Test
     fun throwsIfFetchingOfficialVersionOfDraftOnlySwitchUsingGetOrThrow() {
         val draftSwitch = switchService.saveDraft(LayoutBranch.main, switch(draft = true))
-        assertThrows<NoSuchEntityException> { switchService.getOrThrow(OFFICIAL, draftSwitch.id) }
+        assertThrows<NoSuchEntityException> { switchService.getOrThrow(MainLayoutContext.official, draftSwitch.id) }
     }
 
     @Test
     fun switchConnectedLocationTracksFound() {
         val trackNumber = getOrCreateTrackNumber(TrackNumber("123"))
         val tnId = trackNumber.id as IntId
-        val switch = switchService.get(DRAFT, switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id)!!
+        val switch = switchService.getOrThrow(
+            MainLayoutContext.draft,
+            switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id,
+        )
         val (_, withStartLink) = insertDraft(
             locationTrack(tnId, externalId = someOid(), draft = true).copy(
                 topologyStartSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(1)),
-            ), alignment(someSegment())
+            ),
+            alignment(someSegment()),
         )
         val (_, withEndLink) = insertDraft(
             locationTrack(tnId, externalId = null, draft = true).copy(
                 topologyEndSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
-            ), alignment(someSegment())
+            ),
+            alignment(someSegment()),
         )
         val (_, withSegmentLink) = insertDraft(
             locationTrack(tnId, externalId = someOid(), draft = true),
@@ -296,9 +302,9 @@ class LayoutSwitchServiceIT @Autowired constructor(
         )
         assertEquals(
             listOf<LocationTrackIdentifiers>(),
-            switchDao.findLocationTracksLinkedToSwitch(OFFICIAL, switch.id as IntId),
+            switchDao.findLocationTracksLinkedToSwitch(MainLayoutContext.official, switch.id as IntId),
         )
-        val result = switchDao.findLocationTracksLinkedToSwitch(DRAFT, switch.id as IntId)
+        val result = switchDao.findLocationTracksLinkedToSwitch(MainLayoutContext.draft, switch.id as IntId)
         assertEquals(
             listOf(withStartLink, withEndLink, withSegmentLink),
             result.sortedBy { ids -> ids.rowVersion.id.intValue },
@@ -307,7 +313,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun `Getting location tracks of switches returns empty list if argument is an empty list`() {
-        assertTrue(switchDao.findLocationTracksLinkedToSwitches(OFFICIAL, emptyList()).isEmpty())
+        assertTrue(switchDao.findLocationTracksLinkedToSwitches(MainLayoutContext.official, emptyList()).isEmpty())
     }
 
     @Test
@@ -369,14 +375,17 @@ class LayoutSwitchServiceIT @Autowired constructor(
         )
 
         val linkedLocationTracks = switchDao.findLocationTracksLinkedToSwitchAtMoment(
-            switch.id as IntId, JointNumber(1), Instant.now()
+            switch.id as IntId,
+            JointNumber(1),
+            Instant.now(),
         )
         assertEquals(2, linkedLocationTracks.size)
 
         assertTrue(
             linkedLocationTracks.contains(
                 LocationTrackIdentifiers(
-                    rowVersion = locationTrack1.rowVersion, externalId = locationTrack1Oid
+                    rowVersion = locationTrack1.rowVersion,
+                    externalId = locationTrack1Oid,
                 )
             )
         )
@@ -384,14 +393,13 @@ class LayoutSwitchServiceIT @Autowired constructor(
         assertTrue(
             linkedLocationTracks.contains(
                 LocationTrackIdentifiers(
-                    rowVersion = locationTrack3.rowVersion, externalId = locationTrack3Oid
+                    rowVersion = locationTrack3.rowVersion,
+                    externalId = locationTrack3Oid,
                 )
             )
         )
 
-        assertTrue(linkedLocationTracks.none { lt ->
-            lt.rowVersion == locationTrack2.rowVersion
-        })
+        assertTrue(linkedLocationTracks.none { lt -> lt.rowVersion == locationTrack2.rowVersion })
     }
 
     @Test
@@ -400,13 +408,16 @@ class LayoutSwitchServiceIT @Autowired constructor(
         val switchVersion = switchDao.insert(switch)
         val joint1Point = switch.getJoint(JointNumber(1))!!.location
         val (locationTrack, alignment) = locationTrackAndAlignment(
-            getUnusedTrackNumberId(), segment(joint1Point - 1.0, joint1Point), draft = true
+            getUnusedTrackNumberId(),
+            segment(joint1Point - 1.0, joint1Point),
+            draft = true,
         )
         val locationTrackVersion = locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack.copy(topologyEndSwitch = TopologyLocationTrackSwitch(switchVersion.id, JointNumber(1))),
-            alignment
+            alignment,
         )
-        val connections = switchService.getSwitchJointConnections(DRAFT, switchVersion.id)
+        val connections = switchService.getSwitchJointConnections(MainLayoutContext.draft, switchVersion.id)
 
         assertEquals(
             listOf(TrackLayoutSwitchJointMatch(locationTrackVersion.id, joint1Point)),
@@ -423,9 +434,9 @@ class LayoutSwitchServiceIT @Autowired constructor(
             ownerId = IntId(3),
             trapPoint = null,
         )
-        val switchId = switchService.insertSwitch(switch)
-        val fetchedSwitch = switchService.get(DRAFT, switchId)!!
-        assertNull(switchService.get(OFFICIAL, switchId))
+        val switchId = switchService.insertSwitch(LayoutBranch.main, switch)
+        val fetchedSwitch = switchService.get(MainLayoutContext.draft, switchId)!!
+        assertNull(switchService.get(MainLayoutContext.official, switchId))
 
         assertEquals(DataType.STORED, fetchedSwitch.dataType)
         assertEquals(switch.name, fetchedSwitch.name)
@@ -437,12 +448,14 @@ class LayoutSwitchServiceIT @Autowired constructor(
         locationTrack: LocationTrack,
         alignment: LayoutAlignment,
     ): Pair<LocationTrack, LocationTrackIdentifiers> {
-        val (id, version) = locationTrackService.saveDraft(locationTrack, alignment)
-        return locationTrackService.get(DRAFT, id)!! to LocationTrackIdentifiers(version, locationTrack.externalId)
+        val (id, version) = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
+        val track = locationTrackService.getOrThrow(MainLayoutContext.draft, id)
+        val identifiers = LocationTrackIdentifiers(version, locationTrack.externalId)
+        return track to identifiers
     }
 
     private fun getSwitches(filter: (Pair<TrackLayoutSwitch, SwitchStructure>) -> Boolean): List<TrackLayoutSwitch> =
-        switchService.listWithStructure(OFFICIAL).filter(filter).map { (s, _) -> s }
+        switchService.listWithStructure(MainLayoutContext.official).filter(filter).map { (s, _) -> s }
 
-    private fun getSwitches() = switchService.listWithStructure(OFFICIAL)
+    private fun getSwitches() = switchService.listWithStructure(MainLayoutContext.official)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDaoIT.kt
@@ -3,9 +3,8 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.tracklayout.LayoutState.DELETED
@@ -25,7 +24,7 @@ import kotlin.test.assertEquals
 @SpringBootTest
 class LayoutTrackNumberDaoIT @Autowired constructor(
     private val trackNumberDao: LayoutTrackNumberDao,
-): DBTestBase() {
+) : DBTestBase() {
 
     @Test
     fun trackNumberIsStoredAndLoadedOk() {
@@ -65,22 +64,22 @@ class LayoutTrackNumberDaoIT @Autowired constructor(
         val (id, insertVersion) = trackNumberDao.insert(tempTrackNumber)
         val inserted = trackNumberDao.fetch(insertVersion)
         assertMatches(tempTrackNumber, inserted, contextMatch = false)
-        assertEquals(VersionPair(insertVersion, null), trackNumberDao.fetchVersionPair(id))
+        assertEquals(VersionPair(insertVersion, null), trackNumberDao.fetchVersionPair(LayoutBranch.main, id))
 
         val tempDraft1 = asMainDraft(inserted).copy(description = FreeText("test 2"))
         val draftVersion1 = trackNumberDao.insert(tempDraft1).rowVersion
         val draft1 = trackNumberDao.fetch(draftVersion1)
         assertMatches(tempDraft1, draft1, contextMatch = false)
-        assertEquals(VersionPair(insertVersion, draftVersion1), trackNumberDao.fetchVersionPair(id))
+        assertEquals(VersionPair(insertVersion, draftVersion1), trackNumberDao.fetchVersionPair(LayoutBranch.main, id))
 
         val tempDraft2 = draft1.copy(description = FreeText("test 3"))
         val draftVersion2 = trackNumberDao.update(tempDraft2).rowVersion
         val draft2 = trackNumberDao.fetch(draftVersion2)
         assertMatches(tempDraft2, draft2, contextMatch = false)
-        assertEquals(VersionPair(insertVersion, draftVersion2), trackNumberDao.fetchVersionPair(id))
+        assertEquals(VersionPair(insertVersion, draftVersion2), trackNumberDao.fetchVersionPair(LayoutBranch.main, id))
 
-        trackNumberDao.deleteDraft(insertVersion.id).rowVersion
-        assertEquals(VersionPair(insertVersion, null), trackNumberDao.fetchVersionPair(id))
+        trackNumberDao.deleteDraft(LayoutBranch.main, insertVersion.id).rowVersion
+        assertEquals(VersionPair(insertVersion, null), trackNumberDao.fetchVersionPair(LayoutBranch.main, id))
 
         assertEquals(inserted, trackNumberDao.fetch(insertVersion))
         assertEquals(draft1, trackNumberDao.fetch(draftVersion1))
@@ -94,20 +93,20 @@ class LayoutTrackNumberDaoIT @Autowired constructor(
         val undeletedDraftVersion = insertNewTrackNumber(getUnusedTrackNumber(), true).rowVersion
         val deleteStateDraftVersion = insertNewTrackNumber(getUnusedTrackNumber(), true, DELETED).rowVersion
         val (deletedDraftId, deletedDraftVersion) = insertNewTrackNumber(getUnusedTrackNumber(), true)
-        trackNumberDao.deleteDraft(deletedDraftId)
+        trackNumberDao.deleteDraft(LayoutBranch.main, deletedDraftId)
 
-        val official = trackNumberDao.fetchVersions(OFFICIAL, false)
+        val official = trackNumberDao.fetchVersions(MainLayoutContext.official, false)
         assertContains(official, officialVersion)
         assertFalse(official.contains(undeletedDraftVersion))
         assertFalse(official.contains(deleteStateDraftVersion))
         assertFalse(official.contains(deletedDraftVersion))
 
-        val draftWithoutDeleted = trackNumberDao.fetchVersions(DRAFT, false)
+        val draftWithoutDeleted = trackNumberDao.fetchVersions(MainLayoutContext.draft, false)
         assertContains(draftWithoutDeleted, undeletedDraftVersion)
         assertFalse(draftWithoutDeleted.contains(deleteStateDraftVersion))
         assertFalse(draftWithoutDeleted.contains(deletedDraftVersion))
 
-        val draftWithDeleted = trackNumberDao.fetchVersions(DRAFT, true)
+        val draftWithDeleted = trackNumberDao.fetchVersions(MainLayoutContext.draft, true)
         assertContains(draftWithDeleted, undeletedDraftVersion)
         assertContains(draftWithDeleted, deleteStateDraftVersion)
         assertFalse(draftWithDeleted.contains(deletedDraftVersion))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -6,8 +6,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LocationAccuracy
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.error.DeletingFailureException
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.getSomeValue
@@ -42,19 +41,19 @@ class LocationTrackServiceIT @Autowired constructor(
 
     @BeforeEach
     fun setup() {
-        locationTrackDao.deleteDrafts()
-        alignmentDao.deleteOrphanedAlignments()
-        switchDao.deleteDrafts()
+        locationTrackDao.deleteDrafts(LayoutBranch.main)
+        alignmentDao.deleteOrphanedAlignments(LayoutBranch.main)
+        switchDao.deleteDrafts(LayoutBranch.main)
     }
 
     @Test
     fun creatingAndDeletingUnpublishedTrackWithAlignmentWorks() {
         val (track, alignment) = locationTrackAndAlignment(insertDraftTrackNumber(), someSegment(), draft = true)
-        val (id, version) = locationTrackService.saveDraft(track, alignment)
+        val (id, version) = locationTrackService.saveDraft(LayoutBranch.main, track, alignment)
         val (savedTrack, savedAlignment) = locationTrackService.getWithAlignment(version)
         assertTrue(alignmentExists(savedTrack.alignmentVersion!!.id))
         assertEquals(savedTrack.alignmentVersion?.id, savedAlignment.id as IntId)
-        val deletedVersion = locationTrackService.deleteDraft(id).rowVersion
+        val deletedVersion = locationTrackService.deleteDraft(LayoutBranch.main, id).rowVersion
         assertEquals(version, deletedVersion)
         assertFalse(alignmentExists(savedTrack.alignmentVersion!!.id))
     }
@@ -62,9 +61,9 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun deletingOfficialLocationTrackThrowsException() {
         val (track, alignment) = locationTrackAndAlignment(insertOfficialTrackNumber(), someSegment(), draft = true)
-        val version = locationTrackService.saveDraft(track, alignment)
+        val version = locationTrackService.saveDraft(LayoutBranch.main, track, alignment)
         publish(version.id)
-        assertThrows<DeletingFailureException> { locationTrackService.deleteDraft(version.id) }
+        assertThrows<DeletingFailureException> { locationTrackService.deleteDraft(LayoutBranch.main, version.id) }
     }
 
     @Test
@@ -89,12 +88,14 @@ class LocationTrackServiceIT @Autowired constructor(
             draft = true,
         )
 
-        val alignmentIdInBbox = locationTrackService.saveDraft(trackInside, alignmentInside).id
-        val alignmentIdOutsideBbox = locationTrackService.saveDraft(trackOutside, alignmentOutside).id
+        val alignmentIdInBbox = locationTrackService
+            .saveDraft(LayoutBranch.main, trackInside, alignmentInside).id
+        val alignmentIdOutsideBbox = locationTrackService
+            .saveDraft(LayoutBranch.main, trackOutside, alignmentOutside).id
 
         val boundingBox = BoundingBox(Point(0.0, 0.0), Point(10.0, 10.0))
 
-        val tracksAndAlignments = locationTrackService.listNearWithAlignments(DRAFT, boundingBox)
+        val tracksAndAlignments = locationTrackService.listNearWithAlignments(MainLayoutContext.draft, boundingBox)
 
         assertTrue(tracksAndAlignments.any { (t, _) -> t.id == alignmentIdInBbox })
         assertTrue(tracksAndAlignments.none { (t, _) -> t.id == alignmentIdOutsideBbox })
@@ -108,17 +109,17 @@ class LocationTrackServiceIT @Autowired constructor(
         val (id, insertedTrackVersion) = response
         val changeTimeAfterInsert = locationTrackService.getChangeTime()
 
-        val updateRequest =
-            saveRequest(trackNumberId, 2).copy(topologicalConnectivity = TopologicalConnectivityType.NONE)
-        val updatedTrackVersion = locationTrackService.update(id, updateRequest).rowVersion
+        val updateRequest = saveRequest(trackNumberId, 2)
+            .copy(topologicalConnectivity = TopologicalConnectivityType.NONE)
+        val updatedTrackVersion = locationTrackService.update(LayoutBranch.main, id, updateRequest).rowVersion
         assertEquals(id, updatedTrackVersion.id)
         assertNotEquals(insertedTrackVersion.version, updatedTrackVersion.version)
-        val updatedTrack = locationTrackService.get(DRAFT, id)!!
+        val updatedTrack = locationTrackService.get(MainLayoutContext.draft, id)!!
         assertMatches(updateRequest, updatedTrack)
         assertEquals(insertedTrack.alignmentVersion, updatedTrack.alignmentVersion)
         val changeTimeAfterUpdate = locationTrackService.getChangeTime()
 
-        val changeInfo = locationTrackService.getLayoutAssetChangeInfo(id, DRAFT)
+        val changeInfo = locationTrackService.getLayoutAssetChangeInfo(MainLayoutContext.draft, id)
         assertEquals(changeTimeAfterInsert, changeInfo?.created)
         assertEquals(changeTimeAfterUpdate, changeInfo?.changed)
     }
@@ -127,7 +128,10 @@ class LocationTrackServiceIT @Autowired constructor(
     fun savingCreatesDraft() {
         val (publicationResponse, published) = createPublishedLocationTrack(1)
 
-        val editedVersion = locationTrackService.saveDraft(LayoutBranch.main, published.copy(name = AlignmentName("EDITED1")))
+        val editedVersion = locationTrackService.saveDraft(
+            LayoutBranch.main,
+            published.copy(name = AlignmentName("EDITED1")),
+        )
         assertEquals(publicationResponse.id, editedVersion.id)
         assertNotEquals(publicationResponse.rowVersion.id, editedVersion.rowVersion.id)
 
@@ -136,7 +140,10 @@ class LocationTrackServiceIT @Autowired constructor(
         // Creating a draft should duplicate the alignment
         assertNotEquals(published.alignmentVersion!!.id, editedDraft.alignmentVersion!!.id)
 
-        val editedVersion2 = locationTrackService.saveDraft(LayoutBranch.main, editedDraft.copy(name = AlignmentName("EDITED2")))
+        val editedVersion2 = locationTrackService.saveDraft(
+            LayoutBranch.main,
+            editedDraft.copy(name = AlignmentName("EDITED2")),
+        )
         assertEquals(publicationResponse.id, editedVersion2.id)
         assertNotEquals(publicationResponse.rowVersion.id, editedVersion2.rowVersion.id)
 
@@ -152,7 +159,7 @@ class LocationTrackServiceIT @Autowired constructor(
         val (publicationResponse, published) = createPublishedLocationTrack(2)
 
         val alignmentTmp = alignment(segment(2, 10.0, 20.0, 10.0, 20.0))
-        val editedVersion = locationTrackService.saveDraft(published, alignmentTmp)
+        val editedVersion = locationTrackService.saveDraft(LayoutBranch.main, published, alignmentTmp)
         assertEquals(publicationResponse.id, editedVersion.id)
         assertNotEquals(publicationResponse.rowVersion.id, editedVersion.rowVersion.id)
 
@@ -166,7 +173,7 @@ class LocationTrackServiceIT @Autowired constructor(
         assertNotEquals(published.alignmentVersion!!.id, editedDraft.alignmentVersion!!.id)
 
         val alignmentTmp2 = alignment(segment(4, 10.0, 20.0, 10.0, 20.0))
-        val editedVersion2 = locationTrackService.saveDraft(editedDraft, alignmentTmp2)
+        val editedVersion2 = locationTrackService.saveDraft(LayoutBranch.main, editedDraft, alignmentTmp2)
         assertEquals(publicationResponse.id, editedVersion2.id)
         assertNotEquals(publicationResponse.rowVersion.id, editedVersion2.rowVersion.id)
 
@@ -186,14 +193,18 @@ class LocationTrackServiceIT @Autowired constructor(
         val trackNumberId = insertDraftTrackNumber()
 
         val insertRequest = saveRequest(trackNumberId, 2)
-        val id = locationTrackService.insert(insertRequest).id
-        val locationTrack = locationTrackService.get(DRAFT, id)!!
+        val id = locationTrackService.insert(LayoutBranch.main, insertRequest).id
+        val locationTrack = locationTrackService.get(MainLayoutContext.draft, id)!!
 
         assertNull(locationTrack.externalId)
 
-        locationTrackService.updateExternalId(locationTrack.id as IntId, externalIdForLocationTrack())
+        locationTrackService.updateExternalId(
+            LayoutBranch.main,
+            locationTrack.id as IntId,
+            externalIdForLocationTrack(),
+        )
 
-        val updatedLocationTrack = locationTrackService.get(DRAFT, id)!!
+        val updatedLocationTrack = locationTrackService.get(MainLayoutContext.draft, id)!!
         assertNotNull(updatedLocationTrack.externalId)
     }
 
@@ -202,7 +213,7 @@ class LocationTrackServiceIT @Autowired constructor(
         val trackNumber = insertOfficialTrackNumber()
         val draft = createAndVerifyTrack(trackNumber, 35)
 
-        assertNull(locationTrackService.get(OFFICIAL, draft.first.id))
+        assertNull(locationTrackService.get(MainLayoutContext.official, draft.first.id))
     }
 
     @Test
@@ -210,7 +221,9 @@ class LocationTrackServiceIT @Autowired constructor(
         val trackNumber = insertOfficialTrackNumber()
         val draft = createAndVerifyTrack(trackNumber, 35)
 
-        assertThrows<NoSuchEntityException> { (locationTrackService.getOrThrow(OFFICIAL, draft.first.id)) }
+        assertThrows<NoSuchEntityException> {
+            locationTrackService.getOrThrow(MainLayoutContext.official, draft.first.id)
+        }
     }
 
     @Test
@@ -237,7 +250,8 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
         assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(1)), updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -266,7 +280,8 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(2)), updatedTrack.topologyEndSwitch)
     }
@@ -295,7 +310,8 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -324,7 +340,8 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -352,7 +369,8 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track1.topologyStartSwitch)
         assertEquals(null, track1.topologyEndSwitch)
 
-        val updatedTrack1 = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track1, alignment1)
+        val updatedTrack1 = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track1, alignment1)
         assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack1.topologyStartSwitch)
         assertEquals(null, updatedTrack1.topologyEndSwitch)
 
@@ -363,7 +381,8 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track2.topologyStartSwitch)
         assertEquals(null, track2.topologyEndSwitch)
 
-        val updatedTrack2 = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track2, alignment2)
+        val updatedTrack2 = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track2, alignment2)
         assertEquals(TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack2.topologyStartSwitch)
         assertEquals(null, updatedTrack2.topologyEndSwitch)
 
@@ -374,7 +393,8 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track3.topologyStartSwitch)
         assertEquals(null, track3.topologyEndSwitch)
 
-        val updatedTrack3 = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track3, alignment3)
+        val updatedTrack3 = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track3, alignment3)
         assertEquals(null, updatedTrack3.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack3.topologyEndSwitch)
 
@@ -385,7 +405,8 @@ class LocationTrackServiceIT @Autowired constructor(
         assertEquals(null, track4.topologyStartSwitch)
         assertEquals(null, track4.topologyEndSwitch)
 
-        val updatedTrack4 = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track4, alignment4)
+        val updatedTrack4 = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track4, alignment4)
         assertEquals(null, updatedTrack4.topologyStartSwitch)
         assertEquals(TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack4.topologyEndSwitch)
     }
@@ -405,7 +426,8 @@ class LocationTrackServiceIT @Autowired constructor(
             ),
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
-        val updated = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
+        val updated = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
         assertEquals(track.topologyStartSwitch, updated.topologyStartSwitch)
         assertEquals(track.topologyEndSwitch, updated.topologyEndSwitch)
     }
@@ -430,7 +452,8 @@ class LocationTrackServiceIT @Autowired constructor(
         )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(track, alignment)
+        val updatedTrack = locationTrackService
+            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
         assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(3)), updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -460,7 +483,7 @@ class LocationTrackServiceIT @Autowired constructor(
             ),
         )
 
-        val switches = locationTrackService.getSwitchesForLocationTrack(track.id as IntId, DRAFT)
+        val switches = locationTrackService.getSwitchesForLocationTrack(MainLayoutContext.draft, track.id as IntId)
         assertContains(switches, topologyEndSwitchId)
         assertContains(switches, topologyStartSwitchId)
         assertContains(switches, segmentSwitchId)
@@ -469,7 +492,8 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun fetchDuplicatesIsVersioned() {
         val trackNumberId = getUnusedTrackNumberId()
-        val originalLocationTrackId = locationTrackService.insert(saveRequest(trackNumberId, 1)).id
+        val originalLocationTrackId = locationTrackService
+            .insert(LayoutBranch.main, saveRequest(trackNumberId, 1)).id
         publish(originalLocationTrackId)
         val officialCopy = insertAndFetchDraft(
             locationTrack(getUnusedTrackNumberId(), duplicateOf = originalLocationTrackId, draft = true),
@@ -478,17 +502,18 @@ class LocationTrackServiceIT @Autowired constructor(
         publish(officialCopy.first.id as IntId<LocationTrack>)
 
         val draftCopyVersion = locationTrackService.update(
+            LayoutBranch.main,
             officialCopy.first.id as IntId,
             saveRequest(trackNumberId, 1).copy(duplicateOf = originalLocationTrackId),
         )
-        val draftCopy = locationTrackService.get(DRAFT, draftCopyVersion.id)!!
+        val draftCopy = locationTrackService.get(MainLayoutContext.draft, draftCopyVersion.id)!!
         assertEquals(
             listOf(asLocationTrackDuplicate(officialCopy.first)),
-            locationTrackService.getInfoboxExtras(OFFICIAL, originalLocationTrackId)?.duplicates
+            locationTrackService.getInfoboxExtras(MainLayoutContext.official, originalLocationTrackId)?.duplicates
         )
         assertEquals(
             listOf(asLocationTrackDuplicate(draftCopy)),
-            locationTrackService.getInfoboxExtras(DRAFT, originalLocationTrackId)?.duplicates
+            locationTrackService.getInfoboxExtras(MainLayoutContext.draft, originalLocationTrackId)?.duplicates
         )
     }
 
@@ -530,7 +555,8 @@ class LocationTrackServiceIT @Autowired constructor(
             locationTrack(trackNumberId, alignmentVersion = rlAlignment, duplicateOf = locationTrack.id, draft = false)
         )
 
-        val splittingParams = locationTrackService.getSplittingInitializationParameters(locationTrack.id, DRAFT)
+        val splittingParams = locationTrackService
+            .getSplittingInitializationParameters(MainLayoutContext.draft, locationTrack.id)
         assertNotNull(splittingParams)
         assertEquals(locationTrack.id, splittingParams?.id)
         assertEquals(1, splittingParams?.switches?.size)
@@ -554,8 +580,8 @@ class LocationTrackServiceIT @Autowired constructor(
     private fun insertAndFetchDraft(
         locationTrack: LocationTrack,
         alignment: LayoutAlignment,
-    ): Pair<LocationTrack, LayoutAlignment> =
-        locationTrackService.getWithAlignment(locationTrackService.saveDraft(locationTrack, alignment).rowVersion)
+    ): Pair<LocationTrack, LayoutAlignment> = locationTrackService
+        .getWithAlignment(locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment).rowVersion)
 
     private fun createPublishedLocationTrack(seed: Int): Pair<DaoResponse<LocationTrack>, LocationTrack> {
         val trackNumberId = insertOfficialTrackNumber()
@@ -568,8 +594,8 @@ class LocationTrackServiceIT @Autowired constructor(
         seed: Int,
     ): Pair<DaoResponse<LocationTrack>, LocationTrack> {
         val insertRequest = saveRequest(trackNumberId, seed)
-        val insertResponse = locationTrackService.insert(insertRequest)
-        val insertedTrack = locationTrackService.get(DRAFT, insertResponse.id)!!
+        val insertResponse = locationTrackService.insert(LayoutBranch.main, insertRequest)
+        val insertedTrack = locationTrackService.get(MainLayoutContext.draft, insertResponse.id)!!
         assertMatches(insertRequest, insertedTrack)
         return insertResponse to insertedTrack
     }
@@ -577,12 +603,14 @@ class LocationTrackServiceIT @Autowired constructor(
     private fun publishAndVerify(
         locationTrackId: IntId<LocationTrack>,
     ): Pair<DaoResponse<LocationTrack>, LocationTrack> {
-        val (draft, draftAlignment) = locationTrackService.getWithAlignmentOrThrow(DRAFT, locationTrackId)
+        val (draft, draftAlignment) = locationTrackService
+            .getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
         assertTrue(draft.isDraft)
 
         val publicationResponse = publish(draft.id as IntId)
         val (published, publishedAlignment) = locationTrackService.getWithAlignmentOrThrow(
-            OFFICIAL, publicationResponse.id
+            MainLayoutContext.official,
+            publicationResponse.id,
         )
         assertFalse(published.isDraft)
         assertEquals(draft.id, published.id)
@@ -594,14 +622,14 @@ class LocationTrackServiceIT @Autowired constructor(
     }
 
     private fun getAndVerifyDraft(id: IntId<LocationTrack>): LocationTrack {
-        val draft = locationTrackService.get(DRAFT, id)!!
+        val draft = locationTrackService.get(MainLayoutContext.draft, id)!!
         assertEquals(id, draft.id)
         assertTrue(draft.isDraft)
         return draft
     }
 
     private fun getAndVerifyDraftWithAlignment(id: IntId<LocationTrack>): Pair<LocationTrack, LayoutAlignment> {
-        val (draft, alignment) = locationTrackService.getWithAlignmentOrThrow(DRAFT, id)
+        val (draft, alignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, id)
         assertEquals(id, draft.id)
         assertTrue(draft.isDraft)
         assertEquals(draft.alignmentVersion!!.id, alignment.id)
@@ -639,8 +667,8 @@ class LocationTrackServiceIT @Autowired constructor(
         ownerId = IntId(1)
     )
 
-    private fun publish(id: IntId<LocationTrack>) = locationTrackDao
-        .fetchPublicationVersions(listOf(id))
+    private fun publish(id: IntId<LocationTrack>): DaoResponse<LocationTrack> = locationTrackDao
+        .fetchPublicationVersions(LayoutBranch.main, listOf(id))
         .first()
-        .let { version -> locationTrackService.publish(version) }
+        .let { version -> locationTrackService.publish(LayoutBranch.main, version) }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDaoIT.kt
@@ -3,8 +3,8 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.KmNumber
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.math.Point
@@ -20,7 +20,7 @@ import org.springframework.test.context.ActiveProfiles
 class ReferenceLineDaoIT @Autowired constructor(
     private val alignmentDao: LayoutAlignmentDao,
     private val referenceLineDao: ReferenceLineDao,
-): DBTestBase() {
+) : DBTestBase() {
 
     @Test
     fun referenceLineSaveAndLoadWorks() {
@@ -34,8 +34,8 @@ class ReferenceLineDaoIT @Autowired constructor(
 
         assertEquals(DataType.TEMP, referenceLine.dataType)
         val (id, version) = referenceLineDao.insert(referenceLine)
-        assertEquals(version, referenceLineDao.fetchVersion(id, OFFICIAL))
-        assertEquals(version, referenceLineDao.fetchVersion(id, DRAFT))
+        assertEquals(version, referenceLineDao.fetchVersion(MainLayoutContext.official, id))
+        assertEquals(version, referenceLineDao.fetchVersion(MainLayoutContext.draft, id))
         val fromDb = referenceLineDao.fetch(version)
         assertEquals(DataType.STORED, fromDb.dataType)
         assertMatches(referenceLine, fromDb, contextMatch = false)
@@ -46,8 +46,8 @@ class ReferenceLineDaoIT @Autowired constructor(
         val (updatedId, updatedVersion) = referenceLineDao.update(updatedLine)
         assertEquals(id, updatedId)
         assertEquals(updatedVersion.id, version.id)
-        assertEquals(updatedVersion, referenceLineDao.fetchVersion(id, OFFICIAL))
-        assertEquals(updatedVersion, referenceLineDao.fetchVersion(id, DRAFT))
+        assertEquals(updatedVersion, referenceLineDao.fetchVersion(MainLayoutContext.official, id))
+        assertEquals(updatedVersion, referenceLineDao.fetchVersion(MainLayoutContext.draft, id))
         val updatedFromDb = referenceLineDao.fetch(updatedVersion)
         assertEquals(DataType.STORED, updatedFromDb.dataType)
         assertMatches(updatedLine, updatedFromDb, contextMatch = false)
@@ -68,13 +68,19 @@ class ReferenceLineDaoIT @Autowired constructor(
         val (id, insertVersion) = referenceLineDao.insert(tempTrack)
         val inserted = referenceLineDao.fetch(insertVersion)
         assertMatches(tempTrack, inserted, contextMatch = false)
-        assertEquals(VersionPair(insertVersion, null), referenceLineDao.fetchVersionPair(id))
+        assertEquals(
+            VersionPair(insertVersion, null),
+            referenceLineDao.fetchVersionPair(LayoutBranch.main, id),
+        )
 
         val tempDraft1 = asMainDraft(inserted).copy(startAddress = TrackMeter(2, 4))
         val draftVersion1 = referenceLineDao.insert(tempDraft1).rowVersion
         val draft1 = referenceLineDao.fetch(draftVersion1)
         assertMatches(tempDraft1, draft1, contextMatch = false)
-        assertEquals(VersionPair(insertVersion, draftVersion1), referenceLineDao.fetchVersionPair(id))
+        assertEquals(
+            VersionPair(insertVersion, draftVersion1),
+            referenceLineDao.fetchVersionPair(LayoutBranch.main, id),
+        )
 
         val newTempAlignment = alignment(segment(Point(2.0, 2.0), Point(4.0, 4.0)))
         val newAlignmentVersion = alignmentDao.insert(newTempAlignment)
@@ -82,11 +88,17 @@ class ReferenceLineDaoIT @Autowired constructor(
         val draftVersion2 = referenceLineDao.update(tempDraft2).rowVersion
         val draft2 = referenceLineDao.fetch(draftVersion2)
         assertMatches(tempDraft2, draft2, contextMatch = false)
-        assertEquals(VersionPair(insertVersion, draftVersion2), referenceLineDao.fetchVersionPair(id))
+        assertEquals(
+            VersionPair(insertVersion, draftVersion2),
+            referenceLineDao.fetchVersionPair(LayoutBranch.main, id),
+        )
 
-        referenceLineDao.deleteDraft(id)
-        alignmentDao.deleteOrphanedAlignments()
-        assertEquals(VersionPair(insertVersion, null), referenceLineDao.fetchVersionPair(id))
+        referenceLineDao.deleteDraft(LayoutBranch.main, id)
+        alignmentDao.deleteOrphanedAlignments(LayoutBranch.main)
+        assertEquals(
+            VersionPair(insertVersion, null),
+            referenceLineDao.fetchVersionPair(LayoutBranch.main, id),
+        )
 
         assertEquals(inserted, referenceLineDao.fetch(insertVersion))
         assertEquals(draft1, referenceLineDao.fetch(draftVersion1))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
@@ -23,6 +23,7 @@ fun moveLocationTrackGeometryPointsAndUpdate(
     moveFunc: (point: IPoint3DM) -> IPoint,
     locationTrackService: LocationTrackService,
 ) = locationTrackService.saveDraft(
+    LayoutBranch.main,
     locationTrack,
     moveAlignmentPoints(alignment, moveFunc),
 )
@@ -34,6 +35,7 @@ fun addTopologyEndSwitchIntoLocationTrackAndUpdate(
     jointNumber: JointNumber,
     locationTrackService: LocationTrackService,
 ) = locationTrackService.saveDraft(
+    LayoutBranch.main,
     locationTrack.copy(
         topologyEndSwitch = TopologyLocationTrackSwitch(
             switchId = switchId,
@@ -48,6 +50,7 @@ fun removeTopologySwitchesFromLocationTrackAndUpdate(
     alignment: LayoutAlignment,
     locationTrackService: LocationTrackService,
 ) = locationTrackService.saveDraft(
+    LayoutBranch.main,
     locationTrack.copy(
         topologyStartSwitch = null,
         topologyEndSwitch = null,
@@ -61,7 +64,8 @@ fun addTopologyStartSwitchIntoLocationTrackAndUpdate(
     switchId: IntId<TrackLayoutSwitch>,
     jointNumber: JointNumber,
     locationTrackService: LocationTrackService,
-) = locationTrackService.saveDraft(
+): DaoResponse<LocationTrack> = locationTrackService.saveDraft(
+    LayoutBranch.main,
     locationTrack.copy(
         topologyStartSwitch = TopologyLocationTrackSwitch(
             switchId = switchId,
@@ -76,7 +80,11 @@ fun moveReferenceLineGeometryPointsAndUpdate(
     alignment: LayoutAlignment,
     moveFunc: (point: IPoint3DM) -> IPoint,
     referenceLineService: ReferenceLineService,
-) = referenceLineService.saveDraft(referenceLine, moveAlignmentPoints(alignment, moveFunc))
+): DaoResponse<ReferenceLine> = referenceLineService.saveDraft(
+    LayoutBranch.main,
+    referenceLine,
+    moveAlignmentPoints(alignment, moveFunc),
+)
 
 fun moveAlignmentPoints(
     alignment: LayoutAlignment,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
@@ -1,23 +1,23 @@
 package fi.fta.geoviite.infra.ui.testgroup1
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationRequest
 import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-
-import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.util.DaoBase
 import fi.fta.geoviite.infra.util.setUser
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.ZoneOffset
@@ -131,9 +131,14 @@ class PublicationLogSearchTestUI @Autowired constructor(
     }
 
     private fun testPublish(publicationRequest: PublicationRequest): IntId<Publication> {
-        val versions = publicationService.getValidationVersions(publicationRequest.content)
+        val versions = publicationService.getValidationVersions(LayoutBranch.main, publicationRequest.content)
         val calculatedChanges = publicationService.getCalculatedChanges(versions)
-        val result = publicationService.publishChanges(versions, calculatedChanges, publicationRequest.message)
+        val result = publicationService.publishChanges(
+            LayoutBranch.main,
+            versions,
+            calculatedChanges,
+            publicationRequest.message,
+        )
 
         return result.publicationId!!
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.ui.testgroup1
 
-import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
@@ -61,7 +62,7 @@ class SplitTestUI @Autowired constructor(
             segments = preSegments + switchSegments1 + segments1To2 + switchSegments2 + postSegments
         ).id
 
-        val sourceTrackName = locationTrackService.get(OFFICIAL, sourceTrackId)!!.name.toString()
+        val sourceTrackName = locationTrackService.get(MainLayoutContext.official, sourceTrackId)!!.name.toString()
         splitTestDataService.insertAsTrack(trackNumberId = trackNumberId, segments = turningSegments1)
         splitTestDataService.insertAsTrack(trackNumberId = trackNumberId, segments = turningSegments2)
 
@@ -100,7 +101,10 @@ class SplitTestUI @Autowired constructor(
 
         splittingInfobox.confirmSplit()
 
-        val unpublishedSplit = splitService.findUnpublishedSplits(locationTrackIds = listOf(sourceTrackId)).first()
+        val unpublishedSplit = splitService.findUnpublishedSplits(
+            branch = LayoutBranch.main,
+            locationTrackIds = listOf(sourceTrackId),
+        ).first()
         assertEquals(3, unpublishedSplit.targetLocationTracks.size)
 
         // External IDs are fetched from (fake) Ratko service during publication,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
@@ -1,13 +1,30 @@
 package fi.fta.geoviite.infra.ui.testgroup2
 
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LinearUnit
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
-import fi.fta.geoviite.infra.geometry.*
+import fi.fta.geoviite.infra.geometry.GeometryDao
+import fi.fta.geoviite.infra.geometry.GeometryProfile
+import fi.fta.geoviite.infra.geometry.GeometryUnits
+import fi.fta.geoviite.infra.geometry.VICircularCurve
+import fi.fta.geoviite.infra.geometry.VIPoint
+import fi.fta.geoviite.infra.geometry.geometryAlignment
+import fi.fta.geoviite.infra.geometry.line
+import fi.fta.geoviite.infra.geometry.plan
+import fi.fta.geoviite.infra.geometry.testFile
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.AngularUnit
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
+import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.referenceLine
+import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.map.E2ETrackLayoutPage
 import org.junit.jupiter.api.BeforeEach
@@ -36,6 +53,7 @@ class VerticalGeometryDiagramTestUI @Autowired constructor(
         val trackNumber = getUnusedTrackNumber()
         val trackNumberId = insertOfficialTrackNumber(trackNumber)
         referenceLineService.saveDraft(
+            LayoutBranch.main,
             referenceLine(trackNumberId, draft = true),
             alignment(segment(DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0)))
         )
@@ -49,20 +67,24 @@ class VerticalGeometryDiagramTestUI @Autowired constructor(
         val plan = geometryDao.fetchPlan(
             geometryDao.insertPlan(
                 plan(
-                    trackNumber, units = GeometryUnits(
+                    trackNumber = trackNumber,
+                    units = GeometryUnits(
                         coordinateSystemSrid = LAYOUT_SRID,
                         coordinateSystemName = null,
                         verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
                         directionUnit = AngularUnit.GRADS,
                         linearUnit = LinearUnit.METER,
-                    ), alignments = listOf(
+                    ),
+                    alignments = listOf(
                         geometryAlignment(
                             elements = listOf(
                                 line(
                                     DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0)
                                 )
-                            ), profile = GeometryProfile(
-                                PlanElementName("aoeu"), listOf(
+                            ),
+                            profile = GeometryProfile(
+                                PlanElementName("aoeu"),
+                                listOf(
                                     VIPoint(PlanElementName("startpoint"), Point(0.0, 50.0)),
                                     VICircularCurve(
                                         PlanElementName("rounding"),
@@ -73,13 +95,15 @@ class VerticalGeometryDiagramTestUI @Autowired constructor(
                                     VIPoint(PlanElementName("endpoint"), Point(600.0, 51.0)),
                                 )
                             )
-                        )
-
+                        ),
                     )
-                ), testFile(), null
+                ),
+                testFile(),
+                null,
             )
         )
         locationTrackService.saveDraft(
+            LayoutBranch.main,
             locationTrack(trackNumberId = trackNumberId, name = "foo bar", draft = true),
             alignment(
                 segment(DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0)).copy(
@@ -94,5 +118,4 @@ class VerticalGeometryDiagramTestUI @Autowired constructor(
         page.toolPanel.locationTrackVerticalGeometry.toggleVerticalGeometryDiagram()
         page.verticalGeometryDiagram.waitForContent()
     }
-
 }

--- a/ui/src/common/geocoding-api.ts
+++ b/ui/src/common/geocoding-api.ts
@@ -7,6 +7,7 @@ import { Point } from 'model/geometry';
 import { LayoutContext, TrackMeter } from 'common/common-model';
 import { API_URI, getNullable, queryParams } from 'api/api-fetch';
 import { pointString } from 'common/common-api';
+import { contextInUri } from 'track-layout/track-layout-api';
 
 export const GEOCODING_URI = `${API_URI}/geocoding`;
 
@@ -27,7 +28,7 @@ export type AlignmentAddresses = {
 };
 
 function geocodingUri(layoutContext: LayoutContext) {
-    return `${GEOCODING_URI}/${layoutContext.publicationState.toLowerCase()}`;
+    return `${GEOCODING_URI}/${contextInUri(layoutContext)}`;
 }
 
 export async function getAddress(

--- a/ui/src/data-products/kilometer-lengths/entire-rail-network-km-lengths-listing.tsx
+++ b/ui/src/data-products/kilometer-lengths/entire-rail-network-km-lengths-listing.tsx
@@ -6,6 +6,7 @@ import { Icons } from 'vayla-design-lib/icon/Icon';
 import { getEntireRailNetworkKmLengthsCsvUrl } from 'track-layout/layout-km-post-api';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { DOWNLOAD_GEOMETRY } from 'user/user-model';
+import { officialMainLayoutContext } from 'common/common-model';
 
 export const EntireRailNetworkKmLengthsListing = () => {
     const { t } = useTranslation();
@@ -17,7 +18,9 @@ export const EntireRailNetworkKmLengthsListing = () => {
             </p>
             <PrivilegeRequired privilege={DOWNLOAD_GEOMETRY}>
                 <div className={styles['data-products__search']}>
-                    <a qa-id="km-lengths-csv-download" href={getEntireRailNetworkKmLengthsCsvUrl()}>
+                    <a
+                        qa-id="km-lengths-csv-download"
+                        href={getEntireRailNetworkKmLengthsCsvUrl(officialMainLayoutContext())}>
                         <Button
                             className={
                                 styles['vertical-geometry-list__download-button--left-aligned']

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -41,11 +41,11 @@ import {
     KmNumber,
     LayoutContext,
     LayoutDesignId,
+    officialMainLayoutContext,
     PublicationState,
     TimeStamp,
     TrackNumber,
     VerticalCoordinateSystem,
-    officialMainLayoutContext,
 } from 'common/common-model';
 import { bboxString } from 'common/common-api';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
@@ -421,7 +421,7 @@ export async function getLocationTrackHeights(
     tickLength: number,
 ): Promise<TrackKmHeights[]> {
     return getNonNull(
-        `${GEOMETRY_URI}/${layoutContext.publicationState}/layout/location-tracks/${locationTrackId}/alignment-heights` +
+        `${geometryLayoutPath(layoutContext)}/location-tracks/${locationTrackId}/alignment-heights` +
             queryParams({ startDistance, endDistance, tickLength }),
     ).catch(() => []) as Promise<TrackKmHeights[]>;
 }
@@ -441,7 +441,7 @@ export async function getLocationTrackLinkingSummary(
         `${locationTrackId}_${layoutContext.publicationState}_${layoutContext.designId}`,
         () =>
             getNonNull(
-                `${GEOMETRY_URI}/${layoutContext.publicationState}/layout/location-tracks/${locationTrackId}/linking-summary`,
+                `${geometryLayoutPath(layoutContext)}/location-tracks/${locationTrackId}/linking-summary`,
             ),
     );
 }

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -45,12 +45,14 @@ import {
     TimeStamp,
     TrackNumber,
     VerticalCoordinateSystem,
+    officialMainLayoutContext,
 } from 'common/common-model';
 import { bboxString } from 'common/common-api';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
 import { GeometryTypeIncludingMissing } from 'data-products/data-products-slice';
 import { AlignmentHeader } from 'track-layout/layout-map-api';
 import i18next from 'i18next';
+import { contextInUri } from 'track-layout/track-layout-api';
 
 export const GEOMETRY_URI = `${API_URI}/geometry`;
 
@@ -165,7 +167,9 @@ export async function getLocationTrackElements(
         startAddress: startAddress,
         endAddress: endAddress,
     });
-    return getNonNull(`${GEOMETRY_URI}/layout/location-tracks/${id}/element-listing${params}`);
+    return getNonNull(
+        `${geometryLayoutPath(officialMainLayoutContext())}/location-tracks/${id}/element-listing${params}`,
+    );
 }
 
 export async function getLocationTrackVerticalGeometry(
@@ -181,7 +185,7 @@ export async function getLocationTrackVerticalGeometry(
     });
     const fetch: () => Promise<VerticalGeometryItem[] | undefined> = () =>
         getNonNull(
-            `${GEOMETRY_URI}/layout/${layoutContext.publicationState}/location-tracks/${id}/vertical-geometry${params}`,
+            `${geometryLayoutPath(layoutContext)}/location-tracks/${id}/vertical-geometry${params}`,
         );
     return changeTime === undefined
         ? fetch()
@@ -222,6 +226,9 @@ export const getGeometryPlanVerticalGeometryCsv = (planId: GeometryPlanId) =>
 export const getEntireRailNetworkVerticalGeometryCsvUrl = () =>
     `${GEOMETRY_URI}/rail-network/vertical-geometry/file`;
 
+export const geometryLayoutPath = (context: LayoutContext): string =>
+    `${GEOMETRY_URI}/layout/${contextInUri(context)}`;
+
 export const getLocationTrackElementsCsv = (
     locationTrackId: LocationTrackId,
     elementTypes: GeometryTypeIncludingMissing[],
@@ -234,7 +241,7 @@ export const getLocationTrackElementsCsv = (
         endAddress,
         lang: i18next.language,
     });
-    return `${GEOMETRY_URI}/layout/location-tracks/${locationTrackId}/element-listing/file${searchQueryParameters}`;
+    return `${geometryLayoutPath(officialMainLayoutContext())}/location-tracks/${locationTrackId}/element-listing/file${searchQueryParameters}`;
 };
 
 export async function getGeometryPlan(

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -31,8 +31,14 @@ import { PublicationDetailsTableSortField } from 'publication/table/publication-
 import { SortDirection } from 'utils/table-utils';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { createPublicationCandidateReference } from 'publication/publication-utils';
+import { LayoutDesignId } from 'common/common-model';
+import { toBranchName } from 'track-layout/track-layout-api';
 
 const PUBLICATION_URL = `${API_URI}/publications`;
+
+function publicationUri(designId: LayoutDesignId | undefined): string {
+    return `${PUBLICATION_URL}/${toBranchName(designId).toLowerCase()}`;
+}
 
 export type PublicationCandidatesResponse = {
     trackNumbers: TrackNumberPublicationCandidate[];
@@ -155,19 +161,19 @@ const toValidatedPublicationCandidates = (
 };
 
 export const getPublicationCandidates = (): Promise<PublicationCandidate[]> =>
-    getNonNull<PublicationCandidatesResponse>(`${PUBLICATION_URL}/candidates`).then(
+    getNonNull<PublicationCandidatesResponse>(`${publicationUri(undefined)}/candidates`).then(
         toPublicationCandidates,
     );
 
 export const validatePublicationCandidates = (candidates: PublicationCandidateReference[]) =>
     postNonNull<PublicationRequestIds, ValidatedPublicationCandidatesResponse>(
-        `${PUBLICATION_URL}/validate`,
+        `${publicationUri(undefined)}/validate`,
         toPublicationRequestIds(candidates),
     ).then(toValidatedPublicationCandidates);
 
 export const revertPublicationCandidates = (candidates: PublicationCandidateReference[]) =>
     deleteNonNullAdt<PublicationRequestIds, PublicationResult>(
-        `${PUBLICATION_URL}/candidates`,
+        `${publicationUri(undefined)}/candidates`,
         toPublicationRequestIds(candidates),
     );
 
@@ -180,17 +186,19 @@ export const publishPublicationCandidates = (
         message,
     };
 
-    return postNonNull<PublicationRequest, PublicationResult>(`${PUBLICATION_URL}`, request);
+    return postNonNull<PublicationRequest, PublicationResult>(
+        `${publicationUri(undefined)}`,
+        request,
+    );
 };
 
-export const getLatestPublications = (count: number) => {
+export const getLatestPublications = async (count: number) => {
     const params = queryParams({
         count,
     });
 
-    return getNonNull<Page<PublicationDetails>>(`${PUBLICATION_URL}/latest${params}`).then(
-        (page) => page.items,
-    );
+    const page = await getNonNull<Page<PublicationDetails>>(`${PUBLICATION_URL}/latest${params}`);
+    return page.items;
 };
 
 export const getPublication = (id: PublicationId) =>
@@ -242,13 +250,13 @@ export const getPublicationsCsvUri = (
 
 export const getCalculatedChanges = (candidates: PublicationCandidateReference[]) =>
     postNonNull<PublicationRequestIds, CalculatedChanges>(
-        `${PUBLICATION_URL}/calculated-changes`,
+        `${publicationUri(undefined)}/calculated-changes`,
         toPublicationRequestIds(candidates),
     );
 
 export const getRevertRequestDependencies = (candidates: PublicationCandidateReference[]) =>
     postNonNull<PublicationRequestIds, PublicationRequestIds>(
-        `${PUBLICATION_URL}/candidates/revert-request-dependencies`,
+        `${publicationUri(undefined)}/candidates/revert-request-dependencies`,
         toPublicationRequestIds(candidates),
     ).then(toPublicationCandidateReferences);
 

--- a/ui/src/publication/split/split-api.ts
+++ b/ui/src/publication/split/split-api.ts
@@ -1,11 +1,19 @@
 import { SplitRequest } from 'tool-panel/location-track/split-store';
 import { API_URI, getNullable, postNonNull, putNonNull } from 'api/api-fetch';
 import { Split } from 'publication/publication-model';
+import { LayoutDesignId } from 'common/common-model';
+import { toBranchName } from 'track-layout/track-layout-api';
 
 const SPLIT_URI = `${API_URI}/location-track-split`;
 
-export const postSplitLocationTrack = async (request: SplitRequest): Promise<string> => {
-    return postNonNull<SplitRequest, string>(SPLIT_URI, request);
+export const postSplitLocationTrack = async (
+    request: SplitRequest,
+    designId: LayoutDesignId | undefined,
+): Promise<string> => {
+    return postNonNull<SplitRequest, string>(
+        `${SPLIT_URI}/${toBranchName(designId).toLowerCase()}`,
+        request,
+    );
 };
 
 export const getSplit = async (id: string): Promise<Split | undefined> =>

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -357,6 +357,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                 splittingState.splits,
                 duplicateTracksInCurrentSplits,
             ),
+            undefined,
         )
             .then(async () => {
                 await updateAllChangeTimes();

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -20,7 +20,7 @@ import {
     putNonNullAdt,
     queryParams,
 } from 'api/api-fetch';
-import { changeTimeUri, layoutUri, TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
+import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
 import { getChangeTimes, updateKmPostChangeTime } from 'common/change-time-api';
 import { BoundingBox, Point } from 'model/geometry';
 import { bboxString, pointString } from 'common/common-api';
@@ -217,8 +217,8 @@ export const getKmLengthsAsCsv = (
     return `${layoutUri('track-numbers', layoutContext, trackNumberId)}/km-lengths/as-csv${params}`;
 };
 
-export const getKmPostChangeTimes = (id: LayoutKmPostId, layoutContext: LayoutContext) =>
-    getNullable<LayoutAssetChangeInfo>(changeTimeUri('km-posts', id, layoutContext));
+export const getKmPostChangeInfo = (id: LayoutKmPostId, layoutContext: LayoutContext) =>
+    getNullable<LayoutAssetChangeInfo>(changeInfoUri('km-posts', id, layoutContext));
 
-export const getEntireRailNetworkKmLengthsCsvUrl = () =>
-    `${TRACK_LAYOUT_URI}/track-numbers/rail-network/km-lengths/file`;
+export const getEntireRailNetworkKmLengthsCsvUrl = (layoutContext: LayoutContext) =>
+    `${layoutUri('track-numbers', layoutContext)}/rail-network/km-lengths/file`;

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -26,7 +26,7 @@ import {
     putNonNullAdt,
     queryParams,
 } from 'api/api-fetch';
-import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
+import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
 import { asyncCache } from 'cache/cache';
 import { BoundingBox } from 'model/geometry';
 import { bboxString } from 'common/common-api';
@@ -310,7 +310,7 @@ export const getLocationTrackChangeTimes = (
     id: LocationTrackId,
     layoutContext: LayoutContext,
 ): Promise<LayoutAssetChangeInfo | undefined> => {
-    return getNullable<LayoutAssetChangeInfo>(changeTimeUri('location-tracks', id, layoutContext));
+    return getNullable<LayoutAssetChangeInfo>(changeInfoUri('location-tracks', id, layoutContext));
 };
 
 export const getLocationTrackSectionsByPlan = async (

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -32,7 +32,7 @@ import {
 import { bboxString, pointString } from 'common/common-api';
 import { getTrackLayoutPlan } from 'geometry/geometry-api';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
-import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
+import { TRACK_LAYOUT_URI, contextInUri } from 'track-layout/track-layout-api';
 import { alignmentPointToLinkPoint, createLinkPoints } from 'linking/linking-store';
 import {
     deduplicate,
@@ -128,7 +128,7 @@ export const GEOCODING_URI = `${API_URI}/geocoding`;
 export type AlignmentFetchType = 'LOCATION_TRACKS' | 'REFERENCE_LINES' | 'ALL';
 
 function mapUri(layoutContext: LayoutContext): string {
-    return `${TRACK_LAYOUT_URI}/map/${layoutContext.publicationState.toLowerCase()}`;
+    return `${TRACK_LAYOUT_URI}/map/${contextInUri(layoutContext)}`;
 }
 
 function mapAlignmentUri(
@@ -137,12 +137,12 @@ function mapAlignmentUri(
     content?: string,
 ): string {
     const type = alignmentType == 'LOCATION_TRACK' ? 'location-track' : 'reference-line';
-    const baseUri = `${TRACK_LAYOUT_URI}/map/${layoutContext.publicationState.toLowerCase()}/${type}`;
+    const baseUri = `${TRACK_LAYOUT_URI}/map/${contextInUri(layoutContext)}/${type}`;
     return content ? `${baseUri}/${content}` : baseUri;
 }
 
 function geocodingUri(layoutContext: LayoutContext): string {
-    return `${GEOCODING_URI}/${layoutContext.publicationState.toLowerCase()}`;
+    return `${GEOCODING_URI}/${contextInUri(layoutContext)}`;
 }
 
 function cacheKey(id: ReferenceLineId | LocationTrackId, layoutContext: LayoutContext) {

--- a/ui/src/track-layout/layout-reference-line-api.ts
+++ b/ui/src/track-layout/layout-reference-line-api.ts
@@ -11,7 +11,7 @@ import {
     TimeStamp,
 } from 'common/common-model';
 import { getNonNull, getNullable, queryParams } from 'api/api-fetch';
-import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
+import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
 import { BoundingBox } from 'model/geometry';
 import { bboxString } from 'common/common-api';
 import { asyncCache } from 'cache/cache';
@@ -99,5 +99,5 @@ export const getReferenceLineChangeTimes = (
     id: ReferenceLineId,
     layoutContext: LayoutContext,
 ): Promise<LayoutAssetChangeInfo | undefined> => {
-    return getNullable<LayoutAssetChangeInfo>(changeTimeUri('reference-lines', id, layoutContext));
+    return getNullable<LayoutAssetChangeInfo>(changeInfoUri('reference-lines', id, layoutContext));
 };

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -18,7 +18,7 @@ import {
     putNonNullAdt,
     queryParams,
 } from 'api/api-fetch';
-import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
+import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
 import { bboxString, pointString } from 'common/common-api';
 import { getChangeTimes, updateSwitchChangeTime } from 'common/change-time-api';
 import { asyncCache } from 'cache/cache';
@@ -200,5 +200,5 @@ export const getSwitchChangeTimes = (
     id: LayoutSwitchId,
     layoutContext: LayoutContext,
 ): Promise<LayoutAssetChangeInfo | undefined> => {
-    return getNonNull<LayoutAssetChangeInfo>(changeTimeUri('switches', id, layoutContext));
+    return getNonNull<LayoutAssetChangeInfo>(changeInfoUri('switches', id, layoutContext));
 };

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -14,7 +14,7 @@ import {
     putNonNull,
     queryParams,
 } from 'api/api-fetch';
-import { changeTimeUri, layoutUri } from 'track-layout/track-layout-api';
+import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
 import { TrackNumberSaveRequest } from 'tool-panel/track-number/dialog/track-number-edit-store';
 import {
     getChangeTimes,
@@ -114,5 +114,5 @@ export const getTrackNumberChangeTimes = (
     id: LayoutTrackNumberId,
     layoutContext: LayoutContext,
 ): Promise<LayoutAssetChangeInfo | undefined> => {
-    return getNullable<LayoutAssetChangeInfo>(changeTimeUri('track-numbers', id, layoutContext));
+    return getNullable<LayoutAssetChangeInfo>(changeInfoUri('track-numbers', id, layoutContext));
 };

--- a/ui/src/track-layout/track-layout-api.ts
+++ b/ui/src/track-layout/track-layout-api.ts
@@ -1,4 +1,4 @@
-import { LayoutContext } from 'common/common-model';
+import { LayoutContext, LayoutDesignId } from 'common/common-model';
 import { API_URI } from 'api/api-fetch';
 
 type LayoutDataType =
@@ -10,12 +10,12 @@ type LayoutDataType =
 
 export const TRACK_LAYOUT_URI = `${API_URI}/track-layout`;
 
-export function changeTimeUri(
+export function changeInfoUri(
     dataType: LayoutDataType,
     id: string,
     layoutContext: LayoutContext,
 ): string {
-    return `${TRACK_LAYOUT_URI}/${dataType}/${layoutContext.publicationState}/${id}/change-times`;
+    return `${TRACK_LAYOUT_URI}/${dataType}/${contextInUri(layoutContext)}/${id}/change-info`;
 }
 
 export function layoutUri(
@@ -23,6 +23,14 @@ export function layoutUri(
     layoutContext: LayoutContext,
     id?: string,
 ): string {
-    const baseUri = `${TRACK_LAYOUT_URI}/${dataType}/${layoutContext.publicationState.toLowerCase()}`;
+    const baseUri = `${TRACK_LAYOUT_URI}/${dataType}/${contextInUri(layoutContext)}`;
     return id ? `${baseUri}/${id}` : baseUri;
+}
+
+export function contextInUri(layoutContext: LayoutContext): string {
+    return `${toBranchName(layoutContext.designId).toLowerCase()}/${layoutContext.publicationState.toLowerCase()}`;
+}
+
+export function toBranchName(designId?: LayoutDesignId): string {
+    return designId ? `DESIGN_${designId}` : 'MAIN';
 }

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -46,7 +46,7 @@ import {
     getTrackNumberChangeTimes,
     getTrackNumbers,
 } from 'track-layout/layout-track-number-api';
-import { getKmPost, getKmPostChangeTimes, getKmPosts } from 'track-layout/layout-km-post-api';
+import { getKmPost, getKmPostChangeInfo, getKmPosts } from 'track-layout/layout-km-post-api';
 import { PVDocumentHeader, PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { getPVDocument } from 'infra-model/infra-model-api';
 import { updateAllChangeTimes } from 'common/change-time-api';
@@ -325,7 +325,7 @@ export function useKmPostChangeTimes(
     layoutContext: LayoutContext,
 ): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
-        () => (id ? getKmPostChangeTimes(id, layoutContext) : undefined),
+        () => (id ? getKmPostChangeInfo(id, layoutContext) : undefined),
         [id, layoutContext.designId, layoutContext.publicationState],
     );
 }

--- a/ui/src/track-layout/track-layout-search-api.ts
+++ b/ui/src/track-layout/track-layout-search-api.ts
@@ -5,7 +5,7 @@ import {
     LocationTrackId,
 } from 'track-layout/track-layout-model';
 import { getNonNull, queryParams } from 'api/api-fetch';
-import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
+import { TRACK_LAYOUT_URI, contextInUri } from 'track-layout/track-layout-api';
 import { LayoutContext } from 'common/common-model';
 
 export interface LayoutSearchResult {
@@ -20,7 +20,7 @@ export async function getBySearchTerm(
     locationTrackSearchScope?: LocationTrackId,
     limitPerResultType: number = 10,
 ): Promise<LayoutSearchResult> {
-    const uri = `${TRACK_LAYOUT_URI}/search/${layoutContext.publicationState.toLowerCase()}`;
+    const uri = `${TRACK_LAYOUT_URI}/search/${contextInUri(layoutContext)}`;
 
     const params = queryParams({
         searchTerm: searchTerm,


### PR DESCRIPTION
Pahoittelut jättipullarista, mutta tuntui että tästä ei ehkä ole mieltä irrotella osia. Joitain pieniä stilisointeja olisi ollut kyllä irotettavissakin, mutta lopputulos olisi silti melko tarkkaan sama. Tämä sisältää kaikissa paikoissa hyvin samanlaisia muutoksia, joten kun on nähnyt kunkin variantin, sen toiston pitäisi olla aika nopsaan skimmattavissa. 

Muutokset (kommentoin näistä vielä esimerkkipaikat koodiin):
- Layout API:t sisältää nyt myös layout branchin polussa. Samalla uudelleenjärjestetty joitain path-muuttujia jotta menee samanlaisissa paikoissa samoin.
- Controllereissa yhdistetään branch+state LayoutContext:ksi jos molemmat tulee sisään, mutta huom. kaikissa caseissa ei tarvita molempia. Tärkeimpänä: layoutin muutokset tehdään aina draftiin ja julkaisut on aina draft->official, joten API ei salli edes antaa publicationStatea sisään.
- Branch/context kuljetetaan serviceiden läpi DAO:lle asti. Joissan funkkareissa on vaihdettu argumenttien järjestystä jotta kaikkialla menee samalla tapaa: context ensin, id sitten
- DAO-toteutuksiin ei tässä kosketa vaan kytketään jo toteutettuihin tai mikäli toteutusta ei ole, assertoidaan että `branch == main` jotta ei-tuetusta pyynnöstä lentää poikkeus.
- Serviceiden insert/update metodit toteutettu (lähinnä branchin asetusta läpikutsuihin tämäkin)

Mukana on myös jonkin verran uudelleenformatointeja, koska warnien putsaaminen tiedostosta helpotti omien muutosten verifiointia. Eli jos muutoksessa ei näy branchia/contextia niin kyse on vain noista.