### PR TITLE
GVT-2673 Just display the suggested switch in the linking state, if it exists

### DIFF
--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -527,10 +527,7 @@ const MapView: React.FC<MapViewProps> = ({
                         );
                     case 'switch-linking-layer':
                         return createSwitchLinkingLayer(
-                            mapTiles,
-                            resolution,
                             existingOlLayer as VectorLayer<Feature<OlPoint>>,
-                            layoutContext,
                             selection,
                             linkingState as LinkingSwitch | undefined,
                             (loading) => onLayerLoading(layerName, loading),


### PR DESCRIPTION
Koko vaihdelinkitys kaipaa käytännössä vähän isompaa putsausta, jossa heittää pois kaikki hämärät aikaisemmat ajatukset siitä, mitä kaikenlaisia tapauksia niiden kanssa olisi, mutta tekisin sen mieluiten silloin, kun tiimiä on paikalla hieman enemmän varmistamaan ajatuksia.

Tässä nyt kuitenkin selkein ja suorimmin tärkeä, switch-linking-layerin putsaus. Tuo getSuggestedSwitchesByTile-haku ei tehnyt yhtikäs mitään, paitsi että spämmäsi hakuja, joilla sai koko tietokannan tukkoon pienellä zoomauksella. Todellisuudessahan vaihteiden linkitystapauksia on vain kaksi, ja niissä:

- geometriavaihteen linkityksessä vaihde-ehdotuksen haku tehdään jo geometriavaihde valittaessa GeometrySwitchLinkingInfoboxissa (ja sielläkin huonosti, koska käytettävissä olevaa geometriavaihde-ID:tä ei lähetetä bäkkärille), ja "Aloita linkitys"-nappi asettaa vaan ehdotuksen linkingStateen
- paikannuspohjan vaihteen sovittelussa vaihde-ehdotuksen haku tehdään ToolPanelContainerissa
