### PR TITLE
GVT-2622: FJulkaisunäkymän Tila-sarakkeen sisältö tasautuu oudosti rivittyessään

### DIFF
--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -59,7 +59,6 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     const hasErrors = tableEntry.issues.length > 0;
 
     const statusCellClassName = createClassName(
-        styles['preview-table-item__status-cell'],
         hasErrors && styles['preview-table-item__status-cell--expandable'],
     );
 
@@ -196,20 +195,23 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                                 <Icons.Tick color={IconColor.INHERIT} size={IconSize.SMALL} />
                             </span>
                         )}
-                        {errorTexts.length > 0 && (
-                            <span className={styles['preview-table-item__error-status']}>
-                                {t('preview-table.errors-status-text', {
-                                    errors: errorTexts.length,
-                                })}
-                            </span>
-                        )}
-                        {warningTexts.length > 0 && (
-                            <span className={styles['preview-table-item__warning-status']}>
-                                {t('preview-table.warnings-status-text', {
-                                    warnings: warningTexts.length,
-                                })}
-                            </span>
-                        )}
+                        <span>
+                            {errorTexts.length > 0 && (
+                                <span className={styles['preview-table-item__error-status']}>
+                                    {t('preview-table.errors-status-text', {
+                                        errors: errorTexts.length,
+                                    })}
+                                </span>
+                            )}
+                            {errorTexts.length > 0 && warningTexts.length > 0 && ' '}
+                            {warningTexts.length > 0 && (
+                                <span className={styles['preview-table-item__warning-status']}>
+                                    {t('preview-table.warnings-status-text', {
+                                        warnings: warningTexts.length,
+                                    })}
+                                </span>
+                            )}
+                        </span>
                     </td>
                 )}
                 <td className={'preview-table-item preview-table-item__actions--cell'}>

--- a/ui/src/preview/preview-view.scss
+++ b/ui/src/preview/preview-view.scss
@@ -140,13 +140,6 @@ $-color-warning: vayla-design.$color-lemon-dark;
     }
 }
 
-.preview-table-item__status-cell {
-    > *:not(:first-child):before {
-        margin-left: 8px;
-        content: ' ';
-    }
-}
-
 .preview-table-item__ok-status {
     color: $-color-ok;
     fill: $-color-ok;


### PR DESCRIPTION
En vieläkään tiedä mistä tuo alkuperäinen ongelma johtui ihan täysin, mutta uskon tuon aiemmin olemassaolleen `*:not(:first-child):before`-määritykseen olleen osa ongelmaa. Sen poistamisella ongelma myös korjaantui, ja nyt väli virheiden ja varoitusten väliin tehdään hieman konventionaalisemmalla metodilla.