### PR TITLE
GVT-2403 Fix extremely slow in_layout_context functions

### DIFF
--- a/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
@@ -35,14 +35,19 @@ select
   where case publication_state_in
           when 'OFFICIAL' then not row.draft
           else row.draft
-            or not exists(select *
-                            from layout.track_number overriding_draft
-                            where overriding_draft.design_id is not distinct from design_id_in
-                              and overriding_draft.draft
-                              and row.id = case
-                                             when row.design_id is null then overriding_draft.official_row_id
-                                             else overriding_draft.design_row_id
-                                           end)
+            or case
+                 when row.design_id is null then
+                   not exists(select *
+                                from layout.track_number overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = row.id)
+                 else not exists(select *
+                                   from layout.track_number overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = row.id)
+               end
         end
     and case
           when design_id_in is null then row.design_id is null

--- a/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
@@ -42,14 +42,19 @@ select
   where case publication_state_in
           when 'OFFICIAL' then not row.draft
           else row.draft
-            or not exists(select *
-                            from layout.reference_line overriding_draft
-                            where overriding_draft.design_id is not distinct from design_id_in
-                              and overriding_draft.draft
-                              and row.id = case
-                                             when row.design_id is null then overriding_draft.official_row_id
-                                             else overriding_draft.design_row_id
-                                           end)
+            or case
+                 when row.design_id is null then
+                   not exists(select *
+                                from layout.reference_line overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = row.id)
+                 else not exists(select *
+                                   from layout.reference_line overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = row.id)
+               end
         end
     and case
           when design_id_in is null then row.design_id is null

--- a/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
@@ -64,14 +64,19 @@ select
   where case publication_state_in
           when 'OFFICIAL' then not row.draft
           else row.draft
-            or not exists(select *
-                            from layout.location_track overriding_draft
-                            where overriding_draft.design_id is not distinct from design_id_in
-                              and overriding_draft.draft
-                              and row.id = case
-                                             when row.design_id is null then overriding_draft.official_row_id
-                                             else overriding_draft.design_row_id
-                                           end)
+            or case
+                 when row.design_id is null then
+                   not exists(select *
+                                from layout.location_track overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = row.id)
+                 else not exists(select *
+                                   from layout.location_track overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = row.id)
+               end
         end
     and case
           when design_id_in is null then row.design_id is null

--- a/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
@@ -43,14 +43,19 @@ select
   where case publication_state_in
           when 'OFFICIAL' then not row.draft
           else row.draft
-            or not exists(select *
-                            from layout.switch overriding_draft
-                            where overriding_draft.design_id is not distinct from design_id_in
-                              and overriding_draft.draft
-                              and row.id = case
-                                             when row.design_id is null then overriding_draft.official_row_id
-                                             else overriding_draft.design_row_id
-                                           end)
+            or case
+                 when row.design_id is null then
+                   not exists(select *
+                                from layout.switch overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = row.id)
+                 else not exists(select *
+                                   from layout.switch overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = row.id)
+               end
         end
     and case
           when design_id_in is null then row.design_id is null

--- a/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
@@ -37,14 +37,19 @@ select
   where case publication_state_in
           when 'OFFICIAL' then not row.draft
           else row.draft
-            or not exists(select *
-                            from layout.km_post overriding_draft
-                            where overriding_draft.design_id is not distinct from design_id_in
-                              and overriding_draft.draft
-                              and row.id = case
-                                             when row.design_id is null then overriding_draft.official_row_id
-                                             else overriding_draft.design_row_id
-                                           end)
+            or case
+                 when row.design_id is null then
+                   not exists(select *
+                                from layout.km_post overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = row.id)
+                 else not exists(select *
+                                   from layout.km_post overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = row.id)
+               end
         end
     and case
           when design_id_in is null then row.design_id is null


### PR DESCRIPTION
Perffifiksi. Ei funktionaalista muutosta, mutta tuo postgresql ei osaa vetää tuota "row.design_id is null"-ehtoa ylemmäs itse, joten kyseinen optimointi pitää tehdä käsin (ja puu siitä alaspäin duplikoida). Olin tuomassa tätä sisään aluksi pullarissa https://github.com/finnishtransportagency/geoviite/pull/1253 , mutta koska devi on tämän perffiongelman takia juntturassa, tuon nyt tämän muutoksen kiireemmällä mainiin.