### PR TITLE
GVT-2627: Part 2 - Muokkaustoiminnallisuuksien piilottaminen luonnostilassa muokkausoikeuksien puuttuessa

### DIFF
--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -48,7 +48,7 @@ import {
     calculateBoundingBoxToShowAroundLocation,
     MAP_POINT_OPERATING_POINT_BBOX_OFFSET,
 } from 'map/map-utils';
-import { WorkspaceSelection } from 'tool-bar/workspace-selection';
+import { WorkspaceSelectionContainer } from 'tool-bar/workspace-selection';
 
 export type ToolbarParams = {
     onSelect: OnSelectFunction;
@@ -445,11 +445,9 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                     </PrivilegeRequired>
                 )}
                 {(layoutContext.designId || selectingWorkspace) && (
-                    <WorkspaceSelection
+                    <WorkspaceSelectionContainer
                         selectingWorkspace={selectingWorkspace}
                         setSelectingWorkspace={setSelectingWorkspace}
-                        onLayoutContextChange={onLayoutContextChange}
-                        layoutContext={layoutContext}
                     />
                 )}
                 {layoutContext.publicationState == 'DRAFT' && (

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -430,21 +430,19 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                 />
             </div>
             <div className={styles['tool-bar__right-section']}>
-                {!layoutContext.designId && layoutContext.publicationState === 'DRAFT' && (
-                    <React.Fragment>
+                {layoutContext.publicationState === 'DRAFT' && (
+                    <PrivilegeRequired privilege={EDIT_LAYOUT}>
                         <div className={styles['tool-bar__new-menu-button']} qa-id={'tool-bar.new'}>
-                            <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                                <Button
-                                    ref={menuRef}
-                                    title={t('tool-bar.new')}
-                                    variant={ButtonVariant.GHOST}
-                                    icon={Icons.Append}
-                                    disabled={disableNewAssetMenu}
-                                    onClick={() => setShowNewAssetMenu(!showNewAssetMenu)}
-                                />
-                            </PrivilegeRequired>
+                            <Button
+                                ref={menuRef}
+                                title={t('tool-bar.new')}
+                                variant={ButtonVariant.GHOST}
+                                icon={Icons.Append}
+                                disabled={disableNewAssetMenu}
+                                onClick={() => setShowNewAssetMenu(!showNewAssetMenu)}
+                            />
                         </div>
-                    </React.Fragment>
+                    </PrivilegeRequired>
                 )}
                 {(layoutContext.designId || selectingWorkspace) && (
                     <WorkspaceSelection
@@ -455,19 +453,21 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                     />
                 )}
                 {layoutContext.publicationState == 'DRAFT' && (
-                    <Button
-                        disabled={
-                            selectingWorkspace ||
-                            !!splittingState ||
-                            linkingState?.state === 'allSet' ||
-                            linkingState?.state === 'setup'
-                        }
-                        variant={ButtonVariant.PRIMARY}
-                        title={modeNavigationButtonsDisabledReason()}
-                        qa-id="open-preview-view"
-                        onClick={() => openPreviewAndStopLinking()}>
-                        {t('tool-bar.preview-mode.enable')}
-                    </Button>
+                    <PrivilegeRequired privilege={EDIT_LAYOUT}>
+                        <Button
+                            disabled={
+                                selectingWorkspace ||
+                                !!splittingState ||
+                                linkingState?.state === 'allSet' ||
+                                linkingState?.state === 'setup'
+                            }
+                            variant={ButtonVariant.PRIMARY}
+                            title={modeNavigationButtonsDisabledReason()}
+                            qa-id="open-preview-view"
+                            onClick={() => openPreviewAndStopLinking()}>
+                            {t('tool-bar.preview-mode.enable')}
+                        </Button>
+                    </PrivilegeRequired>
                 )}
             </div>
 

--- a/ui/src/tool-bar/workspace-selection.tsx
+++ b/ui/src/tool-bar/workspace-selection.tsx
@@ -13,6 +13,31 @@ import { WorkspaceDeleteConfirmDialog } from 'tool-bar/workspace-delete-confirm-
 import { LayoutContext } from 'common/common-model';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Icons } from 'vayla-design-lib/icon/Icon';
+import { useTrackLayoutAppSelector } from 'store/hooks';
+import { createDelegates } from 'store/store-utils';
+import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
+
+type WorkspaceSelectionContainerProps = {
+    setSelectingWorkspace: (selectingWorkspace: boolean) => void;
+    selectingWorkspace: boolean;
+};
+
+export const WorkspaceSelectionContainer: React.FC<WorkspaceSelectionContainerProps> = ({
+    setSelectingWorkspace,
+    selectingWorkspace,
+}) => {
+    const trackLayoutState = useTrackLayoutAppSelector((state) => state);
+    const delegates = React.useMemo(() => createDelegates(trackLayoutActionCreators), []);
+
+    return (
+        <WorkspaceSelection
+            layoutContext={trackLayoutState.layoutContext}
+            onLayoutContextChange={delegates.onLayoutContextChange}
+            selectingWorkspace={selectingWorkspace}
+            setSelectingWorkspace={setSelectingWorkspace}
+        />
+    );
+};
 
 type WorkspaceSelectionProps = {
     layoutContext: LayoutContext;

--- a/ui/src/tool-panel/infobox/infobox-field.tsx
+++ b/ui/src/tool-panel/infobox/infobox-field.tsx
@@ -11,7 +11,6 @@ type InfoboxFieldProps = {
     qaId?: string;
     value?: React.ReactNode;
     children?: React.ReactNode;
-    inEditMode?: boolean;
     onEdit?: () => void;
     className?: string;
     iconDisabled?: boolean;
@@ -25,7 +24,6 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
     children,
     className,
     qaId,
-    inEditMode = false,
     iconDisabled = false,
     iconHidden = false,
     hasErrors = false,
@@ -33,6 +31,10 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
 }: InfoboxFieldProps) => {
     const classes = createClassName(styles['infobox__field'], className);
     const { t } = useTranslation();
+    const iconTitle = iconDisabled
+        ? t('tool-panel.disabled.activity-disabled-in-official-mode')
+        : '';
+    const iconColor = iconDisabled ? IconColor.DISABLED : IconColor.ORIGINAL;
 
     return (
         <div className={classes} qa-id={qaId}>
@@ -50,20 +52,13 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
                 )}>
                 {children || value}
             </div>
-            {!inEditMode && props.onEdit && !iconDisabled && !iconHidden && (
+            {props.onEdit && !iconHidden && (
                 <PrivilegeRequired privilege={EDIT_LAYOUT}>
                     <div
                         className={styles['infobox__edit-icon']}
-                        onClick={() => props.onEdit && props.onEdit()}>
-                        <Icons.Edit size={IconSize.SMALL} />
-                    </div>
-                </PrivilegeRequired>
-            )}
-            {iconDisabled && !iconHidden && (
-                <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                    <div className={styles['infobox__edit-icon']}>
-                        <span title={t('tool-panel.disabled.activity-disabled-in-official-mode')}>
-                            <Icons.Edit size={IconSize.SMALL} color={IconColor.DISABLED} />
+                        onClick={() => !iconDisabled && props.onEdit && props.onEdit()}>
+                        <span title={iconTitle}>
+                            <Icons.Edit size={IconSize.SMALL} color={iconColor} />
                         </span>
                     </div>
                 </PrivilegeRequired>

--- a/ui/src/tool-panel/infobox/infobox-field.tsx
+++ b/ui/src/tool-panel/infobox/infobox-field.tsx
@@ -51,11 +51,13 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
                 {children || value}
             </div>
             {!inEditMode && props.onEdit && !iconDisabled && !iconHidden && (
-                <div
-                    className={styles['infobox__edit-icon']}
-                    onClick={() => props.onEdit && props.onEdit()}>
-                    <Icons.Edit size={IconSize.SMALL} />
-                </div>
+                <PrivilegeRequired privilege={EDIT_LAYOUT}>
+                    <div
+                        className={styles['infobox__edit-icon']}
+                        onClick={() => props.onEdit && props.onEdit()}>
+                        <Icons.Edit size={IconSize.SMALL} />
+                    </div>
+                </PrivilegeRequired>
             )}
             {iconDisabled && !iconHidden && (
                 <PrivilegeRequired privilege={EDIT_LAYOUT}>

--- a/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
@@ -7,6 +7,8 @@ import { LocationTrackId } from 'track-layout/track-layout-model';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { useTranslation } from 'react-i18next';
 import { useCommonDataAppSelector } from 'store/hooks';
+import { EDIT_LAYOUT } from 'user/user-model';
+import { PrivilegeRequired } from 'user/privilege-required';
 
 type LocationTrackValidationInfoboxProps = {
     id: LocationTrackId;
@@ -51,16 +53,18 @@ export const LocationTrackValidationInfoboxContainer: React.FC<
             errors={errors}
             warnings={warnings}
             validationLoaderStatus={validationLoaderStatus}>
-            {layoutContext.publicationState === 'OFFICIAL' || (
-                <div>
-                    <Button
-                        size={ButtonSize.SMALL}
-                        variant={ButtonVariant.SECONDARY}
-                        disabled={editingDisabled}
-                        onClick={showLinkedSwitchesRelinkingDialog}>
-                        {t('tool-panel.location-track.open-switch-relinking-dialog')}
-                    </Button>
-                </div>
+            {layoutContext.publicationState === 'DRAFT' && (
+                <PrivilegeRequired privilege={EDIT_LAYOUT}>
+                    <div>
+                        <Button
+                            size={ButtonSize.SMALL}
+                            variant={ButtonVariant.SECONDARY}
+                            disabled={editingDisabled}
+                            onClick={showLinkedSwitchesRelinkingDialog}>
+                            {t('tool-panel.location-track.open-switch-relinking-dialog')}
+                        </Button>
+                    </div>
+                </PrivilegeRequired>
             )}
         </AssetValidationInfobox>
     );


### PR DESCRIPTION
Tämä menikin helpommin kuin luulin, sillä edit-nappien piilottamista oli selkeästi yritetty jo aiemmin, mutta vähän huonoin lopputuloksin. Lisäksi piilotettu esikatselunäkymään meno EDIT_LAYOUT-oikeuden taakse, sillä siellä tehdään lähinnä muutostoimenpiteitä.