### PR TITLE
GVT-2541 Layout Context dokumentaation päivitys

### DIFF
--- a/doc/paikannuspohjan_kontekstit.md
+++ b/doc/paikannuspohjan_kontekstit.md
@@ -23,28 +23,41 @@ tai muuttaa niin että viittaus poistuu.
 Luonnosmuutokset voidaan viedä viralliseen paikannuspohjaan julkaisu-toiminnon (Publication) kautta. Luonnostilassa on
 mahdollista olla tilapäistä / osittaista dataa, koska sitä ollaan vasta luomassa, mutta sellaista ei voi olla
 virallisessa paikannuspohjassa. Tästä johtuen, julkaisuun sisältyy joukko validointeja (julkaisuvalidointi, publication
-validation), jonka avulla varmistetaan että julkaistavat tiedot muodostavat eheän kokonaisuuden. Tässä varmistetaan myös
-että virallisesta paikannustpohjasta ei voida viitata pelkästään luonnoksena olevaan käsitteeseen.
+validation, kts. [Julkaisu](julkaisu.md)), jonka avulla varmistetaan että julkaistavat tiedot muodostavat eheän
+kokonaisuuden. Tässä varmistetaan myös että virallisesta paikannuspohjasta ei voida viitata pelkästään luonnoksena
+olevaan käsitteeseen.
 
 ## Suunniteltu paikannupohja (Planned Layout)
 
 Suunniteltuja paikannuspohjia voi olla monta, sillä ne koostuvat erillisistä suunnitelmista jotka tarjoavat itsenäiset
 joukot suunniteltuja muutoksia. Käyttäjän kannalta ne toimivat pitkälti kuten luonnos paikannuspohja, mutta ne
 ovat kukin omia erillisiä kontekstejaan. Suunniteltu paikannuspohja rakentuu aina virallisen paikannuspohjan päälle,
-eikä siis ole mitenkään tietoinen luonnos paikannuspohjasta.
+eikä siis ole mitenkään tietoinen varsinaisen paikannupohjan luonnos kontekstista.
 
-Suunnitelmille tehdään omia julkaisuja (toisin kuin luonnokselle, jonka julkaisu on virallisen paikannuspohjan muutos).
-Julkaistu suunnitelma viedään Ratkoon suunniltuina käsitteinä, jolloin niihin voidaan suunnitella myös muita kohteita
-Ratkon puolella.
+Suunnitelmilla on myös omat luonnosversionsa ja niistä tehdään omia julkaisujaan, jotka siis menevät julkaistuksi
+suunnitelmaksi, ei varsinaiseen paikannuspohjaan. Vasta julkaistu suunnitelma viedään Ratkoon suunniltuina käsitteinä,
+jolloin niihin voidaan suunnitella myös muita kohteita Ratkon puolella.
 
-Kun suunnitelman käsitteet valmistuvat, ne viedään ensin luonnoksiksi. Luonnospuolella niitä voidaan edelleen muokata
-ja täydentää ennen kun ne julkaistaan normaalin luonnoksen tapaan viralliseksi. Tässä kohtaa myös suunnitelmajulkaisu
-päivitetään valmistuneeksi.
+Kun suunnitelman käsitteet valmistuvat, ne viedään ensin varsinaisen paikannuspohjan luonnoksiksi. Luonnospuolella niitä
+voidaan edelleen muokata ja täydentää ennen kun ne julkaistaan normaalin luonnoksen tapaan viralliseksi. Tässä kohtaa
+myös itse suunnitelma päivitetään valmistuneeksi.
+
+## Kontekstien väliset siirtymät
+
+Sekä virallisen paikannuspohjan että suunnitelmien muutokset tehdään aina luonnosten kautta. Suunnitelmien
+valmistuminenkin on virallisen paikannuspohjan muutos ja menee luonnoksen kautta. Mahdollisia siirtymiä kontekstien
+välillä ovat siis:
+
+-   Virallinen paikannuspohja -> Luonnos paikannuspohja (luonnos muutos)
+-   Luonnos paikannuspohja -> Virallinen paikannuspohja (paikannuspohjan julkaisu)
+-   Virallinen paikannuspohja -> Luonnos suunnitelma (suunniteltu muutos)
+-   Luonnos suunnitelma -> Julkaistu suunnitelma (suunnitelman julkaisu)
+-   Julkaistu suunnitelma -> Luonnos paikannuspohja (suunnitelman valmistuminen)
 
 ## ID käsittely ja viittaukset kontekstien välillä
 
 Eri kontekstien versiot samasta käsitteestä ovat kannassa omia rivejään ja siten niillä on omat ID:nsä. Käyttöliittymän
-kannalta käsittellä on kuitenkin aina vain yksi ID ja lisätietona konteksti jossa sitä tarkastellaan. Tuo yksi ID on
+kannalta käsittellä on kuitenkin aina vain yksi ID ja lisätietona konteksti, jossa sitä tarkastellaan. Tuo yksi ID on
 käsitteenä nimeltään virallinen ID (official ID). Käytännössä se on käsitteen ensimmäisen ilmenemän ID, riippumatta
 missä kontekstissa se ensimmäisen kerran syntyi. Koska tuo ID ei muutu käsitteen siirtyessä eri kontekstien välillä,
 käyttöliittymä voi helposti siirtyä tarkastelemaan koko paikannuspohjaa eri konteksteissa.
@@ -53,10 +66,13 @@ Myös käsitteiden keskinäiset viittaukset tehdään aina tällä virallisella 
 tarvitse korjata silloin kun käsiteestä tehdään uusi versio toiseen kontekstiin -- virallinen ID säilyy aina samana.
 Koska luonnos ja suunnitelmat rakentuvat virallisen paikannuspohjan päälle, tämä tarkoittaa että niiden sisältämät
 käsitteet voivat viitata virallisilla ID:llä sekä oman kontekstin käsitteisiin että virallisiin käsitteisiin.
