### PR TITLE
GVT-2560: Julkaisulokihaku ei indikoi latauksesta ensimmäisen haun yhteydessä

### DIFF
--- a/ui/src/publication/log/publication-log.scss
+++ b/ui/src/publication/log/publication-log.scss
@@ -41,5 +41,10 @@
 
     &__count-header {
         margin-bottom: 12px;
+        display: inline-flex;
+
+        > .spinner {
+            margin-left: 6px;
+        }
     }
 }

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -23,6 +23,7 @@ import { useTrackLayoutAppSelector } from 'store/hooks';
 import { useAppNavigate } from 'common/navigate';
 import { defaultPublicationSearch } from 'publication/publication-utils';
 import { DOWNLOAD_PUBLICATION } from 'user/user-model';
+import { Spinner } from 'vayla-design-lib/spinner/spinner';
 
 let fetchId = 0;
 
@@ -178,6 +179,7 @@ const PublicationLog: React.FC = () => {
                             truncated: truncated ? '+' : '',
                         })}
                     </span>
+                    {isLoading && <Spinner inline={true} />}
                 </div>
                 <PublicationTable
                     isLoading={isLoading}


### PR DESCRIPTION
Tiketillä pyydettiin miettimään lopullinen indikaatio itse ja ehdotettiin spinneriä. Lisätty spinneri tiketin mukaisesti, sillä se näytti ihan fiksulta kokeilun perusteella.