### PR TITLE
GVT-2624: Fix drawing km-numbers in vertical geometry diagram while still handling cursor position properly

### DIFF
--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -65,7 +65,9 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
     const [diagramHeight, setDiagramHeight] = React.useState<number>(height);
     const [diagramWidth, setDiagramWidth] = React.useState<number>(width);
 
-    const ref = React.useRef<SVGSVGElement>(null);
+    const ref = React.useRef<HTMLDivElement>(null);
+    const svgRef = React.useRef<SVGSVGElement>(null);
+
     const elementPosition = ref.current?.getBoundingClientRect();
 
     React.useEffect(() => {
@@ -118,7 +120,7 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
     const onMouseMove: React.EventHandler<React.MouseEvent<unknown>> = (
         e: React.MouseEvent<SVGSVGElement>,
     ) => {
-        const elementBounds = ref.current?.getBoundingClientRect();
+        const elementBounds = svgRef.current?.getBoundingClientRect();
         if (!elementBounds) {
             return;
         }
@@ -211,7 +213,8 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
                 setPanning(undefined);
                 setMousePositionInElement(undefined);
             }}
-            onDoubleClick={onDoubleClick}>
+            onDoubleClick={onDoubleClick}
+            ref={ref}>
             {snap && elementPosition && (
                 <HeightTooltip
                     point={snap}
@@ -219,7 +222,7 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
                     coordinates={coordinates}
                 />
             )}
-            <svg height="100%" width="100%" qa-id="vertical-geometry-diagram-proper" ref={ref}>
+            <svg height="100%" width="100%" qa-id="vertical-geometry-diagram-proper" ref={svgRef}>
                 <>
                     <HeightLines coordinates={coordinates} />
                     <LabeledTicks


### PR DESCRIPTION
The position cross/cursor indicator of the vertical geometry diagram was previously modified in GVT-2583 as it was improperly drawn to the right side of the actual position of the mouse. While the fix made during GVT-2583 did work for the position indicator, it also modified the positioning of the km-numbers drawn to the bottom of the vertical geometry diagram resulting in them being drawn off or not being drawn at all to the vertical geometry diagram's svg.

The changes in this PR should...
* Keep the previous fix to the cursor position still in place
* Draw all other elements as before to the svg

It should be noted that the container used for the svg has 8px padding (on all sides) which means that the container is a little larger than the actual svg image being drawn. This is probably the cause of the original issue of the cursor indicator being drawn with an offset to the side.