### PR TITLE
GVT-2613: Allow copying text from toasts, display full message

### DIFF
--- a/ui/src/geoviite-design-lib/snackbar/snackbar.scss
+++ b/ui/src/geoviite-design-lib/snackbar/snackbar.scss
@@ -18,13 +18,13 @@
     &__toast-text {
         overflow: hidden;
         text-overflow: ellipsis;
+        user-select: text;
         margin-left: 16px;
     }
 
     &__toast-header {
         font-weight: 600;
         line-height: 20px;
-        white-space: nowrap;
         overflow: hidden;
     }
 


### PR DESCRIPTION
Previously it was for example not possible to directly copy the error message/correlationId/timestamp etc info from the toast, even though the user was able to copy and paste the json-formatted error info from the icon button of the error toast.

Long messages were previously also partially hidden as the toast header forcefully cut off too long text strings, this was also fixed.