### PR TITLE
GVT-2608: Tehtävälistan sulkeminen nykytilaan siirtyessä

### DIFF
--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -57,10 +57,14 @@ export const LocationTrackTaskListContainer: React.FC = () => {
     };
 
     React.useEffect(() => {
-        if (locationTrackList && locationTrackList.branch !== layoutContext.branch) {
+        if (
+            locationTrackList &&
+            (locationTrackList.branch !== layoutContext.branch ||
+                layoutContext.publicationState !== 'DRAFT')
+        ) {
             delegates.hideLocationTrackTaskList();
         }
-    }, [layoutContext.branch]);
+    }, [layoutContext.branch, layoutContext.publicationState]);
 
     return createPortal(
         locationTrackList?.type == LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION ? (


### PR DESCRIPTION
Dailyssä puhutun mukaisesti suljetaan tehtävälista aina kun siirrytään nykytilaan. Sen olisi varmaan voinut myös piilottaa, mutta se olisi vaatinut lisää UX:ää -> ainakin toistaiseksi suljetaan vaan kylmästi