### PR TITLE
GVT-2602 Collect statistics on layout.segment_version

### DIFF
--- a/infra/src/main/resources/db/migration/repeatable/R__09.01_layout_segment_version_statistics.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__09.01_layout_segment_version_statistics.sql
@@ -1,0 +1,4 @@
+drop statistics if exists layout.segment_version_alignment_stats;
+create statistics layout.segment_version_alignment_stats on alignment_id, alignment_version from layout.segment_version;
+alter statistics layout.segment_version_alignment_stats set statistics 1000;
+analyze layout.segment_version;


### PR DESCRIPTION
Mietin, tekisikö näitä statistiikkoja muihinkin tauluihin, ja päädyin siihen, että eihän niitä lopulta tarvita. Tämä taulu tarvitsee erikseen statistiikkojen laskentaa, koska _molemmat_ näistä on totta:

- `(alignment_id, alignment_version)` ei ole avain, vaan samalla alignmentilla voi olla paljon segmenttejä
- `alignment_version`in arvot ei ole alignment_id:stä itsenäisiä, vaan osalle alignmentteja tulee enemmän muutoksia ja siten korkeampia versioita kuin useimmille

... joista siis ensimmäinen ehto tarkoittaa, että haussa on solmuja, joiden todellinen rivimäärä on enemmän kuin 1, ja toinen, että postgressi aliarvioi suunnitelmassa rivimääriä hakuehtojen itsenäisyysoletuksen takia. Varmaan meillä voi olla muitakin hakuja, joihin molemmat ehdot pätee, mutta koska tähän tauluun tehtävät on ainoat ID-versioparilla tehtävät sellaiset, niin niitä hakuja pitäisi haravoida vähän kaikkialta: Siksi jätän mieluummin haravoimatta koko appista läpi.