### PR TITLE
GVT-2674 Rework front page layout, add design publications

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -529,3 +529,5 @@ data class MergeFromDesign(override val candidateBranch: DesignBranch): LayoutCo
     override val candidatePublicationState = PublicationState.OFFICIAL
     override val basePublicationState = PublicationState.DRAFT
 }
+
+enum class PublicationListMode { DESIGN, MAIN }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -145,12 +145,12 @@ class PublicationController @Autowired constructor(
     }
 
     @PreAuthorize(AUTH_VIEW_PUBLICATION)
-    @GetMapping("latest")
+    @GetMapping("latest/{mode}")
     fun getLatestPublications(
-        @RequestParam("layoutBranch", required = false) layoutBranch: LayoutBranch?,
+        @PathVariable("mode") mode: PublicationListMode,
         @RequestParam("count") count: Int,
     ): Page<PublicationDetails> {
-        val publications = publicationService.fetchLatestPublicationDetails(layoutBranch ?: LayoutBranch.main, count)
+        val publications = publicationService.fetchLatestPublicationDetails(mode, count)
 
         return Page(totalCount = publications.size, start = 0, items = publications)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -484,17 +484,17 @@ class PublicationDao(
     }
 
     //Inclusive from/start time, but exclusive to/end time
-    fun fetchLatestPublications(layoutBranch: LayoutBranch, count: Int): List<Publication> {
+    fun fetchLatestPublications(mode: PublicationListMode, count: Int): List<Publication> {
         val sql = """
             select id, publication_user, publication_time, message, design_id
             from publication.publication
-            where design_id is not distinct from :design_id
+            where case when :mode = 'MAIN' then design_id is null else design_id is not null end
             order by id desc limit :count
         """.trimIndent()
 
         val params = mapOf(
             "count" to count,
-            "design_id" to layoutBranch.designId?.intValue,
+            "mode" to mode.name,
         )
 
         return jdbcTemplate.query(sql, params) { rs, _ ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -784,8 +784,8 @@ class PublicationService @Autowired constructor(
     }
 
     @Transactional(readOnly = true)
-    fun fetchLatestPublicationDetails(layoutBranch: LayoutBranch, count: Int): List<PublicationDetails> {
-        return publicationDao.fetchLatestPublications(layoutBranch, count).map { getPublicationDetails(it.id) }
+    fun fetchLatestPublicationDetails(mode: PublicationListMode, count: Int): List<PublicationDetails> {
+        return publicationDao.fetchLatestPublications(mode, count).map { getPublicationDetails(it.id) }
     }
 
     @Transactional(readOnly = true)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
@@ -40,6 +40,13 @@ class RatkoController(
         return HttpStatus.NO_CONTENT
     }
 
+    @PreAuthorize(AUTH_EDIT_LAYOUT)
+    @PostMapping("/push-designs")
+    fun pushDesignChangesToRatko(): HttpStatus {
+        // TODO implement
+        return HttpStatus.NO_CONTENT
+    }
+
     @PreAuthorize(AUTH_VIEW_LAYOUT)
     @PostMapping("/push-location-tracks")
     fun pushLocationTracksToRatko(@RequestBody changes: List<LocationTrackChange>): ResponseEntity<String> {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1571,7 +1571,8 @@
         "show-split-info": "Näytä raiteen jakamisen tiedot",
         "mark-as-successful": "Merkitse kohteiden siirto onnistuneeksi",
         "transfer-starts-shortly": "Vienti käynnistyy automaattisesti hetken kuluttua",
-        "bulk-transfer-marked-as-successful": "Kohteiden siirto merkitty onnistuneeksi"
+        "bulk-transfer-marked-as-successful": "Kohteiden siirto merkitty onnistuneeksi",
+        "ratko-push-connection-issue": "Yhteysvirhe Ratko-viennissä"
     },
     "split-details-dialog": {
         "title": "Raiteen jakamisen tiedot",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationDao
+import fi.fta.geoviite.infra.publication.PublicationListMode
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.ratko.RatkoPushDao
 import fi.fta.geoviite.infra.tracklayout.LayoutDaoResponse
@@ -198,7 +199,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
         val locationTrack2Response = insertAndPublishLocationTrack()
         val publicationId2 = createPublication(locationTracks = listOf(locationTrack2Response.id), message = "Test")
 
-        val publications = publicationDao.fetchLatestPublications(LayoutBranch.main, 2)
+        val publications = publicationDao.fetchLatestPublications(PublicationListMode.MAIN, 2)
 
         assertEquals(publications.size, 2)
         assertEquals(publications[0].id, publicationId2)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1293,7 +1293,7 @@ class PublicationServiceIT @Autowired constructor(
             ),
         )
         publishAndVerify(LayoutBranch.main, publicationRequest(trackNumbers = listOf(trackNumber.id as IntId)))
-        val thisAndPreviousPublication = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val thisAndPreviousPublication = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val changes = publicationDao.fetchPublicationTrackNumberChanges(
             LayoutBranch.main,
             thisAndPreviousPublication.first().id,
@@ -1346,7 +1346,7 @@ class PublicationServiceIT @Autowired constructor(
             ),
         )
         publishAndVerify(LayoutBranch.main, publicationRequest(trackNumbers = listOf(trackNumber.id as IntId)))
-        val thisAndPreviousPublication = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val thisAndPreviousPublication = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val changes = publicationDao.fetchPublicationTrackNumberChanges(
             LayoutBranch.main,
             thisAndPreviousPublication.first().id,
@@ -1447,7 +1447,7 @@ class PublicationServiceIT @Autowired constructor(
             ).rowVersion
         )
         publish(publicationService, locationTracks = listOf(updatedLocationTrack.id as IntId<LocationTrack>))
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
@@ -1555,7 +1555,7 @@ class PublicationServiceIT @Autowired constructor(
             ).rowVersion
         )
         publish(publicationService, locationTracks = listOf(updatedLocationTrack.id as IntId<LocationTrack>))
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
@@ -1626,7 +1626,7 @@ class PublicationServiceIT @Autowired constructor(
         )
         publish(publicationService, kmPosts = listOf(updatedKmPost.id as IntId))
 
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs.first()
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
 
@@ -1660,7 +1660,7 @@ class PublicationServiceIT @Autowired constructor(
     }
 
     private fun getLatestPublicationDiffForKmPost(id: IntId<TrackLayoutKmPost>): List<PublicationChange<out Comparable<Nothing>?>> {
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs.first()
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
         return publicationService.diffKmPost(
@@ -1690,7 +1690,7 @@ class PublicationServiceIT @Autowired constructor(
             kmPostService.updateKmPost(LayoutBranch.main, kmPost.id as IntId, saveReq.copy(kmNumber = KmNumber(1))),
         )
         publish(publicationService, kmPosts = listOf(updatedKmPost.id as IntId))
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs.first()
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
 
@@ -1751,7 +1751,7 @@ class PublicationServiceIT @Autowired constructor(
         )
         publish(publicationService, switches = listOf(updatedSwitch.id as IntId))
 
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
@@ -1797,7 +1797,7 @@ class PublicationServiceIT @Autowired constructor(
         )
         publish(publicationService, switches = listOf(updatedSwitch.id as IntId))
 
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
@@ -1915,7 +1915,7 @@ class PublicationServiceIT @Autowired constructor(
                 newSwitchReplacingOldWithSameName.id,
             ),
         )
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs[0]
         val previousPub = latestPubs[1]
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
@@ -2053,7 +2053,7 @@ class PublicationServiceIT @Autowired constructor(
                 newSwitchReplacingOldWithSameName.id,
             ),
         )
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs[0]
         val previousPub = latestPubs[1]
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
@@ -2109,7 +2109,7 @@ class PublicationServiceIT @Autowired constructor(
             newAlignment,
         )
         publish(publicationService, locationTracks = listOf(originalLocationTrack.id))
-        val latestPub = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 1)[0]
+        val latestPub = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 1)[0]
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
 
         val diff = publicationService.diffLocationTrack(
@@ -2226,19 +2226,19 @@ class PublicationServiceIT @Autowired constructor(
 
         assertEquals(2, publicationService.fetchPublications(LayoutBranch.main).size)
 
-        assertEquals(1, publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 1).size)
+        assertEquals(1, publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 1).size)
         assertEquals(
             publish2.publicationId,
-            publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 1)[0].id
+            publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 1)[0].id
         )
 