+Vastaavasti suunnitelman luonnosolio voi viitata suunnitelman luonnoskäsitteisiin, sen julkaistuihin käsitteisiin tai
+virallisen paikannuspohjan käsitteisiin, mutta ei virallisen paikannuspohjan luonnoksiin.
 
-Lopullinen rivi jota viite tarkoittaa pitää siis aina tulkita huomioiden myös konteksti. Jos esimerkiksi viralliseen
-käsitteeseen tulee muutos luonnoskontekstiin, viite olioon säilyy muuttumattomana ja osoittaa nyt luonnosversioon.
-Vastaavasti jos käsite poistuu luonnoskontekstista, viite tarkoittaa nyt virallisesta paikannuspohjasta tulevaa oliota.
+Lopullinen rivi jota viite tarkoittaa pitää siis aina tulkita huomioiden myös käsiteltävä konteksti. Jos esimerkiksi
+viralliseen käsitteeseen tulee muutos luonnoskontekstiin, toisen luonnoksen viite kyseiseen olioon säilyy
+muuttumattomana mutta tarkoittaa nyt luonnosversiota käsitteestä. Vastaavasti jos käsite poistuu luonnoskontekstista,
+sama viite tarkoittaa nyt virallisesta paikannuspohjasta tulevaa oliota.
 
 Käsitteiden elinkaaria uuden luonnissa tai olemassaolevan muutoksissa kuvataan alla tarkemmin eri skenaarioille
 kontekstit huomioiden. Huomattavaa on, että ensimmäisenä syntynyt olio (tietokantarivi) säilyy ja siirtyy lopulta
@@ -68,10 +84,11 @@ julkaisussa. Tämä varmistaa että virallinen ID säilyy muita viittaajia varte
 ```mermaid
 graph TD
     subgraph legendColor [Värikoodit]
-        legendDraft(Luonnos olio)
-        legendOfficial(Virallinen olio)
-        legendPlan(Suunniteltu olio)
-        legendDraft ~~~ legendOfficial ~~~ legendPlan
+        legendDraft(Luonnos paikannuspohja)
+        legendOfficial(Virallinen paikannuspohja)
+legendDraftPlan(Luonnos suunnitelma)
+        legendPlan(Julkaistu suunnitelma)
+        legendDraft ~~~ legendOfficial ~~~ legendDraftPlan ~~~ legendPlan
     end
     subgraph legendSymbol [Symbolit]
         legendOfficialId("Virallinen ID\n❖ id=x")
@@ -83,11 +100,13 @@ graph TD
     end
     classDef draftObject fill: lightyellow, stroke: black, color: black;
     classDef officialObject fill: lightgreen, stroke: black, color: black;
-    classDef planObject fill: pink, stroke: black, color: black;
+    classDef planObject fill: cyan, stroke: black, color: black;
+    classDef draftPlanObject fill: pink, stroke: black, color: black;
     class legendDraft draftObject
     class legendOfficial officialObject
     class legendPlan planObject
-    linkStyle 3 stroke: grey, stroke-dasharray: 5 5
+    class legendDraftPlan draftPlanObject
+    linkStyle 4 stroke: grey, stroke-dasharray: 5 5
 ```
 
 ### Kaavio: Uuden käsitteen luonti luonnoksen kautta
@@ -128,7 +147,7 @@ graph TD
     classDef objectCategory stroke: transparent
     class draftTracks,endTracks,startTrackNumber,draftTrackNumber,endTrackNumber objectCategory
 ```
-
+ 
 ### Kaavio: Olemassaolevan käsitteen muokkaus luonnoksen kautta
 
 Kun oliota muutetaan, muutokset kirjataan luonnoksena tehtyyn kopio-olioon. Kun muutokset julkaistaan, tiedot kopioidaan
@@ -157,7 +176,7 @@ graph TD
         end
         track1InDraft --> officialTnInDraft
         track2InDraft --> officialTnInDraft
-        draftTnInDraft -- draft_of --> officialTnInDraft
+        draftTnInDraft -- official_row --> officialTnInDraft
     end
     subgraph endState [Lopputila: virallinen paikannuspohja muuttunut]
         subgraph endTracks [Muiden viitteet säilyy koska ID ei muutu]
@@ -170,7 +189,7 @@ graph TD
         track1InEnd --> officialTnInEnd
         track2InEnd --> officialTnInEnd
     end
-    startState == Luonnos muutos:\nViralliset oliot ei muutu ==> draftState == Julkaisu:\nVirallinen olio päivittyy\nLuonnosolio poistuu ==> endState
+    startState == Luonnos muutos:\nViralliset oliot eivät muutu ==> draftState == Julkaisu:\nVirallinen olio päivittyy\nLuonnosolio poistuu ==> endState
     officialTnInStart ====> officialTnInDraft ====> officialTnInEnd
     draftTnInDraft -. Luonnosdata kopioidaan\nalkuperäiseen olioon .-> officialTnInEnd
     classDef draftObject fill: lightyellow, stroke: black, color: black;
@@ -184,112 +203,59 @@ graph TD
     class startTracks,draftTracks,endTracks,startTrackNumber,draftTrackNumber,endTrackNumber objectCategory
 ```
 
-### Kaavio: Uuden käsitteen luonti suunnitelman kautta
+### Suunnitelmakäsitteiden luonti ja muokkaus
 
