### PR TITLE
Float plan layout fetching parallelism to browser

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutService.kt
@@ -32,12 +32,12 @@ class PlanLayoutService(
         pointListStepLength: Int = 1,
     ): List<Pair<GeometryPlanLayout?, TransformationError?>> = planIds
         .map { planId ->
-            val planVersion = geometryDao.fetchPlanVersion(planId)
-            planLayoutCache.prepareGetPlanLayout(planVersion, includeGeometryData)
+            handlePointListStepLength(
+                planLayoutCache.getPlanLayout(
+                    geometryDao.fetchPlanVersion(planId), includeGeometryData
+                ), includeGeometryData, pointListStepLength
+            )
         }
-        .parallelStream()
-        .map { process -> handlePointListStepLength(process(), includeGeometryData, pointListStepLength) }
-        .collect(Collectors.toList())
 
     private fun handlePointListStepLength(
         layoutResult: Pair<GeometryPlanLayout?, TransformationError?>,


### PR DESCRIPTION
Käytännössä GVT-2685 toteutuksen osana hoksattu ärsyttävyys: Suunnitelmien geometrioiden haussa ei ole juurikaan sellaista overheadia, jonka takia niitä olisi tarvetta tehdä massana, mutta täysin puhtaalta pöydältä ajoajasta kaksi kolmasosaa menee JSON-serialisointiin.

Siinä olisi varmasti optimoimisen varaa (ensisijaisesti kai siinä, että geometrioitakin yksinkertaistettaisiin zoomaustason mukaan), mutta ensihätään rinnakkaistuksen siirto selaimen tasolle nopeuttaa huomattavasti ison suunnitelmajoukon lataamista kerralla, koska serialisoinnit (ja deserialisoinnit) rinnakkaistuvat näin.