-        assertEquals(2, publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2).size)
+        assertEquals(2, publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2).size)
         assertEquals(
             publish1.publicationId,
-            publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 10)[1].id
+            publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 10)[1].id
         )
 
-        assertTrue { publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 0).isEmpty() }
+        assertTrue { publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 0).isEmpty() }
     }
 
     @Test
@@ -2334,7 +2334,7 @@ class PublicationServiceIT @Autowired constructor(
 
         publish(publicationService, switches = listOf(switch.id), locationTracks = listOf(locationTrack.id))
 
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
@@ -2408,7 +2408,7 @@ class PublicationServiceIT @Autowired constructor(
         switchService.mergeToMainBranch(testBranch, switch.id)
         publish(publicationService, switches = listOf(switch.id), locationTracks = listOf(locationTrack.id))
 
-        val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 2)
+        val latestPubs = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
@@ -4007,7 +4007,7 @@ class PublicationServiceIT @Autowired constructor(
         publish(publicationService, testBranch, trackNumbers = listOf(trackNumber))
         trackNumberService.mergeToMainBranch(testBranch, trackNumber)
         publish(publicationService, trackNumbers = listOf(trackNumber))
-        val latestPub = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 1)
+        val latestPub = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 1)
         assertEquals(Operation.CREATE, latestPub[0].trackNumbers[0].operation)
     }
 
