### PR TITLE
GVT-2588: Handle split source track update error more gracefully

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -160,6 +160,17 @@ class DuplicateLocationTrackNameInPublicationException(
     )
 )
 
+class SplitSourceLocationTrackUpdateException(
+    alignmentName: AlignmentName,
+    cause: Throwable? = null,
+) : ClientException(
+    status = BAD_REQUEST,
+    message = "Split source location track updates are not allowed",
+    cause = cause,
+    localizedMessageKey = "error.split.source-track-update-is-not-allowed",
+    localizedMessageParams = localizationParams("alignmentName" to alignmentName),
+)
+
 enum class Integration { RATKO, PROJEKTIVELHO }
 class IntegrationNotConfiguredException(type: Integration) : ClientException(
     status = SERVICE_UNAVAILABLE,

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -14,6 +14,7 @@
         },
         "split": {
             "source-track-state-not-in-use": "Jakamista ei voitu suorittaa, koska jaettava raide ei ole \"Käytössä\"-tilassa",
+            "source-track-update-is-not-allowed": "Raide {{alignmentName}} on jaettu, eikä sen muokkaaminen ole enää mahdollista",
             "segment-allocation-failed": "Jakamista ei voitu suorittaa, koska katkaisukohtien määritys epäonnistui",
             "switch-segment-mapping-failed": "Raidetta ei voitu jakaa vaihteen {{switchName}} kohdalta, koska sen uudelleenlinkitys epäonnistui",
             "switch-linking-failed": "Jakamista ei voitu suorittaa, koska vaihteiden uudelleenlinkitys epäonnistui",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -576,12 +576,12 @@ class LocationTrackServiceIT @Autowired constructor(
     fun `Trying to update a split source location track should throw`() {
         val split = splitTestDataService
             .insertSplit()
-            .let(splitService::get)!!
+            .let(splitService::getOrThrow)
 
-        val sourceLocationTrack = locationTrackService.get(
+        val sourceLocationTrack = locationTrackService.getOrThrow(
             MainLayoutContext.draft,
             split.sourceLocationTrackId,
-        )!!
+        )
 
         assertThrows<SplitSourceLocationTrackUpdateException> {
             locationTrackService.update(


### PR DESCRIPTION
Tässähän olisi siis ainakin pari tapaa tämä virhe huomata:
* Otetaan kantavirhe kiinni ja muutetaan se mielekkäämmäksi (joka toteutettu)
* Tarkistetaan ennen raiteen päivittämiskantakutsun suorittamista, että onko raide minkä tahansa splitin lähderaide. Tämä vaikutti aluksi mielekkäämmältä, mutta alkoi tuntua melko raskaalta tehdä kantahaku tätä varten jokaisen raiteen päivityksen yhteydessä.

Mielipiteitä?