### PR TITLE
GVT-2685 Optimize plan status fetching harder

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -214,14 +214,14 @@ class LinkingService @Autowired constructor(
     }
 
     fun getGeometryPlanLinkStatus(layoutContext: LayoutContext, planId: IntId<GeometryPlan>): GeometryPlanLinkStatus {
-        return linkingDao.fetchPlanLinkStatus(layoutContext, planId)
+        return linkingDao.fetchPlanLinkStatuses(layoutContext, listOf(planId))[0]
     }
 
     fun getGeometryPlanLinkStatuses(
         layoutContext: LayoutContext,
         planIds: List<IntId<GeometryPlan>>,
     ): List<GeometryPlanLinkStatus> {
-        return planIds.map { planId -> linkingDao.fetchPlanLinkStatus(layoutContext, planId) }
+        return linkingDao.fetchPlanLinkStatuses(layoutContext, planIds)
     }
 
     @Transactional

--- a/infra/src/main/resources/db/migration/prod/V87__create_empty_type.sql
+++ b/infra/src/main/resources/db/migration/prod/V87__create_empty_type.sql
@@ -1,0 +1,2 @@
+-- we can't actually create an empty type in PostgreSQL's syntax, but we can create an empty table and use its type
+create table empty_type ();

--- a/infra/src/main/resources/db/migration/prod/V87__create_empty_type.sql
+++ b/infra/src/main/resources/db/migration/prod/V87__create_empty_type.sql
@@ -1,2 +1,10 @@
--- we can't actually create an empty type in PostgreSQL's syntax, but we can create an empty table and use its type
+/*
+ We use an empty type, or rather setof empty_type, as the return type of table-valued functions used as boolean
+ functions (necessary in PostgreSQL which inlines scalar and table-valued functions differently). Any actual columns
+ in the return value would have to be arbitrary and would complicate queries: All we actually need is a distinction
+ between a zero-row or one-row empty table.
+
+ Unfortunately PostgreSQL doesn't actually allow you to declare an empty type. It does, however, allow declaring an
+ empty table and using it as a type.
+ */
 create table empty_type ();

--- a/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
@@ -1,5 +1,43 @@
 drop function if exists layout.track_number_in_layout_context(layout.publication_state, int);
 drop function if exists layout.track_number_in_layout_context(layout.publication_state, int, int);
+drop function if exists layout.track_number_is_in_layout_context(layout.publication_state, int, layout.track_number);
+
+create function layout.track_number_is_in_layout_context(publication_state_in layout.publication_state,
+                                                         design_id_in int,
+                                                         track_number layout.track_number) returns setof empty_type
+  language sql
+  stable as
+$$
+select
+  where case publication_state_in
+          when 'OFFICIAL' then not track_number.draft
+          else track_number.draft
+            or case
+                 when track_number.design_id is null then
+                   not exists(select *
+                                from layout.track_number overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = track_number.id)
+                 else not exists(select *
+                                   from layout.track_number overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = track_number.id)
+               end
+        end
+    and case
+          when design_id_in is null then track_number.design_id is null
+          else design_id_in = track_number.design_id
+            or (track_number.design_id is null
+              and not track_number.draft
+              and not exists(select *
+                               from layout.track_number overriding_design_official
+                               where overriding_design_official.design_id = design_id_in
+                                 and not overriding_design_official.draft
+                                 and overriding_design_official.official_row_id = track_number.id))
+        end
+$$;
 
 create function layout.track_number_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
                                                       official_id_in int default null)
@@ -51,33 +89,5 @@ select
     select *
       from layout.track_number
       where official_id_in is null
-  ) row
-  where case publication_state_in
-          when 'OFFICIAL' then not row.draft
-          else row.draft
-            or case
-                 when row.design_id is null then
-                   not exists(select *
-                                from layout.track_number overriding_draft
-                                where overriding_draft.design_id is not distinct from design_id_in
-                                  and overriding_draft.draft
-                                  and overriding_draft.official_row_id = row.id)
-                 else not exists(select *
-                                   from layout.track_number overriding_draft
-                                   where overriding_draft.design_id is not distinct from design_id_in
-                                     and overriding_draft.draft
-                                     and overriding_draft.design_row_id = row.id)
-               end
-        end
-    and case
-          when design_id_in is null then row.design_id is null
-          else design_id_in = row.design_id
-            or (row.design_id is null
-              and not draft
-              and not exists(select *
-                               from layout.track_number overriding_design_official
-                               where overriding_design_official.design_id = design_id_in
-                                 and not overriding_design_official.draft
-                                 and overriding_design_official.official_row_id = row.id))
-        end
+  ) row, layout.track_number_is_in_layout_context(publication_state_in, design_id_in, row)
 $$;