@@ -4019,7 +4019,7 @@ class PublicationServiceIT @Autowired constructor(
         publish(publicationService, testBranch, locationTracks = listOf(locationTrack))
         locationTrackService.mergeToMainBranch(testBranch, locationTrack)
         publish(publicationService, locationTracks = listOf(locationTrack))
-        val latestPub = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 1)
+        val latestPub = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 1)
         assertEquals(Operation.CREATE, latestPub[0].locationTracks[0].operation)
     }
 
@@ -4030,7 +4030,7 @@ class PublicationServiceIT @Autowired constructor(
         publish(publicationService, testBranch, switches = listOf(switch))
         switchService.mergeToMainBranch(testBranch, switch)
         publish(publicationService, switches = listOf(switch))
-        val latestPub = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 1)
+        val latestPub = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 1)
         assertEquals(Operation.CREATE, latestPub[0].switches[0].operation)
     }
 
@@ -4042,7 +4042,7 @@ class PublicationServiceIT @Autowired constructor(
         publish(publicationService, testBranch, kmPosts = listOf(kmPost))
         kmPostService.mergeToMainBranch(testBranch, kmPost)
         publish(publicationService, kmPosts = listOf(kmPost))
-        val latestPub = publicationService.fetchLatestPublicationDetails(LayoutBranch.main, 1)
+        val latestPub = publicationService.fetchLatestPublicationDetails(PublicationListMode.MAIN, 1)
         assertEquals(Operation.CREATE, latestPub[0].kmPosts[0].operation)
     }
 

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -9,7 +9,7 @@ import {
 } from 'track-layout/track-layout-model';
 import { compare } from 'utils/array-utils';
 import i18next from 'i18next';
-import { Brand } from 'common/brand';
+import { brand, Brand } from 'common/brand';
 
 export type RotationDirection = 'CW' | 'CCW';
 export type LinearUnit = 'MILLIMETER' | 'CENTIMETER' | 'METER' | 'KILOMETER';
@@ -18,14 +18,17 @@ export type AngularUnit = 'RADIANS' | 'GRADS';
 export type DataType = 'STORED' | 'TEMP';
 
 export type LayoutDesignId = Brand<string, 'LayoutDesignId'>;
-export type MainLayoutBranchId = 'MAIN';
-export type LayoutBranch = MainLayoutBranchId | LayoutDesignId;
+export type MainBranch = 'MAIN';
+export type DesignBranch = Brand<string, 'DesignBranch'>;
+export type LayoutBranch = MainBranch | DesignBranch;
 
 export type PublicationState = 'OFFICIAL' | 'DRAFT';
 export type LayoutContext = {
     publicationState: PublicationState;
     branch: LayoutBranch;
 };
+
+export const designBranch = (designId: LayoutDesignId): DesignBranch => brand(`DESIGN_${designId}`);
 
 export type LayoutContextMode = 'MAIN-OFFICIAL' | 'MAIN-DRAFT' | 'DESIGN';
 
@@ -60,7 +63,7 @@ export const draftMainLayoutContext = (): LayoutContext => draftMainContext;
 export function draftDesignLayoutContext(designId: LayoutDesignId): LayoutContext {
     return {
         publicationState: 'DRAFT',
-        branch: designId,
+        branch: designBranch(designId),
     };
 }
 

--- a/ui/src/frontpage/frontpage.scss
+++ b/ui/src/frontpage/frontpage.scss
@@ -1,20 +1,12 @@
 @use 'vayla-design-lib' as vayla-design;
 
 .frontpage {
-    background: vayla-design.$color-white-dark;
     overflow: hidden auto;
     padding: 8px 16px 16px 16px;
     min-width: 494px;
+    width: 100%;
 
-    .card {
-        margin: 16px;
-        width: 420px;
-    }
-
-    &__photo {
-        flex: 1;
-        background-image: url('geoviite-design-lib/frontpage-background.jpeg');
-        background-size: cover;
-        background-position: right center;
-    }
+    background-image: url('geoviite-design-lib/frontpage-background.jpeg');
+    background-size: cover;
+    background-position: right center;
 }

