### PR TITLE
GVT-2635: Geoviite heittää 500-errorin elementtiluettelossa jos geometriatiedosto sisältää duplikaatti km-pylväitä + muita InfraModel-korjauksia

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -251,14 +251,6 @@ data class GeocodingContext(
             !TrackMeter.isMetersValid(startMeters + length)
         }
 
-        private fun requireKmPostsSanity(kmPosts: List<TrackLayoutKmPost>) {
-            require(kmPosts.distinctBy { it.kmNumber }.size == kmPosts.size) {
-                "There are km posts with duplicate km number, ${
-                    kmPosts.groupingBy { it.kmNumber }.eachCount().filter { it.value > 1 }
-                }}"
-            }
-        }
-
         private fun createReferencePoints(
             startAddress: TrackMeter,
             kmPosts: List<TrackLayoutKmPost>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -132,6 +132,7 @@ enum class KmPostRejectedReason {
     IS_BEFORE_START_ADDRESS,
     INTERSECTS_BEFORE_REFERENCE_LINE,
     INTERSECTS_AFTER_REFERENCE_LINE,
+    DUPLICATE
 }
 
 data class GeocodingContext(
@@ -214,7 +215,6 @@ data class GeocodingContext(
             referenceLineGeometry: IAlignment,
             kmPosts: List<TrackLayoutKmPost>,
         ): GeocodingContextCreateResult {
-            requireKmPostsSanity(kmPosts)
             val (validatedKmPosts, invalidKmPosts) = validateKmPosts(kmPosts, startAddress)
 
             val (validReferencePoints, kmPostsOutsideGeometry) = createReferencePoints(
@@ -284,8 +284,16 @@ data class GeocodingContext(
                 TrackMeter(it.kmNumber, BigDecimal.ZERO) <= startAddress
             }
 
+            val duplicateKmPosts = kmPosts
+                .groupBy { it.kmNumber }
+                .filter { it.value.size > 1 }
+                .values
+                .flatten()
+
             val rejectedKmPosts =
-                withoutLocations.map { it to KmPostRejectedReason.NO_LOCATION } + invalidStartAddresses.map { it to KmPostRejectedReason.IS_BEFORE_START_ADDRESS }
+                withoutLocations.map { it to KmPostRejectedReason.NO_LOCATION } +
+                    invalidStartAddresses.map { it to KmPostRejectedReason.IS_BEFORE_START_ADDRESS } +
+                    duplicateKmPosts.map { it to KmPostRejectedReason.DUPLICATE }
 
             return validKmPosts to rejectedKmPosts.map { (kp, reason) -> KmPostWithRejectedReason(kp, reason) }
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -664,6 +664,10 @@ fun validateGeocodingContext(
             KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE -> LayoutValidationIssue(
                 WARNING, "$VALIDATION_GEOCODING.km-post-outside-line-after", kmPostLocalizationParams
             )
+
+            KmPostRejectedReason.DUPLICATE -> LayoutValidationIssue(
+                ERROR, "$VALIDATION_GEOCODING.duplicate-km-posts", kmPostLocalizationParams
+            )
         }
     }
 

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -40,6 +40,7 @@
                 "VerticalCoordinateSystem": "Korkeusjärjestelmän määritys on virheellinen",
                 "Code": "Kentän sisältö {{value}} on virheellinen",
                 "FreeText": "Tekstikentän sisältö {{value}} on virheellinen",
+                "FreeTextWithNewLines": "Tekstikentän sisältö {{value}} on virheellinen",
                 "ProjectName": "Projektin nimi {{value}} on virheellinen",
                 "CompanyName": "Yrityksen nimi {{value}} on virheellinen",
                 "MetaDataName": "Syötteen {{value}} muoto on virheellinen",
@@ -101,7 +102,7 @@
             },
             "transformation": {
                 "srid-missing": "Suunnitelmaa ei voida esittää kartalla, koska koordinaattijärjestelmää \"{{coordinateSystemName}}\" ei osata muuntaa kartan järjestelmään TM35FIN (EPSG:3067)",
-                "bounds-resolution-failed": "Suunnitelmaa ei voida esittää kartalla, koska sisältö ei ole koordinaattijärjestelmän \"{{coordinateSystemName}} ({{srid}}) rajoissa",
+                "bounds-resolution-failed": "Suunnitelmaa ei voida esittää kartalla, koska sisältö ei ole koordinaattijärjestelmän \"{{coordinateSystemName}} ({{srid}})\" rajoissa",
                 "bounds-outside-finland": "Suunnitelmaa ei voida esittää kartalla, koska koordinaatit ovat Suomen ulkopuolella (tulkittuna koordinaattijärjestelmässä \"{{coordinateSystemName}} ({{srid}}))",
                 "coordinate-transformation-failed": "Suunnitelmaa ei voida esittää kartalla, koska sen koordinaattien muunnos järjestelmästä \"{{coordinateSystemName}}\" ({{srid}}) kartan järjestelmään TM35FIN (EPSG:3067) epäonnistui",
                 "plan-transformation-failed": "Suunnitelman muuntaminen kartalla esitettävään muotoon epäonnistui"

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1131,14 +1131,14 @@
             "switch": {
                 "duplicate-name": "Vaihdenimeä {{switchName}} on käytetty useammalla eri vaihteella",
                 "type-unrecognized": "Vaihteen {{switchName}} tyyppi {{switchType}} on tuntematon",
-                "incorrect-joints": "Vaihteella {{switchName}} on määritelty pääosia jotka eivät kuulu vaihdetyyppiin: vaihteella ({{jointNumbers}}), tyypillä ({{structureJointNumbers}})",
-                "insufficient-joints": "Vaihteella {{switchName}} on määritelty vähemmän kuin kaksi pääosaa, joten sitä ei voi linkittää paikannuspohjaan",
+                "incorrect-joints": "Vaihteella {{switchName}} on määritelty vaihdepisteitä jotka eivät kuulu vaihdetyyppiin: vaihteella ({{jointNumbers}}), tyypillä ({{structureJointNumbers}})",
+                "insufficient-joints": "Vaihteella {{switchName}} on määritelty vähemmän kuin kaksi vaihdepistettä, joten sitä ei voi linkittää paikannuspohjaan",
                 "location-difference": "Vaihteen {{switchName}} suunnitellut päämitat eivät vastaa teoreettista",
-                "incorrect-joint-locations": "Vaihteen {{switchName}} pääosien sijainnit eivät vastaa laskennallisia",
-                "inaccurate-joint-locations": "Vaihteen {{switchName}} pääosien sijainnit epätarkkoja",
-                "no-structure-alignment": "Vaihteen {{switchName}} pääosat ({{jointNumbers}}) raiteella {{alignmentName}} eivät vastaa mitään vaihdetyypin linjaa",
-                "alignment-joint-mismatch": "Vaihteen {{switchName}} pääosat ({{jointNumber}}) raiteella {{alignmentName}} ovat eri sijainnissa kuin muilla raiteilla",
-                "alignment-joint-inaccurate": "Vaihteen {{switchName}} pääosat ({{jointNumber}}) raiteella {{alignmentName}} ovat sijainniltaan epätarkat suhteessa muihin raiteisiin"
+                "incorrect-joint-locations": "Vaihteen {{switchName}} vaihdepisteiden sijainnit eivät vastaa laskennallisia",
+                "inaccurate-joint-locations": "Vaihteen {{switchName}} vaihdepisteiden sijainnit ovat epätarkkoja",
+                "no-structure-alignment": "Vaihteen {{switchName}} vaihdepisteet ({{jointNumbers}}) raiteella {{alignmentName}} eivät vastaa mitään vaihdetyypin linjaa",
+                "alignment-joint-mismatch": "Vaihteen {{switchName}} vaihdepisteet ({{jointNumber}}) raiteella {{alignmentName}} ovat eri sijainnissa kuin muilla raiteilla",
+                "alignment-joint-inaccurate": "Vaihteen {{switchName}} vaihdepisteet ({{jointNumber}}) raiteella {{alignmentName}} ovat sijainniltaan epätarkat suhteessa muihin raiteisiin"
             },
             "km-post": {
                 "duplicate-km-posts": "Suunnitelmassa on useita tasakilometripisteitä seuraaville ratakilometreille: {{value}}",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1032,7 +1032,7 @@
             "title": "Haluatko varmasti tallentaa?",
             "sub-title": "Seuraavat kriittiset tiedot puuttuvat",
             "oid": "Projektin OID",
-            "trackNumberId": "Ratanumero",
+            "trackNumber": "Ratanumero",
             "planPhase": "Suunnitteluvaihe",
             "decisionPhase": "Vaiheen tarkennus",
             "measurementMethod": "Laatu",
@@ -1040,7 +1040,7 @@
             "coordinateSystemSrid": "Koordinaattijärjestelmä",
             "verticalCoordinateSystem": "Korkeusjärjestelmä",
             "error-message": "Tiedostossa on virheitä",
-            "createdDate": "Suunnitelman luontiaika puuttuu"
+            "createdDate": "Suunnitelman luontiaika"
         },
         "tabs": {
             "plans": "Suunnitelmat {{number}} kpl",
@@ -1140,7 +1140,7 @@
                 "alignment-joint-inaccurate": "Vaihteen {{switchName}} pääosat ({{jointNumber}}) raiteella {{alignmentName}} ovat sijainniltaan epätarkat suhteessa muihin raiteisiin"
             },
             "km-post": {
-                "multiple-start-km-posts": "Tasakilometripiste {{value}} esiintyy suunnitelmassa useammin kuin kerran",
+                "duplicate-km-posts": "Suunnitelmassa on useita tasakilometripisteitä seuraaville ratakilometreille: {{value}}",
                 "sta-ahead-not-negative": "Suunnitelman ensimmäisen tasakilometripisteen staAhead-arvo on suurempi kuin 0.0"
             }
         }
@@ -1431,6 +1431,7 @@
                 "km-post-rejected": "Tasakilometripisteitä ({{kmNumber}}) ei voitu sijoittaa ratanumeron {{trackNumber}} pituusmittauslinjalle",
                 "km-post-outside-line-before": "Tasakilometripiste ({{kmNumber}}) sijaitsee ennen linjaa {{trackNumber}}",
                 "km-post-outside-line-after": "Tasakilometripiste ({{kmNumber}}) sijaitsee linjan {{trackNumber}} jälkeen",
+                "duplicate-km-posts": "Linjalla {{trackNumber}} on useita tasakilometripisteitä numerolla {{kmNumber}}",
                 "km-post-smaller-than-track-number-start": "Tasakilometripiste ({{kmNumber}}) on pienempi kuin ratanumeron {{trackNumber}} aloitusarvo",
                 "km-posts-invalid": "Ratanumeron {{trackNumber}} tasakilometripisteet ({{kmNumbers}}) ovat väärässä järjestyksessä",
                 "km-posts-far-from-line": "Ratanumeron {{trackNumber}} tasakilometripisteet ({{kmNumbers}}) sijaitsevat kaukana pituusmittauslinjasta",

--- a/ui/src/api/api-fetch.ts
+++ b/ui/src/api/api-fetch.ts
@@ -125,6 +125,14 @@ export async function postFormNonNullAdt<Output>(
     return fetchFormNonNullAdt<Output>(path, 'POST', data);
 }
 
+export const postFormNonNull = async <Output>(
+    path: string,
+    data: FormData,
+    toastFailure: boolean = true,
+): Promise<Output> => {
+    return fetchFormNonNull(path, 'POST', data, toastFailure);
+};
+
 export async function putNullable<Input, Output>(
     path: string,
     body: Input,
@@ -218,6 +226,21 @@ async function fetchNonNull<Input, Output>(
 
     return result.isOk() ? result.value : Promise.reject(result.error);
 }
+
+const fetchFormNonNull = async <Output>(
+    path: string,
+    method: HttpMethod,
+    data: FormData,
+    toastFailure: boolean = true,
+): Promise<Output> => {
+    const result = await fetchFormNonNullAdt<Output>(path, method, data);
+
+    if (result.isErr() && result.error && toastFailure) {
+        showHttpError(path, result.error);
+    }
+
+    return result.isOk() ? result.value : Promise.reject(result.error);
+};
 
 async function fetchNullableAdt<Input, Output>(
     path: string,

--- a/ui/src/api/api-fetch.ts
+++ b/ui/src/api/api-fetch.ts
@@ -163,11 +163,12 @@ export async function putNullableAdt<Input, Output>(
     return fetchNullableAdt<Input, Output>(path, 'PUT', body);
 }
 
-export async function putFormNonNullAdt<Output>(
+export async function putFormNonNull<Output>(
     path: string,
     data: FormData,
-): Promise<Result<Output, ApiErrorResponse | undefined>> {
-    return fetchFormNonNullAdt<Output>(path, 'PUT', data);
+    toastFailure: boolean = true,
+): Promise<Output> {
+    return fetchFormNonNull<Output>(path, 'PUT', data, toastFailure);
 }
 
 export async function deleteNullable<Output>(

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -3,6 +3,7 @@ import {
     ApiErrorResponse,
     getLocalizedIssue,
     getNonNull,
+    postFormNonNull,
     postFormNonNullAdt,
     putFormNonNullAdt,
     putNonNull,
@@ -89,16 +90,7 @@ export const saveInfraModelFile = async (
     overrideParameters?: OverrideInfraModelParameters,
 ): Promise<GeometryPlanId | undefined> => {
     const formData = createFormData(file, extraParameters, overrideParameters);
-    const response = await postFormNonNullAdt<GeometryPlanId>(INFRAMODEL_URI, formData);
-
-    if (response.isOk()) {
-        Snackbar.success('infra-model.upload.success');
-        await updatePlanChangeTime();
-
-        return response.value;
-    } else {
-        return undefined;
-    }
+    return await postFormNonNull<GeometryPlanId>(INFRAMODEL_URI, formData);
 };
 
 export async function updateGeometryPlan(

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -5,7 +5,7 @@ import {
     getNonNull,
     postFormNonNull,
     postFormNonNullAdt,
-    putFormNonNullAdt,
+    putFormNonNull,
     putNonNull,
     queryParams,
 } from 'api/api-fetch';
@@ -99,17 +99,13 @@ export async function updateGeometryPlan(
     overrideParameters?: OverrideInfraModelParameters,
 ): Promise<GeometryPlanId | undefined> {
     const formData = createFormData(undefined, extraParameters, overrideParameters);
-    const response = await putFormNonNullAdt<GeometryPlanId>(
-        `${INFRAMODEL_URI}/${planId}`,
-        formData,
+    return await putFormNonNull<GeometryPlanId>(`${INFRAMODEL_URI}/${planId}`, formData).then(
+        (r) => {
+            Snackbar.success('infra-model.edit.success');
+            updatePlanChangeTime();
+            return r;
+        },
     );
-
-    if (response.isOk()) {
-        Snackbar.success('infra-model.edit.success');
-        await updatePlanChangeTime();
-    }
-
-    return response.isOk() ? response.value : undefined;
 }
 export async function hidePlan(planId: GeometryPlanId): Promise<GeometryPlanId | undefined> {
     return putNonNull<boolean, GeometryPlanId>(`${INFRAMODEL_URI}/${planId}/hidden`, true).then(

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -90,7 +90,11 @@ export const saveInfraModelFile = async (
     overrideParameters?: OverrideInfraModelParameters,
 ): Promise<GeometryPlanId | undefined> => {
     const formData = createFormData(file, extraParameters, overrideParameters);
-    return await postFormNonNull<GeometryPlanId>(INFRAMODEL_URI, formData);
+    return await postFormNonNull<GeometryPlanId>(INFRAMODEL_URI, formData).then((r) => {
+        Snackbar.success('infra-model.upload.success');
+        updatePlanChangeTime();
+        return r;
+    });
 };
 
 export async function updateGeometryPlan(

--- a/ui/src/infra-model/view/infra-model-upload-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-upload-loader.tsx
@@ -49,8 +49,11 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
     const onSave: () => Promise<boolean> = async () => {
         if (file) {
             props.setLoading(true);
-            const response = await saveInfraModelFile(file, extraParams, overrideParams);
-            props.setLoading(false);
+            const response = await saveInfraModelFile(file, extraParams, overrideParams).finally(
+                () => {
+                    props.setLoading(false);
+                },
+            );
             return response != undefined;
         } else {
             return false;


### PR DESCRIPTION
Täällä siis korjattu varsinainen tuotannossa esiintynyt ongelma, ja sen lisäksi korjattu seuraavia juttuja:
- InfraModelin tallentamisen epäonnistuminen ei näytä virhettä
- Puuttuvan ratanumeron käännösavain on väärin inframallin validoinnin confirm-dialogissa
- Kaikenlaisia muita käännösjuttuja