--- a/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
@@ -1,6 +1,45 @@
 drop function if exists layout.reference_line_in_layout_context(layout.publication_state, int);
 drop function if exists layout.reference_line_in_layout_context(layout.publication_state, int, int);
 
+drop function if exists layout.reference_line_is_in_layout_context(layout.publication_state, int, layout.reference_line);
+
+create function layout.reference_line_is_in_layout_context(publication_state_in layout.publication_state,
+                                                           design_id_in int,
+                                                           reference_line layout.reference_line) returns setof empty_type
+  language sql
+  stable as
+$$
+select
+  where case publication_state_in
+          when 'OFFICIAL' then not reference_line.draft
+          else reference_line.draft
+            or case
+                 when reference_line.design_id is null then
+                   not exists(select *
+                                from layout.reference_line overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = reference_line.id)
+                 else not exists(select *
+                                   from layout.reference_line overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = reference_line.id)
+               end
+        end
+    and case
+          when design_id_in is null then reference_line.design_id is null
+          else design_id_in = reference_line.design_id
+            or (reference_line.design_id is null
+              and not reference_line.draft
+              and not exists(select *
+                               from layout.reference_line overriding_design_official
+                               where overriding_design_official.design_id = design_id_in
+                                 and not overriding_design_official.draft
+                                 and overriding_design_official.official_row_id = reference_line.id))
+        end
+$$;
+
 create function layout.reference_line_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
                                                         official_id_in int default null)
   returns table
@@ -57,34 +96,6 @@ select
     select *
       from layout.reference_line
       where official_id_in is null
-  ) row
-    left join layout.alignment on row.alignment_id = alignment.id
-  where case publication_state_in
-          when 'OFFICIAL' then not row.draft
-          else row.draft
-            or case
-                 when row.design_id is null then
-                   not exists(select *
-                                from layout.reference_line overriding_draft
-                                where overriding_draft.design_id is not distinct from design_id_in
-                                  and overriding_draft.draft
-                                  and overriding_draft.official_row_id = row.id)
-                 else not exists(select *
-                                   from layout.reference_line overriding_draft
-                                   where overriding_draft.design_id is not distinct from design_id_in
-                                     and overriding_draft.draft
-                                     and overriding_draft.design_row_id = row.id)
-               end
-        end
-    and case
-          when design_id_in is null then row.design_id is null
-          else design_id_in = row.design_id
-            or (row.design_id is null
-              and not draft
-              and not exists(select *
-                               from layout.reference_line overriding_design_official
-                               where overriding_design_official.design_id = design_id_in
-                                 and not overriding_design_official.draft
-                                 and overriding_design_official.official_row_id = row.id))
-        end
+  ) row left join layout.alignment on row.alignment_id = alignment.id,
+    layout.reference_line_is_in_layout_context(publication_state_in, design_id_in, row)
 $$

--- a/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
@@ -1,5 +1,43 @@
 drop function if exists layout.location_track_in_layout_context(layout.publication_state, int);
 drop function if exists layout.location_track_in_layout_context(layout.publication_state, int, int);
+drop function if exists layout.location_track_is_in_layout_context(layout.publication_state, int, layout.location_track);
+
+create function layout.location_track_is_in_layout_context(publication_state_in layout.publication_state,
+                                                           design_id_in int,
+                                                           location_track layout.location_track) returns setof empty_type
+  language sql
+  stable as
+$$
+select
+  where case publication_state_in
+          when 'OFFICIAL' then not location_track.draft
+          else location_track.draft
+            or case
+                 when location_track.design_id is null then
+                   not exists(select *
+                                from layout.location_track overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = location_track.id)
+                 else not exists(select *
+                                   from layout.location_track overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = location_track.id)
+               end
+        end
+    and case
+          when design_id_in is null then location_track.design_id is null
+          else design_id_in = location_track.design_id
+            or (location_track.design_id is null
+              and not location_track.draft
+              and not exists(select *
+                               from layout.location_track overriding_design_official
+                               where overriding_design_official.design_id = design_id_in
+                                 and not overriding_design_official.draft
+                                 and overriding_design_official.official_row_id = location_track.id))
+        end
+$$;
 
 create function layout.location_track_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
                                                         official_id_in int default null)
