### PR TITLE
GVT-2621: Raiteen duplikaattilistaus näyttää duplikaattiduplikaatteja

### DIFF
--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
@@ -12,6 +12,7 @@ import { LayoutContext, TimeStamp } from 'common/common-model';
 import { useTrackNumbers } from 'track-layout/track-layout-react-utils';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { createClassName } from 'vayla-design-lib/utils';
+import { filterUniqueById } from 'utils/array-utils';
 
 export type LocationTrackInfoboxDuplicateOfProps = {
     layoutContext: LayoutContext;
@@ -92,7 +93,7 @@ export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDupli
         </React.Fragment>
     ) : duplicatesOfLocationTrack ? (
         <ul className={styles['location-track-infobox-duplicate-of__ul']}>
-            {duplicatesOfLocationTrack.map((duplicate) => (
+            {duplicatesOfLocationTrack.filter(filterUniqueById((d) => d.id)).map((duplicate) => (
                 <li key={duplicate.id}>
                     <LocationTrackLink
                         locationTrackId={duplicate.id}


### PR DESCRIPTION
Aiempi tila johtui siitä, että duplikaattilistaus vain iteroi bäkkäriltä tulleen duplikaattiustietotaulukon läpi tutkimatta sen sisältöä sen kummemmin. Sama raide saattaa kuitenkin esiintyä taulukossa useaan kertaan mikäli sen on jonkin raiteen duplikaatti useammassa eri kohdassa. Bäkkärin puolesta tämä on enemmän ominaisuus kuin bugi (tuota tietoa käytetään hyväksi esim. splittauksessa,) joten päädyin muokkaamaan raiteen infoboksin duplikaattilistausta ja varmistamaan että siellä kukin duplikaatti listataan vain kertaalleen. Mietin muitakin vaihtoehtoja (esim. listauksen muuttamisen vähän esim. Raiteen geometriat -infoboksin tyyliseen muotoon, jossa duplikaattius ilmoitetaan aina rataosoiteväleittäin,) mutta tulin siihen tulokseen että tämä lienee se mitä oikeasti halutaan.