### PR TITLE
WIP: GVT-2616 Branchify publications and publication validation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.linking.switches
 
+import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
@@ -55,6 +56,8 @@ import fi.fta.geoviite.infra.tracklayout.TRACK_SEARCH_AREA_SIZE
 import fi.fta.geoviite.infra.tracklayout.TopologyLocationTrackSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitchJoint
+import fi.fta.geoviite.infra.tracklayout.asDraft
+import fi.fta.geoviite.infra.tracklayout.asDraftInItemBranch
 import fi.fta.geoviite.infra.tracklayout.asMainDraft
 import fi.fta.geoviite.infra.tracklayout.calculateLocationTrackTopology
 import fi.fta.geoviite.infra.tracklayout.clearLinksToSwitch
@@ -775,7 +778,7 @@ private fun withExistingLinksToSwitchCleared(
 
 // some validation logic depends on draftness state, so we need to pre-draft tracks for online validation
 private fun draft(tracks: List<Pair<LocationTrack, LayoutAlignment>>) =
-    tracks.map { (track, alignment) -> asMainDraft(track) to alignment }
+    tracks.map { (track, alignment) -> asDraftInItemBranch(track) to alignment }
 
 fun updateLocationTrackWithTopologyEndLinking(
     locationTrack: LocationTrack,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -80,6 +80,7 @@ open class Publication(
     open val publicationTime: Instant,
     open val publicationUser: UserName,
     open val message: String?,
+    open val layoutBranch: LayoutBranch,
 )
 
 data class PublishedItemListing<T>(
@@ -137,6 +138,7 @@ data class PublicationDetails(
     override val publicationTime: Instant,
     override val publicationUser: UserName,
     override val message: String?,
+    override val layoutBranch: LayoutBranch,
     val trackNumbers: List<PublishedTrackNumber>,
     val referenceLines: List<PublishedReferenceLine>,
     val locationTracks: List<PublishedLocationTrack>,
@@ -146,7 +148,7 @@ data class PublicationDetails(
     val ratkoPushTime: Instant?,
     val indirectChanges: PublishedIndirectChanges,
     val split: SplitHeader?,
-) : Publication(id, publicationTime, publicationUser, message) {
+) : Publication(id, publicationTime, publicationUser, message, layoutBranch) {
     val allPublishedTrackNumbers = trackNumbers + indirectChanges.trackNumbers
     val allPublishedLocationTracks = locationTracks + indirectChanges.locationTracks
     val allPublishedSwitches = switches + indirectChanges.switches

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -127,11 +127,13 @@ class PublicationController @Autowired constructor(
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
     @GetMapping
     fun getPublicationsBetween(
+        @RequestParam("layoutBranch", required = false) layoutBranch: LayoutBranch?,
         @RequestParam("from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
         @RequestParam("to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
     ): Page<PublicationDetails> {
         logger.apiCall("getPublicationsBetween", "from" to from, "to" to to)
-        val publications = publicationService.fetchPublicationDetailsBetweenInstants(from, to)
+        val publications =
+            publicationService.fetchPublicationDetailsBetweenInstants(layoutBranch ?: LayoutBranch.main, from, to)
 
         return Page(
             totalCount = publications.size,
@@ -143,10 +145,11 @@ class PublicationController @Autowired constructor(
     @PreAuthorize(AUTH_VIEW_PUBLICATION)
     @GetMapping("latest")
     fun getLatestPublications(
+        @RequestParam("layoutBranch", required = false) layoutBranch: LayoutBranch?,
         @RequestParam("count") count: Int,
     ): Page<PublicationDetails> {
-        logger.apiCall("getLatestPublications", "count" to count)
-        val publications = publicationService.fetchLatestPublicationDetails(count)
+        logger.apiCall("getLatestPublications", "count" to count, "layoutBranch" to layoutBranch)
+        val publications = publicationService.fetchLatestPublicationDetails(layoutBranch ?: LayoutBranch.main, count)
 
         return Page(totalCount = publications.size, start = 0, items = publications)
     }
@@ -154,6 +157,7 @@ class PublicationController @Autowired constructor(
     @PreAuthorize(AUTH_DOWNLOAD_PUBLICATION)
     @GetMapping("csv")
     fun getPublicationsAsCsv(
+        @RequestParam("layoutBranch", required = false) layoutBranch: LayoutBranch?,
         @RequestParam("from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
         @RequestParam("to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
         @RequestParam("sortBy", required = false) sortBy: PublicationTableColumn?,
@@ -172,7 +176,13 @@ class PublicationController @Autowired constructor(
         )
 
         val publicationsAsCsv = publicationService.fetchPublicationsAsCsv(
-            from, to, sortBy, order, timeZone, localizationService.getLocalization(lang)
+            layoutBranch ?: LayoutBranch.main,
+            from,
+            to,
+            sortBy,
+            order,
+            timeZone,
+            localizationService.getLocalization(lang)
         )
 
         val dateString = getDateStringForFileName(from, to, timeZone ?: ZoneId.of("UTC"))
@@ -184,6 +194,7 @@ class PublicationController @Autowired constructor(
     @PreAuthorize(AUTH_VIEW_PUBLICATION)
     @GetMapping("/table-rows")
     fun getPublicationDetailsAsTableRows(
+        @RequestParam("layoutBranch", required = false) layoutBranch: LayoutBranch?,
         @RequestParam("from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
         @RequestParam("to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
         @RequestParam("sortBy", required = false) sortBy: PublicationTableColumn?,
@@ -200,6 +211,7 @@ class PublicationController @Autowired constructor(
         )
 
         val publications = publicationService.fetchPublicationDetails(
+            layoutBranch = layoutBranch ?: LayoutBranch.main,
             from = from,
             to = to,
             sortBy = sortBy,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -292,7 +292,7 @@ class ValidationContext(
     )
 
     fun fetchSwitchesByName(names: List<SwitchName>): Map<SwitchName, List<IntId<TrackLayoutSwitch>>> {
-        val officialVersions = switchDao.findOfficialNameDuplicates(names)
+        val officialVersions = switchDao.findOfficialNameDuplicates(branch, names)
         cacheOfficialVersions(officialVersions.values.flatten(), switchVersionCache)
         return mapIdsByField(names, { s -> s.name }, publicationSet.switches, officialVersions, switchDao)
     }
@@ -302,7 +302,7 @@ class ValidationContext(
     )
 
     fun fetchLocationTracksByName(names: List<AlignmentName>): Map<AlignmentName, List<IntId<LocationTrack>>> {
-        val officialVersions = locationTrackDao.findOfficialNameDuplicates(names)
+        val officialVersions = locationTrackDao.findOfficialNameDuplicates(branch, names)
         cacheOfficialVersions(officialVersions.values.flatten(), locationTrackVersionCache)
         return mapIdsByField(names, { t -> t.name }, publicationSet.locationTracks, officialVersions, locationTrackDao)
     }
@@ -312,7 +312,7 @@ class ValidationContext(
     )
 
     private fun fetchTrackNumbersByNumber(numbers: List<TrackNumber>): Map<TrackNumber, List<IntId<TrackLayoutTrackNumber>>> {
-        val officialVersions = trackNumberDao.findOfficialNumberDuplicates(numbers)
+        val officialVersions = trackNumberDao.findOfficialNumberDuplicates(branch, numbers)
         cacheOfficialVersions(officialVersions.values.flatten(), trackNumberVersionCache)
         return mapIdsByField(numbers, { t -> t.number }, publicationSet.trackNumbers, officialVersions, trackNumberDao)
     }
@@ -382,7 +382,7 @@ class ValidationContext(
         ids: List<IntId<LocationTrack>>
     ): Map<IntId<LocationTrack>, List<IntId<LocationTrack>>> {
         val officialVersions = publicationDao
-            .fetchOfficialDuplicateTrackVersions(ids)
+            .fetchOfficialDuplicateTrackVersions(branch, ids)
             .mapValues { (_, versions) -> versions.filterNot { v -> publicationSet.containsLocationTrack(v.id) } }
             .also { duplicateMap -> cacheOfficialVersions(duplicateMap.values.flatten(), locationTrackVersionCache) }
         val draftTracks = publicationSet.locationTracks.map { v -> locationTrackDao.fetch(v.validatedAssetVersion) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.integration.SwitchJointChange
 import fi.fta.geoviite.infra.logging.serviceCall
 import fi.fta.geoviite.infra.publication.PublishedSwitch
@@ -28,7 +29,11 @@ class RatkoAssetService @Autowired constructor(
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    fun pushSwitchChangesToRatko(publishedSwitches: Collection<PublishedSwitch>, publicationTime: Instant) {
+    fun pushSwitchChangesToRatko(
+        layoutBranch: LayoutBranch,
+        publishedSwitches: Collection<PublishedSwitch>,
+        publicationTime: Instant,
+    ) {
         publishedSwitches
             .groupBy { it.version.id }
             .map { (_, switches) ->
@@ -48,6 +53,7 @@ class RatkoAssetService @Autowired constructor(
                         .let { oid -> ratkoClient.getSwitchAsset(RatkoOid<RatkoSwitchAsset>(oid)) }
                         ?.also { existingRatkoSwitch ->
                             updateSwitch(
+                                layoutBranch = layoutBranch,
                                 layoutSwitch = layoutSwitch,
                                 existingRatkoSwitch = existingRatkoSwitch,
                                 jointChanges = changedJoints,
@@ -62,6 +68,7 @@ class RatkoAssetService @Autowired constructor(
     }
 
     private fun updateSwitch(
+        layoutBranch: LayoutBranch,
         layoutSwitch: TrackLayoutSwitch,
         existingRatkoSwitch: RatkoSwitchAsset,
         jointChanges: List<SwitchJointChange>,
@@ -98,6 +105,7 @@ class RatkoAssetService @Autowired constructor(
         val baseRatkoLocations =
             if (includeBaseLocations && existingLocations.isNotEmpty())
                 getBaseRatkoSwitchLocations(
+                    layoutBranch = layoutBranch,
                     switchId = layoutSwitch.id,
                     existingRatkoLocations = existingLocations,
                     jointChanges = jointChanges,
@@ -127,6 +135,7 @@ class RatkoAssetService @Autowired constructor(
     }
 
     private fun getBaseRatkoSwitchLocations(
+        layoutBranch: LayoutBranch,
         switchId: IntId<TrackLayoutSwitch>,
         existingRatkoLocations: List<RatkoAssetLocation>,
         jointChanges: Collection<SwitchJointChange>,
@@ -134,6 +143,7 @@ class RatkoAssetService @Autowired constructor(
         moment: Instant,
     ): List<RatkoAssetLocation> {
         val linkedLocationTracks = switchDao.findLocationTracksLinkedToSwitchAtMoment(
+            layoutBranch = layoutBranch,
             switchId = switchId,
             topologyJointNumber = switchStructure.presentationJointNumber,
             moment = moment

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
@@ -43,7 +43,7 @@ class RatkoController(
     @PostMapping("/push")
     fun pushChangesToRatko(): HttpStatus {
         logger.apiCall("pushChangesToRatko")
-        ratkoService.pushChangesToRatko()
+        ratkoService.pushChangesToRatko(LayoutBranch.main)
 
         return HttpStatus.NO_CONTENT
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
@@ -83,7 +83,7 @@ class RatkoService @Autowired constructor(
         withUser(ratkoSchedulerUserName) {
             logger.serviceCall("scheduledRatkoPush")
             // Don't retry failed on auto-push
-            pushChangesToRatko(retryFailed = false)
+            pushChangesToRatko(LayoutBranch.main, retryFailed = false)
         }
     }
 
@@ -101,7 +101,9 @@ class RatkoService @Autowired constructor(
         }
     }
 
-    fun pushChangesToRatko(retryFailed: Boolean = true) {
+    fun pushChangesToRatko(layoutBranch: LayoutBranch, retryFailed: Boolean = true) {
+        assertMainBranch(layoutBranch)
+
         lockDao.runWithLock(DatabaseLock.RATKO, databaseLockDuration) {
             logger.serviceCall("pushChangesToRatko")
 
@@ -116,16 +118,16 @@ class RatkoService @Autowired constructor(
                 val lastPublicationMoment = ratkoPushDao.getLatestPushedPublicationMoment()
 
                 // Inclusive search, therefore the already pushed one is also returned
-                val publications = publicationService.fetchPublications(lastPublicationMoment)
+                val publications = publicationService.fetchPublications(layoutBranch, lastPublicationMoment)
                     .filter { it.publicationTime > lastPublicationMoment }
                     .map { publicationService.getPublicationDetails(it.id) }
 
                 if (publications.isNotEmpty()) {
-                    pushChanges(publications)
+                    pushChanges(layoutBranch, publications)
                 }
 
                 if (ratkoClientConfiguration.bulkTransfersEnabled) {
-                    manageRatkoBulkTransfers(LayoutBranch.main)
+                    manageRatkoBulkTransfers(layoutBranch)
                 }
             }
         }
@@ -257,7 +259,7 @@ class RatkoService @Autowired constructor(
                 latestPublicationMoment,
             )
 
-            ratkoAssetService.pushSwitchChangesToRatko(switchChanges, latestPublicationMoment)
+            ratkoAssetService.pushSwitchChangesToRatko(branch, switchChanges, latestPublicationMoment)
 
             try {
                 ratkoLocationTrackService.forceRedraw(
@@ -274,7 +276,7 @@ class RatkoService @Autowired constructor(
         return states.any { state -> previousPush.status == state }
     }
 
-    private fun pushChanges(publications: List<PublicationDetails>) {
+    private fun pushChanges(layoutBranch: LayoutBranch, publications: List<PublicationDetails>) {
         val ratkoPushId = ratkoPushDao.startPushing(publications.map { it.id })
         val lastPublicationTime = publications.maxOf { it.publicationTime }
         try {
@@ -290,6 +292,7 @@ class RatkoService @Autowired constructor(
             )
 
             pushSwitchChanges(
+                layoutBranch = layoutBranch,
                 publishedSwitches = publications.flatMap { it.allPublishedSwitches },
                 publishedLocationTracks = publications.flatMap { it.allPublishedLocationTracks },
                 publicationTime = lastPublicationTime,
@@ -358,6 +361,7 @@ class RatkoService @Autowired constructor(
     }
 
     private fun pushSwitchChanges(
+        layoutBranch: LayoutBranch,
         publishedSwitches: Collection<PublishedSwitch>,
         publishedLocationTracks: List<PublishedLocationTrack>,
         publicationTime: Instant,
@@ -376,7 +380,7 @@ class RatkoService @Autowired constructor(
             }.map { switchChange -> toFakePublishedSwitch(switchChange, publicationTime) }
 
         val switchChanges = publishedSwitches + locationTrackSwitchChanges
-        ratkoAssetService.pushSwitchChangesToRatko(switchChanges, publicationTime)
+        ratkoAssetService.pushSwitchChangesToRatko(layoutBranch, switchChanges, publicationTime)
     }
 
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -6,7 +6,6 @@ import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
-import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.configuration.layoutCacheDuration
@@ -69,6 +68,8 @@ interface LayoutAssetReader<T : LayoutAsset<T>> {
     fun fetchVersionOrThrow(layoutContext: LayoutContext, id: IntId<T>): RowVersion<T>
     fun fetchVersions(layoutContext: LayoutContext, ids: List<IntId<T>>): List<RowVersion<T>>
 
+    fun fetchOfficialRowVersionForPublishingInBranch(branch: LayoutBranch, version: RowVersion<T>): RowVersion<T>?
+
     fun fetchOfficialVersionAtMomentOrThrow(id: IntId<T>, moment: Instant): RowVersion<T>
     fun fetchOfficialVersionAtMoment(id: IntId<T>, moment: Instant): RowVersion<T>?
 
@@ -123,7 +124,7 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
           id as row_id,
           version as row_version
         from ${table.fullName}
-        where coalesce(official_row_id, id) in (:ids)
+        where coalesce(official_row_id, design_row_id, id) in (:ids)
           and draft and design_id is not distinct from :design_id
     """.trimIndent()
 
@@ -278,6 +279,23 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
             "moment" to Timestamp.from(moment),
         )
         return jdbcTemplate.queryOptional(officialVersionAtMomentSql, params, ::toRowVersion)
+    }
+
+    override fun fetchOfficialRowVersionForPublishingInBranch(
+        branch: LayoutBranch,
+        version: RowVersion<T>,
+    ): RowVersion<T>? {
+        val draft = fetch(version)
+        val designRowId = draft.contextData.designRowId
+        return if (branch.designId == null && draft.contextData.officialRowId == null && designRowId is IntId) {
+            jdbcTemplate.queryOne(
+                "select id, version from ${table.fullName} where id = :designRowId",
+                mapOf("designRowId" to designRowId.intValue)
+            ) { rs, _ ->
+                rs.getRowVersion("id", "version")
+            }
+        } else if (draft.isDesign && draft.contextData.officialRowId != null) null
+        else fetchVersion(branch.official, version.id)
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
@@ -93,7 +93,10 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
     @Transactional
     open fun publish(branch: LayoutBranch, version: ValidationVersion<ObjectType>): DaoResponse<ObjectType> {
         logger.serviceCall("Publish", "branch" to branch, "version" to version)
-        val versions = VersionPair(dao.fetchVersion(branch.official, version.officialId), version.validatedAssetVersion)
+        val versions = VersionPair(
+            dao.fetchOfficialRowVersionForPublishingInBranch(branch, version.validatedAssetVersion),
+            version.validatedAssetVersion
+        )
         return publishInternal(branch, versions)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -156,6 +156,7 @@ data class DesignOfficialContextData<T>(
 ) : DesignContextData<T>() {
     override val id: DomainId<T> get() = officialRowId ?: rowId
     override val editState: EditState get() = EditState.UNEDITED
+    override val isOfficial: Boolean get() = true
     override val isDesign: Boolean get() = true
 
     init {
@@ -219,6 +220,10 @@ data class DesignDraftContextData<T>(
             dataType = STORED, // There will always be an existing row to update: the draft-row or the original official
         )
     }
+}
+
+fun <T : LayoutAsset<T>> asDraftInItemBranch(item: T): T = item.contextData.designId.let { designId ->
+    if (designId is IntId) asDesignDraft(item, designId) else asMainDraft(item)
 }
 
 fun <T : LayoutAsset<T>> asDraft(branch: LayoutBranch, item: T): T = when (branch) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -281,7 +281,7 @@ class LayoutKmPostDao(
               design_id = :design_id
             where id = :km_post_id
             returning 
-              coalesce(official_row_id, id) as official_id,
+              coalesce(official_row_id, design_row_id, id) as official_id,
               id as row_id,
               version as row_version
         """.trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -183,7 +183,7 @@ class LocationTrackService(
     @Transactional
     override fun publish(branch: LayoutBranch, version: ValidationVersion<LocationTrack>): DaoResponse<LocationTrack> {
         logger.serviceCall("publish", "branch" to branch, "version" to version)
-        val officialVersion = dao.fetchVersion(branch.official, version.officialId)
+        val officialVersion = dao.fetchOfficialRowVersionForPublishingInBranch(branch, version.validatedAssetVersion)
         val oldDraft = dao.fetch(version.validatedAssetVersion)
         val oldOfficial = officialVersion?.let(dao::fetch)
         val publishedVersion = publishInternal(branch, VersionPair(officialVersion, version.validatedAssetVersion))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -165,7 +165,7 @@ class ReferenceLineDao(
               design_id = :design_id
             where id = :id
             returning 
-              coalesce(official_row_id, id) as official_id,
+              coalesce(official_row_id, design_row_id, id) as official_id,
               id as row_id,
               version as row_version
         """.trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -121,7 +121,7 @@ class ReferenceLineService(
     @Transactional
     override fun publish(branch: LayoutBranch, version: ValidationVersion<ReferenceLine>): DaoResponse<ReferenceLine> {
         logger.serviceCall("publish", "branch" to branch, "version" to version)
-        val officialVersion = dao.fetchVersion(branch.official, version.officialId)
+        val officialVersion = dao.fetchOfficialRowVersionForPublishingInBranch(branch, version.validatedAssetVersion)
         val oldDraft = dao.fetch(version.validatedAssetVersion)
         val oldOfficial = officialVersion?.let(dao::fetch)
         val publishedVersion = publishInternal(branch, VersionPair(officialVersion, version.validatedAssetVersion))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -261,6 +261,9 @@ fun ResultSet.getPublicationState(draftFlagName: String): PublicationState =
 fun ResultSet.getPublicationStateOrNull(draftFlagName: String): PublicationState? =
     getBooleanOrNull(draftFlagName)?.let { draft -> if (draft) PublicationState.DRAFT else PublicationState.OFFICIAL }
 
+fun ResultSet.getLayoutBranch(designIdName: String): LayoutBranch =
+    getIntIdOrNull<LayoutDesign>(designIdName).let { id -> if (id == null) LayoutBranch.main else DesignBranch.of(id) }
+
 inline fun <reified T> verifyNotNull(column: String, nullableGet: (column: String) -> T?): T =
     requireNotNull(nullableGet(column)) { "Value was null: type=${T::class.simpleName} column=$column" }
 
@@ -305,7 +308,7 @@ fun <T> ResultSet.getLayoutContextData(
         MainDraftContextData(
             officialRowId = officialRowId,
             rowId = rowId,
-            designRowId = null,
+            designRowId = designRowId,
             dataType = DataType.STORED,
         )
     } else {

--- a/infra/src/main/resources/db/migration/prod/V78__add_design_id_to_publication.sql
+++ b/infra/src/main/resources/db/migration/prod/V78__add_design_id_to_publication.sql
@@ -1,0 +1,3 @@
+alter table publication.publication
+  add column design_id int,
+  add constraint publication_design_fk foreign key (design_id) references layout.design (id);

--- a/infra/src/main/resources/db/migration/repeatable/R__03.08_layout_switch_change_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.08_layout_switch_change_view.sql
@@ -9,7 +9,7 @@ select
   switch_version.version,
   switch_version.change_user,
   lag(switch_version.state_category)
-      over (partition by switch_version.id order by switch_version.version) as old_state_category
+      over (partition by switch_version.id, design_id order by switch_version.version) as old_state_category
   from layout.switch_version
-  where layout_context_id = 'main_official'
+  where not draft
 );

--- a/infra/src/main/resources/db/migration/repeatable/R__03.09_layout_km_post_change_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.09_layout_km_post_change_view.sql
@@ -10,7 +10,7 @@ select
   km_post_version.version,
   km_number,
   lag(km_post_version.state)
-      over (partition by km_post_version.id order by km_post_version.version) as old_state
+      over (partition by km_post_version.id, design_id order by km_post_version.version) as old_state
   from layout.km_post_version
-  where layout_context_id = 'main_official'
+  where not draft
 );

--- a/infra/src/main/resources/db/migration/repeatable/R__03.10_layout_track_number_change_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.10_layout_track_number_change_view.sql
@@ -9,7 +9,7 @@ select
   track_number_version.state,
   track_number_version.version,
   lag(track_number_version.state)
-      over (partition by track_number_version.id order by track_number_version.version) old_state
+      over (partition by track_number_version.id, design_id order by track_number_version.version) old_state
   from layout.track_number_version
-  where layout_context_id = 'main_official'
+  where not draft
 );

--- a/infra/src/main/resources/db/migration/repeatable/R__03.11_layout_location_track_change_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.11_layout_location_track_change_view.sql
@@ -12,7 +12,7 @@ select
   location_track_version.change_user,
   location_track_version.version,
   lag(location_track_version.state)
-      over (partition by location_track_version.id order by location_track_version.version) old_state
+      over (partition by location_track_version.id, design_id order by location_track_version.version) old_state
   from layout.location_track_version
-  where layout_context_id = 'main_official'
+  where not draft
 );

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -47,7 +47,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
         // Mark off any old junk as done
         transactional {
             val lastSuccessTime = ratkoPushDao.getLatestPushedPublicationMoment()
-            val hangingPublications = publicationDao.fetchPublicationsBetween(lastSuccessTime, null)
+            val hangingPublications = publicationDao.fetchPublicationsBetween(LayoutBranch.main, lastSuccessTime, null)
                 .filterNot { it.publicationTime == lastSuccessTime }
             if (hangingPublications.isNotEmpty()) {
                 ratkoPushDao.startPushing(hangingPublications.map { publication -> publication.id })
@@ -130,7 +130,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
         val lastPush = ratkoPushDao.getLatestPushedPublicationMoment()
         Assertions.assertTrue(lastPush < publicationMoment)
 
-        val publications = publicationDao.fetchPublicationsBetween(lastPush, null)
+        val publications = publicationDao.fetchPublicationsBetween(LayoutBranch.main, lastPush, null)
         val (publishedLocationTracks, _) = publicationDao.fetchPublishedLocationTracks(publications[1].id)
 
         assertEquals(publicationId, publications[1].id)
@@ -144,7 +144,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
         val latestPushMoment = ratkoPushDao.getLatestPushedPublicationMoment()
         assertEquals(publicationMoment, latestPushMoment)
-        val publications = publicationDao.fetchPublicationsBetween(latestPushMoment, null)
+        val publications = publicationDao.fetchPublicationsBetween(LayoutBranch.main, latestPushMoment, null)
         assertEquals(1, publications.size)
     }
 
@@ -155,7 +155,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
         val latestPushedPublish = ratkoPushDao.getLatestPushedPublicationMoment()
         Assertions.assertTrue(latestPushedPublish < publicationMoment)
-        val publications = publicationDao.fetchPublicationsBetween(latestPushedPublish, null)
+        val publications = publicationDao.fetchPublicationsBetween(LayoutBranch.main, latestPushedPublish, null)
         val (publishedLocationTracks, _) = publicationDao.fetchPublishedLocationTracks(publications[1].id)
 
         assertEquals(2, publications.size)
@@ -173,7 +173,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
 
         val latestPushedMoment = ratkoPushDao.getLatestPushedPublicationMoment()
         Assertions.assertTrue(latestPushedMoment < publicationMoment)
-        val publications = publicationDao.fetchPublicationsBetween(latestPushedMoment, null)
+        val publications = publicationDao.fetchPublicationsBetween(LayoutBranch.main, latestPushedMoment, null)
 
         val fetchedLayoutPublish = publications.find { it.id == publicationId }
         val fetchedLayoutPublish2 = publications.find { it.id == publicationId2 }
@@ -198,7 +198,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
         val locationTrack2Response = insertAndPublishLocationTrack()
         val publicationId2 = createPublication(locationTracks = listOf(locationTrack2Response.id), message = "Test")
 
-        val publications = publicationDao.fetchLatestPublications(2)
+        val publications = publicationDao.fetchLatestPublications(LayoutBranch.main, 2)
 
         assertEquals(publications.size, 2)
         assertEquals(publications[0].id, publicationId2)
@@ -239,13 +239,15 @@ internal class RatkoPushDaoIT @Autowired constructor(
         }
 
     fun createPublication(
+        layoutBranch: LayoutBranch = LayoutBranch.main,
         trackNumbers: List<IntId<TrackLayoutTrackNumber>> = listOf(),
         referenceLines: List<IntId<ReferenceLine>> = listOf(),
         locationTracks: List<IntId<LocationTrack>> = listOf(),
         switches: List<IntId<TrackLayoutSwitch>> = listOf(),
         kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
         message: String = "",
-    ): IntId<Publication> = publicationDao.createPublication(message = message).also { publicationId ->
+    ): IntId<Publication> =
+        publicationDao.createPublication(layoutBranch = layoutBranch, message = message).also { publicationId ->
         val calculatedChanges = CalculatedChanges(
             directChanges = DirectChanges(
                 kmPostChanges = kmPosts,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -227,7 +227,7 @@ class PublicationDaoIT @Autowired constructor(
             ),
             indirectChanges = IndirectChanges(emptyList(), emptyList(), emptyList()),
         )
-        val publicationId = publicationDao.createPublication("")
+        val publicationId = publicationDao.createPublication(LayoutBranch.main, "")
         publicationDao.insertCalculatedChanges(publicationId, changes)
 
         val publishedTrackNumbers = publicationDao.fetchPublishedTrackNumbers(publicationId)
@@ -252,7 +252,7 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun `Publication message is stored and fetched correctly`() {
         val message = "Test"
-        val publicationId = publicationDao.createPublication(message)
+        val publicationId = publicationDao.createPublication(LayoutBranch.main, message)
         assertEquals(message, publicationDao.getPublication(publicationId).message)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -3175,7 +3175,6 @@ class PublicationServiceIT @Autowired constructor(
     }
 
     @Test
-    @Disabled
     fun `create in main and alter in design twice before updating main`() {
         val trackNumber = mainOfficialContext.insert(trackNumber()).id
         val alignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -137,7 +137,7 @@ class RatkoServiceIT @Autowired constructor(
 
     @Test
     fun startRatkoPublish() {
-        ratkoService.pushChangesToRatko()
+        ratkoService.pushChangesToRatko(LayoutBranch.main)
     }
 
     @Test
@@ -1216,7 +1216,7 @@ class RatkoServiceIT @Autowired constructor(
         splitTestDataService.forcefullyFinishAllCurrentlyUnfinishedSplits(LayoutBranch.main)
 
         val splitId = splitTestDataService.insertSplit()
-        val publicationId = publicationDao.createPublication("test: bulk transfer to in progress")
+        val publicationId = publicationDao.createPublication(LayoutBranch.main, "test: bulk transfer to in progress")
         splitDao.updateSplit(splitId = splitId, publicationId = publicationId)
 
         val someBulkTransferId = testDBService.getUnusedBulkTransferId()
@@ -1242,7 +1242,7 @@ class RatkoServiceIT @Autowired constructor(
         splitTestDataService.insertSplit().let { splitId ->
             splitDao.updateSplit(
                 splitId = splitId,
-                publicationId = publicationDao.createPublication("some in progress bulk transfer"),
+                publicationId = publicationDao.createPublication(LayoutBranch.main, "some in progress bulk transfer"),
                 bulkTransferState = BulkTransferState.IN_PROGRESS,
                 bulkTransferId = someBulkTransferId,
             ).id
@@ -1251,7 +1251,7 @@ class RatkoServiceIT @Autowired constructor(
         val pendingSplitId = splitTestDataService.insertSplit().let { splitId ->
             splitDao.updateSplit(
                 splitId = splitId,
-                publicationId = publicationDao.createPublication("pending bulk transfer"),
+                publicationId = publicationDao.createPublication(LayoutBranch.main, "pending bulk transfer"),
             ).id
         }
 
@@ -1270,7 +1270,7 @@ class RatkoServiceIT @Autowired constructor(
         val splitId = splitTestDataService.insertSplit().let { splitId ->
             splitDao.updateSplit(
                 splitId = splitId,
-                publicationId = publicationDao.createPublication("pending bulk transfer"),
+                publicationId = publicationDao.createPublication(LayoutBranch.main, "pending bulk transfer"),
             ).id
         }
 
@@ -1304,7 +1304,7 @@ class RatkoServiceIT @Autowired constructor(
             splitTestDataService.insertSplit().let { splitId ->
                 splitDao.updateSplit(
                     splitId = splitId,
-                    publicationId = publicationDao.createPublication("pending bulk transfer $index"),
+                    publicationId = publicationDao.createPublication(LayoutBranch.main, "pending bulk transfer $index"),
                 ).id
             }
         }
@@ -1335,7 +1335,7 @@ class RatkoServiceIT @Autowired constructor(
                     else ->
                         splitDao.updateSplit(
                             splitId = splitId,
-                            publicationId = publicationDao.createPublication("testing $bulkTransferState"),
+                            publicationId = publicationDao.createPublication(LayoutBranch.main, "testing $bulkTransferState"),
                             bulkTransferId = testDBService.getUnusedBulkTransferId(),
                             bulkTransferState = bulkTransferState,
                         )
@@ -1402,7 +1402,7 @@ class RatkoServiceIT @Autowired constructor(
         val versions = publicationService.getValidationVersions(LayoutBranch.main, ids)
         val calculatedChanges = publicationService.getCalculatedChanges(versions)
         publicationService.publishChanges(LayoutBranch.main, versions, calculatedChanges, "")
-        ratkoService.pushChangesToRatko()
+        ratkoService.pushChangesToRatko(LayoutBranch.main)
     }
 
     private data class EstablishedTrackNumber(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -71,7 +71,7 @@ class SplitDaoIT @Autowired constructor(
             updatedDuplicates = emptyList(),
         ).let(splitDao::getOrThrow)
 
-        val publicationId = publicationDao.createPublication("SPLIT PUBLICATION")
+        val publicationId = publicationDao.createPublication(LayoutBranch.main, "SPLIT PUBLICATION")
         val updatedSplit = splitDao.updateSplit(
             splitId = split.id,
             bulkTransferState = BulkTransferState.FAILED,
@@ -187,7 +187,7 @@ class SplitDaoIT @Autowired constructor(
     @Test
     fun `Split bulk transfer state can be updated`() {
         val splitId = createSplit()
-        val publicationId = publicationDao.createPublication("test: bulk transfer state update")
+        val publicationId = publicationDao.createPublication(LayoutBranch.main, "test: bulk transfer state update")
 
         BulkTransferState.entries.forEach { newBulkTransferState ->
             when (newBulkTransferState) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -345,6 +345,7 @@ class LayoutSwitchServiceIT @Autowired constructor(
         )
 
         val linkedLocationTracks = switchDao.findLocationTracksLinkedToSwitchAtMoment(
+            LayoutBranch.main,
             switchId,
             JointNumber(1),
             Instant.now(),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -1027,7 +1027,7 @@ fun switchLinkingAt(locationTrackId: DomainId<LocationTrack>, segmentIndex: Int,
     )
 
 fun layoutDesign(
-    name: String,
+    name: String = "foo",
     estimatedCompletion: LocalDate = LocalDate.parse("2022-02-02"),
     designState: DesignState = DesignState.ACTIVE,
 ) = LayoutDesignSaveRequest(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.ui.testgroup1
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.integration.CalculatedChanges
@@ -59,14 +60,14 @@ class FrontPageTestUI @Autowired constructor(
         )
         referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = alignmentVersion, draft = false))
 
-        val successfulPublicationId = publicationDao.createPublication("successful")
+        val successfulPublicationId = publicationDao.createPublication(LayoutBranch.main, "successful")
         publicationDao.insertCalculatedChanges(successfulPublicationId, changesTouchingTrackNumber(trackNumberId))
 
         trackNumberDao.update(
             trackNumberDao.fetch(originalTrackNumberVersion).copy(number = TrackNumber("updated name"))
         )
 
-        val failingPublicationId = publicationDao.createPublication("failing test publication")
+        val failingPublicationId = publicationDao.createPublication(LayoutBranch.main, "failing test publication")
         publicationDao.insertCalculatedChanges(failingPublicationId, changesTouchingTrackNumber(trackNumberId))
 
         val failedRatkoPushId = ratkoPushDao.startPushing(listOf(failingPublicationId))


### PR DESCRIPTION
Ei tullutkaan valmiiksi, lähden lomille, tehkää itse loppuun. Huom.: Pohjana Jyrkin GVT-2612-haara. En voi suositella mainiin tuomista 1.14-versioon, kyllä tähän tuli sen verran monta kohtaa, joissa toteutuksesta on epävarmuutta.

Muutoksia ympäri ämpäri kaikkialla, perusajatuksena lisätä julkaisuille design_id, ja toteuttaa:

- julkaisujen validointi validoimaan konsistentisti design-haaran tilaa jos ollaan haarassa (täysin testaamaton, mutta silmämääräisesti helpon oloinen kokonaisuus)
- julkaisu design-haarassa (toimii mutta hatarasti testattu)
- design-haarassa luodun olion julkaisu mainiin (toimii mutta hatarasti testattu)
- main-haarassa luodun olion muokkaus design-haarassa useamman kerran (toimii ehkä, mutta todella hatarasti testattu)