### PR TITLE
GVT-2589 Straighten out error handling in asset updates

### DIFF
--- a/ui/src/tool-panel/km-post/dialog/km-post-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-delete-confirmation-dialog.tsx
@@ -24,15 +24,14 @@ const KmPostDeleteConfirmationDialog: React.FC<KmPostDeleteConfirmationDialogPro
     const { t } = useTranslation();
 
     const deleteKmPost = (id: LayoutKmPostId) =>
-        deleteDraftKmPost(layoutContext, id).then((result) => {
-            result
-                .map((kmPostId) => {
-                    Snackbar.success('km-post-delete-draft-dialog.delete-succeeded');
-                    onSave && onSave(kmPostId);
-                    onClose();
-                })
-                .mapErr(() => Snackbar.error('km-post-delete-draft-dialog.delete-failed'));
-        });
+        deleteDraftKmPost(layoutContext, id).then(
+            (kmPostId) => {
+                Snackbar.success('km-post-delete-draft-dialog.delete-succeeded');
+                onSave && onSave(kmPostId);
+                onClose();
+            },
+            () => Snackbar.error('km-post-delete-draft-dialog.delete-failed'),
+        );
 
     return (
         <Dialog

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -134,22 +134,25 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
 
     async function saveState(state: KmPostEditState): Promise<LayoutKmPostId | undefined> {
         if (state.isNewKmPost) {
-            const result = await insertKmPost(
-                draftLayoutContext(props.layoutContext),
-                state.kmPost,
+            return insertKmPost(draftLayoutContext(props.layoutContext), state.kmPost).then(
+                (kmPostId) => {
+                    Snackbar.success('km-post-dialog.insert-succeeded');
+                    return kmPostId;
+                },
+                () => void Snackbar.error('km-post-dialog.insert-failed'),
             );
-            if (result.isOk()) Snackbar.success('km-post-dialog.insert-succeeded');
-            else Snackbar.error('km-post-dialog.insert-failed');
-            return result.unwrapOr(undefined);
         } else if (state.existingKmPost) {
-            const result = await updateKmPost(
+            return updateKmPost(
                 draftLayoutContext(props.layoutContext),
                 state.existingKmPost.id,
                 state.kmPost,
+            ).then(
+                (kmPostId) => {
+                    Snackbar.success('km-post-dialog.modify-succeeded');
+                    return kmPostId;
+                },
+                () => void Snackbar.error('km-post-dialog.modify-failed'),
             );
-            if (result.isOk()) Snackbar.success('km-post-dialog.modify-succeeded');
-            else Snackbar.error('km-post-dialog.modify-failed');
-            return result.unwrapOr(undefined);
         } else {
             return Promise.resolve(undefined);
         }

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -232,22 +232,20 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         if (canSaveLocationTrack(state) && state.locationTrack) {
             stateActions.onStartSaving();
             if (state.isNewLocationTrack) {
-                insertLocationTrack(layoutContextDraft, state.locationTrack).then((result) => {
-                    stateActions.onEndSaving();
-                    result.map((locationTrackId) => {
+                insertLocationTrack(layoutContextDraft, state.locationTrack)
+                    .then((locationTrackId) => {
                         props.onSave && props.onSave(locationTrackId);
                         Snackbar.success('location-track-dialog.created-successfully');
                         props.onClose();
-                    });
-                });
+                    })
+                    .finally(() => stateActions.onEndSaving());
             } else if (state.existingLocationTrack) {
                 updateLocationTrack(
                     layoutContextDraft,
                     state.existingLocationTrack.id,
                     state.locationTrack,
-                ).then((result) => {
-                    stateActions.onEndSaving();
-                    result.map((locationTrackId) => {
+                )
+                    .then((locationTrackId) => {
                         props.onSave && props.onSave(locationTrackId);
                         const successMessage =
                             state.locationTrack?.state === 'DELETED'
@@ -255,8 +253,8 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                 : 'location-track-dialog.modified-successfully';
                         Snackbar.success(successMessage);
                         props.onClose();
-                    });
-                });
+                    })
+                    .finally(() => stateActions.onEndSaving());
             }
         }
     }

--- a/ui/src/tool-panel/location-track/location-track-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/location-track/location-track-delete-confirmation-dialog.tsx
@@ -21,17 +21,14 @@ const LocationTrackDeleteConfirmationDialog: React.FC<
     const { t } = useTranslation();
 
     const deleteDraftLocationTrack = (id: LocationTrackId) => {
-        deleteLocationTrack(layoutContext, id).then((result) => {
-            result
-                .map((locationTrackId) => {
-                    Snackbar.success('tool-panel.location-track.delete-dialog.delete-succeeded');
-                    onSave && onSave(locationTrackId);
-                    onClose();
-                })
-                .mapErr(() => {
-                    Snackbar.error('tool-panel.location-track.delete-dialog.delete-failed');
-                });
-        });
+        deleteLocationTrack(layoutContext, id).then(
+            (locationTrackId) => {
+                Snackbar.success('tool-panel.location-track.delete-dialog.delete-succeeded');
+                onSave && onSave(locationTrackId);
+                onClose();
+            },
+            () => Snackbar.error('tool-panel.location-track.delete-dialog.delete-failed'),
+        );
     };
 
     return (

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -229,21 +229,14 @@ export const SwitchEditDialog = ({
                 trapPoint: trapPointToBoolean(trapPoint),
             };
 
-            insertSwitch(newSwitch, layoutContext)
-                .then((result) => {
-                    result
-                        .map((switchId) => {
-                            onSave && onSave(switchId);
-                            onClose();
-                            Snackbar.success('switch-dialog.new-switch-added');
-                        })
-                        .mapErr((_err) => {
-                            Snackbar.error('switch-dialog.adding-switch-failed');
-                        });
-                })
-                .catch(() => {
-                    Snackbar.error('switch-dialog.adding-switch-failed');
-                });
+            insertSwitch(newSwitch, layoutContext).then(
+                (switchId) => {
+                    onSave && onSave(switchId);
+                    onClose();
+                    Snackbar.success('switch-dialog.new-switch-added');
+                },
+                () => Snackbar.error('switch-dialog.adding-switch-failed'),
+            );
         }
         //save updated switch here
         if (
@@ -261,21 +254,14 @@ export const SwitchEditDialog = ({
                 ownerId: switchOwnerId,
                 trapPoint: trapPointToBoolean(trapPoint),
             };
-            updateSwitch(existingSwitch.id, updatedSwitch, layoutContext)
-                .then((result) => {
-                    result
-                        .map(() => {
-                            onSave && onSave(existingSwitch.id);
-                            onClose();
-                            Snackbar.success('switch-dialog.modified-successfully');
-                        })
-                        .mapErr((_err) => {
-                            Snackbar.error('switch-dialog.modify-failed');
-                        });
-                })
-                .catch(() => {
-                    Snackbar.error('switch-dialog.modify-failed');
-                });
+            updateSwitch(existingSwitch.id, updatedSwitch, layoutContext).then(
+                () => {
+                    onSave && onSave(existingSwitch.id);
+                    onClose();
+                    Snackbar.success('switch-dialog.modified-successfully');
+                },
+                () => Snackbar.error('switch-dialog.modify-failed'),
+            );
         }
     }
 

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -6,26 +6,25 @@ import {
     LayoutTrackNumberId,
 } from 'track-layout/track-layout-model';
 import {
-    LayoutAssetChangeInfo,
     draftLayoutContext,
     KmNumber,
+    LayoutAssetChangeInfo,
     LayoutContext,
     TimeStamp,
 } from 'common/common-model';
 import {
-    deleteNonNullAdt,
+    deleteNonNull,
     getNonNull,
     getNullable,
-    postNonNullAdt,
-    putNonNullAdt,
+    postNonNull,
+    putNonNull,
     queryParams,
 } from 'api/api-fetch';
 import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
 import { getChangeTimes, updateKmPostChangeTime } from 'common/change-time-api';
 import { BoundingBox, Point } from 'model/geometry';
 import { bboxString, pointString } from 'common/common-api';
-import { KmPostSaveError, KmPostSaveRequest } from 'linking/linking-model';
-import { Result } from 'neverthrow';
+import { KmPostSaveRequest } from 'linking/linking-model';
 import { ValidatedKmPost } from 'publication/publication-model';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
 import i18next from 'i18next';
@@ -121,53 +120,43 @@ export async function getKmPostForLinking(
 export async function insertKmPost(
     layoutContext: LayoutContext,
     kmPost: KmPostSaveRequest,
-): Promise<Result<LayoutKmPostId, KmPostSaveError>> {
-    const apiResult = await postNonNullAdt<KmPostSaveRequest, LayoutKmPostId>(
+): Promise<LayoutKmPostId> {
+    const result = await postNonNull<KmPostSaveRequest, LayoutKmPostId>(
         layoutUri('km-posts', draftLayoutContext(layoutContext)),
         kmPost,
     );
 
     await updateKmPostChangeTime();
 
-    return apiResult.mapErr(() => ({
-        // Here it is possible to return more accurate validation errors
-        validationErrors: [],
-    }));
+    return result;
 }
 
 export async function updateKmPost(
     layoutContext: LayoutContext,
     id: LayoutKmPostId,
     kmPost: KmPostSaveRequest,
-): Promise<Result<LayoutKmPostId, KmPostSaveError>> {
-    const apiResult = await putNonNullAdt<KmPostSaveRequest, LayoutKmPostId>(
+): Promise<LayoutKmPostId> {
+    const result = await putNonNull<KmPostSaveRequest, LayoutKmPostId>(
         layoutUri('km-posts', draftLayoutContext(layoutContext), id),
         kmPost,
     );
 
     await updateKmPostChangeTime();
 
-    return apiResult.mapErr(() => ({
-        // Here it is possible to return more accurate validation errors
-        validationErrors: [],
-    }));
+    return result;
 }
 
 export const deleteDraftKmPost = async (
     layoutContext: LayoutContext,
     id: LayoutKmPostId,
-): Promise<Result<LayoutKmPostId, KmPostSaveError>> => {
-    const apiResult = await deleteNonNullAdt<undefined, LayoutKmPostId>(
+): Promise<LayoutKmPostId> => {
+    const result = await deleteNonNull<LayoutKmPostId>(
         layoutUri('km-posts', draftLayoutContext(layoutContext), id),
-        undefined,
     );
 
     await updateKmPostChangeTime();
 
-    return apiResult.mapErr(() => ({
-        // Here it is possible to return more accurate validation errors
-        validationErrors: [],
-    }));
+    return result;
 };
 
 export async function getKmPostValidation(

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -19,19 +19,18 @@ import {
     TrackMeter,
 } from 'common/common-model';
 import {
-    deleteNonNullAdt,
+    deleteNonNull,
     getNonNull,
     getNullable,
-    postNonNullAdt,
-    putNonNullAdt,
+    postNonNull,
+    putNonNull,
     queryParams,
 } from 'api/api-fetch';
 import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
 import { asyncCache } from 'cache/cache';
 import { BoundingBox } from 'model/geometry';
 import { bboxString } from 'common/common-api';
-import { LocationTrackSaveError, LocationTrackSaveRequest } from 'linking/linking-model';
-import { Result } from 'neverthrow';
+import { LocationTrackSaveRequest } from 'linking/linking-model';
 import { getChangeTimes, updateLocationTrackChangeTime } from 'common/change-time-api';
 import { isNilOrBlank } from 'utils/string-utils';
 import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
@@ -228,53 +227,43 @@ export async function getLocationTracksNear(
 export async function insertLocationTrack(
     layoutContext: LayoutContext,
     locationTrack: LocationTrackSaveRequest,
-): Promise<Result<LocationTrackId, LocationTrackSaveError>> {
-    const apiResult = await postNonNullAdt<LocationTrackSaveRequest, LocationTrackId>(
+): Promise<LocationTrackId> {
+    const result = await postNonNull<LocationTrackSaveRequest, LocationTrackId>(
         layoutUri('location-tracks', draftLayoutContext(layoutContext)),
         locationTrack,
     );
 
     await updateLocationTrackChangeTime();
 
-    return apiResult.mapErr(() => ({
-        // Here it is possible to return more accurate validation errors
-        validationErrors: [],
-    }));
+    return result;
 }
 
 export async function updateLocationTrack(
     layoutContext: LayoutContext,
     id: LocationTrackId,
     locationTrack: LocationTrackSaveRequest,
-): Promise<Result<LocationTrackId, LocationTrackSaveError>> {
-    const apiResult = await putNonNullAdt<LocationTrackSaveRequest, LocationTrackId>(
+): Promise<LocationTrackId> {
+    const apiResult = await putNonNull<LocationTrackSaveRequest, LocationTrackId>(
         layoutUri('location-tracks', draftLayoutContext(layoutContext), id),
         locationTrack,
     );
 
     await updateLocationTrackChangeTime();
 
-    return apiResult.mapErr(() => ({
-        // Here it is possible to return more accurate validation errors
-        validationErrors: [],
-    }));
+    return apiResult;
 }
 
 export const deleteLocationTrack = async (
     layoutContext: LayoutContext,
     id: LocationTrackId,
-): Promise<Result<LocationTrackId, LocationTrackSaveError>> => {
-    const apiResult = await deleteNonNullAdt<undefined, LocationTrackId>(
+): Promise<LocationTrackId> => {
+    const result = await deleteNonNull<LocationTrackId>(
         layoutUri('location-tracks', draftLayoutContext(layoutContext), id),
-        undefined,
     );
 
     await updateLocationTrackChangeTime();
 
-    return apiResult.mapErr(() => ({
-        // Here it is possible to return more accurate validation errors
-        validationErrors: [],
-    }));
+    return result;
 };
 
 export async function getLocationTracks(

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -1,7 +1,7 @@
 import { BoundingBox, Point } from 'model/geometry';
 import {
-    LayoutAssetChangeInfo,
     draftLayoutContext,
+    LayoutAssetChangeInfo,
     LayoutContext,
     TimeStamp,
 } from 'common/common-model';
@@ -14,8 +14,8 @@ import {
     deleteNonNull,
     getNonNull,
     getNullable,
-    postNonNullAdt,
-    putNonNullAdt,
+    postNonNull,
+    putNonNull,
     queryParams,
 } from 'api/api-fetch';
 import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
@@ -23,8 +23,7 @@ import { bboxString, pointString } from 'common/common-api';
 import { getChangeTimes, updateSwitchChangeTime } from 'common/change-time-api';
 import { asyncCache } from 'cache/cache';
 import { MapTile } from 'map/map-model';
-import { Result } from 'neverthrow';
-import { TrackLayoutSaveError, TrackLayoutSwitchSaveRequest } from 'linking/linking-model';
+import { TrackLayoutSwitchSaveRequest } from 'linking/linking-model';
 import { filterNotEmpty, first, indexIntoMap } from 'utils/array-utils';
 import { ValidatedSwitch } from 'publication/publication-model';
 import { getMaxTimestamp } from 'utils/date-utils';
@@ -116,36 +115,30 @@ export async function getSwitchJointConnections(
 export async function insertSwitch(
     newSwitch: TrackLayoutSwitchSaveRequest,
     layoutContext: LayoutContext,
-): Promise<Result<LayoutSwitchId, TrackLayoutSaveError>> {
-    const apiResult = await postNonNullAdt<TrackLayoutSwitchSaveRequest, LayoutSwitchId>(
+): Promise<LayoutSwitchId> {
+    const result = await postNonNull<TrackLayoutSwitchSaveRequest, LayoutSwitchId>(
         layoutUri('switches', draftLayoutContext(layoutContext)),
         newSwitch,
     );
 
     await updateSwitchChangeTime();
 
-    return apiResult.mapErr(() => ({
-        // Here it is possible to return more accurate validation errors
-        validationErrors: [],
-    }));
+    return result;
 }
 
 export async function updateSwitch(
     id: LayoutSwitchId,
     updatedSwitch: TrackLayoutSwitchSaveRequest,
     layoutContext: LayoutContext,
-): Promise<Result<LayoutSwitchId, TrackLayoutSaveError>> {
-    const apiResult = await putNonNullAdt<TrackLayoutSwitchSaveRequest, LayoutSwitchId>(
+): Promise<LayoutSwitchId> {
+    const result = await putNonNull<TrackLayoutSwitchSaveRequest, LayoutSwitchId>(
         layoutUri('switches', draftLayoutContext(layoutContext), id),
         updatedSwitch,
     );
 
     await updateSwitchChangeTime();
 
-    return apiResult.mapErr(() => ({
-        // Here it is possible to return more accurate validation errors
-        validationErrors: [],
-    }));
+    return result;
 }
 
 export async function deleteDraftSwitch(

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -1,13 +1,13 @@
 import { asyncCache } from 'cache/cache';
 import { LayoutTrackNumber, LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import {
-    LayoutAssetChangeInfo,
     draftLayoutContext,
+    LayoutAssetChangeInfo,
     LayoutContext,
     TimeStamp,
 } from 'common/common-model';
 import {
-    deleteNonNullAdt,
+    deleteNonNull,
     getNonNull,
     getNullable,
     postNonNull,
@@ -21,8 +21,6 @@ import {
     updateReferenceLineChangeTime,
     updateTrackNumberChangeTime,
 } from 'common/change-time-api';
-import { LocationTrackSaveError } from 'linking/linking-model';
-import { Result } from 'neverthrow';
 import { ValidatedTrackNumber } from 'publication/publication-model';
 import { AlignmentPlanSection } from 'track-layout/layout-location-track-api';
 import { bboxString } from 'common/common-api';
@@ -77,17 +75,14 @@ export async function createTrackNumber(
 export async function deleteTrackNumber(
     layoutContext: LayoutContext,
     trackNumberId: LayoutTrackNumberId,
-): Promise<Result<LayoutTrackNumberId, LocationTrackSaveError>> {
+): Promise<LayoutTrackNumberId> {
     const path = layoutUri('track-numbers', draftLayoutContext(layoutContext), trackNumberId);
-    const apiResult = await deleteNonNullAdt<undefined, LayoutTrackNumberId>(path, undefined);
+    const result = await deleteNonNull<LayoutTrackNumberId>(path);
 
     await updateTrackNumberChangeTime();
     await updateReferenceLineChangeTime();
 
-    return apiResult.mapErr(() => ({
-        // Here it is possible to return more accurate validation errors
-        validationErrors: [],
-    }));
+    return result;
 }
 
 export async function getTrackNumberValidation(


### PR DESCRIPTION
Noista *adt-metodien käytöistähän ei ollut tässä mitään etua, koska nämä polut palauttavat muutenkin vain joko ID:n tai sisäisen virheen. Suoristetaan kaikki siis käyttämään promiseja enemmän tai vähemmän yhdenmukaisesti.

Osasta tallennuksessa tapahtuvista virhetilanteista tulee nyt kaksi toastia, minkä en ajatellut tässä olevan haitaksi: Toisesta näkee, että serverillä meni jotain vikaan, ja toisesta, että joo juuri tämä nyt yritetty tallennusoperaatio on se, joka meni rikki. Eli siis rumalta se näyttää, mutta silti informatiiviselta, ja jos kaikki toimii, niin näitähän tilanteita ei tule koskaan.