### PR TITLE
GVT-2673 Optimize queries with alignment bounding boxes

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
@@ -252,6 +252,9 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
                   where
                     postgis.st_intersects(
                       postgis.st_makeenvelope (:x_min, :y_min, :x_max, :y_max, :layout_srid),
+                      alignment.bounding_box
+                    ) and postgis.st_intersects(
+                      postgis.st_makeenvelope (:x_min, :y_min, :x_max, :y_max, :layout_srid),
                       sg.bounding_box
                     )
                     and e.switch_id is not null

--- a/infra/src/main/resources/db/migration/prod/V80__index_alignment_bounding_box.sql
+++ b/infra/src/main/resources/db/migration/prod/V80__index_alignment_bounding_box.sql
@@ -1,0 +1,1 @@
+create index layout_alignment_bounding_box_index on layout.alignment using gist (bounding_box);


### PR DESCRIPTION
Sivuoptimointi, joka tuli toteutettua GVT-2673:n osana, vaikka ei olekaan sinällään ihan oleellinen. Tai hyvin lähelle tämä siihen liittyy, mutta koska fetchVersionsNear()ia saatetaan taskin bugin takia kutsua turhaan monia tuhansia kertoja, se, että se menee nyt lähemmäs 50 millisekunnissa kuin 250 millisekunnissa auttaa kyllä, mutta ei vielä riitä siihen, että toiminto toimisi nopeasti.

Jos annettu bbox leikkaa jonkin alignmentin segmentin bounding boxia, niin silloin se leikkaa alignmentinkin bboxia, joten edellisten hakua voi aina rajata tarkistamalla ensin jälkimmäisen; sillä erolla, että live-taulussa on alignmentteja vain viitisentuhatta, kun taas segmenttiversioita on kohta varmaan yli miljoona. Postgressi osaa onneksi käyttää tätä määräeroa varsin hyvin hyödykseen hakusuunnittelussa, niin että jos haussa on samalle tasolle tuotavissa alignmentin ja segment_versionin suodatusehdot, se suodattaa aina ensiksi alignmentteja, ja vasta sitten hakee kyseisten alignmenttien segmenttejä ja suodattaa taas niitä.

Uudella indeksillä ei varsinaisesti ole hakujen nopeudelle suurta merkitystä, koska alignment-taulu itse on pieni, mutta riittävän kokoinen se on, että postgressi sitä kyllä käyttää.