### PR TITLE
GVT-2583 Point vertical geometry diagram ref at correct element

### DIFF
--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -65,7 +65,7 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
     const [diagramHeight, setDiagramHeight] = React.useState<number>(height);
     const [diagramWidth, setDiagramWidth] = React.useState<number>(width);
 
-    const ref = React.useRef<HTMLDivElement>(null);
+    const ref = React.useRef<SVGSVGElement>(null);
     const elementPosition = ref.current?.getBoundingClientRect();
 
     React.useEffect(() => {
@@ -211,8 +211,7 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
                 setPanning(undefined);
                 setMousePositionInElement(undefined);
             }}
-            onDoubleClick={onDoubleClick}
-            ref={ref}>
+            onDoubleClick={onDoubleClick}>
             {snap && elementPosition && (
                 <HeightTooltip
                     point={snap}
@@ -220,7 +219,7 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
                     coordinates={coordinates}
                 />
             )}
-            <svg height="100%" width="100%" qa-id="vertical-geometry-diagram-proper">
+            <svg height="100%" width="100%" qa-id="vertical-geometry-diagram-proper" ref={ref}>
                 <>
                     <HeightLines coordinates={coordinates} />
                     <LabeledTicks


### PR DESCRIPTION
Ulompaa diviä on kaunistettu lisäämällä pari pikseliä paddingia, ja sen myötä laskutoimitukset, jotka käyttivät kursorin sijaintia elementin sisällä, menivät mönkään.