### PR TITLE
GVT-2580: Jos vaihteen uudelleenlinkitys poistaa splitattavan raiteen linkityksen, tämä saisi näkyä kriittisenä virheenä

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
@@ -118,6 +118,8 @@ data class SwitchLinkingTrackLinks(
         check(topologyJoint == null || segmentJoints.isEmpty()) { "Switch linking track link links both to segment and topology"}
         check(segmentJoints.zipWithNext { a, b -> a.m < b.m }.all { it }) { "Switch linking track link segment joints should be m-ordered"}
     }
+
+    fun isLinked(): Boolean = segmentJoints.isNotEmpty() || topologyJoint != null
 }
 
 data class SwitchLinkingJoint(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -420,7 +420,7 @@ class SwitchLinkingService @Autowired constructor(
 
         val suggestedConnections = suggestedSwitch
             .trackLinks
-            .filter { link -> link.value.segmentJoints.any() || link.value.topologyJoint != null }
+            .filter { link -> link.value.isLinked() }
             .keys
 
         return listOfNotNull(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -835,15 +835,15 @@ private fun isAddressDiffOk(address1: TrackMeter?, address2: TrackMeter?): Boole
     else if (address1.kmNumber != address2.kmNumber) true
     else (address2.meters - address1.meters).toDouble() in 0.0..MAX_LAYOUT_METER_LENGTH
 
-fun validate(valid: Boolean, type: LayoutValidationIssueType = ERROR, error: () -> String) =
-    validateWithParams(valid, type) { error() to LocalizationParams.empty }
+fun validate(valid: Boolean, type: LayoutValidationIssueType = ERROR, issue: () -> String) =
+    validateWithParams(valid, type) { issue() to LocalizationParams.empty }
 
-private fun validateWithParams(
+fun validateWithParams(
     valid: Boolean,
     type: LayoutValidationIssueType = ERROR,
-    error: () -> Pair<String, LocalizationParams>,
+    issue: () -> Pair<String, LocalizationParams>,
 ): LayoutValidationIssue? = if (!valid) {
-    error().let { (key, params) -> LayoutValidationIssue(type, LocalizationKey(key), params) }
+    issue().let { (key, params) -> LayoutValidationIssue(type, LocalizationKey(key), params) }
 } else {
     null
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -394,12 +394,6 @@ data class TrackLayoutSwitchJointConnection(
     val accurateMatches: List<TrackLayoutSwitchJointMatch>,
     val locationAccuracy: LocationAccuracy?,
 ) {
-    val matches by lazy {
-        accurateMatches.map { accurateMatch ->
-            accurateMatch.locationTrackId
-        }
-    }
-
     fun merge(other: TrackLayoutSwitchJointConnection): TrackLayoutSwitchJointConnection {
         check(number == other.number) { "expected $number == $other.number in TrackLayoutSwitchJointConnection#merge" }
         // location accuracy comes from the joint and hence can't differ

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1449,7 +1449,7 @@
                 "no-geometry": "Raiteella ei ole geometriaa",
                 "affected-split-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteella {{sourceName}}, jonka jakamista ei ole vielä viety Ratkoon",
                 "track-split-in-progress": "Raiteen {{sourceName}} jakamista ei ole vielä viety Ratkoon, joten muita muutoksia ei voi vielä tehdä",
-                "switch-segment-mapping-failed": "Raide {{sourceName}} ei kulje vaihteen {{switchName}} kautta uudelleenlinkityksen jälkeen"
+                "switch-segment-mapping-failed": "Vaihteen {{switchName}} kaikki linjat eivät enää kulje vaihteen kautta uudelleenlinkityksen jälkeen"
             }
         }
     },

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1448,7 +1448,8 @@
                 "trackmeters-changed": "Jaetun raiteen geometria ei sisällä samoja tasametripisteitä",
                 "no-geometry": "Raiteella ei ole geometriaa",
                 "affected-split-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteella {{sourceName}}, jonka jakamista ei ole vielä viety Ratkoon",
-                "track-split-in-progress": "Raiteen {{sourceName}} jakamista ei ole vielä viety Ratkoon, joten muita muutoksia ei voi vielä tehdä"
+                "track-split-in-progress": "Raiteen {{sourceName}} jakamista ei ole vielä viety Ratkoon, joten muita muutoksia ei voi vielä tehdä",
+                "switch-segment-mapping-failed": "Raide {{sourceName}} ei kulje vaihteen {{switchName}} kautta uudelleenlinkityksen jälkeen"
             }
         }
     },

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1449,7 +1449,7 @@
                 "no-geometry": "Raiteella ei ole geometriaa",
                 "affected-split-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteella {{sourceName}}, jonka jakamista ei ole vielä viety Ratkoon",
                 "track-split-in-progress": "Raiteen {{sourceName}} jakamista ei ole vielä viety Ratkoon, joten muita muutoksia ei voi vielä tehdä",
-                "switch-segment-mapping-failed": "Vaihteen {{switchName}} kaikki linjat eivät enää kulje vaihteen kautta uudelleenlinkityksen jälkeen"
+                "track-links-missing-after-relinking": "Vaihteen {{switchName}} kaikki linjat eivät enää kulje vaihteen kautta uudelleenlinkityksen jälkeen"
             }
         }
     },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -1137,7 +1137,13 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 SwitchRelinkingValidationResult(
                     id = okSwitch.id,
                     successfulSuggestion = SwitchRelinkingSuggestion(basePoint, TrackMeter("0000+0010.000")),
-                    validationIssues = listOf(),
+                    validationIssues = listOf(
+                        LayoutValidationIssue(
+                        LayoutValidationIssueType.ERROR,
+                        localizationKey = LocalizationKey("validation.layout.split.track-links-missing-after-relinking"),
+                        params = LocalizationParams(mapOf("switchName" to "ok", "sourceName" to "topoTrack")),
+                    )
+                    ),
                 ),
                 SwitchRelinkingValidationResult(
                     id = switchSomewhereElse.id,

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -268,7 +268,7 @@ const infraModelSlice = createSlice({
     },
 });
 
