### PR TITLE
GVT-2605: Työtilojen luonti, muokkaus, poisto frontilta

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
@@ -32,6 +32,7 @@ data class CollectedChangeTimes(
     val pvDocument: Instant,
     val split: Instant,
     val operatingPoints: Instant,
+    val layoutDesign: Instant,
 )
 
 @RestController
@@ -48,6 +49,7 @@ class ChangeTimeController(
     private val pvDocumentService: PVDocumentService,
     private val splitService: SplitService,
     private val ratkoOperatingPointDao: RatkoOperatingPointDao,
+    private val layoutDesignDao: LayoutDesignDao,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -71,6 +73,7 @@ class ChangeTimeController(
             pvDocument = pvDocumentService.getDocumentChangeTime(),
             split = splitService.getChangeTime(),
             operatingPoints = ratkoOperatingPointDao.getChangeTime(),
+            layoutDesign = layoutDesignDao.getChangeTime(),
         )
     }
 
@@ -149,5 +152,12 @@ class ChangeTimeController(
     fun getSplitChangeTime(): Instant {
         logger.apiCall("getSplitChangeTime")
         return splitService.getChangeTime()
+    }
+
+    @PreAuthorize(AUTH_BASIC)
+    @GetMapping("/layout-designs")
+    fun getLayoutDesignChangeTime(): Instant {
+        logger.apiCall("getLayoutDesignChangeTime")
+        return layoutDesignDao.getChangeTime()
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
@@ -15,6 +15,11 @@ data class LayoutDesign(
     val id: DomainId<LayoutDesign>,
     val name: FreeText,
     val estimatedCompletion: LocalDate,
-    val planPhase: PlanPhase,
+    val designState: DesignState,
+)
+
+data class LayoutDesignSaveRequest(
+    val name: FreeText,
+    val estimatedCompletion: LocalDate,
     val designState: DesignState,
 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignController.kt
@@ -1,0 +1,49 @@
+package fi.fta.geoviite.infra.tracklayout
+
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.logging.apiCall
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/track-layout/layout-design")
+class LayoutDesignController(
+    val layoutDesignService: LayoutDesignService,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    @GetMapping("/")
+    fun getLayoutDesigns(): List<LayoutDesign> {
+        logger.apiCall("getLayoutDesigns")
+        return layoutDesignService.list()
+    }
+
+    @GetMapping("/{id}")
+    fun getLayoutDesign(@PathVariable id: IntId<LayoutDesign>): LayoutDesign {
+        logger.apiCall("getLayoutDesign", "id" to id)
+        return layoutDesignService.getOrThrow(id)
+    }
+
+    @PostMapping("/")
+    fun insertLayoutDesign(@RequestBody request: LayoutDesignSaveRequest): IntId<LayoutDesign> {
+        logger.apiCall("insertLayoutDesign", "request" to request)
+        return layoutDesignService.insert(request)
+    }
+
+    @PutMapping("/{id}/")
+    fun updateLayoutDesign(
+        @PathVariable id: IntId<LayoutDesign>,
+        @RequestBody request: LayoutDesignSaveRequest,
+    ): IntId<LayoutDesign> {
+        logger.apiCall("updateLayoutDesign", "id" to id, "request" to request)
+        return layoutDesignService.update(id, request)
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.tracklayout
 
+import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
@@ -28,7 +29,7 @@ class LayoutDesignDao(
         val sql = """
             select id, name, estimated_completion, design_state
             from layout.design
-            where id = :id and design_state = 'ACTIVE'::layout.design_state
+            where id = :id
         """.trimIndent()
         return jdbcTemplate.queryOne(sql, mapOf("id" to id.intValue)) { rs, _ ->
             LayoutDesign(
@@ -57,10 +58,10 @@ class LayoutDesignDao(
     }
 
     @Transactional
-    fun update(design: LayoutDesign): IntId<LayoutDesign> {
+    fun update(id: DomainId<LayoutDesign>, design: LayoutDesignSaveRequest): IntId<LayoutDesign> {
         jdbcTemplate.setUser()
         val params = mapOf(
-            "id" to toDbId(design.id).intValue,
+            "id" to toDbId(id).intValue,
             "name" to design.name,
             "estimated_completion" to design.estimatedCompletion,
             "design_state" to design.designState.name,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
@@ -1,18 +1,22 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.logging.AccessType
+import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.util.DaoBase
+import fi.fta.geoviite.infra.util.DbTable
 import fi.fta.geoviite.infra.util.getEnum
 import fi.fta.geoviite.infra.util.getFreeText
-import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.getIntId
 import fi.fta.geoviite.infra.util.getLocalDate
+import fi.fta.geoviite.infra.util.getRowVersion
+import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.setUser
 import fi.fta.geoviite.infra.util.toDbId
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Timestamp
+import java.time.Instant
 
 @Component
 @Transactional(readOnly = true)
@@ -20,59 +24,85 @@ class LayoutDesignDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
 ) : DaoBase(jdbcTemplateParam) {
 
+    fun fetch(id: IntId<LayoutDesign>): LayoutDesign {
+        val sql = """
+            select id, name, estimated_completion, design_state
+            from layout.design
+            where id = :id and design_state = 'ACTIVE'::layout.design_state
+        """.trimIndent()
+        return jdbcTemplate.queryOne(sql, mapOf("id" to id.intValue)) { rs, _ ->
+            LayoutDesign(
+                rs.getIntId("id"),
+                rs.getFreeText("name"),
+                rs.getLocalDate("estimated_completion"),
+                rs.getEnum("design_state"),
+            )
+        }
+    }
+
     fun list(): List<LayoutDesign> {
         val sql = """
-            select id, name, estimated_completion, plan_phase, design_state
+            select id, name, estimated_completion, design_state
             from layout.design
+            where design_state = 'ACTIVE'::layout.design_state
         """.trimIndent()
         return jdbcTemplate.query(sql) { rs, _ ->
             LayoutDesign(
                 rs.getIntId("id"),
                 rs.getFreeText("name"),
                 rs.getLocalDate("estimated_completion"),
-                rs.getEnum("plan_phase"),
                 rs.getEnum("design_state"),
             )
         }
     }
 
     @Transactional
-    fun update(design: LayoutDesign) {
+    fun update(design: LayoutDesign): IntId<LayoutDesign> {
         jdbcTemplate.setUser()
+        val params = mapOf(
+            "id" to toDbId(design.id).intValue,
+            "name" to design.name,
+            "estimated_completion" to design.estimatedCompletion,
+            "design_state" to design.designState.name,
+        )
+
         val sql = """
             update layout.design
             set name = :name,
                 estimated_completion = :estimated_completion,
-                plan_phase = :plan_phase::geometry.plan_phase,
                 design_state = :design_state::layout.design_state
             where id = :id
+            returning id, version
         """.trimIndent()
-        jdbcTemplate.update(
-            sql, mapOf(
-                "id" to toDbId(design.id).intValue,
-                "name" to design.name,
-                "estimated_completion" to design.estimatedCompletion,
-                "plan_phase" to design.planPhase.name,
-                "design_state" to design.designState.name,
-            )
-        )
+        val response = jdbcTemplate.queryForObject(
+            sql, params
+        ) { rs, _ -> rs.getRowVersion<LayoutDesign>("id", "version") }
+            ?: throw IllegalStateException("Failed to generate ID for new row version of updated layout design")
+        logger.daoAccess(AccessType.UPDATE, LayoutDesign::class, response)
+        return response.id
     }
 
     @Transactional
-    fun insert(design: LayoutDesign): IntId<LayoutDesign> {
+    fun insert(design: LayoutDesignSaveRequest): IntId<LayoutDesign> {
         jdbcTemplate.setUser()
         val sql = """
-            insert into layout.design (name, estimated_completion, plan_phase, design_state)
-            values (:name, :estimated_completion, :plan_phase::geometry.plan_phase, :design_state::layout.design_state)
-            returning id
+            insert into layout.design (name, estimated_completion, design_state)
+            values (:name, :estimated_completion, :design_state::layout.design_state)
+            returning id, version
         """.trimIndent()
-        return jdbcTemplate.query(
+        val response = jdbcTemplate.queryForObject(
             sql, mapOf(
                 "name" to design.name,
                 "estimated_completion" to design.estimatedCompletion,
-                "plan_phase" to design.planPhase.name,
                 "design_state" to design.designState.name,
             )
-        ) { rs, _ -> rs.getIntId<LayoutDesign>("id") }[0]
+        ) { rs, _ -> rs.getRowVersion<LayoutDesign>("id", "version") }
+            ?: throw IllegalStateException("Failed to generate ID for new layout design")
+        logger.daoAccess(AccessType.INSERT, LayoutDesign::class, response)
+        return response.id
+    }
+
+    fun getChangeTime(): Instant {
+        return fetchLatestChangeTime(DbTable.LAYOUT_DESIGN)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
@@ -1,0 +1,37 @@
+package fi.fta.geoviite.infra.tracklayout
+
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.logging.serviceCall
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class LayoutDesignService(
+    private val dao: LayoutDesignDao,
+) {
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    fun list(): List<LayoutDesign> {
+        logger.serviceCall("list")
+        return dao.list()
+    }
+
+    fun getOrThrow(id: IntId<LayoutDesign>): LayoutDesign {
+        logger.serviceCall("getOrThrow", "id" to id)
+        return dao.fetch(id)
+    }
+
+    @Transactional
+    fun update(id: IntId<LayoutDesign>, request: LayoutDesignSaveRequest): IntId<LayoutDesign> {
+        logger.serviceCall("update", "design" to request)
+        return dao.update(LayoutDesign(id, request.name, request.estimatedCompletion, request.designState))
+    }
+
+    @Transactional
+    fun insert(request: LayoutDesignSaveRequest): IntId<LayoutDesign> {
+        logger.serviceCall("insert", "request" to request)
+        return dao.insert(request)
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
@@ -25,8 +25,8 @@ class LayoutDesignService(
 
     @Transactional
     fun update(id: IntId<LayoutDesign>, request: LayoutDesignSaveRequest): IntId<LayoutDesign> {
-        logger.serviceCall("update", "design" to request)
-        return dao.update(LayoutDesign(id, request.name, request.estimatedCompletion, request.designState))
+        logger.serviceCall("update", "request" to request)
+        return dao.update(id, request)
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -33,6 +33,7 @@ enum class DbTable(schema: String, table: String, sortColumns: List<String> = li
     LAYOUT_KM_POST("layout", "km_post", listOf("track_number_id", "km_number")),
     LAYOUT_TRACK_NUMBER("layout", "track_number"),
 
+    LAYOUT_DESIGN("layout", "design"),
     OPERATING_POINT("layout", "operating_point"),
 
     GEOMETRY_PLAN("geometry", "plan"),

--- a/infra/src/main/resources/db/migration/prod/V75__add_design_context.sql
+++ b/infra/src/main/resources/db/migration/prod/V75__add_design_context.sql
@@ -5,7 +5,6 @@ create table layout.design
   id                   int primary key generated always as identity,
   name                 text                not null,
   estimated_completion date                not null,
-  plan_phase           geometry.plan_phase not null,
   design_state         layout.design_state not null
 );
 comment on table layout.design is 'Overlays for planned changes to the layout.';

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1731,7 +1731,12 @@
         "title-edit": "Muokkaa työtilaa",
         "basic-info": "Perustiedot",
         "name": "Työtilan nimi",
-        "completion-date": "Arvioitu valmistumisajankohta"
+        "completion-date": "Arvioitu valmistumisajankohta",
+        "delete-confirm": {
+            "title": "Työtilan poistaminen",
+            "guide": "Poistettua työtilaa ei voi palauttaa eikä sen sisältöä muokata.",
+            "confirm": "Haluatko poistaa työtilan?"
+        }
     },
     "switch-delete-dialog": {
         "title": "Poistetaanko luonnos?",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDaoIT.kt
@@ -1,16 +1,12 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.DomainId
-import fi.fta.geoviite.infra.common.StringId
-import fi.fta.geoviite.infra.geometry.PlanPhase
 import fi.fta.geoviite.infra.util.FreeText
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
 import java.time.LocalDate
 import kotlin.test.assertEquals
 
@@ -24,28 +20,26 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
     }
 
     @Test
-    fun `insert, update and list work`() {
-        val abcId = layoutDesignDao.insert(layoutDesign("aa bee see"))
-        val insertAsIs = layoutDesign("foo bar")
-        val insertAsIsId = layoutDesignDao.insert(insertAsIs)
-        val update = layoutDesign(
-            "abc",
-            abcId,
-            LocalDate.parse("2024-01-01"),
-            PlanPhase.RAILWAY_CONSTRUCTION_PLAN,
-            DesignState.COMPLETED,
+    fun `insert, update, list and fetch work`() {
+        val insertAsIs = layoutDesignDao.insert(layoutDesignSaveRequest("foo bar")).let(layoutDesignDao::fetch)
+        val update = layoutDesignDao.insert(layoutDesignSaveRequest("aa bee see")).let(layoutDesignDao::fetch)
+        layoutDesignDao.update(
+            update.copy(
+                name = FreeText("abc"),
+                estimatedCompletion = LocalDate.parse("2024-01-02")
+            )
         )
-        layoutDesignDao.update(update)
         assertEquals(
-            listOf(update, insertAsIs.copy(id = insertAsIsId)), layoutDesignDao.list().sortedBy(LayoutDesign::name)
+            listOf(
+                update.copy(name = FreeText("abc"), estimatedCompletion = LocalDate.parse("2024-01-02")),
+                insertAsIs
+            ), layoutDesignDao.list().sortedBy(LayoutDesign::name)
         )
     }
 
-    private fun layoutDesign(
+    private fun layoutDesignSaveRequest(
         name: String,
-        id: DomainId<LayoutDesign> = StringId(),
         estimatedCompletion: LocalDate = LocalDate.parse("2035-01-02"),
-        planPhase: PlanPhase = PlanPhase.RAILWAY_PLAN,
         designState: DesignState = DesignState.ACTIVE,
-    ) = LayoutDesign(id, FreeText(name), estimatedCompletion, planPhase, designState)
+    ) = LayoutDesignSaveRequest(FreeText(name), estimatedCompletion, designState)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDaoIT.kt
@@ -24,9 +24,11 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
         val insertAsIs = layoutDesignDao.insert(layoutDesignSaveRequest("foo bar")).let(layoutDesignDao::fetch)
         val update = layoutDesignDao.insert(layoutDesignSaveRequest("aa bee see")).let(layoutDesignDao::fetch)
         layoutDesignDao.update(
-            update.copy(
+            update.id,
+            LayoutDesignSaveRequest(
                 name = FreeText("abc"),
-                estimatedCompletion = LocalDate.parse("2024-01-02")
+                estimatedCompletion = LocalDate.parse("2024-01-02"),
+                designState = update.designState
             )
         )
         assertEquals(

--- a/ui/src/common/change-time-api.ts
+++ b/ui/src/common/change-time-api.ts
@@ -108,6 +108,14 @@ export function updateSplitChangeTime(): Promise<TimeStamp> {
     );
 }
 
+export function updateLayoutDesignChangeTime(): Promise<TimeStamp> {
+    return updateChangeTime(
+        `${CHANGES_API}/layout-designs`,
+        delegates.setLayoutDesignChangeTime,
+        getChangeTimes().layoutDesign,
+    );
+}
+
 function updateChangeTime(
     url: string,
     storeUpdate: (ts: TimeStamp) => void,

--- a/ui/src/common/common-slice.ts
+++ b/ui/src/common/common-slice.ts
@@ -18,6 +18,7 @@ export type ChangeTimes = {
     pvDocument: TimeStamp;
     split: TimeStamp;
     operatingPoints: TimeStamp;
+    layoutDesign: TimeStamp;
 };
 
 export const initialChangeTime: TimeStamp = '1970-01-01T00:00:00.000Z';
@@ -35,6 +36,7 @@ export const initialChangeTimes: ChangeTimes = {
     pvDocument: initialChangeTime,
     split: initialChangeTime,
     operatingPoints: initialChangeTime,
+    layoutDesign: initialChangeTime,
 };
 
 export type CommonState = {
@@ -135,6 +137,9 @@ const commonSlice = createSlice({
         },
         setSplitChangeTime: function ({ changeTimes }, { payload }) {
             updateChangeTime(changeTimes, 'split', payload);
+        },
+        setLayoutDesignChangeTime: function ({ changeTimes }, { payload }) {
+            updateChangeTime(changeTimes, 'layoutDesign', payload);
         },
         setUser: (state: CommonState, { payload: user }: PayloadAction<User>): void => {
             state.user = user;

--- a/ui/src/map/layer-menu/map-layer-menu.tsx
+++ b/ui/src/map/layer-menu/map-layer-menu.tsx
@@ -167,15 +167,7 @@ export const MapLayerMenu: React.FC<MapLayerMenuProps> = ({
                     offsetY={layerOffset}
                     className={styles['map-layer-menu']}
                     positionRef={buttonRef}
-                    onClickOutside={() => undefined}>
-                    <span className={styles['map-layer-menu__close-button']}>
-                        <Button
-                            variant={ButtonVariant.GHOST}
-                            icon={Icons.Close}
-                            onClick={() => setShowMapLayerMenu(false)}
-                        />
-                    </span>
-
+                    onClickOutside={() => setShowMapLayerMenu(false)}>
                     <MapLayerGroup
                         title={t('map-layer-menu.layout-title')}
                         menuItemVisibilities={mapLayerMenuGroups.layout}

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -311,6 +311,14 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         setSelectingWorkspace(false);
     };
 
+    const unselectDesign = () => {
+        onLayoutContextChange({
+            publicationState: layoutContext.publicationState,
+            designId: undefined,
+        });
+        setSelectingWorkspace(true);
+    };
+
     function openPreviewAndStopLinking() {
         onOpenPreview();
         onStopLinking();
@@ -422,7 +430,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         <Dropdown
                             inputRef={selectWorkspaceDropdownRef}
                             placeholder={t('tool-bar.choose-workspace')}
-                            openOverride={selectingWorkspace}
+                            openOverride={selectingWorkspace || undefined}
                             onAddClick={() => setShowCreateWorkspaceDialog(true)}
                             onChange={(designId) => {
                                 setSelectingWorkspace(false);
@@ -549,7 +557,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                 <WorkspaceDeleteConfirmDialog
                     closeDialog={() => setShowDeleteWorkspaceDialog(false)}
                     currentDesign={currentDesign}
-                    onLayoutContextChange={onLayoutContextChange}
+                    onDesignDeleted={unselectDesign}
                 />
             )}
         </div>

--- a/ui/src/tool-bar/workspace-delete-confirm-dialog.tsx
+++ b/ui/src/tool-bar/workspace-delete-confirm-dialog.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { LayoutDesign, updateLayoutDesign } from 'track-layout/layout-design-api';
+import { updateLayoutDesignChangeTime } from 'common/change-time-api';
+import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
+import { LayoutContext } from 'common/common-model';
+
+type WorkspaceDeleteConfirmDialogProps = {
+    closeDialog: () => void;
+    currentDesign: LayoutDesign;
+    onLayoutContextChange: (layoutContext: LayoutContext) => void;
+};
+
+export const WorkspaceDeleteConfirmDialog: React.FC<WorkspaceDeleteConfirmDialogProps> = ({
+    currentDesign,
+    onLayoutContextChange,
+    closeDialog,
+}) => {
+    const { t } = useTranslation();
+    const onDelete = () => {
+        updateLayoutDesign(currentDesign.id, {
+            ...currentDesign,
+            designState: 'DELETED',
+        }).then(() => {
+            updateLayoutDesignChangeTime();
+            onLayoutContextChange({
+                publicationState: 'OFFICIAL',
+                designId: undefined,
+            });
+            closeDialog();
+        });
+    };
+
+    return (
+        <Dialog
+            allowClose={false}
+            variant={DialogVariant.DARK}
+            title={t('workspace-dialog.delete-confirm.title')}
+            footerContent={
+                <div className={dialogStyles['dialog__footer-content--centered']}>
+                    <Button onClick={closeDialog} variant={ButtonVariant.SECONDARY}>
+                        {t('button.cancel')}
+                    </Button>
+                    <Button
+                        qa-id="confirm-workspace-delete"
+                        onClick={onDelete}
+                        variant={ButtonVariant.PRIMARY_WARNING}>
+                        {t('button.delete')}
+                    </Button>
+                </div>
+            }>
+            <p>{t('workspace-dialog.delete-confirm.guide')}</p>
+            <p>{t('workspace-dialog.delete-confirm.confirm')}</p>
+        </Dialog>
+    );
+};

--- a/ui/src/tool-bar/workspace-delete-confirm-dialog.tsx
+++ b/ui/src/tool-bar/workspace-delete-confirm-dialog.tsx
@@ -5,17 +5,17 @@ import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { LayoutDesign, updateLayoutDesign } from 'track-layout/layout-design-api';
 import { updateLayoutDesignChangeTime } from 'common/change-time-api';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
-import { LayoutContext } from 'common/common-model';
+import { LayoutDesignId } from 'common/common-model';
 
 type WorkspaceDeleteConfirmDialogProps = {
     closeDialog: () => void;
     currentDesign: LayoutDesign;
-    onLayoutContextChange: (layoutContext: LayoutContext) => void;
+    onDesignDeleted: (id: LayoutDesignId) => void;
 };
 
 export const WorkspaceDeleteConfirmDialog: React.FC<WorkspaceDeleteConfirmDialogProps> = ({
     currentDesign,
-    onLayoutContextChange,
+    onDesignDeleted,
     closeDialog,
 }) => {
     const { t } = useTranslation();
@@ -25,10 +25,7 @@ export const WorkspaceDeleteConfirmDialog: React.FC<WorkspaceDeleteConfirmDialog
             designState: 'DELETED',
         }).then(() => {
             updateLayoutDesignChangeTime();
-            onLayoutContextChange({
-                publicationState: 'OFFICIAL',
-                designId: undefined,
-            });
+            onDesignDeleted(currentDesign.id);
             closeDialog();
         });
     };

--- a/ui/src/tool-bar/workspace-dialog.scss
+++ b/ui/src/tool-bar/workspace-dialog.scss
@@ -1,3 +1,8 @@
 .workspace-dialog {
     height: 340px;
+
+    .form-layout {
+        min-height: auto;
+        padding-bottom: 0px;
+    }
 }

--- a/ui/src/tool-bar/workspace-dialog.tsx
+++ b/ui/src/tool-bar/workspace-dialog.tsx
@@ -81,7 +81,7 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
                             <DatePicker
                                 value={selectedDate}
                                 onChange={(date) => setSelectedDate(date)}
-                                //wide={true}
+                                wide={true}
                             />
                         }
                     />

--- a/ui/src/tool-bar/workspace-dialog.tsx
+++ b/ui/src/tool-bar/workspace-dialog.tsx
@@ -51,6 +51,7 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
                             {t('button.cancel')}
                         </Button>
                         <Button
+                            disabled={!name || !selectedDate}
                             onClick={() => {
                                 if (name && selectedDate) {
                                     onSave(existingDesign?.id, saveRequest(name, selectedDate));
@@ -80,7 +81,7 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
                             <DatePicker
                                 value={selectedDate}
                                 onChange={(date) => setSelectedDate(date)}
-                                wide={true}
+                                //wide={true}
                             />
                         }
                     />

--- a/ui/src/track-layout/layout-design-api.ts
+++ b/ui/src/track-layout/layout-design-api.ts
@@ -1,0 +1,32 @@
+import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
+import { getNonNull, postNonNull, putNonNull } from 'api/api-fetch';
+import { LayoutDesignId, TimeStamp } from 'common/common-model';
+import { asyncCache } from 'cache/cache';
+
+const designCache = asyncCache<string, LayoutDesign[]>();
+
+const baseUri = `${TRACK_LAYOUT_URI}/layout-design`;
+
+export type LayoutDesignSaveRequest = {
+    name: string;
+    estimatedCompletion: TimeStamp;
+    designState: 'ACTIVE' | 'DELETED' | 'COMPLETED';
+};
+export type LayoutDesign = {
+    id: string;
+} & LayoutDesignSaveRequest;
+
+export const getLayoutDesigns = async (changeTime: TimeStamp) =>
+    designCache.get(changeTime, '', () => getNonNull<LayoutDesign[]>(`${baseUri}/`));
+
+export const updateLayoutDesign = async (
+    layoutDesignId: string,
+    saveRequest: LayoutDesignSaveRequest,
+) =>
+    putNonNull<LayoutDesignSaveRequest, LayoutDesignId>(
+        `${baseUri}/${layoutDesignId}/`,
+        saveRequest,
+    );
+
+export const insertLayoutDesign = async (saveRequest: LayoutDesignSaveRequest) =>
+    postNonNull<LayoutDesignSaveRequest, LayoutDesignId>(`${baseUri}/`, saveRequest);

--- a/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
+++ b/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
@@ -118,7 +118,6 @@ export const CloseableModal: React.FC<CloseableModalProps> = ({
             ref={modalRef}
             style={{
                 position: 'absolute',
-                overflowY: 'auto',
                 visibility: modalPosition === undefined ? 'hidden' : undefined,
                 ...modalPosition,
                 ...modalSize,

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -135,10 +135,6 @@ export const Dropdown = function <TItemValue>({
         inputRef.current?.select();
     }
 
-    function openListUnlessOverridden() {
-        openListAndFocusSelectedItem();
-    }
-
     function openListAndFocusSelectedItem() {
         setOpen(true);
         focusSelectedItem();
@@ -157,13 +153,9 @@ export const Dropdown = function <TItemValue>({
         }
     }
 
-    function closeListUnlessOverridden() {
-        setOpen(false);
-    }
-
     function select(value: TItemValue | undefined) {
         props.onChange && props.onChange(value);
-        closeListUnlessOverridden();
+        setOpen(false);
         setSearchTermCommitted(false);
         searchFor('');
     }
@@ -192,7 +184,7 @@ export const Dropdown = function <TItemValue>({
             focusInput();
         } else {
             setHasFocus(false);
-            closeListUnlessOverridden();
+            setOpen(false);
             searchFor('');
         }
     }
@@ -228,7 +220,7 @@ export const Dropdown = function <TItemValue>({
 
     function handleInputKeyPress(e: React.KeyboardEvent<HTMLInputElement>) {
         if (!searchable && e.code == 'Space') {
-            openListUnlessOverridden();
+            openListAndFocusSelectedItem();
             e.preventDefault();
         }
     }
@@ -259,7 +251,7 @@ export const Dropdown = function <TItemValue>({
         } else {
             switch (e.code) {
                 case 'ArrowDown':
-                    openListUnlessOverridden();
+                    openListAndFocusSelectedItem();
                     e.preventDefault();
                     break;
             }
@@ -275,7 +267,7 @@ export const Dropdown = function <TItemValue>({
     }
 
     const searchFor = (term: string) => {
-        term ? openListUnlessOverridden() : closeListUnlessOverridden();
+        term ? openListAndFocusSelectedItem() : setOpen(false);
         if (props.options && !isOptionsArray(props.options)) {
             loadOptions(props.options(term));
         }
@@ -331,7 +323,7 @@ export const Dropdown = function <TItemValue>({
                     if (!props.disabled) {
                         e.stopPropagation();
                         focusInput();
-                        isOpen() ? closeListUnlessOverridden() : openListUnlessOverridden();
+                        isOpen() ? setOpen(false) : openListAndFocusSelectedItem();
                     }
                 }}
                 title={props.title ? props.title : selectedName}>
@@ -366,7 +358,7 @@ export const Dropdown = function <TItemValue>({
             {isOpen() && (
                 <CloseableModal
                     useRefWidth
-                    onClickOutside={closeListUnlessOverridden}
+                    onClickOutside={() => setOpen(false)}
                     className={styles['dropdown__list-container']}
                     offsetY={36}
                     maxHeight={270}

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -84,15 +84,15 @@ export const Dropdown = function <TItemValue>({
         }
         earlySelect.current = false;
     });
-    const [open, setOpen] = React.useState(
-        props.openOverride !== undefined ? props.openOverride : false,
-    );
+    const [open, setOpen] = React.useState(false);
     const [hasFocus, _setHasFocus] = React.useState(false);
     const [searchTerm, setSearchTerm] = React.useState('');
     const [searchCommitted, setSearchTermCommitted] = React.useState(false);
     const [optionFocusIndex, setOptionFocusIndex] = React.useState(0);
     const showEmptyOption = props.canUnselect && !searchTerm && (props.value || optionsIsFunc);
     const inputRef = props.inputRef ?? inputRefInternal;
+
+    const isOpen = () => (props.openOverride !== undefined ? props.openOverride : open);
 
     let isMouseDown = false;
     const className = createClassName(
@@ -136,7 +136,7 @@ export const Dropdown = function <TItemValue>({
     }
 
     function openListUnlessOverridden() {
-        if (props.openOverride === undefined) openListAndFocusSelectedItem();
+        openListAndFocusSelectedItem();
     }
 
     function openListAndFocusSelectedItem() {
@@ -158,7 +158,7 @@ export const Dropdown = function <TItemValue>({
     }
 
     function closeListUnlessOverridden() {
-        if (props.openOverride === undefined) setOpen(false);
+        setOpen(false);
     }
 
     function select(value: TItemValue | undefined) {
@@ -234,7 +234,7 @@ export const Dropdown = function <TItemValue>({
     }
 
     function handleInputKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-        if (open) {
+        if (isOpen()) {
             switch (e.code) {
                 case 'ArrowUp':
                     updateOptionFocusIndex(-1);
@@ -318,12 +318,6 @@ export const Dropdown = function <TItemValue>({
         );
     }, [options]);
 
-    React.useEffect(() => {
-        if (props.openOverride !== undefined) {
-            props.openOverride ? openListAndFocusSelectedItem() : setOpen(false);
-        }
-    }, [props.openOverride]);
-
     return (
         <div
             qa-id={props.qaId}
@@ -337,7 +331,7 @@ export const Dropdown = function <TItemValue>({
                     if (!props.disabled) {
                         e.stopPropagation();
                         focusInput();
-                        open ? closeListUnlessOverridden() : openListUnlessOverridden();
+                        isOpen() ? closeListUnlessOverridden() : openListUnlessOverridden();
                     }
                 }}
                 title={props.title ? props.title : selectedName}>
@@ -369,7 +363,7 @@ export const Dropdown = function <TItemValue>({
                     )}
                 </div>
             </div>
-            {open && (
+            {isOpen() && (
                 <CloseableModal
                     useRefWidth
                     onClickOutside={closeListUnlessOverridden}


### PR DESCRIPTION
Täällä siis käytännössä tehty vaadittavat uudet controllerit ja servicet sekä DAO-tason muutokset että työtiloja pystyy luomaan frontilta. Fronttipuolelle siis tehty wiretykset työtilojen luontidialogiin ja laajennettu sitä kattamaan olemassaolevan työtilan muokkaaminen, sekä lisätty varmistusdialogi työtilan poistoon. Tähän tikettiin liittyy myös `DatePicker`-komponentin sisäinen refaktorointi, joka on irrotettu omaksi reviewikseen ihan sen monimutkaisuuden takia.