@@ -79,34 +117,6 @@ select
     select *
       from layout.location_track
       where official_id_in is null
-  ) row
-    left join layout.alignment on row.alignment_id = alignment.id
-  where case publication_state_in
-          when 'OFFICIAL' then not row.draft
-          else row.draft
-            or case
-                 when row.design_id is null then
-                   not exists(select *
-                                from layout.location_track overriding_draft
-                                where overriding_draft.design_id is not distinct from design_id_in
-                                  and overriding_draft.draft
-                                  and overriding_draft.official_row_id = row.id)
-                 else not exists(select *
-                                   from layout.location_track overriding_draft
-                                   where overriding_draft.design_id is not distinct from design_id_in
-                                     and overriding_draft.draft
-                                     and overriding_draft.design_row_id = row.id)
-               end
-        end
-    and case
-          when design_id_in is null then row.design_id is null
-          else design_id_in = row.design_id
-            or (row.design_id is null
-              and not draft
-              and not exists(select *
-                               from layout.location_track overriding_design_official
-                               where overriding_design_official.design_id = design_id_in
-                                 and not overriding_design_official.draft
-                                 and overriding_design_official.official_row_id = row.id))
-        end
+  ) row left join layout.alignment on row.alignment_id = alignment.id,
+    layout.location_track_is_in_layout_context(publication_state_in, design_id_in, row)
 $$;

--- a/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
@@ -1,6 +1,42 @@
 drop function if exists layout.switch_in_layout_context(layout.publication_state, int);
 drop function if exists layout.switch_in_layout_context(layout.publication_state, int, int);
 
+create function layout.switch_is_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
+                                                   switch layout.switch) returns setof empty_type
+  language sql
+  stable as
+$$
+select
+  where case publication_state_in
+          when 'OFFICIAL' then not switch.draft
+          else switch.draft
+            or case
+                 when switch.design_id is null then
+                   not exists(select *
+                                from layout.switch overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = switch.id)
+                 else not exists(select *
+                                   from layout.switch overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = switch.id)
+               end
+        end
+    and case
+          when design_id_in is null then switch.design_id is null
+          else design_id_in = switch.design_id
+            or (switch.design_id is null
+              and not switch.draft
+              and not exists(select *
+                               from layout.switch overriding_design_official
+                               where overriding_design_official.design_id = design_id_in
+                                 and not overriding_design_official.draft
+                                 and overriding_design_official.official_row_id = switch.id))
+        end
+$$;
+
 create function layout.switch_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
                                                 official_id_in int default null)
   returns table
@@ -59,33 +95,5 @@ select
     select *
       from layout.switch
       where official_id_in is null
-  ) row
-  where case publication_state_in
-          when 'OFFICIAL' then not row.draft
-          else row.draft
-            or case
-                 when row.design_id is null then
-                   not exists(select *
-                                from layout.switch overriding_draft
-                                where overriding_draft.design_id is not distinct from design_id_in
-                                  and overriding_draft.draft
-                                  and overriding_draft.official_row_id = row.id)
-                 else not exists(select *
-                                   from layout.switch overriding_draft
-                                   where overriding_draft.design_id is not distinct from design_id_in
-                                     and overriding_draft.draft
-                                     and overriding_draft.design_row_id = row.id)
-               end
-        end
-    and case
-          when design_id_in is null then row.design_id is null
-          else design_id_in = row.design_id
-            or (row.design_id is null
-              and not draft
-              and not exists(select *
-                               from layout.switch overriding_design_official
-                               where overriding_design_official.design_id = design_id_in
-                                 and not overriding_design_official.draft
-                                 and overriding_design_official.official_row_id = row.id))
-        end
+  ) row, layout.switch_is_in_layout_context(publication_state_in, design_id_in, row)
 $$;

