### PR TITLE
GVT-2618&GVT-2672 Korjauksia suunnitelmatilaisiin linkityksiin + suunnitelmassa luotujen olioiden näkyminen julkaisulistalla

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
@@ -249,7 +249,7 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
                     inner join geometry.element e
                       on e.alignment_id = s.geometry_alignment_id 
                         and e.element_index = s.geometry_element_index
-                  left join layout.switch_in_layout_context('DRAFT', null) switch 
+                  left join layout.switch_in_layout_context('DRAFT', :design_id::int) switch
                     on switch.official_id = s.switch_id
                   where
                     postgis.st_intersects(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.linking
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
@@ -202,6 +203,7 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
     }
 
     fun getMissingLayoutSwitchLinkings(
+        layoutBranch: LayoutBranch,
         bbox: BoundingBox,
         geometrySwitchId: IntId<GeometrySwitch>? = null,
     ): List<MissingLayoutSwitchLinking> {
@@ -217,7 +219,7 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
               plan.srid,
               plan.id as plan_id
             from layout.segment_version
-            inner join layout.location_track_in_layout_context('DRAFT', null) location_track
+            inner join layout.location_track_in_layout_context('DRAFT', :design_id::int) location_track
               on location_track.alignment_id = segment_version.alignment_id
                 and location_track.alignment_version = segment_version.alignment_version
                 and location_track.state != 'DELETED'
@@ -263,6 +265,7 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
         """.trimIndent()
 
         val params = mapOf(
+            "design_id" to layoutBranch.designId?.intValue,
             "geometry_switch_id" to geometrySwitchId,
             "layout_srid" to LAYOUT_SRID.code,
             "x_min" to bbox.min.x,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
@@ -76,7 +76,7 @@ class SwitchFittingService @Autowired constructor(
 
     @Transactional(readOnly = true)
     fun getFitsInArea(branch: LayoutBranch, bbox: BoundingBox): List<FittedSwitch> {
-        val missing = linkingDao.getMissingLayoutSwitchLinkings(bbox)
+        val missing = linkingDao.getMissingLayoutSwitchLinkings(branch, bbox)
         return missing.mapNotNull { missingLayoutSwitchLinking ->
             // Transform joints to layout space and calculate missing joints
             val geomSwitch = geometryDao.getSwitch(missingLayoutSwitchLinking.geometrySwitchId)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -552,7 +552,7 @@ class PublicationDao(
                 on old_tn.id = track_number.track_number_id 
                   and ((track_number.direct_change = true and old_tn.version = track_number_version - 1) 
                     or (track_number.direct_change = false and old_tn.version = track_number_version)) 
-                  and old_tn.draft = false
+                  and old_tn.draft = false and old_tn.design_id is null
               left join layout.reference_line_at(:comparison_time) old_rl on old_rl.id = rl.id and old_rl.draft = false
               left join layout.alignment_version old_av on old_av.id = old_rl.alignment_id and old_av.version = old_rl.alignment_version
               left join layout.segment_version old_sv_first on old_av.id = old_sv_first.alignment_id and old_av.version = old_sv_first.alignment_version and old_sv_first.segment_index = 0
@@ -739,6 +739,7 @@ class PublicationDao(
                               or (old_ltv.version = ltv.version
                               and location_track.direct_change = false))
                             and old_ltv.draft = false
+                            and old_ltv.design_id is null
                 left join layout.alignment_version old_av
                           on old_ltv.alignment_id = old_av.id and old_ltv.alignment_version = old_av.version
                 left join layout.segment_version old_sv_first
@@ -937,6 +938,7 @@ class PublicationDao(
                       on old_km_post_version.id = km_post_version.id 
                         and old_km_post_version.version = km_post_version.version - 1 
                         and old_km_post_version.draft = false
+                        and old_km_post_version.design_id is null
             where publication_id = :publication_id
         """.trimIndent()
 
@@ -991,6 +993,7 @@ class PublicationDao(
                           on old_rlv.id = rlv.id
                             and old_rlv.version = rlv.version - 1 
                             and old_rlv.draft = false
+                            and old_rlv.design_id is null
                 left join layout.alignment_version old_av
                           on old_rlv.alignment_id = old_av.id
                             and old_rlv.alignment_version = old_av.version

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -406,7 +406,7 @@ class PublicationService @Autowired constructor(
      * each ID is fetched from ratko and becomes an object there -> we want to store it, even if the rest fail
      */
     fun updateExternalId(branch: LayoutBranch, request: PublicationRequestIds) {
-        val draftContext = LayoutContext.of(LayoutBranch.main, DRAFT)
+        val draftContext = branch.draft
         try {
             request.locationTracks
                 .filter { trackId -> locationTrackService.getOrThrow(draftContext, trackId).externalId == null }

--- a/infra/src/main/resources/db/migration/prod/V81__remove_live_table_fk_reference_from_publication_table.sql
+++ b/infra/src/main/resources/db/migration/prod/V81__remove_live_table_fk_reference_from_publication_table.sql
@@ -1,0 +1,1 @@
+alter table publication.switch_location_tracks drop constraint publication_switch_location_tracks_location_track_fk;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -45,12 +45,17 @@ fun validationVersions(
 
 fun publish(
     publicationService: PublicationService,
+    branch: LayoutBranch = LayoutBranch.main,
     trackNumbers: List<IntId<TrackLayoutTrackNumber>> = listOf(),
     kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
     switches: List<IntId<TrackLayoutSwitch>> = listOf(),
     referenceLines: List<IntId<ReferenceLine>> = listOf(),
     locationTracks: List<IntId<LocationTrack>> = listOf(),
-) = publish(publicationService, publicationRequest(trackNumbers, kmPosts, switches, referenceLines, locationTracks))
+) = publish(
+    publicationService,
+    publicationRequest(trackNumbers, kmPosts, switches, referenceLines, locationTracks),
+    branch
+)
 
 fun publish(
     publicationService: PublicationService,


### PR DESCRIPTION
Jonkin verran bugifiksejä paikkoihin, missä haaratietoja ei viety tai käsitelty oikein.

Julkaisussa julkaistujen olioiden haku ei yritä vielä etukenossa tehdä mitään järkevää, jos niitä yritetään kutsua suunnitelmien sisäisille julkaisuille, vaan ainostaan mainin julkaisuille, joissa on suunnitelmissa tehtyjä muutoksia (olivat sitten suunnitelmassa luotuja olioita tai mainista tulleita suunnitelmassa muokattuja).