--- a/ui/src/frontpage/frontpage.tsx
+++ b/ui/src/frontpage/frontpage.tsx
@@ -31,10 +31,17 @@ const Frontpage: React.FC<FrontPageProps> = ({
                     ratkoPushChangeTime={ratkoPushChangeTime}
                     splitChangeTime={splitChangeTime}
                     ratkoStatus={ratkoStatus}
+                    publicationListMode="MAIN"
+                />
+                <PublicationCard
+                    publicationChangeTime={publicationChangeTime}
+                    ratkoPushChangeTime={ratkoPushChangeTime}
+                    splitChangeTime={splitChangeTime}
+                    ratkoStatus={ratkoStatus}
+                    publicationListMode="DESIGN"
                 />
                 <UserCardContainer />
             </div>
-            <div className={styles['frontpage__photo']} />
         </React.Fragment>
     );
 };

--- a/ui/src/linking/linking-api.ts
+++ b/ui/src/linking/linking-api.ts
@@ -41,7 +41,7 @@ import { getSuggestedSwitchId } from 'linking/linking-utils';
 import { bboxString, pointString } from 'common/common-api';
 import { BoundingBox, Point } from 'model/geometry';
 import { filterNotEmpty, first, indexIntoMap } from 'utils/array-utils';
-import { contextInUri, toBranchName } from 'track-layout/track-layout-api';
+import { contextInUri } from 'track-layout/track-layout-api';
 
 const LINKING_URI = `${API_URI}/linking`;
 
@@ -75,7 +75,7 @@ function linkingUri(
     linkingType: LinkingType,
     id?: string,
 ): string {
-    const base = `${LINKING_URI}/${toBranchName(layoutBranch).toLowerCase()}/${dataType}`;
+    const base = `${LINKING_URI}/${layoutBranch.toLowerCase()}/${dataType}`;
     const idSection = id ? `/${id}` : '';
     return `${base}/${idSection}/${linkingType}`;
 }

