### PR TITLE
GVT-2559 (part 2): Add support for searching operating points by their oids

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
@@ -139,6 +139,7 @@ class RatkoOperatingPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : D
             from layout.operating_point
               where name ilike :searchPattern 
               or abbreviation ilike :searchPattern
+              or external_id ilike :searchPattern
             order by name
             limit :resultLimit
         """.trimIndent()


### PR DESCRIPTION
Previously all other assets could be found by their oids. As it was also simple to add support for searching operating points by their oids, support for them was also added to the search.