### PR TITLE
GVT-2630 Optimize in_layout_context functions for querying by official_id

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
@@ -180,9 +180,10 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
                 location_track on location_track.alignment_id = segment_version.alignment_id
                         and location_track.alignment_version = segment_version.alignment_version
                         and location_track.state != 'DELETED'
-            left join layout.switch_in_layout_context(:publication_state::layout.publication_state, :design_id)
-              layout_switch on layout_switch.official_id = segment_version.switch_id
-                        and layout_switch.state_category != 'NOT_EXISTING'
+            left join lateral layout.switch_in_layout_context(:publication_state::layout.publication_state,
+                                                              :design_id,
+                                                              segment_version.switch_id)
+              layout_switch on layout_switch.state_category != 'NOT_EXISTING'
           where switch.plan_id = :plan_id
           group by switch.id;
         """.trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -220,8 +220,9 @@ class ReferenceLineDao(
               rl.row_id,
               rl.row_version
             from layout.reference_line_in_layout_context(:publication_state::layout.publication_state, :design_id) rl
-              left join layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id) tn
-                on rl.track_number_id = tn.official_id
+              left join lateral layout.track_number_in_layout_context(:publication_state::layout.publication_state,
+                                                                      :design_id,
+                                                                      rl.track_number_id) tn on true
             where (:include_deleted = true or tn.state != 'DELETED')
         """.trimIndent()
         val params = mapOf(
@@ -251,8 +252,7 @@ class ReferenceLineDao(
                                               bounding_box)
               ) sv
                 join layout.reference_line_in_layout_context(:publication_state::layout.publication_state, :design_id) rl using (alignment_id, alignment_version)
-                join layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id) tn
-                  on rl.track_number_id = tn.official_id
+                cross join lateral layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id, rl.track_number_id) tn
               where tn.state != 'DELETED';
         """.trimIndent()
 
@@ -277,8 +277,9 @@ class ReferenceLineDao(
               rl.row_id,
               rl.row_version
             from layout.reference_line_in_layout_context(:publication_state::layout.publication_state, :design_id) rl
-              left join layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id) tn
-                on rl.track_number_id = tn.official_id
+              left join lateral layout.track_number_in_layout_context(:publication_state::layout.publication_state,
+                                                                      :design_id,
+                                                                      rl.track_number_id) tn on(true)
             where tn.state != 'DELETED'
               and rl.segment_count = 0
         """.trimIndent()

--- a/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
@@ -1,6 +1,8 @@
 drop function if exists layout.track_number_in_layout_context(layout.publication_state, int);
+drop function if exists layout.track_number_in_layout_context(layout.publication_state, int, int);
 
