### PR TITLE
GVT-2562: Estetään poistetun raiteen alun/lopun lyhentäminen

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -707,7 +707,9 @@
                 }
             },
             "splitting-blocks-geometry-changes": "Raiteen geometriaa ei voi muokata koska sen jakaminen on kesken",
-            "unsupported-state-for-splitting": "Vain \"Käytössä\"-tilaisen raiteen voi jakaa"
+            "cannot-shorten-deleted-track": "Postettua raidetta ei voi lyhentää",
+            "unsupported-state-for-splitting": "Vain \"Käytössä\"-tilaisen raiteen voi jakaa",
+            "no-geometry": "Raiteella ei ole geometriaa"
         },
         "disabled": {
             "activity-disabled-in-official-mode": "Toiminto on aktiivinen vain luonnostilassa."

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -150,6 +150,10 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
             return t('tool-panel.disabled.activity-disabled-in-official-mode');
         } else if (splittingState || extraInfo?.partOfUnfinishedSplit) {
             return t('tool-panel.location-track.splitting-blocks-geometry-changes');
+        } else if (locationTrack.state === 'DELETED') {
+            return t('tool-panel.location-track.cannot-shorten-deleted-track');
+        } else if (!startAndEndPoints?.start?.point || !startAndEndPoints?.end?.point) {
+            return t('tool-panel.location-track.no-geometry');
         } else {
             return undefined;
         }
@@ -204,6 +208,23 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                 .finally(() => setUpdatingLength(false));
         }
     };
+
+    const shorteningDisabled =
+        locationTrack.state === 'DELETED' ||
+        !isDraft ||
+        !!splittingState ||
+        extraInfo?.partOfUnfinishedSplit ||
+        !startAndEndPoints?.start?.point ||
+        !startAndEndPoints?.end?.point ||
+        startingSplitting;
+
+    const splittingDisabled =
+        locationTrack.state !== 'IN_USE' ||
+        !isDraft ||
+        locationTrackIsDraft ||
+        duplicatesOnOtherTrackNumbers ||
+        extraInfo?.partOfUnfinishedSplit ||
+        startingSplitting;
 
     return (
         startAndEndPoints &&
@@ -263,14 +284,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                             size={ButtonSize.SMALL}
                                             qa-id="modify-start-or-end"
                                             title={getModifyStartOrEndDisabledReasonTranslated()}
-                                            disabled={
-                                                layoutContext.publicationState !== 'DRAFT' ||
-                                                !!splittingState ||
-                                                extraInfo?.partOfUnfinishedSplit ||
-                                                !startAndEndPoints.start?.point ||
-                                                !startAndEndPoints.end?.point ||
-                                                startingSplitting
-                                            }
+                                            disabled={shorteningDisabled}
                                             onClick={() => {
                                                 getEndLinkPoints(
                                                     locationTrack.id,
@@ -342,14 +356,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                             <Button
                                                 variant={ButtonVariant.SECONDARY}
                                                 size={ButtonSize.SMALL}
-                                                disabled={
-                                                    locationTrack.state !== 'IN_USE' ||
-                                                    !isDraft ||
-                                                    locationTrackIsDraft ||
-                                                    duplicatesOnOtherTrackNumbers ||
-                                                    extraInfo?.partOfUnfinishedSplit ||
-                                                    startingSplitting
-                                                }
+                                                disabled={splittingDisabled}
                                                 isProcessing={startingSplitting}
                                                 title={getSplittingDisabledReasonsTranslated()}
                                                 onClick={startSplitting}


### PR DESCRIPTION
Samalla refaktoroitu muutenkin hiukan raiteen lyhennys- ja splittausnappien disablointeja. Ne on nyt otettu ulos JSX:stä omiin muuttujiinsa, ja lisätty samalla hover tilanteelle, jossa raidetta ei voida lyhentää koska siltä puuttuu geometria.

Huom! Tuo sama lyhennystoiminnallisuus löytyy myös ratanumeroilta, mutta ratanumeron poiston yhteydessä koko tuon napin sisältävä infoboksi menee piiloon -> en lisännyt sille omaa disablointia.