### PR TITLE
GVT-2676 Fix slow query in loading publication candidates

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -208,7 +208,7 @@ class PublicationDao(
               candidate_switch.change_time,
               candidate_switch.change_user,
               (select array_agg(sltn)
-                 from layout.switch_linked_track_numbers(coalesce(base_switch.row_id, candidate_switch.row_id),
+                 from layout.switch_linked_track_numbers(candidate_switch.official_id,
                                                          :candidate_state::layout.publication_state,
                                                          :candidate_design_id) sltn
               ) as track_numbers,


### PR DESCRIPTION
Pääteema jälleen haun esittäminen tavalla, joka on postgressille selkeä. En lukenut tässä tapauksessa hakusuunnitelmia niin tarkkaan, että osaisin sanoa, miksi entinen muoto toimi huonosti, se vaan oli selvästi paljon hitaampi.

Korjattu myös vaihteen ID-viittaus.