### PR TITLE
GVT-2616 LayoutBranchify and optimize fetchLinkedLocationTracks

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -359,7 +359,7 @@ class ValidationContext(
     private fun fetchSwitchTrackLinks(
         ids: List<IntId<TrackLayoutSwitch>>,
     ): Map<IntId<TrackLayoutSwitch>, List<IntId<LocationTrack>>> = publicationDao
-        .fetchLinkedLocationTracks(ids, publicationSet.locationTracks.map { v -> v.officialId })
+        .fetchLinkedLocationTracks(branch, ids, publicationSet.locationTracks.map { v -> v.officialId })
         .mapValues { (_, versions) ->
             val officialVersions = versions.filterNot { v -> publicationSet.containsLocationTrack(v.officialId) }
             cacheOfficialVersions(officialVersions.map { v -> v.validatedAssetVersion }, locationTrackVersionCache)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -360,11 +360,15 @@ class PublicationDaoIT @Autowired constructor(
                 daoResponseToValidationVersion(officialLinkedAlignment),
                 daoResponseToValidationVersion(draftLinkedAlignment),
             ),
-            publicationDao.fetchLinkedLocationTracks(listOf(switchByAlignment))[switchByAlignment],
+            publicationDao.fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByAlignment))[switchByAlignment],
         )
         assertEquals(
             setOf(daoResponseToValidationVersion(officialLinkedAlignment)),
-            publicationDao.fetchLinkedLocationTracks(listOf(switchByAlignment), listOf())[switchByAlignment]
+            publicationDao.fetchLinkedLocationTracks(
+                LayoutBranch.main,
+                listOf(switchByAlignment),
+                listOf()
+            )[switchByAlignment]
         )
         assertEquals(
             setOf(
@@ -372,6 +376,7 @@ class PublicationDaoIT @Autowired constructor(
                 daoResponseToValidationVersion(draftLinkedAlignment),
             ),
             publicationDao.fetchLinkedLocationTracks(
+                LayoutBranch.main,
                 listOf(switchByAlignment),
                 listOf(draftLinkedAlignment.id),
             )[switchByAlignment],
@@ -381,15 +386,19 @@ class PublicationDaoIT @Autowired constructor(
                 daoResponseToValidationVersion(officialLinkedTopo),
                 daoResponseToValidationVersion(draftLinkedTopo),
             ),
-            publicationDao.fetchLinkedLocationTracks(listOf(switchByTopo))[switchByTopo],
+            publicationDao.fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByTopo))[switchByTopo],
         )
         assertEquals(
             setOf(daoResponseToValidationVersion(officialLinkedTopo)),
-            publicationDao.fetchLinkedLocationTracks(listOf(switchByTopo), listOf())[switchByTopo]
+            publicationDao.fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByTopo), listOf())[switchByTopo]
         )
         assertEquals(
             setOf(daoResponseToValidationVersion(officialLinkedTopo), daoResponseToValidationVersion(draftLinkedTopo)),
-            publicationDao.fetchLinkedLocationTracks(listOf(switchByTopo), listOf(draftLinkedTopo.id))[switchByTopo]
+            publicationDao.fetchLinkedLocationTracks(
+                LayoutBranch.main,
+                listOf(switchByTopo),
+                listOf(draftLinkedTopo.id)
+            )[switchByTopo]
         )
     }
 


### PR DESCRIPTION
Totta puhuen enemmän optimointia kuin LayoutBranchifiointia, varsinainen uuden tiedon tuominenhan tässä on ihan triviaalius.

Mutta kun fetchLinkedLocationTracks itse näkyi ikävästi profilerissa jo ennen mitään muutoksia kun heiluin Ilmalassa, joten optimoin sitä käsittelemään hieman paremmin erikokoisia switch_id-joukkoja (ja optimoimisvaraa olisi vielä jäljelläkin, mutta menisi jo yksittäisten millisekuntien tiristämiseksi). Hyvin paljolti sama temppu kuin aiemmin https://github.com/finnishtransportagency/geoviite/pull/1263 kanssa, eli että ollaan vaan tarkkoja sen kanssa, että segment_version-taulusta tehtävät massahaut ei tee mitään ylimääräistä vaan hakevat ainoastaan juuri tarvittavan tiedon.