-create function layout.track_number_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
+create function layout.track_number_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
+                                                      official_id_in int default null)
   returns table
           (
             row_id      integer,
@@ -31,7 +33,23 @@ select
   row.draft,
   row.change_user,
   row.change_time
-  from layout.track_number row
+  from (
+    select *
+      from layout.track_number
+      where official_row_id = official_id_in
+    union all
+    select *
+      from layout.track_number
+      where design_row_id = official_id_in
+    union all
+    select *
+      from layout.track_number
+      where id = official_id_in
+    union all
+    select *
+      from layout.track_number
+      where official_id_in is null
+  ) row
   where case publication_state_in
           when 'OFFICIAL' then not row.draft
           else row.draft

--- a/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
@@ -1,6 +1,8 @@
 drop function if exists layout.reference_line_in_layout_context(layout.publication_state, int);
+drop function if exists layout.reference_line_in_layout_context(layout.publication_state, int, int);
 
-create function layout.reference_line_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
+create function layout.reference_line_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
+                                                        official_id_in int default null)
   returns table
           (
             row_id            integer,
@@ -37,7 +39,23 @@ select
   alignment.bounding_box,
   alignment.length,
   alignment.segment_count
-  from layout.reference_line row
+  from (
+    select *
+      from layout.reference_line
+      where official_row_id = official_id_in
+    union all
+    select *
+      from layout.reference_line
+      where design_row_id = official_id_in
+    union all
+    select *
+      from layout.reference_line
+      where id = official_id_in
+    union all
+    select *
+      from layout.reference_line
+      where official_id_in is null
+  ) row
     left join layout.alignment on row.alignment_id = alignment.id
   where case publication_state_in
           when 'OFFICIAL' then not row.draft

--- a/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
@@ -1,6 +1,8 @@
 drop function if exists layout.location_track_in_layout_context(layout.publication_state, int);
+drop function if exists layout.location_track_in_layout_context(layout.publication_state, int, int);
 
-create function layout.location_track_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
+create function layout.location_track_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
+                                                        official_id_in int default null)
   returns table
           (
             row_id                             integer,
@@ -59,7 +61,23 @@ select
   alignment.bounding_box,
   alignment.length,
   alignment.segment_count
-  from layout.location_track row
+  from (
+    select *
+      from layout.location_track
+      where official_row_id = official_id_in
+    union all
+    select *
+      from layout.location_track
+      where design_row_id = official_id_in
+    union all
+    select *
+      from layout.location_track
+      where id = official_id_in
+    union all
+    select *
+      from layout.location_track
+      where official_id_in is null
+  ) row
     left join layout.alignment on row.alignment_id = alignment.id
   where case publication_state_in
           when 'OFFICIAL' then not row.draft

--- a/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
@@ -1,6 +1,8 @@
 drop function if exists layout.switch_in_layout_context(layout.publication_state, int);
+drop function if exists layout.switch_in_layout_context(layout.publication_state, int, int);
 
-create function layout.switch_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
+create function layout.switch_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
+                                                official_id_in int default null)
   returns table
           (
             row_id              integer,
@@ -39,7 +41,23 @@ select
   row.change_time,
   row.source,
   row.draft
-  from layout.switch row
+  from (
+    select *
+      from layout.switch
+      where official_row_id = official_id_in
+    union all
+    select *
+      from layout.switch
+      where design_row_id = official_id_in
+    union all
+    select *
+      from layout.switch
+      where id = official_id_in
+    union all
+    select *
+      from layout.switch
+      where official_id_in is null
+  ) row
   where case publication_state_in
           when 'OFFICIAL' then not row.draft
           else row.draft

--- a/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
@@ -1,6 +1,8 @@
 drop function if exists layout.km_post_in_layout_context(layout.publication_state, int);
+drop function if exists layout.km_post_in_layout_context(layout.publication_state, int, int);
 
-create function layout.km_post_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
+create function layout.km_post_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
+                                                 official_id_in int default null)
   returns table
           (
             row_id              integer,
@@ -33,7 +35,23 @@ select
   row.change_user,
   row.change_time,
   row.draft
-  from layout.km_post row
+  from (
+    select *
+      from layout.km_post
+      where official_row_id = official_id_in
+    union all
+    select *
+      from layout.km_post
+      where design_row_id = official_id_in
+    union all
+    select *
+      from layout.km_post
+      where id = official_id_in
+    union all
+    select *
+      from layout.km_post
+      where official_id_in is null
+  ) row
   where case publication_state_in
           when 'OFFICIAL' then not row.draft
           else row.draft


### PR DESCRIPTION
in_layout_context-funktioiden kanssa ärsyttää isosti, että asioiden haku official_id:n perusteella on niille hyvin tavallinen käyttötapaus, mutta niissä on peräisin yhä alkuperäisiin julkaisunäkymiin keksitty `coalesce`-mekanismi, jonka läpi postgres ei osaa optimoida hakuja: Jos haetaan `select * from foo_in_layout_context(s, b) where official_id = 123`, postgressi materialisoi koko taulun sisällön ja rivi kerrallaan tutkii, onko nyt juuri tällä rivillä tuo pyydetty official_id.

Toisaalta näiden funktioiden halutaan myös olevan nopeita muidenkin ehtojen perusteella hakiessa, esim. jos haetaan `select * from location_track_in_layout_context(s, b) where track_number_id = 123`, niin parastahan olisi, että ne kanta tietäisi keskittyä track_number_id:n perusteella hakuun.

Testasin pari eri tapaa esittää tilanteen kannalle, ja tämä näytti olevan toimivin: in_layout_context-funktioilla on nyt valinnainen official_id_in-parametri. Jos se on annettu, funktio tekee optimaaliset haut käyttämällä juuri annettua id:tä, joista jokainen osuu indekseihin, ja postgressi osaa todentaa, että `union all`in haara, jossa `official_id_in is null` ei voi palauttaa yhtään riviä, eikä siksi aja sitä lainkaan. Samoin jos taas funktiota kutsutaan antamatta `official_id_in`iä, kanta osaa todentaa, että muita haaroja kuin viimeistä ei tarvitse yrittääkään ajaa.

Koska parametrilla saa sisään vain yhden id:n kerrallaan, sitä ei pysty käyttämään tavallisilla joineilla, mutta lateraleilla se toimii, ja hakusuunnitelmat ovat suunnilleen niin optimaalisia kuin voivat olla: esim. tuo oleellinen ReferenceLineDaon haku käy silmukassa viitisensataa kertaa track_number-tiedon haun, mutta jokainen käynti tekee vain index scanneja, joten koko haku menee sentään parissakymmenessä millisekunnissa. 

fetchContextVersion-haku yksinkertaistuu huomattavasti, koska nyt sen tarvitsee enää vain etsiä haettua id:tä vastaava virallinen id, ja sitten vaan hakea olion kontekstin versio kyseisen official_id:n perusteella. Sitten kun toteutetaan https://extranet.vayla.fi/jira/browse/GVT-2629, hausta voi poistaa vielä tuon ensimmäisen osankin ja antaa vaan sisään suoraan official_id:n.