--- a/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
@@ -1,6 +1,44 @@
 drop function if exists layout.km_post_in_layout_context(layout.publication_state, int);
 drop function if exists layout.km_post_in_layout_context(layout.publication_state, int, int);
 
+drop function if exists layout.km_post_is_in_layout_context(layout.publication_state, int, layout.km_post);
+
+create function layout.km_post_is_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
+                                                    km_post layout.km_post) returns setof empty_type
+  language sql
+  stable as
+$$
+select
+  where case publication_state_in
+          when 'OFFICIAL' then not km_post.draft
+          else km_post.draft
+            or case
+                 when km_post.design_id is null then
+                   not exists(select *
+                                from layout.km_post overriding_draft
+                                where overriding_draft.design_id is not distinct from design_id_in
+                                  and overriding_draft.draft
+                                  and overriding_draft.official_row_id = km_post.id)
+                 else not exists(select *
+                                   from layout.km_post overriding_draft
+                                   where overriding_draft.design_id is not distinct from design_id_in
+                                     and overriding_draft.draft
+                                     and overriding_draft.design_row_id = km_post.id)
+               end
+        end
+    and case
+          when design_id_in is null then km_post.design_id is null
+          else design_id_in = km_post.design_id
+            or (km_post.design_id is null
+              and not km_post.draft
+              and not exists(select *
+                               from layout.km_post overriding_design_official
+                               where overriding_design_official.design_id = design_id_in
+                                 and not overriding_design_official.draft
+                                 and overriding_design_official.official_row_id = km_post.id))
+        end
+$$;
+
 create function layout.km_post_in_layout_context(publication_state_in layout.publication_state, design_id_in int,
                                                  official_id_in int default null)
   returns table
@@ -55,33 +93,5 @@ select
     select *
       from layout.km_post
       where official_id_in is null
-  ) row
-  where case publication_state_in
-          when 'OFFICIAL' then not row.draft
-          else row.draft
-            or case
-                 when row.design_id is null then
-                   not exists(select *
-                                from layout.km_post overriding_draft
-                                where overriding_draft.design_id is not distinct from design_id_in
-                                  and overriding_draft.draft
-                                  and overriding_draft.official_row_id = row.id)
-                 else not exists(select *
-                                   from layout.km_post overriding_draft
-                                   where overriding_draft.design_id is not distinct from design_id_in
-                                     and overriding_draft.draft
-                                     and overriding_draft.design_row_id = row.id)
-               end
-        end
-    and case
-          when design_id_in is null then row.design_id is null
-          else design_id_in = row.design_id
-            or (row.design_id is null
-              and not draft
-              and not exists(select *
-                               from layout.km_post overriding_design_official
-                               where overriding_design_official.design_id = design_id_in
-                                 and not overriding_design_official.draft
-                                 and overriding_design_official.official_row_id = row.id))
-        end
+  ) row, layout.km_post_is_in_layout_context(publication_state_in, design_id_in, row)
 $$;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.ElevationMeasurementMethod
 import fi.fta.geoviite.infra.common.FeatureTypeCode
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LinearUnit
 import fi.fta.geoviite.infra.common.MeasurementMethod
@@ -15,6 +16,7 @@ import fi.fta.geoviite.infra.common.RotationDirection.CW
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.StringId
+import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
 import fi.fta.geoviite.infra.geography.CoordinateSystemName
