### PR TITLE
GVT-2608: Tehtävälista jää näkyviin aktivoitaessa suunnitelmatila

### DIFF
--- a/ui/src/tool-panel/location-track/dialog/location-track-switch-relinking-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-switch-relinking-dialog.tsx
@@ -102,6 +102,7 @@ export const LocationTrackSwitchRelinkingDialog: React.FC<
             showLocationTrackTaskList({
                 locationTrackId,
                 type: LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION,
+                designId: layoutContext.designId,
             });
         }
     };

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -34,9 +34,12 @@ type SwitchRelinkingValidationTaskListProps = {
     onShowSwitch: (layoutSwitch: LayoutSwitch, point?: Point) => void;
     onClose: () => void;
     selectedSwitches: LayoutSwitchId[];
+    selectingWorkspace: boolean;
 };
 
-export const LocationTrackTaskListContainer: React.FC = () => {
+export const LocationTrackTaskListContainer: React.FC<{ selectingWorkspace: boolean }> = ({
+    selectingWorkspace,
+}) => {
     const delegates = createDelegates(TrackLayoutActions);
     const locationTrackList = useTrackLayoutAppSelector((state) => state.locationTrackTaskList);
     const layoutContext = useTrackLayoutAppSelector((state) => state.layoutContext);
@@ -56,6 +59,15 @@ export const LocationTrackTaskListContainer: React.FC = () => {
         delegates.hideLocationTrackTaskList();
     };
 
+    React.useEffect(() => {
+        if (
+            locationTrackList &&
+            (locationTrackList.designId !== layoutContext.designId || selectingWorkspace)
+        ) {
+            delegates.hideLocationTrackTaskList();
+        }
+    }, [layoutContext.designId, selectingWorkspace]);
+
     return createPortal(
         locationTrackList?.type == LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION ? (
             <SwitchRelinkingValidationTaskList
@@ -64,6 +76,7 @@ export const LocationTrackTaskListContainer: React.FC = () => {
                 onClose={onClose}
                 onShowSwitch={onShowSwitch}
                 selectedSwitches={selectedSwitches}
+                selectingWorkspace={selectingWorkspace}
             />
         ) : (
             <React.Fragment />

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -185,6 +185,7 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
         delegates.showLocationTrackTaskList({
             type: LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION,
             locationTrackId: locationTrack,
+            designId: layoutContext.designId,
         });
     };
 

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -11,9 +11,13 @@ import { first } from 'utils/array-utils';
 
 type ToolPanelContainerProps = {
     setHoveredOverItem: (item: HighlightedAlignment | undefined) => void;
+    selectingWorkspace: boolean;
 };
 
-const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({ setHoveredOverItem }) => {
+const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({
+    setHoveredOverItem,
+    selectingWorkspace,
+}) => {
     const store = useTrackLayoutAppSelector((state) => state);
 
     const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
@@ -82,6 +86,7 @@ const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({ setHoveredOverI
             viewport={store.map.viewport}
             verticalGeometryDiagramVisible={store.map.verticalGeometryDiagramState.visible}
             onHoverOverPlanSection={setHoveredOverItem}
+            selectingWorkspace={selectingWorkspace}
         />
     );
 };

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -68,6 +68,7 @@ type ToolPanelProps = {
     onInfoboxVisibilityChange: (visibilities: InfoboxVisibilities) => void;
     verticalGeometryDiagramVisible: boolean;
     onHoverOverPlanSection: (item: HighlightedAlignment | undefined) => void;
+    selectingWorkspace: boolean;
 };
 
 export type ToolPanelAsset = {
@@ -115,6 +116,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
     onInfoboxVisibilityChange,
     verticalGeometryDiagramVisible,
     onHoverOverPlanSection,
+    selectingWorkspace,
 }: ToolPanelProps) => {
     const [previousTabs, setPreviousTabs] = React.useState<ToolPanelTab[]>([]);
     const [tabs, setTabs] = React.useState<ToolPanelTab[]>([]);
@@ -495,7 +497,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             {anyTabSelected
                 ? tabs.find((t) => isSameAsset(t.asset, selectedAsset))?.element
                 : first(tabs)?.element}
-            <LocationTrackTaskListContainer />
+            <LocationTrackTaskListContainer selectingWorkspace={selectingWorkspace} />
         </div>
     );
 };

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -20,6 +20,7 @@ import { linkingReducers } from 'linking/linking-store';
 import { LinkingState, LinkingType } from 'linking/linking-model';
 import {
     LayoutContext,
+    LayoutDesignId,
     LayoutMode,
     officialMainLayoutContext,
     PublicationState,
@@ -179,6 +180,7 @@ export enum LocationTrackTaskListType {
 export type SwitchRelinkingValidationTaskList = {
     type: LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION;
     locationTrackId: LocationTrackId;
+    designId: LayoutDesignId | undefined;
 };
 
 export type TrackLayoutState = {

--- a/ui/src/track-layout/track-layout-view.tsx
+++ b/ui/src/track-layout/track-layout-view.tsx
@@ -63,7 +63,10 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = ({
                             </MapContext.Provider>
                         </div>
                         <div className={styles['track-layout__tool-panel']}>
-                            <ToolPanelContainer setHoveredOverItem={setHoveredOverPlanSection} />
+                            <ToolPanelContainer
+                                setHoveredOverItem={setHoveredOverPlanSection}
+                                selectingWorkspace={selectingWorkspace}
+                            />
                         </div>
                     </div>
 


### PR DESCRIPTION
Tiketti ei ollut täysin selkeä siitä miten piilotus halutaan suorittaa, joten tein tänne oman intuitioni mukaisen arvauksen asiasta. Käytännössä tämän myötä tehtävälista sulkeutuu seuraavissa tapauksissa:
1. Operaattori siirtyy valitsemaan suunnitelmaa (ts. navigoi "Suunnitelmatila"-tabiin toolbarista)
2. Karttanäkymän `LayoutContext` vaihtuu osoittamaan eri designiin kuin missä tehtävälista avattiin

Protoilin myös seuraavia vaihtoehtoja, mutta niistä mikään ei oikeastaan tuntunut oikealta:
* Tehtävälistaa ei suljeta automaattisesti Suunnitelmatilaan mentäessä, se vain piilotetaan. Jos työlistan haluaa sulkea, se pitää sulkea yläkulman ruksinappulasta. Käyttäjän palatessa Luonnostila-tabiin piilotettu tehtävälista palautetaan näkyviin (Avautuva tehtävälista saattaa herättää ihmetystä jos suunnitelmatilassa viettää tunteja/päiviä, varsinkin kun tehtävälistan tiedot on tallennettu reduxiin, joten se avautuisi vaikka olisi refreshannut tai sulkenut Geoviitteen välissä)
* Tehtävälista suljetaan vasta kun jokin työtila valitaan ja piilotetaan siihen saakka (Vahinkoklikkaus Suunnitelmatila-tabiin ei vielä aiheuta sitä, että tehtävälista pitää käydä avaamassa uudestaan käsin, mutta toisaalta operaattorille on epäselvää milloin tehtävälista oikeasti sulkeutuu, joka voi aiheuttaa tunteen epäkonsistentista käyttäytymisestä)
* Tehtävälista suljetaan aina kun mennään pois Luonnostilasta (Millekään tehtävälistan vaihteelle ei voi tehdä mitään Nykytilassa ja Suunnitelmatila-tabissakin käynti sulkee tehtävälistan, mutta toisaalta työtilat ovat myös todella selkeämmin oma maailmansa kuin Nyky-/Luonnostila, ja Nykytilasta saattaa haluta käydä katsomassa jotain ilman että työlista sulkeutuu)