### PR TITLE
GVT-2614: Roolien ja oikeuksien käännösavainten poisto kannasta

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/UserData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/UserData.kt
@@ -16,9 +16,9 @@ data class UserDetails(
     val organization: AuthName?,
 )
 
-data class Role(val code: Code, val name: AuthName, val privileges: List<Privilege>)
+data class Role(val code: Code, val privileges: List<Privilege>)
 
-data class Privilege(val code: Code, val name: AuthName, val description: FreeText) : GrantedAuthority {
+data class Privilege(val code: Code) : GrantedAuthority {
     @JsonIgnore
     override fun getAuthority(): String = code.toString()
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/RequestFilter.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/RequestFilter.kt
@@ -89,7 +89,6 @@ class RequestFilter @Autowired constructor(
             details = UserDetails(UserName.of("HEALTH_CHECK"), null, null, null),
             role = Role(
                 code = Code("health-check"),
-                name = AuthName.of("Service Health Check"),
                 privileges = listOf(),
             ),
             availableRoles = listOf()

--- a/infra/src/main/resources/db/migration/prod/V78__remove_name_and_description_columns_from_roles.sql
+++ b/infra/src/main/resources/db/migration/prod/V78__remove_name_and_description_columns_from_roles.sql
@@ -1,0 +1,8 @@
+alter table common.privilege drop column name;
+alter table common.privilege drop column description;
+
+alter table common.privilege_version drop column name;
+alter table common.privilege_version drop column description;
+
+alter table common.role drop column name;
+alter table common.role_version drop column name;

--- a/infra/src/main/resources/db/migration/repeatable/R__01_role_data.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__01_role_data.sql
@@ -1,30 +1,30 @@
 -- As a repeatable migration, this will be re-run whenever the file changes. It must be idempotent.
 create temp table new_role on commit drop as
-with temp(code, name, user_group) as (
+with temp(code, user_group) as (
     values
-      ('operator', 'Operaattori', 'geoviite_operaattori'),
-      ('browser', 'Selaaja', 'geoviite_selaaja'), -- Deprecated: remove when users are updated in AD to "authority"
-      ('authority', 'Virastokäyttäjä', 'geoviite_virasto'),
-      ('consultant', 'Konsultti', 'geoviite_konsultti'),
-      ('team', 'Kehitystiimi', 'geoviite_tiimi')
+      ('operator', 'geoviite_operaattori'),
+      ('browser', 'geoviite_selaaja'), -- Deprecated: remove when users are updated in AD to "authority"
+      ('authority', 'geoviite_virasto'),
+      ('consultant', 'geoviite_konsultti'),
+      ('team', 'geoviite_tiimi')
 )
 select *
   from temp;
 
 create temp table new_privilege on commit drop as
-with temp(code, name, description) as (
+with temp(code) as (
     values
-      ('view-basic', 'privilege.view-basic', 'privilege.description.view-basic'),
-      ('view-layout', 'privilege.view-layout', 'privilege.description.view-layout'),
-      ('view-layout-draft', 'privilege.view-layout-draft', 'privilege.description.view-layout-draft'),
-      ('edit-layout', 'privilege.edit-layout', 'privilege.description.edit-layout'),
-      ('view-geometry', 'privilege.view-geometry', 'privilege.description.view-geometry'),
-      ('edit-geometry-file', 'privilege.edit-geometry-file', 'privilege.description.edit-geometry-file'),
-      ('download-geometry', 'privilege.download-geometry', 'privilege.description.download-geometry'),
-      ('view-pv-documents', 'privilege.view-pv-documents', 'privilege.description.view-pv-documents'),
-      ('view-geometry-file', 'privilege.view-geometry-file', 'privilege.description.view-geometry-file'),
-      ('view-publication', 'privilege.view-publication', 'privilege.description.view-publication'),
-      ('download-publication', 'privilege.download-publication', 'privilege.description.download-publication')
+      ('view-basic'),
+      ('view-layout'),
+      ('view-layout-draft'),
+      ('edit-layout'),
+      ('view-geometry'),
+      ('edit-geometry-file'),
+      ('download-geometry'),
+      ('view-pv-documents'),
+      ('view-geometry-file'),
+      ('view-publication'),
+      ('download-publication')
 )
 select *
   from temp;
@@ -96,21 +96,21 @@ delete
   where not exists(select from new_role where new_role.code = role.code);
 
 -- Upsert using 'except' to avoid updating rows that are already identical
-insert into common.role(code, name, user_group)
+insert into common.role(code, user_group)
 select *
   from new_role
 except
-select code, name, user_group
+select code, user_group
   from common.role
-on conflict (code) do update set name = excluded.name, user_group = excluded.user_group;
+on conflict (code) do update set user_group = excluded.user_group;
 
-insert into common.privilege(code, name, description)
+insert into common.privilege(code)
 select *
   from new_privilege
 except
-select code, name, description
+select code
   from common.privilege
-on conflict (code) do update set name = excluded.name, description = excluded.description;
+on conflict (code) do nothing;
 
 insert into common.role_privilege(role_code, privilege_code)
 select *

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/MetaDataIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/MetaDataIT.kt
@@ -17,7 +17,6 @@ const val TEST_ROLE_CODE = "it_tst"
 class MetaDataIT: DBTestBase() {
 
     private data class VersionData(
-        val name: String,
         val changeUser: String,
         val deleted: Boolean,
     )
@@ -28,67 +27,66 @@ class MetaDataIT: DBTestBase() {
     }
 
     @Test
-    fun versioningWorks() {
-        assertEquals(null, getName(TEST_ROLE_CODE))
+    fun `Versioning works`() {
+        assertEquals(null, getUserGroup(TEST_ROLE_CODE))
 
-        insertRole(TEST_ROLE_CODE, "IT_test_role")
-        assertEquals("IT_test_role", getName(TEST_ROLE_CODE))
+        insertRole(TEST_ROLE_CODE, "IT_test_group")
+        assertEquals("IT_test_group", getUserGroup(TEST_ROLE_CODE))
 
-        updateRole(TEST_ROLE_CODE, "IT_test_name_2")
-        assertEquals("IT_test_name_2", getName(TEST_ROLE_CODE))
+        updateRole(TEST_ROLE_CODE, "IT_test_group_2")
+        assertEquals("IT_test_group_2", getUserGroup(TEST_ROLE_CODE))
 
-        withUser(UserName.of("TST_USER_2")) { updateRole(TEST_ROLE_CODE, "IT_test_name_3") }
-        assertEquals("IT_test_name_3", getName(TEST_ROLE_CODE))
+        withUser(UserName.of("TST_USER_2")) { updateRole(TEST_ROLE_CODE, "IT_test_group_3") }
+        assertEquals("IT_test_group_3", getUserGroup(TEST_ROLE_CODE))
 
         withUser(UserName.of("TST_USER_3")) { deleteRole(TEST_ROLE_CODE) }
-        assertEquals(null, getName(TEST_ROLE_CODE))
+        assertEquals(null, getUserGroup(TEST_ROLE_CODE))
 
         withUser(UserName.of("TST_USER_4")) { insertRole(TEST_ROLE_CODE, "IT_test_restored") }
-        assertEquals("IT_test_restored", getName(TEST_ROLE_CODE))
+        assertEquals("IT_test_restored", getUserGroup(TEST_ROLE_CODE))
 
         assertEquals(
             mapOf(
-                1 to VersionData("IT_test_role", TEST_USER, false),
-                2 to VersionData("IT_test_name_2", TEST_USER, false),
-                3 to VersionData("IT_test_name_3", "TST_USER_2", false),
-                4 to VersionData("IT_test_name_3", "TST_USER_3", true),
-                5 to VersionData("IT_test_restored", "TST_USER_4", false),
+                1 to VersionData(TEST_USER, false),
+                2 to VersionData(TEST_USER, false),
+                3 to VersionData("TST_USER_2", false),
+                4 to VersionData("TST_USER_3", true),
+                5 to VersionData("TST_USER_4", false),
             ),
             getRoleVersionData(TEST_ROLE_CODE),
         )
     }
 
-    private fun getName(code: String): String? {
-        val sql = "select name from common.role where code = :code"
-        val names = jdbc.query(sql, mapOf("code" to code)) { rs, _ -> rs.getString("name") }
-        assertTrue(names.size <= 1)
-        return names.firstOrNull()
+    private fun getUserGroup(code: String): String? {
+        val sql = "select user_group from common.role where code = :code"
+        val userGroups = jdbc.query(sql, mapOf("code" to code)) { rs, _ -> rs.getString("user_group") }
+        assertTrue(userGroups.size <= 1)
+        return userGroups.firstOrNull()
     }
 
     private fun getRoleVersionData(code: String): Map<Int, VersionData> {
-        val sql = "select version, name, change_user, deleted from common.role_version where code = :code"
+        val sql = "select version, change_user, deleted from common.role_version where code = :code"
         return jdbc.query(sql, mapOf("code" to code)) { rs, _ ->
             rs.getInt("version") to VersionData(
-                name = rs.getString("name"),
                 changeUser = rs.getString("change_user"),
                 deleted = rs.getBoolean("deleted"),
             )
         }.associate { it }
     }
 
-    private fun insertRole(code: String, name: String) {
+    private fun insertRole(code: String, userGroup: String) {
         transaction.execute {
             jdbc.setUser()
-            val sql = "insert into common.role(code, name, user_group) values (:code, :name, 'tst_group')"
-            jdbc.update(sql, mapOf("code" to code, "name" to name))
+            val sql = "insert into common.role(code, user_group) values (:code, :user_group)"
+            jdbc.update(sql, mapOf("code" to code, "user_group" to userGroup))
         }
     }
 
-    private fun updateRole(code: String, name: String) {
+    private fun updateRole(code: String, userGroup: String) {
         transaction.execute {
             jdbc.setUser()
-            val sql = "update common.role set name=:name where code=:code"
-            jdbc.update(sql, mapOf("code" to code, "name" to name))
+            val sql = "update common.role set user_group=:user_group where code=:code"
+            jdbc.update(sql, mapOf("code" to code, "user_group" to userGroup))
         }
     }
 

--- a/ui/src/user/user-card.tsx
+++ b/ui/src/user/user-card.tsx
@@ -59,8 +59,10 @@ export const UserCard: React.FC<UserCardProps> = ({ user }: UserCardProps) => {
                                 </h3>
                                 <span>
                                     {user.role.privileges.map((priv, index) => (
-                                        <span key={priv.name} title={t(priv.description)}>
-                                            {t(priv.name)}
+                                        <span
+                                            key={priv.code}
+                                            title={t(`privilege.description.${priv.code}`)}>
+                                            {t(`privilege.${priv.code}`)}
                                             {index < user.role.privileges.length - 1 && ', '}
                                         </span>
                                     ))}

--- a/ui/src/user/user-model.ts
+++ b/ui/src/user/user-model.ts
@@ -42,14 +42,11 @@ export type UserDetails = {
 
 export type Role = {
     code: RoleCode;
-    name: string;
     privileges: Privilege[];
 };
 
 export type Privilege = {
     code: PrivilegeCode;
-    name: string;
-    description: string;
 };
 
 export const userHasPrivilege = (privileges: PrivilegeCode[], privilege: PrivilegeCode) =>


### PR DESCRIPTION
Alkuperäinen review-kommentti oli siis että oikeuksilla on turha olla käännösavaimia kannassa sillä ne voidaan päätellä koodin perusteella. Tällä tiketillä poistettu ka. columnit (`common.privilege`:n `name` ja `description`) sekä poistettu roolien nimikenttä (`common.role`:n `name`.) Roolien nimille olikin jo aiemmalta käännökset joten niiden poisto ei aiheuttanut fronttiin minkäänlaisia muutostarpeita, mutta yksi IT-testi perustui roolien nimien puljaamista, joten se piti reworkata käyttämään muita arvoja.