@@ -37,6 +39,7 @@ import fi.fta.geoviite.infra.math.pointInDirection
 import fi.fta.geoviite.infra.math.radsToGrads
 import fi.fta.geoviite.infra.math.rotateAroundOrigin
 import fi.fta.geoviite.infra.math.round
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
@@ -591,6 +594,20 @@ fun geometryCant(points: List<GeometryCantPoint>) = GeometryCant(
     gauge = FINNISH_RAIL_GAUGE,
     rotationPoint = CantRotationPoint.INSIDE_RAIL,
     points = points,
+)
+
+fun geometrySwitch(
+    name: String = "TEST V001",
+    switchStructureId: IntId<SwitchStructure>? = null,
+) = GeometrySwitch(
+    name = SwitchName(name),
+    state = PlanState.EXISTING,
+    switchStructureId = switchStructureId,
+    joints = listOf(
+        GeometrySwitchJoint(JointNumber(1), Point(1.0, 1.0)),
+        GeometrySwitchJoint(JointNumber(2), Point(2.0, 2.0)),
+    ),
+    typeName = GeometrySwitchTypeName("TestSwitchType"),
 )
 
 fun kmPosts(srid: Srid) = listOf(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -21,6 +21,7 @@ import fi.fta.geoviite.infra.geography.GeometryPoint
 import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.geography.transformToGKCoordinate
 import fi.fta.geoviite.infra.geometry.GeometryElement
+import fi.fta.geoviite.infra.geometry.GeometryKmPost
 import fi.fta.geoviite.infra.geometry.MetaDataName
 import fi.fta.geoviite.infra.getSomeNullableValue
 import fi.fta.geoviite.infra.getSomeValue
@@ -949,6 +950,7 @@ fun kmPost(
     state: LayoutState = LayoutState.IN_USE,
     gkLocationConfirmed: Boolean = false,
     gkLocationSource: KmPostGkLocationSource? = null,
+    sourceId: IntId<GeometryKmPost>? = null,
     contextData: LayoutContextData<TrackLayoutKmPost> = createMainContext(null, null, draft),
 ): TrackLayoutKmPost {
 
@@ -956,7 +958,7 @@ fun kmPost(
         trackNumberId = trackNumberId,
         kmNumber = km,
         state = state,
-        sourceId = null,
+        sourceId = sourceId,
         contextData = contextData,
         gkLocation = if (gkLocation == null && roughLayoutLocation != null) {
             transformToGKCoordinate(LAYOUT_SRID, roughLayoutLocation)


### PR DESCRIPTION
Hieman sivusta tullut hakuoptimointijuttu sisältää varsin ison ehdotuksen siitä, miten layout-kontekstia käyttäviä hakuja voitaisiin tehdä.

Vaihtoehtoja olisi nyt (esimerkkinä sijaintiraidehaku, main-draft-kontekstissa):
- Jos haetaan virallisen id:n perusteella: `select * from layout.location_track_in_layout_context('DRAFT', null, 123)`, kuten aiemminkin. Toimii luotettavasti nopeasti.
- Jos haetaan jonkin muun kentän perusteella, esim. ratanumeron: `select * from layout.location_track, layout.location_track_is_in_layout_context('DRAFT', null, location_track) where track_number_id = 123`. Toimii myös luotettavan nopeasti, ehkä. Ainakin sen verran luotettavan nopeasti, että sain sillä korjattua tämän taskin varsinaisen perffiongelman.
- Muita vaihtoehtoja on, ja niitä käytetään, mutta niitä voisi putsata pois, koska nyt niitä ei taida enää juuri tarvita.

Tässä siis `location_track_is_in_layout_context`-funktio suodattaa rivejä ja kertoo, onko rivi, jota nyt katsotaan, juuri se, joka tässä kontekstissa on näkyvissä. Täydellisessä maailmassa kutsun syntaksi olisi selkeämpi, eli luonnostaan `select * from layout.location_track where track_number_id = 123 and layout.location_track_is_in_layout_context('DRAFT', null, location_track)`, mutta tässä maailmassa se ei ole, koska hakujen perffi riippuu suoraan inlinetyksestä, yhden booleanin palauttava funktio on skalaarifunktio, ja postgressisä skalaarifunktioiden inlinetys tapahtuu aivan oman logiikkansa mukaan: https://wiki.postgresql.org/wiki/Inlining_of_SQL_functions

Yksinkertaisin tapa palauttaa boolean-arvo taulumuotoisena on nk. table_dee/table_dum, ts. taulut, jotka postgressissä saa aikaan ajamalla `select where true` tai `select where false`. Jotta päästään tähän asti, pitää vähän kiertää syntaksia, koska postgressissä ei pysty suoraan määrittämään funktiota, joka palauttaa sarakkeettoman taulun. Etuna on, että hakuihin ei synny muuta ylimääräistä tauhkaa, syntaksi vaan on vähän outo.

Samassa pullarissa bonusoptimointina mukana myös suunnitelmien linkitystilojen hakujen siirto massahauiksi. Näissä oli aika paljon overheadia, niin että esim. taskilla GVT-2685 käyttämäni esimerkkihaku nopeutui tämän muutoksen vielä suunnilleen 1.1 sekunnista noin 0.13 sekuntiin.