### PR TITLE
GVT-2639: Fix local browser cache purge missing redirect in inframodel upload page

### DIFF
--- a/ui/src/common/navigate.ts
+++ b/ui/src/common/navigate.ts
@@ -3,7 +3,7 @@ import { PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { useNavigate } from 'react-router-dom';
 import { PublicationId } from 'publication/publication-model';
 
-const appPath = {
+export const appPath = {
     'frontpage': '/',
     'publication-search': '/publications',
     'publication-view': (id: PublicationId) => `/publications/${id}`,

--- a/ui/src/version-holder/version-holder-view.tsx
+++ b/ui/src/version-holder/version-holder-view.tsx
@@ -1,16 +1,27 @@
 import * as React from 'react';
 import styles from './version-holder-view.scss';
 import { purgePersistentState } from 'index';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { appPath } from 'common/navigate';
 
 type VersionHolderViewProps = {
     version: string;
 };
 
 export const VersionHolderView: React.FC<VersionHolderViewProps> = ({ version }) => {
+    const routerLocation = useLocation();
+    const navigate = useNavigate();
+
     const clearStorage = () => {
         const isOk = confirm('Välimuisti tyhjennetään ja sivu ladataan uudelleen');
         if (isOk) {
             purgePersistentState();
+
+            const urlsRoutedToFrontPage: string[] = [appPath['inframodel-upload']];
+            if (urlsRoutedToFrontPage.includes(routerLocation.pathname)) {
+                navigate('/');
+            }
+
             location.reload();
         }
     };


### PR DESCRIPTION
Most of the pages contain information that can be re-fetched even without local browser cache. The upload page contains non-uploaded content, meaning that it will be lost on cache purge, which lead to a broken page layout.