### PR TITLE
GVT-2609/GVT-2669 Type and consistently pass layout branch on UI

### DIFF
--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -18,10 +18,13 @@ export type AngularUnit = 'RADIANS' | 'GRADS';
 export type DataType = 'STORED' | 'TEMP';
 
 export type LayoutDesignId = Brand<string, 'LayoutDesignId'>;
+export type MainLayoutBranchId = 'MAIN';
+export type LayoutBranch = MainLayoutBranchId | LayoutDesignId;
+
 export type PublicationState = 'OFFICIAL' | 'DRAFT';
 export type LayoutContext = {
     publicationState: PublicationState;
-    designId: LayoutDesignId | undefined;
+    branch: LayoutBranch;
 };
 
 export const officialLayoutContext = (layoutContext: LayoutContext): LayoutContext =>
@@ -29,7 +32,7 @@ export const officialLayoutContext = (layoutContext: LayoutContext): LayoutConte
         ? layoutContext
         : {
               publicationState: 'OFFICIAL',
-              designId: layoutContext.designId,
+              branch: layoutContext.branch,
           };
 
 export const draftLayoutContext = (layoutContext: LayoutContext): LayoutContext =>
@@ -37,16 +40,16 @@ export const draftLayoutContext = (layoutContext: LayoutContext): LayoutContext 
         ? layoutContext
         : {
               publicationState: 'DRAFT',
-              designId: layoutContext.designId,
+              branch: layoutContext.branch,
           };
 
 const officialMainContext: LayoutContext = Object.freeze({
     publicationState: 'OFFICIAL',
-    designId: undefined,
+    branch: 'MAIN',
 });
 const draftMainContext: LayoutContext = Object.freeze({
     publicationState: 'DRAFT',
-    designId: undefined,
+    branch: 'MAIN',
 });
 
 export const officialMainLayoutContext = (): LayoutContext => officialMainContext;

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -39,8 +39,8 @@ import { getChangeTimes } from 'common/change-time-api';
 import {
     ElevationMeasurementMethod,
     KmNumber,
+    LayoutBranch,
     LayoutContext,
-    LayoutDesignId,
     officialMainLayoutContext,
     PublicationState,
     TimeStamp,
@@ -67,8 +67,7 @@ const planVerticalGeometryCache = asyncCache<
     PlanVerticalGeometryKey,
     VerticalGeometryItem[] | undefined
 >;
-type LocationTrackVerticalGeometryKey =
-    `${LocationTrackId}_${PublicationState}_${LayoutDesignId | 'undefined'}`;
+type LocationTrackVerticalGeometryKey = `${LocationTrackId}_${PublicationState}_${LayoutBranch}`;
 const locationTrackVerticalGeometryCache = asyncCache<
     LocationTrackVerticalGeometryKey,
     VerticalGeometryItem[] | undefined
@@ -192,7 +191,7 @@ export async function getLocationTrackVerticalGeometry(
         ? fetch()
         : locationTrackVerticalGeometryCache.get(
               changeTime,
-              `${id}_${layoutContext.publicationState}_${layoutContext.designId}`,
+              `${id}_${layoutContext.publicationState}_${layoutContext.branch}`,
               fetch,
           );
 }
@@ -428,7 +427,7 @@ export async function getLocationTrackHeights(
 }
 
 const locationTrackLinkingSummaryCache = asyncCache<
-    `${LocationTrackId}_${PublicationState}_${LayoutDesignId | 'undefined'}`,
+    `${LocationTrackId}_${PublicationState}_${LayoutBranch}`,
     PlanLinkingSummaryItem[]
 >();
 
@@ -439,7 +438,7 @@ export async function getLocationTrackLinkingSummary(
 ): Promise<PlanLinkingSummaryItem[]> {
     return locationTrackLinkingSummaryCache.get(
         changeTime,
-        `${locationTrackId}_${layoutContext.publicationState}_${layoutContext.designId}`,
+        `${locationTrackId}_${layoutContext.publicationState}_${layoutContext.branch}`,
         () =>
             getNonNull(
                 `${geometryLayoutPath(layoutContext)}/location-tracks/${locationTrackId}/linking-summary`,

--- a/ui/src/geoviite-design-lib/switch/switch-link.tsx
+++ b/ui/src/geoviite-design-lib/switch/switch-link.tsx
@@ -53,7 +53,7 @@ export const SwitchLink: React.FC<SwitchLinkProps> = (props: SwitchLinkProps) =>
         [
             props.switchId,
             props.layoutContext.publicationState,
-            props.layoutContext.designId,
+            props.layoutContext.branch,
             props.changeTime,
         ],
     );

--- a/ui/src/linking/linking-status.tsx
+++ b/ui/src/linking/linking-status.tsx
@@ -28,7 +28,7 @@ export const LinkingStatus: React.FC<LinkingStatusProps> = ({
         () => (planId ? getPlanLinkStatus(planId, layoutContext) : undefined),
         [
             planId,
-            layoutContext.designId,
+            layoutContext.branch,
             layoutContext.publicationState,
             switchChangeTime,
             locationTrackChangeTime,

--- a/ui/src/linking/switch/switch-suggestion-creator-dialog.tsx
+++ b/ui/src/linking/switch/switch-suggestion-creator-dialog.tsx
@@ -131,7 +131,7 @@ export const SwitchSuggestionCreatorDialog: React.FC<SwitchSuggestionCreatorProp
             .filter(filterNotEmpty);
 
         if (hasEnoughDataToTrySwitchSuggestion(switchStructureId, alignmentMappings)) {
-            return createSuggestedSwitch({
+            return createSuggestedSwitch(layoutContext.branch, {
                 locationTrackEndpoint: locationTrackEndpoint,
                 switchStructureId: switchStructureId,
                 alignmentMappings: alignmentMappings,

--- a/ui/src/map/layers/switch/switch-linking-layer.ts
+++ b/ui/src/map/layers/switch/switch-linking-layer.ts
@@ -21,6 +21,7 @@ import { filterNotEmpty, first } from 'utils/array-utils';
 import { Rectangle } from 'model/geometry';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
+import { LayoutContext } from 'common/common-model';
 
 function createSwitchFeatures(
     suggestedSwitch: SuggestedSwitch,
@@ -57,6 +58,7 @@ export function createSwitchLinkingLayer(
     mapTiles: MapTile[],
     resolution: number,
     existingOlLayer: VectorLayer<Feature<OlPoint>> | undefined,
+    layoutContext: LayoutContext,
     selection: Selection,
     linkingState: LinkingSwitch | undefined,
     onLoadingData: (loading: boolean) => void,
@@ -68,7 +70,7 @@ export function createSwitchLinkingLayer(
     const getSuggestedSwitchesPromises =
         resolution <= SUGGESTED_SWITCH_SHOW && linkingState
             ? []
-            : mapTiles.map((tile) => getSuggestedSwitchesByTile(tile));
+            : mapTiles.map((tile) => getSuggestedSwitchesByTile(layoutContext.branch, tile));
 
     const dataPromise: Promise<SuggestedSwitch[]> = Promise.all(getSuggestedSwitchesPromises).then(
         (suggestedSwitches) =>

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -530,6 +530,7 @@ const MapView: React.FC<MapViewProps> = ({
                             mapTiles,
                             resolution,
                             existingOlLayer as VectorLayer<Feature<OlPoint>>,
+                            layoutContext,
                             selection,
                             linkingState as LinkingSwitch | undefined,
                             (loading) => onLayerLoading(layerName, loading),

--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -95,7 +95,7 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
         setPublishing(true);
         publishWith(
             publishPublicationCandidates(
-                props.layoutContext.designId,
+                props.layoutContext.branch,
                 props.stagedPublicationCandidates,
                 message,
             ),
@@ -103,10 +103,10 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
     };
 
     const mergeToMain = () => {
+        const branch = props.layoutContext.branch;
+        if (branch === 'MAIN') return;
         setPublishing(true);
-        publishWith(
-            mergeCandidatesToMain(props.layoutContext.designId, props.stagedPublicationCandidates),
-        );
+        publishWith(mergeCandidatesToMain(branch, props.stagedPublicationCandidates));
     };
 
     const candidateCount = props.stagedPublicationCandidates.length;
@@ -147,9 +147,9 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
                         publish={publish}
                     />
                 ) : (
-                    props.layoutContext.designId && (
+                    props.layoutContext.branch !== 'MAIN' && (
                         <PreviewMergeToMainConfirmationDialog
-                            designId={props.layoutContext.designId}
+                            designId={props.layoutContext.branch}
                             isPublishing={isPublishing}
                             onCancel={() => setPublishConfirmVisible(false)}
                             candidateCount={candidateCount}

--- a/ui/src/preview/preview-tool-bar.tsx
+++ b/ui/src/preview/preview-tool-bar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { useTranslation } from 'react-i18next';
 import { createClassName } from 'vayla-design-lib/utils';
-import { LayoutDesignId } from 'common/common-model';
+import { LayoutBranch } from 'common/common-model';
 import { Radio } from 'vayla-design-lib/radio/radio';
 import styles from './preview-view.scss';
 
@@ -10,7 +10,7 @@ export type DesignPublicationMode = 'PUBLISH_CHANGES' | 'MERGE_TO_MAIN';
 
 export type PreviewToolBarParams = {
     onClosePreview: () => void;
-    designId: LayoutDesignId | undefined;
+    layoutBranch: LayoutBranch;
     designPublicationMode: DesignPublicationMode;
     onChangeDesignPublicationMode: (mode: DesignPublicationMode) => void;
 };
@@ -18,7 +18,7 @@ export type PreviewToolBarParams = {
 export const PreviewToolBar: React.FC<PreviewToolBarParams> = (props: PreviewToolBarParams) => {
     const { t } = useTranslation();
 
-    const showingDesignProject = !!props.designId;
+    const showingDesignProject = props.layoutBranch !== 'MAIN';
     const className = createClassName(
         'preview-tool-bar',
         showingDesignProject ? 'preview-tool-bar__design' : 'preview-tool-bar__draft',

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -31,16 +31,16 @@ import { PublicationDetailsTableSortField } from 'publication/table/publication-
 import { SortDirection } from 'utils/table-utils';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { createPublicationCandidateReference } from 'publication/publication-utils';
-import { LayoutDesignId, PublicationState } from 'common/common-model';
+import { LayoutBranch, LayoutDesignId, PublicationState } from 'common/common-model';
 import { toBranchName } from 'track-layout/track-layout-api';
 
 const PUBLICATION_URL = `${API_URI}/publications`;
 
-function publicationUri(designId: LayoutDesignId | undefined): string {
-    return `${PUBLICATION_URL}/${toBranchName(designId).toLowerCase()}`;
+function publicationUri(layoutBranch: LayoutBranch): string {
+    return `${PUBLICATION_URL}/${toBranchName(layoutBranch).toLowerCase()}`;
 }
 
-function mergeToMainUri(designId: LayoutDesignId | undefined): string {
+function mergeToMainUri(designId: LayoutDesignId): string {
     return `${PUBLICATION_URL}/merge-to-main/${toBranchName(designId).toLowerCase()}`;
 }
 
@@ -165,7 +165,7 @@ const toValidatedPublicationCandidates = (
 };
 
 export const getPublicationCandidates = (
-    layoutBranch: LayoutDesignId | undefined,
+    layoutBranch: LayoutBranch,
     fromState: PublicationState,
 ): Promise<PublicationCandidate[]> =>
     getNonNull<PublicationCandidatesResponse>(
@@ -173,7 +173,7 @@ export const getPublicationCandidates = (
     ).then(toPublicationCandidates);
 
 export const validatePublicationCandidates = (
-    layoutBranch: LayoutDesignId | undefined,
+    layoutBranch: LayoutBranch,
     candidates: PublicationCandidateReference[],
 ) =>
     postNonNull<PublicationRequestIds, ValidatedPublicationCandidatesResponse>(
@@ -182,7 +182,7 @@ export const validatePublicationCandidates = (
     ).then(toValidatedPublicationCandidates);
 
 export const revertPublicationCandidates = (
-    layoutBranch: LayoutDesignId | undefined,
+    layoutBranch: LayoutBranch,
     candidates: PublicationCandidateReference[],
 ) =>
     deleteNonNullAdt<PublicationRequestIds, PublicationResult>(
@@ -191,7 +191,7 @@ export const revertPublicationCandidates = (
     );
 
 export const publishPublicationCandidates = (
-    layoutBranch: LayoutDesignId | undefined,
+    layoutBranch: LayoutBranch,
     candidates: PublicationCandidateReference[],
     message: string,
 ) => {
@@ -207,7 +207,7 @@ export const publishPublicationCandidates = (
 };
 
 export const mergeCandidatesToMain = (
-    layoutBranch: LayoutDesignId | undefined,
+    layoutBranch: LayoutDesignId,
     candidates: PublicationCandidateReference[],
 ) => {
     const request = toPublicationRequestIds(candidates);
@@ -275,7 +275,7 @@ export const getPublicationsCsvUri = (
 };
 
 export const getCalculatedChanges = (
-    layoutBranch: LayoutDesignId | undefined,
+    layoutBranch: LayoutBranch,
     candidates: PublicationCandidateReference[],
 ) =>
     postNonNull<PublicationRequestIds, CalculatedChanges>(
@@ -283,9 +283,12 @@ export const getCalculatedChanges = (
         toPublicationRequestIds(candidates),
     );
 
-export const getRevertRequestDependencies = (candidates: PublicationCandidateReference[]) =>
+export const getRevertRequestDependencies = (
+    layoutBranch: LayoutBranch,
+    candidates: PublicationCandidateReference[],
+) =>
     postNonNull<PublicationRequestIds, PublicationRequestIds>(
-        `${publicationUri(undefined)}/candidates/revert-request-dependencies`,
+        `${publicationUri(layoutBranch)}/candidates/revert-request-dependencies`,
         toPublicationRequestIds(candidates),
     ).then(toPublicationCandidateReferences);
 

--- a/ui/src/publication/split/split-api.ts
+++ b/ui/src/publication/split/split-api.ts
@@ -1,17 +1,17 @@
 import { SplitRequest } from 'tool-panel/location-track/split-store';
 import { API_URI, getNullable, postNonNull, putNonNull } from 'api/api-fetch';
 import { Split } from 'publication/publication-model';
-import { LayoutDesignId } from 'common/common-model';
+import { LayoutBranch } from 'common/common-model';
 import { toBranchName } from 'track-layout/track-layout-api';
 
 const SPLIT_URI = `${API_URI}/location-track-split`;
 
 export const postSplitLocationTrack = async (
     request: SplitRequest,
-    designId: LayoutDesignId | undefined,
+    branch: LayoutBranch,
 ): Promise<string> => {
     return postNonNull<SplitRequest, string>(
-        `${SPLIT_URI}/${toBranchName(designId).toLowerCase()}`,
+        `${SPLIT_URI}/${toBranchName(branch).toLowerCase()}`,
         request,
     );
 };

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -325,7 +325,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     }
 
     function switchToMainOfficial() {
-        onLayoutContextChange({ publicationState: 'OFFICIAL', designId: undefined });
+        onLayoutContextChange({ publicationState: 'OFFICIAL', branch: 'MAIN' });
         setShowNewAssetMenu(false);
         setSelectingWorkspace(false);
     }
@@ -333,7 +333,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     const switchToMainDraft = () => {
         onLayoutContextChange({
             publicationState: 'DRAFT',
-            designId: undefined,
+            branch: 'MAIN',
         });
         setSelectingWorkspace(false);
     };
@@ -369,8 +369,8 @@ export const ToolBar: React.FC<ToolbarParams> = ({
 
     const className = createClassName(
         'tool-bar',
-        !layoutContext.designId && `tool-bar--${layoutContext.publicationState.toLowerCase()}`,
-        (layoutContext.designId || selectingWorkspace) && `tool-bar--design`,
+        !layoutContext.branch && `tool-bar--${layoutContext.publicationState.toLowerCase()}`,
+        (layoutContext.branch || selectingWorkspace) && `tool-bar--design`,
     );
 
     return (
@@ -381,7 +381,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         className={styles['tool-bar__tab-header']}
                         qaId="current-mode-tab"
                         selected={
-                            !layoutContext.designId &&
+                            layoutContext.branch === 'MAIN' &&
                             !selectingWorkspace &&
                             layoutContext.publicationState === 'OFFICIAL'
                         }
@@ -393,7 +393,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                             className={styles['tool-bar__tab-header']}
                             qaId={'draft-mode-tab'}
                             selected={
-                                !layoutContext.designId &&
+                                layoutContext.branch === 'MAIN' &&
                                 !selectingWorkspace &&
                                 layoutContext.publicationState === 'DRAFT'
                             }
@@ -406,7 +406,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                             <TabHeader
                                 className={styles['tool-bar__tab-header']}
                                 qaId={'design-mode-tab'}
-                                selected={!!layoutContext.designId || selectingWorkspace}
+                                selected={layoutContext.branch !== 'MAIN' || selectingWorkspace}
                                 onClick={() => setSelectingWorkspace(true)}>
                                 {t('tool-bar.design-mode')}
                             </TabHeader>
@@ -446,7 +446,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         </div>
                     </PrivilegeRequired>
                 )}
-                {(layoutContext.designId || selectingWorkspace) && (
+                {(layoutContext.branch !== 'MAIN' || selectingWorkspace) && (
                     <WorkspaceSelectionContainer
                         selectingWorkspace={selectingWorkspace}
                         setSelectingWorkspace={setSelectingWorkspace}

--- a/ui/src/tool-bar/workspace-selection.tsx
+++ b/ui/src/tool-bar/workspace-selection.tsx
@@ -70,12 +70,12 @@ export const WorkspaceSelection: React.FC<WorkspaceSelectionProps> = ({
         () => getLayoutDesigns(getChangeTimes().layoutDesign),
         [getChangeTimes().layoutDesign],
     );
-    const currentDesign = designs?.find((d) => d.id === layoutContext.designId);
+    const currentDesign = designs?.find((d) => d.id === layoutContext.branch);
 
     const unselectDesign = () => {
         onLayoutContextChange({
             publicationState: layoutContext.publicationState,
-            designId: undefined,
+            branch: 'MAIN',
         });
         setSelectingWorkspace(true);
     };
@@ -94,7 +94,7 @@ export const WorkspaceSelection: React.FC<WorkspaceSelectionProps> = ({
                     setSelectingWorkspace(false);
                     onLayoutContextChange({
                         publicationState: 'DRAFT',
-                        designId: designId,
+                        branch: designId ?? 'MAIN',
                     });
                 }}
                 options={
@@ -104,21 +104,21 @@ export const WorkspaceSelection: React.FC<WorkspaceSelectionProps> = ({
                         qaId: `workspace-${design.id}`,
                     })) ?? []
                 }
-                value={layoutContext.designId}
+                value={layoutContext.branch}
                 qaId={'workspace-selection'}
             />
             <PrivilegeRequired privilege={EDIT_LAYOUT}>
                 <Button
                     variant={ButtonVariant.GHOST}
                     icon={Icons.Edit}
-                    disabled={!layoutContext.designId}
+                    disabled={layoutContext.branch === 'MAIN'}
                     onClick={() => setShowEditWorkspaceDialog(true)}
                     qa-id={'workspace-edit-button'}
                 />
                 <Button
                     variant={ButtonVariant.GHOST}
                     icon={Icons.Delete}
-                    disabled={!layoutContext.designId}
+                    disabled={layoutContext.branch === 'MAIN'}
                     onClick={() => setShowDeleteWorkspaceDialog(true)}
                     qa-id={'workspace-delete-button'}
                 />
@@ -133,7 +133,10 @@ export const WorkspaceSelection: React.FC<WorkspaceSelectionProps> = ({
                         insertLayoutDesign(request)
                             .then((id) => {
                                 setSelectingWorkspace(false);
-                                onLayoutContextChange({ publicationState: 'DRAFT', designId: id });
+                                onLayoutContextChange({
+                                    publicationState: 'DRAFT',
+                                    branch: id,
+                                });
                             })
                             .finally(() => {
                                 updateLayoutDesignChangeTime();

--- a/ui/src/tool-panel/asset-validation-infobox-container.tsx
+++ b/ui/src/tool-panel/asset-validation-infobox-container.tsx
@@ -54,7 +54,7 @@ export const AssetValidationInfoboxContainer: React.FC<AssetValidationInfoboxPro
         idAndType.id,
         idAndType.type,
         layoutContext.publicationState,
-        layoutContext.designId,
+        layoutContext.branch,
         changeTime,
     ]);
     const errors = validation?.errors.filter((err) => err.type === 'ERROR') || [];

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -162,7 +162,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
             changeTimes.layoutLocationTrack,
             changeTimes.layoutReferenceLine,
             layoutContext.publicationState,
-            layoutContext.designId,
+            layoutContext.branch,
         ],
     );
 
@@ -209,7 +209,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
     }, [
         planId,
         layoutContext.publicationState,
-        layoutContext.designId,
+        layoutContext.branch,
         changeTimes.layoutLocationTrack,
         changeTimes.layoutReferenceLine,
     ]);
@@ -265,8 +265,8 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                     createLinkingGeometryWithAlignmentParameters(linkingState);
 
                 await (linkingState.layoutAlignment.type == 'LOCATION_TRACK'
-                    ? linkGeometryWithLocationTrack(linkingParameters)
-                    : linkGeometryWithReferenceLine(linkingParameters));
+                    ? linkGeometryWithLocationTrack(layoutContext.branch, linkingParameters)
+                    : linkGeometryWithReferenceLine(layoutContext.branch, linkingParameters));
 
                 Snackbar.success(
                     'tool-panel.alignment.geometry.linking-succeeded-and-previous-unlinked',
@@ -277,8 +277,8 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                 const linkingParameters =
                     createLinkingGeometryWithEmptyAlignmentParameters(linkingState);
                 await (linkingState.layoutAlignment.type == 'LOCATION_TRACK'
-                    ? linkGeometryWithEmptyLocationTrack(linkingParameters)
-                    : linkGeometryWithEmptyReferenceLine(linkingParameters));
+                    ? linkGeometryWithEmptyLocationTrack(layoutContext.branch, linkingParameters)
+                    : linkGeometryWithEmptyReferenceLine(layoutContext.branch, linkingParameters));
 
                 Snackbar.success('tool-panel.alignment.geometry.linking-succeeded');
                 onStopLinking();

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -85,7 +85,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                 : [];
         }, [
             layoutContext.publicationState,
-            layoutContext.designId,
+            layoutContext.branch,
             geometryKmPost.trackNumberId,
             geometryKmPost.location,
             layoutKmPost,
@@ -103,7 +103,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
 
         try {
             if (linkingState && geometryKmPost && geometryKmPost.sourceId && layoutKmPost) {
-                await linkKmPost({
+                await linkKmPost(layoutContext.branch, {
                     geometryPlanId: planId,
                     geometryKmPostId: geometryKmPost.sourceId,
                     layoutKmPostId: layoutKmPost.id,

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -59,7 +59,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     const [confirmingDraftDelete, setConfirmingDraftDelete] = React.useState(false);
     const updatedKmPost = useLoader(
         () => getKmPost(kmPost.id, layoutContext),
-        [kmPost.id, kmPostChangeTime, layoutContext.publicationState, layoutContext.designId],
+        [kmPost.id, kmPostChangeTime, layoutContext.publicationState, layoutContext.branch],
     );
 
     const [kmPostLength, kmPostLengthLoading] = useLoaderWithStatus(
@@ -67,7 +67,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
         [
             kmPost.id,
             kmPost.state,
-            layoutContext.designId,
+            layoutContext.branch,
             layoutContext.publicationState,
             changeTimes.layoutKmPost,
             changeTimes.layoutReferenceLine,

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -286,7 +286,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     const getDuplicateTrackOptions = React.useCallback(
         (searchTerm: string) =>
             findDuplicateTrackOptions(layoutContextDraft, props.locationTrack?.id, searchTerm),
-        [layoutContextDraft.designId, props.locationTrack?.id],
+        [layoutContextDraft.branch, props.locationTrack?.id],
     );
 
     function onDuplicateTrackSelected(duplicateTrack: LocationTrackItemValue | undefined) {

--- a/ui/src/tool-panel/location-track/dialog/location-track-switch-relinking-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-switch-relinking-dialog.tsx
@@ -33,7 +33,7 @@ export const LocationTrackSwitchRelinkingDialogContainer: React.FC<
     const delegates = createDelegates(TrackLayoutActions);
     const relinkableSwitchesCount = useLoader(
         () => getRelinkableSwitchesCount(props.locationTrackId, props.layoutContext),
-        [props.locationTrackId, props.layoutContext.publicationState, props.layoutContext.designId],
+        [props.locationTrackId, props.layoutContext.publicationState, props.layoutContext.branch],
     );
 
     return relinkableSwitchesCount === undefined ? (
@@ -74,7 +74,7 @@ export const LocationTrackSwitchRelinkingDialog: React.FC<
 
     const startRelinking = async () => {
         setIsRelinking(true);
-        const relinkingResult = await relinkTrackSwitches(layoutContext.designId, locationTrackId);
+        const relinkingResult = await relinkTrackSwitches(layoutContext.branch, locationTrackId);
         closeDialog();
         const validation = await getSwitchesValidation(
             draftLayoutContext(layoutContext),
@@ -102,7 +102,7 @@ export const LocationTrackSwitchRelinkingDialog: React.FC<
             showLocationTrackTaskList({
                 locationTrackId,
                 type: LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION,
-                designId: layoutContext.designId,
+                branch: layoutContext.branch,
             });
         }
     };

--- a/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
@@ -109,7 +109,7 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
             ),
         [
             locationTrack?.id,
-            layoutContext.designId,
+            layoutContext.branch,
             layoutContext.publicationState,
             changeTimes.layoutLocationTrack,
         ],

--- a/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
@@ -47,7 +47,7 @@ export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfobox
                 useBoundingBox ? viewport.area : undefined,
             ),
         1000,
-        [locationTrackId, layoutContext.publicationState, layoutContext.designId, viewportDep],
+        [locationTrackId, layoutContext.publicationState, layoutContext.branch, viewportDep],
     );
     const onHighlightSection: OnHighlightSection = (section) =>
         onHighlightItem(

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -300,7 +300,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
             state.layoutAlignment.type === 'LOCATION_TRACK'
         ) {
             setUpdatingLength(true);
-            updateLocationTrackGeometry(state.layoutAlignment.id, {
+            updateLocationTrackGeometry(layoutContext.branch, state.layoutAlignment.id, {
                 min: state.layoutAlignmentInterval.start.m,
                 max: state.layoutAlignmentInterval.end.m,
             })

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -62,11 +62,11 @@ export const LocationTrackTaskListContainer: React.FC<{ selectingWorkspace: bool
     React.useEffect(() => {
         if (
             locationTrackList &&
-            (locationTrackList.designId !== layoutContext.designId || selectingWorkspace)
+            (locationTrackList.branch !== layoutContext.branch || selectingWorkspace)
         ) {
             delegates.hideLocationTrackTaskList();
         }
-    }, [layoutContext.designId, selectingWorkspace]);
+    }, [layoutContext.branch, selectingWorkspace]);
 
     return createPortal(
         locationTrackList?.type == LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION ? (
@@ -102,7 +102,10 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
     );
 
     const [switchesAndErrors, switchesLoadingStatus] = useLoaderWithStatus(async () => {
-        const relinkingResults = await validateLocationTrackSwitchRelinking(locationTrackId);
+        const relinkingResults = await validateLocationTrackSwitchRelinking(
+            layoutContext.branch,
+            locationTrackId,
+        );
         const switchIds = relinkingResults
             .filter((r) => r.validationIssues.length > 0 || r.successfulSuggestion == null)
             .map((s) => s.id);

--- a/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
@@ -34,12 +34,7 @@ export const LocationTrackValidationInfoboxContainer: React.FC<
 
     const [validation, validationLoaderStatus] = useLoaderWithStatus(
         () => getLocationTrackValidation(layoutContext, id),
-        [
-            id,
-            layoutContext.publicationState,
-            layoutContext.designId,
-            changeTimes.layoutLocationTrack,
-        ],
+        [id, layoutContext.publicationState, layoutContext.branch, changeTimes.layoutLocationTrack],
     );
 
     const errors = validation?.errors.filter((err) => err.type === 'ERROR') || [];

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -159,9 +159,10 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
     const [switchRelinkingErrors, switchRelinkingLoaderState] = useLoaderWithStatus(
         () =>
             splittingState
-                ? validateLocationTrackSwitchRelinking(splittingState.originLocationTrack.id).then(
-                      (results) => results.filter((res) => res.validationIssues.length > 0),
-                  )
+                ? validateLocationTrackSwitchRelinking(
+                      layoutContext.branch,
+                      splittingState.originLocationTrack.id,
+                  ).then((results) => results.filter((res) => res.validationIssues.length > 0))
                 : Promise.resolve([]),
         [changeTimes.layoutLocationTrack, changeTimes.layoutSwitch],
     );
@@ -183,7 +184,7 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
         delegates.showLocationTrackTaskList({
             type: LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION,
             locationTrackId: locationTrack,
-            designId: layoutContext.designId,
+            branch: layoutContext.branch,
         });
     };
 
@@ -399,7 +400,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
                 splittingState.splits,
                 duplicateTracksInCurrentSplits,
             ),
-            undefined,
+            layoutContext.branch,
         )
             .then(async () => {
                 await updateAllChangeTimes();

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -93,10 +93,11 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
                 area: boundingBox,
                 resolution: 0,
             };
-            return getSuggestedSwitchesByTile(fakeMapTile).then((suggestedSwitches) =>
-                suggestedSwitches.find(
-                    (suggestedSwitch) => suggestedSwitch.geometrySwitchId == geometrySwitchId,
-                ),
+            return getSuggestedSwitchesByTile(layoutContext.branch, fakeMapTile).then(
+                (suggestedSwitches) =>
+                    suggestedSwitches.find(
+                        (suggestedSwitch) => suggestedSwitch.geometrySwitchId == geometrySwitchId,
+                    ),
             );
         }
         return undefined;
@@ -156,7 +157,7 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
             setLinkingCallInProgress(true);
             try {
                 await linkSwitch(
-                    layoutContext.designId,
+                    layoutContext.branch,
                     linkingState.suggestedSwitch,
                     linkingState.layoutSwitchId,
                 );

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -153,19 +153,14 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
     const switchStructures = useLoader(() => getSwitchStructures(), []);
     const layoutSwitch = useLoader(
         () => getSwitch(switchId, layoutContext),
-        [
-            switchId,
-            changeTimes.layoutSwitch,
-            layoutContext.designId,
-            layoutContext.publicationState,
-        ],
+        [switchId, changeTimes.layoutSwitch, layoutContext.branch, layoutContext.publicationState],
     );
     const structure = switchStructures?.find(
         (structure) => structure.id === layoutSwitch?.switchStructureId,
     );
     const switchJointConnections = useLoader(
         () => getSwitchJointConnections(layoutContext, switchId),
-        [layoutContext.designId, layoutContext.publicationState, layoutSwitch],
+        [layoutContext.branch, layoutContext.publicationState, layoutSwitch],
     );
     const switchChangeTimes = useSwitchChangeTimes(layoutSwitch?.id, layoutContext);
 
@@ -173,12 +168,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
         return switchJointConnections
             ? getSwitchJointTrackMeters(switchJointConnections, layoutContext, changeTimes)
             : undefined;
-    }, [
-        switchJointConnections,
-        layoutContext.designId,
-        layoutContext.publicationState,
-        changeTimes,
-    ]);
+    }, [switchJointConnections, layoutContext.branch, layoutContext.publicationState, changeTimes]);
 
     const SwitchImage = structure && makeSwitchImage(structure.baseType, structure.hand);
     const switchLocation =

--- a/ui/src/tool-panel/switch/switch-joint-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-joint-infobox.tsx
@@ -47,7 +47,7 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
             [
                 switchAlignments,
                 jointConnections,
-                layoutContext.designId,
+                layoutContext.branch,
                 layoutContext.publicationState,
             ],
         ),

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -48,18 +48,20 @@ const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({
     React.useEffect(() => {
         const linkingState = store.linkingState;
         if (linkingState?.type == LinkingType.PlacingSwitch && linkingState.location) {
-            getSuggestedSwitchByPoint(linkingState.location, linkingState.layoutSwitch.id).then(
-                (suggestedSwitches) => {
-                    delegates.stopLinking();
+            getSuggestedSwitchByPoint(
+                store.layoutContext.branch,
+                linkingState.location,
+                linkingState.layoutSwitch.id,
+            ).then((suggestedSwitches) => {
+                delegates.stopLinking();
 
-                    const suggestedSwitch = first(suggestedSwitches);
-                    if (suggestedSwitch) {
-                        startSwitchLinking(suggestedSwitch, linkingState.layoutSwitch);
-                    } else {
-                        delegates.hideLayers(['switch-linking-layer']);
-                    }
-                },
-            );
+                const suggestedSwitch = first(suggestedSwitches);
+                if (suggestedSwitch) {
+                    startSwitchLinking(suggestedSwitch, linkingState.layoutSwitch);
+                } else {
+                    delegates.hideLayers(['switch-linking-layer']);
+                }
+            });
         }
     }, [store.linkingState]);
 

--- a/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
@@ -29,7 +29,7 @@ const TrackNumberDeleteConfirmationDialog: React.FC<TrackNumberDeleteConfirmatio
 
     const deleteDraftLocationTrack = () => {
         revertPublicationCandidates(
-            layoutContext.designId,
+            layoutContext.branch,
             changesBeingReverted.changeIncludingDependencies,
         ).then((result) => {
             result

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -129,7 +129,8 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
         .map((s) => ({ ...s, qaId: s.value }));
 
     const confirmNewDraftDelete = () => {
-        inEditTrackNumber && onRequestDeleteTrackNumber(inEditTrackNumber, setDeletingDraft);
+        inEditTrackNumber &&
+            onRequestDeleteTrackNumber(layoutContext.branch, inEditTrackNumber, setDeletingDraft);
     };
 
     const saveOrConfirm = () => {

--- a/ui/src/tool-panel/track-number/track-number-deletion.ts
+++ b/ui/src/tool-panel/track-number/track-number-deletion.ts
@@ -3,12 +3,14 @@ import { LayoutTrackNumber } from 'track-layout/track-layout-model';
 import { RevertRequestType } from 'preview/preview-view-revert-request';
 import { ChangesBeingReverted } from 'preview/preview-view';
 import { getRevertRequestDependencies } from 'publication/publication-api';
+import { LayoutBranch } from 'common/common-model';
 
 export const onRequestDeleteTrackNumber = (
+    layoutBranch: LayoutBranch,
     trackNumber: LayoutTrackNumber,
     setChangesBeingReverted: (changes: ChangesBeingReverted) => void,
 ) => {
-    getRevertRequestDependencies([
+    getRevertRequestDependencies(layoutBranch, [
         {
             id: trackNumber.id,
             type: DraftChangeType.TRACK_NUMBER,

--- a/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
@@ -52,7 +52,7 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
         [
             trackNumberId,
             layoutContext.publicationState,
-            layoutContext.designId,
+            layoutContext.branch,
             viewportDep,
             changeTime,
         ],

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -125,7 +125,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
             state.layoutAlignment.type === 'REFERENCE_LINE'
         ) {
             setUpdatingLength(true);
-            updateReferenceLineGeometry(state.layoutAlignment.id, {
+            updateReferenceLineGeometry(layoutContext.branch, state.layoutAlignment.id, {
                 min: state.layoutAlignmentInterval.start.m,
                 max: state.layoutAlignmentInterval.end.m,
             })
@@ -147,7 +147,8 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
         onUnselect,
     );
 
-    const onRequestDelete = () => onRequestDeleteTrackNumber(trackNumber, setDeleting);
+    const onRequestDelete = () =>
+        onRequestDeleteTrackNumber(layoutContext.branch, trackNumber, setDeleting);
 
     return (
         <React.Fragment>

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -34,7 +34,7 @@ const kmPostForLinkingCache = asyncCache<string, LayoutKmPost[]>();
 const kmPostCache = asyncCache<string, LayoutKmPost | undefined>();
 
 const cacheKey = (id: LayoutKmPostId, layoutContext: LayoutContext) =>
-    `${id}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    `${id}_${layoutContext.publicationState}_${layoutContext.branch}`;
 
 export async function getKmPost(
     id: LayoutKmPostId,
@@ -93,7 +93,7 @@ export async function getKmPostsByTile(
     });
     return kmPostListCache.get(
         changeTime,
-        `${layoutContext.publicationState}_${layoutContext.designId}_${JSON.stringify(params)}`,
+        `${layoutContext.publicationState}_${layoutContext.branch}_${JSON.stringify(params)}`,
         () => getNonNull(`${layoutUri('km-posts', layoutContext)}${params}`),
     );
 }

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -103,7 +103,7 @@ export type SplitInitializationParameters = {
 };
 
 const cacheKey = (id: LocationTrackId, layoutContext: LayoutContext) =>
-    `${id}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    `${id}_${layoutContext.publicationState}_${layoutContext.branch}`;
 
 export async function getLocationTrack(
     id: LocationTrackId,

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -146,7 +146,7 @@ function geocodingUri(layoutContext: LayoutContext): string {
 }
 
 function cacheKey(id: ReferenceLineId | LocationTrackId, layoutContext: LayoutContext) {
-    return `${id}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    return `${id}_${layoutContext.publicationState}_${layoutContext.branch}`;
 }
 
 export async function getMapAlignmentsByTiles(
@@ -312,7 +312,7 @@ function getLocationTrackSectionsWithoutProfileByTile(
     layoutContext: LayoutContext,
     mapTile: MapTile,
 ): Promise<AlignmentHighlight[]> {
-    const tileKey = `${mapTile.id}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    const tileKey = `${mapTile.id}_${layoutContext.publicationState}_${layoutContext.branch}`;
     const params = queryParams({ bbox: bboxString(mapTile.area) });
     return sectionsWithoutProfileCache.get(changeTime, tileKey, () =>
         getNonNull(`${mapUri(layoutContext)}/location-track/without-profile${params}`),
@@ -340,7 +340,7 @@ async function getAlignmentSectionsWithoutLinkingByTile(
     type: AlignmentFetchType,
     mapTile: MapTile,
 ): Promise<AlignmentHighlight[]> {
-    const tileKey = `${mapTile.id}_${type}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    const tileKey = `${mapTile.id}_${type}_${layoutContext.publicationState}_${layoutContext.branch}`;
     const params = queryParams({ bbox: bboxString(mapTile.area), type: type });
     return sectionsWithoutLinkingCache.get(changeTime, tileKey, () =>
         getNonNull(`${mapUri(layoutContext)}/alignment/without-linking${params}`),
@@ -480,7 +480,7 @@ async function getPolyLines(
     layoutContext: LayoutContext,
     fetchType: AlignmentFetchType,
 ): Promise<AlignmentPolyLine[]> {
-    const tileKey = `${mapTile.id}_${layoutContext.publicationState}_${layoutContext.designId}_${fetchType}`;
+    const tileKey = `${mapTile.id}_${layoutContext.publicationState}_${layoutContext.branch}_${fetchType}`;
     const params = queryParams({
         resolution: toMapAlignmentResolution(mapTile.resolution),
         bbox: bboxString(mapTile.area),
@@ -497,7 +497,7 @@ async function getLocationTrackPolyline(
     changeTime: TimeStamp,
     layoutContext: LayoutContext,
 ): Promise<AlignmentPolyLine | undefined> {
-    const tileKey = `${locationTrackId}_${mapTile.id}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    const tileKey = `${locationTrackId}_${mapTile.id}_${layoutContext.publicationState}_${layoutContext.branch}`;
     const params = queryParams({
         resolution: toMapAlignmentResolution(mapTile.resolution),
         bbox: bboxString(mapTile.area),

--- a/ui/src/track-layout/layout-reference-line-api.ts
+++ b/ui/src/track-layout/layout-reference-line-api.ts
@@ -21,7 +21,7 @@ import { filterNotEmpty, indexIntoMap } from 'utils/array-utils';
 const referenceLineCache = asyncCache<string, LayoutReferenceLine | undefined>();
 
 export function cacheKey(id: ReferenceLineId, layoutContext: LayoutContext) {
-    return `${id}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    return `${id}_${layoutContext.publicationState}_${layoutContext.branch}`;
 }
 
 export async function getReferenceLine(
@@ -60,7 +60,7 @@ export async function getTrackNumberReferenceLine(
     layoutContext: LayoutContext,
     changeTime: TimeStamp = getChangeTimes().layoutReferenceLine,
 ): Promise<LayoutReferenceLine | undefined> {
-    const cacheKey = `TN_${trackNumberId}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    const cacheKey = `TN_${trackNumberId}_${layoutContext.publicationState}_${layoutContext.branch}`;
     return referenceLineCache.get(changeTime, cacheKey, () =>
         getNullable<LayoutReferenceLine>(
             `${layoutUri('reference-lines', layoutContext)}/by-track-number/${trackNumberId}`,

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -34,7 +34,7 @@ const switchValidationCache = asyncCache<string, ValidatedSwitch>();
 const tiledSwitchValidationCache = asyncCache<string, ValidatedSwitch[]>();
 
 const cacheKey = (id: LayoutSwitchId, layoutContext: LayoutContext) =>
-    `${id}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    `${id}_${layoutContext.publicationState}_${layoutContext.branch}`;
 
 export async function getSwitchesByBoundingBox(
     bbox: BoundingBox,
@@ -55,7 +55,7 @@ export async function getSwitchesByTile(
     mapTile: MapTile,
     layoutContext: LayoutContext,
 ): Promise<LayoutSwitch[]> {
-    const tileKey = `${mapTile.id}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    const tileKey = `${mapTile.id}_${layoutContext.publicationState}_${layoutContext.branch}`;
     return switchGroupsCache.get(changeTime, tileKey, () =>
         getSwitchesByBoundingBox(mapTile.area, layoutContext),
     );

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -43,7 +43,7 @@ export async function getTrackNumbers(
     changeTime: TimeStamp = getChangeTimes().layoutTrackNumber,
     includeDeleted = false,
 ): Promise<LayoutTrackNumber[]> {
-    const cacheKey = `${includeDeleted}_${layoutContext.publicationState}_${layoutContext.designId}`;
+    const cacheKey = `${includeDeleted}_${layoutContext.publicationState}_${layoutContext.branch}`;
     return trackNumbersCache.get(changeTime, cacheKey, () =>
         getNonNull<LayoutTrackNumber[]>(
             layoutUri('track-numbers', layoutContext) + queryParams({ includeDeleted }),

--- a/ui/src/track-layout/track-layout-api.ts
+++ b/ui/src/track-layout/track-layout-api.ts
@@ -1,4 +1,4 @@
-import { LayoutContext, LayoutDesignId } from 'common/common-model';
+import { LayoutBranch, LayoutContext } from 'common/common-model';
 import { API_URI } from 'api/api-fetch';
 
 type LayoutDataType =
@@ -28,9 +28,9 @@ export function layoutUri(
 }
 
 export function contextInUri(layoutContext: LayoutContext): string {
-    return `${toBranchName(layoutContext.designId).toLowerCase()}/${layoutContext.publicationState.toLowerCase()}`;
+    return `${toBranchName(layoutContext.branch).toLowerCase()}/${layoutContext.publicationState.toLowerCase()}`;
 }
 
-export function toBranchName(designId?: LayoutDesignId): string {
-    return designId ? `DESIGN_${designId}` : 'MAIN';
+export function toBranchName(layoutBranch: LayoutBranch) {
+    return layoutBranch === 'MAIN' ? layoutBranch : `DESIGN_${layoutBranch}`;
 }

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -71,7 +71,7 @@ export function useTrackNumberReferenceLine(
             trackNumberId
                 ? getTrackNumberReferenceLine(trackNumberId, layoutContext, changeTime)
                 : undefined,
-        [trackNumberId, layoutContext.designId, layoutContext.publicationState, changeTime],
+        [trackNumberId, layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -82,7 +82,7 @@ export function useReferenceLine(
 ): LayoutReferenceLine | undefined {
     return useOptionalLoader(
         () => (id ? getReferenceLine(id, layoutContext) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState, changeTime],
+        [id, layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -94,12 +94,7 @@ export function useReferenceLines(
     return (
         useLoader(
             () => (ids ? getReferenceLines(ids, layoutContext) : undefined),
-            [
-                JSON.stringify(ids),
-                layoutContext.publicationState,
-                layoutContext.designId,
-                changeTime,
-            ],
+            [JSON.stringify(ids), layoutContext.publicationState, layoutContext.branch, changeTime],
         ) || []
     );
 }
@@ -111,7 +106,7 @@ export function useLocationTrack(
 ): LayoutLocationTrack | undefined {
     return useOptionalLoader(
         () => (id ? getLocationTrack(id, layoutContext) : undefined),
-        [id, layoutContext.publicationState, layoutContext.designId, changeTime],
+        [id, layoutContext.publicationState, layoutContext.branch, changeTime],
     );
 }
 
@@ -123,12 +118,7 @@ export function useLocationTracks(
     return (
         useLoader(
             () => (ids ? getLocationTracks(ids, layoutContext) : undefined),
-            [
-                JSON.stringify(ids),
-                layoutContext.designId,
-                layoutContext.publicationState,
-                changeTime,
-            ],
+            [JSON.stringify(ids), layoutContext.branch, layoutContext.publicationState, changeTime],
         ) || []
     );
 }
@@ -140,7 +130,7 @@ export function useSwitch(
 ): LayoutSwitch | undefined {
     return useOptionalLoader(
         () => (id ? getSwitch(id, layoutContext) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState, changeTime],
+        [id, layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -152,12 +142,7 @@ export function useSwitches(
     return (
         useLoader(
             () => (ids ? getSwitches(ids, layoutContext) : undefined),
-            [
-                JSON.stringify(ids),
-                layoutContext.designId,
-                layoutContext.publicationState,
-                changeTime,
-            ],
+            [JSON.stringify(ids), layoutContext.branch, layoutContext.publicationState, changeTime],
         ) || []
     );
 }
@@ -173,7 +158,7 @@ export function useTrackNumber(
 ): LayoutTrackNumber | undefined {
     return useLoader(
         () => (id ? getTrackNumberById(id, layoutContext, changeTime) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState, changeTime],
+        [id, layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -184,7 +169,7 @@ export function useTrackNumberWithStatus(
 ): [LayoutTrackNumber | undefined, LoaderStatus] {
     return useLoaderWithStatus(
         () => (id ? getTrackNumberById(id, layoutContext, changeTime) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState, changeTime],
+        [id, layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -194,7 +179,7 @@ export function useTrackNumbers(
 ): LayoutTrackNumber[] | undefined {
     return useLoader(
         () => getTrackNumbers(layoutContext, changeTime),
-        [layoutContext.designId, layoutContext.publicationState, changeTime],
+        [layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -204,7 +189,7 @@ export function useTrackNumbersIncludingDeleted(
 ): LayoutTrackNumber[] | undefined {
     return useLoader(
         () => getTrackNumbers(layoutContext, changeTime, true),
-        [layoutContext.designId, layoutContext.publicationState, changeTime],
+        [layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -215,7 +200,7 @@ export function useReferenceLineStartAndEnd(
 ): AlignmentStartAndEnd | undefined {
     return useLoader(
         () => (id ? getReferenceLineStartAndEnd(id, layoutContext) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState, changeTime],
+        [id, layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -231,7 +216,7 @@ export function useLocationTrackStartAndEnd(
     );
     return useLoaderWithStatus(
         () => (id ? getLocationTrackStartAndEnd(id, layoutContext, changeTime) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState, changeTime],
+        [id, layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -245,7 +230,7 @@ export function useLocationTrackInfoboxExtras(
             id === undefined
                 ? undefined
                 : getLocationTrackInfoboxExtras(id, layoutContext, changeTimes),
-        [id, layoutContext.designId, layoutContext.publicationState, changeTimes],
+        [id, layoutContext.branch, layoutContext.publicationState, changeTimes],
     );
 }
 export function useConflictingTracks(
@@ -270,7 +255,7 @@ export function useConflictingTracks(
             trackNumberId,
             namesString,
             trackIdsString,
-            layoutContext.designId,
+            layoutContext.branch,
             layoutContext.publicationState,
         ],
     );
@@ -286,7 +271,7 @@ export function useTrackNumberChangeTimes(
 ): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getTrackNumberChangeTimes(id, layoutContext) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState],
+        [id, layoutContext.branch, layoutContext.publicationState],
     );
 }
 
@@ -296,7 +281,7 @@ export function useReferenceLineChangeTimes(
 ): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getReferenceLineChangeTimes(id, layoutContext) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState],
+        [id, layoutContext.branch, layoutContext.publicationState],
     );
 }
 
@@ -306,7 +291,7 @@ export function useLocationTrackChangeTimes(
 ): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getLocationTrackChangeTimes(id, layoutContext) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState],
+        [id, layoutContext.branch, layoutContext.publicationState],
     );
 }
 
@@ -316,7 +301,7 @@ export function useSwitchChangeTimes(
 ): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getSwitchChangeTimes(id, layoutContext) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState],
+        [id, layoutContext.branch, layoutContext.publicationState],
     );
 }
 
@@ -326,7 +311,7 @@ export function useKmPostChangeTimes(
 ): LayoutAssetChangeInfo | undefined {
     return useOptionalLoader(
         () => (id ? getKmPostChangeInfo(id, layoutContext) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState],
+        [id, layoutContext.branch, layoutContext.publicationState],
     );
 }
 
@@ -341,7 +326,7 @@ export function useKmPost(
 ): LayoutKmPost | undefined {
     return useOptionalLoader(
         () => (id ? getKmPost(id, layoutContext, changeTime) : undefined),
-        [id, layoutContext.designId, layoutContext.publicationState, changeTime],
+        [id, layoutContext.branch, layoutContext.publicationState, changeTime],
     );
 }
 
@@ -353,12 +338,7 @@ export function useKmPosts(
     return (
         useLoader(
             () => (ids ? getKmPosts(ids, layoutContext, changeTime) : undefined),
-            [
-                JSON.stringify(ids),
-                layoutContext.designId,
-                layoutContext.publicationState,
-                changeTime,
-            ],
+            [JSON.stringify(ids), layoutContext.branch, layoutContext.publicationState, changeTime],
         ) || []
     );
 }

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -19,8 +19,8 @@ import {
 import { linkingReducers } from 'linking/linking-store';
 import { LinkingState, LinkingType } from 'linking/linking-model';
 import {
+    LayoutBranch,
     LayoutContext,
-    LayoutDesignId,
     LayoutMode,
     officialMainLayoutContext,
     PublicationState,
@@ -184,7 +184,7 @@ export enum LocationTrackTaskListType {
 export type SwitchRelinkingValidationTaskList = {
     type: LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION;
     locationTrackId: LocationTrackId;
-    designId: LayoutDesignId | undefined;
+    branch: LayoutBranch;
 };
 
 export type TrackLayoutState = {
@@ -468,7 +468,7 @@ const trackLayoutSlice = createSlice({
         ): void => {
             state.layoutContext = {
                 publicationState: publicationState,
-                designId: state.layoutContext.designId,
+                branch: state.layoutContext.branch,
             };
             if (publicationState === 'OFFICIAL') linkingReducers.stopLinking(state);
         },
@@ -478,7 +478,7 @@ const trackLayoutSlice = createSlice({
         ): void => {
             state.layoutContext = {
                 publicationState: layoutContext.publicationState,
-                designId: layoutContext.designId,
+                branch: layoutContext.branch,
             };
             if (layoutContext.publicationState === 'OFFICIAL') linkingReducers.stopLinking(state);
         },

--- a/ui/src/vertical-geometry/km-heights-api.ts
+++ b/ui/src/vertical-geometry/km-heights-api.ts
@@ -45,7 +45,7 @@ function heightCacheKey(
     tickLength: number,
 ): HeightCacheKey {
     return 'locationTrackId' in alignmentId
-        ? `${alignmentId.locationTrackId}_${alignmentId.layoutContext.publicationState}_${alignmentId.layoutContext.designId}_${tickLength}`
+        ? `${alignmentId.locationTrackId}_${alignmentId.layoutContext.publicationState}_${alignmentId.layoutContext.branch}_${tickLength}`
         : `${alignmentId.planId}_${alignmentId.alignmentId}_${tickLength}`;
 }
 


### PR DESCRIPTION
Korvattu nullable designId-tieto branch-tiedolla, joka saattaa olla 'MAIN', ja viety sen avulla aikalailla kaikkiin API-kutsuihin yhdenmukaisesti läpi todellinen haaratieto, eikä vain olettamusta että kai undefined käy.

Pitkälti hyvin itsestäänselvää muutosta, sen jälkeen kun tyypitti LayoutContextin paremmin. TypeScriptin tyyppien kavennus toimii sen kanssa yhdessä yllättävänkin hyvin, ts. niin, että jos ollaan haarassa, jossa tiedetään että jokin `layoutBranch !== 'MAIN'`, niin sitten sen tiedetään olevan tyyppiä LayoutDesignId. 