### PR TITLE
GVT-2685 Optimize fetchSwitchLinkStatus

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
@@ -161,33 +161,42 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
         planId: IntId<GeometryPlan>,
     ): List<GeometrySwitchLinkStatus> {
         val sql = """
-        select
-            switch.id,
-            bool_or(case 
-              when segment_version.switch_id is not null 
-               and layout_switch.row_id is not null 
-               and location_track.row_id is not null
-              then true 
-              else false 
-            end) as is_linked
-          from geometry.switch
-            left join geometry.element
-                      on switch.id = element.switch_id
-            left join layout.segment_version
-                      on segment_version.geometry_element_index = element.element_index
-                        and segment_version.geometry_alignment_id = element.alignment_id
-            left join
-              layout.location_track_in_layout_context(:publication_state::layout.publication_state, :design_id)
-                location_track on location_track.alignment_id = segment_version.alignment_id
-                        and location_track.alignment_version = segment_version.alignment_version
-                        and location_track.state != 'DELETED'
-            left join lateral layout.switch_in_layout_context(:publication_state::layout.publication_state,
-                                                              :design_id,
-                                                              segment_version.switch_id)
-              layout_switch on layout_switch.state_category != 'NOT_EXISTING'
-          where switch.plan_id = :plan_id
-          group by switch.id;
+            select
+              switch.id,
+              exists(
+                  select *
+                    from geometry.element
+                    where element.switch_id = switch.id
+                      and exists(
+                        select *
+                          from layout.segment_version
+                          where segment_version.geometry_element_index = element.element_index
+                            and segment_version.geometry_alignment_id = element.alignment_id
+                            and segment_version.switch_id is not null
+                            and exists(select *
+                                         from layout.location_track
+                                           join lateral layout.location_track_in_layout_context(
+                                             :publication_state::layout.publication_state, :design_id,
+                                             coalesce(location_track.official_row_id,
+                                                      location_track.design_row_id,
+                                                      location_track.id))
+                                                on location_track.id = location_track_in_layout_context.row_id
+                                                  and location_track.version = location_track_in_layout_context.row_version
+                                         where location_track.state != 'DELETED'
+                                           and location_track.alignment_id = segment_version.alignment_id
+                                           and location_track.alignment_version = segment_version.alignment_version
+                            )
+                            and exists(select *
+                                         from layout.switch_in_layout_context(:publication_state::layout.publication_state,
+                                                                              :design_id,
+                                                                              segment_version.switch_id)
+                                         where state_category != 'NOT_EXISTING')
+                      )
+                ) as is_linked
+              from geometry.switch
+              where switch.plan_id = :plan_id;
         """.trimIndent()
+
         val params = mapOf(
             "plan_id" to planId.intValue,
             "publication_state" to layoutContext.state.name,


### PR DESCRIPTION
Haun rakenne muuttuu aika paljon, ja integraatiotestejä ei ole, mutta ainakin nykyisellä suunnitelmien ja paikannuspohjan tilalla tulokset on ilman plan_id-suodatusta tasan samat kuin entisellä toteutuksella. Mutta paljon nopeammin.

Suunnitelmatilaisuuden kanssa paikannuspohjan olioiden kantahauissa näyttää tulevan jatkuvaksi kuvioksi, että jos halutaan hakea olioita jonkin kentän perusteella, mutta virallista ID:tä ei ole vielä tiedossa:
- Haetaan live-taulusta kaikki versiot, jotka löytyvät kentän haun perusteella
- Haetaan lateral joinilla kunkin rivin virallisen ID:n perusteella oikean kontekstin versio
- Tarkistetaan rivi-id:n (ja rivin version, vaikkei kyllä tarvitsisi) perusteella, oliko live-taulusta löytynyt rivi se, joka oikeasit on oikeassa kontekstissa

Tällä kuviolla haut toimii nopeasti, mutta on se hieman ikävä kirjoittaa. Pitää vielä koetella, saisiko hakuja yksinkertaistettua tappamatta perffiä.