### PR TITLE
GVT-2682 & GVT-2617: Splittaus- ja tilasiirtymäparannuksia UI-puolelle

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -707,7 +707,8 @@
                     "duplicate-not-published": "Duplikaattiraiteen {{duplicateName}} muutoksia ei ole julkaistu Ratkoon. Poikkeavat tiedot Geoviitteen ja Ratkon välillä voivat aiheuttaa ongelmia kohteiden massasiirrossa Ratkossa.",
                     "publish-duplicate": "Julkaise tai hylkää duplikaattiraiteen muutokset ja yritä jakamista sitten uudestaan.",
                     "has-errors": "Tiedoissa on virheitä",
-                    "show": "näytä"
+                    "show": "näytä",
+                    "branch-not-main": "Raiteita voi jakaa vain luonnostilassa"
                 },
                 "validation-in-progress": "Raiteen vaihteita validoidaan...",
                 "relink-critical-errors": "Raiteen vaihteiden linkityksessä on kriittisiä ongelmia, jotka täytyy korjata ennen raiteen jakamista",

--- a/ui/src/geoviite-design-lib/tab-header/tab-header.scss
+++ b/ui/src/geoviite-design-lib/tab-header/tab-header.scss
@@ -23,7 +23,7 @@
     }
 
     &--disabled {
-        cursor: pointer;
+        cursor: default;
         color: vayla-design.$color-black-lighter;
     }
 }

--- a/ui/src/geoviite-design-lib/tab-header/tab-header.scss
+++ b/ui/src/geoviite-design-lib/tab-header/tab-header.scss
@@ -21,4 +21,9 @@
     &--selected {
         border-color: vayla-design.$color-blue-light;
     }
+
+    &--disabled {
+        cursor: pointer;
+        color: vayla-design.$color-black-lighter;
+    }
 }

