### PR TITLE
GVT-2628: Menun refaktorointia (pesäero Dropdownin ja Menun välille, autoclose-parametrisaatio menuitemeille)

### DIFF
--- a/ui/src/app-bar/app-bar-more-menu.tsx
+++ b/ui/src/app-bar/app-bar-more-menu.tsx
@@ -5,9 +5,9 @@ import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import {
     Menu,
     MenuDividerOption,
-    menuDividerOption,
+    menuDivider,
     MenuSelectOption,
-    menuSelectOption,
+    menuOption,
 } from 'vayla-design-lib/menu/menu';
 import styles from 'app-bar/app-bar.scss';
 import { useTranslation } from 'react-i18next';
@@ -36,9 +36,8 @@ const AppBarMoreMenu: React.FC = () => {
             ? `${roleOptionTranslation}`
             : t(`user-roles.${role.code}`);
 
-        return menuSelectOption(
+        return menuOption(
             () => {
-                setShowMenu(false);
                 postDesiredRole(role.code).then((_roleCode) => {
                     purgePersistentState();
                     navigate('/');
@@ -53,31 +52,27 @@ const AppBarMoreMenu: React.FC = () => {
 
     const createRoleSelectionOptions = (): (MenuSelectOption | MenuDividerOption)[] => {
         return availableRoles.length > 1
-            ? [
-                  menuDividerOption(),
-                  ...availableRoles.map(createRoleSelectionOption),
-                  menuDividerOption(),
-              ]
+            ? [menuDivider(), ...availableRoles.map(createRoleSelectionOption), menuDivider()]
             : [];
     };
 
     const moreActions: (MenuSelectOption | MenuDividerOption)[] = [
-        menuSelectOption(
+        menuOption(
             () => {
-                setShowMenu(false);
                 navigate('licenses');
             },
             t('app-bar.licenses'),
             'licenses',
+            true,
         ),
         ...createRoleSelectionOptions(),
-        menuSelectOption(
+        menuOption(
             () => {
-                setShowMenu(false);
                 setShowLogoutConfirmation(true);
             },
             t('app-bar.logout'),
             'logout',
+            true,
         ),
     ];
 
@@ -100,6 +95,7 @@ const AppBarMoreMenu: React.FC = () => {
                     onClickOutside={() => setShowMenu(false)}
                     opensTowards={'LEFT'}
                     qa-id={'app-bar-more-menu'}
+                    onClose={() => setShowMenu(false)}
                 />
             )}
 

--- a/ui/src/app-bar/app-bar-more-menu.tsx
+++ b/ui/src/app-bar/app-bar-more-menu.tsx
@@ -63,7 +63,6 @@ const AppBarMoreMenu: React.FC = () => {
             },
             t('app-bar.licenses'),
             'licenses',
-            true,
         ),
         ...createRoleSelectionOptions(),
         menuOption(
@@ -72,7 +71,6 @@ const AppBarMoreMenu: React.FC = () => {
             },
             t('app-bar.logout'),
             'logout',
-            true,
         ),
     ];
 

--- a/ui/src/app-bar/data-products-menu.tsx
+++ b/ui/src/app-bar/data-products-menu.tsx
@@ -26,7 +26,6 @@ const DataProductsMenu: React.FC = () => {
                   },
                   t('app-bar.data-products.element-list'),
                   'element-list-menu-link',
-                  true,
               )
             : undefined,
         userHasPrivilege(currentPrivileges, VIEW_GEOMETRY_FILE)
@@ -36,7 +35,6 @@ const DataProductsMenu: React.FC = () => {
                   },
                   t('app-bar.data-products.vertical-geometry'),
                   'vertical-geometry-menu-link',
-                  true,
               )
             : undefined,
         userHasPrivilege(currentPrivileges, VIEW_GEOMETRY)
@@ -46,7 +44,6 @@ const DataProductsMenu: React.FC = () => {
                   },
                   t('app-bar.data-products.km-lengths'),
                   'kilometer-length-menu-link',
-                  true,
               )
             : undefined,
     ].filter(filterNotEmpty);

--- a/ui/src/app-bar/data-products-menu.tsx
+++ b/ui/src/app-bar/data-products-menu.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styles from './app-bar.scss';
-import { Menu, menuSelectOption } from 'vayla-design-lib/menu/menu';
+import { Menu, menuOption } from 'vayla-design-lib/menu/menu';
 import { createClassName } from 'vayla-design-lib/utils';
 import { filterNotEmpty } from 'utils/array-utils';
 import { VIEW_GEOMETRY_FILE, userHasPrivilege, VIEW_GEOMETRY } from 'user/user-model';
@@ -20,33 +20,33 @@ const DataProductsMenu: React.FC = () => {
 
     const dataProducts = [
         userHasPrivilege(currentPrivileges, VIEW_GEOMETRY_FILE)
-            ? menuSelectOption(
+            ? menuOption(
                   () => {
-                      setShowMenu(false);
                       navigate('data-products/element-list');
                   },
                   t('app-bar.data-products.element-list'),
                   'element-list-menu-link',
+                  true,
               )
             : undefined,
         userHasPrivilege(currentPrivileges, VIEW_GEOMETRY_FILE)
-            ? menuSelectOption(
+            ? menuOption(
                   () => {
-                      setShowMenu(false);
                       navigate('data-products/vertical-geometry');
                   },
                   t('app-bar.data-products.vertical-geometry'),
                   'vertical-geometry-menu-link',
+                  true,
               )
             : undefined,
         userHasPrivilege(currentPrivileges, VIEW_GEOMETRY)
-            ? menuSelectOption(
+            ? menuOption(
                   () => {
-                      setShowMenu(false);
                       navigate('data-products/kilometer-lengths');
                   },
                   t('app-bar.data-products.km-lengths'),
                   'kilometer-length-menu-link',
+                  true,
               )
             : undefined,
     ].filter(filterNotEmpty);
@@ -80,6 +80,7 @@ const DataProductsMenu: React.FC = () => {
                             className={styles['app-bar__data-products-menu']}
                             onClickOutside={() => setShowMenu(false)}
                             qa-id={'data-products-menu'}
+                            onClose={() => setShowMenu(false)}
                         />
                     )}
                 </div>

--- a/ui/src/geoviite-design-lib/split-button/split-button.tsx
+++ b/ui/src/geoviite-design-lib/split-button/split-button.tsx
@@ -4,18 +4,18 @@ import { Button, ButtonProps } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import styles from './split-button.scss';
 
-type SplitButtonProps<TMenuItem> = {
-    menuItems: MenuOption<TMenuItem>[];
+type SplitButtonProps = {
+    menuItems: MenuOption[];
     children?: React.ReactNode;
     qaId?: string;
 } & ButtonProps;
 
-export const SplitButton = function <TMenuItem>({
+export const SplitButton = function ({
     menuItems,
     children,
     qaId,
     ...buttonProps
-}: SplitButtonProps<TMenuItem>) {
+}: SplitButtonProps) {
     const ref = React.useRef<HTMLSpanElement>(null);
     const [menuOpen, setMenuOpen] = React.useState(false);
 
@@ -36,6 +36,7 @@ export const SplitButton = function <TMenuItem>({
                 <Menu
                     positionRef={ref}
                     onClickOutside={() => setMenuOpen(false)}
+                    onClose={() => setMenuOpen(false)}
                     items={menuItems}
                 />
             )}

--- a/ui/src/infra-model/projektivelho/pv-file-list.tsx
+++ b/ui/src/infra-model/projektivelho/pv-file-list.tsx
@@ -306,7 +306,6 @@ const PVFileListRow = ({
                 assignmentCount: itemCounts.assignment ?? '-',
             }),
             'pv-reject-or-restore-by-assignment',
-            true,
             !item.assignment?.oid,
         ),
         menuOption(
@@ -337,7 +336,6 @@ const PVFileListRow = ({
                 projectCount: itemCounts.project ?? '-',
             }),
             'pv-reject-or-restore-by-project',
-            true,
             !item.project?.oid,
         ),
         menuOption(
@@ -368,7 +366,6 @@ const PVFileListRow = ({
                 groupCount: itemCounts.projectGroup ?? '-',
             }),
             'pv-reject-or-restore-by-project-group',
-            true,
             !item.projectGroup?.oid,
         ),
     ];

--- a/ui/src/infra-model/projektivelho/pv-file-list.tsx
+++ b/ui/src/infra-model/projektivelho/pv-file-list.tsx
@@ -27,7 +27,7 @@ import {
     sortPVTableColumns,
 } from 'infra-model/projektivelho/pv-file-list-utils';
 import { getSortDirectionIcon, SortDirection } from 'utils/table-utils';
-import { Menu, MenuSelectOption, menuSelectOption } from 'vayla-design-lib/menu/menu';
+import { Menu, MenuSelectOption, menuOption } from 'vayla-design-lib/menu/menu';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { PVRedirectLink } from 'infra-model/projektivelho/pv-redirect-link';
 import { PrivilegedLink } from 'user/privileged-link';
@@ -278,7 +278,7 @@ const PVFileListRow = ({
     const dialogTranslationPrefix = `confirm-dialog.${suggestedList ? 'reject' : 'restore'}`;
 
     const fileActions: MenuSelectOption[] = [
-        menuSelectOption(
+        menuOption(
             () => {
                 dialogParams.current = {
                     title: t(`${dialogTranslationPrefix}.by-assignment-title`),
@@ -301,15 +301,15 @@ const PVFileListRow = ({
                 };
 
                 setShowConfirmDialog(true);
-                setFileActionMenuVisible(false);
             },
             t(`${dialogTranslationPrefix}.by-assignment`, {
                 assignmentCount: itemCounts.assignment ?? '-',
             }),
             'pv-reject-or-restore-by-assignment',
+            true,
             !item.assignment?.oid,
         ),
-        menuSelectOption(
+        menuOption(
             () => {
                 dialogParams.current = {
                     title: t(`${dialogTranslationPrefix}.by-project-title`),
@@ -332,15 +332,15 @@ const PVFileListRow = ({
                 };
 
                 setShowConfirmDialog(true);
-                setFileActionMenuVisible(false);
             },
             t(`${dialogTranslationPrefix}.by-project`, {
                 projectCount: itemCounts.project ?? '-',
             }),
             'pv-reject-or-restore-by-project',
+            true,
             !item.project?.oid,
         ),
-        menuSelectOption(
+        menuOption(
             () => {
                 dialogParams.current = {
                     title: t(`${dialogTranslationPrefix}.by-project-group-title`),
@@ -363,12 +363,12 @@ const PVFileListRow = ({
                 };
 
                 setShowConfirmDialog(true);
-                setFileActionMenuVisible(false);
             },
             t(`${dialogTranslationPrefix}.by-project-group`, {
                 groupCount: itemCounts.projectGroup ?? '-',
             }),
             'pv-reject-or-restore-by-project-group',
+            true,
             !item.projectGroup?.oid,
         ),
     ];
@@ -470,6 +470,7 @@ const PVFileListRow = ({
                                 positionRef={actionMenuRef}
                                 items={fileActions}
                                 onClickOutside={() => setFileActionMenuVisible(false)}
+                                onClose={() => setFileActionMenuVisible(false)}
                             />
                         )}
                         {showConfirmDialog && confirmDialog()}

--- a/ui/src/infra-model/view/dialogs/charset-select-dialog.tsx
+++ b/ui/src/infra-model/view/dialogs/charset-select-dialog.tsx
@@ -5,14 +5,13 @@ import styles from '../form/infra-model-form.module.scss';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Dialog } from 'geoviite-design-lib/dialog/dialog';
-import { Dropdown, Item } from 'vayla-design-lib/dropdown/dropdown';
-import { menuValueOption } from 'vayla-design-lib/menu/menu';
+import { Dropdown, Item, dropdownOption } from 'vayla-design-lib/dropdown/dropdown';
 
 const xmlEncodingOptions: Item<XmlCharset>[] = [
-    menuValueOption('ISO_8859_1' as const, 'ISO-8859-1', 'ISO-8859-1'),
-    menuValueOption('UTF_8' as const, 'UTF-8', 'UTF-8'),
-    menuValueOption('UTF_16' as const, 'UTF-16', 'UTF-16'),
-    menuValueOption('US_ASCII' as const, 'US ASCII', 'US ASCII'),
+    dropdownOption('ISO_8859_1' as const, 'ISO-8859-1', 'ISO-8859-1'),
+    dropdownOption('UTF_8' as const, 'UTF-8', 'UTF-8'),
+    dropdownOption('UTF_16' as const, 'UTF-16', 'UTF-16'),
+    dropdownOption('US_ASCII' as const, 'US ASCII', 'US ASCII'),
 ];
 
 export type CharsetSelectDialogProps = {

--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -15,7 +15,7 @@ import {
     InfraModelParametersProp,
     OverrideInfraModelParameters,
 } from 'infra-model/infra-model-slice';
-import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
+import { Dropdown, dropdownOption } from 'vayla-design-lib/dropdown/dropdown';
 import {
     compareNamed,
     CoordinateSystem as CoordinateSystemModel,
@@ -50,7 +50,6 @@ import FormgroupTextarea from 'infra-model/view/formgroup/formgroup-textarea';
 import { PVRedirectLink } from 'infra-model/projektivelho/pv-redirect-link';
 import { useLoader } from 'utils/react-utils';
 import i18next from 'i18next';
-import { menuValueOption } from 'vayla-design-lib/menu/menu';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_GEOMETRY_FILE, userHasPrivilege, VIEW_LAYOUT_DRAFT } from 'user/user-model';
 import { useCommonDataAppSelector } from 'store/hooks';
@@ -136,12 +135,12 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
     const authors = useLoader(() => fetchAuthors(), [changeTimes.author]) || [];
 
     const planSourceOptions = [
-        menuValueOption(
+        dropdownOption(
             'GEOMETRIAPALVELU' as PlanSource,
             t('enum.plan-source.GEOMETRIAPALVELU'),
             'GEOMETRIAPALVELU',
         ),
-        menuValueOption(
+        dropdownOption(
             'PAIKANNUSPALVELU' as PlanSource,
             t('enum.plan-source.PAIKANNUSPALVELU'),
             'PAIKANNUSPALVELU',
@@ -363,7 +362,7 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                                         wide
                                         value={geometryPlan.author?.id}
                                         options={authorsIncludingFromPlan().map((author) =>
-                                            menuValueOption(
+                                            dropdownOption(
                                                 author.id,
                                                 author.companyName,
                                                 `author-${author.id}`,
@@ -409,7 +408,7 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                                                 trackNumberList
                                                     ? trackNumberList
                                                           .map((tn) =>
-                                                              menuValueOption(
+                                                              dropdownOption(
                                                                   tn,
                                                                   tn,
                                                                   `track-number-${tn}`,
@@ -459,7 +458,7 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                                             sridList
                                                 ? sridList
                                                       .map((srid) =>
-                                                          menuValueOption(
+                                                          dropdownOption(
                                                               srid.srid,
                                                               `${srid.name} ${srid.srid}`,
                                                               srid.srid,

--- a/ui/src/infra-model/view/infra-model-toolbar.tsx
+++ b/ui/src/infra-model/view/infra-model-toolbar.tsx
@@ -30,7 +30,6 @@ export const InfraModelToolbar: React.FC<InfraModelToolbarProps> = (
             },
             item.name,
             item.qaId,
-            true,
             item.disabled,
         ),
     );

--- a/ui/src/infra-model/view/infra-model-toolbar.tsx
+++ b/ui/src/infra-model/view/infra-model-toolbar.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { useAppNavigate } from 'common/navigate';
-import { Menu, menuValueOption } from 'vayla-design-lib/menu/menu';
+import { Menu, menuOption } from 'vayla-design-lib/menu/menu';
 import { Item } from 'vayla-design-lib/dropdown/dropdown';
 
 export type FileMenuOption = 'fix-encoding';
@@ -24,7 +24,15 @@ export const InfraModelToolbar: React.FC<InfraModelToolbarProps> = (
     const fileMenuRef = React.useRef(null);
 
     const items = props.fileMenuItems.map((item) =>
-        menuValueOption(item.value, item.name, item.qaId, item.disabled),
+        menuOption(
+            () => {
+                props.fileMenuItemSelected(item.value);
+            },
+            item.name,
+            item.qaId,
+            true,
+            item.disabled,
+        ),
     );
 
     return (
@@ -52,11 +60,8 @@ export const InfraModelToolbar: React.FC<InfraModelToolbarProps> = (
                 <Menu
                     positionRef={fileMenuRef}
                     items={items}
-                    onSelect={(item) => {
-                        props.fileMenuItemSelected(item);
-                        setFileMenuVisible(false);
-                    }}
                     onClickOutside={() => setFileMenuVisible(false)}
+                    onClose={() => setFileMenuVisible(false)}
                 />
             )}
         </div>

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -10,9 +10,9 @@ import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { ChangesBeingReverted, PreviewOperations } from 'preview/preview-view';
 import {
     Menu,
-    menuDividerOption,
+    menuDivider,
     MenuOption,
-    menuSelectOption,
+    menuOption,
     MenuSelectOption,
 } from 'vayla-design-lib/menu/menu';
 import { PreviewTableEntry } from 'preview/preview-table';
@@ -78,93 +78,92 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         name: tableEntry.name,
     };
 
-    const menuAction = (menuActionFunction: () => void) => (): void => {
-        menuActionFunction();
-        setActionMenuVisible(false);
-    };
-
-    const menuOptionMoveAllShownChanges: MenuSelectOption = menuSelectOption(
-        menuAction(() =>
+    const menuOptionMoveAllShownChanges: MenuSelectOption = menuOption(
+        () =>
             previewOperations.setPublicationStage.forAllShownChanges(
                 displayedPublicationStage,
                 moveTargetStage,
             ),
-        ),
         t('publish.move-all-shown-changes', {
             amount: displayedTotalPublicationAssetAmount,
         }),
         'preview-move-all-shown-changes',
+        true,
     );
 
-    const menuOptionMovePublicationGroupStage: MenuSelectOption = menuSelectOption(
-        menuAction(() => {
+    const menuOptionMovePublicationGroupStage: MenuSelectOption = menuOption(
+        () => {
             if (tableEntry.publicationGroup) {
                 previewOperations.setPublicationStage.forPublicationGroup(
                     tableEntry.publicationGroup,
                     moveTargetStage,
                 );
             }
-        }),
+        },
         t('publish.move-publication-group', {
             amount: publicationGroupAssetAmount,
         }),
         `preview-move-publication-group-${tableEntry.publicationGroup?.id ?? 'unknown'}`,
+        true,
     );
 
-    const menuOptionRevertSingleChange: MenuSelectOption = menuSelectOption(
-        menuAction(() =>
+    const menuOptionRevertSingleChange: MenuSelectOption = menuOption(
+        () =>
             previewOperations.revert.changesWithDependencies(
                 [tableEntry.publishCandidate],
                 tableEntryAsRevertRequestSource,
             ),
-        ),
         t('publish.revert-change'),
         'preview-revert-change',
+        true,
     );
 
-    const menuOptionRevertAllShownChanges: MenuSelectOption = menuSelectOption(
-        menuAction(() => {
+    const menuOptionRevertAllShownChanges: MenuSelectOption = menuOption(
+        () => {
             previewOperations.revert.stageChanges(
                 displayedPublicationStage,
                 tableEntryAsRevertRequestSource,
             );
-        }),
+        },
         t('publish.revert-all-shown-changes', {
             amount: displayedTotalPublicationAssetAmount,
         }),
         'preview-revert-all-shown-changes',
+        true,
     );
 
-    const menuOptionPublicationGroupRevert: MenuSelectOption = menuSelectOption(
-        menuAction(() => {
+    const menuOptionPublicationGroupRevert: MenuSelectOption = menuOption(
+        () => {
             if (tableEntry.publicationGroup) {
                 previewOperations.revert.publicationGroup(
                     tableEntry.publicationGroup,
                     tableEntryAsRevertRequestSource,
                 );
             }
-        }),
+        },
         t('publish.revert-publication-group', {
             amount: publicationGroupAssetAmount,
         }),
         'preview-revert-publication-group',
+        true,
     );
 
-    const menuOptionShowOnMap: MenuSelectOption = menuSelectOption(
-        menuAction(() => {
+    const menuOptionShowOnMap: MenuSelectOption = menuOption(
+        () => {
             tableEntry.boundingBox && onShowOnMap(tableEntry.boundingBox);
-        }),
+        },
         t('publish.show-on-map'),
         'preview-show-on-map',
+        true,
         !tableEntry.boundingBox,
     );
 
-    const menuOptions: MenuOption<never>[] = [
+    const menuOptions: MenuOption[] = [
         ...conditionalMenuOption(tableEntry.publicationGroup, menuOptionMovePublicationGroupStage),
         menuOptionMoveAllShownChanges,
-        menuDividerOption(),
+        menuDivider(),
         menuOptionShowOnMap,
-        menuDividerOption(),
+        menuDivider(),
         ...conditionalMenuOption(!tableEntry.publicationGroup, menuOptionRevertSingleChange),
         ...conditionalMenuOption(tableEntry.publicationGroup, menuOptionPublicationGroupRevert),
         menuOptionRevertAllShownChanges,
@@ -279,6 +278,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                     positionRef={actionMenuRef}
                     items={menuOptions}
                     onClickOutside={() => setActionMenuVisible(false)}
+                    onClose={() => setActionMenuVisible(false)}
                 />
             )}
         </React.Fragment>

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -88,7 +88,6 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
             amount: displayedTotalPublicationAssetAmount,
         }),
         'preview-move-all-shown-changes',
-        true,
     );
 
     const menuOptionMovePublicationGroupStage: MenuSelectOption = menuOption(
@@ -104,7 +103,6 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
             amount: publicationGroupAssetAmount,
         }),
         `preview-move-publication-group-${tableEntry.publicationGroup?.id ?? 'unknown'}`,
-        true,
     );
 
     const menuOptionRevertSingleChange: MenuSelectOption = menuOption(
@@ -115,7 +113,6 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
             ),
         t('publish.revert-change'),
         'preview-revert-change',
-        true,
     );
 
     const menuOptionRevertAllShownChanges: MenuSelectOption = menuOption(
@@ -129,7 +126,6 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
             amount: displayedTotalPublicationAssetAmount,
         }),
         'preview-revert-all-shown-changes',
-        true,
     );
 
     const menuOptionPublicationGroupRevert: MenuSelectOption = menuOption(
@@ -145,7 +141,6 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
             amount: publicationGroupAssetAmount,
         }),
         'preview-revert-publication-group',
-        true,
     );
 
     const menuOptionShowOnMap: MenuSelectOption = menuOption(
@@ -154,7 +149,6 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         },
         t('publish.show-on-map'),
         'preview-show-on-map',
-        true,
         !tableEntry.boundingBox,
     );
 

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -89,7 +89,6 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
             },
             t('publication-card.show-split-info'),
             'show-split-info-link',
-            true,
         ),
         menuOption(
             () => {
@@ -108,7 +107,6 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
             },
             t('publication-card.mark-as-successful'),
             'mark-bulk-transfer-as-finished-link',
-            true,
             publication.split?.bulkTransferState === 'DONE',
         ),
     ];

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -11,7 +11,7 @@ import { Link } from 'vayla-design-lib/link/link';
 import { formatDateFull } from 'utils/date-utils';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { AppNavigateFunction } from 'common/navigate';
-import { Menu, menuSelectOption, MenuSelectOption } from 'vayla-design-lib/menu/menu';
+import { Menu, menuOption, MenuSelectOption } from 'vayla-design-lib/menu/menu';
 import { SplitDetailsDialog } from 'publication/split/split-details-dialog';
 import { putBulkTransferState } from 'publication/split/split-api';
 import { success } from 'geoviite-design-lib/snackbar/snackbar';
@@ -83,15 +83,15 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
     const menuRef = React.createRef<HTMLDivElement>();
 
     const actions: MenuSelectOption[] = [
-        menuSelectOption(
+        menuOption(
             () => {
-                setMenuOpen(false);
                 setSplitDetailsDialogOpen(true);
             },
             t('publication-card.show-split-info'),
             'show-split-info-link',
+            true,
         ),
-        menuSelectOption(
+        menuOption(
             () => {
                 if (publication.split)
                     putBulkTransferState(publication.split.id, 'DONE')
@@ -105,10 +105,10 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                             );
                         })
                         .then(() => updateSplitChangeTime());
-                setMenuOpen(false);
             },
             t('publication-card.mark-as-successful'),
             'mark-bulk-transfer-as-finished-link',
+            true,
             publication.split?.bulkTransferState === 'DONE',
         ),
     ];
@@ -168,6 +168,7 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                                     onClickOutside={() => setMenuOpen(true)}
                                     items={actions}
                                     qa-id={'publication-actions-menu'}
+                                    onClose={() => setMenuOpen(false)}
                                 />
                             </div>
                         )}

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -238,25 +238,21 @@ export const ToolBar: React.FC<ToolbarParams> = ({
             () => showAddDialog(NewMenuItems.trackNumber),
             t('tool-bar.new-track-number'),
             'tool-bar.new-track-number',
-            true,
         ),
         menuOption(
             () => showAddDialog(NewMenuItems.locationTrack),
             t('tool-bar.new-location-track'),
             'tool-bar.new-location-track',
-            true,
         ),
         menuOption(
             () => showAddDialog(NewMenuItems.switch),
             t('tool-bar.new-switch'),
             'tool-bar.new-switch',
-            true,
         ),
         menuOption(
             () => showAddDialog(NewMenuItems.kmPost),
             t('tool-bar.new-km-post'),
             'tool-bar.new-km-post',
-            true,
         ),
     ];
 

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
-import { Dropdown, DropdownSize, Item } from 'vayla-design-lib/dropdown/dropdown';
+import { Dropdown, DropdownSize, Item, dropdownOption } from 'vayla-design-lib/dropdown/dropdown';
 import { getLocationTrackDescriptions } from 'track-layout/layout-location-track-api';
 import {
     LayoutLocationTrack,
@@ -24,7 +24,7 @@ import { LocationTrackEditDialogContainer } from 'tool-panel/location-track/dial
 import { SwitchEditDialogContainer } from 'tool-panel/switch/dialog/switch-edit-dialog';
 import { KmPostEditDialogContainer } from 'tool-panel/km-post/dialog/km-post-edit-dialog';
 import { TrackNumberEditDialogContainer } from 'tool-panel/track-number/dialog/track-number-edit-dialog';
-import { Menu, MenuOption, menuValueOption } from 'vayla-design-lib/menu/menu';
+import { Menu, MenuOption, menuOption } from 'vayla-design-lib/menu/menu';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { MapLayerMenuChange, MapLayerMenuGroups, MapLayerName } from 'map/map-model';
 import { getTrackNumberReferenceLine } from 'track-layout/layout-reference-line-api';
@@ -84,7 +84,7 @@ function createLocationTrackOptionItem(
     locationTrack: LayoutLocationTrack,
     description: string,
 ): Item<LocationTrackItemValue> {
-    return menuValueOption(
+    return dropdownOption(
         {
             type: 'locationTrackSearchItem',
             locationTrack: locationTrack,
@@ -100,7 +100,7 @@ type SwitchItemValue = {
 };
 
 function createSwitchOptionItem(layoutSwitch: LayoutSwitch): Item<SwitchItemValue> {
-    return menuValueOption(
+    return dropdownOption(
         {
             type: 'switchSearchItem',
             layoutSwitch: layoutSwitch,
@@ -118,7 +118,7 @@ type TrackNumberItemValue = {
 function createTrackNumberOptionItem(
     layoutTrackNumber: LayoutTrackNumber,
 ): Item<TrackNumberItemValue> {
-    return menuValueOption(
+    return dropdownOption(
         {
             type: 'trackNumberSearchItem',
             trackNumber: layoutTrackNumber,
@@ -136,7 +136,7 @@ type OperatingPointItemValue = {
 function createOperatingPointOptionItem(
     operatingPoint: OperatingPoint,
 ): Item<OperatingPointItemValue> {
-    return menuValueOption(
+    return dropdownOption(
         {
             operatingPoint: operatingPoint,
             type: 'operatingPointSearchItem',
@@ -233,24 +233,32 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         'kmPost' = 4,
     }
 
-    const newMenuItems: MenuOption<NewMenuItems>[] = [
-        menuValueOption(
-            NewMenuItems.trackNumber,
+    const newMenuItems: MenuOption[] = [
+        menuOption(
+            () => showAddDialog(NewMenuItems.trackNumber),
             t('tool-bar.new-track-number'),
             'tool-bar.new-track-number',
+            true,
         ),
-        menuValueOption(
-            NewMenuItems.locationTrack,
+        menuOption(
+            () => showAddDialog(NewMenuItems.locationTrack),
             t('tool-bar.new-location-track'),
             'tool-bar.new-location-track',
+            true,
         ),
-        menuValueOption(NewMenuItems.switch, t('tool-bar.new-switch'), 'tool-bar.new-switch'),
-        menuValueOption(NewMenuItems.kmPost, t('tool-bar.new-km-post'), 'tool-bar.new-km-post'),
+        menuOption(
+            () => showAddDialog(NewMenuItems.switch),
+            t('tool-bar.new-switch'),
+            'tool-bar.new-switch',
+            true,
+        ),
+        menuOption(
+            () => showAddDialog(NewMenuItems.kmPost),
+            t('tool-bar.new-km-post'),
+            'tool-bar.new-km-post',
+            true,
+        ),
     ];
-
-    const handleNewMenuItemChange = (item: NewMenuItems) => {
-        showAddDialog(item);
-    };
 
     // Use debounced function to collect keystrokes before triggering a search
     const debouncedGetOptions = debounceAsync(getOptions, 250);
@@ -340,8 +348,6 @@ export const ToolBar: React.FC<ToolbarParams> = ({
             default:
                 return exhaustiveMatchingGuard(dialog);
         }
-
-        setShowNewAssetMenu(false);
     }
 
     function switchToMainOfficial() {
@@ -530,8 +536,8 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                 <Menu
                     positionRef={menuRef}
                     items={newMenuItems}
-                    onSelect={(item) => item && handleNewMenuItemChange(item)}
                     onClickOutside={() => setShowNewAssetMenu(false)}
+                    onClose={() => setShowNewAssetMenu(false)}
                 />
             )}
 

--- a/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
@@ -131,7 +131,6 @@ export const ButtonExamples: React.FC = () => {
                                                         () => console.log(`I'm doing something!`),
                                                         'Item 1',
                                                         'Item 1',
-                                                        true,
                                                     ),
                                                 ]}>
                                                 Button

--- a/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
@@ -3,11 +3,11 @@ import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/butto
 import { Icons } from 'vayla-design-lib/icon/Icon';
 import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
 import { TextField } from 'vayla-design-lib/text-field/text-field';
-import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
+import { Dropdown, dropdownOption } from 'vayla-design-lib/dropdown/dropdown';
 import { ExamplePerson } from 'vayla-design-lib/demo/examples/dropdown-examples';
 import examplePersonsData from 'vayla-design-lib/demo/example-persons.json';
-import { menuValueOption } from 'vayla-design-lib/menu/menu';
 import { SplitButton } from 'geoviite-design-lib/split-button/split-button';
+import { menuOption } from 'vayla-design-lib/menu/menu';
 
 export const ButtonExamples: React.FC = () => {
     const [isProcessing, setProcessing] = React.useState(false);
@@ -39,6 +39,8 @@ export const ButtonExamples: React.FC = () => {
                         <th>With icon + disabled</th>
                         <th>Icon only</th>
                         <th>Icon only + disabled</th>
+                        <th>Split button</th>
+                        <th>Split button + disabled</th>
                     </tr>
                 </thead>
 
@@ -125,9 +127,15 @@ export const ButtonExamples: React.FC = () => {
                                                 variant={variant}
                                                 icon={Icons.Append}
                                                 menuItems={[
-                                                    menuValueOption('1', 'Item 1', 'Item 1'),
-                                                ]}
-                                            />
+                                                    menuOption(
+                                                        () => console.log(`I'm doing something!`),
+                                                        'Item 1',
+                                                        'Item 1',
+                                                        true,
+                                                    ),
+                                                ]}>
+                                                Button
+                                            </SplitButton>
                                         </td>
                                         <td>
                                             <SplitButton
@@ -136,8 +144,9 @@ export const ButtonExamples: React.FC = () => {
                                                 disabled
                                                 icon={Icons.Append}
                                                 isProcessing={isProcessing}
-                                                menuItems={[]}
-                                            />
+                                                menuItems={[]}>
+                                                Button
+                                            </SplitButton>
                                         </td>
                                     </tr>
                                 );
@@ -162,7 +171,7 @@ export const ButtonExamples: React.FC = () => {
                     value={person}
                     onChange={(person) => setPerson(person)}
                     options={examplePersonsData.map((person) =>
-                        menuValueOption(person, person.name, person.name),
+                        dropdownOption(person, person.name, person.name),
                     )}
                     attachRight
                 />

--- a/ui/src/vayla-design-lib/demo/examples/menu-example.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/menu-example.tsx
@@ -4,9 +4,9 @@ import { Button } from 'vayla-design-lib/button/button';
 
 export const MenuExample: React.FC = () => {
     const items = [
-        menuOption(() => setChosenItem('MENU1'), 'Menu option 1', 'MENU1', true),
-        menuOption(() => setChosenItem('MENU2'), 'Menu option 2', 'MENU2', true),
-        menuOption(() => setChosenItem('MENU3'), 'Menu option 3', 'MENU3', true),
+        menuOption(() => setChosenItem('MENU1'), 'Menu option 1', 'MENU1'),
+        menuOption(() => setChosenItem('MENU2'), 'Menu option 2', 'MENU2'),
+        menuOption(() => setChosenItem('MENU3'), 'Menu option 3', 'MENU3'),
     ];
 
     const [chosenItem, setChosenItem] = React.useState<string>('');

--- a/ui/src/vayla-design-lib/demo/examples/menu-example.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/menu-example.tsx
@@ -1,20 +1,16 @@
 import * as React from 'react';
-import { Menu, menuValueOption } from 'vayla-design-lib/menu/menu';
+import { Menu, menuOption } from 'vayla-design-lib/menu/menu';
 import { Button } from 'vayla-design-lib/button/button';
 
 export const MenuExample: React.FC = () => {
     const items = [
-        menuValueOption('MENU1', 'Menu option 1', 'MENU1'),
-        menuValueOption('MENU2', 'Menu option 2', 'MENU2'),
-        menuValueOption('MENU3', 'Menu option 3', 'MENU3'),
+        menuOption(() => setChosenItem('MENU1'), 'Menu option 1', 'MENU1', true),
+        menuOption(() => setChosenItem('MENU2'), 'Menu option 2', 'MENU2', true),
+        menuOption(() => setChosenItem('MENU3'), 'Menu option 3', 'MENU3', true),
     ];
 
     const [chosenItem, setChosenItem] = React.useState<string>('');
     const [showMenu, setShowMenu] = React.useState(false);
-
-    const handleItemChange = (item: string) => {
-        setChosenItem(item);
-    };
 
     const menuRef = React.useRef(null);
 
@@ -32,8 +28,8 @@ export const MenuExample: React.FC = () => {
                 <Menu
                     positionRef={menuRef}
                     items={items}
-                    onSelect={(item) => item && handleItemChange(item)}
                     onClickOutside={() => {}}
+                    onClose={() => setShowMenu(false)}
                 />
             )}
         </div>

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -7,6 +7,26 @@ import { CloseableModal } from 'vayla-design-lib/closeable-modal/closeable-modal
 import { useImmediateLoader } from 'utils/react-utils';
 import { first } from 'utils/array-utils';
 import { useTranslation } from 'react-i18next';
+import { OptionBase } from 'vayla-design-lib/menu/menu';
+
+export type DropdownOption<TValue> = {
+    type: 'VALUE';
+    name: string;
+    value: TValue;
+} & OptionBase;
+
+export const dropdownOption = <TValue,>(
+    value: TValue,
+    name: string,
+    qaId: string,
+    disabled: boolean = false,
+): DropdownOption<TValue> => ({
+    type: 'VALUE',
+    name,
+    value,
+    disabled,
+    qaId,
+});
 
 export enum DropdownSize {
     SMALL = 'dropdown--small',

--- a/ui/src/vayla-design-lib/menu/menu.tsx
+++ b/ui/src/vayla-design-lib/menu/menu.tsx
@@ -7,11 +7,13 @@ export type MenuOption = MenuSelectOption | MenuDividerOption;
 
 export type OptionBase = { disabled: boolean; qaId: string };
 
+type MenuClosingBehaviour = 'CLOSE_AFTER_SELECT' | 'CLOSE_MANUALLY';
+
 export type MenuSelectOption = {
     type: 'SELECT';
     name: string;
     onSelect: () => void;
-    closeAfterSelect: boolean;
+    closingBehaviour: MenuClosingBehaviour;
 } & OptionBase;
 
 export type MenuDividerOption = {
@@ -22,14 +24,14 @@ export const menuOption = (
     onSelect: () => void,
     name: string,
     qaId: string,
-    closeAfterSelect: boolean,
     disabled: boolean = false,
+    closingBehaviour: MenuClosingBehaviour = 'CLOSE_AFTER_SELECT',
 ): MenuSelectOption => ({
     type: 'SELECT',
     onSelect,
     name,
     disabled,
-    closeAfterSelect,
+    closingBehaviour,
     qaId,
 });
 
@@ -80,7 +82,7 @@ export const Menu = function ({
                                 onClick={() => {
                                     if (!i.disabled && i.type === 'SELECT') {
                                         i.onSelect();
-                                        if (i.closeAfterSelect && onClose) {
+                                        if (i.closingBehaviour === 'CLOSE_AFTER_SELECT') {
                                             onClose();
                                         }
                                     }

--- a/ui/src/vayla-design-lib/menu/menu.tsx
+++ b/ui/src/vayla-design-lib/menu/menu.tsx
@@ -3,73 +3,57 @@ import styles from './menu.scss';
 import { CloseableModal, OpenTowards } from 'vayla-design-lib/closeable-modal/closeable-modal';
 import { createClassName } from 'vayla-design-lib/utils';
 
-export type MenuOption<TValue> = MenuValueOption<TValue> | MenuSelectOption | MenuDividerOption;
+export type MenuOption = MenuSelectOption | MenuDividerOption;
 
-type MenuOptionBase = { disabled: boolean; qaId: string };
-
-export type MenuValueOption<TValue> = {
-    type: 'VALUE';
-    name: string;
-    value: TValue;
-} & MenuOptionBase;
+export type OptionBase = { disabled: boolean; qaId: string };
 
 export type MenuSelectOption = {
     type: 'SELECT';
     name: string;
     onSelect: () => void;
-} & MenuOptionBase;
+    closeAfterSelect: boolean;
+} & OptionBase;
 
 export type MenuDividerOption = {
     type: 'DIVIDER';
 };
 
-export const menuValueOption = <TValue,>(
-    value: TValue,
-    name: string,
-    qaId: string,
-    disabled: boolean = false,
-): MenuValueOption<TValue> => ({
-    type: 'VALUE',
-    name,
-    value,
-    disabled,
-    qaId,
-});
-
-export const menuSelectOption = (
+export const menuOption = (
     onSelect: () => void,
     name: string,
     qaId: string,
+    closeAfterSelect: boolean,
     disabled: boolean = false,
 ): MenuSelectOption => ({
     type: 'SELECT',
     onSelect,
     name,
     disabled,
+    closeAfterSelect,
     qaId,
 });
 
-export const menuDividerOption = (): MenuDividerOption => ({
+export const menuDivider = (): MenuDividerOption => ({
     type: 'DIVIDER',
 });
 
-type MenuProps<TValue> = {
+type MenuProps = {
     positionRef: React.MutableRefObject<HTMLElement | null>;
     onClickOutside: () => void;
-    onSelect?: (item: TValue) => void;
-    items: MenuOption<TValue>[];
+    items: MenuOption[];
     opensTowards?: OpenTowards;
+    onClose: () => void;
 } & Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'>;
 
-export const Menu = function <TValue>({
+export const Menu = function ({
     positionRef,
     onClickOutside,
     items,
-    onSelect,
     className,
     opensTowards = 'RIGHT',
+    onClose,
     ...props
-}: MenuProps<TValue>) {
+}: MenuProps) {
     const { height: offsetY } = positionRef.current?.getBoundingClientRect() ?? { height: 0 };
 
     return (
@@ -94,9 +78,11 @@ export const Menu = function <TValue>({
                                     i.disabled && styles['menu__item--disabled'],
                                 )}
                                 onClick={() => {
-                                    if (!i.disabled) {
-                                        if (i.type === 'SELECT') i.onSelect();
-                                        else if (onSelect) onSelect(i.value);
+                                    if (!i.disabled && i.type === 'SELECT') {
+                                        i.onSelect();
+                                        if (i.closeAfterSelect && onClose) {
+                                            onClose();
+                                        }
                                     }
                                 }}>
                                 {i.name}

--- a/ui/src/vayla-design-lib/menu/menu.tsx
+++ b/ui/src/vayla-design-lib/menu/menu.tsx
@@ -66,28 +66,28 @@ export const Menu = function ({
             openTowards={opensTowards}
             offsetY={offsetY + 6}>
             <ol className={styles['menu__items']} {...props}>
-                {items.map((i, index) => {
-                    if (i.type === 'DIVIDER') {
+                {items.map((item, index) => {
+                    if (item.type === 'DIVIDER') {
                         return <div key={`${index}`} className={styles['menu__divider']} />;
                     } else {
                         return (
                             <li
                                 key={`${index}`}
-                                qa-id={i.qaId}
-                                title={`${i.name}`}
+                                qa-id={item.qaId}
+                                title={`${item.name}`}
                                 className={createClassName(
                                     styles['menu__item'],
-                                    i.disabled && styles['menu__item--disabled'],
+                                    item.disabled && styles['menu__item--disabled'],
                                 )}
                                 onClick={() => {
-                                    if (!i.disabled && i.type === 'SELECT') {
-                                        i.onSelect();
-                                        if (i.closingBehaviour === 'CLOSE_AFTER_SELECT') {
+                                    if (!item.disabled && item.type === 'SELECT') {
+                                        item.onSelect();
+                                        if (item.closingBehaviour === 'CLOSE_AFTER_SELECT') {
                                             onClose();
                                         }
                                     }
                                 }}>
-                                {i.name}
+                                {item.name}
                             </li>
                         );
                     }


### PR DESCRIPTION
Tämä refaktorointi lähti pullarilla https://github.com/finnishtransportagency/geoviite/pull/1278 esiin nousseesta tarpeesta sulkea `SplitButton`:in menu sen jälkeen kun jotain sen itemiä klikataan. Keksin tähän pari vaihtoehtoa:

a) Tehdä aiemmalla mallilla ja säilyttää tieto `SplitButton`:in menun auki olemisesta jossain ulkoisessa tilassa joka välitetään SplitButtonille ja koodata menun sulkeminen jokaiseen sen menuitemiin (kuulostaa turhalta koodin monistamiselta ja siltä, että vastuu menun auki olemisesta on väärässä paikassa)
b) Refaktoroida `Menu`:a siten, että menuitemeille voidaan antaa tieto siitä suljetaanko menu jonkin sen itemin klikkauksen jälkeen ja menulle sulkemisfunktio (Menu ei edelleenkään tiedä aukiolostaan mitään,) ja parametrisoidaan nämä SplitButtonissa ja muissa Menun käyttöpaikoissa.

Päädyin näistä vaihtoehtoon B. Samalla tässä yhteydessä täytyi tehdä pesäeroa Dropdownin ja Menun Option-luontien välille, sillä ne olivat aiemmin käyttäneet samoja tietotyyppejä ja osittain samoja luontifunktioita -> Tein näiden välille isomman pesäeron.