### PR TITLE
GVT-2611 (part 1): Add Geoviite-aspects for Controller, Service and Dao layers

### DIFF
--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
         exclude("commons-logging", "commons-logging")
         exclude("commons-collections", "commons-collections")
     }
+    implementation("org.aspectj:aspectjweaver:1.9.22.1")
     compileOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.glassfish.jaxb:jaxb-runtime:4.0.5")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteController.kt
@@ -1,0 +1,28 @@
+package fi.fta.geoviite.infra.aspects
+
+import fi.fta.geoviite.infra.logging.apiCall
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.RestController
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@RestController
+annotation class GeoviiteController
+
+@Aspect
+@Component
+class GeoviiteControllerAspect {
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    @Before("within(@GeoviiteController *)")
+    fun logBefore(joinPoint: JoinPoint) {
+        if (logger.isInfoEnabled) {
+            reflectedLogBefore(joinPoint, logger::apiCall)
+        }
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteDao.kt
@@ -1,0 +1,27 @@
+package fi.fta.geoviite.infra.aspects
+
+import fi.fta.geoviite.infra.logging.daoAccess
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Component
+annotation class GeoviiteDao
+
+@Aspect
+@Component
+class GeoviiteDaoAspect {
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    @AfterReturning("within(@GeoviiteDao *)", returning = "result")
+    fun logAfterReturn(joinPoint: JoinPoint, result: Any?) {
+        if (logger.isInfoEnabled) {
+            reflectedLogWithReturnValue(joinPoint, result, logger::daoAccess)
+        }
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteService.kt
@@ -1,0 +1,28 @@
+package fi.fta.geoviite.infra.aspects
+
+import fi.fta.geoviite.infra.logging.serviceCall
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Service
+annotation class GeoviiteService
+
+@Aspect
+@Component
+class GeoviiteServiceAspect {
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    @Before("within(@GeoviiteService *)")
+    fun logBefore(joinPoint: JoinPoint) {
+        if (logger.isDebugEnabled) {
+            reflectedLogBefore(joinPoint, logger::serviceCall)
+        }
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteService.kt
@@ -8,6 +8,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
@@ -17,10 +18,15 @@ annotation class GeoviiteService
 @Aspect
 @Component
 class GeoviiteServiceAspect {
-    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val loggerCache = ConcurrentHashMap<Class<*>, Logger>()
 
     @Before("within(@GeoviiteService *)")
     fun logBefore(joinPoint: JoinPoint) {
+        val targetClass = joinPoint.target::class.java
+        val logger = loggerCache.computeIfAbsent(targetClass) { classRef ->
+            LoggerFactory.getLogger(classRef)
+        }
+
         if (logger.isDebugEnabled) {
             reflectedLogBefore(joinPoint, logger::serviceCall)
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/ReflectedLogging.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/ReflectedLogging.kt
@@ -47,7 +47,6 @@ private val parameterNameDiscoverer = DefaultParameterNameDiscoverer()
 fun reflectedLogBefore(
     joinPoint: JoinPoint,
     loggerMethod: (
-        className: String,
         methodName: String,
         params: List<Pair<String, *>>,
     ) -> Unit,
@@ -62,7 +61,6 @@ fun reflectedLogWithReturnValue(
     joinPoint: JoinPoint,
     returnValue: Any?,
     loggerMethodWithReturnValue: (
-        className: String,
         methodName: String,
         params: List<Pair<String, *>>,
         returnValue: Any?,
@@ -78,20 +76,19 @@ fun reflectedLogWithReturnValue(
 private fun logInternal(
     joinPoint: JoinPoint,
     returnValue: Any? = null,
-    loggerMethod: ((String, String, List<Pair<String, *>>) -> Unit)? = null,
-    loggerMethodWithReturnValue: ((String, String, List<Pair<String, *>>, Any?) -> Unit)? = null,
+    loggerMethod: ((String, List<Pair<String, *>>) -> Unit)? = null,
+    loggerMethodWithReturnValue: ((String, List<Pair<String, *>>, Any?) -> Unit)? = null,
 ) {
     val method = (joinPoint.signature as MethodSignature).method
 
     if (method.isAnnotationPresent(DisableLogging::class.java)) {
         return
     } else {
-        val className = joinPoint.target.javaClass.simpleName
         val methodName = joinPoint.signature.name
         val loggedParams = reflectParams(joinPoint)
 
-        loggerMethod?.invoke(className, methodName, loggedParams)
-        loggerMethodWithReturnValue?.invoke(className, methodName, loggedParams, returnValue)
+        loggerMethod?.invoke(methodName, loggedParams)
+        loggerMethodWithReturnValue?.invoke(methodName, loggedParams, returnValue)
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/ReflectedLogging.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/ReflectedLogging.kt
@@ -1,0 +1,111 @@
+package fi.fta.geoviite.infra.aspects
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.springframework.core.DefaultParameterNameDiscoverer
+
+/*
+ * Annotate a function which should not be automatically logged at all.
+ * Example:
+ *
+ * @GeoviiteController
+ * class SomeController {
+ *    @GetMapping("/some-path")
+ *    @DisableLogging
+ *    fun someFunction(
+ *        @RequestParam("someAutomaticallyLoggedParam") foo: Int,
+ *        @RequestParam("someOtherNotLoggedParam") bar: Int,
+ *    } {
+ *        // This function call is not written to the log at all. Manual logging can be used instead.
+ *    }
+ * }
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DisableLogging
+
+/*
+ * Annotate a function parameter which should not be automatically written to log
+ * Example:
+ *
+ * @GeoviiteService
+ * class SomeService {
+ *    fun someFunction(
+ *        @RequestParam("someAutomaticallyLoggedParam") someAutomaticallyLoggedParam: Int,
+ *        @DoNotWriteToLog @RequestParam("someOtherNotLoggedParam") someOtherNotLoggedParam: Int,
+ *    } {
+ *        // This function call is logged, but only the someAutomaticallyLoggedParam is written to the log.
+ *    }
+ * }
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DoNotWriteToLog
+
+private val parameterNameDiscoverer = DefaultParameterNameDiscoverer()
+
+fun reflectedLogBefore(
+    joinPoint: JoinPoint,
+    loggerMethod: (
+        className: String,
+        methodName: String,
+        params: List<Pair<String, *>>,
+    ) -> Unit,
+) {
+    logInternal(
+        joinPoint = joinPoint,
+        loggerMethod = loggerMethod,
+    )
+}
+
+fun reflectedLogWithReturnValue(
+    joinPoint: JoinPoint,
+    returnValue: Any?,
+    loggerMethodWithReturnValue: (
+        className: String,
+        methodName: String,
+        params: List<Pair<String, *>>,
+        returnValue: Any?,
+    ) -> Unit,
+) {
+    logInternal(
+        joinPoint = joinPoint,
+        returnValue = returnValue,
+        loggerMethodWithReturnValue = loggerMethodWithReturnValue,
+    )
+}
+
+private fun logInternal(
+    joinPoint: JoinPoint,
+    returnValue: Any? = null,
+    loggerMethod: ((String, String, List<Pair<String, *>>) -> Unit)? = null,
+    loggerMethodWithReturnValue: ((String, String, List<Pair<String, *>>, Any?) -> Unit)? = null,
+) {
+    val method = (joinPoint.signature as MethodSignature).method
+
+    if (method.isAnnotationPresent(DisableLogging::class.java)) {
+        return
+    } else {
+        val className = joinPoint.target.javaClass.simpleName
+        val methodName = joinPoint.signature.name
+        val loggedParams = reflectParams(joinPoint)
+
+        loggerMethod?.invoke(className, methodName, loggedParams)
+        loggerMethodWithReturnValue?.invoke(className, methodName, loggedParams, returnValue)
+    }
+}
+
+private fun reflectParams(
+    joinPoint: JoinPoint,
+): List<Pair<String, *>> {
+    val method = (joinPoint.signature as MethodSignature).method
+    val parameterNames = parameterNameDiscoverer.getParameterNames(method) ?: emptyArray()
+
+    return parameterNames
+        .filterIndexed { index, _ ->
+            method.parameterAnnotations[index].none { annotation ->
+                annotation is DoNotWriteToLog
+            }
+        }
+        .zip(joinPoint.args)
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
@@ -74,10 +74,9 @@ fun Logger.daoAccess(accessType: AccessType, objectType: String, ids: List<Any>)
     }
 }
 
-fun Logger.daoAccess(className: String, method: String, params: List<Pair<String, *>>, returnValue: Any?) {
+fun Logger.daoAccess(method: String, params: List<Pair<String, *>>, returnValue: Any?) {
     info(
-        "class={} method={} params={} returnValue={}",
-        className,
+        "method={} params={} returnValue={}",
         method,
         paramsToLog(params),
         returnValueToLog(returnValue),
@@ -88,16 +87,16 @@ fun Logger.apiCall(method: String, vararg params: Pair<String, *>) {
     if (isInfoEnabled) info("method=$method params=${paramsToLog(*params)}")
 }
 
-fun Logger.apiCall(className: String, method: String, params: List<Pair<String, *>>) {
-    if (isInfoEnabled) info("class=$className method=$method params=${paramsToLog(params)}")
-}
-
 fun Logger.serviceCall(method: String, vararg params: Pair<String, *>) {
     if (isDebugEnabled) debug("method={} params={}", method, paramsToLog(*params))
 }
 
-fun Logger.serviceCall(className: String, method: String, params: List<Pair<String, *>>) {
-    if (isDebugEnabled) debug("class={} method={} params={}", className, method, paramsToLog(params))
+fun Logger.apiCall(method: String, params: List<Pair<String, *>>) {
+    if (isInfoEnabled) info("method={} params={}", method, paramsToLog(params))
+}
+
+fun Logger.serviceCall(method: String, params: List<Pair<String, *>>) {
+    if (isDebugEnabled) debug("method={} params={}", method, paramsToLog(params))
 }
 
 fun paramsToLog(vararg params: Pair<String, *>): List<String> =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
@@ -74,12 +74,30 @@ fun Logger.daoAccess(accessType: AccessType, objectType: String, ids: List<Any>)
     }
 }
 
+fun Logger.daoAccess(className: String, method: String, params: List<Pair<String, *>>, returnValue: Any?) {
+    info(
+        "class={} method={} params={} returnValue={}",
+        className,
+        method,
+        paramsToLog(params),
+        returnValueToLog(returnValue),
+    )
+}
+
 fun Logger.apiCall(method: String, vararg params: Pair<String, *>) {
     if (isInfoEnabled) info("method=$method params=${paramsToLog(*params)}")
 }
 
+fun Logger.apiCall(className: String, method: String, params: List<Pair<String, *>>) {
+    if (isInfoEnabled) info("class=$className method=$method params=${paramsToLog(params)}")
+}
+
 fun Logger.serviceCall(method: String, vararg params: Pair<String, *>) {
     if (isDebugEnabled) debug("method={} params={}", method, paramsToLog(*params))
+}
+
+fun Logger.serviceCall(className: String, method: String, params: List<Pair<String, *>>) {
+    if (isDebugEnabled) debug("class={} method={} params={}", className, method, paramsToLog(params))
 }
 
 fun paramsToLog(vararg params: Pair<String, *>): List<String> =
@@ -88,6 +106,17 @@ fun paramsToLog(vararg params: Pair<String, *>): List<String> =
             formatForLog(if (obj is Loggable) obj.toLog() else obj.toString(), 1000)
         }}"
     }
+
+fun paramsToLog(params: List<Pair<String, *>>): List<String> =
+    params.map { p ->
+        "${p.first}=${p.second?.let { obj ->
+            formatForLog(if (obj is Loggable) obj.toLog() else obj.toString(), 1000)
+        }}"
+    }
+
+fun returnValueToLog(returnValue: Any?): String {
+    return formatForLog(if (returnValue is Loggable) returnValue.toLog() else returnValue.toString(), 1000)
+}
 
 fun Logger.integrationCall(method: String, vararg params: Pair<String, *>) {
     info("method=$method params=${paramsToLog(*params)}")


### PR DESCRIPTION
These aspects will initially be used for automated logging of controller/service/dao calls,
which will ease required effort for a developer to remember to add and update manual logger
calls.

_Note: Actual usage (removal of current manual logger calls) will be done in another pull request._

--

Lisähuomiona vielä, että 1.14 oli tarkoitus paketoida ennenkuin tämä (ja tuleva käyttöpaikkapullari) nakataan mainiin.