### PR TITLE
GVT-2403 Fix official rows not being overridden by design-draft rows

### DIFF
--- a/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
@@ -40,7 +40,7 @@ select
                             where overriding_draft.design_id is not distinct from design_id_in
                               and overriding_draft.draft
                               and row.id = case
-                                             when design_id_in is null then overriding_draft.official_row_id
+                                             when row.design_id is null then overriding_draft.official_row_id
                                              else overriding_draft.design_row_id
                                            end)
         end

--- a/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
@@ -47,7 +47,7 @@ select
                             where overriding_draft.design_id is not distinct from design_id_in
                               and overriding_draft.draft
                               and row.id = case
-                                             when design_id_in is null then overriding_draft.official_row_id
+                                             when row.design_id is null then overriding_draft.official_row_id
                                              else overriding_draft.design_row_id
                                            end)
         end

--- a/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
@@ -69,7 +69,7 @@ select
                             where overriding_draft.design_id is not distinct from design_id_in
                               and overriding_draft.draft
                               and row.id = case
-                                             when design_id_in is null then overriding_draft.official_row_id
+                                             when row.design_id is null then overriding_draft.official_row_id
                                              else overriding_draft.design_row_id
                                            end)
         end

--- a/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
@@ -48,7 +48,7 @@ select
                             where overriding_draft.design_id is not distinct from design_id_in
                               and overriding_draft.draft
                               and row.id = case
-                                             when design_id_in is null then overriding_draft.official_row_id
+                                             when row.design_id is null then overriding_draft.official_row_id
                                              else overriding_draft.design_row_id
                                            end)
         end

--- a/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
@@ -42,7 +42,7 @@ select
                             where overriding_draft.design_id is not distinct from design_id_in
                               and overriding_draft.draft
                               and row.id = case
-                                             when design_id_in is null then overriding_draft.official_row_id
+                                             when row.design_id is null then overriding_draft.official_row_id
                                              else overriding_draft.design_row_id
                                            end)
         end


### PR DESCRIPTION
Olihan tässä ihan suoraan väärä oleva tapaus. Löytyi kirjoittamalla testejä; testit itse toimii vasta parin eri pullarin päällä, joten ne tulee erikseen.

En nyt vieläkään ole ihan sataprosenttisen varma, etteikö tässä voi olla jokin logiikkavirhe, mutta eipä ole ainakaan enää sitä, että main-official-rivi huomaa design-draft-tilassa sitä korvaavaa design-draft-riviä.