-Kun uusi käsite luodaan suunnitelmaan, uusi olio ilmestyy suunnitelmaoliona. Kun suunnitelma valmistuu, siitä luodaan
-luonnosolio kopiona ja sitä voidaan muokata vielä edelleen. Kun suunnitelman valmistuminen julkaistaan, suunnitelmaolio
-muutetaan viralliseksi ja siihen kopioidaan lopulliset tiedot luonnosoliosta. Suunnitelmaolion ID on virallinen ID ja se
-säilyy, koska sama olio päivitetään lopulta viralliseksi.
+Suunnitelmakäsitteiden luonti, muokkaus ja julkaisu tapahtuu samoin kuin virallisessa paikannuspohjassa, luonnosten
+kautta. Näistä ketjuista ei ole erillisiä kaavioita, koska prosessi on sama kuin yllä. On kuitenkin hyvä huomata
+viittauksiin tulee yksi kerros lisää, sillä suunnitelmaluonnos voi viitata sekä julkaistuun suunnitelmaan että
+viralliseen paikannuspohjaan. Virallisen paikannuspohjan luonnokset ja suunnitelmaluonnokset elävät kuitenkin täysin
+erillään, eikä niiden välillä voi olla viittauksia.
 
-```mermaid
-graph TD
-    subgraph planState [Suunnitelma: uudet versiot suunnitelman kontekstissa]
-        subgraph planTracks [Muut oliot viittaavat suunnitelmaan]
-            track1InPlan(Raide X)
-        end
-        subgraph planTrackNumber [&nbsp]
-            planTnInPlan("Ratanumero 001\n❖ id=1, version=1")
-        end
-        track1InPlan --> planTnInPlan
-    end
-    subgraph draftState [Muutos: uudet versiot luonnosolioissa]
-        subgraph draftTracks [Muut oliot viittaavat viralliseen]
-            track1InDraft(Raide X)
-            track2InDraft(Raide Y)
-        end
-        subgraph draftTrackNumber [Luonnos viittaa viralliseen]
-            draftTnInDraft(Ratanumero 001\nid=123, version=1)
-            planTnInDraft("Ratanumero 001\n❖ id=1, version=1")
-        end
-        track1InDraft --> planTnInDraft
-        track2InDraft --> planTnInDraft
-        draftTnInDraft -- draft_of --> planTnInDraft
-    end
-    subgraph endState [Lopputila: virallinen paikannuspohja muuttunut]
-        subgraph endTracks [Muiden viitteet säilyy koska ID ei muutu]
-            track1InEnd(Raide X)
-            track2InEnd(Raide Y)
-        end
-        subgraph endTrackNumber [&nbsp]
-            officialTnInEnd("Ratanumero 001\n❖ id=1, version=2")
-        end
-        track1InEnd --> officialTnInEnd
-        track2InEnd --> officialTnInEnd
-    end
-    planState == Luonnos muutos:\nSuunnitelman oliot ei muutu ==> draftState == Julkaisu:\nSuunnitelmaolio muuttuu viralliseksi\nLuonnos poistuu ==> endState
-    planTnInPlan ====> planTnInDraft ====> officialTnInEnd
-    planTnInPlan -. Suunnitelmadata kopioidaan\nluonnosolioon .-> draftTnInDraft
-    draftTnInDraft -. Luonnosdata kopioidaan\nsuunnitelmaolioon .-> officialTnInEnd
-    classDef draftObject fill: lightyellow, stroke: black, color: black;
-    classDef officialObject fill: lightgreen, stroke: black, color: black;
-    classDef planObject fill: pink, stroke: black, color: black;
-    class draftTnInDraft,track2InDraft,track2InEnd draftObject
-    class officialTnInEnd officialObject
-    class planTnInPlan,planTnInDraft,track1InPlan,track1InDraft,track1InEnd planObject
-    linkStyle 8,9 stroke: grey, stroke-dasharray: 5 5
-    classDef phaseCategory font-size: 18px, font-weight: bold
-    class startState,planState,draftState,endState phaseCategory
-    classDef objectCategory stroke: transparent
-    class startTracks,planTracks,draftTracks,endTracks,startTrackNumber,planTrackNumber,draftTrackNumber,endTrackNumber objectCategory
-```
+### Kaavio: Uuden käsitteen tuonti viralliseen paikannuspohjaan suunnitelman kautta
 
-### Kaavio: Olemassaolevan käsitteen muokkaus suunnitelman kautta
+Kun uusi käsite luodaan suunnitelmaan, se syntyy ensin luonnossuunnitelmaoliona. Se julkaistaan ensin viralliseksi
+suunnitelmaksi, sillä vain virallisesta suunnitelmasta voidaan tuoda dataa viralliseen paikannuspohjaan.
 
