### PR TITLE
GVT-2628: SplitButton-komponentti

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -652,6 +652,7 @@
                 "relinking-finished-with-errors": "{{relinkedCount}} vaihdetta linkitetty. Ongelmia sisältävät vaihteet ({{invalidCount}} kpl) näytetään tehtävälistassa."
             },
             "start-splitting": "Aloita raiteen jakaminen",
+            "start-splitting-prefilled": "Aloita raiteen jakaminen (automaattinen täyttö)",
             "splitting": {
                 "title": "Raiteen jakaminen osiin",
                 "confirm-split": "Suorita jako",

--- a/ui/src/geoviite-design-lib/split-button/split-button.scss
+++ b/ui/src/geoviite-design-lib/split-button/split-button.scss
@@ -1,0 +1,18 @@
+.split-button {
+    display: inline-flex;
+
+    > :not(:last-child) {
+        margin-right: 0px;
+    }
+
+    > :first-child {
+        border-bottom-right-radius: 0px;
+        border-top-right-radius: 0px;
+    }
+
+    > :last-child {
+        border-bottom-left-radius: 0px;
+        border-top-left-radius: 0px;
+        border-left-width: 0px;
+    }
+}

--- a/ui/src/geoviite-design-lib/split-button/split-button.tsx
+++ b/ui/src/geoviite-design-lib/split-button/split-button.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { Menu, MenuOption } from 'vayla-design-lib/menu/menu';
+import { Button, ButtonProps } from 'vayla-design-lib/button/button';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+import styles from './split-button.scss';
+
+type SplitButtonProps<TMenuItem> = {
+    menuItems: MenuOption<TMenuItem>[];
+    children?: React.ReactNode;
+    qaId?: string;
+} & ButtonProps;
+
+export const SplitButton = function <TMenuItem>({
+    menuItems,
+    children,
+    qaId,
+    ...buttonProps
+}: SplitButtonProps<TMenuItem>) {
+    const ref = React.useRef<HTMLSpanElement>(null);
+    const [menuOpen, setMenuOpen] = React.useState(false);
+
+    return (
+        <span className={styles['split-button']} ref={ref}>
+            <Button {...buttonProps} qa-id={qaId}>
+                {children}
+            </Button>
+            <Button
+                icon={Icons.Down}
+                onClick={() => setMenuOpen(!menuOpen)}
+                size={buttonProps.size}
+                variant={buttonProps.variant}
+                qa-id={`${qaId}-menu`}
+                disabled={buttonProps.disabled}
+            />
+            {menuOpen && (
+                <Menu
+                    positionRef={ref}
+                    onClickOutside={() => setMenuOpen(false)}
+                    items={menuItems}
+                />
+            )}
+        </span>
+    );
+};

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -353,10 +353,38 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                                 isProcessing={startingSplitting}
                                                 title={getSplittingDisabledReasonsTranslated()}
                                                 onClick={startSplitting}
-                                                qa-id="start-splitting"
-                                                >
+                                                qa-id="start-splitting">
                                                 {t('tool-panel.location-track.start-splitting')}
                                             </Button>
+                                            /* TODO: Uncomment once splitting with prefilled data is implemented
+                                            <SplitButton
+                                                variant={ButtonVariant.SECONDARY}
+                                                size={ButtonSize.SMALL}
+                                                disabled={
+                                                    locationTrack.state !== 'IN_USE' ||
+                                                    !isDraft ||
+                                                    locationTrackIsDraft ||
+                                                    duplicatesOnOtherTrackNumbers ||
+                                                    extraInfo?.partOfUnfinishedSplit ||
+                                                    startingSplitting
+                                                }
+                                                isProcessing={startingSplitting}
+                                                title={getSplittingDisabledReasonsTranslated()}
+                                                onClick={startSplitting}
+                                                qaId={'start-splitting'}
+                                                menuItems={[
+                                                    menuSelectOption(
+                                                        () => {
+                                                            startSplitting();
+                                                        },
+                                                        t(
+                                                            'tool-panel.location-track.start-splitting-prefilled',
+                                                        ),
+                                                        'start-splitting-prefilled',
+                                                    ),
+                                                ]}>
+                                                {t('tool-panel.location-track.start-splitting')}
+                                            </SplitButton>*/
                                         )}
                                     </InfoboxButtons>
                                 </PrivilegeRequired>

--- a/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
@@ -7,6 +7,7 @@ import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
 import { ExamplePerson } from 'vayla-design-lib/demo/examples/dropdown-examples';
 import examplePersonsData from 'vayla-design-lib/demo/example-persons.json';
 import { menuValueOption } from 'vayla-design-lib/menu/menu';
+import { SplitButton } from 'geoviite-design-lib/split-button/split-button';
 
 export const ButtonExamples: React.FC = () => {
     const [isProcessing, setProcessing] = React.useState(false);
@@ -112,7 +113,30 @@ export const ButtonExamples: React.FC = () => {
                                                 variant={variant}
                                                 disabled
                                                 icon={Icons.Append}
+                                                isProcessing={
+                                                    isProcessing ||
+                                                    buttonProcessing == key + 'icon-only'
+                                                }
+                                            />
+                                        </td>
+                                        <td>
+                                            <SplitButton
+                                                size={size}
+                                                variant={variant}
+                                                icon={Icons.Append}
+                                                menuItems={[
+                                                    menuValueOption('1', 'Item 1', 'Item 1'),
+                                                ]}
+                                            />
+                                        </td>
+                                        <td>
+                                            <SplitButton
+                                                size={size}
+                                                variant={variant}
+                                                disabled
+                                                icon={Icons.Append}
                                                 isProcessing={isProcessing}
+                                                menuItems={[]}
                                             />
                                         </td>
                                     </tr>


### PR DESCRIPTION
Täällä luotu alustava versio `SplitButton`-komponentista. Tämä poiki myös isohkon, ei-pakollisen mutta mielestäni fiksuhkon refaktoroinnin meidän menuihin ja dropdowneihin, joka lähti liikkeelle siitä, että `SplitButton`:in (ja siten kaikkien menujen) olisi ehkä kiva tietää parametrin tasolla että suljetaanko menu jonkin itemin klikkauksen jälkeen vai ei (tähän mennessä menun sulkeminen a) tehtiin jokaisessa menu itemissä koko koodipesässä ja b) oli menuitemin itsensä vastuulla kaikkialla.) Pistän tuon kuitenkin omana pullarinaan. Tämä ei siten ole siis täysin valmis versio aiheesta (vaikka aika lähellä jo onkin.) Refaktorointipullari ja tämä ovat kuitenkin yksi yksikkö: mikäli refakkijutut halutaankin rejectata, niin tämä komponetti tarvii vielä vähän lisäsäätöä. 