### PR TITLE
GVT-2580: Validaatiovirheiden uudelleennimeäminen

### DIFF
--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -72,7 +72,7 @@
 
 - Object models that are not part of the main domain model
 - Each API may have their own additional types, and they should reside in said APIs package
-- For example, the geometry validation API needs a model for describing the results: `ValidationError`
+- For example, the geometry validation API needs a model for describing the results: `GeometryValidationIssue`
 
 ### Error Handling
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.codeDictionary.FeatureType
 import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.geometry.CantRotationPoint.CENTER
-import fi.fta.geoviite.infra.geometry.ErrorType.*
+import fi.fta.geoviite.infra.geometry.GeometryIssueType.*
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.*
 import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
@@ -18,7 +18,7 @@ import kotlin.math.abs
 import kotlin.math.sin
 import kotlin.math.sqrt
 
-enum class ErrorType {
+enum class GeometryIssueType {
     PARSING_ERROR,
     TRANSFORMATION_ERROR,
     VALIDATION_ERROR,
@@ -40,49 +40,49 @@ val trackTypeCodes = listOf(
     FeatureTypeCode("111"),
 )
 
-interface ValidationError {
+interface GeometryValidationIssue {
     val localizationKey: LocalizationKey
-    val errorType: ErrorType
+    val issueType: GeometryIssueType
 }
 
-data class ValidationErrorData(
+data class GeometryValidationIssueData(
     override val localizationKey: LocalizationKey,
-    override val errorType: ErrorType,
-) : ValidationError {
-    constructor(parentKey: String, errorKey: String, errorType: ErrorType) : this(
+    override val issueType: GeometryIssueType,
+) : GeometryValidationIssue {
+    constructor(parentKey: String, errorKey: String, errorType: GeometryIssueType) : this(
         LocalizationKey("$VALIDATION.$parentKey.$errorKey"),
         errorType,
     )
 }
 
 data class MetadataError(
-    @JsonIgnore private val data: ValidationErrorData,
+    @JsonIgnore private val data: GeometryValidationIssueData,
     val value: String?,
-) : ValidationError by data {
-    constructor(key: String, type: ErrorType, value: String? = null) : this(
-        ValidationErrorData(VALIDATION_METADATA, key, type),
+) : GeometryValidationIssue by data {
+    constructor(key: String, type: GeometryIssueType, value: String? = null) : this(
+        GeometryValidationIssueData(VALIDATION_METADATA, key, type),
         value,
     )
 }
 
 data class SwitchDefinitionError(
-    @JsonIgnore private val data: ValidationErrorData,
+    @JsonIgnore private val data: GeometryValidationIssueData,
     val switchName: SwitchName,
     val switchType: GeometrySwitchTypeName?,
     val jointNumbers: List<JointNumber>?,
     val structureJointNumbers: List<JointNumber>?,
     val alignmentName: AlignmentName?,
-) : ValidationError by data {
+) : GeometryValidationIssue by data {
     constructor(
         key: String,
-        type: ErrorType,
+        type: GeometryIssueType,
         switchName: SwitchName,
         switchType: GeometrySwitchTypeName? = null,
         jointNumbers: List<JointNumber>? = null,
         structureJointNumbers: List<JointNumber>? = null,
         alignmentName: AlignmentName? = null,
     ) : this(
-        data = ValidationErrorData(VALIDATION_SWITCH, key, type),
+        data = GeometryValidationIssueData(VALIDATION_SWITCH, key, type),
         switchName = switchName,
         switchType = switchType,
         jointNumbers = jointNumbers,
@@ -91,33 +91,33 @@ data class SwitchDefinitionError(
     )
 }
 
-data class AlignmentError(
-    @JsonIgnore private val data: ValidationErrorData,
+data class AlignmentIssue(
+    @JsonIgnore private val data: GeometryValidationIssueData,
     val alignmentName: AlignmentName,
     val value: String?,
-) : ValidationError by data {
-    constructor(key: String, type: ErrorType, alignmentName: AlignmentName, value: CharSequence? = null) : this(
-        ValidationErrorData(VALIDATION_ALIGNMENT, key, type),
+) : GeometryValidationIssue by data {
+    constructor(key: String, type: GeometryIssueType, alignmentName: AlignmentName, value: CharSequence? = null) : this(
+        GeometryValidationIssueData(VALIDATION_ALIGNMENT, key, type),
         alignmentName,
         value?.toString(),
     )
 }
 
-data class ElementError(
-    @JsonIgnore private val data: ValidationErrorData,
+data class ElementIssue(
+    @JsonIgnore private val data: GeometryValidationIssueData,
     val alignmentName: AlignmentName,
     val elementName: PlanElementName?,
     val elementType: GeometryElementType,
     val value: String?,
-) : ValidationError by data {
+) : GeometryValidationIssue by data {
     constructor(
         key: String,
-        type: ErrorType,
+        type: GeometryIssueType,
         alignmentName: AlignmentName,
         element: GeometryElement,
         value: String? = null
     ) : this(
-        data = ValidationErrorData(VALIDATION_ELEMENT, key, type),
+        data = GeometryValidationIssueData(VALIDATION_ELEMENT, key, type),
         alignmentName = alignmentName,
         elementName = element.name ?: element.oidPart,
         elementType = element.type,
@@ -125,49 +125,49 @@ data class ElementError(
     )
 }
 
-data class ProfileError(
-    @JsonIgnore private val data: ValidationErrorData,
+data class ProfileIssue(
+    @JsonIgnore private val data: GeometryValidationIssueData,
     val profileName: PlanElementName,
     val viName: PlanElementName,
     val value: String?,
-) : ValidationError by data {
+) : GeometryValidationIssue by data {
     constructor(
         key: String,
-        type: ErrorType,
+        type: GeometryIssueType,
         profileName: PlanElementName,
         viName: PlanElementName,
         value: String? = null,
-    ) : this(ValidationErrorData(VALIDATION_PROFILE, key, type), profileName, viName, value)
+    ) : this(GeometryValidationIssueData(VALIDATION_PROFILE, key, type), profileName, viName, value)
 }
 
-data class CantError(
-    @JsonIgnore private val data: ValidationErrorData,
+data class CantIssue(
+    @JsonIgnore private val data: GeometryValidationIssueData,
     val cantName: PlanElementName,
     val station: BigDecimal,
     val value: String?,
-) : ValidationError by data {
-    constructor(key: String, type: ErrorType, cantName: PlanElementName, station: BigDecimal, value: String? = null):
-            this(ValidationErrorData(VALIDATION_CANT, key, type), cantName, station, value)
+) : GeometryValidationIssue by data {
+    constructor(key: String, type: GeometryIssueType, cantName: PlanElementName, station: BigDecimal, value: String? = null):
+            this(GeometryValidationIssueData(VALIDATION_CANT, key, type), cantName, station, value)
 }
 
-data class KmPostError(
-    @JsonIgnore private val data: ValidationErrorData,
+data class KmPostIssue(
+    @JsonIgnore private val data: GeometryValidationIssueData,
     val kmPostName: PlanElementName,
     val value: String?,
-) : ValidationError by data {
-    constructor(key: String, type: ErrorType, kmPostName: PlanElementName, value: String? = null) : this(
-        ValidationErrorData(VALIDATION_KM_POST, key, type),
+) : GeometryValidationIssue by data {
+    constructor(key: String, type: GeometryIssueType, kmPostName: PlanElementName, value: String? = null) : this(
+        GeometryValidationIssueData(VALIDATION_KM_POST, key, type),
         kmPostName,
         value,
     )
 }
 
-data class CollectionError(
-    @JsonIgnore private val data: ValidationErrorData,
+data class CollectionIssue(
+    @JsonIgnore private val data: GeometryValidationIssueData,
     val value: String?,
-) : ValidationError by data {
-    constructor(key: String, groupingType: String, type: ErrorType, value: CharSequence? = null) : this(
-        ValidationErrorData(groupingType, key, type),
+) : GeometryValidationIssue by data {
+    constructor(key: String, groupingType: String, type: GeometryIssueType, value: CharSequence? = null) : this(
+        GeometryValidationIssueData(groupingType, key, type),
         value?.toString(),
     )
 }
@@ -201,15 +201,15 @@ fun validate(
     featureTypes: List<FeatureType>,
     switchStructures: Map<IntId<SwitchStructure>, SwitchStructure>,
     officialTrackNumbers: List<TrackNumber>,
-): List<ValidationError> {
+): List<GeometryValidationIssue> {
     return validateMetadata(plan, officialTrackNumbers) +
             validateAlignments(plan.alignments, featureTypes) +
             validateSwitches(plan.switches, plan.alignments, switchStructures) +
             validateKmPosts(plan.kmPosts)
 }
 
-fun validateMetadata(plan: GeometryPlan, officialTrackNumbers: List<TrackNumber>): List<ValidationError> =
-    listOfNotNull<ValidationError>(
+fun validateMetadata(plan: GeometryPlan, officialTrackNumbers: List<TrackNumber>): List<GeometryValidationIssue> =
+    listOfNotNull<GeometryValidationIssue>(
     validate(plan.units.coordinateSystemSrid != null) {
         val key =
             if (plan.units.coordinateSystemName == null) "coordinate-system-missing"
@@ -239,13 +239,13 @@ fun validateMetadata(plan: GeometryPlan, officialTrackNumbers: List<TrackNumber>
 fun validateAlignments(
     alignments: List<GeometryAlignment>,
     featureTypes: List<FeatureType>,
-): List<ValidationError> {
+): List<GeometryValidationIssue> {
     val duplicateNames = alignments.mapNotNull { alignment ->
         if (alignments.any { other -> other.id != alignment.id && other.name == alignment.name }) {
             alignment.name
         } else null
     }.toSet()
-    val duplicateErrors = duplicateNames.map { name -> AlignmentError("duplicate-name", OBSERVATION_MAJOR, name) }
+    val duplicateErrors = duplicateNames.map { name -> AlignmentIssue("duplicate-name", OBSERVATION_MAJOR, name) }
 
     val alignmentErrors = alignments.flatMap { alignment -> validateAlignment(alignment, featureTypes) }
 
@@ -258,7 +258,7 @@ fun validateSwitches(
     switches: List<GeometrySwitch>,
     alignments: List<GeometryAlignment>,
     switchStructures: Map<IntId<SwitchStructure>, SwitchStructure>,
-): List<ValidationError> {
+): List<GeometryValidationIssue> {
     val duplicateNames = switches.mapNotNull { switch ->
         if (switches.any { other -> other.id != switch.id && other.name == switch.name }) {
             switch.name
@@ -277,7 +277,7 @@ fun validateSwitches(
     return duplicateErrors + switchErrors
 }
 
-fun validateKmPosts(kmPosts: List<GeometryKmPost>): List<ValidationError> {
+fun validateKmPosts(kmPosts: List<GeometryKmPost>): List<GeometryValidationIssue> {
     val singularKmPostsValidations =  kmPosts.flatMapIndexed { i, p ->
         // Don't validate 1st km-post as it's just a 0-point with different data
         if (i > 0) validateKmPost(p) else listOf()
@@ -286,16 +286,16 @@ fun validateKmPosts(kmPosts: List<GeometryKmPost>): List<ValidationError> {
     return singularKmPostsValidations + validateKmPostCollection(kmPosts)
 }
 
-private fun validateKmPostCollection(kmPosts: List<GeometryKmPost>): List<CollectionError> {
+private fun validateKmPostCollection(kmPosts: List<GeometryKmPost>): List<CollectionIssue> {
     val groupedKmPosts = kmPosts.filter { it.kmNumber != null }.sortedBy { it.kmNumber }
     val firstKmPost = groupedKmPosts.firstOrNull()
 
     val generalErrors = listOfNotNull(
         validate(groupedKmPosts.filter { kmPost -> kmPost.kmNumber == firstKmPost?.kmNumber }.size == 1) {
-            CollectionError("multiple-start-km-posts", VALIDATION_KM_POST, VALIDATION_ERROR, firstKmPost?.kmNumber?.toString())
+            CollectionIssue("multiple-start-km-posts", VALIDATION_KM_POST, VALIDATION_ERROR, firstKmPost?.kmNumber?.toString())
         },
         validate(firstKmPost != null && firstKmPost.staAhead <= BigDecimal.ZERO) {
-            CollectionError("sta-ahead-not-negative", VALIDATION_KM_POST, VALIDATION_ERROR, firstKmPost?.staAhead?.toString())
+            CollectionIssue("sta-ahead-not-negative", VALIDATION_KM_POST, VALIDATION_ERROR, firstKmPost?.staAhead?.toString())
         },
     )
     return generalErrors
@@ -303,32 +303,32 @@ private fun validateKmPostCollection(kmPosts: List<GeometryKmPost>): List<Collec
 
 fun validateKmPost(post: GeometryKmPost) = listOfNotNull(
     validate(post.location != null) {
-        KmPostError("location-missing", OBSERVATION_MAJOR, post.description)
+        KmPostIssue("location-missing", OBSERVATION_MAJOR, post.description)
     },
     validate(post.kmNumber != null) {
-        KmPostError("km-number-incorrect", OBSERVATION_MINOR, post.description)
+        KmPostIssue("km-number-incorrect", OBSERVATION_MINOR, post.description)
     },
 )
 
-fun validateAlignmentCollection(alignments: List<GeometryAlignment>): List<ValidationError> {
+fun validateAlignmentCollection(alignments: List<GeometryAlignment>): List<GeometryValidationIssue> {
     val referenceLineAlignments = alignments.filter { alignment ->
         alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE
     }
     return listOfNotNull(
         validate(referenceLineAlignments.isNotEmpty()) {
-            CollectionError("no-reference-lines", VALIDATION_ALIGNMENT, OBSERVATION_MAJOR)
+            CollectionIssue("no-reference-lines", VALIDATION_ALIGNMENT, OBSERVATION_MAJOR)
         },
         validate(referenceLineAlignments.size <= 1) {
-            CollectionError("multiple-reference-lines", VALIDATION_ALIGNMENT, VALIDATION_ERROR)
+            CollectionIssue("multiple-reference-lines", VALIDATION_ALIGNMENT, VALIDATION_ERROR)
         },
     )
 }
 
-fun validateAlignmentGeometry(alignment: GeometryAlignment): List<ValidationError> {
+fun validateAlignmentGeometry(alignment: GeometryAlignment): List<GeometryValidationIssue> {
     return validatePieces(alignment.name, alignment.elements, ::validateElement, ::validateElementVsPrevious)
 }
 
-fun validateAlignmentProfile(alignment: GeometryAlignment): List<ValidationError> {
+fun validateAlignmentProfile(alignment: GeometryAlignment): List<GeometryValidationIssue> {
     return alignment.profile?.let { profile ->
         val intersectionErrors = validatePieces(
             profile.name,
@@ -343,20 +343,20 @@ fun validateAlignmentProfile(alignment: GeometryAlignment): List<ValidationError
             ::validateProfileSegmentVsPrevious,
         )
         intersectionErrors + segmentErrors
-    } ?: listOf(AlignmentError("no-profile", OBSERVATION_MAJOR, alignment.name))
+    } ?: listOf(AlignmentIssue("no-profile", OBSERVATION_MAJOR, alignment.name))
 }
 
-fun validateAlignmentCant(alignment: GeometryAlignment): List<ValidationError> {
+fun validateAlignmentCant(alignment: GeometryAlignment): List<GeometryValidationIssue> {
     return alignment.cant?.let { cant ->
         val cantErrors = listOfNotNull(
             validate(cant.rotationPoint != null || alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE) {
-                AlignmentError("cant-rotation-point-undefined", VALIDATION_ERROR, alignment.name)
+                AlignmentIssue("cant-rotation-point-undefined", VALIDATION_ERROR, alignment.name)
             },
             validate(cant.rotationPoint != CENTER) {
-                AlignmentError("cant-rotation-point-center", VALIDATION_ERROR, alignment.name)
+                AlignmentIssue("cant-rotation-point-center", VALIDATION_ERROR, alignment.name)
             },
             validate(cant.gauge == FINNISH_RAIL_GAUGE) {
-                AlignmentError("cant-gauge-invalid", OBSERVATION_MAJOR, alignment.name, value = cant.gauge.toString())
+                AlignmentIssue("cant-gauge-invalid", OBSERVATION_MAJOR, alignment.name, value = cant.gauge.toString())
             },
         )
         val pointErrors = validatePieces(
@@ -366,38 +366,38 @@ fun validateAlignmentCant(alignment: GeometryAlignment): List<ValidationError> {
             itemVsPreviousValidator = ::validateCantPointVsPrevious,
         )
         cantErrors + pointErrors
-    } ?: listOf(AlignmentError("no-cant", OBSERVATION_MAJOR, alignment.name))
+    } ?: listOf(AlignmentIssue("no-cant", OBSERVATION_MAJOR, alignment.name))
 }
 
-fun validateAlignment(alignment: GeometryAlignment, featureTypes: List<FeatureType>): List<ValidationError> {
+fun validateAlignment(alignment: GeometryAlignment, featureTypes: List<FeatureType>): List<GeometryValidationIssue> {
     val typeCode = alignment.featureTypeCode
     val type = typeCode?.let { c -> featureTypes.find { ft -> ft.code == c } }
     val typeCodeError = if (typeCode == null) {
-        AlignmentError("no-feature-type", OBSERVATION_MAJOR, alignment.name)
+        AlignmentIssue("no-feature-type", OBSERVATION_MAJOR, alignment.name)
     } else if (type == null) {
-        AlignmentError("unknown-feature-type", OBSERVATION_MAJOR, alignment.name, typeCode)
+        AlignmentIssue("unknown-feature-type", OBSERVATION_MAJOR, alignment.name, typeCode)
     } else if (type.code !in trackTypeCodes) {
-        AlignmentError("wrong-feature-type", OBSERVATION_MINOR, alignment.name, "${type.code} (${type.description})")
+        AlignmentIssue("wrong-feature-type", OBSERVATION_MINOR, alignment.name, "${type.code} (${type.description})")
     } else {
         null
     }
-    val alignmentErrors = listOfNotNull(
+    val alignmentIssues = listOfNotNull(
         typeCodeError,
         validate(alignment.state != null) {
-            AlignmentError("no-state", OBSERVATION_MINOR, alignment.name)
+            AlignmentIssue("no-state", OBSERVATION_MINOR, alignment.name)
         },
     )
-    return alignmentErrors +
+    return alignmentIssues +
             validateAlignmentGeometry(alignment) +
             validateAlignmentProfile(alignment) +
             validateAlignmentCant(alignment)
 }
 
-private fun validateElement(alignmentName: AlignmentName, element: GeometryElement): List<ElementError> {
+private fun validateElement(alignmentName: AlignmentName, element: GeometryElement): List<ElementIssue> {
     val lengthDelta = abs(element.length.toDouble() - element.calculatedLength)
     val fieldErrors = listOfNotNull(
         validate(element.length > BigDecimal.ZERO) {
-            ElementError(
+            ElementIssue(
                 key = "field-invalid-length",
                 type = OBSERVATION_MAJOR,
                 alignmentName = alignmentName,
@@ -407,7 +407,7 @@ private fun validateElement(alignmentName: AlignmentName, element: GeometryEleme
         },
         validate(element.length <= BigDecimal.ZERO || lengthDelta < ACCURATE_LENGTH_DELTA) {
             val isIncorrect = lengthDelta > LENGTH_DELTA
-            ElementError(
+            ElementIssue(
                 key = if (isIncorrect) "field-incorrect-length" else "field-inaccurate-length",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
@@ -421,7 +421,7 @@ private fun validateElement(alignmentName: AlignmentName, element: GeometryEleme
     val calculatedEnd = element.getCoordinateAt(element.calculatedLength)
     val endPointErrors = listOfNotNull(
         validate(!element.start.isSame(element.end, ACCURATE_COORDINATE_DELTA)) {
-            ElementError(
+            ElementIssue(
                 key = "start-end-same",
                 type = OBSERVATION_MAJOR,
                 alignmentName = alignmentName,
@@ -430,7 +430,7 @@ private fun validateElement(alignmentName: AlignmentName, element: GeometryEleme
         },
         validate(calculatedStart.isSame(element.start, ACCURATE_COORDINATE_DELTA)) {
             val isIncorrect = !calculatedStart.isSame(element.start, COORDINATE_DELTA)
-            ElementError(
+            ElementIssue(
                 key = if (isIncorrect) "incorrect-start-point" else "inaccurate-start-point",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
@@ -440,7 +440,7 @@ private fun validateElement(alignmentName: AlignmentName, element: GeometryEleme
         },
         validate(calculatedEnd.isSame(element.end, ACCURATE_COORDINATE_DELTA)) {
             val isIncorrect = !calculatedEnd.isSame(element.end, COORDINATE_DELTA)
-            ElementError(
+            ElementIssue(
                 key = if (isIncorrect) "incorrect-end-point" else "inaccurate-end-point",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
@@ -464,12 +464,12 @@ private fun validateElementVsPrevious(
     alignmentName: AlignmentName,
     element: GeometryElement,
     previous: GeometryElement,
-): List<ElementError> {
+): List<ElementIssue> {
     val directionDiff = angleDiffRads(element.startDirectionRads, previous.endDirectionRads)
     return listOfNotNull(
         validate(element.start.isSame(previous.end, ACCURATE_COORDINATE_DELTA)) {
             val isIncorrect = !element.start.isSame(previous.end, COORDINATE_DELTA)
-            ElementError(
+            ElementIssue(
                 key = if (isIncorrect) "coordinates-not-continuous" else "coordinates-inaccurate",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
@@ -479,7 +479,7 @@ private fun validateElementVsPrevious(
         },
         validate(directionDiff <= ACCURATE_ELEMENT_DIRECTION_DELTA) {
             val isIncorrect = directionDiff > ELEMENT_DIRECTION_DELTA
-            ElementError(
+            ElementIssue(
                 key = if (isIncorrect) "directions-not-continuous" else "directions-inaccurate",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
@@ -488,7 +488,7 @@ private fun validateElementVsPrevious(
             )
         },
         validate(element.staStart > previous.staStart) {
-            ElementError(
+            ElementIssue(
                 key = "station-not-increasing",
                 type = OBSERVATION_MAJOR,
                 alignmentName = alignmentName,
@@ -499,7 +499,7 @@ private fun validateElementVsPrevious(
     )
 }
 
-private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): List<ElementError> {
+private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): List<ElementIssue> {
     val startRadiusDiff = abs(lineLength(curve.center, curve.start) - curve.radius.toDouble())
     val endRadiusDiff = abs(lineLength(curve.center, curve.start) - curve.radius.toDouble())
     val chordDiff = abs(lineLength(curve.start, curve.end) - curve.chord.toDouble())
@@ -507,7 +507,7 @@ private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): L
     return listOfNotNull(
         validate(startRadiusDiff <= ACCURATE_RADIUS_DELTA) {
             val isIncorrect = startRadiusDiff > RADIUS_DELTA
-            ElementError(
+            ElementIssue(
                 key = if (isIncorrect) "curve-radius-incorrect-start" else "curve-radius-inaccurate-start",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
@@ -517,7 +517,7 @@ private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): L
         },
         validate(endRadiusDiff <= ACCURATE_RADIUS_DELTA) {
             val isIncorrect = endRadiusDiff > RADIUS_DELTA
-            ElementError(
+            ElementIssue(
                 key = if (isIncorrect) "curve-radius-incorrect-end" else "curve-radius-inaccurate-end",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
@@ -527,7 +527,7 @@ private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): L
         },
         validate(chordDiff <= ACCURATE_LENGTH_DELTA) {
             val isIncorrect = chordDiff > LENGTH_DELTA
-            ElementError(
+            ElementIssue(
                 key = if (isIncorrect) "curve-chord-incorrect" else "curve-chord-inaccurate",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
@@ -535,7 +535,7 @@ private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): L
             )
         },
         validate(curve.radius.toDouble() >= MINIMUM_TURN_RADIUS) {
-            ElementError(
+            ElementIssue(
                 key = "curve-steep",
                 type = OBSERVATION_MAJOR,
                 alignmentName = alignmentName,
@@ -546,12 +546,12 @@ private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): L
     )
 }
 
-private fun validateSpiral(alignmentName: AlignmentName, spiral: GeometrySpiral): List<ElementError> {
+private fun validateSpiral(alignmentName: AlignmentName, spiral: GeometrySpiral): List<ElementIssue> {
     val startRadius = spiral.radiusStart
     val endRadius = spiral.radiusEnd
     return listOfNotNull(
         validate(startRadius == null || startRadius.toDouble() >= MINIMUM_TURN_RADIUS) {
-            ElementError(
+            ElementIssue(
                 key = "spiral-start-steep",
                 type = OBSERVATION_MAJOR,
                 alignmentName = alignmentName,
@@ -560,7 +560,7 @@ private fun validateSpiral(alignmentName: AlignmentName, spiral: GeometrySpiral)
             )
         },
         validate(endRadius == null || endRadius.toDouble() >= MINIMUM_TURN_RADIUS) {
-            ElementError(
+            ElementIssue(
                 key = "spiral-end-steep",
                 type = OBSERVATION_MAJOR,
                 alignmentName = alignmentName,
@@ -571,7 +571,7 @@ private fun validateSpiral(alignmentName: AlignmentName, spiral: GeometrySpiral)
     )
 }
 
-private fun validateClothoid(alignmentName: AlignmentName, clothoid: GeometryClothoid): List<ElementError> {
+private fun validateClothoid(alignmentName: AlignmentName, clothoid: GeometryClothoid): List<ElementIssue> {
     val calculatedConstant =
         if (clothoid.radiusStart != null) {
             sqrt(clothoid.radiusStart.toDouble() * clothoid.segmentToClothoidDistance(0.0))
@@ -584,7 +584,7 @@ private fun validateClothoid(alignmentName: AlignmentName, clothoid: GeometryClo
             val constantDiff = abs(calculated - clothoid.constant.toDouble())
             validate(constantDiff <= ACCURATE_CONSTANT_A_DELTA) {
                 val isIncorrect = constantDiff > CONSTANT_A_DELTA
-                ElementError(
+                ElementIssue(
                     key = if (isIncorrect) "clothoid-incorrect-constant" else "clothoid-inaccurate-constant",
                     type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                     alignmentName = alignmentName,
@@ -596,11 +596,11 @@ private fun validateClothoid(alignmentName: AlignmentName, clothoid: GeometryClo
     )
 }
 
-private fun validateIntersection(profileName: PlanElementName, intersection: VerticalIntersection): List<ProfileError> {
+private fun validateIntersection(profileName: PlanElementName, intersection: VerticalIntersection): List<ProfileIssue> {
     return if (intersection is VICircularCurve) {
         listOfNotNull(
             validate(intersection.length != null) {
-                ProfileError(
+                ProfileIssue(
                     key = "curve-length-missing",
                     type = OBSERVATION_MAJOR,
                     profileName = profileName,
@@ -608,7 +608,7 @@ private fun validateIntersection(profileName: PlanElementName, intersection: Ver
                 )
             },
             validate(intersection.radius != null) {
-                ProfileError(
+                ProfileIssue(
                     key = "curve-radius-missing",
                     type = OBSERVATION_MAJOR,
                     profileName = profileName,
@@ -623,17 +623,17 @@ private fun validateIntersectionVsPrevious(
     profileName: PlanElementName,
     intersection: VerticalIntersection,
     previous: VerticalIntersection,
-) : List<ProfileError> {
+) : List<ProfileIssue> {
     val deltaX = intersection.point.x - previous.point.x
     val deltaY = intersection.point.y - previous.point.y
     val profileAngle = if (deltaX > 0) radsToDegrees(sin(deltaY/deltaX)) else null
     return listOfNotNull(
         validate(deltaX > 0) {
-            ProfileError("incorrect-station", OBSERVATION_MAJOR, profileName, intersection.description)
+            ProfileIssue("incorrect-station", OBSERVATION_MAJOR, profileName, intersection.description)
         },
         profileAngle?.let { angle ->
             validate(abs(angle) <= MAX_PROFILE_SLOPE_DEGREES) {
-                ProfileError(
+                ProfileIssue(
                     key = "incorrect-slope",
                     type = OBSERVATION_MAJOR,
                     profileName = profileName,
@@ -645,10 +645,10 @@ private fun validateIntersectionVsPrevious(
     )
 }
 
-private fun validateProfileSegment(profileName: PlanElementName, segment: ProfileSegment): List<ProfileError> {
+private fun validateProfileSegment(profileName: PlanElementName, segment: ProfileSegment): List<ProfileIssue> {
     return listOfNotNull(
         validate(segment !is LinearProfileSegment || segment.valid) {
-            ProfileError(
+            ProfileIssue(
                 key = "calculation-failed",
                 type = OBSERVATION_MAJOR,
                 profileName = profileName,
@@ -663,12 +663,12 @@ private fun validateProfileSegmentVsPrevious(
     profileName: PlanElementName,
     segment: ProfileSegment,
     previous: ProfileSegment,
-) : List<ProfileError> {
+) : List<ProfileIssue> {
     val segmentValid = segment is LinearProfileSegment && !segment.valid
     val previousValid = previous is LinearProfileSegment && !previous.valid
     return listOfNotNull(
         validate(abs(segment.start.x - previous.end.x) <= 0.0001) {
-            ProfileError(
+            ProfileIssue(
                 key = "segment-station-not-continuous",
                 type = OBSERVATION_MAJOR,
                 profileName = profileName,
@@ -677,7 +677,7 @@ private fun validateProfileSegmentVsPrevious(
             )
         },
         validate(abs(segment.start.y - previous.end.y) <= 0.0001) {
-            ProfileError(
+            ProfileIssue(
                 key = "segment-height-not-continuous",
                 type = OBSERVATION_MAJOR,
                 profileName = profileName,
@@ -686,7 +686,7 @@ private fun validateProfileSegmentVsPrevious(
             )
         },
         validate(!segmentValid || !previousValid || abs(segment.startAngle - previous.endAngle) <= 0.0001) {
-            ProfileError(
+            ProfileIssue(
                 key = "segment-angle-not-continuous",
                 type = OBSERVATION_MAJOR,
                 profileName = profileName,
@@ -701,10 +701,10 @@ private fun validateCantPoint(
     cantName: PlanElementName,
     cantPoint: GeometryCantPoint,
     gauge: BigDecimal
-): List<CantError> {
+): List<CantIssue> {
     return listOfNotNull(
         validate (cantPoint.appliedCant.toDouble() in 0.0..gauge.toDouble()) {
-            CantError(
+            CantIssue(
                 key = "value-incorrect",
                 type = OBSERVATION_MAJOR,
                 cantName = cantName,
@@ -719,10 +719,10 @@ private fun validateCantPointVsPrevious(
     cantName: PlanElementName,
     cantPoint: GeometryCantPoint,
     previous: GeometryCantPoint,
-): List<CantError> {
+): List<CantIssue> {
     return listOfNotNull(
         validate(cantPoint.station > previous.station) {
-            CantError("station-not-continuous", OBSERVATION_MAJOR, cantName, cantPoint.station)
+            CantIssue("station-not-continuous", OBSERVATION_MAJOR, cantName, cantPoint.station)
         },
     )
 }
@@ -731,7 +731,7 @@ fun validateSwitch(
     switch: GeometrySwitch,
     structure: SwitchStructure?,
     alignmentSwitches: List<AlignmentSwitch>,
-): List<ValidationError> {
+): List<GeometryValidationIssue> {
     val jointNumbers = switch.joints.map(GeometrySwitchJoint::number)
     val structureJointNumbers = structure?.joints?.map(SwitchJoint::number) ?: listOf()
 
@@ -884,7 +884,7 @@ data class AlignmentSwitch(val alignment: GeometryAlignment, val joints: List<Al
 }
 data class AlignmentSwitchJoint(val number: JointNumber, val location: Point)
 
-private fun <T: ValidationError> validate(check: Boolean, lazyError: () -> T): T? =
+private fun <T: GeometryValidationIssue> validate(check: Boolean, lazyError: () -> T): T? =
     if (check) null
     else lazyError()
 
@@ -892,12 +892,12 @@ private fun <T: ValidationError> validate(check: Boolean, lazyError: () -> T): T
  * Validate a list of items, using one function to check the items themselves and another to check them versus the
  * previous one for consistency
  */
-private fun <N : CharSequence, T : Any, E: ValidationError> validatePieces(
+private fun <N : CharSequence, T : Any, E: GeometryValidationIssue> validatePieces(
     parentName: N,
     pieces: List<T>,
     itemValidator: (N, T) -> List<E>,
     itemVsPreviousValidator: (N, T, T) -> List<E> = { _, _, _ -> listOf() },
-): List<ValidationError> {
+): List<GeometryValidationIssue> {
     return pieces.flatMapIndexed { index, item ->
         val pointErrors = itemValidator(parentName, item)
         val previous = pieces.getOrNull(index - 1)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
@@ -27,8 +27,8 @@ const val INFRAMODEL_TRANSFORMATION_KEY_PARENT = "error.infra-model.transformati
 data class TransformationError(
     private val key: String,
     private val units: GeometryUnits,
-): ValidationError {
-    override val errorType = ErrorType.TRANSFORMATION_ERROR
+): GeometryValidationIssue {
+    override val issueType = GeometryIssueType.TRANSFORMATION_ERROR
     override val localizationKey = LocalizationKey("$INFRAMODEL_TRANSFORMATION_KEY_PARENT.$key")
     val srid = units.coordinateSystemSrid
     val coordinateSystemName = units.coordinateSystemName

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
@@ -4,14 +4,13 @@ import fi.fta.geoviite.infra.common.*
 import fi.fta.geoviite.infra.error.HasLocalizedMessage
 import fi.fta.geoviite.infra.geometry.*
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
-import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import fi.fta.geoviite.infra.util.LocalizationKey
 import fi.fta.geoviite.infra.util.XmlCharset
 import java.time.Instant
 
 data class ValidationResponse(
-    val validationErrors: List<ValidationError>,
+    val geometryValidationIssues: List<GeometryValidationIssue>,
     val geometryPlan: GeometryPlan?,
     val planLayout: GeometryPlanLayout?,
     val source: PlanSource,
@@ -41,7 +40,7 @@ fun tryParsing(source: PlanSource?, op: () -> ValidationResponse): ValidationRes
 } catch (e: Exception) {
     logger.warn("Failed to parse InfraModel", e)
     ValidationResponse(
-        validationErrors = listOf(
+        geometryValidationIssues = listOf(
             ParsingError(
                 if (e is HasLocalizedMessage) e.localizationKey
                 else LocalizationKey(INFRAMODEL_PARSING_KEY_GENERIC)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelParsing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelParsing.kt
@@ -3,10 +3,10 @@ package fi.fta.geoviite.infra.inframodel
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.error.InframodelParsingException
 import fi.fta.geoviite.infra.geography.CoordinateSystemName
-import fi.fta.geoviite.infra.geometry.ErrorType
+import fi.fta.geoviite.infra.geometry.GeometryIssueType
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.geometry.PlanSource
-import fi.fta.geoviite.infra.geometry.ValidationError
+import fi.fta.geoviite.infra.geometry.GeometryValidationIssue
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 import fi.fta.geoviite.infra.util.FileName
@@ -35,8 +35,8 @@ const val INFRAMODEL_PARSING_KEY_PARENT = "error.infra-model.parsing"
 const val INFRAMODEL_PARSING_KEY_GENERIC = "$INFRAMODEL_PARSING_KEY_PARENT.generic"
 const val INFRAMODEL_PARSING_KEY_EMPTY = "$INFRAMODEL_PARSING_KEY_PARENT.empty"
 
-data class ParsingError(override val localizationKey: LocalizationKey) : ValidationError {
-    override val errorType = ErrorType.PARSING_ERROR
+data class ParsingError(override val localizationKey: LocalizationKey) : GeometryValidationIssue {
+    override val issueType = GeometryIssueType.PARSING_ERROR
 }
 
 private val jaxbContext: JAXBContext by lazy {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -171,8 +171,8 @@ class InfraModelService @Autowired constructor(
             includeGeometryData = true,
             pointListStepLength = VALIDATION_LAYOUT_POINTS_RESOLUTION,
         )
-        val validationErrors = validateGeometryPlanContent(plan) + listOfNotNull(layoutCreationError)
-        return ValidationResponse(validationErrors, plan, planLayout?.withLayoutGeometry(), plan.source)
+        val validationIssues = validateGeometryPlanContent(plan) + listOfNotNull(layoutCreationError)
+        return ValidationResponse(validationIssues, plan, planLayout?.withLayoutGeometry(), plan.source)
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -16,7 +16,7 @@ import fi.fta.geoviite.infra.geometry.PlanLayoutCache
 import fi.fta.geoviite.infra.geometry.PlanSource
 import fi.fta.geoviite.infra.geometry.Project
 import fi.fta.geoviite.infra.geometry.TransformationError
-import fi.fta.geoviite.infra.geometry.ValidationError
+import fi.fta.geoviite.infra.geometry.GeometryValidationIssue
 import fi.fta.geoviite.infra.geometry.getBoundingPolygonPointsFromAlignments
 import fi.fta.geoviite.infra.geometry.validate
 import fi.fta.geoviite.infra.localization.localizationParams
@@ -39,7 +39,7 @@ const val VALIDATION_LAYOUT_POINTS_RESOLUTION = 10
 val noFileValidationError = ParsingError(LocalizationKey(INFRAMODEL_PARSING_KEY_EMPTY))
 
 fun noFileValidationResponse(overrideParameters: OverrideParameters?) = ValidationResponse(
-    validationErrors = listOf(noFileValidationError),
+    geometryValidationIssues = listOf(noFileValidationError),
     geometryPlan = null,
     planLayout = null,
     source = overrideParameters?.source ?: PlanSource.GEOMETRIAPALVELU,
@@ -243,7 +243,7 @@ class InfraModelService @Autowired constructor(
         )
     }
 
-    private fun validateGeometryPlanContent(geometryPlan: GeometryPlan): List<ValidationError> {
+    private fun validateGeometryPlanContent(geometryPlan: GeometryPlan): List<GeometryValidationIssue> {
         return validate(
             geometryPlan,
             codeDictionaryService.getFeatureTypes(),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
@@ -7,7 +7,7 @@ import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.geometry.GeometrySwitch
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Range
-import fi.fta.geoviite.infra.publication.PublicationValidationError
+import fi.fta.geoviite.infra.publication.LayoutValidationIssue
 import fi.fta.geoviite.infra.switchLibrary.*
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.FreeText
@@ -180,7 +180,7 @@ data class KmPostLinkingParameters(
 data class SwitchRelinkingValidationResult(
     val id: IntId<TrackLayoutSwitch>,
     val successfulSuggestion: SwitchRelinkingSuggestion?,
-    val validationErrors: List<PublicationValidationError>,
+    val validationIssues: List<LayoutValidationIssue>,
 )
 data class SwitchRelinkingSuggestion(
     val location: Point,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -31,8 +31,8 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoint
 import fi.fta.geoviite.infra.math.boundingBoxAroundPointsOrNull
 import fi.fta.geoviite.infra.math.isSame
-import fi.fta.geoviite.infra.publication.PublicationValidationError
-import fi.fta.geoviite.infra.publication.PublicationValidationErrorType
+import fi.fta.geoviite.infra.publication.LayoutValidationIssue
+import fi.fta.geoviite.infra.publication.LayoutValidationIssueType
 import fi.fta.geoviite.infra.publication.VALIDATION_SWITCH
 import fi.fta.geoviite.infra.publication.validateSwitchLocationTrackLinkStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
@@ -304,8 +304,8 @@ class SwitchLinkingService @Autowired constructor(
                     switchId,
                     null,
                     listOf(
-                        PublicationValidationError(
-                            PublicationValidationErrorType.ERROR,
+                        LayoutValidationIssue(
+                            LayoutValidationIssueType.ERROR,
                             "$VALIDATION_SWITCH.track-linkage.relinking-failed",
                             mapOf("switch" to switchService.getOrThrow(branch.draft, switchId).name)
                         )
@@ -373,7 +373,7 @@ class SwitchLinkingService @Autowired constructor(
         suggestedSwitch: SuggestedSwitch,
         switchId: IntId<TrackLayoutSwitch>,
         relevantLocationTracks: Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>,
-    ): Pair<List<PublicationValidationError>, Point> {
+    ): Pair<List<LayoutValidationIssue>, Point> {
 
         val changedTracks = withChangesFromLinkingSwitch(
             suggestedSwitch,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -167,7 +167,7 @@ data class ValidatedPublicationCandidates(
 
 data class ValidatedAsset<T>(
     val id: IntId<T>,
-    val errors: List<PublicationValidationError>,
+    val errors: List<LayoutValidationIssue>,
 )
 
 data class PublicationCandidates(
@@ -280,14 +280,14 @@ data class PublicationResult(
     val kmPosts: Int,
 )
 
-enum class PublicationValidationErrorType { ERROR, WARNING }
-data class PublicationValidationError(
-    val type: PublicationValidationErrorType,
+enum class LayoutValidationIssueType { ERROR, WARNING }
+data class LayoutValidationIssue(
+    val type: LayoutValidationIssueType,
     val localizationKey: LocalizationKey,
     val params: LocalizationParams = LocalizationParams.empty,
 ) {
     constructor(
-        type: PublicationValidationErrorType,
+        type: LayoutValidationIssueType,
         key: String,
         params: Map<String, Any?> = emptyMap(),
     ) : this(type, LocalizationKey(key), localizationParams(params))
@@ -299,7 +299,7 @@ interface PublicationCandidate<T> {
     val rowVersion: RowVersion<T>
     val draftChangeTime: Instant
     val userName: UserName
-    val errors: List<PublicationValidationError>
+    val issues: List<LayoutValidationIssue>
     val operation: Operation?
     val publicationGroup: PublicationGroup?
 
@@ -312,7 +312,7 @@ data class TrackNumberPublicationCandidate(
     val number: TrackNumber,
     override val draftChangeTime: Instant,
     override val userName: UserName,
-    override val errors: List<PublicationValidationError> = listOf(),
+    override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation,
     override val publicationGroup: PublicationGroup? = null,
     val boundingBox: BoundingBox?,
@@ -327,7 +327,7 @@ data class ReferenceLinePublicationCandidate(
     val trackNumberId: IntId<TrackLayoutTrackNumber>,
     override val draftChangeTime: Instant,
     override val userName: UserName,
-    override val errors: List<PublicationValidationError> = listOf(),
+    override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation?,
     override val publicationGroup: PublicationGroup? = null,
     val boundingBox: BoundingBox?,
@@ -343,7 +343,7 @@ data class LocationTrackPublicationCandidate(
     override val draftChangeTime: Instant,
     val duplicateOf: IntId<LocationTrack>?,
     override val userName: UserName,
-    override val errors: List<PublicationValidationError> = listOf(),
+    override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation,
     override val publicationGroup: PublicationGroup? = null,
     val boundingBox: BoundingBox?,
@@ -358,7 +358,7 @@ data class SwitchPublicationCandidate(
     val trackNumberIds: List<IntId<TrackLayoutTrackNumber>>,
     override val draftChangeTime: Instant,
     override val userName: UserName,
-    override val errors: List<PublicationValidationError> = listOf(),
+    override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation,
     override val publicationGroup: PublicationGroup? = null,
     val location: Point?,
@@ -373,7 +373,7 @@ data class KmPostPublicationCandidate(
     val kmNumber: KmNumber,
     override val draftChangeTime: Instant,
     override val userName: UserName,
-    override val errors: List<PublicationValidationError> = listOf(),
+    override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation,
     override val publicationGroup: PublicationGroup? = null,
     val location: Point?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -9,8 +9,8 @@ import fi.fta.geoviite.infra.math.IntersectType.WITHIN
 import fi.fta.geoviite.infra.math.angleDiffRads
 import fi.fta.geoviite.infra.math.directionBetweenPoints
 import fi.fta.geoviite.infra.math.lineLength
-import fi.fta.geoviite.infra.publication.PublicationValidationErrorType.ERROR
-import fi.fta.geoviite.infra.publication.PublicationValidationErrorType.WARNING
+import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.ERROR
+import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.WARNING
 import fi.fta.geoviite.infra.switchLibrary.SwitchConnectivityType
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.switchConnectivityType
@@ -32,7 +32,7 @@ const val MAX_LAYOUT_POINT_ANGLE_CHANGE = PI / 2
 const val MAX_LAYOUT_METER_LENGTH = 2.0
 const val MAX_KM_POST_OFFSET = 10.0
 
-fun validateDraftTrackNumberFields(trackNumber: TrackLayoutTrackNumber): List<PublicationValidationError> =
+fun validateDraftTrackNumberFields(trackNumber: TrackLayoutTrackNumber): List<LayoutValidationIssue> =
     listOfNotNull(validate(trackNumber.state.isPublishable()) { "$VALIDATION_TRACK_NUMBER.state.${trackNumber.state}" })
 
 fun validateTrackNumberReferences(
@@ -40,7 +40,7 @@ fun validateTrackNumberReferences(
     referenceLine: ReferenceLine?,
     kmPosts: List<TrackLayoutKmPost>,
     locationTracks: List<LocationTrack>,
-): List<PublicationValidationError> = listOfNotNull(
+): List<LayoutValidationIssue> = listOfNotNull(
     validate(referenceLine != null) { "$VALIDATION_TRACK_NUMBER.reference-line.not-published" },
     locationTracks.filter(LocationTrack::exists).let { existingTracks ->
         validateWithParams(trackNumber.exists || existingTracks.isEmpty()) {
@@ -59,16 +59,16 @@ fun validateTrackNumberReferences(
 fun validateTrackNumberNumberDuplication(
     trackNumber: TrackLayoutTrackNumber,
     duplicates: List<TrackLayoutTrackNumber>,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     return if (trackNumber.exists) {
         val officialDuplicateExists = duplicates.any { d -> d.id != trackNumber.id && d.isOfficial }
         val draftDuplicateExists = duplicates.any { d -> d.id != trackNumber.id && d.isDraft }
 
         listOfNotNull(
-            if (!draftDuplicateExists && officialDuplicateExists) PublicationValidationError(
+            if (!draftDuplicateExists && officialDuplicateExists) LayoutValidationIssue(
                 ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-official", mapOf("trackNumber" to trackNumber.number)
             ) else null,
-            if (draftDuplicateExists) PublicationValidationError(
+            if (draftDuplicateExists) LayoutValidationIssue(
                 ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-draft", mapOf("trackNumber" to trackNumber.number)
             ) else null,
         )
@@ -78,7 +78,7 @@ fun validateTrackNumberNumberDuplication(
 }
 
 //Location is validated by GeocodingContext
-fun validateDraftKmPostFields(kmPost: TrackLayoutKmPost): List<PublicationValidationError> =
+fun validateDraftKmPostFields(kmPost: TrackLayoutKmPost): List<LayoutValidationIssue> =
     listOfNotNull(validate(kmPost.state.isPublishable()) { "$VALIDATION_KM_POST.state.${kmPost.state}" })
 
 fun validateKmPostReferences(
@@ -86,7 +86,7 @@ fun validateKmPostReferences(
     trackNumber: TrackLayoutTrackNumber?,
     referenceLine: ReferenceLine?,
     trackNumberNumber: TrackNumber?,
-): List<PublicationValidationError> = listOfNotNull(
+): List<LayoutValidationIssue> = listOfNotNull(
     validateWithParams(trackNumber != null) {
         "$VALIDATION_KM_POST.track-number.not-published" to localizationParams("trackNumber" to trackNumberNumber)
     },
@@ -101,14 +101,14 @@ fun validateKmPostReferences(
     },
 )
 
-fun validateDraftSwitchFields(switch: TrackLayoutSwitch): List<PublicationValidationError> = listOfNotNull(
+fun validateDraftSwitchFields(switch: TrackLayoutSwitch): List<LayoutValidationIssue> = listOfNotNull(
     validate(switch.stateCategory.isPublishable()) { "$VALIDATION_SWITCH.state-category.${switch.stateCategory}" },
 )
 
 fun validateSwitchLocationTrackLinkReferences(
     switch: TrackLayoutSwitch,
     locationTracks: List<LocationTrack>,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     return listOfNotNull(locationTracks.filter(LocationTrack::exists).let { existingTracks ->
         validateWithParams(switch.exists || existingTracks.isEmpty()) {
             val existingNames = existingTracks.joinToString(", ") { track -> track.name }
@@ -117,7 +117,7 @@ fun validateSwitchLocationTrackLinkReferences(
     })
 }
 
-fun validateSwitchLocation(switch: TrackLayoutSwitch): List<PublicationValidationError> =
+fun validateSwitchLocation(switch: TrackLayoutSwitch): List<LayoutValidationIssue> =
     listOfNotNull(validate(switch.joints.isNotEmpty()) {
         "$VALIDATION_SWITCH.no-location"
     })
@@ -125,7 +125,7 @@ fun validateSwitchLocation(switch: TrackLayoutSwitch): List<PublicationValidatio
 fun validateSwitchNameDuplication(
     switch: TrackLayoutSwitch,
     duplicates: List<TrackLayoutSwitch>,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     return if (switch.exists) {
         val officialDuplicateExists = duplicates.any { d -> d.id != switch.id && d.isOfficial }
         val draftDuplicateExists = duplicates.any { d -> d.id != switch.id && d.isDraft }
@@ -147,7 +147,7 @@ fun validateLocationTrackNameDuplication(
     track: LocationTrack,
     trackNumber: TrackNumber?,
     duplicates: List<LocationTrack>,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     return if (track.exists && duplicates.any { d -> d.id != track.id }) {
         // Location track names must be unique within the same track number, but there can be location tracks with the
         // same name on other track numbers
@@ -174,7 +174,7 @@ fun validateSwitchLocationTrackLinkStructure(
     switch: TrackLayoutSwitch,
     structure: SwitchStructure,
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     val existingTracks = locationTracks.filter { (track, _) -> track.exists }
     val segmentGroups = existingTracks // Only consider the non-deleted tracks for switch alignments
         .map { (track, alignment) -> track to alignment.segments.filter { segment -> segment.switchId == switch.id } }
@@ -216,7 +216,7 @@ fun validateSwitchLocationTrackLinkStructure(
 fun validateLocationTrackSwitchConnectivity(
     layoutTrack: LocationTrack,
     alignment: LayoutAlignment,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     val startSegment = alignment.segments.firstOrNull()
     val endSegment = alignment.segments.lastOrNull()
     val topologyStartSwitch = layoutTrack.topologyStartSwitch?.switchId
@@ -278,7 +278,7 @@ fun validateSwitchTopologicalConnectivity(
     structure: SwitchStructure,
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
     validatingTrack: LocationTrack?,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     val connectivityType = switchConnectivityType(structure)
     val nonDuplicateTracks = locationTracks.filter { (locationTrack, _) -> locationTrack.duplicateOf == null }
     val nonDuplicateTracksThroughJoints = getTracksThroughJoints(structure, nonDuplicateTracks, switch)
@@ -313,7 +313,7 @@ private fun validateFrontJointTopology(
     switchStructure: SwitchStructure,
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
     validatingTrack: LocationTrack?,
-): PublicationValidationError? {
+): LayoutValidationIssue? {
     val connectivityType = switchConnectivityType(switchStructure)
     fun tracksHaveOkFrontJointLink(tracks: List<Pair<LocationTrack, LayoutAlignment>>) =
         tracks.any { (locationTrack, _) ->
@@ -348,7 +348,7 @@ private fun validateExcessTracksThroughJoint(
     tracksThroughJoint: Map<JointNumber, List<LocationTrack>>,
     switchName: SwitchName,
     validatingTrack: LocationTrack?,
-): PublicationValidationError? {
+): LayoutValidationIssue? {
     val excesses = tracksThroughJoint.filter { (joint, tracks) ->
         joint != connectivityType.sharedPassThroughJoint && tracks.size > 1
     }
@@ -385,7 +385,7 @@ fun validateSwitchAlignmentTopology(
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
     switchName: SwitchName,
     validatingTrack: LocationTrack?,
-): PublicationValidationError? {
+): LayoutValidationIssue? {
     val nonDuplicateTracks = locationTracks.filter { (lt) -> lt.duplicateOf == null }
     val switchAlignmentsUnlinkedToNonduplicates = connectivityType.trackLinkedAlignmentsJoints.filter { switchAlignment ->
         nonDuplicateTracks.none { (_, alignment) ->
@@ -443,7 +443,7 @@ fun validateDuplicateOfState(
     duplicateOfLocationTrack: LocationTrack?,
     duplicateOfLocationTrackDraftName: AlignmentName?,
     duplicates: List<LocationTrack>,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     val duplicateNameParams = localizationParams(
         "duplicateTrack" to (duplicateOfLocationTrack?.name ?: duplicateOfLocationTrackDraftName)
     )
@@ -486,7 +486,7 @@ fun validateDuplicateOfState(
     return ownDuplicateOfErrors + otherDuplicateReferenceErrors
 }
 
-fun validateDraftLocationTrackFields(locationTrack: LocationTrack): List<PublicationValidationError> = listOfNotNull(
+fun validateDraftLocationTrackFields(locationTrack: LocationTrack): List<LayoutValidationIssue> = listOfNotNull(
     validate(locationTrack.state.isPublishable()) { "$VALIDATION_LOCATION_TRACK.state.${locationTrack.state}" },
 )
 
@@ -494,7 +494,7 @@ fun validateReferenceLineReference(
     referenceLine: ReferenceLine,
     trackNumberNumber: TrackNumber?,
     trackNumber: TrackLayoutTrackNumber?,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     val numberParams = localizationParams("trackNumber" to trackNumberNumber)
     return listOfNotNull(
         validateWithParams(trackNumber != null) {
@@ -510,7 +510,7 @@ fun validateLocationTrackReference(
     locationTrack: LocationTrack,
     trackNumber: TrackLayoutTrackNumber?,
     trackNumberName: TrackNumber?,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     return if (trackNumber == null) listOf(
         validationError("$VALIDATION_LOCATION_TRACK.track-number.not-published", "trackNumber" to trackNumberName),
     )
@@ -538,7 +538,7 @@ data class SegmentSwitch(
 fun validateSegmentSwitchReferences(
     locationTrack: LocationTrack,
     segmentSwitches: List<SegmentSwitch>,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     return segmentSwitches.flatMap { segmentSwitch ->
         val switch = segmentSwitch.switch
         val switchStructure = segmentSwitch.switchStructure
@@ -549,7 +549,7 @@ fun validateSegmentSwitchReferences(
         if (switch == null || switchStructure == null) {
             listOf(validationError("$VALIDATION_LOCATION_TRACK.switch.not-published", nameLocalizationParams))
         } else {
-            val stateErrors: List<PublicationValidationError> = listOfNotNull(
+            val stateErrors: List<LayoutValidationIssue> = listOfNotNull(
                 validateWithParams(segments.all { segment -> switch.id == segment.switchId }) {
                     "$VALIDATION_LOCATION_TRACK.switch.not-official" to nameLocalizationParams
                 },
@@ -558,7 +558,7 @@ fun validateSegmentSwitchReferences(
                 },
             )
 
-            val geometryErrors: List<PublicationValidationError> = if (locationTrack.exists && switch.exists) {
+            val geometryErrors: List<LayoutValidationIssue> = if (locationTrack.exists && switch.exists) {
                 val structureJoints = collectJoints(segmentSwitch.switchStructure)
                 val segmentJoints = collectJoints(segments)
                 listOfNotNull(
@@ -588,7 +588,7 @@ fun validateSegmentSwitchReferences(
 fun validateTopologicallyConnectedSwitchReferences(
     locationTrack: LocationTrack,
     topologicallyConnectedSwitches: List<Pair<SwitchName, TrackLayoutSwitch?>>,
-): List<PublicationValidationError> = topologicallyConnectedSwitches.mapNotNull { (name, switch) ->
+): List<LayoutValidationIssue> = topologicallyConnectedSwitches.mapNotNull { (name, switch) ->
     val nameParams = localizationParams("switch" to name)
     if (switch == null) {
         validationError("$VALIDATION_LOCATION_TRACK.switch.not-published", nameParams)
@@ -603,12 +603,12 @@ private fun jointSequence(joints: List<JointNumber>) =
     joints.joinToString("-") { jointNumber -> "${jointNumber.intValue}" }
 
 fun noGeocodingContext(validationTargetLocalizationPrefix: String) =
-    PublicationValidationError(ERROR, "$validationTargetLocalizationPrefix.no-context")
+    LayoutValidationIssue(ERROR, "$validationTargetLocalizationPrefix.no-context")
 
 fun validateGeocodingContext(
     contextCreateResult: GeocodingContextCreateResult,
     trackNumber: TrackNumber,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     val context = contextCreateResult.geocodingContext
 
     val badStartPoint = validateWithParams(contextCreateResult.startPointRejectedReason == null) {
@@ -645,23 +645,23 @@ fun validateGeocodingContext(
         val kmPostLocalizationParams = mapOf("trackNumber" to trackNumber, "kmNumber" to kmPost.kmNumber)
 
         when (reason) {
-            KmPostRejectedReason.TOO_FAR_APART -> PublicationValidationError(
+            KmPostRejectedReason.TOO_FAR_APART -> LayoutValidationIssue(
                 ERROR, "$VALIDATION_GEOCODING.km-post-too-long", kmPostLocalizationParams
             )
 
-            KmPostRejectedReason.NO_LOCATION -> PublicationValidationError(
+            KmPostRejectedReason.NO_LOCATION -> LayoutValidationIssue(
                 ERROR, "$VALIDATION_GEOCODING.km-post-no-location", kmPostLocalizationParams
             )
 
-            KmPostRejectedReason.IS_BEFORE_START_ADDRESS -> PublicationValidationError(
+            KmPostRejectedReason.IS_BEFORE_START_ADDRESS -> LayoutValidationIssue(
                 WARNING, "$VALIDATION_GEOCODING.km-post-smaller-than-track-number-start", kmPostLocalizationParams
             )
 
-            KmPostRejectedReason.INTERSECTS_BEFORE_REFERENCE_LINE -> PublicationValidationError(
+            KmPostRejectedReason.INTERSECTS_BEFORE_REFERENCE_LINE -> LayoutValidationIssue(
                 WARNING, "$VALIDATION_GEOCODING.km-post-outside-line-before", kmPostLocalizationParams
             )
 
-            KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE -> PublicationValidationError(
+            KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE -> LayoutValidationIssue(
                 WARNING, "$VALIDATION_GEOCODING.km-post-outside-line-after", kmPostLocalizationParams
             )
         }
@@ -679,21 +679,21 @@ fun validateAddressPoints(
     locationTrack: LocationTrack,
     validationTargetLocalizationPrefix: String,
     geocode: () -> AlignmentAddresses?,
-): List<PublicationValidationError> = try {
+): List<LayoutValidationIssue> = try {
     geocode()?.let { addresses ->
         validateAddressPoints(trackNumber, locationTrack, addresses)
     } ?: listOf(
-        PublicationValidationError(ERROR, "$validationTargetLocalizationPrefix.no-context", emptyMap()),
+        LayoutValidationIssue(ERROR, "$validationTargetLocalizationPrefix.no-context", emptyMap()),
     )
 } catch (e: ClientException) {
-    listOf(PublicationValidationError(ERROR, e.localizationKey))
+    listOf(LayoutValidationIssue(ERROR, e.localizationKey))
 }
 
 fun validateAddressPoints(
     trackNumber: TrackLayoutTrackNumber,
     locationTrack: LocationTrack,
     addresses: AlignmentAddresses,
-): List<PublicationValidationError> {
+): List<LayoutValidationIssue> {
     val allPoints = listOf(addresses.startPoint) + addresses.midPoints + listOf(addresses.endPoint)
     val allCoordinates = allPoints.map(AddressPoint::point)
     val allAddresses = allPoints.map(AddressPoint::address)
@@ -835,15 +835,15 @@ private fun isAddressDiffOk(address1: TrackMeter?, address2: TrackMeter?): Boole
     else if (address1.kmNumber != address2.kmNumber) true
     else (address2.meters - address1.meters).toDouble() in 0.0..MAX_LAYOUT_METER_LENGTH
 
-fun validate(valid: Boolean, type: PublicationValidationErrorType = ERROR, error: () -> String) =
+fun validate(valid: Boolean, type: LayoutValidationIssueType = ERROR, error: () -> String) =
     validateWithParams(valid, type) { error() to LocalizationParams.empty }
 
 private fun validateWithParams(
     valid: Boolean,
-    type: PublicationValidationErrorType = ERROR,
+    type: LayoutValidationIssueType = ERROR,
     error: () -> Pair<String, LocalizationParams>,
-): PublicationValidationError? = if (!valid) {
-    error().let { (key, params) -> PublicationValidationError(type, LocalizationKey(key), params) }
+): LayoutValidationIssue? = if (!valid) {
+    error().let { (key, params) -> LayoutValidationIssue(type, LocalizationKey(key), params) }
 } else {
     null
 }
@@ -877,14 +877,14 @@ fun <T> combineVersions(
     return (officialVersions + validationVersions).distinct()
 }
 
-fun validationError(key: String, vararg params: Pair<String, Any?>): PublicationValidationError =
-    PublicationValidationError(ERROR, key, params.associate { it })
+fun validationError(key: String, vararg params: Pair<String, Any?>): LayoutValidationIssue =
+    LayoutValidationIssue(ERROR, key, params.associate { it })
 
-fun validationError(key: String, params: LocalizationParams): PublicationValidationError =
-    PublicationValidationError(ERROR, LocalizationKey(key), params)
+fun validationError(key: String, params: LocalizationParams): LayoutValidationIssue =
+    LayoutValidationIssue(ERROR, LocalizationKey(key), params)
 
-fun validationWarning(key: String, vararg params: Pair<String, Any?>): PublicationValidationError =
-    PublicationValidationError(WARNING, key, params.associate { it })
+fun validationWarning(key: String, vararg params: Pair<String, Any?>): LayoutValidationIssue =
+    LayoutValidationIssue(WARNING, key, params.associate { it })
 
-fun validationWarning(key: String, params: LocalizationParams): PublicationValidationError =
-    PublicationValidationError(WARNING, LocalizationKey(key), params)
+fun validationWarning(key: String, params: LocalizationParams): LayoutValidationIssue =
+    LayoutValidationIssue(WARNING, LocalizationKey(key), params)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -95,7 +95,7 @@ data class SplitLayoutValidationIssues(
     val locationTracks: Map<IntId<LocationTrack>, List<LayoutValidationIssue>>,
     val switches: Map<IntId<TrackLayoutSwitch>, List<LayoutValidationIssue>>,
 ) {
-    fun allErrors(): List<LayoutValidationIssue> =
+    fun allIssues(): List<LayoutValidationIssue> =
         (trackNumbers.values + referenceLines.values + kmPosts.values + locationTracks.values + switches.values).flatten()
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -5,7 +5,7 @@ import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.publication.Publication
-import fi.fta.geoviite.infra.publication.PublicationValidationError
+import fi.fta.geoviite.infra.publication.LayoutValidationIssue
 import fi.fta.geoviite.infra.tracklayout.DescriptionSuffixType
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
@@ -88,14 +88,14 @@ data class SplitTarget(
     val operation: SplitTargetOperation,
 )
 
-data class SplitPublicationValidationErrors(
-    val trackNumbers: Map<IntId<TrackLayoutTrackNumber>, List<PublicationValidationError>>,
-    val referenceLines: Map<IntId<ReferenceLine>, List<PublicationValidationError>>,
-    val kmPosts: Map<IntId<TrackLayoutKmPost>, List<PublicationValidationError>>,
-    val locationTracks: Map<IntId<LocationTrack>, List<PublicationValidationError>>,
-    val switches: Map<IntId<TrackLayoutSwitch>, List<PublicationValidationError>>,
+data class SplitLayoutValidationIssues(
+    val trackNumbers: Map<IntId<TrackLayoutTrackNumber>, List<LayoutValidationIssue>>,
+    val referenceLines: Map<IntId<ReferenceLine>, List<LayoutValidationIssue>>,
+    val kmPosts: Map<IntId<TrackLayoutKmPost>, List<LayoutValidationIssue>>,
+    val locationTracks: Map<IntId<LocationTrack>, List<LayoutValidationIssue>>,
+    val switches: Map<IntId<TrackLayoutSwitch>, List<LayoutValidationIssue>>,
 ) {
-    fun allErrors(): List<PublicationValidationError> =
+    fun allErrors(): List<LayoutValidationIssue> =
         (trackNumbers.values + referenceLines.values + kmPosts.values + locationTracks.values + switches.values).flatten()
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
@@ -36,7 +36,7 @@ class ValidationTest {
         val alignment = geometryAlignment(
             elements = lines(Point(1.0, 2.0), 1, 12.34, 1.0)
         )
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateAlignmentGeometry(alignment),
             listOf("$VALIDATION_ELEMENT.field-incorrect-length"),
         )
@@ -45,7 +45,7 @@ class ValidationTest {
     @Test
     fun validationFindsNonContinuousLine() {
         val lines = lines(Point(1.0, 2.0), 3, 12.34).filterIndexed { i, _ -> i % 2 == 0 }
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateAlignmentGeometry(geometryAlignment(elements = lines)),
             listOf("$VALIDATION_ELEMENT.coordinates-not-continuous")
         )
@@ -56,7 +56,7 @@ class ValidationTest {
         val alignment = geometryAlignment(
             elements = lines(Point(1.0, 2.0), 1, 12.34, 1.0)
         )
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateAlignmentCant(alignment),
             listOf("$VALIDATION_ALIGNMENT.no-cant"),
         )
@@ -68,7 +68,7 @@ class ValidationTest {
             elements = lines(Point(1.0, 2.0), 1, 12.34, 1.0),
             profile = null,
         )
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateAlignmentProfile(alignment),
             listOf("$VALIDATION_ALIGNMENT.no-profile"),
         )
@@ -92,7 +92,7 @@ class ValidationTest {
             viPoint(3.0, 0.04),
         )
         val alignment = geometryAlignment(profile = profile(points))
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateAlignmentProfile(alignment),
             listOf("$VALIDATION_PROFILE.incorrect-station", "$VALIDATION_PROFILE.calculation-failed"),
         )
@@ -105,7 +105,7 @@ class ValidationTest {
             viPoint(2.0, 2.0),
         )
         val alignment = geometryAlignment(profile = profile(points))
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateAlignmentProfile(alignment),
             listOf("$VALIDATION_PROFILE.incorrect-slope"),
         )
@@ -130,7 +130,7 @@ class ValidationTest {
             cantPoint(3.0, 0.3, CCW),
         )
         val alignment = geometryAlignment(cant = cant(points))
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateAlignmentCant(alignment),
             listOf("$VALIDATION_CANT.station-not-continuous"),
         )
@@ -150,7 +150,7 @@ class ValidationTest {
             featureTypeCode = FeatureTypeCode("281"), // cant should exist on tracks
         )
 
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateAlignmentCant(alignment),
             listOf("$VALIDATION_ALIGNMENT.cant-rotation-point-undefined"),
         )
@@ -164,7 +164,7 @@ class ValidationTest {
             cantPoint(3.0, 0.3, CCW),
         )
         val alignment = geometryAlignment(cant = cant(points))
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateAlignmentCant(alignment),
             listOf("$VALIDATION_CANT.value-incorrect"),
         )
@@ -201,7 +201,7 @@ class ValidationTest {
         val alignmentSwitches = alignments.mapNotNull { alignment ->
             collectAlignmentSwitchJoints(invalidSwitch.id, alignment)
         }
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateSwitch(invalidSwitch, yvStructure, alignmentSwitches),
             listOf("$VALIDATION_SWITCH.incorrect-joint-locations"),
         )
@@ -226,13 +226,13 @@ class ValidationTest {
         val alignmentSwitches = alignments.mapNotNull { alignment ->
             collectAlignmentSwitchJoints(inaccurateSwitch.id, alignment)
         }
-        assertValidationErrors(
+        assertGeometryValidationIssues(
             validateSwitch(inaccurateSwitch, yvStructure, alignmentSwitches),
             listOf("$VALIDATION_SWITCH.inaccurate-joint-locations"),
         )
     }
 
-    private fun assertValidationErrors(
+    private fun assertGeometryValidationIssues(
         errors: List<GeometryValidationIssue>,
         keyParts: List<String>
     ) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
@@ -28,7 +28,7 @@ class ValidationTest {
         val alignment = geometryAlignment(
             elements = lines(Point(1.0, 2.0), 4, 12.34)
         )
-        assertEquals(listOf<ValidationError>(), validateAlignmentGeometry(alignment))
+        assertEquals(listOf<GeometryValidationIssue>(), validateAlignmentGeometry(alignment))
     }
 
     @Test
@@ -81,7 +81,7 @@ class ValidationTest {
             viPoint(10.1, 1.0),
         )
         val alignment = geometryAlignment(profile = profile(points))
-        assertEquals(listOf<ValidationError>(), validateAlignmentProfile(alignment))
+        assertEquals(listOf<GeometryValidationIssue>(), validateAlignmentProfile(alignment))
     }
 
     @Test
@@ -119,7 +119,7 @@ class ValidationTest {
             cantPoint(2.1, 0.15, CCW),
         )
         val alignment = geometryAlignment(cant = cant(points))
-        assertEquals(listOf<ValidationError>(), validateAlignmentCant(alignment))
+        assertEquals(listOf<GeometryValidationIssue>(), validateAlignmentCant(alignment))
     }
 
     @Test
@@ -179,7 +179,7 @@ class ValidationTest {
         val alignmentSwitches = alignments.mapNotNull { alignment ->
             collectAlignmentSwitchJoints(switch.id, alignment)
         }
-        assertEquals(listOf<ValidationError>(), validateSwitch(switch, yvStructure, alignmentSwitches))
+        assertEquals(listOf<GeometryValidationIssue>(), validateSwitch(switch, yvStructure, alignmentSwitches))
     }
 
     @Test
@@ -233,7 +233,7 @@ class ValidationTest {
     }
 
     private fun assertValidationErrors(
-        errors: List<ValidationError>,
+        errors: List<GeometryValidationIssue>,
         keyParts: List<String>
     ) {
         assertEquals(keyParts.size, errors.size, errors.toString())

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelControllerIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelControllerIT.kt
@@ -30,10 +30,10 @@ internal class InfraModelControllerIT @Autowired constructor(
         )
         val result = infraModelService.validateInfraModelFile(emptyFile, null)
         assertNull(result.geometryPlan)
-        assertEquals(1, result.validationErrors.size)
+        assertEquals(1, result.geometryValidationIssues.size)
         assertEquals(
             LocalizationKey(INFRAMODEL_PARSING_KEY_EMPTY),
-            result.validationErrors[0].localizationKey,
+            result.geometryValidationIssues[0].localizationKey,
         )
     }
 
@@ -59,10 +59,10 @@ internal class InfraModelControllerIT @Autowired constructor(
         )
         val result = infraModelService.validateInfraModelFile(textFile, null)
         assertNull(result.geometryPlan)
-        assertEquals(1, result.validationErrors.size)
+        assertEquals(1, result.geometryValidationIssues.size)
         assertEquals(
             LocalizationKey("$INFRAMODEL_PARSING_KEY_PARENT.wrong-content-type"),
-            result.validationErrors[0].localizationKey,
+            result.geometryValidationIssues[0].localizationKey,
         )
     }
 
@@ -77,6 +77,6 @@ internal class InfraModelControllerIT @Autowired constructor(
         )
         val result = infraModelService.validateInfraModelFile(invalidFile, null)
         assertNull(result.geometryPlan)
-        assertEquals(1, result.validationErrors.size)
+        assertEquals(1, result.geometryValidationIssues.size)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -25,8 +25,8 @@ import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Range
-import fi.fta.geoviite.infra.publication.PublicationValidationError
-import fi.fta.geoviite.infra.publication.PublicationValidationErrorType
+import fi.fta.geoviite.infra.publication.LayoutValidationIssue
+import fi.fta.geoviite.infra.publication.LayoutValidationIssueType
 import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
@@ -991,14 +991,14 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 SwitchRelinkingValidationResult(
                     id = okSwitch.id,
                     successfulSuggestion = SwitchRelinkingSuggestion(Point(0.0, 0.0), TrackMeter("0000+0000.000")),
-                    validationErrors = listOf(),
+                    validationIssues = listOf(),
                 ),
                 SwitchRelinkingValidationResult(
                     id = okButValidationErrorSwitch.id,
                     successfulSuggestion = SwitchRelinkingSuggestion(shift1, TrackMeter("0000+0044.430")),
-                    validationErrors = listOf(
-                        PublicationValidationError(
-                            type = PublicationValidationErrorType.WARNING,
+                    validationIssues = listOf(
+                        LayoutValidationIssue(
+                            type = LayoutValidationIssueType.WARNING,
                             localizationKey = LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-only-connected-to-duplicate"),
                             params = LocalizationParams(mapOf("locationTracks" to "1-3", "switch" to "ok but val"))
                         )
@@ -1007,9 +1007,9 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 SwitchRelinkingValidationResult(
                     id = unsaveableSwitch.id,
                     successfulSuggestion = null,
-                    validationErrors = listOf(
-                        PublicationValidationError(
-                            type = PublicationValidationErrorType.ERROR,
+                    validationIssues = listOf(
+                        LayoutValidationIssue(
+                            type = LayoutValidationIssueType.ERROR,
                             localizationKey = LocalizationKey("validation.layout.switch.track-linkage.relinking-failed"),
                             params = LocalizationParams(mapOf("switch" to "unsaveable"))
                         )
@@ -1137,14 +1137,14 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 SwitchRelinkingValidationResult(
                     id = okSwitch.id,
                     successfulSuggestion = SwitchRelinkingSuggestion(basePoint, TrackMeter("0000+0010.000")),
-                    validationErrors = listOf(),
+                    validationIssues = listOf(),
                 ),
                 SwitchRelinkingValidationResult(
                     id = switchSomewhereElse.id,
                     successfulSuggestion = SwitchRelinkingSuggestion(somewhereElse, TrackMeter("0000+0100.000")),
-                    validationErrors = listOf(
-                        PublicationValidationError(
-                            PublicationValidationErrorType.WARNING,
+                    validationIssues = listOf(
+                        LayoutValidationIssue(
+                            LayoutValidationIssueType.WARNING,
                             localizationKey = LocalizationKey("validation.layout.switch.track-linkage.front-joint-not-connected"),
                             params = LocalizationParams(mapOf("switch" to "somewhere else")),
                         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -893,13 +893,13 @@ class PublicationValidationTest {
     }
 
     private fun assertContainsConnectivityWarning(
-        warnings: Collection<PublicationValidationError>,
+        warnings: Collection<LayoutValidationIssue>,
         translationKey: String,
     ) {
         assertContains(
             warnings,
-            PublicationValidationError(
-                PublicationValidationErrorType.WARNING,
+            LayoutValidationIssue(
+                LayoutValidationIssueType.WARNING,
                 "validation.layout.location-track.topological-connectivity.$translationKey",
             ),
         )
@@ -1021,7 +1021,7 @@ class PublicationValidationTest {
     private fun getSwitchSegmentStructureErrors(
         switch: TrackLayoutSwitch,
         tracks: List<Pair<LocationTrack, LayoutAlignment>>,
-    ): List<PublicationValidationError> = validateSwitchLocationTrackLinkStructure(switch, structure, tracks)
+    ): List<LayoutValidationIssue> = validateSwitchLocationTrackLinkStructure(switch, structure, tracks)
 
     private fun assertAddressPointError(hasError: Boolean, geocode: () -> AlignmentAddresses?, error: String) {
         assertContainsError(
@@ -1049,7 +1049,7 @@ class PublicationValidationTest {
         assertEquals(errorRangeDescription, errors[0].params.get("kmNumbers"))
     }
 
-    private fun assertContainsError(contains: Boolean, errors: List<PublicationValidationError>, error: String) {
+    private fun assertContainsError(contains: Boolean, errors: List<LayoutValidationIssue>, error: String) {
         val message = "Expected to ${if (contains) "have" else "not have"} error: expected=$error actual=$errors"
         assertEquals(contains, errors.any { e -> e.localizationKey == LocalizationKey(error) }, message)
     }

--- a/ui/src/api/api-fetch.ts
+++ b/ui/src/api/api-fetch.ts
@@ -365,10 +365,14 @@ async function tryToReadText(response: Response): Promise<string | undefined> {
 }
 
 const showHttpError = (path: string, response: ApiErrorResponse) => {
-    Snackbar.apiError(getLocalizedError(response, 'error.request-failed', { path }), path, response);
+    Snackbar.apiError(
+        getLocalizedIssue(response, 'error.request-failed', { path }),
+        path,
+        response,
+    );
 };
 
-export const getLocalizedError = (
+export const getLocalizedIssue = (
     response: ApiErrorResponse | undefined,
     defaultKey: string,
     defaultParams: LocalizationParams = {},

--- a/ui/src/data-products/data-products-slice.ts
+++ b/ui/src/data-products/data-products-slice.ts
@@ -3,8 +3,8 @@ import {
     isPropEditFieldCommitted,
     PropEdit,
     validate,
-    ValidationError,
-    ValidationErrorType,
+    FieldValidationIssue,
+    FieldValidationIssueType,
 } from 'utils/validation-utils';
 import { filterNotEmpty } from 'utils/array-utils';
 import {
@@ -36,7 +36,7 @@ export type PlanGeometrySearchState = {
     searchGeometries: SearchGeometries;
 
     elements: ElementItem[];
-    validationErrors: ValidationError<PlanGeometrySearchState>[];
+    validationIssues: FieldValidationIssue<PlanGeometrySearchState>[];
     committedFields: (keyof PlanGeometrySearchState)[];
 };
 
@@ -50,7 +50,7 @@ export type LocationTrackVerticalGeometrySearchState = {
     searchFields: LocationTrackVerticalGeometrySearchParameters;
     searchParameters: LocationTrackVerticalGeometrySearchParameters;
 
-    validationErrors: ValidationError<LocationTrackVerticalGeometrySearchParameters>[];
+    validationIssues: FieldValidationIssue<LocationTrackVerticalGeometrySearchParameters>[];
     committedFields: (keyof LocationTrackVerticalGeometrySearchParameters)[];
     verticalGeometry: VerticalGeometryItem[];
 };
@@ -59,7 +59,7 @@ export type PlanVerticalGeometrySearchState = {
     source: PlanSource;
     plan: GeometryPlanHeader | undefined;
 
-    validationErrors: ValidationError<PlanVerticalGeometrySearchState>[];
+    validationIssues: FieldValidationIssue<PlanVerticalGeometrySearchState>[];
     committedFields: (keyof PlanVerticalGeometrySearchState)[];
     verticalGeometry: VerticalGeometryItem[];
 };
@@ -71,7 +71,7 @@ export type KmLengthsSearchState = {
     startKm: KmNumber | undefined;
     endKm: KmNumber | undefined;
 
-    validationErrors: ValidationError<KmLengthsSearchState>[];
+    validationIssues: FieldValidationIssue<KmLengthsSearchState>[];
     committedFields: (keyof KmLengthsSearchState)[];
     kmLengths: LayoutKmLengthDetails[];
 
@@ -95,7 +95,7 @@ export const initialPlanGeometrySearchState: PlanGeometrySearchState = {
     },
 
     elements: [],
-    validationErrors: [],
+    validationIssues: [],
     committedFields: [],
 };
 
@@ -111,7 +111,7 @@ export type ElementListContinuousGeometrySearchState = {
     searchParameters: ContinuousSearchParameters;
 
     elements: ElementItem[];
-    validationErrors: ValidationError<ContinuousSearchParameters>[];
+    validationIssues: FieldValidationIssue<ContinuousSearchParameters>[];
     committedFields: (keyof ContinuousSearchParameters)[];
 };
 
@@ -141,7 +141,7 @@ export const initialContinuousSearchState: ElementListContinuousGeometrySearchSt
     },
 
     elements: [],
-    validationErrors: [],
+    validationIssues: [],
     committedFields: [],
 };
 
@@ -156,7 +156,7 @@ const initialLocationTrackVerticalGeometrySearchState: LocationTrackVerticalGeom
         startTrackMeter: '',
         endTrackMeter: '',
     },
-    validationErrors: [],
+    validationIssues: [],
     committedFields: [],
     verticalGeometry: [],
 };
@@ -164,7 +164,7 @@ const initialLocationTrackVerticalGeometrySearchState: LocationTrackVerticalGeom
 const initialPlanVerticalGeometrySearchState: PlanVerticalGeometrySearchState = {
     plan: undefined,
     source: 'GEOMETRIAPALVELU',
-    validationErrors: [],
+    validationIssues: [],
     committedFields: [],
     verticalGeometry: [],
 };
@@ -176,7 +176,7 @@ const initialKmLengthsSearchState: KmLengthsSearchState = {
     startKm: undefined,
     endKm: undefined,
 
-    validationErrors: [],
+    validationIssues: [],
     committedFields: [],
     kmLengths: [],
 };
@@ -207,12 +207,12 @@ export const validTrackMeterOrUndefined = (trackMeterCandidate: string) => {
 
 const validateContinuousGeometry = (
     state: ElementListContinuousGeometrySearchState,
-): ValidationError<ContinuousSearchParameters>[] =>
+): FieldValidationIssue<ContinuousSearchParameters>[] =>
     [
         validate(hasAtLeastOneTypeSelected(state.searchFields.searchGeometries), {
             field: 'searchGeometries',
             reason: 'no-types-selected',
-            type: ValidationErrorType.ERROR,
+            type: FieldValidationIssueType.ERROR,
         }),
         validate(
             state.searchFields.startTrackMeter === '' ||
@@ -220,7 +220,7 @@ const validateContinuousGeometry = (
             {
                 field: 'startTrackMeter',
                 reason: 'invalid-track-meter',
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ),
         validate(
@@ -233,7 +233,7 @@ const validateContinuousGeometry = (
             {
                 field: 'endTrackMeter',
                 reason: 'end-before-start',
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ),
         validate(
@@ -242,14 +242,14 @@ const validateContinuousGeometry = (
             {
                 field: 'endTrackMeter' as keyof ContinuousSearchParameters,
                 reason: 'invalid-track-meter',
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ),
     ].filter(filterNotEmpty);
 
 const validateLocationTrackVerticalGeometrySearch = (
     state: LocationTrackVerticalGeometrySearchState,
-): ValidationError<LocationTrackVerticalGeometrySearchParameters>[] =>
+): FieldValidationIssue<LocationTrackVerticalGeometrySearchParameters>[] =>
     [
         validate(
             state.searchFields.startTrackMeter === '' ||
@@ -257,7 +257,7 @@ const validateLocationTrackVerticalGeometrySearch = (
             {
                 field: 'startTrackMeter',
                 reason: 'invalid-track-meter',
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ),
         validate(
@@ -270,7 +270,7 @@ const validateLocationTrackVerticalGeometrySearch = (
             {
                 field: 'endTrackMeter',
                 reason: 'end-before-start',
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ),
         validate(
@@ -279,7 +279,7 @@ const validateLocationTrackVerticalGeometrySearch = (
             {
                 field: 'endTrackMeter' as keyof LocationTrackVerticalGeometrySearchParameters,
                 reason: 'invalid-track-meter',
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ),
     ].filter(filterNotEmpty);
@@ -300,8 +300,8 @@ export const continuousGeometrySearchSlice = createSlice({
                 state.searchFields['endTrackMeter'] = '';
             }
 
-            state.validationErrors = validateContinuousGeometry(state);
-            if (isPropEditFieldCommitted(propEdit, state.committedFields, state.validationErrors)) {
+            state.validationIssues = validateContinuousGeometry(state);
+            if (isPropEditFieldCommitted(propEdit, state.committedFields, state.validationIssues)) {
                 // Valid value entered for a field, mark that field as committed
                 state.committedFields = [...state.committedFields, propEdit.key];
             }
@@ -334,14 +334,14 @@ export const planSearchSlice = createSlice({
             { payload: propEdit }: PayloadAction<PropEdit<PlanGeometrySearchState, TKey>>,
         ) {
             state[propEdit.key] = propEdit.value;
-            state.validationErrors = [
+            state.validationIssues = [
                 validate(hasAtLeastOneTypeSelected(state.searchGeometries), {
                     field: 'searchGeometries' as keyof PlanGeometrySearchState,
                     reason: 'no-types-selected',
-                    type: ValidationErrorType.ERROR,
+                    type: FieldValidationIssueType.ERROR,
                 }),
             ].filter(filterNotEmpty);
-            if (isPropEditFieldCommitted(propEdit, state.committedFields, state.validationErrors)) {
+            if (isPropEditFieldCommitted(propEdit, state.committedFields, state.validationIssues)) {
                 // Valid value entered for a field, mark that field as committed
                 state.committedFields = [...state.committedFields, propEdit.key];
             }
@@ -375,8 +375,8 @@ export const locationTrackVerticalGeometrySearchSlice = createSlice({
                 state.searchFields['endTrackMeter'] = '';
             }
 
-            state.validationErrors = validateLocationTrackVerticalGeometrySearch(state);
-            if (isPropEditFieldCommitted(propEdit, state.committedFields, state.validationErrors)) {
+            state.validationIssues = validateLocationTrackVerticalGeometrySearch(state);
+            if (isPropEditFieldCommitted(propEdit, state.committedFields, state.validationIssues)) {
                 // Valid value entered for a field, mark that field as committed
                 state.committedFields = [...state.committedFields, propEdit.key];
             }
@@ -410,7 +410,7 @@ export const planVerticalGeometrySearchSlice = createSlice({
             { payload: propEdit }: PayloadAction<PropEdit<PlanVerticalGeometrySearchState, TKey>>,
         ) {
             state[propEdit.key] = propEdit.value;
-            if (isPropEditFieldCommitted(propEdit, state.committedFields, state.validationErrors)) {
+            if (isPropEditFieldCommitted(propEdit, state.committedFields, state.validationIssues)) {
                 // Valid value entered for a field, mark that field as committed
                 state.committedFields = [...state.committedFields, propEdit.key];
             }
@@ -442,11 +442,11 @@ export const kmLengthsSearchSlice = createSlice({
                     new Set([...state.committedFields, propEdit.key]),
                 );
             }
-            state.validationErrors = [
+            state.validationIssues = [
                 validate(!state.startKm || !state.endKm || state.endKm >= state.startKm, {
                     field: 'endKm',
                     reason: 'km-end-before-start',
-                    type: ValidationErrorType.ERROR,
+                    type: FieldValidationIssueType.ERROR,
                 }),
             ].filter(filterNotEmpty);
         },

--- a/ui/src/data-products/data-products-utils.ts
+++ b/ui/src/data-products/data-products-utils.ts
@@ -2,7 +2,7 @@ import { GeometryPlanHeader, PlanSource } from 'geometry/geometry-model';
 import { isNilOrBlank } from 'utils/string-utils';
 import { getGeometryPlanHeadersBySearchTerms } from 'geometry/geometry-api';
 import { debounceAsync } from 'utils/async-utils';
-import { ValidationError } from 'utils/validation-utils';
+import { FieldValidationIssue } from 'utils/validation-utils';
 import { getLocationTracksBySearchTerm } from 'track-layout/layout-location-track-api';
 import { LayoutLocationTrack, LocationTrackDescription } from 'track-layout/track-layout-model';
 import { CoordinateSystem, Srid } from 'common/common-model';
@@ -55,19 +55,19 @@ export const getLocationTrackOptions = (
 
 export function getVisibleErrorsByProp<T>(
     committedFields: (keyof T)[],
-    validationErrors: ValidationError<T>[],
+    validationIssues: FieldValidationIssue<T>[],
     prop: keyof T,
 ): string[] {
     return committedFields.includes(prop)
-        ? validationErrors.filter((error) => error.field == prop).map((error) => error.reason)
+        ? validationIssues.filter((error) => error.field == prop).map((error) => error.reason)
         : [];
 }
 
 export const hasErrors = <T>(
     committedFields: (keyof T)[],
-    validationErrors: ValidationError<T>[],
+    validationIssues: FieldValidationIssue<T>[],
     prop: keyof T,
-) => getVisibleErrorsByProp(committedFields, validationErrors, prop).length > 0;
+) => getVisibleErrorsByProp(committedFields, validationIssues, prop).length > 0;
 
 export type ElementHeading = {
     name: string;

--- a/ui/src/data-products/element-list/location-track-element-listing-search.tsx
+++ b/ui/src/data-products/element-list/location-track-element-listing-search.tsx
@@ -82,9 +82,9 @@ const LocationTrackElementListingSearch = ({
 
     const [elementList, fetchStatus] = useLoaderWithStatus(() => {
         return !state.searchParameters.locationTrack ||
-            hasErrors(state.committedFields, state.validationErrors, 'searchGeometries') ||
-            hasErrors(state.committedFields, state.validationErrors, 'startTrackMeter') ||
-            hasErrors(state.committedFields, state.validationErrors, 'endTrackMeter')
+            hasErrors(state.committedFields, state.validationIssues, 'searchGeometries') ||
+            hasErrors(state.committedFields, state.validationIssues, 'startTrackMeter') ||
+            hasErrors(state.committedFields, state.validationIssues, 'endTrackMeter')
             ? Promise.resolve(state.elements)
             : debouncedTrackElementsFetch(
                   state.searchParameters.locationTrack.id,
@@ -131,7 +131,7 @@ const LocationTrackElementListingSearch = ({
                             onBlur={() => onCommitField('startTrackMeter')}
                             hasError={hasErrors(
                                 state.committedFields,
-                                state.validationErrors,
+                                state.validationIssues,
                                 'startTrackMeter',
                             )}
                             wide
@@ -139,7 +139,7 @@ const LocationTrackElementListingSearch = ({
                     }
                     errors={getVisibleErrorsByProp(
                         state.committedFields,
-                        state.validationErrors,
+                        state.validationIssues,
                         'startTrackMeter',
                     ).map((error) => t(`data-products.search.${error}`))}
                 />
@@ -153,7 +153,7 @@ const LocationTrackElementListingSearch = ({
                             onBlur={() => onCommitField('endTrackMeter')}
                             hasError={hasErrors(
                                 state.committedFields,
-                                state.validationErrors,
+                                state.validationIssues,
                                 'endTrackMeter',
                             )}
                             wide
@@ -161,7 +161,7 @@ const LocationTrackElementListingSearch = ({
                     }
                     errors={getVisibleErrorsByProp(
                         state.committedFields,
-                        state.validationErrors,
+                        state.validationIssues,
                         'endTrackMeter',
                     ).map((error) => t(`data-products.search.${error}`))}
                 />
@@ -220,7 +220,7 @@ const LocationTrackElementListingSearch = ({
                         }
                         errors={getVisibleErrorsByProp(
                             state.committedFields,
-                            state.validationErrors,
+                            state.validationIssues,
                             'searchGeometries',
                         ).map((error) => t(`data-products.search.${error}`))}
                     />

--- a/ui/src/data-products/element-list/plan-geometry-element-listing-search.tsx
+++ b/ui/src/data-products/element-list/plan-geometry-element-listing-search.tsx
@@ -62,7 +62,7 @@ const PlanGeometryElementListingSearch = ({
 
     function hasErrors(prop: keyof PlanGeometrySearchState) {
         return (
-            getVisibleErrorsByProp(state.committedFields, state.validationErrors, prop).length > 0
+            getVisibleErrorsByProp(state.committedFields, state.validationIssues, prop).length > 0
         );
     }
 
@@ -164,7 +164,7 @@ const PlanGeometryElementListingSearch = ({
                         }
                         errors={getVisibleErrorsByProp(
                             state.committedFields,
-                            state.validationErrors,
+                            state.validationIssues,
                             'searchGeometries',
                         ).map((error) => t(`data-products.search.${error}`))}
                     />

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-search.tsx
@@ -134,7 +134,7 @@ export const KilometerLengthsSearch: React.FC<KilometerLengthsSearchProps> = ({
                     }
                     errors={getVisibleErrorsByProp(
                         state.committedFields,
-                        state.validationErrors,
+                        state.validationIssues,
                         'endKm',
                     ).map((error) => t(`data-products.search.${error}`))}
                 />

--- a/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
+++ b/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
@@ -82,8 +82,8 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
             return Promise.resolve([]);
         }
         if (
-            hasErrors(state.committedFields, state.validationErrors, 'startTrackMeter') ||
-            hasErrors(state.committedFields, state.validationErrors, 'endTrackMeter')
+            hasErrors(state.committedFields, state.validationIssues, 'startTrackMeter') ||
+            hasErrors(state.committedFields, state.validationIssues, 'endTrackMeter')
         ) {
             return Promise.resolve(state.verticalGeometry);
         }
@@ -132,7 +132,7 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
                             onBlur={() => onCommitField('startTrackMeter')}
                             hasError={hasErrors(
                                 state.committedFields,
-                                state.validationErrors,
+                                state.validationIssues,
                                 'startTrackMeter',
                             )}
                             wide
@@ -140,7 +140,7 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
                     }
                     errors={getVisibleErrorsByProp(
                         state.committedFields,
-                        state.validationErrors,
+                        state.validationIssues,
                         'startTrackMeter',
                     ).map((error) => t(`data-products.search.${error}`))}
                 />
@@ -153,7 +153,7 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
                             onBlur={() => onCommitField('endTrackMeter')}
                             hasError={hasErrors(
                                 state.committedFields,
-                                state.validationErrors,
+                                state.validationIssues,
                                 'endTrackMeter',
                             )}
                             wide
@@ -161,7 +161,7 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
                     }
                     errors={getVisibleErrorsByProp(
                         state.committedFields,
-                        state.validationErrors,
+                        state.validationIssues,
                         'endTrackMeter',
                     ).map((error) => t(`data-products.search.${error}`))}
                 />

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -1,7 +1,7 @@
 import {
     API_URI,
     ApiErrorResponse,
-    getLocalizedError,
+    getLocalizedIssue,
     getNonNull,
     postFormNonNullAdt,
     putFormNonNullAdt,
@@ -42,26 +42,26 @@ export const inframodelDownloadUri = (planId: GeometryPlanId) => `${INFRAMODEL_U
 export const projektivelhoDocumentDownloadUri = (docId: PVDocumentId) =>
     `${PROJEKTIVELHO_URI}/${docId}`;
 
-const defaultValidationErrorHandler = (
+const defaultValidationIssueHandler = (
     response: ApiErrorResponse | undefined,
 ): ValidationResponse => ({
     ...EMPTY_VALIDATION_RESPONSE,
     geometryValidationIssues: [
         {
-            localizationKey: getLocalizedError(response, 'error.infra-model.request-failed'),
+            localizationKey: getLocalizedIssue(response, 'error.infra-model.request-failed'),
             issueType: 'REQUEST_ERROR',
         },
     ],
 });
 
-export const getValidationErrorsForInfraModelFile = async (
+export const getGeometryValidationIssuesForInfraModelFile = async (
     file?: File,
     overrideParameters?: OverrideInfraModelParameters,
 ): Promise<ValidationResponse> => {
     if (file) {
         const formData = createFormData(file, undefined, overrideParameters);
         return postFormNonNullAdt<ValidationResponse>(`${INFRAMODEL_URI}/validate`, formData).then(
-            (r) => (r.isOk() ? r.value : defaultValidationErrorHandler(r.error)),
+            (r) => (r.isOk() ? r.value : defaultValidationIssueHandler(r.error)),
         );
     } else {
         return Promise.resolve({
@@ -71,7 +71,7 @@ export const getValidationErrorsForInfraModelFile = async (
     }
 };
 
-export const getValidationErrorsForGeometryPlan = async (
+export const getValidationIssuesForGeometryPlan = async (
     planId: GeometryPlanId,
     overrideParameters: OverrideInfraModelParameters,
 ): Promise<ValidationResponse> => {
@@ -80,7 +80,7 @@ export const getValidationErrorsForGeometryPlan = async (
     return postFormNonNullAdt<ValidationResponse>(
         `${INFRAMODEL_URI}/${planId}/validate`,
         formData,
-    ).then((r) => (r.isOk() ? r.value : defaultValidationErrorHandler(r.error)));
+    ).then((r) => (r.isOk() ? r.value : defaultValidationIssueHandler(r.error)));
 };
 
 export const saveInfraModelFile = async (
@@ -184,7 +184,7 @@ export async function restorePVDocuments(id: PVDocumentId[]): Promise<undefined>
     });
 }
 
-export const getValidationErrorsForPVDocument = async (
+export const getValidationIssuesForPVDocument = async (
     pvDocumentId: PVDocumentId,
     overrideParameters?: OverrideInfraModelParameters,
 ): Promise<ValidationResponse> => {
@@ -194,7 +194,7 @@ export const getValidationErrorsForPVDocument = async (
         formData,
     );
 
-    return result.isOk() ? result.value : defaultValidationErrorHandler(result.error);
+    return result.isOk() ? result.value : defaultValidationIssueHandler(result.error);
 };
 
 export async function importPVDocument(

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -26,7 +26,7 @@ import { asyncCache } from 'cache/cache';
 import { Oid, TimeStamp } from 'common/common-model';
 
 export const EMPTY_VALIDATION_RESPONSE: ValidationResponse = {
-    validationErrors: [],
+    geometryValidationIssues: [],
     geometryPlan: undefined,
     planLayout: undefined,
 };
@@ -46,10 +46,10 @@ const defaultValidationErrorHandler = (
     response: ApiErrorResponse | undefined,
 ): ValidationResponse => ({
     ...EMPTY_VALIDATION_RESPONSE,
-    validationErrors: [
+    geometryValidationIssues: [
         {
             localizationKey: getLocalizedError(response, 'error.infra-model.request-failed'),
-            errorType: 'REQUEST_ERROR',
+            issueType: 'REQUEST_ERROR',
         },
     ],
 });

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -285,36 +285,36 @@ function validateParams(
     extraParams: ExtraInfraModelParameters,
     overrideParams: OverrideInfraModelParameters,
 ): FieldValidationIssue<InfraModelParameters>[] {
-    const errors: FieldValidationIssue<InfraModelParameters>[] = [];
+    const issues: FieldValidationIssue<InfraModelParameters>[] = [];
 
     extraParams.planPhase === undefined &&
-        errors.push(createError('planPhase', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(createError('planPhase', 'critical', FieldValidationIssueType.WARNING));
     extraParams.measurementMethod === undefined &&
-        errors.push(createError('measurementMethod', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(createError('measurementMethod', 'critical', FieldValidationIssueType.WARNING));
     extraParams.elevationMeasurementMethod === undefined &&
-        errors.push(
+        issues.push(
             createError('elevationMeasurementMethod', 'critical', FieldValidationIssueType.WARNING),
         );
     extraParams.decisionPhase === undefined &&
-        errors.push(createError('decisionPhase', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(createError('decisionPhase', 'critical', FieldValidationIssueType.WARNING));
     overrideParams.createdDate === undefined &&
         plan?.planTime === undefined &&
-        errors.push(createError('createdDate', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(createError('createdDate', 'critical', FieldValidationIssueType.WARNING));
     overrideParams.trackNumber === undefined &&
         plan?.trackNumber === undefined &&
-        errors.push(createError('trackNumber', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(createError('trackNumber', 'critical', FieldValidationIssueType.WARNING));
     overrideParams.verticalCoordinateSystem === undefined &&
         plan?.units.verticalCoordinateSystem === undefined &&
-        errors.push(
+        issues.push(
             createError('verticalCoordinateSystem', 'critical', FieldValidationIssueType.WARNING),
         );
     overrideParams.coordinateSystemSrid === undefined &&
         plan?.units.coordinateSystemSrid === undefined &&
-        errors.push(
+        issues.push(
             createError('coordinateSystemSrid', 'critical', FieldValidationIssueType.WARNING),
         );
 
-    return errors;
+    return issues;
 }
 
 export const infraModelReducer = infraModelSlice.reducer;

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -83,7 +83,7 @@ export type InfraModelParametersProp = keyof InfraModelParameters;
 
 export type LocalizationKey = string;
 
-export type ErrorType =
+export type GeometryValidationIssueType =
     | 'REQUEST_ERROR'
     | 'PARSING_ERROR'
     | 'TRANSFORMATION_ERROR'
@@ -91,16 +91,16 @@ export type ErrorType =
     | 'OBSERVATION_MAJOR'
     | 'OBSERVATION_MINOR';
 
-export interface CustomValidationError extends LocalizationParams {
+export type CustomGeometryValidationIssue = {
     localizationKey: LocalizationKey;
-    errorType: ErrorType;
-}
+    issueType: GeometryValidationIssueType;
+} & LocalizationParams;
 
-export interface ValidationResponse {
-    validationErrors: CustomValidationError[];
+export type ValidationResponse = {
+    geometryValidationIssues: CustomGeometryValidationIssue[];
     geometryPlan?: GeometryPlan;
     planLayout?: GeometryPlanLayout;
-}
+};
 
 const visibleMapLayers: MapLayerName[] = [
     'background-map-layer',

--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -24,7 +24,7 @@ import {
     TrackNumber,
 } from 'common/common-model';
 import { getCoordinateSystem, getSridList } from 'common/common-api';
-import { ValidationError, ValidationErrorType } from 'utils/validation-utils';
+import { FieldValidationIssue, FieldValidationIssueType } from 'utils/validation-utils';
 import { Prop } from 'utils/type-utils';
 import { useTranslation } from 'react-i18next';
 import { fetchAuthors, getProject } from 'geometry/geometry-api';
@@ -58,7 +58,9 @@ import { ManualTrackNumberDialog } from 'infra-model/view/dialogs/manual-track-n
 
 type InframodelViewFormContainerProps = {
     changeTimes: ChangeTimes;
-    validationErrors: ValidationError<ExtraInfraModelParameters & OverrideInfraModelParameters>[];
+    validationIssues: FieldValidationIssue<
+        ExtraInfraModelParameters & OverrideInfraModelParameters
+    >[];
     upLoading: boolean;
     geometryPlan: GeometryPlan;
     onInfraModelOverrideParametersChange: (
@@ -104,7 +106,7 @@ function profileInformationAvailable(alignments: GeometryAlignment[]): boolean {
 
 const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
     changeTimes,
-    validationErrors,
+    validationIssues,
     upLoading,
     geometryPlan,
     onInfraModelOverrideParametersChange,
@@ -233,9 +235,10 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
 
     function getVisibleErrorsByProp(prop: InfraModelParametersProp) {
         return committedFields.includes(prop)
-            ? validationErrors
+            ? validationIssues
                   .filter(
-                      (error) => error.field == prop && error.type === ValidationErrorType.ERROR,
+                      (error) =>
+                          error.field == prop && error.type === FieldValidationIssueType.ERROR,
                   )
                   .map((error) => {
                       return t(`im-form.${error.reason}`);

--- a/ui/src/infra-model/view/infra-model-edit-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-edit-loader.tsx
@@ -6,7 +6,7 @@ import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { InfraModelBaseProps, InfraModelView } from 'infra-model/view/infra-model-view';
 import { ValidationResponse } from 'infra-model/infra-model-slice';
 import {
-    getValidationErrorsForGeometryPlan,
+    getValidationIssuesForGeometryPlan,
     updateGeometryPlan,
 } from 'infra-model/infra-model-api';
 
@@ -27,7 +27,7 @@ export const InfraModelEditLoader: React.FC<InfraModelLoaderProps> = ({ ...props
     const onValidate: () => void = async () => {
         if (planId && planId === initializedPlanId) {
             props.setLoading(true);
-            props.onValidation(await getValidationErrorsForGeometryPlan(planId, overrideParams));
+            props.onValidation(await getValidationIssuesForGeometryPlan(planId, overrideParams));
             props.setLoading(false);
         }
     };

--- a/ui/src/infra-model/view/infra-model-import-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-import-loader.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { InfraModelBaseProps, InfraModelView } from 'infra-model/view/infra-model-view';
-import { getValidationErrorsForPVDocument, importPVDocument } from 'infra-model/infra-model-api';
+import { getValidationIssuesForPVDocument, importPVDocument } from 'infra-model/infra-model-api';
 import { ValidationResponse } from 'infra-model/infra-model-slice';
 import { PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { GeometryPlan } from 'geometry/geometry-model';
@@ -21,7 +21,7 @@ export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ 
     const onInit: () => void = async () => {
         if (pvDocumentId) {
             props.setLoading(true);
-            const validation = await getValidationErrorsForPVDocument(pvDocumentId);
+            const validation = await getValidationIssuesForPVDocument(pvDocumentId);
             props.setExistingInfraModel(validation.geometryPlan);
             props.onValidation(validation);
             setInitPVDocumentId(pvDocumentId);
@@ -32,7 +32,7 @@ export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ 
         if (pvDocumentId && pvDocumentId == initPVDocumentId) {
             props.setLoading(true);
             props.onValidation(
-                await getValidationErrorsForPVDocument(pvDocumentId, overrideParams),
+                await getValidationIssuesForPVDocument(pvDocumentId, overrideParams),
             );
             props.setLoading(false);
         }

--- a/ui/src/infra-model/view/infra-model-upload-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-upload-loader.tsx
@@ -56,8 +56,8 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
     };
 
     const fileHandlingFailedErrors =
-        props.validationResponse?.validationErrors
-            .filter((e) => e.errorType === 'PARSING_ERROR' || e.errorType === 'REQUEST_ERROR')
+        props.validationResponse?.geometryValidationIssues
+            .filter((e) => e.issueType === 'PARSING_ERROR' || e.issueType === 'REQUEST_ERROR')
             .map((item) => item.localizationKey) || [];
     const showFileHandlingFailed = fileHandlingFailedErrors.length > 0;
 

--- a/ui/src/infra-model/view/infra-model-upload-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-upload-loader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './form/infra-model-form.module.scss';
 import { InfraModelBaseProps, InfraModelView } from 'infra-model/view/infra-model-view';
 import {
-    getValidationErrorsForInfraModelFile,
+    getGeometryValidationIssuesForInfraModelFile,
     saveInfraModelFile,
 } from 'infra-model/infra-model-api';
 import { convertToNativeFile, SerializableFile } from 'utils/file-utils';
@@ -35,7 +35,9 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
     const onValidate: () => void = async () => {
         if (file) {
             props.setLoading(true);
-            props.onValidation(await getValidationErrorsForInfraModelFile(file, overrideParams));
+            props.onValidation(
+                await getGeometryValidationIssuesForInfraModelFile(file, overrideParams),
+            );
             props.setLoading(false);
         }
     };

--- a/ui/src/infra-model/view/infra-model-validation-error-list.tsx
+++ b/ui/src/infra-model/view/infra-model-validation-error-list.tsx
@@ -3,8 +3,8 @@ import styles from './form/infra-model-form.module.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { useTranslation } from 'react-i18next';
 import {
-    CustomValidationError,
-    ErrorType,
+    CustomGeometryValidationIssue,
+    GeometryValidationIssueType,
     ValidationResponse,
 } from 'infra-model/infra-model-slice';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
@@ -13,8 +13,8 @@ type InframodelValidationErrorListProps = {
     validationResponse?: ValidationResponse;
 };
 
-const getIcon = (errorType: ErrorType) => {
-    switch (errorType) {
+const getIcon = (issueType: GeometryValidationIssueType) => {
+    switch (issueType) {
         case 'REQUEST_ERROR':
         case 'PARSING_ERROR':
         case 'VALIDATION_ERROR':
@@ -24,12 +24,12 @@ const getIcon = (errorType: ErrorType) => {
         case 'OBSERVATION_MINOR':
             return Icons.StatusError;
         default:
-            return exhaustiveMatchingGuard(errorType);
+            return exhaustiveMatchingGuard(issueType);
     }
 };
 
-const createErrorRow = (errorType: ErrorType, message: string, index: number) => {
-    const Icon = getIcon(errorType);
+const createErrorRow = (issueType: GeometryValidationIssueType, message: string, index: number) => {
+    const Icon = getIcon(issueType);
     return (
         <li key={index}>
             <div className={styles['infra-model-upload__error']}>
@@ -45,14 +45,18 @@ const InfraModelValidationErrorList: React.FC<InframodelValidationErrorListProps
 }: InframodelValidationErrorListProps) => {
     const { t } = useTranslation();
     const errorListDiv = (errorList: ValidationResponse) => {
-        const errors = errorList.validationErrors.filter(
+        const errors = errorList.geometryValidationIssues.filter(
             (e) =>
-                e.errorType === 'PARSING_ERROR' ||
-                e.errorType === 'VALIDATION_ERROR' ||
-                e.errorType === 'TRANSFORMATION_ERROR',
+                e.issueType === 'PARSING_ERROR' ||
+                e.issueType === 'VALIDATION_ERROR' ||
+                e.issueType === 'TRANSFORMATION_ERROR',
         );
-        const major = errorList.validationErrors.filter((e) => e.errorType === 'OBSERVATION_MAJOR');
-        const minor = errorList.validationErrors.filter((e) => e.errorType === 'OBSERVATION_MINOR');
+        const major = errorList.geometryValidationIssues.filter(
+            (e) => e.issueType === 'OBSERVATION_MAJOR',
+        );
+        const minor = errorList.geometryValidationIssues.filter(
+            (e) => e.issueType === 'OBSERVATION_MINOR',
+        );
 
         return (
             <div className={styles['infra-model-upload__validation-errors']}>
@@ -62,9 +66,9 @@ const InfraModelValidationErrorList: React.FC<InframodelValidationErrorListProps
                             {t('im-form.validation-errors')}
                         </h2>
                         <ul className={styles['infra-model-upload__errors']}>
-                            {errors.map((error: CustomValidationError, index: number) =>
+                            {errors.map((error: CustomGeometryValidationIssue, index: number) =>
                                 createErrorRow(
-                                    error.errorType,
+                                    error.issueType,
                                     t(error.localizationKey, error),
                                     index,
                                 ),
@@ -80,7 +84,7 @@ const InfraModelValidationErrorList: React.FC<InframodelValidationErrorListProps
                         <ol className={styles['infra-model-upload__errors']}>
                             {major.map((error, index) =>
                                 createErrorRow(
-                                    error.errorType,
+                                    error.issueType,
                                     t(error.localizationKey, error),
                                     index,
                                 ),
@@ -88,7 +92,7 @@ const InfraModelValidationErrorList: React.FC<InframodelValidationErrorListProps
 
                             {minor.map((error, index) =>
                                 createErrorRow(
-                                    error.errorType,
+                                    error.issueType,
                                     t(error.localizationKey, error),
                                     index,
                                 ),

--- a/ui/src/infra-model/view/infra-model-validation-issue-list.tsx
+++ b/ui/src/infra-model/view/infra-model-validation-issue-list.tsx
@@ -9,7 +9,7 @@ import {
 } from 'infra-model/infra-model-slice';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 
-type InframodelValidationErrorListProps = {
+type InframodelValidationIssueListProps = {
     validationResponse?: ValidationResponse;
 };
 
@@ -40,9 +40,9 @@ const createErrorRow = (issueType: GeometryValidationIssueType, message: string,
     );
 };
 
-const InfraModelValidationErrorList: React.FC<InframodelValidationErrorListProps> = ({
+const InfraModelValidationIssueList: React.FC<InframodelValidationIssueListProps> = ({
     validationResponse,
-}: InframodelValidationErrorListProps) => {
+}: InframodelValidationIssueListProps) => {
     const { t } = useTranslation();
     const errorListDiv = (errorList: ValidationResponse) => {
         const errors = errorList.geometryValidationIssues.filter(
@@ -115,4 +115,4 @@ const InfraModelValidationErrorList: React.FC<InframodelValidationErrorListProps
     );
 };
 
-export default InfraModelValidationErrorList;
+export default InfraModelValidationIssueList;

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -11,11 +11,11 @@ import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Dialog } from 'geoviite-design-lib/dialog/dialog';
 import { Prop } from 'utils/type-utils';
-import { ValidationErrorType } from 'utils/validation-utils';
+import { FieldValidationIssueType } from 'utils/validation-utils';
 import { useTranslation } from 'react-i18next';
 import { FileMenuOption, InfraModelToolbar } from 'infra-model/view/infra-model-toolbar';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
-import InfraModelValidationErrorList from 'infra-model/view/infra-model-validation-error-list';
+import InfraModelValidationIssueList from 'infra-model/view/infra-model-validation-issue-list';
 import { ChangeTimes } from 'common/common-slice';
 import { Item } from 'vayla-design-lib/dropdown/dropdown';
 import { CharsetSelectDialog } from './dialogs/charset-select-dialog';
@@ -77,18 +77,22 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
             .map((item) => item.localizationKey) || [];
 
     const getFieldValidationWarnings = () => {
-        return props.validationErrors.filter((error) => error.type === ValidationErrorType.WARNING);
+        return props.validationIssues.filter(
+            (error) => error.type === FieldValidationIssueType.WARNING,
+        );
     };
 
-    const getFieldValidationErrors = () => {
-        return props.validationErrors.filter((error) => error.type === ValidationErrorType.ERROR);
+    const getFieldValidationIssues = () => {
+        return props.validationIssues.filter(
+            (error) => error.type === FieldValidationIssueType.ERROR,
+        );
     };
 
     const getVisibleErrors = () => {
-        const fieldValidationErrors = getFieldValidationErrors().map((error) =>
+        const fieldValidationIssues = getFieldValidationIssues().map((error) =>
             t(`im-form.${error.reason}`),
         );
-        return fieldValidationErrors.length > 0 ? fieldValidationErrors.join(', ') : '';
+        return fieldValidationIssues.length > 0 ? fieldValidationIssues.join(', ') : '';
     };
 
     const fileName = geometryPlan?.fileName || '';
@@ -107,7 +111,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                     {geometryPlan && (
                         <InfraModelForm
                             changeTimes={props.changeTimes}
-                            validationErrors={props.validationErrors}
+                            validationIssues={props.validationIssues}
                             upLoading={props.isLoading}
                             geometryPlan={geometryPlan}
                             onInfraModelOverrideParametersChange={props.onOverrideParametersChange}
@@ -120,7 +124,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                 </div>
 
                 {props.validationResponse && (
-                    <InfraModelValidationErrorList validationResponse={props.validationResponse} />
+                    <InfraModelValidationIssueList validationResponse={props.validationResponse} />
                 )}
 
                 <div className={styles['infra-model-upload__buttons-container']}>
@@ -150,7 +154,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                                 props.isLoading ||
                                 !props.validationResponse ||
                                 fileHandlingFailedErrors.length > 0 ||
-                                getFieldValidationErrors().length > 0
+                                getFieldValidationIssues().length > 0
                             }
                             icon={Icons.Tick}
                             isProcessing={props.isLoading}>

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -72,8 +72,8 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
     };
 
     const fileHandlingFailedErrors =
-        props.validationResponse?.validationErrors
-            .filter((e) => e.errorType === 'PARSING_ERROR' || e.errorType === 'REQUEST_ERROR')
+        props.validationResponse?.geometryValidationIssues
+            .filter((e) => e.issueType === 'PARSING_ERROR' || e.issueType === 'REQUEST_ERROR')
             .map((item) => item.localizationKey) || [];
 
     const getFieldValidationWarnings = () => {

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -34,7 +34,7 @@ import {
     SwitchStructureId,
     TrackMeter,
 } from 'common/common-model';
-import { PublicationValidationError } from 'publication/publication-model';
+import { LayoutValidationIssue } from 'publication/publication-model';
 
 export type LocationTrackSaveRequest = {
     name: string;
@@ -46,10 +46,6 @@ export type LocationTrackSaveRequest = {
     duplicateOf?: string;
     topologicalConnectivity?: TopologicalConnectivityType;
     ownerId?: LocationTrackOwnerId;
-};
-
-export type LocationTrackSaveError = {
-    validationErrors: string[];
 };
 
 export type LinkingState =
@@ -170,10 +166,6 @@ export type KmPostSaveRequest = {
     kmNumber: KmNumber;
     state?: LayoutState;
     trackNumberId?: LayoutTrackNumberId;
-};
-
-export type KmPostSaveError = {
-    validationErrors: string[];
 };
 
 export enum LinkingType {
@@ -322,10 +314,6 @@ export type TrackLayoutSwitchSaveRequest = {
     trapPoint?: boolean;
 };
 
-export type TrackLayoutSaveError = {
-    validationErrors: string[];
-};
-
 export type LocationTrackEndpoint = {
     // "id" generated at runtime and is for UI only
     id: string;
@@ -349,7 +337,7 @@ export type SuggestedSwitchCreateParams = {
 export type SwitchRelinkingValidationResult = {
     id: LayoutSwitchId;
     successfulSuggestion: SwitchRelinkingSuggestion;
-    validationErrors: PublicationValidationError[];
+    validationIssues: LayoutValidationIssue[];
 };
 
 export type SwitchRelinkingSuggestion = {

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -105,7 +105,7 @@ export type LinkingPhase = 'preliminary' | 'setup' | 'allSet';
 type LinkingBaseType = {
     type: LinkingType;
     state: LinkingPhase;
-    errors: string[];
+    issues: string[];
 };
 
 export type GeometryPreliminaryLinkingParameters = {

--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -60,7 +60,7 @@ export const linkingReducers = {
                 state: 'setup',
                 layoutAlignment: payload.alignment,
                 type: payload.type,
-                errors: [],
+                issues: [],
             };
         }
     },
@@ -189,7 +189,7 @@ export const linkingReducers = {
                 layoutAlignmentInterval: interval,
                 type: LinkingType.LinkingAlignment,
                 state: 'setup',
-                errors: [],
+                issues: [],
             });
         }
     },
@@ -202,7 +202,7 @@ export const linkingReducers = {
             layoutSwitch: layoutSwitch,
             location: undefined,
             state: 'preliminary',
-            errors: [],
+            issues: [],
         };
     },
     startSwitchLinking: (
@@ -214,7 +214,7 @@ export const linkingReducers = {
             type: LinkingType.LinkingSwitch,
             suggestedSwitch: payload,
             state: 'preliminary',
-            errors: [],
+            issues: [],
         };
 
         // Ensure that layout switch is not selected by accident,
@@ -241,7 +241,7 @@ export const linkingReducers = {
             type: LinkingType.LinkingKmPost,
             geometryKmPostId: geometryKmPostId,
             state: 'setup',
-            errors: [],
+            issues: [],
         };
     },
 };
@@ -343,7 +343,7 @@ function validateLinkingGeometryWithAlignment(
     return {
         ...state,
         state: canLink ? 'allSet' : 'setup',
-        errors: errors,
+        issues: errors,
     };
 }
 

--- a/ui/src/preview/change-table-sorting.ts
+++ b/ui/src/preview/change-table-sorting.ts
@@ -8,7 +8,7 @@ export enum SortProps {
     OPERATION = 'OPERATION',
     CHANGE_TIME = 'CHANGE_TIME',
     USER_NAME = 'USER_NAME',
-    ERRORS = 'ERRORS',
+    ISSUES = 'ISSUES',
 }
 
 export type SortInformation = {
@@ -17,14 +17,14 @@ export type SortInformation = {
     function: (v1: unknown, v2: unknown) => number;
 };
 
-const includesErrors = (errors: LayoutValidationIssue[]) =>
-    errors.some((err) => err.type == 'ERROR');
-const includesWarnings = (errors: LayoutValidationIssue[]) =>
-    errors.some((err) => err.type == 'WARNING');
-const errorSeverityPriority = (errors: LayoutValidationIssue[]) => {
+const includesErrors = (issues: LayoutValidationIssue[]) =>
+    issues.some((err) => err.type == 'ERROR');
+const includesWarnings = (issues: LayoutValidationIssue[]) =>
+    issues.some((err) => err.type == 'WARNING');
+const errorSeverityPriority = (issues: LayoutValidationIssue[]) => {
     let priority = 0;
-    if (includesErrors(errors)) priority += 2;
-    if (includesWarnings(errors)) priority += 1;
+    if (includesErrors(issues)) priority += 2;
+    if (includesWarnings(issues)) priority += 1;
     return priority;
 };
 
@@ -33,11 +33,11 @@ const trackNumberCompare = fieldComparator((entry: { trackNumber: string }) => e
 const userNameCompare = fieldComparator((entry: { userName: string }) => entry.userName);
 const changeTimeCompare = fieldComparator((entry: { changeTime: string }) => entry.changeTime);
 const errorListCompare = (
-    a: { errors: LayoutValidationIssue[] },
-    b: { errors: LayoutValidationIssue[] },
+    a: { issues: LayoutValidationIssue[] },
+    b: { issues: LayoutValidationIssue[] },
 ) => {
-    const priorityBySeverity = errorSeverityPriority(b.errors) - errorSeverityPriority(a.errors);
-    return priorityBySeverity !== 0 ? priorityBySeverity : b.errors.length - a.errors.length;
+    const priorityBySeverity = errorSeverityPriority(b.issues) - errorSeverityPriority(a.issues);
+    return priorityBySeverity !== 0 ? priorityBySeverity : b.issues.length - a.issues.length;
 };
 export const operationPriority = (operation: Operation | undefined) => {
     if (operation === 'CREATE') return 4;
@@ -55,7 +55,7 @@ const sortFunctionsByPropName = {
     OPERATION: operationCompare,
     CHANGE_TIME: changeTimeCompare,
     USER_NAME: userNameCompare,
-    ERRORS: errorListCompare,
+    ISSUES: errorListCompare,
 };
 
 export const InitiallyUnsorted = {

--- a/ui/src/preview/change-table-sorting.ts
+++ b/ui/src/preview/change-table-sorting.ts
@@ -1,4 +1,4 @@
-import { Operation, PublicationValidationError } from 'publication/publication-model';
+import { Operation, LayoutValidationIssue } from 'publication/publication-model';
 import { fieldComparator } from 'utils/array-utils';
 import { nextSortDirection, SortDirection } from 'utils/table-utils';
 
@@ -17,11 +17,11 @@ export type SortInformation = {
     function: (v1: unknown, v2: unknown) => number;
 };
 
-const includesErrors = (errors: PublicationValidationError[]) =>
+const includesErrors = (errors: LayoutValidationIssue[]) =>
     errors.some((err) => err.type == 'ERROR');
-const includesWarnings = (errors: PublicationValidationError[]) =>
+const includesWarnings = (errors: LayoutValidationIssue[]) =>
     errors.some((err) => err.type == 'WARNING');
-const errorSeverityPriority = (errors: PublicationValidationError[]) => {
+const errorSeverityPriority = (errors: LayoutValidationIssue[]) => {
     let priority = 0;
     if (includesErrors(errors)) priority += 2;
     if (includesWarnings(errors)) priority += 1;
@@ -33,8 +33,8 @@ const trackNumberCompare = fieldComparator((entry: { trackNumber: string }) => e
 const userNameCompare = fieldComparator((entry: { userName: string }) => entry.userName);
 const changeTimeCompare = fieldComparator((entry: { changeTime: string }) => entry.changeTime);
 const errorListCompare = (
-    a: { errors: PublicationValidationError[] },
-    b: { errors: PublicationValidationError[] },
+    a: { errors: LayoutValidationIssue[] },
+    b: { errors: LayoutValidationIssue[] },
 ) => {
     const priorityBySeverity = errorSeverityPriority(b.errors) - errorSeverityPriority(a.errors);
     return priorityBySeverity !== 0 ? priorityBySeverity : b.errors.length - a.errors.length;

--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -18,7 +18,7 @@ import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
 import {
     PublicationCandidate,
     PublicationResult,
-    PublicationValidationError,
+    LayoutValidationIssue,
 } from 'publication/publication-model';
 import { OnSelectFunction } from 'selection/selection-model';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
@@ -42,7 +42,7 @@ function describe(name: string, value: number | undefined): string | undefined {
     return value !== undefined && value > 0 ? `${name}: ${value}` : undefined;
 }
 
-function publishErrors(publishCandidates: PublicationCandidate[]): PublicationValidationError[] {
+function publishErrors(publishCandidates: PublicationCandidate[]): LayoutValidationIssue[] {
     return publishCandidates.flatMap((candidate) => candidate.errors);
 }
 

--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -43,7 +43,7 @@ function describe(name: string, value: number | undefined): string | undefined {
 }
 
 function publishErrors(publishCandidates: PublicationCandidate[]): LayoutValidationIssue[] {
-    return publishCandidates.flatMap((candidate) => candidate.errors);
+    return publishCandidates.flatMap((candidate) => candidate.issues);
 }
 
 export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooterProps) => {

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -50,13 +50,13 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     const [isErrorRowExpanded, setIsErrorRowExpanded] = React.useState(false);
     const [actionMenuVisible, setActionMenuVisible] = React.useState(false);
 
-    const errorsToStrings = (list: LayoutValidationIssue[], type: 'ERROR' | 'WARNING') => {
+    const issuesToStrings = (list: LayoutValidationIssue[], type: 'ERROR' | 'WARNING') => {
         const filtered = list.filter((e) => e.type === type);
         return filtered.map((error) => t(error.localizationKey, error.params));
     };
-    const errorTexts = errorsToStrings(tableEntry.errors, 'ERROR');
-    const warningTexts = errorsToStrings(tableEntry.errors, 'WARNING');
-    const hasErrors = tableEntry.errors.length > 0;
+    const errorTexts = issuesToStrings(tableEntry.issues, 'ERROR');
+    const warningTexts = issuesToStrings(tableEntry.issues, 'WARNING');
+    const hasErrors = tableEntry.issues.length > 0;
 
     const statusCellClassName = createClassName(
         styles['preview-table-item__status-cell'],

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -3,7 +3,7 @@ import styles from './preview-view.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { formatDateFull } from 'utils/date-utils';
 import { useTranslation } from 'react-i18next';
-import { PublicationStage, PublicationValidationError } from 'publication/publication-model';
+import { PublicationStage, LayoutValidationIssue } from 'publication/publication-model';
 import { createClassName } from 'vayla-design-lib/utils';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
@@ -50,7 +50,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     const [isErrorRowExpanded, setIsErrorRowExpanded] = React.useState(false);
     const [actionMenuVisible, setActionMenuVisible] = React.useState(false);
 
-    const errorsToStrings = (list: PublicationValidationError[], type: 'ERROR' | 'WARNING') => {
+    const errorsToStrings = (list: LayoutValidationIssue[], type: 'ERROR' | 'WARNING') => {
         const filtered = list.filter((e) => e.type === type);
         return filtered.map((error) => t(error.localizationKey, error.params));
     };

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -28,7 +28,7 @@ import {
 import {
     DraftChangeType,
     PublicationCandidate,
-    PublicationValidationError,
+    LayoutValidationIssue,
 } from 'publication/publication-model';
 import { ChangesBeingReverted, PreviewOperations } from 'preview/preview-view';
 import { BoundingBox } from 'model/geometry';
@@ -52,7 +52,7 @@ export type PublishableObjectId =
 export type PreviewTableEntry = {
     publishCandidate: PublicationCandidate;
     type: DraftChangeType;
-    errors: PublicationValidationError[];
+    errors: LayoutValidationIssue[];
     pendingValidation: boolean;
     boundingBox?: BoundingBox;
 } & ChangeTableEntry;

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -52,7 +52,7 @@ export type PublishableObjectId =
 export type PreviewTableEntry = {
     publishCandidate: PublicationCandidate;
     type: DraftChangeType;
-    errors: LayoutValidationIssue[];
+    issues: LayoutValidationIssue[];
     pendingValidation: boolean;
     boundingBox?: BoundingBox;
 } & ChangeTableEntry;
@@ -143,7 +143,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
             ...tableEntry,
             publishCandidate: candidate,
             boundingBox,
-            errors: candidate.errors,
+            issues: candidate.issues,
             type: candidate.type,
             pendingValidation: candidate.pendingValidation,
         };
@@ -192,7 +192,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
                             'preview-table.modified-moment',
                         )}
                         {sortableTableHeader(SortProps.USER_NAME, 'preview-table.user')}
-                        {sortableTableHeader(SortProps.ERRORS, 'preview-table.status')}
+                        {sortableTableHeader(SortProps.ISSUES, 'preview-table.status')}
                         <Th>{t('preview-table.actions')}</Th>
                     </tr>
                 </thead>

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -22,7 +22,7 @@ import { BoundingBox, Point } from 'model/geometry';
 import { LocalizationParams } from 'i18n/config';
 import { SplitTargetOperation } from 'tool-panel/location-track/split-store';
 
-export type PublicationValidationError = {
+export type LayoutValidationIssue = {
     type: 'ERROR' | 'WARNING';
     localizationKey: string;
     params: LocalizationParams;
@@ -62,7 +62,7 @@ export type BasePublicationCandidate = {
     userName: string;
     operation: Operation;
     publicationGroup?: PublicationGroup;
-    errors: PublicationValidationError[];
+    errors: LayoutValidationIssue[];
     validated: boolean;
     pendingValidation: boolean;
     stage: PublicationStage;
@@ -242,7 +242,7 @@ export type PublicationChange = {
 
 export type ValidatedAsset<Id extends AssetId> = {
     id: Id;
-    errors: PublicationValidationError[];
+    errors: LayoutValidationIssue[];
 };
 
 export type ValidatedTrackNumber = ValidatedAsset<LayoutTrackNumberId>;

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -62,7 +62,7 @@ export type BasePublicationCandidate = {
     userName: string;
     operation: Operation;
     publicationGroup?: PublicationGroup;
-    errors: LayoutValidationIssue[];
+    issues: LayoutValidationIssue[];
     validated: boolean;
     pendingValidation: boolean;
     stage: PublicationStage;

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -109,7 +109,7 @@ export const addValidationState = (
         return validatedCandidate
             ? {
                   ...candidate,
-                  errors: validatedCandidate.errors,
+                  issues: validatedCandidate.issues,
                   pendingValidation: false,
               }
             : candidate;

--- a/ui/src/tool-panel/asset-validation-infobox.tsx
+++ b/ui/src/tool-panel/asset-validation-infobox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import Infobox from 'tool-panel/infobox/infobox';
-import { PublicationValidationError } from 'publication/publication-model';
+import { LayoutValidationIssue } from 'publication/publication-model';
 import { LoaderStatus } from 'utils/react-utils';
 import { useTranslation } from 'react-i18next';
 import styles from './asset-validation-infobox.scss';
@@ -17,8 +17,8 @@ type AssetType = 'TRACK_NUMBER' | 'REFERENCE_LINE' | 'LOCATION_TRACK' | 'SWITCH'
 
 type AssetValidationInfoboxProps = {
     type: AssetType;
-    errors: PublicationValidationError[];
-    warnings: PublicationValidationError[];
+    errors: LayoutValidationIssue[];
+    warnings: LayoutValidationIssue[];
     validationLoaderStatus: LoaderStatus;
     contentVisible: boolean;
     onContentVisibilityChange: () => void;

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -396,7 +396,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                     </MessageBox>
                                 </InfoboxContentSpread>
                             )}
-                            {linkingState.errors.map((errorKey) => (
+                            {linkingState.issues.map((errorKey) => (
                                 <InfoboxContentSpread key={errorKey}>
                                     <MessageBox>{t(errorKey)}</MessageBox>
                                 </InfoboxContentSpread>

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -183,9 +183,9 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
 
     function getVisibleErrorsByProp(prop: keyof KmPostSaveRequest) {
         return state.allFieldsCommitted || state.committedFields.includes(prop)
-            ? state.validationErrors
-                  .filter((error) => error.field == prop)
-                  .map((error) => t(`km-post-dialog.${error.reason}`))
+            ? state.validationIssues
+                  .filter((issue) => issue.field == prop)
+                  .map((issue) => t(`km-post-dialog.${issue.reason}`))
             : [];
     }
 
@@ -249,7 +249,7 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                                     isProcessing={state.isSaving}
                                     onClick={() => saveOrConfirm()}
                                     title={getSaveDisabledReasons(
-                                        state.validationErrors.map((e) => e.reason),
+                                        state.validationIssues.map((e) => e.reason),
                                         state.isSaving,
                                     )
                                         .map((reason) => t(`km-post-dialog.${reason}`))

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -160,7 +160,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         if (duplicate && !selectedDuplicateTrack) setSelectedDuplicateTrack(duplicate);
     }, [duplicate]);
 
-    const validTrackName = !state.validationErrors.some((e) => e.field === 'name')
+    const validTrackName = !state.validationIssues.some((e) => e.field === 'name')
         ? state.locationTrack.name
         : '';
     const trackWithSameName = ifDefined(
@@ -272,9 +272,9 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
 
     function getVisibleErrorsByProp(prop: keyof LocationTrackSaveRequest) {
         return state.allFieldsCommitted || state.committedFields.includes(prop)
-            ? state.validationErrors
-                  .filter((error) => error.field == prop)
-                  .map((error) => t(`location-track-dialog.${error.reason}`))
+            ? state.validationIssues
+                  .filter((issue) => issue.field == prop)
+                  .map((issue) => t(`location-track-dialog.${issue.reason}`))
             : [];
     }
 
@@ -408,7 +408,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                     saveOrConfirm();
                                 }}
                                 title={getSaveDisabledReasons(
-                                    state.validationErrors.map((e) => e.reason),
+                                    state.validationIssues.map((e) => e.reason),
                                     state.isSaving,
                                 )
                                     .map((reason) => t(`location-track-dialog.${reason}`))

--- a/ui/src/tool-panel/location-track/dialog/location-track-validation.ts
+++ b/ui/src/tool-panel/location-track/dialog/location-track-validation.ts
@@ -1,15 +1,17 @@
-import { ValidationError, ValidationErrorType } from 'utils/validation-utils';
+import { FieldValidationIssue, FieldValidationIssueType } from 'utils/validation-utils';
 
 export const ALIGNMENT_NAME_REGEX = /^[A-Za-zÄÖÅäöå0-9 \-_]+$/g;
 export const ALIGNMENT_NAME_MAX_LENGTH = 50;
 
-export const validateLocationTrackName = (name: string): ValidationError<{ name: string }>[] => {
+export const validateLocationTrackName = (
+    name: string,
+): FieldValidationIssue<{ name: string }>[] => {
     if (name && (!name.match(ALIGNMENT_NAME_REGEX) || name.length > ALIGNMENT_NAME_MAX_LENGTH)) {
         return [
             {
                 field: 'name',
                 reason: `invalid-name`,
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ];
     } else if (name.trim() === '') {
@@ -17,7 +19,7 @@ export const validateLocationTrackName = (name: string): ValidationError<{ name:
             {
                 field: 'name',
                 reason: `mandatory-field`,
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ];
     } else {
@@ -27,13 +29,13 @@ export const validateLocationTrackName = (name: string): ValidationError<{ name:
 
 export const validateLocationTrackDescriptionBase = (
     descriptionBase: string | undefined,
-): ValidationError<{ descriptionBase?: string }>[] => {
+): FieldValidationIssue<{ descriptionBase?: string }>[] => {
     return descriptionBase && (descriptionBase.length < 4 || descriptionBase.length > 256)
         ? [
               {
                   field: 'descriptionBase',
                   reason: 'invalid-description',
-                  type: ValidationErrorType.ERROR,
+                  type: FieldValidationIssueType.ERROR,
               },
           ]
         : [];

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -91,7 +91,7 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
     const [switchesAndErrors, switchesLoadingStatus] = useLoaderWithStatus(async () => {
         const errors = await validateLocationTrackSwitchRelinking(locationTrackId);
         const switchIds = errors
-            .filter((r) => r.validationErrors.length > 0 || r.successfulSuggestion == null)
+            .filter((r) => r.validationIssues.length > 0 || r.successfulSuggestion == null)
             .map((s) => s.id);
 
         return {

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -50,9 +50,9 @@ type SplitProps = CommonProps & {
     onRemove?: (switchId: LayoutSwitchId) => void;
     updateSplit: (updateSplit: SplitTargetCandidate | FirstSplitTargetCandidate) => void;
     duplicateTrackId: LocationTrackId | undefined;
-    nameErrors: FieldValidationIssue<SplitTargetCandidate>[];
-    descriptionErrors: FieldValidationIssue<SplitTargetCandidate>[];
-    switchErrors: FieldValidationIssue<SplitTargetCandidate>[];
+    nameIssues: FieldValidationIssue<SplitTargetCandidate>[];
+    descriptionIssues: FieldValidationIssue<SplitTargetCandidate>[];
+    switchIssues: FieldValidationIssue<SplitTargetCandidate>[];
     nameRef: React.RefObject<HTMLInputElement>;
     descriptionBaseRef: React.RefObject<HTMLInputElement>;
     deletingDisabled: boolean;
@@ -127,9 +127,9 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
     onRemove,
     updateSplit,
     duplicateTrackId,
-    nameErrors,
-    descriptionErrors,
-    switchErrors,
+    nameIssues,
+    descriptionIssues,
+    switchIssues,
     editingDisabled,
     deletingDisabled,
     nameRef,
@@ -152,25 +152,25 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
     const [descriptionCommitted, setDescriptionCommitted] = React.useState(
         split.descriptionBase !== '',
     );
-    const startSwitchMatchingError = switchErrors.find(
+    const startSwitchMatchingError = switchIssues.find(
         (error) => error.reason == START_SWITCH_NOT_MATCHING_ERROR,
     );
-    const endSwitchMatchingError = switchErrors.find(
+    const endSwitchMatchingError = switchIssues.find(
         (error) => error.reason == END_SWITCH_NOT_MATCHING_ERROR,
     );
 
     // TODO: Adding any kind of dependency array causes infinite re-render loops, find out why
     React.useEffect(() => {
-        if (!nameErrors.length) {
+        if (!nameIssues.length) {
             setNameCommitted(true);
         }
-        if (!descriptionErrors.length) {
+        if (!descriptionIssues.length) {
             setDescriptionCommitted(true);
         }
     });
 
-    const nameErrorsVisible = nameCommitted && nameErrors.length > 0;
-    const descriptionErrorsVisible = descriptionCommitted && descriptionErrors.length > 0;
+    const nameErrorsVisible = nameCommitted && nameIssues.length > 0;
+    const descriptionErrorsVisible = descriptionCommitted && descriptionIssues.length > 0;
 
     function showSwitchOnMap(location: Point) {
         showArea(getShowSwitchOnMapBoundingBox(location));
@@ -310,7 +310,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                                 />
                             )}
                             {nameErrorsVisible &&
-                                nameErrors.map((error, i) => (
+                                nameIssues.map((error, i) => (
                                     <SplitErrorMessage key={i.toString()} error={error} />
                                 ))}
                         </InfoboxField>
@@ -351,7 +351,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                             hasErrors={descriptionErrorsVisible}
                             label={''}>
                             {descriptionErrorsVisible &&
-                                descriptionErrors.map((error, index) => (
+                                descriptionIssues.map((error, index) => (
                                     <InfoboxText
                                         value={t(
                                             `tool-panel.location-track.splitting.validation.${error.reason}`,

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ValidationError, ValidationErrorType } from 'utils/validation-utils';
+import { FieldValidationIssue, FieldValidationIssueType } from 'utils/validation-utils';
 import styles from 'tool-panel/location-track/location-track-infobox.scss';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { TextField } from 'vayla-design-lib/text-field/text-field';
@@ -50,9 +50,9 @@ type SplitProps = CommonProps & {
     onRemove?: (switchId: LayoutSwitchId) => void;
     updateSplit: (updateSplit: SplitTargetCandidate | FirstSplitTargetCandidate) => void;
     duplicateTrackId: LocationTrackId | undefined;
-    nameErrors: ValidationError<SplitTargetCandidate>[];
-    descriptionErrors: ValidationError<SplitTargetCandidate>[];
-    switchErrors: ValidationError<SplitTargetCandidate>[];
+    nameErrors: FieldValidationIssue<SplitTargetCandidate>[];
+    descriptionErrors: FieldValidationIssue<SplitTargetCandidate>[];
+    switchErrors: FieldValidationIssue<SplitTargetCandidate>[];
     nameRef: React.RefObject<HTMLInputElement>;
     descriptionBaseRef: React.RefObject<HTMLInputElement>;
     deletingDisabled: boolean;
@@ -383,7 +383,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                             className={createClassName(
                                 styles['location-track-infobox__split-switch-error-msg'],
                                 styles['location-track-infobox__split-switch-error-msg--end'],
-                                endSwitchMatchingError.type == ValidationErrorType.ERROR &&
+                                endSwitchMatchingError.type == FieldValidationIssueType.ERROR &&
                                     styles['location-track-infobox__split-switch-error-msg--error'],
                             )}>
                             {t(
@@ -399,12 +399,12 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
 };
 
 type SplitErrorMessageProps = {
-    error: ValidationError<SplitTargetCandidate>;
+    error: FieldValidationIssue<SplitTargetCandidate>;
 };
 const SplitErrorMessage: React.FC<SplitErrorMessageProps> = ({ error }) => {
     const { t } = useTranslation();
     const style =
-        error.type === ValidationErrorType.ERROR
+        error.type === FieldValidationIssueType.ERROR
             ? 'location-track-infobox__split-error'
             : 'location-track-infobox__split-warning';
     return (

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -162,7 +162,7 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
         () =>
             splittingState
                 ? validateLocationTrackSwitchRelinking(splittingState.originLocationTrack.id).then(
-                      (results) => results.filter((res) => res.validationErrors.length > 0),
+                      (results) => results.filter((res) => res.validationIssues.length > 0),
                   )
                 : Promise.resolve([]),
         [changeTimes.layoutLocationTrack, changeTimes.layoutSwitch],

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -256,7 +256,7 @@ const createSplitComponent = (
                 s.id === validatedSplit.split.switch.switchId,
         )?.stateCategory !== 'NOT_EXISTING';
 
-    const { split, nameErrors, descriptionErrors, switchErrors } = validatedSplit;
+    const { split, nameIssues, descriptionIssues, switchIssues } = validatedSplit;
 
     function showSplitTrackOnMap() {
         showArea(multiplyBoundingBox(boundingBoxAroundPoints([startPoint, endPoint]), 1.15));
@@ -276,9 +276,9 @@ const createSplitComponent = (
                 onRemove={split.type === 'SPLIT' ? removeSplit : undefined}
                 updateSplit={updateSplit}
                 duplicateTrackId={split.duplicateTrackId}
-                nameErrors={nameErrors}
-                descriptionErrors={descriptionErrors}
-                switchErrors={switchErrors}
+                nameIssues={nameIssues}
+                descriptionIssues={descriptionIssues}
+                switchIssues={switchIssues}
                 editingDisabled={splittingState.disabled || !switchExists || isPostingSplit}
                 deletingDisabled={splittingState.disabled || isPostingSplit}
                 nameRef={nameRef}
@@ -377,9 +377,9 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
         ),
     );
     const allErrors = splitsValidated.flatMap((validated) => [
-        ...validated.descriptionErrors,
-        ...validated.nameErrors,
-        ...validated.switchErrors,
+        ...validated.descriptionIssues,
+        ...validated.nameIssues,
+        ...validated.switchIssues,
     ]);
     const anyMissingFields = allErrors.map((s) => s.reason).some(mandatoryFieldMissing);
     const anyOtherErrors = allErrors.map((s) => s.reason).some(otherError);

--- a/ui/src/tool-panel/location-track/splitting/split-utils.ts
+++ b/ui/src/tool-panel/location-track/splitting/split-utils.ts
@@ -29,9 +29,9 @@ export const END_SWITCH_NOT_MATCHING_ERROR = 'switch-not-matching-end-switch';
 
 export type ValidatedSplit = {
     split: SplitTargetCandidate | FirstSplitTargetCandidate;
-    nameErrors: FieldValidationIssue<SplitTargetCandidate>[];
-    descriptionErrors: FieldValidationIssue<SplitTargetCandidate>[];
-    switchErrors: FieldValidationIssue<SplitTargetCandidate>[];
+    nameIssues: FieldValidationIssue<SplitTargetCandidate>[];
+    descriptionIssues: FieldValidationIssue<SplitTargetCandidate>[];
+    switchIssues: FieldValidationIssue<SplitTargetCandidate>[];
 };
 
 export type SplitComponentAndRefs = {
@@ -83,9 +83,9 @@ export const validateSplit = (
     lastSwitch: LayoutSwitch | undefined,
 ): ValidatedSplit => ({
     split: split,
-    nameErrors: validateSplitName(split.name, allSplitNames, conflictingTrackNames),
-    descriptionErrors: validateSplitDescription(split.descriptionBase, split.duplicateTrackId),
-    switchErrors: validateSplitSwitch(
+    nameIssues: validateSplitName(split.name, allSplitNames, conflictingTrackNames),
+    descriptionIssues: validateSplitDescription(split.descriptionBase, split.duplicateTrackId),
+    switchIssues: validateSplitSwitch(
         split,
         nextSplit,
         switches
@@ -192,13 +192,13 @@ export const findRefToFirstErroredField = (
 ): React.RefObject<HTMLInputElement> | undefined => {
     const invalidNameIndex = splitComponents.findIndex((s) =>
         hasErrors(
-            s.splitAndValidation.nameErrors.map((err) => err.reason),
+            s.splitAndValidation.nameIssues.map((err) => err.reason),
             predicate,
         ),
     );
     const invalidDescriptionBaseIndex = splitComponents.findIndex((s) =>
         hasErrors(
-            s.splitAndValidation.descriptionErrors.map((err) => err.reason),
+            s.splitAndValidation.descriptionIssues.map((err) => err.reason),
             predicate,
         ),
     );

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -16,7 +16,7 @@ import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
-import { ValidationError, ValidationErrorType } from 'utils/validation-utils';
+import { FieldValidationIssue, FieldValidationIssueType } from 'utils/validation-utils';
 import { TrackLayoutSwitchSaveRequest } from 'linking/linking-model';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import {
@@ -265,7 +265,7 @@ export const SwitchEditDialog = ({
         }
     }
 
-    const validationErrors = [
+    const validationIssues = [
         ...validateSwitchName(switchName),
         ...validateSwitchStateCategory(switchStateCategory),
         ...validateSwitchStructureId(switchStructureId),
@@ -278,7 +278,7 @@ export const SwitchEditDialog = ({
 
     function getVisibleErrorsByProp(prop: keyof TrackLayoutSwitchSaveRequest) {
         if (visitedFields.includes(prop)) {
-            return validationErrors
+            return validationIssues
                 .filter((error) => error.field == prop)
                 .map(({ reason }) => t(`switch-dialog.${reason}`));
         }
@@ -324,11 +324,11 @@ export const SwitchEditDialog = ({
                             </Button>
                             <Button
                                 qa-id="save-switch-changes"
-                                disabled={validationErrors.length > 0 || isSaving}
+                                disabled={validationIssues.length > 0 || isSaving}
                                 isProcessing={isSaving}
                                 onClick={saveOrConfirm}
                                 title={getSaveDisabledReasons(
-                                    validationErrors.map((e) => e.reason),
+                                    validationIssues.map((e) => e.reason),
                                     isSaving,
                                 )
                                     .map((reason) => t(`switch-dialog.${reason}`))
@@ -526,27 +526,27 @@ export const SwitchEditDialog = ({
     );
 };
 
-function validateSwitchName(name: string): ValidationError<TrackLayoutSwitchSaveRequest>[] {
-    const errors: ValidationError<TrackLayoutSwitchSaveRequest>[] = [];
+function validateSwitchName(name: string): FieldValidationIssue<TrackLayoutSwitchSaveRequest>[] {
+    const errors: FieldValidationIssue<TrackLayoutSwitchSaveRequest>[] = [];
     if (!name) {
         errors.push({
             field: 'name',
             reason: 'mandatory-field',
-            type: ValidationErrorType.ERROR,
+            type: FieldValidationIssueType.ERROR,
         });
     }
     if (name.length > 20) {
         errors.push({
             field: 'name',
             reason: 'name-max-limit',
-            type: ValidationErrorType.ERROR,
+            type: FieldValidationIssueType.ERROR,
         });
     }
     if (!name.match(SWITCH_NAME_REGEX)) {
         errors.push({
             field: 'name',
             reason: 'invalid-name',
-            type: ValidationErrorType.ERROR,
+            type: FieldValidationIssueType.ERROR,
         });
     }
     return errors;
@@ -554,13 +554,13 @@ function validateSwitchName(name: string): ValidationError<TrackLayoutSwitchSave
 
 function validateSwitchStateCategory(
     stateCategory?: LayoutStateCategory,
-): ValidationError<TrackLayoutSwitchSaveRequest>[] {
+): FieldValidationIssue<TrackLayoutSwitchSaveRequest>[] {
     if (!stateCategory)
         return [
             {
                 field: 'stateCategory',
                 reason: 'mandatory-field',
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ];
     else return [];
@@ -568,13 +568,13 @@ function validateSwitchStateCategory(
 
 function validateSwitchStructureId(
     structureId?: SwitchStructureId,
-): ValidationError<TrackLayoutSwitchSaveRequest>[] {
+): FieldValidationIssue<TrackLayoutSwitchSaveRequest>[] {
     if (!structureId)
         return [
             {
                 field: 'switchStructureId',
                 reason: 'mandatory-field',
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ];
     else return [];
@@ -582,13 +582,13 @@ function validateSwitchStructureId(
 
 function validateSwitchOwnerId(
     ownerId?: SwitchStructureId,
-): ValidationError<TrackLayoutSwitchSaveRequest>[] {
+): FieldValidationIssue<TrackLayoutSwitchSaveRequest>[] {
     if (!ownerId)
         return [
             {
                 field: 'ownerId',
                 reason: 'mandatory-field',
-                type: ValidationErrorType.ERROR,
+                type: FieldValidationIssueType.ERROR,
             },
         ];
     else return [];

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -22,7 +22,7 @@ import {
     TrackNumberSaveRequest,
 } from './track-number-edit-store';
 import { createDelegatesWithDispatcher } from 'store/store-utils';
-import { ValidationErrorType } from 'utils/validation-utils';
+import { FieldValidationIssueType } from 'utils/validation-utils';
 import {
     LayoutReferenceLine,
     LayoutTrackNumber,
@@ -162,7 +162,7 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
     };
 
     const hasErrors =
-        state.validationErrors.filter((e) => e.type === ValidationErrorType.ERROR).length > 0;
+        state.validationIssues.filter((e) => e.type === FieldValidationIssueType.ERROR).length > 0;
     const numberErrors = getErrors(state, 'number');
     const stateErrors = getErrors(state, 'state');
     const descriptionErrors = getErrors(state, 'description');
@@ -217,7 +217,7 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
                                 qa-id="save-track-number-changes"
                                 onClick={saveOrConfirm}
                                 title={getSaveDisabledReasons(
-                                    state.validationErrors.map((e) => e.reason),
+                                    state.validationIssues.map((e) => e.reason),
                                     saveInProgress,
                                 )
                                     .map((reason) => t(mapError(reason)))

--- a/ui/src/utils/validation-utils.ts
+++ b/ui/src/utils/validation-utils.ts
@@ -1,15 +1,15 @@
 import { TOptions } from 'i18next';
 import { filterNotEmpty } from 'utils/array-utils';
 
-export enum ValidationErrorType {
+export enum FieldValidationIssueType {
     WARNING = 'WARNING',
     ERROR = 'ERROR',
 }
 
-export type ValidationError<TEntity> = {
+export type FieldValidationIssue<TEntity> = {
     field: keyof TEntity;
     reason: string;
-    type: ValidationErrorType;
+    type: FieldValidationIssueType;
     params?: TOptions;
 };
 
@@ -27,12 +27,12 @@ const OID_REGEX = /^\d+(\.\d+){2,9}$/g;
 export function isPropEditFieldCommitted<T, TKey extends keyof T>(
     propEdit: PropEdit<T, TKey>,
     committedFields: TKey[],
-    validationErrors: ValidationError<T>[],
+    validationIssues: FieldValidationIssue<T>[],
 ) {
     return (
         propEdit.editingExistingValue ||
         (!committedFields.includes(propEdit.key) &&
-            !validationErrors.some((error) => error.field == propEdit.key))
+            !validationIssues.some((error) => error.field == propEdit.key))
     );
 }
 
@@ -49,5 +49,5 @@ export function validateOid(oid: string): string[] {
     ].filter(filterNotEmpty);
 }
 
-export const validate = <T>(isValid: boolean, error: ValidationError<T>) =>
+export const validate = <T>(isValid: boolean, error: FieldValidationIssue<T>) =>
     isValid ? undefined : error;


### PR DESCRIPTION
Tämä vähän eskaloitui alkuperäisestä, sillä päädyin uudelleennimeämään myös frontin inputfieldien validointiin liittyvän `ValidationError`-tyypin, samoin kuin about kaikki tietotyyppien ja funktioiden `errors`-kentät, nimet ja funktiot. Vanha `Error`-kattotermi muuttui muotoon `Issue`, ja siten jos jossain puhutaan tämän refakin jäljiltä vielä `error`-termillä, niin silloin sen pitäisi tarkoittaa virhetason `Issue`:ta (huomionarvoista esim. muuttujien ja funktioiden nimissä.) Vanhanmallisia `Error`-viittauksia löytyy tosin varmasti edelleen, sillä niitä oli _niin_ paljon, enkä lähtenyt ihan koko koodipesää käymään käsin läpi.