-Suunniteltaessa muutos olemassaolevaan käsitteeseen, suunnitelmaan luodaan kopio johon muutokset tehdään. Kun
-suunnitelma valmistuu, sen tiedot kopioidaan luonnosolioon, jota voidaan muokata edelleen. Kun suunnitelman
-valmistuminen julkaistaan, alkuperäiselle oliolle kopioidaan data luonnosoliolta ja luonnos sekä suunnitelman olio
-poistetaan. Alkuperäisen virallisen olion ID on virallinen ID ja se säilyy koska oliota vain päivitetään.
+Kun suunnitelma valmistuu, siitä luodaan luonnosolio kopiona ja sitä voidaan muokata vielä edelleen. Kun suunnitelman
+valmistuminen julkaistaan, suunnitelmaolio muutetaan viralliseksi ja siihen kopioidaan lopulliset tiedot luonnosoliosta.
+Suunnitelmaolion ID on virallinen ID ja se säilyy, koska sama olio päivitetään lopulta viralliseksi.
 
 ```mermaid
 graph TD
-    subgraph startState [Alkutila: virallinen paikannuspohja]
-        subgraph startTracks [Muut oliot viittaavat viralliseen]
-            track1InStart(Raide X)
+    subgraph planDraftState [Luonnossuunnitelma: uusi suunnitelmakäsite syntyy luonnoksena]
+        subgraph planDraftTracks [Muut oliot viittaavat luonnossuunnitelmaan]
+            track1InPlanDraft(Raide X)
         end
-        subgraph startTrackNumber [&nbsp]
-            officialTnInStart("Ratanumero 001\n❖ id=1, version=1")
+        subgraph planDraftTrackNumber [&nbsp]
+            planTnInPlanDraft("Ratanumero 001\n❖ id=1, version=1")
         end
-        track1InStart --> officialTnInStart
+        track1InPlanDraft --> planTnInPlanDraft
     end
-    subgraph planState [Suunnitelma: uudet versiot suunnitelman kontekstissa]
-        subgraph planTracks [Muut oliot viittaavat viralliseen]
+    subgraph planState [Julkaistu suunnitelma: olio säilyy]
+        subgraph planTracks [Muut oliot viittaavat julkaistuun suunnitelmaan]
             track1InPlan(Raide X)
             track2InPlan(Raide Y)
         end
-        subgraph planTrackNumber [Suunnitelma viittaa viralliseen]
-            planTnInPlan(Ratanumero 001\nid=123, version=1)
-            officialTnInPlan("Ratanumero 001\n❖ id=1, version=1")
+        subgraph planTrackNumber [&nbsp]
+            planTnInPlan("Ratanumero 001\n❖ id=1, version=2")
         end
-        track1InPlan --> officialTnInPlan
-        track2InPlan --> officialTnInPlan
-        planTnInPlan -- plan_of --> officialTnInPlan
+        track1InPlan --> planTnInPlan
+        track2InPlan --> planTnInPlan
     end
-    subgraph draftState [Muutos: uudet versiot luonnosolioissa]
-        subgraph draftTracks [Muut oliot viittaavat viralliseen]
+    subgraph draftState [Paikannuspohjan luonnokseen tuodut muutokset]
+        subgraph draftTracks [Muut oliot viittaavat edelleen viralliseen suunnitelmaan]
             track1InDraft(Raide X)
             track2InDraft(Raide Y)
             track3InDraft(Raide Z)
         end
-        subgraph draftTrackNumber [Luonnos viittaa viralliseen]
-            draftTnInDraft(Ratanumero 001\nid=456, version=1)
-            planTnInDraft(Ratanumero 001\nid=123, version=1)
-            officialTnInDraft("Ratanumero 001\n❖ id=1, version=1")
+        subgraph draftTrackNumber [Luonnos viittaa suunnitelmaan]
+            draftTnInDraft(Ratanumero 001\nid=123, version=1)
+            planTnInDraft("Ratanumero 001\n❖ id=1, version=2")
         end
-        track1InDraft --> officialTnInDraft
-        track2InDraft --> officialTnInDraft
-        track3InDraft --> officialTnInDraft
-        planTnInDraft -- plan_of --> officialTnInDraft
-        draftTnInDraft -- draft_of --> officialTnInDraft
+        track1InDraft --> planTnInDraft
+        track2InDraft --> planTnInDraft
+        track3InDraft --> planTnInDraft
+        draftTnInDraft -- design_row --> planTnInDraft
     end
     subgraph endState [Lopputila: virallinen paikannuspohja muuttunut]
         subgraph endTracks [Muiden viitteet säilyy koska ID ei muutu]
@@ -298,26 +264,131 @@ graph TD
             track3InEnd(Raide Z)
         end
         subgraph endTrackNumber [&nbsp]
-            officialTnInEnd("Ratanumero 001\n❖ id=1, version=2")
+            officialTnInEnd("Ratanumero 001\n❖ id=1, version=3")
         end
         track1InEnd --> officialTnInEnd
         track2InEnd --> officialTnInEnd
         track3InEnd --> officialTnInEnd
     end
-    startState == Suunniteltu muutos:\nViralliset oliot ei muutu ==> planState == Luonnos muutos:\nSuunnitelman oliot ei muutu ==> draftState == Julkaisu:\nVirallinen olio päivittyy\nLuonnos ja suunnitelmaolio poistuu ==> endState
-    planTnInPlan ====> planTnInDraft
-    officialTnInStart ====> officialTnInPlan ====> officialTnInDraft ====> officialTnInEnd
+    planTnInPlanDraft ====> planTnInPlan ====> planTnInDraft ====> officialTnInEnd
+    planDraftState == Suunnitelman julkaisu:\nLuonnosolio muuttuu viralliseksi ==> planState == Luonnos muutos:\nSuunnitelman oliot eivät muutu ==> draftState == Julkaisu:\nSuunnitelmaolio muuttuu viralliseksi\nLuonnos poistuu ==> endState
+    planTnInPlan -. Suunnitelmadata kopioidaan\nluonnosolioon .-> draftTnInDraft
+    draftTnInDraft -. Luonnosdata kopioidaan\nsuunnitelmaolioon .-> officialTnInEnd
+    classDef draftObject fill: lightyellow, stroke: black, color: black;
+    classDef officialObject fill: lightgreen, stroke: black, color: black;
+    classDef planObject fill: cyan, stroke: black, color: black;
+    classDef draftPlanObject fill: pink, stroke: black, color: black;
+    class track3InDraft,track3InEnd,draftTnInDraft draftObject
+    class officialTnInEnd officialObject
+    class track2InPlan,track2InDraft,track2InEnd,planTnInPlan,planTnInDraft planObject
+    class track1InPlanDraft,track1InPlan,track1InDraft,track1InEnd,planTnInPlanDraft draftPlanObject
+    linkStyle 10,11,12 stroke: grey, stroke-dasharray: 5 5
+    classDef phaseCategory font-size: 18px, font-weight: bold
+    class startState,planDraftState,planState,draftState,endState phaseCategory
+    classDef objectCategory stroke: transparent
+    class startTracks,planDraftTracks,planTracks,draftTracks,endTracks,startTrackNumber,planTrackNumber,draftTrackNumber,endTrackNumber objectCategory
+```
+
+### Kaavio: Olemassaolevan käsitteen muokkaus suunnitelman kautta
+
+Suunniteltaessa muutos olemassaolevaan käsitteeseen, suunnitelmaan luodaan ensin luonnoskopio johon muutokset tehdään.
+Nämä muutokset on julkaistava viralliseksi suunnitelmaksi ennen kun muutosta voidaan viedä viralliseen paikannuspohjaan.
+
+Kun suunnitelma valmistuu, sen tiedot kopioidaan virallisen paikannuspohjan luonnosolioon, jota voidaan muokata
+edelleen. Kun suunnitelman valmistuminen julkaistaan, alkuperäiselle oliolle kopioidaan data luonnosoliolta ja luonnos
+sekä suunnitelman olio poistetaan. Alkuperäisen virallisen olion ID on virallinen ID ja se säilyy koska oliota vain
+päivitetään.
+
+```mermaid
+graph TD
+    subgraph startState [Alkutila: virallinen paikannuspohja]
+        subgraph startTrackNumber [&nbsp]
+            officialTnInStart("Ratanumero 001\n❖ id=1, version=1")
+        end
+        subgraph startTracks [Muut oliot viittaavat viralliseen]
+            track1InStart(Raide X)
+        end
+        track1InStart --> officialTnInStart
+    end
+    subgraph planDraftState [Suunnitelmaluonnos: uudet versiot suunnitelman kontekstissa]
+        subgraph planDraftTrackNumber [Luonnossuunnitelma viittaa viralliseen]
+            officialTnInPlanDraft("Ratanumero 001\n❖ id=1, version=1")
+            planTnInPlanDraft(Ratanumero 001\nid=123, version=1)
+        end
+        subgraph planDraftTracks [Muut oliot viittaavat viralliseen]
+            track1InPlanDraft(Raide X)
+            track2InPlanDraft(Raide Y)
+        end
+        track1InPlanDraft --> officialTnInPlanDraft
+        track2InPlanDraft --> officialTnInPlanDraft
+        planTnInPlanDraft -- official_row --> officialTnInPlanDraft
+    end
+    subgraph planState [Julkaistu suunnitelma]
+        subgraph planTrackNumber [Suunnitelma viittaa viralliseen]
+            officialTnInPlan("Ratanumero 001\n❖ id=1, version=1")
+            planTnInPlan(Ratanumero 001\nid=123, version=1)
+        end
+        subgraph planTracks [Muut oliot viittaavat viralliseen]
+            track1InPlan(Raide X)
+            track2InPlan(Raide Y)
+            track3InPlan(Raide Z)
+        end
+        track1InPlan --> officialTnInPlan
+        track2InPlan --> officialTnInPlan
+        track3InPlan --> officialTnInPlan
+        planTnInPlan -- official_row --> officialTnInPlan
+    end
+    subgraph draftState [Muutos: uudet versiot luonnosolioissa]
+        subgraph draftTrackNumber [Luonnos viittaa viralliseen]
+            planTnInDraft(Ratanumero 001\nid=123, version=1)
+            draftTnInDraft(Ratanumero 001\nid=456, version=1)
+            officialTnInDraft("Ratanumero 001\n❖ id=1, version=1")
+        end
+        subgraph draftTracks [Muut oliot viittaavat viralliseen]
+            track1InDraft(Raide X)
+            track2InDraft(Raide Y)
+            track3InDraft(Raide Z)
+            track4InDraft(Raide Å)
+        end
+        track1InDraft --> officialTnInDraft
+        track2InDraft --> officialTnInDraft
+        track3InDraft --> officialTnInDraft
+        track4InDraft --> officialTnInDraft
+        planTnInDraft -- official_row --> officialTnInDraft
+        draftTnInDraft -- design_row --> planTnInDraft
+        draftTnInDraft -- official_row --> officialTnInDraft
+    end
+    subgraph endState [Lopputila: virallinen paikannuspohja muuttunut]
+        subgraph endTracks [Muiden viitteet säilyy koska ID ei muutu]
+            track1InEnd(Raide X)
+            track2InEnd(Raide Y)
+            track3InEnd(Raide Z)
+            track4InEnd(Raide Å)
+        end
+        subgraph endTrackNumber [&nbsp]
+            officialTnInEnd("Ratanumero 001\n❖ id=1, version=2")
+        end
+        track1InEnd --> officialTnInEnd
+        track2InEnd --> officialTnInEnd
+        track3InEnd --> officialTnInEnd
+        track4InEnd --> officialTnInEnd
+    end
+    startState == Suunniteltu luonnosmuutos:\nViralliset oliot eivät muutu ==> planDraftState == Suunnitelman julkaisu:\nViralliset oliot eivät muutu ==> planState == Luonnos muutos:\nSuunnitelman oliot eivät muutu ==> draftState == Julkaisu:\nVirallinen olio päivittyy\nLuonnos ja suunnitelmaolio poistuu ==> endState
+    officialTnInStart ====> officialTnInPlanDraft ====> officialTnInPlan ====> officialTnInDraft ====> officialTnInEnd
+    planTnInPlanDraft ====>  planTnInPlan ====> planTnInDraft
     planTnInPlan -. Suunnitelmadata kopioidaan\nluonnosolioon .-> draftTnInDraft
     draftTnInDraft -. Luonnosdata kopioidaan\nalkuperäiseen olioon .-> officialTnInEnd
     classDef draftObject fill: lightyellow, stroke: black, color: black;
     classDef officialObject fill: lightgreen, stroke: black, color: black;
-    classDef planObject fill: pink, stroke: black, color: black;
-    class draftTnInDraft,track3InDraft,track3InEnd draftObject
-    class officialTnInStart,officialTnInPlan,officialTnInDraft,officialTnInEnd,track1InStart,track1InPlan,track1InDraft,track1InEnd officialObject
-    class planTnInPlan,planTnInDraft,track2InPlan,track2InDraft,track2InEnd planObject
-    linkStyle 15,17,18 stroke: grey, stroke-dasharray: 5 5
+    classDef planObject fill: cyan, stroke: black, color: black;
+    classDef draftPlanObject fill: pink, stroke: black, color: black;
+    class draftTnInDraft,track4InPlan,track4InDraft,track4InEnd draftObject
+    class officialTnInStart,officialTnInPlanDraft,officialTnInPlan,officialTnInDraft,officialTnInEnd,track1InStart,track1InPlanDraft,track1InPlan,track1InDraft,track1InEnd officialObject
+    class planTnInPlan,planTnInDraft,track3InPlan,track3InDraft,track3InEnd planObject
+    class planTnInPlanDraft,track2InPlanDraft,track2InPlan,track2InDraft,track2InEnd draftPlanObject
+    linkStyle 23,24,25,26 stroke: grey, stroke-dasharray: 5 5
     classDef phaseCategory font-size: 18px, font-weight: bold
-    class startState,planState,draftState,endState phaseCategory
+    class startState,planDraftState,planState,draftState,endState phaseCategory
     classDef objectCategory stroke: transparent
-    class startTracks,planTracks,draftTracks,endTracks,startTrackNumber,planTrackNumber,draftTrackNumber,endTrackNumber objectCategory
+    class startTracks,planDraftTracks,planTracks,draftTracks,endTracks,startTrackNumber,planDraftTrackNumber,planTrackNumber,draftTrackNumber,endTrackNumber objectCategory
 ```

