### PR TITLE
GVT-2516 Muutosten yhdistäminen suunnitelmasta mainiin, take 1

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
@@ -1,10 +1,7 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.common.DomainId
-import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.geometry.PlanPhase
 import fi.fta.geoviite.infra.util.FreeText
-import java.time.Instant
 import java.time.LocalDate
 
 enum class DesignState {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -678,6 +678,15 @@ class LocationTrackService(
             track to alignment
         }
     }
+
+    override fun mergeToMainBranch(fromBranch: LayoutBranch, id: IntId<LocationTrack>): DaoResponse<LocationTrack> {
+        val (versions, track) = fetchAndCheckVersionsForMerging(fromBranch, id)
+        return mergeToMainBranchInternal(
+            versions, if (track.alignmentVersion == null) track else {
+                track.copy(alignmentVersion = alignmentService.saveAsNew(alignmentDao.fetch(track.alignmentVersion)))
+            }
+        )
+    }
 }
 
 fun collectAllSwitches(locationTrack: LocationTrack, alignment: LayoutAlignment): List<IntId<TrackLayoutSwitch>> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -211,6 +211,15 @@ class ReferenceLineService(
     fun listNear(layoutContext: LayoutContext, bbox: BoundingBox): List<ReferenceLine> {
         return dao.fetchVersionsNear(layoutContext, bbox).map(dao::fetch)
     }
+
+    override fun mergeToMainBranch(fromBranch: LayoutBranch, id: IntId<ReferenceLine>): DaoResponse<ReferenceLine> {
+        val (versions, line) = fetchAndCheckVersionsForMerging(fromBranch, id)
+        return mergeToMainBranchInternal(
+            versions, if (line.alignmentVersion == null) line else {
+                line.copy(alignmentVersion = alignmentService.saveAsNew(alignmentDao.fetch(line.alignmentVersion)))
+            }
+        )
+    }
 }
 
 fun referenceLineWithAlignment(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -24,6 +24,11 @@ fun idOrIdsEqualSqlFragment(fetchType: FetchType) = when (fetchType) {
     SINGLE -> "= :id"
 }
 
+fun idOrIdsSqlFragment(fetchType: FetchType) = when (fetchType) {
+    MULTI -> "unnest (array[:ids])"
+    SINGLE -> "(values (:id))"
+}
+
 enum class LayoutAssetTable(val dbTable: DbTable, layoutContextFunction: String) {
     LAYOUT_ASSET_TRACK_NUMBER(DbTable.LAYOUT_TRACK_NUMBER, "track_number_in_layout_context"),
     LAYOUT_ASSET_REFERENCE_LINE(DbTable.LAYOUT_REFERENCE_LINE, "reference_line_in_layout_context"),

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
       connection-timeout: 10000
       leak-detection-threshold: 60000
       validation-timeout: 5000
+      connection-init-sql: "set jit=off;"
   jdbc:
     template:
       query-timeout: 15

--- a/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
@@ -7,6 +7,7 @@ create function layout.track_number_in_layout_context(publication_state_in layou
           (
             row_id      integer,
             official_id integer,
+            design_id   integer,
             draft_id    integer,
             row_version integer,
             external_id varchar(50),
@@ -24,6 +25,7 @@ $$
 select
   row.id as row_id,
   coalesce(row.official_row_id, row.design_row_id, row.id) as official_id,
+  design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,
   row.external_id,

--- a/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
@@ -7,6 +7,7 @@ create function layout.reference_line_in_layout_context(publication_state_in lay
           (
             row_id            integer,
             official_id       integer,
+            design_id         integer,
             draft_id          integer,
             row_version       integer,
             track_number_id   int,
@@ -27,6 +28,7 @@ $$
 select
   row.id as row_id,
   coalesce(official_row_id, design_row_id, row.id) as official_id,
+  design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,
   row.track_number_id,

--- a/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
@@ -7,6 +7,7 @@ create function layout.location_track_in_layout_context(publication_state_in lay
           (
             row_id                             integer,
             official_id                        integer,
+            design_id                          integer,
             draft_id                           integer,
             row_version                        integer,
             alignment_id                       integer,
@@ -38,6 +39,7 @@ $$
 select
   row.id as row_id,
   coalesce(official_row_id, design_row_id, row.id) as official_id,
+  design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,
   row.alignment_id,

--- a/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
@@ -7,6 +7,7 @@ create function layout.switch_in_layout_context(publication_state_in layout.publ
           (
             row_id              integer,
             official_id         integer,
+            design_id           integer,
             draft_id            integer,
             row_version         integer,
             external_id         varchar(50),
@@ -28,6 +29,7 @@ $$
 select
   row.id as row_id,
   coalesce(official_row_id, design_row_id, row.id) as official_id,
+  design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,
   row.external_id,

--- a/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
@@ -7,6 +7,7 @@ create function layout.km_post_in_layout_context(publication_state_in layout.pub
           (
             row_id              integer,
             official_id         integer,
+            design_id           integer,
             draft_id            integer,
             row_version         integer,
             track_number_id     integer,
@@ -25,6 +26,7 @@ $$
 select
   row.id as row_id,
   coalesce(official_row_id, design_row_id, row.id) as official_id,
+  design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,
   row.track_number_id,

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1206,6 +1206,7 @@
     "preview-view": {
         "unstaged-changes-title": "Muutokset ({{amount}} kpl)",
         "staged-changes-title": "Julkaistavat muutokset ({{amount}} kpl)",
+        "merging-to-main-changes-title": "Valitut muutokset ({{amount}} kpl)",
         "show-only-mine": "Näytä vain omat muutokset ({{amount}} kpl)",
         "map-crop": "Rajaa kartalta",
         "track-address-changes": "Rataosoitemuutokset",
@@ -1213,7 +1214,8 @@
         "disabled-message": "(Rataosoitemuutoksia ei voi laskea)",
         "location-tracks": "Sijaintiraiteet",
         "switches": "Vaihteet",
-        "no-calculated-changes-text": "Ei rataosoitemuutoksia"
+        "no-calculated-changes-text": "Ei rataosoitemuutoksia",
+        "design-has-design-drafts-error": "Suunnitelmaan liittyy hyväksymättömiä muutoksia. Vain hyväksytyt muutokset voi siirtää luonnostilaan.  Voit käydä hyväksymässä suunnitelman muutokset <actionLink>täällä</actionLink>."
     },
     "preview-table": {
         "change-target": "Muutoskohde",
@@ -1246,6 +1248,13 @@
         "publish-confirm": {
             "title": "Julkaise muutokset",
             "description": "Syötä vielä muutoksia kuvaava selite. Julkaisun jälkeen Geoviite lähettää muutokset automaattisesti Ratkoon.",
+            "cancel": "Peruuta",
+            "message": "Selite",
+            "confirm": "Julkaise muutokset ({{candidates}} kpl)"
+        },
+        "merge-to-main-confirm": {
+            "title": "Siirrä muutokset luonnostilaan",
+            "description": "Haluatko siirtää suunnitelman {{design}} tehdyt muutokset ({{candidateCount}} kpl) luonnostilaan?",
             "cancel": "Peruuta",
             "message": "Selite",
             "confirm": "Julkaise muutokset ({{candidates}} kpl)"

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -72,11 +72,11 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun noPublicationCandidatesFoundWithoutDrafts() {
-        assertTrue(publicationDao.fetchTrackNumberPublicationCandidates(LayoutBranch.main).isEmpty())
-        assertTrue(publicationDao.fetchReferenceLinePublicationCandidates(LayoutBranch.main).isEmpty())
-        assertTrue(publicationDao.fetchLocationTrackPublicationCandidates(LayoutBranch.main).isEmpty())
-        assertTrue(publicationDao.fetchSwitchPublicationCandidates(LayoutBranch.main).isEmpty())
-        assertTrue(publicationDao.fetchKmPostPublicationCandidates(LayoutBranch.main).isEmpty())
+        assertTrue(publicationDao.fetchTrackNumberPublicationCandidates(PublicationInMain).isEmpty())
+        assertTrue(publicationDao.fetchReferenceLinePublicationCandidates(PublicationInMain).isEmpty())
+        assertTrue(publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain).isEmpty())
+        assertTrue(publicationDao.fetchSwitchPublicationCandidates(PublicationInMain).isEmpty())
+        assertTrue(publicationDao.fetchKmPostPublicationCandidates(PublicationInMain).isEmpty())
     }
 
     @Test
@@ -86,7 +86,7 @@ class PublicationDaoIT @Autowired constructor(
         val (_, draft) = insertAndCheck(
             asMainDraft(line).copy(startAddress = TrackMeter("0123", 658.321, 3))
         )
-        val candidates = publicationDao.fetchReferenceLinePublicationCandidates(LayoutBranch.main)
+        val candidates = publicationDao.fetchReferenceLinePublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(line.id, candidates.first().id)
         assertEquals(draft.trackNumberId, candidates.first().trackNumberId)
@@ -100,7 +100,7 @@ class PublicationDaoIT @Autowired constructor(
         val (_, draft) = insertAndCheck(
             asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT"))
         )
-        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(LayoutBranch.main)
+        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
         assertEquals(draft.name, candidates.first().name)
@@ -113,7 +113,7 @@ class PublicationDaoIT @Autowired constructor(
     fun switchPublicationCandidatesAreFound() {
         val (_, switch) = insertAndCheck(switch(987, draft = false))
         val (_, draft) = insertAndCheck(asMainDraft(switch).copy(name = SwitchName("${switch.name} DRAFT")))
-        val candidates = publicationDao.fetchSwitchPublicationCandidates(LayoutBranch.main)
+        val candidates = publicationDao.fetchSwitchPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(switch.id, candidates.first().id)
         assertEquals(draft.name, candidates.first().name)
@@ -124,7 +124,7 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun createOperationIsInferredCorrectly() {
         val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = true))
-        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(LayoutBranch.main)
+        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
         assertEquals(Operation.CREATE, candidates.first().operation)
@@ -141,7 +141,7 @@ class PublicationDaoIT @Autowired constructor(
                 lt.copy(name = AlignmentName("${lt.name} TEST"))
             },
         )
-        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(LayoutBranch.main)
+        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
         assertEquals(Operation.MODIFY, candidates.first().operation)
@@ -157,7 +157,7 @@ class PublicationDaoIT @Autowired constructor(
             locationTrackService.getOrThrow(MainLayoutContext.official, draft.id as IntId)
                 .copy(state = LocationTrackState.DELETED),
         )
-        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(LayoutBranch.main)
+        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
         assertEquals(Operation.DELETE, candidates.first().operation)
@@ -178,7 +178,7 @@ class PublicationDaoIT @Autowired constructor(
             locationTrackService.getOrThrow(MainLayoutContext.official, draft.id as IntId)
                 .copy(state = LocationTrackState.IN_USE),
         )
-        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(LayoutBranch.main)
+        val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
         assertEquals(Operation.RESTORE, candidates.first().operation)
@@ -268,7 +268,7 @@ class PublicationDaoIT @Autowired constructor(
         )
         insertAndCheck(asMainDraft(switch.copy(name = SwitchName("FooEdited"))))
 
-        val publicationCandidates = publicationDao.fetchSwitchPublicationCandidates(LayoutBranch.main)
+        val publicationCandidates = publicationDao.fetchSwitchPublicationCandidates(PublicationInMain)
         val editedCandidate = publicationCandidates.first { s -> s.name == SwitchName("FooEdited") }
         assertEquals(editedCandidate.trackNumberIds, listOf(trackNumberId))
     }
@@ -286,7 +286,7 @@ class PublicationDaoIT @Autowired constructor(
                 )
             )
         )
-        val publicationCandidates = publicationDao.fetchSwitchPublicationCandidates(LayoutBranch.main)
+        val publicationCandidates = publicationDao.fetchSwitchPublicationCandidates(PublicationInMain)
         val editedCandidate = publicationCandidates.first { s -> s.name == SwitchName("Foo") }
         assertEquals(editedCandidate.trackNumberIds, listOf(trackNumberId))
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
@@ -1,0 +1,174 @@
+package fi.fta.geoviite.infra.tracklayout
+
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.util.FreeText
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class LayoutAssetServiceIT @Autowired constructor(
+    private val layoutTrackNumberService: LayoutTrackNumberService,
+    private val layoutReferenceLineService: ReferenceLineService,
+    private val layoutLocationTrackService: LocationTrackService,
+    private val layoutSwitchService: LayoutSwitchService,
+    private val layoutKmPostService: LayoutKmPostService,
+) : DBTestBase() {
+
+    @BeforeEach
+    fun cleanup() {
+        testDBService.clearLayoutTables()
+    }
+
+    @Test
+    fun `objects with alignments can be merged to main-draft and then deleted from main-draft`() {
+        val someDesignBranch = testDBService.createDesignBranch()
+        val designOfficialContext = testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
+
+        val trackNumberId = designOfficialContext.insert(trackNumber()).id
+        val referenceLineId = designOfficialContext.insert(referenceLineAndAlignment(trackNumberId)).id
+        val locationTrackId = designOfficialContext.insert(locationTrackAndAlignment(trackNumberId)).id
+
+        layoutTrackNumberService.mergeToMainBranch(someDesignBranch, trackNumberId)
+        layoutReferenceLineService.mergeToMainBranch(someDesignBranch, referenceLineId)
+        layoutLocationTrackService.mergeToMainBranch(someDesignBranch, locationTrackId)
+
+        layoutLocationTrackService.deleteDraft(LayoutBranch.main, locationTrackId)
+        layoutReferenceLineService.deleteDraft(LayoutBranch.main, referenceLineId)
+
+        assertNull(mainDraftContext.fetch(locationTrackId))
+        assertNull(mainDraftContext.fetch(referenceLineId))
+    }
+
+    @Test
+    fun `object in design-official can be merged to main-draft`() {
+        val someDesignBranch = testDBService.createDesignBranch()
+        val designOfficialContext = testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
+
+        val trackNumberId = designOfficialContext.insert(trackNumber()).id
+        val referenceLineId = designOfficialContext.insert(referenceLineAndAlignment(trackNumberId)).id
+        val locationTrackId = designOfficialContext.insert(locationTrackAndAlignment(trackNumberId)).id
+        val switchId = designOfficialContext.insert(switch()).id
+        val kmPostId = designOfficialContext.insert(kmPost(trackNumberId, KmNumber(123))).id
+
+        layoutTrackNumberService.mergeToMainBranch(someDesignBranch, trackNumberId)
+        layoutReferenceLineService.mergeToMainBranch(someDesignBranch, referenceLineId)
+        layoutLocationTrackService.mergeToMainBranch(someDesignBranch, locationTrackId)
+        layoutSwitchService.mergeToMainBranch(someDesignBranch, switchId)
+        layoutKmPostService.mergeToMainBranch(someDesignBranch, kmPostId)
+
+        assertNotEquals(trackNumberId.intValue, mainDraftContext.fetch(trackNumberId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(referenceLineId.intValue, mainDraftContext.fetch(referenceLineId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(locationTrackId.intValue, mainDraftContext.fetch(locationTrackId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(switchId.intValue, mainDraftContext.fetch(switchId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(kmPostId.intValue, mainDraftContext.fetch(kmPostId)!!.contextData.rowId!!.intValue)
+
+        assertEquals(trackNumberId.intValue, mainDraftContext.fetch(trackNumberId)!!.contextData.designRowId!!.intValue)
+        assertEquals(referenceLineId.intValue, mainDraftContext.fetch(referenceLineId)!!.contextData.designRowId!!.intValue)
+        assertEquals(locationTrackId.intValue, mainDraftContext.fetch(locationTrackId)!!.contextData.designRowId!!.intValue)
+        assertEquals(switchId.intValue, mainDraftContext.fetch(switchId)!!.contextData.designRowId!!.intValue)
+        assertEquals(kmPostId.intValue, mainDraftContext.fetch(kmPostId)!!.contextData.designRowId!!.intValue)
+
+        assertEquals(trackNumberId.intValue, designOfficialContext.fetch(trackNumberId)!!.contextData.rowId!!.intValue)
+        assertEquals(referenceLineId.intValue, designOfficialContext.fetch(referenceLineId)!!.contextData.rowId!!.intValue)
+        assertEquals(locationTrackId.intValue, designOfficialContext.fetch(locationTrackId)!!.contextData.rowId!!.intValue)
+        assertEquals(switchId.intValue, designOfficialContext.fetch(switchId)!!.contextData.rowId!!.intValue)
+        assertEquals(kmPostId.intValue, designOfficialContext.fetch(kmPostId)!!.contextData.rowId!!.intValue)
+    }
+
+    @Test
+    fun `existing main-draft is overridden when merging object from design-official`() {
+        val someDesignBranch = testDBService.createDesignBranch()
+        val designOfficialContext = testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
+        val designDraftContext = testDBService.testContext(someDesignBranch, PublicationState.DRAFT)
+
+        val trackNumberId = mainOfficialContext.insert(trackNumber()).id
+        val referenceLineId = mainOfficialContext.insert(referenceLineAndAlignment(trackNumberId)).id
+        val locationTrackId = mainOfficialContext.insert(locationTrackAndAlignment(trackNumberId)).id
+        val switchId = mainOfficialContext.insert(switch()).id
+        val kmPostId = mainOfficialContext.insert(kmPost(trackNumberId, KmNumber(123))).id
+
+        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(trackNumberId)!!).copy(description = FreeText("edited in main")))
+        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(referenceLineId)!!).copy(startAddress = TrackMeter("0000+0123")))
+        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(locationTrackId)!!).copy(name = AlignmentName("edited in main")))
+        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(switchId)!!).copy(name = SwitchName("edited in main")))
+        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(kmPostId)!!).copy(kmNumber = KmNumber(123)))
+
+        val designOfficialTrackNumberRowId = designOfficialContext.moveFrom(
+            designDraftContext.insert(
+                asDesignDraft(
+                    mainOfficialContext.fetch(trackNumberId)!!.copy(description = FreeText("edited in design")),
+                    someDesignBranch.designId
+                )
+            ).rowVersion
+        ).rowVersion.rowId
+        val designOfficialReferenceLineRowId = designOfficialContext.moveFrom(
+            designDraftContext.insert(
+                asDesignDraft(
+                    mainOfficialContext.fetch(referenceLineId)!!.copy(startAddress = TrackMeter("0123+0000")),
+                    someDesignBranch.designId
+                )
+            ).rowVersion
+        ).rowVersion.rowId
+        val designOfficialLocationTrackRowId = designOfficialContext.moveFrom(
+            designDraftContext.insert(
+                asDesignDraft(
+                    mainOfficialContext.fetch(locationTrackId)!!.copy(name = AlignmentName("edited in design")),
+                    someDesignBranch.designId
+                )
+            ).rowVersion
+        ).rowVersion.rowId
+        val designOfficialSwitchRowId = designOfficialContext.moveFrom(
+            designDraftContext.insert(
+                asDesignDraft(
+                    mainOfficialContext.fetch(switchId)!!.copy(name = SwitchName("edited in design")),
+                    someDesignBranch.designId
+                )
+            ).rowVersion
+        ).rowVersion.rowId
+        val designOfficialKmPostRowId = designOfficialContext.moveFrom(
+            designDraftContext.insert(
+                asDesignDraft(
+                    mainOfficialContext.fetch(kmPostId)!!.copy(kmNumber = KmNumber(321)),
+                    someDesignBranch.designId
+                )
+            ).rowVersion
+        ).rowVersion.rowId
+
+        layoutTrackNumberService.mergeToMainBranch(someDesignBranch, trackNumberId)
+        layoutReferenceLineService.mergeToMainBranch(someDesignBranch, referenceLineId)
+        layoutLocationTrackService.mergeToMainBranch(someDesignBranch, locationTrackId)
+        layoutSwitchService.mergeToMainBranch(someDesignBranch, switchId)
+        layoutKmPostService.mergeToMainBranch(someDesignBranch, kmPostId)
+
+        assertNotEquals(trackNumberId.intValue, mainDraftContext.fetch(trackNumberId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(referenceLineId.intValue, mainDraftContext.fetch(referenceLineId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(locationTrackId.intValue, mainDraftContext.fetch(locationTrackId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(switchId.intValue, mainDraftContext.fetch(switchId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(kmPostId.intValue, mainDraftContext.fetch(kmPostId)!!.contextData.rowId!!.intValue)
+
+        assertEquals(designOfficialTrackNumberRowId, mainDraftContext.fetch(trackNumberId)!!.contextData.designRowId)
+        assertEquals(designOfficialReferenceLineRowId, mainDraftContext.fetch(referenceLineId)!!.contextData.designRowId)
+        assertEquals(designOfficialLocationTrackRowId, mainDraftContext.fetch(locationTrackId)!!.contextData.designRowId)
+        assertEquals(designOfficialSwitchRowId, mainDraftContext.fetch(switchId)!!.contextData.designRowId)
+        assertEquals(designOfficialKmPostRowId, mainDraftContext.fetch(kmPostId)!!.contextData.designRowId)
+
+        assertEquals("edited in design", mainDraftContext.fetch(trackNumberId)!!.description.toString())
+        assertEquals(123, mainDraftContext.fetch(referenceLineId)!!.startAddress.kmNumber.number)
+        assertEquals("edited in design", mainDraftContext.fetch(locationTrackId)!!.name.toString())
+        assertEquals("edited in design", mainDraftContext.fetch(switchId)!!.name.toString())
+        assertEquals(321, mainDraftContext.fetch(kmPostId)!!.kmNumber.number)
+    }
+}

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -17,7 +17,7 @@ export type AngularUnit = 'RADIANS' | 'GRADS';
 
 export type DataType = 'STORED' | 'TEMP';
 
-export type LayoutDesignId = string;
+export type LayoutDesignId = Brand<string, 'LayoutDesignId'>;
 export type PublicationState = 'OFFICIAL' | 'DRAFT';
 export type LayoutContext = {
     publicationState: PublicationState;

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -67,7 +67,8 @@ const planVerticalGeometryCache = asyncCache<
     PlanVerticalGeometryKey,
     VerticalGeometryItem[] | undefined
 >;
-type LocationTrackVerticalGeometryKey = `${LocationTrackId}_${PublicationState}_${LayoutDesignId}`;
+type LocationTrackVerticalGeometryKey =
+    `${LocationTrackId}_${PublicationState}_${LayoutDesignId | 'undefined'}`;
 const locationTrackVerticalGeometryCache = asyncCache<
     LocationTrackVerticalGeometryKey,
     VerticalGeometryItem[] | undefined
@@ -427,7 +428,7 @@ export async function getLocationTrackHeights(
 }
 
 const locationTrackLinkingSummaryCache = asyncCache<
-    `${LocationTrackId}_${PublicationState}_${LayoutDesignId}`,
+    `${LocationTrackId}_${PublicationState}_${LayoutDesignId | 'undefined'}`,
     PlanLinkingSummaryItem[]
 >();
 

--- a/ui/src/linking/linking-api.ts
+++ b/ui/src/linking/linking-api.ts
@@ -274,11 +274,12 @@ export async function getSuggestedSwitchByPoint(
 }
 
 export async function linkSwitch(
+    layoutBranch: LayoutDesignId | undefined,
     params: SuggestedSwitch,
     switchId: LayoutSwitchId,
 ): Promise<LayoutSwitchId> {
     const result = await postNonNull<SuggestedSwitch, LayoutSwitchId>(
-        linkingUri(undefined, 'switches', 'geometry', switchId),
+        linkingUri(layoutBranch, 'switches', 'geometry', switchId),
         params,
     );
 
@@ -326,10 +327,11 @@ export async function validateLocationTrackSwitchRelinking(
 }
 
 export async function relinkTrackSwitches(
+    layoutBranch: LayoutDesignId | undefined,
     id: LocationTrackId,
 ): Promise<TrackSwitchRelinkingResult[]> {
     const rv = await postNonNull<null, TrackSwitchRelinkingResult[]>(
-        linkingUri(undefined, 'location-tracks', 'relink-switches', id),
+        linkingUri(layoutBranch, 'location-tracks', 'relink-switches', id),
         null,
     );
     await Promise.all([updateSwitchChangeTime(), updateLocationTrackChangeTime()]);

--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -4,8 +4,7 @@ import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Switch } from 'vayla-design-lib/switch/switch';
 import { useTranslation } from 'react-i18next';
 import styles from './preview-view.scss';
-import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
-import { publishPublicationCandidates } from 'publication/publication-api';
+import { mergeCandidatesToMain, publishPublicationCandidates } from 'publication/publication-api';
 import { filterNotEmpty } from 'utils/array-utils';
 import {
     updateKmPostChangeTime,
@@ -14,24 +13,27 @@ import {
     updateSwitchChangeTime,
     updateTrackNumberChangeTime,
 } from 'common/change-time-api';
-import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
 import {
+    LayoutValidationIssue,
     PublicationCandidate,
     PublicationResult,
-    LayoutValidationIssue,
 } from 'publication/publication-model';
 import { OnSelectFunction } from 'selection/selection-model';
-import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
-import { TextArea } from 'vayla-design-lib/text-area/text-area';
-import { draftLayoutContext, LayoutContext, officialLayoutContext } from 'common/common-model';
+import { LayoutContext } from 'common/common-model';
+import { PreviewPublicationConfirmationDialog } from 'preview/preview-publication-confirmation-dialog';
+import { DesignPublicationMode } from 'preview/preview-tool-bar';
+import { PreviewMergeToMainConfirmationDialog } from 'preview/preview-merge-to-main-confirmation-dialog';
+import { MapDisplayTransitionSide } from 'preview/preview-view';
 
 type PreviewFooterProps = {
     onSelect: OnSelectFunction;
     onPublish: () => void;
     layoutContext: LayoutContext;
-    onChangeLayoutContext: (context: LayoutContext) => void;
+    onChangeMapDisplayTransitionSide: (side: MapDisplayTransitionSide) => void;
+    mapDisplayTransitionSide: MapDisplayTransitionSide;
     stagedPublicationCandidates: PublicationCandidate[];
-    validating: boolean;
+    disablePublication: boolean;
+    designPublicationMode: DesignPublicationMode;
 };
 
 function previewChangesCanBePublished(publishCandidates: PublicationCandidate[]) {
@@ -76,11 +78,9 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
     const [publishConfirmVisible, setPublishConfirmVisible] = React.useState(false);
 
     const [isPublishing, setPublishing] = React.useState(false);
-    const [message, setMessage] = React.useState('');
 
-    const publish = () => {
-        setPublishing(true);
-        publishPublicationCandidates(props.stagedPublicationCandidates, message)
+    const publishWith = (publicationPromise: Promise<PublicationResult>) =>
+        publicationPromise
             .then((r) => {
                 Snackbar.success('publish.publish-success', describeResult(r));
                 updateChangeTimes(r);
@@ -90,6 +90,23 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
                 setPublishConfirmVisible(false);
                 setPublishing(false);
             });
+
+    const publish = (message: string) => {
+        setPublishing(true);
+        publishWith(
+            publishPublicationCandidates(
+                props.layoutContext.designId,
+                props.stagedPublicationCandidates,
+                message,
+            ),
+        );
+    };
+
+    const mergeToMain = () => {
+        setPublishing(true);
+        publishWith(
+            mergeCandidatesToMain(props.layoutContext.designId, props.stagedPublicationCandidates),
+        );
     };
 
     const candidateCount = props.stagedPublicationCandidates.length;
@@ -103,7 +120,7 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
                     disabled={
                         candidateCount === 0 ||
                         publishConfirmVisible ||
-                        props.validating ||
+                        props.disablePublication ||
                         (allPublishErrors && allPublishErrors?.length > 0) ||
                         !publishPreviewChanges
                     }>
@@ -113,57 +130,33 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
             <div className={styles['preview-footer__map-toggle']}>
                 <Switch
                     onCheckedChange={(check) =>
-                        props.onChangeLayoutContext(
-                            check
-                                ? draftLayoutContext(props.layoutContext)
-                                : officialLayoutContext(props.layoutContext),
+                        props.onChangeMapDisplayTransitionSide(
+                            check ? 'WITH_CHANGES' : 'BASE_CONTEXT',
                         )
                     }
-                    checked={props.layoutContext.publicationState === 'DRAFT'}>
+                    checked={props.mapDisplayTransitionSide === 'WITH_CHANGES'}>
                     {t('preview-footer.publish-tracklayout')}
                 </Switch>
             </div>
-            {publishConfirmVisible && (
-                <Dialog
-                    title={t('publish.publish-confirm.title')}
-                    variant={DialogVariant.LIGHT}
-                    allowClose={!isPublishing}
-                    onClose={() => setPublishConfirmVisible(false)}
-                    footerContent={
-                        <div className={dialogStyles['dialog__footer-content--centered']}>
-                            <Button
-                                onClick={() => setPublishConfirmVisible(false)}
-                                disabled={candidateCount === 0 || isPublishing}
-                                variant={ButtonVariant.SECONDARY}>
-                                {t('publish.publish-confirm.cancel')}
-                            </Button>
-                            <Button
-                                qa-id={'publication-confirm'}
-                                disabled={isPublishing || message.length === 0}
-                                isProcessing={isPublishing}
-                                onClick={publish}>
-                                {t('publish.publish-confirm.confirm', {
-                                    candidates: candidateCount,
-                                })}
-                            </Button>
-                        </div>
-                    }>
-                    <div className={styles['preview-confirm__description']}>
-                        {t('publish.publish-confirm.description')}
-                    </div>
-                    <FieldLayout
-                        label={`${t('publish.publish-confirm.message')} *`}
-                        value={
-                            <TextArea
-                                qa-id={'publication-message'}
-                                value={message}
-                                wide
-                                onChange={(e) => setMessage(e.currentTarget.value)}
-                            />
-                        }
+            {publishConfirmVisible &&
+                (props.designPublicationMode === 'PUBLISH_CHANGES' ? (
+                    <PreviewPublicationConfirmationDialog
+                        isPublishing={isPublishing}
+                        onCancel={() => setPublishConfirmVisible(false)}
+                        candidateCount={candidateCount}
+                        publish={publish}
                     />
-                </Dialog>
-            )}
+                ) : (
+                    props.layoutContext.designId && (
+                        <PreviewMergeToMainConfirmationDialog
+                            designId={props.layoutContext.designId}
+                            isPublishing={isPublishing}
+                            onCancel={() => setPublishConfirmVisible(false)}
+                            candidateCount={candidateCount}
+                            mergeToMain={mergeToMain}
+                        />
+                    )
+                ))}
         </footer>
     );
 };

--- a/ui/src/preview/preview-merge-to-main-confirmation-dialog.tsx
+++ b/ui/src/preview/preview-merge-to-main-confirmation-dialog.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import styles from './preview-view.scss';
+import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
+import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { useTranslation } from 'react-i18next';
+import { getLayoutDesign } from 'track-layout/layout-design-api';
+import { useLoader } from 'utils/react-utils';
+import { LayoutDesignId } from 'common/common-model';
+import { getChangeTimes } from 'common/change-time-api';
+
+export type PreviewMergeToMainConfirmationDialogProps = {
+    designId: LayoutDesignId;
+    isPublishing: boolean;
+    onCancel: () => void;
+    candidateCount: number;
+    mergeToMain: () => void;
+};
+
+export const PreviewMergeToMainConfirmationDialog: React.FC<
+    PreviewMergeToMainConfirmationDialogProps
+> = ({ designId, isPublishing, onCancel, candidateCount, mergeToMain }) => {
+    const { t } = useTranslation();
+    const design =
+        useLoader(() => getLayoutDesign(getChangeTimes().layoutDesign, designId), [designId])
+            ?.name ?? '';
+
+    return (
+        <Dialog
+            title={t('publish.merge-to-main-confirm.title')}
+            variant={DialogVariant.LIGHT}
+            allowClose={!isPublishing}
+            onClose={onCancel}
+            footerContent={
+                <div className={dialogStyles['dialog__footer-content--centered']}>
+                    <Button
+                        onClick={onCancel}
+                        disabled={candidateCount === 0 || isPublishing}
+                        variant={ButtonVariant.SECONDARY}>
+                        {t('publish.merge-to-main-confirm.cancel')}
+                    </Button>
+                    <Button
+                        qa-id={'publication-confirm'}
+                        disabled={isPublishing}
+                        isProcessing={isPublishing}
+                        onClick={mergeToMain}>
+                        {t('publish.merge-to-main-confirm.confirm', {
+                            candidates: candidateCount,
+                        })}
+                    </Button>
+                </div>
+            }>
+            <div className={styles['preview-confirm__description']}>
+                {t('publish.merge-to-main-confirm.description', { design, candidateCount })}
+            </div>
+        </Dialog>
+    );
+};

--- a/ui/src/preview/preview-publication-confirmation-dialog.tsx
+++ b/ui/src/preview/preview-publication-confirmation-dialog.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import styles from './preview-view.scss';
+import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
+import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
+import { TextArea } from 'vayla-design-lib/text-area/text-area';
+import { useTranslation } from 'react-i18next';
+
+export type PreviewPublicationDialogProps = {
+    isPublishing: boolean;
+    onCancel: () => void;
+    candidateCount: number;
+    publish: (message: string) => void;
+};
+
+export const PreviewPublicationConfirmationDialog: React.FC<PreviewPublicationDialogProps> = ({
+    isPublishing,
+    onCancel,
+    candidateCount,
+    publish,
+}) => {
+    const { t } = useTranslation();
+    const [message, setMessage] = React.useState('');
+
+    return (
+        <Dialog
+            title={t('publish.publish-confirm.title')}
+            variant={DialogVariant.LIGHT}
+            allowClose={!isPublishing}
+            onClose={onCancel}
+            footerContent={
+                <div className={dialogStyles['dialog__footer-content--centered']}>
+                    <Button
+                        onClick={onCancel}
+                        disabled={candidateCount === 0 || isPublishing}
+                        variant={ButtonVariant.SECONDARY}>
+                        {t('publish.publish-confirm.cancel')}
+                    </Button>
+                    <Button
+                        qa-id={'publication-confirm'}
+                        disabled={isPublishing || message.length === 0}
+                        isProcessing={isPublishing}
+                        onClick={() => publish(message)}>
+                        {t('publish.publish-confirm.confirm', {
+                            candidates: candidateCount,
+                        })}
+                    </Button>
+                </div>
+            }>
+            <div className={styles['preview-confirm__description']}>
+                {t('publish.publish-confirm.description')}
+            </div>
+            <FieldLayout
+                label={`${t('publish.publish-confirm.message')} *`}
+                value={
+                    <TextArea
+                        qa-id={'publication-message'}
+                        value={message}
+                        wide
+                        onChange={(e) => setMessage(e.currentTarget.value)}
+                    />
+                }
+            />
+        </Dialog>
+    );
+};

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -34,6 +34,7 @@ export type PreviewTableItemProps = {
     displayedTotalPublicationAssetAmount: number;
     onShowOnMap: (bbox: BoundingBox) => void;
     isValidating: (item: PreviewTableEntry) => boolean;
+    canRevertChanges: boolean;
 };
 
 export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
@@ -45,6 +46,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     displayedTotalPublicationAssetAmount,
     onShowOnMap,
     isValidating,
+    canRevertChanges,
 }) => {
     const { t } = useTranslation();
     const [isErrorRowExpanded, setIsErrorRowExpanded] = React.useState(false);
@@ -158,9 +160,19 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         menuDivider(),
         menuOptionShowOnMap,
         menuDivider(),
-        ...conditionalMenuOption(!tableEntry.publicationGroup, menuOptionRevertSingleChange),
-        ...conditionalMenuOption(tableEntry.publicationGroup, menuOptionPublicationGroupRevert),
-        menuOptionRevertAllShownChanges,
+        ...(canRevertChanges
+            ? [
+                  ...conditionalMenuOption(
+                      !tableEntry.publicationGroup,
+                      menuOptionRevertSingleChange,
+                  ),
+                  ...conditionalMenuOption(
+                      tableEntry.publicationGroup,
+                      menuOptionPublicationGroupRevert,
+                  ),
+                  menuOptionRevertAllShownChanges,
+              ]
+            : []),
     ];
 
     return (

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -69,6 +69,7 @@ type PreviewTableProps = {
     previewOperations: PreviewOperations;
     validationInProgress: boolean;
     isRowValidating: (tableEntry: PreviewTableEntry) => boolean;
+    canRevertChanges: boolean;
 };
 
 const PreviewTable: React.FC<PreviewTableProps> = ({
@@ -83,6 +84,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
     onShowOnMap,
     validationInProgress,
     isRowValidating,
+    canRevertChanges,
 }) => {
     const { t } = useTranslation();
     const trackNumbers =
@@ -211,6 +213,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
                                         displayedTotalPublicationAssetAmount
                                     }
                                     isValidating={isRowValidating}
+                                    canRevertChanges={canRevertChanges}
                                 />
                             }
                         </React.Fragment>

--- a/ui/src/preview/preview-tool-bar.tsx
+++ b/ui/src/preview/preview-tool-bar.tsx
@@ -6,17 +6,17 @@ import { LayoutDesignId } from 'common/common-model';
 import { Radio } from 'vayla-design-lib/radio/radio';
 import styles from './preview-view.scss';
 
-type DesignPublicationMode = 'PUBLISH_CHANGES' | 'DESIGN_TO_DRAFT';
+export type DesignPublicationMode = 'PUBLISH_CHANGES' | 'MERGE_TO_MAIN';
 
 export type PreviewToolBarParams = {
     onClosePreview: () => void;
     designId: LayoutDesignId | undefined;
+    designPublicationMode: DesignPublicationMode;
+    onChangeDesignPublicationMode: (mode: DesignPublicationMode) => void;
 };
 
 export const PreviewToolBar: React.FC<PreviewToolBarParams> = (props: PreviewToolBarParams) => {
     const { t } = useTranslation();
-    const [designPublicationMode, setDesignPublicationMode] =
-        React.useState<DesignPublicationMode>('PUBLISH_CHANGES');
 
     const showingDesignProject = !!props.designId;
     const className = createClassName(
@@ -33,13 +33,13 @@ export const PreviewToolBar: React.FC<PreviewToolBarParams> = (props: PreviewToo
                 {showingDesignProject && (
                     <span className={styles['preview-tool-bar__radio-buttons']}>
                         <Radio
-                            checked={designPublicationMode === 'PUBLISH_CHANGES'}
-                            onChange={() => setDesignPublicationMode('PUBLISH_CHANGES')}>
+                            checked={props.designPublicationMode === 'PUBLISH_CHANGES'}
+                            onChange={() => props.onChangeDesignPublicationMode('PUBLISH_CHANGES')}>
                             {t('preview-toolbar.publish-changes')}
                         </Radio>
                         <Radio
-                            checked={designPublicationMode === 'DESIGN_TO_DRAFT'}
-                            onChange={() => setDesignPublicationMode('DESIGN_TO_DRAFT')}>
+                            checked={props.designPublicationMode === 'MERGE_TO_MAIN'}
+                            onChange={() => props.onChangeDesignPublicationMode('MERGE_TO_MAIN')}>
                             {t('preview-toolbar.design-to-draft')}
                         </Radio>
                     </span>

--- a/ui/src/preview/preview-view-design-drafts-exist-error.tsx
+++ b/ui/src/preview/preview-view-design-drafts-exist-error.tsx
@@ -1,0 +1,31 @@
+import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'vayla-design-lib/link/link';
+import * as React from 'react';
+
+export type DesignDraftsExistErrorProps = { goToPublishChangesMode: () => void };
+
+export const DesignDraftsExistError: React.FC<DesignDraftsExistErrorProps> = ({
+    goToPublishChangesMode,
+}) => {
+    const { t } = useTranslation();
+    const actionLink = (
+        <Link
+            onClick={(e) => {
+                goToPublishChangesMode();
+                e.preventDefault();
+            }}
+        />
+    );
+    return (
+        <div style={{ marginTop: '5px' }}>
+            <MessageBox type="ERROR">
+                <Trans
+                    t={t}
+                    i18nKey={'preview-view.design-has-design-drafts-error'}
+                    components={{ actionLink }}
+                />
+            </MessageBox>
+        </div>
+    );
+};

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -66,6 +66,7 @@ export type BasePublicationCandidate = {
     validated: boolean;
     pendingValidation: boolean;
     stage: PublicationStage;
+    designRowReferrer: DesignRowReferrer;
 };
 
 export type PublicationCandidate =
@@ -352,3 +353,5 @@ export type SplitTargetInPublication = {
     endAddress: TrackMeter;
     operation: SplitTargetOperation;
 };
+
+export type DesignRowReferrer = 'MAIN_DRAFT' | 'DESIGN_DRAFT' | 'NONE';

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -7,6 +7,7 @@ import {
     PublicationCandidateReference,
     DraftChangeType,
     PublicationCandidateId,
+    CalculatedChanges,
 } from 'publication/publication-model';
 import { currentDay } from 'utils/date-utils';
 import { candidateIdAndTypeMatches } from 'preview/preview-view-filters';
@@ -114,4 +115,27 @@ export const addValidationState = (
               }
             : candidate;
     });
+};
+
+// TODO GVT-2421: Only needed while we don't do real validation
+export const pretendValidated = (candidate: PublicationCandidate): PublicationCandidate => ({
+    ...candidate,
+    validated: true,
+    pendingValidation: false,
+    issues: [],
+});
+
+export const noCalculatedChanges: CalculatedChanges = {
+    directChanges: {
+        kmPostChanges: [],
+        locationTrackChanges: [],
+        switchChanges: [],
+        referenceLineChanges: [],
+        trackNumberChanges: [],
+    },
+    indirectChanges: {
+        locationTrackChanges: [],
+        switchChanges: [],
+        trackNumberChanges: [],
+    },
 };

--- a/ui/src/tool-panel/location-track/dialog/location-track-switch-relinking-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-switch-relinking-dialog.tsx
@@ -74,7 +74,7 @@ export const LocationTrackSwitchRelinkingDialog: React.FC<
 
     const startRelinking = async () => {
         setIsRelinking(true);
-        const relinkingResult = await relinkTrackSwitches(locationTrackId);
+        const relinkingResult = await relinkTrackSwitches(layoutContext.designId, locationTrackId);
         closeDialog();
         const validation = await getSwitchesValidation(
             draftLayoutContext(layoutContext),

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -155,7 +155,11 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
         if (linkingState?.suggestedSwitch && linkingState.layoutSwitchId) {
             setLinkingCallInProgress(true);
             try {
-                await linkSwitch(linkingState.suggestedSwitch, linkingState.layoutSwitchId);
+                await linkSwitch(
+                    layoutContext.designId,
+                    linkingState.suggestedSwitch,
+                    linkingState.layoutSwitchId,
+                );
                 SnackBar.success('tool-panel.switch.geometry.linking-succeed-msg');
                 onStopLinking();
             } finally {

--- a/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
@@ -28,20 +28,20 @@ const TrackNumberDeleteConfirmationDialog: React.FC<TrackNumberDeleteConfirmatio
     const { t } = useTranslation();
 
     const deleteDraftLocationTrack = () => {
-        revertPublicationCandidates(changesBeingReverted.changeIncludingDependencies).then(
-            (result) => {
-                result
-                    .map(() => {
-                        Snackbar.success('tool-panel.track-number.delete-dialog.delete-succeeded');
-                        onSave &&
-                            onSave(brand(changesBeingReverted.requestedRevertChange.source.id));
-                        onClose();
-                    })
-                    .mapErr(() => {
-                        Snackbar.error('tool-panel.track-number.delete-dialog.delete-failed');
-                    });
-            },
-        );
+        revertPublicationCandidates(
+            layoutContext.designId,
+            changesBeingReverted.changeIncludingDependencies,
+        ).then((result) => {
+            result
+                .map(() => {
+                    Snackbar.success('tool-panel.track-number.delete-dialog.delete-succeeded');
+                    onSave && onSave(brand(changesBeingReverted.requestedRevertChange.source.id));
+                    onClose();
+                })
+                .mapErr(() => {
+                    Snackbar.error('tool-panel.track-number.delete-dialog.delete-failed');
+                });
+        });
     };
 
     return (

--- a/ui/src/track-layout/layout-design-api.ts
+++ b/ui/src/track-layout/layout-design-api.ts
@@ -19,6 +19,9 @@ export type LayoutDesign = {
 export const getLayoutDesigns = async (changeTime: TimeStamp) =>
     designCache.get(changeTime, '', () => getNonNull<LayoutDesign[]>(`${baseUri}/`));
 
+export const getLayoutDesign = async (changeTime: TimeStamp, id: LayoutDesignId) =>
+    getLayoutDesigns(changeTime).then((designs) => designs.find((design) => design.id === id));
+
 export const updateLayoutDesign = async (
     layoutDesignId: string,
     saveRequest: LayoutDesignSaveRequest,

--- a/ui/src/track-layout/layout-design-api.ts
+++ b/ui/src/track-layout/layout-design-api.ts
@@ -13,7 +13,7 @@ export type LayoutDesignSaveRequest = {
     designState: 'ACTIVE' | 'DELETED' | 'COMPLETED';
 };
 export type LayoutDesign = {
-    id: string;
+    id: LayoutDesignId;
 } & LayoutDesignSaveRequest;
 
 export const getLayoutDesigns = async (changeTime: TimeStamp) =>

--- a/ui/src/utils/react-utils.tsx
+++ b/ui/src/utils/react-utils.tsx
@@ -125,9 +125,9 @@ export function useTwoPartEffectWithStatus<TEntity>(
 ): LoaderStatus {
     const [loaderStatus, setLoaderStatus] = React.useState<LoaderStatus>(LoaderStatus.Initialized);
 
-    let cancelled = false;
     useEffect(() => {
         const promise = loadFunc();
+        let cancelled = false;
 
         if (promise) {
             setLoaderStatus(LoaderStatus.Loading);


### PR DESCRIPTION
Tilasiirtymien nimiä on palloteltu aika paljon suuntaan ja toiseen. Päädyin siihen, että jokin yhtenäinen nimi tilasiirtymälle design-official->main-draft pitää olla, ja olkoon se nyt "merge", koska sitä sanaa satuttiin Karin kanssa juttelussa käyttämään.

Tässä pullarissa:
- Jotakuinkin toimiva "Muutosten siirto luonnostilaan"-näkymä, frontilla ja bäkkärillä
- Osittainen mutta ei kattavasti tehty designId-tiedon tuominen mukaan paikannuspohjan muutoksiin, niin että suoraan käliltä tekemällä saa aikaan muutoksia tähän näkymään

Oleellisimmat toiminnalliset puutteet tällä hetkellä:
- Validointia ei tehdä muutosten yhdistämisessä millään tavalla, vaan kaikkien siirrettävien olioiden tilat näytetään vaan OK:na. Tässä tilasiirtymässähän validointia ei *tarvita*; yhtäältä se voisi ehkä olla hyvä olla, toisaalta ehkä tähän tilaan olisi hyödyllisempää tunkea tietoa vaikka mahdollisista merge-konflikteista (ts. suunnitelman elinkaaren aikana tapahtuneista mainiin tulleista muutoksista) jne.
- Selkeyspuute: Mainiin siirretyt muutokset jäävät suunnitelmaan olemaan yhä hollilla sanasta suunnitelmasta mainiin siirrettäväksi, koska niinhän on, että eihän ne sieltä varsinainesti "siirry"kään, vaan ne kopioidaan