### PR TITLE
GVT-2694 Fix context ignorance in validation caching

### DIFF
--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -524,7 +524,7 @@ export async function getTrackMeter(
 
     return trackNumberTrackMeterCache.get(
         changeTime,
-        `${trackNumberId}_${layoutContext.publicationState}_${pointString(location)}`,
+        `${trackNumberId}_${layoutContext.publicationState}_${layoutContext.branch}_${pointString(location)}`,
         () => {
             return getNullable<TrackMeter>(
                 `${geocodingUri(layoutContext)}/address/${trackNumberId}${params}`,

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -169,8 +169,10 @@ export const getSwitchesValidation = async (
             const switchValidationMap = indexIntoMap<LayoutSwitchId, ValidatedSwitch>(switches);
             return (id: LayoutSwitchId) => switchValidationMap.get(id) as ValidatedSwitch;
         });
+    const cacheKey = (id: LayoutSwitchId) =>
+        `${layoutContext.branch}_${layoutContext.publicationState}_${id}`;
     return switchValidationCache
-        .getMany(maxTime, ids, (id) => id, fetchOperation)
+        .getMany(maxTime, ids, cacheKey, fetchOperation)
         .then((switches) => switches.filter(filterNotEmpty));
 };
 
@@ -179,7 +181,7 @@ export const getSwitchesValidationByTile = async (
     mapTile: MapTile,
     layoutContext: LayoutContext,
 ): Promise<ValidatedSwitch[]> => {
-    const tileKey = `${mapTile.id}_${layoutContext.publicationState}`;
+    const tileKey = `${mapTile.id}_${layoutContext.publicationState}_${layoutContext.branch}`;
     return tiledSwitchValidationCache.get(changeTime, tileKey, () =>
         getNonNull<ValidatedSwitch[]>(
             `${layoutUri('switches', layoutContext)}/validation${queryParams({


### PR DESCRIPTION
Mietin, pitäisikö nuo kaikki `${layoutContext.publicationState}_${layoutContext.branch}`t ympäri koodikantaa yhdistää joksikin layoutContextKey-funktioksi, mutta päätin että no ainakin aivan tähän hätään YAGNI.