### PR TITLE
GVT-2671: Review-korjauksia designien nimen uniikkiustarkasteluun

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -178,3 +178,14 @@ class IntegrationNotConfiguredException(type: Integration) : ClientException(
     cause = null,
     localizedMessageKey = "error.integration-not-configured.$type",
 )
+
+class DuplicateDesignNameException(
+    name: String,
+    cause: Throwable? = null,
+) : ClientException(
+    status = BAD_REQUEST,
+    message = "Duplicate design name: $name",
+    cause = cause,
+    localizedMessageKey = "error.design.duplicate-name",
+    localizedMessageParams = localizationParams("name" to name),
+)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ErrorHandling.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ErrorHandling.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.util.LocalizationKey
 import jakarta.xml.bind.UnmarshalException
 import org.geotools.api.referencing.operation.TransformException
+import org.postgresql.util.PSQLException
 import org.springframework.beans.ConversionNotSupportedException
 import org.springframework.beans.TypeMismatchException
 import org.springframework.boot.context.properties.bind.BindException
@@ -306,4 +307,11 @@ data class ErrorDescription(
         params,
         priority,
     )
+}
+
+fun getPSQLExceptionConstraintAndDetailOrRethrow(psqlException: PSQLException): Pair<String, String> {
+    val constraint = psqlException.serverErrorMessage?.constraint ?: throw psqlException
+    val detail = psqlException.serverErrorMessage?.detail ?: throw psqlException
+
+    return constraint to detail
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
@@ -66,14 +66,6 @@ class LayoutDesignDao(
     @Transactional
     fun update(id: DomainId<LayoutDesign>, design: LayoutDesignSaveRequest): IntId<LayoutDesign> {
         jdbcTemplate.setUser()
-        require(list(includeCompleted = true)
-            .none { existing ->
-                existing.name.equalsIgnoreCase(design.name) && existing.id != id
-            }
-        ) {
-            "Name must be unique"
-        }
-
         val params = mapOf(
             "id" to toDbId(id).intValue,
             "name" to design.name,
@@ -100,12 +92,6 @@ class LayoutDesignDao(
     @Transactional
     fun insert(design: LayoutDesignSaveRequest): IntId<LayoutDesign> {
         jdbcTemplate.setUser()
-        require(
-            list(includeCompleted = true).none { existing -> existing.name.equalsIgnoreCase(design.name) }
-        ) {
-            "Name must be unique"
-        }
-
         val sql = """
             insert into layout.design (name, estimated_completion, design_state)
             values (:name, :estimated_completion, :design_state::layout.design_state)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
@@ -2,12 +2,18 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.error.DuplicateDesignNameException
+import fi.fta.geoviite.infra.error.getPSQLExceptionConstraintAndDetailOrRethrow
+import org.postgresql.util.PSQLException
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 
 @GeoviiteService
 class LayoutDesignService(
     private val dao: LayoutDesignDao,
 ) {
+    private val duplicateSwitchErrorRegex = Regex("""Key \(lower\(name\)\)=\(([^,]+)\) conflicts with existing key""")
+
     fun list(): List<LayoutDesign> {
         return dao.list()
     }
@@ -17,12 +23,30 @@ class LayoutDesignService(
     }
 
     @Transactional
-    fun update(id: IntId<LayoutDesign>, request: LayoutDesignSaveRequest): IntId<LayoutDesign> {
-        return dao.update(id, request)
+    fun update(id: IntId<LayoutDesign>, request: LayoutDesignSaveRequest): IntId<LayoutDesign> = try {
+        dao.update(id, request)
+    } catch (e: DataIntegrityViolationException) {
+        handleDuplicateNameOrRethrow(e)
     }
 
     @Transactional
-    fun insert(request: LayoutDesignSaveRequest): IntId<LayoutDesign> {
-        return dao.insert(request)
+    fun insert(request: LayoutDesignSaveRequest): IntId<LayoutDesign> = try {
+        dao.insert(request)
+    } catch (e: DataIntegrityViolationException) {
+        handleDuplicateNameOrRethrow(e)
+    }
+
+    private fun handleDuplicateNameOrRethrow(e: DataIntegrityViolationException): Nothing {
+        val cause = e.cause
+        if (cause !is PSQLException) throw e
+
+        val (constraint, detail) = getPSQLExceptionConstraintAndDetailOrRethrow(cause)
+
+        duplicateSwitchErrorRegex.matchAt(detail, 0)?.let { match -> match.groups[1]?.value }?.let { name ->
+            if (constraint == "layout_design_unique_name") {
+                throw DuplicateDesignNameException(name, e)
+            }
+        }
+        throw e
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/SanitizedString.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/SanitizedString.kt
@@ -32,7 +32,6 @@ data class FreeText @JsonCreator(mode = DELEGATING) constructor(private val valu
     override fun toString(): String = value
     override fun compareTo(other: FreeText): Int = value.compareTo(other.value)
     operator fun plus(addition: String) = FreeText("$value$addition")
-    fun equalsIgnoreCase(other: FreeText): Boolean = value.toString().lowercase().compareTo(other.value.toString().lowercase()) == 0
 }
 
 data class FreeTextWithNewLines @JsonCreator(mode = DELEGATING) constructor(private val value: String)

--- a/infra/src/main/resources/db/migration/prod/V82__add_design_name_uniqueness_constraint.sql
+++ b/infra/src/main/resources/db/migration/prod/V82__add_design_name_uniqueness_constraint.sql
@@ -1,0 +1,1 @@
+alter table layout.design add constraint layout_design_unique_name exclude (lower(name) with = ) where (design_state != 'DELETED');

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -149,6 +149,9 @@
         }
     },
     "reference-line": "Pituusmittauslinja",
+    "design": {
+        "duplicate-name": "Nimi {{name}} on jo käytössä"
+    },
     "enum": {
         "plan-phase": {
             "RAILWAY_PLAN": "Ratasuunnitelma, RaS",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDaoIT.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.context.ActiveProfiles
 import java.time.LocalDate
 import kotlin.test.assertContains
@@ -19,7 +20,7 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
 
     @BeforeEach
     fun cleanup() {
-        testDBService.clearAllTables()
+        testDBService.clearLayoutTables()
     }
 
     @Test
@@ -48,13 +49,13 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
         layoutDesignDao.insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE))
         layoutDesignDao.insert(layoutDesignSaveRequest("foo barbar", designState = DesignState.COMPLETED))
         layoutDesignDao.insert(layoutDesignSaveRequest("boo too far", designState = DesignState.DELETED))
-        assertThrows<IllegalArgumentException> {
+        assertThrows<DataIntegrityViolationException> {
             layoutDesignDao.insert(layoutDesignSaveRequest("foo bar"))
         }
-        assertThrows<IllegalArgumentException> {
+        assertThrows<DataIntegrityViolationException> {
             layoutDesignDao.insert(layoutDesignSaveRequest("FOO BAR"))
         }
-        assertThrows<IllegalArgumentException> {
+        assertThrows<DataIntegrityViolationException> {
             layoutDesignDao.insert(layoutDesignSaveRequest("foo barbar"))
         }
         assertDoesNotThrow { layoutDesignDao.insert(layoutDesignSaveRequest("boo too far")) }
@@ -66,7 +67,7 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
         layoutDesignDao.insert(layoutDesignSaveRequest("boo too far", designState = DesignState.COMPLETED)).let(layoutDesignDao::fetch)
         layoutDesignDao.insert(layoutDesignSaveRequest("way too far", designState = DesignState.DELETED)).let(layoutDesignDao::fetch)
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<DataIntegrityViolationException> {
             layoutDesignDao.update(
                 design.id,
                 LayoutDesignSaveRequest(
@@ -76,7 +77,7 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
                 )
             )
         }
-        assertThrows<IllegalArgumentException> {
+        assertThrows<DataIntegrityViolationException> {
             layoutDesignDao.update(
                 design.id,
                 LayoutDesignSaveRequest(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
@@ -40,7 +40,7 @@ class LocationTrackDaoIT @Autowired constructor(
 ) : DBTestBase() {
     @BeforeEach
     fun cleanup() {
-        testDBService.clearAllTables()
+        testDBService.clearLayoutTables()
     }
 
     @Test


### PR DESCRIPTION
Isoin juttu täällä on, että nimen uniikkiustarkastelu on muutettu kantarajoitukseksi (kiitokset tässä Arille EXCLUDE-esimerkistä, joka meni ajoon about sellaisenaan.) Tämän myötä myös refaktoroitu ja yhtenäistetty errorkäsittelyä paikoissa joissa tehdään nyt samoja asioita ja korjattu testit. 