### PR TITLE
GVT-2659 Optimize fetchVersions(), disable postgresql JIT

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -24,6 +24,11 @@ fun idOrIdsEqualSqlFragment(fetchType: FetchType) = when (fetchType) {
     SINGLE -> "= :id"
 }
 
+fun idOrIdsSqlFragment(fetchType: FetchType) = when (fetchType) {
+    MULTI -> "unnest (array[:ids])"
+    SINGLE -> "(values (:id))"
+}
+
 enum class LayoutAssetTable(val dbTable: DbTable, layoutContextFunction: String) {
     LAYOUT_ASSET_TRACK_NUMBER(DbTable.LAYOUT_TRACK_NUMBER, "track_number_in_layout_context"),
     LAYOUT_ASSET_REFERENCE_LINE(DbTable.LAYOUT_REFERENCE_LINE, "reference_line_in_layout_context"),

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
       connection-timeout: 10000
       leak-detection-threshold: 60000
       validation-timeout: 5000
+      connection-init-sql: "set jit=off;"
   jdbc:
     template:
       query-timeout: 15


### PR DESCRIPTION
Varsinainen alkuperäinen ajatus: Nyt kun [GVT-2629](https://extranet.vayla.fi/jira/browse/GVT-2629) on sisässä, [GVT-2630](https://extranet.vayla.fi/jira/browse/GVT-2630) toteutuksen voi viedä loppuun asti: Koska annettujen id:den voi olettaa nyt olevan virallisia, haussa ei tarvitse enää erikseen vaihetta, missä virallinen id haetaan.

Mutta kesän aikana tähän asti tuntemattomasta syystä sekä optimoituun että optimoimattomaan hakuun on pesiytynyt uusi ongelma: Postgressin hakujen JIT-kääntäminen tarttuu nyt näihin hakuihin, ja turhaan, koska oikeasti kaikista isoimpiinkin in_layout_context-hakuihin menee varsinaiseen ajoon ehkä 10 millisekuntia, mutta kovimpaan JIT-kääntämiseen 700 millisekuntia.

JIT-kääntämisen disablointi hidastaa hieman isoja monimutkaisia massahakuja, joissa tehdään laskutoimituksia tietokannassa, mutta meillähän ei oikein tehdä sellaisia, ainakaan appiksesta. Eli sen voi surutta kytkeä pois päältä.

(enemmän tausta-asiaa:

Ongelman takana on *osittain* in_layout_context-funktioiden toteutukseen https://github.com/finnishtransportagency/geoviite/pull/1276 -pullarissa tehty jekku: Jos in_layout_context-funktiolle antaa official_id_in-argumentin, niin postgres osaa *ajon* aikana välttää kokonaan sen UNION ALLin haaran ajon, missä on ehtona `where official_id_in is null`; mutta *suunnittelun* aikana se ei sitä osaa tehdä, vaan olettaa että hausta tulee ulos kaikki taulun rivit, ja siksi luulee hakua paljon todellisuutta kalliimmaksi, ja siksi päätyy tekemään JIT-kääntöä. Kts. https://www.postgresql.org/message-id/54F119A6.9080106%40agliodbs.com . Tämä ongelma vie hakujen hinta-arviot niin kuuseen, että postgres asettaa kaikki optimointiasetukset päälle, ja tähän menee se 0.7 sekuntia minun koneella.

Nuo in_layout_context-funktiot on mahdollista toteuttaa myös niin, että kaksi- ja kolmiparametriset versiot ovat erillisiä, ja kolmiparametrinen, ts. se, jolle annetaan official_id_in, ei sisällä lainkaan haaraa, joka hakisi koko taulun sisällön, jos official_id_iniä ei ole annettu. Tämä selkeyttää kyllä postgressille funktion toimintaa jonkin verran, mutta siltikin JIT-kääntö hidastaa asioita, tosin tällöin ero on ennemmin sellainen, että ilman kääntöä isoon ajoon menee 10 millisekuntia, käännön kanssa 50. Helpompi siis vaan olla tekemättä JITtiä, eritoten koska tuosta erottelustahan tulisi aika hirvittävää toisteisuutta.)