### PR TITLE
GVT-2627: Karttanäkymän tila-tab-headerien piilotus oikeuksien mukaan (Part 1)

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignController.kt
@@ -1,9 +1,12 @@
 package fi.fta.geoviite.infra.tracklayout
 
+import fi.fta.geoviite.infra.authorization.AUTH_EDIT_LAYOUT
+import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT_DRAFT
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.logging.apiCall
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -20,24 +23,28 @@ class LayoutDesignController(
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
+    @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
     @GetMapping("/")
     fun getLayoutDesigns(): List<LayoutDesign> {
         logger.apiCall("getLayoutDesigns")
         return layoutDesignService.list()
     }
 
+    @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
     @GetMapping("/{id}")
     fun getLayoutDesign(@PathVariable id: IntId<LayoutDesign>): LayoutDesign {
         logger.apiCall("getLayoutDesign", "id" to id)
         return layoutDesignService.getOrThrow(id)
     }
 
+    @PreAuthorize(AUTH_EDIT_LAYOUT)
     @PostMapping("/")
     fun insertLayoutDesign(@RequestBody request: LayoutDesignSaveRequest): IntId<LayoutDesign> {
         logger.apiCall("insertLayoutDesign", "request" to request)
         return layoutDesignService.insert(request)
     }
 
+    @PreAuthorize(AUTH_EDIT_LAYOUT)
     @PutMapping("/{id}")
     fun updateLayoutDesign(
         @PathVariable id: IntId<LayoutDesign>,

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -39,24 +39,16 @@ import { getBySearchTerm } from 'track-layout/track-layout-search-api';
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { LinkingState, LinkingType } from 'linking/linking-model';
 import { PrivilegeRequired } from 'user/privilege-required';
-import { EDIT_LAYOUT } from 'user/user-model';
+import { EDIT_LAYOUT, VIEW_LAYOUT_DRAFT } from 'user/user-model';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
 import { TabHeader } from 'geoviite-design-lib/tab-header/tab-header';
 import { createClassName } from 'vayla-design-lib/utils';
-import { WorkspaceDialog } from 'tool-bar/workspace-dialog';
 import { EnvRestricted } from 'environment/env-restricted';
-import {
-    getLayoutDesigns,
-    insertLayoutDesign,
-    updateLayoutDesign,
-} from 'track-layout/layout-design-api';
-import { useLoader } from 'utils/react-utils';
-import { getChangeTimes, updateLayoutDesignChangeTime } from 'common/change-time-api';
-import { WorkspaceDeleteConfirmDialog } from 'tool-bar/workspace-delete-confirm-dialog';
 import {
     calculateBoundingBoxToShowAroundLocation,
     MAP_POINT_OPERATING_POINT_BBOX_OFFSET,
 } from 'map/map-utils';
+import { WorkspaceSelection } from 'tool-bar/workspace-selection';
 
 export type ToolbarParams = {
     onSelect: OnSelectFunction;
@@ -203,21 +195,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     const [showAddSwitchDialog, setShowAddSwitchDialog] = React.useState(false);
     const [showAddLocationTrackDialog, setShowAddLocationTrackDialog] = React.useState(false);
     const [showAddKmPostDialog, setShowAddKmPostDialog] = React.useState(false);
-    const [showCreateWorkspaceDialog, setShowCreateWorkspaceDialog] = React.useState(false);
-    const [showEditWorkspaceDialog, setShowEditWorkspaceDialog] = React.useState(false);
-    const [showDeleteWorkspaceDialog, setShowDeleteWorkspaceDialog] = React.useState(false);
     const menuRef = React.useRef(null);
-    const selectWorkspaceDropdownRef = React.useRef<HTMLInputElement>(null);
-
-    const designs = useLoader(
-        () => getLayoutDesigns(getChangeTimes().layoutDesign),
-        [getChangeTimes().layoutDesign],
-    );
-    const currentDesign = designs?.find((d) => d.id === layoutContext.designId);
-
-    React.useEffect(() => {
-        if (selectingWorkspace) selectWorkspaceDropdownRef?.current?.focus();
-    }, [selectingWorkspace]);
 
     const disableNewAssetMenu =
         layoutContext.publicationState !== 'DRAFT' ||
@@ -358,14 +336,6 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         setSelectingWorkspace(false);
     };
 
-    const unselectDesign = () => {
-        onLayoutContextChange({
-            publicationState: layoutContext.publicationState,
-            designId: undefined,
-        });
-        setSelectingWorkspace(true);
-    };
-
     function openPreviewAndStopLinking() {
         onOpenPreview();
         onStopLinking();
@@ -416,25 +386,29 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         onClick={() => switchToMainOfficial()}>
                         {t('tool-bar.current-mode')}
                     </TabHeader>
-                    <TabHeader
-                        className={styles['tool-bar__tab-header']}
-                        qaId={'draft-mode-tab'}
-                        selected={
-                            !layoutContext.designId &&
-                            !selectingWorkspace &&
-                            layoutContext.publicationState === 'DRAFT'
-                        }
-                        onClick={() => switchToMainDraft()}>
-                        {t('tool-bar.draft-mode')}
-                    </TabHeader>
-                    <EnvRestricted restrictTo={'test'}>
+                    <PrivilegeRequired privilege={VIEW_LAYOUT_DRAFT}>
                         <TabHeader
                             className={styles['tool-bar__tab-header']}
-                            qaId={'design-mode-tab'}
-                            selected={!!layoutContext.designId || selectingWorkspace}
-                            onClick={() => setSelectingWorkspace(true)}>
-                            {t('tool-bar.design-mode')}
+                            qaId={'draft-mode-tab'}
+                            selected={
+                                !layoutContext.designId &&
+                                !selectingWorkspace &&
+                                layoutContext.publicationState === 'DRAFT'
+                            }
+                            onClick={() => switchToMainDraft()}>
+                            {t('tool-bar.draft-mode')}
                         </TabHeader>
+                    </PrivilegeRequired>
+                    <EnvRestricted restrictTo={'test'}>
+                        <PrivilegeRequired privilege={VIEW_LAYOUT_DRAFT}>
+                            <TabHeader
+                                className={styles['tool-bar__tab-header']}
+                                qaId={'design-mode-tab'}
+                                selected={!!layoutContext.designId || selectingWorkspace}
+                                onClick={() => setSelectingWorkspace(true)}>
+                                {t('tool-bar.design-mode')}
+                            </TabHeader>
+                        </PrivilegeRequired>
                     </EnvRestricted>
                 </span>
                 <Dropdown
@@ -473,41 +447,12 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                     </React.Fragment>
                 )}
                 {(layoutContext.designId || selectingWorkspace) && (
-                    <React.Fragment>
-                        <Dropdown
-                            inputRef={selectWorkspaceDropdownRef}
-                            placeholder={t('tool-bar.choose-workspace')}
-                            openOverride={selectingWorkspace || undefined}
-                            onAddClick={() => setShowCreateWorkspaceDialog(true)}
-                            onChange={(designId) => {
-                                setSelectingWorkspace(false);
-                                onLayoutContextChange({
-                                    publicationState: 'DRAFT',
-                                    designId: designId,
-                                });
-                            }}
-                            options={
-                                designs?.map((design) => ({
-                                    value: design.id,
-                                    name: design.name,
-                                    qaId: `workspace-${design.id}`,
-                                })) ?? []
-                            }
-                            value={layoutContext.designId}
-                        />
-                        <Button
-                            variant={ButtonVariant.GHOST}
-                            icon={Icons.Edit}
-                            disabled={!layoutContext.designId}
-                            onClick={() => setShowEditWorkspaceDialog(true)}
-                        />
-                        <Button
-                            variant={ButtonVariant.GHOST}
-                            icon={Icons.Delete}
-                            disabled={!layoutContext.designId}
-                            onClick={() => setShowDeleteWorkspaceDialog(true)}
-                        />
-                    </React.Fragment>
+                    <WorkspaceSelection
+                        selectingWorkspace={selectingWorkspace}
+                        setSelectingWorkspace={setSelectingWorkspace}
+                        onLayoutContextChange={onLayoutContextChange}
+                        layoutContext={layoutContext}
+                    />
                 )}
                 {layoutContext.publicationState == 'DRAFT' && (
                     <Button
@@ -559,52 +504,6 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                 <KmPostEditDialogContainer
                     onClose={() => setShowAddKmPostDialog(false)}
                     onSave={handleKmPostSave}
-                />
-            )}
-
-            {showCreateWorkspaceDialog && (
-                <WorkspaceDialog
-                    onCancel={() => {
-                        setShowCreateWorkspaceDialog(false);
-                        setSelectingWorkspace(false);
-                    }}
-                    onSave={(_, request) => {
-                        insertLayoutDesign(request)
-                            .then((id) => {
-                                setSelectingWorkspace(false);
-                                onLayoutContextChange({ publicationState: 'DRAFT', designId: id });
-                            })
-                            .finally(() => {
-                                updateLayoutDesignChangeTime();
-                                setShowCreateWorkspaceDialog(false);
-                            });
-                    }}
-                />
-            )}
-
-            {showEditWorkspaceDialog && (
-                <WorkspaceDialog
-                    existingDesign={currentDesign}
-                    onCancel={() => {
-                        setShowEditWorkspaceDialog(false);
-                        setSelectingWorkspace(false);
-                    }}
-                    onSave={(_, request) => {
-                        if (currentDesign) {
-                            updateLayoutDesign(currentDesign.id, request).finally(() => {
-                                updateLayoutDesignChangeTime();
-                                setShowEditWorkspaceDialog(false);
-                            });
-                        }
-                    }}
-                />
-            )}
-
-            {showDeleteWorkspaceDialog && currentDesign && (
-                <WorkspaceDeleteConfirmDialog
-                    closeDialog={() => setShowDeleteWorkspaceDialog(false)}
-                    currentDesign={currentDesign}
-                    onDesignDeleted={unselectDesign}
                 />
             )}
         </div>

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -48,7 +48,7 @@ import {
     calculateBoundingBoxToShowAroundLocation,
     MAP_POINT_OPERATING_POINT_BBOX_OFFSET,
 } from 'map/map-utils';
-import { WorkspaceSelection } from 'tool-bar/workspace-selection';
+import { WorkspaceSelectionContainer } from 'tool-bar/workspace-selection';
 
 export type ToolbarParams = {
     onSelect: OnSelectFunction;
@@ -430,44 +430,42 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                 />
             </div>
             <div className={styles['tool-bar__right-section']}>
-                {!layoutContext.designId && layoutContext.publicationState === 'DRAFT' && (
-                    <React.Fragment>
+                {layoutContext.publicationState === 'DRAFT' && (
+                    <PrivilegeRequired privilege={EDIT_LAYOUT}>
                         <div className={styles['tool-bar__new-menu-button']} qa-id={'tool-bar.new'}>
-                            <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                                <Button
-                                    ref={menuRef}
-                                    title={t('tool-bar.new')}
-                                    variant={ButtonVariant.GHOST}
-                                    icon={Icons.Append}
-                                    disabled={disableNewAssetMenu}
-                                    onClick={() => setShowNewAssetMenu(!showNewAssetMenu)}
-                                />
-                            </PrivilegeRequired>
+                            <Button
+                                ref={menuRef}
+                                title={t('tool-bar.new')}
+                                variant={ButtonVariant.GHOST}
+                                icon={Icons.Append}
+                                disabled={disableNewAssetMenu}
+                                onClick={() => setShowNewAssetMenu(!showNewAssetMenu)}
+                            />
                         </div>
-                    </React.Fragment>
+                    </PrivilegeRequired>
                 )}
                 {(layoutContext.designId || selectingWorkspace) && (
-                    <WorkspaceSelection
+                    <WorkspaceSelectionContainer
                         selectingWorkspace={selectingWorkspace}
                         setSelectingWorkspace={setSelectingWorkspace}
-                        onLayoutContextChange={onLayoutContextChange}
-                        layoutContext={layoutContext}
                     />
                 )}
                 {layoutContext.publicationState == 'DRAFT' && (
-                    <Button
-                        disabled={
-                            selectingWorkspace ||
-                            !!splittingState ||
-                            linkingState?.state === 'allSet' ||
-                            linkingState?.state === 'setup'
-                        }
-                        variant={ButtonVariant.PRIMARY}
-                        title={modeNavigationButtonsDisabledReason()}
-                        qa-id="open-preview-view"
-                        onClick={() => openPreviewAndStopLinking()}>
-                        {t('tool-bar.preview-mode.enable')}
-                    </Button>
+                    <PrivilegeRequired privilege={EDIT_LAYOUT}>
+                        <Button
+                            disabled={
+                                selectingWorkspace ||
+                                !!splittingState ||
+                                linkingState?.state === 'allSet' ||
+                                linkingState?.state === 'setup'
+                            }
+                            variant={ButtonVariant.PRIMARY}
+                            title={modeNavigationButtonsDisabledReason()}
+                            qa-id="open-preview-view"
+                            onClick={() => openPreviewAndStopLinking()}>
+                            {t('tool-bar.preview-mode.enable')}
+                        </Button>
+                    </PrivilegeRequired>
                 )}
             </div>
 

--- a/ui/src/tool-bar/workspace-selection.tsx
+++ b/ui/src/tool-bar/workspace-selection.tsx
@@ -13,6 +13,31 @@ import { WorkspaceDeleteConfirmDialog } from 'tool-bar/workspace-delete-confirm-
 import { LayoutContext } from 'common/common-model';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
+import { useTrackLayoutAppSelector } from 'store/hooks';
+import { createDelegates } from 'store/store-utils';
+import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
+
+type WorkspaceSelectionContainerProps = {
+    setSelectingWorkspace: (selectingWorkspace: boolean) => void;
+    selectingWorkspace: boolean;
+};
+
+export const WorkspaceSelectionContainer: React.FC<WorkspaceSelectionContainerProps> = ({
+    setSelectingWorkspace,
+    selectingWorkspace,
+}) => {
+    const trackLayoutState = useTrackLayoutAppSelector((state) => state);
+    const delegates = React.useMemo(() => createDelegates(trackLayoutActionCreators), []);
+
+    return (
+        <WorkspaceSelection
+            layoutContext={trackLayoutState.layoutContext}
+            onLayoutContextChange={delegates.onLayoutContextChange}
+            selectingWorkspace={selectingWorkspace}
+            setSelectingWorkspace={setSelectingWorkspace}
+        />
+    );
+};
 
 type WorkspaceSelectionProps = {
     layoutContext: LayoutContext;

--- a/ui/src/tool-bar/workspace-selection.tsx
+++ b/ui/src/tool-bar/workspace-selection.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
+import { useLoader } from 'utils/react-utils';
+import {
+    getLayoutDesigns,
+    insertLayoutDesign,
+    updateLayoutDesign,
+} from 'track-layout/layout-design-api';
+import { getChangeTimes, updateLayoutDesignChangeTime } from 'common/change-time-api';
+import { WorkspaceDialog } from 'tool-bar/workspace-dialog';
+import { WorkspaceDeleteConfirmDialog } from 'tool-bar/workspace-delete-confirm-dialog';
+import { LayoutContext } from 'common/common-model';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+
+type WorkspaceSelectionProps = {
+    layoutContext: LayoutContext;
+    onLayoutContextChange: (layoutContext: LayoutContext) => void;
+    selectingWorkspace: boolean;
+    setSelectingWorkspace: (selectingWorkspace: boolean) => void;
+};
+
+export const WorkspaceSelection: React.FC<WorkspaceSelectionProps> = ({
+    layoutContext,
+    onLayoutContextChange,
+    selectingWorkspace,
+    setSelectingWorkspace,
+}) => {
+    const { t } = useTranslation();
+
+    const [showCreateWorkspaceDialog, setShowCreateWorkspaceDialog] = React.useState(false);
+    const [showEditWorkspaceDialog, setShowEditWorkspaceDialog] = React.useState(false);
+    const [showDeleteWorkspaceDialog, setShowDeleteWorkspaceDialog] = React.useState(false);
+
+    const selectWorkspaceDropdownRef = React.useRef<HTMLInputElement>(null);
+
+    React.useEffect(() => {
+        if (selectingWorkspace) selectWorkspaceDropdownRef?.current?.focus();
+    }, [selectingWorkspace]);
+
+    const designs = useLoader(
+        () => getLayoutDesigns(getChangeTimes().layoutDesign),
+        [getChangeTimes().layoutDesign],
+    );
+    const currentDesign = designs?.find((d) => d.id === layoutContext.designId);
+
+    const unselectDesign = () => {
+        onLayoutContextChange({
+            publicationState: layoutContext.publicationState,
+            designId: undefined,
+        });
+        setSelectingWorkspace(true);
+    };
+
+    return (
+        <React.Fragment>
+            <Dropdown
+                inputRef={selectWorkspaceDropdownRef}
+                placeholder={t('tool-bar.choose-workspace')}
+                openOverride={selectingWorkspace || undefined}
+                onAddClick={() => setShowCreateWorkspaceDialog(true)}
+                onChange={(designId) => {
+                    setSelectingWorkspace(false);
+                    onLayoutContextChange({
+                        publicationState: 'DRAFT',
+                        designId: designId,
+                    });
+                }}
+                options={
+                    designs?.map((design) => ({
+                        value: design.id,
+                        name: design.name,
+                        qaId: `workspace-${design.id}`,
+                    })) ?? []
+                }
+                value={layoutContext.designId}
+            />
+            <Button
+                variant={ButtonVariant.GHOST}
+                icon={Icons.Edit}
+                disabled={!layoutContext.designId}
+                onClick={() => setShowEditWorkspaceDialog(true)}
+            />
+            <Button
+                variant={ButtonVariant.GHOST}
+                icon={Icons.Delete}
+                disabled={!layoutContext.designId}
+                onClick={() => setShowDeleteWorkspaceDialog(true)}
+            />
+            {showCreateWorkspaceDialog && (
+                <WorkspaceDialog
+                    onCancel={() => {
+                        setShowCreateWorkspaceDialog(false);
+                        setSelectingWorkspace(false);
+                    }}
+                    onSave={(_, request) => {
+                        insertLayoutDesign(request)
+                            .then((id) => {
+                                setSelectingWorkspace(false);
+                                onLayoutContextChange({ publicationState: 'DRAFT', designId: id });
+                            })
+                            .finally(() => {
+                                updateLayoutDesignChangeTime();
+                                setShowCreateWorkspaceDialog(false);
+                            });
+                    }}
+                />
+            )}
+
+            {showEditWorkspaceDialog && (
+                <WorkspaceDialog
+                    existingDesign={currentDesign}
+                    onCancel={() => {
+                        setShowEditWorkspaceDialog(false);
+                        setSelectingWorkspace(false);
+                    }}
+                    onSave={(_, request) => {
+                        if (currentDesign) {
+                            updateLayoutDesign(currentDesign.id, request).finally(() => {
+                                updateLayoutDesignChangeTime();
+                                setShowEditWorkspaceDialog(false);
+                            });
+                        }
+                    }}
+                />
+            )}
+
+            {showDeleteWorkspaceDialog && currentDesign && (
+                <WorkspaceDeleteConfirmDialog
+                    closeDialog={() => setShowDeleteWorkspaceDialog(false)}
+                    currentDesign={currentDesign}
+                    onDesignDeleted={unselectDesign}
+                />
+            )}
+        </React.Fragment>
+    );
+};

--- a/ui/src/tool-panel/infobox/infobox-field.tsx
+++ b/ui/src/tool-panel/infobox/infobox-field.tsx
@@ -11,7 +11,6 @@ type InfoboxFieldProps = {
     qaId?: string;
     value?: React.ReactNode;
     children?: React.ReactNode;
-    inEditMode?: boolean;
     onEdit?: () => void;
     className?: string;
     iconDisabled?: boolean;
@@ -25,7 +24,6 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
     children,
     className,
     qaId,
-    inEditMode = false,
     iconDisabled = false,
     iconHidden = false,
     hasErrors = false,
@@ -33,6 +31,10 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
 }: InfoboxFieldProps) => {
     const classes = createClassName(styles['infobox__field'], className);
     const { t } = useTranslation();
+    const iconTitle = iconDisabled
+        ? t('tool-panel.disabled.activity-disabled-in-official-mode')
+        : '';
+    const iconColor = iconDisabled ? IconColor.DISABLED : IconColor.ORIGINAL;
 
     return (
         <div className={classes} qa-id={qaId}>
@@ -50,18 +52,13 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
                 )}>
                 {children || value}
             </div>
-            {!inEditMode && props.onEdit && !iconDisabled && !iconHidden && (
-                <div
-                    className={styles['infobox__edit-icon']}
-                    onClick={() => props.onEdit && props.onEdit()}>
-                    <Icons.Edit size={IconSize.SMALL} />
-                </div>
-            )}
-            {iconDisabled && !iconHidden && (
+            {props.onEdit && !iconHidden && (
                 <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                    <div className={styles['infobox__edit-icon']}>
-                        <span title={t('tool-panel.disabled.activity-disabled-in-official-mode')}>
-                            <Icons.Edit size={IconSize.SMALL} color={IconColor.DISABLED} />
+                    <div
+                        className={styles['infobox__edit-icon']}
+                        onClick={() => !iconDisabled && props.onEdit && props.onEdit()}>
+                        <span title={iconTitle}>
+                            <Icons.Edit size={IconSize.SMALL} color={iconColor} />
                         </span>
                     </div>
                 </PrivilegeRequired>

--- a/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
@@ -7,6 +7,8 @@ import { LocationTrackId } from 'track-layout/track-layout-model';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { useTranslation } from 'react-i18next';
 import { useCommonDataAppSelector } from 'store/hooks';
+import { EDIT_LAYOUT } from 'user/user-model';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 type LocationTrackValidationInfoboxProps = {
     id: LocationTrackId;
@@ -51,16 +53,18 @@ export const LocationTrackValidationInfoboxContainer: React.FC<
             errors={errors}
             warnings={warnings}
             validationLoaderStatus={validationLoaderStatus}>
-            {layoutContext.publicationState === 'OFFICIAL' || (
-                <div>
-                    <Button
-                        size={ButtonSize.SMALL}
-                        variant={ButtonVariant.SECONDARY}
-                        disabled={editingDisabled}
-                        onClick={showLinkedSwitchesRelinkingDialog}>
-                        {t('tool-panel.location-track.open-switch-relinking-dialog')}
-                    </Button>
-                </div>
+            {layoutContext.publicationState === 'DRAFT' && (
+                <PrivilegeRequired privilege={EDIT_LAYOUT}>
+                    <div>
+                        <Button
+                            size={ButtonSize.SMALL}
+                            variant={ButtonVariant.SECONDARY}
+                            disabled={editingDisabled}
+                            onClick={showLinkedSwitchesRelinkingDialog}>
+                            {t('tool-panel.location-track.open-switch-relinking-dialog')}
+                        </Button>
+                    </div>
+                </PrivilegeRequired>
             )}
         </AssetValidationInfobox>
     );


### PR DESCRIPTION
Täällä on toteutettuna nyt minimi siihen, miten näiden halutaan toimivan 1.14:ssa: Luonnostila- ja Suunnitelmatila-tabit näkyvät ja ovat valittavissa ainoastaan, jos käyttäjällä on oikeudet katsella luonnostilaa. Jo tämä aiheutti kevyitä refaktorointeja:

- `LayoutDesignController`:ista puuttui kokonaan `@PreAuthorize`-annotaatiot, joten ne eivät tarkistelleet oikeuksia ollenkaan. Ne on nyt lisätty
- Edellämainitusta johtuen työtilojen haut alkoivat heittää virhettä kaikilla niillä käyttäjäryhmillä, joilla ei ole oikeutta katsella luonnostilaisia asioita -> jouduin wrappaamaan ne omaan komponenttiinsa, joka näytetään ainoastaan kun Luonnostila-tabi on aktiivinen

Tästä jäi vielä jatkotyöksi seuraavat:

- Tiketillä mainittu E2E-kliksuttelutestin päivitys (tutkitaan että ei näy mitään väärää)
- Muokkaustoiminnallisuuksien ottaminen pois näkyvistä. Luonnostilassa ei tällä hetkellä piiloteta mitään luonti- tai muokkausnappuloita, ja niitä on sen verran paljon, että niiden korjaamisesta kannattanee tehdä oma PR:nsä