### PR TITLE
Integraatiotesteihin Springin cache päälle + testikorjauksia

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,7 +74,13 @@ jobs:
          --name geoviite-db-github gvt-postgres
 
         cd infra
+        ./gradlew cleanTest test-without-cache --tests "*DaoIT"
         ./gradlew cleanTest test --tests "*IT"
+
+    - name: Run DAO integration tests without cache in infra (backend)
+      run: |
+        cd infra
+        ./gradlew cleanTest test-without-cache --tests "*DaoIT"
 
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@75b84e78b3f0aaea7ed7cf8d1d100d7f97f963ec

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,7 +74,6 @@ jobs:
          --name geoviite-db-github gvt-postgres
 
         cd infra
-        ./gradlew cleanTest test-without-cache --tests "*DaoIT"
         ./gradlew cleanTest test --tests "*IT"
 
     - name: Run DAO integration tests without cache in infra (backend)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,16 +74,16 @@ jobs:
          --name geoviite-db-github gvt-postgres
 
         cd infra
-        ./gradlew cleanTest test --tests "*IT"
+        ./gradlew integrationtest --tests "*IT"
 
     - name: Run DAO integration tests without cache in infra (backend)
       run: |
         cd infra
-        ./gradlew cleanTest test-without-cache --tests "*DaoIT"
+        ./gradlew integrationtest-without-cache --tests "*DaoIT"
 
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@75b84e78b3f0aaea7ed7cf8d1d100d7f97f963ec
       if: success() || failure()
       with:
-        report_paths: '**/build/test-results/test/TEST*.xml'
+        report_paths: '**/build/test-results/*test*/TEST*.xml'
         detailed_summary: true

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -36,6 +36,11 @@ configurations {
     }
 }
 
+val test2 = tasks.register<Test>("test-without-cache") {
+    systemProperty("geoviite.cache.enabled", false)
+    useJUnit()
+}
+
 ext["selenium.version"] = "4.19.1"
 dependencies {
     // Version overrides for transitive deps (due to known vulnerabilities)

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -36,7 +36,7 @@ configurations {
     }
 }
 
-val test2 = tasks.register<Test>("test-without-cache") {
+tasks.register<Test>("test-without-cache") {
     systemProperty("geoviite.cache.enabled", false)
     useJUnit()
 }

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -36,11 +36,6 @@ configurations {
     }
 }
 