--- a/ui/src/geoviite-design-lib/tab-header/tab-header.tsx
+++ b/ui/src/geoviite-design-lib/tab-header/tab-header.tsx
@@ -8,6 +8,7 @@ type TabHeaderProps = {
     children: React.ReactNode;
     className?: string;
     qaId?: string;
+    disabled?: boolean;
 };
 
 export const TabHeader: React.FC<TabHeaderProps> = ({
@@ -16,14 +17,21 @@ export const TabHeader: React.FC<TabHeaderProps> = ({
     children,
     className,
     qaId,
+    disabled,
 }) => {
     const tabClassName = createClassName(
         styles['tab-header'],
         selected && styles['tab-header--selected'],
+        disabled && styles['tab-header--disabled'],
         className,
     );
     return (
-        <a className={tabClassName} onClick={onClick} qa-id={qaId}>
+        <a
+            className={tabClassName}
+            onClick={() => {
+                !disabled && onClick();
+            }}
+            qa-id={qaId}>
             {children}
         </a>
     );

--- a/ui/src/geoviite-design-lib/tab-header/tab-header.tsx
+++ b/ui/src/geoviite-design-lib/tab-header/tab-header.tsx
@@ -9,6 +9,7 @@ type TabHeaderProps = {
     className?: string;
     qaId?: string;
     disabled?: boolean;
+    title?: string;
 };
 
 export const TabHeader: React.FC<TabHeaderProps> = ({
@@ -18,6 +19,7 @@ export const TabHeader: React.FC<TabHeaderProps> = ({
     className,
     qaId,
     disabled,
+    title,
 }) => {
     const tabClassName = createClassName(
         styles['tab-header'],
@@ -27,6 +29,7 @@ export const TabHeader: React.FC<TabHeaderProps> = ({
     );
     return (
         <a
+            title={title}
             className={tabClassName}
             onClick={() => {
                 !disabled && onClick();

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -395,6 +395,10 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     const handleSwitchSave = refreshSwitchSelection(layoutContextDraft, onSelect, onUnselect);
     const handleKmPostSave = refereshKmPostSelection(layoutContextDraft, onSelect, onUnselect);
 
+    const layoutContextTransferDisabledReason = splittingState
+        ? t('tool-bar.splitting-in-progress')
+        : undefined;
+
     const modeNavigationButtonsDisabledReason = () => {
         if (splittingState) {
             return t('tool-bar.splitting-in-progress');
@@ -404,6 +408,8 @@ export const ToolBar: React.FC<ToolbarParams> = ({
             return undefined;
         }
     };
+
+    const newMenuTooltip = splittingState ? t('tool-bar.splitting-in-progress') : t('tool-bar.new');
 
     const className = createClassName(
         'tool-bar',
@@ -424,6 +430,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         className={styles['tool-bar__tab-header']}
                         qaId="current-mode-tab"
                         selected={layoutContextMode === 'MAIN-OFFICIAL'}
+                        title={layoutContextTransferDisabledReason}
                         disabled={!!splittingState}
                         onClick={() => switchToMainOfficial()}>
                         {t('tool-bar.current-mode')}
@@ -445,6 +452,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                                     qaId={'design-mode-tab'}
                                     selected={layoutContextMode === 'DESIGN'}
                                     onClick={switchToDesign}
+                                    title={layoutContextTransferDisabledReason}
                                     disabled={!!splittingState}>
                                     <div className={styles['tool-bar__design-tab-content']}>
                                         {t('tool-bar.design-mode')}
@@ -455,6 +463,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                                                 size={ButtonSize.SMALL}
                                                 icon={Icons.Down}
                                                 iconPosition={ButtonIconPosition.END}
+                                                disabled={!!splittingState}
                                                 inheritTypography={true}
                                                 onClick={(e) => {
                                                     e.stopPropagation(); // otherwise layout selection gets the click
@@ -529,7 +538,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         <div className={styles['tool-bar__new-menu-button']} qa-id={'tool-bar.new'}>
                             <Button
                                 ref={menuRef}
-                                title={t('tool-bar.new')}
+                                title={newMenuTooltip}
                                 variant={ButtonVariant.GHOST}
                                 icon={Icons.Append}
                                 disabled={disableNewAssetMenu}

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -424,6 +424,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         className={styles['tool-bar__tab-header']}
                         qaId="current-mode-tab"
                         selected={layoutContextMode === 'MAIN-OFFICIAL'}
+                        disabled={!!splittingState}
                         onClick={() => switchToMainOfficial()}>
                         {t('tool-bar.current-mode')}
                     </TabHeader>
@@ -443,7 +444,8 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                                     className={styles['tool-bar__tab-header']}
                                     qaId={'design-mode-tab'}
                                     selected={layoutContextMode === 'DESIGN'}
-                                    onClick={switchToDesign}>
+                                    onClick={switchToDesign}
+                                    disabled={!!splittingState}>
                                     <div className={styles['tool-bar__design-tab-content']}>
                                         {t('tool-bar.design-mode')}
                                         <span>{currentDesign && `:`}</span>
@@ -454,8 +456,8 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                                                 icon={Icons.Down}
                                                 iconPosition={ButtonIconPosition.END}
                                                 inheritTypography={true}
-                                                onClick={(_e) => {
-                                                    _e.stopPropagation(); // otherwise layout selection gets the click
+                                                onClick={(e) => {
+                                                    e.stopPropagation(); // otherwise layout selection gets the click
                                                     switchToDesign();
                                                     setDesignIdSelectorOpened(
                                                         !designIdSelectorOpened,

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -148,6 +148,10 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
             return t('tool-panel.disabled.activity-disabled-in-official-mode');
         }
 
+        if (layoutContext.branch !== 'MAIN') {
+            return t('tool-panel.location-track.splitting.validation.branch-not-main');
+        }
+
         if (extraInfo?.partOfUnfinishedSplit) {
             return t('tool-panel.location-track.splitting-blocks-geometry-changes');
         }
@@ -156,14 +160,16 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
             return t('tool-panel.location-track.unsupported-state-for-splitting');
         }
 
-        if (locationTrackIsDraft)
+        if (locationTrackIsDraft) {
             reasons.push(t('tool-panel.location-track.splitting.validation.track-draft-exists'));
-        if (duplicatesOnOtherTrackNumbers)
+        }
+        if (duplicatesOnOtherTrackNumbers) {
             reasons.push(
                 t(
                     'tool-panel.location-track.splitting.validation.duplicates-on-different-track-number',
                 ),
             );
+        }
 
         return reasons.join('\n\n');
     };
@@ -327,7 +333,8 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         locationTrackIsDraft ||
         duplicatesOnOtherTrackNumbers ||
         extraInfo?.partOfUnfinishedSplit ||
-        startingSplitting;
+        startingSplitting ||
+        layoutContext.branch !== 'MAIN';
 
     return (
         startAndEndPoints &&


### PR DESCRIPTION
Täällä tehtynä:
* Nykytila- ja Suunnitelmatila-tabien disablointi silloin kun raiteen jakaminen on päällä
* "Aloita raiteen jakaminen" -napin disablointi silloin kun ollaan suunnitelmatilassa. Tätähän olisi sinällään toiminnallisuutena mahdollista tukea meidän puolelta, mutta se vaatisi tuen myös Ratkolle -> disabloidaan toistaiseksi