### PR TITLE
GVT-2605: DatePickerin refaktorointi

### DIFF
--- a/ui/src/vayla-design-lib/datepicker/datepicker.scss
+++ b/ui/src/vayla-design-lib/datepicker/datepicker.scss
@@ -33,6 +33,14 @@
             transform: rotate(0);
         }
     }
+
+    &__popup-container {
+        z-index: 101;
+    }
+
+    &--wide {
+        width: 100%;
+    }
 }
 
 .react-datepicker-popper {

--- a/ui/src/vayla-design-lib/datepicker/datepicker.tsx
+++ b/ui/src/vayla-design-lib/datepicker/datepicker.tsx
@@ -15,7 +15,6 @@ type DatePickerProps = {
     value: Date | undefined;
     onChange: (date: Date | undefined) => void;
     wide?: boolean;
-    className?: string;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>;
 
 type DatePickerInputProps = {

--- a/ui/src/vayla-design-lib/datepicker/datepicker.tsx
+++ b/ui/src/vayla-design-lib/datepicker/datepicker.tsx
@@ -6,12 +6,78 @@ import { fi } from 'date-fns/locale';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { createClassName } from 'vayla-design-lib/utils';
 import { TextField, TextInputIconPosition } from 'vayla-design-lib/text-field/text-field';
+import { CloseableModal } from 'vayla-design-lib/closeable-modal/closeable-modal';
+import { formatDateShort } from 'utils/date-utils';
+import { parse, isValid } from 'date-fns';
 import { useCloneRef } from 'utils/react-utils';
 
 type DatePickerProps = {
     value: Date | undefined;
-    onChange?: (date: Date | undefined) => void;
+    onChange: (date: Date | undefined) => void;
+    wide?: boolean;
+    className?: string;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>;
+
+type DatePickerInputProps = {
+    openDatePicker: () => void;
+    date: Date | undefined;
+    setDate: (date: Date | undefined) => void;
+    wide: boolean | undefined;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>;
+
+const DatePickerInput = React.forwardRef<HTMLInputElement, DatePickerInputProps>(
+    ({ openDatePicker, date, setDate, wide, ...props }, ref) => {
+        const [value, setValue] = React.useState<string>('');
+        const localRef = useCloneRef<HTMLInputElement>(ref);
+        React.useEffect(() => {
+            if (document.activeElement !== localRef.current) {
+                setValue(date ? formatDateShort(date) : '');
+            }
+        }, [date]);
+
+        function setValueAndSetDateIfValid(e: React.ChangeEvent<HTMLInputElement>): void {
+            setValue(e.target.value);
+
+            const newDate = parse(e.target.value, 'dd.MM.yyyy', new Date());
+            if (isValid(newDate)) {
+                setDate(newDate);
+            }
+        }
+
+        function setDateOrResetIfInvalid(e: React.FocusEvent<HTMLInputElement>): void {
+            const newDate = parse(e.target.value, 'dd.MM.yyyy', new Date());
+            if (isValid(newDate)) {
+                setDate(newDate);
+            } else {
+                setValue(date ? formatDateShort(date) : '');
+            }
+        }
+
+        return (
+            <TextField
+                Icon={(iconProps) => (
+                    <Icons.SetDate
+                        {...iconProps}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            localRef.current?.focus();
+                        }}
+                    />
+                )}
+                iconPosition={TextInputIconPosition.RIGHT}
+                wide={wide}
+                value={value}
+                onFocusCapture={openDatePicker}
+                onChange={(e) => setValueAndSetDateIfValid(e)}
+                onBlur={(e) => setDateOrResetIfInvalid(e)}
+                onClick={openDatePicker}
+                ref={localRef}
+                {...props}
+            />
+        );
+    },
+);
+DatePickerInput.displayName = 'DatePickerInput';
 
 function getHeaderElement({
     date,
@@ -55,49 +121,57 @@ function getHeaderElement({
     );
 }
 
-const DatePickerInput = React.forwardRef<
-    HTMLInputElement,
-    React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>
->((props, ref) => {
-    const localRef = useCloneRef(ref);
-    return (
-        <TextField
-            {...props}
-            Icon={(iconProps) => (
-                <Icons.SetDate {...iconProps} onClick={() => localRef.current?.focus()} />
-            )}
-            iconPosition={TextInputIconPosition.RIGHT}
-            ref={localRef}
-        />
-    );
-});
-
-DatePickerInput.displayName = 'DatePickerInput';
-
 const DATE_PICKER_POPUP_LEFT_PAD_PX = 14;
 
-export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, ...props }) => {
+export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, ...props }) => {
+    const [open, setOpen] = React.useState(false);
+    const ref = React.useRef<HTMLInputElement>(null);
+    const className = createClassName(styles['datepicker'], wide && styles['datepicker--wide']);
+    const [date, setDate] = React.useState<Date | undefined>(value);
+
+    React.useEffect(() => {
+        onChange(date);
+    }, [date]);
+
     return (
-        <div className={'datepicker'}>
-            <ReactDatePicker
-                renderCustomHeader={getHeaderElement}
-                dateFormat="dd.MM.yyyy"
-                locale={fi}
-                selected={value}
-                onChange={(date) => onChange && onChange(date ?? undefined)}
-                calendarStartDay={1}
-                showWeekNumbers
-                popperModifiers={[
-                    {
-                        name: 'offset',
-                        fn: (state) => ({
-                            ...state,
-                            x: state.x + DATE_PICKER_POPUP_LEFT_PAD_PX,
-                        }),
-                    },
-                ]}
-                customInput={<DatePickerInput {...props} />}
+        <div className={className}>
+            <DatePickerInput
+                openDatePicker={() => setOpen(true)}
+                date={date}
+                setDate={setDate}
+                wide={wide}
+                ref={ref}
+                {...props}
             />
+            {open && (
+                <CloseableModal
+                    onClickOutside={() => setOpen(false)}
+                    offsetY={ref.current?.getBoundingClientRect().height ?? 0}
+                    positionRef={ref}
+                    className={styles['datepicker__popup-container']}>
+                    <ReactDatePicker
+                        renderCustomHeader={getHeaderElement}
+                        locale={fi}
+                        selected={value}
+                        onChange={(date) => {
+                            setDate(date ?? undefined);
+                            setOpen(false);
+                        }}
+                        calendarStartDay={1}
+                        showWeekNumbers
+                        inline
+                        popperModifiers={[
+                            {
+                                name: 'offset',
+                                fn: (state) => ({
+                                    ...state,
+                                    x: state.x + DATE_PICKER_POPUP_LEFT_PAD_PX,
+                                }),
+                            },
+                        ]}
+                    />
+                </CloseableModal>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
Aiemmin `DatePicker` ei siis suostunut piirtymään kivasti silloin jos sen parenttikomponentilla oli tosi vähän tilaa käytössä (kuten esim. dialogeissa.) Ratkaisu tähän löytyi sen siirtämisestä `CloseableModal`:in sisälle, mutta tämä johti aikamoiseen komponentin sisäiseen refaktorointiin.