--- a/doc/paikannuspohjan_kontekstit.md
+++ b/doc/paikannuspohjan_kontekstit.md
@@ -9,9 +9,9 @@ Virallinen paikannuspohja on se data joka viedään ratkoon ja joka esittää ra
 saatavilla olevan tiedon mukaan. Jos joku käsite on kerran ollut virallisessa paikannuspohjassa, se ei ikinä enää poistu
 täydellisesti vaan sen poistot tehdään nk. soft deletenä, eli asettamalla ne "poistettu" (Deleted) tilaan.
 
-## Luonnos paikannuspohja (Draft Layout)
+## Luonnospaikannuspohja (Draft Layout)
 
-Luonnos paikannuspohja on työtila jossa paikannuspohjaan voidaan tehdä muutoksia: uusien käsitteiden luontia ja
+Luonnospaikannuspohja on työtila jossa paikannuspohjaan voidaan tehdä muutoksia: uusien käsitteiden luontia ja
 olemassaolevien muokkauksia. Koska luonnos on oma kontekstinsa, mikään muutos siellä ei vaikuta viralliseen
 paikannuspohjaan suoraan.
 
@@ -30,9 +30,9 @@ olevaan käsitteeseen.
 ## Suunniteltu paikannupohja (Planned Layout)
 
 Suunniteltuja paikannuspohjia voi olla monta, sillä ne koostuvat erillisistä suunnitelmista jotka tarjoavat itsenäiset