-function createError<TEntity>(
+function createValidationIssue<TEntity>(
     field: keyof TEntity,
     reason: string,
     type: FieldValidationIssueType,
@@ -288,30 +288,56 @@ function validateParams(
     const issues: FieldValidationIssue<InfraModelParameters>[] = [];
 
     extraParams.planPhase === undefined &&
-        issues.push(createError('planPhase', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(
+            createValidationIssue('planPhase', 'critical', FieldValidationIssueType.WARNING),
+        );
     extraParams.measurementMethod === undefined &&
-        issues.push(createError('measurementMethod', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(
+            createValidationIssue(
+                'measurementMethod',
+                'critical',
+                FieldValidationIssueType.WARNING,
+            ),
+        );
     extraParams.elevationMeasurementMethod === undefined &&
         issues.push(
-            createError('elevationMeasurementMethod', 'critical', FieldValidationIssueType.WARNING),
+            createValidationIssue(
+                'elevationMeasurementMethod',
+                'critical',
+                FieldValidationIssueType.WARNING,
+            ),
         );
     extraParams.decisionPhase === undefined &&
-        issues.push(createError('decisionPhase', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(
+            createValidationIssue('decisionPhase', 'critical', FieldValidationIssueType.WARNING),
+        );
     overrideParams.createdDate === undefined &&
         plan?.planTime === undefined &&
-        issues.push(createError('createdDate', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(
+            createValidationIssue('createdDate', 'critical', FieldValidationIssueType.WARNING),
+        );
     overrideParams.trackNumber === undefined &&
         plan?.trackNumber === undefined &&
-        issues.push(createError('trackNumber', 'critical', FieldValidationIssueType.WARNING));
+        issues.push(
+            createValidationIssue('trackNumber', 'critical', FieldValidationIssueType.WARNING),
+        );
     overrideParams.verticalCoordinateSystem === undefined &&
         plan?.units.verticalCoordinateSystem === undefined &&
         issues.push(
-            createError('verticalCoordinateSystem', 'critical', FieldValidationIssueType.WARNING),
+            createValidationIssue(
+                'verticalCoordinateSystem',
+                'critical',
+                FieldValidationIssueType.WARNING,
+            ),
         );
     overrideParams.coordinateSystemSrid === undefined &&
         plan?.units.coordinateSystemSrid === undefined &&
         issues.push(
-            createError('coordinateSystemSrid', 'critical', FieldValidationIssueType.WARNING),
+            createValidationIssue(
+                'coordinateSystemSrid',
+                'critical',
+                FieldValidationIssueType.WARNING,
+            ),
         );
 
     return issues;

--- a/ui/src/preview/change-table-sorting.ts
+++ b/ui/src/preview/change-table-sorting.ts
@@ -21,7 +21,7 @@ const includesErrors = (issues: LayoutValidationIssue[]) =>
     issues.some((err) => err.type == 'ERROR');
 const includesWarnings = (issues: LayoutValidationIssue[]) =>
     issues.some((err) => err.type == 'WARNING');
-const errorSeverityPriority = (issues: LayoutValidationIssue[]) => {
+const issueSeverityPriority = (issues: LayoutValidationIssue[]) => {
     let priority = 0;
     if (includesErrors(issues)) priority += 2;
     if (includesWarnings(issues)) priority += 1;
@@ -32,11 +32,11 @@ const nameCompare = fieldComparator((entry: { name: string }) => entry.name.toLo
 const trackNumberCompare = fieldComparator((entry: { trackNumber: string }) => entry.trackNumber);
 const userNameCompare = fieldComparator((entry: { userName: string }) => entry.userName);
 const changeTimeCompare = fieldComparator((entry: { changeTime: string }) => entry.changeTime);
-const errorListCompare = (
+const issueListCompare = (
     a: { issues: LayoutValidationIssue[] },
     b: { issues: LayoutValidationIssue[] },
 ) => {
-    const priorityBySeverity = errorSeverityPriority(b.issues) - errorSeverityPriority(a.issues);
+    const priorityBySeverity = issueSeverityPriority(b.issues) - issueSeverityPriority(a.issues);
     return priorityBySeverity !== 0 ? priorityBySeverity : b.issues.length - a.issues.length;
 };
 export const operationPriority = (operation: Operation | undefined) => {
@@ -55,7 +55,7 @@ const sortFunctionsByPropName = {
     OPERATION: operationCompare,
     CHANGE_TIME: changeTimeCompare,
     USER_NAME: userNameCompare,
-    ISSUES: errorListCompare,
+    ISSUES: issueListCompare,
 };
 
 export const InitiallyUnsorted = {

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -153,11 +153,11 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
                                 );
                                 const relinkingFailed =
                                     !switchRelinkingResult?.successfulSuggestion ||
-                                    switchRelinkingResult?.validationErrors.some(
+                                    switchRelinkingResult?.validationIssues?.some(
                                         (t) => t.type === 'ERROR',
                                     );
                                 const firstError = ifDefined(
-                                    switchRelinkingResult?.validationErrors?.filter(
+                                    switchRelinkingResult?.validationIssues?.filter(
                                         (e) => e.type === 'ERROR',
                                     ),
                                     first,

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -27,8 +27,6 @@ import { useTrackLayoutAppSelector } from 'store/hooks';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
-import { ifDefined } from 'utils/type-utils';
-import { first } from 'utils/array-utils';
 
 type SwitchRelinkingValidationTaskListProps = {
     layoutContext: LayoutContext;
@@ -91,18 +89,19 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
     );
 
     const [switchesAndErrors, switchesLoadingStatus] = useLoaderWithStatus(async () => {
-        const errors = await validateLocationTrackSwitchRelinking(locationTrackId);
-        const switchIds = errors
+        const relinkingResults = await validateLocationTrackSwitchRelinking(locationTrackId);
+        const switchIds = relinkingResults
             .filter((r) => r.validationIssues.length > 0 || r.successfulSuggestion == null)
             .map((s) => s.id);
+        const switches = await getSwitches(switchIds, draftLayoutContext(layoutContext));
 
         return {
-            errors,
-            switches: await getSwitches(switchIds, draftLayoutContext(layoutContext)),
+            relinkingResults,
+            switches,
         };
     }, [changeTimes.layoutSwitch, locationTrackId, changeTimes.layoutLocationTrack]);
     const switches = switchesAndErrors?.switches;
-    const errors = switchesAndErrors?.errors;
+    const relinkingResults = switchesAndErrors?.relinkingResults;
 
     const onClick = (layoutSwitch: LayoutSwitch) => {
         const presJointNumber = switchStructures?.find(
@@ -148,30 +147,22 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
                         <ul className={styles['switch-relinking-validation-task-list__switches']}>
                             {switches.map((lSwitch) => {
                                 const selected = selectedSwitches.some((sId) => sId == lSwitch.id);
-                                const switchRelinkingResult = errors?.find(
+                                const switchRelinkingResult = relinkingResults?.find(
                                     (e) => e.id == lSwitch.id,
                                 );
-                                const relinkingFailed =
-                                    !switchRelinkingResult?.successfulSuggestion ||
-                                    switchRelinkingResult?.validationIssues?.some(
-                                        (t) => t.type === 'ERROR',
-                                    );
-                                const firstError = ifDefined(
+
+                                const errors =
                                     switchRelinkingResult?.validationIssues?.filter(
                                         (e) => e.type === 'ERROR',
-                                    ),
-                                    first,
-                                );
+                                    ) ?? [];
 
-                                const errorTitle = firstError
-                                    ? t(firstError.localizationKey, firstError.params)
-                                    : t(
-                                          'tool-panel.location-track.task-list.switch-relinking.relinking-failed',
-                                      );
+                                const title = errors
+                                    .map((e) => t(e.localizationKey, e.params))
+                                    .join('\n');
 
                                 return (
                                     <li
-                                        title={relinkingFailed ? errorTitle : undefined}
+                                        title={title}
                                         key={lSwitch.id}
                                         className={
                                             styles['switch-relinking-validation-task-list__switch']
@@ -185,7 +176,7 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
                                                     : SwitchBadgeStatus.DEFAULT
                                             }
                                         />
-                                        {relinkingFailed && (
+                                        {errors.length > 0 && (
                                             <span
                                                 className={
                                                     'switch-relinking-validation-task-list__critical-error'

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -27,6 +27,8 @@ import { useTrackLayoutAppSelector } from 'store/hooks';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
+import { ifDefined } from 'utils/type-utils';
+import { first } from 'utils/array-utils';
 
 type SwitchRelinkingValidationTaskListProps = {
     layoutContext: LayoutContext;
@@ -146,18 +148,30 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
                         <ul className={styles['switch-relinking-validation-task-list__switches']}>
                             {switches.map((lSwitch) => {
                                 const selected = selectedSwitches.some((sId) => sId == lSwitch.id);
-                                const relinkingFailed = !errors?.find((e) => e.id == lSwitch.id)
-                                    ?.successfulSuggestion;
+                                const switchRelinkingResult = errors?.find(
+                                    (e) => e.id == lSwitch.id,
+                                );
+                                const relinkingFailed =
+                                    !switchRelinkingResult?.successfulSuggestion ||
+                                    switchRelinkingResult?.validationErrors.some(
+                                        (t) => t.type === 'ERROR',
+                                    );
+                                const firstError = ifDefined(
+                                    switchRelinkingResult?.validationErrors?.filter(
+                                        (e) => e.type === 'ERROR',
+                                    ),
+                                    first,
+                                );
+
+                                const errorTitle = firstError
+                                    ? t(firstError.localizationKey, firstError.params)
+                                    : t(
+                                          'tool-panel.location-track.task-list.switch-relinking.relinking-failed',
+                                      );
 
                                 return (
                                     <li
-                                        title={
-                                            relinkingFailed
-                                                ? t(
-                                                      'tool-panel.location-track.task-list.switch-relinking.relinking-failed',
-                                                  )
-                                                : ''
-                                        }
+                                        title={relinkingFailed ? errorTitle : undefined}
                                         key={lSwitch.id}
                                         className={
                                             styles['switch-relinking-validation-task-list__switch']

--- a/ui/src/tool-panel/location-track/splitting/split-utils.ts
+++ b/ui/src/tool-panel/location-track/splitting/split-utils.ts
@@ -230,8 +230,13 @@ export const getSplitAddressPoint = (
     }
 };
 
-export const hasUnrelinkableSwitches = (switchRelinkingErrors: SwitchRelinkingValidationResult[]) =>
-    switchRelinkingErrors?.some((err) => !err.successfulSuggestion) || false;
+export const hasUnrelinkableSwitches = (
+    relinkingValidationResults: SwitchRelinkingValidationResult[],
+) =>
+    relinkingValidationResults.some((err) => !err.successfulSuggestion) ||
+    relinkingValidationResults.some((err) =>
+        err.validationErrors.some((ve) => ve.type === 'ERROR'),
+    );
 
 export const getOperation = (
     trackId: LocationTrackId,

--- a/ui/src/tool-panel/location-track/splitting/split-utils.ts
+++ b/ui/src/tool-panel/location-track/splitting/split-utils.ts
@@ -238,7 +238,6 @@ export const getSplitAddressPoint = (
 export const hasUnrelinkableSwitches = (
     relinkingValidationResults: SwitchRelinkingValidationResult[],
 ) =>
-    relinkingValidationResults.some((err) => !err.successfulSuggestion) ||
     relinkingValidationResults.some((err) =>
         err.validationIssues.some((ve) => ve.type === 'ERROR'),
     );

--- a/ui/src/tool-panel/location-track/splitting/split-utils.ts
+++ b/ui/src/tool-panel/location-track/splitting/split-utils.ts
@@ -240,7 +240,7 @@ export const hasUnrelinkableSwitches = (
 ) =>
     relinkingValidationResults.some((err) => !err.successfulSuggestion) ||
     relinkingValidationResults.some((err) =>
-        err.validationErrors.some((ve) => ve.type === 'ERROR'),
+        err.validationIssues.some((ve) => ve.type === 'ERROR'),
     );
 
 export const getOperation = (

--- a/ui/src/utils/validation-utils.ts
+++ b/ui/src/utils/validation-utils.ts
@@ -1,5 +1,4 @@
 import { TOptions } from 'i18next';
-import { filterNotEmpty } from 'utils/array-utils';
 
 export enum FieldValidationIssueType {
     WARNING = 'WARNING',
@@ -19,8 +18,6 @@ export type PropEdit<T, TKey extends keyof T> = {
     editingExistingValue: boolean;
 };
 
-const OID_REGEX = /^\d+(\.\d+){2,9}$/g;
-
 // When editing something pre-existing previous values should be committed from
 // the start. When creating something new, only mark the field as committed when
 // a valid value has been reached in order not to show annoying errors before that.
@@ -32,22 +29,9 @@ export function isPropEditFieldCommitted<T, TKey extends keyof T>(
     return (
         propEdit.editingExistingValue ||
         (!committedFields.includes(propEdit.key) &&
-            !validationIssues.some((error) => error.field == propEdit.key))
+            !validationIssues.some((issue) => issue.field == propEdit.key))
     );
 }
 
-export function validateOid(oid: string): string[] {
-    const regexpMatch = oid.match(OID_REGEX);
-
-    const tooShort = oid.length <= 4;
-    const tooLong = oid.length > 50;
-
-    return [
-        regexpMatch ? undefined : 'invalid-oid',
-        tooShort ? 'not-enough-values' : undefined,
-        tooLong ? 'too-many-values' : undefined,
-    ].filter(filterNotEmpty);
-}
-
-export const validate = <T>(isValid: boolean, error: FieldValidationIssue<T>) =>
-    isValid ? undefined : error;
+export const validate = <T>(isValid: boolean, issue: FieldValidationIssue<T>) =>
+    isValid ? undefined : issue;


### PR DESCRIPTION
Täällä tiketin varsinainen pihvi. Validaatiota on nyt muutettu siten, että uudelleenlinkitys tarkistaa löytyykö raiteelta varmasti linkit kaikkiin sen entisiin sijaintiraiteisiin. Jos ei löydy, niin nostetaan punainen virhe. Samalla täällä on muutettu splittauksen error-käsittelyä siten, että uudelleenlinkityksessä kaikki "tavalliset" julkaisuvalidaatiovirheet muutetaan varoituksiksi - ne eivät estä splittausta ja voidaan korjata jälkeenpäin, - ja ainoastaan vaihde-ehdotuksen uupumaan jääminen sekä tämä täällä lisätty linjojen puuttuminen aiheuttavat virheen. Täten voidaan hyödyntää frontilla virheiden näyttämisessä puhtaasti issuen tasoa.

Samalla täällä on jatkettu error-nimien muuttamista issueiksi, sekä sitä mukaa kun niitä on tullut vastaan että review-kommenttien perusteella.

HUOM! Täällä ei vielä oteta kantaa siihen, mitä tapahtuu raiteen infoboksin "Linkitä raiteen vaihteet..." -nappulaa painettaessa. Se tulee omalla pullarillaan kunhan keksitään sille sopiva UX