### PR TITLE
GVT-2481: OpenLayersin päivitys

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,7 +19,7 @@
                 "memory-cache": "~0.2.0",
                 "neverthrow": "~6.1.0",
                 "normalize.css": "~8.0.1",
-                "ol": "~8.1.0",
+                "ol": "~9.2.2",
                 "proj4": "~2.10.0",
                 "react": "~18.2.0",
                 "react-datepicker": "~6.1.0",
@@ -3712,6 +3712,36 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
+        },
+        "node_modules/color-parse": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+            "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+            "dependencies": {
+                "color-name": "^2.0.0"
+            }
+        },
+        "node_modules/color-parse/node_modules/color-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+            "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+            "engines": {
+                "node": ">=12.20"
+            }
+        },
+        "node_modules/color-rgba": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
+            "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
+            "dependencies": {
+                "color-parse": "^2.0.0",
+                "color-space": "^2.0.0"
+            }
+        },
+        "node_modules/color-space": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
+            "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA=="
         },
         "node_modules/colorette": {
             "version": "2.0.20",
@@ -9066,10 +9096,12 @@
             "dev": true
         },
         "node_modules/ol": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/ol/-/ol-8.1.0.tgz",
-            "integrity": "sha512-cx3SH2plpFS9fM8pp1nCypgQXGJD7Mcb1E3mEySmy5XEw1DUEo+kkNzgtAZz5qupekqi7aU9iBJEjCoMfqvO2Q==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/ol/-/ol-9.2.2.tgz",
+            "integrity": "sha512-YkuZW5MQTiKrr/0al1xuKarctNRvVj/anHZuq8rYMMq5BECG5E8rEOENOVFxhrbMX6T+un48D1Q0GtqBmU8Qdg==",
             "dependencies": {
+                "color-rgba": "^3.0.0",
+                "color-space": "^2.0.1",
                 "earcut": "^2.2.3",
                 "geotiff": "^2.0.7",
                 "pbf": "3.2.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,7 +61,7 @@
         "memory-cache": "~0.2.0",
         "neverthrow": "~6.1.0",
         "normalize.css": "~8.0.1",
-        "ol": "~8.1.0",
+        "ol": "~9.2.2",
         "proj4": "~2.10.0",
         "react": "~18.2.0",
         "react-datepicker": "~6.1.0",

--- a/ui/src/map/layers/alignment/alignment-linking-layer.ts
+++ b/ui/src/map/layers/alignment/alignment-linking-layer.ts
@@ -1006,7 +1006,7 @@ const layerName: MapLayerName = 'alignment-linking-layer';
 
 export function createAlignmentLinkingLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint | LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint | LineString>> | undefined,
     layoutContext: LayoutContext,
     selection: Selection,
     linkingState: LinkingState | undefined,

--- a/ui/src/map/layers/alignment/location-track-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-alignment-layer.ts
@@ -16,7 +16,7 @@ import {
 import { LocationTrackId } from 'track-layout/track-layout-model';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
 import {
     getLocationTrackMapAlignmentsByTiles,
     LocationTrackAlignmentDataHolder,
@@ -48,7 +48,7 @@ const layerName: MapLayerName = 'location-track-alignment-layer';
 
 export function createLocationTrackAlignmentLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString | OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString | OlPoint>> | undefined,
     selection: Selection,
     isSplitting: boolean,
     layoutContext: LayoutContext,

--- a/ui/src/map/layers/alignment/location-track-background-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-background-layer.ts
@@ -11,7 +11,7 @@ import { ChangeTimes } from 'common/common-slice';
 import { createAlignmentBackgroundFeatures } from 'map/layers/utils/background-layer-utils';
 import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
 import { Selection } from 'selection/selection-model';
 import {
     NORMAL_ALIGNMENT_OPACITY,
@@ -25,7 +25,7 @@ const layerName: MapLayerName = 'location-track-background-layer';
 
 export function createLocationTrackBackgroundLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString>> | undefined,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,
     resolution: number,

--- a/ui/src/map/layers/alignment/location-track-badge-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-badge-layer.ts
@@ -10,7 +10,7 @@ import {
     getBadgeDrawDistance,
 } from 'map/layers/utils/badge-layer-utils';
 import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
-import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
 import VectorLayer from 'ol/layer/Vector';
 import {
     getLocationTrackMapAlignmentsByTiles,
@@ -22,7 +22,7 @@ const layerName: MapLayerName = 'location-track-badge-layer';
 
 export function createLocationTrackBadgeLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     selection: Selection,
     layoutContext: LayoutContext,
     linkingState: LinkingState | undefined,

--- a/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-duplicate-endpoint-indicator-layer.ts
@@ -6,7 +6,6 @@ import { HIGHLIGHTS_SHOW } from 'map/layers/utils/layer-visibility-limits';
 import { AlignmentDataHolder, getMapAlignmentsByTiles } from 'track-layout/layout-map-api';
 import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import Feature from 'ol/Feature';
 import { AlignmentStartAndEnd, LocationTrackDuplicate } from 'track-layout/track-layout-model';
 import { SplittingState } from 'tool-panel/location-track/split-store';
@@ -253,7 +252,7 @@ const layerName: MapLayerName = 'location-track-duplicate-endpoint-address-layer
 
 export function createDuplicateTrackEndpointAddressLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,
     resolution: number,

--- a/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
@@ -7,7 +7,7 @@ import { MapLayer } from 'map/layers/utils/layer-model';
 import * as Limits from 'map/layers/utils/layer-visibility-limits';
 import { ChangeTimes } from 'common/common-slice';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
 import {
     AlignmentDataHolder,
     getSelectedLocationTrackMapAlignmentByTiles,
@@ -30,7 +30,7 @@ const layerName: MapLayerName = 'location-track-selected-alignment-layer';
 
 export function createLocationTrackSelectedAlignmentLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString | OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString | OlPoint>> | undefined,
     selection: Selection,
     layoutContext: LayoutContext,
     splittingIsActive: boolean, // TODO: This will be removed when layer visibility logic is revised

--- a/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
@@ -6,7 +6,6 @@ import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { ChangeTimes } from 'common/common-slice';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import {
     AlignmentDataHolder,
     getSelectedLocationTrackMapAlignmentByTiles,
@@ -68,7 +67,7 @@ function splitToParts(
 
 export function createLocationTrackSplitAlignmentLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString | OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString | OlPoint>> | undefined,
     layoutContext: LayoutContext,
     splittingState: SplittingState | undefined,
     changeTimes: ChangeTimes,

--- a/ui/src/map/layers/alignment/location-track-split-badge-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-badge-layer.ts
@@ -10,7 +10,6 @@ import {
     getBadgePoints,
 } from 'map/layers/utils/badge-layer-utils';
 import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
-import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
 import {
     AlignmentDataHolder,
@@ -21,6 +20,7 @@ import { AlignmentStartAndEnd } from 'track-layout/track-layout-model';
 import { getLocationTrackStartAndEnd } from 'track-layout/layout-location-track-api';
 import { first } from 'utils/array-utils';
 import { LayoutContext } from 'common/common-model';
+import Feature from 'ol/Feature';
 
 type SplitBoundsAndName = {
     start: number;
@@ -100,7 +100,7 @@ const layerName: MapLayerName = 'location-track-split-badge-layer';
 
 export function createLocationTrackSplitBadgeLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     layoutContext: LayoutContext,
     splittingState: SplittingState | undefined,
     changeTimes: ChangeTimes,

--- a/ui/src/map/layers/alignment/location-track-split-location-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-location-layer.ts
@@ -1,7 +1,6 @@
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { Point as OlPoint } from 'ol/geom';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import Feature from 'ol/Feature';
 import Style from 'ol/style/Style';
 import { Circle, Fill, Stroke } from 'ol/style';
@@ -47,7 +46,7 @@ type SwitchIdAndLocation = {
 const layerName: MapLayerName = 'location-track-split-location-layer';
 
 export const createLocationTrackSplitLocationLayer = (
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     layoutContext: LayoutContext,
     splittingState: SplittingState | undefined,
     onLoadingData: (loading: boolean) => void,

--- a/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
@@ -19,9 +19,9 @@ import {
 import { ReferenceLineId } from 'track-layout/track-layout-model';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
+import Feature from 'ol/Feature';
 
 let shownReferenceLinesCompare: string;
 
@@ -45,7 +45,7 @@ const layerName: MapLayerName = 'reference-line-alignment-layer';
 
 export function createReferenceLineAlignmentLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString | OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString | OlPoint>> | undefined,
     selection: Selection,
     isSplitting: boolean,
     layoutContext: LayoutContext,

--- a/ui/src/map/layers/alignment/reference-line-background-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-background-layer.ts
@@ -10,17 +10,17 @@ import { ChangeTimes } from 'common/common-slice';
 import { createAlignmentBackgroundFeatures } from 'map/layers/utils/background-layer-utils';
 import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import {
     NORMAL_ALIGNMENT_OPACITY,
     OTHER_ALIGNMENTS_OPACITY_WHILE_SPLITTING,
 } from 'map/layers/utils/alignment-layer-utils';
+import Feature from 'ol/Feature';
 
 const layerName: MapLayerName = 'reference-line-background-layer';
 
 export function createReferenceLineBackgroundLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString>> | undefined,
     isSplitting: boolean,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,

--- a/ui/src/map/layers/alignment/reference-line-badge-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-badge-layer.ts
@@ -14,14 +14,14 @@ import {
     getBadgeDrawDistance,
 } from 'map/layers/utils/badge-layer-utils';
 import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
-import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
 import VectorLayer from 'ol/layer/Vector';
 
 const layerName: MapLayerName = 'reference-line-badge-layer';
 
 export function createReferenceLineBadgeLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     selection: Selection,
     layoutContext: LayoutContext,
     linkingState: LinkingState | undefined,

--- a/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
@@ -5,7 +5,7 @@ import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { ChangeTimes } from 'common/common-slice';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
 import {
     AlignmentDataHolder,
     getSelectedReferenceLineMapAlignmentByTiles,
@@ -28,7 +28,7 @@ const layerName: MapLayerName = 'reference-line-selected-alignment-layer';
 
 export function createSelectedReferenceLineAlignmentLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString | OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString | OlPoint>> | undefined,
     selection: Selection,
     layoutContext: LayoutContext,
     splittingIsActive: boolean, // TODO: This will be removed when layer visibility logic is revised

--- a/ui/src/map/layers/debug/debug-1m-points-layer.ts
+++ b/ui/src/map/layers/debug/debug-1m-points-layer.ts
@@ -8,7 +8,6 @@ import { DEBUG_1M_POINTS } from '../utils/layer-visibility-limits';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { first } from 'utils/array-utils';
 import { MapLayerName } from 'map/map-model';
 
@@ -79,7 +78,7 @@ function createDebugFeatures(points: DebugLayerPoint[]): Feature<OlPoint>[] {
 const layerName: MapLayerName = 'debug-1m-points-layer';
 
 export function createDebug1mPointsLayer(
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     selection: Selection,
     layoutContext: LayoutContext,
     resolution: number,

--- a/ui/src/map/layers/debug/debug-layer.ts
+++ b/ui/src/map/layers/debug/debug-layer.ts
@@ -5,7 +5,6 @@ import { Circle, Fill, Stroke, Style, Text } from 'ol/style';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { clearFeatures, createLayer, pointToCoords } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { MapLayerName } from 'map/map-model';
 
 type DebugLayerPoint = {
@@ -70,7 +69,7 @@ function createDebugFeatures(points: DebugLayerPoint[]): Feature<OlPoint>[] {
 const layerName: MapLayerName = 'debug-layer';
 
 export function createDebugLayer(
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
 ): MapLayer {
     const { layer, source } = createLayer(layerName, existingOlLayer);
 

--- a/ui/src/map/layers/geometry/geometry-alignment-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-alignment-layer.ts
@@ -28,7 +28,6 @@ import {
 } from 'map/layers/utils/alignment-layer-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import { cache } from 'cache/cache';
 import { MapLayerName, MapTile } from 'map/map-model';
@@ -149,7 +148,7 @@ type PlanAlignments = {
 
 export function createGeometryAlignmentLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString>> | undefined,
     selection: Selection,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,

--- a/ui/src/map/layers/geometry/geometry-km-post-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-km-post-layer.ts
@@ -15,18 +15,18 @@ import {
 } from '../utils/km-post-layer-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { filterNotEmpty } from 'utils/array-utils';
 import { ChangeTimes } from 'common/common-slice';
 import { MapLayerName, MapTile } from 'map/map-model';
 import { LayoutContext } from 'common/common-model';
+import Feature from 'ol/Feature';
 
 const layerName: MapLayerName = 'geometry-km-post-layer';
 
 export function createGeometryKmPostLayer(
     mapTiles: MapTile[],
     resolution: number,
-    existingOlLayer: VectorLayer<VectorSource<OlPoint | Rectangle>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint | Rectangle>> | undefined,
     selection: Selection,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,

--- a/ui/src/map/layers/geometry/geometry-switch-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-switch-layer.ts
@@ -17,16 +17,16 @@ import {
 } from 'map/layers/utils/switch-layer-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { filterNotEmpty } from 'utils/array-utils';
 import { ChangeTimes } from 'common/common-slice';
 import { MapLayerName, MapTile } from 'map/map-model';
+import Feature from 'ol/Feature';
 
 const layerName: MapLayerName = 'geometry-switch-layer';
 
 export function createGeometrySwitchLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     selection: Selection,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,

--- a/ui/src/map/layers/geometry/plan-area-layer.ts
+++ b/ui/src/map/layers/geometry/plan-area-layer.ts
@@ -9,7 +9,6 @@ import { ChangeTimes } from 'common/common-slice';
 import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 
 function deduplicatePlanAreas(planAreas: PlanArea[]): PlanArea[] {
     return [...new Map(planAreas.map((area) => [area.id, area])).values()];
@@ -44,7 +43,7 @@ const layerName: MapLayerName = 'plan-area-layer';
 
 export function createPlanAreaLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<Polygon>> | undefined,
+    existingOlLayer: VectorLayer<Feature<Polygon>> | undefined,
     changeTimes: ChangeTimes,
     onLoadingData: (loading: boolean) => void,
 ): MapLayer {

--- a/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
@@ -8,7 +8,6 @@ import {
 } from 'track-layout/layout-map-api';
 import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { LineString } from 'ol/geom';
 import Feature from 'ol/Feature';
 import {
@@ -130,7 +129,7 @@ const layerName: MapLayerName = 'duplicate-split-section-highlight-layer';
 
 export function createDuplicateSplitSectionHighlightLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString>> | undefined,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,
     resolution: number,

--- a/ui/src/map/layers/highlight/duplicate-tracks-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/duplicate-tracks-highlight-layer.ts
@@ -11,7 +11,6 @@ import { ChangeTimes } from 'common/common-slice';
 import { HIGHLIGHTS_SHOW } from 'map/layers/utils/layer-visibility-limits';
 import { redHighlightStyle } from 'map/layers/utils/highlight-layer-utils';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { LayoutContext } from 'common/common-model';
 
 function createHighlightFeatures(locationTracks: AlignmentDataHolder[]): Feature<LineString>[] {
@@ -30,7 +29,7 @@ const layerName: MapLayerName = 'duplicate-tracks-highlight-layer';
 
 export function createDuplicateTracksHighlightLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString>> | undefined,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,
     resolution: number,

--- a/ui/src/map/layers/highlight/missing-linking-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/missing-linking-highlight-layer.ts
@@ -15,7 +15,7 @@ import { HIGHLIGHTS_SHOW } from 'map/layers/utils/layer-visibility-limits';
 import { createHighlightFeatures } from 'map/layers/utils/highlight-layer-utils';
 import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
 
 const highlightBackgroundStyle = new Style({
     stroke: new Stroke({
@@ -33,7 +33,7 @@ const layerName: MapLayerName = 'missing-linking-highlight-layer';
 
 export function createMissingLinkingHighlightLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString>> | undefined,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,
     resolution: number,

--- a/ui/src/map/layers/highlight/missing-profile-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/missing-profile-highlight-layer.ts
@@ -13,7 +13,7 @@ import { ChangeTimes } from 'common/common-slice';
 import { HIGHLIGHTS_SHOW } from 'map/layers/utils/layer-visibility-limits';
 import { createHighlightFeatures } from 'map/layers/utils/highlight-layer-utils';
 import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
-import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
 import VectorLayer from 'ol/layer/Vector';
 
 const highlightBackgroundStyle = new Style({
@@ -27,7 +27,7 @@ const layerName: MapLayerName = 'missing-profile-highlight-layer';
 
 export function createMissingProfileHighlightLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString>> | undefined,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,
     resolution: number,

--- a/ui/src/map/layers/highlight/plan-section-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/plan-section-highlight-layer.ts
@@ -11,7 +11,6 @@ import {
 } from 'track-layout/layout-map-api';
 import { createLayer, loadLayerData } from 'map/layers/utils/layer-utils';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { LineString } from 'ol/geom';
 import Feature from 'ol/Feature';
 import { blueHighlightStyle } from 'map/layers/utils/highlight-layer-utils';
@@ -80,7 +79,7 @@ function getAlignments(
 
 export function createPlanSectionHighlightLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString>> | undefined,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,
     resolution: number,

--- a/ui/src/map/layers/highlight/track-number-diagram-layer.ts
+++ b/ui/src/map/layers/highlight/track-number-diagram-layer.ts
@@ -19,7 +19,6 @@ import {
     getDefaultColorKey,
     TrackNumberColor,
 } from 'selection-panel/track-number-panel/color-selector/color-selector-utils';
-import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
 
 const getColorForTrackNumber = (
@@ -68,7 +67,7 @@ const layerName: MapLayerName = 'track-number-diagram-layer';
 
 export function createTrackNumberDiagramLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<LineString>> | undefined,
+    existingOlLayer: VectorLayer<Feature<LineString>> | undefined,
     changeTimes: ChangeTimes,
     layoutContext: LayoutContext,
     resolution: number,

--- a/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
+++ b/ui/src/map/layers/highlight/track-number-end-point-addresses-layer.ts
@@ -22,7 +22,6 @@ import { formatTrackMeter } from 'utils/geography-utils';
 import { Coordinate } from 'ol/coordinate';
 import mapStyles from 'map/map.module.scss';
 import { State } from 'ol/render';
-import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
 import {
     DASHED_LINE_INDICATOR_FONT_SIZE,
@@ -156,7 +155,7 @@ const layerName: MapLayerName = 'track-number-addresses-layer';
 
 export function createTrackNumberEndPointAddressesLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     changeTimes: ChangeTimes,
     layoutContext: LayoutContext,
     resolution: number,

--- a/ui/src/map/layers/km-post/km-post-layer.ts
+++ b/ui/src/map/layers/km-post/km-post-layer.ts
@@ -14,7 +14,7 @@ import {
 } from 'map/layers/utils/km-post-layer-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
 import { filterUniqueById } from 'utils/array-utils';
 import { LayoutContext } from 'common/common-model';
 
@@ -24,7 +24,7 @@ const layerName: MapLayerName = 'km-post-layer';
 
 export function createKmPostLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint | Rectangle>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint | Rectangle>> | undefined,
     selection: Selection,
     layoutContext: LayoutContext,
     changeTimes: ChangeTimes,

--- a/ui/src/map/layers/operating-point/operating-points-layer.ts
+++ b/ui/src/map/layers/operating-point/operating-points-layer.ts
@@ -1,6 +1,5 @@
 import { MapLayerName, MapTile } from 'map/map-model';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { Point as OlPoint } from 'ol/geom';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
@@ -40,7 +39,7 @@ const operatingPointStyleResolutions = [
 
 export function createOperatingPointLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     olView: OlView,
     changeTimes: ChangeTimes,
 ): MapLayer {

--- a/ui/src/map/layers/switch/switch-layer.ts
+++ b/ui/src/map/layers/switch/switch-layer.ts
@@ -22,11 +22,11 @@ import { ChangeTimes } from 'common/common-slice';
 import { filterUniqueById } from 'utils/array-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import { fromExtent } from 'ol/geom/Polygon';
 import { getAllowedSwitchesFromState, SplittingState } from 'tool-panel/location-track/split-store';
 import { getMaxTimestamp } from 'utils/date-utils';
 import { ValidatedSwitch } from 'publication/publication-model';
+import Feature from 'ol/Feature';
 
 let shownSwitchesCompare: string;
 
@@ -49,7 +49,7 @@ const layerName: MapLayerName = 'switch-layer';
 
 export function createSwitchLayer(
     mapTiles: MapTile[],
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     selection: Selection,
     splittingState: SplittingState | undefined,
     layoutContext: LayoutContext,

--- a/ui/src/map/layers/switch/switch-linking-layer.ts
+++ b/ui/src/map/layers/switch/switch-linking-layer.ts
@@ -56,7 +56,7 @@ const layerName: MapLayerName = 'switch-linking-layer';
 export function createSwitchLinkingLayer(
     mapTiles: MapTile[],
     resolution: number,
-    existingOlLayer: VectorLayer<VectorSource<OlPoint>> | undefined,
+    existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
     selection: Selection,
     linkingState: LinkingSwitch | undefined,
     onLoadingData: (loading: boolean) => void,

--- a/ui/src/map/layers/utils/alignment-layer-utils.ts
+++ b/ui/src/map/layers/utils/alignment-layer-utils.ts
@@ -18,6 +18,7 @@ import { SearchItemsOptions } from 'map/layers/utils/layer-model';
 import { Rectangle } from 'model/geometry';
 import { cache } from 'cache/cache';
 import { exhaustiveMatchingGuard, expectCoordinate } from 'utils/type-utils';
+import { FeatureLike } from 'ol/Feature';
 
 const tickImageCache = cache<string, RegularShape>();
 
@@ -43,7 +44,7 @@ export function getTickStyle(
         cacheKey,
         () =>
             new RegularShape({
-                stroke: style.getStroke(),
+                stroke: style.getStroke() || undefined,
                 points: 2,
                 radius: length,
                 radius2: 0,
@@ -219,7 +220,7 @@ export const ALIGNMENT_FEATURE_DATA_PROPERTY = 'alignment-data';
 
 export function findMatchingAlignments(
     hitArea: Rectangle,
-    source: VectorSource,
+    source: VectorSource<FeatureLike>,
     options: SearchItemsOptions,
 ): AlignmentDataHolder[] {
     return findMatchingEntities<AlignmentDataHolder>(

--- a/ui/src/map/layers/utils/alignment-layer-utils.ts
+++ b/ui/src/map/layers/utils/alignment-layer-utils.ts
@@ -219,7 +219,7 @@ export const ALIGNMENT_FEATURE_DATA_PROPERTY = 'alignment-data';
 
 export function findMatchingAlignments(
     hitArea: Rectangle,
-    source: VectorSource<Feature>,
+    source: VectorSource,
     options: SearchItemsOptions,
 ): AlignmentDataHolder[] {
     return findMatchingEntities<AlignmentDataHolder>(

--- a/ui/src/map/layers/utils/alignment-layer-utils.ts
+++ b/ui/src/map/layers/utils/alignment-layer-utils.ts
@@ -18,7 +18,6 @@ import { SearchItemsOptions } from 'map/layers/utils/layer-model';
 import { Rectangle } from 'model/geometry';
 import { cache } from 'cache/cache';
 import { exhaustiveMatchingGuard, expectCoordinate } from 'utils/type-utils';
-import { FeatureLike } from 'ol/Feature';
 
 const tickImageCache = cache<string, RegularShape>();
 
@@ -220,7 +219,7 @@ export const ALIGNMENT_FEATURE_DATA_PROPERTY = 'alignment-data';
 
 export function findMatchingAlignments(
     hitArea: Rectangle,
-    source: VectorSource<FeatureLike>,
+    source: VectorSource<Feature>,
     options: SearchItemsOptions,
 ): AlignmentDataHolder[] {
     return findMatchingEntities<AlignmentDataHolder>(

--- a/ui/src/map/layers/utils/layer-utils.ts
+++ b/ui/src/map/layers/utils/layer-utils.ts
@@ -1,4 +1,4 @@
-import Feature from 'ol/Feature';
+import Feature, { FeatureLike } from 'ol/Feature';
 import { Coordinate } from 'ol/coordinate';
 import { Geometry, LineString, Point as OlPoint, Polygon } from 'ol/geom';
 import { GeometryPlanLayout, LAYOUT_SRID, PlanAndStatus } from 'track-layout/track-layout-model';
@@ -108,7 +108,7 @@ export function getDistance(point: OlPoint, geom: Geometry): number {
 
 export function findMatchingEntities<T>(
     hitArea: Rectangle,
-    source: VectorSource,
+    source: VectorSource<FeatureLike>,
     propertyName: string,
     options?: SearchItemsOptions,
 ): T[] {
@@ -122,7 +122,7 @@ export function findMatchingEntities<T>(
 
 export function findIntersectingFeatures<T extends Geometry>(
     hitArea: Rectangle,
-    source: VectorSource,
+    source: VectorSource<FeatureLike>,
 ): Feature<T>[] {
     const features: Feature<T>[] = [];
 
@@ -154,15 +154,15 @@ const incrementAndGetLayerId = (name: MapLayerName) => {
 };
 const isLatestLayerId = (name: MapLayerName, id: number) => latestLayerIds.get(name) === id;
 
-export type LayerResult<FeatureType extends Geometry> = {
+export type LayerResult<FeatureType extends FeatureLike> = {
     layer: BaseLayer;
     source: VectorSource<FeatureType>;
     isLatest: () => boolean;
 };
 
-export function createLayer<FeatureType extends Geometry>(
+export function createLayer<FeatureType extends FeatureLike>(
     name: MapLayerName,
-    existingLayer: VectorLayer<VectorSource<FeatureType>> | undefined,
+    existingLayer: VectorLayer<FeatureType> | undefined,
     allowDefaultStyle: boolean = true,
     declutter: boolean = false,
 ): LayerResult<FeatureType> {
@@ -182,12 +182,12 @@ export function createLayer<FeatureType extends Geometry>(
     };
 }
 
-export function loadLayerData<Data, FeatureType extends Geometry>(
+export function loadLayerData<Data, FeatureType extends FeatureLike>(
     source: VectorSource<FeatureType>,
     isLatest: () => boolean,
     onLoadingData: (loading: boolean, loadedData: Data | undefined) => void,
     dataPromise: Promise<Data>,
-    createFeatures: (data: Data) => Feature<FeatureType>[],
+    createFeatures: (data: Data) => FeatureType[],
 ) {
     onLoadingData(true, undefined);
     dataPromise
@@ -207,7 +207,7 @@ export function loadLayerData<Data, FeatureType extends Geometry>(
         });
 }
 
-export const clearFeatures = (vectorSource: VectorSource) => vectorSource.clear();
+export const clearFeatures = (vectorSource: VectorSource<FeatureLike>) => vectorSource.clear();
 
 function mergeOptionalArrays<T>(a1: T[] | undefined, a2: T[] | undefined): T[] | undefined {
     if (a1 === undefined) return a2;

--- a/ui/src/map/layers/utils/layer-utils.ts
+++ b/ui/src/map/layers/utils/layer-utils.ts
@@ -1,4 +1,4 @@
-import Feature, { FeatureLike } from 'ol/Feature';
+import Feature from 'ol/Feature';
 import { Coordinate } from 'ol/coordinate';
 import { Geometry, LineString, Point as OlPoint, Polygon } from 'ol/geom';
 import { GeometryPlanLayout, LAYOUT_SRID, PlanAndStatus } from 'track-layout/track-layout-model';
@@ -108,7 +108,7 @@ export function getDistance(point: OlPoint, geom: Geometry): number {
 
 export function findMatchingEntities<T>(
     hitArea: Rectangle,
-    source: VectorSource<FeatureLike>,
+    source: VectorSource<Feature>,
     propertyName: string,
     options?: SearchItemsOptions,
 ): T[] {
@@ -122,7 +122,7 @@ export function findMatchingEntities<T>(
 
 export function findIntersectingFeatures<T extends Geometry>(
     hitArea: Rectangle,
-    source: VectorSource<FeatureLike>,
+    source: VectorSource<Feature>,
 ): Feature<T>[] {
     const features: Feature<T>[] = [];
 
@@ -154,13 +154,13 @@ const incrementAndGetLayerId = (name: MapLayerName) => {
 };
 const isLatestLayerId = (name: MapLayerName, id: number) => latestLayerIds.get(name) === id;
 
-export type LayerResult<FeatureType extends FeatureLike> = {
+export type LayerResult<FeatureType extends Feature> = {
     layer: BaseLayer;
     source: VectorSource<FeatureType>;
     isLatest: () => boolean;
 };
 
-export function createLayer<FeatureType extends FeatureLike>(
+export function createLayer<FeatureType extends Feature>(
     name: MapLayerName,
     existingLayer: VectorLayer<FeatureType> | undefined,
     allowDefaultStyle: boolean = true,
@@ -182,7 +182,7 @@ export function createLayer<FeatureType extends FeatureLike>(
     };
 }
 
-export function loadLayerData<Data, FeatureType extends FeatureLike>(
+export function loadLayerData<Data, FeatureType extends Feature>(
     source: VectorSource<FeatureType>,
     isLatest: () => boolean,
     onLoadingData: (loading: boolean, loadedData: Data | undefined) => void,
@@ -207,7 +207,7 @@ export function loadLayerData<Data, FeatureType extends FeatureLike>(
         });
 }
 
-export const clearFeatures = (vectorSource: VectorSource<FeatureLike>) => vectorSource.clear();
+export const clearFeatures = (vectorSource: VectorSource<Feature>) => vectorSource.clear();
 
 function mergeOptionalArrays<T>(a1: T[] | undefined, a2: T[] | undefined): T[] | undefined {
     if (a1 === undefined) return a2;

--- a/ui/src/map/layers/utils/layer-utils.ts
+++ b/ui/src/map/layers/utils/layer-utils.ts
@@ -154,15 +154,15 @@ const incrementAndGetLayerId = (name: MapLayerName) => {
 };
 const isLatestLayerId = (name: MapLayerName, id: number) => latestLayerIds.get(name) === id;
 
-export type LayerResult<FeatureType extends Feature> = {
+export type LayerResult<FeatureType extends Geometry> = {
     layer: BaseLayer;
-    source: VectorSource<FeatureType>;
+    source: VectorSource<Feature<FeatureType>>;
     isLatest: () => boolean;
 };
 
-export function createLayer<FeatureType extends Feature>(
+export function createLayer<FeatureType extends Geometry>(
     name: MapLayerName,
-    existingLayer: VectorLayer<FeatureType> | undefined,
+    existingLayer: VectorLayer<Feature<FeatureType>> | undefined,
     allowDefaultStyle: boolean = true,
     declutter: boolean = false,
 ): LayerResult<FeatureType> {
@@ -182,12 +182,12 @@ export function createLayer<FeatureType extends Feature>(
     };
 }
 
-export function loadLayerData<Data, FeatureType extends Feature>(
-    source: VectorSource<FeatureType>,
+export function loadLayerData<Data, FeatureType extends Geometry>(
+    source: VectorSource<Feature<FeatureType>>,
     isLatest: () => boolean,
     onLoadingData: (loading: boolean, loadedData: Data | undefined) => void,
     dataPromise: Promise<Data>,
-    createFeatures: (data: Data) => FeatureType[],
+    createFeatures: (data: Data) => Feature<FeatureType>[],
 ) {
     onLoadingData(true, undefined);
     dataPromise
@@ -207,7 +207,7 @@ export function loadLayerData<Data, FeatureType extends Feature>(
         });
 }
 
-export const clearFeatures = (vectorSource: VectorSource<Feature>) => vectorSource.clear();
+export const clearFeatures = (vectorSource: VectorSource) => vectorSource.clear();
 
 function mergeOptionalArrays<T>(a1: T[] | undefined, a2: T[] | undefined): T[] | undefined {
     if (a1 === undefined) return a2;

--- a/ui/src/map/layers/utils/layer-utils.ts
+++ b/ui/src/map/layers/utils/layer-utils.ts
@@ -108,7 +108,7 @@ export function getDistance(point: OlPoint, geom: Geometry): number {
 
 export function findMatchingEntities<T>(
     hitArea: Rectangle,
-    source: VectorSource<Feature>,
+    source: VectorSource,
     propertyName: string,
     options?: SearchItemsOptions,
 ): T[] {
@@ -122,7 +122,7 @@ export function findMatchingEntities<T>(
 
 export function findIntersectingFeatures<T extends Geometry>(
     hitArea: Rectangle,
-    source: VectorSource<Feature>,
+    source: VectorSource,
 ): Feature<T>[] {
     const features: Feature<T>[] = [];
 

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -42,7 +42,6 @@ import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 import { ChangeTimes } from 'common/common-slice';
 import { createTrackNumberDiagramLayer } from 'map/layers/highlight/track-number-diagram-layer';
 import VectorLayer from 'ol/layer/Vector';
-import VectorSource from 'ol/source/Vector';
 import useResizeObserver from 'use-resize-observer';
 import { createGeometryAlignmentLayer } from 'map/layers/geometry/geometry-alignment-layer';
 import { createGeometryKmPostLayer } from 'map/layers/geometry/geometry-km-post-layer';
@@ -87,6 +86,7 @@ import { createOperatingPointLayer } from 'map/layers/operating-point/operating-
 import { layersCoveringLayers } from 'map/map-store';
 import { createLocationTrackSplitAlignmentLayer } from 'map/layers/alignment/location-track-split-alignment-layer';
 import { MapLayerMenu } from 'map/layer-menu/map-layer-menu';
+import Feature from 'ol/Feature';
 
 declare global {
     interface Window {
@@ -339,7 +339,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'track-number-diagram-layer':
                         return createTrackNumberDiagramLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             changeTimes,
                             layoutContext,
                             resolution,
@@ -349,7 +349,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'track-number-addresses-layer':
                         return createTrackNumberEndPointAddressesLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             changeTimes,
                             layoutContext,
                             resolution,
@@ -359,7 +359,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'reference-line-alignment-layer':
                         return createReferenceLineAlignmentLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString | OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<LineString | OlPoint>>,
                             selection,
                             !!splittingState,
                             layoutContext,
@@ -370,7 +370,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'reference-line-background-layer':
                         return createReferenceLineBackgroundLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             !!splittingState,
                             layoutContext,
                             changeTimes,
@@ -379,7 +379,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'reference-line-badge-layer':
                         return createReferenceLineBadgeLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             selection,
                             layoutContext,
                             linkingState,
@@ -390,7 +390,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'location-track-alignment-layer':
                         return createLocationTrackAlignmentLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString | OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<LineString | OlPoint>>,
                             selection,
                             !!splittingState,
                             layoutContext,
@@ -402,7 +402,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'location-track-background-layer':
                         return createLocationTrackBackgroundLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             layoutContext,
                             changeTimes,
                             resolution,
@@ -413,7 +413,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'location-track-badge-layer':
                         return createLocationTrackBadgeLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             selection,
                             layoutContext,
                             linkingState,
@@ -424,7 +424,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'missing-linking-highlight-layer':
                         return createMissingLinkingHighlightLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             layoutContext,
                             changeTimes,
                             resolution,
@@ -433,7 +433,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'duplicate-tracks-highlight-layer':
                         return createDuplicateTracksHighlightLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             layoutContext,
                             changeTimes,
                             resolution,
@@ -442,7 +442,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'missing-profile-highlight-layer':
                         return createMissingProfileHighlightLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             layoutContext,
                             changeTimes,
                             resolution,
@@ -451,7 +451,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'plan-section-highlight-layer':
                         return createPlanSectionHighlightLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             layoutContext,
                             changeTimes,
                             resolution,
@@ -461,7 +461,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'km-post-layer':
                         return createKmPostLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint | Rectangle>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint | Rectangle>>,
                             selection,
                             layoutContext,
                             changeTimes,
@@ -472,7 +472,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'switch-layer':
                         return createSwitchLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             selection,
                             splittingState,
                             layoutContext,
@@ -484,7 +484,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'geometry-alignment-layer':
                         return createGeometryAlignmentLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             selection,
                             layoutContext,
                             changeTimes,
@@ -496,7 +496,7 @@ const MapView: React.FC<MapViewProps> = ({
                         return createGeometryKmPostLayer(
                             mapTiles,
                             resolution,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint | Rectangle>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint | Rectangle>>,
                             selection,
                             layoutContext,
                             changeTimes,
@@ -506,7 +506,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'geometry-switch-layer':
                         return createGeometrySwitchLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             selection,
                             layoutContext,
                             changeTimes,
@@ -517,7 +517,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'alignment-linking-layer':
                         return createAlignmentLinkingLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint | LineString>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint | LineString>>,
                             layoutContext,
                             selection,
                             linkingState,
@@ -529,14 +529,14 @@ const MapView: React.FC<MapViewProps> = ({
                         return createSwitchLinkingLayer(
                             mapTiles,
                             resolution,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             selection,
                             linkingState as LinkingSwitch | undefined,
                             (loading) => onLayerLoading(layerName, loading),
                         );
                     case 'location-track-split-location-layer':
                         return createLocationTrackSplitLocationLayer(
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             layoutContext,
                             splittingState,
                             (loading) => onLayerLoading(layerName, loading),
@@ -544,7 +544,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'duplicate-split-section-highlight-layer':
                         return createDuplicateSplitSectionHighlightLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             layoutContext,
                             changeTimes,
                             resolution,
@@ -554,7 +554,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'location-track-duplicate-endpoint-address-layer':
                         return createDuplicateTrackEndpointAddressLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             layoutContext,
                             changeTimes,
                             resolution,
@@ -564,7 +564,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'location-track-split-badge-layer':
                         return createLocationTrackSplitBadgeLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             layoutContext,
                             splittingState,
                             changeTimes,
@@ -574,7 +574,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'location-track-selected-alignment-layer':
                         return createLocationTrackSelectedAlignmentLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             selection,
                             layoutContext,
                             splittingState !== undefined,
@@ -585,7 +585,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'location-track-split-alignment-layer':
                         return createLocationTrackSplitAlignmentLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             layoutContext,
                             splittingState,
                             changeTimes,
@@ -594,7 +594,7 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'reference-line-selected-alignment-layer':
                         return createSelectedReferenceLineAlignmentLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<LineString>>,
+                            existingOlLayer as VectorLayer<Feature<LineString>>,
                             selection,
                             layoutContext,
                             splittingState !== undefined,
@@ -604,29 +604,27 @@ const MapView: React.FC<MapViewProps> = ({
                     case 'plan-area-layer':
                         return createPlanAreaLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<Polygon>>,
+                            existingOlLayer as VectorLayer<Feature<Polygon>>,
                             changeTimes,
                             (loading) => onLayerLoading(layerName, loading),
                         );
                     case 'operating-points-layer':
                         return createOperatingPointLayer(
                             mapTiles,
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             olView,
                             changeTimes,
                         );
                     case 'debug-1m-points-layer':
                         return createDebug1mPointsLayer(
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
+                            existingOlLayer as VectorLayer<Feature<OlPoint>>,
                             selection,
                             layoutContext,
                             resolution,
                             (loading) => onLayerLoading(layerName, loading),
                         );
                     case 'debug-layer':
-                        return createDebugLayer(
-                            existingOlLayer as VectorLayer<VectorSource<OlPoint>>,
-                        );
+                        return createDebugLayer(existingOlLayer as VectorLayer<Feature<OlPoint>>);
                     case 'virtual-km-post-linking-layer': // Virtual map layers
                     case 'virtual-hide-geometry-layer':
                         return undefined;


### PR DESCRIPTION
Täällä siis päivitetty OpenLayers seuraavaan major-versioo. Tarkka uusi versionumero on 9.2.2. Vaikuttaisi siltä että toiminnallisuuden puolesta kaikki toimii kuten ennenkin ilman koodimuutoksia, mutta OpenLayers on välpännyt sisäisesti tyyppejään sen verran paljon, että muutoksia tuli mm. jokaiseen karttatasoon, ja siksi review näyttää isolta.