### PR TITLE
General: Disable detekt's LongParameterList check

### DIFF
--- a/infra/detekt.yml
+++ b/infra/detekt.yml
@@ -130,7 +130,7 @@ complexity:
     active: true
     threshold: 120
   LongParameterList:
-    active: true
+    active: false
     functionThreshold: 6
     constructorThreshold: 21
     ignoreDefaultParameters: false


### PR DESCRIPTION
Previously we have often had warnings for functions with over 6 parameters and sometimes also for service classes containing more than 21 injected dependencies in their constructors.

As modifications have not been made during the warnings, this warning has seemed somewhat unnecessary in terms of noise, even though it does notify about complex functions and large service-classes.