-joukot suunniteltuja muutoksia. Käyttäjän kannalta ne toimivat pitkälti kuten luonnos paikannuspohja, mutta ne
+joukot suunniteltuja muutoksia. Käyttäjän kannalta ne toimivat pitkälti kuten luonnospaikannuspohja, mutta ne
 ovat kukin omia erillisiä kontekstejaan. Suunniteltu paikannuspohja rakentuu aina virallisen paikannuspohjan päälle,
-eikä siis ole mitenkään tietoinen varsinaisen paikannupohjan luonnos kontekstista.
+eikä siis ole mitenkään tietoinen varsinaisen paikannupohjan luonnoskontekstista.
 
 Suunnitelmilla on myös omat luonnosversionsa ja niistä tehdään omia julkaisujaan, jotka siis menevät julkaistuksi
 suunnitelmaksi, ei varsinaiseen paikannuspohjaan. Vasta julkaistu suunnitelma viedään Ratkoon suunniltuina käsitteinä,
@@ -48,11 +48,11 @@ Sekä virallisen paikannuspohjan että suunnitelmien muutokset tehdään aina lu
 valmistuminenkin on virallisen paikannuspohjan muutos ja menee luonnoksen kautta. Mahdollisia siirtymiä kontekstien
 välillä ovat siis:
 