--- a/ui/src/preview/preview-footer.tsx
+++ b/ui/src/preview/preview-footer.tsx
@@ -149,7 +149,7 @@ export const PreviewFooter: React.FC<PreviewFooterProps> = (props: PreviewFooter
                 ) : (
                     props.layoutContext.branch !== 'MAIN' && (
                         <PreviewMergeToMainConfirmationDialog
-                            designId={props.layoutContext.branch}
+                            designBranch={props.layoutContext.branch}
                             isPublishing={isPublishing}
                             onCancel={() => setPublishConfirmVisible(false)}
                             candidateCount={candidateCount}

--- a/ui/src/preview/preview-merge-to-main-confirmation-dialog.tsx
+++ b/ui/src/preview/preview-merge-to-main-confirmation-dialog.tsx
@@ -4,13 +4,13 @@ import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { useTranslation } from 'react-i18next';
-import { getLayoutDesign } from 'track-layout/layout-design-api';
+import { getLayoutDesignByBranch } from 'track-layout/layout-design-api';
 import { useLoader } from 'utils/react-utils';
-import { LayoutDesignId } from 'common/common-model';
+import { DesignBranch } from 'common/common-model';
 import { getChangeTimes } from 'common/change-time-api';
 
 export type PreviewMergeToMainConfirmationDialogProps = {
-    designId: LayoutDesignId;
+    designBranch: DesignBranch;
     isPublishing: boolean;
     onCancel: () => void;
     candidateCount: number;
@@ -19,11 +19,14 @@ export type PreviewMergeToMainConfirmationDialogProps = {
 
 export const PreviewMergeToMainConfirmationDialog: React.FC<
     PreviewMergeToMainConfirmationDialogProps
-> = ({ designId, isPublishing, onCancel, candidateCount, mergeToMain }) => {
+> = ({ designBranch, isPublishing, onCancel, candidateCount, mergeToMain }) => {
     const { t } = useTranslation();
+
     const design =
-        useLoader(() => getLayoutDesign(getChangeTimes().layoutDesign, designId), [designId])
-            ?.name ?? '';
+        useLoader(
+            () => getLayoutDesignByBranch(getChangeTimes().layoutDesign, designBranch),
+            [designBranch],
+        )?.name ?? '';
 
     return (
         <Dialog

--- a/ui/src/publication/card/publication-card.scss
+++ b/ui/src/publication/card/publication-card.scss
@@ -2,6 +2,10 @@
 
 .publication-card {
     padding-top: 0;
+    width: 420px;
+    height: fit-content;
+    float: left;
+    margin: 5px 20px 5px 20px;
 
     &__title {
         @include vayla-design.typography-heading;

--- a/ui/src/publication/card/publication-card.tsx
+++ b/ui/src/publication/card/publication-card.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { compareTimestamps } from 'utils/date-utils';
 import { PublicationList } from 'publication/card/publication-list';
@@ -13,7 +14,6 @@ import { Link } from 'vayla-design-lib/link/link';
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
-import { useEffect } from 'react';
 import { useAppNavigate } from 'common/navigate';
 import { defaultPublicationSearch } from 'publication/publication-utils';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
@@ -23,13 +23,14 @@ import {
     ProgressIndicatorType,
     ProgressIndicatorWrapper,
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
-import { first } from 'utils/array-utils';
+import { PublicationListMode } from 'publication/publication-model';
 
 type PublishListProps = {
     publicationChangeTime: TimeStamp;
     ratkoPushChangeTime: TimeStamp;
     splitChangeTime: TimeStamp;
     ratkoStatus: RatkoStatus | undefined;
+    publicationListMode: PublicationListMode;
 };
 
 const parseRatkoConnectionError = (errorType: string, ratkoStatusCode: number, contact: string) => {
@@ -77,6 +78,7 @@ const PublicationCard: React.FC<PublishListProps> = ({
     ratkoPushChangeTime,
     splitChangeTime,
     ratkoStatus,
+    publicationListMode,
 }) => {
     const { t } = useTranslation();
     const navigate = useAppNavigate();
@@ -92,7 +94,7 @@ const PublicationCard: React.FC<PublishListProps> = ({
 
     const [pageCount, setPageCount] = React.useState(1);
     const [publications, publicationFetchStatus] = useLoaderWithStatus(
-        () => getLatestPublications(MAX_LISTED_PUBLICATIONS * pageCount),
+        () => getLatestPublications(MAX_LISTED_PUBLICATIONS * pageCount, publicationListMode),
         [publicationChangeTime, ratkoPushChangeTime, splitChangeTime, pageCount],
     );
 
@@ -109,10 +111,9 @@ const PublicationCard: React.FC<PublishListProps> = ({
         ratkoPushSucceeded(publication.ratkoPushStatus),
     );
 
-    const latestFailure = first(
-        allPublications.filter((publication) => ratkoPushFailed(publication.ratkoPushStatus)),
+    const latestFailures = allPublications.filter((publication) =>
+        ratkoPushFailed(publication.ratkoPushStatus),
     );
-
     const ratkoConnectionError =
         ratkoStatus && !ratkoStatus.isOnline && ratkoStatus.statusCode >= 300;
 
@@ -144,9 +145,9 @@ const PublicationCard: React.FC<PublishListProps> = ({
                                         {parseRatkoOfflineStatus(ratkoStatus)}
                                     </p>
                                 )}
-                                {latestFailure && (
-                                    <RatkoPushErrorDetails latestFailure={latestFailure} />
-                                )}
+                                {latestFailures.map((fail) => (
+                                    <RatkoPushErrorDetails key={fail.id} failedPublication={fail} />
+                                ))}
                                 <PublicationList publications={nonSuccesses} />
                                 {allWaiting && (
                                     <div className={styles['publication-card__waiting-text']}>
@@ -157,9 +158,12 @@ const PublicationCard: React.FC<PublishListProps> = ({
                                         <span>{t('publication-card.transfer-starts-shortly')}</span>
                                     </div>
                                 )}
-                                {latestFailure && (
+                                {latestFailures.length > 0 && (
                                     <div className={styles['publication-card__ratko-push-button']}>
-                                        <RatkoPublishButton disabled={ratkoConnectionError} />
+                                        <RatkoPublishButton
+                                            mode={publicationListMode}
+                                            disabled={ratkoConnectionError}
+                                        />
                                     </div>
                                 )}
                             </section>
@@ -181,13 +185,15 @@ const PublicationCard: React.FC<PublishListProps> = ({
                             </Link>
                         </div>
                         <br />
-                        <div>
-                            <Link
-                                onClick={() => navigateToPublicationLog()}
-                                qa-id={'open-publication-log'}>
-                                {t('publication-card.log-link')}
-                            </Link>
-                        </div>
+                        {publicationListMode === 'MAIN' && (
+                            <div>
+                                <Link
+                                    onClick={() => navigateToPublicationLog()}
+                                    qa-id={'open-publication-log'}>
+                                    {t('publication-card.log-link')}
+                                </Link>
+                            </div>
+                        )}
                     </ProgressIndicatorWrapper>
                 </React.Fragment>
             }

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -15,7 +15,8 @@ import { Menu, menuOption, MenuSelectOption } from 'vayla-design-lib/menu/menu';
 import { SplitDetailsDialog } from 'publication/split/split-details-dialog';
 import { putBulkTransferState } from 'publication/split/split-api';
 import { success } from 'geoviite-design-lib/snackbar/snackbar';
-import { updateSplitChangeTime } from 'common/change-time-api';
+import { getChangeTimes, updateSplitChangeTime } from 'common/change-time-api';
+import { useLayoutDesign } from 'track-layout/track-layout-react-utils';
 
 type PublicationListRowProps = {
     publication: PublicationDetails;
@@ -75,6 +76,8 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
 }) => {
     const { t } = useTranslation();
 
+    const design = useLayoutDesign(getChangeTimes().layoutDesign, publication.layoutBranch)?.name;
+
     const [menuOpen, setMenuOpen] = React.useState(false);
     const [splitDetailsDialogOpen, setSplitDetailsDialogOpen] = React.useState(false);
     const buttonClassNames = createClassName(
@@ -124,15 +127,25 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                         </span>
                     )}
                     <span className={styles['publication-list-item__text']}>
-                        <Link
-                            onClick={() => {
-                                setSelectedPublicationId(publication.id);
-                                navigate('publication-view', publication.id);
-                            }}>
-                            {formatDateFull(publication.publicationTime)}
-                        </Link>
+                        {(() => {
+                            const text = formatDateFull(publication.publicationTime);
+                            return publication.layoutBranch === 'MAIN' ? (
+                                <Link
+                                    onClick={() => {
+                                        setSelectedPublicationId(publication.id);
+                                        navigate('publication-view', publication.id);
+                                    }}>
+                                    {text}
+                                </Link>
+                            ) : (
+                                text
+                            );
+                        })()}
                     </span>
                 </span>
+                {design && (
+                    <span className={styles['publication-list-item__design-name']}>{design}: </span>
+                )}
                 <span>{publication.message}</span>
             </div>
             {publication.split && (

--- a/ui/src/publication/card/publication-list.scss
+++ b/ui/src/publication/card/publication-list.scss
@@ -98,4 +98,9 @@
             margin-right: 6px;
         }
     }
+
+    &__design-name {
+        font-weight: 600;
+        margin-right: 2px;
+    }
 }

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -15,6 +15,7 @@ import {
     PublicationCandidateReference,
     PublicationDetails,
     PublicationId,
+    PublicationListMode,
     PublicationRequest,
     PublicationRequestIds,
     PublicationResult,
@@ -31,17 +32,16 @@ import { PublicationDetailsTableSortField } from 'publication/table/publication-
 import { SortDirection } from 'utils/table-utils';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { createPublicationCandidateReference } from 'publication/publication-utils';
-import { LayoutBranch, LayoutDesignId, PublicationState } from 'common/common-model';
-import { toBranchName } from 'track-layout/track-layout-api';
+import { DesignBranch, LayoutBranch, PublicationState } from 'common/common-model';
 
 const PUBLICATION_URL = `${API_URI}/publications`;
 
 function publicationUri(layoutBranch: LayoutBranch): string {
-    return `${PUBLICATION_URL}/${toBranchName(layoutBranch).toLowerCase()}`;
+    return `${PUBLICATION_URL}/${layoutBranch.toLowerCase()}`;
 }
 
-function mergeToMainUri(designId: LayoutDesignId): string {
-    return `${PUBLICATION_URL}/merge-to-main/${toBranchName(designId).toLowerCase()}`;
+function mergeToMainUri(designBranch: DesignBranch): string {
+    return `${PUBLICATION_URL}/merge-to-main/${designBranch.toLowerCase()}`;
 }
 
 export type PublicationCandidatesResponse = {
@@ -207,7 +207,7 @@ export const publishPublicationCandidates = (
 };
 
 export const mergeCandidatesToMain = (
-    layoutBranch: LayoutDesignId,
+    layoutBranch: DesignBranch,
     candidates: PublicationCandidateReference[],
 ) => {
     const request = toPublicationRequestIds(candidates);
@@ -218,12 +218,14 @@ export const mergeCandidatesToMain = (
     );
 };
 
-export const getLatestPublications = async (count: number) => {
+export const getLatestPublications = async (count: number, mode: PublicationListMode) => {
     const params = queryParams({
         count,
     });
 
-    const page = await getNonNull<Page<PublicationDetails>>(`${PUBLICATION_URL}/latest${params}`);
+    const page = await getNonNull<Page<PublicationDetails>>(
+        `${PUBLICATION_URL}/latest/${mode}${params}`,
+    );
     return page.items;
 };
 

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -2,6 +2,7 @@ import {
     AssetId,
     JointNumber,
     KmNumber,
+    LayoutBranch,
     Oid,
     Range,
     RowVersion,
@@ -166,6 +167,7 @@ export type PublicationDetails = {
     id: PublicationId;
     publicationTime: TimeStamp;
     publicationUser: string;
+    layoutBranch: LayoutBranch;
     trackNumbers: PublishedTrackNumber[];
     referenceLines: PublishedReferenceLine[];
     locationTracks: PublishedLocationTrack[];
@@ -355,3 +357,5 @@ export type SplitTargetInPublication = {
 };
 
 export type DesignRowReferrer = 'MAIN_DRAFT' | 'DESIGN_DRAFT' | 'NONE';
+
+export type PublicationListMode = 'MAIN' | 'DESIGN';

--- a/ui/src/publication/split/split-api.ts
+++ b/ui/src/publication/split/split-api.ts
@@ -2,7 +2,6 @@ import { SplitRequest } from 'tool-panel/location-track/split-store';
 import { API_URI, getNullable, postNonNull, putNonNull } from 'api/api-fetch';
 import { Split } from 'publication/publication-model';
 import { LayoutBranch } from 'common/common-model';
-import { toBranchName } from 'track-layout/track-layout-api';
 
 const SPLIT_URI = `${API_URI}/location-track-split`;
 
@@ -10,10 +9,7 @@ export const postSplitLocationTrack = async (
     request: SplitRequest,
     branch: LayoutBranch,
 ): Promise<string> => {
-    return postNonNull<SplitRequest, string>(
-        `${SPLIT_URI}/${toBranchName(branch).toLowerCase()}`,
-        request,
-    );
+    return postNonNull<SplitRequest, string>(`${SPLIT_URI}/${branch.toLowerCase()}`, request);
 };
 
 export const getSplit = async (id: string): Promise<Split | undefined> =>

--- a/ui/src/ratko/ratko-api.ts
+++ b/ui/src/ratko/ratko-api.ts
@@ -1,12 +1,13 @@
 import { API_URI, getNonNull, getNonNullAdt, postNullable } from 'api/api-fetch';
-import { PublicationId } from 'publication/publication-model';
+import { PublicationId, PublicationListMode } from 'publication/publication-model';
 import { RatkoPushError } from 'ratko/ratko-model';
 import { LocationTrackId } from 'track-layout/track-layout-model';
 import { KmNumber } from 'common/common-model';
 
 const RATKO_URI = `${API_URI}/ratko`;
 
-export const pushToRatko = () => postNullable(`${RATKO_URI}/push`, undefined);
+export const pushToRatko = (mode: PublicationListMode) =>
+    postNullable(`${RATKO_URI}/push${mode === 'MAIN' ? '' : '-designs'}`, undefined);
 
 export const getRatkoPushError = (publicationId: PublicationId) =>
     getNonNull<RatkoPushError>(`${RATKO_URI}/errors/${publicationId}`);

--- a/ui/src/ratko/ratko-publish-button.tsx
+++ b/ui/src/ratko/ratko-publish-button.tsx
@@ -7,13 +7,15 @@ import { Dialog } from 'geoviite-design-lib/dialog/dialog';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
+import { PublicationListMode } from 'publication/publication-model';
 
 type RatkoPublishButtonProps = {
     size?: ButtonSize;
     disabled?: boolean;
+    mode: PublicationListMode;
 };
 
-const RatkoPublishButton: React.FC<RatkoPublishButtonProps> = ({ size, disabled }) => {
+const RatkoPublishButton: React.FC<RatkoPublishButtonProps> = ({ size, disabled, mode }) => {
     const { t } = useTranslation();
     const [isPublishing, setIsPublishing] = React.useState(false);
     const [showingConfirmation, setShowingConfirmation] = React.useState(false);
@@ -21,7 +23,7 @@ const RatkoPublishButton: React.FC<RatkoPublishButtonProps> = ({ size, disabled 
         setShowingConfirmation(false);
         setIsPublishing(true);
         // TODO Catch cases where RatkoAPI is not online
-        pushToRatko().finally(() => setIsPublishing(false));
+        pushToRatko(mode).finally(() => setIsPublishing(false));
     };
 
     return (

--- a/ui/src/ratko/ratko-push-error.scss
+++ b/ui/src/ratko/ratko-push-error.scss
@@ -5,4 +5,9 @@
     text-transform: none;
     color: vayla-design.$color-red-dark;
     margin-bottom: 12px;
+
+    &__design-name {
+        font-weight: 600;
+        margin-right: 2px;
+    }
 }

--- a/ui/src/track-layout/layout-design-api.ts
+++ b/ui/src/track-layout/layout-design-api.ts
@@ -1,6 +1,6 @@
 import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
 import { getNonNull, postNonNull, putNonNull } from 'api/api-fetch';
-import { LayoutDesignId, TimeStamp } from 'common/common-model';
+import { designBranch, DesignBranch, LayoutDesignId, TimeStamp } from 'common/common-model';
 import { asyncCache } from 'cache/cache';
 
 const designCache = asyncCache<string, LayoutDesign[]>();
@@ -26,6 +26,14 @@ export async function getLayoutDesign(changeTime: TimeStamp, id: LayoutDesignId)
         }
         return design;
     });
+}
+
+export async function getLayoutDesignByBranch(
+    changeTime: TimeStamp,
+    branch: DesignBranch,
+): Promise<LayoutDesign | undefined> {
+    const designs = await getLayoutDesigns(changeTime);
+    return designs.find((design) => designBranch(design.id) === branch);
 }
 
 export const getLayoutDesignOrUndefined = async (changeTime: TimeStamp, id: LayoutDesignId) =>

--- a/ui/src/track-layout/track-layout-api.ts
+++ b/ui/src/track-layout/track-layout-api.ts
@@ -1,4 +1,4 @@
-import { LayoutBranch, LayoutContext } from 'common/common-model';
+import { LayoutContext } from 'common/common-model';
 import { API_URI } from 'api/api-fetch';
 
 type LayoutDataType =
@@ -28,9 +28,5 @@ export function layoutUri(
 }
 
 export function contextInUri(layoutContext: LayoutContext): string {
-    return `${toBranchName(layoutContext.branch).toLowerCase()}/${layoutContext.publicationState.toLowerCase()}`;
-}
-
-export function toBranchName(layoutBranch: LayoutBranch) {
-    return layoutBranch === 'MAIN' ? layoutBranch : `DESIGN_${layoutBranch}`;
+    return `${layoutContext.branch.toLowerCase()}/${layoutContext.publicationState.toLowerCase()}`;
 }

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -16,6 +16,7 @@ import { LoaderStatus, useLoader, useLoaderWithStatus, useOptionalLoader } from 
 import {
     CoordinateSystem,
     LayoutAssetChangeInfo,
+    LayoutBranch,
     LayoutContext,
     Srid,
     SwitchStructure,
@@ -49,17 +50,18 @@ import {
 import { getKmPost, getKmPostChangeInfo, getKmPosts } from 'track-layout/layout-km-post-api';
 import { PVDocumentHeader, PVDocumentId } from 'infra-model/projektivelho/pv-model';
 import { getPVDocument } from 'infra-model/infra-model-api';
-import { updateAllChangeTimes } from 'common/change-time-api';
-import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import {
+    updateAllChangeTimes,
     updateKmPostChangeTime,
-    updateSwitchChangeTime,
     updateLocationTrackChangeTime,
+    updateSwitchChangeTime,
 } from 'common/change-time-api';
+import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import { deduplicate } from 'utils/array-utils';
 import { validateLocationTrackName } from 'tool-panel/location-track/dialog/location-track-validation';
 import { getMaxTimestamp } from 'utils/date-utils';
 import { ChangeTimes } from 'common/common-slice';
+import { getLayoutDesignByBranch, LayoutDesign } from 'track-layout/layout-design-api';
 
 export function useTrackNumberReferenceLine(
     trackNumberId: LayoutTrackNumberId | undefined,
@@ -423,3 +425,13 @@ export const getSaveDisabledReasons = (reasons: string[], saveInProgress: boolea
                   else return reason;
               }),
           );
+
+export const useLayoutDesign = (
+    changeTime: TimeStamp,
+    layoutBranch: LayoutBranch,
+): LayoutDesign | undefined =>
+    useLoader(
+        () =>
+            layoutBranch === 'MAIN' ? undefined : getLayoutDesignByBranch(changeTime, layoutBranch),
+        [layoutBranch],
+    );

--- a/ui/src/user/user-card.scss
+++ b/ui/src/user/user-card.scss
@@ -2,6 +2,10 @@
 
 .user-card {
     padding-top: 12px;
+    width: 420px;
+    height: fit-content;
+    float: left;
+    margin: 5px 20px 5px 20px;
 
     &__username-title {
         @include vayla-design.typography-sub-heading;


### PR DESCRIPTION
Päämuutos, että frontin layout muutettu uuteen kuosiin, ja julkaisukorttiin lisätty ominaisuus, että se pystyy hakemaan design-puolen julkaisulistaa. "Design-puoli" tässä tapauksessa tarkoittaa siis, että kaikki designien muutokset menee samaan listaan. Ratko-puskua design-puolella ei vielä yritetäkään.

Frontin tyypitystä muutettu vastaamaan enemmän bäkkäriä niin, että nyt käytetään enemmän DesignBranch-tyyppiä, jota pystyy sitten käyttämään suorempaan urleissa.