-tasks.register<Test>("test-without-cache") {
-    systemProperty("geoviite.cache.enabled", false)
-    useJUnit()
-}
-
 ext["selenium.version"] = "4.19.1"
 dependencies {
     // Version overrides for transitive deps (due to known vulnerabilities)
@@ -132,6 +127,15 @@ tasks.withType<Test> {
     testLogging.exceptionFormat = FULL
     //testLogging.events = mutableSetOf(FAILED, PASSED, SKIPPED)
     testLogging.events = mutableSetOf(FAILED, PASSED, SKIPPED, STANDARD_OUT, STANDARD_ERROR)
+}
+
+tasks.register<Test>("integrationtest") {
+    useJUnitPlatform()
+}
+
+tasks.register<Test>("integrationtest-without-cache") {
+    systemProperty("geoviite.cache.enabled", false)
+    useJUnitPlatform()
 }
 
 tasks.withType<AbstractArchiveTask> {

--- a/infra/run_it_tests.sh
+++ b/infra/run_it_tests.sh
@@ -4,5 +4,5 @@ set -e
 cd "$(dirname "$0")"
 
 echo "Running IT Tests..."
-./gradlew cleanTest test-without-cache --tests "*DaoIT"
-./gradlew cleanTest test --tests "*IT"
+./gradlew cleanTest integrationtest-without-cache --tests "*DaoIT"
+./gradlew integrationtest --tests "*IT"

--- a/infra/run_it_tests.sh
+++ b/infra/run_it_tests.sh
@@ -4,4 +4,5 @@ set -e
 cd "$(dirname "$0")"
 
 echo "Running IT Tests..."
+./gradlew cleanTest test-without-cache --tests "*DaoIT"
 ./gradlew cleanTest test --tests "*IT"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
@@ -17,12 +17,10 @@ import java.time.Duration
 
 const val CACHE_GEOMETRY_PLAN = "geometry-plan"
 const val CACHE_GEOMETRY_SWITCH = "geometry-switch"
-const val CACHE_GEOMETRY_PLAN_LAYOUT = "geometry-plan-layout"
 
 const val CACHE_ROLES = "roles"
 const val CACHE_COORDINATE_SYSTEMS = "coordinate-systems"
 const val CACHE_FEATURE_TYPES = "feature-types"
-const val CACHE_COMMON_SWITCH_STRUCTURE = "switch-structure"
 const val CACHE_COMMON_SWITCH_OWNER = "switch-owner"
 const val CACHE_COMMON_LOCATION_TRACK_OWNER = "location-track-owner"
 const val CACHE_KKJ_TM35FIN_TRIANGULATION_NETWORK = "kkj-tm35fin-triangles"
@@ -58,7 +56,6 @@ class CacheConfiguration @Autowired constructor(
             manager.registerCustomCache(CACHE_ROLES, cache(10, staticDataCacheDuration))
             manager.registerCustomCache(CACHE_COORDINATE_SYSTEMS, cache(1, staticDataCacheDuration))
             manager.registerCustomCache(CACHE_FEATURE_TYPES, cache(1, staticDataCacheDuration))
-            manager.registerCustomCache(CACHE_COMMON_SWITCH_STRUCTURE, cache(1, staticDataCacheDuration))
             manager.registerCustomCache(CACHE_KKJ_TM35FIN_TRIANGULATION_NETWORK, cache(2, staticDataCacheDuration))
 
             manager.registerCustomCache(CACHE_GEOCODING_CONTEXTS, cache(500, layoutCacheDuration))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloader.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloader.kt
@@ -26,7 +26,6 @@ class CachePreloader(
     private val referenceLineDao: ReferenceLineDao,
     private val locationTrackDao: LocationTrackDao,
     private val alignmentDao: LayoutAlignmentDao,
-    private val switchStructureDao: SwitchStructureDao,
     private val geometryDao: GeometryDao,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -34,7 +33,6 @@ class CachePreloader(
     @Scheduled(fixedDelay = CACHE_RELOAD_INTERVAL, initialDelay = CACHE_WARMUP_DELAY)
     fun scheduleLayoutAssetReload() {
         if (cacheEnabled && cachePreloadEnabled) {
-            switchStructureDao.fetchSwitchStructures()
             listOf(
                 layoutTrackNumberDao, referenceLineDao, locationTrackDao, switchDao, layoutKmPostDao
             ).parallelStream().forEach { dao -> refreshCache(dao) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchLibraryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchLibraryService.kt
@@ -11,23 +11,18 @@ class SwitchLibraryService(
     private val switchStructureDao: SwitchStructureDao,
     private val switchOwnerDao: SwitchOwnerDao,
 ) {
+    private val structures: List<SwitchStructure> by lazy {
+        switchStructureDao.fetchSwitchStructures()
+    }
+
     private val structuresById: Map<IntId<SwitchStructure>, SwitchStructure> by lazy {
-        switchStructureDao.fetchSwitchStructures().associateBy { switchStructure ->
+        structures.associateBy { switchStructure ->
             switchStructure.id as IntId
         }
     }
 
-    fun getSwitchStructures(): List<SwitchStructure> {
-        return switchStructureDao.fetchSwitchStructures()
-    }
-
-    fun getSwitchStructuresById(): Map<IntId<SwitchStructure>, SwitchStructure> {
-        return structuresById
-    }
-
-    fun getSwitchStructureByType(type: SwitchType):SwitchStructure? {
-        return getSwitchStructures().find { switchStructure -> switchStructure.type == type }
-    }
+    fun getSwitchStructures(): List<SwitchStructure> = structures
+    fun getSwitchStructuresById(): Map<IntId<SwitchStructure>, SwitchStructure> = structuresById
 
     fun getSwitchStructure(id: IntId<SwitchStructure>): SwitchStructure {
         return getOrThrow(id)
@@ -35,10 +30,6 @@ class SwitchLibraryService(
 
     fun getPresentationJointNumber(id: IntId<SwitchStructure>): JointNumber {
         return getOrThrow(id).presentationJointNumber
-    }
-
-    fun getSwitchType(id: IntId<SwitchStructure>): SwitchType {
-        return getOrThrow(id).type
     }
 
     fun getSwitchOwners(): List<SwitchOwner> {
@@ -57,12 +48,11 @@ class SwitchLibraryService(
         structuresById[id] ?: throw NoSuchEntityException(SwitchStructure::class, id)
 
     @Transactional
-    fun upsertSwitchStructure(switchStructure: SwitchStructure) {
-        val existingSwitchStructure = getSwitchStructureByType(switchStructure.type)
+    fun upsertSwitchStructure(newSwitchStructure: SwitchStructure, existingSwitchStructure: SwitchStructure?) {
         if (existingSwitchStructure == null) {
-            switchStructureDao.insertSwitchStructure(switchStructure)
+            switchStructureDao.insertSwitchStructure(newSwitchStructure)
         } else {
-            val switchStructureWithExistingId = switchStructure.copy(id =existingSwitchStructure.id)
+            val switchStructureWithExistingId = newSwitchStructure.copy(id =existingSwitchStructure.id)
             if (!existingSwitchStructure.isSame(switchStructureWithExistingId)) {
                 switchStructureDao.updateSwitchStructure(switchStructureWithExistingId)
             }
@@ -71,7 +61,7 @@ class SwitchLibraryService(
 
     @Transactional
     fun replaceExistingSwitchStructures(newSwitchStructures: List<SwitchStructure>) {
-        val existingSwitchStructures = getSwitchStructures()
+        val existingSwitchStructures = switchStructureDao.fetchSwitchStructures()
         existingSwitchStructures.forEach { existingSwitchStructure ->
             val existsInNewSet = newSwitchStructures.any { newSwitchStructure ->
                 newSwitchStructure.type == existingSwitchStructure.type
@@ -81,6 +71,9 @@ class SwitchLibraryService(
             }
         }
 
-        newSwitchStructures.forEach { switchStructure -> upsertSwitchStructure(switchStructure) }
+        newSwitchStructures.forEach { newSwitchStructure ->
+            val existingSwitchStructure = existingSwitchStructures.find { it.type == newSwitchStructure.type }
+            upsertSwitchStructure(newSwitchStructure, existingSwitchStructure)
+        }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructureDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructureDao.kt
@@ -3,7 +3,6 @@ package fi.fta.geoviite.infra.switchLibrary
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.RowVersion
-import fi.fta.geoviite.infra.configuration.CACHE_COMMON_SWITCH_STRUCTURE
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.AccessType.FETCH
 import fi.fta.geoviite.infra.logging.daoAccess
@@ -31,7 +30,6 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
 
     fun fetchSwitchStructureVersion(id: IntId<SwitchStructure>) = fetchRowVersion(id, DbTable.COMMON_SWITCH_STRUCTURE)
 
-    @Cacheable(CACHE_COMMON_SWITCH_STRUCTURE, sync = true)
     fun fetchSwitchStructures(): List<SwitchStructure> {
         val sql = """
             select
@@ -55,7 +53,6 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
         return switchStructures
     }
 
-    @Cacheable(CACHE_COMMON_SWITCH_STRUCTURE, sync = true)
     fun fetchSwitchStructure(version: RowVersion<SwitchStructure>): SwitchStructure {
         val sql = """
             select

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureIT.kt
@@ -159,7 +159,8 @@ class SwitchStructureIT @Autowired constructor(
         }
 
         val versionBeforeUpsert = switchStructureDao.fetchSwitchStructureVersion(versionId.id)
-        switchLibraryService.upsertSwitchStructure(modifiedSwitchStructure)
+        val existingSwitchStructure = switchStructureDao.fetchSwitchStructure(versionBeforeUpsert)
+        switchLibraryService.upsertSwitchStructure(modifiedSwitchStructure, existingSwitchStructure)
         val versionAfterUpsert = switchStructureDao.fetchSwitchStructureVersion(versionId.id)
         assertNotEquals(versionBeforeUpsert.version, versionAfterUpsert.version)
     }
@@ -180,14 +181,15 @@ class SwitchStructureIT @Autowired constructor(
         )
 
         val versionBeforeUpsert = switchStructureDao.fetchSwitchStructureVersion(versionId.id)
-        switchLibraryService.upsertSwitchStructure(similarSwitchStructure)
+        val existingSwitchStructure = switchStructureDao.fetchSwitchStructure(versionBeforeUpsert)
+        switchLibraryService.upsertSwitchStructure(similarSwitchStructure, existingSwitchStructure)
         val versionAfterUpsert = switchStructureDao.fetchSwitchStructureVersion(versionId.id)
         assertEquals(versionBeforeUpsert.version, versionAfterUpsert.version)
     }
 
     @Test
     fun `Replacing switch structures should add new ones`() {
-        val existingSwitchStructuresBeforeUpdate = switchLibraryService.getSwitchStructures()
+        val existingSwitchStructuresBeforeUpdate = switchStructureDao.fetchSwitchStructures()
 
         val seq = System.currentTimeMillis()
         val newSwitchType = SwitchType("YV60-$seq-1:9")
@@ -199,14 +201,14 @@ class SwitchStructureIT @Autowired constructor(
             existingSwitchStructuresBeforeUpdate + newSwitchStructure
         )
 
-        val existingSwitchStructuresAfterUpdate = switchLibraryService.getSwitchStructures()
+        val existingSwitchStructuresAfterUpdate = switchStructureDao.fetchSwitchStructures()
         assert(existingSwitchStructuresBeforeUpdate.none { s -> s.type==newSwitchType })
         assert(existingSwitchStructuresAfterUpdate.any { s -> s.type==newSwitchType })
     }
 
     @Test
     fun `Replacing switch structures should delete not-defined structures`() {
-        val existingSwitchStructuresBeforeUpdate = switchLibraryService.getSwitchStructures()
+        val existingSwitchStructuresBeforeUpdate = switchStructureDao.fetchSwitchStructures()
 
         val seq = System.currentTimeMillis()
         val newSwitchType = SwitchType("YV60-$seq-1:9")
@@ -217,12 +219,12 @@ class SwitchStructureIT @Autowired constructor(
         switchLibraryService.replaceExistingSwitchStructures(
             existingSwitchStructuresBeforeUpdate + newSwitchStructure
         )
-        val existingSwitchStructuresAfterFirstUpdate = switchLibraryService.getSwitchStructures()
+        val existingSwitchStructuresAfterFirstUpdate = switchStructureDao.fetchSwitchStructures()
 
         switchLibraryService.replaceExistingSwitchStructures(
             existingSwitchStructuresBeforeUpdate
         )
-        val existingSwitchStructuresAfterSecondUpdate = switchLibraryService.getSwitchStructures()
+        val existingSwitchStructuresAfterSecondUpdate = switchStructureDao.fetchSwitchStructures()
 
         assert(existingSwitchStructuresBeforeUpdate.none { s -> s.type==newSwitchType })
         assert(existingSwitchStructuresAfterFirstUpdate.any { s -> s.type==newSwitchType })

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -69,7 +69,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
-@SpringBootTest(properties = ["geoviite.cache.enabled=true"])
+@SpringBootTest
 class CalculatedChangesServiceIT @Autowired constructor(
     val calculatedChangesService: CalculatedChangesService,
     val switchDao: LayoutSwitchDao,

--- a/infra/src/test/resources/application-test.yml
+++ b/infra/src/test/resources/application-test.yml
@@ -7,7 +7,6 @@ geoviite:
   scheduling:
     enabled: false
   cache:
-    enabled: false
     preload: false
   data:
     import: false


### PR DESCRIPTION
Pullarin nimen mukaisesti integraatiotestejä ajetaan tästä eteenpäin Springin kakutus päällä. Jotta voidaan varmistua siitä, että kaikki kanta-access toimisi varmasti myös ilman kakutusta, täällä lisättiin myös tuki DAO-testien ajamiselle ilman cachea, ja nämä ajot on lisätty myös testiajoskribuloihin ja GitHub Actions -workflow'hun.

Tämän lisäksi korjattu ongelma mistä näiden korjailu alunperin johtui, eli parin `SwitchStructureIT`:n käyminen kannassa niin paljon, että round-tripit rupesivat timeouttailemaan. SwitchStructuret kakutetaan nyt service-tasolla DAO-tason sijaan, sillä SwitchStructuret ovat aina (migraatioiden ajoa lukuunottamatta) täysin muuttumattomia koko bäkkärin eliniän ajan.