--   Virallinen paikannuspohja -> Luonnos paikannuspohja (luonnos muutos)
--   Luonnos paikannuspohja -> Virallinen paikannuspohja (paikannuspohjan julkaisu)
--   Virallinen paikannuspohja -> Luonnos suunnitelma (suunniteltu muutos)
--   Luonnos suunnitelma -> Julkaistu suunnitelma (suunnitelman julkaisu)
--   Julkaistu suunnitelma -> Luonnos paikannuspohja (suunnitelman valmistuminen)
+-   Virallinen paikannuspohja -> Luonnospaikannuspohja (luonnosmuutos)
+-   Luonnospaikannuspohja -> Virallinen paikannuspohja (paikannuspohjan julkaisu)
+-   Virallinen paikannuspohja -> Luonnossuunnitelma (suunniteltu muutos)
+-   Luonnossuunnitelma -> Julkaistu suunnitelma (suunnitelman julkaisu)
+-   Julkaistu suunnitelma -> Luonnospaikannuspohja (suunnitelman valmistuminen)
 
 ## ID käsittely ja viittaukset kontekstien välillä
 
@@ -86,14 +86,14 @@ Alla oleva taulukko kuvaa eri kontekstien esitystavat tietokannan sarakkeissa, s
 | Konteksti                 | Virallinen ID                                | draft | design_id | official_row_id | design_row_id |
 |---------------------------|----------------------------------------------|-------|-----------|-----------------|---------------|
 | Virallinen paikannuspohja | id                                           | false | null      | null            | null          |
-| Luonnos paikannuspohja    | coalesce(official_row_id, id)                | true  | null      | X / null        | X / null      |
+| Luonnospaikannuspohja     | coalesce(official_row_id, design_row_id, id) | true  | null      | X / null        | X / null      |
 | Julkaistu suunnitelma     | coalesce(official_row_id, id)                | false | X         | X / null        | null          |
-| Luonnos suunnitelma       | coalesce(official_row_id, design_row_id, id) | false | X         | X / null        | X / null      |
+| Luonnossuunnitelma        | coalesce(official_row_id, design_row_id, id) | false | X         | X / null        | X / null      |
 
 #### Virallinen paikannuspohja
 - Virallinen käsite ei voi koskaan viitata muihin konteksteihin, eikä siihen voi liittyä suunnitelmaa
  
-#### Luonnos paikannuspohja
+#### Luonnospaikannuspohja
 - Jos official_row_id on määritelty, kyseessä on luonnosmuutos, muutoin kyseessä on uusi luonnos
 - Jos design_row_id on määritelty, draft on luotu toteuttamalla se suunnitelmasta
   - Julkaisun yhteydessä sekä suunnitelmarivi että luonnosrivi poistuu, sillä kyse on suunnitelman valmistumisesta
@@ -101,7 +101,7 @@ Alla oleva taulukko kuvaa eri kontekstien esitystavat tietokannan sarakkeissa, s
 #### Julkaistu suunnitelma
 - Jos official_row_id on määritelty, kyseessä on muutossuunnitelma. Muutoin kyseessä on uuden olion suunnitelma.
  
-#### Luonnos suunnitelma
+#### Luonnossuunnitelma
 - Jos design_row_id on määritelty, kyseessä on luonnosmuutos olemassaolevaan suunnitelmaan, muutoin kyseessä on uusi luonnos
 - Jos official_row_id on määritelty, kyseessä on suunniteltu muutos viralliseen paikannuspohjaan, muutoin kyseessä on uuden käsitteen suunnitelma
 - Huom. kaikki yhdistelmät official_row_id:n ja design_row_id:n kanssa ovat mahdollisia:
@@ -115,9 +115,9 @@ Alla oleva taulukko kuvaa eri kontekstien esitystavat tietokannan sarakkeissa, s
 ```mermaid
 graph TD
     subgraph legendColor [Värikoodit]
-        legendDraft(Luonnos paikannuspohja)
+        legendDraft(Luonnospaikannuspohja)
         legendOfficial(Virallinen paikannuspohja)
-legendDraftPlan(Luonnos suunnitelma)
+legendDraftPlan(Luonnossuunnitelma)
         legendPlan(Julkaistu suunnitelma)
         legendDraft ~~~ legendOfficial ~~~ legendDraftPlan ~~~ legendPlan
     end
@@ -125,9 +125,9 @@ legendDraftPlan(Luonnos suunnitelma)
         legendOfficialId("Virallinen ID\n❖ id=x")
     end
     subgraph legendLine [Viivat]
-        A -- Viite olioiden välillä --> B
-        Cv1 == Olio siirtyy ==> Cv2
-        D -. Olion data kopioidaan .-> E
+        A -- Viite olioiden välillä\n(yhtenäinen viiva) --> B
+        Cv1 == Olion kantarivi säilyy\n(katkoviiva) ==> Cv2
+        D -. Olion data kopioidaan toiselle riville\n(pisteviiva) .-> E
     end
     classDef draftObject fill: lightyellow, stroke: black, color: black;
     classDef officialObject fill: lightgreen, stroke: black, color: black;
@@ -220,7 +220,7 @@ graph TD
         track1InEnd --> officialTnInEnd
         track2InEnd --> officialTnInEnd
     end
-    startState == Luonnos muutos:\nViralliset oliot eivät muutu ==> draftState == Julkaisu:\nVirallinen olio päivittyy\nLuonnosolio poistuu ==> endState
+    startState == Luonnosmuutos:\nViralliset oliot eivät muutu ==> draftState == Julkaisu:\nVirallinen olio päivittyy\nLuonnosolio poistuu ==> endState
     officialTnInStart ====> officialTnInDraft ====> officialTnInEnd
     draftTnInDraft -. Luonnosdata kopioidaan\nalkuperäiseen olioon .-> officialTnInEnd
     classDef draftObject fill: lightyellow, stroke: black, color: black;
@@ -302,7 +302,7 @@ graph TD
         track3InEnd --> officialTnInEnd
     end
     planTnInPlanDraft ====> planTnInPlan ====> planTnInDraft ====> officialTnInEnd
-    planDraftState == Suunnitelman julkaisu:\nLuonnosolio muuttuu viralliseksi ==> planState == Luonnos muutos:\nSuunnitelman oliot eivät muutu ==> draftState == Julkaisu:\nSuunnitelmaolio muuttuu viralliseksi\nLuonnos poistuu ==> endState
+    planDraftState == Suunnitelman julkaisu:\nLuonnosolio muuttuu viralliseksi ==> planState == Luonnosmuutos:\nSuunnitelman oliot eivät muutu ==> draftState == Julkaisu:\nSuunnitelmaolio muuttuu viralliseksi\nLuonnos poistuu ==> endState
     planTnInPlan -. Suunnitelmadata kopioidaan\nluonnosolioon .-> draftTnInDraft
     draftTnInDraft -. Luonnosdata kopioidaan\nsuunnitelmaolioon .-> officialTnInEnd
     classDef draftObject fill: lightyellow, stroke: black, color: black;
@@ -404,7 +404,7 @@ graph TD
         track3InEnd --> officialTnInEnd
         track4InEnd --> officialTnInEnd
     end
-    startState == Suunniteltu luonnosmuutos:\nViralliset oliot eivät muutu ==> planDraftState == Suunnitelman julkaisu:\nViralliset oliot eivät muutu ==> planState == Luonnos muutos:\nSuunnitelman oliot eivät muutu ==> draftState == Julkaisu:\nVirallinen olio päivittyy\nLuonnos ja suunnitelmaolio poistuu ==> endState
+    startState == Suunniteltu luonnosmuutos:\nViralliset oliot eivät muutu ==> planDraftState == Suunnitelman julkaisu:\nViralliset oliot eivät muutu ==> planState == Luonnosmuutos:\nSuunnitelman oliot eivät muutu ==> draftState == Julkaisu:\nVirallinen olio päivittyy\nLuonnos ja suunnitelmaolio poistuu ==> endState
     officialTnInStart ====> officialTnInPlanDraft ====> officialTnInPlan ====> officialTnInDraft ====> officialTnInEnd
     planTnInPlanDraft ====>  planTnInPlan ====> planTnInDraft
     planTnInPlan -. Suunnitelmadata kopioidaan\nluonnosolioon .-> draftTnInDraft

--- a/doc/paikannuspohjan_kontekstit.md
+++ b/doc/paikannuspohjan_kontekstit.md
@@ -79,6 +79,37 @@ kontekstit huomioiden. Huomattavaa on, että ensimmäisenä syntynyt olio (tieto
 viralliseen paikannuspohjaan, mutta muokattaessa muutokset tehdään kopioon, josta data kopioidaan alkuperäiselle
 julkaisussa. Tämä varmistaa että virallinen ID säilyy muita viittaajia varten kaikissa ketjuissa.
 
+
+### Käsitteiden viitteet ja kontekstin esitys tietokannassa
+Alla oleva taulukko kuvaa eri kontekstien esitystavat tietokannan sarakkeissa, sekä virallisen ID:n määräytymisen.
+
+| Konteksti                 | Virallinen ID                                | draft | design_id | official_row_id | design_row_id |
+|---------------------------|----------------------------------------------|-------|-----------|-----------------|---------------|
+| Virallinen paikannuspohja | id                                           | false | null      | null            | null          |
+| Luonnos paikannuspohja    | coalesce(official_row_id, id)                | true  | null      | X / null        | X / null      |
+| Julkaistu suunnitelma     | coalesce(official_row_id, id)                | false | X         | X / null        | null          |
+| Luonnos suunnitelma       | coalesce(official_row_id, design_row_id, id) | false | X         | X / null        | X / null      |
+
+#### Virallinen paikannuspohja
+- Virallinen käsite ei voi koskaan viitata muihin konteksteihin, eikä siihen voi liittyä suunnitelmaa
+ 
+#### Luonnos paikannuspohja
+- Jos official_row_id on määritelty, kyseessä on luonnosmuutos, muutoin kyseessä on uusi luonnos
+- Jos design_row_id on määritelty, draft on luotu toteuttamalla se suunnitelmasta
+  - Julkaisun yhteydessä sekä suunnitelmarivi että luonnosrivi poistuu, sillä kyse on suunnitelman valmistumisesta
+
+#### Julkaistu suunnitelma
+- Jos official_row_id on määritelty, kyseessä on muutossuunnitelma. Muutoin kyseessä on uuden olion suunnitelma.
+ 
+#### Luonnos suunnitelma
+- Jos design_row_id on määritelty, kyseessä on luonnosmuutos olemassaolevaan suunnitelmaan, muutoin kyseessä on uusi luonnos
+- Jos official_row_id on määritelty, kyseessä on suunniteltu muutos viralliseen paikannuspohjaan, muutoin kyseessä on uuden käsitteen suunnitelma
+- Huom. kaikki yhdistelmät official_row_id:n ja design_row_id:n kanssa ovat mahdollisia:
+  - Uusi luonnossuunnitelma uudelle raiteelle: ei kumpaakaan määritelty
+  - Uusi luonnossuunnitelma olemassaolevalle raiteelle: vain official_row_id määritelty
+  - Muokattu luonnossuunnitelma uudelle raiteelle: vain design_row_id määritelty
+  - Muokattu luonnossuunitelma olemassaolevalle raiteelle: molemmat määritelty
+
 ### Kaavioiden merkinnät
 
 ```mermaid


### PR DESCRIPTION
Lisätty: 

- Design-Draft konteksti-siirtymien kuviin. Näistä tuli mermaidissa entistä rumempia mutta ei nyt ihan lukukelvottomia.
- Kuvaus kontekstien tietokantaesityksestä
