### PR TITLE
GVT-2653: Koko koodipesän autoformat ktfmt:llä

### DIFF
--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -19,10 +19,13 @@ plugins {
     id("com.github.jk1.dependency-license-report") version "2.5"
     kotlin("jvm") version "1.9.23"
     kotlin("plugin.spring") version "1.9.23"
+    id("com.ncorti.ktfmt.gradle") version "0.19.0"
 }
 
 group = "fi.fta.geoviite"
+
 version = "SNAPSHOT"
+
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
@@ -30,13 +33,12 @@ repositories {
     mavenCentral()
 }
 
-configurations {
-    all {
-        exclude("org.springframework.boot", "spring-boot-starter-logging")
-    }
-}
+configurations { all { exclude("org.springframework.boot", "spring-boot-starter-logging") } }
+
+ktfmt { kotlinLangStyle() }
 
 ext["selenium.version"] = "4.19.1"
+
 dependencies {
     // Version overrides for transitive deps (due to known vulnerabilities)
 
@@ -60,7 +62,7 @@ dependencies {
     implementation("com.zaxxer:HikariCP:5.1.0")
     implementation("org.flywaydb:flyway-core:9.22.3")
     // v enable once going to Flyway 10.0 (requires Spring Boot 2.7.18)
-    //implementation("org.flywaydb:flyway-database-postgresql:10.0.0")
+    // implementation("org.flywaydb:flyway-database-postgresql:10.0.0")
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
     implementation("org.geotools:gt-main:$geotoolsVersion") {
         // Excluded as the license (JDL or JRL) compatibility is unconfirmed. We don't need this.
@@ -100,10 +102,11 @@ dependencies {
 
 licenseReport {
     renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("report.html", "Backend"))
-    filters = arrayOf<DependencyFilter>(
-        LicenseBundleNormalizer(),
-        // ExcludeTransitiveDependenciesFilter(),
-    )
+    filters =
+        arrayOf<DependencyFilter>(
+            LicenseBundleNormalizer(),
+            // ExcludeTransitiveDependenciesFilter(),
+        )
     allowedLicensesFile = File("$projectDir/allowed-licenses.json")
 }
 
@@ -113,6 +116,7 @@ tasks.withType<KotlinCompile> {
         jvmTarget = "17"
     }
 }
+
 tasks.withType<Jar> {
     from("${rootProject.projectDir}/..") {
         include("LICENSE.txt")
@@ -125,13 +129,11 @@ tasks.withType<Test> {
     systemProperty("browser.name", System.getProperty("browser.name"))
     systemProperty("browser.headless", System.getProperty("browser.headless"))
     testLogging.exceptionFormat = FULL
-    //testLogging.events = mutableSetOf(FAILED, PASSED, SKIPPED)
+    // testLogging.events = mutableSetOf(FAILED, PASSED, SKIPPED)
     testLogging.events = mutableSetOf(FAILED, PASSED, SKIPPED, STANDARD_OUT, STANDARD_ERROR)
 }
 
-tasks.register<Test>("integrationtest") {
-    useJUnitPlatform()
-}
+tasks.register<Test>("integrationtest") { useJUnitPlatform() }
 
 tasks.register<Test>("integrationtest-without-cache") {
     systemProperty("geoviite.cache.enabled", false)

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/aspects/GeoviiteIntegrationApiController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/aspects/GeoviiteIntegrationApiController.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.api.aspects
 
 import fi.fta.geoviite.infra.aspects.reflectedLogBefore
 import fi.fta.geoviite.infra.logging.apiCall
+import java.util.concurrent.ConcurrentHashMap
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Before
@@ -12,7 +13,6 @@ import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.concurrent.ConcurrentHashMap
 
 @Profile("integration-api")
 @Target(AnnotationTarget.CLASS)
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap
 @RestController
 @RequestMapping
 annotation class GeoviiteIntegrationApiController(
-    @get: AliasFor(annotation = RequestMapping::class) val path: Array<String>,
+    @get:AliasFor(annotation = RequestMapping::class) val path: Array<String>,
 )
 
 @Aspect
@@ -31,9 +31,10 @@ class GeoviiteIntegrationApiControllerAspect {
     @Before("within(@GeoviiteIntegrationApiController *)")
     fun logBefore(joinPoint: JoinPoint) {
         val targetClass = joinPoint.target::class.java
-        val logger = loggerCache.computeIfAbsent(targetClass) { classRef ->
-            LoggerFactory.getLogger(classRef)
-        }
+        val logger =
+            loggerCache.computeIfAbsent(targetClass) { classRef ->
+                LoggerFactory.getLogger(classRef)
+            }
 
         if (logger.isInfoEnabled) {
             reflectedLogBefore(joinPoint, logger::apiCall)

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
@@ -24,7 +24,8 @@ class FrameConverterApiObjectMapperV1 {
     @Bean
     fun objectMapper(builder: Jackson2ObjectMapperBuilder): ObjectMapper {
         val module = SimpleModule()
-        module.addDeserializer(FrameConverterRequestV1::class.java, FrameConverterRequestDeserializerV1())
+        module.addDeserializer(
+            FrameConverterRequestV1::class.java, FrameConverterRequestDeserializerV1())
         return builder.build<ObjectMapper>().registerModule(module)
     }
 }
@@ -38,7 +39,9 @@ class FrameConverterApiObjectMapperV1 {
         "/rata-vkm/dev/v1",
     ],
 )
-class FrameConverterControllerV1 @Autowired constructor(
+class FrameConverterControllerV1
+@Autowired
+constructor(
     private val frameConverterServiceV1: FrameConverterServiceV1,
 ) {
 
@@ -65,8 +68,8 @@ class FrameConverterControllerV1 @Autowired constructor(
     private fun processRequest(request: FrameConverterRequestV1): List<GeoJsonFeature> {
         return when (request) {
             is CoordinateToTrackMeterRequestV1 -> {
-                val (validatedRequest, errorResponse)
-                    = frameConverterServiceV1.validateCoordinateToTrackMeterRequest(request)
+                val (validatedRequest, errorResponse) =
+                    frameConverterServiceV1.validateCoordinateToTrackMeterRequest(request)
 
                 if (validatedRequest == null) {
                     errorResponse
@@ -78,10 +81,11 @@ class FrameConverterControllerV1 @Autowired constructor(
                 }
             }
 
-            else -> throw IntegrationApiException(
-                message = "Unsupported request type",
-                localizedMessageKey = "unsupported-request-type",
-            )
+            else ->
+                throw IntegrationApiException(
+                    message = "Unsupported request type",
+                    localizedMessageKey = "unsupported-request-type",
+                )
         }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterDataConvertersV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterDataConvertersV1.kt
@@ -7,15 +7,14 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import fi.fta.geoviite.infra.error.IntegrationApiException
-import org.springframework.core.convert.converter.Converter
-import org.springframework.stereotype.Component
 import java.io.IOException
 import kotlin.reflect.KClass
+import org.springframework.core.convert.converter.Converter
+import org.springframework.stereotype.Component
 
 @Component
-class FrameConverterRequestConverterV1(
-    private val objectMapper: ObjectMapper
-) : Converter<String, FrameConverterRequestV1> {
+class FrameConverterRequestConverterV1(private val objectMapper: ObjectMapper) :
+    Converter<String, FrameConverterRequestV1> {
 
     override fun convert(source: String): FrameConverterRequestV1? {
         return try {
@@ -31,15 +30,15 @@ class FrameConverterRequestConverterV1(
 }
 
 @Component
-class FrameConverterListRequestConverterV1(
-    private val objectMapper: ObjectMapper
-) : Converter<String, List<FrameConverterRequestV1>> {
+class FrameConverterListRequestConverterV1(private val objectMapper: ObjectMapper) :
+    Converter<String, List<FrameConverterRequestV1>> {
 
     override fun convert(source: String): List<FrameConverterRequestV1>? {
-        val collectionType = objectMapper.typeFactory.constructCollectionType(
-            List::class.java,
-            FrameConverterRequestV1::class.java,
-        )
+        val collectionType =
+            objectMapper.typeFactory.constructCollectionType(
+                List::class.java,
+                FrameConverterRequestV1::class.java,
+            )
 
         return try {
             objectMapper.readValue(source, collectionType)
@@ -62,15 +61,14 @@ class FrameConverterRequestDeserializerV1 : JsonDeserializer<FrameConverterReque
     }
 
     private fun determineClass(node: JsonNode): KClass<out FrameConverterRequestV1> {
-        val classMap = listOf(
-            CoordinateToTrackMeterRequestV1::class to listOf("x", "y"),
-            CoordinateToTrackMeterRequestV1::class to listOf("x"),
-            CoordinateToTrackMeterRequestV1::class to listOf("y"),
-        )
+        val classMap =
+            listOf(
+                CoordinateToTrackMeterRequestV1::class to listOf("x", "y"),
+                CoordinateToTrackMeterRequestV1::class to listOf("x"),
+                CoordinateToTrackMeterRequestV1::class to listOf("y"),
+            )
 
-        val clazz = classMap.firstOrNull { (_, keys) ->
-            keys.all { key -> node.has(key) }
-        }?.first
+        val clazz = classMap.firstOrNull { (_, keys) -> keys.all { key -> node.has(key) } }?.first
 
         if (clazz == null) {
             throw IntegrationApiException(
@@ -84,24 +82,33 @@ class FrameConverterRequestDeserializerV1 : JsonDeserializer<FrameConverterReque
 }
 
 class FrameConverterStringDeserializerV1 : JsonDeserializer<FrameConverterStringV1>() {
-    override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): FrameConverterStringV1 {
+    override fun deserialize(
+        p: JsonParser?,
+        ctxt: DeserializationContext?
+    ): FrameConverterStringV1 {
         val value = p?.valueAsString ?: ""
         return FrameConverterStringV1(value)
     }
 }
 
-class FrameConverterResponseSettingsDeserializerV1 : JsonDeserializer<Set<FrameConverterResponseSettingV1>>() {
-    override fun deserialize(parser: JsonParser, ctxt: DeserializationContext): Set<FrameConverterResponseSettingV1> {
+class FrameConverterResponseSettingsDeserializerV1 :
+    JsonDeserializer<Set<FrameConverterResponseSettingV1>>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): Set<FrameConverterResponseSettingV1> {
         val intArray = parser.readValueAs(Array<Int>::class.java)
-        return intArray
-            .map { FrameConverterResponseSettingV1.fromValue(it) }
-            .toSet()
+        return intArray.map { FrameConverterResponseSettingV1.fromValue(it) }.toSet()
     }
 }
 
-class FrameConverterLocationTrackTypeDeserializerV1 : JsonDeserializer<FrameConverterLocationTrackTypeV1>() {
+class FrameConverterLocationTrackTypeDeserializerV1 :
+    JsonDeserializer<FrameConverterLocationTrackTypeV1>() {
     @Throws(IOException::class)
-    override fun deserialize(parser: JsonParser, ctxt: DeserializationContext): FrameConverterLocationTrackTypeV1 {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): FrameConverterLocationTrackTypeV1 {
         val value = parser.text
         return FrameConverterLocationTrackTypeV1.fromValue(value)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterDataV1.kt
@@ -13,32 +13,35 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import fi.fta.geoviite.infra.util.FreeText
 
 typealias FrameConverterIdentifierV1 = FreeText
+
 typealias FrameConverterResponseSettingsV1 = Set<FrameConverterResponseSettingV1>
 
 /**
  * @property BasicFeatureMatchData Response will include all fields from [BasicFeatureMatchDataV1]
  * @property FeatureGeometry Response will include geometry data, such as [GeoJsonGeometryPoint]
- * @property FeatureMatchDetails Response will include detailed data depending on request,
- * such as [CoordinateToTrackMeterConversionDetailsV1]
- *
- * @property INVALID Response will include an error this value was mapped to set of response settings.
+ * @property FeatureMatchDetails Response will include detailed data depending on request, such as
+ *   [CoordinateToTrackMeterConversionDetailsV1]
+ * @property INVALID Response will include an error this value was mapped to set of response
+ *   settings.
  */
 enum class FrameConverterResponseSettingV1(val code: Int) {
     BasicFeatureMatchData(1),
     FeatureGeometry(5),
     FeatureMatchDetails(10),
-
     INVALID(-1);
 
     companion object {
         private val map = entries.associateBy(FrameConverterResponseSettingV1::code)
+
         fun fromValue(type: Int) = map[type] ?: INVALID
     }
 }
 
 data class FrameConverterStringV1(val value: String) {
     init {
-        require(value.length <= MAX_LENGTH) { "String field length must be at most $MAX_LENGTH characters" }
+        require(value.length <= MAX_LENGTH) {
+            "String field length must be at most $MAX_LENGTH characters"
+        }
     }
 
     override fun toString(): String {
@@ -55,11 +58,11 @@ enum class FrameConverterLocationTrackTypeV1(val value: String) {
     SIDE("sivuraide"),
     TRAP("turvaraide"),
     CHORD("kujaraide"),
-
     INVALID("invalid");
 
     companion object {
         private val map = entries.associateBy(FrameConverterLocationTrackTypeV1::value)
+
         fun fromValue(value: String): FrameConverterLocationTrackTypeV1 {
             return map[value] ?: INVALID
         }
@@ -70,12 +73,15 @@ data class GeoJsonFeatureErrorResponseV1(
     override val geometry: GeoJsonGeometry = GeoJsonGeometryPoint.empty(),
     override val properties: GeoJsonFeatureErrorResponsePropertiesV1,
 ) : GeoJsonFeature() {
-    constructor(identifier: FrameConverterIdentifierV1?, errorMessages: String) : this(
-        properties = GeoJsonFeatureErrorResponsePropertiesV1(
-            identifier = identifier,
-            errors = errorMessages,
-        )
-    )
+    constructor(
+        identifier: FrameConverterIdentifierV1?,
+        errorMessages: String
+    ) : this(
+        properties =
+            GeoJsonFeatureErrorResponsePropertiesV1(
+                identifier = identifier,
+                errors = errorMessages,
+            ))
 }
 
 data class GeoJsonFeatureErrorResponsePropertiesV1(
@@ -86,56 +92,48 @@ data class GeoJsonFeatureErrorResponsePropertiesV1(
 sealed class FrameConverterRequestV1
 
 /**
- * @property identifier User provided request identifier which is also included in the response feature(s).
+ * @property identifier User provided request identifier which is also included in the response
+ *   feature(s).
  * @property x User provided x coordinate in ETRS-TM35FIN (EPSG:3067)
  * @property y User provided y coordinate in ETRS-TM35FIN (EPSG:3067)
- *
  * @property searchRadius User provided search radius filter in meters, defaults to 100m.
  * @property trackNumberName User provided track number name filter, optional.
  * @property locationTrackName User provided location track name filter, optional.
  * @property locationTrackType User provided location track type filter, optional.
- * @property responseSettings User provided array of integers, which map to enum values, optional, has defaults.
+ * @property responseSettings User provided array of integers, which map to enum values, optional,
+ *   has defaults.
  */
 data class CoordinateToTrackMeterRequestV1(
     @JsonProperty("tunniste") val identifier: FrameConverterIdentifierV1? = null,
-
     val x: Double? = null,
     val y: Double? = null,
-
     @JsonProperty("sade") val searchRadius: Double? = 100.0,
-
     @JsonProperty("ratanumero")
     @JsonDeserialize(using = FrameConverterStringDeserializerV1::class)
     val trackNumberName: FrameConverterStringV1? = null,
-
     @JsonProperty("sijaintiraide")
     @JsonDeserialize(using = FrameConverterStringDeserializerV1::class)
     val locationTrackName: FrameConverterStringV1? = null,
-
     @JsonProperty("sijaintiraide_tyyppi")
     @JsonDeserialize(using = FrameConverterLocationTrackTypeDeserializerV1::class)
     val locationTrackType: FrameConverterLocationTrackTypeV1? = null,
-
     @JsonProperty("palautusarvot")
     @JsonDeserialize(using = FrameConverterResponseSettingsDeserializerV1::class)
-    val responseSettings: FrameConverterResponseSettingsV1 = setOf(
-        FrameConverterResponseSettingV1.BasicFeatureMatchData,
-        FrameConverterResponseSettingV1.FeatureMatchDetails,
-    ),
-
+    val responseSettings: FrameConverterResponseSettingsV1 =
+        setOf(
+            FrameConverterResponseSettingV1.BasicFeatureMatchData,
+            FrameConverterResponseSettingV1.FeatureMatchDetails,
+        ),
 ) : FrameConverterRequestV1()
 
 data class ValidCoordinateToTrackMeterRequestV1(
     val identifier: FrameConverterIdentifierV1?,
-
     val x: Double,
     val y: Double,
     val searchRadius: Double,
-
     val trackNumberName: TrackNumber?,
     val locationTrackName: AlignmentName?,
     val locationTrackType: LocationTrackType?,
-
     val responseSettings: FrameConverterResponseSettingsV1,
 ) : FrameConverterRequestV1()
 
@@ -156,8 +154,10 @@ data class CoordinateToTrackMeterResponsePropertiesV1(
 ) : GeoJsonProperties()
 
 /**
- * @property x The x coordinate on the alignment of the matched location track ETRS-TM35FIN (EPSG:3067)
- * @property y The y coordinate on the alignment of the matched location track in ETRS-TM35FIN (EPSG:3067)
+ * @property x The x coordinate on the alignment of the matched location track ETRS-TM35FIN
+ *   (EPSG:3067)
+ * @property y The y coordinate on the alignment of the matched location track in ETRS-TM35FIN
+ *   (EPSG:3067)
  * @property distanceFromRequestPoint Calculated distance from user-specified coordinate in meters.
  */
 data class BasicFeatureMatchDataV1(
@@ -175,5 +175,3 @@ data class CoordinateToTrackMeterConversionDetailsV1(
     @JsonProperty("ratametri") val trackMeter: Int,
     @JsonProperty("ratametri_desimaalit") val trackMeterDecimals: Int,
 )
-
-

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/InfraApplication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/InfraApplication.kt
@@ -12,17 +12,18 @@ import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 
 @SpringBootApplication(
-    exclude = [
-        SecurityAutoConfiguration::class,
-        UserDetailsServiceAutoConfiguration::class,
-    ]
-)
+    exclude =
+        [
+            SecurityAutoConfiguration::class,
+            UserDetailsServiceAutoConfiguration::class,
+        ])
 @EnableMethodSecurity
 @ComponentScan(basePackages = ["fi.fta.geoviite"])
 class InfraApplication
 
 @Configuration
-@ConditionalOnProperty(prefix = "geoviite.scheduling", name = ["enabled"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(
+    prefix = "geoviite.scheduling", name = ["enabled"], havingValue = "true", matchIfMissing = true)
 @EnableScheduling
 class InfraScheduling
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/SpringContextUtility.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/SpringContextUtility.kt
@@ -5,8 +5,8 @@ import org.springframework.context.ApplicationContextAware
 import org.springframework.stereotype.Component
 
 /**
- * This utility allows you to access spring beans and properties in a hacky way, past normal CI mechanisms.
- * It should be used only if normal @Autowire isn't usable.
+ * This utility allows you to access spring beans and properties in a hacky way, past normal CI
+ * mechanisms. It should be used only if normal @Autowire isn't usable.
  */
 @Component
 class SpringContextUtility : ApplicationContextAware {
@@ -15,10 +15,12 @@ class SpringContextUtility : ApplicationContextAware {
 
         inline fun <reified T> getBean(): T = getContext().getBean(T::class.java)
 
-        inline fun <reified T> getProperty(key: String): T = getContext().environment.getProperty(key, T::class.java)
-            ?: throw IllegalStateException("No such property: $key")
+        inline fun <reified T> getProperty(key: String): T =
+            getContext().environment.getProperty(key, T::class.java)
+                ?: throw IllegalStateException("No such property: $key")
 
-        fun getContext() = applicationContext ?: throw IllegalStateException("Application context not initialized")
+        fun getContext() =
+            applicationContext ?: throw IllegalStateException("Application context not initialized")
     }
 
     override fun setApplicationContext(applicationContext: ApplicationContext) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteController.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.aspects
 
 import fi.fta.geoviite.infra.logging.apiCall
+import java.util.concurrent.ConcurrentHashMap
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Before
@@ -11,7 +12,6 @@ import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.concurrent.ConcurrentHashMap
 
 @Profile("backend")
 @Target(AnnotationTarget.CLASS)
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentHashMap
 @RestController
 @RequestMapping
 annotation class GeoviiteController(
-    @get: AliasFor(annotation = RequestMapping::class) val path: String,
+    @get:AliasFor(annotation = RequestMapping::class) val path: String,
 )
 
 @Aspect
@@ -30,9 +30,10 @@ class GeoviiteControllerAspect {
     @Before("within(@GeoviiteController *)")
     fun logBefore(joinPoint: JoinPoint) {
         val targetClass = joinPoint.target::class.java
-        val logger = loggerCache.computeIfAbsent(targetClass) { classRef ->
-            LoggerFactory.getLogger(classRef)
-        }
+        val logger =
+            loggerCache.computeIfAbsent(targetClass) { classRef ->
+                LoggerFactory.getLogger(classRef)
+            }
 
         if (logger.isInfoEnabled) {
             reflectedLogBefore(joinPoint, logger::apiCall)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteDao.kt
@@ -1,13 +1,13 @@
 package fi.fta.geoviite.infra.aspects
 
 import fi.fta.geoviite.infra.logging.daoAccess
+import java.util.concurrent.ConcurrentHashMap
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.annotation.AfterReturning
 import org.aspectj.lang.annotation.Aspect
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.util.concurrent.ConcurrentHashMap
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
@@ -22,9 +22,10 @@ class GeoviiteDaoAspect {
     @AfterReturning("within(@GeoviiteDao *)", returning = "result")
     fun logAfterReturn(joinPoint: JoinPoint, result: Any?) {
         val targetClass = joinPoint.target::class.java
-        val logger = loggerCache.computeIfAbsent(targetClass) { classRef ->
-            LoggerFactory.getLogger(classRef)
-        }
+        val logger =
+            loggerCache.computeIfAbsent(targetClass) { classRef ->
+                LoggerFactory.getLogger(classRef)
+            }
 
         if (logger.isInfoEnabled) {
             reflectedLogWithReturnValue(joinPoint, result, logger::daoAccess)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/GeoviiteService.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.aspects
 
 import fi.fta.geoviite.infra.logging.serviceCall
+import java.util.concurrent.ConcurrentHashMap
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Before
@@ -8,7 +9,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
-import java.util.concurrent.ConcurrentHashMap
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
@@ -23,9 +23,10 @@ class GeoviiteServiceAspect {
     @Before("within(@GeoviiteService *)")
     fun logBefore(joinPoint: JoinPoint) {
         val targetClass = joinPoint.target::class.java
-        val logger = loggerCache.computeIfAbsent(targetClass) { classRef ->
-            LoggerFactory.getLogger(classRef)
-        }
+        val logger =
+            loggerCache.computeIfAbsent(targetClass) { classRef ->
+                LoggerFactory.getLogger(classRef)
+            }
 
         if (logger.isDebugEnabled) {
             reflectedLogBefore(joinPoint, logger::serviceCall)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/ReflectedLogging.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/aspects/ReflectedLogging.kt
@@ -46,10 +46,11 @@ private val parameterNameDiscoverer = DefaultParameterNameDiscoverer()
 
 fun reflectedLogBefore(
     joinPoint: JoinPoint,
-    loggerMethod: (
-        methodName: String,
-        params: List<Pair<String, *>>,
-    ) -> Unit,
+    loggerMethod:
+        (
+            methodName: String,
+            params: List<Pair<String, *>>,
+        ) -> Unit,
 ) {
     logInternal(
         joinPoint = joinPoint,
@@ -60,11 +61,12 @@ fun reflectedLogBefore(
 fun reflectedLogWithReturnValue(
     joinPoint: JoinPoint,
     returnValue: Any?,
-    loggerMethodWithReturnValue: (
-        methodName: String,
-        params: List<Pair<String, *>>,
-        returnValue: Any?,
-    ) -> Unit,
+    loggerMethodWithReturnValue:
+        (
+            methodName: String,
+            params: List<Pair<String, *>>,
+            returnValue: Any?,
+        ) -> Unit,
 ) {
     logInternal(
         joinPoint = joinPoint,
@@ -100,9 +102,7 @@ private fun reflectParams(
 
     return parameterNames
         .filterIndexed { index, _ ->
-            method.parameterAnnotations[index].none { annotation ->
-                annotation is DoNotWriteToLog
-            }
+            method.parameterAnnotations[index].none { annotation -> annotation is DoNotWriteToLog }
         }
         .zip(joinPoint.args)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationController.kt
@@ -5,8 +5,8 @@ import fi.fta.geoviite.infra.cloudfront.CloudFrontCookies
 import fi.fta.geoviite.infra.cloudfront.CookieSigner
 import fi.fta.geoviite.infra.error.ApiUnauthorizedException
 import fi.fta.geoviite.infra.util.Code
-import jakarta.servlet.http.HttpServletResponse
 import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -30,11 +30,12 @@ class AuthorizationController @Autowired constructor(private val signer: CookieS
         @RequestParam("code") code: Code,
         response: HttpServletResponse,
     ): Code {
-        val roleCookie = Cookie(DESIRED_ROLE_COOKIE_NAME, code.toString()).apply {
-            path = "/"
-            isHttpOnly = true
-            secure = true
-        }
+        val roleCookie =
+            Cookie(DESIRED_ROLE_COOKIE_NAME, code.toString()).apply {
+                path = "/"
+                isHttpOnly = true
+                secure = true
+            }
 
         response.addCookie(roleCookie)
         return code
@@ -42,7 +43,9 @@ class AuthorizationController @Autowired constructor(private val signer: CookieS
 
     @PreAuthorize(AUTH_BASIC)
     @GetMapping("/cf-cookies")
-    fun getCloudFrontCookies(@RequestParam("redirect") redirectPath: String = ""): ResponseEntity<CloudFrontCookies> {
+    fun getCloudFrontCookies(
+        @RequestParam("redirect") redirectPath: String = ""
+    ): ResponseEntity<CloudFrontCookies> {
         val cloudFrontCookies = signer.createSignedCustomCookies()
         val httpHeaders = HttpHeaders()
 
@@ -53,10 +56,7 @@ class AuthorizationController @Autowired constructor(private val signer: CookieS
         httpHeaders.add("Set-Cookie", cloudFrontCookies.keyPairId)
         httpHeaders.add("Location", "https://${cloudFrontCookies.domain}/$trimmedRedirectPath")
 
-        return ResponseEntity
-            .status(HttpStatus.FOUND)
-            .headers(httpHeaders)
-            .body(cloudFrontCookies)
+        return ResponseEntity.status(HttpStatus.FOUND).headers(httpHeaders).body(cloudFrontCookies)
     }
 
     @PreAuthorize(AUTH_BASIC)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationDao.kt
@@ -6,11 +6,11 @@ import fi.fta.geoviite.infra.configuration.staticDataCacheDuration
 import fi.fta.geoviite.infra.logging.AccessType.FETCH
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.util.*
+import java.util.*
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.util.*
 
 const val AUTHORIZATION_ROLE_CACHE_SIZE = 100L
 
@@ -36,78 +36,75 @@ class AuthorizationDao(
             .build()
 
     fun getRolesByRoleCodes(roleCodes: List<Code>): List<Role> {
-        return roleCodes.mapNotNull { roleCode ->
-            getRoleByRoleCode(roleCode = roleCode)
-        }
+        return roleCodes.mapNotNull { roleCode -> getRoleByRoleCode(roleCode = roleCode) }
     }
 
     fun getRolesByUserGroups(ldapGroups: List<Code>): List<Role> {
-        return ldapGroups.mapNotNull { userGroup ->
-            getRoleByUserGroup(userGroup = userGroup)
-        }
+        return ldapGroups.mapNotNull { userGroup -> getRoleByUserGroup(userGroup = userGroup) }
     }
 
     fun getRoleByRoleCode(roleCode: Code): Role? {
-        val role = if (cacheEnabled) {
-            roleCodeCache.get(roleCode) { code ->
-                fetchRoleInternal(roleCode = code)
+        val role =
+            if (cacheEnabled) {
+                roleCodeCache.get(roleCode) { code -> fetchRoleInternal(roleCode = code) }
+            } else {
+                fetchRoleInternal(roleCode = roleCode)
             }
-        } else {
-            fetchRoleInternal(roleCode = roleCode)
-        }
 
         return role.orElse(null)
     }
 
     fun getRoleByUserGroup(userGroup: Code): Role? {
-        val role = if (cacheEnabled) {
-            userGroupCache.get(userGroup) { group ->
-                fetchRoleInternal(userGroup = group)
+        val role =
+            if (cacheEnabled) {
+                userGroupCache.get(userGroup) { group -> fetchRoleInternal(userGroup = group) }
+            } else {
+                fetchRoleInternal(userGroup = userGroup)
             }
-        } else {
-            fetchRoleInternal(userGroup = userGroup)
-        }
 
         return role.orElse(null)
     }
 
     private fun fetchRoleInternal(roleCode: Code? = null, userGroup: Code? = null): Optional<Role> {
-        check(roleCode != null || userGroup != null) {
-            "Can't fetch role without name/group"
-        }
+        check(roleCode != null || userGroup != null) { "Can't fetch role without name/group" }
 
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select code from common.role 
             where (:role_code::varchar is null or code = :role_code) 
               and (:user_group::varchar is null or user_group = :user_group)
-        """.trimIndent()
-        val params = mapOf(
-            "role_code" to roleCode,
-            "user_group" to userGroup,
-        )
-        val role = jdbcTemplate.queryOptional(sql, params) { rs, _ ->
-            val code: Code = rs.getCode("code")
-            Role(
-                code = code,
-                privileges = fetchRolePrivilegesInternal(code),
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "role_code" to roleCode,
+                "user_group" to userGroup,
             )
-        }
+        val role =
+            jdbcTemplate.queryOptional(sql, params) { rs, _ ->
+                val code: Code = rs.getCode("code")
+                Role(
+                    code = code,
+                    privileges = fetchRolePrivilegesInternal(code),
+                )
+            }
         logger.daoAccess(FETCH, Role::class, listOfNotNull(roleCode, userGroup))
         return Optional.ofNullable(role)
     }
 
     private fun fetchRolePrivilegesInternal(code: Code): List<Privilege> {
-        val sql = """
+        val sql =
+            """
             select privilege.code
             from common.role_privilege rp
               left join common.privilege on privilege.code = rp.privilege_code
             where rp.role_code = :role_code
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("role_code" to code)
-        val privileges = jdbcTemplate.query(sql, params) { rs, _ ->
-            Privilege(code = rs.getCode("code"))
-        }
+        val privileges =
+            jdbcTemplate.query(sql, params) { rs, _ -> Privilege(code = rs.getCode("code")) }
         logger.daoAccess(FETCH, Privilege::class, privileges.map { p -> p.code })
         return privileges
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationService.kt
@@ -39,17 +39,14 @@ class AuthorizationService @Autowired constructor(private val authorizationDao: 
     fun getRolesByUserGroups(ldapGroupNames: List<Code>): List<Role> {
         return ldapGroupNames
             .filter { groupName -> groupName.startsWith(LDAP_GROUP_GEOVIITE_PREFIX) }
-            .let { geoviiteUserGroups ->
-                authorizationDao.getRolesByUserGroups(geoviiteUserGroups)
-            }
+            .let { geoviiteUserGroups -> authorizationDao.getRolesByUserGroups(geoviiteUserGroups) }
     }
 
     fun getDefaultRole(userRoles: List<Role>): Role {
-        check(userRoles.isNotEmpty()) {
-            "There must be at least one available user role!"
-        }
+        check(userRoles.isNotEmpty()) { "There must be at least one available user role!" }
 
-        return defaultRoleCodeOrder.asSequence()
+        return defaultRoleCodeOrder
+            .asSequence()
             .mapNotNull { defaultRoleCode ->
                 userRoles.find { userRole -> userRole.code == defaultRoleCode }
             }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/Privileges.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/Privileges.kt
@@ -14,6 +14,7 @@ const val AUTH_VIEW_PV_DOCUMENTS = "hasAuthority('view-pv-documents')"
 
 const val LAYOUT_BRANCH = "layoutBranch"
 const val PUBLICATION_STATE = "publicationState"
-const val AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE = "(#$PUBLICATION_STATE.name() == 'DRAFT' && $AUTH_VIEW_LAYOUT_DRAFT) || (#$PUBLICATION_STATE.name() == 'OFFICIAL' && $AUTH_VIEW_LAYOUT)"
+const val AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE =
+    "(#$PUBLICATION_STATE.name() == 'DRAFT' && $AUTH_VIEW_LAYOUT_DRAFT) || (#$PUBLICATION_STATE.name() == 'OFFICIAL' && $AUTH_VIEW_LAYOUT)"
 
 const val AUTH_API_FRAME_CONVERTER = "hasAuthority('api-frame-converter')"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/RequestContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/RequestContext.kt
@@ -3,30 +3,35 @@ import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.util.Code
 import org.apache.logging.log4j.ThreadContext
 
-private class RequestProperty<T>(val type: Type, private val init: (String) -> T) : IRequestProperty<T> {
+private class RequestProperty<T>(val type: Type, private val init: (String) -> T) :
+    IRequestProperty<T> {
     override fun set(newValue: T) = ThreadContext.put(type.header, newValue.toString())
 
     override fun clear() = ThreadContext.remove(type.header)
 
-    override fun get(): T = requireNotNull(getOrNull()) {
-        "Value for ${type.name} (header ${type.header}) not found in context"
-    }
+    override fun get(): T =
+        requireNotNull(getOrNull()) {
+            "Value for ${type.name} (header ${type.header}) not found in context"
+        }
 
     override fun getOrNull(): T? = ThreadContext.get(type.header)?.let(init)
 
     enum class Type(val header: String) {
-        CORRELATION_ID_HEADER("correlationId"), USER("user"), ROLE("role"),
+        CORRELATION_ID_HEADER("correlationId"),
+        USER("user"),
+        ROLE("role"),
     }
-
 }
 
 interface IRequestProperty<T> {
     fun set(newValue: T)
+
     fun clear()
+
     fun get(): T
+
     fun getOrNull(): T?
 }
-
 
 val currentUser: IRequestProperty<UserName> = RequestProperty(USER, UserName::of)
 val currentUserRole: IRequestProperty<Code> = RequestProperty(ROLE, ::Code)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/UserData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/UserData.kt
@@ -19,34 +19,39 @@ data class UserDetails(
 data class Role(val code: Code, val privileges: List<Privilege>)
 
 data class Privilege(val code: Code) : GrantedAuthority {
-    @JsonIgnore
-    override fun getAuthority(): String = code.toString()
+    @JsonIgnore override fun getAuthority(): String = code.toString()
 }
 
 val userNameLength = 3..300
 
-data class UserName @JsonCreator(mode = DELEGATING) private constructor(private val value: String)
-    : Comparable<UserName>, CharSequence by value {
+data class UserName @JsonCreator(mode = DELEGATING) private constructor(private val value: String) :
+    Comparable<UserName>, CharSequence by value {
     companion object {
         fun of(name: String) = UserName(removeLogUnsafe(name))
     }
-    init { assertLength<UserName>(value, userNameLength) }
 
-    @JsonValue
-    override fun toString(): String = value
+    init {
+        assertLength<UserName>(value, userNameLength)
+    }
+
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: UserName): Int = value.compareTo(other.value)
 }
 
 val authNameLength = 1..300
 
-data class AuthName @JsonCreator(mode = DELEGATING) private constructor(private val value: String)
-    : Comparable<AuthName>, CharSequence by value {
+data class AuthName @JsonCreator(mode = DELEGATING) private constructor(private val value: String) :
+    Comparable<AuthName>, CharSequence by value {
     companion object {
         fun of(name: String) = AuthName(removeLogUnsafe(name))
     }
-    init { assertLength<AuthName>(value, authNameLength) }
 
-    @JsonValue
-    override fun toString(): String = value
+    init {
+        assertLength<AuthName>(value, authNameLength)
+    }
+
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: AuthName): Int = value.compareTo(other.value)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/cloudfront/CookieSigner.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/cloudfront/CookieSigner.kt
@@ -3,19 +3,24 @@ package fi.fta.geoviite.infra.cloudfront
 import com.amazonaws.services.cloudfront.CloudFrontCookieSigner
 import fi.fta.geoviite.infra.SpringContextUtility
 import fi.fta.geoviite.infra.cloudfront.KeyUtils.Companion.parseBase64DerToPrivateKey
-import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Component
 import java.text.SimpleDateFormat
 import java.time.Duration
 import java.time.Instant
 import java.util.*
-
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
 
 @Component
 class CookieSigner {
-    private val keyPairId: String by lazy { SpringContextUtility.getProperty("geoviite.cloudfront.key-pair-id") }
-    private val encodedKey: String by lazy { SpringContextUtility.getProperty("geoviite.cloudfront.private-key") }
-    private val distributionDnsName: String by lazy { SpringContextUtility.getProperty("geoviite.cloudfront.distribution-name") }
+    private val keyPairId: String by lazy {
+        SpringContextUtility.getProperty("geoviite.cloudfront.key-pair-id")
+    }
+    private val encodedKey: String by lazy {
+        SpringContextUtility.getProperty("geoviite.cloudfront.private-key")
+    }
+    private val distributionDnsName: String by lazy {
+        SpringContextUtility.getProperty("geoviite.cloudfront.distribution-name")
+    }
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     fun createSignedCustomCookies(): CloudFrontCookies {
@@ -23,30 +28,33 @@ class CookieSigner {
             "KeyPairId=[{}] - Encoded Key Length=[{}] - distribution dns name=[{}]",
             keyPairId,
             encodedKey.length,
-            distributionDnsName
-        )
+            distributionDnsName)
 
         val resourcePath = "https://$distributionDnsName/*"
         val privateKey = parseBase64DerToPrivateKey(encodedKey)
         val activeFrom = Instant.now().minusSeconds(5)
         val expiresOn = activeFrom.plus(Duration.ofHours(8))
-        val df = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).also { date ->
-            date.timeZone = TimeZone.getTimeZone("GMT")
-        }
+        val df =
+            SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).also { date ->
+                date.timeZone = TimeZone.getTimeZone("GMT")
+            }
 
-        val customPolicyCookies = CloudFrontCookieSigner.getCookiesForCustomPolicy(
-            resourcePath,
-            privateKey,
-            keyPairId,
-            Date.from(expiresOn),
-            Date.from(activeFrom),
-            "0.0.0.0/0"
-        )
+        val customPolicyCookies =
+            CloudFrontCookieSigner.getCookiesForCustomPolicy(
+                resourcePath,
+                privateKey,
+                keyPairId,
+                Date.from(expiresOn),
+                Date.from(activeFrom),
+                "0.0.0.0/0")
 
-        val cookieAttributes = "SameSite=Lax; Path=/; Secure; HttpOnly; Expires=${df.format(Date.from(expiresOn))}"
-        val keyPairIdCookie = "CloudFront-Key-Pair-Id=${customPolicyCookies.keyPairId.value};$cookieAttributes"
+        val cookieAttributes =
+            "SameSite=Lax; Path=/; Secure; HttpOnly; Expires=${df.format(Date.from(expiresOn))}"
+        val keyPairIdCookie =
+            "CloudFront-Key-Pair-Id=${customPolicyCookies.keyPairId.value};$cookieAttributes"
         val policyCookie = "CloudFront-Policy=${customPolicyCookies.policy.value};$cookieAttributes"
-        val signatureCookie = "CloudFront-Signature=${customPolicyCookies.signature.value};$cookieAttributes"
+        val signatureCookie =
+            "CloudFront-Signature=${customPolicyCookies.signature.value};$cookieAttributes"
 
         return CloudFrontCookies(
             policy = policyCookie,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/cloudfront/SecurityProviderInitialization.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/cloudfront/SecurityProviderInitialization.kt
@@ -1,12 +1,11 @@
 package fi.fta.geoviite.infra.cloudfront
 
 import jakarta.annotation.PostConstruct
+import java.security.Security
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.security.Security
-
 
 @Component
 class SecurityProviderInitialization {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/codeDictionary/CodeDictionaryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/codeDictionary/CodeDictionaryDao.kt
@@ -13,18 +13,19 @@ import org.springframework.transaction.annotation.Transactional
 
 @Transactional(readOnly = true)
 @Component
-class CodeDictionaryDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTemplateParam) {
+class CodeDictionaryDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
+    DaoBase(jdbcTemplateParam) {
 
     @Cacheable(CACHE_FEATURE_TYPES, sync = true)
     fun getFeatureTypes(): List<FeatureType> {
         val sql = "select code, description from common.feature_type"
         val params = emptyMap<String, Int>()
-        val result = jdbcTemplate.query(sql, params) { rs, _ ->
-            FeatureType(
-                code = rs.getFeatureTypeCode("code"),
-                description = rs.getFreeText("description")
-            )
-        }
+        val result =
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                FeatureType(
+                    code = rs.getFeatureTypeCode("code"),
+                    description = rs.getFreeText("description"))
+            }
         logger.daoAccess(FETCH, FeatureType::class, result.map { r -> r.code })
         return result
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/codeDictionary/CodeDictionaryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/codeDictionary/CodeDictionaryService.kt
@@ -4,9 +4,10 @@ import fi.fta.geoviite.infra.aspects.GeoviiteService
 import org.springframework.beans.factory.annotation.Autowired
 
 @GeoviiteService
-class CodeDictionaryService @Autowired constructor(private val codeDictionaryDao: CodeDictionaryDao) {
+class CodeDictionaryService
+@Autowired
+constructor(private val codeDictionaryDao: CodeDictionaryDao) {
     fun getFeatureTypes(): List<FeatureType> {
         return codeDictionaryDao.getFeatureTypes()
     }
-
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/AlignmentName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/AlignmentName.kt
@@ -8,13 +8,17 @@ import fi.fta.geoviite.infra.util.assertSanitized
 val alignmentNameLength = 1..50
 val alignmentNameRegex = Regex("^[A-Za-zÄÖÅäöå0-9 \\-_!?§]+\$")
 
-data class AlignmentName @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<AlignmentName>, CharSequence by value {
+data class AlignmentName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<AlignmentName>, CharSequence by value {
 
-    init { assertSanitized<AlignmentName>(value, alignmentNameRegex, alignmentNameLength, allowBlank = false) }
+    init {
+        assertSanitized<AlignmentName>(
+            value, alignmentNameRegex, alignmentNameLength, allowBlank = false)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: AlignmentName): Int = value.compareTo(other.value)
+
     fun padStart(length: Int, padChar: Char) = AlignmentName(value.padStart(length, padChar))
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
@@ -9,10 +9,10 @@ import fi.fta.geoviite.infra.ratko.RatkoOperatingPointDao
 import fi.fta.geoviite.infra.ratko.RatkoPushDao
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.tracklayout.*
+import java.time.Instant
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
-import java.time.Instant
 
 data class CollectedChangeTimes(
     val layoutTrackNumber: Instant,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/DomainId.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/DomainId.kt
@@ -24,9 +24,8 @@ enum class IdType(val shortName: String) {
     }
 }
 
-private inline fun <reified T> parsingError(source: String): Nothing = throw IllegalArgumentException(
-    "Invalid ${T::class.simpleName}: ${formatForException(source)}"
-)
+private inline fun <reified T> parsingError(source: String): Nothing =
+    throw IllegalArgumentException("Invalid ${T::class.simpleName}: ${formatForException(source)}")
 
 sealed class DomainId<T> {
     companion object {
@@ -34,21 +33,24 @@ sealed class DomainId<T> {
 
         @JvmStatic
         @JsonCreator
-        fun <T> parse(source: String): DomainId<T> = tryParse(source) ?: parsingError<DomainId<T>>(source)
+        fun <T> parse(source: String): DomainId<T> =
+            tryParse(source) ?: parsingError<DomainId<T>>(source)
 
-        private fun <T> tryParse(source: String): DomainId<T>? = source
-            .takeIf { v -> v.length in stringLength }
-            ?.let { v ->
-                when (getType(v)) {
-                    INT -> IntId.tryParse(v)
-                    STRING -> StringId.tryParse(v)
-                    INDEXED -> IndexedId.tryParse(v)
-                    null -> null
+        private fun <T> tryParse(source: String): DomainId<T>? =
+            source
+                .takeIf { v -> v.length in stringLength }
+                ?.let { v ->
+                    when (getType(v)) {
+                        INT -> IntId.tryParse(v)
+                        STRING -> StringId.tryParse(v)
+                        INDEXED -> IndexedId.tryParse(v)
+                        null -> null
+                    }
                 }
-            }
 
         @JvmStatic
-        protected fun getType(source: String): IdType? = IdType.entries.firstOrNull { t -> t.typeMatches(source) }
+        protected fun getType(source: String): IdType? =
+            IdType.entries.firstOrNull { t -> t.typeMatches(source) }
     }
 }
 
@@ -58,16 +60,17 @@ data class StringId<T>(val stringValue: String = "${UUID.randomUUID()}") : Domai
 
         @JvmStatic
         @JsonCreator
-        fun <T> parse(source: String): StringId<T> = tryParse(source) ?: parsingError<IntId<T>>(source)
+        fun <T> parse(source: String): StringId<T> =
+            tryParse(source) ?: parsingError<IntId<T>>(source)
 
-        fun <T> tryParse(source: String): StringId<T>? = source
-            .takeIf { s -> s.length in stringLength && getType(s) == STRING }
-            ?.let { STRING.clipType(source) }
-            ?.let(::StringId)
+        fun <T> tryParse(source: String): StringId<T>? =
+            source
+                .takeIf { s -> s.length in stringLength && getType(s) == STRING }
+                ?.let { STRING.clipType(source) }
+                ?.let(::StringId)
     }
 
-    @JsonValue
-    override fun toString(): String = "${STRING.shortName}$SEPARATOR$stringValue"
+    @JsonValue override fun toString(): String = "${STRING.shortName}$SEPARATOR$stringValue"
 }
 
 data class IntId<T>(val intValue: Int) : DomainId<T>() {
@@ -78,14 +81,14 @@ data class IntId<T>(val intValue: Int) : DomainId<T>() {
         @JsonCreator
         fun <T> parse(source: String): IntId<T> = tryParse(source) ?: parsingError<IntId<T>>(source)
 
-        fun <T> tryParse(source: String): IntId<T>? = source
-            .takeIf { s -> s.length in stringLength && getType(s) == INT }
-            ?.let { INT.clipType(source).toIntOrNull() }
-            ?.let(::IntId)
+        fun <T> tryParse(source: String): IntId<T>? =
+            source
+                .takeIf { s -> s.length in stringLength && getType(s) == INT }
+                ?.let { INT.clipType(source).toIntOrNull() }
+                ?.let(::IntId)
     }
 
-    @JsonValue
-    override fun toString(): String = "${INT.shortName}$SEPARATOR$intValue"
+    @JsonValue override fun toString(): String = "${INT.shortName}$SEPARATOR$intValue"
 }
 
 data class IndexedId<T>(val parentId: Int, val index: Int) : DomainId<T>() {
@@ -94,16 +97,19 @@ data class IndexedId<T>(val parentId: Int, val index: Int) : DomainId<T>() {
 
         @JvmStatic
         @JsonCreator
-        fun <T> parse(source: String): IndexedId<T> = tryParse(source) ?: parsingError<IndexedId<T>>(source)
+        fun <T> parse(source: String): IndexedId<T> =
+            tryParse(source) ?: parsingError<IndexedId<T>>(source)
 
-        fun <T> tryParse(source: String): IndexedId<T>? = source
-            .takeIf { s -> s.length in stringLength && getType(s) == INDEXED }
-            ?.let { s ->
-                val parts = INDEXED.clipType(s).split(SEPARATOR).map(String::toInt)
-                val parent = parts.getOrNull(0)
-                val index = parts.getOrNull(1)
-                if (parts.size == 2 && parent != null && index != null) IndexedId(parent, index) else null
-            }
+        fun <T> tryParse(source: String): IndexedId<T>? =
+            source
+                .takeIf { s -> s.length in stringLength && getType(s) == INDEXED }
+                ?.let { s ->
+                    val parts = INDEXED.clipType(s).split(SEPARATOR).map(String::toInt)
+                    val parent = parts.getOrNull(0)
+                    val index = parts.getOrNull(1)
+                    if (parts.size == 2 && parent != null && index != null) IndexedId(parent, index)
+                    else null
+                }
     }
 
     @JsonValue

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/FeatureTypeCode.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/FeatureTypeCode.kt
@@ -8,10 +8,11 @@ import fi.fta.geoviite.infra.util.assertSanitized
 private val featureTypeCodeLength = 3..3
 private val featureTypeCodeRegex = Regex("^\\d{3}\$")
 
-data class FeatureTypeCode @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : CharSequence by value {
-    init { assertSanitized<FeatureTypeCode>(value, featureTypeCodeRegex, featureTypeCodeLength) }
+data class FeatureTypeCode @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    CharSequence by value {
+    init {
+        assertSanitized<FeatureTypeCode>(value, featureTypeCodeRegex, featureTypeCodeLength)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/JointNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/JointNumber.kt
@@ -8,13 +8,16 @@ import fi.fta.geoviite.infra.util.parsePrefixedInt
 
 private const val JOINT_PREFIX = "JOINT_"
 
-data class JointNumber @JsonCreator(mode = DISABLED) constructor(val intValue: Int) : Comparable<JointNumber> {
+data class JointNumber @JsonCreator(mode = DISABLED) constructor(val intValue: Int) :
+    Comparable<JointNumber> {
     @JsonCreator(mode = DELEGATING)
     constructor(value: String) : this(parsePrefixedInt<JointNumber>(JOINT_PREFIX, value))
 
-    init { require(intValue >= 0) { "Invalid joint number: \"$intValue\"" } }
+    init {
+        require(intValue >= 0) { "Invalid joint number: \"$intValue\"" }
+    }
 
-    @JsonValue
-    override fun toString(): String = JOINT_PREFIX + intValue
+    @JsonValue override fun toString(): String = JOINT_PREFIX + intValue
+
     override fun compareTo(other: JointNumber): Int = intValue.compareTo(other.intValue)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
@@ -21,14 +21,15 @@ const val DEFAULT_TRACK_METER_DECIMALS = 3
 private val extensionLength = 1..2
 private val extensionRegex = Regex("^[A-Z]*\$")
 
-data class KmNumber @JsonCreator(mode = DISABLED) constructor(
+data class KmNumber
+@JsonCreator(mode = DISABLED)
+constructor(
     val number: Int,
     val extension: String? = null,
 ) : Comparable<KmNumber> {
     private constructor(values: Pair<Int, String?>) : this(values.first, values.second)
 
-    @JsonCreator(mode = DELEGATING)
-    constructor(value: String) : this(parseKmNumberParts(value))
+    @JsonCreator(mode = DELEGATING) constructor(value: String) : this(parseKmNumberParts(value))
 
     companion object {
         val ZERO = KmNumber(0)
@@ -38,8 +39,7 @@ data class KmNumber @JsonCreator(mode = DISABLED) constructor(
         "${number.toString().padStart(4, '0')}${extension ?: ""}"
     }
 
-    @JsonValue
-    override fun toString(): String = stringValue
+    @JsonValue override fun toString(): String = stringValue
 
     init {
         extension?.let {
@@ -54,6 +54,7 @@ data class KmNumber @JsonCreator(mode = DISABLED) constructor(
 
 private const val METERS_MAX_INTEGER_DIGITS = 4
 private const val METERS_MAX_DECIMAL_DIGITS = 6
+
 private fun limitScale(meters: BigDecimal) =
     if (meters.scale() < 0) {
         meters.setScale(0)
@@ -71,11 +72,17 @@ interface ITrackMeter : Comparable<ITrackMeter> {
     val meters: BigDecimal
 
     fun format(): String = formatTrackMeter(kmNumber, meters)
-    fun formatDropDecimals(decimals: Int = 0): String = formatTrackMeter(kmNumber, metersFloor(decimals))
-    fun formatRoundDecimals(decimals: Int = 0): String = formatTrackMeter(kmNumber, metersRound(decimals))
+
+    fun formatDropDecimals(decimals: Int = 0): String =
+        formatTrackMeter(kmNumber, metersFloor(decimals))
+
+    fun formatRoundDecimals(decimals: Int = 0): String =
+        formatTrackMeter(kmNumber, metersRound(decimals))
 
     fun metersFloor(decimals: Int = 0): BigDecimal = meters.setScale(decimals, DOWN)
+
     fun metersCeil(decimals: Int = 0): BigDecimal = meters.setScale(decimals, UP)
+
     fun metersRound(decimals: Int = 0): BigDecimal = meters.setScale(decimals, HALF_UP)
 
     fun decimalCount(): Int = meters.scale()
@@ -86,7 +93,9 @@ interface ITrackMeter : Comparable<ITrackMeter> {
     override operator fun compareTo(other: ITrackMeter): Int = compare(this, other)
 }
 
-data class TrackMeter @JsonCreator(mode = DISABLED) constructor(
+data class TrackMeter
+@JsonCreator(mode = DISABLED)
+constructor(
     override val kmNumber: KmNumber,
     override val meters: BigDecimal,
 ) : ITrackMeter {
@@ -108,8 +117,7 @@ data class TrackMeter @JsonCreator(mode = DISABLED) constructor(
 
     private constructor(values: Pair<KmNumber, BigDecimal>) : this(values.first, values.second)
 
-    @JsonCreator(mode = DELEGATING)
-    constructor(value: String) : this(parseTrackMeterParts(value))
+    @JsonCreator(mode = DELEGATING) constructor(value: String) : this(parseTrackMeterParts(value))
 
     companion object {
         val ZERO = TrackMeter(KmNumber.ZERO, BigDecimal.ZERO)
@@ -131,46 +139,94 @@ data class TrackMeter @JsonCreator(mode = DISABLED) constructor(
     }
 
     constructor(kmNumber: KmNumber, meters: Int) : this(kmNumber, meters.toBigDecimal())
-    constructor(kmNumber: KmNumber, meters: Double, decimals: Int) : this(kmNumber, round(meters, decimals))
-    constructor(kmNumber: KmNumber, meters: String) : this(kmNumber, meters.toBigDecimal())
-    constructor(kmNumber: String, meters: Int) : this(KmNumber(kmNumber), meters)
-    constructor(kmNumber: String, meters: Double, decimals: Int) : this(KmNumber(kmNumber), meters, decimals)
-    constructor(kmNumber: String, meters: String) : this(KmNumber(kmNumber), meters)
-    constructor(kmNumber: String, meters: BigDecimal) : this(KmNumber(kmNumber), meters)
-    constructor(kmNumber: Int, meters: Int) : this(KmNumber(kmNumber), meters)
-    constructor(kmNumber: Int, meters: Double, decimals: Int) : this(KmNumber(kmNumber), meters, decimals)
-    constructor(kmNumber: Int, meters: String) : this(KmNumber(kmNumber), meters)
-    constructor(kmNumber: Int, meters: BigDecimal) : this(KmNumber(kmNumber), meters)
-    constructor(kmNumber: Int, extension: String, meters: Int) : this(KmNumber(kmNumber, extension), meters)
-    constructor(kmNumber: Int, extension: String, meters: Double, decimals: Int) : this(
-        KmNumber(kmNumber, extension),
-        meters,
-        decimals
-    )
 
-    constructor(kmNumber: Int, extension: String, meters: String) : this(KmNumber(kmNumber, extension), meters)
-    constructor(kmNumber: Int, extension: String, meters: BigDecimal) : this(KmNumber(kmNumber, extension), meters)
+    constructor(
+        kmNumber: KmNumber,
+        meters: Double,
+        decimals: Int
+    ) : this(kmNumber, round(meters, decimals))
+
+    constructor(kmNumber: KmNumber, meters: String) : this(kmNumber, meters.toBigDecimal())
+
+    constructor(kmNumber: String, meters: Int) : this(KmNumber(kmNumber), meters)
+
+    constructor(
+        kmNumber: String,
+        meters: Double,
+        decimals: Int
+    ) : this(KmNumber(kmNumber), meters, decimals)
+
+    constructor(kmNumber: String, meters: String) : this(KmNumber(kmNumber), meters)
+
+    constructor(kmNumber: String, meters: BigDecimal) : this(KmNumber(kmNumber), meters)
+
+    constructor(kmNumber: Int, meters: Int) : this(KmNumber(kmNumber), meters)
+
+    constructor(
+        kmNumber: Int,
+        meters: Double,
+        decimals: Int
+    ) : this(KmNumber(kmNumber), meters, decimals)
+
+    constructor(kmNumber: Int, meters: String) : this(KmNumber(kmNumber), meters)
+
+    constructor(kmNumber: Int, meters: BigDecimal) : this(KmNumber(kmNumber), meters)
+
+    constructor(
+        kmNumber: Int,
+        extension: String,
+        meters: Int
+    ) : this(KmNumber(kmNumber, extension), meters)
+
+    constructor(
+        kmNumber: Int,
+        extension: String,
+        meters: Double,
+        decimals: Int
+    ) : this(KmNumber(kmNumber, extension), meters, decimals)
+
+    constructor(
+        kmNumber: Int,
+        extension: String,
+        meters: String
+    ) : this(KmNumber(kmNumber, extension), meters)
+
+    constructor(
+        kmNumber: Int,
+        extension: String,
+        meters: BigDecimal
+    ) : this(KmNumber(kmNumber, extension), meters)
 
     override fun toString() = format()
 
     fun floor(decimals: Int = 0) = TrackMeter(kmNumber, metersFloor(decimals))
+
     fun ceil(decimals: Int = 0) = TrackMeter(kmNumber, metersCeil(decimals))
+
     fun round(decimals: Int = 0) = TrackMeter(kmNumber, metersRound(decimals))
 
     operator fun plus(metersDelta: Int) = plus(metersDelta.toBigDecimal())
+
     operator fun plus(metersDelta: Double) = plus(metersDelta, meters.scale())
+
     operator fun plus(metersDelta: BigDecimal) = TrackMeter(kmNumber, meters + metersDelta)
+
     fun plus(metersDelta: Double, decimals: Int) = plus(round(metersDelta, decimals))
 
     operator fun minus(metersDelta: Int) = minus(metersDelta.toBigDecimal())
+
     operator fun minus(metersDelta: Double) = minus(metersDelta, meters.scale())
+
     operator fun minus(metersDelta: BigDecimal) = TrackMeter(kmNumber, meters - metersDelta)
+
     fun minus(metersDelta: Double, decimals: Int) = minus(round(metersDelta, decimals))
+
     fun stripTrailingZeroes() = TrackMeter(kmNumber, limitScale(meters.stripTrailingZeros()))
 }
 
-private fun getMetersFormat(decimals: Int) = meterFormats[decimals]
-    ?: throw IllegalStateException("No meters format defined for scale $decimals")
+private fun getMetersFormat(decimals: Int) =
+    meterFormats[decimals]
+        ?: throw IllegalStateException("No meters format defined for scale $decimals")
 
 private val meterFormats: Map<Int, DecimalFormat> by lazy {
     (0..METERS_MAX_DECIMAL_DIGITS).associateWith { decimals ->
@@ -194,8 +250,10 @@ private fun parseTrackMeterParts(value: String): Pair<KmNumber, BigDecimal> {
 private fun parseKmNumberParts(kmString: String): Pair<Int, String?> {
     val letterStart = kmString.indexOfFirst { c -> !c.isDigit() }
     val numberPart = if (letterStart > 0) kmString.substring(0, letterStart) else kmString
-    val number = numberPart.toIntOrNull()
-        ?: throw IllegalArgumentException("KM-number doesn't have a number: ${formatForException(kmString)}")
+    val number =
+        numberPart.toIntOrNull()
+            ?: throw IllegalArgumentException(
+                "KM-number doesn't have a number: ${formatForException(kmString)}")
     val letterPart = if (letterStart > 0) kmString.substring(letterStart).uppercase() else null
     return number to letterPart
 }
@@ -208,5 +266,6 @@ fun compare(trackMeter1: ITrackMeter, trackMeter2: ITrackMeter): Int {
 }
 
 fun compare(trackMeter1: ITrackMeter, trackMeter2: ITrackMeter, decimals: Int): Int {
-    return compareValuesBy(trackMeter1, trackMeter2, { tm -> tm.kmNumber }, { tm -> tm.metersRound(decimals) })
+    return compareValuesBy(
+        trackMeter1, trackMeter2, { tm -> tm.kmNumber }, { tm -> tm.metersRound(decimals) })
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/LayoutContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/LayoutContext.kt
@@ -6,37 +6,47 @@ import fi.fta.geoviite.infra.tracklayout.LayoutDesign
 import fi.fta.geoviite.infra.util.formatForException
 import java.util.concurrent.ConcurrentHashMap
 
-enum class PublicationState { OFFICIAL, DRAFT }
-
-enum class LayoutBranchType { MAIN, DESIGN }
-
-fun assertMainBranch(branch: LayoutBranch) = require(branch == LayoutBranch.main) {
-    // TODO: Design branch support missing in Ratko integration and splits
-    "Design branch use is not yet supported"
+enum class PublicationState {
+    OFFICIAL,
+    DRAFT
 }
+
+enum class LayoutBranchType {
+    MAIN,
+    DESIGN
+}
+
+fun assertMainBranch(branch: LayoutBranch) =
+    require(branch == LayoutBranch.main) {
+        // TODO: Design branch support missing in Ratko integration and splits
+        "Design branch use is not yet supported"
+    }
 
 sealed class LayoutBranch {
     companion object {
-        @JvmStatic
-        protected val separator = '_'
+        @JvmStatic protected val separator = '_'
 
         val main = MainBranch.instance
+
         fun design(id: IntId<LayoutDesign>) = DesignBranch.of(id)
 
-        fun tryParse(value: String): LayoutBranch? = MainBranch.tryParse(value) ?: DesignBranch.tryParse(value)
+        fun tryParse(value: String): LayoutBranch? =
+            MainBranch.tryParse(value) ?: DesignBranch.tryParse(value)
 
         @JvmStatic
         @JsonCreator
-        fun parse(value: String): LayoutBranch = requireNotNull(tryParse(value)) {
-            "Value is not a ${LayoutBranch::class.simpleName}: ${formatForException(value)}"
-        }
+        fun parse(value: String): LayoutBranch =
+            requireNotNull(tryParse(value)) {
+                "Value is not a ${LayoutBranch::class.simpleName}: ${formatForException(value)}"
+            }
     }
 
     val draft by lazy { LayoutContext.of(this, PublicationState.DRAFT) }
 
     val official by lazy { LayoutContext.of(this, PublicationState.OFFICIAL) }
 
-    open val designId: IntId<LayoutDesign>? get() = null
+    open val designId: IntId<LayoutDesign>?
+        get() = null
 }
 
 class MainBranch private constructor() : LayoutBranch() {
@@ -50,44 +60,48 @@ class MainBranch private constructor() : LayoutBranch() {
 
         @JvmStatic
         @JsonCreator
-        fun parse(value: String): MainBranch = requireNotNull(tryParse(value)) {
-            "Value is not a ${MainBranch::class.simpleName}: ${formatForException(value)}"
-        }
+        fun parse(value: String): MainBranch =
+            requireNotNull(tryParse(value)) {
+                "Value is not a ${MainBranch::class.simpleName}: ${formatForException(value)}"
+            }
     }
 
-    @JsonValue
-    override fun toString(): String = type.name
+    @JsonValue override fun toString(): String = type.name
 }
 
 @Suppress("DataClassPrivateConstructor")
-data class DesignBranch private constructor(override val designId: IntId<LayoutDesign>) : LayoutBranch() {
+data class DesignBranch private constructor(override val designId: IntId<LayoutDesign>) :
+    LayoutBranch() {
     private val stringFormat by lazy { "$prefix$designId" }
 
     companion object {
         val type: LayoutBranchType = LayoutBranchType.DESIGN
         val prefix: String = "$type$separator"
 
-        private val branches: ConcurrentHashMap<IntId<LayoutDesign>, DesignBranch> = ConcurrentHashMap()
-        private val stringLength: IntRange = (IntId.stringLength.first + prefix.length)..(IntId.stringLength.last + prefix.length)
+        private val branches: ConcurrentHashMap<IntId<LayoutDesign>, DesignBranch> =
+            ConcurrentHashMap()
+        private val stringLength: IntRange =
+            (IntId.stringLength.first + prefix.length)..(IntId.stringLength.last + prefix.length)
 
         fun of(designId: IntId<LayoutDesign>): DesignBranch =
             branches.computeIfAbsent(designId) { id -> DesignBranch(id) }
 
-        fun tryParse(value: String): DesignBranch? = value
-            .takeIf { v -> v.length in stringLength }
-            ?.uppercase()
-            ?.takeIf { v -> v.startsWith(prefix) }
-            ?.let { v -> of(IntId.parse(v.substring(prefix.length))) }
+        fun tryParse(value: String): DesignBranch? =
+            value
+                .takeIf { v -> v.length in stringLength }
+                ?.uppercase()
+                ?.takeIf { v -> v.startsWith(prefix) }
+                ?.let { v -> of(IntId.parse(v.substring(prefix.length))) }
 
         @JvmStatic
         @JsonCreator
-        fun parse(string: String): DesignBranch = requireNotNull(tryParse(string)) {
-            "Value is not a ${DesignBranch::class.simpleName}: ${formatForException(string)}"
-        }
+        fun parse(string: String): DesignBranch =
+            requireNotNull(tryParse(string)) {
+                "Value is not a ${DesignBranch::class.simpleName}: ${formatForException(string)}"
+            }
     }
 
-    @JsonValue
-    override fun toString(): String = stringFormat
+    @JsonValue override fun toString(): String = stringFormat
 }
 
 sealed class LayoutContext {
@@ -95,40 +109,49 @@ sealed class LayoutContext {
     abstract val state: PublicationState
 
     companion object {
-        fun of(branch: LayoutBranch, state: PublicationState): LayoutContext = when (branch) {
-            is MainBranch -> MainLayoutContext.of(state)
-            is DesignBranch -> DesignLayoutContext.of(branch.designId, state)
-        }
+        fun of(branch: LayoutBranch, state: PublicationState): LayoutContext =
+            when (branch) {
+                is MainBranch -> MainLayoutContext.of(state)
+                is DesignBranch -> DesignLayoutContext.of(branch.designId, state)
+            }
     }
 }
 
 @Suppress("DataClassPrivateConstructor")
-data class MainLayoutContext private constructor(override val state: PublicationState) : LayoutContext() {
+data class MainLayoutContext private constructor(override val state: PublicationState) :
+    LayoutContext() {
     override val branch: LayoutBranch = MainBranch.instance
 
     companion object {
         val official = MainLayoutContext(PublicationState.OFFICIAL)
         val draft = MainLayoutContext(PublicationState.DRAFT)
 
-        fun of(state: PublicationState): MainLayoutContext = when (state) {
-            PublicationState.OFFICIAL -> official
-            PublicationState.DRAFT -> draft
-        }
+        fun of(state: PublicationState): MainLayoutContext =
+            when (state) {
+                PublicationState.OFFICIAL -> official
+                PublicationState.DRAFT -> draft
+            }
     }
 }
 
 @Suppress("DataClassPrivateConstructor")
-data class DesignLayoutContext private constructor(
+data class DesignLayoutContext
+private constructor(
     override val branch: DesignBranch,
     override val state: PublicationState,
 ) : LayoutContext() {
     companion object {
-        private val contexts: ConcurrentHashMap<Pair<Int, PublicationState>, DesignLayoutContext> = ConcurrentHashMap()
+        private val contexts: ConcurrentHashMap<Pair<Int, PublicationState>, DesignLayoutContext> =
+            ConcurrentHashMap()
 
         fun of(id: IntId<LayoutDesign>, state: PublicationState): DesignLayoutContext =
-            contexts.computeIfAbsent(id.intValue to state) { DesignLayoutContext(DesignBranch.of(id), state) }
+            contexts.computeIfAbsent(id.intValue to state) {
+                DesignLayoutContext(DesignBranch.of(id), state)
+            }
 
         fun of(branch: DesignBranch, state: PublicationState): DesignLayoutContext =
-            contexts.computeIfAbsent(branch.designId.intValue to state) { DesignLayoutContext(branch, state) }
+            contexts.computeIfAbsent(branch.designId.intValue to state) {
+                DesignLayoutContext(branch, state)
+            }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/LinearUnit.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/LinearUnit.kt
@@ -1,4 +1,6 @@
 package fi.fta.geoviite.infra.common
 
 // Other values possible but not currently supported: MILLIMETER, CENTIMETER, METER, KILOMETER
-enum class LinearUnit { METER }
+enum class LinearUnit {
+    METER
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Oid.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Oid.kt
@@ -8,10 +8,12 @@ import fi.fta.geoviite.infra.util.assertSanitized
 private val oidLength = 5..50
 private val oidRegex = Regex("^\\d+(\\.\\d+){2,9}\$")
 
-data class Oid<T> @JsonCreator(mode = DELEGATING) constructor(private val value: String) : CharSequence by value {
+data class Oid<T> @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    CharSequence by value {
 
-    init { assertSanitized<Oid<T>>(value, oidRegex, oidLength, allowBlank = false) }
+    init {
+        assertSanitized<Oid<T>>(value, oidRegex, oidLength, allowBlank = false)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ProjectName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ProjectName.kt
@@ -8,9 +8,11 @@ import fi.fta.geoviite.infra.util.assertSanitized
 val projectNameLength = 1..100
 val projectNameRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 _\\-/+&.,]+\$")
 
-data class ProjectName @JsonCreator(mode = DELEGATING) constructor(private val value: String) : CharSequence by value {
-    init { assertSanitized<ProjectName>(value, projectNameRegex, projectNameLength, allowBlank = false) }
+data class ProjectName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    CharSequence by value {
+    init {
+        assertSanitized<ProjectName>(value, projectNameRegex, projectNameLength, allowBlank = false)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/RotationDirection.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/RotationDirection.kt
@@ -1,3 +1,6 @@
 package fi.fta.geoviite.infra.common
 
-enum class RotationDirection { CW, CCW }
+enum class RotationDirection {
+    CW,
+    CCW
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/RowVersion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/RowVersion.kt
@@ -6,22 +6,29 @@ import com.fasterxml.jackson.annotation.JsonCreator.Mode.DISABLED
 import com.fasterxml.jackson.annotation.JsonValue
 
 private const val VERSION_SEPARATOR = "v"
-data class RowVersion<T> @JsonCreator(mode = DISABLED) constructor(val id: IntId<T>, val version: Int) {
+
+data class RowVersion<T>
+@JsonCreator(mode = DISABLED)
+constructor(val id: IntId<T>, val version: Int) {
     private constructor(valuePair: Pair<IntId<T>, Int>) : this(valuePair.first, valuePair.second)
-    @JsonCreator(mode = DELEGATING)
-    constructor(value: String) : this(parseVersionValues(value))
 
-    init { require(version > 0) { "Version numbers start at 1: version=$version" } }
+    @JsonCreator(mode = DELEGATING) constructor(value: String) : this(parseVersionValues(value))
 
-    @JsonValue
-    override fun toString(): String = "${id.intValue}$VERSION_SEPARATOR$version"
+    init {
+        require(version > 0) { "Version numbers start at 1: version=$version" }
+    }
+
+    @JsonValue override fun toString(): String = "${id.intValue}$VERSION_SEPARATOR$version"
 
     fun next() = RowVersion(id, version + 1)
+
     fun previous() = if (version > 1) RowVersion(id, version - 1) else null
 }
 
 private fun <T> parseVersionValues(stringVersion: String): Pair<IntId<T>, Int> {
     val split = stringVersion.split(VERSION_SEPARATOR)
-    require(split.size == 2) { "${RowVersion::class.simpleName} must contain 2 numbers: found ${split.size}" }
+    require(split.size == 2) {
+        "${RowVersion::class.simpleName} must contain 2 numbers: found ${split.size}"
+    }
     return IntId<T>(split[0].toInt()) to split[1].toInt()
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Srid.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Srid.kt
@@ -21,6 +21,5 @@ data class Srid @JsonCreator(mode = DISABLED) constructor(val code: Int) {
         }
     }
 
-    @JsonValue
-    override fun toString(): String = SRID_PREFIX + code
+    @JsonValue override fun toString(): String = SRID_PREFIX + code
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/SwitchName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/SwitchName.kt
@@ -8,14 +8,14 @@ import fi.fta.geoviite.infra.util.assertSanitized
 val switchNameLength = 1..50
 val switchNameRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 \\-_/,.]+\$")
 
-data class SwitchName @JsonCreator(mode = DELEGATING) constructor(private val value: String) : Comparable<SwitchName>,
-    CharSequence by value {
+data class SwitchName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<SwitchName>, CharSequence by value {
     init {
         assertSanitized<SwitchName>(value, switchNameRegex, switchNameLength, allowBlank = false)
     }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: SwitchName): Int = value.compareTo(other.value)
 
     fun equalsIgnoreCase(other: SwitchName): Boolean = value.equals(other.value, ignoreCase = true)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/TrackNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/TrackNumber.kt
@@ -8,11 +8,13 @@ import fi.fta.geoviite.infra.util.assertSanitized
 val trackNumberLength = 2..30
 val trackNumberRegex = Regex("^[äÄöÖåÅA-Za-z0-9 ]+\$")
 
-data class TrackNumber @JsonCreator(mode = DELEGATING) constructor(val value: String)
-    : Comparable<TrackNumber>, CharSequence by value {
-    init { assertSanitized<TrackNumber>(value, trackNumberRegex, trackNumberLength, allowBlank = false) }
+data class TrackNumber @JsonCreator(mode = DELEGATING) constructor(val value: String) :
+    Comparable<TrackNumber>, CharSequence by value {
+    init {
+        assertSanitized<TrackNumber>(value, trackNumberRegex, trackNumberLength, allowBlank = false)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: TrackNumber): Int = value.compareTo(other.value)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.configuration
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
+import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,8 +13,6 @@ import org.springframework.cache.caffeine.CaffeineCacheManager
 import org.springframework.cache.support.NoOpCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.time.Duration
-
 
 const val CACHE_GEOMETRY_PLAN = "geometry-plan"
 const val CACHE_GEOMETRY_SWITCH = "geometry-switch"
@@ -39,7 +38,9 @@ val staticDataCacheDuration: Duration = Duration.ofHours(24)
 
 @EnableCaching
 @Configuration
-class CacheConfiguration @Autowired constructor(
+class CacheConfiguration
+@Autowired
+constructor(
     @Value("\${geoviite.cache.enabled}") private val cacheEnabled: Boolean,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -56,7 +57,8 @@ class CacheConfiguration @Autowired constructor(
             manager.registerCustomCache(CACHE_ROLES, cache(10, staticDataCacheDuration))
             manager.registerCustomCache(CACHE_COORDINATE_SYSTEMS, cache(1, staticDataCacheDuration))
             manager.registerCustomCache(CACHE_FEATURE_TYPES, cache(1, staticDataCacheDuration))
-            manager.registerCustomCache(CACHE_KKJ_TM35FIN_TRIANGULATION_NETWORK, cache(2, staticDataCacheDuration))
+            manager.registerCustomCache(
+                CACHE_KKJ_TM35FIN_TRIANGULATION_NETWORK, cache(2, staticDataCacheDuration))
 
             manager.registerCustomCache(CACHE_GEOCODING_CONTEXTS, cache(500, layoutCacheDuration))
 
@@ -64,11 +66,13 @@ class CacheConfiguration @Autowired constructor(
             manager.registerCustomCache(CACHE_GEOMETRY_SWITCH, cache(10000, planCacheDuration))
             manager.registerCustomCache(CACHE_PLAN_GEOCODING_CONTEXTS, cache(50, planCacheDuration))
 
-            manager.registerCustomCache(CACHE_RATKO_HEALTH_STATUS, ephemeralCache(1, healthCheckLifetime))
+            manager.registerCustomCache(
+                CACHE_RATKO_HEALTH_STATUS, ephemeralCache(1, healthCheckLifetime))
 
-            manager.registerCustomCache(CACHE_PUBLISHED_LOCATION_TRACKS, cache(500, staticDataCacheDuration))
-            manager.registerCustomCache(CACHE_PUBLISHED_SWITCHES, cache(500, staticDataCacheDuration))
-
+            manager.registerCustomCache(
+                CACHE_PUBLISHED_LOCATION_TRACKS, cache(500, staticDataCacheDuration))
+            manager.registerCustomCache(
+                CACHE_PUBLISHED_SWITCHES, cache(500, staticDataCacheDuration))
 
             manager
         } else {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloader.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloader.kt
@@ -1,16 +1,15 @@
 package fi.fta.geoviite.infra.configuration
 
 import fi.fta.geoviite.infra.geometry.GeometryDao
-import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
 import fi.fta.geoviite.infra.tracklayout.*
+import java.time.Duration
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.time.Duration
-import java.time.Instant
 
 const val CACHE_WARMUP_DELAY = 1000L
 const val CACHE_RELOAD_INTERVAL = 45 * 60 * 1000L
@@ -34,8 +33,13 @@ class CachePreloader(
     fun scheduleLayoutAssetReload() {
         if (cacheEnabled && cachePreloadEnabled) {
             listOf(
-                layoutTrackNumberDao, referenceLineDao, locationTrackDao, switchDao, layoutKmPostDao
-            ).parallelStream().forEach { dao -> refreshCache(dao) }
+                    layoutTrackNumberDao,
+                    referenceLineDao,
+                    locationTrackDao,
+                    switchDao,
+                    layoutKmPostDao)
+                .parallelStream()
+                .forEach { dao -> refreshCache(dao) }
         }
     }
 
@@ -61,6 +65,7 @@ class CachePreloader(
         logger.info("Refreshing cache: name=$name")
         val start = Instant.now()
         refresh()
-        logger.info("Cache refreshed: name=$name duration=${Duration.between(start, Instant.now()).toMillis()}ms")
+        logger.info(
+            "Cache refreshed: name=$name duration=${Duration.between(start, Instant.now()).toMillis()}ms")
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/RequestFilter.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/RequestFilter.kt
@@ -20,6 +20,14 @@ import fi.fta.geoviite.infra.util.isValidCode
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import java.net.URL
+import java.security.KeyFactory
+import java.security.interfaces.ECPublicKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.X509EncodedKeySpec
+import java.time.Duration
+import java.time.Instant
+import java.util.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -32,14 +40,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
-import java.net.URL
-import java.security.KeyFactory
-import java.security.interfaces.ECPublicKey
-import java.security.interfaces.RSAPublicKey
-import java.security.spec.X509EncodedKeySpec
-import java.time.Duration
-import java.time.Instant
-import java.util.*
 
 const val HTTP_HEADER_REMOTE_IP = "X-FORWARDED-FOR"
 const val HTTP_HEADER_CORRELATION_ID = "X-Amzn-Trace-Id"
@@ -54,7 +54,9 @@ val slowRequestThreshold: Duration = Duration.ofSeconds(5)
 @ConditionalOnWebApplication
 @Component
 @Order(1)
-class RequestFilter @Autowired constructor(
+class RequestFilter
+@Autowired
+constructor(
     @Value("\${geoviite.skip-auth:false}") private val skipAuth: Boolean,
     @Value("\${geoviite.jwt.validation.enabled:true}") private val validationEnabled: Boolean,
     @Value("\${geoviite.jwt.validation.jwks-url:}") private val jwksUrl: String,
@@ -63,56 +65,63 @@ class RequestFilter @Autowired constructor(
 
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
 
-    private val authorizationService: AuthorizationService by lazy { SpringContextUtility.getBean() }
+    private val authorizationService: AuthorizationService by lazy {
+        SpringContextUtility.getBean()
+    }
     private val objectMapper: ObjectMapper by lazy { SpringContextUtility.getBean() }
 
     private val jwkProvider: UrlJwkProvider by lazy {
-        check(jwksUrl.isNotBlank()) { "Invalid configuration: set property geoviite.jwt.validation.url" }
+        check(jwksUrl.isNotBlank()) {
+            "Invalid configuration: set property geoviite.jwt.validation.url"
+        }
         UrlJwkProvider(URL("$jwksUrl/.well-known/jwks.json"))
     }
 
     private fun localUser(activeRole: Role, availableRoles: List<Role>): User {
         return User(
-            details = UserDetails(
-                userName = UserName.of("LOCAL_USER"),
-                firstName = AuthName.of("Local"),
-                lastName = AuthName.of("User"),
-                organization = AuthName.of("Geoviite"),
-            ),
+            details =
+                UserDetails(
+                    userName = UserName.of("LOCAL_USER"),
+                    firstName = AuthName.of("Local"),
+                    lastName = AuthName.of("User"),
+                    organization = AuthName.of("Geoviite"),
+                ),
             role = activeRole,
             availableRoles = availableRoles,
         )
     }
 
     private fun integrationApiUser(userType: IntegrationApiUserType): User {
-        val activeRole = authorizationService.getRole(userType.roleCode)
-            ?: throw ApiUnauthorizedException("Could not determine integration api user role.")
+        val activeRole =
+            authorizationService.getRole(userType.roleCode)
+                ?: throw ApiUnauthorizedException("Could not determine integration api user role.")
 
-        val userDetails = when (userType) {
-            IntegrationApiUserType.LOCAL ->
-                UserDetails(
-                    userName = UserName.of("API_LOCAL"),
-                    firstName = AuthName.of("Local"),
-                    lastName = AuthName.of("Api User"),
-                    organization = AuthName.of("Geoviite"),
-                )
+        val userDetails =
+            when (userType) {
+                IntegrationApiUserType.LOCAL ->
+                    UserDetails(
+                        userName = UserName.of("API_LOCAL"),
+                        firstName = AuthName.of("Local"),
+                        lastName = AuthName.of("Api User"),
+                        organization = AuthName.of("Geoviite"),
+                    )
 
-            IntegrationApiUserType.PUBLIC ->
-                UserDetails(
-                    userName = UserName.of("API_PUBLIC"),
-                    firstName = AuthName.of("Public"),
-                    lastName = AuthName.of("Api User"),
-                    organization = AuthName.of("Geoviite"),
-                )
+                IntegrationApiUserType.PUBLIC ->
+                    UserDetails(
+                        userName = UserName.of("API_PUBLIC"),
+                        firstName = AuthName.of("Public"),
+                        lastName = AuthName.of("Api User"),
+                        organization = AuthName.of("Geoviite"),
+                    )
 
-            IntegrationApiUserType.PRIVATE ->
-                UserDetails(
-                    userName = UserName.of("API_PRIVATE"),
-                    firstName = AuthName.of("Private"),
-                    lastName = AuthName.of("Api User"),
-                    organization = AuthName.of("Geoviite"),
-                )
-        }
+                IntegrationApiUserType.PRIVATE ->
+                    UserDetails(
+                        userName = UserName.of("API_PRIVATE"),
+                        firstName = AuthName.of("Private"),
+                        lastName = AuthName.of("Api User"),
+                        organization = AuthName.of("Geoviite"),
+                    )
+            }
 
         return User(
             details = userDetails,
@@ -124,19 +133,18 @@ class RequestFilter @Autowired constructor(
     private val healthCheckUser by lazy {
         User(
             details = UserDetails(UserName.of("HEALTH_CHECK"), null, null, null),
-            role = Role(
-                code = Code("health-check"),
-                privileges = listOf(),
-            ),
-            availableRoles = listOf()
-        )
+            role =
+                Role(
+                    code = Code("health-check"),
+                    privileges = listOf(),
+                ),
+            availableRoles = listOf())
     }
 
     init {
         log.info(
             "Initializing request filter: " +
-                "skipAuth=$skipAuth validationEnabled=$validationEnabled jwksUrl=$jwksUrl elbJwtUrl=$elbJwtUrl"
-        )
+                "skipAuth=$skipAuth validationEnabled=$validationEnabled jwksUrl=$jwksUrl elbJwtUrl=$elbJwtUrl")
     }
 
     override fun doFilterInternal(
@@ -156,16 +164,13 @@ class RequestFilter @Autowired constructor(
             currentUserRole.set(user.role.code)
 
             log.apiRequest(request, requestIP)
-            val auth = UsernamePasswordAuthenticationToken(
-                user,
-                "",
-                user.role.privileges
-            )
+            val auth = UsernamePasswordAuthenticationToken(user, "", user.role.privileges)
             SecurityContextHolder.getContext().authentication = auth
             chain.doFilter(request, response)
         } catch (ex: Exception) {
             val errorResponse = createErrorResponse(log, ex)
-            response.contentType = errorResponse.headers.contentType?.toString() ?: MediaType.APPLICATION_JSON_VALUE
+            response.contentType =
+                errorResponse.headers.contentType?.toString() ?: MediaType.APPLICATION_JSON_VALUE
             response.status = errorResponse.statusCode.value()
             response.writer.write(objectMapper.writeValueAsString(errorResponse.body))
             response.writer.flush()
@@ -184,16 +189,18 @@ class RequestFilter @Autowired constructor(
             if (isIntegrationApiRequest(request)) {
                 integrationApiUser(IntegrationApiUserType.LOCAL)
             } else {
-                val availableRolesForLocalUser = authorizationService.getRoles(
-                    authorizationService.defaultRoleCodeOrder,
-                )
+                val availableRolesForLocalUser =
+                    authorizationService.getRoles(
+                        authorizationService.defaultRoleCodeOrder,
+                    )
 
                 localUser(
                     activeRole = getActiveUserRole(request, availableRolesForLocalUser),
                     availableRoles = availableRolesForLocalUser,
                 )
             }
-        } else if (request.requestURI == "/actuator/health" && headers.none { h -> h.startsWith("x-iam") }) {
+        } else if (request.requestURI == "/actuator/health" &&
+            headers.none { h -> h.startsWith("x-iam") }) {
             healthCheckUser
         } else if (isIntegrationApiRequest(request)) {
             determineIntegrationApiUserOrThrow(request)
@@ -202,14 +209,12 @@ class RequestFilter @Autowired constructor(
 
             log.info(
                 "JWT authorization headers processed: " +
-                    "validated=$validationEnabled user=${content.userDetails.userName} groups=${content.groupNames}"
-            )
+                    "validated=$validationEnabled user=${content.userDetails.userName} groups=${content.groupNames}")
 
             val availableRoles = authorizationService.getRolesByUserGroups(content.groupNames)
             if (availableRoles.isEmpty()) {
                 throw ApiUnauthorizedException(
-                    "User doesn't have a valid role: userId=${content.userDetails.userName} groups=${content.groupNames}"
-                )
+                    "User doesn't have a valid role: userId=${content.userDetails.userName} groups=${content.groupNames}")
             }
 
             User(
@@ -221,16 +226,13 @@ class RequestFilter @Autowired constructor(
     }
 
     private fun getActiveUserRole(request: HttpServletRequest, availableRoles: List<Role>): Role {
-        return request.cookies?.firstOrNull { cookie ->
-            cookie?.name == DESIRED_ROLE_COOKIE_NAME
-        }?.let { desiredRoleCookie ->
-            val desiredRoleCode = Code(desiredRoleCookie.value)
+        return request.cookies
+            ?.firstOrNull { cookie -> cookie?.name == DESIRED_ROLE_COOKIE_NAME }
+            ?.let { desiredRoleCookie ->
+                val desiredRoleCode = Code(desiredRoleCookie.value)
 
-            availableRoles.find { availableRole ->
-                availableRole.code == desiredRoleCode
-            }
-
-        } ?: authorizationService.getDefaultRole(availableRoles)
+                availableRoles.find { availableRole -> availableRole.code == desiredRoleCode }
+            } ?: authorizationService.getDefaultRole(availableRoles)
     }
 
     private fun getJwtData(request: HttpServletRequest): JwtContent {
@@ -245,10 +247,13 @@ class RequestFilter @Autowired constructor(
     private fun validateAccessToken(jwt: DecodedJWT) {
         @Suppress("TooGenericExceptionCaught")
         try {
-            val algorithm = when (jwt.algorithm) {
-                ALGORITHM_RS256 -> getCognitoValidationAlgorithm(jwt.keyId)
-                else -> throw IllegalArgumentException("Unsupported access JWT algorithm: ${jwt.algorithm}")
-            }
+            val algorithm =
+                when (jwt.algorithm) {
+                    ALGORITHM_RS256 -> getCognitoValidationAlgorithm(jwt.keyId)
+                    else ->
+                        throw IllegalArgumentException(
+                            "Unsupported access JWT algorithm: ${jwt.algorithm}")
+                }
             JWT.require(algorithm).withIssuer(jwksUrl).build().verify(jwt)
             log.debug("JWT access token validated")
         } catch (ex: TokenExpiredException) {
@@ -265,10 +270,13 @@ class RequestFilter @Autowired constructor(
     private fun validateDataToken(jwt: DecodedJWT) {
         @Suppress("TooGenericExceptionCaught")
         try {
-            val algorithm = when (jwt.algorithm) {
-                ALGORITHM_ES256 -> getElbValidationAlgorithm(jwt.keyId)
-                else -> throw IllegalArgumentException("Unsupported data JWT algorithm: ${jwt.algorithm}")
-            }
+            val algorithm =
+                when (jwt.algorithm) {
+                    ALGORITHM_ES256 -> getElbValidationAlgorithm(jwt.keyId)
+                    else ->
+                        throw IllegalArgumentException(
+                            "Unsupported data JWT algorithm: ${jwt.algorithm}")
+                }
             JWT.require(algorithm).withIssuer(jwksUrl).build().verify(jwt)
             log.debug("JWT data token validated")
         } catch (ex: TokenExpiredException) {
@@ -284,9 +292,13 @@ class RequestFilter @Autowired constructor(
 
     private fun getCognitoValidationAlgorithm(keyId: String): Algorithm {
         val jwk = jwkProvider.get(keyId)
-        val publicKey = jwk.publicKey as? RSAPublicKey
-            ?: throw IllegalArgumentException("Invalid key type: ${jwk.publicKey::class.qualifiedName}")
-        check(jwk.algorithm == ALGORITHM_RS256) { "Unsupported JWK RSA algorithm: ${jwk.algorithm}" }
+        val publicKey =
+            jwk.publicKey as? RSAPublicKey
+                ?: throw IllegalArgumentException(
+                    "Invalid key type: ${jwk.publicKey::class.qualifiedName}")
+        check(jwk.algorithm == ALGORITHM_RS256) {
+            "Unsupported JWK RSA algorithm: ${jwk.algorithm}"
+        }
         return Algorithm.RSA256(publicKey, null)
     }
 
@@ -296,8 +308,10 @@ class RequestFilter @Autowired constructor(
         val keyData = unwrapPublicKey(keyString)
         val kf: KeyFactory = KeyFactory.getInstance("EC")
         val generated = kf.generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(keyData)))
-        val publicKey = generated as? ECPublicKey
-            ?: throw IllegalArgumentException("Invalid key (expected ECPublicKey): ${generated::class.qualifiedName}")
+        val publicKey =
+            generated as? ECPublicKey
+                ?: throw IllegalArgumentException(
+                    "Invalid key (expected ECPublicKey): ${generated::class.qualifiedName}")
         return Algorithm.ECDSA256(publicKey, null)
     }
 
@@ -307,7 +321,8 @@ class RequestFilter @Autowired constructor(
     }
 
     private fun determineIntegrationApiUserOrThrow(request: HttpServletRequest): User {
-        return request.getHeader("x-forwarded-host")
+        return request
+            .getHeader("x-forwarded-host")
             ?.takeIf { it.isNotEmpty() }
             ?.split(".")
             ?.firstOrNull()
@@ -317,20 +332,24 @@ class RequestFilter @Autowired constructor(
                     "api" -> integrationApiUser(IntegrationApiUserType.PRIVATE)
 
                     else ->
-                        throw ApiUnauthorizedException("Could not determine integration api user type (invalid host).")
+                        throw ApiUnauthorizedException(
+                            "Could not determine integration api user type (invalid host).")
                 }
-            } ?: throw ApiUnauthorizedException("Could not determine integration api user type (missing host).")
+            }
+            ?: throw ApiUnauthorizedException(
+                "Could not determine integration api user type (missing host).")
     }
 }
 
 const val PUBLIC_KEY_PREFIX = "-----BEGIN PUBLIC KEY-----"
 const val PUBLIC_KEY_POSTFIX = "-----END PUBLIC KEY-----"
 
-private fun unwrapPublicKey(keyData: String): String = keyData
-    .replace("\n", "")
-    .trim()
-    .drop(PUBLIC_KEY_PREFIX.length)
-    .dropLast(PUBLIC_KEY_POSTFIX.length)
+private fun unwrapPublicKey(keyData: String): String =
+    keyData
+        .replace("\n", "")
+        .trim()
+        .drop(PUBLIC_KEY_PREFIX.length)
+        .dropLast(PUBLIC_KEY_POSTFIX.length)
 
 private fun extractRequestIP(req: HttpServletRequest): String {
     return (req.getHeader(HTTP_HEADER_REMOTE_IP) ?: req.remoteAddr).split(",")[0]
@@ -342,22 +361,27 @@ private fun extractRequestCorrelationId(request: HttpServletRequest): String {
 
 private fun randomCorrelationId(): String = "NCI-${UUID.randomUUID()}"
 
-private fun jwtDataContent(dataToken: DecodedJWT) = JwtContent(
-    userDetails = UserDetails(
-        userName = UserName.of(dataToken.getMandatoryClaim(JwtClaim.USER_ID)),
-        firstName = dataToken.getOptionalClaim(JwtClaim.FIRST_NAME)?.let(AuthName::of),
-        lastName = dataToken.getOptionalClaim(JwtClaim.LAST_NAME)?.let(AuthName::of),
-        organization = dataToken.getOptionalClaim(JwtClaim.ORGANIZATION)?.let(AuthName::of),
-    ),
-    groupNames = dataToken
-        .getMandatoryClaim(JwtClaim.ROLES)
-        .split(",")
-        .filter(::isValidCode)
-        .map(::Code),
-)
+private fun jwtDataContent(dataToken: DecodedJWT) =
+    JwtContent(
+        userDetails =
+            UserDetails(
+                userName = UserName.of(dataToken.getMandatoryClaim(JwtClaim.USER_ID)),
+                firstName = dataToken.getOptionalClaim(JwtClaim.FIRST_NAME)?.let(AuthName::of),
+                lastName = dataToken.getOptionalClaim(JwtClaim.LAST_NAME)?.let(AuthName::of),
+                organization = dataToken.getOptionalClaim(JwtClaim.ORGANIZATION)?.let(AuthName::of),
+            ),
+        groupNames =
+            dataToken
+                .getMandatoryClaim(JwtClaim.ROLES)
+                .split(",")
+                .filter(::isValidCode)
+                .map(::Code),
+    )
 
 private fun extractJwtToken(request: HttpServletRequest, header: String): DecodedJWT {
-    val tokenString = request.getHeader(header) ?: throw ApiUnauthorizedException("JWT header is missing: $header")
+    val tokenString =
+        request.getHeader(header)
+            ?: throw ApiUnauthorizedException("JWT header is missing: $header")
     return decodeJwt(tokenString)
 }
 
@@ -385,5 +409,8 @@ enum class JwtClaim(val header: String) {
 }
 
 fun DecodedJWT.getOptionalClaim(claim: JwtClaim): String? = claims[claim.header]?.asString()
-fun DecodedJWT.getMandatoryClaim(claim: JwtClaim): String = getOptionalClaim(claim)
-    ?: throw ApiUnauthorizedException("JWT token does not contain required claim ${claim.header}")
+
+fun DecodedJWT.getMandatoryClaim(claim: JwtClaim): String =
+    getOptionalClaim(claim)
+        ?: throw ApiUnauthorizedException(
+            "JWT token does not contain required claim ${claim.header}")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/SecurityConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/SecurityConfiguration.kt
@@ -10,7 +10,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy.STATELESS
 import org.springframework.security.web.SecurityFilterChain
 
-
 @ConditionalOnWebApplication
 @EnableWebSecurity
 @Configuration
@@ -26,7 +25,8 @@ class SecurityConfiguration {
             .cors { it.disable() }
             // Disable CSRF: JWT is stored in ALB -> session not configured here
             .csrf { it.disable() }
-            // Disable SecurityContextPersistenceFilter which by default would replace the security context set up in
+            // Disable SecurityContextPersistenceFilter which by default would replace the security
+            // context set up in
             // RequestFilter with an empty one
             .securityContext { it.disable() }
             // Set session management to stateless

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/TransactionConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/TransactionConfiguration.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.configuration
 
+import java.lang.reflect.AnnotatedElement
 import org.springframework.beans.factory.config.BeanDefinition
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -9,7 +10,6 @@ import org.springframework.transaction.annotation.ProxyTransactionManagementConf
 import org.springframework.transaction.interceptor.DelegatingTransactionAttribute
 import org.springframework.transaction.interceptor.TransactionAttribute
 import org.springframework.transaction.interceptor.TransactionAttributeSource
-import java.lang.reflect.AnnotatedElement
 
 @Configuration
 class TransactionConfiguration : ProxyTransactionManagementConfiguration() {
@@ -17,13 +17,16 @@ class TransactionConfiguration : ProxyTransactionManagementConfiguration() {
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     override fun transactionAttributeSource(): TransactionAttributeSource =
         object : AnnotationTransactionAttributeSource() {
-            override fun determineTransactionAttribute(element: AnnotatedElement): TransactionAttribute? {
+            override fun determineTransactionAttribute(
+                element: AnnotatedElement
+            ): TransactionAttribute? {
                 val txAttr = super.determineTransactionAttribute(element) ?: return null
                 return object : DelegatingTransactionAttribute(txAttr) {
                     /**
-                     * By default, transactions are rolled back only on non-checked exceptions.
-                     * In Kotlin that can lead to easy mistakes, as there are no checked ones as such, but you can still create them.
-                     * Also, we don't want to use exceptions as normal program flow, so not rolling back doesn't make sense.
+                     * By default, transactions are rolled back only on non-checked exceptions. In
+                     * Kotlin that can lead to easy mistakes, as there are no checked ones as such,
+                     * but you can still create them. Also, we don't want to use exceptions as
+                     * normal program flow, so not rolling back doesn't make sense.
                      */
                     override fun rollbackOn(ex: Throwable) = true
                 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
@@ -145,9 +145,12 @@ class WebConfig(
     }
 }
 
-inline fun <reified T : Enum<T>> enumCaseInsensitive(value: String): T = enumValueOf(value.uppercase())
+inline fun <reified T : Enum<T>> enumCaseInsensitive(value: String): T =
+    enumValueOf(value.uppercase())
 
-inline fun <reified T> FormatterRegistry.addStringConstructorConverter(noinline initializer: (String) -> T) {
+inline fun <reified T> FormatterRegistry.addStringConstructorConverter(
+    noinline initializer: (String) -> T
+) {
     addConverter(String::class.java, T::class.java, initializer)
     addConverter(T::class.java, String::class.java) { t -> t.toString() }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvFile.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvFile.kt
@@ -4,29 +4,33 @@ import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.geography.parse2DLineString
 import fi.fta.geoviite.infra.geography.parse2DPoint
 import fi.fta.geoviite.infra.math.Point
+import java.io.File
+import kotlin.reflect.KClass
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser
 import org.apache.commons.csv.CSVRecord
-import java.io.File
-import kotlin.reflect.KClass
 
 class CsvFile<T : Enum<T>>(val filePath: String, private val type: KClass<T>) : AutoCloseable {
 
     val file = File(filePath)
 
-    private val csvFormat = CSVFormat.Builder.create()
-        .setHeader()
-        .setSkipHeaderRecord(true)
-        .setIgnoreHeaderCase(true)
-        .setIgnoreEmptyLines(true)
-        .setDelimiter(',')
-        .setQuote('"')
-        .build()
-    private val expectedColumns: List<String> by lazy { type.java.enumConstants.map { value -> value.name.lowercase() } }
+    private val csvFormat =
+        CSVFormat.Builder.create()
+            .setHeader()
+            .setSkipHeaderRecord(true)
+            .setIgnoreHeaderCase(true)
+            .setIgnoreEmptyLines(true)
+            .setDelimiter(',')
+            .setQuote('"')
+            .build()
+    private val expectedColumns: List<String> by lazy {
+        type.java.enumConstants.map { value -> value.name.lowercase() }
+    }
     private var parser: CSVParser? = null
 
     fun <S> parseLines(handler: (CsvLine<T>) -> S?): List<S> {
-        if (!file.isFile) throw IllegalStateException("No such CSV file found: ${file.absolutePath}")
+        if (!file.isFile)
+            throw IllegalStateException("No such CSV file found: ${file.absolutePath}")
         return CSVParser(file.bufferedReader(Charsets.UTF_8), csvFormat).use { parser ->
             validateHeaders(parser)
             parser.mapNotNull { record -> handler(CsvLine<T>(record)) }
@@ -34,11 +38,11 @@ class CsvFile<T : Enum<T>>(val filePath: String, private val type: KClass<T>) : 
     }
 
     fun <S> parseLinesStreaming(handler: (CsvLine<T>) -> S?): Sequence<S> {
-        if (!file.isFile) throw IllegalStateException("No such CSV file found: ${file.absolutePath}")
+        if (!file.isFile)
+            throw IllegalStateException("No such CSV file found: ${file.absolutePath}")
         parser = CSVParser(file.bufferedReader(Charsets.UTF_8), csvFormat)
         validateHeaders(parser ?: throw IllegalStateException("Parser lost"))
-        return parser?.asSequence()
-            ?.mapNotNull { record -> handler(CsvLine<T>(record)) }
+        return parser?.asSequence()?.mapNotNull { record -> handler(CsvLine<T>(record)) }
             ?: throw IllegalStateException("Parser lost")
     }
 
@@ -49,44 +53,53 @@ class CsvFile<T : Enum<T>>(val filePath: String, private val type: KClass<T>) : 
 
     private fun validateHeaders(parser: CSVParser) {
         if (parser.headerNames.map { h -> h.lowercase() } != expectedColumns) {
-            throw IllegalStateException("CSV columns wrong: expected=$expectedColumns actual=${parser.headerNames}")
+            throw IllegalStateException(
+                "CSV columns wrong: expected=$expectedColumns actual=${parser.headerNames}")
         }
     }
 
     class CsvLine<T : Enum<T>>(private val record: CSVRecord) {
         fun get(field: T): String = record.get(field.name.lowercase())
+
         fun getNonEmpty(field: T): String? = get(field).let { s -> s.ifBlank { null } }
 
         fun getPoint(geometryField: T): Point = parse2DPoint(get(geometryField))
 
-        fun getLinestringPoints(geometryField: T): List<Point> = parse2DLineString(get(geometryField))
+        fun getLinestringPoints(geometryField: T): List<Point> =
+            parse2DLineString(get(geometryField))
 
         inline fun <reified S> getOid(field: T): Oid<S> = Oid(get(field))
 
-        inline fun <reified S> getOidOrNull(field: T): Oid<S>? = get(field).let {
-            when (it) {
-                "" -> null
-                else -> Oid(it)
+        inline fun <reified S> getOidOrNull(field: T): Oid<S>? =
+            get(field).let {
+                when (it) {
+                    "" -> null
+                    else -> Oid(it)
+                }
             }
-        }
 
         inline fun <reified S : Enum<S>> getEnum(field: T): S = enumValueOf(get(field))
+
         inline fun <reified S : Enum<S>> getEnumOrNull(field: T): S? =
             getNonEmpty(field)?.let { s -> enumValueOf<S>(s) }
 
         fun getInt(field: T): Int = get(field).toInt()
+
         fun getIntOrNull(field: T): Int? = getNonEmpty(field)?.toInt()
 
         fun getDouble(field: T): Double = get(field).toDouble()
+
         fun getDoubleOrNull(field: T): Double? = getNonEmpty(field)?.toDouble()
 
         fun getBoolean(field: T): Boolean =
-            getBooleanOrNull(field) ?: throw NullPointerException("Field $field contains null value")
+            getBooleanOrNull(field)
+                ?: throw NullPointerException("Field $field contains null value")
 
-        fun getBooleanOrNull(field: T): Boolean? = when (get(field)) {
-            "f" -> false
-            "t" -> true
-            else -> null
-        }
+        fun getBooleanOrNull(field: T): Boolean? =
+            when (get(field)) {
+                "f" -> false
+                "t" -> true
+                else -> null
+            }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvImportMigrations.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvImportMigrations.kt
@@ -3,10 +3,11 @@ package fi.fta.geoviite.infra.dataImport
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 
 /**
- * These migrations must be retained for flyway versioning, but their implementation is intentionally removed.
+ * These migrations must be retained for flyway versioning, but their implementation is
+ * intentionally removed.
  *
- * This initial data import was done with a migration on version v1.0.0 data model.
- * If a new initial import is ever needed, it can be accomplished by either:
+ * This initial data import was done with a migration on version v1.0.0 data model. If a new initial
+ * import is ever needed, it can be accomplished by either:
  * - Running the import with 1.0.0 and then upgrading the system to current version
  * - Implementing a new import on the current model and (if desired) flattening versioned migrations
  */
@@ -15,6 +16,7 @@ class V11_01__Csv_import_track_numbers : CsvMigration() {
     override fun migrate(jdbcTemplate: NamedParameterJdbcTemplate) {
         throw NotImplementedError("Initial data migration not supported in this version.")
     }
+
     override fun getFiles() = listOf<CsvFile<*>>()
 }
 
@@ -23,6 +25,7 @@ class V14_01__Csv_import_km_posts : CsvMigration() {
     override fun migrate(jdbcTemplate: NamedParameterJdbcTemplate) {
         throw NotImplementedError("Initial data migration not supported in this version.")
     }
+
     override fun getFiles() = listOf<CsvFile<*>>()
 }
 
@@ -31,6 +34,7 @@ class V14_02__Csv_import_switches : CsvMigration() {
     override fun migrate(jdbcTemplate: NamedParameterJdbcTemplate) {
         throw NotImplementedError("Initial data migration not supported in this version.")
     }
+
     override fun getFiles() = listOf<CsvFile<*>>()
 }
 
@@ -39,6 +43,7 @@ class V14_03__Csv_import_reference_lines : CsvMigration() {
     override fun migrate(jdbcTemplate: NamedParameterJdbcTemplate) {
         throw NotImplementedError("Initial data migration not supported in this version.")
     }
+
     override fun getFiles() = listOf<CsvFile<*>>()
 }
 
@@ -47,5 +52,6 @@ class V14_04__Csv_import_location_tracks : CsvMigration() {
     override fun migrate(jdbcTemplate: NamedParameterJdbcTemplate) {
         throw NotImplementedError("Initial data migration not supported in this version.")
     }
+
     override fun getFiles() = listOf<CsvFile<*>>()
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvMigration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/CsvMigration.kt
@@ -14,40 +14,50 @@ abstract class CsvMigration : BaseJavaMigration() {
 
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    open val importEnabled: Boolean by lazy { SpringContextUtility.getProperty("geoviite.data.import") }
+    open val importEnabled: Boolean by lazy {
+        SpringContextUtility.getProperty("geoviite.data.import")
+    }
 
     private val fileList by lazy { getFiles() }
     private val fileNames by lazy { fileList.joinToString(", ") { it.file.absolutePath } }
 
-    final override fun migrate(context: Context?) = withImportUser(ImportUser.CSV_IMPORT) {
-        logger.info("CSV Import files: $fileNames")
-        if (importEnabled && fileList.all { f -> f.file.exists() }) {
-            logger.info("Running CSV import: version=$version description=$description")
-            try {
-                val connection = context?.connection
-                    ?: throw IllegalStateException("Can't run imports without DB connection")
-                val jdbcTemplate = NamedParameterJdbcTemplate(SingleConnectionDataSource(connection, true))
-                migrate(jdbcTemplate)
-            } catch (e: Exception) {
-                logger.error("CSV import failed: $e", e)
-                throw e
+    final override fun migrate(context: Context?) =
+        withImportUser(ImportUser.CSV_IMPORT) {
+            logger.info("CSV Import files: $fileNames")
+            if (importEnabled && fileList.all { f -> f.file.exists() }) {
+                logger.info("Running CSV import: version=$version description=$description")
+                try {
+                    val connection =
+                        context?.connection
+                            ?: throw IllegalStateException(
+                                "Can't run imports without DB connection")
+                    val jdbcTemplate =
+                        NamedParameterJdbcTemplate(SingleConnectionDataSource(connection, true))
+                    migrate(jdbcTemplate)
+                } catch (e: Exception) {
+                    logger.error("CSV import failed: $e", e)
+                    throw e
+                }
+            } else {
+                logger.info(
+                    "Not running CSV import: version=$version description=$description enabled=$importEnabled filesExist=${fileList.map { f -> "${f.file.absolutePath}:${f.file.exists()}" }}")
             }
-        } else {
-            logger.info("Not running CSV import: version=$version description=$description enabled=$importEnabled filesExist=${fileList.map { f -> "${f.file.absolutePath}:${f.file.exists()}" }}")
         }
-    }
 
     /**
-     * We could checksum the data files, but if we check it via flyway, we'd have to keep the initial files available
-     * infinitely in production.
-     **/
+     * We could checksum the data files, but if we check it via flyway, we'd have to keep the
+     * initial files available infinitely in production.
+     */
     override fun getChecksum(): Int? {
         if (importEnabled && fileList.all { f -> f.file.exists() }) {
-            // Note: We're not using Flyway to verify these checksums, but we log it anyhow for debugging
+            // Note: We're not using Flyway to verify these checksums, but we log it anyhow for
+            // debugging
             val checksums = fileList.map { f -> calculateChecksum(f) }
-            logger.info("CSV import checksum - imports enabled: files=[$fileNames] checksums=$checksums")
+            logger.info(
+                "CSV import checksum - imports enabled: files=[$fileNames] checksums=$checksums")
         } else if (importEnabled) {
-            logger.warn("CSV import checksum - imports enabled, but required files don't exist: files=[$fileNames]")
+            logger.warn(
+                "CSV import checksum - imports enabled, but required files don't exist: files=[$fileNames]")
         } else {
             logger.info("CSV import checksum - imports disabled")
         }
@@ -56,6 +66,7 @@ abstract class CsvMigration : BaseJavaMigration() {
     }
 
     abstract fun migrate(jdbcTemplate: NamedParameterJdbcTemplate)
+
     abstract fun getFiles(): List<CsvFile<*>>
 
     private fun calculateChecksum(file: CsvFile<*>): Int =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/DataImportUtil.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/DataImportUtil.kt
@@ -3,6 +3,11 @@ package fi.fta.geoviite.infra.dataImport
 import fi.fta.geoviite.infra.authorization.UserName
 import withUser
 
-enum class ImportUser { IM_IMPORT, CSV_IMPORT, SWITCH_LIB_IMPORT }
+enum class ImportUser {
+    IM_IMPORT,
+    CSV_IMPORT,
+    SWITCH_LIB_IMPORT
+}
 
-inline fun <reified T> withImportUser(user: ImportUser, noinline op: () -> T): T = withUser(UserName.of(user.name), op)
+inline fun <reified T> withImportUser(user: ImportUser, noinline op: () -> T): T =
+    withUser(UserName.of(user.name), op)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/InfraModelMigration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/InfraModelMigration.kt
@@ -7,10 +7,11 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 /**
- * These migrations must be retained for flyway versioning, but their implementation is intentionally removed.
+ * These migrations must be retained for flyway versioning, but their implementation is
+ * intentionally removed.
  *
- * This initial data import was done with a migration on version v1.0.0 data model.
- * If a new initial import is ever needed, it can be accomplished by either:
+ * This initial data import was done with a migration on version v1.0.0 data model. If a new initial
+ * import is ever needed, it can be accomplished by either:
  * - Running the import with 1.0.0 and then upgrading the system to current version
  * - Implementing a new import on the current model and (if desired) flattening versioned migrations
  */
@@ -19,13 +20,17 @@ class V12_01__InfraModelMigration : BaseJavaMigration() {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    private val importEnabled: Boolean by lazy { SpringContextUtility.getProperty("geoviite.data.import") }
-
-    override fun migrate(context: Context?) = withImportUser(ImportUser.IM_IMPORT) {
-        if (importEnabled) {
-            throw NotImplementedError("Initial inframodel migration not supported in this version.")
-        } else {
-            logger.info("InfraModel import disabled")
-        }
+    private val importEnabled: Boolean by lazy {
+        SpringContextUtility.getProperty("geoviite.data.import")
     }
+
+    override fun migrate(context: Context?) =
+        withImportUser(ImportUser.IM_IMPORT) {
+            if (importEnabled) {
+                throw NotImplementedError(
+                    "Initial inframodel migration not supported in this version.")
+            } else {
+                logger.info("InfraModel import disabled")
+            }
+        }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/SwitchLibraryDataMigration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/SwitchLibraryDataMigration.kt
@@ -121,7 +121,6 @@ val switchStructures: List<SwitchStructure> by lazy {
         KRV43_233_1_9(),
         KRV43_270_1_9_514(),
         KRV54_200_1_9(),
-
         KV30_270_1_9_514_O(),
         KV30_270_1_9_514_V(),
         KV43_300_1_9_514_O(),
@@ -130,26 +129,21 @@ val switchStructures: List<SwitchStructure> by lazy {
         KV54_200_1_9_V(),
         KV54_200N_1_9_O(),
         KV54_200N_1_9_V(),
-
         RR43_1_9_514(),
         RR54_1_9(),
         RR54_2x1_9(),
         RR54_4x1_9(),
-
         SKV60_800_423_1_15_5_O(),
         SKV60_800_423_1_15_5_V(),
         SKV60_1000_474_1_15_5_O(),
         SKV60_1000_474_1_15_5_V(),
-
         SRR54_2x1_9_4_8(),
         SRR54_2x1_9_6_0(),
         SRR60_2x1_9_4_8(),
-
         TYV54_200_1_4_44(),
         TYV54_200_1_4_44TPE(),
         TYV54_225_1_6_46(),
         TYV54_225_1_6_46TPE(),
-
         UKV54_800_258_1_9_O(),
         UKV54_800_258_1_9_V(),
         UKV54_1000_244_1_9_O(),
@@ -160,14 +154,11 @@ val switchStructures: List<SwitchStructure> by lazy {
         UKV60_600_281_1_9_V(),
         UKV60_1000_244_1_9_O(),
         UKV60_1000_244_1_9_V(),
-
         YRV54_200_1_9(),
-
         YV30_270_1_7_O(),
         YV30_270_1_7_V(),
         YV30_270_1_9_514_O(),
         YV30_270_1_9_514_V(),
-
         YV43_205_1_9_O(),
         YV43_205_1_9_V(),
         YV43_205_1_9_514_O(),
@@ -182,7 +173,6 @@ val switchStructures: List<SwitchStructure> by lazy {
         YV43_300_1_9_514_1435_V(),
         YV43_530_1_15_O(),
         YV43_530_1_15_V(),
-
         YV54_165_1_7_O(),
         YV54_165_1_7_V(),
         YV54_190_1_7_O(),
@@ -199,7 +189,6 @@ val switchStructures: List<SwitchStructure> by lazy {
         YV54_200_1_9_1524_1435_V(),
         YV54_900_1_15_5_O(),
         YV54_900_1_15_5_V(),
-
         YV60_300_1_9_O(),
         YV60_300_1_9_V(),
         YV60_300A_1_9_O(),
@@ -237,30 +226,32 @@ val switchStructures: List<SwitchStructure> by lazy {
     )
 }
 
-val inframodelAliases = mapOf(
-    "YV54-200(N)-1:9" to "YV54-200N-1:9",
-    "YV60-2500-1:26" to "YV60-5000/2500-1:26",
-    "YV60-3000-1:28" to "YV60-5000/3000-1:28",
-)
+val inframodelAliases =
+    mapOf(
+        "YV54-200(N)-1:9" to "YV54-200N-1:9",
+        "YV60-2500-1:26" to "YV60-5000/2500-1:26",
+        "YV60-3000-1:28" to "YV60-5000/3000-1:28",
+    )
 
 @Suppress("unused", "ClassName")
 class V10_03_06__SwitchLibraryDataMigration : BaseJavaMigration() {
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    override fun migrate(context: Context?) = withImportUser(ImportUser.SWITCH_LIB_IMPORT) {
-        logger.info("Add switch structures into library")
+    override fun migrate(context: Context?) =
+        withImportUser(ImportUser.SWITCH_LIB_IMPORT) {
+            logger.info("Add switch structures into library")
 
-        val connection = context?.connection
-            ?: throw IllegalStateException("Can't run imports without DB connection")
-        val jdbcTemplate = NamedParameterJdbcTemplate(
-            SingleConnectionDataSource(connection, true)
-        )
-        val switchStructureDao = SwitchStructureDao(jdbcTemplate)
-        switchStructures.forEach(switchStructureDao::insertSwitchStructure)
-        inframodelAliases.forEach { (alias, type) ->
-            switchStructureDao.insertInframodelAlias(alias, type)
+            val connection =
+                context?.connection
+                    ?: throw IllegalStateException("Can't run imports without DB connection")
+            val jdbcTemplate =
+                NamedParameterJdbcTemplate(SingleConnectionDataSource(connection, true))
+            val switchStructureDao = SwitchStructureDao(jdbcTemplate)
+            switchStructures.forEach(switchStructureDao::insertSwitchStructure)
+            inframodelAliases.forEach { (alias, type) ->
+                switchStructureDao.insertInframodelAlias(alias, type)
+            }
         }
-    }
 
     // Increase this manually when switch library data changes
     override fun getChecksum(): Int = 6
@@ -285,10 +276,10 @@ class R__10_01__update_all_switch_structures : BaseJavaMigration() {
         withImportUser(ImportUser.SWITCH_LIB_IMPORT) {
             logger.info("Update all switch structures")
             val connection =
-                context?.connection ?: throw IllegalStateException("Can't run imports without DB connection")
-            val jdbcTemplate = NamedParameterJdbcTemplate(
-                SingleConnectionDataSource(connection, true)
-            )
+                context?.connection
+                    ?: throw IllegalStateException("Can't run imports without DB connection")
+            val jdbcTemplate =
+                NamedParameterJdbcTemplate(SingleConnectionDataSource(connection, true))
             val switchStructureDao = SwitchStructureDao(jdbcTemplate)
             val switchOwnerDao = SwitchOwnerDao(jdbcTemplate)
             val switchLibraryService = SwitchLibraryService(switchStructureDao, switchOwnerDao)
@@ -296,5 +287,6 @@ class R__10_01__update_all_switch_structures : BaseJavaMigration() {
         }
     }
 
-    override fun getChecksum(): Int = switchStructures.map { s -> s.stripUniqueIdentifiers() }.hashCode()
+    override fun getChecksum(): Int =
+        switchStructures.map { s -> s.stripUniqueIdentifiers() }.hashCode()
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ApiErrorHandler.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ApiErrorHandler.kt
@@ -30,19 +30,24 @@ class ApiErrorHandler {
 
 fun createErrorResponse(log: Logger, ex: Exception): ResponseEntity<ApiErrorResponse> {
     val correlationId: String = correlationId.getOrNull() ?: "N/A"
-    val response = createResponse(ex, correlationId) ?: run {
-        log.warn(
-            "Error handling failed. Defaulting to \"Internal server error\": " +
-                    "correlationId=$correlationId exceptionChain=${getCauseChain(ex)}"
-        )
-        createTerseErrorResponse(correlationId, INTERNAL_SERVER_ERROR)
-    }
+    val response =
+        createResponse(ex, correlationId)
+            ?: run {
+                log.warn(
+                    "Error handling failed. Defaulting to \"Internal server error\": " +
+                        "correlationId=$correlationId exceptionChain=${getCauseChain(ex)}")
+                createTerseErrorResponse(correlationId, INTERNAL_SERVER_ERROR)
+            }
     when {
         // Log server errors with full stack
-        response.statusCode.is5xxServerError -> log.error("Server error: correlationId=$correlationId $response", ex)
+        response.statusCode.is5xxServerError ->
+            log.error("Server error: correlationId=$correlationId $response", ex)
         // Log handled (client) errors with Exception.toString -> no stack
-        response.statusCode.is4xxClientError -> log.warn("Client error: correlationId=$correlationId $response exception=\"$ex\"")
-        else -> log.info("Non-error response: correlationId=$correlationId ${response.statusCode} exception=\"$ex\"")
+        response.statusCode.is4xxClientError ->
+            log.warn("Client error: correlationId=$correlationId $response exception=\"$ex\"")
+        else ->
+            log.info(
+                "Non-error response: correlationId=$correlationId ${response.statusCode} exception=\"$ex\"")
     }
     return response
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -9,12 +9,12 @@ import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.util.LocalizationKey
 import fi.fta.geoviite.infra.util.formatForException
+import kotlin.reflect.KClass
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE
 import org.springframework.http.HttpStatus.UNAUTHORIZED
-import kotlin.reflect.KClass
 
 interface HasLocalizedMessage {
     val localizationKey: LocalizationKey
@@ -44,7 +44,12 @@ class LinkingFailureException(
     message: String,
     cause: Throwable? = null,
     localizedMessageKey: String = "generic",
-) : ClientException(BAD_REQUEST, "Linking failed: $message", cause, "$LOCALIZATION_KEY_BASE.$localizedMessageKey") {
+) :
+    ClientException(
+        BAD_REQUEST,
+        "Linking failed: $message",
+        cause,
+        "$LOCALIZATION_KEY_BASE.$localizedMessageKey") {
     companion object {
         const val LOCALIZATION_KEY_BASE = "error.linking"
     }
@@ -55,13 +60,14 @@ class SplitFailureException(
     cause: Throwable? = null,
     localizedMessageKey: String = "generic",
     localizationParams: LocalizationParams = LocalizationParams.empty,
-) : ClientException(
-    BAD_REQUEST,
-    "Split failed: $message",
-    cause,
-    "$LOCALIZATION_KEY_BASE.$localizedMessageKey",
-    localizationParams,
-) {
+) :
+    ClientException(
+        BAD_REQUEST,
+        "Split failed: $message",
+        cause,
+        "$LOCALIZATION_KEY_BASE.$localizedMessageKey",
+        localizationParams,
+    ) {
     companion object {
         const val LOCALIZATION_KEY_BASE = "error.split"
     }
@@ -72,7 +78,12 @@ class PublicationFailureException(
     cause: Throwable? = null,
     localizedMessageKey: String = "generic",
     status: HttpStatus = BAD_REQUEST,
-) : ClientException(status, "Publishing failed: $message", cause, "$LOCALIZATION_KEY_BASE.$localizedMessageKey") {
+) :
+    ClientException(
+        status,
+        "Publishing failed: $message",
+        cause,
+        "$LOCALIZATION_KEY_BASE.$localizedMessageKey") {
     companion object {
         const val LOCALIZATION_KEY_BASE = "error.publication"
     }
@@ -90,13 +101,14 @@ class InputValidationException(
     value: String,
     cause: Throwable? = null,
     localizationKey: String = "error.input.validation.${type.simpleName}",
-) : ClientException(
-    BAD_REQUEST,
-    "Input validation failed: $message",
-    cause,
-    localizationKey,
-    localizationParams("value" to formatForException(value, VALUE_MAX_LENGTH)),
-) {
+) :
+    ClientException(
+        BAD_REQUEST,
+        "Input validation failed: $message",
+        cause,
+        localizationKey,
+        localizationParams("value" to formatForException(value, VALUE_MAX_LENGTH)),
+    ) {
     companion object {
         const val VALUE_MAX_LENGTH = 25
     }
@@ -113,95 +125,122 @@ class InframodelParsingException(
     cause: Throwable? = null,
     localizedMessageKey: String = INFRAMODEL_PARSING_KEY_GENERIC,
     localizedMessageParams: LocalizationParams = LocalizationParams.empty,
-) : ClientException(
-    BAD_REQUEST,
-    "InfraModel could not be parsed: $message",
-    cause,
-    localizedMessageKey,
-    localizedMessageParams,
-)
+) :
+    ClientException(
+        BAD_REQUEST,
+        "InfraModel could not be parsed: $message",
+        cause,
+        localizedMessageKey,
+        localizedMessageParams,
+    )
 
 class NoSuchEntityException(
     type: String,
     id: String,
     localizedMessageKey: String = "error.entity-not-found",
-) : ClientException(NOT_FOUND, "No element of type $type exists with id $id", null, localizedMessageKey) {
-    constructor(type: KClass<*>, id: DomainId<*>) : this(type.simpleName ?: type.toString(), id.toString())
-    constructor(type: KClass<*>, id: RowVersion<*>) : this(type.simpleName ?: type.toString(), id.toString())
+) :
+    ClientException(
+        NOT_FOUND, "No element of type $type exists with id $id", null, localizedMessageKey) {
+    constructor(
+        type: KClass<*>,
+        id: DomainId<*>
+    ) : this(type.simpleName ?: type.toString(), id.toString())
+
+    constructor(
+        type: KClass<*>,
+        id: RowVersion<*>
+    ) : this(type.simpleName ?: type.toString(), id.toString())
+
     constructor(type: String, id: DomainId<*>) : this(type, id.toString())
+
     constructor(type: KClass<*>, id: String) : this(type.simpleName ?: type.toString(), id)
 }
 
-enum class DuplicateNameInPublication { SWITCH, TRACK_NUMBER }
+enum class DuplicateNameInPublication {
+    SWITCH,
+    TRACK_NUMBER
+}
+
 class DuplicateNameInPublicationException(
     type: DuplicateNameInPublication,
     duplicatedName: String,
     cause: Throwable? = null,
-) : ClientException(
-    status = BAD_REQUEST,
-    message = "Duplicate $type in publication: $duplicatedName",
-    cause = cause,
-    localizedMessageKey = "error.publication.duplicate-name-on.${if (type == DuplicateNameInPublication.SWITCH) "switch" else "track-number"}",
-    localizedMessageParams = localizationParams("name" to duplicatedName),
-)
+) :
+    ClientException(
+        status = BAD_REQUEST,
+        message = "Duplicate $type in publication: $duplicatedName",
+        cause = cause,
+        localizedMessageKey =
+            "error.publication.duplicate-name-on.${if (type == DuplicateNameInPublication.SWITCH) "switch" else "track-number"}",
+        localizedMessageParams = localizationParams("name" to duplicatedName),
+    )
 
 class DuplicateLocationTrackNameInPublicationException(
     alignmentName: AlignmentName,
     trackNumber: TrackNumber,
     cause: Throwable? = null,
-) : ClientException(
-    status = BAD_REQUEST,
-    message = "Duplicate location track $alignmentName in $trackNumber",
-    cause = cause,
-    localizedMessageKey = "error.publication.duplicate-name-on.location-track",
-    localizedMessageParams = localizationParams(
-        "locationTrack" to alignmentName,
-        "trackNumber" to trackNumber,
-    )
-)
+) :
+    ClientException(
+        status = BAD_REQUEST,
+        message = "Duplicate location track $alignmentName in $trackNumber",
+        cause = cause,
+        localizedMessageKey = "error.publication.duplicate-name-on.location-track",
+        localizedMessageParams =
+            localizationParams(
+                "locationTrack" to alignmentName,
+                "trackNumber" to trackNumber,
+            ))
 
 class SplitSourceLocationTrackUpdateException(
     alignmentName: AlignmentName,
     cause: Throwable? = null,
-) : ClientException(
-    status = BAD_REQUEST,
-    message = "Split source location track updates are not allowed",
-    cause = cause,
-    localizedMessageKey = "error.split.source-track-update-is-not-allowed",
-    localizedMessageParams = localizationParams("alignmentName" to alignmentName),
-)
+) :
+    ClientException(
+        status = BAD_REQUEST,
+        message = "Split source location track updates are not allowed",
+        cause = cause,
+        localizedMessageKey = "error.split.source-track-update-is-not-allowed",
+        localizedMessageParams = localizationParams("alignmentName" to alignmentName),
+    )
 
-enum class Integration { RATKO, PROJEKTIVELHO }
-class IntegrationNotConfiguredException(type: Integration) : ClientException(
-    status = SERVICE_UNAVAILABLE,
-    message = "Integration not configured: $type",
-    cause = null,
-    localizedMessageKey = "error.integration-not-configured.$type",
-)
+enum class Integration {
+    RATKO,
+    PROJEKTIVELHO
+}
+
+class IntegrationNotConfiguredException(type: Integration) :
+    ClientException(
+        status = SERVICE_UNAVAILABLE,
+        message = "Integration not configured: $type",
+        cause = null,
+        localizedMessageKey = "error.integration-not-configured.$type",
+    )
 
 class DuplicateDesignNameException(
     name: String,
     cause: Throwable? = null,
-) : ClientException(
-    status = BAD_REQUEST,
-    message = "Duplicate design name: $name",
-    cause = cause,
-    localizedMessageKey = "error.design.duplicate-name",
-    localizedMessageParams = localizationParams("name" to name),
-)
+) :
+    ClientException(
+        status = BAD_REQUEST,
+        message = "Duplicate design name: $name",
+        cause = cause,
+        localizedMessageKey = "error.design.duplicate-name",
+        localizedMessageParams = localizationParams("name" to name),
+    )
 
 class IntegrationApiException(
     message: String,
     cause: Throwable? = null,
     localizedMessageKey: String = "generic",
     localizationParams: LocalizationParams = LocalizationParams.empty,
-) : ClientException(
-    BAD_REQUEST,
-    "Invalid request: $message",
-    cause,
-    "$LOCALIZATION_KEY_BASE.$localizedMessageKey",
-    localizationParams,
-) {
+) :
+    ClientException(
+        BAD_REQUEST,
+        "Invalid request: $message",
+        cause,
+        "$LOCALIZATION_KEY_BASE.$localizedMessageKey",
+        localizationParams,
+    ) {
     companion object {
         const val LOCALIZATION_KEY_BASE = "integration-api.error"
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ErrorHandling.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ErrorHandling.kt
@@ -60,14 +60,18 @@ fun createResponse(exception: Exception, correlationId: String): ResponseEntity<
     }
 }
 
-fun createTerseErrorResponse(correlationId: String, status: HttpStatus): ResponseEntity<ApiErrorResponse> =
+fun createTerseErrorResponse(
+    correlationId: String,
+    status: HttpStatus
+): ResponseEntity<ApiErrorResponse> =
     createResponse(listOf(describe(status)), status, correlationId)
 
 fun createDescriptiveErrorResponse(
     correlationId: String,
     status: HttpStatus,
     causeChain: List<Exception>,
-): ResponseEntity<ApiErrorResponse> = createResponse(causeChain.mapNotNull(::describe), status, correlationId)
+): ResponseEntity<ApiErrorResponse> =
+    createResponse(causeChain.mapNotNull(::describe), status, correlationId)
 
 fun createResponse(
     messageRows: List<ErrorDescription>,
@@ -89,8 +93,10 @@ fun createResponse(
     )
 }
 
-fun getPrimaryDescription(messageRows: List<ErrorDescription>, status: HttpStatus): ErrorDescription =
-    messageRows.minByOrNull { r -> r.priority } ?: describe(status)
+fun getPrimaryDescription(
+    messageRows: List<ErrorDescription>,
+    status: HttpStatus
+): ErrorDescription = messageRows.minByOrNull { r -> r.priority } ?: describe(status)
 
 fun getCauseChain(exception: Exception): List<Exception> {
     val chain = mutableListOf<Exception>()
@@ -109,186 +115,218 @@ fun getStatusCode(causeChain: List<Exception>): HttpStatus? =
     if (causeChain.any { e -> e is ServerException }) INTERNAL_SERVER_ERROR
     else causeChain.firstNotNullOfOrNull(::getStatusCode)
 
-fun getStatusCode(exception: Exception): HttpStatus? = when (exception) {
-    // Our own exceptions
-    is ServerException -> INTERNAL_SERVER_ERROR
-    is ClientException -> exception.status
-    // Spring exceptions
-    is AccessDeniedException -> FORBIDDEN
-    is HttpRequestMethodNotSupportedException -> METHOD_NOT_ALLOWED
-    is HttpMediaTypeNotSupportedException -> UNSUPPORTED_MEDIA_TYPE
-    is HttpMediaTypeNotAcceptableException -> NOT_ACCEPTABLE
-    is MissingPathVariableException -> INTERNAL_SERVER_ERROR
-    is MissingServletRequestParameterException -> BAD_REQUEST
-    is ServletRequestBindingException -> BAD_REQUEST
-    is ConversionNotSupportedException -> INTERNAL_SERVER_ERROR
-    is TypeMismatchException -> BAD_REQUEST
-    is HttpMessageNotReadableException -> BAD_REQUEST
-    is HttpMessageNotWritableException -> INTERNAL_SERVER_ERROR
-    is MethodArgumentNotValidException -> BAD_REQUEST
-    is MissingServletRequestPartException -> BAD_REQUEST
-    is BindException -> BAD_REQUEST
-    is NoHandlerFoundException -> NOT_FOUND
-    is AsyncRequestTimeoutException -> SERVICE_UNAVAILABLE
-    is MaxUploadSizeExceededException -> BAD_REQUEST
-    is TransactionTimedOutException -> REQUEST_TIMEOUT
-    // We don't know -> return nothing to continue resolving through the cause chain
-    else -> null
-}
+fun getStatusCode(exception: Exception): HttpStatus? =
+    when (exception) {
+        // Our own exceptions
+        is ServerException -> INTERNAL_SERVER_ERROR
+        is ClientException -> exception.status
+        // Spring exceptions
+        is AccessDeniedException -> FORBIDDEN
+        is HttpRequestMethodNotSupportedException -> METHOD_NOT_ALLOWED
+        is HttpMediaTypeNotSupportedException -> UNSUPPORTED_MEDIA_TYPE
+        is HttpMediaTypeNotAcceptableException -> NOT_ACCEPTABLE
+        is MissingPathVariableException -> INTERNAL_SERVER_ERROR
+        is MissingServletRequestParameterException -> BAD_REQUEST
+        is ServletRequestBindingException -> BAD_REQUEST
+        is ConversionNotSupportedException -> INTERNAL_SERVER_ERROR
+        is TypeMismatchException -> BAD_REQUEST
+        is HttpMessageNotReadableException -> BAD_REQUEST
+        is HttpMessageNotWritableException -> INTERNAL_SERVER_ERROR
+        is MethodArgumentNotValidException -> BAD_REQUEST
+        is MissingServletRequestPartException -> BAD_REQUEST
+        is BindException -> BAD_REQUEST
+        is NoHandlerFoundException -> NOT_FOUND
+        is AsyncRequestTimeoutException -> SERVICE_UNAVAILABLE
+        is MaxUploadSizeExceededException -> BAD_REQUEST
+        is TransactionTimedOutException -> REQUEST_TIMEOUT
+        // We don't know -> return nothing to continue resolving through the cause chain
+        else -> null
+    }
 
-fun describe(status: HttpStatus) = ErrorDescription(
-    message = status.reasonPhrase,
-    key = if (status.is4xxClientError) {
-        "error.client-error"
-    } else {
-        "error.internal-server-error"
-    },
-    params = localizationParams("code" to status.value()),
-)
+fun describe(status: HttpStatus) =
+    ErrorDescription(
+        message = status.reasonPhrase,
+        key =
+            if (status.is4xxClientError) {
+                "error.client-error"
+            } else {
+                "error.internal-server-error"
+            },
+        params = localizationParams("code" to status.value()),
+    )
 
 fun describe(ex: Exception): ErrorDescription? {
     val message = ex.message ?: "${ex::class.simpleName}"
     return when (ex) {
-        // Our own exceptions: prioritized for error display as they likely contain the most understandable message
-        is HasLocalizedMessage -> ErrorDescription(
-            message = message,
-            localizationKey = ex.localizationKey,
-            localizationParams = ex.localizationParams,
-            priority = ErrorPriority.HIGH,
-        )
+        // Our own exceptions: prioritized for error display as they likely contain the most
+        // understandable message
+        is HasLocalizedMessage ->
+            ErrorDescription(
+                message = message,
+                localizationKey = ex.localizationKey,
+                localizationParams = ex.localizationParams,
+                priority = ErrorPriority.HIGH,
+            )
 
         // General Kotlin exceptions
-        is IllegalArgumentException -> ErrorDescription(
-            message = message,
-            key = "error.exception.illegal-argument",
-            priority = ErrorPriority.LOW,
-        )
+        is IllegalArgumentException ->
+            ErrorDescription(
+                message = message,
+                key = "error.exception.illegal-argument",
+                priority = ErrorPriority.LOW,
+            )
 
         // Spring exceptions
         is AccessDeniedException -> ErrorDescription(message, "error.authentication.unauthorized")
 
-        is HttpMessageNotReadableException -> ErrorDescription(
-            message = "Request body not readable",
-            key = "error.bad-request.invalid-body",
-        )
+        is HttpMessageNotReadableException ->
+            ErrorDescription(
+                message = "Request body not readable",
+                key = "error.bad-request.invalid-body",
+            )
 
-        is HttpRequestMethodNotSupportedException -> ErrorDescription(
-            message = message,
-            key = "error.bad-request.invalid-path",
-            params = localizationParams("method" to ex.method),
-        )
+        is HttpRequestMethodNotSupportedException ->
+            ErrorDescription(
+                message = message,
+                key = "error.bad-request.invalid-path",
+                params = localizationParams("method" to ex.method),
+            )
 
-        is NoHandlerFoundException -> ErrorDescription(
-            message = "No handler found: ${ex.httpMethod} ${ex.requestURL}",
-            key = "error.bad-request.invalid-path",
-            params = localizationParams("method" to ex.httpMethod),
-        )
+        is NoHandlerFoundException ->
+            ErrorDescription(
+                message = "No handler found: ${ex.httpMethod} ${ex.requestURL}",
+                key = "error.bad-request.invalid-path",
+                params = localizationParams("method" to ex.httpMethod),
+            )
 
-        is MissingServletRequestParameterException -> ErrorDescription(
-            message = "Missing parameter: ${ex.parameterName} of type ${ex.parameterType}",
-            key = "error.bad-request.missing-parameter",
-            params = localizationParams("param" to ex.parameterName, "type" to ex.parameterType),
-        )
+        is MissingServletRequestParameterException ->
+            ErrorDescription(
+                message = "Missing parameter: ${ex.parameterName} of type ${ex.parameterType}",
+                key = "error.bad-request.missing-parameter",
+                params =
+                    localizationParams("param" to ex.parameterName, "type" to ex.parameterType),
+            )
 
-        is MethodArgumentTypeMismatchException -> ErrorDescription(
-            message = "Argument type mismatch: ${ex.name} (type ${ex.requiredType?.simpleName}) ${ex.parameter}",
-            key = "error.bad-request.conversion-failed",
-            params = localizationParams(
-                "name" to ex.name,
-                "parameter" to ex.parameter,
-                "target" to ex.requiredType?.simpleName,
-            ),
-        )
+        is MethodArgumentTypeMismatchException ->
+            ErrorDescription(
+                message =
+                    "Argument type mismatch: ${ex.name} (type ${ex.requiredType?.simpleName}) ${ex.parameter}",
+                key = "error.bad-request.conversion-failed",
+                params =
+                    localizationParams(
+                        "name" to ex.name,
+                        "parameter" to ex.parameter,
+                        "target" to ex.requiredType?.simpleName,
+                    ),
+            )
 
-        is ConversionFailedException -> ErrorDescription(
-            message = "Conversion failed for value \"${ex.value}\": " +
-                "[${ex.sourceType?.type?.simpleName}] -> [${ex.targetType.type.simpleName}]",
-            key = "error.bad-request.conversion-failed",
-            params = localizationParams("target" to ex.targetType.type.simpleName),
-            priority = ErrorPriority.LOW,
-        )
+        is ConversionFailedException ->
+            ErrorDescription(
+                message =
+                    "Conversion failed for value \"${ex.value}\": " +
+                        "[${ex.sourceType?.type?.simpleName}] -> [${ex.targetType.type.simpleName}]",
+                key = "error.bad-request.conversion-failed",
+                params = localizationParams("target" to ex.targetType.type.simpleName),
+                priority = ErrorPriority.LOW,
+            )
 
         // Jackson exceptions
-        is MismatchedInputException -> ErrorDescription(
-            message = message,
-            key = "error.bad-request.conversion-failed",
-            params = localizationParams("target" to ex.targetType?.simpleName),
-            priority = ErrorPriority.LOW,
-        )
+        is MismatchedInputException ->
+            ErrorDescription(
+                message = message,
+                key = "error.bad-request.conversion-failed",
+                params = localizationParams("target" to ex.targetType?.simpleName),
+                priority = ErrorPriority.LOW,
+            )
 
-        is JsonParseException -> ErrorDescription(
-            message = "Failed to parse JSON input",
-            key = "error.bad-request.invalid-body",
-        )
+        is JsonParseException ->
+            ErrorDescription(
+                message = "Failed to parse JSON input",
+                key = "error.bad-request.invalid-body",
+            )
 
-        is ValueInstantiationException -> ErrorDescription(
-            message = "Failed to instantiate ${ex.type?.genericSignature}",
-            key = "error.bad-request.conversion-failed",
-            params = localizationParams("target" to ex.type?.genericSignature),
-            priority = ErrorPriority.LOW,
-        )
+        is ValueInstantiationException ->
+            ErrorDescription(
+                message = "Failed to instantiate ${ex.type?.genericSignature}",
+                key = "error.bad-request.conversion-failed",
+                params = localizationParams("target" to ex.type?.genericSignature),
+                priority = ErrorPriority.LOW,
+            )
 
         // Jaxb exceptions (XML parsing)
-        is UnmarshalException -> ErrorDescription(
-            message = message,
-            key = "error.xml-unmarshal-failed",
-        )
+        is UnmarshalException ->
+            ErrorDescription(
+                message = message,
+                key = "error.xml-unmarshal-failed",
+            )
 
         // Geotools exceptions
-        is TransformException -> ErrorDescription(
-            message = message,
-            key = "error.coordinate-transformation-failed",
-        )
+        is TransformException ->
+            ErrorDescription(
+                message = message,
+                key = "error.coordinate-transformation-failed",
+            )
 
         // Token decoding: JWT.java
-        is JWTDecodeException -> ErrorDescription(
-            message = "JWT - Unparseable token: $message",
-            key = "error.authentication.invalid-token",
-        )
+        is JWTDecodeException ->
+            ErrorDescription(
+                message = "JWT - Unparseable token: $message",
+                key = "error.authentication.invalid-token",
+            )
 
         // Token verification: JWTVerifier.java
-        is TokenExpiredException -> ErrorDescription(
-            message = "JWT - Token expired: $message",
-            key = "error.authentication.token-expired",
-        )
+        is TokenExpiredException ->
+            ErrorDescription(
+                message = "JWT - Token expired: $message",
+                key = "error.authentication.token-expired",
+            )
 
-        is InvalidClaimException -> ErrorDescription(
-            message = "JWT - Invalid claim: $message",
-            key = "error.authentication.invalid-token",
-        )
+        is InvalidClaimException ->
+            ErrorDescription(
+                message = "JWT - Invalid claim: $message",
+                key = "error.authentication.invalid-token",
+            )
 
-        is SignatureVerificationException -> ErrorDescription(
-            message = "JWT - Invalid signature: $message",
-            key = "error.authentication.invalid-token",
-        )
+        is SignatureVerificationException ->
+            ErrorDescription(
+                message = "JWT - Invalid signature: $message",
+                key = "error.authentication.invalid-token",
+            )
 
-        is AlgorithmMismatchException -> ErrorDescription(
-            message = "JWT - Wrong signature algorithm: $message",
-            key = "error.authentication.invalid-token",
-        )
+        is AlgorithmMismatchException ->
+            ErrorDescription(
+                message = "JWT - Wrong signature algorithm: $message",
+                key = "error.authentication.invalid-token",
+            )
 
-        is MaxUploadSizeExceededException -> ErrorDescription(
-            message = "Maximum upload size exceeded: ${ex.mostSpecificCause.message}",
-            key = "error.file-size-limit-exceeded",
-        )
+        is MaxUploadSizeExceededException ->
+            ErrorDescription(
+                message = "Maximum upload size exceeded: ${ex.mostSpecificCause.message}",
+                key = "error.file-size-limit-exceeded",
+            )
 
-        is TransactionTimedOutException -> ErrorDescription(
-            message = "Request timed out",
-            key = "error.request-timed-out",
-        )
+        is TransactionTimedOutException ->
+            ErrorDescription(
+                message = "Request timed out",
+                key = "error.request-timed-out",
+            )
 
         // Switch to this if you want to see what types end up in the chain:
-//        else -> ErrorDescription(
-//            message = message,
-//            key = "error.exception",
-//            params = localizationParams("type" to ex::class.simpleName),
-//        )
+        //        else -> ErrorDescription(
+        //            message = message,
+        //            key = "error.exception",
+        //            params = localizationParams("type" to ex::class.simpleName),
+        //        )
 
         else -> null
     }
 }
 
-enum class ErrorPriority { HIGH, AVERAGE, LOW }
+enum class ErrorPriority {
+    HIGH,
+    AVERAGE,
+    LOW
+}
 
 data class ErrorDescription(
     val message: String,
@@ -309,7 +347,9 @@ data class ErrorDescription(
     )
 }
 
-fun getPSQLExceptionConstraintAndDetailOrRethrow(psqlException: PSQLException): Pair<String, String> {
+fun getPSQLExceptionConstraintAndDetailOrRethrow(
+    psqlException: PSQLException
+): Pair<String, String> {
     val constraint = psqlException.serverErrorMessage?.constraint ?: throw psqlException
     val detail = psqlException.serverErrorMessage?.detail ?: throw psqlException
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ServerException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ServerException.kt
@@ -1,3 +1,3 @@
 package fi.fta.geoviite.infra.error
 
-class ServerException(message: String, cause: Throwable? = null): RuntimeException(message, cause)
+class ServerException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
@@ -34,7 +34,10 @@ class AddressPointsCache(
     val geocodingCacheService: GeocodingCacheService,
 ) {
     private val cache: Cache<AddressPointCacheKey, AlignmentAddresses?> =
-        Caffeine.newBuilder().maximumSize(ADDRESS_POINT_CACHE_SIZE).expireAfterAccess(layoutCacheDuration).build()
+        Caffeine.newBuilder()
+            .maximumSize(ADDRESS_POINT_CACHE_SIZE)
+            .expireAfterAccess(layoutCacheDuration)
+            .build()
 
     @Transactional(readOnly = true)
     fun getAddressPointCacheKey(
@@ -43,7 +46,8 @@ class AddressPointsCache(
     ): AddressPointCacheKey? {
         return locationTrackDao.fetchVersion(layoutContext, locationTrackId)?.let { trackVersion ->
             val track = locationTrackDao.fetch(trackVersion)
-            val contextCacheKey = geocodingDao.getLayoutGeocodingContextCacheKey(layoutContext, track.trackNumberId)
+            val contextCacheKey =
+                geocodingDao.getLayoutGeocodingContextCacheKey(layoutContext, track.trackNumberId)
             if (track.alignmentVersion != null && contextCacheKey != null) {
                 AddressPointCacheKey(track.alignmentVersion, contextCacheKey)
             } else {
@@ -55,14 +59,18 @@ class AddressPointsCache(
     /**
      * This is for caching address points. Please don't call this directly if possible, please
      * prefer GeocodingService's getAddressPoints method instead
-     **/
+     */
     fun getAddressPoints(cacheKey: AddressPointCacheKey): AlignmentAddresses? {
         return getAddressPointCalculationData(cacheKey)?.let(::getAddressPoints)
     }
 
-    fun getAddressPointCalculationData(cacheKey: AddressPointCacheKey): AddressPointCalculationData? =
-        geocodingCacheService.getGeocodingContext(cacheKey.geocodingContextCacheKey)?.let { geocodingContext ->
-            AddressPointCalculationData(cacheKey, alignmentDao.fetch(cacheKey.alignmentVersion), geocodingContext)
+    fun getAddressPointCalculationData(
+        cacheKey: AddressPointCacheKey
+    ): AddressPointCalculationData? =
+        geocodingCacheService.getGeocodingContext(cacheKey.geocodingContextCacheKey)?.let {
+            geocodingContext ->
+            AddressPointCalculationData(
+                cacheKey, alignmentDao.fetch(cacheKey.alignmentVersion), geocodingContext)
         }
 
     fun getAddressPoints(input: AddressPointCalculationData): AlignmentAddresses? =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -32,15 +32,16 @@ import fi.fta.geoviite.infra.tracklayout.LAYOUT_M_DELTA
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.SegmentPoint
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.math.PI
 import kotlin.math.abs
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 data class AddressPoint(val point: AlignmentPoint, val address: TrackMeter) {
     fun isSame(other: AddressPoint) = address.isSame(other.address) && point.isSame(other.point)
+
     fun withIntegerPrecision(): AddressPoint? =
         if (address.hasIntegerPrecision()) {
             this
@@ -66,7 +67,9 @@ data class AlignmentAddresses(
     @get:JsonIgnore
     val integerPrecisionPoints: List<AddressPoint> by lazy {
         // midPoints are even anyhow, so just transform start/end
-        listOfNotNull(startPoint.withIntegerPrecision()) + midPoints + listOfNotNull(endPoint.withIntegerPrecision())
+        listOfNotNull(startPoint.withIntegerPrecision()) +
+            midPoints +
+            listOfNotNull(endPoint.withIntegerPrecision())
     }
 }
 
@@ -94,28 +97,31 @@ data class GeocodingReferencePoint(
 data class AddressAndM(val address: TrackMeter, val m: Double, val intersectType: IntersectType)
 
 /**
- * Don't generate a meter that is shorter than this.
- * Prevents an extra projection being generated when the KM changes on an exact meter.
+ * Don't generate a meter that is shorter than this. Prevents an extra projection being generated
+ * when the KM changes on an exact meter.
  */
 private const val MIN_METER_LENGTH = 0.001
 
 /**
- * Projection line validation parameter.
- * They should be 1m apart from each other along reference line by definition.
- * This is the maximum deviation allowed - must accommodate some difference for turns.
+ * Projection line validation parameter. They should be 1m apart from each other along reference
+ * line by definition. This is the maximum deviation allowed - must accommodate some difference for
+ * turns.
  */
 private const val PROJECTION_LINE_DISTANCE_DEVIATION = 0.05
 
 /**
- * Projection line validation parameter.
- * If the line makes rough turns, the projections will result in convoluted addresses.
- * This is the maximum angle-change between 2 projection points (1m on reference line).
+ * Projection line validation parameter. If the line makes rough turns, the projections will result
+ * in convoluted addresses. This is the maximum angle-change between 2 projection points (1m on
+ * reference line).
  */
 private const val PROJECTION_LINE_MAX_ANGLE_DELTA = PI / 16
 
 private val logger: Logger = LoggerFactory.getLogger(GeocodingContext::class.java)
 
-data class KmPostWithRejectedReason(val kmPost: TrackLayoutKmPost, val rejectedReason: KmPostRejectedReason)
+data class KmPostWithRejectedReason(
+    val kmPost: TrackLayoutKmPost,
+    val rejectedReason: KmPostRejectedReason
+)
 
 data class GeocodingContextCreateResult(
     val geocodingContext: GeocodingContext,
@@ -124,7 +130,9 @@ data class GeocodingContextCreateResult(
     val startPointRejectedReason: StartPointRejectedReason?,
 )
 
-enum class StartPointRejectedReason { TOO_LONG }
+enum class StartPointRejectedReason {
+    TOO_LONG
+}
 
 enum class KmPostRejectedReason {
     TOO_FAR_APART,
@@ -156,22 +164,24 @@ data class GeocodingContext(
         require(
             referencePoints
                 .zipWithNext { a, b -> abs(b.distance - a.distance) }
-                .all { TrackMeter.isMetersValid(it) }
-        ) {
-            "Reference points are too far apart from each other, trackNumber=${trackNumber}"
-        }
+                .all { TrackMeter.isMetersValid(it) }) {
+                "Reference points are too far apart from each other, trackNumber=${trackNumber}"
+            }
     }
 
-    private val polyLineEdges: List<PolyLineEdge> by lazy { getPolyLineEdges(referenceLineGeometry) }
+    private val polyLineEdges: List<PolyLineEdge> by lazy {
+        getPolyLineEdges(referenceLineGeometry)
+    }
     val projectionLines: List<ProjectionLine> by lazy {
         require(isSame(polyLineEdges.last().endM, referenceLineGeometry.length, LAYOUT_M_DELTA)) {
             "Polyline edges should cover the whole reference line geometry: " +
-                    "trackNumber=${trackNumber} " +
-                    "alignment=${referenceLineGeometry.id} " +
-                    "edgeMValues=${polyLineEdges.map { e -> e.startM..e.endM }}"
+                "trackNumber=${trackNumber} " +
+                "alignment=${referenceLineGeometry.id} " +
+                "edgeMValues=${polyLineEdges.map { e -> e.startM..e.endM }}"
         }
         createProjectionLines(referencePoints, polyLineEdges).also { lines ->
-            validateProjectionLines(lines, projectionLineDistanceDeviation, projectionLineMaxAngleDelta)
+            validateProjectionLines(
+                lines, projectionLineDistanceDeviation, projectionLineMaxAngleDelta)
         }
     }
     val allKms: List<KmNumber> by lazy {
@@ -185,28 +195,40 @@ data class GeocodingContext(
     }
 
     val endProjection: ProjectionLine by lazy {
-        val meters = referenceLineGeometry.length - referencePoints.last().let { p -> p.distance - p.meters.toDouble() }
-        val address = TrackMeter(referencePoints.last().kmNumber, meters, referencePoints.first().meters.scale())
+        val meters =
+            referenceLineGeometry.length -
+                referencePoints.last().let { p -> p.distance - p.meters.toDouble() }
+        val address =
+            TrackMeter(
+                referencePoints.last().kmNumber, meters, referencePoints.first().meters.scale())
         val projectionLine = polyLineEdges.last().crossSectionAt(referenceLineGeometry.length)
         ProjectionLine(address, projectionLine, referenceLineGeometry.length)
     }
 
     fun getProjectionLine(address: TrackMeter): ProjectionLine? =
-        if (address.decimalCount() == 0 || address <= startProjection.address || address >= endProjection.address) {
+        if (address.decimalCount() == 0 ||
+            address <= startProjection.address ||
+            address >= endProjection.address) {
             findCachedProjectionLine(address)
-        } else findCachedProjectionLine(address.floor())?.let { previous ->
-            val distance = previous.distance + (address.meters.toDouble() - previous.address.meters.toDouble())
-            findEdge(distance, polyLineEdges)?.let { edge ->
-                ProjectionLine(address, edge.crossSectionAt(distance), distance)
+        } else
+            findCachedProjectionLine(address.floor())?.let { previous ->
+                val distance =
+                    previous.distance +
+                        (address.meters.toDouble() - previous.address.meters.toDouble())
+                findEdge(distance, polyLineEdges)?.let { edge ->
+                    ProjectionLine(address, edge.crossSectionAt(distance), distance)
+                }
             }
-        }
 
     private fun findCachedProjectionLine(address: TrackMeter) =
         if (address !in startProjection.address..endProjection.address) null
         else if (address == startProjection.address) startProjection
         else if (address == endProjection.address) endProjection
         else if (projectionLines.isEmpty()) null
-        else projectionLines.binarySearch { line -> line.address.compareTo(address) }.let(projectionLines::getOrNull)
+        else
+            projectionLines
+                .binarySearch { line -> line.address.compareTo(address) }
+                .let(projectionLines::getOrNull)
 
     companion object {
         fun create(
@@ -217,50 +239,61 @@ data class GeocodingContext(
         ): GeocodingContextCreateResult {
             val (validatedKmPosts, invalidKmPosts) = validateKmPosts(kmPosts, startAddress)
 
-            val (validReferencePoints, kmPostsOutsideGeometry) = createReferencePoints(
-                startAddress, validatedKmPosts, referenceLineGeometry
-            )
+            val (validReferencePoints, kmPostsOutsideGeometry) =
+                createReferencePoints(startAddress, validatedKmPosts, referenceLineGeometry)
 
-            val validKmPosts = validatedKmPosts.filterNot { vkp ->
-                kmPostsOutsideGeometry.any { kp -> kp.kmPost.id == vkp.id }
-            }
+            val validKmPosts =
+                validatedKmPosts.filterNot { vkp ->
+                    kmPostsOutsideGeometry.any { kp -> kp.kmPost.id == vkp.id }
+                }
 
-            val startKmIsTooLong = startKmIsTooLong(startAddress, referenceLineGeometry, validReferencePoints)
+            val startKmIsTooLong =
+                startKmIsTooLong(startAddress, referenceLineGeometry, validReferencePoints)
 
             return GeocodingContextCreateResult(
-                geocodingContext = GeocodingContext(
-                    trackNumber = trackNumber,
-                    referenceLineGeometry = referenceLineGeometry,
-                    referencePoints = validReferencePoints,
-                    startAddress = startAddress
-                ),
+                geocodingContext =
+                    GeocodingContext(
+                        trackNumber = trackNumber,
+                        referenceLineGeometry = referenceLineGeometry,
+                        referencePoints = validReferencePoints,
+                        startAddress = startAddress),
                 rejectedKmPosts = invalidKmPosts + kmPostsOutsideGeometry,
                 validKmPosts = validKmPosts,
-                startPointRejectedReason = if (startKmIsTooLong) StartPointRejectedReason.TOO_LONG else null
-            )
+                startPointRejectedReason =
+                    if (startKmIsTooLong) StartPointRejectedReason.TOO_LONG else null)
         }
 
         private fun startKmIsTooLong(
             startAddress: TrackMeter,
             referenceLineGeometry: IAlignment,
             referencePoints: List<GeocodingReferencePoint>,
-        ): Boolean = if (referencePoints.isEmpty()) false else {
-            val startMeters =
-                referencePoints[0].distance + startAddress.meters.setScale(0, RoundingMode.CEILING).toDouble()
-            val length = if (referencePoints.size > 1) referencePoints[1].distance else referenceLineGeometry.length
-            !TrackMeter.isMetersValid(startMeters + length)
-        }
+        ): Boolean =
+            if (referencePoints.isEmpty()) false
+            else {
+                val startMeters =
+                    referencePoints[0].distance +
+                        startAddress.meters.setScale(0, RoundingMode.CEILING).toDouble()
+                val length =
+                    if (referencePoints.size > 1) referencePoints[1].distance
+                    else referenceLineGeometry.length
+                !TrackMeter.isMetersValid(startMeters + length)
+            }
 
         private fun createReferencePoints(
             startAddress: TrackMeter,
             kmPosts: List<TrackLayoutKmPost>,
             referenceLineGeometry: IAlignment,
         ): Pair<List<GeocodingReferencePoint>, List<KmPostWithRejectedReason>> {
-            val kpReferencePoints = kmPosts.mapNotNull { post ->
-                post.layoutLocation?.let { location -> toReferencePoint(location, post.kmNumber, referenceLineGeometry) }
-            }
+            val kpReferencePoints =
+                kmPosts.mapNotNull { post ->
+                    post.layoutLocation?.let { location ->
+                        toReferencePoint(location, post.kmNumber, referenceLineGeometry)
+                    }
+                }
 
-            val firstPoint = GeocodingReferencePoint(startAddress.kmNumber, startAddress.meters, 0.0, 0.0, WITHIN)
+            val firstPoint =
+                GeocodingReferencePoint(
+                    startAddress.kmNumber, startAddress.meters, 0.0, 0.0, WITHIN)
             val referencePoints = listOf(firstPoint) + kpReferencePoints
 
             return validateReferencePoints(referencePoints, kmPosts)
@@ -272,60 +305,74 @@ data class GeocodingContext(
         ): Pair<List<TrackLayoutKmPost>, List<KmPostWithRejectedReason>> {
             val (withoutLocations, withLocations) = kmPosts.partition { it.layoutLocation == null }
 
-            val (invalidStartAddresses, validKmPosts) = withLocations.partition {
-                TrackMeter(it.kmNumber, BigDecimal.ZERO) <= startAddress
-            }
+            val (invalidStartAddresses, validKmPosts) =
+                withLocations.partition { TrackMeter(it.kmNumber, BigDecimal.ZERO) <= startAddress }
 
-            val duplicateKmPosts = kmPosts
-                .groupBy { it.kmNumber }
-                .filter { it.value.size > 1 }
-                .values
-                .flatten()
+            val duplicateKmPosts =
+                kmPosts.groupBy { it.kmNumber }.filter { it.value.size > 1 }.values.flatten()
 
             val rejectedKmPosts =
                 withoutLocations.map { it to KmPostRejectedReason.NO_LOCATION } +
-                    invalidStartAddresses.map { it to KmPostRejectedReason.IS_BEFORE_START_ADDRESS } +
+                    invalidStartAddresses.map {
+                        it to KmPostRejectedReason.IS_BEFORE_START_ADDRESS
+                    } +
                     duplicateKmPosts.map { it to KmPostRejectedReason.DUPLICATE }
 
-            return validKmPosts to rejectedKmPosts.map { (kp, reason) -> KmPostWithRejectedReason(kp, reason) }
+            return validKmPosts to
+                rejectedKmPosts.map { (kp, reason) -> KmPostWithRejectedReason(kp, reason) }
         }
 
         private fun validateReferencePoints(
             referencePoints: List<GeocodingReferencePoint>,
             kmPosts: List<TrackLayoutKmPost>,
         ): Pair<List<GeocodingReferencePoint>, List<KmPostWithRejectedReason>> {
-            val (withinPoints, beforePoints, afterPoints) = referencePoints.groupBy { it.intersectType }
-                .let { byIntersect ->
-                    Triple(byIntersect[WITHIN] ?: emptyList(),
-                        byIntersect[BEFORE]?.map { it to KmPostRejectedReason.INTERSECTS_BEFORE_REFERENCE_LINE }
-                            ?: emptyList(),
-                        byIntersect[AFTER]?.map { it to KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE }
-                            ?: emptyList())
+            val (withinPoints, beforePoints, afterPoints) =
+                referencePoints
+                    .groupBy { it.intersectType }
+                    .let { byIntersect ->
+                        Triple(
+                            byIntersect[WITHIN] ?: emptyList(),
+                            byIntersect[BEFORE]?.map {
+                                it to KmPostRejectedReason.INTERSECTS_BEFORE_REFERENCE_LINE
+                            } ?: emptyList(),
+                            byIntersect[AFTER]?.map {
+                                it to KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE
+                            } ?: emptyList())
+                    }
+
+            val invalidIndex =
+                withinPoints
+                    .zipWithNext { a, b -> abs(b.distance - a.distance) }
+                    .let { distances -> distances.indexOfFirst { !TrackMeter.isMetersValid(it) } }
+
+            val (validPoints, invalidPoints) =
+                if (invalidIndex == -1) withinPoints to emptyList()
+                else {
+                    val idx = invalidIndex + 1
+                    withinPoints.take(idx) to
+                        listOf(withinPoints[idx] to KmPostRejectedReason.TOO_FAR_APART)
                 }
 
-            val invalidIndex = withinPoints.zipWithNext { a, b -> abs(b.distance - a.distance) }
-                .let { distances -> distances.indexOfFirst { !TrackMeter.isMetersValid(it) } }
+            val rejectedKmPosts =
+                (beforePoints + afterPoints + invalidPoints).map { (rp, reason) ->
+                    val kp = kmPosts.first { k -> k.kmNumber == rp.kmNumber }
 
-            val (validPoints, invalidPoints) = if (invalidIndex == -1) withinPoints to emptyList()
-            else {
-                val idx = invalidIndex + 1
-                withinPoints.take(idx) to listOf(withinPoints[idx] to KmPostRejectedReason.TOO_FAR_APART)
-            }
-
-            val rejectedKmPosts = (beforePoints + afterPoints + invalidPoints).map { (rp, reason) ->
-                val kp = kmPosts.first { k -> k.kmNumber == rp.kmNumber }
-
-                KmPostWithRejectedReason(kp, reason)
-            }
+                    KmPostWithRejectedReason(kp, reason)
+                }
 
             return validPoints.distinctBy { it.distance } to rejectedKmPosts
         }
 
-        private fun toReferencePoint(location: IPoint, kmNumber: KmNumber, referenceLineGeometry: IAlignment) =
+        private fun toReferencePoint(
+            location: IPoint,
+            kmNumber: KmNumber,
+            referenceLineGeometry: IAlignment
+        ) =
             referenceLineGeometry.getClosestPointM(location)?.let { (distance, intersectType) ->
-                val pointOnLine = requireNotNull(referenceLineGeometry.getPointAtM(distance)) {
-                    "Couldn't resolve distance to point on reference line: not continuous?"
-                }
+                val pointOnLine =
+                    requireNotNull(referenceLineGeometry.getPointAtM(distance)) {
+                        "Couldn't resolve distance to point on reference line: not continuous?"
+                    }
 
                 GeocodingReferencePoint(
                     kmNumber = kmNumber,
@@ -339,18 +386,31 @@ data class GeocodingContext(
 
     fun getM(coordinate: IPoint) = referenceLineGeometry.getClosestPointM(coordinate)
 
-    fun getAddressAndM(coordinate: IPoint, addressDecimals: Int = DEFAULT_TRACK_METER_DECIMALS): AddressAndM? =
+    fun getAddressAndM(
+        coordinate: IPoint,
+        addressDecimals: Int = DEFAULT_TRACK_METER_DECIMALS
+    ): AddressAndM? =
         referenceLineGeometry.getClosestPointM(coordinate)?.let { (mValue, type) ->
-            getAddress(mValue, addressDecimals)?.let { address -> AddressAndM(address, mValue, type) }
+            getAddress(mValue, addressDecimals)?.let { address ->
+                AddressAndM(address, mValue, type)
+            }
         }
 
-    fun getAddress(coordinate: IPoint, decimals: Int = DEFAULT_TRACK_METER_DECIMALS): Pair<TrackMeter, IntersectType>? =
+    fun getAddress(
+        coordinate: IPoint,
+        decimals: Int = DEFAULT_TRACK_METER_DECIMALS
+    ): Pair<TrackMeter, IntersectType>? =
         getAddressAndM(coordinate, decimals)?.let { (address, _, type) -> address to type }
 
-    fun getAddress(targetDistance: Double, decimals: Int = DEFAULT_TRACK_METER_DECIMALS): TrackMeter? {
+    fun getAddress(
+        targetDistance: Double,
+        decimals: Int = DEFAULT_TRACK_METER_DECIMALS
+    ): TrackMeter? {
         val addressPoint = findPreviousPoint(targetDistance)
-        val meters = round(addressPoint.meters.toDouble() + targetDistance - addressPoint.distance, decimals)
-        return if (TrackMeter.isMetersValid(meters)) TrackMeter(addressPoint.kmNumber, meters) else null
+        val meters =
+            round(addressPoint.meters.toDouble() + targetDistance - addressPoint.distance, decimals)
+        return if (TrackMeter.isMetersValid(meters)) TrackMeter(addressPoint.kmNumber, meters)
+        else null
     }
 
     val referenceLineAddresses by lazy {
@@ -359,7 +419,10 @@ data class GeocodingContext(
         }
     }
 
-    private fun toAddressPoint(point: AlignmentPoint, decimals: Int = DEFAULT_TRACK_METER_DECIMALS) =
+    private fun toAddressPoint(
+        point: AlignmentPoint,
+        decimals: Int = DEFAULT_TRACK_METER_DECIMALS
+    ) =
         getAddress(point, decimals)?.let { (address, intersectType) ->
             AddressPoint(point, address) to intersectType
         }
@@ -368,9 +431,11 @@ data class GeocodingContext(
         val startPoint = alignment.start?.let(::toAddressPoint)
         val endPoint = alignment.end?.let(::toAddressPoint)
         return if (startPoint != null && endPoint != null) {
-            val midPoints = getMidPoints(
-                alignment, (startPoint.first.address + MIN_METER_LENGTH)..(endPoint.first.address - MIN_METER_LENGTH)
-            )
+            val midPoints =
+                getMidPoints(
+                    alignment,
+                    (startPoint.first.address + MIN_METER_LENGTH)..(endPoint.first.address -
+                            MIN_METER_LENGTH))
 
             AlignmentAddresses(
                 startPoint = startPoint.first,
@@ -387,15 +452,18 @@ data class GeocodingContext(
         val alignmentEnd = alignment.end
         val startAddress = alignmentStart?.let(::getAddress)?.first
         val endAddress = alignmentEnd?.let(::getAddress)?.first
-        return if (startAddress == null || endAddress == null || address !in startAddress..endAddress) {
+        return if (startAddress == null ||
+            endAddress == null ||
+            address !in startAddress..endAddress) {
             null
         } else if (startAddress.isSame(address)) {
             AddressPoint(alignmentStart, startAddress)
         } else if (endAddress.isSame(address)) {
             AddressPoint(alignmentEnd, endAddress)
-        } else getProjectionLine(address)?.let { projectionLine ->
-            getProjectedAddressPoint(projectionLine, alignment)
-        }
+        } else
+            getProjectionLine(address)?.let { projectionLine ->
+                getProjectedAddressPoint(projectionLine, alignment)
+            }
     }
 
     fun getStartAndEnd(alignment: IAlignment): AlignmentStartAndEnd {
@@ -404,31 +472,48 @@ data class GeocodingContext(
         return AlignmentStartAndEnd(startAddress?.first, endAddress?.first)
     }
 
-    private fun getMidPoints(alignment: IAlignment, range: ClosedRange<TrackMeter>): List<AddressPoint> {
-        val projectionLines = getSublistForRangeInOrderedList(projectionLines, range) { p, e -> p.address.compareTo(e) }
+    private fun getMidPoints(
+        alignment: IAlignment,
+        range: ClosedRange<TrackMeter>
+    ): List<AddressPoint> {
+        val projectionLines =
+            getSublistForRangeInOrderedList(projectionLines, range) { p, e ->
+                p.address.compareTo(e)
+            }
         return getProjectedAddressPoints(projectionLines, alignment)
     }
 
     fun getSwitchPoints(alignment: LayoutAlignment): List<AddressPoint> {
-        val locations = alignment.segments.flatMap { segment ->
-            listOfNotNull(
-                segment.startJointNumber?.let { segment.alignmentStart },
-                segment.endJointNumber?.let { segment.alignmentEnd },
-            )
-        }
-        return locations.mapNotNull { location: AlignmentPoint ->
-            getAddress(location, 3)?.let { (address) -> AddressPoint(location, address) }
-        }.distinctBy { addressPoint -> addressPoint.address }
+        val locations =
+            alignment.segments.flatMap { segment ->
+                listOfNotNull(
+                    segment.startJointNumber?.let { segment.alignmentStart },
+                    segment.endJointNumber?.let { segment.alignmentEnd },
+                )
+            }
+        return locations
+            .mapNotNull { location: AlignmentPoint ->
+                getAddress(location, 3)?.let { (address) -> AddressPoint(location, address) }
+            }
+            .distinctBy { addressPoint -> addressPoint.address }
     }
 
     private fun findPreviousPoint(targetDistance: Double): GeocodingReferencePoint {
-        val target = roundTo3Decimals(targetDistance) // Round to 1mm to work around small imprecision
-        if (target < BigDecimal.ZERO) throw GeocodingFailureException("Cannot geocode with negative distance")
-        return referencePoints.findLast { (_, _, distance: Double) -> roundTo3Decimals(distance) <= target }
-            ?: throw GeocodingFailureException("Target point is not withing the reference line length")
+        val target =
+            roundTo3Decimals(targetDistance) // Round to 1mm to work around small imprecision
+        if (target < BigDecimal.ZERO)
+            throw GeocodingFailureException("Cannot geocode with negative distance")
+        return referencePoints.findLast { (_, _, distance: Double) ->
+            roundTo3Decimals(distance) <= target
+        }
+            ?: throw GeocodingFailureException(
+                "Target point is not withing the reference line length")
     }
 
-    fun cutRangeByKms(range: ClosedRange<TrackMeter>, kms: Set<KmNumber>): List<ClosedRange<TrackMeter>> {
+    fun cutRangeByKms(
+        range: ClosedRange<TrackMeter>,
+        kms: Set<KmNumber>
+    ): List<ClosedRange<TrackMeter>> {
         if (projectionLines.isEmpty()) return listOf()
         val addressRanges = getKmRanges(kms).mapNotNull(::toAddressRange)
         return splitRange(range, addressRanges)
@@ -438,33 +523,42 @@ data class GeocodingContext(
         val ranges: MutableList<ClosedRange<KmNumber>> = mutableListOf()
         var currentRange: ClosedRange<KmNumber>? = null
         allKms.forEach { kmNumber ->
-            currentRange = if (kms.contains(kmNumber)) {
-                currentRange?.let { c -> c.start..kmNumber } ?: kmNumber..kmNumber
-            } else {
-                currentRange?.let(ranges::add)
-                null
-            }
+            currentRange =
+                if (kms.contains(kmNumber)) {
+                    currentRange?.let { c -> c.start..kmNumber } ?: kmNumber..kmNumber
+                } else {
+                    currentRange?.let(ranges::add)
+                    null
+                }
         }
         currentRange?.let(ranges::add)
         return ranges
     }
 
     /**
-     * Returns the inclusive range of addresses in the given range of km-numbers.
-     * Note: Since this is inclusive, it does not include decimal meters after the last even meter,
-     * even though such addresses can be calculated
+     * Returns the inclusive range of addresses in the given range of km-numbers. Note: Since this
+     * is inclusive, it does not include decimal meters after the last even meter, even though such
+     * addresses can be calculated
      */
     private fun toAddressRange(kmRange: ClosedRange<KmNumber>): ClosedRange<TrackMeter>? {
-        val startAddress = projectionLines.find { l -> l.address.kmNumber == kmRange.start }?.address
-        val endAddress = projectionLines.findLast { l -> l.address.kmNumber == kmRange.endInclusive }?.address
+        val startAddress =
+            projectionLines.find { l -> l.address.kmNumber == kmRange.start }?.address
+        val endAddress =
+            projectionLines.findLast { l -> l.address.kmNumber == kmRange.endInclusive }?.address
         return if (startAddress != null && endAddress != null) startAddress..endAddress else null
     }
 }
 
-fun splitRange(range: ClosedRange<TrackMeter>, splits: List<ClosedRange<TrackMeter>>): List<ClosedRange<TrackMeter>> =
+fun splitRange(
+    range: ClosedRange<TrackMeter>,
+    splits: List<ClosedRange<TrackMeter>>
+): List<ClosedRange<TrackMeter>> =
     splits.mapNotNull { allowedRange ->
-        if (range.start >= allowedRange.endInclusive || range.endInclusive <= allowedRange.start) null
-        else maxOf(range.start, allowedRange.start)..minOf(range.endInclusive, allowedRange.endInclusive)
+        if (range.start >= allowedRange.endInclusive || range.endInclusive <= allowedRange.start)
+            null
+        else
+            maxOf(range.start, allowedRange.start)..minOf(
+                    range.endInclusive, allowedRange.endInclusive)
     }
 
 fun <T, R : Comparable<R>> getSublistForRangeInOrderedList(
@@ -489,7 +583,8 @@ fun getProjectedAddressPoint(
 ): AddressPoint? {
     val segment = getCollisionSegment(projection.projection, alignment)
     val segmentEdges = segment?.let { s -> getPolyLineEdges(s, null, null) }
-    val edgeAndPortion = segmentEdges?.let { edges -> getIntersection(projection.projection, edges) }
+    val edgeAndPortion =
+        segmentEdges?.let { edges -> getIntersection(projection.projection, edges) }
     return edgeAndPortion?.let { (edge, portion) ->
         AddressPoint(
             point = edge.interpolateAlignmentPointAtPortion(portion),
@@ -518,7 +613,9 @@ fun getProjectedAddressPoints(
 
             WITHIN -> {
                 addressPoints.add(
-                    AddressPoint(edge.interpolateAlignmentPointAtPortion(intersection.segment1Portion), projection.address),
+                    AddressPoint(
+                        edge.interpolateAlignmentPointAtPortion(intersection.segment1Portion),
+                        projection.address),
                 )
                 projectionIndex += 1
             }
@@ -538,19 +635,22 @@ private fun createProjectionLines(
     val endDistance = edges.lastOrNull()?.endM ?: 0.0
     return addressPoints.flatMapIndexed { index: Int, point: GeocodingReferencePoint ->
         val minMeter = point.meters.setScale(0, RoundingMode.CEILING).toInt()
-        val maxDistance = (addressPoints.getOrNull(index + 1)?.distance?.minus(MIN_METER_LENGTH) ?: endDistance)
+        val maxDistance =
+            (addressPoints.getOrNull(index + 1)?.distance?.minus(MIN_METER_LENGTH) ?: endDistance)
         val maxMeter = (point.meters.toDouble() + maxDistance - point.distance).toInt()
 
         (minMeter..maxMeter step 1).map { meter ->
             val distance = point.distance + (meter.toDouble() - point.meters.toDouble())
-            val edge = findEdge(distance, edges) ?: throw GeocodingFailureException(
-                "Could not produce projection: " +
-                        "km=${point.kmNumber} m=$meter distance=$distance " +
-                        "endDistance=$endDistance refPointDistance=${point.distance} " +
-                        "minMeter=$minMeter maxMeter=$maxMeter maxDistance=$maxDistance" +
-                        "edges=${edges.filter { e -> e.startM in distance - 10.0..distance + 10.0 }}"
-            )
-            ProjectionLine(TrackMeter(point.kmNumber, meter), edge.crossSectionAt(distance), distance)
+            val edge =
+                findEdge(distance, edges)
+                    ?: throw GeocodingFailureException(
+                        "Could not produce projection: " +
+                            "km=${point.kmNumber} m=$meter distance=$distance " +
+                            "endDistance=$endDistance refPointDistance=${point.distance} " +
+                            "minMeter=$minMeter maxMeter=$maxMeter maxDistance=$maxDistance" +
+                            "edges=${edges.filter { e -> e.startM in distance - 10.0..distance + 10.0 }}")
+            ProjectionLine(
+                TrackMeter(point.kmNumber, meter), edge.crossSectionAt(distance), distance)
         }
     }
 }
@@ -563,46 +663,54 @@ private fun validateProjectionLines(
     val distanceRange = (1.0 - distanceDelta)..(1.0 + distanceDelta)
     return lines.filterIndexed { index, line ->
         val previous = lines.getOrNull(index - 1)
-        val distanceApprox = previous?.let { prev ->
-            if (prev.address.kmNumber == line.address.kmNumber) {
-                lineLength(prev.projection.start, line.projection.start)
-            } else null
-        }
-        val angleDiff = previous?.let { prev -> angleDiffRads(prev.projection.angle, line.projection.angle) }
+        val distanceApprox =
+            previous?.let { prev ->
+                if (prev.address.kmNumber == line.address.kmNumber) {
+                    lineLength(prev.projection.start, line.projection.start)
+                } else null
+            }
+        val angleDiff =
+            previous?.let { prev -> angleDiffRads(prev.projection.angle, line.projection.angle) }
         if (distanceApprox != null && distanceApprox !in distanceRange) {
             logger.warn(
-                "Projection lines at un-even intervals: " + "index=$index distance=$distanceApprox angleDiff=$angleDiff previous=$previous next=$line"
-            )
+                "Projection lines at un-even intervals: " +
+                    "index=$index distance=$distanceApprox angleDiff=$angleDiff previous=$previous next=$line")
         }
         if (angleDiff != null && angleDiff > angleDelta) {
             logger.error(
-                "Projection lines turn unexpectedly (filtering out projection): " + "index=$index distance=$distanceApprox angleDiff=$angleDiff previous=$previous next=$line"
-            )
+                "Projection lines turn unexpectedly (filtering out projection): " +
+                    "index=$index distance=$distanceApprox angleDiff=$angleDiff previous=$previous next=$line")
         }
         (angleDiff == null || angleDiff <= angleDelta)
     }
 }
 
 private fun getCollisionSegment(projection: Line, alignment: IAlignment): ISegment? {
-    return alignment.segments.mapNotNull { s ->
-        val intersection = lineIntersection(s.segmentStart, s.segmentEnd, projection.start, projection.end)
-        if (intersection?.inSegment1 == WITHIN) intersection.relativeDistance2 to s else null
-    }.minByOrNull { (distance, _) -> distance }?.second
+    return alignment.segments
+        .mapNotNull { s ->
+            val intersection =
+                lineIntersection(s.segmentStart, s.segmentEnd, projection.start, projection.end)
+            if (intersection?.inSegment1 == WITHIN) intersection.relativeDistance2 to s else null
+        }
+        .minByOrNull { (distance, _) -> distance }
+        ?.second
 }
 
 fun getIntersection(projection: Line, edges: List<PolyLineEdge>): Pair<PolyLineEdge, Double>? {
     var intersection: Intersection? = null
-    val collisionEdge = edges.getOrNull(edges.binarySearch { edge ->
-        val edgeIntersection = intersection(edge, projection)
-        when (edgeIntersection.inSegment1) {
-            BEFORE -> 1
-            AFTER -> -1
-            else -> {
-                intersection = edgeIntersection
-                0
-            }
-        }
-    })
+    val collisionEdge =
+        edges.getOrNull(
+            edges.binarySearch { edge ->
+                val edgeIntersection = intersection(edge, projection)
+                when (edgeIntersection.inSegment1) {
+                    BEFORE -> 1
+                    AFTER -> -1
+                    else -> {
+                        intersection = edgeIntersection
+                        0
+                    }
+                }
+            })
     return if (collisionEdge != null) {
         intersection?.let { i -> collisionEdge to i.segment1Portion }
     } else {
@@ -611,35 +719,45 @@ fun getIntersection(projection: Line, edges: List<PolyLineEdge>): Pair<PolyLineE
 }
 
 private fun getPolyLineEdges(alignment: IAlignment): List<PolyLineEdge> {
-    return alignment.segments.flatMapIndexed { index, segment ->
-        getPolyLineEdges(
-            segment,
-            alignment.segments.getOrNull(index - 1)?.endDirection,
-            alignment.segments.getOrNull(index + 1)?.startDirection,
-        )
-    }.also { edges ->
-        edges.forEachIndexed { index, edge ->
-            val prev = edges.getOrNull(index-1)
-            if (prev != null) require(prev.endM == edge.startM) { "Edges not continuous: edges=$edges" }
+    return alignment.segments
+        .flatMapIndexed { index, segment ->
+            getPolyLineEdges(
+                segment,
+                alignment.segments.getOrNull(index - 1)?.endDirection,
+                alignment.segments.getOrNull(index + 1)?.startDirection,
+            )
         }
-    }
+        .also { edges ->
+            edges.forEachIndexed { index, edge ->
+                val prev = edges.getOrNull(index - 1)
+                if (prev != null)
+                    require(prev.endM == edge.startM) { "Edges not continuous: edges=$edges" }
+            }
+        }
 }
 
-private fun getPolyLineEdges(segment: ISegment, prevDir: Double?, nextDir: Double?): List<PolyLineEdge> {
+private fun getPolyLineEdges(
+    segment: ISegment,
+    prevDir: Double?,
+    nextDir: Double?
+): List<PolyLineEdge> {
     return segment.segmentPoints.mapIndexedNotNull { pointIndex: Int, point: SegmentPoint ->
         if (pointIndex == 0) null
         else {
             val previous = segment.segmentPoints[pointIndex - 1]
             // Direction for projection lines from the edge: 90 degrees turned from own direction
-            val pointDirection = if (segment.source != GeometrySource.GENERATED) {
-                directionBetweenPoints(previous, point)
-            } else if (prevDir == null || nextDir == null) {
-                // Generated connection segments can have a sideways offset, but the real line doesn't
-                // change direction. To compensate, we want to project with the direction of previous/next segments
-                prevDir ?: nextDir ?: directionBetweenPoints(previous, point)
-            } else {
-                angleAvgRads(prevDir, nextDir)
-            }
+            val pointDirection =
+                if (segment.source != GeometrySource.GENERATED) {
+                    directionBetweenPoints(previous, point)
+                } else if (prevDir == null || nextDir == null) {
+                    // Generated connection segments can have a sideways offset, but the real line
+                    // doesn't
+                    // change direction. To compensate, we want to project with the direction of
+                    // previous/next segments
+                    prevDir ?: nextDir ?: directionBetweenPoints(previous, point)
+                } else {
+                    angleAvgRads(prevDir, nextDir)
+                }
             val direction = PI / 2 + pointDirection
             PolyLineEdge(previous, point, segment.startM, direction)
         }
@@ -647,20 +765,24 @@ private fun getPolyLineEdges(segment: ISegment, prevDir: Double?, nextDir: Doubl
 }
 
 /**
- * Since segment start distance and m-values are stored with a limited precision, allow finding
- * a segment with that much delta-value. Otherwise, it's possible to get a distance-value "between segments"
+ * Since segment start distance and m-values are stored with a limited precision, allow finding a
+ * segment with that much delta-value. Otherwise, it's possible to get a distance-value "between
+ * segments"
  */
-private fun findEdge(distance: Double, all: List<PolyLineEdge>, delta: Double = 0.000001): PolyLineEdge? =
-    all.getOrNull(all.binarySearch { edge ->
-        if (edge.startM > distance + delta) 1
-        else if (edge.endM < distance - delta) -1
-        else 0
-    })
+private fun findEdge(
+    distance: Double,
+    all: List<PolyLineEdge>,
+    delta: Double = 0.000001
+): PolyLineEdge? =
+    all.getOrNull(
+        all.binarySearch { edge ->
+            if (edge.startM > distance + delta) 1 else if (edge.endM < distance - delta) -1 else 0
+        })
 
 private fun intersection(edge: PolyLineEdge, projection: Line) =
-    lineIntersection(edge.start, edge.end, projection.start, projection.end) ?: throw GeocodingFailureException(
-        "Projection line parallel to segment: edge=${edge.start}-${edge.end} projection=${projection.start}-${projection.end}"
-    )
+    lineIntersection(edge.start, edge.end, projection.start, projection.end)
+        ?: throw GeocodingFailureException(
+            "Projection line parallel to segment: edge=${edge.start}-${edge.end} projection=${projection.start}-${projection.end}")
 
 const val PROJECTION_LINE_LENGTH = 100.0
 
@@ -670,24 +792,30 @@ data class PolyLineEdge(
     val segmentStart: Double,
     val projectionDirection: Double,
 ) {
-    val startM: Double get() = start.m + segmentStart
-    val endM: Double get() = end.m + segmentStart
-    val length: Double get() = end.m - start.m
+    val startM: Double
+        get() = start.m + segmentStart
 
-    fun crossSectionAt(distance: Double) = interpolatePointAtM(distance).let { point ->
-        Line(point, pointInDirection(point, distance = PROJECTION_LINE_LENGTH, direction = projectionDirection))
-    }
+    val endM: Double
+        get() = end.m + segmentStart
+
+    val length: Double
+        get() = end.m - start.m
+
+    fun crossSectionAt(distance: Double) =
+        interpolatePointAtM(distance).let { point ->
+            Line(
+                point,
+                pointInDirection(
+                    point, distance = PROJECTION_LINE_LENGTH, direction = projectionDirection))
+        }
 
     private fun interpolatePointAtM(m: Double): IPoint =
         if (m <= startM) start
-        else if (m >= endM) end
-        else interpolate(start, end, (m - startM) / length)
+        else if (m >= endM) end else interpolate(start, end, (m - startM) / length)
 
     fun interpolateAlignmentPointAtPortion(portion: Double): AlignmentPoint =
         interpolateSegmentPointAtPortion(portion).toAlignmentPoint(segmentStart)
 
     fun interpolateSegmentPointAtPortion(portion: Double): SegmentPoint =
-        if (portion <= 0.0) start
-        else if (portion >= 1.0) end
-        else interpolate(start, end, portion)
+        if (portion <= 0.0) start else if (portion >= 1.0) end else interpolate(start, end, portion)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
@@ -36,7 +36,8 @@ class GeocodingController(
         @RequestParam("coordinate") coordinate: Point,
     ): ResponseEntity<TrackMeter> {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        return toResponse(geocodingService.getAddressIfWithin(layoutContext, trackNumberId, coordinate))
+        return toResponse(
+            geocodingService.getAddressIfWithin(layoutContext, trackNumberId, coordinate))
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT)
@@ -48,7 +49,8 @@ class GeocodingController(
         @RequestParam("address") address: TrackMeter,
     ): ResponseEntity<AddressPoint> {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        return toResponse(locationTrackService.getTrackPoint(layoutContext, locationTrackId, address))
+        return toResponse(
+            locationTrackService.getTrackPoint(layoutContext, locationTrackId, address))
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
@@ -22,12 +22,12 @@ import fi.fta.geoviite.infra.util.getLayoutRowVersionOrNull
 import fi.fta.geoviite.infra.util.getOptional
 import fi.fta.geoviite.infra.util.queryNotNull
 import fi.fta.geoviite.infra.util.queryOptional
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Transactional(readOnly = true)
 @Component
@@ -40,21 +40,25 @@ class GeocodingDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
 ) : DaoBase(jdbcTemplateParam) {
 
-    fun listLayoutGeocodingContextCacheKeys(layoutContext: LayoutContext): List<LayoutGeocodingContextCacheKey> =
+    fun listLayoutGeocodingContextCacheKeys(
+        layoutContext: LayoutContext
+    ): List<LayoutGeocodingContextCacheKey> =
         getLayoutGeocodingContextCacheKeysInternal(layoutContext, null)
 
     fun getLayoutGeocodingContextCacheKey(
         layoutContext: LayoutContext,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): LayoutGeocodingContextCacheKey? =
-        getOptional(trackNumberId, getLayoutGeocodingContextCacheKeysInternal(layoutContext, trackNumberId))
+        getOptional(
+            trackNumberId, getLayoutGeocodingContextCacheKeysInternal(layoutContext, trackNumberId))
 
     private fun getLayoutGeocodingContextCacheKeysInternal(
         layoutContext: LayoutContext,
         trackNumberId: IntId<TrackLayoutTrackNumber>?,
     ): List<LayoutGeocodingContextCacheKey> {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select
               tn.official_id as tn_official_id,
               tn.row_id as tn_row_id,
@@ -74,12 +78,14 @@ class GeocodingDao(
                 and kmp.state = 'IN_USE'
             where (:tn_id::int is null or :tn_id = tn.official_id)
             group by tn.official_id, tn.row_id, tn.row_version, rl.row_id, rl.row_version
-        """.trimIndent()
-        val params = mapOf(
-            "tn_id" to trackNumberId?.intValue,
-            "publication_state" to layoutContext.state.name,
-            "design_id" to layoutContext.branch.designId?.intValue,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "tn_id" to trackNumberId?.intValue,
+                "publication_state" to layoutContext.state.name,
+                "design_id" to layoutContext.branch.designId?.intValue,
+            )
         return jdbcTemplate.queryNotNull(sql, params) { rs, _ -> toGeocodingContextCacheKey(rs) }
     }
 
@@ -88,8 +94,9 @@ class GeocodingDao(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         moment: Instant,
     ): GeocodingContextCacheKey? {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             with 
               tn_versions as (
                 select distinct on (id) 
@@ -155,29 +162,34 @@ class GeocodingDao(
               left join rl on true 
               left join kmp on true
             group by tn.official_id, tn.id, tn.version, rl.id, rl.version
-        """.trimIndent()
-        val params = mapOf(
-            "tn_id" to trackNumberId.intValue,
-            "moment" to Timestamp.from(moment),
-            "design_id" to branch.designId?.intValue,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "tn_id" to trackNumberId.intValue,
+                "moment" to Timestamp.from(moment),
+                "design_id" to branch.designId?.intValue,
+            )
         return jdbcTemplate.queryOptional(sql, params) { rs, _ -> toGeocodingContextCacheKey(rs) }
     }
 
     private fun toGeocodingContextCacheKey(rs: ResultSet): LayoutGeocodingContextCacheKey? {
-        val tnVersion = rs.getLayoutRowVersionOrNull<TrackLayoutTrackNumber>("tn_row_id", "tn_row_version")
+        val tnVersion =
+            rs.getLayoutRowVersionOrNull<TrackLayoutTrackNumber>("tn_row_id", "tn_row_version")
         val rlVersion = rs.getLayoutRowVersionOrNull<ReferenceLine>("rl_row_id", "rl_row_version")
         return if (tnVersion == null || rlVersion == null) {
             null
-        } else LayoutGeocodingContextCacheKey(
-            trackNumberId = rs.getIntId("tn_official_id"),
-            trackNumberVersion = tnVersion,
-            referenceLineVersion = rlVersion,
-            kmPostVersions = toLayoutRowVersions(
-                ids = rs.getLayoutRowIdArray("kmp_row_ids"),
-                versions = rs.getIntArrayOrNull("kmp_row_versions") ?: listOf(),
-            ),
-        )
+        } else
+            LayoutGeocodingContextCacheKey(
+                trackNumberId = rs.getIntId("tn_official_id"),
+                trackNumberVersion = tnVersion,
+                referenceLineVersion = rlVersion,
+                kmPostVersions =
+                    toLayoutRowVersions(
+                        ids = rs.getLayoutRowIdArray("kmp_row_ids"),
+                        versions = rs.getIntArrayOrNull("kmp_row_versions") ?: listOf(),
+                    ),
+            )
     }
 
     fun getLayoutGeocodingContextCacheKey(
@@ -186,31 +198,47 @@ class GeocodingDao(
     ): GeocodingContextCacheKey? {
         val official = getLayoutGeocodingContextCacheKey(versions.branch.official, trackNumberId)
         val trackNumberVersion =
-            versions.findTrackNumber(trackNumberId)?.validatedAssetVersion ?: official?.trackNumberVersion
+            versions.findTrackNumber(trackNumberId)?.validatedAssetVersion
+                ?: official?.trackNumberVersion
         // We have to fetch the actual objects (reference line & km-post) here to check references
-        // However, when this is done, the objects are needed elsewhere as well -> they should always be in cache
-        val referenceLineVersion = versions.referenceLines
-            .find { v -> referenceLineDao.fetch(v.validatedAssetVersion).trackNumberId == trackNumberId }
-            ?.validatedAssetVersion
-            ?: official?.referenceLineVersion
+        // However, when this is done, the objects are needed elsewhere as well -> they should
+        // always be in cache
+        val referenceLineVersion =
+            versions.referenceLines
+                .find { v ->
+                    referenceLineDao.fetch(v.validatedAssetVersion).trackNumberId == trackNumberId
+                }
+                ?.validatedAssetVersion ?: official?.referenceLineVersion
         return if (trackNumberVersion != null && referenceLineVersion != null) {
-            val mainOrDesignOfficialRowIdsWithDraftKmPosts = versions.kmPosts
-                .map { v -> kmPostDao.fetch(v.validatedAssetVersion) }
-                .flatMap { draft -> listOfNotNull(draft.contextData.designRowId, draft.contextData.officialRowId) }
-            val officialKmPosts = official
-                ?.kmPostVersions
-                ?.filter { v -> !mainOrDesignOfficialRowIdsWithDraftKmPosts.contains(v.rowId) }
-                ?: listOf()
-            val draftKmPosts = versions.kmPosts.filter { draftPost ->
-                val draft = kmPostDao.fetch(draftPost.validatedAssetVersion)
-                draft.trackNumberId == trackNumberId && draft.state == LayoutState.IN_USE
-            }.map { v -> v.validatedAssetVersion }
+            val mainOrDesignOfficialRowIdsWithDraftKmPosts =
+                versions.kmPosts
+                    .map { v -> kmPostDao.fetch(v.validatedAssetVersion) }
+                    .flatMap { draft ->
+                        listOfNotNull(
+                            draft.contextData.designRowId, draft.contextData.officialRowId)
+                    }
+            val officialKmPosts =
+                official?.kmPostVersions?.filter { v ->
+                    !mainOrDesignOfficialRowIdsWithDraftKmPosts.contains(v.rowId)
+                } ?: listOf()
+            val draftKmPosts =
+                versions.kmPosts
+                    .filter { draftPost ->
+                        val draft = kmPostDao.fetch(draftPost.validatedAssetVersion)
+                        draft.trackNumberId == trackNumberId && draft.state == LayoutState.IN_USE
+                    }
+                    .map { v -> v.validatedAssetVersion }
             val kmPostVersions = (officialKmPosts + draftKmPosts).sortedBy { p -> p.rowId.intValue }
-            LayoutGeocodingContextCacheKey(trackNumberId, trackNumberVersion, referenceLineVersion, kmPostVersions)
+            LayoutGeocodingContextCacheKey(
+                trackNumberId, trackNumberVersion, referenceLineVersion, kmPostVersions)
         } else null
     }
 
-    private fun <T> toLayoutRowVersions(ids: List<LayoutRowId<T>>, versions: List<Int>) = ids
-        .also { check(it.size == versions.size) { "Unmatched row-versions: ids=$ids versions=$versions" } }
-        .mapIndexed { index, id -> LayoutRowVersion(id, versions[index]) }
+    private fun <T> toLayoutRowVersions(ids: List<LayoutRowId<T>>, versions: List<Int>) =
+        ids.also {
+                check(it.size == versions.size) {
+                    "Unmatched row-versions: ids=$ids versions=$versions"
+                }
+            }
+            .mapIndexed { index, id -> LayoutRowVersion(id, versions[index]) }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -17,8 +17,8 @@ import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
-import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import org.springframework.transaction.annotation.Transactional
 
 @GeoviiteService
 class GeocodingService(
@@ -40,7 +40,8 @@ class GeocodingService(
         contextKey: GeocodingContextCacheKey,
         alignmentVersion: RowVersion<LayoutAlignment>,
     ): AlignmentAddresses? {
-        return addressPointsCache.getAddressPoints(AddressPointCacheKey(alignmentVersion, contextKey))
+        return addressPointsCache.getAddressPoints(
+            AddressPointCacheKey(alignmentVersion, contextKey))
     }
 
     fun getAddress(
@@ -56,9 +57,10 @@ class GeocodingService(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         location: IPoint,
     ): TrackMeter? {
-        return getGeocodingContext(layoutContext, trackNumberId)
-            ?.getAddress(location)
-            ?.let { (address, intersect) -> if (intersect != WITHIN) null else address }
+        return getGeocodingContext(layoutContext, trackNumberId)?.getAddress(location)?.let {
+            (address, intersect) ->
+            if (intersect != WITHIN) null else address
+        }
     }
 
     fun getLocationTrackStartAndEnd(
@@ -66,7 +68,8 @@ class GeocodingService(
         locationTrack: LocationTrack,
         alignment: LayoutAlignment,
     ): AlignmentStartAndEnd? {
-        return getGeocodingContext(layoutContext, locationTrack.trackNumberId)?.getStartAndEnd(alignment)
+        return getGeocodingContext(layoutContext, locationTrack.trackNumberId)
+            ?.getStartAndEnd(alignment)
     }
 
     fun getReferenceLineStartAndEnd(
@@ -74,7 +77,8 @@ class GeocodingService(
         referenceLine: ReferenceLine,
         alignment: LayoutAlignment,
     ): AlignmentStartAndEnd? {
-        return getGeocodingContext(layoutContext, referenceLine.trackNumberId)?.getStartAndEnd(alignment)
+        return getGeocodingContext(layoutContext, referenceLine.trackNumberId)
+            ?.getStartAndEnd(alignment)
     }
 
     fun getTrackLocation(
@@ -83,19 +87,23 @@ class GeocodingService(
         alignment: LayoutAlignment,
         address: TrackMeter,
     ): AddressPoint? {
-        return getGeocodingContext(layoutContext, locationTrack.trackNumberId)?.getTrackLocation(alignment, address)
+        return getGeocodingContext(layoutContext, locationTrack.trackNumberId)
+            ?.getTrackLocation(alignment, address)
     }
 
     @Transactional(readOnly = true)
-    fun getGeocodingContexts(layoutContext: LayoutContext): Map<IntId<TrackLayoutTrackNumber>, GeocodingContext?> =
-        geocodingDao
-            .listLayoutGeocodingContextCacheKeys(layoutContext)
-            .associate { key -> key.trackNumberId to geocodingCacheService.getGeocodingContext(key) }
+    fun getGeocodingContexts(
+        layoutContext: LayoutContext
+    ): Map<IntId<TrackLayoutTrackNumber>, GeocodingContext?> =
+        geocodingDao.listLayoutGeocodingContextCacheKeys(layoutContext).associate { key ->
+            key.trackNumberId to geocodingCacheService.getGeocodingContext(key)
+        }
 
     fun getGeocodingContext(
         layoutContext: LayoutContext,
         trackNumberId: DomainId<TrackLayoutTrackNumber>?,
-    ): GeocodingContext? = if (trackNumberId is IntId) getGeocodingContext(layoutContext, trackNumberId) else null
+    ): GeocodingContext? =
+        if (trackNumberId is IntId) getGeocodingContext(layoutContext, trackNumberId) else null
 
     fun getGeocodingContext(geocodingContextCacheKey: GeocodingContextCacheKey) =
         geocodingCacheService.getGeocodingContext(geocodingContextCacheKey)
@@ -103,7 +111,8 @@ class GeocodingService(
     fun getGeocodingContext(
         layoutContext: LayoutContext,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
-    ): GeocodingContext? = getGeocodingContextCreateResult(layoutContext, trackNumberId)?.geocodingContext
+    ): GeocodingContext? =
+        getGeocodingContextCreateResult(layoutContext, trackNumberId)?.geocodingContext
 
     fun getGeocodingContextCreateResult(
         layoutContext: LayoutContext,
@@ -126,16 +135,19 @@ class GeocodingService(
     fun getGeocodingContextCacheKey(
         layoutContext: LayoutContext,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
-    ): LayoutGeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(layoutContext, trackNumberId)
+    ): LayoutGeocodingContextCacheKey? =
+        geocodingDao.getLayoutGeocodingContextCacheKey(layoutContext, trackNumberId)
 
     fun getGeocodingContextCacheKey(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         versions: ValidationVersions,
-    ): GeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(trackNumberId, versions)
+    ): GeocodingContextCacheKey? =
+        geocodingDao.getLayoutGeocodingContextCacheKey(trackNumberId, versions)
 
     fun getGeocodingContextCacheKey(
         branch: LayoutBranch,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         moment: Instant,
-    ): GeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(branch, trackNumberId, moment)
+    ): GeocodingContextCacheKey? =
+        geocodingDao.getLayoutGeocodingContextCacheKey(branch, trackNumberId, moment)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CommonSrid.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CommonSrid.kt
@@ -54,4 +54,5 @@ val geoviiteDefaultSrids by lazy {
         KKJ5_SRID,
     )
 }
+
 fun isGkFinSrid(srid: Srid) = srid.code in 3873..3885

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateSystem.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateSystem.kt
@@ -15,18 +15,26 @@ data class CoordinateSystem(
 val csNameLength = 1..100
 val csNameRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 _\\-/(),]+\$")
 
-data class CoordinateSystemName @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : CharSequence by value {
-    init { assertSanitized<CoordinateSystemName>(value, csNameRegex, csNameLength, allowBlank = false) }
+data class CoordinateSystemName
+@JsonCreator(mode = DELEGATING)
+constructor(private val value: String) : CharSequence by value {
+    init {
+        assertSanitized<CoordinateSystemName>(value, csNameRegex, csNameLength, allowBlank = false)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     fun uppercase(): CoordinateSystemName = CoordinateSystemName(value.uppercase())
 }
 
-fun mapByNameOrAlias(coordinateSystems: List<CoordinateSystem>) = coordinateSystems
-    .flatMap { cs ->
-        val allNames = cs.aliases + cs.aliases.map(CoordinateSystemName::uppercase) + cs.name + cs.name.uppercase()
-        allNames.distinct().map { name -> name to cs.srid }
-    }
-    .associate { it }
+fun mapByNameOrAlias(coordinateSystems: List<CoordinateSystem>) =
+    coordinateSystems
+        .flatMap { cs ->
+            val allNames =
+                cs.aliases +
+                    cs.aliases.map(CoordinateSystemName::uppercase) +
+                    cs.name +
+                    cs.name.uppercase()
+            allNames.distinct().map { name -> name to cs.srid }
+        }
+        .associate { it }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationService.kt
@@ -8,14 +8,15 @@ import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import java.util.concurrent.ConcurrentHashMap
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem
 import org.geotools.api.referencing.operation.MathTransform
 import org.geotools.geometry.jts.JTS
 import org.geotools.referencing.CRS
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.concurrent.ConcurrentHashMap
 
-data class Transformation private constructor(
+data class Transformation
+private constructor(
     val sourceSrid: Srid,
     val targetSrid: Srid,
     val kkjToEtrsTriangulationNetwork: RTree<KkjTm35finTriangle, Rectangle>?,
@@ -26,39 +27,58 @@ data class Transformation private constructor(
     private val math: MathTransform by lazy { CRS.findMathTransform(sourceCrs, targetCrs) }
 
     companion object {
-        fun possiblyTriangulableTransform(sourceSrid: Srid, targetSrid: Srid, ykjEtrsTriangles: RTree<KkjTm35finTriangle, Rectangle>, etrsYkjTriangles: RTree<KkjTm35finTriangle, Rectangle>) =
-            Transformation(sourceSrid, targetSrid, ykjEtrsTriangles, etrsYkjTriangles)
+        fun possiblyTriangulableTransform(
+            sourceSrid: Srid,
+            targetSrid: Srid,
+            ykjEtrsTriangles: RTree<KkjTm35finTriangle, Rectangle>,
+            etrsYkjTriangles: RTree<KkjTm35finTriangle, Rectangle>
+        ) = Transformation(sourceSrid, targetSrid, ykjEtrsTriangles, etrsYkjTriangles)
 
         fun nonTriangulableTransform(sourceSrid: Srid, targetSrid: Srid) =
-            Transformation(sourceSrid, targetSrid, kkjToEtrsTriangulationNetwork = null, etrsToKkjTriangulationNetwork = null)
+            Transformation(
+                sourceSrid,
+                targetSrid,
+                kkjToEtrsTriangulationNetwork = null,
+                etrsToKkjTriangulationNetwork = null)
     }
 
     init {
-        require((kkjToEtrsTriangulationNetwork != null && !kkjToEtrsTriangulationNetwork.isEmpty) || !isKKJ(sourceSrid) || targetSrid != LAYOUT_SRID) {
-            "Trying to convert from KKJx ($sourceSrid) to $targetSrid without triangulation network"
-        }
+        require(
+            (kkjToEtrsTriangulationNetwork != null && !kkjToEtrsTriangulationNetwork.isEmpty) ||
+                !isKKJ(sourceSrid) ||
+                targetSrid != LAYOUT_SRID) {
+                "Trying to convert from KKJx ($sourceSrid) to $targetSrid without triangulation network"
+            }
     }
 
     fun transform(point: IPoint): Point {
         try {
             // Intercept transforms from KKJx to ETRS
-            return if (kkjToEtrsTriangulationNetwork != null && !kkjToEtrsTriangulationNetwork.isEmpty && isKKJ(sourceSrid) && targetSrid == LAYOUT_SRID) {
+            return if (kkjToEtrsTriangulationNetwork != null &&
+                !kkjToEtrsTriangulationNetwork.isEmpty &&
+                isKKJ(sourceSrid) &&
+                targetSrid == LAYOUT_SRID) {
                 val ykjPoint = transformKkjToYkjAndNormalizeAxes(point)
-                val triangle = kkjToEtrsTriangulationNetwork
-                    .search(Geometries.point(ykjPoint.x, ykjPoint.y))
-                    .find { it.value().intersects(ykjPoint) }
-                    ?.value()
+                val triangle =
+                    kkjToEtrsTriangulationNetwork
+                        .search(Geometries.point(ykjPoint.x, ykjPoint.y))
+                        .find { it.value().intersects(ykjPoint) }
+                        ?.value()
 
                 requireNotNull(triangle) {
                     "Point was not inside the triangulation network: point=$point ykjPoint=$ykjPoint"
                 }
                 transformPointInTriangle(ykjPoint, targetCrs, triangle)
-            } else if (etrsToKkjTriangulationNetwork != null && !etrsToKkjTriangulationNetwork.isEmpty && sourceSrid == LAYOUT_SRID && isKKJ(targetSrid)) {
+            } else if (etrsToKkjTriangulationNetwork != null &&
+                !etrsToKkjTriangulationNetwork.isEmpty &&
+                sourceSrid == LAYOUT_SRID &&
+                isKKJ(targetSrid)) {
                 val jtsPoint = toJtsPoint(point, crs(sourceSrid))
-                val triangle = etrsToKkjTriangulationNetwork
-                    .search(Geometries.point(point.x, point.y))
-                    .find { it.value().intersects(jtsPoint) }
-                    ?.value()
+                val triangle =
+                    etrsToKkjTriangulationNetwork
+                        .search(Geometries.point(point.x, point.y))
+                        .find { it.value().intersects(jtsPoint) }
+                        ?.value()
 
                 requireNotNull(triangle) {
                     "Point was not inside the triangulation network: point=$point"
@@ -67,7 +87,8 @@ data class Transformation private constructor(
                 toGvtPoint(transformYkjToKkjAndNormalizeAxes(ykjPoint), targetCrs)
             } else {
                 val jtsPoint = toJtsPoint(point, sourceCrs)
-                val jtsPointTransformed = JTS.transform(jtsPoint, math) as org.locationtech.jts.geom.Point
+                val jtsPointTransformed =
+                    JTS.transform(jtsPoint, math) as org.locationtech.jts.geom.Point
                 toGvtPoint(jtsPointTransformed, targetCrs)
             }
         } catch (e: Exception) {
@@ -78,20 +99,22 @@ data class Transformation private constructor(
     private fun transformKkjToYkjAndNormalizeAxes(point: IPoint): org.locationtech.jts.geom.Point {
         // Geotools is accurate enough for transformations between KKJx and YKJ, so use it for those
         val kkjToYkj = nonTriangulableTransform(sourceSrid, KKJ3_YKJ_SRID)
-        return JTS.transform(toJtsPoint(point, sourceCrs), kkjToYkj.math) as org.locationtech.jts.geom.Point
+        return JTS.transform(toJtsPoint(point, sourceCrs), kkjToYkj.math)
+            as org.locationtech.jts.geom.Point
     }
 
     private fun transformYkjToKkjAndNormalizeAxes(point: IPoint): org.locationtech.jts.geom.Point {
         // Geotools is accurate enough for transformations between KKJx and YKJ, so use it for those
         val ykjToKkj = nonTriangulableTransform(KKJ3_YKJ_SRID, targetSrid)
-        return JTS.transform(toJtsPoint(point, YKJ_CRS), ykjToKkj.math) as org.locationtech.jts.geom.Point
+        return JTS.transform(toJtsPoint(point, YKJ_CRS), ykjToKkj.math)
+            as org.locationtech.jts.geom.Point
     }
 }
 
 @GeoviiteService
-class CoordinateTransformationService @Autowired constructor(
-    private val kkjTm35FinTriangulationDao: KkjTm35finTriangulationDao
-) {
+class CoordinateTransformationService
+@Autowired
+constructor(private val kkjTm35FinTriangulationDao: KkjTm35finTriangulationDao) {
     private val transformations = ConcurrentHashMap<Pair<Srid, Srid>, Transformation>()
 
     fun getLayoutTransformation(sourceSrid: Srid) = getTransformation(sourceSrid, LAYOUT_SRID)
@@ -101,8 +124,10 @@ class CoordinateTransformationService @Autowired constructor(
             Transformation.possiblyTriangulableTransform(
                 sourceSrid,
                 targetSrid,
-                kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.KKJ_TO_TM35FIN),
-                kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.TM35FIN_TO_KKJ),
+                kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                    TriangulationDirection.KKJ_TO_TM35FIN),
+                kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                    TriangulationDirection.TM35FIN_TO_KKJ),
             )
         }
 
@@ -110,4 +135,5 @@ class CoordinateTransformationService @Autowired constructor(
         getTransformation(sourceSrid, targetSrid).transform(point)
 }
 
-fun isKKJ(srid: Srid) = listOf(KKJ0_SRID, KKJ1_SRID, KKJ2_SRID, KKJ3_YKJ_SRID, KKJ4_SRID, KKJ5_SRID).contains(srid)
+fun isKKJ(srid: Srid) =
+    listOf(KKJ0_SRID, KKJ1_SRID, KKJ2_SRID, KKJ3_YKJ_SRID, KKJ4_SRID, KKJ5_SRID).contains(srid)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
@@ -4,6 +4,8 @@ import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.util.logger
+import kotlin.concurrent.getOrSet
+import kotlin.math.round
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem
 import org.geotools.geometry.jts.JTS
 import org.geotools.geometry.jts.JTSFactoryFinder
@@ -14,18 +16,16 @@ import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.Polygon
 import org.locationtech.jts.geom.PrecisionModel
-import kotlin.concurrent.getOrSet
-import kotlin.math.round
 
 val FINNISH_GK_LONGITUDE_RANGE = 19..31
 
 /**
- * GeoTools will lazily intialize some classes, which can be an issue if the first invocation comes from a
- * thread in ForkJoinPool as they have a different classloader. To ensure that the classes are properly loaded,
- * call this method from the main thread before launching Geoviite.
+ * GeoTools will lazily intialize some classes, which can be an issue if the first invocation comes
+ * from a thread in ForkJoinPool as they have a different classloader. To ensure that the classes
+ * are properly loaded, call this method from the main thread before launching Geoviite.
  *
- * For details, see Spring issue: https://github.com/spring-projects/spring-boot/issues/39843
- * Also https://extranet.vayla.fi/jira/browse/GVT-2698 for more specifics on geoviite
+ * For details, see Spring issue: https://github.com/spring-projects/spring-boot/issues/39843 Also
+ * https://extranet.vayla.fi/jira/browse/GVT-2698 for more specifics on geoviite
  */
 fun initGeotools() {
     logger.info("Initializing GeoTools (preload default crs)")
@@ -36,10 +36,11 @@ fun transformNonKKJCoordinate(sourceSrid: Srid, targetSrid: Srid, point: IPoint)
     return Transformation.nonTriangulableTransform(sourceSrid, targetSrid).transform(point)
 }
 
-fun getFinnishGKCoordinateProjectionByLongitude(longitude:Double): Srid {
+fun getFinnishGKCoordinateProjectionByLongitude(longitude: Double): Srid {
     val nearestLongitude = round(longitude).toInt()
     if (!FINNISH_GK_LONGITUDE_RANGE.contains(nearestLongitude))
-        throw IllegalArgumentException("Cannot get Finnish GK coordinate projection by longitude $nearestLongitude")
+        throw IllegalArgumentException(
+            "Cannot get Finnish GK coordinate projection by longitude $nearestLongitude")
     val longitudeRelativeToGk19 = nearestLongitude - 19
     return Srid(FIN_GK19_SRID.code + longitudeRelativeToGk19)
 }
@@ -51,20 +52,20 @@ fun transformToGKCoordinate(sourceSrid: Srid, point: IPoint): GeometryPoint {
     val etrs89Coord = transformNonKKJCoordinate(sourceSrid, ETRS89_SRID, point)
     val gkSrid = getFinnishGKCoordinateProjectionByLongitude(etrs89Coord.x)
     val gkPoint = transformNonKKJCoordinate(sourceSrid, gkSrid, point)
-    return GeometryPoint(
-        gkPoint.x,
-        gkPoint.y,
-        gkSrid
-    )
+    return GeometryPoint(gkPoint.x, gkPoint.y, gkSrid)
 }
 
-fun calculateDistance(points: List<IPoint>, srid: Srid): Double = calculateDistance(points, crs(srid))
+fun calculateDistance(points: List<IPoint>, srid: Srid): Double =
+    calculateDistance(points, crs(srid))
 
-fun calculateDistance(srid: Srid, vararg points: IPoint): Double = calculateDistance(points.toList(), crs(srid))
+fun calculateDistance(srid: Srid, vararg points: IPoint): Double =
+    calculateDistance(points.toList(), crs(srid))
 
 private object GeodeticCalculatorCache {
     val cache: ThreadLocal<Map<CoordinateReferenceSystem, GeodeticCalculator>> = ThreadLocal()
-    fun get(crs: CoordinateReferenceSystem) = cache.getOrSet { HashMap() }.getOrElse(crs) { GeodeticCalculator(crs) }
+
+    fun get(crs: CoordinateReferenceSystem) =
+        cache.getOrSet { HashMap() }.getOrElse(crs) { GeodeticCalculator(crs) }
 }
 
 fun calculateDistance(points: List<IPoint>, ref: CoordinateReferenceSystem): Double {
@@ -72,7 +73,9 @@ fun calculateDistance(points: List<IPoint>, ref: CoordinateReferenceSystem): Dou
 
     val coordinates = points.map { toCoordinate(it, ref) }
     return coordinates
-        .mapIndexedNotNull { index, coordinate -> if (index == 0) null else listOf(coordinates[index - 1], coordinate) }
+        .mapIndexedNotNull { index, coordinate ->
+            if (index == 0) null else listOf(coordinates[index - 1], coordinate)
+        }
         .fold(0.0) { sum, coordinate ->
             gc.startingPosition = JTS.toDirectPosition(coordinate[0], ref)
             gc.destinationPosition = JTS.toDirectPosition(coordinate[1], ref)
@@ -81,12 +84,16 @@ fun calculateDistance(points: List<IPoint>, ref: CoordinateReferenceSystem): Dou
 }
 
 private val crsCache: MutableMap<Srid, CoordinateReferenceSystem> = mutableMapOf()
-fun crs(srid: Srid): CoordinateReferenceSystem = crsCache.getOrPut(srid) { CRS.decode(srid.toString()) }
+
+fun crs(srid: Srid): CoordinateReferenceSystem =
+    crsCache.getOrPut(srid) { CRS.decode(srid.toString()) }
 
 private val geometryFactory = JTSFactoryFinder.getGeometryFactory()
+
 fun toJtsPolygon(polygonPoints: List<IPoint>, ref: CoordinateReferenceSystem): Polygon? {
     val geometryPointList = polygonPoints.map { point -> toJtsPoint(point, ref) }
-    val geometryCollection = geometryFactory.createGeometryCollection(geometryPointList.toTypedArray()).coordinates
+    val geometryCollection =
+        geometryFactory.createGeometryCollection(geometryPointList.toTypedArray()).coordinates
     return geometryFactory.createPolygon(geometryCollection)
 }
 
@@ -107,7 +114,9 @@ fun toPoint(coordinate: Coordinate, ref: CoordinateReferenceSystem): Point {
     return when (val order = CRS.getAxisOrder(ref)) {
         CRS.AxisOrder.EAST_NORTH -> Point(coordinate.x, coordinate.y)
         CRS.AxisOrder.NORTH_EAST -> Point(coordinate.y, coordinate.x)
-        else -> throw CoordinateTransformationException(order, coordinate.x, coordinate.y, ref.name.code)
+        else ->
+            throw CoordinateTransformationException(
+                order, coordinate.x, coordinate.y, ref.name.code)
     }
 }
 
@@ -118,18 +127,29 @@ private fun toCoordinate(point: IPoint, ref: CoordinateReferenceSystem): Coordin
         else -> throw CoordinateTransformationException(order, point.x, point.y, ref.name.code)
     }
 
-fun boundingPolygonPointsByConvexHull(points: List<IPoint>, crs: CoordinateReferenceSystem): List<Point> {
+fun boundingPolygonPointsByConvexHull(
+    points: List<IPoint>,
+    crs: CoordinateReferenceSystem
+): List<Point> {
     val coordinates = points.map { p -> toCoordinate(p, crs) }.toTypedArray()
-    val geometryFactory = GeometryFactory(PrecisionModel(PrecisionModel.FLOATING), CRS.lookupEpsgCode(crs, false))
+    val geometryFactory =
+        GeometryFactory(PrecisionModel(PrecisionModel.FLOATING), CRS.lookupEpsgCode(crs, false))
     val convexHull = ConvexHull(coordinates, geometryFactory).convexHull
     return convexHull.coordinates.map { c -> toPoint(c, crs) }
 }
 
-class CoordinateTransformationException(message: String, cause: Throwable? = null) : Exception(message, cause) {
+class CoordinateTransformationException(message: String, cause: Throwable? = null) :
+    Exception(message, cause) {
 
-    constructor(point: IPoint, cause: Throwable? = null) :
-            this("Could not transform coordinate $point", cause)
+    constructor(
+        point: IPoint,
+        cause: Throwable? = null
+    ) : this("Could not transform coordinate $point", cause)
 
-    constructor(order: CRS.AxisOrder, x: Double, y: Double, crs: String) :
-            this("Cannot determine coordinate axis order x=$x y=$y crs=$crs order=$order")
+    constructor(
+        order: CRS.AxisOrder,
+        x: Double,
+        y: Double,
+        crs: String
+    ) : this("Cannot determine coordinate axis order x=$x y=$y crs=$crs order=$order")
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeographyService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeographyService.kt
@@ -17,7 +17,8 @@ class GeographyService(
     }
 
     /**
-     * Returns a mapping of application coordinate systems' names and aliases to their respective SRID code
+     * Returns a mapping of application coordinate systems' names and aliases to their respective
+     * SRID code
      */
     fun getCoordinateSystemNameToSridMapping(): Map<CoordinateSystemName, Srid> {
         return mapByNameOrAlias(coordinateSystemDao.fetchApplicationCoordinateSystems())

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeometryPoint.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeometryPoint.kt
@@ -2,8 +2,7 @@ package fi.fta.geoviite.infra.geography
 
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.math.IPoint
-import fi.fta.geoviite.infra.math.Point
 
 data class GeometryPoint(override val x: Double, override val y: Double, val srid: Srid) : IPoint {
-    constructor (point: IPoint, srid: Srid) : this(point.x, point.y, srid)
+    constructor(point: IPoint, srid: Srid) : this(point.x, point.y, srid)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTransformation.kt
@@ -5,7 +5,11 @@ import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.lineYAtX
 
-fun interpolateHeightAtGivenPoint(heightTriangle: HeightTriangle, point: IPoint, originalPointHeight: Double): Double {
+fun interpolateHeightAtGivenPoint(
+    heightTriangle: HeightTriangle,
+    point: IPoint,
+    originalPointHeight: Double
+): Double {
     val interpolationZ1 = lineYAtX(heightTriangle.corner1XZ, heightTriangle.corner2XZ, point.x)
     val interpolationPoint1 = Point(point.x, interpolationZ1)
     val interpolationZ = lineYAtX(interpolationPoint1, heightTriangle.corner3XZ, point.x)
@@ -24,10 +28,13 @@ fun transformHeightValue(
             val triangle = heightTriangles.find { t -> t.contains(point) }
             if (triangle != null) interpolateHeightAtGivenPoint(triangle, point, height)
             else {
-                fi.fta.geoviite.infra.inframodel.logger.error("triangles=$heightTriangles point=$point")
-                throw IllegalArgumentException("Could not transform height N60 -> N2000. Point not in any triangle.")
+                fi.fta.geoviite.infra.inframodel.logger.error(
+                    "triangles=$heightTriangles point=$point")
+                throw IllegalArgumentException(
+                    "Could not transform height N60 -> N2000. Point not in any triangle.")
             }
         }
-        VerticalCoordinateSystem.N43 -> throw IllegalArgumentException("N43 -> N2000 transformation not supported")
+        VerticalCoordinateSystem.N43 ->
+            throw IllegalArgumentException("N43 -> N2000 transformation not supported")
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTriangle.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTriangle.kt
@@ -9,10 +9,12 @@ data class HeightTriangle(
     val corner2: Point,
     val corner3: Point,
     val corner1Diff: Double,
-    val corner2Diff:Double,
-    val corner3Diff:Double
+    val corner2Diff: Double,
+    val corner3Diff: Double
 ) {
-    private val polygon by lazy { toJtsPolygon(listOf(corner1, corner2, corner3, corner1), LAYOUT_CRS) }
+    private val polygon by lazy {
+        toJtsPolygon(listOf(corner1, corner2, corner3, corner1), LAYOUT_CRS)
+    }
     val corner1XZ: Point by lazy { Point(corner1.x, corner1Diff) }
     val corner2XZ: Point by lazy { Point(corner2.x, corner2Diff) }
     val corner3XZ: Point by lazy { Point(corner3.x, corner3Diff) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTriangleDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTriangleDao.kt
@@ -15,10 +15,12 @@ import org.springframework.transaction.annotation.Transactional
 
 @Transactional(readOnly = true)
 @Component
-class HeightTriangleDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTemplateParam) {
+class HeightTriangleDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
+    DaoBase(jdbcTemplateParam) {
 
     fun fetchTriangles(boundingPolygon: List<Point>): List<HeightTriangle> {
-        val sql = """
+        val sql =
+            """
             select tn.coord1_id, 
                    t1.n2000 - t1.n60  as corner1_difference, 
                    postgis.st_x(t1.point_transformed) as x1, 
@@ -40,34 +42,38 @@ class HeightTriangleDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBas
               tn.polygon_transformed,
               postgis.st_polygonfromtext(:bounding_polygon, :srid)
             )  
-        """.trimIndent()
-        val params = mapOf(
-            "bounding_polygon" to create2DPolygonString(boundingPolygon),
-            "srid" to LAYOUT_SRID.code,
-        )
-
-        val triangles = jdbcTemplate.query(sql, params) { rs, _ ->
-            HeightTriangle(
-                corner1 = rs.getPoint("x1", "y1"),
-                corner2 = rs.getPoint("x2", "y2"),
-                corner3 = rs.getPoint("x3", "y3"),
-                corner1Diff = rs.getDouble("corner1_difference"),
-                corner2Diff = rs.getDouble("corner2_difference"),
-                corner3Diff = rs.getDouble("corner3_difference")
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "bounding_polygon" to create2DPolygonString(boundingPolygon),
+                "srid" to LAYOUT_SRID.code,
             )
-        }
+
+        val triangles =
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                HeightTriangle(
+                    corner1 = rs.getPoint("x1", "y1"),
+                    corner2 = rs.getPoint("x2", "y2"),
+                    corner3 = rs.getPoint("x3", "y3"),
+                    corner1Diff = rs.getDouble("corner1_difference"),
+                    corner2Diff = rs.getDouble("corner2_difference"),
+                    corner3Diff = rs.getDouble("corner3_difference"))
+            }
         logger.daoAccess(AccessType.FETCH, HeightTriangle::class)
         return triangles
     }
 
     fun fetchTriangulationNetworkBounds(): BoundingBox {
         logger.daoAccess(AccessType.FETCH, BoundingBox::class)
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select postgis.st_astext(postgis.st_extent(polygon_transformed)) bounds
             from common.n60_n2000_triangulation_network
-        """.trimIndent()
-        return jdbcTemplate.queryOne(sql, mapOf<String,Any>()) { rs, _ ->
+        """
+                .trimIndent()
+        return jdbcTemplate.queryOne(sql, mapOf<String, Any>()) { rs, _ ->
             boundingBoxAroundPoints(parse2DPolygon(rs.getString("bounds")))
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/KkjEtrsTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/KkjEtrsTransformation.kt
@@ -19,18 +19,22 @@ data class KkjTm35finTriangle(
     private val crs: CoordinateReferenceSystem,
 ) {
     val polygon by lazy {
-        toJtsPolygon(listOf(corner1, corner2, corner3, corner1), crs(KKJ3_YKJ_SRID)) // Last parameter just indicates which axis is which
-            ?: throw IllegalStateException("Failed to create polygon")
+        toJtsPolygon(
+            listOf(corner1, corner2, corner3, corner1),
+            crs(KKJ3_YKJ_SRID)) // Last parameter just indicates which axis is which
+        ?: throw IllegalStateException("Failed to create polygon")
     }
 
-    fun intersects(point: org.locationtech.jts.geom.Point): Boolean =
-        polygon.intersects(point)
+    fun intersects(point: org.locationtech.jts.geom.Point): Boolean = polygon.intersects(point)
 
-    fun intersects(poly: org.locationtech.jts.geom.Polygon): Boolean =
-        polygon.intersects(poly)
+    fun intersects(poly: org.locationtech.jts.geom.Polygon): Boolean = polygon.intersects(poly)
 }
 
-fun transformPointInTriangle(point: org.locationtech.jts.geom.Point, targetCrs: CoordinateReferenceSystem, triangle: KkjTm35finTriangle): Point {
+fun transformPointInTriangle(
+    point: org.locationtech.jts.geom.Point,
+    targetCrs: CoordinateReferenceSystem,
+    triangle: KkjTm35finTriangle
+): Point {
     val x = (triangle.a2 * point.y) + (triangle.a1 * point.x) + triangle.deltaE
     val y = (triangle.b2 * point.y) + (triangle.b1 * point.x) + triangle.deltaN
     return toPoint(Coordinate(x, y), targetCrs)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/KkjTm35finTriangulationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/KkjTm35finTriangulationDao.kt
@@ -19,8 +19,9 @@ enum class TriangulationDirection(val direction: String) {
     TM35FIN_TO_KKJ("TM35FIN_TO_KKJ"),
 }
 
-//language=SQL
-val KKJ_TO_TM35FIN_SQL = """
+// language=SQL
+val KKJ_TO_TM35FIN_SQL =
+    """
   select
     postgis.st_x(t1.coord_kkj) as x1,
     postgis.st_y(t1.coord_kkj) as y1,
@@ -34,10 +35,12 @@ val KKJ_TO_TM35FIN_SQL = """
     inner join common.kkj_etrs_triangle_corner_point t2 on kkj_etrs_triangulation_network.coord2_id = t2.id
     inner join common.kkj_etrs_triangle_corner_point t3 on kkj_etrs_triangulation_network.coord3_id = t3.id
   where kkj_etrs_triangulation_network.direction = 'KKJ_TO_TM35FIN'
-""".trimIndent()
+"""
+        .trimIndent()
 
-//language=SQL
-val TM35FIN_TO_KKJ_SQL = """
+// language=SQL
+val TM35FIN_TO_KKJ_SQL =
+    """
   select
     postgis.st_x(t1.coord_etrs) as x1,
     postgis.st_y(t1.coord_etrs) as y1,
@@ -51,40 +54,48 @@ val TM35FIN_TO_KKJ_SQL = """
     inner join common.kkj_etrs_triangle_corner_point t2 on kkj_etrs_triangulation_network.coord2_id = t2.id
     inner join common.kkj_etrs_triangle_corner_point t3 on kkj_etrs_triangulation_network.coord3_id = t3.id
   where kkj_etrs_triangulation_network.direction = 'TM35FIN_TO_KKJ'
-""".trimIndent()
+"""
+        .trimIndent()
 
 @Component
-class KkjTm35finTriangulationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTemplateParam) {
+class KkjTm35finTriangulationDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
+    DaoBase(jdbcTemplateParam) {
     @Cacheable(CACHE_KKJ_TM35FIN_TRIANGULATION_NETWORK, sync = true)
-    fun fetchTriangulationNetwork(direction: TriangulationDirection): RTree<KkjTm35finTriangle, Rectangle> {
+    fun fetchTriangulationNetwork(
+        direction: TriangulationDirection
+    ): RTree<KkjTm35finTriangle, Rectangle> {
         logger.daoAccess(AccessType.FETCH, HeightTriangle::class)
-        val sql = when (direction) {
-            TriangulationDirection.KKJ_TO_TM35FIN -> KKJ_TO_TM35FIN_SQL
-            TriangulationDirection.TM35FIN_TO_KKJ -> TM35FIN_TO_KKJ_SQL
-        }
+        val sql =
+            when (direction) {
+                TriangulationDirection.KKJ_TO_TM35FIN -> KKJ_TO_TM35FIN_SQL
+                TriangulationDirection.TM35FIN_TO_KKJ -> TM35FIN_TO_KKJ_SQL
+            }
 
-        val triangles = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, i ->
-            KkjTm35finTriangle(
-                corner1 = rs.getPoint("x1", "y1"),
-                corner2 = rs.getPoint("x2", "y2"),
-                corner3 = rs.getPoint("x3", "y3"),
-                a1 = rs.getDouble("a1"),
-                a2 = rs.getDouble("a2"),
-                deltaE = rs.getDouble("delta_e"),
-                b1 = rs.getDouble("b1"),
-                b2 = rs.getDouble("b2"),
-                deltaN = rs.getDouble("delta_n"),
-                crs = when (direction) {
-                    TriangulationDirection.KKJ_TO_TM35FIN -> crs(KKJ3_YKJ_SRID)
-                    TriangulationDirection.TM35FIN_TO_KKJ -> LAYOUT_CRS
-                }
-            )
-        }
+        val triangles =
+            jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, i ->
+                KkjTm35finTriangle(
+                    corner1 = rs.getPoint("x1", "y1"),
+                    corner2 = rs.getPoint("x2", "y2"),
+                    corner3 = rs.getPoint("x3", "y3"),
+                    a1 = rs.getDouble("a1"),
+                    a2 = rs.getDouble("a2"),
+                    deltaE = rs.getDouble("delta_e"),
+                    b1 = rs.getDouble("b1"),
+                    b2 = rs.getDouble("b2"),
+                    deltaN = rs.getDouble("delta_n"),
+                    crs =
+                        when (direction) {
+                            TriangulationDirection.KKJ_TO_TM35FIN -> crs(KKJ3_YKJ_SRID)
+                            TriangulationDirection.TM35FIN_TO_KKJ -> LAYOUT_CRS
+                        })
+            }
         return triangulationNetworkToRTree(triangles)
     }
 
     private fun triangulationNetworkToRTree(triangulationNetwork: List<KkjTm35finTriangle>) =
-        triangulationNetwork.fold(RTree.star().create<KkjTm35finTriangle, Rectangle>()) { tree, triangle ->
+        triangulationNetwork.fold(RTree.star().create<KkjTm35finTriangle, Rectangle>()) {
+            tree,
+            triangle ->
             val bbox = boundingBoxAroundPoints(triangle.corner1, triangle.corner2, triangle.corner3)
             tree.add(triangle, Geometries.rectangle(bbox.min.y, bbox.min.x, bbox.max.y, bbox.max.x))
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/WktGeometries.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/WktGeometries.kt
@@ -17,12 +17,14 @@ private const val POLYGON_TYPE_2D = "POLYGON"
 
 fun parse2DPoint(point: String): Point = parse2DPointValues(dropWktType(point, POINT_TYPE_2D))
 
-fun parse2DLineString(lineString: String): List<Point> = split2DPointValues(dropWktType(lineString, LINESTRING_TYPE_2D))
+fun parse2DLineString(lineString: String): List<Point> =
+    split2DPointValues(dropWktType(lineString, LINESTRING_TYPE_2D))
 
 fun parse3DMLineString(lineString: String): List<Point3DM> =
     get3DMLineStringContent(lineString).map { s -> parse3DMPointValue(s) }
 
-fun parse2DPolygon(polygon: String): List<Point> = split2DPointValues(dropWktType(polygon, POLYGON_TYPE_2D, 2))
+fun parse2DPolygon(polygon: String): List<Point> =
+    split2DPointValues(dropWktType(polygon, POLYGON_TYPE_2D, 2))
 
 fun create2DPoint(coordinate: IPoint): String {
     val content = point2DToString(coordinate)
@@ -44,7 +46,8 @@ fun create2DPolygonString(coordinates: List<IPoint>): String {
     return "$POLYGON_TYPE_2D${addParenthesis(content, 2)}"
 }
 
-private fun point2DToString(coordinate: IPoint): String = "${coordinate.x}$COORDINATE_SEPARATOR${coordinate.y}"
+private fun point2DToString(coordinate: IPoint): String =
+    "${coordinate.x}$COORDINATE_SEPARATOR${coordinate.y}"
 
 private fun point3DMToString(coordinate: IPoint3DM): String =
     "${coordinate.x}$COORDINATE_SEPARATOR${coordinate.y}$COORDINATE_SEPARATOR${coordinate.m}"
@@ -56,12 +59,13 @@ fun split2DPointValues(valuesString: String): List<Point> {
 fun get3DMLineStringContent(string: String): List<String> =
     split3DMPointValues(dropWktType(string, LINESTRING_TYPE_3DM))
 
-fun split3DMPointValues(valuesString: String): List<String> = try {
-    valuesString.split(POINT_SEPARATOR)
-} catch (e: NumberFormatException) {
-    logger.error("tried=$valuesString")
-    throw e
-}
+fun split3DMPointValues(valuesString: String): List<String> =
+    try {
+        valuesString.split(POINT_SEPARATOR)
+    } catch (e: NumberFormatException) {
+        logger.error("tried=$valuesString")
+        throw e
+    }
 
 fun parse2DPointValues(pointString: String): Point {
     val values = splitPointValues(pointString, 2)
@@ -73,10 +77,13 @@ fun parse3DMPointValue(pointString: String): Point3DM {
     return Point3DM(values[0], values[1], values[2])
 }
 
-fun splitPointValues(pointString: String, count: Int): List<Double> = pointString
-    .split(COORDINATE_SEPARATOR)
-    .also { values -> require(values.size == count) { "Invalid point value count: ${values.size} <> $count" } }
-    .map(String::toDouble)
+fun splitPointValues(pointString: String, count: Int): List<Double> =
+    pointString
+        .split(COORDINATE_SEPARATOR)
+        .also { values ->
+            require(values.size == count) { "Invalid point value count: ${values.size} <> $count" }
+        }
+        .map(String::toDouble)
 
 fun parseSegmentPoint(pointString: String, zValue: Double?, cantValue: Double?): SegmentPoint {
     val values = splitPointValues(pointString, 3)
@@ -91,7 +98,9 @@ fun parseSegmentPoint(pointString: String, zValue: Double?, cantValue: Double?):
 
 private fun dropWktType(wkt: String, typeString: String, parenthesis: Int = 1): String {
     val actualTypeString = wkt.substringBefore("(")
-    require(typeString == actualTypeString.trim()) { "WKT type does not match: expected=$typeString actual=$actualTypeString" }
+    require(typeString == actualTypeString.trim()) {
+        "WKT type does not match: expected=$typeString actual=$actualTypeString"
+    }
     return wkt.substring(actualTypeString.length + parenthesis, wkt.length - parenthesis)
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
@@ -15,6 +15,7 @@ data class TrackMeterHeight(
     val height: Double?,
     val point: Point,
 )
+
 data class KmHeights(
     val kmNumber: KmNumber,
     val trackMeterHeights: List<TrackMeterHeight>,
@@ -30,4 +31,3 @@ data class PlanLinkingSummaryItem(
     val verticalCoordinateSystem: VerticalCoordinateSystem?,
     val elevationMeasurementMethod: ElevationMeasurementMethod?,
 )
-

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/BoundingPolygon.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/BoundingPolygon.kt
@@ -9,8 +9,10 @@ import fi.fta.geoviite.infra.math.Point
 fun collectAnglePoints(alignments: List<GeometryAlignment>): List<Point> =
     alignments.flatMap { a: GeometryAlignment -> a.elements.flatMap { e -> e.bounds } }
 
-fun getBoundingPolygonPointsFromAlignments(alignments: List<GeometryAlignment>, transformation: Transformation): List<Point> =
-    tryCreateBoundingPolygonPoints(collectAnglePoints(alignments), transformation)
+fun getBoundingPolygonPointsFromAlignments(
+    alignments: List<GeometryAlignment>,
+    transformation: Transformation
+): List<Point> = tryCreateBoundingPolygonPoints(collectAnglePoints(alignments), transformation)
 
 fun tryCreateBoundingPolygonPoints(
     anglePoints: List<IPoint>,
@@ -23,10 +25,7 @@ fun tryCreateBoundingPolygonPoints(
     }
 }
 
-fun createBoundingPolygonPoints(
-    points: List<IPoint>,
-    transformation: Transformation
-): List<Point> {
+fun createBoundingPolygonPoints(points: List<IPoint>, transformation: Transformation): List<Point> {
     val bounds = boundingPolygonPointsByConvexHull(points, crs(transformation.sourceSrid))
     return bounds.map { p -> transformation.transform(p) }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
@@ -51,19 +51,14 @@ data class ElementListing(
     val fileName: FileName?,
     val coordinateSystemSrid: Srid?,
     val coordinateSystemName: CoordinateSystemName?,
-
     val trackNumber: TrackNumber?,
     val trackNumberDescription: PlanElementName?,
-
     val alignmentId: DomainId<GeometryAlignment>?,
     val alignmentName: AlignmentName?,
-
     val locationTrackName: AlignmentName?,
-
     val elementId: DomainId<GeometryElement>?,
     val elementType: TrackGeometryElementType,
     val lengthMeters: BigDecimal,
-
     val start: ElementLocation,
     val end: ElementLocation,
     val connectedSwitchName: SwitchName?,
@@ -87,12 +82,13 @@ enum class TrackGeometryElementType {
     ;
 
     companion object {
-        fun of(elementType: GeometryElementType): TrackGeometryElementType = when (elementType) {
-            GeometryElementType.LINE -> LINE
-            GeometryElementType.CURVE -> CURVE
-            GeometryElementType.CLOTHOID -> CLOTHOID
-            GeometryElementType.BIQUADRATIC_PARABOLA -> BIQUADRATIC_PARABOLA
-        }
+        fun of(elementType: GeometryElementType): TrackGeometryElementType =
+            when (elementType) {
+                GeometryElementType.LINE -> LINE
+                GeometryElementType.CURVE -> CURVE
+                GeometryElementType.CLOTHOID -> CLOTHOID
+                GeometryElementType.BIQUADRATIC_PARABOLA -> BIQUADRATIC_PARABOLA
+            }
     }
 }
 
@@ -105,57 +101,65 @@ fun toElementListing(
     elementTypes: List<TrackGeometryElementType>,
     startAddress: TrackMeter?,
     endAddress: TrackMeter?,
-    getPlanHeaderAndAlignment: (id: IntId<GeometryAlignment>) -> Pair<GeometryPlanHeader, GeometryAlignment>,
+    getPlanHeaderAndAlignment:
+        (id: IntId<GeometryAlignment>) -> Pair<GeometryPlanHeader, GeometryAlignment>,
     getSwitchName: (IntId<TrackLayoutSwitch>) -> SwitchName,
 ): List<ElementListing> {
-    val linkedElementIds = collectLinkedElements(layoutAlignment.segments, context, startAddress, endAddress)
-    val lengthOfSegmentsConnectedToSameElement = linkedElementIds.groupBy { it.second }.map {
-        it.key to it.value.sumOf { (segment, _) -> segment.length }
-    }
-    val linkedAlignmentIds = linkedElementIds.mapNotNull { (_, id) -> id?.let(::getAlignmentId) }.distinct()
-    val headersAndAlignments = linkedAlignmentIds.associateWith { id -> getPlanHeaderAndAlignment(id) }
+    val linkedElementIds =
+        collectLinkedElements(layoutAlignment.segments, context, startAddress, endAddress)
+    val lengthOfSegmentsConnectedToSameElement =
+        linkedElementIds
+            .groupBy { it.second }
+            .map { it.key to it.value.sumOf { (segment, _) -> segment.length } }
+    val linkedAlignmentIds =
+        linkedElementIds.mapNotNull { (_, id) -> id?.let(::getAlignmentId) }.distinct()
+    val headersAndAlignments =
+        linkedAlignmentIds.associateWith { id -> getPlanHeaderAndAlignment(id) }
 
-    return linkedElementIds.mapNotNull { (segment, elementId) ->
-        if (elementId == null) {
-            if (elementTypes.contains(MISSING_SECTION)) toMissingElementListing(
-                context,
-                trackNumber,
-                segment,
-                track,
-                getSwitchName
-            )
-            else null
-        } else {
-            val (planHeader, alignment) = headersAndAlignments[getAlignmentId(elementId)]
-                ?: throw IllegalStateException("Failed to fetch geometry alignment for element: element=$elementId")
-            val element = alignment.elements.find { e -> e.id == elementId } ?: throw IllegalStateException(
-                "Geometry element not found on its parent alignment: alignment=${alignment.id} element=$elementId"
-            )
-            if (elementTypes.contains(TrackGeometryElementType.of(element.type))) {
-                toElementListing(
-                    context,
-                    getTransformation,
-                    track,
-                    planHeader,
-                    alignment,
-                    trackNumber,
-                    element,
-                    segment,
-                    getSwitchName
-                )
+    return linkedElementIds
+        .mapNotNull { (segment, elementId) ->
+            if (elementId == null) {
+                if (elementTypes.contains(MISSING_SECTION))
+                    toMissingElementListing(context, trackNumber, segment, track, getSwitchName)
+                else null
             } else {
-                null
+                val (planHeader, alignment) =
+                    headersAndAlignments[getAlignmentId(elementId)]
+                        ?: throw IllegalStateException(
+                            "Failed to fetch geometry alignment for element: element=$elementId")
+                val element =
+                    alignment.elements.find { e -> e.id == elementId }
+                        ?: throw IllegalStateException(
+                            "Geometry element not found on its parent alignment: alignment=${alignment.id} element=$elementId")
+                if (elementTypes.contains(TrackGeometryElementType.of(element.type))) {
+                    toElementListing(
+                        context,
+                        getTransformation,
+                        track,
+                        planHeader,
+                        alignment,
+                        trackNumber,
+                        element,
+                        segment,
+                        getSwitchName)
+                } else {
+                    null
+                }
             }
         }
-    }.distinctBy(ElementListing::id).map { listing ->
-        val calculatedSegmentLength =
-            lengthOfSegmentsConnectedToSameElement.find { (elementId, _) -> elementId == listing.elementId }?.second
-        listing.copy(
-            isPartial = if (calculatedSegmentLength != null && listing.planId != null)
-                abs(calculatedSegmentLength - listing.lengthMeters.toDouble()) > SEGMENT_AND_ELEMENT_LENGTH_MAX_DELTA
-            else false
-        )
-    }
+        .distinctBy(ElementListing::id)
+        .map { listing ->
+            val calculatedSegmentLength =
+                lengthOfSegmentsConnectedToSameElement
+                    .find { (elementId, _) -> elementId == listing.elementId }
+                    ?.second
+            listing.copy(
+                isPartial =
+                    if (calculatedSegmentLength != null && listing.planId != null)
+                        abs(calculatedSegmentLength - listing.lengthMeters.toDouble()) >
+                            SEGMENT_AND_ELEMENT_LENGTH_MAX_DELTA
+                    else false)
+        }
 }
 
 fun toElementListing(
@@ -164,11 +168,15 @@ fun toElementListing(
     plan: GeometryPlan,
     elementTypes: List<GeometryElementType>,
     getSwitchName: (IntId<TrackLayoutSwitch>) -> SwitchName,
-) = plan.alignments.flatMap { alignment ->
-    alignment.elements
-        .filter { element -> elementTypes.contains(element.type) }
-        .map { element -> toElementListing(context, getTransformation, plan, alignment, element, getSwitchName) }
-}
+) =
+    plan.alignments.flatMap { alignment ->
+        alignment.elements
+            .filter { element -> elementTypes.contains(element.type) }
+            .map { element ->
+                toElementListing(
+                    context, getTransformation, plan, alignment, element, getSwitchName)
+            }
+    }
 
 private fun toMissingElementListing(
     context: GeocodingContext?,
@@ -176,26 +184,28 @@ private fun toMissingElementListing(
     segment: LayoutSegment,
     locationTrack: LocationTrack,
     getSwitchName: (IntId<TrackLayoutSwitch>) -> SwitchName,
-) = ElementListing(
-    id = StringId("MEL_${segment.id}"),
-    planId = null,
-    planSource = null,
-    fileName = null,
-    coordinateSystemSrid = LAYOUT_SRID,
-    coordinateSystemName = null,
-    trackNumber = trackNumber,
-    trackNumberDescription = null,
-    alignmentId = null,
-    alignmentName = null,
-    elementId = null,
-    elementType = MISSING_SECTION,
-    lengthMeters = round(segment.length, LENGTH_DECIMALS),
-    start = getLocation(context, segment.alignmentStart, segment.startDirection),
-    end = getLocation(context, segment.alignmentEnd, segment.endDirection),
-    locationTrackName = locationTrack.name,
-    connectedSwitchName = segment.switchId?.let { id -> if (id is IntId) getSwitchName(id) else null },
-    isPartial = false,
-)
+) =
+    ElementListing(
+        id = StringId("MEL_${segment.id}"),
+        planId = null,
+        planSource = null,
+        fileName = null,
+        coordinateSystemSrid = LAYOUT_SRID,
+        coordinateSystemName = null,
+        trackNumber = trackNumber,
+        trackNumberDescription = null,
+        alignmentId = null,
+        alignmentName = null,
+        elementId = null,
+        elementType = MISSING_SECTION,
+        lengthMeters = round(segment.length, LENGTH_DECIMALS),
+        start = getLocation(context, segment.alignmentStart, segment.startDirection),
+        end = getLocation(context, segment.alignmentEnd, segment.endDirection),
+        locationTrackName = locationTrack.name,
+        connectedSwitchName =
+            segment.switchId?.let { id -> if (id is IntId) getSwitchName(id) else null },
+        isPartial = false,
+    )
 
 private fun toElementListing(
     context: GeocodingContext?,
@@ -207,21 +217,21 @@ private fun toElementListing(
     element: GeometryElement,
     segment: LayoutSegment,
     getSwitchName: (IntId<TrackLayoutSwitch>) -> SwitchName
-) = elementListing(
-    context = context,
-    getTransformation = getTransformation,
-    planId = planHeader.id,
-    planSource = planHeader.source,
-    fileName = planHeader.fileName,
-    units = planHeader.units,
-    trackNumber = trackNumber,
-    trackNumberDescription = null,
-    alignment = alignment,
-    element = element,
-    locationTrack = locationTrack,
-    segment = segment,
-    getSwitchName = getSwitchName
-)
+) =
+    elementListing(
+        context = context,
+        getTransformation = getTransformation,
+        planId = planHeader.id,
+        planSource = planHeader.source,
+        fileName = planHeader.fileName,
+        units = planHeader.units,
+        trackNumber = trackNumber,
+        trackNumberDescription = null,
+        alignment = alignment,
+        element = element,
+        locationTrack = locationTrack,
+        segment = segment,
+        getSwitchName = getSwitchName)
 
 private fun toElementListing(
     context: GeocodingContext?,
@@ -230,21 +240,22 @@ private fun toElementListing(
     alignment: GeometryAlignment,
     element: GeometryElement,
     getSwitchName: (IntId<TrackLayoutSwitch>) -> SwitchName,
-) = elementListing(
-    context = context,
-    getTransformation = getTransformation,
-    planId = plan.id,
-    planSource = plan.source,
-    fileName = plan.fileName,
-    units = plan.units,
-    trackNumber = plan.trackNumber,
-    trackNumberDescription = plan.trackNumberDescription,
-    alignment = alignment,
-    element = element,
-    locationTrack = null,
-    segment = null,
-    getSwitchName = getSwitchName,
-)
+) =
+    elementListing(
+        context = context,
+        getTransformation = getTransformation,
+        planId = plan.id,
+        planSource = plan.source,
+        fileName = plan.fileName,
+        units = plan.units,
+        trackNumber = plan.trackNumber,
+        trackNumberDescription = plan.trackNumberDescription,
+        alignment = alignment,
+        element = element,
+        locationTrack = null,
+        segment = null,
+        getSwitchName = getSwitchName,
+    )
 
 fun planElementListingToCsv(
     elementListing: List<ElementListing>,
@@ -261,76 +272,106 @@ private fun trackNumberCsvEntry(translation: Translation) =
         it.trackNumber
     }
 
-private fun commonElementListingCsvEntries(translation: Translation): List<CsvEntry<ElementListing>> =
-    mapOf<String, (item: ElementListing) -> Any?>("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.plan-track" to { it.alignmentName },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.element-type" to {
-            translateTrackGeometryElementType(
-                it.elementType, translation
-            )
-        },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.track-address-start" to {
-            it.start.address?.let { address ->
-                formatTrackMeter(
-                    address.kmNumber, address.meters
-                )
-            }
-        },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.track-address-end" to {
-            it.end.address?.let { address ->
-                formatTrackMeter(
-                    address.kmNumber, address.meters
-                )
-            }
-        },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.crs" to {
-            it.coordinateSystemSrid ?: it.coordinateSystemName
-        },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-start-e" to { it.start.coordinate.roundedX.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-start-n" to { it.start.coordinate.roundedY.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-end-e" to { it.end.coordinate.roundedX.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-end-n" to { it.end.coordinate.roundedY.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.length" to { it.lengthMeters },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.radius-start" to { it.start.radiusMeters?.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.radius-end" to { it.end.radiusMeters?.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.cant-start" to { it.start.cant?.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.cant-end" to { it.end.cant?.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.direction-start" to { it.start.directionGrads.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.direction-end" to { it.end.directionGrads.toPlainString() },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.plan-name" to { it.fileName },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.plan-source" to { it.planSource },
-        "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.remarks" to { remarks(it, translation) }).map { (key, fn) ->
-        CsvEntry(
-            translation.t(key),
-            fn
-        )
-    }
+private fun commonElementListingCsvEntries(
+    translation: Translation
+): List<CsvEntry<ElementListing>> =
+    mapOf<String, (item: ElementListing) -> Any?>(
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.plan-track" to { it.alignmentName },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.element-type" to
+                {
+                    translateTrackGeometryElementType(it.elementType, translation)
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.track-address-start" to
+                {
+                    it.start.address?.let { address ->
+                        formatTrackMeter(address.kmNumber, address.meters)
+                    }
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.track-address-end" to
+                {
+                    it.end.address?.let { address ->
+                        formatTrackMeter(address.kmNumber, address.meters)
+                    }
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.crs" to
+                {
+                    it.coordinateSystemSrid ?: it.coordinateSystemName
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-start-e" to
+                {
+                    it.start.coordinate.roundedX.toPlainString()
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-start-n" to
+                {
+                    it.start.coordinate.roundedY.toPlainString()
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-end-e" to
+                {
+                    it.end.coordinate.roundedX.toPlainString()
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-end-n" to
+                {
+                    it.end.coordinate.roundedY.toPlainString()
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.length" to { it.lengthMeters },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.radius-start" to
+                {
+                    it.start.radiusMeters?.toPlainString()
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.radius-end" to
+                {
+                    it.end.radiusMeters?.toPlainString()
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.cant-start" to { it.start.cant?.toPlainString() },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.cant-end" to { it.end.cant?.toPlainString() },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.direction-start" to
+                {
+                    it.start.directionGrads.toPlainString()
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.direction-end" to
+                {
+                    it.end.directionGrads.toPlainString()
+                },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.plan-name" to { it.fileName },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.plan-source" to { it.planSource },
+            "$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.remarks" to { remarks(it, translation) })
+        .map { (key, fn) -> CsvEntry(translation.t(key), fn) }
 
 fun translateTrackGeometryElementType(type: TrackGeometryElementType, translation: Translation) =
     when (type) {
         TrackGeometryElementType.LINE -> translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.line")
-        TrackGeometryElementType.CURVE -> translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.curve")
-        TrackGeometryElementType.CLOTHOID -> translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.clothoid")
-        TrackGeometryElementType.BIQUADRATIC_PARABOLA -> translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.biquadratic-parabola")
+        TrackGeometryElementType.CURVE ->
+            translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.curve")
+        TrackGeometryElementType.CLOTHOID ->
+            translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.clothoid")
+        TrackGeometryElementType.BIQUADRATIC_PARABOLA ->
+            translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.biquadratic-parabola")
         MISSING_SECTION -> translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.missing-section")
     }
 
-fun locationTrackCsvEntries(translation: Translation) = listOf(
-    trackNumberCsvEntry(translation),
-    CsvEntry(translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-track")) { it.locationTrackName },
-) + commonElementListingCsvEntries(translation)
+fun locationTrackCsvEntries(translation: Translation) =
+    listOf(
+        trackNumberCsvEntry(translation),
+        CsvEntry(translation.t("$ELEMENT_LIST_CSV_TRANSLATION_PREFIX.location-track")) {
+            it.locationTrackName
+        },
+    ) + commonElementListingCsvEntries(translation)
 
-fun planCsvEntries(translation: Translation) = listOf(
-    trackNumberCsvEntry(translation)
-) + commonElementListingCsvEntries(translation)
+fun planCsvEntries(translation: Translation) =
+    listOf(trackNumberCsvEntry(translation)) + commonElementListingCsvEntries(translation)
 
 private fun remarks(elementListing: ElementListing, translation: Translation) =
     listOfNotNull(
-        if (elementListing.isPartial) translation.t("data-products.element-list.remarks.is-partial") else null,
-        if (elementListing.connectedSwitchName != null) translation.t(
-            "data-products.element-list.remarks.connected-to-switch",
-            LocalizationParams(mapOf("switchName" to elementListing.connectedSwitchName.toString()))
-        ) else null
-    ).joinToString(separator = ", ")
+            if (elementListing.isPartial)
+                translation.t("data-products.element-list.remarks.is-partial")
+            else null,
+            if (elementListing.connectedSwitchName != null)
+                translation.t(
+                    "data-products.element-list.remarks.connected-to-switch",
+                    LocalizationParams(
+                        mapOf("switchName" to elementListing.connectedSwitchName.toString())))
+            else null)
+        .joinToString(separator = ", ")
 
 private fun elementListing(
     context: GeocodingContext?,
@@ -346,88 +387,101 @@ private fun elementListing(
     element: GeometryElement,
     segment: LayoutSegment?,
     getSwitchName: (IntId<TrackLayoutSwitch>) -> SwitchName,
-) = units.coordinateSystemSrid?.let(getTransformation).let { transformation ->
-    val start = getStartLocation(context, transformation, alignment, element)
-    val end = getEndLocation(context, transformation, alignment, element)
-    ElementListing(
-        id = StringId("EL_${element.id}"),
-        planId = planId,
-        planSource = planSource,
-        fileName = fileName,
-        coordinateSystemSrid = units.coordinateSystemSrid,
-        coordinateSystemName = units.coordinateSystemName,
-        trackNumber = trackNumber,
-        trackNumberDescription = trackNumberDescription,
-        alignmentId = alignment.id,
-        alignmentName = alignment.name,
-        locationTrackName = locationTrack?.name,
-        elementId = element.id,
-        elementType = TrackGeometryElementType.of(element.type),
-        lengthMeters = round(element.calculatedLength, LENGTH_DECIMALS),
-        start = start,
-        end = end,
-        connectedSwitchName = segment?.switchId?.let { id -> if (id is IntId) getSwitchName(id) else null },
-        isPartial = false,
-    )
-}
+) =
+    units.coordinateSystemSrid?.let(getTransformation).let { transformation ->
+        val start = getStartLocation(context, transformation, alignment, element)
+        val end = getEndLocation(context, transformation, alignment, element)
+        ElementListing(
+            id = StringId("EL_${element.id}"),
+            planId = planId,
+            planSource = planSource,
+            fileName = fileName,
+            coordinateSystemSrid = units.coordinateSystemSrid,
+            coordinateSystemName = units.coordinateSystemName,
+            trackNumber = trackNumber,
+            trackNumberDescription = trackNumberDescription,
+            alignmentId = alignment.id,
+            alignmentName = alignment.name,
+            locationTrackName = locationTrack?.name,
+            elementId = element.id,
+            elementType = TrackGeometryElementType.of(element.type),
+            lengthMeters = round(element.calculatedLength, LENGTH_DECIMALS),
+            start = start,
+            end = end,
+            connectedSwitchName =
+                segment?.switchId?.let { id -> if (id is IntId) getSwitchName(id) else null },
+            isPartial = false,
+        )
+    }
 
 private fun getLocation(
     context: GeocodingContext?,
     point: AlignmentPoint,
     directionRads: Double,
-) = ElementLocation(
-    coordinate = point.round(COORDINATE_DECIMALS),
-    address = context?.getAddress(point)?.first,
-    directionGrads = getDirectionGrads(directionRads),
-    radiusMeters = null,
-    cant = point.cant?.let { c -> round(c, CANT_DECIMALS) },
-)
+) =
+    ElementLocation(
+        coordinate = point.round(COORDINATE_DECIMALS),
+        address = context?.getAddress(point)?.first,
+        directionGrads = getDirectionGrads(directionRads),
+        radiusMeters = null,
+        cant = point.cant?.let { c -> round(c, CANT_DECIMALS) },
+    )
 
 private fun getStartLocation(
     context: GeocodingContext?,
     transformation: Transformation?,
     alignment: GeometryAlignment,
     element: GeometryElement,
-) = ElementLocation(
-    coordinate = element.start.round(COORDINATE_DECIMALS),
-    address = getAddress(context, transformation, element.start),
-    directionGrads = getDirectionGrads(element.startDirectionRads),
-    radiusMeters = getStartRadius(element),
-    cant = getStartCant(alignment, element),
-)
+) =
+    ElementLocation(
+        coordinate = element.start.round(COORDINATE_DECIMALS),
+        address = getAddress(context, transformation, element.start),
+        directionGrads = getDirectionGrads(element.startDirectionRads),
+        radiusMeters = getStartRadius(element),
+        cant = getStartCant(alignment, element),
+    )
 
 private fun getEndLocation(
     context: GeocodingContext?,
     transformation: Transformation?,
     alignment: GeometryAlignment,
     element: GeometryElement,
-) = ElementLocation(
-    coordinate = element.end.round(COORDINATE_DECIMALS),
-    address = getAddress(context, transformation, element.end),
-    directionGrads = getDirectionGrads(element.endDirectionRads),
-    radiusMeters = getEndRadius(element),
-    cant = getEndCant(alignment, element),
-)
+) =
+    ElementLocation(
+        coordinate = element.end.round(COORDINATE_DECIMALS),
+        address = getAddress(context, transformation, element.end),
+        directionGrads = getDirectionGrads(element.endDirectionRads),
+        radiusMeters = getEndRadius(element),
+        cant = getEndCant(alignment, element),
+    )
 
-fun getAlignmentId(elementId: IndexedId<GeometryElement>) = IntId<GeometryAlignment>(elementId.parentId)
+fun getAlignmentId(elementId: IndexedId<GeometryElement>) =
+    IntId<GeometryAlignment>(elementId.parentId)
 
-private fun getAddress(context: GeocodingContext?, transformation: Transformation?, coordinate: Point) =
+private fun getAddress(
+    context: GeocodingContext?,
+    transformation: Transformation?,
+    coordinate: Point
+) =
     if (context == null || transformation == null) null
     else context.getAddress(transformation.transform(coordinate), ADDRESS_DECIMALS)?.first
 
-private fun getDirectionGrads(rads: Double) = round(radsToGrads(radsMathToGeo(rads)), DIRECTION_DECIMALS)
+private fun getDirectionGrads(rads: Double) =
+    round(radsToGrads(radsMathToGeo(rads)), DIRECTION_DECIMALS)
 
-private fun getStartRadius(element: GeometryElement) = when (element) {
-    is GeometryLine -> null
-    is GeometryCurve -> element.radius
-    is GeometrySpiral -> element.radiusStart
-}
+private fun getStartRadius(element: GeometryElement) =
+    when (element) {
+        is GeometryLine -> null
+        is GeometryCurve -> element.radius
+        is GeometrySpiral -> element.radiusStart
+    }
 
-private fun getEndRadius(element: GeometryElement) = when (element) {
-    is GeometryLine -> null
-    is GeometryCurve -> element.radius
-    is GeometrySpiral -> element.radiusEnd
-}
+private fun getEndRadius(element: GeometryElement) =
+    when (element) {
+        is GeometryLine -> null
+        is GeometryCurve -> element.radius
+        is GeometrySpiral -> element.radiusEnd
+    }
 
 private fun getStartCant(alignment: GeometryAlignment, element: GeometryElement) =
     getCantAt(alignment, getElementStartLength(alignment, element.id))
@@ -435,9 +489,12 @@ private fun getStartCant(alignment: GeometryAlignment, element: GeometryElement)
 private fun getEndCant(alignment: GeometryAlignment, element: GeometryElement) =
     getCantAt(alignment, getElementStartLength(alignment, element.id) + element.calculatedLength)
 
-private fun getElementStartLength(alignment: GeometryAlignment, elementId: DomainId<GeometryElement>) =
-    alignment.elements.takeWhile { e -> e.id != elementId }.sumOf { e -> e.calculatedLength }
+private fun getElementStartLength(
+    alignment: GeometryAlignment,
+    elementId: DomainId<GeometryElement>
+) = alignment.elements.takeWhile { e -> e.id != elementId }.sumOf { e -> e.calculatedLength }
 
 private fun getCantAt(alignment: GeometryAlignment, locationDistance: Double) =
-    // Cant station values are alignment m-values, calculated from 0 (ignoring alignment station-start)
+    // Cant station values are alignment m-values, calculated from 0 (ignoring alignment
+    // station-start)
     alignment.cant?.getCantValue(locationDistance)?.let { v -> round(v, CANT_DECIMALS) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryAlignment.kt
@@ -32,15 +32,17 @@ data class GeometryAlignment(
     val bounds by lazy { boundingBoxAroundPointsOrNull(elements.flatMap { e -> e.bounds }) }
 
     fun getElementAt(distance: Double) =
-        foldElementLengths(elements).findLast { element -> element.first <= distance }
+        foldElementLengths(elements)
+            .findLast { element -> element.first <= distance }
             ?.let { match ->
-                    val distanceLeft = distance - match.first
-                    if (distanceLeft <= match.second.calculatedLength) match
-                    else null
-                }
+                val distanceLeft = distance - match.first
+                if (distanceLeft <= match.second.calculatedLength) match else null
+            }
 
     fun getCoordinateAt(distance: Double) =
-        getElementAt(distance)?.let { match -> match.second.getCoordinateAt(distance - match.first) }
+        getElementAt(distance)?.let { match ->
+            match.second.getCoordinateAt(distance - match.first)
+        }
 
     fun stationValueNormalized(station: Double) =
         station - (elements.firstOrNull()?.staStart?.toDouble() ?: 0.0)
@@ -51,7 +53,8 @@ data class GeometryAlignment(
             ?.let { match -> match.first..(match.first + match.second.calculatedLength) }
             ?: throw IllegalArgumentException("Element not found from alignment")
 
-    override fun toLog(): String = logFormat("id" to id, "name" to name, "elements" to elements.size)
+    override fun toLog(): String =
+        logFormat("id" to id, "name" to name, "elements" to elements.size)
 }
 
 private fun foldElementLengths(elements: List<GeometryElement>) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryCant.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryCant.kt
@@ -7,7 +7,12 @@ import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.biquadraticSTransition
 import java.math.BigDecimal
 
-enum class CantRotationPoint { LEFT, RIGHT, INSIDE_RAIL, CENTER }
+enum class CantRotationPoint {
+    LEFT,
+    RIGHT,
+    INSIDE_RAIL,
+    CENTER
+}
 
 enum class CantTransitionType {
     LINEAR,
@@ -30,18 +35,28 @@ data class GeometryCant(
         var previous = points.findLast { cp -> cp.station.toDouble() <= station }
         next = next ?: previous
         previous = previous ?: next
-        return if (next != null && previous != null) calculateGeometryPointCantValue(previous, next, station) else null
+        return if (next != null && previous != null)
+            calculateGeometryPointCantValue(previous, next, station)
+        else null
     }
 }
 
-fun calculateGeometryPointCantValue(previous: GeometryCantPoint, next: GeometryCantPoint, station: Double): Double {
+fun calculateGeometryPointCantValue(
+    previous: GeometryCantPoint,
+    next: GeometryCantPoint,
+    station: Double
+): Double {
     val offset = station - previous.station.toDouble()
     val lengthBtwStations: Double = (next.station - previous.station).toDouble()
     val cantTotalDelta = (next.appliedCant - previous.appliedCant).toDouble()
-    val cantDelta = if (lengthBtwStations <= 0.0) 0.0 else when (previous.transitionType) {
-        LINEAR -> cantTotalDelta * (offset / lengthBtwStations)
-        BIQUADRATIC_PARABOLA -> biquadraticSTransition(offset, cantTotalDelta, lengthBtwStations)
-    }
+    val cantDelta =
+        if (lengthBtwStations <= 0.0) 0.0
+        else
+            when (previous.transitionType) {
+                LINEAR -> cantTotalDelta * (offset / lengthBtwStations)
+                BIQUADRATIC_PARABOLA ->
+                    biquadraticSTransition(offset, cantTotalDelta, lengthBtwStations)
+            }
     return previous.appliedCant.toDouble() + cantDelta
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -40,7 +40,9 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 
 @GeoviiteController("/geometry")
-class GeometryController @Autowired constructor(
+class GeometryController
+@Autowired
+constructor(
     private val geometryService: GeometryService,
     private val planLayoutService: PlanLayoutService,
 ) {
@@ -60,8 +62,11 @@ class GeometryController @Autowired constructor(
     ): GeometryPlanHeadersSearchResult {
         val filter = geometryService.getFilter(freeText, trackNumbers ?: listOf())
         val headers = geometryService.getPlanHeaders(sources, bbox, filter)
-        val comparator = geometryService.getComparator(sortField ?: ID, sortOrder ?: ASCENDING, lang)
-        val results = pageAndRest(items = headers, offset = offset ?: 0, limit = limit ?: 50, comparator = comparator)
+        val comparator =
+            geometryService.getComparator(sortField ?: ID, sortOrder ?: ASCENDING, lang)
+        val results =
+            pageAndRest(
+                items = headers, offset = offset ?: 0, limit = limit ?: 50, comparator = comparator)
         return GeometryPlanHeadersSearchResult(
             planHeaders = results.page,
             remainingIds = results.rest.map { plan -> plan.id },
@@ -103,12 +108,17 @@ class GeometryController @Autowired constructor(
         @RequestParam("planIds") planIds: List<IntId<GeometryPlan>>,
         @RequestParam("includeGeometryData") includeGeometryData: Boolean = true,
     ): ResponseEntity<List<GeometryPlanLayout>> {
-        return toResponse(planLayoutService.getManyLayoutPlans(planIds, includeGeometryData).mapNotNull { it.first })
+        return toResponse(
+            planLayoutService.getManyLayoutPlans(planIds, includeGeometryData).mapNotNull {
+                it.first
+            })
     }
 
     @PreAuthorize(AUTH_VIEW_GEOMETRY)
     @GetMapping("/switches/{switchId}")
-    fun getGeometrySwitch(@PathVariable("switchId") switchId: IntId<GeometrySwitch>): GeometrySwitch {
+    fun getGeometrySwitch(
+        @PathVariable("switchId") switchId: IntId<GeometrySwitch>
+    ): GeometrySwitch {
         return geometryService.getSwitch(switchId)
     }
 
@@ -128,7 +138,9 @@ class GeometryController @Autowired constructor(
 
     @PreAuthorize(AUTH_VIEW_GEOMETRY)
     @GetMapping("/plans/elements/{id}")
-    fun getGeometryElement(@PathVariable("id") geometryElementId: IndexedId<GeometryElement>): GeometryElement {
+    fun getGeometryElement(
+        @PathVariable("id") geometryElementId: IndexedId<GeometryElement>
+    ): GeometryElement {
         return geometryService.getGeometryElement(geometryElementId)
     }
 
@@ -191,7 +203,8 @@ class GeometryController @Autowired constructor(
     }
 
     @PreAuthorize(AUTH_VIEW_GEOMETRY_FILE)
-    @GetMapping("/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/element-listing")
+    @GetMapping(
+        "/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/element-listing")
     fun getTrackElementListing(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
@@ -201,11 +214,13 @@ class GeometryController @Autowired constructor(
         @RequestParam("endAddress") endAddress: TrackMeter? = null,
     ): List<ElementListing> {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        return geometryService.getElementListing(layoutContext, id, elementTypes, startAddress, endAddress)
+        return geometryService.getElementListing(
+            layoutContext, id, elementTypes, startAddress, endAddress)
     }
 
     @PreAuthorize(AUTH_DOWNLOAD_GEOMETRY)
-    @GetMapping("/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/element-listing/file")
+    @GetMapping(
+        "/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/element-listing/file")
     fun getTrackElementListingCSV(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
@@ -216,14 +231,15 @@ class GeometryController @Autowired constructor(
         @RequestParam("lang") lang: LocalizationLanguage,
     ): ResponseEntity<ByteArray> {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        val (filename, content) = geometryService.getElementListingCsv(
-            layoutContext = layoutContext,
-            trackId = id,
-            elementTypes = elementTypes,
-            startAddress = startAddress,
-            endAddress = endAddress,
-            lang = lang,
-        )
+        val (filename, content) =
+            geometryService.getElementListingCsv(
+                layoutContext = layoutContext,
+                trackId = id,
+                elementTypes = elementTypes,
+                startAddress = startAddress,
+                endAddress = endAddress,
+                lang = lang,
+            )
         return toFileDownloadResponse(filename.withSuffix(CSV), content.toByteArray(Charsets.UTF_8))
     }
 
@@ -233,8 +249,8 @@ class GeometryController @Autowired constructor(
         val elementListingFile = geometryService.getElementListingCsv()
         return elementListingFile?.let {
             toFileDownloadResponse(
-                elementListingFile.name.withSuffix(CSV), elementListingFile.content.toByteArray(Charsets.UTF_8)
-            )
+                elementListingFile.name.withSuffix(CSV),
+                elementListingFile.content.toByteArray(Charsets.UTF_8))
         } ?: ResponseEntity(HttpStatus.NO_CONTENT)
     }
 
@@ -257,7 +273,8 @@ class GeometryController @Autowired constructor(
     }
 
     @PreAuthorize(AUTH_VIEW_GEOMETRY_FILE)
-    @GetMapping("/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/vertical-geometry")
+    @GetMapping(
+        "/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/vertical-geometry")
     fun getTrackVerticalGeometryListing(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
@@ -282,7 +299,8 @@ class GeometryController @Autowired constructor(
         @RequestParam("endAddress") endAddress: TrackMeter? = null,
         @RequestParam("lang") lang: LocalizationLanguage,
     ): ResponseEntity<ByteArray> {
-        val (filename, content) = geometryService.getVerticalGeometryListingCsv(id, startAddress, endAddress, lang)
+        val (filename, content) =
+            geometryService.getVerticalGeometryListingCsv(id, startAddress, endAddress, lang)
         return toFileDownloadResponse(filename.withSuffix(CSV), content)
     }
 
@@ -316,12 +334,13 @@ class GeometryController @Autowired constructor(
         @RequestParam("endDistance") endDistance: Double,
         @RequestParam("tickLength") tickLength: Int,
     ): List<KmHeights> {
-        return geometryService.getPlanAlignmentHeights(planId, planAlignmentId, startDistance, endDistance, tickLength)
-            ?: emptyList()
+        return geometryService.getPlanAlignmentHeights(
+            planId, planAlignmentId, startDistance, endDistance, tickLength) ?: emptyList()
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/linking-summary")
+    @GetMapping(
+        "/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/linking-summary")
     fun getLocationTrackLinkingSummary(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
@@ -332,7 +351,8 @@ class GeometryController @Autowired constructor(
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/alignment-heights")
+    @GetMapping(
+        "/layout/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/location-tracks/{id}/alignment-heights")
     fun getLayoutAlignmentHeights(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -23,31 +23,37 @@ import fi.fta.geoviite.infra.math.toAngle
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.util.*
 import fi.fta.geoviite.infra.util.DbTable.*
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
-import java.sql.Timestamp
-import java.time.Instant
 
 enum class VerticalIntersectionType {
-    POINT, CIRCULAR_CURVE,
+    POINT,
+    CIRCULAR_CURVE,
 }
 
 const val PLAN_HEADER_CACHE_SIZE = 10000L
 
 @Transactional(readOnly = true)
 @Component
-class GeometryDao @Autowired constructor(
+class GeometryDao
+@Autowired
+constructor(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
     @Value("\${geoviite.cache.enabled}") private val cacheEnabled: Boolean,
 ) : DaoBase(jdbcTemplateParam) {
 
     private val headerCache: Cache<RowVersion<GeometryPlan>, GeometryPlanHeader> =
-        Caffeine.newBuilder().maximumSize(PLAN_HEADER_CACHE_SIZE).expireAfterAccess(planCacheDuration).build()
+        Caffeine.newBuilder()
+            .maximumSize(PLAN_HEADER_CACHE_SIZE)
+            .expireAfterAccess(planCacheDuration)
+            .build()
 
     @Transactional
     fun insertPlan(
@@ -57,18 +63,25 @@ class GeometryDao @Autowired constructor(
     ): RowVersion<GeometryPlan> {
         jdbcTemplate.setUser()
 
-        val projectId: IntId<Project> = if (plan.project.id is IntId) plan.project.id
-        else findProject(plan.project.name)?.id as IntId? ?: insertProjectInternal(plan.project).id
+        val projectId: IntId<Project> =
+            if (plan.project.id is IntId) plan.project.id
+            else
+                findProject(plan.project.name)?.id as IntId?
+                    ?: insertProjectInternal(plan.project).id
 
-        val authorId: IntId<Author>? = plan.author?.let { author: Author ->
-            if (author.id is IntId) author.id
-            else findAuthor(author.companyName)?.id as IntId? ?: insertAuthorInternal(author).id
-        }
-        val applicationId: IntId<Application> = if (plan.application.id is IntId) plan.application.id
-        else findApplication(plan.application.name, plan.application.version)?.id as IntId?
-            ?: insertApplicationInternal(plan.application).id
+        val authorId: IntId<Author>? =
+            plan.author?.let { author: Author ->
+                if (author.id is IntId) author.id
+                else findAuthor(author.companyName)?.id as IntId? ?: insertAuthorInternal(author).id
+            }
+        val applicationId: IntId<Application> =
+            if (plan.application.id is IntId) plan.application.id
+            else
+                findApplication(plan.application.name, plan.application.version)?.id as IntId?
+                    ?: insertApplicationInternal(plan.application).id
 
-        val sql = """
+        val sql =
+            """
             insert into geometry.plan(
               track_number,
               track_number_description,
@@ -116,34 +129,36 @@ class GeometryDao @Autowired constructor(
               :hidden
             )
             returning id, version
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "track_number" to plan.trackNumber?.toString(),
-            "track_number_description" to plan.trackNumberDescription,
-            "plan_project_id" to projectId.intValue,
-            "plan_author_id" to authorId?.intValue,
-            "plan_application_id" to applicationId.intValue,
-            "plan_time" to plan.planTime?.let { instant -> Timestamp.from(instant) },
-            "linear_unit" to plan.units.linearUnit.name,
-            "direction_unit" to plan.units.directionUnit.name,
-            "srid" to plan.units.coordinateSystemSrid?.code,
-            "coordinate_system_name" to plan.units.coordinateSystemName,
-            "polygon_string" to if (!boundingBoxInLayoutCoordinates.isNullOrEmpty()) create2DPolygonString(
-                boundingBoxInLayoutCoordinates
+        val params =
+            mapOf(
+                "track_number" to plan.trackNumber?.toString(),
+                "track_number_description" to plan.trackNumberDescription,
+                "plan_project_id" to projectId.intValue,
+                "plan_author_id" to authorId?.intValue,
+                "plan_application_id" to applicationId.intValue,
+                "plan_time" to plan.planTime?.let { instant -> Timestamp.from(instant) },
+                "linear_unit" to plan.units.linearUnit.name,
+                "direction_unit" to plan.units.directionUnit.name,
+                "srid" to plan.units.coordinateSystemSrid?.code,
+                "coordinate_system_name" to plan.units.coordinateSystemName,
+                "polygon_string" to
+                    if (!boundingBoxInLayoutCoordinates.isNullOrEmpty())
+                        create2DPolygonString(boundingBoxInLayoutCoordinates)
+                    else null,
+                "vertical_coordinate_system" to plan.units.verticalCoordinateSystem?.name,
+                "mapSrid" to LAYOUT_SRID.code,
+                "source" to plan.source.name,
+                "projektivelho_document_id" to plan.pvDocumentId?.intValue,
+                "plan_phase" to plan.planPhase?.name,
+                "plan_decision" to plan.decisionPhase?.name,
+                "measurement_method" to plan.measurementMethod?.name,
+                "elevation_measurement_method" to plan.elevationMeasurementMethod?.name,
+                "message" to plan.message,
+                "hidden" to plan.isHidden,
             )
-            else null,
-            "vertical_coordinate_system" to plan.units.verticalCoordinateSystem?.name,
-            "mapSrid" to LAYOUT_SRID.code,
-            "source" to plan.source.name,
-            "projektivelho_document_id" to plan.pvDocumentId?.intValue,
-            "plan_phase" to plan.planPhase?.name,
-            "plan_decision" to plan.decisionPhase?.name,
-            "measurement_method" to plan.measurementMethod?.name,
-            "elevation_measurement_method" to plan.elevationMeasurementMethod?.name,
-            "message" to plan.message,
-            "hidden" to plan.isHidden,
-        )
 
         val planId: RowVersion<GeometryPlan> =
             jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
@@ -157,20 +172,27 @@ class GeometryDao @Autowired constructor(
         return planId
     }
 
-    private fun insertPlanFile(planId: IntId<GeometryPlan>, file: InfraModelFile): IntId<InfraModelFile> {
-        val sql = """
+    private fun insertPlanFile(
+        planId: IntId<GeometryPlan>,
+        file: InfraModelFile
+    ): IntId<InfraModelFile> {
+        val sql =
+            """
            insert into geometry.plan_file(plan_id, name, content) 
            values (:plan_id, :file_name, xmlparse(document :file_content))
            returning id, hash
-       """.trimIndent()
-        val params = mapOf(
-            "plan_id" to planId.intValue,
-            "file_name" to file.name,
-            "file_content" to file.content,
-        )
-        val (fileId, hash) = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getIntId<InfraModelFile>("id") to rs.getString("hash")
-        } ?: throw IllegalStateException("Failed to insert plan file into DB")
+       """
+                .trimIndent()
+        val params =
+            mapOf(
+                "plan_id" to planId.intValue,
+                "file_name" to file.name,
+                "file_content" to file.content,
+            )
+        val (fileId, hash) =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+                rs.getIntId<InfraModelFile>("id") to rs.getString("hash")
+            } ?: throw IllegalStateException("Failed to insert plan file into DB")
         require(hash == file.hash) {
             "Backend hash calculation should match the automatic DB-generated: file=${file.name} db=$hash backend=${file.hash}"
         }
@@ -180,49 +202,61 @@ class GeometryDao @Autowired constructor(
     }
 
     fun getPlanFile(planId: IntId<GeometryPlan>): InfraModelFileWithSource {
-        val sql = """
+        val sql =
+            """
           select name as file_name, plan.source, xmlserialize(document content as varchar) as file_content
             from geometry.plan_file
             inner join geometry.plan 
             on plan_id = plan.id
           where plan_id = :plan_id
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("plan_id" to planId.intValue)
-        return getOne(planId, jdbcTemplate.query(sql, params) { rs, _ ->
-            InfraModelFileWithSource(
-                file = InfraModelFile(
-                    name = rs.getFileName("file_name"),
-                    content = rs.getString("file_content"),
-                ), source = rs.getEnum("source")
-            )
-        })
+        return getOne(
+            planId,
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                InfraModelFileWithSource(
+                    file =
+                        InfraModelFile(
+                            name = rs.getFileName("file_name"),
+                            content = rs.getString("file_content"),
+                        ),
+                    source = rs.getEnum("source"))
+            })
     }
 
-    fun fetchDuplicateGeometryPlanVersion(newFile: InfraModelFile, source: PlanSource): RowVersion<GeometryPlan>? {
-        //language=SQL
-        val sql = """
+    fun fetchDuplicateGeometryPlanVersion(
+        newFile: InfraModelFile,
+        source: PlanSource
+    ): RowVersion<GeometryPlan>? {
+        // language=SQL
+        val sql =
+            """
             select plan.id, plan.version
             from geometry.plan 
               left join geometry.plan_file on plan.id = plan_file.plan_id
             where plan_file.hash = :hash 
               and plan.source = :source::geometry.plan_source
               and plan.hidden = false
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("hash" to newFile.hash, "source" to source.name)
 
-        return jdbcTemplate.queryOptional<RowVersion<GeometryPlan>>(sql, params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        }?.also {
-            logger.daoAccess(FETCH, GeometryPlan::class, it)
-        }
+        return jdbcTemplate
+            .queryOptional<RowVersion<GeometryPlan>>(sql, params) { rs, _ ->
+                rs.getRowVersion("id", "version")
+            }
+            ?.also { logger.daoAccess(FETCH, GeometryPlan::class, it) }
     }
 
-    fun getPlanLinking(planId: IntId<GeometryPlan>): GeometryPlanLinkedItems = getPlanLinkings(listOf(planId)).first()
+    fun getPlanLinking(planId: IntId<GeometryPlan>): GeometryPlanLinkedItems =
+        getPlanLinkings(listOf(planId)).first()
 
     fun getPlanLinkings(planIds: List<IntId<GeometryPlan>>): List<GeometryPlanLinkedItems> {
         if (planIds.isEmpty()) return listOf()
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             with
               location_tracks as (
                 select
@@ -247,41 +281,53 @@ class GeometryDao @Autowired constructor(
               (select array_agg(id) from location_tracks where plan_id in (:plan_ids)) as location_track_ids,
               (select array_agg(id) from switches where plan_id in (:plan_ids)) as switch_ids,
               (select array_agg(id) from km_posts where plan_id in (:plan_ids)) as km_post_ids
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("plan_ids" to planIds.map(IntId<GeometryPlan>::intValue))
-        return jdbcTemplate.query(sql, params) { rs, _ ->
-            GeometryPlanLinkedItems(
-                rs.getIntIdArray("location_track_ids"),
-                rs.getIntIdArray("switch_ids"),
-                rs.getIntIdArray("km_post_ids"),
-            )
-        }.also { logger.daoAccess(FETCH, GeometryPlanLinkedItems::class, planIds) }
+        return jdbcTemplate
+            .query(sql, params) { rs, _ ->
+                GeometryPlanLinkedItems(
+                    rs.getIntIdArray("location_track_ids"),
+                    rs.getIntIdArray("switch_ids"),
+                    rs.getIntIdArray("km_post_ids"),
+                )
+            }
+            .also { logger.daoAccess(FETCH, GeometryPlanLinkedItems::class, planIds) }
     }
 
     @Transactional
     fun setPlanHidden(id: IntId<GeometryPlan>, hidden: Boolean): RowVersion<GeometryPlan> {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             update geometry.plan
             set hidden = :hidden
             where id = :id
             returning id, version
-        """.trimIndent()
-        val params = mapOf(
-            "id" to id.intValue,
-            "hidden" to hidden,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "id" to id.intValue,
+                "hidden" to hidden,
+            )
 
         jdbcTemplate.setUser()
-        return jdbcTemplate.queryOne<RowVersion<GeometryPlan>>(sql, params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        }.also { v -> logger.daoAccess(UPDATE, GeometryPlan::class, id) }
+        return jdbcTemplate
+            .queryOne<RowVersion<GeometryPlan>>(sql, params) { rs, _ ->
+                rs.getRowVersion("id", "version")
+            }
+            .also { v -> logger.daoAccess(UPDATE, GeometryPlan::class, id) }
     }
 
     @Transactional
-    fun updatePlan(planId: IntId<GeometryPlan>, geometryPlan: GeometryPlan): RowVersion<GeometryPlan> {
+    fun updatePlan(
+        planId: IntId<GeometryPlan>,
+        geometryPlan: GeometryPlan
+    ): RowVersion<GeometryPlan> {
         jdbcTemplate.setUser()
-        val sql = """
+        val sql =
+            """
             update geometry.plan
             set
               track_number = :track_number,
@@ -302,33 +348,36 @@ class GeometryDao @Autowired constructor(
               hidden = :hidden
             where id = :id
             returning id, version
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "id" to planId.intValue,
-            "track_number" to geometryPlan.trackNumber?.toString(),
-            "track_number_description" to geometryPlan.trackNumberDescription,
-            "plan_project_id" to (geometryPlan.project.id as IntId).intValue,
-            "plan_author_id" to (geometryPlan.author?.id as IntId?)?.intValue,
-            "plan_time" to geometryPlan.planTime?.let { instant -> Timestamp.from(instant) },
-            "srid" to geometryPlan.units.coordinateSystemSrid?.code,
-            "coordinate_system_name" to geometryPlan.units.coordinateSystemName,
-            "vertical_coordinate_system" to geometryPlan.units.verticalCoordinateSystem?.name,
-            "projektivelho_document_id" to geometryPlan.pvDocumentId?.intValue,
-            "plan_phase" to geometryPlan.planPhase?.name,
-            "plan_decision" to geometryPlan.decisionPhase?.name,
-            "measurement_method" to geometryPlan.measurementMethod?.name,
-            "elevation_measurement_method" to geometryPlan.elevationMeasurementMethod?.name,
-            "message" to geometryPlan.message,
-            "source" to geometryPlan.source.name,
-            "hidden" to geometryPlan.isHidden,
-        )
+        val params =
+            mapOf(
+                "id" to planId.intValue,
+                "track_number" to geometryPlan.trackNumber?.toString(),
+                "track_number_description" to geometryPlan.trackNumberDescription,
+                "plan_project_id" to (geometryPlan.project.id as IntId).intValue,
+                "plan_author_id" to (geometryPlan.author?.id as IntId?)?.intValue,
+                "plan_time" to geometryPlan.planTime?.let { instant -> Timestamp.from(instant) },
+                "srid" to geometryPlan.units.coordinateSystemSrid?.code,
+                "coordinate_system_name" to geometryPlan.units.coordinateSystemName,
+                "vertical_coordinate_system" to geometryPlan.units.verticalCoordinateSystem?.name,
+                "projektivelho_document_id" to geometryPlan.pvDocumentId?.intValue,
+                "plan_phase" to geometryPlan.planPhase?.name,
+                "plan_decision" to geometryPlan.decisionPhase?.name,
+                "measurement_method" to geometryPlan.measurementMethod?.name,
+                "elevation_measurement_method" to geometryPlan.elevationMeasurementMethod?.name,
+                "message" to geometryPlan.message,
+                "source" to geometryPlan.source.name,
+                "hidden" to geometryPlan.isHidden,
+            )
 
-        return getOne(planId, jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getRowVersion<GeometryPlan>("id", "version")
-        }).also {
-            logger.daoAccess(UPDATE, GeometryPlan::class, planId)
-        }
+        return getOne(
+                planId,
+                jdbcTemplate.query(sql, params) { rs, _ ->
+                    rs.getRowVersion<GeometryPlan>("id", "version")
+                })
+            .also { logger.daoAccess(UPDATE, GeometryPlan::class, planId) }
     }
 
     @Transactional
@@ -338,17 +387,17 @@ class GeometryDao @Autowired constructor(
     }
 
     private fun insertProjectInternal(project: Project): RowVersion<Project> {
-        val sql = """
+        val sql =
+            """
             insert into geometry.plan_project(name, description) 
             values (:name, :description) 
             returning id, version
-        """.trimIndent()
-        val params = mapOf(
-            "name" to project.name, "description" to project.description
-        )
-        val projectVersion: RowVersion<Project> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        } ?: throw IllegalStateException("Failed to get generated ID for new project")
+        """
+                .trimIndent()
+        val params = mapOf("name" to project.name, "description" to project.description)
+        val projectVersion: RowVersion<Project> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
+                ?: throw IllegalStateException("Failed to get generated ID for new project")
         logger.daoAccess(INSERT, Project::class, projectVersion)
         return projectVersion
     }
@@ -360,16 +409,18 @@ class GeometryDao @Autowired constructor(
     }
 
     private fun insertAuthorInternal(author: Author): RowVersion<Author> {
-        val sql = """
+        val sql =
+            """
             insert into geometry.plan_author(company_name)
             values (:company_name)
             returning id, version
-        """.trimIndent()
+        """
+                .trimIndent()
 
         val params = mapOf("company_name" to author.companyName)
-        val authorVersion: RowVersion<Author> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        } ?: throw IllegalStateException("Failed to get generated ID for new author")
+        val authorVersion: RowVersion<Author> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
+                ?: throw IllegalStateException("Failed to get generated ID for new author")
         logger.daoAccess(INSERT, Author::class, authorVersion)
         return authorVersion
     }
@@ -381,47 +432,55 @@ class GeometryDao @Autowired constructor(
     }
 
     private fun insertApplicationInternal(application: Application): RowVersion<Application> {
-        val sql = """
+        val sql =
+            """
             insert into geometry.plan_application(name, manufacturer, application_version)
             values (:name, :manufacturer, :application_version) 
             returning id, version
             """
-        val params = mapOf(
-            "name" to application.name,
-            "manufacturer" to application.manufacturer,
-            "application_version" to application.version,
-        )
-        val appId: RowVersion<Application> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        } ?: throw IllegalStateException("Failed to get generated ID for new application")
+        val params =
+            mapOf(
+                "name" to application.name,
+                "manufacturer" to application.manufacturer,
+                "application_version" to application.version,
+            )
+        val appId: RowVersion<Application> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
+                ?: throw IllegalStateException("Failed to get generated ID for new application")
         logger.daoAccess(INSERT, Application::class, appId)
         return appId
     }
 
     fun findApplication(name: MetaDataName, version: MetaDataName): Application? {
-        val sql = """
+        val sql =
+            """
             select
               id, name, manufacturer, application_version
             from geometry.plan_application
             where unique_name = common.nospace_lowercase(:name) || ' ' || common.nospace_lowercase(:application_version)
-        """.trimIndent()
+        """
+                .trimIndent()
 
         val params = mapOf("name" to name, "application_version" to version)
-        val application = jdbcTemplate.query(sql, params) { rs, _ ->
-            Application(
-                id = rs.getIntId("id"),
-                name = MetaDataName(rs.getString("name")),
-                manufacturer = MetaDataName(rs.getString("manufacturer")),
-                version = MetaDataName(rs.getString("application_version")),
-            )
-        }.firstOrNull()
+        val application =
+            jdbcTemplate
+                .query(sql, params) { rs, _ ->
+                    Application(
+                        id = rs.getIntId("id"),
+                        name = MetaDataName(rs.getString("name")),
+                        manufacturer = MetaDataName(rs.getString("manufacturer")),
+                        version = MetaDataName(rs.getString("application_version")),
+                    )
+                }
+                .firstOrNull()
 
         application?.also { logger.daoAccess(FETCH, Application::class, it.id) }
         return application
     }
 
     fun getApplication(applicationId: IntId<Application>): Application {
-        val sql = """
+        val sql =
+            """
             select 
             id,
             name,
@@ -429,18 +488,22 @@ class GeometryDao @Autowired constructor(
             application_version
             from geometry.plan_application
             where id = :id
-        """.trimIndent()
+        """
+                .trimIndent()
 
         val params = mapOf("id" to applicationId.intValue)
 
-        val application = jdbcTemplate.query(sql, params) { rs, _ ->
-            Application(
-                id = rs.getIntId("id"),
-                name = MetaDataName(rs.getString("name")),
-                manufacturer = MetaDataName(rs.getString("manufacturer")),
-                version = MetaDataName(rs.getString("application_version")),
-            )
-        }.firstOrNull() ?: throw NoSuchEntityException(Project::class, applicationId)
+        val application =
+            jdbcTemplate
+                .query(sql, params) { rs, _ ->
+                    Application(
+                        id = rs.getIntId("id"),
+                        name = MetaDataName(rs.getString("name")),
+                        manufacturer = MetaDataName(rs.getString("manufacturer")),
+                        version = MetaDataName(rs.getString("application_version")),
+                    )
+                }
+                .firstOrNull() ?: throw NoSuchEntityException(Project::class, applicationId)
         logger.daoAccess(FETCH, Application::class, application.id)
 
         return application
@@ -453,8 +516,12 @@ class GeometryDao @Autowired constructor(
         return switches.map { switch -> switch.id to insertSwitch(planId, switch) }.associate { it }
     }
 
-    private fun insertSwitch(plandId: IntId<GeometryPlan>, switch: GeometrySwitch): IntId<GeometrySwitch> {
-        val sql = """
+    private fun insertSwitch(
+        plandId: IntId<GeometryPlan>,
+        switch: GeometrySwitch
+    ): IntId<GeometrySwitch> {
+        val sql =
+            """
             insert into geometry.switch(
               plan_id, 
               name,
@@ -470,33 +537,42 @@ class GeometryDao @Autowired constructor(
               :state::geometry.plan_state
             )
             returning id
-        """.trimIndent()
-        val params = mapOf(
-            "plan_id" to plandId.intValue,
-            "name" to switch.name,
-            "switch_structure_id" to switch.switchStructureId?.intValue,
-            "type_name" to switch.typeName,
-            "state" to switch.state?.name
-        )
-        val id = jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getIntId<GeometrySwitch>("id") }
-            ?: throw IllegalStateException("Failed to get generated ID for new switch")
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "plan_id" to plandId.intValue,
+                "name" to switch.name,
+                "switch_structure_id" to switch.switchStructureId?.intValue,
+                "type_name" to switch.typeName,
+                "state" to switch.state?.name)
+        val id =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getIntId<GeometrySwitch>("id") }
+                ?: throw IllegalStateException("Failed to get generated ID for new switch")
         insertSwitchJoints(id, switch.joints)
         return id
     }
 
-    private fun insertSwitchJoints(switchId: IntId<GeometrySwitch>, joints: List<GeometrySwitchJoint>) {
-        val sql = """
+    private fun insertSwitchJoints(
+        switchId: IntId<GeometrySwitch>,
+        joints: List<GeometrySwitchJoint>
+    ) {
+        val sql =
+            """
             insert into geometry.switch_joint(switch_id, number, location)
             values (:switch_id, :number, postgis.st_point(:x, :y))
             """
-        val params = joints.map { joint ->
-            mapOf(
-                "switch_id" to switchId.intValue,
-                "number" to joint.number.intValue,
-                "x" to joint.location.x,
-                "y" to joint.location.y,
-            )
-        }.toTypedArray()
+        val params =
+            joints
+                .map { joint ->
+                    mapOf(
+                        "switch_id" to switchId.intValue,
+                        "number" to joint.number.intValue,
+                        "x" to joint.location.x,
+                        "y" to joint.location.y,
+                    )
+                }
+                .toTypedArray()
         jdbcTemplate.batchUpdate(sql, params)
     }
 
@@ -505,33 +581,38 @@ class GeometryDao @Autowired constructor(
         alignments: List<GeometryAlignment>,
         switchDatabaseIds: Map<DomainId<GeometrySwitch>, IntId<GeometrySwitch>>,
     ) {
-        val idToAlignment: List<Pair<IntId<GeometryAlignment>, GeometryAlignment>> = alignments.map { alignment ->
-            insertAlignment(planId, alignment).id to alignment
-        }
+        val idToAlignment: List<Pair<IntId<GeometryAlignment>, GeometryAlignment>> =
+            alignments.map { alignment -> insertAlignment(planId, alignment).id to alignment }
 
-        val elementParams = idToAlignment.flatMap { (alignmentId, alignment) ->
-            getGeometryElementSqlParams(alignmentId, alignment.elements, switchDatabaseIds)
-        }
+        val elementParams =
+            idToAlignment.flatMap { (alignmentId, alignment) ->
+                getGeometryElementSqlParams(alignmentId, alignment.elements, switchDatabaseIds)
+            }
         insertGeometryElements(elementParams)
 
-        val viParams = idToAlignment.flatMap { (alignmentId, alignment) ->
-            alignment.profile?.let { profile -> getVerticalIntersectionSqlParams(alignmentId, profile.elements) }
-                ?: listOf()
-        }
+        val viParams =
+            idToAlignment.flatMap { (alignmentId, alignment) ->
+                alignment.profile?.let { profile ->
+                    getVerticalIntersectionSqlParams(alignmentId, profile.elements)
+                } ?: listOf()
+            }
         if (viParams.isNotEmpty()) {
             insertVerticalIntersections(viParams)
         }
 
-        val cantParams = idToAlignment.flatMap { (alignmentId, alignment) ->
-            alignment.cant?.let { cant -> getCantPointSqlParams(alignmentId, cant.points) } ?: listOf()
-        }
+        val cantParams =
+            idToAlignment.flatMap { (alignmentId, alignment) ->
+                alignment.cant?.let { cant -> getCantPointSqlParams(alignmentId, cant.points) }
+                    ?: listOf()
+            }
         if (cantParams.isNotEmpty()) {
             insertCantPoints(cantParams)
         }
     }
 
     private fun insertKmPosts(kmPostParams: List<Map<String, Any?>>) {
-        val sql = """
+        val sql =
+            """
             insert into geometry.km_post(
               km_post_index,
               plan_id,
@@ -582,7 +663,8 @@ class GeometryDao @Autowired constructor(
         planId: IntId<GeometryPlan>,
         alignment: GeometryAlignment,
     ): RowVersion<GeometryAlignment> {
-        val sql = """ 
+        val sql =
+            """ 
             insert into geometry.alignment(
               plan_id,
               name,
@@ -608,27 +690,29 @@ class GeometryDao @Autowired constructor(
               :cant_rotation_point::geometry.cant_rotation_point,
               :feature_type_code)
             returning id --, version
-        """.trimIndent()
-        val params = mapOf(
-            "plan_id" to planId.intValue,
-            "name" to alignment.name,
-            "description" to alignment.description,
-            "state" to alignment.state?.name,
-            "sta_start" to alignment.staStart,
-            "profile_name" to alignment.profile?.name,
-            "cant_name" to alignment.cant?.name,
-            "cant_description" to alignment.cant?.description,
-            "cant_gauge" to alignment.cant?.gauge,
-            "cant_rotation_point" to alignment.cant?.rotationPoint?.name,
-            "feature_type_code" to alignment.featureTypeCode
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "plan_id" to planId.intValue,
+                "name" to alignment.name,
+                "description" to alignment.description,
+                "state" to alignment.state?.name,
+                "sta_start" to alignment.staStart,
+                "profile_name" to alignment.profile?.name,
+                "cant_name" to alignment.cant?.name,
+                "cant_description" to alignment.cant?.description,
+                "cant_gauge" to alignment.cant?.gauge,
+                "cant_rotation_point" to alignment.cant?.rotationPoint?.name,
+                "feature_type_code" to alignment.featureTypeCode)
         return jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            RowVersion(rs.getIntId("id"), 1)//rs.getRowVersion("id", "version")
+            RowVersion(rs.getIntId("id"), 1) // rs.getRowVersion("id", "version")
         } ?: throw IllegalStateException("Failed to get generated ID for new alignment")
     }
 
     fun preloadHeaderCache() {
-        val sql = """
+        val sql =
+            """
           select 
             plan.id as plan_id, 
             plan.version as plan_version, 
@@ -667,24 +751,29 @@ class GeometryDao @Autowired constructor(
                 bool_or(cant_name is not null) as has_cant
               from geometry.alignment where plan_id = plan.id
             ) alignments on (true)
-        """.trimIndent()
-        val headers = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ -> getPlanHeader(rs) }
-            .associateBy(GeometryPlanHeader::version)
+        """
+                .trimIndent()
+        val headers =
+            jdbcTemplate
+                .query(sql, mapOf<String, Any>()) { rs, _ -> getPlanHeader(rs) }
+                .associateBy(GeometryPlanHeader::version)
         logger.daoAccess(FETCH, GeometryPlanHeader::class, headers.keys)
         headerCache.putAll(headers)
     }
 
     fun getPlanHeader(planId: IntId<GeometryPlan>) = getPlanHeader(fetchPlanVersion(planId))
 
-    fun getPlanHeaders(planIds: List<IntId<GeometryPlan>>) = fetchManyPlanVersions(planIds).map(::getPlanHeader)
+    fun getPlanHeaders(planIds: List<IntId<GeometryPlan>>) =
+        fetchManyPlanVersions(planIds).map(::getPlanHeader)
 
     fun getPlanHeader(rowVersion: RowVersion<GeometryPlan>): GeometryPlanHeader =
         if (cacheEnabled) headerCache.get(rowVersion) { v -> getPlanHeaderInternal(v) }
         else getPlanHeaderInternal(rowVersion)
 
     private fun getPlanHeaderInternal(rowVersion: RowVersion<GeometryPlan>): GeometryPlanHeader {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
           select 
             plan.id as plan_id, 
             plan.version as plan_version, 
@@ -725,22 +814,24 @@ class GeometryDao @Autowired constructor(
             ) alignments on (true)
           where :plan_id = plan.id 
             and :plan_version = plan.version
-        """.trimIndent()
-        val params = mapOf(
-            "plan_id" to rowVersion.id.intValue,
-            "plan_version" to rowVersion.version,
-        )
-        return getOne(rowVersion.id, jdbcTemplate.query(sql, params) { rs, _ -> getPlanHeader(rs) }).also { header ->
-            logger.daoAccess(FETCH, GeometryPlanHeader::class, header.version)
-        }
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "plan_id" to rowVersion.id.intValue,
+                "plan_version" to rowVersion.version,
+            )
+        return getOne(rowVersion.id, jdbcTemplate.query(sql, params) { rs, _ -> getPlanHeader(rs) })
+            .also { header -> logger.daoAccess(FETCH, GeometryPlanHeader::class, header.version) }
     }
 
     private fun getPlanHeader(rs: ResultSet): GeometryPlanHeader {
-        val project = Project(
-            id = rs.getIntId("project_id"),
-            name = ProjectName(rs.getString("project_name")),
-            description = rs.getFreeTextOrNull("project_description"),
-        )
+        val project =
+            Project(
+                id = rs.getIntId("project_id"),
+                name = ProjectName(rs.getString("project_name")),
+                description = rs.getFreeTextOrNull("project_description"),
+            )
 
         val minKm = rs.getKmNumberOrNull("min_km_number")
         val maxKm = rs.getKmNumberOrNull("max_km_number")
@@ -755,19 +846,23 @@ class GeometryDao @Autowired constructor(
             planTime = rs.getInstantOrNull("plan_time"),
             trackNumber = rs.getTrackNumberOrNull("track_number"),
             measurementMethod = rs.getEnumOrNull<MeasurementMethod>("measurement_method"),
-            elevationMeasurementMethod = rs.getEnumOrNull<ElevationMeasurementMethod>("elevation_measurement_method"),
+            elevationMeasurementMethod =
+                rs.getEnumOrNull<ElevationMeasurementMethod>("elevation_measurement_method"),
             decisionPhase = rs.getEnumOrNull<PlanDecisionPhase>("plan_decision"),
             planPhase = rs.getEnumOrNull<PlanPhase>("plan_phase"),
             message = rs.getFreeTextWithNewLinesOrNull("message"),
             linkedAsPlanId = rs.getIntIdOrNull("linked_as_plan_id"),
             uploadTime = rs.getInstant("upload_time"),
-            units = GeometryUnits(
-                coordinateSystemSrid = rs.getSridOrNull("srid"),
-                coordinateSystemName = rs.getString("coordinate_system_name")?.let(::CoordinateSystemName),
-                verticalCoordinateSystem = rs.getEnumOrNull<VerticalCoordinateSystem>("vertical_coordinate_system"),
-                directionUnit = rs.getEnum("direction_unit"),
-                linearUnit = rs.getEnum("linear_unit"),
-            ),
+            units =
+                GeometryUnits(
+                    coordinateSystemSrid = rs.getSridOrNull("srid"),
+                    coordinateSystemName =
+                        rs.getString("coordinate_system_name")?.let(::CoordinateSystemName),
+                    verticalCoordinateSystem =
+                        rs.getEnumOrNull<VerticalCoordinateSystem>("vertical_coordinate_system"),
+                    directionUnit = rs.getEnum("direction_unit"),
+                    linearUnit = rs.getEnum("linear_unit"),
+                ),
             author = rs.getString("author"),
             hasProfile = rs.getBoolean("has_profile"),
             hasCant = rs.getBoolean("has_cant"),
@@ -782,7 +877,8 @@ class GeometryDao @Autowired constructor(
         sources: List<PlanSource>,
         bbox: BoundingBox?,
     ): List<RowVersion<GeometryPlan>> {
-        val sql = """
+        val sql =
+            """
             select id, version
             from geometry.plan
             where source::text in (:sources)
@@ -791,43 +887,48 @@ class GeometryDao @Autowired constructor(
                 plan.bounding_polygon_simple,
                 postgis.st_polygonfromtext(:polygon_wkt::varchar, :map_srid)
               ))
-        """.trimIndent()
-        val params = mapOf(
-            "sources" to (sources.ifEmpty { PlanSource.values().toList() }).map(PlanSource::name),
-            "polygon_wkt" to bbox?.let { b -> create2DPolygonString(b.polygonFromCorners) },
-            "map_srid" to LAYOUT_SRID.code,
-        )
-        return jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        }
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "sources" to
+                    (sources.ifEmpty { PlanSource.values().toList() }).map(PlanSource::name),
+                "polygon_wkt" to bbox?.let { b -> create2DPolygonString(b.polygonFromCorners) },
+                "map_srid" to LAYOUT_SRID.code,
+            )
+        return jdbcTemplate.query(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
     }
 
     fun fetchPlanVersions() = fetchRowVersions<GeometryPlan>(GEOMETRY_PLAN)
 
     fun fetchPlanVersion(id: IntId<GeometryPlan>) = fetchRowVersion(id, GEOMETRY_PLAN)
 
-    fun fetchManyPlanVersions(ids: List<IntId<GeometryPlan>>) = fetchManyRowVersions(ids, GEOMETRY_PLAN)
+    fun fetchManyPlanVersions(ids: List<IntId<GeometryPlan>>) =
+        fetchManyRowVersions(ids, GEOMETRY_PLAN)
 
     fun fetchAlignmentPlanVersion(alignmentId: IntId<GeometryAlignment>): RowVersion<GeometryPlan> {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select plan.id, plan.version
             from geometry.alignment 
               left join geometry.plan on plan.id = alignment.plan_id
             where alignment.id = :alignment_id
-        """.trimIndent()
-        val params = mapOf(
-            "alignment_id" to alignmentId.intValue,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "alignment_id" to alignmentId.intValue,
+            )
         return jdbcTemplate.queryOne(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
     }
-
 
     fun fetchPlanChangeTime(): Instant = fetchLatestChangeTime(GEOMETRY_PLAN)
 
     fun fetchPlanAreas(mapBoundingBox: BoundingBox): List<GeometryPlanArea> {
         val searchPolygonWkt = create2DPolygonString(mapBoundingBox.polygonFromCorners)
-        val sql = """
+        val sql =
+            """
           select 
             plan.id,
             plan_file.name as file_name,
@@ -839,26 +940,33 @@ class GeometryDao @Autowired constructor(
                   plan.bounding_polygon_simple, 
                   postgis.st_polygonfromtext(:polygon_wkt, :map_srid)
               )
-        """.trimIndent()
-        val params = mapOf(
-            "polygon_wkt" to searchPolygonWkt,
-            "map_srid" to LAYOUT_SRID.code,
-        )
-        val result = jdbcTemplate.query(sql, params) { rs, _ ->
-            val area = GeometryPlanArea(
-                id = rs.getIntId("id"),
-                fileName = rs.getFileName("file_name"),
-                polygon = rs.getPolygonPointList("bounding_polygon"),
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "polygon_wkt" to searchPolygonWkt,
+                "map_srid" to LAYOUT_SRID.code,
             )
-            area
-        }.filterNotNull()
+        val result =
+            jdbcTemplate
+                .query(sql, params) { rs, _ ->
+                    val area =
+                        GeometryPlanArea(
+                            id = rs.getIntId("id"),
+                            fileName = rs.getFileName("file_name"),
+                            polygon = rs.getPolygonPointList("bounding_polygon"),
+                        )
+                    area
+                }
+                .filterNotNull()
         logger.daoAccess(FETCH, GeometryPlanArea::class, result.map { a -> a.id })
         return result
     }
 
     @Cacheable(CACHE_GEOMETRY_PLAN, sync = true)
     fun fetchPlan(planVersion: RowVersion<GeometryPlan>): GeometryPlan {
-        val sql = """
+        val sql =
+            """
             select
               plan.id,
               plan.source,
@@ -891,110 +999,142 @@ class GeometryDao @Autowired constructor(
               left join geometry.plan_author on plan.plan_author_id = plan_author.id
               left join geometry.plan_application on plan.plan_application_id = plan_application.id
             where plan.id = :plan_id
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("plan_id" to planVersion.id.intValue)
 
-        val plan = jdbcTemplate.query(sql, params) { rs, i ->
-            val units = GeometryUnits(
-                coordinateSystemSrid = rs.getSridOrNull("srid"),
-                coordinateSystemName = rs.getString("coordinate_system_name")?.let(::CoordinateSystemName),
-                verticalCoordinateSystem = rs.getEnumOrNull<VerticalCoordinateSystem>("vertical_coordinate_system"),
-                directionUnit = rs.getEnum("direction_unit"),
-                linearUnit = rs.getEnum("linear_unit"),
-            )
-            val authorId = rs.getIntIdOrNull<Author>("author_id")
-            val geometryPlan = GeometryPlan(
-                id = rs.getIntId("id"),
-                source = rs.getEnum<PlanSource>("source"),
-                project = getProject(rs.getIntId("plan_project_id")),
-                author = authorId?.let { id ->
-                    Author(id = id, companyName = CompanyName(rs.getString("author_company_name")))
-                },
-                application = Application(
-                    id = rs.getIntId("application_id"),
-                    name = MetaDataName(rs.getString("application_name")),
-                    manufacturer = MetaDataName(rs.getString("application_manufacturer")),
-                    version = MetaDataName(rs.getString("application_version")),
-                ),
-                planTime = rs.getInstantOrNull("plan_time"),
-                units = units,
-                trackNumber = rs.getTrackNumberOrNull("track_number"),
-                trackNumberDescription = PlanElementName(rs.getString("track_number_description")),
-                alignments = fetchAlignments(units, planVersion.id),
-                switches = fetchSwitches(planId = planVersion.id, switchId = null),
-                kmPosts = fetchKmPosts(planVersion.id),
-                fileName = rs.getFileName("file_name"),
-                pvDocumentId = rs.getIntIdOrNull("projektivelho_document_id"),
-                planPhase = rs.getEnumOrNull<PlanPhase>("plan_phase"),
-                decisionPhase = rs.getEnumOrNull<PlanDecisionPhase>("plan_decision"),
-                measurementMethod = rs.getEnumOrNull<MeasurementMethod>("measurement_method"),
-                elevationMeasurementMethod = rs.getEnumOrNull<ElevationMeasurementMethod>("elevation_measurement_method"),
-                dataType = DataType.STORED,
-                message = rs.getFreeTextWithNewLinesOrNull("message"),
-                uploadTime = rs.getInstant("upload_time"),
-                isHidden = rs.getBoolean("hidden"),
-            )
-            geometryPlan
-        }.firstOrNull() ?: throw NoSuchEntityException(GeometryPlan::class, planVersion.id)
+        val plan =
+            jdbcTemplate
+                .query(sql, params) { rs, i ->
+                    val units =
+                        GeometryUnits(
+                            coordinateSystemSrid = rs.getSridOrNull("srid"),
+                            coordinateSystemName =
+                                rs.getString("coordinate_system_name")?.let(::CoordinateSystemName),
+                            verticalCoordinateSystem =
+                                rs.getEnumOrNull<VerticalCoordinateSystem>(
+                                    "vertical_coordinate_system"),
+                            directionUnit = rs.getEnum("direction_unit"),
+                            linearUnit = rs.getEnum("linear_unit"),
+                        )
+                    val authorId = rs.getIntIdOrNull<Author>("author_id")
+                    val geometryPlan =
+                        GeometryPlan(
+                            id = rs.getIntId("id"),
+                            source = rs.getEnum<PlanSource>("source"),
+                            project = getProject(rs.getIntId("plan_project_id")),
+                            author =
+                                authorId?.let { id ->
+                                    Author(
+                                        id = id,
+                                        companyName =
+                                            CompanyName(rs.getString("author_company_name")))
+                                },
+                            application =
+                                Application(
+                                    id = rs.getIntId("application_id"),
+                                    name = MetaDataName(rs.getString("application_name")),
+                                    manufacturer =
+                                        MetaDataName(rs.getString("application_manufacturer")),
+                                    version = MetaDataName(rs.getString("application_version")),
+                                ),
+                            planTime = rs.getInstantOrNull("plan_time"),
+                            units = units,
+                            trackNumber = rs.getTrackNumberOrNull("track_number"),
+                            trackNumberDescription =
+                                PlanElementName(rs.getString("track_number_description")),
+                            alignments = fetchAlignments(units, planVersion.id),
+                            switches = fetchSwitches(planId = planVersion.id, switchId = null),
+                            kmPosts = fetchKmPosts(planVersion.id),
+                            fileName = rs.getFileName("file_name"),
+                            pvDocumentId = rs.getIntIdOrNull("projektivelho_document_id"),
+                            planPhase = rs.getEnumOrNull<PlanPhase>("plan_phase"),
+                            decisionPhase = rs.getEnumOrNull<PlanDecisionPhase>("plan_decision"),
+                            measurementMethod =
+                                rs.getEnumOrNull<MeasurementMethod>("measurement_method"),
+                            elevationMeasurementMethod =
+                                rs.getEnumOrNull<ElevationMeasurementMethod>(
+                                    "elevation_measurement_method"),
+                            dataType = DataType.STORED,
+                            message = rs.getFreeTextWithNewLinesOrNull("message"),
+                            uploadTime = rs.getInstant("upload_time"),
+                            isHidden = rs.getBoolean("hidden"),
+                        )
+                    geometryPlan
+                }
+                .firstOrNull() ?: throw NoSuchEntityException(GeometryPlan::class, planVersion.id)
         logger.daoAccess(FETCH, GeometryPlan::class, planVersion)
         return plan
     }
 
     fun getProject(projectId: IntId<Project>): Project {
-        val sql = """
+        val sql =
+            """
             select id, name, description
             from geometry.plan_project
             where id = :id
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("id" to projectId.intValue)
 
-        val project = jdbcTemplate.query(sql, params) { rs, _ ->
-            Project(
-                id = rs.getIntId("id"),
-                name = ProjectName(rs.getString("name")),
-                description = rs.getFreeTextOrNull("description"),
-            )
-        }.firstOrNull() ?: throw NoSuchEntityException(Project::class, projectId)
+        val project =
+            jdbcTemplate
+                .query(sql, params) { rs, _ ->
+                    Project(
+                        id = rs.getIntId("id"),
+                        name = ProjectName(rs.getString("name")),
+                        description = rs.getFreeTextOrNull("description"),
+                    )
+                }
+                .firstOrNull() ?: throw NoSuchEntityException(Project::class, projectId)
         logger.daoAccess(FETCH, Project::class, project.id)
         return project
     }
 
     fun findProject(projectName: ProjectName): Project? {
-        val sql = """
+        val sql =
+            """
             select
               id, name, description
             from geometry.plan_project
             where unique_name = common.nospace_lowercase(:name)
-        """.trimIndent()
+        """
+                .trimIndent()
 
         val params = mapOf("name" to projectName)
-        val project = jdbcTemplate.query(sql, params) { rs, _ ->
-            Project(
-                id = rs.getIntId("id"),
-                name = ProjectName(rs.getString("name")),
-                description = rs.getFreeTextOrNull("description"),
-            )
-        }.firstOrNull()
+        val project =
+            jdbcTemplate
+                .query(sql, params) { rs, _ ->
+                    Project(
+                        id = rs.getIntId("id"),
+                        name = ProjectName(rs.getString("name")),
+                        description = rs.getFreeTextOrNull("description"),
+                    )
+                }
+                .firstOrNull()
 
         project?.also { logger.daoAccess(FETCH, Project::class, it.id) }
         return project
     }
 
     fun fetchProjects(): List<Project> {
-        val sql = """
+        val sql =
+            """
             select
               id
             , name
             , description
             from geometry.plan_project
-        """.trimIndent()
-        val projects = jdbcTemplate.query(sql) { rs, _ ->
-            Project(
-                id = rs.getIntId("id"),
-                name = ProjectName(rs.getString("name")),
-                description = rs.getFreeTextOrNull("description"),
-            )
-        }
+        """
+                .trimIndent()
+        val projects =
+            jdbcTemplate.query(sql) { rs, _ ->
+                Project(
+                    id = rs.getIntId("id"),
+                    name = ProjectName(rs.getString("name")),
+                    description = rs.getFreeTextOrNull("description"),
+                )
+            }
 
         logger.daoAccess(FETCH, Project::class)
         return projects
@@ -1005,59 +1145,72 @@ class GeometryDao @Autowired constructor(
     fun fetchAuthorChangeTime(): Instant = fetchLatestChangeTime(GEOMETRY_PLAN_AUTHOR)
 
     fun findAuthor(companyName: CompanyName): Author? {
-        val sql = """
+        val sql =
+            """
             select
               id
             , company_name
             from geometry.plan_author
             where unique_company_name = common.nospace_lowercase(:company_name)
-        """.trimIndent()
+        """
+                .trimIndent()
 
         val params = mapOf("company_name" to companyName)
-        val author = jdbcTemplate.query(sql, params) { rs, _ ->
-            Author(
-                id = rs.getIntId("id"),
-                companyName = CompanyName(rs.getString("company_name")),
-            )
-        }.firstOrNull()
+        val author =
+            jdbcTemplate
+                .query(sql, params) { rs, _ ->
+                    Author(
+                        id = rs.getIntId("id"),
+                        companyName = CompanyName(rs.getString("company_name")),
+                    )
+                }
+                .firstOrNull()
 
         author?.also { logger.daoAccess(FETCH, Author::class, it.id) }
         return author
     }
 
     fun getAuthor(authorId: IntId<Author>): Author {
-        val sql = """
+        val sql =
+            """
             select
               id
             , company_name
             from geometry.plan_author
             where id = :id
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("id" to authorId.intValue)
 
-        val author = jdbcTemplate.query(sql, params) { rs, _ ->
-            Author(
-                id = rs.getIntId("id"),
-                companyName = CompanyName(rs.getString("company_name")),
-            )
-        }.firstOrNull() ?: throw NoSuchEntityException(Project::class, authorId)
+        val author =
+            jdbcTemplate
+                .query(sql, params) { rs, _ ->
+                    Author(
+                        id = rs.getIntId("id"),
+                        companyName = CompanyName(rs.getString("company_name")),
+                    )
+                }
+                .firstOrNull() ?: throw NoSuchEntityException(Project::class, authorId)
         logger.daoAccess(FETCH, Author::class, author.id)
         return author
     }
 
     fun fetchAuthors(): List<Author> {
-        val sql = """
+        val sql =
+            """
             select
               id
             , company_name
             from geometry.plan_author
-        """.trimIndent()
-        val authors = jdbcTemplate.query(sql) { rs, _ ->
-            Author(
-                id = rs.getIntId("id"),
-                companyName = CompanyName(rs.getString("company_name")),
-            )
-        }
+        """
+                .trimIndent()
+        val authors =
+            jdbcTemplate.query(sql) { rs, _ ->
+                Author(
+                    id = rs.getIntId("id"),
+                    companyName = CompanyName(rs.getString("company_name")),
+                )
+            }
 
         logger.daoAccess(FETCH, Author::class, authors.map { it.id })
         return authors
@@ -1068,7 +1221,8 @@ class GeometryDao @Autowired constructor(
         planId: IntId<GeometryPlan>? = null,
         geometryAlignmentId: IntId<GeometryAlignment>? = null,
     ): List<GeometryAlignment> {
-        val sql = """
+        val sql =
+            """
             select 
               alignment.id, alignment.oid_part, 
               alignment.name, alignment.state, alignment.description,
@@ -1081,52 +1235,66 @@ class GeometryDao @Autowired constructor(
             where (:plan_id::int is null or alignment.plan_id = :plan_id)
               and (:alignment_id::int is null or alignment.id = :alignment_id)
             order by alignment.id
-        """.trimIndent()
+        """
+                .trimIndent()
         return jdbcTemplate.query(
-            sql, mapOf("plan_id" to planId?.intValue, "alignment_id" to geometryAlignmentId?.intValue)
-        ) { rs, _ ->
-            val alignmentId = rs.getIntId<GeometryAlignment>("id")
-            val profileName = rs.getString("profile_name")
-            val cantName = rs.getString("cant_name")
-            val featureTypeCode = rs.getFeatureTypeCodeOrNull("feature_type_code")
-            GeometryAlignment(
-                id = alignmentId,
-                name = AlignmentName(rs.getString("name")),
-                description = rs.getFreeTextOrNull("description"),
-                oidPart = rs.getFreeTextOrNull("oid_part"),
-                state = rs.getEnumOrNull<PlanState>("state"),
-                staStart = rs.getBigDecimal("sta_start"),
-                elements = fetchElements(alignmentId, units),
-                profile = profileName?.let { name ->
-                    GeometryProfile(
-                        name = PlanElementName(name), elements = fetchProfileElements(alignmentId)
-                    )
-                },
-                cant = cantName?.let { name ->
-                    GeometryCant(
-                        name = PlanElementName(name),
-                        description = PlanElementName(rs.getString("cant_description")),
-                        gauge = rs.getBigDecimal("cant_gauge"),
-                        rotationPoint = rs.getEnumOrNull<CantRotationPoint>("cant_rotation_point"),
-                        points = fetchCantPoints(alignmentId),
-                    )
-                },
-                featureTypeCode = featureTypeCode,
-            )
-        }
+            sql,
+            mapOf(
+                "plan_id" to planId?.intValue, "alignment_id" to geometryAlignmentId?.intValue)) {
+                rs,
+                _ ->
+                val alignmentId = rs.getIntId<GeometryAlignment>("id")
+                val profileName = rs.getString("profile_name")
+                val cantName = rs.getString("cant_name")
+                val featureTypeCode = rs.getFeatureTypeCodeOrNull("feature_type_code")
+                GeometryAlignment(
+                    id = alignmentId,
+                    name = AlignmentName(rs.getString("name")),
+                    description = rs.getFreeTextOrNull("description"),
+                    oidPart = rs.getFreeTextOrNull("oid_part"),
+                    state = rs.getEnumOrNull<PlanState>("state"),
+                    staStart = rs.getBigDecimal("sta_start"),
+                    elements = fetchElements(alignmentId, units),
+                    profile =
+                        profileName?.let { name ->
+                            GeometryProfile(
+                                name = PlanElementName(name),
+                                elements = fetchProfileElements(alignmentId))
+                        },
+                    cant =
+                        cantName?.let { name ->
+                            GeometryCant(
+                                name = PlanElementName(name),
+                                description = PlanElementName(rs.getString("cant_description")),
+                                gauge = rs.getBigDecimal("cant_gauge"),
+                                rotationPoint =
+                                    rs.getEnumOrNull<CantRotationPoint>("cant_rotation_point"),
+                                points = fetchCantPoints(alignmentId),
+                            )
+                        },
+                    featureTypeCode = featureTypeCode,
+                )
+            }
     }
 
     @Cacheable(CACHE_GEOMETRY_SWITCH, sync = true)
-    fun getSwitch(id: IntId<GeometrySwitch>) = getOne(id, fetchSwitches(planId = null, switchId = id))
+    fun getSwitch(id: IntId<GeometrySwitch>) =
+        getOne(id, fetchSwitches(planId = null, switchId = id))
 
-    fun getSwitchPlanId(id: IntId<GeometrySwitch>): IntId<GeometryPlan>? = jdbcTemplate.queryOptional(
-        "select plan_id from geometry.switch where id = :id", mapOf("id" to id.intValue)
-    ) { rs, _ ->
-        rs.getIntId("plan_id")
-    }
+    fun getSwitchPlanId(id: IntId<GeometrySwitch>): IntId<GeometryPlan>? =
+        jdbcTemplate.queryOptional(
+            "select plan_id from geometry.switch where id = :id", mapOf("id" to id.intValue)) {
+                rs,
+                _ ->
+                rs.getIntId("plan_id")
+            }
 
-    private fun fetchSwitches(planId: IntId<GeometryPlan>?, switchId: IntId<GeometrySwitch>?): List<GeometrySwitch> {
-        val sql = """
+    private fun fetchSwitches(
+        planId: IntId<GeometryPlan>?,
+        switchId: IntId<GeometrySwitch>?
+    ): List<GeometrySwitch> {
+        val sql =
+            """
             select
               id,
               name,
@@ -1136,7 +1304,8 @@ class GeometryDao @Autowired constructor(
             from geometry.switch
             where (:plan_id::int is null or plan_id = :plan_id) 
               and (:switch_id::int is null or id = :switch_id)
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("plan_id" to planId?.intValue, "switch_id" to switchId?.intValue)
         return jdbcTemplate.query(sql, params) { rs, _ ->
             val id: IntId<GeometrySwitch> = rs.getIntId("id")
@@ -1152,43 +1321,53 @@ class GeometryDao @Autowired constructor(
     }
 
     private fun getSwitchJoints(switchId: IntId<GeometrySwitch>): List<GeometrySwitchJoint> {
-        val sql = """
+        val sql =
+            """
             select 
               number,
               postgis.st_x(location) as location_x,
               postgis.st_y(location) as location_y
             from geometry.switch_joint
             where switch_id = :switch_id
-        """.trimIndent()
-        return jdbcTemplate.query(sql, mapOf("switch_id" to switchId.intValue)) { rs, _ ->
-            GeometrySwitchJoint(
-                number = rs.getJointNumber("number"),
-                location = rs.getPoint("location_x", "location_y"),
-            )
-        }.sortedBy { j -> j.number }
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(sql, mapOf("switch_id" to switchId.intValue)) { rs, _ ->
+                GeometrySwitchJoint(
+                    number = rs.getJointNumber("number"),
+                    location = rs.getPoint("location_x", "location_y"),
+                )
+            }
+            .sortedBy { j -> j.number }
     }
 
     fun getSwitchSrid(id: IntId<GeometrySwitch>): Srid? {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select
                 plan.srid
             from geometry.switch
                 left join geometry.plan plan on switch.plan_id = plan.id
             where switch.id = :switch_id
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("switch_id" to id.intValue)
         logger.daoAccess(FETCH, GeometrySwitch::class, params)
-        return jdbcTemplate.queryOne(sql, params, id.toString()) { rs, _ -> rs.getSridOrNull("srid") }
+        return jdbcTemplate.queryOne(sql, params, id.toString()) { rs, _ ->
+            rs.getSridOrNull("srid")
+        }
     }
 
-    fun getKmPost(id: IntId<GeometryKmPost>) = getOne(id, fetchKmPosts(planId = null, kmPostId = id))
+    fun getKmPost(id: IntId<GeometryKmPost>) =
+        getOne(id, fetchKmPosts(planId = null, kmPostId = id))
 
     fun fetchKmPosts(
         planId: IntId<GeometryPlan>? = null,
         kmPostId: IntId<GeometryKmPost>? = null,
     ): List<GeometryKmPost> {
-        val sql = """
+        val sql =
+            """
             select
               km_post.id,
               km_post.km_post_index, 
@@ -1203,10 +1382,9 @@ class GeometryDao @Autowired constructor(
             from geometry.km_post
             where (:plan_id::int is null or plan_id = :plan_id) 
               and (:km_post_id::int is null or id = :km_post_id)
-        """.trimIndent()
-        val params = mapOf(
-            "plan_id" to planId?.intValue, "km_post_id" to kmPostId?.intValue
-        )
+        """
+                .trimIndent()
+        val params = mapOf("plan_id" to planId?.intValue, "km_post_id" to kmPostId?.intValue)
         return jdbcTemplate.query(sql, params) { rs, _ ->
             GeometryKmPost(
                 id = rs.getIntId("id"),
@@ -1222,16 +1400,20 @@ class GeometryDao @Autowired constructor(
     }
 
     fun getKmPostSrid(id: IntId<GeometryKmPost>): Srid? {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select
                 plan.srid
             from geometry.km_post
                 left join geometry.plan plan on km_post.plan_id = plan.id
             where km_post.id = :km_post_id
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("km_post_id" to id.intValue)
-        return jdbcTemplate.queryOne(sql, params, id.toString()) { rs, _ -> rs.getSridOrNull("srid") }
+        return jdbcTemplate.queryOne(sql, params, id.toString()) { rs, _ ->
+            rs.getSridOrNull("srid")
+        }
     }
 
     fun fetchElement(geometryElementId: IndexedId<GeometryElement>): GeometryElement {
@@ -1243,7 +1425,8 @@ class GeometryDao @Autowired constructor(
     }
 
     fun fetchPlanUnits(alignmentId: IntId<GeometryAlignment>): GeometryPlanUnits {
-        val sql = """
+        val sql =
+            """
             select 
                 plan.id, 
                 plan.direction_unit, 
@@ -1254,19 +1437,26 @@ class GeometryDao @Autowired constructor(
             from geometry.alignment alignment 
               left join geometry.plan plan on alignment.plan_id = plan.id
             where alignment.id = :alignment_id
-        """.trimIndent()
-        return jdbcTemplate.query(sql, mapOf("alignment_id" to alignmentId.intValue)) { rs, _ ->
-            GeometryPlanUnits(
-                id = rs.getIntId("id"),
-                units = GeometryUnits(
-                    coordinateSystemSrid = rs.getSridOrNull("srid"),
-                    coordinateSystemName = rs.getString("coordinate_system_name")?.let(::CoordinateSystemName),
-                    verticalCoordinateSystem = rs.getEnumOrNull<VerticalCoordinateSystem>("vertical_coordinate_system"),
-                    directionUnit = rs.getEnum("direction_unit"),
-                    linearUnit = rs.getEnum("linear_unit"),
-                ),
-            )
-        }.firstOrNull() ?: throw NoSuchEntityException(GeometryAlignment::class, alignmentId)
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(sql, mapOf("alignment_id" to alignmentId.intValue)) { rs, _ ->
+                GeometryPlanUnits(
+                    id = rs.getIntId("id"),
+                    units =
+                        GeometryUnits(
+                            coordinateSystemSrid = rs.getSridOrNull("srid"),
+                            coordinateSystemName =
+                                rs.getString("coordinate_system_name")?.let(::CoordinateSystemName),
+                            verticalCoordinateSystem =
+                                rs.getEnumOrNull<VerticalCoordinateSystem>(
+                                    "vertical_coordinate_system"),
+                            directionUnit = rs.getEnum("direction_unit"),
+                            linearUnit = rs.getEnum("linear_unit"),
+                        ),
+                )
+            }
+            .firstOrNull() ?: throw NoSuchEntityException(GeometryAlignment::class, alignmentId)
     }
 
     fun fetchElements(
@@ -1274,7 +1464,8 @@ class GeometryDao @Autowired constructor(
         units: GeometryUnits,
         geometryElementId: IndexedId<GeometryElement>? = null,
     ): List<GeometryElement> {
-        val sql = """
+        val sql =
+            """
             select
               alignment_id,
               element_index,
@@ -1306,42 +1497,47 @@ class GeometryDao @Autowired constructor(
             where alignment_id = :alignment_id
               and (:element_index::int is null or element_index = :element_index)
             order by element_index
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "alignment_id" to alignmentId.intValue, "element_index" to geometryElementId?.index
-        )
+        val params =
+            mapOf(
+                "alignment_id" to alignmentId.intValue, "element_index" to geometryElementId?.index)
 
         return jdbcTemplate.query(sql, params) { rs, _ ->
             val id = rs.getIndexedId<GeometryElement>("alignment_id", "element_index")
             when (rs.getEnum<GeometryElementType>("type")) {
-                LINE -> GeometryLine(
-                    elementData = getElementData(rs),
-                    switchData = getSwitchData(rs),
-                    id = id,
-                )
+                LINE ->
+                    GeometryLine(
+                        elementData = getElementData(rs),
+                        switchData = getSwitchData(rs),
+                        id = id,
+                    )
 
-                CURVE -> GeometryCurve(
-                    elementData = getElementData(rs),
-                    curveData = getCurveData(rs),
-                    switchData = getSwitchData(rs),
-                    id = id,
-                )
+                CURVE ->
+                    GeometryCurve(
+                        elementData = getElementData(rs),
+                        curveData = getCurveData(rs),
+                        switchData = getSwitchData(rs),
+                        id = id,
+                    )
 
-                CLOTHOID -> GeometryClothoid(
-                    elementData = getElementData(rs),
-                    spiralData = getSpiralData(rs, units),
-                    switchData = getSwitchData(rs),
-                    constant = rs.getBigDecimal("clothoid_constant"),
-                    id = id,
-                )
+                CLOTHOID ->
+                    GeometryClothoid(
+                        elementData = getElementData(rs),
+                        spiralData = getSpiralData(rs, units),
+                        switchData = getSwitchData(rs),
+                        constant = rs.getBigDecimal("clothoid_constant"),
+                        id = id,
+                    )
 
-                BIQUADRATIC_PARABOLA -> BiquadraticParabola(
-                    elementData = getElementData(rs),
-                    spiralData = getSpiralData(rs, units),
-                    switchData = getSwitchData(rs),
-                    id = id,
-                )
+                BIQUADRATIC_PARABOLA ->
+                    BiquadraticParabola(
+                        elementData = getElementData(rs),
+                        spiralData = getSpiralData(rs, units),
+                        switchData = getSwitchData(rs),
+                        id = id,
+                    )
             }
         }
     }
@@ -1357,73 +1553,88 @@ class GeometryDao @Autowired constructor(
         )
     }
 
-    private fun getSwitchData(rs: ResultSet): SwitchData = SwitchData(
-        switchId = rs.getIntIdOrNull("switch_id"),
-        startJointNumber = rs.getJointNumberOrNull("switch_start_joint_number"),
-        endJointNumber = rs.getJointNumberOrNull("switch_end_joint_number"),
-    )
+    private fun getSwitchData(rs: ResultSet): SwitchData =
+        SwitchData(
+            switchId = rs.getIntIdOrNull("switch_id"),
+            startJointNumber = rs.getJointNumberOrNull("switch_start_joint_number"),
+            endJointNumber = rs.getJointNumberOrNull("switch_end_joint_number"),
+        )
 
-    private fun getCurveData(rs: ResultSet): CurveData = CurveData(
-        rotation = rs.getEnum("rotation"),
-        radius = rs.getBigDecimal("curve_radius"),
-        chord = rs.getBigDecimal("curve_chord"),
-        center = rs.getPoint("curve_center_x", "curve_center_y"),
-    )
+    private fun getCurveData(rs: ResultSet): CurveData =
+        CurveData(
+            rotation = rs.getEnum("rotation"),
+            radius = rs.getBigDecimal("curve_radius"),
+            chord = rs.getBigDecimal("curve_chord"),
+            center = rs.getPoint("curve_center_x", "curve_center_y"),
+        )
 
-    private fun getSpiralData(rs: ResultSet, units: GeometryUnits): SpiralData = SpiralData(
-        rotation = rs.getEnum("rotation"),
-        directionStart = rs.getBigDecimal("spiral_dir_start")?.let { bd -> toAngle(bd, units.directionUnit) },
-        directionEnd = rs.getBigDecimal("spiral_dir_end")?.let { bd -> toAngle(bd, units.directionUnit) },
-        radiusStart = rs.getBigDecimal("spiral_radius_start"),
-        radiusEnd = rs.getBigDecimal("spiral_radius_end"),
-        pi = rs.getPoint("spiral_pi_x", "spiral_pi_y"),
-    )
+    private fun getSpiralData(rs: ResultSet, units: GeometryUnits): SpiralData =
+        SpiralData(
+            rotation = rs.getEnum("rotation"),
+            directionStart =
+                rs.getBigDecimal("spiral_dir_start")?.let { bd ->
+                    toAngle(bd, units.directionUnit)
+                },
+            directionEnd =
+                rs.getBigDecimal("spiral_dir_end")?.let { bd -> toAngle(bd, units.directionUnit) },
+            radiusStart = rs.getBigDecimal("spiral_radius_start"),
+            radiusEnd = rs.getBigDecimal("spiral_radius_end"),
+            pi = rs.getPoint("spiral_pi_x", "spiral_pi_y"),
+        )
 
-    private fun fetchProfileElements(alignmentId: IntId<GeometryAlignment>): List<VerticalIntersection> {
-        val sql = """
+    private fun fetchProfileElements(
+        alignmentId: IntId<GeometryAlignment>
+    ): List<VerticalIntersection> {
+        val sql =
+            """
             select type, description, postgis.st_x(point) as point_x, postgis.st_y(point) as point_y, circular_radius, circular_length
             from geometry.vertical_intersection
             where alignment_id = :alignment_id
             order by intersection_index
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("alignment_id" to alignmentId.intValue)
         return jdbcTemplate.query(sql, params) { rs, _ ->
             when (rs.getEnum<VerticalIntersectionType>("type")) {
-                VerticalIntersectionType.POINT -> VIPoint(
-                    description = PlanElementName(rs.getString("description")),
-                    point = rs.getPoint("point_x", "point_y"),
-                )
+                VerticalIntersectionType.POINT ->
+                    VIPoint(
+                        description = PlanElementName(rs.getString("description")),
+                        point = rs.getPoint("point_x", "point_y"),
+                    )
 
-                VerticalIntersectionType.CIRCULAR_CURVE -> VICircularCurve(
-                    description = PlanElementName(rs.getString("description")),
-                    point = rs.getPoint("point_x", "point_y"),
-                    radius = rs.getBigDecimal("circular_radius"),
-                    length = rs.getBigDecimal("circular_length"),
-                )
+                VerticalIntersectionType.CIRCULAR_CURVE ->
+                    VICircularCurve(
+                        description = PlanElementName(rs.getString("description")),
+                        point = rs.getPoint("point_x", "point_y"),
+                        radius = rs.getBigDecimal("circular_radius"),
+                        length = rs.getBigDecimal("circular_length"),
+                    )
             }
         }
     }
 
     private fun fetchCantPoints(alignmentId: IntId<GeometryAlignment>): List<GeometryCantPoint> {
-        val sql = """
+        val sql =
+            """
             select station, applied_cant, curvature, transition_type
             from geometry.cant_point
             where alignment_id = :alignment_id
             order by cant_point_index
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("alignment_id" to alignmentId.intValue)
         return jdbcTemplate.query(sql, params) { rs, _ ->
             GeometryCantPoint(
                 station = rs.getBigDecimal("station"),
                 appliedCant = rs.getBigDecimal("applied_cant"),
                 curvature = rs.getEnum("curvature"),
-                transitionType = rs.getEnum("transition_type")
-            )
+                transitionType = rs.getEnum("transition_type"))
         }
     }
 
     private fun insertGeometryElements(elementSqlParams: List<Map<String, Any?>>) {
-        val sql = """
+        val sql =
+            """
             insert into geometry.element(
               alignment_id,
               element_index,
@@ -1468,7 +1679,8 @@ class GeometryDao @Autowired constructor(
               :switch_start_joint_number,
               :switch_end_joint_number
             )
-        """.trimIndent()
+        """
+                .trimIndent()
         jdbcTemplate.batchUpdate(sql, elementSqlParams.toTypedArray())
     }
 
@@ -1478,60 +1690,70 @@ class GeometryDao @Autowired constructor(
         switchIds: Map<DomainId<GeometrySwitch>, IntId<GeometrySwitch>>,
     ): List<Map<String, Any?>> {
         return elements.mapIndexed { index, element ->
-            val common = mapOf(
-                "alignment_id" to alignmentId.intValue,
-                "element_index" to index,
-                "type" to element.type.name,
-                "oid_part" to element.oidPart,
-                "name" to element.name,
-                "sta_start" to element.staStart,
-                "length" to element.length,
-                "rotation" to null,
-                "curve_radius" to null,
-                "curve_chord" to null,
-                "clothoid_constant" to null,
-                "spiral_dir_start" to null,
-                "spiral_dir_end" to null,
-                "spiral_radius_start" to null,
-                "spiral_radius_end" to null,
-                "spiral_dir_end" to null,
-            ).plus(getPointSqlParams("start_point", element.start))
-                .plus(getPointSqlParams("end_point", element.end))
-                .plus(getPointSqlParams("curve_center_point", null))
-                .plus(getPointSqlParams("spiral_pi_point", null))
-            val specific = when (element) {
-                is GeometryLine -> mapOf()
-                is GeometryCurve -> mapOf(
-                    "rotation" to element.rotation.name,
-                    "curve_radius" to element.radius,
-                    "curve_chord" to element.chord,
-                ).plus(getPointSqlParams("curve_center_point", element.center))
+            val common =
+                mapOf(
+                        "alignment_id" to alignmentId.intValue,
+                        "element_index" to index,
+                        "type" to element.type.name,
+                        "oid_part" to element.oidPart,
+                        "name" to element.name,
+                        "sta_start" to element.staStart,
+                        "length" to element.length,
+                        "rotation" to null,
+                        "curve_radius" to null,
+                        "curve_chord" to null,
+                        "clothoid_constant" to null,
+                        "spiral_dir_start" to null,
+                        "spiral_dir_end" to null,
+                        "spiral_radius_start" to null,
+                        "spiral_radius_end" to null,
+                        "spiral_dir_end" to null,
+                    )
+                    .plus(getPointSqlParams("start_point", element.start))
+                    .plus(getPointSqlParams("end_point", element.end))
+                    .plus(getPointSqlParams("curve_center_point", null))
+                    .plus(getPointSqlParams("spiral_pi_point", null))
+            val specific =
+                when (element) {
+                    is GeometryLine -> mapOf()
+                    is GeometryCurve ->
+                        mapOf(
+                                "rotation" to element.rotation.name,
+                                "curve_radius" to element.radius,
+                                "curve_chord" to element.chord,
+                            )
+                            .plus(getPointSqlParams("curve_center_point", element.center))
 
-                is GeometrySpiral -> mapOf(
-                    "rotation" to element.rotation.name,
-                    "spiral_dir_start" to element.directionStart?.original,
-                    "spiral_dir_end" to element.directionEnd?.original,
-                    "spiral_radius_start" to element.radiusStart,
-                    "spiral_radius_end" to element.radiusEnd,
-                ).plus(getPointSqlParams("spiral_pi_point", element.pi)).plus(
-                    when (element) {
-                        is GeometryClothoid -> mapOf("clothoid_constant" to element.constant)
-                        is BiquadraticParabola -> mapOf()
-                    }
+                    is GeometrySpiral ->
+                        mapOf(
+                                "rotation" to element.rotation.name,
+                                "spiral_dir_start" to element.directionStart?.original,
+                                "spiral_dir_end" to element.directionEnd?.original,
+                                "spiral_radius_start" to element.radiusStart,
+                                "spiral_radius_end" to element.radiusEnd,
+                            )
+                            .plus(getPointSqlParams("spiral_pi_point", element.pi))
+                            .plus(
+                                when (element) {
+                                    is GeometryClothoid ->
+                                        mapOf("clothoid_constant" to element.constant)
+                                    is BiquadraticParabola -> mapOf()
+                                })
+                }
+            val switch =
+                mapOf(
+                    "switch_id" to element.switchId?.let { tempId -> switchIds[tempId]?.intValue },
+                    "switch_start_joint_number" to element.startJointNumber?.intValue,
+                    "switch_end_joint_number" to element.endJointNumber?.intValue,
                 )
-            }
-            val switch = mapOf(
-                "switch_id" to element.switchId?.let { tempId -> switchIds[tempId]?.intValue },
-                "switch_start_joint_number" to element.startJointNumber?.intValue,
-                "switch_end_joint_number" to element.endJointNumber?.intValue,
-            )
 
             common + specific + switch
         }
     }
 
     private fun insertVerticalIntersections(viParams: List<Map<String, Any?>>) {
-        val sql = """
+        val sql =
+            """
             insert into geometry.vertical_intersection(
               alignment_id,
               intersection_index,
@@ -1550,7 +1772,8 @@ class GeometryDao @Autowired constructor(
               :circular_radius,
               :circular_length
             )
-        """.trimIndent()
+        """
+                .trimIndent()
 
         jdbcTemplate.batchUpdate(sql, viParams.toTypedArray())
     }
@@ -1560,29 +1783,33 @@ class GeometryDao @Autowired constructor(
         vis: List<VerticalIntersection>,
     ): List<Map<String, Any?>> {
         return vis.mapIndexed { index, vi ->
-            val common = mapOf(
-                "alignment_id" to alignmentId.intValue,
-                "intersection_index" to index,
-                "description" to vi.description,
-                "point_x" to vi.point.x,
-                "point_y" to vi.point.y,
-                "circular_radius" to null,
-                "circular_length" to null,
-            )
-            val typed = when (vi) {
-                is VIPoint -> mapOf("type" to VerticalIntersectionType.POINT.name)
-                is VICircularCurve -> mapOf(
-                    "type" to VerticalIntersectionType.CIRCULAR_CURVE.name,
-                    "circular_radius" to vi.radius,
-                    "circular_length" to vi.length,
+            val common =
+                mapOf(
+                    "alignment_id" to alignmentId.intValue,
+                    "intersection_index" to index,
+                    "description" to vi.description,
+                    "point_x" to vi.point.x,
+                    "point_y" to vi.point.y,
+                    "circular_radius" to null,
+                    "circular_length" to null,
                 )
-            }
+            val typed =
+                when (vi) {
+                    is VIPoint -> mapOf("type" to VerticalIntersectionType.POINT.name)
+                    is VICircularCurve ->
+                        mapOf(
+                            "type" to VerticalIntersectionType.CIRCULAR_CURVE.name,
+                            "circular_radius" to vi.radius,
+                            "circular_length" to vi.length,
+                        )
+                }
             common + typed
         }
     }
 
     private fun insertCantPoints(cantPointParams: List<Map<String, Any?>>) {
-        val sql = """
+        val sql =
+            """
             insert into geometry.cant_point(
               alignment_id, 
               cant_point_index, 
@@ -1599,7 +1826,8 @@ class GeometryDao @Autowired constructor(
               :curvature::common.rotation_direction, 
               :transition_type::geometry.cant_transition_type
             )
-        """.trimIndent()
+        """
+                .trimIndent()
         jdbcTemplate.batchUpdate(sql, cantPointParams.toTypedArray())
     }
 
@@ -1624,36 +1852,41 @@ class GeometryDao @Autowired constructor(
     }
 
     fun getMeasurementMethodForSwitch(id: IntId<GeometrySwitch>): MeasurementMethod? {
-        val sql = """
+        val sql =
+            """
             select plan.measurement_method
             from geometry.plan
                 join geometry.switch on plan.id = switch.plan_id
             where switch.id = :switch_id
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        return jdbcTemplate.query(
-            sql, mapOf(
-                "switch_id" to id.intValue
-            )
-        ) { rs, _ ->
-            rs.getEnumOrNull<MeasurementMethod>("measurement_method")
-        }.firstOrNull()
+        return jdbcTemplate
+            .query(sql, mapOf("switch_id" to id.intValue)) { rs, _ ->
+                rs.getEnumOrNull<MeasurementMethod>("measurement_method")
+            }
+            .firstOrNull()
     }
 
-    /**
-     * If planIds is null, returns all plans' linking summaries
-     */
-    fun getLinkingSummaries(planIds: List<IntId<GeometryPlan>>? = null): Map<IntId<GeometryPlan>, GeometryPlanLinkingSummary> {
+    /** If planIds is null, returns all plans' linking summaries */
+    fun getLinkingSummaries(
+        planIds: List<IntId<GeometryPlan>>? = null
+    ): Map<IntId<GeometryPlan>, GeometryPlanLinkingSummary> {
         if (planIds?.isEmpty() == true) {
             return mapOf()
         }
 
-        // For a given linkable object, treat the first version of it that was linked to a given plan as the one where
-        // linking happened, hence taking that version's change_time and change_user as the linking time and user.
-        // For objects composed of parts where it's the parts that get linked (i.e. location tracks and reference lines,
-        // made of segments), versioning still goes based on the segment, but the change time and change user come
+        // For a given linkable object, treat the first version of it that was linked to a given
+        // plan as the one where
+        // linking happened, hence taking that version's change_time and change_user as the linking
+        // time and user.
+        // For objects composed of parts where it's the parts that get linked (i.e. location tracks
+        // and reference lines,
+        // made of segments), versioning still goes based on the segment, but the change time and
+        // change user come
         // from the actual publishable unit.
-        val sql = """
+        val sql =
+            """
             with
               segment_links as (
                 select plan_id, segment.change_user, segment.change_time
@@ -1735,23 +1968,35 @@ class GeometryDao @Autowired constructor(
               ) as linked_layout_object
               where linked_layout_object.plan_id in (:plan_ids) or :return_all
               group by linked_layout_object.plan_id;
-        """.trimIndent()
+        """
+                .trimIndent()
 
         val params =
-            mapOf("plan_ids" to (planIds?.map { it.intValue } ?: listOf(null)), "return_all" to (planIds == null))
-        return jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getIntId<GeometryPlan>("plan_id") to GeometryPlanLinkingSummary(
-                linkedAt = rs.getInstantOrNull("linked_at"),
-                linkedByUsers = rs.getStringArrayOrNull("linked_by_users")?.map(UserName::of) ?: listOf(),
-                currentlyLinked = rs.getBoolean("is_currently_linked"),
-            )
-        }.associate { it }
+            mapOf(
+                "plan_ids" to (planIds?.map { it.intValue } ?: listOf(null)),
+                "return_all" to (planIds == null))
+        return jdbcTemplate
+            .query(sql, params) { rs, _ ->
+                rs.getIntId<GeometryPlan>("plan_id") to
+                    GeometryPlanLinkingSummary(
+                        linkedAt = rs.getInstantOrNull("linked_at"),
+                        linkedByUsers =
+                            rs.getStringArrayOrNull("linked_by_users")?.map(UserName::of)
+                                ?: listOf(),
+                        currentlyLinked = rs.getBoolean("is_currently_linked"),
+                    )
+            }
+            .associate { it }
     }
 
     fun getPlanIdForKmPost(id: IntId<GeometryKmPost>): IntId<GeometryPlan>? {
-        val sql = """
+        val sql =
+            """
             select plan_id from geometry.km_post where id = :id
-        """.trimIndent()
-        return jdbcTemplate.queryOptional(sql, mapOf("id" to id.intValue)) { rs, _ -> rs.getIntId("plan_id") }
+        """
+                .trimIndent()
+        return jdbcTemplate.queryOptional(sql, mapOf("id" to id.intValue)) { rs, _ ->
+            rs.getIntId("plan_id")
+        }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryElement.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryElement.kt
@@ -14,11 +14,13 @@ import java.math.BigDecimal
 import kotlin.math.PI
 import kotlin.math.min
 
-/**
- * Type enumeration for JSON & database representations
- **/
-
-enum class GeometryElementType { LINE, CURVE, CLOTHOID, BIQUADRATIC_PARABOLA }
+/** Type enumeration for JSON & database representations */
+enum class GeometryElementType {
+    LINE,
+    CURVE,
+    CLOTHOID,
+    BIQUADRATIC_PARABOLA
+}
 
 interface ElementContent {
     val name: PlanElementName?
@@ -38,9 +40,9 @@ data class ElementData(
     override val length: BigDecimal,
 ) : ElementContent {
     init {
-        if (start == end) throw IllegalArgumentException(
-            "Element start and end should differ: name=$name oid=$oidPart start=$start end=$end"
-        )
+        if (start == end)
+            throw IllegalArgumentException(
+                "Element start and end should differ: name=$name oid=$oidPart start=$start end=$end")
     }
 }
 
@@ -74,22 +76,22 @@ data class CurveData(
 ) : CurveContent
 
 interface SpiralContent {
-    /** Direction of spiral curvature, relative to rail forward direction **/
+    /** Direction of spiral curvature, relative to rail forward direction * */
     val rotation: RotationDirection
 
-    /** Forward direction of the rail at segment start **/
+    /** Forward direction of the rail at segment start * */
     val directionStart: Angle?
 
-    /** Forward direction of the rail at segment end **/
+    /** Forward direction of the rail at segment end * */
     val directionEnd: Angle?
 
-    /** Spiral steepness at segment start, expressed as the circle radius of the curve **/
+    /** Spiral steepness at segment start, expressed as the circle radius of the curve * */
     val radiusStart: BigDecimal?
 
-    /** Spiral steepness at segment end, expressed as the circle radius of the curve **/
+    /** Spiral steepness at segment end, expressed as the circle radius of the curve * */
     val radiusEnd: BigDecimal?
 
-    /** Segment start & end point tangents' intersection **/
+    /** Segment start & end point tangents' intersection * */
     val pi: Point
 }
 
@@ -103,22 +105,22 @@ data class SpiralData(
 ) : SpiralContent
 
 /**
- * Geometry element is a single mathematically defined piece of the overall geometry building up an alignment
+ * Geometry element is a single mathematically defined piece of the overall geometry building up an
+ * alignment
  */
 sealed class GeometryElement : ElementContent, SwitchContent {
     abstract val type: GeometryElementType
     abstract val id: DomainId<GeometryElement>
     abstract val calculatedLength: Double
 
-    @get:JsonIgnore
-    abstract val bounds: List<Point>
-    @get:JsonIgnore
-    abstract val startDirectionRads: Double
-    @get:JsonIgnore
-    abstract val endDirectionRads: Double
+    @get:JsonIgnore abstract val bounds: List<Point>
+    @get:JsonIgnore abstract val startDirectionRads: Double
+    @get:JsonIgnore abstract val endDirectionRads: Double
 
     abstract fun getCoordinateAt(distance: Double): Point
+
     abstract fun contentEquals(other: GeometryElement): Boolean
+
     abstract fun getLengthUntil(target: Point): Double
 }
 
@@ -134,12 +136,17 @@ data class GeometryLine(
     override val startDirectionRads: Double = directionBetweenPoints(start, end)
     override val endDirectionRads: Double = directionBetweenPoints(start, end)
 
-    override fun getCoordinateAt(distance: Double): Point = linePointAtDistance(start, end, distance)
+    override fun getCoordinateAt(distance: Double): Point =
+        linePointAtDistance(start, end, distance)
+
     override fun contentEquals(other: GeometryElement): Boolean {
-        return other is GeometryLine && other.elementData == elementData && switchData.contentEquals(other.switchData)
+        return other is GeometryLine &&
+            other.elementData == elementData &&
+            switchData.contentEquals(other.switchData)
     }
 
-    override fun getLengthUntil(target: Point): Double = lineLength(start, closestPointOnLine(start, end, target))
+    override fun getLengthUntil(target: Point): Double =
+        lineLength(start, closestPointOnLine(start, end, target))
 }
 
 data class GeometryCurve(
@@ -147,10 +154,16 @@ data class GeometryCurve(
     private val curveData: CurveData,
     private val switchData: SwitchData,
     override val id: DomainId<GeometryElement> = StringId(),
-) : ElementContent by elementData, CurveContent by curveData, SwitchContent by switchData, GeometryElement() {
+) :
+    ElementContent by elementData,
+    CurveContent by curveData,
+    SwitchContent by switchData,
+    GeometryElement() {
 
     override val type: GeometryElementType = CURVE
-    override val calculatedLength: Double by lazy { circleArcLength(radius.toDouble(), chord.toDouble()) }
+    override val calculatedLength: Double by lazy {
+        circleArcLength(radius.toDouble(), chord.toDouble())
+    }
 
     override val bounds: List<Point> by lazy {
         val directionStartToEnd = directionBetweenPoints(start, end)
@@ -159,19 +172,23 @@ data class GeometryCurve(
         val rotatedCenter = rotateAroundPoint(start, -directionStartToEnd, center)
         val rotatedEndPoint = rotateAroundPoint(start, -directionStartToEnd, end)
 
-        // Now the X ranges from start to end now and Y is flat. The farthest Y is at the center of the curve.
+        // Now the X ranges from start to end now and Y is flat. The farthest Y is at the center of
+        // the curve.
         val radiusOffset = Point(0.0, radius.toDouble())
-        val rotatedCurvePoint = if (rotation == CW) rotatedCenter + radiusOffset else rotatedCenter - radiusOffset
+        val rotatedCurvePoint =
+            if (rotation == CW) rotatedCenter + radiusOffset else rotatedCenter - radiusOffset
 
-        // Define minimal bounding corners in this rotated coordinate system and then rotate them back
-        val rotatedCorners = boundingBoxAroundPoints(start, rotatedCurvePoint, rotatedEndPoint).corners
+        // Define minimal bounding corners in this rotated coordinate system and then rotate them
+        // back
+        val rotatedCorners =
+            boundingBoxAroundPoints(start, rotatedCurvePoint, rotatedEndPoint).corners
         rotatedCorners.map { point -> rotateAroundPoint(start, directionStartToEnd, point) }
     }
     override val startDirectionRads: Double by lazy {
-        rotateAngle(directionBetweenPoints(center, start), rotationDirectionSign * PI/2)
+        rotateAngle(directionBetweenPoints(center, start), rotationDirectionSign * PI / 2)
     }
     override val endDirectionRads: Double by lazy {
-        rotateAngle(directionBetweenPoints(center, end), rotationDirectionSign * PI/2)
+        rotateAngle(directionBetweenPoints(center, end), rotationDirectionSign * PI / 2)
     }
 
     override fun getCoordinateAt(distance: Double): Point {
@@ -181,11 +198,12 @@ data class GeometryCurve(
 
     private val rotationDirectionSign by lazy { if (rotation == CCW) 1 else -1 }
     private val chordDirection: Double by lazy { directionBetweenPoints(center, start) }
+
     override fun contentEquals(other: GeometryElement): Boolean {
-        return other is GeometryCurve
-                && other.elementData == elementData
-                && other.curveData == curveData
-                && switchData.contentEquals(other.switchData)
+        return other is GeometryCurve &&
+            other.elementData == elementData &&
+            other.curveData == curveData &&
+            switchData.contentEquals(other.switchData)
     }
 
     override fun getLengthUntil(target: Point): Double {
@@ -211,8 +229,10 @@ data class GeometryCurve(
 
 sealed class GeometrySpiral : SpiralContent, GeometryElement() {
     override val bounds: List<Point> by lazy {
-        // Rotate the curved end's point so that the flat part starts with positive X and curves up/down
-        // Define minimal bounding corners in this rotated coordinate system and then rotate them back
+        // Rotate the curved end's point so that the flat part starts with positive X and curves
+        // up/down
+        // Define minimal bounding corners in this rotated coordinate system and then rotate them
+        // back
         if (isSteepening) {
             val rotatedEnd = rotateAroundPoint(start, -startDirectionRads, end)
             val rotatedCorners = boundingBoxAroundPoints(start, rotatedEnd).corners
@@ -227,38 +247,50 @@ sealed class GeometrySpiral : SpiralContent, GeometryElement() {
     override val endDirectionRads: Double by lazy { directionBetweenPoints(pi, end) }
 
     /**
-     * We calculate everything from the first segment point along the spiral.
-     * This tells us if that's the start-point (steepening) or the end-point (flattening)
+     * We calculate everything from the first segment point along the spiral. This tells us if
+     * that's the start-point (steepening) or the end-point (flattening)
      */
     protected val isSteepening: Boolean by lazy {
-        (radiusStart?.toDouble() ?: Double.POSITIVE_INFINITY) >= (radiusEnd?.toDouble() ?: Double.POSITIVE_INFINITY)
+        (radiusStart?.toDouble() ?: Double.POSITIVE_INFINITY) >=
+            (radiusEnd?.toDouble() ?: Double.POSITIVE_INFINITY)
     }
 
     /**
-     * Ideal spiral turns counter-clockwise from spiral origin (goes along positive X, turning towards positive Y)
-     * This is the wrong direction if actual spiral is (steepening & clockwise) OR (flattening & counter-clockwise)
+     * Ideal spiral turns counter-clockwise from spiral origin (goes along positive X, turning
+     * towards positive Y) This is the wrong direction if actual spiral is (steepening & clockwise)
+     * OR (flattening & counter-clockwise)
      */
     protected val turnsClockwise: Boolean by lazy { (rotation == CW) == isSteepening }
 
     // In math, we always assume to start from straight line and go "into" the spiral.
-    // If we're going the other direction, we have to treat the end as the start-point and vice versa.
+    // If we're going the other direction, we have to treat the end as the start-point and vice
+    // versa.
     protected val segmentStart: Point by lazy { if (isSteepening) start else end }
-    protected val segmentStartRadius: Double? by lazy { if (isSteepening) radiusStart?.toDouble() else radiusEnd?.toDouble() }
-    protected val segmentStartAngle: Double by lazy { if (isSteepening) startDirectionRads else endDirectionRads - PI }
+    protected val segmentStartRadius: Double? by lazy {
+        if (isSteepening) radiusStart?.toDouble() else radiusEnd?.toDouble()
+    }
+    protected val segmentStartAngle: Double by lazy {
+        if (isSteepening) startDirectionRads else endDirectionRads - PI
+    }
 }
 
 data class GeometryClothoid(
     private val elementData: ElementData,
     private val spiralData: SpiralData,
     private val switchData: SwitchData,
-    /** Clothoid flatness constant A = sqrt(R*L) **/
+    /** Clothoid flatness constant A = sqrt(R*L) * */
     val constant: BigDecimal,
     override val id: DomainId<GeometryElement> = StringId(),
-) : ElementContent by elementData, SpiralContent by spiralData, SwitchContent by switchData, GeometrySpiral() {
+) :
+    ElementContent by elementData,
+    SpiralContent by spiralData,
+    SwitchContent by switchData,
+    GeometrySpiral() {
 
     init {
         if (radiusStart == null && radiusEnd == null) {
-            throw IllegalArgumentException("Clothoid cannot be defined without a start- or end-radius.")
+            throw IllegalArgumentException(
+                "Clothoid cannot be defined without a start- or end-radius.")
         }
     }
 
@@ -279,24 +311,25 @@ data class GeometryClothoid(
     }
 
     override fun contentEquals(other: GeometryElement): Boolean {
-        return other is GeometryClothoid
-                && other.elementData == elementData
-                && other.spiralData == spiralData
-                && other.constant == constant
-                && switchData.contentEquals(other.switchData)
+        return other is GeometryClothoid &&
+            other.elementData == elementData &&
+            other.spiralData == spiralData &&
+            other.constant == constant &&
+            switchData.contentEquals(other.switchData)
     }
 
     fun segmentToClothoidDistance(segmentDistance: Double): Double {
         // If our spiral is flattening, calculate the point going backwards from the end
-        return clothoidSegmentOffset + if (isSteepening) segmentDistance else calculatedLength - segmentDistance
+        return clothoidSegmentOffset +
+            if (isSteepening) segmentDistance else calculatedLength - segmentDistance
     }
 
     /**
      * Spiral origin is the point where the spiral becomes straight (R=INF)
      *
-     * This might be the segment start (steepening) or end (flattening), but can also be "before" or "after" the segment
-     * itself, as the segment can be taken from farther in the spiral (a spiral between 2 curves has some curvature on
-     * both ends).
+     * This might be the segment start (steepening) or end (flattening), but can also be "before" or
+     * "after" the segment itself, as the segment can be taken from farther in the spiral (a spiral
+     * between 2 curves has some curvature on both ends).
      */
     private val clothoidOrigin: Point by lazy {
         when {
@@ -304,7 +337,8 @@ data class GeometryClothoid(
             radiusEnd == null -> end
             else -> {
                 val idealOffset = clothoidPointAtOffset(constant.toDouble(), clothoidSegmentOffset)
-                val flipped = if (turnsClockwise) Point(idealOffset.x, -1 * idealOffset.y) else idealOffset
+                val flipped =
+                    if (turnsClockwise) Point(idealOffset.x, -1 * idealOffset.y) else idealOffset
                 val rotatedOffset = rotateAroundOrigin(clothoidAngle, flipped)
                 segmentStart - rotatedOffset
             }
@@ -321,8 +355,8 @@ data class GeometryClothoid(
     }
 
     /**
-     * Distance between the clothoid origin and the closest point of segment (start or end, depending on direction).
-     * Offset = 0, if the spiral begins or ends at a straight line.
+     * Distance between the clothoid origin and the closest point of segment (start or end,
+     * depending on direction). Offset = 0, if the spiral begins or ends at a straight line.
      * Offset > 0, if the segment is from farther in the spiral, having curvature in both ends.
      */
     private val clothoidSegmentOffset: Double by lazy {
@@ -358,23 +392,28 @@ data class GeometryClothoid(
         return segmentStartAngle + sign * spiralTwist
     }
 
-    private fun splitLengthToMaxTwist(range: ClosedRange<Double>, maxTwistRads: Double): List<ClosedRange<Double>> {
+    private fun splitLengthToMaxTwist(
+        range: ClosedRange<Double>,
+        maxTwistRads: Double
+    ): List<ClosedRange<Double>> {
         val angleDiff = angleDiffRads(directionAt(range.start), directionAt(range.endInclusive))
         return if (angleDiff < maxTwistRads) {
             listOf(range)
         } else {
             val halfPoint = (range.start + range.endInclusive) / 2
             splitLengthToMaxTwist(range.start..halfPoint, maxTwistRads) +
-                    splitLengthToMaxTwist(halfPoint..range.endInclusive, maxTwistRads)
+                splitLengthToMaxTwist(halfPoint..range.endInclusive, maxTwistRads)
         }
     }
 
     override fun getLengthUntil(target: Point): Double {
         for (segment in estimationSegments) {
             val closest = closestPointOnLine(segment.start, segment.end, target)
-            // If it's off from the end-side, move on to check the next segment. Otherwise, this is as close as it gets.
+            // If it's off from the end-side, move on to check the next segment. Otherwise, this is
+            // as close as it gets.
             if (closest != segment.end) {
-                val distancePortion = lineLength(segment.start, closest) / lineLength(segment.start, segment.end)
+                val distancePortion =
+                    lineLength(segment.start, closest) / lineLength(segment.start, segment.end)
                 return min(calculatedLength, segment.startLength + segment.length * distancePortion)
             }
         }
@@ -387,14 +426,20 @@ data class BiquadraticParabola(
     private val spiralData: SpiralData,
     private val switchData: SwitchData,
     override val id: DomainId<GeometryElement> = StringId(),
-) : ElementContent by elementData, SpiralContent by spiralData, SwitchContent by switchData, GeometrySpiral() {
+) :
+    ElementContent by elementData,
+    SpiralContent by spiralData,
+    SwitchContent by switchData,
+    GeometrySpiral() {
 
     init {
         if (radiusStart == null && radiusEnd == null) {
-            throw IllegalArgumentException("Biquadratic parabola cannot be defined without a start- or end-radius.")
+            throw IllegalArgumentException(
+                "Biquadratic parabola cannot be defined without a start- or end-radius.")
         }
         if (radiusStart != null && radiusEnd != null) {
-            throw IllegalArgumentException("Biquadratic parabola is not supported between curves (only on of start- and end-radius can be given).")
+            throw IllegalArgumentException(
+                "Biquadratic parabola is not supported between curves (only on of start- and end-radius can be given).")
         }
     }
 
@@ -407,7 +452,8 @@ data class BiquadraticParabola(
 
     override fun getCoordinateAt(distance: Double): Point {
         val spiralDistance = if (isSteepening) distance else length.toDouble() - distance
-        var offset = biquadraticParabolaPointAtOffset(spiralDistance, spiralRadiusChange, length.toDouble())
+        var offset =
+            biquadraticParabolaPointAtOffset(spiralDistance, spiralRadiusChange, length.toDouble())
         if (turnsClockwise) {
             offset = Point(offset.x, -1 * offset.y)
         }
@@ -416,10 +462,10 @@ data class BiquadraticParabola(
     }
 
     override fun contentEquals(other: GeometryElement): Boolean {
-        return other is BiquadraticParabola
-                && other.elementData == elementData
-                && other.spiralData == spiralData
-                && switchData.contentEquals(other.switchData)
+        return other is BiquadraticParabola &&
+            other.elementData == elementData &&
+            other.spiralData == spiralData &&
+            switchData.contentEquals(other.switchData)
     }
 
     private val spiralRadiusChange: Double by lazy {
@@ -429,5 +475,6 @@ data class BiquadraticParabola(
     // Calculate parabola spiral as if it were a line:
     // this is inaccurate, but only as much as the official length-to-point formula
     // For more, see biquadraticParabolaPointAtOffset() and X-axis calculation
-    override fun getLengthUntil(target: Point): Double = lineLength(start, closestPointOnLine(start, end, target))
+    override fun getLengthUntil(target: Point): Double =
+        lineLength(start, closestPointOnLine(start, end, target))
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
@@ -31,13 +31,11 @@ import fi.fta.geoviite.infra.util.Page
 import java.time.Instant
 
 enum class PlanSource {
-    GEOMETRIAPALVELU, PAIKANNUSPALVELU,
+    GEOMETRIAPALVELU,
+    PAIKANNUSPALVELU,
 }
 
-/**
- * GeometryPlanHeader is a lightweight object to be us
- * ed as list items etc.
- */
+/** GeometryPlanHeader is a lightweight object to be us ed as list items etc. */
 data class GeometryPlanHeader(
     val id: IntId<GeometryPlan>,
     val version: RowVersion<GeometryPlan>,
@@ -65,13 +63,16 @@ data class GeometryPlanHeader(
         listOfNotNull(fileName, project.name, message).map { o -> o.toString().lowercase() }
     }
 
-    override fun toLog(): String = logFormat("version" to version, "name" to fileName, "source" to source)
+    override fun toLog(): String =
+        logFormat("version" to version, "name" to fileName, "source" to source)
 }
 
 /**
- * Plan is a design for a portion of railways/roads/etc. that can go through various states of completion.
+ * Plan is a design for a portion of railways/roads/etc. that can go through various states of
+ * completion.
  *
- * It is typically handled as a single file, and can consists of a number of parallel ways (alignments), each with their own geometries.
+ * It is typically handled as a single file, and can consists of a number of parallel ways
+ * (alignments), each with their own geometries.
  */
 data class GeometryPlan(
     val source: PlanSource,
@@ -100,14 +101,15 @@ data class GeometryPlan(
     @get:JsonIgnore
     val bounds by lazy { boundingBoxCombining(alignments.mapNotNull { a -> a.bounds }) }
 
-    override fun toLog(): String = logFormat(
-        "id" to id,
-        "name" to fileName,
-        "source" to source,
-        "alignments" to alignments.map(GeometryAlignment::toLog),
-        "switches" to switches.map(GeometrySwitch::toLog),
-        "kmPosts" to kmPosts.map(GeometryKmPost::toLog),
-    )
+    override fun toLog(): String =
+        logFormat(
+            "id" to id,
+            "name" to fileName,
+            "source" to source,
+            "alignments" to alignments.map(GeometryAlignment::toLog),
+            "switches" to switches.map(GeometrySwitch::toLog),
+            "kmPosts" to kmPosts.map(GeometryKmPost::toLog),
+        )
 }
 
 data class GeometryPlanArea(
@@ -123,7 +125,8 @@ data class GeometryPlanUnits(
 
 data class GeometryUnits(
     val coordinateSystemSrid: Srid?,
-    val coordinateSystemName: CoordinateSystemName?, // Redundant, if SRID is resolved, but it might not be
+    val coordinateSystemName:
+        CoordinateSystemName?, // Redundant, if SRID is resolved, but it might not be
     val verticalCoordinateSystem: VerticalCoordinateSystem?,
     val directionUnit: AngularUnit,
     val linearUnit: LinearUnit,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlanLinkStatus.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlanLinkStatus.kt
@@ -18,8 +18,10 @@ data class GeometryAlignmentLinkStatus(
     val elements: List<GeometryElementLinkStatus>,
 ) {
     val isLinked = elements.any(GeometryElementLinkStatus::isLinked)
-    val linkedLocationTrackIds = elements.flatMap(GeometryElementLinkStatus::linkedLocationTrackIds).distinct()
-    val linkedReferenceLineIds = elements.flatMap(GeometryElementLinkStatus::linkedReferenceLineIds).distinct()
+    val linkedLocationTrackIds =
+        elements.flatMap(GeometryElementLinkStatus::linkedLocationTrackIds).distinct()
+    val linkedReferenceLineIds =
+        elements.flatMap(GeometryElementLinkStatus::linkedReferenceLineIds).distinct()
 }
 
 data class GeometryElementLinkStatus(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfile.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfile.kt
@@ -1,13 +1,12 @@
 package fi.fta.geoviite.infra.geometry
 
-
 import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.*
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import kotlin.math.*
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 val LOG: Logger = LoggerFactory.getLogger(GeometryProfile::class.java)
 
@@ -28,13 +27,14 @@ data class VICircularCurve(
     val length: BigDecimal?,
 ) : VerticalIntersection() {
     init {
-        require(radius?.compareTo(BigDecimal.ZERO) != 0) { "Circular curve cannot have zero radius" }
+        require(radius?.compareTo(BigDecimal.ZERO) != 0) {
+            "Circular curve cannot have zero radius"
+        }
     }
 }
 
 data class GeometryProfile(val name: PlanElementName, val elements: List<VerticalIntersection>) {
-    @get:JsonIgnore
-    val segments: List<ProfileSegment> by lazy { createSegments(elements) }
+    @get:JsonIgnore val segments: List<ProfileSegment> by lazy { createSegments(elements) }
 
     fun getHeightAt(distance: Double): Double? {
         return when {
@@ -42,12 +42,13 @@ data class GeometryProfile(val name: PlanElementName, val elements: List<Vertica
             distance <= elements.first().point.x -> elements.first().point.y
             distance >= elements.last().point.x -> elements.last().point.y
             else -> {
-                val segment = segments.find { s -> s.contains(distance) } ?: throw IllegalArgumentException(
-                    "Requested point outside profile segments: " +
-                            "$distance <> " +
-                            "[${elements.first().point.x} to ${elements.last().point.x}] => " +
-                            "${segments.map { s -> "${s.start.x}-${s.end.x}" }}"
-                )
+                val segment =
+                    segments.find { s -> s.contains(distance) }
+                        ?: throw IllegalArgumentException(
+                            "Requested point outside profile segments: " +
+                                "$distance <> " +
+                                "[${elements.first().point.x} to ${elements.last().point.x}] => " +
+                                "${segments.map { s -> "${s.start.x}-${s.end.x}" }}")
                 segment.getYValueAt(distance)
             }
         }
@@ -57,9 +58,14 @@ data class GeometryProfile(val name: PlanElementName, val elements: List<Vertica
 private fun createSegments(elements: List<VerticalIntersection>): List<ProfileSegment> {
     return when {
         elements.size < 2 -> listOf()
-        elements.size == 2 -> listOfNotNull(
-            createLinearIfNeeded(elements.last().description, elements.first().point, elements.last().point, true),
-        )
+        elements.size == 2 ->
+            listOfNotNull(
+                createLinearIfNeeded(
+                    elements.last().description,
+                    elements.first().point,
+                    elements.last().point,
+                    true),
+            )
         else -> {
             val segments: MutableList<ProfileSegment> = mutableListOf()
             var segmentStart: Point = elements.first().point
@@ -67,7 +73,8 @@ private fun createSegments(elements: List<VerticalIntersection>): List<ProfileSe
             (1..elements.lastIndex).forEach { index ->
                 val element = elements[index]
                 val nextElement = elements.getOrNull(index + 1)
-                val calculationResult = createProfileSegments(segmentStart, startValid, element, nextElement)
+                val calculationResult =
+                    createProfileSegments(segmentStart, startValid, element, nextElement)
                 segments.addAll(calculationResult.segments)
                 segmentStart = calculationResult.end
                 startValid = calculationResult.endValid
@@ -77,7 +84,11 @@ private fun createSegments(elements: List<VerticalIntersection>): List<ProfileSe
     }
 }
 
-private data class ProfileCalculationResult(val end: Point, val endValid: Boolean, val segments: List<ProfileSegment>)
+private data class ProfileCalculationResult(
+    val end: Point,
+    val endValid: Boolean,
+    val segments: List<ProfileSegment>
+)
 
 private fun createProfileSegments(
     start: Point,
@@ -91,29 +102,47 @@ private fun createProfileSegments(
     }
     when (intersection) {
         is VIPoint -> {
-            val segment = createLinearIfNeeded(intersection.description, start, intersection.point, startValid)
+            val segment =
+                createLinearIfNeeded(
+                    intersection.description, start, intersection.point, startValid)
             return ProfileCalculationResult(intersection.point, true, listOfNotNull(segment))
         }
         is VICircularCurve -> {
-            if (intersection.radius != null && nextIntersection != null && intersection.length?.compareTo(BigDecimal.ZERO) != 0) {
+            if (intersection.radius != null &&
+                nextIntersection != null &&
+                intersection.length?.compareTo(BigDecimal.ZERO) != 0) {
                 try {
                     val radius = intersection.radius.toDouble()
-                    val tangents = tangentPointsOfPvi(start, intersection.point, nextIntersection.point, radius)
+                    val tangents =
+                        tangentPointsOfPvi(
+                            start, intersection.point, nextIntersection.point, radius)
                     // Linear segment connecting previous point to first curve tangent
-                    val connectSegment = createLinearIfNeeded(intersection.description, start, tangents.first, startValid)
+                    val connectSegment =
+                        createLinearIfNeeded(
+                            intersection.description, start, tangents.first, startValid)
                     // The actual curve segment
-                    val center = circularCurveCenterPoint(radius, tangents.first, intersection.point)
+                    val center =
+                        circularCurveCenterPoint(radius, tangents.first, intersection.point)
                     val curvedSegment =
                         if (tangents.first.x >= tangents.second.x) null
-                        else CurvedProfileSegment(intersection.description, tangents.first, tangents.second, center, radius)
-                    return ProfileCalculationResult(tangents.second, true, listOfNotNull(connectSegment, curvedSegment))
+                        else
+                            CurvedProfileSegment(
+                                intersection.description,
+                                tangents.first,
+                                tangents.second,
+                                center,
+                                radius)
+                    return ProfileCalculationResult(
+                        tangents.second, true, listOfNotNull(connectSegment, curvedSegment))
                 } catch (e: IllegalArgumentException) {
-                   LOG.warn("Profile curve calculation failed: element=$intersection cause=${e.message}")
+                    LOG.warn(
+                        "Profile curve calculation failed: element=$intersection cause=${e.message}")
                 }
             }
 
             // Faulty curve params -> can't calculate the curve
-            val segment = createLinearIfNeeded(intersection.description, start, intersection.point, false)
+            val segment =
+                createLinearIfNeeded(intersection.description, start, intersection.point, false)
             return ProfileCalculationResult(intersection.point, false, listOfNotNull(segment))
         }
     }
@@ -136,6 +165,7 @@ sealed class ProfileSegment {
     abstract val endAngle: Double
 
     fun contains(x: Double) = x in start.x..end.x
+
     abstract fun getYValueAt(x: Double): Double?
 }
 
@@ -148,7 +178,9 @@ data class LinearProfileSegment(
     override val endAngle: Double = startAngle,
 ) : ProfileSegment() {
     init {
-        require(start.x <= end.x) { "Linear profile segment x must be growing: start=${start.x} end=${end.x}" }
+        require(start.x <= end.x) {
+            "Linear profile segment x must be growing: start=${start.x} end=${end.x}"
+        }
     }
 
     override fun getYValueAt(x: Double) = if (valid) lineYAtX(start, end, x) else null
@@ -160,11 +192,14 @@ data class CurvedProfileSegment(
     override val end: Point,
     val center: Point,
     val radius: Double,
-    override val startAngle: Double = directionBetweenPoints(center, start) + (sign(center.y) * PI/2),
-    override val endAngle: Double = directionBetweenPoints(center, end) + (sign(center.y) * PI/2),
+    override val startAngle: Double =
+        directionBetweenPoints(center, start) + (sign(center.y) * PI / 2),
+    override val endAngle: Double = directionBetweenPoints(center, end) + (sign(center.y) * PI / 2),
 ) : ProfileSegment() {
     init {
-        require(start.x <= end.x) { "Curved profile segment x must be growing: start=${start.x} end=${end.x}" }
+        require(start.x <= end.x) {
+            "Curved profile segment x must be growing: start=${start.x} end=${end.x}"
+        }
     }
 
     override fun getYValueAt(x: Double) = circleArcYAtX(center, radius, x)
@@ -182,7 +217,7 @@ fun tangentPointsOfPvi(
     rightPvi: Point,
     radius: Double,
 ): Pair<Point, Point> {
-    require (leftPvi.x < middlePvi.x) {
+    require(leftPvi.x < middlePvi.x) {
         "Profile curve preceding X must be before middle point X: leftPvi=$leftPvi middlePvi=$middlePvi"
     }
     require(middlePvi.x < rightPvi.x) {
@@ -196,37 +231,46 @@ fun tangentPointsOfPvi(
     return Pair(leftTangentPoint, rightTangentPoint)
 }
 
-fun lengthFromPviToTangent(leftPvi: Point, middlePvi: Point, rightPvi: Point, radius: Double): Double {
-    val leftHalfAngle = halfAngleOfPviPoint(
-        deltaX = middlePvi.x - leftPvi.x,
-        deltaY = if (radius < 0.0) middlePvi.y - leftPvi.y else leftPvi.y - middlePvi.y,
-    )
-    val rightHalfAngle = halfAngleOfPviPoint(
-        deltaX = rightPvi.x - middlePvi.x,
-        deltaY = if (radius < 0.0) middlePvi.y - rightPvi.y else rightPvi.y - middlePvi.y,
-    )
+fun lengthFromPviToTangent(
+    leftPvi: Point,
+    middlePvi: Point,
+    rightPvi: Point,
+    radius: Double
+): Double {
+    val leftHalfAngle =
+        halfAngleOfPviPoint(
+            deltaX = middlePvi.x - leftPvi.x,
+            deltaY = if (radius < 0.0) middlePvi.y - leftPvi.y else leftPvi.y - middlePvi.y,
+        )
+    val rightHalfAngle =
+        halfAngleOfPviPoint(
+            deltaX = rightPvi.x - middlePvi.x,
+            deltaY = if (radius < 0.0) middlePvi.y - rightPvi.y else rightPvi.y - middlePvi.y,
+        )
     return lengthFromPviToTangent(leftHalfAngle, rightHalfAngle, radius).also { length ->
         require(length > 0.0) { "PVI - tangent length should be positive: length=$length" }
     }
 }
 
-fun halfAngleOfPviPoint(deltaX: Double, deltaY: Double): Double = checkHalfAngle(
-    if (deltaY == 0.0) PI/2.0
-    else if (deltaY > 0.0) atan(deltaX / deltaY)
-    else PI/2.0 + abs(atan(deltaY / deltaX))
-)
+fun halfAngleOfPviPoint(deltaX: Double, deltaY: Double): Double =
+    checkHalfAngle(
+        if (deltaY == 0.0) PI / 2.0
+        else if (deltaY > 0.0) atan(deltaX / deltaY) else PI / 2.0 + abs(atan(deltaY / deltaX)))
 
-fun checkHalfAngle(halfAngle: Double) = halfAngle.also { angle ->
-    require(angle > 0.0) { "VI half-angle component should be positive: angle=$angle" }
-    require(angle < PI) { "VI half-angle component should under PI: angle=$angle" }
-}
+fun checkHalfAngle(halfAngle: Double) =
+    halfAngle.also { angle ->
+        require(angle > 0.0) { "VI half-angle component should be positive: angle=$angle" }
+        require(angle < PI) { "VI half-angle component should under PI: angle=$angle" }
+    }
 
 fun lengthFromPviToTangent(leftHalfAngle: Double, rightHalfAngle: Double, radius: Double): Double {
     val halfAngleOfAlfa = (leftHalfAngle + rightHalfAngle) / 2
-    require(halfAngleOfAlfa > 0.0) { "VI angle should be positive: left=$leftHalfAngle right=$rightHalfAngle" }
-    require(halfAngleOfAlfa < PI/2) {
+    require(halfAngleOfAlfa > 0.0) {
+        "VI angle should be positive: left=$leftHalfAngle right=$rightHalfAngle"
+    }
+    require(halfAngleOfAlfa < PI / 2) {
         "VI angle should not exceed PI (is the radius sign correct?): " +
-                "left=$leftHalfAngle right=$rightHalfAngle radius=$radius"
+            "left=$leftHalfAngle right=$rightHalfAngle radius=$radius"
     }
     return abs(radius) / tan(halfAngleOfAlfa)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometrySwitch.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometrySwitch.kt
@@ -24,16 +24,19 @@ data class GeometrySwitch(
     fun getJoint(number: JointNumber): GeometrySwitchJoint? =
         joints.find { j -> j.number == number }
 
-    override fun toLog(): String = logFormat("id" to id, "name" to name, "joints" to joints.map { j -> j.number.intValue })
+    override fun toLog(): String =
+        logFormat("id" to id, "name" to name, "joints" to joints.map { j -> j.number.intValue })
 }
 
-data class GeometrySwitchJoint(override val number: JointNumber, override val location: Point) : ISwitchJoint
+data class GeometrySwitchJoint(override val number: JointNumber, override val location: Point) :
+    ISwitchJoint
 
 private val geometrySwitchTypeNameLength = 0..30
 private val geometrySwitchTypeNameRegex = Regex("^[A-Za-z0-9:\\-/(),.]*\$")
 
-data class GeometrySwitchTypeName @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<GeometrySwitchTypeName>, CharSequence by value {
+data class GeometrySwitchTypeName
+@JsonCreator(mode = DELEGATING)
+constructor(private val value: String) : Comparable<GeometrySwitchTypeName>, CharSequence by value {
     init {
         assertSanitized<GeometrySwitchTypeName>(
             value,
@@ -43,7 +46,7 @@ data class GeometrySwitchTypeName @JsonCreator(mode = DELEGATING) constructor(pr
         )
     }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: GeometrySwitchTypeName): Int = value.compareTo(other.value)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
@@ -35,10 +35,11 @@ const val VALIDATION_CANT = "cant"
 const val VALIDATION_SWITCH = "switch"
 const val VALIDATION_KM_POST = "km-post"
 
-val trackTypeCodes = listOf(
-    FeatureTypeCode("281"),
-    FeatureTypeCode("111"),
-)
+val trackTypeCodes =
+    listOf(
+        FeatureTypeCode("281"),
+        FeatureTypeCode("111"),
+    )
 
 interface GeometryValidationIssue {
     val localizationKey: LocalizationKey
@@ -49,7 +50,11 @@ data class GeometryValidationIssueData(
     override val localizationKey: LocalizationKey,
     override val issueType: GeometryIssueType,
 ) : GeometryValidationIssue {
-    constructor(parentKey: String, errorKey: String, errorType: GeometryIssueType) : this(
+    constructor(
+        parentKey: String,
+        errorKey: String,
+        errorType: GeometryIssueType
+    ) : this(
         LocalizationKey("$VALIDATION.$parentKey.$errorKey"),
         errorType,
     )
@@ -59,7 +64,11 @@ data class MetadataError(
     @JsonIgnore private val data: GeometryValidationIssueData,
     val value: String?,
 ) : GeometryValidationIssue by data {
-    constructor(key: String, type: GeometryIssueType, value: String? = null) : this(
+    constructor(
+        key: String,
+        type: GeometryIssueType,
+        value: String? = null
+    ) : this(
         GeometryValidationIssueData(VALIDATION_METADATA, key, type),
         value,
     )
@@ -96,7 +105,12 @@ data class AlignmentIssue(
     val alignmentName: AlignmentName,
     val value: String?,
 ) : GeometryValidationIssue by data {
-    constructor(key: String, type: GeometryIssueType, alignmentName: AlignmentName, value: CharSequence? = null) : this(
+    constructor(
+        key: String,
+        type: GeometryIssueType,
+        alignmentName: AlignmentName,
+        value: CharSequence? = null
+    ) : this(
         GeometryValidationIssueData(VALIDATION_ALIGNMENT, key, type),
         alignmentName,
         value?.toString(),
@@ -146,8 +160,13 @@ data class CantIssue(
     val station: BigDecimal,
     val value: String?,
 ) : GeometryValidationIssue by data {
-    constructor(key: String, type: GeometryIssueType, cantName: PlanElementName, station: BigDecimal, value: String? = null):
-            this(GeometryValidationIssueData(VALIDATION_CANT, key, type), cantName, station, value)
+    constructor(
+        key: String,
+        type: GeometryIssueType,
+        cantName: PlanElementName,
+        station: BigDecimal,
+        value: String? = null
+    ) : this(GeometryValidationIssueData(VALIDATION_CANT, key, type), cantName, station, value)
 }
 
 data class KmPostIssue(
@@ -155,7 +174,12 @@ data class KmPostIssue(
     val kmPostName: PlanElementName,
     val value: String?,
 ) : GeometryValidationIssue by data {
-    constructor(key: String, type: GeometryIssueType, kmPostName: PlanElementName, value: String? = null) : this(
+    constructor(
+        key: String,
+        type: GeometryIssueType,
+        kmPostName: PlanElementName,
+        value: String? = null
+    ) : this(
         GeometryValidationIssueData(VALIDATION_KM_POST, key, type),
         kmPostName,
         value,
@@ -166,7 +190,12 @@ data class CollectionIssue(
     @JsonIgnore private val data: GeometryValidationIssueData,
     val value: String?,
 ) : GeometryValidationIssue by data {
-    constructor(key: String, groupingType: String, type: GeometryIssueType, value: CharSequence? = null) : this(
+    constructor(
+        key: String,
+        groupingType: String,
+        type: GeometryIssueType,
+        value: CharSequence? = null
+    ) : this(
         GeometryValidationIssueData(groupingType, key, type),
         value?.toString(),
     )
@@ -203,51 +232,59 @@ fun validate(
     officialTrackNumbers: List<TrackNumber>,
 ): List<GeometryValidationIssue> {
     return validateMetadata(plan, officialTrackNumbers) +
-            validateAlignments(plan.alignments, featureTypes) +
-            validateSwitches(plan.switches, plan.alignments, switchStructures) +
-            validateKmPosts(plan.kmPosts)
+        validateAlignments(plan.alignments, featureTypes) +
+        validateSwitches(plan.switches, plan.alignments, switchStructures) +
+        validateKmPosts(plan.kmPosts)
 }
 
-fun validateMetadata(plan: GeometryPlan, officialTrackNumbers: List<TrackNumber>): List<GeometryValidationIssue> =
+fun validateMetadata(
+    plan: GeometryPlan,
+    officialTrackNumbers: List<TrackNumber>
+): List<GeometryValidationIssue> =
     listOfNotNull<GeometryValidationIssue>(
-    validate(plan.units.coordinateSystemSrid != null) {
-        val key =
-            if (plan.units.coordinateSystemName == null) "coordinate-system-missing"
-            else "coordinate-system-unsupported"
-        MetadataError(key, VALIDATION_ERROR, plan.units.coordinateSystemName?.toString())
-    },
-    validate(plan.units.verticalCoordinateSystem != null || plan.alignments.all { a -> a.profile == null }) {
-        MetadataError("vertical-coordinate-system-missing", VALIDATION_ERROR)
-    },
-    validate(plan.trackNumber != null) {
-        MetadataError("track-number-missing", OBSERVATION_MAJOR)
-    },
-    validate(plan.trackNumber == null || officialTrackNumbers.contains(plan.trackNumber)) {
-        MetadataError("track-number-not-found", OBSERVATION_MAJOR, plan.trackNumber?.toString())
-    },
-    validate(plan.planTime != null) {
-        MetadataError("plan-time-missing", OBSERVATION_MINOR)
-    },
-    validate(plan.author != null) {
-        MetadataError("author-missing", OBSERVATION_MINOR)
-    },
-    validate(plan.kmPosts.isNotEmpty()) {
-        MetadataError("km-posts-missing", OBSERVATION_MAJOR)
-    },
-)
+        validate(plan.units.coordinateSystemSrid != null) {
+            val key =
+                if (plan.units.coordinateSystemName == null) "coordinate-system-missing"
+                else "coordinate-system-unsupported"
+            MetadataError(key, VALIDATION_ERROR, plan.units.coordinateSystemName?.toString())
+        },
+        validate(
+            plan.units.verticalCoordinateSystem != null ||
+                plan.alignments.all { a -> a.profile == null }) {
+                MetadataError("vertical-coordinate-system-missing", VALIDATION_ERROR)
+            },
+        validate(plan.trackNumber != null) {
+            MetadataError("track-number-missing", OBSERVATION_MAJOR)
+        },
+        validate(plan.trackNumber == null || officialTrackNumbers.contains(plan.trackNumber)) {
+            MetadataError("track-number-not-found", OBSERVATION_MAJOR, plan.trackNumber?.toString())
+        },
+        validate(plan.planTime != null) { MetadataError("plan-time-missing", OBSERVATION_MINOR) },
+        validate(plan.author != null) { MetadataError("author-missing", OBSERVATION_MINOR) },
+        validate(plan.kmPosts.isNotEmpty()) {
+            MetadataError("km-posts-missing", OBSERVATION_MAJOR)
+        },
+    )
 
 fun validateAlignments(
     alignments: List<GeometryAlignment>,
     featureTypes: List<FeatureType>,
 ): List<GeometryValidationIssue> {
-    val duplicateNames = alignments.mapNotNull { alignment ->
-        if (alignments.any { other -> other.id != alignment.id && other.name == alignment.name }) {
-            alignment.name
-        } else null
-    }.toSet()
-    val duplicateErrors = duplicateNames.map { name -> AlignmentIssue("duplicate-name", OBSERVATION_MAJOR, name) }
+    val duplicateNames =
+        alignments
+            .mapNotNull { alignment ->
+                if (alignments.any { other ->
+                    other.id != alignment.id && other.name == alignment.name
+                }) {
+                    alignment.name
+                } else null
+            }
+            .toSet()
+    val duplicateErrors =
+        duplicateNames.map { name -> AlignmentIssue("duplicate-name", OBSERVATION_MAJOR, name) }
 
-    val alignmentErrors = alignments.flatMap { alignment -> validateAlignment(alignment, featureTypes) }
+    val alignmentErrors =
+        alignments.flatMap { alignment -> validateAlignment(alignment, featureTypes) }
 
     val alignmentCollectionErrors = validateAlignmentCollection(alignments)
 
@@ -259,29 +296,35 @@ fun validateSwitches(
     alignments: List<GeometryAlignment>,
     switchStructures: Map<IntId<SwitchStructure>, SwitchStructure>,
 ): List<GeometryValidationIssue> {
-    val duplicateNames = switches.mapNotNull { switch ->
-        if (switches.any { other -> other.id != switch.id && other.name == switch.name }) {
-            switch.name
-        } else null
-    }.toSet()
-    val duplicateErrors = duplicateNames.map { name ->
-        SwitchDefinitionError("duplicate-name", OBSERVATION_MAJOR, name)
-    }
-    val switchErrors = switches.flatMap { switch ->
-        validateSwitch(
-            switch,
-            switch.switchStructureId?.let(switchStructures::get),
-            alignments.mapNotNull { a -> collectAlignmentSwitchJoints(switch.id, a) },
-        )
-    }
+    val duplicateNames =
+        switches
+            .mapNotNull { switch ->
+                if (switches.any { other -> other.id != switch.id && other.name == switch.name }) {
+                    switch.name
+                } else null
+            }
+            .toSet()
+    val duplicateErrors =
+        duplicateNames.map { name ->
+            SwitchDefinitionError("duplicate-name", OBSERVATION_MAJOR, name)
+        }
+    val switchErrors =
+        switches.flatMap { switch ->
+            validateSwitch(
+                switch,
+                switch.switchStructureId?.let(switchStructures::get),
+                alignments.mapNotNull { a -> collectAlignmentSwitchJoints(switch.id, a) },
+            )
+        }
     return duplicateErrors + switchErrors
 }
 
 fun validateKmPosts(kmPosts: List<GeometryKmPost>): List<GeometryValidationIssue> {
-    val singularKmPostsValidations =  kmPosts.flatMapIndexed { i, p ->
-        // Don't validate 1st km-post as it's just a 0-point with different data
-        if (i > 0) validateKmPost(p) else listOf()
-    }
+    val singularKmPostsValidations =
+        kmPosts.flatMapIndexed { i, p ->
+            // Don't validate 1st km-post as it's just a 0-point with different data
+            if (i > 0) validateKmPost(p) else listOf()
+        }
 
     return singularKmPostsValidations + validateKmPostCollection(kmPosts)
 }
@@ -291,35 +334,41 @@ private fun validateKmPostCollection(kmPosts: List<GeometryKmPost>): List<Collec
     val firstKmPost = groupedKmPosts.firstOrNull()
     val duplicateKmPosts = groupedKmPosts.groupBy { it.kmNumber }.filter { it.value.size > 1 }.keys
 
-    val generalErrors = listOfNotNull(
-        validate(duplicateKmPosts.isEmpty()) {
-            CollectionIssue(
-                "duplicate-km-posts",
-                VALIDATION_KM_POST,
-                VALIDATION_ERROR,
-                duplicateKmPosts.map { it.toString() }.joinToString(", ")
-            )
-        },
-        validate(firstKmPost != null && firstKmPost.staAhead <= BigDecimal.ZERO) {
-            CollectionIssue("sta-ahead-not-negative", VALIDATION_KM_POST, VALIDATION_ERROR, firstKmPost?.staAhead?.toString())
-        },
-    )
+    val generalErrors =
+        listOfNotNull(
+            validate(duplicateKmPosts.isEmpty()) {
+                CollectionIssue(
+                    "duplicate-km-posts",
+                    VALIDATION_KM_POST,
+                    VALIDATION_ERROR,
+                    duplicateKmPosts.map { it.toString() }.joinToString(", "))
+            },
+            validate(firstKmPost != null && firstKmPost.staAhead <= BigDecimal.ZERO) {
+                CollectionIssue(
+                    "sta-ahead-not-negative",
+                    VALIDATION_KM_POST,
+                    VALIDATION_ERROR,
+                    firstKmPost?.staAhead?.toString())
+            },
+        )
     return generalErrors
 }
 
-fun validateKmPost(post: GeometryKmPost) = listOfNotNull(
-    validate(post.location != null) {
-        KmPostIssue("location-missing", OBSERVATION_MAJOR, post.description)
-    },
-    validate(post.kmNumber != null) {
-        KmPostIssue("km-number-incorrect", OBSERVATION_MINOR, post.description)
-    },
-)
+fun validateKmPost(post: GeometryKmPost) =
+    listOfNotNull(
+        validate(post.location != null) {
+            KmPostIssue("location-missing", OBSERVATION_MAJOR, post.description)
+        },
+        validate(post.kmNumber != null) {
+            KmPostIssue("km-number-incorrect", OBSERVATION_MINOR, post.description)
+        },
+    )
 
-fun validateAlignmentCollection(alignments: List<GeometryAlignment>): List<GeometryValidationIssue> {
-    val referenceLineAlignments = alignments.filter { alignment ->
-        alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE
-    }
+fun validateAlignmentCollection(
+    alignments: List<GeometryAlignment>
+): List<GeometryValidationIssue> {
+    val referenceLineAlignments =
+        alignments.filter { alignment -> alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE }
     return listOfNotNull(
         validate(referenceLineAlignments.isNotEmpty()) {
             CollectionIssue("no-reference-lines", VALIDATION_ALIGNMENT, OBSERVATION_MAJOR)
@@ -331,137 +380,165 @@ fun validateAlignmentCollection(alignments: List<GeometryAlignment>): List<Geome
 }
 
 fun validateAlignmentGeometry(alignment: GeometryAlignment): List<GeometryValidationIssue> {
-    return validatePieces(alignment.name, alignment.elements, ::validateElement, ::validateElementVsPrevious)
+    return validatePieces(
+        alignment.name, alignment.elements, ::validateElement, ::validateElementVsPrevious)
 }
 
 fun validateAlignmentProfile(alignment: GeometryAlignment): List<GeometryValidationIssue> {
     return alignment.profile?.let { profile ->
-        val intersectionErrors = validatePieces(
-            profile.name,
-            profile.elements,
-            ::validateIntersection,
-            ::validateIntersectionVsPrevious,
-        )
-        val segmentErrors = validatePieces(
-            profile.name,
-            profile.segments,
-            ::validateProfileSegment,
-            ::validateProfileSegmentVsPrevious,
-        )
+        val intersectionErrors =
+            validatePieces(
+                profile.name,
+                profile.elements,
+                ::validateIntersection,
+                ::validateIntersectionVsPrevious,
+            )
+        val segmentErrors =
+            validatePieces(
+                profile.name,
+                profile.segments,
+                ::validateProfileSegment,
+                ::validateProfileSegmentVsPrevious,
+            )
         intersectionErrors + segmentErrors
     } ?: listOf(AlignmentIssue("no-profile", OBSERVATION_MAJOR, alignment.name))
 }
 
 fun validateAlignmentCant(alignment: GeometryAlignment): List<GeometryValidationIssue> {
     return alignment.cant?.let { cant ->
-        val cantErrors = listOfNotNull(
-            validate(cant.rotationPoint != null || alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE) {
-                AlignmentIssue("cant-rotation-point-undefined", VALIDATION_ERROR, alignment.name)
-            },
-            validate(cant.rotationPoint != CENTER) {
-                AlignmentIssue("cant-rotation-point-center", VALIDATION_ERROR, alignment.name)
-            },
-            validate(cant.gauge == FINNISH_RAIL_GAUGE) {
-                AlignmentIssue("cant-gauge-invalid", OBSERVATION_MAJOR, alignment.name, value = cant.gauge.toString())
-            },
-        )
-        val pointErrors = validatePieces(
-            parentName = cant.name,
-            pieces = cant.points,
-            itemValidator = { cantName, cp -> validateCantPoint(cantName, cp, cant.gauge) },
-            itemVsPreviousValidator = ::validateCantPointVsPrevious,
-        )
+        val cantErrors =
+            listOfNotNull(
+                validate(
+                    cant.rotationPoint != null ||
+                        alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE) {
+                        AlignmentIssue(
+                            "cant-rotation-point-undefined", VALIDATION_ERROR, alignment.name)
+                    },
+                validate(cant.rotationPoint != CENTER) {
+                    AlignmentIssue("cant-rotation-point-center", VALIDATION_ERROR, alignment.name)
+                },
+                validate(cant.gauge == FINNISH_RAIL_GAUGE) {
+                    AlignmentIssue(
+                        "cant-gauge-invalid",
+                        OBSERVATION_MAJOR,
+                        alignment.name,
+                        value = cant.gauge.toString())
+                },
+            )
+        val pointErrors =
+            validatePieces(
+                parentName = cant.name,
+                pieces = cant.points,
+                itemValidator = { cantName, cp -> validateCantPoint(cantName, cp, cant.gauge) },
+                itemVsPreviousValidator = ::validateCantPointVsPrevious,
+            )
         cantErrors + pointErrors
     } ?: listOf(AlignmentIssue("no-cant", OBSERVATION_MAJOR, alignment.name))
 }
 
-fun validateAlignment(alignment: GeometryAlignment, featureTypes: List<FeatureType>): List<GeometryValidationIssue> {
+fun validateAlignment(
+    alignment: GeometryAlignment,
+    featureTypes: List<FeatureType>
+): List<GeometryValidationIssue> {
     val typeCode = alignment.featureTypeCode
     val type = typeCode?.let { c -> featureTypes.find { ft -> ft.code == c } }
-    val typeCodeError = if (typeCode == null) {
-        AlignmentIssue("no-feature-type", OBSERVATION_MAJOR, alignment.name)
-    } else if (type == null) {
-        AlignmentIssue("unknown-feature-type", OBSERVATION_MAJOR, alignment.name, typeCode)
-    } else if (type.code !in trackTypeCodes) {
-        AlignmentIssue("wrong-feature-type", OBSERVATION_MINOR, alignment.name, "${type.code} (${type.description})")
-    } else {
-        null
-    }
-    val alignmentIssues = listOfNotNull(
-        typeCodeError,
-        validate(alignment.state != null) {
-            AlignmentIssue("no-state", OBSERVATION_MINOR, alignment.name)
-        },
-    )
+    val typeCodeError =
+        if (typeCode == null) {
+            AlignmentIssue("no-feature-type", OBSERVATION_MAJOR, alignment.name)
+        } else if (type == null) {
+            AlignmentIssue("unknown-feature-type", OBSERVATION_MAJOR, alignment.name, typeCode)
+        } else if (type.code !in trackTypeCodes) {
+            AlignmentIssue(
+                "wrong-feature-type",
+                OBSERVATION_MINOR,
+                alignment.name,
+                "${type.code} (${type.description})")
+        } else {
+            null
+        }
+    val alignmentIssues =
+        listOfNotNull(
+            typeCodeError,
+            validate(alignment.state != null) {
+                AlignmentIssue("no-state", OBSERVATION_MINOR, alignment.name)
+            },
+        )
     return alignmentIssues +
-            validateAlignmentGeometry(alignment) +
-            validateAlignmentProfile(alignment) +
-            validateAlignmentCant(alignment)
+        validateAlignmentGeometry(alignment) +
+        validateAlignmentProfile(alignment) +
+        validateAlignmentCant(alignment)
 }
 
-private fun validateElement(alignmentName: AlignmentName, element: GeometryElement): List<ElementIssue> {
+private fun validateElement(
+    alignmentName: AlignmentName,
+    element: GeometryElement
+): List<ElementIssue> {
     val lengthDelta = abs(element.length.toDouble() - element.calculatedLength)
-    val fieldErrors = listOfNotNull(
-        validate(element.length > BigDecimal.ZERO) {
-            ElementIssue(
-                key = "field-invalid-length",
-                type = OBSERVATION_MAJOR,
-                alignmentName = alignmentName,
-                element = element,
-                value = element.length.toString(),
-            )
-        },
-        validate(element.length <= BigDecimal.ZERO || lengthDelta < ACCURATE_LENGTH_DELTA) {
-            val isIncorrect = lengthDelta > LENGTH_DELTA
-            ElementIssue(
-                key = if (isIncorrect) "field-incorrect-length" else "field-inaccurate-length",
-                type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
-                alignmentName = alignmentName,
-                element = element,
-                value = "${element.length} <> ${round(element.calculatedLength, element.length.scale())}"
-            )
-        },
-    )
+    val fieldErrors =
+        listOfNotNull(
+            validate(element.length > BigDecimal.ZERO) {
+                ElementIssue(
+                    key = "field-invalid-length",
+                    type = OBSERVATION_MAJOR,
+                    alignmentName = alignmentName,
+                    element = element,
+                    value = element.length.toString(),
+                )
+            },
+            validate(element.length <= BigDecimal.ZERO || lengthDelta < ACCURATE_LENGTH_DELTA) {
+                val isIncorrect = lengthDelta > LENGTH_DELTA
+                ElementIssue(
+                    key = if (isIncorrect) "field-incorrect-length" else "field-inaccurate-length",
+                    type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
+                    alignmentName = alignmentName,
+                    element = element,
+                    value =
+                        "${element.length} <> ${round(element.calculatedLength, element.length.scale())}")
+            },
+        )
 
     val calculatedStart = element.getCoordinateAt(0.0)
     val calculatedEnd = element.getCoordinateAt(element.calculatedLength)
-    val endPointErrors = listOfNotNull(
-        validate(!element.start.isSame(element.end, ACCURATE_COORDINATE_DELTA)) {
-            ElementIssue(
-                key = "start-end-same",
-                type = OBSERVATION_MAJOR,
-                alignmentName = alignmentName,
-                element = element,
-            )
-        },
-        validate(calculatedStart.isSame(element.start, ACCURATE_COORDINATE_DELTA)) {
-            val isIncorrect = !calculatedStart.isSame(element.start, COORDINATE_DELTA)
-            ElementIssue(
-                key = if (isIncorrect) "incorrect-start-point" else "inaccurate-start-point",
-                type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
-                alignmentName = alignmentName,
-                element = element,
-                value = roundTo3Decimals(lineLength(element.start, calculatedStart)).toString(),
-            )
-        },
-        validate(calculatedEnd.isSame(element.end, ACCURATE_COORDINATE_DELTA)) {
-            val isIncorrect = !calculatedEnd.isSame(element.end, COORDINATE_DELTA)
-            ElementIssue(
-                key = if (isIncorrect) "incorrect-end-point" else "inaccurate-end-point",
-                type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
-                alignmentName = alignmentName,
-                element = element,
-                value = roundTo3Decimals(lineLength(element.end, calculatedEnd)).toString(),
-            )
-        },
-    )
+    val endPointErrors =
+        listOfNotNull(
+            validate(!element.start.isSame(element.end, ACCURATE_COORDINATE_DELTA)) {
+                ElementIssue(
+                    key = "start-end-same",
+                    type = OBSERVATION_MAJOR,
+                    alignmentName = alignmentName,
+                    element = element,
+                )
+            },
+            validate(calculatedStart.isSame(element.start, ACCURATE_COORDINATE_DELTA)) {
+                val isIncorrect = !calculatedStart.isSame(element.start, COORDINATE_DELTA)
+                ElementIssue(
+                    key = if (isIncorrect) "incorrect-start-point" else "inaccurate-start-point",
+                    type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
+                    alignmentName = alignmentName,
+                    element = element,
+                    value = roundTo3Decimals(lineLength(element.start, calculatedStart)).toString(),
+                )
+            },
+            validate(calculatedEnd.isSame(element.end, ACCURATE_COORDINATE_DELTA)) {
+                val isIncorrect = !calculatedEnd.isSame(element.end, COORDINATE_DELTA)
+                ElementIssue(
+                    key = if (isIncorrect) "incorrect-end-point" else "inaccurate-end-point",
+                    type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
+                    alignmentName = alignmentName,
+                    element = element,
+                    value = roundTo3Decimals(lineLength(element.end, calculatedEnd)).toString(),
+                )
+            },
+        )
 
-    val typeErrors = when (element) {
-        is GeometryLine -> listOf()
-        is GeometryCurve -> validateCurve(alignmentName, element)
-        is GeometryClothoid -> validateSpiral(alignmentName, element) + validateClothoid(alignmentName, element)
-        is BiquadraticParabola -> validateSpiral(alignmentName, element)
-    }
+    val typeErrors =
+        when (element) {
+            is GeometryLine -> listOf()
+            is GeometryCurve -> validateCurve(alignmentName, element)
+            is GeometryClothoid ->
+                validateSpiral(alignmentName, element) + validateClothoid(alignmentName, element)
+            is BiquadraticParabola -> validateSpiral(alignmentName, element)
+        }
 
     return fieldErrors + endPointErrors + typeErrors
 }
@@ -490,7 +567,8 @@ private fun validateElementVsPrevious(
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
                 element = element,
-                value = "${roundTo3Decimals(previous.endDirectionRads)} <> ${roundTo3Decimals(element.startDirectionRads)}",
+                value =
+                    "${roundTo3Decimals(previous.endDirectionRads)} <> ${roundTo3Decimals(element.startDirectionRads)}",
             )
         },
         validate(element.staStart > previous.staStart) {
@@ -514,7 +592,9 @@ private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): L
         validate(startRadiusDiff <= ACCURATE_RADIUS_DELTA) {
             val isIncorrect = startRadiusDiff > RADIUS_DELTA
             ElementIssue(
-                key = if (isIncorrect) "curve-radius-incorrect-start" else "curve-radius-inaccurate-start",
+                key =
+                    if (isIncorrect) "curve-radius-incorrect-start"
+                    else "curve-radius-inaccurate-start",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
                 element = curve,
@@ -524,7 +604,9 @@ private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): L
         validate(endRadiusDiff <= ACCURATE_RADIUS_DELTA) {
             val isIncorrect = endRadiusDiff > RADIUS_DELTA
             ElementIssue(
-                key = if (isIncorrect) "curve-radius-incorrect-end" else "curve-radius-inaccurate-end",
+                key =
+                    if (isIncorrect) "curve-radius-incorrect-end"
+                    else "curve-radius-inaccurate-end",
                 type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                 alignmentName = alignmentName,
                 element = curve,
@@ -552,7 +634,10 @@ private fun validateCurve(alignmentName: AlignmentName, curve: GeometryCurve): L
     )
 }
 
-private fun validateSpiral(alignmentName: AlignmentName, spiral: GeometrySpiral): List<ElementIssue> {
+private fun validateSpiral(
+    alignmentName: AlignmentName,
+    spiral: GeometrySpiral
+): List<ElementIssue> {
     val startRadius = spiral.radiusStart
     val endRadius = spiral.radiusEnd
     return listOfNotNull(
@@ -577,12 +662,17 @@ private fun validateSpiral(alignmentName: AlignmentName, spiral: GeometrySpiral)
     )
 }
 
-private fun validateClothoid(alignmentName: AlignmentName, clothoid: GeometryClothoid): List<ElementIssue> {
+private fun validateClothoid(
+    alignmentName: AlignmentName,
+    clothoid: GeometryClothoid
+): List<ElementIssue> {
     val calculatedConstant =
         if (clothoid.radiusStart != null) {
             sqrt(clothoid.radiusStart.toDouble() * clothoid.segmentToClothoidDistance(0.0))
         } else if (clothoid.radiusEnd != null) {
-            sqrt(clothoid.radiusEnd.toDouble() * clothoid.segmentToClothoidDistance(clothoid.length.toDouble()))
+            sqrt(
+                clothoid.radiusEnd.toDouble() *
+                    clothoid.segmentToClothoidDistance(clothoid.length.toDouble()))
         } else null
 
     return listOfNotNull(
@@ -591,7 +681,9 @@ private fun validateClothoid(alignmentName: AlignmentName, clothoid: GeometryClo
             validate(constantDiff <= ACCURATE_CONSTANT_A_DELTA) {
                 val isIncorrect = constantDiff > CONSTANT_A_DELTA
                 ElementIssue(
-                    key = if (isIncorrect) "clothoid-incorrect-constant" else "clothoid-inaccurate-constant",
+                    key =
+                        if (isIncorrect) "clothoid-incorrect-constant"
+                        else "clothoid-inaccurate-constant",
                     type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
                     alignmentName = alignmentName,
                     element = clothoid,
@@ -602,7 +694,10 @@ private fun validateClothoid(alignmentName: AlignmentName, clothoid: GeometryClo
     )
 }
 
-private fun validateIntersection(profileName: PlanElementName, intersection: VerticalIntersection): List<ProfileIssue> {
+private fun validateIntersection(
+    profileName: PlanElementName,
+    intersection: VerticalIntersection
+): List<ProfileIssue> {
     return if (intersection is VICircularCurve) {
         listOfNotNull(
             validate(intersection.length != null) {
@@ -629,13 +724,14 @@ private fun validateIntersectionVsPrevious(
     profileName: PlanElementName,
     intersection: VerticalIntersection,
     previous: VerticalIntersection,
-) : List<ProfileIssue> {
+): List<ProfileIssue> {
     val deltaX = intersection.point.x - previous.point.x
     val deltaY = intersection.point.y - previous.point.y
-    val profileAngle = if (deltaX > 0) radsToDegrees(sin(deltaY/deltaX)) else null
+    val profileAngle = if (deltaX > 0) radsToDegrees(sin(deltaY / deltaX)) else null
     return listOfNotNull(
         validate(deltaX > 0) {
-            ProfileIssue("incorrect-station", OBSERVATION_MAJOR, profileName, intersection.description)
+            ProfileIssue(
+                "incorrect-station", OBSERVATION_MAJOR, profileName, intersection.description)
         },
         profileAngle?.let { angle ->
             validate(abs(angle) <= MAX_PROFILE_SLOPE_DEGREES) {
@@ -651,7 +747,10 @@ private fun validateIntersectionVsPrevious(
     )
 }
 
-private fun validateProfileSegment(profileName: PlanElementName, segment: ProfileSegment): List<ProfileIssue> {
+private fun validateProfileSegment(
+    profileName: PlanElementName,
+    segment: ProfileSegment
+): List<ProfileIssue> {
     return listOfNotNull(
         validate(segment !is LinearProfileSegment || segment.valid) {
             ProfileIssue(
@@ -669,7 +768,7 @@ private fun validateProfileSegmentVsPrevious(
     profileName: PlanElementName,
     segment: ProfileSegment,
     previous: ProfileSegment,
-) : List<ProfileIssue> {
+): List<ProfileIssue> {
     val segmentValid = segment is LinearProfileSegment && !segment.valid
     val previousValid = previous is LinearProfileSegment && !previous.valid
     return listOfNotNull(
@@ -691,15 +790,19 @@ private fun validateProfileSegmentVsPrevious(
                 value = "${roundTo3Decimals(previous.end.y)}<>${roundTo3Decimals(segment.start.y)}",
             )
         },
-        validate(!segmentValid || !previousValid || abs(segment.startAngle - previous.endAngle) <= 0.0001) {
-            ProfileIssue(
-                key = "segment-angle-not-continuous",
-                type = OBSERVATION_MAJOR,
-                profileName = profileName,
-                viName = segment.viName,
-                value = "${roundTo3Decimals(radsToDegrees(previous.endAngle))}<>${roundTo3Decimals(radsToDegrees(segment.startAngle))}",
-            )
-        },
+        validate(
+            !segmentValid ||
+                !previousValid ||
+                abs(segment.startAngle - previous.endAngle) <= 0.0001) {
+                ProfileIssue(
+                    key = "segment-angle-not-continuous",
+                    type = OBSERVATION_MAJOR,
+                    profileName = profileName,
+                    viName = segment.viName,
+                    value =
+                        "${roundTo3Decimals(radsToDegrees(previous.endAngle))}<>${roundTo3Decimals(radsToDegrees(segment.startAngle))}",
+                )
+            },
     )
 }
 
@@ -709,7 +812,7 @@ private fun validateCantPoint(
     gauge: BigDecimal
 ): List<CantIssue> {
     return listOfNotNull(
-        validate (cantPoint.appliedCant.toDouble() in 0.0..gauge.toDouble()) {
+        validate(cantPoint.appliedCant.toDouble() in 0.0..gauge.toDouble()) {
             CantIssue(
                 key = "value-incorrect",
                 type = OBSERVATION_MAJOR,
@@ -741,33 +844,36 @@ fun validateSwitch(
     val jointNumbers = switch.joints.map(GeometrySwitchJoint::number)
     val structureJointNumbers = structure?.joints?.map(SwitchJoint::number) ?: listOf()
 
-    val fieldErrors = listOfNotNull(
-        validate(structure != null) {
-            SwitchDefinitionError("type-unrecognized", OBSERVATION_MAJOR, switch.name, switch.typeName)
-        },
-        validate(structure == null || jointNumbers.all(structureJointNumbers::contains)) {
-            SwitchDefinitionError(
-                key = "incorrect-joints",
-                switchName = switch.name,
-                jointNumbers = jointNumbers,
-                structureJointNumbers = structureJointNumbers,
-                type = OBSERVATION_MAJOR,
-            )
-        },
-        validate(jointNumbers.size >= 2) {
-            SwitchDefinitionError(
-                key = "insufficient-joints",
-                switchName = switch.name,
-                jointNumbers = jointNumbers,
-                structureJointNumbers = structureJointNumbers,
-                type = OBSERVATION_MINOR,
-            )
-        }
-    )
+    val fieldErrors =
+        listOfNotNull(
+            validate(structure != null) {
+                SwitchDefinitionError(
+                    "type-unrecognized", OBSERVATION_MAJOR, switch.name, switch.typeName)
+            },
+            validate(structure == null || jointNumbers.all(structureJointNumbers::contains)) {
+                SwitchDefinitionError(
+                    key = "incorrect-joints",
+                    switchName = switch.name,
+                    jointNumbers = jointNumbers,
+                    structureJointNumbers = structureJointNumbers,
+                    type = OBSERVATION_MAJOR,
+                )
+            },
+            validate(jointNumbers.size >= 2) {
+                SwitchDefinitionError(
+                    key = "insufficient-joints",
+                    switchName = switch.name,
+                    jointNumbers = jointNumbers,
+                    structureJointNumbers = structureJointNumbers,
+                    type = OBSERVATION_MINOR,
+                )
+            })
 
     val geometryErrors = structure?.let { s -> validateSwitchGeometry(switch, s) } ?: emptyList()
 
-    val alignmentErrors = structure?.let { s -> validateSwitchAlignments(switch, s, alignmentSwitches) } ?: emptyList()
+    val alignmentErrors =
+        structure?.let { s -> validateSwitchAlignments(switch, s, alignmentSwitches) }
+            ?: emptyList()
 
     return fieldErrors + geometryErrors + alignmentErrors
 }
@@ -778,29 +884,37 @@ fun validateSwitchGeometry(
 ): List<SwitchDefinitionError> {
     val joints: List<GeometrySwitchJoint> = switch.joints
     val positionTransformation =
-        if (joints.size > 1) getSwitchPositionTransformation(switchStructure, joints)
-        else null
+        if (joints.size > 1) getSwitchPositionTransformation(switchStructure, joints) else null
     return if (positionTransformation == null) {
-        listOfNotNull(validate(joints.size <= 1) {
-            SwitchDefinitionError("location-difference", OBSERVATION_MAJOR, switch.name)
-        })
-    } else {
-        val locationPairs = joints.mapNotNull { joint ->
-            switchStructure.joints
-                .find { structureJoint -> structureJoint.number == joint.number }
-                ?.let { structureJoint -> transformSwitchPoint(positionTransformation, structureJoint.location) }
-                ?.let { calculatedLocation -> joint.location to calculatedLocation }
-        }
         listOfNotNull(
-            validate(locationPairs.all { (loc, calc) -> loc.isSame(calc, ACCURATE_JOINT_LOCATION_DELTA) }) {
-                val isIncorrect = locationPairs.any { (loc, calc) -> !loc.isSame(calc, JOINT_LOCATION_DELTA) }
-                SwitchDefinitionError(
-                    key = if (isIncorrect) "incorrect-joint-locations" else "inaccurate-joint-locations",
-                    type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
-                    switchName = switch.name,
-                )
+            validate(joints.size <= 1) {
+                SwitchDefinitionError("location-difference", OBSERVATION_MAJOR, switch.name)
+            })
+    } else {
+        val locationPairs =
+            joints.mapNotNull { joint ->
+                switchStructure.joints
+                    .find { structureJoint -> structureJoint.number == joint.number }
+                    ?.let { structureJoint ->
+                        transformSwitchPoint(positionTransformation, structureJoint.location)
+                    }
+                    ?.let { calculatedLocation -> joint.location to calculatedLocation }
             }
-        )
+        listOfNotNull(
+            validate(
+                locationPairs.all { (loc, calc) ->
+                    loc.isSame(calc, ACCURATE_JOINT_LOCATION_DELTA)
+                }) {
+                    val isIncorrect =
+                        locationPairs.any { (loc, calc) -> !loc.isSame(calc, JOINT_LOCATION_DELTA) }
+                    SwitchDefinitionError(
+                        key =
+                            if (isIncorrect) "incorrect-joint-locations"
+                            else "inaccurate-joint-locations",
+                        type = if (isIncorrect) OBSERVATION_MAJOR else OBSERVATION_MINOR,
+                        switchName = switch.name,
+                    )
+                })
     }
 }
 
@@ -811,19 +925,21 @@ fun validateSwitchAlignments(
 ): List<SwitchDefinitionError> {
     val joints: List<GeometrySwitchJoint> = switch.joints
     return alignmentSwitches.flatMap { alignmentSwitch ->
-        val structureAlignment = switchStructure.alignments.find { sa ->
-            sa.jointNumbers.containsAll(sa.jointNumbers)
-        }
+        val structureAlignment =
+            switchStructure.alignments.find { sa -> sa.jointNumbers.containsAll(sa.jointNumbers) }
         val incorrectJoints = mutableListOf<JointNumber>()
         val inaccurateJoints = mutableListOf<JointNumber>()
         alignmentSwitch.joints.forEach { asj ->
-            joints.find { j -> j.number == asj.number }?.also { joint ->
-                if (!asj.location.isSame(joint.location, JOINT_LOCATION_DELTA)) {
-                    incorrectJoints.add(asj.number)
-                } else if (!asj.location.isSame(joint.location, ACCURATE_JOINT_LOCATION_DELTA)) {
-                    inaccurateJoints.add(asj.number)
+            joints
+                .find { j -> j.number == asj.number }
+                ?.also { joint ->
+                    if (!asj.location.isSame(joint.location, JOINT_LOCATION_DELTA)) {
+                        incorrectJoints.add(asj.number)
+                    } else if (!asj.location.isSame(
+                        joint.location, ACCURATE_JOINT_LOCATION_DELTA)) {
+                        inaccurateJoints.add(asj.number)
+                    }
                 }
-            }
         }
 
         listOfNotNull(
@@ -861,7 +977,10 @@ fun validateSwitchAlignments(
     }
 }
 
-fun getSwitchPositionTransformation(switchStructure: SwitchStructure, joints: List<GeometrySwitchJoint>) =
+fun getSwitchPositionTransformation(
+    switchStructure: SwitchStructure,
+    joints: List<GeometrySwitchJoint>
+) =
     try {
         calculateSwitchLocationDelta(joints, switchStructure)
     } catch (e: Exception) {
@@ -883,22 +1002,28 @@ fun collectAlignmentSwitchJoints(
         .let { joints -> if (joints.isEmpty()) null else AlignmentSwitch(alignment, joints) }
 }
 
-data class AlignmentSwitch(val alignment: GeometryAlignment, val joints: List<AlignmentSwitchJoint>) {
-    val jointNumbers = joints
-        .filterIndexed { i, j -> j.number.intValue != 0 && (i == 0 || joints[i].number != j.number) }
-        .map(AlignmentSwitchJoint::number)
+data class AlignmentSwitch(
+    val alignment: GeometryAlignment,
+    val joints: List<AlignmentSwitchJoint>
+) {
+    val jointNumbers =
+        joints
+            .filterIndexed { i, j ->
+                j.number.intValue != 0 && (i == 0 || joints[i].number != j.number)
+            }
+            .map(AlignmentSwitchJoint::number)
 }
+
 data class AlignmentSwitchJoint(val number: JointNumber, val location: Point)
 
-private fun <T: GeometryValidationIssue> validate(check: Boolean, lazyError: () -> T): T? =
-    if (check) null
-    else lazyError()
+private fun <T : GeometryValidationIssue> validate(check: Boolean, lazyError: () -> T): T? =
+    if (check) null else lazyError()
 
 /**
- * Validate a list of items, using one function to check the items themselves and another to check them versus the
- * previous one for consistency
+ * Validate a list of items, using one function to check the items themselves and another to check
+ * them versus the previous one for consistency
  */
-private fun <N : CharSequence, T : Any, E: GeometryValidationIssue> validatePieces(
+private fun <N : CharSequence, T : Any, E : GeometryValidationIssue> validatePieces(
     parentName: N,
     pieces: List<T>,
     itemValidator: (N, T) -> List<E>,
@@ -907,7 +1032,8 @@ private fun <N : CharSequence, T : Any, E: GeometryValidationIssue> validatePiec
     return pieces.flatMapIndexed { index, item ->
         val pointErrors = itemValidator(parentName, item)
         val previous = pieces.getOrNull(index - 1)
-        val consistencyErrors = previous?.let { p -> itemVsPreviousValidator(parentName, item, p) } ?: listOf()
+        val consistencyErrors =
+            previous?.let { p -> itemVsPreviousValidator(parentName, item, p) } ?: listOf()
         (pointErrors + consistencyErrors)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ListingCommon.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ListingCommon.kt
@@ -10,9 +10,10 @@ fun collectLinkedElements(
     context: GeocodingContext?,
     startAddress: TrackMeter?,
     endAddress: TrackMeter?,
-) = segments
-    .filter { segment -> overlapsAddressInterval(segment, context, startAddress, endAddress) }
-    .map { s -> if (s.sourceId is IndexedId) s to s.sourceId else s to null }
+) =
+    segments
+        .filter { segment -> overlapsAddressInterval(segment, context, startAddress, endAddress) }
+        .map { s -> if (s.sourceId is IndexedId) s to s.sourceId else s to null }
 
 private fun overlapsAddressInterval(
     segment: LayoutSegment,
@@ -20,8 +21,10 @@ private fun overlapsAddressInterval(
     start: TrackMeter?,
     end: TrackMeter?,
 ): Boolean =
-    (end == null || context != null && getStartAddress(segment, context)?.let { it < end } == true) &&
-            (start == null || context != null && getEndAddress(segment, context)?.let { it > start } == true)
+    (end == null ||
+        context != null && getStartAddress(segment, context)?.let { it < end } == true) &&
+        (start == null ||
+            context != null && getEndAddress(segment, context)?.let { it > start } == true)
 
 private fun getStartAddress(segment: LayoutSegment, context: GeocodingContext) =
     context.getAddress(segment.alignmentStart)?.first

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutService.kt
@@ -4,7 +4,6 @@ import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
-import java.util.stream.Collectors
 
 @GeoviiteService
 class PlanLayoutService(
@@ -15,28 +14,31 @@ class PlanLayoutService(
         planVersion: RowVersion<GeometryPlan>,
         includeGeometryData: Boolean = true,
         pointListStepLength: Int = 1,
-    ): Pair<GeometryPlanLayout?, TransformationError?> = handlePointListStepLength(
-        planLayoutCache.getPlanLayout(planVersion, includeGeometryData), includeGeometryData, pointListStepLength
-    )
+    ): Pair<GeometryPlanLayout?, TransformationError?> =
+        handlePointListStepLength(
+            planLayoutCache.getPlanLayout(planVersion, includeGeometryData),
+            includeGeometryData,
+            pointListStepLength)
 
     fun getLayoutPlan(
         geometryPlanId: IntId<GeometryPlan>,
         includeGeometryData: Boolean = true,
         pointListStepLength: Int = 1,
     ): Pair<GeometryPlanLayout?, TransformationError?> =
-        getLayoutPlan(geometryDao.fetchPlanVersion(geometryPlanId), includeGeometryData, pointListStepLength)
+        getLayoutPlan(
+            geometryDao.fetchPlanVersion(geometryPlanId), includeGeometryData, pointListStepLength)
 
     fun getManyLayoutPlans(
         planIds: List<IntId<GeometryPlan>>,
         includeGeometryData: Boolean = true,
         pointListStepLength: Int = 1,
-    ): List<Pair<GeometryPlanLayout?, TransformationError?>> = planIds
-        .map { planId ->
+    ): List<Pair<GeometryPlanLayout?, TransformationError?>> =
+        planIds.map { planId ->
             handlePointListStepLength(
                 planLayoutCache.getPlanLayout(
-                    geometryDao.fetchPlanVersion(planId), includeGeometryData
-                ), includeGeometryData, pointListStepLength
-            )
+                    geometryDao.fetchPlanVersion(planId), includeGeometryData),
+                includeGeometryData,
+                pointListStepLength)
         }
 
     private fun handlePointListStepLength(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanMetaData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanMetaData.kt
@@ -9,7 +9,12 @@ import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.assertSanitized
 
-enum class PlanState { ABANDONED, DESTROYED, EXISTING, PROPOSED }
+enum class PlanState {
+    ABANDONED,
+    DESTROYED,
+    EXISTING,
+    PROPOSED
+}
 
 enum class PlanPhase {
     RAILWAY_PLAN,
@@ -21,9 +26,17 @@ enum class PlanPhase {
     REMOVED_FROM_USE,
 }
 
-enum class PlanDecisionPhase { APPROVED_PLAN, UNDER_CONSTRUCTION, IN_USE }
+enum class PlanDecisionPhase {
+    APPROVED_PLAN,
+    UNDER_CONSTRUCTION,
+    IN_USE
+}
 
-data class Project(val name: ProjectName, val description: FreeText?, val id: DomainId<Project> = StringId())
+data class Project(
+    val name: ProjectName,
+    val description: FreeText?,
+    val id: DomainId<Project> = StringId()
+)
 
 data class Application(
     val name: MetaDataName,
@@ -37,16 +50,20 @@ data class Author(val companyName: CompanyName, val id: DomainId<Author> = Strin
 val metaDataNameLength = 1..100
 val metaDataNameRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 _\\-/+&,.:()]+\$")
 
-data class CompanyName @JsonCreator(mode = DELEGATING) constructor(private val value: String) : CharSequence by value {
-    init { assertSanitized<CompanyName>(value, metaDataNameRegex, metaDataNameLength) }
+data class CompanyName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    CharSequence by value {
+    init {
+        assertSanitized<CompanyName>(value, metaDataNameRegex, metaDataNameLength)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
 }
 
-data class MetaDataName @JsonCreator(mode = DELEGATING) constructor(private val value: String) : CharSequence by value {
-    init { assertSanitized<MetaDataName>(value, metaDataNameRegex, metaDataNameLength) }
+data class MetaDataName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    CharSequence by value {
+    init {
+        assertSanitized<MetaDataName>(value, metaDataNameRegex, metaDataNameLength)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
@@ -27,7 +27,13 @@ data class CurvedSectionEndpoint(
     val location: RoundedPoint?,
 )
 
-fun toCurvedSectionEndpoint(address: TrackMeter?, location: RoundedPoint?, height: Double, angle: Double?, station: Double) =
+fun toCurvedSectionEndpoint(
+    address: TrackMeter?,
+    location: RoundedPoint?,
+    height: Double,
+    angle: Double?,
+    station: Double
+) =
     CurvedSectionEndpoint(
         address = address,
         height = roundTo3Decimals(height),
@@ -43,7 +49,12 @@ data class IntersectionPoint(
     val location: RoundedPoint?,
 )
 
-fun toIntersectionPoint(address: TrackMeter?, location: RoundedPoint?, height: Double, station: Double) =
+fun toIntersectionPoint(
+    address: TrackMeter?,
+    location: RoundedPoint?,
+    height: Double,
+    station: Double
+) =
     IntersectionPoint(
         address = address,
         height = roundTo3Decimals(height),
@@ -59,18 +70,15 @@ data class LinearSection(
 fun toLinearSection(stationValueDistance: Double?, linearSegmentLength: Double?) =
     LinearSection(
         stationValueDistance = stationValueDistance?.let(::roundTo3Decimals),
-        linearSegmentLength = linearSegmentLength?.let(::roundTo3Decimals)
-    )
+        linearSegmentLength = linearSegmentLength?.let(::roundTo3Decimals))
 
 data class VerticalGeometryListing(
     val id: StringId<ElementListing>,
     val planId: DomainId<GeometryPlan>?,
     val planSource: PlanSource?,
     val fileName: FileName?,
-
     val alignmentId: DomainId<GeometryAlignment>?,
     val alignmentName: AlignmentName?,
-
     val locationTrackName: AlignmentName?,
     val start: CurvedSectionEndpoint,
     val end: CurvedSectionEndpoint,
@@ -85,11 +93,9 @@ data class VerticalGeometryListing(
     val coordinateSystemSrid: Srid?,
     val coordinateSystemName: CoordinateSystemName?,
     val creationTime: Instant?,
-
     val layoutStartStation: Double? = null,
     val layoutPointStation: Double? = null,
     val layoutEndStation: Double? = null,
-
     val trackNumber: TrackNumber? = null,
 )
 
@@ -99,42 +105,38 @@ fun toVerticalGeometryListing(
     planHeader: GeometryPlanHeader,
     geocodingContext: GeocodingContext?
 ): List<VerticalGeometryListing> {
-    return planAlignments.filter { it.profile != null }.map { alignment ->
-        val (curvedSegments, linearSegments) =
-            alignment.profile?.segments
-                ?.let(::separateCurvedAndLinearProfileSegments)
-                ?: (emptyList<CurvedProfileSegment>() to emptyList())
-        curvedSegments.map { segment ->
-            val coordinateTransform = planHeader.units.coordinateSystemSrid?.let(getTransformation)
-            val (segmentStartAddress, segmentEndAddress) =
-                if (geocodingContext != null && coordinateTransform != null) {
-                    getTrackAddressAtStation(
-                        geocodingContext,
-                        coordinateTransform,
-                        alignment,
-                        segment.start.x
-                    ) to getTrackAddressAtStation(
-                        geocodingContext,
-                        coordinateTransform,
-                        alignment,
-                        segment.end.x
-                    )
-                } else (null to null)
+    return planAlignments
+        .filter { it.profile != null }
+        .map { alignment ->
+            val (curvedSegments, linearSegments) =
+                alignment.profile?.segments?.let(::separateCurvedAndLinearProfileSegments)
+                    ?: (emptyList<CurvedProfileSegment>() to emptyList())
+            curvedSegments.map { segment ->
+                val coordinateTransform =
+                    planHeader.units.coordinateSystemSrid?.let(getTransformation)
+                val (segmentStartAddress, segmentEndAddress) =
+                    if (geocodingContext != null && coordinateTransform != null) {
+                        getTrackAddressAtStation(
+                            geocodingContext, coordinateTransform, alignment, segment.start.x) to
+                            getTrackAddressAtStation(
+                                geocodingContext, coordinateTransform, alignment, segment.end.x)
+                    } else (null to null)
 
-            toVerticalGeometryListing(
-                segment,
-                alignment,
-                null,
-                coordinateTransform,
-                planHeader,
-                geocodingContext,
-                curvedSegments,
-                linearSegments,
-                segmentStartAddress,
-                segmentEndAddress,
-            )
+                toVerticalGeometryListing(
+                    segment,
+                    alignment,
+                    null,
+                    coordinateTransform,
+                    planHeader,
+                    geocodingContext,
+                    curvedSegments,
+                    linearSegments,
+                    segmentStartAddress,
+                    segmentEndAddress,
+                )
+            }
         }
-    }.flatten()
+        .flatten()
 }
 
 fun toVerticalGeometryListing(
@@ -144,62 +146,78 @@ fun toVerticalGeometryListing(
     endAddress: TrackMeter?,
     geocodingContext: GeocodingContext?,
     getTransformation: (srid: Srid) -> Transformation,
-    getPlanHeaderAndAlignment: (id: IntId<GeometryAlignment>) -> Pair<GeometryPlanHeader, GeometryAlignment>,
+    getPlanHeaderAndAlignment:
+        (id: IntId<GeometryAlignment>) -> Pair<GeometryPlanHeader, GeometryAlignment>,
 ): List<VerticalGeometryListing> {
-    val linkedElementIds = collectLinkedElements(
-        layoutAlignment.segments,
-        geocodingContext,
-        startAddress,
-        endAddress
-    ).mapNotNull { it.second }
-    val headersAndAlignments = linkedElementIds
-        .map(::getAlignmentId)
-        .distinct()
-        .associateWith(getPlanHeaderAndAlignment)
+    val linkedElementIds =
+        collectLinkedElements(layoutAlignment.segments, geocodingContext, startAddress, endAddress)
+            .mapNotNull { it.second }
+    val headersAndAlignments =
+        linkedElementIds.map(::getAlignmentId).distinct().associateWith(getPlanHeaderAndAlignment)
 
-    val listing = linkedElementIds.flatMap { elementId ->
-        val (planHeader, geometryAlignment) = headersAndAlignments.getValue(getAlignmentId(elementId))
-        val elementRange = Range(geometryAlignment.getElementStationRangeWithinAlignment(elementId))
+    val listing =
+        linkedElementIds
+            .flatMap { elementId ->
+                val (planHeader, geometryAlignment) =
+                    headersAndAlignments.getValue(getAlignmentId(elementId))
+                val elementRange =
+                    Range(geometryAlignment.getElementStationRangeWithinAlignment(elementId))
 
-        val (curvedProfileSegments, linearProfileSegments) = separateCurvedAndLinearProfileSegments(geometryAlignment.profile?.segments ?: emptyList())
-        geometryAlignment.profile?.segments?.mapNotNull { segment ->
-            val segmentRange = Range(geometryAlignment.stationValueNormalized(segment.start.x)..geometryAlignment.stationValueNormalized(segment.end.x))
-            if (segment is CurvedProfileSegment && segmentRange.overlaps(elementRange)) {
-                toVerticalGeometry(
-                    planHeader,
-                    getTransformation,
-                    geocodingContext,
-                    geometryAlignment,
-                    segment,
-                    endAddress,
-                    startAddress,
-                    track,
-                    curvedProfileSegments,
-                    linearProfileSegments,
-                )?.let { segment to it }
+                val (curvedProfileSegments, linearProfileSegments) =
+                    separateCurvedAndLinearProfileSegments(
+                        geometryAlignment.profile?.segments ?: emptyList())
+                geometryAlignment.profile?.segments?.mapNotNull { segment ->
+                    val segmentRange =
+                        Range(
+                            geometryAlignment.stationValueNormalized(
+                                segment.start.x)..geometryAlignment.stationValueNormalized(
+                                    segment.end.x))
+                    if (segment is CurvedProfileSegment && segmentRange.overlaps(elementRange)) {
+                        toVerticalGeometry(
+                                planHeader,
+                                getTransformation,
+                                geocodingContext,
+                                geometryAlignment,
+                                segment,
+                                endAddress,
+                                startAddress,
+                                track,
+                                curvedProfileSegments,
+                                linearProfileSegments,
+                            )
+                            ?.let { segment to it }
+                    } else null
+                } ?: emptyList()
             }
-            else null
-        } ?: emptyList()
-    }.distinctBy { it.first }.map { it.second }
+            .distinctBy { it.first }
+            .map { it.second }
 
     fun getAlignmentStation(maybeAddress: TrackMeter?) =
-        maybeAddress?.let { address -> geocodingContext?.getTrackLocation(layoutAlignment, address)?.point?.m }
+        maybeAddress?.let { address ->
+            geocodingContext?.getTrackLocation(layoutAlignment, address)?.point?.m
+        }
 
-    return listing.parallelStream().map { entry ->
-        entry.copy(
-            overlapsAnother = listing.filter { overlapCandidate ->
-                entry.start.address != null &&
-                        entry.end.address != null &&
-                        overlapCandidate.start.address != null &&
-                        overlapCandidate.end.address != null &&
-                        entry.start.address <= overlapCandidate.end.address &&
-                        entry.end.address >= overlapCandidate.start.address
-            }.size > 1,
-            layoutStartStation = getAlignmentStation(entry.start.address),
-            layoutPointStation = getAlignmentStation(entry.point.address),
-            layoutEndStation = getAlignmentStation(entry.end.address),
-        )
-    }.collect(Collectors.toList())
+    return listing
+        .parallelStream()
+        .map { entry ->
+            entry.copy(
+                overlapsAnother =
+                    listing
+                        .filter { overlapCandidate ->
+                            entry.start.address != null &&
+                                entry.end.address != null &&
+                                overlapCandidate.start.address != null &&
+                                overlapCandidate.end.address != null &&
+                                entry.start.address <= overlapCandidate.end.address &&
+                                entry.end.address >= overlapCandidate.start.address
+                        }
+                        .size > 1,
+                layoutStartStation = getAlignmentStation(entry.start.address),
+                layoutPointStation = getAlignmentStation(entry.point.address),
+                layoutEndStation = getAlignmentStation(entry.end.address),
+            )
+        }
+        .collect(Collectors.toList())
 }
 
 private fun toVerticalGeometry(
@@ -218,21 +236,18 @@ private fun toVerticalGeometry(
     val (segmentStartAddress, segmentEndAddress) =
         if (geocodingContext != null && coordinateTransform != null) {
             getTrackAddressAtStation(
-                geocodingContext,
-                coordinateTransform,
-                geometryAlignment,
-                segment.start.x
-            ) to getTrackAddressAtStation(
-                geocodingContext,
-                coordinateTransform,
-                geometryAlignment,
-                segment.end.x
-            )
+                geocodingContext, coordinateTransform, geometryAlignment, segment.start.x) to
+                getTrackAddressAtStation(
+                    geocodingContext, coordinateTransform, geometryAlignment, segment.end.x)
         } else (null to null)
 
-    return if (segmentStartAddress != null && endAddress != null && segmentStartAddress > endAddress) {
+    return if (segmentStartAddress != null &&
+        endAddress != null &&
+        segmentStartAddress > endAddress) {
         null
-    } else if (segmentEndAddress != null && startAddress != null && segmentEndAddress < startAddress) {
+    } else if (segmentEndAddress != null &&
+        startAddress != null &&
+        segmentEndAddress < startAddress) {
         null
     } else {
         toVerticalGeometryListing(
@@ -263,15 +278,15 @@ fun toVerticalGeometryListing(
     segmentEndAddress: TrackMeter?,
 ): VerticalGeometryListing {
     val stationPoint = circCurveStationPoint(segment)
-    val stationPointLocation = alignment
-        .getCoordinateAt(alignment.stationValueNormalized(stationPoint.x))
-        ?.round(COORDINATE_DECIMALS)
-    val stationPointAddress = if (geocodingContext != null && coordinateTransform != null) getTrackAddressAtStation(
-        geocodingContext,
-        coordinateTransform,
-        alignment,
-        stationPoint.x
-    ) else null
+    val stationPointLocation =
+        alignment
+            .getCoordinateAt(alignment.stationValueNormalized(stationPoint.x))
+            ?.round(COORDINATE_DECIMALS)
+    val stationPointAddress =
+        if (geocodingContext != null && coordinateTransform != null)
+            getTrackAddressAtStation(
+                geocodingContext, coordinateTransform, alignment, stationPoint.x)
+        else null
 
     return VerticalGeometryListing(
         id = StringId("${alignment.id}_${segment.start.x}"),
@@ -281,26 +296,29 @@ fun toVerticalGeometryListing(
         alignmentId = alignment.id,
         alignmentName = alignment.name,
         locationTrackName = locationTrackName,
-        start = toCurvedSectionEndpoint(
-            address = segmentStartAddress,
-            height = segment.start.y,
-            angle = angleFractionBetweenPoints(stationPoint, segment.start),
-            station = segment.start.x,
-            location = roundedLocationM(alignment, segment.start.x),
-        ),
-        end = toCurvedSectionEndpoint(
-            address = segmentEndAddress,
-            height = segment.end.y,
-            angle = angleFractionBetweenPoints(stationPoint, segment.end),
-            station = segment.end.x,
-            location = roundedLocationM(alignment, segment.end.x),
-        ),
-        point = toIntersectionPoint(
-            address = stationPointAddress,
-            height = stationPoint.y,
-            station = stationPoint.x,
-            location = stationPointLocation,
-        ),
+        start =
+            toCurvedSectionEndpoint(
+                address = segmentStartAddress,
+                height = segment.start.y,
+                angle = angleFractionBetweenPoints(stationPoint, segment.start),
+                station = segment.start.x,
+                location = roundedLocationM(alignment, segment.start.x),
+            ),
+        end =
+            toCurvedSectionEndpoint(
+                address = segmentEndAddress,
+                height = segment.end.y,
+                angle = angleFractionBetweenPoints(stationPoint, segment.end),
+                station = segment.end.x,
+                location = roundedLocationM(alignment, segment.end.x),
+            ),
+        point =
+            toIntersectionPoint(
+                address = stationPointAddress,
+                height = stationPoint.y,
+                station = stationPoint.x,
+                location = stationPointLocation,
+            ),
         radius = round(segment.radius, 0),
         tangent = lineLength(segment.start, stationPoint).let(::roundTo3Decimals),
         linearSectionBackward = previousLinearSection(segment, curvedSegments, linearSegments),
@@ -313,92 +331,157 @@ fun toVerticalGeometryListing(
         overlapsAnother = false,
     )
 }
+
 fun roundedLocationM(alignment: GeometryAlignment, distance: Double): RoundedPoint? =
-    alignment.getCoordinateAt(alignment.stationValueNormalized(distance))?.round(COORDINATE_DECIMALS)
+    alignment
+        .getCoordinateAt(alignment.stationValueNormalized(distance))
+        ?.round(COORDINATE_DECIMALS)
 
-fun locationTrackVerticalGeometryListingToCsv(listing: List<VerticalGeometryListing>, translation: Translation) =
-    printCsv(listOf(locationTrackCsvEntry(translation)) + commonVerticalGeometryListingCsvEntries(translation), listing)
+fun locationTrackVerticalGeometryListingToCsv(
+    listing: List<VerticalGeometryListing>,
+    translation: Translation
+) =
+    printCsv(
+        listOf(locationTrackCsvEntry(translation)) +
+            commonVerticalGeometryListingCsvEntries(translation),
+        listing)
 
-fun entireTrackNetworkVerticalGeometryListingToCsv(listing: List<VerticalGeometryListing>, translation: Translation) =
+fun entireTrackNetworkVerticalGeometryListingToCsv(
+    listing: List<VerticalGeometryListing>,
+    translation: Translation
+) =
     printCsv(
         listOf(
             trackNumberCsvEntry(translation),
             locationTrackCsvEntry(translation),
         ) + commonVerticalGeometryListingCsvEntries(translation),
-        listing
-    )
+        listing)
 
-fun planVerticalGeometryListingToCsv(listing: List<VerticalGeometryListing>, translation: Translation) =
-    printCsv(commonVerticalGeometryListingCsvEntries(translation).toList(), listing)
+fun planVerticalGeometryListingToCsv(
+    listing: List<VerticalGeometryListing>,
+    translation: Translation
+) = printCsv(commonVerticalGeometryListingCsvEntries(translation).toList(), listing)
 
 private fun trackNumberCsvEntry(translation: Translation) =
-    CsvEntry<VerticalGeometryListing>(translation.t("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.track-number")) {
-        verticalGeometryListing -> verticalGeometryListing.trackNumber ?: ""
-    }
+    CsvEntry<VerticalGeometryListing>(
+        translation.t("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.track-number")) {
+            verticalGeometryListing ->
+            verticalGeometryListing.trackNumber ?: ""
+        }
 
 private fun locationTrackCsvEntry(translation: Translation) =
-    CsvEntry<VerticalGeometryListing>(translation.t("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-track")) {
-        it.locationTrackName
-    }
+    CsvEntry<VerticalGeometryListing>(
+        translation.t("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-track")) {
+            it.locationTrackName
+        }
 
-private fun commonVerticalGeometryListingCsvEntries(translation: Translation): List<CsvEntry<VerticalGeometryListing>> =
-    mapOf<String, (item: VerticalGeometryListing) -> Any?>("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.plan-name" to { it.fileName },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.crs" to { it.coordinateSystemSrid ?: it.coordinateSystemName },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.creation-date" to { it.creationTime?.let(::toCsvDate) },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.plan-track" to { it.alignmentName },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.track-address-start" to {
-            it.start.address?.let { address ->
-                formatTrackMeter(
-                    address.kmNumber, address.meters
-                )
-            }
-        },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.height-start" to { it.start.height },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.angle-start" to { it.start.angle },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-e-start" to { it.start.location?.roundedX },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-n-start" to { it.start.location?.roundedY },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.track-address-point" to {
-            it.point.address?.let { address ->
-                formatTrackMeter(
-                    address.kmNumber, address.meters
-                )
-            }
-        },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.height-point" to { it.point.height },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-e-point" to { it.point.location?.roundedX },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-n-point" to { it.point.location?.roundedY },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.track-address-end" to {
-            it.end.address?.let { address ->
-                formatTrackMeter(
-                    address.kmNumber, address.meters
-                )
-            }
-        },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.height-end" to { it.end.height },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.angle-end" to { it.end.angle },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-e-end" to { it.end.location?.roundedX },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-n-end" to { it.end.location?.roundedY },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.radius" to { it.radius },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.tangent" to { it.tangent },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.linear-section-backward-length" to { it.linearSectionBackward.stationValueDistance },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.linear-section-backward-linear-section" to { it.linearSectionBackward.linearSegmentLength },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.linear-section-forward-length" to { it.linearSectionForward.stationValueDistance },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.linear-section-forward-linear-section" to { it.linearSectionForward.linearSegmentLength },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.station-start" to { it.start.station },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.station-point" to { it.point.station },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.station-end" to { it.end.station },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.vertical-coordinate-system" to { it.verticalCoordinateSystem },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.elevation-measurement-method" to {
-            translateElevationMeasurementMethod(it.elevationMeasurementMethod, translation)
-        },
-        "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.remarks" to {
-            if (it.overlapsAnother) translation.t("data-products.vertical-geometry.overlaps-another") else ""
-        }).map { (key, fn) -> CsvEntry(translation.t(key), fn) }
+private fun commonVerticalGeometryListingCsvEntries(
+    translation: Translation
+): List<CsvEntry<VerticalGeometryListing>> =
+    mapOf<String, (item: VerticalGeometryListing) -> Any?>(
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.plan-name" to { it.fileName },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.crs" to
+                {
+                    it.coordinateSystemSrid ?: it.coordinateSystemName
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.creation-date" to
+                {
+                    it.creationTime?.let(::toCsvDate)
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.plan-track" to { it.alignmentName },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.track-address-start" to
+                {
+                    it.start.address?.let { address ->
+                        formatTrackMeter(address.kmNumber, address.meters)
+                    }
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.height-start" to { it.start.height },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.angle-start" to { it.start.angle },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-e-start" to
+                {
+                    it.start.location?.roundedX
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-n-start" to
+                {
+                    it.start.location?.roundedY
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.track-address-point" to
+                {
+                    it.point.address?.let { address ->
+                        formatTrackMeter(address.kmNumber, address.meters)
+                    }
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.height-point" to { it.point.height },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-e-point" to
+                {
+                    it.point.location?.roundedX
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-n-point" to
+                {
+                    it.point.location?.roundedY
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.track-address-end" to
+                {
+                    it.end.address?.let { address ->
+                        formatTrackMeter(address.kmNumber, address.meters)
+                    }
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.height-end" to { it.end.height },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.angle-end" to { it.end.angle },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-e-end" to
+                {
+                    it.end.location?.roundedX
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.location-n-end" to
+                {
+                    it.end.location?.roundedY
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.radius" to { it.radius },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.tangent" to { it.tangent },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.linear-section-backward-length" to
+                {
+                    it.linearSectionBackward.stationValueDistance
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.linear-section-backward-linear-section" to
+                {
+                    it.linearSectionBackward.linearSegmentLength
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.linear-section-forward-length" to
+                {
+                    it.linearSectionForward.stationValueDistance
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.linear-section-forward-linear-section" to
+                {
+                    it.linearSectionForward.linearSegmentLength
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.station-start" to { it.start.station },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.station-point" to { it.point.station },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.station-end" to { it.end.station },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.vertical-coordinate-system" to
+                {
+                    it.verticalCoordinateSystem
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.elevation-measurement-method" to
+                {
+                    translateElevationMeasurementMethod(it.elevationMeasurementMethod, translation)
+                },
+            "$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.remarks" to
+                {
+                    if (it.overlapsAnother)
+                        translation.t("data-products.vertical-geometry.overlaps-another")
+                    else ""
+                })
+        .map { (key, fn) -> CsvEntry(translation.t(key), fn) }
 
-fun translateElevationMeasurementMethod(elevationMeasurementMethod: ElevationMeasurementMethod?, translation: Translation) =
+fun translateElevationMeasurementMethod(
+    elevationMeasurementMethod: ElevationMeasurementMethod?,
+    translation: Translation
+) =
     when (elevationMeasurementMethod) {
-        ElevationMeasurementMethod.TOP_OF_SLEEPER -> translation.t("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.top-of-sleeper")
-        ElevationMeasurementMethod.TOP_OF_RAIL -> translation.t("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.top-of-rail")
+        ElevationMeasurementMethod.TOP_OF_SLEEPER ->
+            translation.t("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.top-of-sleeper")
+        ElevationMeasurementMethod.TOP_OF_RAIL ->
+            translation.t("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.top-of-rail")
         null -> translation.t("$VERTICAL_GEOMETRY_CSV_TRANSLATION_PREFIX.unknown")
     }
 
@@ -409,16 +492,23 @@ fun previousLinearSection(
 ): LinearSection {
     val previousCurvedSegment = curvedSegments.findLast { it.start.x < currentSegment.start.x }
     val previousLinearSegment =
-        linearSegments.findLast { it.start.x < currentSegment.start.x && (previousCurvedSegment == null || it.start.x > previousCurvedSegment.start.x) }
-    return toLinearSection(
-        linearSegmentLength = previousLinearSegment?.let { previousLinearSegment.end.x - previousLinearSegment.start.x },
-        stationValueDistance = previousLinearSegment?.let {
-            val currentStationPoint = circCurveStationPoint(currentSegment)
-            val previousStationPoint = previousCurvedSegment?.let { prev -> circCurveStationPoint(prev) }
-                ?: previousLinearSegment.start
-            currentStationPoint.x - previousStationPoint.x
+        linearSegments.findLast {
+            it.start.x < currentSegment.start.x &&
+                (previousCurvedSegment == null || it.start.x > previousCurvedSegment.start.x)
         }
-    )
+    return toLinearSection(
+        linearSegmentLength =
+            previousLinearSegment?.let {
+                previousLinearSegment.end.x - previousLinearSegment.start.x
+            },
+        stationValueDistance =
+            previousLinearSegment?.let {
+                val currentStationPoint = circCurveStationPoint(currentSegment)
+                val previousStationPoint =
+                    previousCurvedSegment?.let { prev -> circCurveStationPoint(prev) }
+                        ?: previousLinearSegment.start
+                currentStationPoint.x - previousStationPoint.x
+            })
 }
 
 fun nextLinearSection(
@@ -428,28 +518,34 @@ fun nextLinearSection(
 ): LinearSection {
     val nextCurvedSegment = curvedSegments.find { it.start.x > currentSegment.start.x }
     val nextLinearSegment =
-        linearSegments.find { it.start.x > currentSegment.start.x && (nextCurvedSegment == null || it.start.x < nextCurvedSegment.start.x) }
-    return toLinearSection(
-        linearSegmentLength = nextLinearSegment?.let { nextLinearSegment.end.x - nextLinearSegment.start.x },
-        stationValueDistance = nextLinearSegment?.let {
-            val currentStationPoint = circCurveStationPoint(currentSegment)
-            val nextStationPoint = nextCurvedSegment?.let { next -> circCurveStationPoint(next) }
-                ?: nextLinearSegment.end
-            nextStationPoint.x - currentStationPoint.x
+        linearSegments.find {
+            it.start.x > currentSegment.start.x &&
+                (nextCurvedSegment == null || it.start.x < nextCurvedSegment.start.x)
         }
-    )
+    return toLinearSection(
+        linearSegmentLength =
+            nextLinearSegment?.let { nextLinearSegment.end.x - nextLinearSegment.start.x },
+        stationValueDistance =
+            nextLinearSegment?.let {
+                val currentStationPoint = circCurveStationPoint(currentSegment)
+                val nextStationPoint =
+                    nextCurvedSegment?.let { next -> circCurveStationPoint(next) }
+                        ?: nextLinearSegment.end
+                nextStationPoint.x - currentStationPoint.x
+            })
 }
 
 fun circCurveStationPoint(curve: CurvedProfileSegment): IPoint {
     val line1 = circCurveTangentLine(curve.start, curve.startAngle)
     val line2 = circCurveTangentLine(curve.end, curve.endAngle)
     val intersection = lineIntersection(line1.start, line1.end, line2.start, line2.end)
-    requireNotNull(intersection) {"Circular curve must have an intersection point"}
+    requireNotNull(intersection) { "Circular curve must have an intersection point" }
     return intersection.point
 }
 
 private fun circCurveTangentLine(point: IPoint, angle: Double): Line {
-    // Line length is meaningless here as this is used as an intermediary step for station point calculation
+    // Line length is meaningless here as this is used as an intermediary step for station point
+    // calculation
     val newX = point.x + 1.0
     val newY = (tan(angle)) + point.y
     return Line(point, Point(newX, newY))
@@ -461,9 +557,11 @@ fun angleFractionBetweenPoints(point1: IPoint, point2: IPoint) =
     else (point1.y - point2.y) / (point1.x - point2.x)
 
 private fun separateCurvedAndLinearProfileSegments(segments: List<ProfileSegment>) =
-    segments.partition { it is CurvedProfileSegment }
+    segments
+        .partition { it is CurvedProfileSegment }
         .let { partitioned ->
-            partitioned.first.map { it as CurvedProfileSegment } to partitioned.second.map { it as LinearProfileSegment }
+            partitioned.first.map { it as CurvedProfileSegment } to
+                partitioned.second.map { it as LinearProfileSegment }
         }
 
 fun getTrackAddressAtStation(
@@ -471,7 +569,9 @@ fun getTrackAddressAtStation(
     coordinateTransform: Transformation,
     geometryAlignment: GeometryAlignment,
     station: Double
-) = geometryAlignment
+) =
+    geometryAlignment
         .getCoordinateAt(geometryAlignment.stationValueNormalized(station))
         ?.let(coordinateTransform::transform)
-        ?.let(geocodingContext::getAddress)?.first
+        ?.let(geocodingContext::getAddress)
+        ?.first

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDao.kt
@@ -3,23 +3,26 @@ package fi.fta.geoviite.infra.geometry
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.util.*
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 data class VerticalGeometryListingFile(val name: FileName, val content: String)
 
 @Transactional(readOnly = true)
 @Component
-class VerticalGeometryListingFileDao @Autowired constructor(
+class VerticalGeometryListingFileDao
+@Autowired
+constructor(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
 ) : DaoBase(jdbcTemplateParam) {
 
     @Transactional
     fun upsertVerticalGeometryListingFile(file: VerticalGeometryListingFile) {
-        val sql = """
+        val sql =
+            """
             insert into layout.vertical_geometry_listing_file(
               name,
               content,
@@ -37,11 +40,13 @@ class VerticalGeometryListingFileDao @Autowired constructor(
               content = :content,
               change_time = now(),
               change_user = current_setting('geoviite.edit_user')
-        """.trimIndent()
-        val params = mapOf(
-            "name" to file.name,
-            "content" to file.content,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "name" to file.name,
+                "content" to file.content,
+            )
         jdbcTemplate.setUser()
         jdbcTemplate.update(sql, params).also {
             logger.daoAccess(AccessType.UPSERT, VerticalGeometryListingFile::class, file.name)
@@ -49,26 +54,40 @@ class VerticalGeometryListingFileDao @Autowired constructor(
     }
 
     fun getVerticalGeometryListingFile(): VerticalGeometryListingFile? {
-        val sql = """
+        val sql =
+            """
             select name, content
             from layout.vertical_geometry_listing_file
             where id = 1
-        """.trimIndent()
-        return jdbcTemplate.query(sql, mapOf<String,Any>()) { rs, _ -> VerticalGeometryListingFile(
-            name = rs.getFileName("name"),
-            content = rs.getString("content"),
-        ) }
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(sql, mapOf<String, Any>()) { rs, _ ->
+                VerticalGeometryListingFile(
+                    name = rs.getFileName("name"),
+                    content = rs.getString("content"),
+                )
+            }
             .firstOrNull()
-            .also { file -> logger.daoAccess(AccessType.FETCH, VerticalGeometryListingFile::class, "${file?.name}") }
+            .also { file ->
+                logger.daoAccess(
+                    AccessType.FETCH, VerticalGeometryListingFile::class, "${file?.name}")
+            }
     }
 
     fun getLastFileListingTime(): Instant {
-        val sql = """
+        val sql =
+            """
             select max(change_time) change_time 
             from layout.vertical_geometry_listing_file
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        return jdbcTemplate.queryOne(sql) { rs , _ -> rs.getInstantOrNull("change_time") ?: Instant.EPOCH }
-            .also { logger.daoAccess(AccessType.FETCH, "${VerticalGeometryListingFile::class.simpleName}.changeTime") }
+        return jdbcTemplate
+            .queryOne(sql) { rs, _ -> rs.getInstantOrNull("change_time") ?: Instant.EPOCH }
+            .also {
+                logger.daoAccess(
+                    AccessType.FETCH, "${VerticalGeometryListingFile::class.simpleName}.changeTime")
+            }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel.kt
@@ -1,4 +1,5 @@
 package fi.fta.geoviite.infra.inframodel
+
 import fi.fta.geoviite.infra.error.InframodelParsingException
 
 interface InfraModel {
@@ -34,7 +35,7 @@ interface InfraModelProject {
     val feature: InfraModelFeature?
 }
 
-interface InfraModelApplication{
+interface InfraModelApplication {
     val name: String
     val desc: String?
     val manufacturer: String
@@ -43,7 +44,7 @@ interface InfraModelApplication{
     val author: InfraModelAuthor?
 }
 
-interface InfraModelAuthor{
+interface InfraModelAuthor {
     val createdBy: String?
     val createdByEmail: String?
     val company: String?
@@ -51,21 +52,21 @@ interface InfraModelAuthor{
     val timeStamp: String?
 }
 
-interface InfraModelCoordinateSystem{
+interface InfraModelCoordinateSystem {
     val name: String
     val epsgCode: String
     val verticalCoordinateSystemName: String
     val rotationAngle: String
 }
 
-interface InfraModelAlignmentGroup{
+interface InfraModelAlignmentGroup {
     val name: String
     val desc: String?
     val state: String?
     val alignments: List<InfraModelAlignment>
 }
 
-interface InfraModelAlignment{
+interface InfraModelAlignment {
     val name: String
     val desc: String?
     val state: String?
@@ -78,7 +79,7 @@ interface InfraModelAlignment{
     val staEquations: List<InfraModelStaEquation>
 }
 
-interface InfraModelStaEquation{
+interface InfraModelStaEquation {
     val staBack: String
     val staAhead: String
     val staInternal: String
@@ -96,16 +97,16 @@ interface InfraModelGeometryElement {
     val features: List<InfraModelFeature>
 }
 
-interface InfraModelLine: InfraModelGeometryElement
+interface InfraModelLine : InfraModelGeometryElement
 
-interface InfraModelCurve: InfraModelGeometryElement {
+interface InfraModelCurve : InfraModelGeometryElement {
     val rot: String
     val radius: String
     val chord: String
     val center: String
 }
 
-interface InfraModelSpiral: InfraModelGeometryElement {
+interface InfraModelSpiral : InfraModelGeometryElement {
     val rot: String
     val constant: String?
     val dirStart: String?
@@ -116,7 +117,7 @@ interface InfraModelSpiral: InfraModelGeometryElement {
     val pi: String
 }
 
-interface InfraModelCant{
+interface InfraModelCant {
     val name: String
     val desc: String?
     val gauge: String
@@ -124,20 +125,19 @@ interface InfraModelCant{
     val stations: List<InfraModelCantStation>
 }
 
-interface InfraModelCantStation{
+interface InfraModelCantStation {
     val station: String
     val appliedCant: String
     val curvature: String
     val transitionType: String?
 }
 
-interface InfraModelProfile{
+interface InfraModelProfile {
     val profAlign: InfraModelProfAlign?
     val features: List<InfraModelFeature>
 }
 
-
-interface InfraModelProfAlign{
+interface InfraModelProfAlign {
     val name: String
     val elements: List<InfraModelProfileElement>
     val features: List<InfraModelFeature>
@@ -153,7 +153,7 @@ interface InfraModelPvi {
     val point: String
 }
 
-interface InfraModelCircCurve{
+interface InfraModelCircCurve {
     val length: String
     val radius: String
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel403.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel403.kt
@@ -1,15 +1,14 @@
 package fi.fta.geoviite.infra.inframodel
+
 import fi.fta.geoviite.infra.error.InframodelParsingException
 import jakarta.xml.bind.annotation.*
 
 const val XMLNS_403 = "http://www.inframodel.fi/inframodel"
 
-
 @XmlRootElement(name = "LandXML", namespace = XMLNS_403)
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModel403(
     @field:XmlAttribute override val language: String? = null,
-
     @field:XmlElement(name = "FeatureDictionary", namespace = XMLNS_403)
     override val featureDictionary: InfraModelFeatureDictionary403? = null,
     @field:XmlElement(name = "Units", namespace = XMLNS_403)
@@ -22,19 +21,19 @@ data class InfraModel403(
     override val application: InfraModelApplication403? = null,
     @field:XmlElement(name = "Alignments", namespace = XMLNS_403)
     override val alignmentGroups: List<InfraModelAlignmentGroup403> = arrayListOf(),
-): InfraModel
+) : InfraModel
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelFeatureDictionary403(
     @field:XmlAttribute override val name: String = "",
     @field:XmlAttribute override val version: String? = null
-):InfraModelFeatureDictionary
+) : InfraModelFeatureDictionary
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelUnits403(
     @field:XmlElement(name = "Metric", namespace = XMLNS_403)
     override val metric: InfraModelMetric403? = null,
-):InfraModelUnits
+) : InfraModelUnits
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelMetric403(
@@ -43,7 +42,7 @@ data class InfraModelMetric403(
     @field:XmlAttribute override val volumeUnit: String = "",
     @field:XmlAttribute override val angularUnit: String = "",
     @field:XmlAttribute override val directionUnit: String = "",
-):InfraModelMetric
+) : InfraModelMetric
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelProject403(
@@ -51,7 +50,7 @@ data class InfraModelProject403(
     @field:XmlAttribute override val desc: String? = null,
     @field:XmlElement(name = "Feature", namespace = XMLNS_403)
     override val feature: InfraModelFeature403? = null,
-):InfraModelProject
+) : InfraModelProject
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelApplication403(
@@ -62,7 +61,7 @@ data class InfraModelApplication403(
     @field:XmlAttribute override val version: String = "",
     @field:XmlElement(name = "Author", namespace = XMLNS_403)
     override val author: InfraModelAuthor403? = null,
-):InfraModelApplication
+) : InfraModelApplication
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelAuthor403(
@@ -71,7 +70,7 @@ data class InfraModelAuthor403(
     @field:XmlAttribute override val company: String? = null,
     @field:XmlAttribute override val companyUR: String? = null,
     @field:XmlAttribute override val timeStamp: String? = null,
-):InfraModelAuthor
+) : InfraModelAuthor
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelCoordinateSystem403(
@@ -79,7 +78,7 @@ data class InfraModelCoordinateSystem403(
     @field:XmlAttribute override val epsgCode: String = "",
     @field:XmlAttribute override val verticalCoordinateSystemName: String = "",
     @field:XmlAttribute override val rotationAngle: String = "",
-):InfraModelCoordinateSystem
+) : InfraModelCoordinateSystem
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelAlignmentGroup403(
@@ -88,7 +87,7 @@ data class InfraModelAlignmentGroup403(
     @field:XmlAttribute override val state: String? = null,
     @field:XmlElement(name = "Alignment", namespace = XMLNS_403)
     override val alignments: List<InfraModelAlignment403> = arrayListOf(),
-):InfraModelAlignmentGroup
+) : InfraModelAlignmentGroup
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelAlignment403(
@@ -97,27 +96,21 @@ data class InfraModelAlignment403(
     @field:XmlAttribute override val state: String? = null,
     @field:XmlAttribute override val oid: String? = null,
     @field:XmlAttribute override val staStart: String = "",
-
     @field:XmlElementWrapper(name = "CoordGeom", namespace = XMLNS_403)
     @field:XmlElements(
         XmlElement(name = "Line", namespace = XMLNS_403, type = InfraModelLine403::class),
         XmlElement(name = "Curve", namespace = XMLNS_403, type = InfraModelCurve403::class),
-        XmlElement(name = "Spiral", namespace = XMLNS_403, type = InfraModelSpiral403::class)
-    )
+        XmlElement(name = "Spiral", namespace = XMLNS_403, type = InfraModelSpiral403::class))
     override val elements: List<InfraModelGeometryElement> = arrayListOf(),
-
     @field:XmlElement(name = "Cant", namespace = XMLNS_403)
     override val cant: InfraModelCant403? = null,
-
     @field:XmlElement(name = "Profile", namespace = XMLNS_403)
     override val profile: InfraModelProfile403? = null,
-
     @field:XmlElement(name = "Feature", namespace = XMLNS_403)
     override val features: List<InfraModelFeature403> = arrayListOf(),
-
     @field:XmlElement(name = "StaEquation", namespace = XMLNS_403)
     override val staEquations: List<InfraModelStaEquation403> = arrayListOf(),
-):InfraModelAlignment
+) : InfraModelAlignment
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelStaEquation403(
@@ -127,10 +120,7 @@ data class InfraModelStaEquation403(
     @field:XmlAttribute override val desc: String = "",
     @field:XmlElement(name = "Feature", namespace = XMLNS_403)
     override val feature: InfraModelFeature403? = null,
-):InfraModelStaEquation
-
-
-
+) : InfraModelStaEquation
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelLine403(
@@ -138,11 +128,8 @@ data class InfraModelLine403(
     @field:XmlAttribute override val staStart: String = "",
     @field:XmlAttribute override val length: String = "",
     @field:XmlAttribute override val oID: String? = null,
-
-    @field:XmlElement(name = "Start", namespace = XMLNS_403)
-    override val start: String = "",
-    @field:XmlElement(name = "End", namespace = XMLNS_403)
-    override val end: String = "",
+    @field:XmlElement(name = "Start", namespace = XMLNS_403) override val start: String = "",
+    @field:XmlElement(name = "End", namespace = XMLNS_403) override val end: String = "",
     @field:XmlElement(name = "Feature", namespace = XMLNS_403)
     override val features: List<InfraModelFeature403> = arrayListOf(),
 ) : InfraModelLine
@@ -156,16 +143,12 @@ data class InfraModelCurve403(
     @field:XmlAttribute override val rot: String = "",
     @field:XmlAttribute override val radius: String = "",
     @field:XmlAttribute override val chord: String = "",
-
-    @field:XmlElement(name = "Start", namespace = XMLNS_403)
-    override val start: String = "",
-    @field:XmlElement(name = "Center", namespace = XMLNS_403)
-    override val center: String = "",
-    @field:XmlElement(name = "End", namespace = XMLNS_403)
-    override val end: String = "",
+    @field:XmlElement(name = "Start", namespace = XMLNS_403) override val start: String = "",
+    @field:XmlElement(name = "Center", namespace = XMLNS_403) override val center: String = "",
+    @field:XmlElement(name = "End", namespace = XMLNS_403) override val end: String = "",
     @field:XmlElement(name = "Feature", namespace = XMLNS_403)
     override val features: List<InfraModelFeature403> = arrayListOf(),
-): InfraModelCurve
+) : InfraModelCurve
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelSpiral403(
@@ -180,13 +163,9 @@ data class InfraModelSpiral403(
     @field:XmlAttribute override val radiusStart: String? = null,
     @field:XmlAttribute override val radiusEnd: String? = null,
     @field:XmlAttribute override val spiType: String = "",
-
-    @field:XmlElement(name = "Start", namespace = XMLNS_403)
-    override val start: String = "",
-    @field:XmlElement(name = "PI", namespace = XMLNS_403)
-    override val pi: String = "",
-    @field:XmlElement(name = "End", namespace = XMLNS_403)
-    override val end: String = "",
+    @field:XmlElement(name = "Start", namespace = XMLNS_403) override val start: String = "",
+    @field:XmlElement(name = "PI", namespace = XMLNS_403) override val pi: String = "",
+    @field:XmlElement(name = "End", namespace = XMLNS_403) override val end: String = "",
     @field:XmlElement(name = "Feature", namespace = XMLNS_403)
     override val features: List<InfraModelFeature403> = arrayListOf(),
 ) : InfraModelSpiral
@@ -197,10 +176,9 @@ data class InfraModelCant403(
     @field:XmlAttribute override val desc: String? = null,
     @field:XmlAttribute override val gauge: String = "",
     @field:XmlAttribute override val rotationPoint: String = "",
-
     @field:XmlElement(name = "CantStation", namespace = XMLNS_403)
     override val stations: List<InfraModelCantStation403> = arrayListOf(),
-):InfraModelCant
+) : InfraModelCant
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelCantStation403(
@@ -208,7 +186,7 @@ data class InfraModelCantStation403(
     @field:XmlAttribute override val appliedCant: String = "",
     @field:XmlAttribute override val curvature: String = "",
     @field:XmlAttribute override val transitionType: String? = null,
-):InfraModelCantStation
+) : InfraModelCantStation
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelProfile403(
@@ -216,28 +194,24 @@ data class InfraModelProfile403(
     override val profAlign: InfraModelProfAlign403? = null,
     @field:XmlElement(name = "Feature", namespace = XMLNS_403)
     override val features: List<InfraModelFeature403> = arrayListOf(),
-):InfraModelProfile
+) : InfraModelProfile
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelProfAlign403(
     @field:XmlAttribute override val name: String = "",
-
     @field:XmlElements(
         XmlElement(name = "PVI", namespace = XMLNS_403, type = InfraModelPvi403::class),
-        XmlElement(name = "CircCurve", namespace = XMLNS_403, type = InfraModelCircCurve403::class)
-    )
+        XmlElement(name = "CircCurve", namespace = XMLNS_403, type = InfraModelCircCurve403::class))
     override val elements: List<InfraModelProfileElement> = arrayListOf(),
-
     @field:XmlElement(name = "Feature", namespace = XMLNS_403)
     override val features: List<InfraModelFeature403> = arrayListOf(),
-):InfraModelProfAlign
-
+) : InfraModelProfAlign
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelPvi403(
     @field:XmlAttribute override val desc: String? = null,
     @field:XmlValue override val point: String = "",
-) : InfraModelPvi,InfraModelProfileElement
+) : InfraModelPvi, InfraModelProfileElement
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelCircCurve403(
@@ -250,10 +224,9 @@ data class InfraModelCircCurve403(
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelFeature403(
     @field:XmlAttribute override val code: String = "",
-
     @field:XmlElement(name = "Property", namespace = XMLNS_403)
     override val properties: List<InfraModelProperty403> = arrayListOf(),
-):InfraModelFeature {
+) : InfraModelFeature {
     override fun getProperty(label: String): String {
         return properties.find { p -> p.label == label }?.value
             ?: throw InframodelParsingException("Feature $code doesn't have property $label")
@@ -268,4 +241,4 @@ data class InfraModelFeature403(
 data class InfraModelProperty403(
     @field:XmlAttribute override val label: String = "",
     @field:XmlAttribute override val value: String = "",
-):InfraModelProperty
+) : InfraModelProperty

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel404.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModel404.kt
@@ -9,7 +9,6 @@ const val XMLNS_404 = "http://buildingsmart.fi/inframodel/404"
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModel404(
     @field:XmlAttribute override val language: String? = null,
-
     @field:XmlElement(name = "FeatureDictionary", namespace = XMLNS_404)
     override val featureDictionary: InfraModelFeatureDictionary404? = null,
     @field:XmlElement(name = "Units", namespace = XMLNS_404)
@@ -22,19 +21,19 @@ data class InfraModel404(
     override val application: InfraModelApplication404? = null,
     @field:XmlElement(name = "Alignments", namespace = XMLNS_404)
     override val alignmentGroups: List<InfraModelAlignmentGroup404> = arrayListOf(),
-): InfraModel
+) : InfraModel
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelFeatureDictionary404(
     @field:XmlAttribute override val name: String = "",
     @field:XmlAttribute override val version: String? = null
-):InfraModelFeatureDictionary
+) : InfraModelFeatureDictionary
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelUnits404(
     @field:XmlElement(name = "Metric", namespace = XMLNS_404)
     override val metric: InfraModelMetric404? = null,
-):InfraModelUnits
+) : InfraModelUnits
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelMetric404(
@@ -43,7 +42,7 @@ data class InfraModelMetric404(
     @field:XmlAttribute override val volumeUnit: String = "",
     @field:XmlAttribute override val angularUnit: String = "",
     @field:XmlAttribute override val directionUnit: String = "",
-):InfraModelMetric
+) : InfraModelMetric
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelProject404(
@@ -51,7 +50,7 @@ data class InfraModelProject404(
     @field:XmlAttribute override val desc: String? = null,
     @field:XmlElement(name = "Feature", namespace = XMLNS_404)
     override val feature: InfraModelFeature404? = null,
-):InfraModelProject
+) : InfraModelProject
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelApplication404(
@@ -62,7 +61,7 @@ data class InfraModelApplication404(
     @field:XmlAttribute override val version: String = "",
     @field:XmlElement(name = "Author", namespace = XMLNS_404)
     override val author: InfraModelAuthor404? = null,
-):InfraModelApplication
+) : InfraModelApplication
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelAuthor404(
@@ -71,7 +70,7 @@ data class InfraModelAuthor404(
     @field:XmlAttribute override val company: String? = null,
     @field:XmlAttribute override val companyUR: String? = null,
     @field:XmlAttribute override val timeStamp: String? = null,
-):InfraModelAuthor
+) : InfraModelAuthor
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelCoordinateSystem404(
@@ -79,7 +78,7 @@ data class InfraModelCoordinateSystem404(
     @field:XmlAttribute override val epsgCode: String = "",
     @field:XmlAttribute override val verticalCoordinateSystemName: String = "",
     @field:XmlAttribute override val rotationAngle: String = "",
-):InfraModelCoordinateSystem
+) : InfraModelCoordinateSystem
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelAlignmentGroup404(
@@ -88,7 +87,7 @@ data class InfraModelAlignmentGroup404(
     @field:XmlAttribute override val state: String? = null,
     @field:XmlElement(name = "Alignment", namespace = XMLNS_404)
     override val alignments: List<InfraModelAlignment404> = arrayListOf(),
-):InfraModelAlignmentGroup
+) : InfraModelAlignmentGroup
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelAlignment404(
@@ -97,27 +96,21 @@ data class InfraModelAlignment404(
     @field:XmlAttribute override val state: String? = null,
     @field:XmlAttribute override val oid: String? = null,
     @field:XmlAttribute override val staStart: String = "",
-
     @field:XmlElementWrapper(name = "CoordGeom", namespace = XMLNS_404)
     @field:XmlElements(
         XmlElement(name = "Line", namespace = XMLNS_404, type = InfraModelLine404::class),
         XmlElement(name = "Curve", namespace = XMLNS_404, type = InfraModelCurve404::class),
-        XmlElement(name = "Spiral", namespace = XMLNS_404, type = InfraModelSpiral404::class)
-    )
+        XmlElement(name = "Spiral", namespace = XMLNS_404, type = InfraModelSpiral404::class))
     override val elements: List<InfraModelGeometryElement> = arrayListOf(),
-
     @field:XmlElement(name = "Cant", namespace = XMLNS_404)
     override val cant: InfraModelCant404? = null,
-
     @field:XmlElement(name = "Profile", namespace = XMLNS_404)
     override val profile: InfraModelProfile404? = null,
-
     @field:XmlElement(name = "Feature", namespace = XMLNS_404)
     override val features: List<InfraModelFeature404> = arrayListOf(),
-
     @field:XmlElement(name = "StaEquation", namespace = XMLNS_404)
     override val staEquations: List<InfraModelStaEquation404> = arrayListOf(),
-):InfraModelAlignment
+) : InfraModelAlignment
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelStaEquation404(
@@ -127,7 +120,7 @@ data class InfraModelStaEquation404(
     @field:XmlAttribute override val desc: String = "",
     @field:XmlElement(name = "Feature", namespace = XMLNS_404)
     override val feature: InfraModelFeature404? = null,
-):InfraModelStaEquation
+) : InfraModelStaEquation
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelLine404(
@@ -135,11 +128,8 @@ data class InfraModelLine404(
     @field:XmlAttribute override val staStart: String = "",
     @field:XmlAttribute override val length: String = "",
     @field:XmlAttribute override val oID: String? = null,
-
-    @field:XmlElement(name = "Start", namespace = XMLNS_404)
-    override val start: String = "",
-    @field:XmlElement(name = "End", namespace = XMLNS_404)
-    override val end: String = "",
+    @field:XmlElement(name = "Start", namespace = XMLNS_404) override val start: String = "",
+    @field:XmlElement(name = "End", namespace = XMLNS_404) override val end: String = "",
     @field:XmlElement(name = "Feature", namespace = XMLNS_404)
     override val features: List<InfraModelFeature404> = arrayListOf(),
 ) : InfraModelLine
@@ -153,16 +143,12 @@ data class InfraModelCurve404(
     @field:XmlAttribute override val rot: String = "",
     @field:XmlAttribute override val radius: String = "",
     @field:XmlAttribute override val chord: String = "",
-
-    @field:XmlElement(name = "Start", namespace = XMLNS_404)
-    override val start: String = "",
-    @field:XmlElement(name = "Center", namespace = XMLNS_404)
-    override val center: String = "",
-    @field:XmlElement(name = "End", namespace = XMLNS_404)
-    override val end: String = "",
+    @field:XmlElement(name = "Start", namespace = XMLNS_404) override val start: String = "",
+    @field:XmlElement(name = "Center", namespace = XMLNS_404) override val center: String = "",
+    @field:XmlElement(name = "End", namespace = XMLNS_404) override val end: String = "",
     @field:XmlElement(name = "Feature", namespace = XMLNS_404)
     override val features: List<InfraModelFeature404> = arrayListOf(),
-): InfraModelCurve
+) : InfraModelCurve
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelSpiral404(
@@ -177,13 +163,9 @@ data class InfraModelSpiral404(
     @field:XmlAttribute override val radiusStart: String? = null,
     @field:XmlAttribute override val radiusEnd: String? = null,
     @field:XmlAttribute override val spiType: String = "",
-
-    @field:XmlElement(name = "Start", namespace = XMLNS_404)
-    override val start: String = "",
-    @field:XmlElement(name = "PI", namespace = XMLNS_404)
-    override val pi: String = "",
-    @field:XmlElement(name = "End", namespace = XMLNS_404)
-    override val end: String = "",
+    @field:XmlElement(name = "Start", namespace = XMLNS_404) override val start: String = "",
+    @field:XmlElement(name = "PI", namespace = XMLNS_404) override val pi: String = "",
+    @field:XmlElement(name = "End", namespace = XMLNS_404) override val end: String = "",
     @field:XmlElement(name = "Feature", namespace = XMLNS_404)
     override val features: List<InfraModelFeature404> = arrayListOf(),
 ) : InfraModelSpiral
@@ -194,10 +176,9 @@ data class InfraModelCant404(
     @field:XmlAttribute override val desc: String? = null,
     @field:XmlAttribute override val gauge: String = "",
     @field:XmlAttribute override val rotationPoint: String = "",
-
     @field:XmlElement(name = "CantStation", namespace = XMLNS_404)
     override val stations: List<InfraModelCantStation404> = arrayListOf(),
-):InfraModelCant
+) : InfraModelCant
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelCantStation404(
@@ -205,7 +186,7 @@ data class InfraModelCantStation404(
     @field:XmlAttribute override val appliedCant: String = "",
     @field:XmlAttribute override val curvature: String = "",
     @field:XmlAttribute override val transitionType: String? = null,
-):InfraModelCantStation
+) : InfraModelCantStation
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelProfile404(
@@ -213,28 +194,24 @@ data class InfraModelProfile404(
     override val profAlign: InfraModelProfAlign404? = null,
     @field:XmlElement(name = "Feature", namespace = XMLNS_404)
     override val features: List<InfraModelFeature404> = arrayListOf(),
-):InfraModelProfile
+) : InfraModelProfile
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelProfAlign404(
     @field:XmlAttribute override val name: String = "",
-
     @field:XmlElements(
         XmlElement(name = "PVI", namespace = XMLNS_404, type = InfraModelPvi404::class),
-        XmlElement(name = "CircCurve", namespace = XMLNS_404, type = InfraModelCircCurve404::class)
-    )
+        XmlElement(name = "CircCurve", namespace = XMLNS_404, type = InfraModelCircCurve404::class))
     override val elements: List<InfraModelProfileElement> = arrayListOf(),
-
     @field:XmlElement(name = "Feature", namespace = XMLNS_404)
     override val features: List<InfraModelFeature404> = arrayListOf(),
-):InfraModelProfAlign
-
+) : InfraModelProfAlign
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelPvi404(
     @field:XmlAttribute override val desc: String? = null,
     @field:XmlValue override val point: String = "",
-) : InfraModelPvi,InfraModelProfileElement
+) : InfraModelPvi, InfraModelProfileElement
 
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelCircCurve404(
@@ -247,10 +224,9 @@ data class InfraModelCircCurve404(
 @XmlAccessorType(XmlAccessType.FIELD)
 data class InfraModelFeature404(
     @field:XmlAttribute override val code: String = "",
-
     @field:XmlElement(name = "Property", namespace = XMLNS_404)
     override val properties: List<InfraModelProperty404> = arrayListOf(),
-):InfraModelFeature {
+) : InfraModelFeature {
     override fun getProperty(label: String): String {
         return properties.find { p -> p.label == label }?.value
             ?: throw InframodelParsingException("Feature $code doesn't have property $label")
@@ -265,4 +241,4 @@ data class InfraModelFeature404(
 data class InfraModelProperty404(
     @field:XmlAttribute override val label: String = "",
     @field:XmlAttribute override val value: String = "",
-):InfraModelProperty
+) : InfraModelProperty

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
@@ -35,19 +35,20 @@ data class OverrideParameters(
     val source: PlanSource?,
 )
 
-fun tryParsing(source: PlanSource?, op: () -> ValidationResponse): ValidationResponse = try {
-    op()
-} catch (e: Exception) {
-    logger.warn("Failed to parse InfraModel", e)
-    ValidationResponse(
-        geometryValidationIssues = listOf(
-            ParsingError(
-                if (e is HasLocalizedMessage) e.localizationKey
-                else LocalizationKey(INFRAMODEL_PARSING_KEY_GENERIC)
-            ),
-        ),
-        geometryPlan = null,
-        planLayout = null,
-        source = source ?: PlanSource.GEOMETRIAPALVELU,
-    )
-}
+fun tryParsing(source: PlanSource?, op: () -> ValidationResponse): ValidationResponse =
+    try {
+        op()
+    } catch (e: Exception) {
+        logger.warn("Failed to parse InfraModel", e)
+        ValidationResponse(
+            geometryValidationIssues =
+                listOf(
+                    ParsingError(
+                        if (e is HasLocalizedMessage) e.localizationKey
+                        else LocalizationKey(INFRAMODEL_PARSING_KEY_GENERIC)),
+                ),
+            geometryPlan = null,
+            planLayout = null,
+            source = source ?: PlanSource.GEOMETRIAPALVELU,
+        )
+    }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
@@ -17,7 +17,9 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
 @GeoviiteController("/inframodel")
-class InfraModelController @Autowired constructor(
+class InfraModelController
+@Autowired
+constructor(
     private val infraModelService: InfraModelService,
     private val geometryService: GeometryService,
     private val pvDocumentService: PVDocumentService,
@@ -72,7 +74,9 @@ class InfraModelController @Autowired constructor(
 
     @PreAuthorize(AUTH_VIEW_GEOMETRY)
     @PutMapping("/{planId}/linked-items")
-    fun getInfraModelLinkedItems(@PathVariable("planId") planId: IntId<GeometryPlan>): GeometryPlanLinkedItems {
+    fun getInfraModelLinkedItems(
+        @PathVariable("planId") planId: IntId<GeometryPlan>
+    ): GeometryPlanLinkedItems {
         return geometryService.getPlanLinkedItems(planId)
     }
 
@@ -84,7 +88,9 @@ class InfraModelController @Autowired constructor(
 
     @PreAuthorize(AUTH_VIEW_PV_DOCUMENTS)
     @GetMapping("/projektivelho/documents")
-    fun getPVDocumentHeaders(@RequestParam("status") status: PVDocumentStatus?): List<PVDocumentHeader> {
+    fun getPVDocumentHeaders(
+        @RequestParam("status") status: PVDocumentStatus?
+    ): List<PVDocumentHeader> {
         return pvDocumentService.getDocumentHeaders(status)
     }
 
@@ -130,10 +136,10 @@ class InfraModelController @Autowired constructor(
 
     @PreAuthorize(AUTH_DOWNLOAD_GEOMETRY)
     @GetMapping("/projektivelho/{documentId}", MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    fun downloadPVDocument(@PathVariable("documentId") documentId: IntId<PVDocument>): ResponseEntity<ByteArray> {
-        return pvDocumentService.getFile(documentId)
-            ?.let(::toFileDownloadResponse)
+    fun downloadPVDocument(
+        @PathVariable("documentId") documentId: IntId<PVDocument>
+    ): ResponseEntity<ByteArray> {
+        return pvDocumentService.getFile(documentId)?.let(::toFileDownloadResponse)
             ?: throw NoSuchEntityException(PVDocument::class, documentId)
     }
-
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
@@ -14,14 +14,14 @@ import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.formatForException
 import fi.fta.geoviite.infra.util.formatForLog
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.math.BigDecimal.ZERO
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 const val INFRAMODEL_SWITCH_CODE = "IM_switch"
 const val INFRAMODEL_SWITCH_TYPE = "switchType"
@@ -54,54 +54,63 @@ fun toGvtPlan(
     val metricUnits = mandatorySection("units", infraModel.units?.metric)
     if (infraModel.alignmentGroups.size != 1) {
         throw InframodelParsingException(
-            message = "Plan should have precisely one alignment group: groups=${infraModel.alignmentGroups.size}",
+            message =
+                "Plan should have precisely one alignment group: groups=${infraModel.alignmentGroups.size}",
             localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.missing-section.alignment-group",
         )
     }
 
     if (!isSupportedInframodelVersion(infraModel.featureDictionary?.version)) {
         throw InframodelParsingException(
-            message = "Plan InfraModel version isn't supported. version=${infraModel.featureDictionary?.version}",
-            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.unsupported-version"
-        )
+            message =
+                "Plan InfraModel version isn't supported. version=${infraModel.featureDictionary?.version}",
+            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.unsupported-version")
     }
 
     val units = parseUnits(coordinateSystem, metricUnits, coordinateSystemNameToSrid)
-    val gvtSwitches = collectGeometrySwitches(switchStructuresByType, switchTypeNameAliases, infraModel.alignmentGroups)
+    val gvtSwitches =
+        collectGeometrySwitches(
+            switchStructuresByType, switchTypeNameAliases, infraModel.alignmentGroups)
     val trackNumberDescription = infraModel.alignmentGroups.first().name
     val trackNumber = tryParseTrackNumber(trackNumberDescription)
     val alignments = mutableListOf<GeometryAlignment>()
     val kmPosts = mutableListOf<GeometryKmPost>()
 
     infraModel.alignmentGroups.forEach { group ->
-        val trackNumberState = group.state?.let { stateString ->
-            tryParsePlanState("Track number ${group.name} state", stateString)
-        }
+        val trackNumberState =
+            group.state?.let { stateString ->
+                tryParsePlanState("Track number ${group.name} state", stateString)
+            }
 
-        alignments.addAll(group.alignments.map { xmlAlignment ->
-            toGvtAlignment(xmlAlignment, units, gvtSwitches, trackNumberState)
-        })
-        kmPosts.addAll(group.alignments.flatMap { alignment ->
-            val alignmentState = alignment.state?.let { stateString ->
-                tryParsePlanState("Alignment ${alignment.name} state", stateString)
-            }
-            alignment.staEquations.map { s ->
-                toGvtKmPost(s, alignmentState ?: trackNumberState)
-            }
-        })
+        alignments.addAll(
+            group.alignments.map { xmlAlignment ->
+                toGvtAlignment(xmlAlignment, units, gvtSwitches, trackNumberState)
+            })
+        kmPosts.addAll(
+            group.alignments.flatMap { alignment ->
+                val alignmentState =
+                    alignment.state?.let { stateString ->
+                        tryParsePlanState("Alignment ${alignment.name} state", stateString)
+                    }
+                alignment.staEquations.map { s ->
+                    toGvtKmPost(s, alignmentState ?: trackNumberState)
+                }
+            })
     }
 
     return GeometryPlan(
         source = source,
-        project = Project(
-            name = tryParseText(project.name, ::ProjectName) ?: ProjectName(""),
-            description = project.desc?.let(::tryParseFreeText),
-        ),
-        application = Application(
-            name = MetaDataName(application.name),
-            manufacturer = MetaDataName(application.manufacturer),
-            version = MetaDataName(application.version),
-        ),
+        project =
+            Project(
+                name = tryParseText(project.name, ::ProjectName) ?: ProjectName(""),
+                description = project.desc?.let(::tryParseFreeText),
+            ),
+        application =
+            Application(
+                name = MetaDataName(application.name),
+                manufacturer = MetaDataName(application.manufacturer),
+                version = MetaDataName(application.version),
+            ),
         author = author.company?.let(::tryParseCompanyName)?.let(::Author),
         planTime = author.timeStamp?.let(::parseTime),
         units = units,
@@ -122,38 +131,45 @@ fun toGvtPlan(
     )
 }
 
-fun <T> mandatorySection(name: String, section: T?): T = section ?: throw InframodelParsingException(
-    message = "Plan is missing mandatory section: $name",
-    localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.missing-section.$name",
-)
-
+fun <T> mandatorySection(name: String, section: T?): T =
+    section
+        ?: throw InframodelParsingException(
+            message = "Plan is missing mandatory section: $name",
+            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.missing-section.$name",
+        )
 
 fun parseUnits(
     coordinateSystem: InfraModelCoordinateSystem,
     metricUnits: InfraModelMetric,
     coordinateSystemNameToSrid: Map<CoordinateSystemName, Srid>,
 ): GeometryUnits {
-    val coordinateSystemName = if (coordinateSystem.name.isBlank()) null
-    else CoordinateSystemName(coordinateSystem.name.trim())
+    val coordinateSystemName =
+        if (coordinateSystem.name.isBlank()) null
+        else CoordinateSystemName(coordinateSystem.name.trim())
     val rotationAngle = coordinateSystem.rotationAngle
     if (rotationAngle.isNotBlank() && rotationAngle.toBigDecimal().compareTo(ZERO) != 0) {
-        throw InframodelParsingException("Plan rotation is not supported: value=${formatForException(rotationAngle)}")
+        throw InframodelParsingException(
+            "Plan rotation is not supported: value=${formatForException(rotationAngle)}")
     }
     return GeometryUnits(
-        coordinateSystemSrid = toSrid(coordinateSystemName, coordinateSystem.epsgCode, coordinateSystemNameToSrid),
+        coordinateSystemSrid =
+            toSrid(coordinateSystemName, coordinateSystem.epsgCode, coordinateSystemNameToSrid),
         coordinateSystemName = coordinateSystemName,
-        verticalCoordinateSystem = coordinateSystem.verticalCoordinateSystemName.let(::toVerticalCoordinateSystem),
+        verticalCoordinateSystem =
+            coordinateSystem.verticalCoordinateSystemName.let(::toVerticalCoordinateSystem),
         directionUnit = parseEnum("Plan direction measurement unit", metricUnits.directionUnit),
         linearUnit = parseEnum("Plan linear measurement unit", metricUnits.linearUnit),
     )
 }
 
 private val SUPPORTED_INFRAMODEL_VERSIONS = listOf("4.0.3", "4.0.4")
+
 private fun isSupportedInframodelVersion(versionString: String?) =
     versionString == null || SUPPORTED_INFRAMODEL_VERSIONS.contains(versionString)
 
-fun parseTime(timeString: String): Instant = if (timeString.endsWith("Z")) Instant.parse(timeString)
-else ZonedDateTime.of(LocalDateTime.parse(timeString), defaultTimeZone).toInstant()
+fun parseTime(timeString: String): Instant =
+    if (timeString.endsWith("Z")) Instant.parse(timeString)
+    else ZonedDateTime.of(LocalDateTime.parse(timeString), defaultTimeZone).toInstant()
 
 fun toSrid(
     csName: CoordinateSystemName?,
@@ -161,19 +177,21 @@ fun toSrid(
     coordinateSystemNameToSrid: Map<CoordinateSystemName, Srid>,
 ): Srid? {
     val code = epsgCode?.let { code -> parseOptionalInt("Coordinate system EPSG code", code) }
-    // Note: EPSG 4022 is just a code for "deprecated" and cannot be used for transformations as such
+    // Note: EPSG 4022 is just a code for "deprecated" and cannot be used for transformations as
+    // such
     val parsedSrid = if (code != null && code > 0 && code != 4022) Srid(code) else null
     return parsedSrid ?: csName?.let { name -> coordinateSystemNameToSrid[name.uppercase()] }
 }
 
-fun toVerticalCoordinateSystem(name: String): VerticalCoordinateSystem? = if (name.isNotBlank()) {
-    try {
-        parseOptionalEnum<VerticalCoordinateSystem>("Plan vertical coordinate system", name)
-    } catch (ex: InputValidationException) {
-        logger.warn("Unknown vertical coordinate system: ${formatForException(name)}")
-        null
-    }
-} else null
+fun toVerticalCoordinateSystem(name: String): VerticalCoordinateSystem? =
+    if (name.isNotBlank()) {
+        try {
+            parseOptionalEnum<VerticalCoordinateSystem>("Plan vertical coordinate system", name)
+        } catch (ex: InputValidationException) {
+            logger.warn("Unknown vertical coordinate system: ${formatForException(name)}")
+            null
+        }
+    } else null
 
 fun toGvtAlignment(
     alignment: InfraModelAlignment,
@@ -184,26 +202,33 @@ fun toGvtAlignment(
     val profile = alignment.profile?.let { p -> toGvtProfile(p) }
     val cant = alignment.cant?.let { c -> toGvtCant(c) }
     return GeometryAlignment(
-        name = tryParseAlignmentName(alignment.name) ?: throw InputValidationException(
-            message = "Invalid alignment name: ${formatForException(alignment.name)}",
-            type = AlignmentName::class,
-            value = alignment.name,
-        ),
+        name =
+            tryParseAlignmentName(alignment.name)
+                ?: throw InputValidationException(
+                    message = "Invalid alignment name: ${formatForException(alignment.name)}",
+                    type = AlignmentName::class,
+                    value = alignment.name,
+                ),
         description = alignment.desc?.let(::tryParseFreeText),
         oidPart = alignment.oid?.let(::tryParseFreeText),
-        state = parseOptionalEnum<PlanState>("Alignment ${alignment.name} state", alignment.state) ?: parentState,
-        staStart = parseBigDecimal("Alignment ${alignment.name} station start value", alignment.staStart),
+        state =
+            parseOptionalEnum<PlanState>("Alignment ${alignment.name} state", alignment.state)
+                ?: parentState,
+        staStart =
+            parseBigDecimal("Alignment ${alignment.name} station start value", alignment.staStart),
         featureTypeCode = getAlignmentImCodingFeatureType(alignment.features),
-        elements = alignment.elements.mapNotNull { e ->
-            if (e.start != e.end) toGvtGeometryElement(e, units, switches) else null
-        },
+        elements =
+            alignment.elements.mapNotNull { e ->
+                if (e.start != e.end) toGvtGeometryElement(e, units, switches) else null
+            },
         profile = profile,
         cant = cant,
     )
 }
 
 private fun getAlignmentImCodingFeatureType(features: List<InfraModelFeature>): FeatureTypeCode? =
-    features.find { feature -> feature.code == "IM_coding" }
+    features
+        .find { feature -> feature.code == "IM_coding" }
         ?.getPropertyAnyMatch(listOf("terrainCoding", "infraCoding"))
         ?.let(::tryParseFeatureTypeCode)
 
@@ -214,13 +239,17 @@ fun toGvtKmPost(
     val kmFeature: InfraModelFeature? = staEquation.feature
     val northing = kmFeature?.properties?.find { f -> f.label == KM_POST_N_LABEL }
     val easting = kmFeature?.properties?.find { f -> f.label == KM_POST_E_LABEL }
-    val location = if (northing == null || easting == null) null
-    else parsePoint("KM Post ${staEquation.desc} coordinates", y = northing.value, x = easting.value)
+    val location =
+        if (northing == null || easting == null) null
+        else
+            parsePoint(
+                "KM Post ${staEquation.desc} coordinates", y = northing.value, x = easting.value)
     val description = staEquation.desc.trim()
     return GeometryKmPost(
         staBack = parseOptionalBigDecimal("KM Post $description station back", staEquation.staBack),
         staAhead = parseBigDecimal("KM Post $description station ahead", staEquation.staAhead),
-        staInternal = parseBigDecimal("KM Post $description station internal", staEquation.staInternal),
+        staInternal =
+            parseBigDecimal("KM Post $description station internal", staEquation.staInternal),
         kmNumber = tryParseKmNumber(description),
         description = PlanElementName(description),
         location = location,
@@ -237,65 +266,76 @@ fun toGvtGeometryElement(
     val start = xmlCoordinateToPoint("$name start point", element.start)
     val end = xmlCoordinateToPoint("$name end point", element.end)
     val switch: GeometrySwitch? = getSwitchKey(element)?.let(switches::get)
-    val switchData = SwitchData(
-        switchId = switch?.id,
-        startJointNumber = switch?.getJoint(start, COORDINATE_ACCURACY)?.number,
-        endJointNumber = switch?.getJoint(end, COORDINATE_ACCURACY)?.number,
-    )
-    val elementData = ElementData(
-        name = element.name?.let(::tryParsePlanElementName),
-        oidPart = element.oID?.let(::tryParsePlanElementName),
-        start = start,
-        end = end,
-        staStart = parseBigDecimal("$name station start value", element.staStart),
-        length = parseBigDecimal("$name length", element.length),
-    )
+    val switchData =
+        SwitchData(
+            switchId = switch?.id,
+            startJointNumber = switch?.getJoint(start, COORDINATE_ACCURACY)?.number,
+            endJointNumber = switch?.getJoint(end, COORDINATE_ACCURACY)?.number,
+        )
+    val elementData =
+        ElementData(
+            name = element.name?.let(::tryParsePlanElementName),
+            oidPart = element.oID?.let(::tryParsePlanElementName),
+            start = start,
+            end = end,
+            staStart = parseBigDecimal("$name station start value", element.staStart),
+            length = parseBigDecimal("$name length", element.length),
+        )
     return when (element) {
         is InfraModelLine -> GeometryLine(elementData = elementData, switchData = switchData)
-        is InfraModelCurve -> GeometryCurve(
-            elementData = elementData,
-            curveData = CurveData(
-                rotation = parseEnum("$name rotation direction", element.rot),
-                radius = parseBigDecimal("$name circle radius", element.radius),
-                chord = parseBigDecimal("$name circle arc chord", element.chord),
-                center = xmlCoordinateToPoint("$name circular radius center point", element.center),
-            ),
-            switchData = switchData,
-        )
+        is InfraModelCurve ->
+            GeometryCurve(
+                elementData = elementData,
+                curveData =
+                    CurveData(
+                        rotation = parseEnum("$name rotation direction", element.rot),
+                        radius = parseBigDecimal("$name circle radius", element.radius),
+                        chord = parseBigDecimal("$name circle arc chord", element.chord),
+                        center =
+                            xmlCoordinateToPoint(
+                                "$name circular radius center point", element.center),
+                    ),
+                switchData = switchData,
+            )
 
         is InfraModelSpiral -> {
             val pi = xmlCoordinateToPoint("$name spiral PI point", element.pi)
-            val startAngle = angle("$name start direction", element.dirStart ?: "", units.directionUnit)
+            val startAngle =
+                angle("$name start direction", element.dirStart ?: "", units.directionUnit)
             val endAngle = angle("$name end direction", element.dirEnd ?: "", units.directionUnit)
-            val spiralData = SpiralData(
-                rotation = parseEnum("$name spiral curvature direction", element.rot),
-                directionStart = startAngle,
-                directionEnd = endAngle,
-                radiusStart = spiralRadius(element.radiusStart),
-                radiusEnd = spiralRadius(element.radiusEnd),
-                pi = pi,
-            )
+            val spiralData =
+                SpiralData(
+                    rotation = parseEnum("$name spiral curvature direction", element.rot),
+                    directionStart = startAngle,
+                    directionEnd = endAngle,
+                    radiusStart = spiralRadius(element.radiusStart),
+                    radiusEnd = spiralRadius(element.radiusEnd),
+                    pi = pi,
+                )
             when (element.spiType.uppercase()) {
-                "CLOTHOID" -> GeometryClothoid(
-                    elementData = elementData,
-                    spiralData = spiralData,
-                    switchData = switchData,
-                    constant = parseBigDecimal("$name clothoid constant", element.constant ?: ""),
-                )
+                "CLOTHOID" ->
+                    GeometryClothoid(
+                        elementData = elementData,
+                        spiralData = spiralData,
+                        switchData = switchData,
+                        constant =
+                            parseBigDecimal("$name clothoid constant", element.constant ?: ""),
+                    )
 
-                "BIQUADRATICPARABOLA" -> BiquadraticParabola(
-                    elementData = elementData,
-                    spiralData = spiralData,
-                    switchData = switchData,
-                )
+                "BIQUADRATICPARABOLA" ->
+                    BiquadraticParabola(
+                        elementData = elementData,
+                        spiralData = spiralData,
+                        switchData = switchData,
+                    )
 
-                else -> throw InframodelParsingException(
-                    "${formatForException(name)} has unknown spiral type ${
+                else ->
+                    throw InframodelParsingException(
+                        "${formatForException(name)} has unknown spiral type ${
                         formatForException(
                             element.spiType
                         )
-                    }"
-                )
+                    }")
             }
         }
 
@@ -304,23 +344,27 @@ fun toGvtGeometryElement(
 }
 
 fun toGvtProfile(profile: InfraModelProfile): GeometryProfile? {
-    val profAlign = profile.profAlign ?: throw InframodelParsingException(
-        message = "XML Profile lacks ProfAlign element",
-        localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.missing-section.prof-align",
-    )
+    val profAlign =
+        profile.profAlign
+            ?: throw InframodelParsingException(
+                message = "XML Profile lacks ProfAlign element",
+                localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.missing-section.prof-align",
+            )
     return try {
         GeometryProfile(
-            name = tryParsePlanElementName(profAlign.name) ?: emptyName(),
-            elements = profAlign.elements.map { pa -> toGvtVerticalIntersection(pa) },
-        ).let { geometryProfile ->
-            // Ensure that profile segment calculation works
-            if (geometryProfile.segments.isEmpty()) {
-                logger.warn("GeometryProfile elements don't produce valid segments")
-                null
-            } else geometryProfile
-        }
+                name = tryParsePlanElementName(profAlign.name) ?: emptyName(),
+                elements = profAlign.elements.map { pa -> toGvtVerticalIntersection(pa) },
+            )
+            .let { geometryProfile ->
+                // Ensure that profile segment calculation works
+                if (geometryProfile.segments.isEmpty()) {
+                    logger.warn("GeometryProfile elements don't produce valid segments")
+                    null
+                } else geometryProfile
+            }
     } catch (ex: Exception) {
-        logger.warn("Failed to parse profile: name=${formatForLog(profAlign.name)} elements=${profAlign.elements} cause=$ex")
+        logger.warn(
+            "Failed to parse profile: name=${formatForLog(profAlign.name)} elements=${profAlign.elements} cause=$ex")
         null
     }
 }
@@ -328,42 +372,51 @@ fun toGvtProfile(profile: InfraModelProfile): GeometryProfile? {
 fun toGvtVerticalIntersection(profileElement: InfraModelProfileElement): VerticalIntersection {
     val name = "Profile element ${profileElement.desc}"
     return when (profileElement) {
-        is InfraModelPvi -> VIPoint(
-            description = profileElement.desc?.let(::tryParsePlanElementName) ?: emptyName(),
-            point = xmlPointToPoint("$name x/z", profileElement.point),
-        )
+        is InfraModelPvi ->
+            VIPoint(
+                description = profileElement.desc?.let(::tryParsePlanElementName) ?: emptyName(),
+                point = xmlPointToPoint("$name x/z", profileElement.point),
+            )
 
-        is InfraModelCircCurve -> VICircularCurve(
-            description = profileElement.desc?.let(::tryParsePlanElementName) ?: emptyName(),
-            point = xmlPointToPoint("$name x/z", profileElement.point),
-            radius = parseOptionalBigDecimal("$name curve radius", profileElement.radius)?.let { r ->
-                if (r.compareTo(ZERO) == 0) null else r
-            },
-            length = parseOptionalBigDecimal("$name curve length", profileElement.length),
-        )
+        is InfraModelCircCurve ->
+            VICircularCurve(
+                description = profileElement.desc?.let(::tryParsePlanElementName) ?: emptyName(),
+                point = xmlPointToPoint("$name x/z", profileElement.point),
+                radius =
+                    parseOptionalBigDecimal("$name curve radius", profileElement.radius)?.let { r ->
+                        if (r.compareTo(ZERO) == 0) null else r
+                    },
+                length = parseOptionalBigDecimal("$name curve length", profileElement.length),
+            )
 
-        else -> throw InputValidationException(
-            message = "${formatForException(name)} has unknown type: ${profileElement::class.simpleName}",
-            type = InfraModelProfileElement::class,
-            value = profileElement::class.simpleName ?: "null",
-        )
+        else ->
+            throw InputValidationException(
+                message =
+                    "${formatForException(name)} has unknown type: ${profileElement::class.simpleName}",
+                type = InfraModelProfileElement::class,
+                value = profileElement::class.simpleName ?: "null",
+            )
     }
 }
 
 fun toGvtCant(cant: InfraModelCant): GeometryCant {
-    return GeometryCant(name = tryParsePlanElementName(cant.name) ?: emptyName(),
+    return GeometryCant(
+        name = tryParsePlanElementName(cant.name) ?: emptyName(),
         description = cant.desc?.let(::tryParsePlanElementName) ?: emptyName(),
         gauge = parseBigDecimal("Cant gauge", cant.gauge),
-        rotationPoint = when (cant.rotationPoint) {
-            "insideRail" -> CantRotationPoint.INSIDE_RAIL
-            "center" -> CantRotationPoint.CENTER
-            "" -> null
-            else -> throw InputValidationException(
-                message = "XML Cant rotation point unrecognized: ${formatForException(cant.rotationPoint)}",
-                type = CantRotationPoint::class,
-                value = cant.rotationPoint,
-            )
-        },
+        rotationPoint =
+            when (cant.rotationPoint) {
+                "insideRail" -> CantRotationPoint.INSIDE_RAIL
+                "center" -> CantRotationPoint.CENTER
+                "" -> null
+                else ->
+                    throw InputValidationException(
+                        message =
+                            "XML Cant rotation point unrecognized: ${formatForException(cant.rotationPoint)}",
+                        type = CantRotationPoint::class,
+                        value = cant.rotationPoint,
+                    )
+            },
         points = cant.stations.map { s -> toGvtCantPoint(s) })
 }
 
@@ -373,26 +426,31 @@ fun toGvtCantPoint(station: InfraModelCantStation): GeometryCantPoint {
         station = parseBigDecimal("Cant point station", station.station),
         appliedCant = parseBigDecimal("Cant point applied cant", station.appliedCant),
         curvature = parseEnum("Cant point curvature direction", station.curvature),
-        transitionType = when (station.transitionType) {
-            null -> LINEAR
-            "biquadraticParabola" -> BIQUADRATIC_PARABOLA
-            else -> throw InputValidationException(
-                message = "Unknown XML Cant transition type: ${station.transitionType?.let(::formatForException)}",
-                type = CantTransitionType::class,
-                value = station.transitionType ?: "null",
-            )
-        }
-    )
+        transitionType =
+            when (station.transitionType) {
+                null -> LINEAR
+                "biquadraticParabola" -> BIQUADRATIC_PARABOLA
+                else ->
+                    throw InputValidationException(
+                        message =
+                            "Unknown XML Cant transition type: ${station.transitionType?.let(::formatForException)}",
+                        type = CantTransitionType::class,
+                        value = station.transitionType ?: "null",
+                    )
+            })
 }
 
 fun spiralRadius(value: String?): BigDecimal? {
-    // Spiral starts from R=INF (straight) and reaches R=0 (infinite angle) at infinite length (impossible in practice).
+    // Spiral starts from R=INF (straight) and reaches R=0 (infinite angle) at infinite length
+    // (impossible in practice).
     // We use R=null to mark R=INF and also default to this value.
-    return if (value == "INF") null else value?.let { v -> parseBigDecimal("Element spiral radius", v) }
+    return if (value == "INF") null
+    else value?.let { v -> parseBigDecimal("Element spiral radius", v) }
 }
 
 fun angle(name: String, value: String, unit: AngularUnit): Angle? {
-    // Plans include geo-angles (0=north, clockwise), so turn them into mathematical ones (0=positive-X, counter-clockwise)
+    // Plans include geo-angles (0=north, clockwise), so turn them into mathematical ones
+    // (0=positive-X, counter-clockwise)
     return parseOptionalBigDecimal(name, value)?.let { d -> toAngle(d, unit).geoToMath() }
 }
 
@@ -403,22 +461,27 @@ fun angleBetween(point1: Point, point2: Point, unit: AngularUnit): Angle {
 
 fun xmlPointToPoint(name: String, xmlPoint: String): Point {
     val pieces = splitStringOnSpaces(xmlPoint)
-    if (pieces.size != 2) throw InputValidationException(
-        message = "Cannot parse ${formatForException(name)} from string: ${formatForException(xmlPoint)}",
-        type = Point::class,
-        value = xmlPoint,
-    )
+    if (pieces.size != 2)
+        throw InputValidationException(
+            message =
+                "Cannot parse ${formatForException(name)} from string: ${formatForException(xmlPoint)}",
+            type = Point::class,
+            value = xmlPoint,
+        )
     return parsePoint(name, pieces[0], pieces[1])
 }
 
 fun xmlCoordinateToPoint(name: String, xmlCoordinate: String): Point {
     val pieces = splitStringOnSpaces(xmlCoordinate)
-    // Some systems write in Z-coordinate as well. We use Profile to calculate it, so ignore it here.
-    if (pieces.size !in 2..3) throw InputValidationException(
-        message = "Cannot parse ${formatForException(name)} from string: ${formatForException(xmlCoordinate)}",
-        type = Point::class,
-        value = xmlCoordinate,
-    )
+    // Some systems write in Z-coordinate as well. We use Profile to calculate it, so ignore it
+    // here.
+    if (pieces.size !in 2..3)
+        throw InputValidationException(
+            message =
+                "Cannot parse ${formatForException(name)} from string: ${formatForException(xmlCoordinate)}",
+            type = Point::class,
+            value = xmlCoordinate,
+        )
     // Geodetic coordinates: Northing = Latitude = Y, Easting = Longitude = X
     return parsePoint(name, pieces[1], pieces[0])
 }
@@ -426,19 +489,25 @@ fun xmlCoordinateToPoint(name: String, xmlCoordinate: String): Point {
 fun switchTypeHand(switchHand: String): SwitchHand {
     return SwitchHand.values().find { h -> h.name.startsWith(switchHand.uppercase()) }
         ?: throw InputValidationException(
-            message = "Can't recognize switch hand type from value: ${formatForException(switchHand)}",
+            message =
+                "Can't recognize switch hand type from value: ${formatForException(switchHand)}",
             type = SwitchHand::class,
             value = switchHand,
         )
 }
 
-fun normalizeSwitchTypeName(switchStructureNameAliases: Map<String, String>, switchTypeName: String): String {
+fun normalizeSwitchTypeName(
+    switchStructureNameAliases: Map<String, String>,
+    switchTypeName: String
+): String {
     val withDecimalComma = switchTypeName.replace('.', ',')
-    val withLowerCaseX = if (withDecimalComma.startsWith("RR") || withDecimalComma.startsWith("SRR")) {
-        // RATO4 says this lowercase, for example: RR54-2x1:9. https://www.doria.fi/handle/10024/121411
-        // Sometimes the IM files have uppercase, so fix it for leniency
-        switchTypeName.replace('X', 'x')
-    } else withDecimalComma
+    val withLowerCaseX =
+        if (withDecimalComma.startsWith("RR") || withDecimalComma.startsWith("SRR")) {
+            // RATO4 says this lowercase, for example: RR54-2x1:9.
+            // https://www.doria.fi/handle/10024/121411
+            // Sometimes the IM files have uppercase, so fix it for leniency
+            switchTypeName.replace('X', 'x')
+        } else withDecimalComma
     return switchStructureNameAliases[withLowerCaseX] ?: withLowerCaseX
 }
 
@@ -447,62 +516,81 @@ fun collectGeometrySwitches(
     switchTypeNameAliases: Map<String, String>,
     alignmentGroups: List<InfraModelAlignmentGroup>,
 ): Map<SwitchKey, GeometrySwitch> {
-    val tempSwitchAndJoints: List<TempSwitchAndJoints> = alignmentGroups.flatMap { group ->
-        group.alignments.flatMap { alignment -> getInfraModelSwitches(alignment, group.state) }
-    }
+    val tempSwitchAndJoints: List<TempSwitchAndJoints> =
+        alignmentGroups.flatMap { group ->
+            group.alignments.flatMap { alignment -> getInfraModelSwitches(alignment, group.state) }
+        }
 
     return tempSwitchAndJoints
-        // Switches have no proper id -> group individual pieces by a composite key of name + other things
-        .groupBy { imSwitch -> imSwitch.tempSwitch.key }.mapValues { (_, switchAndJoints) ->
+        // Switches have no proper id -> group individual pieces by a composite key of name + other
+        // things
+        .groupBy { imSwitch -> imSwitch.tempSwitch.key }
+        .mapValues { (_, switchAndJoints) ->
             val xmlSwitches = switchAndJoints.map { it.tempSwitch }
             val switchJoints = switchAndJoints.map { it.joints }.flatten()
             val deduplicatedJoints =
-                switchJoints.groupBy { j -> j.number }.values.map { list -> list.first() }.sortedBy { j -> j.number }
+                switchJoints
+                    .groupBy { j -> j.number }
+                    .values
+                    .map { list -> list.first() }
+                    .sortedBy { j -> j.number }
 
-            val switchName = verifySameField("Switch name", xmlSwitches, TempSwitch::name, TempSwitch::name)
+            val switchName =
+                verifySameField("Switch name", xmlSwitches, TempSwitch::name, TempSwitch::name)
             val switchTypeNameXml =
-                verifySameField("Switch typeName", xmlSwitches, TempSwitch::typeName, TempSwitch::name)
+                verifySameField(
+                    "Switch typeName", xmlSwitches, TempSwitch::typeName, TempSwitch::name)
             val switchTypeName = normalizeSwitchTypeName(switchTypeNameAliases, switchTypeNameXml)
-            val switchTypeRequiresHandedness = tryParseSwitchType(switchTypeName).let { switchType ->
-                    if (switchType != null) switchTypeRequiresHandedness(switchType.parts.baseType) else false
+            val switchTypeRequiresHandedness =
+                tryParseSwitchType(switchTypeName).let { switchType ->
+                    if (switchType != null) switchTypeRequiresHandedness(switchType.parts.baseType)
+                    else false
                 }
-            val switchTypeHand = verifySameField(
-                "Switch hand", xmlSwitches, TempSwitch::hand, TempSwitch::name
-            )
-            val fullSwitchTypeName = switchTypeHand.let { hand ->
-                if (hand == SwitchHand.NONE || !switchTypeRequiresHandedness) switchTypeName
-                else "$switchTypeName-${hand.abbreviation}"
-            }
+            val switchTypeHand =
+                verifySameField("Switch hand", xmlSwitches, TempSwitch::hand, TempSwitch::name)
+            val fullSwitchTypeName =
+                switchTypeHand.let { hand ->
+                    if (hand == SwitchHand.NONE || !switchTypeRequiresHandedness) switchTypeName
+                    else "$switchTypeName-${hand.abbreviation}"
+                }
 
             val switchType = tryParseSwitchType(fullSwitchTypeName)
             val switchStructure = switchType?.let { type -> switchStructuresByType[type] }
 
             if (switchType == null) {
                 logger.warn(
-                    "Invalid switch type name: " + "full=${formatForLog(fullSwitchTypeName)} " + "orig=${
+                    "Invalid switch type name: " +
+                        "full=${formatForLog(fullSwitchTypeName)} " +
+                        "orig=${
                         formatForLog(
                             switchTypeName
                         )
-                    }"
-                )
+                    }")
             }
 
             GeometrySwitch(
-                name = tryParseSwitchName(switchName.trim()) ?: throw InputValidationException(
-                    message = "Could not parse name for switch: name=${formatForException(switchName)}",
-                    type = SwitchName::class,
-                    value = switchName,
-                ),
+                name =
+                    tryParseSwitchName(switchName.trim())
+                        ?: throw InputValidationException(
+                            message =
+                                "Could not parse name for switch: name=${formatForException(switchName)}",
+                            type = SwitchName::class,
+                            value = switchName,
+                        ),
                 state = combineSwitchState(xmlSwitches.mapNotNull(TempSwitch::state)),
                 joints = deduplicatedJoints,
                 switchStructureId = switchStructure?.id as? IntId,
-                typeName = tryParseGeometrySwitchTypeName(switchTypeName) ?: GeometrySwitchTypeName("")
-            )
+                typeName =
+                    tryParseGeometrySwitchTypeName(switchTypeName) ?: GeometrySwitchTypeName(""))
         }
 }
 
-
-fun <T, S> verifySameField(description: String, objects: List<T>, getter: (T) -> S, nameGetter: (T) -> String): S {
+fun <T, S> verifySameField(
+    description: String,
+    objects: List<T>,
+    getter: (T) -> S,
+    nameGetter: (T) -> String
+): S {
     val first = getter(objects.first())
     if (objects.any { o: T -> getter(o) != first }) {
         val names = objects.map { o -> formatForException("${nameGetter(o)}:${getter(o)}") }
@@ -515,54 +603,66 @@ fun combineSwitchState(alignmentStates: List<PlanState>): PlanState? =
     if (alignmentStates.contains(DESTROYED)) DESTROYED
     else if (alignmentStates.contains(ABANDONED)) ABANDONED
     else if (alignmentStates.contains(PROPOSED)) PROPOSED
-    else if (alignmentStates.contains(EXISTING)) EXISTING
-    else null
+    else if (alignmentStates.contains(EXISTING)) EXISTING else null
 
 fun getInfraModelSwitches(
     alignment: InfraModelAlignment,
     trackNumberState: String?,
 ): List<TempSwitchAndJoints> {
-    val state = parseOptionalEnum<PlanState>(
-        "Alignment ${alignment.name} state", alignment.state ?: trackNumberState
-    )
-    return alignment.elements.mapIndexedNotNull { index, element -> getSwitchElement(index, element, state) }
+    val state =
+        parseOptionalEnum<PlanState>(
+            "Alignment ${alignment.name} state", alignment.state ?: trackNumberState)
+    return alignment.elements
+        .mapIndexedNotNull { index, element -> getSwitchElement(index, element, state) }
         // Group switch-elements by the switch "identity" (no real id -> name + other things)
         .groupBy { switchElement -> switchElement.switch.key }
-        // Each group is a bundle of tempSwitches representing the same switch -> create joints per group
+        // Each group is a bundle of tempSwitches representing the same switch -> create joints per
+        // group
         .map { group -> toGeometrySwitchJoints(group.value) }
 }
 
 fun toGeometrySwitchJoints(originalElements: List<TempSwitchElement>): TempSwitchAndJoints {
-    // Unify representations: Repeating joint-numbers mean that the same element has been split -> resolve as 0
+    // Unify representations: Repeating joint-numbers mean that the same element has been split ->
+    // resolve as 0
     val sortedElements = originalElements.sortedBy { element -> element.elementIndex }
-    val elements: List<TempSwitchElement> = sortedElements.mapIndexed { index, element ->
-        val prevNumber = sortedElements.getOrNull(index - 1)?.jointNumber
-        if (prevNumber == element.jointNumber) element.copy(jointNumber = 0) else element
-    }
+    val elements: List<TempSwitchElement> =
+        sortedElements.mapIndexed { index, element ->
+            val prevNumber = sortedElements.getOrNull(index - 1)?.jointNumber
+            if (prevNumber == element.jointNumber) element.copy(jointNumber = 0) else element
+        }
 
     val switch = elements.first().switch
 
     // Sanity check: this should not be possible, as the method is invoked per [alignment & switch]
     if (elements.any { ss -> ss.switch != switch }) {
-        val elementNames = elements.map { e -> "${e.elementIndex}/${formatForException(e.switch.name)}" }
+        val elementNames =
+            elements.map { e -> "${e.elementIndex}/${formatForException(e.switch.name)}" }
         throw InframodelParsingException("Switch element grouping failed: $elementNames")
     }
 
-    return TempSwitchAndJoints(switch, elements.flatMapIndexed { index: Int, element: TempSwitchElement ->
-        val startJoint = if (element.jointNumber == 0) null
-        else GeometrySwitchJoint(JointNumber(element.jointNumber), element.startLocation)
-        val endJointNumber = if (index < elements.lastIndex) elements.getOrNull(index + 1)?.jointNumber
-        else null
-        val endJoint = if (endJointNumber != null && endJointNumber > 0) GeometrySwitchJoint(
-            JointNumber(endJointNumber),
-            element.endLocation
-        ) else null
-        listOfNotNull(startJoint, endJoint)
-    })
+    return TempSwitchAndJoints(
+        switch,
+        elements.flatMapIndexed { index: Int, element: TempSwitchElement ->
+            val startJoint =
+                if (element.jointNumber == 0) null
+                else GeometrySwitchJoint(JointNumber(element.jointNumber), element.startLocation)
+            val endJointNumber =
+                if (index < elements.lastIndex) elements.getOrNull(index + 1)?.jointNumber else null
+            val endJoint =
+                if (endJointNumber != null && endJointNumber > 0)
+                    GeometrySwitchJoint(JointNumber(endJointNumber), element.endLocation)
+                else null
+            listOfNotNull(startJoint, endJoint)
+        })
 }
 
-fun getSwitchElement(elementIndex: Int, element: InfraModelGeometryElement, state: PlanState?): TempSwitchElement? {
-    return element.features.find { feature -> feature.code == INFRAMODEL_SWITCH_CODE }
+fun getSwitchElement(
+    elementIndex: Int,
+    element: InfraModelGeometryElement,
+    state: PlanState?
+): TempSwitchElement? {
+    return element.features
+        .find { feature -> feature.code == INFRAMODEL_SWITCH_CODE }
         ?.let { found -> parseSwitchElementFromFeature(elementIndex, element, found, state) }
 }
 
@@ -572,61 +672,79 @@ fun parseSwitchElementFromFeature(
     feature: InfraModelFeature,
     state: PlanState?,
 ): TempSwitchElement {
-    val name = element.name ?: throw InframodelParsingException("Switch element [$elementIndex] must have a name")
+    val name =
+        element.name
+            ?: throw InframodelParsingException("Switch element [$elementIndex] must have a name")
     val typeName = feature.getProperty(INFRAMODEL_SWITCH_TYPE)
     val hand = switchTypeHand(feature.getProperty(INFRAMODEL_SWITCH_HAND))
     val joint = feature.getProperty(INFRAMODEL_SWITCH_JOINT)
     return TempSwitchElement(
-        switch = TempSwitch(
-            key = SwitchKey(name, typeName, hand),
-            name = name,
-            state = state,
-            typeName = typeName,
-            hand = hand,
-        ),
+        switch =
+            TempSwitch(
+                key = SwitchKey(name, typeName, hand),
+                name = name,
+                state = state,
+                typeName = typeName,
+                hand = hand,
+            ),
         elementIndex = elementIndex,
-        jointNumber = parseOptionalInt("Switch segment ${element.name}[$elementIndex] joint number", joint) ?: 0,
-        startLocation = xmlCoordinateToPoint(
-            "Switch segment ${element.name}[$elementIndex] start point",
-            element.start,
-        ),
-        endLocation = xmlCoordinateToPoint("Switch segment ${element.name}[$elementIndex] end point", element.end),
+        jointNumber =
+            parseOptionalInt("Switch segment ${element.name}[$elementIndex] joint number", joint)
+                ?: 0,
+        startLocation =
+            xmlCoordinateToPoint(
+                "Switch segment ${element.name}[$elementIndex] start point",
+                element.start,
+            ),
+        endLocation =
+            xmlCoordinateToPoint(
+                "Switch segment ${element.name}[$elementIndex] end point", element.end),
     )
 }
 
 fun getSwitchKey(element: InfraModelGeometryElement): SwitchKey? =
-    element.features.find { feature -> feature.code == INFRAMODEL_SWITCH_CODE }?.let { feature ->
-            val name = element.name ?: throw InframodelParsingException("Switch element must have a name")
+    element.features
+        .find { feature -> feature.code == INFRAMODEL_SWITCH_CODE }
+        ?.let { feature ->
+            val name =
+                element.name ?: throw InframodelParsingException("Switch element must have a name")
             val typeName = feature.getProperty(INFRAMODEL_SWITCH_TYPE)
             val hand = switchTypeHand(feature.getProperty(INFRAMODEL_SWITCH_HAND))
             SwitchKey(name, typeName, hand)
         }
 
-fun tryParsePlanState(name: String, value: String): PlanState? = tryParseText(value) { v ->
-    parseOptionalEnum<PlanState>(name, v)
-}
+fun tryParsePlanState(name: String, value: String): PlanState? =
+    tryParseText(value) { v -> parseOptionalEnum<PlanState>(name, v) }
 
-fun tryParseTrackNumber(text: String): TrackNumber? = if (text == "N/A") null
-else tryParseText(text, ::TrackNumber)
+fun tryParseTrackNumber(text: String): TrackNumber? =
+    if (text == "N/A") null else tryParseText(text, ::TrackNumber)
 
-fun tryParseKmNumber(text: String): KmNumber? = if (text == "AKM" || text == "APU") {
-    null
-} else if (text.length in 1..6 && text.all(Char::isLetterOrDigit) && text.first().isDigit()) {
-    KmNumber(text)
-} else {
-    logger.warn("StaEquation desc is not a KM-number: ${formatForLog(text)}")
-    null
-}
+fun tryParseKmNumber(text: String): KmNumber? =
+    if (text == "AKM" || text == "APU") {
+        null
+    } else if (text.length in 1..6 && text.all(Char::isLetterOrDigit) && text.first().isDigit()) {
+        KmNumber(text)
+    } else {
+        logger.warn("StaEquation desc is not a KM-number: ${formatForLog(text)}")
+        null
+    }
 
 fun tryParseCompanyName(text: String): CompanyName? = tryParseText(text, ::CompanyName)
+
 fun tryParseAlignmentName(text: String): AlignmentName? = tryParseText(text, ::AlignmentName)
+
 fun tryParseSwitchName(text: String): SwitchName? = tryParseText(text, ::SwitchName)
+
 fun tryParsePlanElementName(text: String): PlanElementName? = tryParseText(text, ::PlanElementName)
 
 fun emptyName() = PlanElementName("")
+
 fun tryParseFreeText(text: String): FreeText? = tryParseText(text, ::FreeText)
+
 fun tryParseFeatureTypeCode(text: String): FeatureTypeCode? = tryParseText(text, ::FeatureTypeCode)
-fun tryParseGeometrySwitchTypeName(text: String): GeometrySwitchTypeName? = tryParseText(text, ::GeometrySwitchTypeName)
+
+fun tryParseGeometrySwitchTypeName(text: String): GeometrySwitchTypeName? =
+    tryParseText(text, ::GeometrySwitchTypeName)
 
 data class TempSwitchAndJoints(val tempSwitch: TempSwitch, val joints: List<GeometrySwitchJoint>)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelFile.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelFile.kt
@@ -13,20 +13,20 @@ data class InfraModelFile(
     val hash: String by lazy { DigestUtils.md5Hex(content) }
 
     init {
-        require(!containsIdentifyingInfo(content)) { "Identifying info must be censored from IM before storing" }
-        if (content.isBlank()) throw InframodelParsingException(
-            message = "File \"${name}\" is empty",
-            localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.empty",
-        )
+        require(!containsIdentifyingInfo(content)) {
+            "Identifying info must be censored from IM before storing"
+        }
+        if (content.isBlank())
+            throw InframodelParsingException(
+                message = "File \"${name}\" is empty",
+                localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.empty",
+            )
     }
 
     override fun toLog(): String = logFormat("name" to name, "hash" to hash)
 }
 
-data class InfraModelFileWithSource(
-    val file: InfraModelFile,
-    val source: PlanSource
-)
+data class InfraModelFileWithSource(val file: InfraModelFile, val source: PlanSource)
 
 private val authorTagRegex = Regex("<Author [^>]*>")
 private val createdByRegex = Regex("createdBy=\"[^\"]+\"")
@@ -35,24 +35,26 @@ const val EMPTY_CREATED_BY = "createdBy=\"\""
 const val EMPTY_CREATED_BY_EMAIL = "createdByEmail=\"\""
 
 fun containsIdentifyingInfo(content: String): Boolean =
-    getAuthorTag(content)
-        ?.let { tag -> tag.contains(createdByRegex) || tag.contains(createdByEmailRegex) }
-        ?: false
+    getAuthorTag(content)?.let { tag ->
+        tag.contains(createdByRegex) || tag.contains(createdByEmailRegex)
+    } ?: false
 
 fun censorAuthorIdentifyingInfo(content: String): String {
     val originalAuthorTag = getAuthorTag(content)
     return if (originalAuthorTag == null) {
         content
     } else {
-        val censoredTag: String = originalAuthorTag
-            .replace(createdByRegex, EMPTY_CREATED_BY)
-            .replace(createdByEmailRegex, EMPTY_CREATED_BY_EMAIL)
+        val censoredTag: String =
+            originalAuthorTag
+                .replace(createdByRegex, EMPTY_CREATED_BY)
+                .replace(createdByEmailRegex, EMPTY_CREATED_BY_EMAIL)
         content.replace(originalAuthorTag, censoredTag)
     }
 }
 
 fun getAuthorTag(content: String): String? =
     authorTagRegex.findAll(content).toList().let { matches ->
-        if (matches.size > 1) throw InframodelParsingException("Multiple Author tags in one InfraModel")
+        if (matches.size > 1)
+            throw InframodelParsingException("Multiple Author tags in one InfraModel")
         matches.firstOrNull()?.value
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -13,11 +13,11 @@ import fi.fta.geoviite.infra.geometry.Author
 import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.geometry.GeometryService
+import fi.fta.geoviite.infra.geometry.GeometryValidationIssue
 import fi.fta.geoviite.infra.geometry.PlanLayoutCache
 import fi.fta.geoviite.infra.geometry.PlanSource
 import fi.fta.geoviite.infra.geometry.Project
 import fi.fta.geoviite.infra.geometry.TransformationError
-import fi.fta.geoviite.infra.geometry.GeometryValidationIssue
 import fi.fta.geoviite.infra.geometry.getBoundingPolygonPointsFromAlignments
 import fi.fta.geoviite.infra.geometry.validate
 import fi.fta.geoviite.infra.localization.localizationParams
@@ -35,15 +35,18 @@ const val VALIDATION_LAYOUT_POINTS_RESOLUTION = 10
 
 val noFileValidationError = ParsingError(LocalizationKey(INFRAMODEL_PARSING_KEY_EMPTY))
 
-fun noFileValidationResponse(overrideParameters: OverrideParameters?) = ValidationResponse(
-    geometryValidationIssues = listOf(noFileValidationError),
-    geometryPlan = null,
-    planLayout = null,
-    source = overrideParameters?.source ?: PlanSource.GEOMETRIAPALVELU,
-)
+fun noFileValidationResponse(overrideParameters: OverrideParameters?) =
+    ValidationResponse(
+        geometryValidationIssues = listOf(noFileValidationError),
+        geometryPlan = null,
+        planLayout = null,
+        source = overrideParameters?.source ?: PlanSource.GEOMETRIAPALVELU,
+    )
 
 @GeoviiteService
-class InfraModelService @Autowired constructor(
+class InfraModelService
+@Autowired
+constructor(
     private val geometryService: GeometryService,
     private val layoutCache: PlanLayoutCache,
     private val geometryDao: GeometryDao,
@@ -55,8 +58,11 @@ class InfraModelService @Autowired constructor(
 ) {
 
     @Transactional
-    fun saveInfraModel(file: MultipartFile, overrides: OverrideParameters?, extraInfo: ExtraInfoParameters?) =
-        saveInfraModel(toInfraModelFile(file, overrides?.encoding?.charset), overrides, extraInfo)
+    fun saveInfraModel(
+        file: MultipartFile,
+        overrides: OverrideParameters?,
+        extraInfo: ExtraInfoParameters?
+    ) = saveInfraModel(toInfraModelFile(file, overrides?.encoding?.charset), overrides, extraInfo)
 
     @Transactional
     fun saveInfraModel(
@@ -65,9 +71,14 @@ class InfraModelService @Autowired constructor(
         extraInfo: ExtraInfoParameters?,
     ): RowVersion<GeometryPlan> {
         val geometryPlan = cleanMissingFeatureTypeCodes(parseInfraModel(file, overrides, extraInfo))
-        val transformedBoundingBox = geometryPlan.units.coordinateSystemSrid
-            ?.let { planSrid -> coordinateTransformationService.getTransformation(planSrid, LAYOUT_SRID) }
-            ?.let { transformation -> getBoundingPolygonPointsFromAlignments(geometryPlan.alignments, transformation) }
+        val transformedBoundingBox =
+            geometryPlan.units.coordinateSystemSrid
+                ?.let { planSrid ->
+                    coordinateTransformationService.getTransformation(planSrid, LAYOUT_SRID)
+                }
+                ?.let { transformation ->
+                    getBoundingPolygonPointsFromAlignments(geometryPlan.alignments, transformation)
+                }
 
         checkForDuplicateFile(file, geometryPlan.source)
 
@@ -79,15 +90,17 @@ class InfraModelService @Autowired constructor(
         overrides: OverrideParameters? = null,
         extraInfo: ExtraInfoParameters? = null,
     ): GeometryPlan {
-        val switchStructuresByType = switchLibraryService.getSwitchStructures().associateBy { it.type }
+        val switchStructuresByType =
+            switchLibraryService.getSwitchStructures().associateBy { it.type }
 
-        val parsed = parseInfraModelFile(
-            overrides?.source ?: PlanSource.GEOMETRIAPALVELU,
-            file,
-            geographyService.getCoordinateSystemNameToSridMapping(),
-            switchStructuresByType,
-            switchLibraryService.getInframodelAliases(),
-        )
+        val parsed =
+            parseInfraModelFile(
+                overrides?.source ?: PlanSource.GEOMETRIAPALVELU,
+                file,
+                geographyService.getCoordinateSystemNameToSridMapping(),
+                switchStructuresByType,
+                switchLibraryService.getInframodelAliases(),
+            )
         return overrideGeometryPlanWithParameters(parsed, overrides, extraInfo)
     }
 
@@ -108,18 +121,24 @@ class InfraModelService @Autowired constructor(
         return tryParsing(overrideParameters?.source) { validateInternal(file, overrideParameters) }
     }
 
-    private fun validateInternal(file: InfraModelFile, overrides: OverrideParameters?): ValidationResponse {
+    private fun validateInternal(
+        file: InfraModelFile,
+        overrides: OverrideParameters?
+    ): ValidationResponse {
         val geometryPlan = parseInfraModel(file, overrides)
         return validateAndTransformToLayoutPlan(geometryPlan)
     }
 
     private fun cleanMissingFeatureTypeCodes(plan: GeometryPlan): GeometryPlan {
         val codes = codeDictionaryService.getFeatureTypes().map(FeatureType::code)
-        val cleanedAlignments = plan.alignments.map { a ->
-            if (a.featureTypeCode != null && a.featureTypeCode !in codes) a.copy(featureTypeCode = null)
-            else a
-        }
-        return if (cleanedAlignments != plan.alignments) plan.copy(alignments = cleanedAlignments) else plan
+        val cleanedAlignments =
+            plan.alignments.map { a ->
+                if (a.featureTypeCode != null && a.featureTypeCode !in codes)
+                    a.copy(featureTypeCode = null)
+                else a
+            }
+        return if (cleanedAlignments != plan.alignments) plan.copy(alignments = cleanedAlignments)
+        else plan
     }
 
     @Transactional(readOnly = true)
@@ -128,18 +147,22 @@ class InfraModelService @Autowired constructor(
         overrideParameters: OverrideParameters?,
     ): ValidationResponse {
         val geometryPlan = geometryService.getGeometryPlan(planId)
-        val planWithParameters = overrideGeometryPlanWithParameters(geometryPlan, overrideParameters)
+        val planWithParameters =
+            overrideGeometryPlanWithParameters(geometryPlan, overrideParameters)
         return validateAndTransformToLayoutPlan(planWithParameters)
     }
 
     private fun validateAndTransformToLayoutPlan(plan: GeometryPlan): ValidationResponse {
-        val (planLayout: GeometryPlanLayout?, layoutCreationError: TransformationError?) = layoutCache.transformToLayoutPlan(
-            geometryPlan = plan,
-            includeGeometryData = true,
-            pointListStepLength = VALIDATION_LAYOUT_POINTS_RESOLUTION,
-        )
-        val validationIssues = validateGeometryPlanContent(plan) + listOfNotNull(layoutCreationError)
-        return ValidationResponse(validationIssues, plan, planLayout?.withLayoutGeometry(), plan.source)
+        val (planLayout: GeometryPlanLayout?, layoutCreationError: TransformationError?) =
+            layoutCache.transformToLayoutPlan(
+                geometryPlan = plan,
+                includeGeometryData = true,
+                pointListStepLength = VALIDATION_LAYOUT_POINTS_RESOLUTION,
+            )
+        val validationIssues =
+            validateGeometryPlanContent(plan) + listOfNotNull(layoutCreationError)
+        return ValidationResponse(
+            validationIssues, plan, planLayout?.withLayoutGeometry(), plan.source)
     }
 
     @Transactional
@@ -149,7 +172,9 @@ class InfraModelService @Autowired constructor(
         extraInfoParameters: ExtraInfoParameters?,
     ): RowVersion<GeometryPlan> {
         val geometryPlan = geometryService.getGeometryPlan(planId)
-        val overriddenPlan = overrideGeometryPlanWithParameters(geometryPlan, overrideParameters, extraInfoParameters)
+        val overriddenPlan =
+            overrideGeometryPlanWithParameters(
+                geometryPlan, overrideParameters, extraInfoParameters)
 
         if (overriddenPlan.source != geometryPlan.source) {
             checkForDuplicateFile(geometryService.getPlanFile(planId), overriddenPlan.source)
@@ -164,30 +189,39 @@ class InfraModelService @Autowired constructor(
         extraInfoParameters: ExtraInfoParameters? = null,
     ): GeometryPlan {
         val planProject =
-            if (overrideParameters?.projectId is IntId<Project>) geometryDao.getProject(overrideParameters.projectId)
+            if (overrideParameters?.projectId is IntId<Project>)
+                geometryDao.getProject(overrideParameters.projectId)
             else geometryDao.findProject(plan.project.name) ?: plan.project
 
         val planAuthor =
-            if (overrideParameters?.authorId is IntId<Author>) geometryDao.getAuthor(overrideParameters.authorId)
+            if (overrideParameters?.authorId is IntId<Author>)
+                geometryDao.getAuthor(overrideParameters.authorId)
             else plan.author?.let { author -> geometryDao.findAuthor(author.companyName) ?: author }
 
-        val application = geometryDao.findApplication(plan.application.name, plan.application.version)
-            ?: plan.application
+        val application =
+            geometryDao.findApplication(plan.application.name, plan.application.version)
+                ?: plan.application
 
-        val overrideCs = overrideParameters?.coordinateSystemSrid?.let(geographyService::getCoordinateSystem)
+        val overrideCs =
+            overrideParameters?.coordinateSystemSrid?.let(geographyService::getCoordinateSystem)
 
-        val messageWithNormalizedLinebreaks = extraInfoParameters
-            ?.message?.let { normalizeLinebreaksToUnixFormat(extraInfoParameters.message) }
+        val messageWithNormalizedLinebreaks =
+            extraInfoParameters?.message?.let {
+                normalizeLinebreaksToUnixFormat(extraInfoParameters.message)
+            }
 
-        // Nullable fields that do not contain a default parameter via the elvis-operator are considered to be assignable
+        // Nullable fields that do not contain a default parameter via the elvis-operator are
+        // considered to be assignable
         // to null even if they have non-null values stored in the database.
         return plan.copy(
-            units = plan.units.copy(
-                coordinateSystemSrid = overrideCs?.srid ?: plan.units.coordinateSystemSrid,
-                coordinateSystemName = overrideCs?.name ?: plan.units.coordinateSystemName,
-                verticalCoordinateSystem = overrideParameters?.verticalCoordinateSystem
-                    ?: plan.units.verticalCoordinateSystem,
-            ),
+            units =
+                plan.units.copy(
+                    coordinateSystemSrid = overrideCs?.srid ?: plan.units.coordinateSystemSrid,
+                    coordinateSystemName = overrideCs?.name ?: plan.units.coordinateSystemName,
+                    verticalCoordinateSystem =
+                        overrideParameters?.verticalCoordinateSystem
+                            ?: plan.units.verticalCoordinateSystem,
+                ),
             trackNumber = overrideParameters?.trackNumber ?: plan.trackNumber,
             project = planProject,
             author = planAuthor,
@@ -203,7 +237,9 @@ class InfraModelService @Autowired constructor(
         )
     }
 
-    private fun validateGeometryPlanContent(geometryPlan: GeometryPlan): List<GeometryValidationIssue> {
+    private fun validateGeometryPlanContent(
+        geometryPlan: GeometryPlan
+    ): List<GeometryValidationIssue> {
         return validate(
             geometryPlan,
             codeDictionaryService.getFeatureTypes(),
@@ -216,7 +252,8 @@ class InfraModelService @Autowired constructor(
         geometryService.fetchDuplicateGeometryPlanHeader(planFile, source)?.also { duplicate ->
             throw InframodelParsingException(
                 message = "InfraModel file exists already",
-                localizedMessageKey = "$INFRAMODEL_PARSING_KEY_PARENT.duplicate-inframodel-file-content",
+                localizedMessageKey =
+                    "$INFRAMODEL_PARSING_KEY_PARENT.duplicate-inframodel-file-content",
                 localizedMessageParams = localizationParams("fileName" to duplicate.fileName),
             )
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/PlanElementName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/PlanElementName.kt
@@ -3,13 +3,14 @@ package fi.fta.geoviite.infra.inframodel
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.util.assertSanitized
 
-
 val elementNameLength = 0..100
 val elementNameRegex = Regex("^[A-Za-zÄÖÅäöå0-9 \\-+_/!?§]*\$")
 
 data class PlanElementName(val value: String) : CharSequence by value {
-    init { assertSanitized<PlanElementName>(value, elementNameRegex, elementNameLength, allowBlank = true) }
+    init {
+        assertSanitized<PlanElementName>(
+            value, elementNameRegex, elementNameLength, allowBlank = true)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/StringParsing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/StringParsing.kt
@@ -11,6 +11,7 @@ val missingNumericValues = listOf("NaN", "N/A", "null", "?", "").map { v -> v.up
 const val FIELD_DATA_SEPARATOR = "\\s+"
 
 fun isMissingNumeric(value: String) = missingNumericValues.any { v -> v == value.uppercase() }
+
 fun isMissingEnum(value: String) = missingEnumValues.any { v -> v == value.uppercase() }
 
 fun parseOptionalBigDecimal(name: String, value: String): BigDecimal? =
@@ -22,14 +23,12 @@ fun parseBigDecimal(name: String, value: String): BigDecimal =
 fun parseOptionalDouble(name: String, value: String): Double? =
     if (isMissingNumeric(value)) null else parseDouble(name, value)
 
-fun parseDouble(name: String, value: String): Double =
-    parseMandatory(name, value, String::toDouble)
+fun parseDouble(name: String, value: String): Double = parseMandatory(name, value, String::toDouble)
 
 fun parseOptionalInt(name: String, value: String): Int? =
     if (isMissingNumeric(value)) null else parseInt(name, value)
 
-fun parseInt(name: String, value: String): Int =
-    parseMandatory(name, value, String::toInt)
+fun parseInt(name: String, value: String): Int = parseMandatory(name, value, String::toInt)
 
 fun splitStringOnSpaces(string: String): List<String> =
     string.trim().split(Regex(FIELD_DATA_SEPARATOR))
@@ -49,7 +48,8 @@ inline fun <reified T> parseMandatory(name: String, value: String, function: (St
         return function(value)
     } catch (e: Exception) {
         throw InputValidationException(
-            message = "Cannot parse ${formatForException(name)} from value ${formatForException(value)}",
+            message =
+                "Cannot parse ${formatForException(name)} from value ${formatForException(value)}",
             type = T::class,
             value = value,
             cause = e,
@@ -57,16 +57,20 @@ inline fun <reified T> parseMandatory(name: String, value: String, function: (St
     }
 }
 
-// U+FFFD � REPLACEMENT CHARACTER used to replace an unknown, unrecognized, or unrepresentable character
+// U+FFFD � REPLACEMENT CHARACTER used to replace an unknown, unrecognized, or unrepresentable
+// character
 const val REPLACEMENT_CHAR = '�'
-inline fun <reified T> tryParseText(text: String, toTyped: (string: String) -> T) = try {
-    if (text.contains(REPLACEMENT_CHAR)) {
-        logger.warn("${T::class.simpleName} string ${formatForLog(text)} contains UTF-8 replacement char.")
-        toTyped(text.filter { c -> c != REPLACEMENT_CHAR })
-    } else {
-        toTyped(text)
+
+inline fun <reified T> tryParseText(text: String, toTyped: (string: String) -> T) =
+    try {
+        if (text.contains(REPLACEMENT_CHAR)) {
+            logger.warn(
+                "${T::class.simpleName} string ${formatForLog(text)} contains UTF-8 replacement char.")
+            toTyped(text.filter { c -> c != REPLACEMENT_CHAR })
+        } else {
+            toTyped(text)
+        }
+    } catch (e: InputValidationException) {
+        logger.warn("Failed to parse ${T::class.simpleName} from string: ${e.message}")
+        null
     }
-} catch (e: InputValidationException) {
-    logger.warn("Failed to parse ${T::class.simpleName} from string: ${e.message}")
-    null
-}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/AddressChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/AddressChangesService.kt
@@ -10,8 +10,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 
 fun addressPointsAreEqual(point1: AddressPoint?, point2: AddressPoint?): Boolean =
     if (point1 == null && point2 == null) true
-    else if (point1 == null || point2 == null) false
-    else point1.isSame(point2)
+    else if (point1 == null || point2 == null) false else point1.isSame(point2)
 
 fun resolveChangedGeometryKilometers(
     originalAddresses: AlignmentAddresses?,
@@ -67,6 +66,7 @@ data class AddressChanges(
     companion object {
         fun empty() = AddressChanges(setOf(), startPointChanged = false, endPointChanged = false)
     }
+
     fun isChanged() = changedKmNumbers.isNotEmpty() || startPointChanged || endPointChanged
 }
 
@@ -88,7 +88,10 @@ class AddressChangesService(val geocodingService: GeocodingService) {
             )
         }
 
-    private fun getAddresses(track: LocationTrack?, contextKey: GeocodingContextCacheKey?): AlignmentAddresses? =
+    private fun getAddresses(
+        track: LocationTrack?,
+        contextKey: GeocodingContextCacheKey?
+    ): AlignmentAddresses? =
         if (track == null || contextKey == null || !track.exists) null
         else geocodingService.getAddressPoints(contextKey, track.getAlignmentVersionOrThrow())
 }
@@ -96,8 +99,10 @@ class AddressChangesService(val geocodingService: GeocodingService) {
 fun getAddressChanges(
     oldAddresses: AlignmentAddresses?,
     newAddresses: AlignmentAddresses?,
-) = AddressChanges(
-    changedKmNumbers = resolveChangedGeometryKilometers(oldAddresses, newAddresses),
-    startPointChanged = !addressPointsAreEqual(oldAddresses?.startPoint, newAddresses?.startPoint),
-    endPointChanged = !addressPointsAreEqual(oldAddresses?.endPoint, newAddresses?.endPoint),
-)
+) =
+    AddressChanges(
+        changedKmNumbers = resolveChangedGeometryKilometers(oldAddresses, newAddresses),
+        startPointChanged =
+            !addressPointsAreEqual(oldAddresses?.startPoint, newAddresses?.startPoint),
+        endPointChanged = !addressPointsAreEqual(oldAddresses?.endPoint, newAddresses?.endPoint),
+    )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -57,12 +57,12 @@ data class LocationTrackChange(
         fun create(
             locationTrackId: IntId<LocationTrack>,
             addressChanges: AddressChanges?,
-        ) = LocationTrackChange(
-            locationTrackId = locationTrackId,
-            changedKmNumbers = addressChanges?.changedKmNumbers ?: emptySet(),
-            isStartChanged = addressChanges?.startPointChanged ?: true,
-            isEndChanged = addressChanges?.endPointChanged ?: true
-        )
+        ) =
+            LocationTrackChange(
+                locationTrackId = locationTrackId,
+                changedKmNumbers = addressChanges?.changedKmNumbers ?: emptySet(),
+                isStartChanged = addressChanges?.startPointChanged ?: true,
+                isEndChanged = addressChanges?.endPointChanged ?: true)
     }
 }
 
@@ -104,38 +104,39 @@ data class CalculatedChanges(
         checkDuplicates(
             directChanges.kmPostChanges,
             { it },
-            "Duplicate km posts in direct changes, directChanges=${directChanges.kmPostChanges}"
-        )
+            "Duplicate km posts in direct changes, directChanges=${directChanges.kmPostChanges}")
 
         checkDuplicates(
             directChanges.referenceLineChanges,
             { it },
-            "Duplicate reference lines in direct changes, directChanges=${directChanges.referenceLineChanges}"
-        )
+            "Duplicate reference lines in direct changes, directChanges=${directChanges.referenceLineChanges}")
 
-        val trackNumberChanges = (directChanges.trackNumberChanges + indirectChanges.trackNumberChanges)
+        val trackNumberChanges =
+            (directChanges.trackNumberChanges + indirectChanges.trackNumberChanges)
         checkDuplicates(
             trackNumberChanges,
             { it.trackNumberId },
-            "Duplicate track numbers in direct and indirect changes, directChanges=${directChanges.trackNumberChanges} indirectChanges=${indirectChanges.trackNumberChanges}"
-        )
+            "Duplicate track numbers in direct and indirect changes, directChanges=${directChanges.trackNumberChanges} indirectChanges=${indirectChanges.trackNumberChanges}")
 
-        val locationTrackChanges = (directChanges.locationTrackChanges + indirectChanges.locationTrackChanges)
+        val locationTrackChanges =
+            (directChanges.locationTrackChanges + indirectChanges.locationTrackChanges)
         checkDuplicates(
             locationTrackChanges,
             { it.locationTrackId },
-            "Duplicate location tracks in direct and indirect changes, directChanges=${directChanges.locationTrackChanges} indirectChanges=${indirectChanges.locationTrackChanges}"
-        )
+            "Duplicate location tracks in direct and indirect changes, directChanges=${directChanges.locationTrackChanges} indirectChanges=${indirectChanges.locationTrackChanges}")
 
         val switchChanges = (directChanges.switchChanges + indirectChanges.switchChanges)
         checkDuplicates(
             switchChanges,
             { it.switchId },
-            "Duplicate switches in direct and indirect changes, directChanges=${directChanges.switchChanges} indirectChanges=${indirectChanges.switchChanges}"
-        )
+            "Duplicate switches in direct and indirect changes, directChanges=${directChanges.switchChanges} indirectChanges=${indirectChanges.switchChanges}")
     }
 
-    private fun <T, R> checkDuplicates(changes: Collection<T>, groupingBy: (v: T) -> R, message: String) {
+    private fun <T, R> checkDuplicates(
+        changes: Collection<T>,
+        groupingBy: (v: T) -> R,
+        message: String
+    ) {
         check(changes.groupingBy(groupingBy).eachCount().all { it.value == 1 }) { message }
     }
 }
@@ -160,71 +161,91 @@ class CalculatedChangesService(
     fun getCalculatedChanges(versions: ValidationVersions): CalculatedChanges {
         val changeContext = createChangeContext(versions)
 
-        val (trackNumberChanges, changedLocationTrackIdsByTrackNumbers) = calculateTrackNumberChanges(
-            versions.trackNumbers.map { it.officialId },
-            changeContext,
-        )
+        val (trackNumberChanges, changedLocationTrackIdsByTrackNumbers) =
+            calculateTrackNumberChanges(
+                versions.trackNumbers.map { it.officialId },
+                changeContext,
+            )
 
-        val kPRLTrackNumberIds = (versions.kmPosts.mapNotNull { v ->
-            kmPostDao.fetch(v.validatedAssetVersion).trackNumberId
-        } + versions.referenceLines.map { v ->
-            referenceLineDao.fetch(v.validatedAssetVersion).trackNumberId
-        }).distinct()
+        val kPRLTrackNumberIds =
+            (versions.kmPosts.mapNotNull { v ->
+                    kmPostDao.fetch(v.validatedAssetVersion).trackNumberId
+                } +
+                    versions.referenceLines.map { v ->
+                        referenceLineDao.fetch(v.validatedAssetVersion).trackNumberId
+                    })
+                .distinct()
 
-        val (kPRLTrackNumberChanges, changedLocationTrackIdsByKPRL) = calculateTrackNumberChanges(
-            kPRLTrackNumberIds,
-            changeContext,
-        )
+        val (kPRLTrackNumberChanges, changedLocationTrackIdsByKPRL) =
+            calculateTrackNumberChanges(
+                kPRLTrackNumberIds,
+                changeContext,
+            )
 
-        val directLocationTrackChanges = calculateLocationTrackChanges(
-            versions.locationTracks.map { v -> v.officialId },
-            changeContext,
-        )
+        val directLocationTrackChanges =
+            calculateLocationTrackChanges(
+                versions.locationTracks.map { v -> v.officialId },
+                changeContext,
+            )
 
-        val locationTrackChangesByTrackNumbers = calculateLocationTrackChanges(
-            (changedLocationTrackIdsByTrackNumbers + changedLocationTrackIdsByKPRL).distinct(),
-            changeContext,
-        )
+        val locationTrackChangesByTrackNumbers =
+            calculateLocationTrackChanges(
+                (changedLocationTrackIdsByTrackNumbers + changedLocationTrackIdsByKPRL).distinct(),
+                changeContext,
+            )
 
         val directSwitchChanges = asDirectSwitchChanges(versions.switches.map { v -> v.officialId })
 
-        val (switchChangesByLocationTracks, locationTrackChangesBySwitches) = getSwitchChangesByGeometryChanges(
-            mergeLocationTrackChanges(directLocationTrackChanges, locationTrackChangesByTrackNumbers),
-            changeContext,
-        )
+        val (switchChangesByLocationTracks, locationTrackChangesBySwitches) =
+            getSwitchChangesByGeometryChanges(
+                mergeLocationTrackChanges(
+                    directLocationTrackChanges, locationTrackChangesByTrackNumbers),
+                changeContext,
+            )
 
-        val (indirectDirectTrackNumberChanges, indirectTrackNumberChanges) = kPRLTrackNumberChanges.partition { indirectChange ->
-            trackNumberChanges.any { indirectChange.trackNumberId == it.trackNumberId }
-        }
+        val (indirectDirectTrackNumberChanges, indirectTrackNumberChanges) =
+            kPRLTrackNumberChanges.partition { indirectChange ->
+                trackNumberChanges.any { indirectChange.trackNumberId == it.trackNumberId }
+            }
 
-        val (indirectDirectLocationTrackChanges, indirectLocationTrackChanges) = mergeLocationTrackChanges(
-            locationTrackChangesByTrackNumbers,
-            locationTrackChangesBySwitches,
-        ).partition { indirectChange ->
-            directLocationTrackChanges.any { indirectChange.locationTrackId == it.locationTrackId }
-        }
+        val (indirectDirectLocationTrackChanges, indirectLocationTrackChanges) =
+            mergeLocationTrackChanges(
+                    locationTrackChangesByTrackNumbers,
+                    locationTrackChangesBySwitches,
+                )
+                .partition { indirectChange ->
+                    directLocationTrackChanges.any {
+                        indirectChange.locationTrackId == it.locationTrackId
+                    }
+                }
 
-        val (indirectDirectSwitchChanges, indirectSwitchChanges) = switchChangesByLocationTracks.partition { indirectChange ->
-            directSwitchChanges.any { indirectChange.switchId == it.switchId }
-        }
+        val (indirectDirectSwitchChanges, indirectSwitchChanges) =
+            switchChangesByLocationTracks.partition { indirectChange ->
+                directSwitchChanges.any { indirectChange.switchId == it.switchId }
+            }
 
         return CalculatedChanges(
-            directChanges = DirectChanges(
-                kmPostChanges = versions.kmPosts.map { it.officialId },
-                referenceLineChanges = versions.referenceLines.map { it.officialId },
-                trackNumberChanges = mergeTrackNumberChanges(trackNumberChanges, indirectDirectTrackNumberChanges),
-                locationTrackChanges = mergeLocationTrackChanges(
-                    directLocationTrackChanges,
-                    indirectDirectLocationTrackChanges,
+            directChanges =
+                DirectChanges(
+                    kmPostChanges = versions.kmPosts.map { it.officialId },
+                    referenceLineChanges = versions.referenceLines.map { it.officialId },
+                    trackNumberChanges =
+                        mergeTrackNumberChanges(
+                            trackNumberChanges, indirectDirectTrackNumberChanges),
+                    locationTrackChanges =
+                        mergeLocationTrackChanges(
+                            directLocationTrackChanges,
+                            indirectDirectLocationTrackChanges,
+                        ),
+                    switchChanges =
+                        mergeSwitchChanges(directSwitchChanges, indirectDirectSwitchChanges),
                 ),
-                switchChanges = mergeSwitchChanges(directSwitchChanges, indirectDirectSwitchChanges),
-            ),
-            indirectChanges = IndirectChanges(
-                locationTrackChanges = indirectLocationTrackChanges,
-                switchChanges = indirectSwitchChanges,
-                trackNumberChanges = indirectTrackNumberChanges,
-            )
-        )
+            indirectChanges =
+                IndirectChanges(
+                    locationTrackChanges = indirectLocationTrackChanges,
+                    switchChanges = indirectSwitchChanges,
+                    trackNumberChanges = indirectTrackNumberChanges,
+                ))
     }
 
     fun getAllSwitchChangesByLocationTrackAtMoment(
@@ -232,41 +253,48 @@ class CalculatedChangesService(
         locationTrackId: IntId<LocationTrack>,
         moment: Instant,
     ): List<SwitchChange> {
-        val (locationTrack, alignment) = locationTrackService.getOfficialWithAlignmentAtMoment(layoutBranch, locationTrackId, moment)
-            ?: throw NoSuchEntityException(LocationTrack::class, locationTrackId)
+        val (locationTrack, alignment) =
+            locationTrackService.getOfficialWithAlignmentAtMoment(
+                layoutBranch, locationTrackId, moment)
+                ?: throw NoSuchEntityException(LocationTrack::class, locationTrackId)
 
         val trackNumberId = locationTrack.trackNumberId
-        val trackNumber = trackNumberService.getOfficialAtMoment(layoutBranch, trackNumberId, moment)
-            ?: throw NoSuchEntityException(TrackLayoutTrackNumber::class, trackNumberId)
+        val trackNumber =
+            trackNumberService.getOfficialAtMoment(layoutBranch, trackNumberId, moment)
+                ?: throw NoSuchEntityException(TrackLayoutTrackNumber::class, trackNumberId)
 
-        val currentGeocodingContext = geocodingService.getGeocodingContextAtMoment(layoutBranch, trackNumberId, moment)
+        val currentGeocodingContext =
+            geocodingService.getGeocodingContextAtMoment(layoutBranch, trackNumberId, moment)
 
-        val switches = currentGeocodingContext?.let { context ->
-            getSwitchJointChanges(
-                locationTrack = locationTrack,
-                alignment = alignment,
-                geocodingContext = context,
-                fetchSwitch = { switchId -> switchService.getOfficialAtMoment(layoutBranch, switchId, moment) },
-                fetchStructure = switchLibraryService::getSwitchStructure,
-            )
-        } ?: emptyList()
+        val switches =
+            currentGeocodingContext?.let { context ->
+                getSwitchJointChanges(
+                    locationTrack = locationTrack,
+                    alignment = alignment,
+                    geocodingContext = context,
+                    fetchSwitch = { switchId ->
+                        switchService.getOfficialAtMoment(layoutBranch, switchId, moment)
+                    },
+                    fetchStructure = switchLibraryService::getSwitchStructure,
+                )
+            } ?: emptyList()
 
         return switches.map { (switch, changeData) ->
             SwitchChange(
                 switchId = switch,
-                changedJoints = changeData.map { change ->
-                    SwitchJointChange(
-                        number = change.joint.number,
-                        isRemoved = false,
-                        address = change.address,
-                        point = change.point.toPoint(),
-                        locationTrackId = locationTrackId,
-                        locationTrackExternalId = locationTrack.externalId,
-                        trackNumberId = trackNumberId,
-                        trackNumberExternalId = trackNumber.externalId,
-                    )
-                }
-            )
+                changedJoints =
+                    changeData.map { change ->
+                        SwitchJointChange(
+                            number = change.joint.number,
+                            isRemoved = false,
+                            address = change.address,
+                            point = change.point.toPoint(),
+                            locationTrackId = locationTrackId,
+                            locationTrackExternalId = locationTrack.externalId,
+                            trackNumberId = trackNumberId,
+                            trackNumberExternalId = trackNumber.externalId,
+                        )
+                    })
         }
     }
 
@@ -274,7 +302,8 @@ class CalculatedChangesService(
         trackNumberIds: Collection<IntId<TrackLayoutTrackNumber>>,
         changeContext: ChangeContext,
     ): Pair<List<TrackNumberChange>, List<IntId<LocationTrack>>> {
-        val (tnChanges, affectedTracks) = trackNumberIds.map { id -> getTrackNumberChange(id, changeContext) }.unzip()
+        val (tnChanges, affectedTracks) =
+            trackNumberIds.map { id -> getTrackNumberChange(id, changeContext) }.unzip()
         return tnChanges to affectedTracks.flatten().distinct()
     }
 
@@ -284,133 +313,159 @@ class CalculatedChangesService(
     ): Pair<TrackNumberChange, List<IntId<LocationTrack>>> {
         val beforeContext = changeContext.getGeocodingContextBefore(trackNumberId)
         val afterContext = changeContext.getGeocodingContextAfter(trackNumberId)
-        val addressChanges = getAddressChanges(
-            beforeContext?.referenceLineAddresses,
-            afterContext?.referenceLineAddresses,
-        )
-        val trackNumberChange = TrackNumberChange(
-            trackNumberId = trackNumberId,
-            changedKmNumbers = addressChanges.changedKmNumbers,
-            isStartChanged = addressChanges.startPointChanged,
-            isEndChanged = addressChanges.endPointChanged,
-        )
-        // Affected tracks are those that aren't directly changed, but are changed by the geocoding context change
-        // That is: all those that used the former one as ones that started using new context must have changed anyhow
-        val affectedTracks = beforeContext?.let { context ->
-            calculateOverlappingLocationTracks(
-                geocodingContext = context,
-                kilometers = addressChanges.changedKmNumbers,
-                locationTracks = changeContext.getTrackNumberTracksBefore(trackNumberId)
-                    .map(locationTrackService::getWithAlignment),
+        val addressChanges =
+            getAddressChanges(
+                beforeContext?.referenceLineAddresses,
+                afterContext?.referenceLineAddresses,
             )
-        } ?: listOf()
+        val trackNumberChange =
+            TrackNumberChange(
+                trackNumberId = trackNumberId,
+                changedKmNumbers = addressChanges.changedKmNumbers,
+                isStartChanged = addressChanges.startPointChanged,
+                isEndChanged = addressChanges.endPointChanged,
+            )
+        // Affected tracks are those that aren't directly changed, but are changed by the geocoding
+        // context change
+        // That is: all those that used the former one as ones that started using new context must
+        // have changed anyhow
+        val affectedTracks =
+            beforeContext?.let { context ->
+                calculateOverlappingLocationTracks(
+                    geocodingContext = context,
+                    kilometers = addressChanges.changedKmNumbers,
+                    locationTracks =
+                        changeContext
+                            .getTrackNumberTracksBefore(trackNumberId)
+                            .map(locationTrackService::getWithAlignment),
+                )
+            } ?: listOf()
         return trackNumberChange to affectedTracks
     }
 
     private fun calculateLocationTrackChanges(
         trackIds: Collection<IntId<LocationTrack>>,
         changeContext: ChangeContext,
-    ) = trackIds.map { trackId ->
-        val trackBefore = changeContext.locationTracks.getBefore(trackId)
-        val trackAfter = changeContext.locationTracks.getAfter(trackId)
-        val addressChanges = addressChangesService.getAddressChanges(
-            beforeTrack = trackBefore,
-            afterTrack = trackAfter,
-            beforeContextKey = trackBefore?.let { t -> changeContext.geocodingKeysBefore[t.trackNumberId] },
-            afterContextKey = changeContext.geocodingKeysAfter[trackAfter.trackNumberId],
-        )
-        LocationTrackChange.create(trackId, addressChanges)
-    }
+    ) =
+        trackIds.map { trackId ->
+            val trackBefore = changeContext.locationTracks.getBefore(trackId)
+            val trackAfter = changeContext.locationTracks.getAfter(trackId)
+            val addressChanges =
+                addressChangesService.getAddressChanges(
+                    beforeTrack = trackBefore,
+                    afterTrack = trackAfter,
+                    beforeContextKey =
+                        trackBefore?.let { t ->
+                            changeContext.geocodingKeysBefore[t.trackNumberId]
+                        },
+                    afterContextKey = changeContext.geocodingKeysAfter[trackAfter.trackNumberId],
+                )
+            LocationTrackChange.create(trackId, addressChanges)
+        }
 
     private fun getSwitchChangesByLocationTrack(
         trackId: IntId<LocationTrack>,
         changeContext: ChangeContext,
     ): List<SwitchChange> {
-        val (oldLocationTrack, oldAlignment) = changeContext.locationTracks.beforeVersion(trackId)
-            ?.let(locationTrackService::getWithAlignment) ?: (null to null)
+        val (oldLocationTrack, oldAlignment) =
+            changeContext.locationTracks
+                .beforeVersion(trackId)
+                ?.let(locationTrackService::getWithAlignment) ?: (null to null)
 
-        val (newLocationTrack, newAlignment) = changeContext.locationTracks.afterVersion(trackId)
-            .let(locationTrackService::getWithAlignment)
+        val (newLocationTrack, newAlignment) =
+            changeContext.locationTracks
+                .afterVersion(trackId)
+                .let(locationTrackService::getWithAlignment)
 
-        val oldTrackNumber = oldLocationTrack?.let { track ->
-            changeContext.trackNumbers.getBefore(track.trackNumberId)
-        }
-
-        val newTrackNumber = newLocationTrack.let { track ->
-            changeContext.trackNumbers.getAfterIfExists(track.trackNumberId)
-        }
-
-        val oldGeocodingContext = oldLocationTrack?.trackNumberId?.let { tnId ->
-            changeContext.getGeocodingContextBefore(tnId)
-        }
-
-        val newGeocodingContext = newLocationTrack.trackNumberId.let { tnId ->
-            changeContext.getGeocodingContextAfter(tnId)
-        }
-
-        val oldSwitches = oldAlignment?.let { alignment ->
-            oldGeocodingContext?.let { geocodingContext ->
-                getSwitchJointChanges(
-                    locationTrack = oldLocationTrack,
-                    alignment = alignment,
-                    geocodingContext = geocodingContext,
-                    fetchSwitch = changeContext.switches::getBefore,
-                    fetchStructure = switchLibraryService::getSwitchStructure,
-                )
+        val oldTrackNumber =
+            oldLocationTrack?.let { track ->
+                changeContext.trackNumbers.getBefore(track.trackNumberId)
             }
-        } ?: emptyList()
 
-        val newSwitches = newGeocodingContext?.let { context ->
-            getSwitchJointChanges(
-                locationTrack = newLocationTrack,
-                alignment = newAlignment,
-                geocodingContext = context,
-                fetchSwitch = changeContext.switches::getAfterIfExists,
-                fetchStructure = switchLibraryService::getSwitchStructure,
-            )
-        } ?: emptyList()
-
-        val deletedSwitches = findSwitchJointDifferences(oldSwitches, newSwitches) { switch, joint, _ ->
-            switch.joint.number == joint.number
-        }.mapNotNull { switch ->
-            oldLocationTrack?.let {
-                SwitchChange(
-                    switchId = switch.first,
-                    changedJoints = switch.second.map { changeData ->
-                        SwitchJointChange(
-                            number = changeData.joint.number,
-                            isRemoved = true,
-                            address = changeData.address,
-                            point = changeData.point.toPoint(),
-                            locationTrackId = oldLocationTrack.id as IntId,
-                            locationTrackExternalId = oldLocationTrack.externalId,
-                            trackNumberId = oldLocationTrack.trackNumberId,
-                            trackNumberExternalId = oldTrackNumber?.externalId,
-                        )
-                    }
-                )
+        val newTrackNumber =
+            newLocationTrack.let { track ->
+                changeContext.trackNumbers.getAfterIfExists(track.trackNumberId)
             }
-        }
 
-        val changedSwitches = findSwitchJointDifferences(newSwitches, oldSwitches) { switch, joint, address ->
-            switch.joint == joint && switch.address == address
-        }.map { switch ->
-            SwitchChange(
-                switchId = switch.first,
-                changedJoints = switch.second.map { changeData ->
-                    SwitchJointChange(
-                        number = changeData.joint.number,
-                        isRemoved = false,
-                        address = changeData.address,
-                        point = changeData.point.toPoint(),
-                        locationTrackId = newLocationTrack.id as IntId,
-                        locationTrackExternalId = newLocationTrack.externalId,
-                        trackNumberId = newLocationTrack.trackNumberId,
-                        trackNumberExternalId = newTrackNumber?.externalId,
+        val oldGeocodingContext =
+            oldLocationTrack?.trackNumberId?.let { tnId ->
+                changeContext.getGeocodingContextBefore(tnId)
+            }
+
+        val newGeocodingContext =
+            newLocationTrack.trackNumberId.let { tnId ->
+                changeContext.getGeocodingContextAfter(tnId)
+            }
+
+        val oldSwitches =
+            oldAlignment?.let { alignment ->
+                oldGeocodingContext?.let { geocodingContext ->
+                    getSwitchJointChanges(
+                        locationTrack = oldLocationTrack,
+                        alignment = alignment,
+                        geocodingContext = geocodingContext,
+                        fetchSwitch = changeContext.switches::getBefore,
+                        fetchStructure = switchLibraryService::getSwitchStructure,
                     )
                 }
-            )
-        }
+            } ?: emptyList()
+
+        val newSwitches =
+            newGeocodingContext?.let { context ->
+                getSwitchJointChanges(
+                    locationTrack = newLocationTrack,
+                    alignment = newAlignment,
+                    geocodingContext = context,
+                    fetchSwitch = changeContext.switches::getAfterIfExists,
+                    fetchStructure = switchLibraryService::getSwitchStructure,
+                )
+            } ?: emptyList()
+
+        val deletedSwitches =
+            findSwitchJointDifferences(oldSwitches, newSwitches) { switch, joint, _ ->
+                    switch.joint.number == joint.number
+                }
+                .mapNotNull { switch ->
+                    oldLocationTrack?.let {
+                        SwitchChange(
+                            switchId = switch.first,
+                            changedJoints =
+                                switch.second.map { changeData ->
+                                    SwitchJointChange(
+                                        number = changeData.joint.number,
+                                        isRemoved = true,
+                                        address = changeData.address,
+                                        point = changeData.point.toPoint(),
+                                        locationTrackId = oldLocationTrack.id as IntId,
+                                        locationTrackExternalId = oldLocationTrack.externalId,
+                                        trackNumberId = oldLocationTrack.trackNumberId,
+                                        trackNumberExternalId = oldTrackNumber?.externalId,
+                                    )
+                                })
+                    }
+                }
+
+        val changedSwitches =
+            findSwitchJointDifferences(newSwitches, oldSwitches) { switch, joint, address ->
+                    switch.joint == joint && switch.address == address
+                }
+                .map { switch ->
+                    SwitchChange(
+                        switchId = switch.first,
+                        changedJoints =
+                            switch.second.map { changeData ->
+                                SwitchJointChange(
+                                    number = changeData.joint.number,
+                                    isRemoved = false,
+                                    address = changeData.address,
+                                    point = changeData.point.toPoint(),
+                                    locationTrackId = newLocationTrack.id as IntId,
+                                    locationTrackExternalId = newLocationTrack.externalId,
+                                    trackNumberId = newLocationTrack.trackNumberId,
+                                    trackNumberExternalId = newTrackNumber?.externalId,
+                                )
+                            })
+                }
 
         return (deletedSwitches + changedSwitches)
             .filter { it.changedJoints.isNotEmpty() }
@@ -423,60 +478,77 @@ class CalculatedChangesService(
         locationTracksChanges: Collection<LocationTrackChange>,
         changeContext: ChangeContext,
     ): Pair<List<SwitchChange>, List<LocationTrackChange>> {
-        val switchChanges = mergeSwitchChanges(
-            locationTracksChanges
-                .flatMap { locationTrackChange ->
-                    getSwitchChangesByLocationTrack(locationTrackChange.locationTrackId, changeContext)
-                }.filter { switchChange ->
-                    switchChange.changedJoints.isNotEmpty()
-                }
-        )
+        val switchChanges =
+            mergeSwitchChanges(
+                locationTracksChanges
+                    .flatMap { locationTrackChange ->
+                        getSwitchChangesByLocationTrack(
+                            locationTrackChange.locationTrackId, changeContext)
+                    }
+                    .filter { switchChange -> switchChange.changedJoints.isNotEmpty() })
 
-        val locationTrackGeometryChanges = locationTracksChanges.map { locationTrackChange ->
-            val locationTrackJointChanges = switchChanges.flatMap { switchChange ->
-                switchChange.changedJoints
-                    .filterNot { it.isRemoved }
-                    .filter { cj -> cj.locationTrackId == locationTrackChange.locationTrackId }
+        val locationTrackGeometryChanges =
+            locationTracksChanges.map { locationTrackChange ->
+                val locationTrackJointChanges =
+                    switchChanges.flatMap { switchChange ->
+                        switchChange.changedJoints
+                            .filterNot { it.isRemoved }
+                            .filter { cj ->
+                                cj.locationTrackId == locationTrackChange.locationTrackId
+                            }
+                    }
+
+                val locationTrack =
+                    changeContext.locationTracks.getAfter(locationTrackChange.locationTrackId)
+                val geocodingCacheKey =
+                    changeContext.geocodingKeysAfter[locationTrack.trackNumberId]
+                val addresses =
+                    geocodingCacheKey?.let { cacheKey ->
+                        geocodingService.getAddressPoints(
+                            cacheKey, locationTrack.getAlignmentVersionOrThrow())
+                    }
+
+                LocationTrackChange(
+                    locationTrackId = locationTrackChange.locationTrackId,
+                    changedKmNumbers =
+                        locationTrackJointChanges.map { it.address.kmNumber }.toSet(),
+                    isStartChanged =
+                        locationTrackJointChanges.any { change ->
+                            addresses?.startPoint?.address?.isSame(change.address) == true
+                        },
+                    isEndChanged =
+                        locationTrackJointChanges.any { change ->
+                            addresses?.endPoint?.address?.isSame(change.address) == true
+                        },
+                )
             }
-
-            val locationTrack = changeContext.locationTracks.getAfter(locationTrackChange.locationTrackId)
-            val geocodingCacheKey = changeContext.geocodingKeysAfter[locationTrack.trackNumberId]
-            val addresses = geocodingCacheKey?.let { cacheKey ->
-                geocodingService.getAddressPoints(cacheKey, locationTrack.getAlignmentVersionOrThrow())
-            }
-
-            LocationTrackChange(
-                locationTrackId = locationTrackChange.locationTrackId,
-                changedKmNumbers = locationTrackJointChanges.map { it.address.kmNumber }.toSet(),
-                isStartChanged = locationTrackJointChanges.any { change ->
-                    addresses?.startPoint?.address?.isSame(change.address) == true
-                },
-                isEndChanged = locationTrackJointChanges.any { change ->
-                    addresses?.endPoint?.address?.isSame(change.address) == true
-                },
-            )
-        }
 
         return switchChanges to locationTrackGeometryChanges
     }
 
-    private fun createChangeContext(versions: ValidationVersions) = ChangeContext(
-        geocodingService = geocodingService,
-        trackNumbers = createTypedContext(versions.branch, trackNumberDao, versions.trackNumbers),
-        referenceLines = createTypedContext(versions.branch, referenceLineDao, versions.referenceLines),
-        kmPosts = createTypedContext(versions.branch, kmPostDao, versions.kmPosts),
-        locationTracks = createTypedContext(versions.branch, locationTrackDao, versions.locationTracks),
-        switches = createTypedContext(versions.branch, switchDao, versions.switches),
-        geocodingKeysBefore = LazyMap { id: IntId<TrackLayoutTrackNumber> ->
-            geocodingService.getGeocodingContextCacheKey(versions.branch.official, id)
-        },
-        geocodingKeysAfter = LazyMap { id: IntId<TrackLayoutTrackNumber> ->
-            geocodingService.getGeocodingContextCacheKey(id, versions)
-        },
-        getTrackNumberTracksBefore = { trackNumberId: IntId<TrackLayoutTrackNumber> ->
-            locationTrackDao.fetchVersions(versions.branch.official, false, trackNumberId)
-        },
-    )
+    private fun createChangeContext(versions: ValidationVersions) =
+        ChangeContext(
+            geocodingService = geocodingService,
+            trackNumbers =
+                createTypedContext(versions.branch, trackNumberDao, versions.trackNumbers),
+            referenceLines =
+                createTypedContext(versions.branch, referenceLineDao, versions.referenceLines),
+            kmPosts = createTypedContext(versions.branch, kmPostDao, versions.kmPosts),
+            locationTracks =
+                createTypedContext(versions.branch, locationTrackDao, versions.locationTracks),
+            switches = createTypedContext(versions.branch, switchDao, versions.switches),
+            geocodingKeysBefore =
+                LazyMap { id: IntId<TrackLayoutTrackNumber> ->
+                    geocodingService.getGeocodingContextCacheKey(versions.branch.official, id)
+                },
+            geocodingKeysAfter =
+                LazyMap { id: IntId<TrackLayoutTrackNumber> ->
+                    geocodingService.getGeocodingContextCacheKey(id, versions)
+                },
+            getTrackNumberTracksBefore = { trackNumberId: IntId<TrackLayoutTrackNumber> ->
+                locationTrackDao.fetchVersions(versions.branch.official, false, trackNumberId)
+            },
+        )
 }
 
 private fun asDirectSwitchChanges(switchIds: Collection<IntId<TrackLayoutSwitch>>) =
@@ -489,25 +561,29 @@ private fun getSwitchJointChanges(
     fetchSwitch: (switchId: IntId<TrackLayoutSwitch>) -> TrackLayoutSwitch?,
     fetchStructure: (structureId: IntId<SwitchStructure>) -> SwitchStructure,
 ): List<Pair<IntId<TrackLayoutSwitch>, List<SwitchJointDataHolder>>> {
-    val switchChanges = alignment.segments
-        .asSequence()
-        .mapNotNull { segment ->
-            if (segment.switchId is IntId) segment to fetchSwitch(segment.switchId)
-            else null
-        }
-        .mapNotNull { (segment, switch) ->
-            if (switch == null) null
-            else (switch.id as IntId) to findMatchingJoints(
-                segment = segment,
-                switch = switch,
-                geocodingContext = geocodingContext,
-            )
-        }
-        .toList()
+    val switchChanges =
+        alignment.segments
+            .asSequence()
+            .mapNotNull { segment ->
+                if (segment.switchId is IntId) segment to fetchSwitch(segment.switchId) else null
+            }
+            .mapNotNull { (segment, switch) ->
+                if (switch == null) null
+                else
+                    (switch.id as IntId) to
+                        findMatchingJoints(
+                            segment = segment,
+                            switch = switch,
+                            geocodingContext = geocodingContext,
+                        )
+            }
+            .toList()
 
-    val topologySwitches = topologySwitchLinks(locationTrack, alignment).mapNotNull { (topologySwitch, location) ->
-        getTopologySwitchJointDataHolder(topologySwitch, location, geocodingContext, fetchSwitch, fetchStructure)
-    }
+    val topologySwitches =
+        topologySwitchLinks(locationTrack, alignment).mapNotNull { (topologySwitch, location) ->
+            getTopologySwitchJointDataHolder(
+                topologySwitch, location, geocodingContext, fetchSwitch, fetchStructure)
+        }
 
     return (switchChanges + topologySwitches)
         .groupBy({ it.first }, { it.second })
@@ -522,69 +598,78 @@ private fun getTopologySwitchJointDataHolder(
     fetchSwitch: (switchId: IntId<TrackLayoutSwitch>) -> TrackLayoutSwitch?,
     fetchStructure: (structureId: IntId<SwitchStructure>) -> SwitchStructure,
 ): Pair<IntId<TrackLayoutSwitch>, List<SwitchJointDataHolder>>? {
-    val switch = fetchSwitch(topologySwitch.switchId)
-        ?: return null
+    val switch = fetchSwitch(topologySwitch.switchId) ?: return null
     // Use presentation joint to filter joints to update because
     // - that is joint number that is normally used to connect tracks and switch topologically
     // - and Ratko may not want other joint numbers in this case
     val presentationJointNumber = fetchStructure(switch.switchStructureId).presentationJointNumber
     val address = geocodingContext.getAddress(point)?.first
-    val joint = requireNotNull(switch.getJoint(topologySwitch.jointNumber)) {
-        "Topology switch contains invalid joint number: $topologySwitch"
-    }
+    val joint =
+        requireNotNull(switch.getJoint(topologySwitch.jointNumber)) {
+            "Topology switch contains invalid joint number: $topologySwitch"
+        }
     return if (presentationJointNumber == joint.number && address != null) {
-        topologySwitch.switchId to listOf(SwitchJointDataHolder(address = address, point = point, joint = joint))
+        topologySwitch.switchId to
+            listOf(SwitchJointDataHolder(address = address, point = point, joint = joint))
     } else null
 }
 
-private fun topologySwitchLinks(track: LocationTrack, alignment: LayoutAlignment) = listOfNotNull(
-    switchIdAndLocation(track.topologyStartSwitch, alignment.firstSegmentStart),
-    switchIdAndLocation(track.topologyEndSwitch, alignment.lastSegmentEnd),
-)
+private fun topologySwitchLinks(track: LocationTrack, alignment: LayoutAlignment) =
+    listOfNotNull(
+        switchIdAndLocation(track.topologyStartSwitch, alignment.firstSegmentStart),
+        switchIdAndLocation(track.topologyEndSwitch, alignment.lastSegmentEnd),
+    )
 
-private fun switchIdAndLocation(topologySwitch: TopologyLocationTrackSwitch?, location: SegmentPoint?) =
-    if (topologySwitch != null && location != null) topologySwitch to location.toPoint()
-    else null
+private fun switchIdAndLocation(
+    topologySwitch: TopologyLocationTrackSwitch?,
+    location: SegmentPoint?
+) = if (topologySwitch != null && location != null) topologySwitch to location.toPoint() else null
 
 private fun mergeLocationTrackChanges(
     vararg changeLists: Collection<LocationTrackChange>,
-) = changeLists
-    .flatMap { it }
-    .groupBy { it.locationTrackId }
-    .map { (locationTrackId, changes) ->
-        val mergedKmMs = changes.flatMap(LocationTrackChange::changedKmNumbers).toSet()
-        LocationTrackChange(
-            locationTrackId = locationTrackId,
-            changedKmNumbers = mergedKmMs,
-            isStartChanged = changes.any { it.isStartChanged },
-            isEndChanged = changes.any { it.isEndChanged },
-        )
-    }
+) =
+    changeLists
+        .flatMap { it }
+        .groupBy { it.locationTrackId }
+        .map { (locationTrackId, changes) ->
+            val mergedKmMs = changes.flatMap(LocationTrackChange::changedKmNumbers).toSet()
+            LocationTrackChange(
+                locationTrackId = locationTrackId,
+                changedKmNumbers = mergedKmMs,
+                isStartChanged = changes.any { it.isStartChanged },
+                isEndChanged = changes.any { it.isEndChanged },
+            )
+        }
 
 private fun mergeSwitchChanges(
     vararg changeLists: Collection<SwitchChange>,
-) = changeLists
-    .flatMap { it }
-    .groupBy { it.switchId }
-    .map { (switchId, changes) ->
-        val mergedJoints = changes.flatMap { it.changedJoints }.distinctBy { joint -> joint.number to joint.locationTrackId }
-        SwitchChange(switchId = switchId, changedJoints = mergedJoints)
-    }
+) =
+    changeLists
+        .flatMap { it }
+        .groupBy { it.switchId }
+        .map { (switchId, changes) ->
+            val mergedJoints =
+                changes
+                    .flatMap { it.changedJoints }
+                    .distinctBy { joint -> joint.number to joint.locationTrackId }
+            SwitchChange(switchId = switchId, changedJoints = mergedJoints)
+        }
 
 private fun mergeTrackNumberChanges(
     vararg changeLists: Collection<TrackNumberChange>,
-) = changeLists
-    .flatMap { it }
-    .groupBy { it.trackNumberId }
-    .map { (trackNumberId, changes) ->
-        val mergedKmMs = changes.flatMap(TrackNumberChange::changedKmNumbers).toSet()
-        TrackNumberChange(
-            trackNumberId = trackNumberId,
-            changedKmNumbers = mergedKmMs,
-            isStartChanged = changes.any { it.isStartChanged },
-            isEndChanged = changes.any { it.isEndChanged },
-        )
-    }
+) =
+    changeLists
+        .flatMap { it }
+        .groupBy { it.trackNumberId }
+        .map { (trackNumberId, changes) ->
+            val mergedKmMs = changes.flatMap(TrackNumberChange::changedKmNumbers).toSet()
+            TrackNumberChange(
+                trackNumberId = trackNumberId,
+                changedKmNumbers = mergedKmMs,
+                isStartChanged = changes.any { it.isStartChanged },
+                isEndChanged = changes.any { it.isEndChanged },
+            )
+        }
 
 private fun alignmentContainsKilometer(
     geocodingContext: GeocodingContext,
@@ -602,30 +687,36 @@ private fun calculateOverlappingLocationTracks(
     geocodingContext: GeocodingContext,
     kilometers: Set<KmNumber>,
     locationTracks: Collection<Pair<LocationTrack, LayoutAlignment>>,
-) = locationTracks
-    .filter { (_, alignment) -> alignmentContainsKilometer(geocodingContext, alignment, kilometers) }
-    .map { (locationTrack, _) -> locationTrack.id as IntId }
+) =
+    locationTracks
+        .filter { (_, alignment) ->
+            alignmentContainsKilometer(geocodingContext, alignment, kilometers)
+        }
+        .map { (locationTrack, _) -> locationTrack.id as IntId }
 
 private fun findMatchingJoints(
     segment: LayoutSegment,
     switch: TrackLayoutSwitch,
     geocodingContext: GeocodingContext,
-) = switch.joints.mapNotNull { joint ->
-    val segmentPoint = when (joint.number) {
-        segment.startJointNumber -> segment.alignmentStart
-        segment.endJointNumber -> segment.alignmentEnd
-        else -> null
-    }
+) =
+    switch.joints.mapNotNull { joint ->
+        val segmentPoint =
+            when (joint.number) {
+                segment.startJointNumber -> segment.alignmentStart
+                segment.endJointNumber -> segment.alignmentEnd
+                else -> null
+            }
 
-    if (segmentPoint == null) null
-    else geocodingContext.getAddress(segmentPoint)?.let { (address) ->
-        SwitchJointDataHolder(
-            address = address,
-            point = segmentPoint,
-            joint = joint,
-        )
+        if (segmentPoint == null) null
+        else
+            geocodingContext.getAddress(segmentPoint)?.let { (address) ->
+                SwitchJointDataHolder(
+                    address = address,
+                    point = segmentPoint,
+                    joint = joint,
+                )
+            }
     }
-}
 
 private data class SwitchJointDataHolder(
     val joint: TrackLayoutSwitchJoint,
@@ -636,7 +727,11 @@ private data class SwitchJointDataHolder(
 private fun findSwitchJointDifferences(
     list1: List<Pair<IntId<TrackLayoutSwitch>, List<SwitchJointDataHolder>>>,
     list2: List<Pair<IntId<TrackLayoutSwitch>, List<SwitchJointDataHolder>>>,
-    compare: (switch: SwitchJointDataHolder, joint: TrackLayoutSwitchJoint, address: TrackMeter) -> Boolean,
+    compare:
+        (
+            switch: SwitchJointDataHolder,
+            joint: TrackLayoutSwitchJoint,
+            address: TrackMeter) -> Boolean,
 ): List<Pair<IntId<TrackLayoutSwitch>, List<SwitchJointDataHolder>>> {
     return list1
         .map { switch1 ->
@@ -645,9 +740,11 @@ private fun findSwitchJointDifferences(
             list2
                 .find { (switchId2, _) -> switchId2 == switchId1 }
                 ?.let { (_, switch) ->
-                    switchId1 to switch1.second.filterNot { (joint, address) ->
-                        switch.any { compare(it, joint, address) }
-                    }
+                    switchId1 to
+                        switch1.second.filterNot { (joint, address) ->
+                            switch.any { compare(it, joint, address) }
+                        }
                 } ?: switch1
-        }.filter { it.second.isNotEmpty() }
+        }
+        .filter { it.second.isNotEmpty() }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/IntegrationModels.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/IntegrationModels.kt
@@ -4,9 +4,24 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
 import java.time.Instant
 
-enum class RatkoPushErrorType { PROPERTIES, LOCATION, GEOMETRY, STATE }
-enum class RatkoOperation { CREATE, UPDATE, DELETE }
-enum class RatkoAssetType { TRACK_NUMBER, LOCATION_TRACK, SWITCH }
+enum class RatkoPushErrorType {
+    PROPERTIES,
+    LOCATION,
+    GEOMETRY,
+    STATE
+}
+
+enum class RatkoOperation {
+    CREATE,
+    UPDATE,
+    DELETE
+}
+
+enum class RatkoAssetType {
+    TRACK_NUMBER,
+    LOCATION_TRACK,
+    SWITCH
+}
 
 data class RatkoPush(
     val id: IntId<RatkoPush>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/LockDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/LockDao.kt
@@ -1,10 +1,10 @@
 package fi.fta.geoviite.infra.integration
 
 import fi.fta.geoviite.infra.util.DaoBase
+import java.time.Duration
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
-import java.time.Duration
 
 enum class DatabaseLock {
     PUBLICATION,
@@ -17,13 +17,12 @@ enum class DatabaseLock {
 }
 
 /**
- * Note, this DAO is intentionally non-transactional as running with the lock should not
- * require an encompassing transaction.
+ * Note, this DAO is intentionally non-transactional as running with the lock should not require an
+ * encompassing transaction.
  */
 @Component
-class LockDao @Autowired constructor(
-    jdbcTemplateParam: NamedParameterJdbcTemplate?
-) : DaoBase(jdbcTemplateParam) {
+class LockDao @Autowired constructor(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
+    DaoBase(jdbcTemplateParam) {
 
     fun <R> runWithLock(lockName: DatabaseLock, maxLockDuration: Duration, fn: () -> R): R? {
         val lock = obtainLock(lockName, maxLockDuration)
@@ -41,31 +40,31 @@ class LockDao @Autowired constructor(
     }
 
     private fun obtainLock(lockName: DatabaseLock, duration: Duration): DatabaseLock? {
-        val sql = """
+        val sql =
+            """
             insert into integrations.lock (name, locked_until, locked_at)
             values (:lock_name, now() + :lock_duration * interval '1 second', now())
             on conflict (name) do update
             set locked_until = excluded.locked_until,
                 locked_at = excluded.locked_at
             where lock.locked_until < now();
-        """.trimIndent()
-        val params = mapOf(
-            "lock_name" to lockName.name,
-            "lock_duration" to duration.seconds
-        )
+        """
+                .trimIndent()
+        val params = mapOf("lock_name" to lockName.name, "lock_duration" to duration.seconds)
 
         val affectedRows = jdbcTemplate.update(sql, params)
         return if (affectedRows == 1) lockName else null
     }
 
     private fun releaseLock(lockName: DatabaseLock) {
-        val sql = """
+        val sql =
+            """
             update integrations.lock 
             set locked_until = now()
             where name = :lock_name
-        """.trimIndent()
+        """
+                .trimIndent()
 
         jdbcTemplate.update(sql, mapOf("lock_name" to lockName.name))
     }
-
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
@@ -14,7 +14,8 @@ import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.FreeText
 
 enum class LocationTrackPointUpdateType {
-    START_POINT, END_POINT
+    START_POINT,
+    END_POINT
 }
 
 data class LayoutInterval<T>(
@@ -58,7 +59,9 @@ data class LocationTrackSaveRequest(
 }
 
 enum class SuggestedSwitchJointMatchType {
-    START, END, LINE,
+    START,
+    END,
+    LINE,
 }
 
 data class FittedSwitchJointMatch(
@@ -71,6 +74,7 @@ data class FittedSwitchJointMatch(
     val distanceToAlignment: Double,
     val alignmentId: IntId<LayoutAlignment>?,
 )
+
 data class FittedSwitchJoint(
     override val number: JointNumber,
     override val location: Point,
@@ -102,7 +106,8 @@ data class SuggestedSwitch(
 )
 
 enum class TrackEnd {
-    START, END
+    START,
+    END
 }
 
 data class SwitchLinkingTopologicalTrackLink(
@@ -116,8 +121,12 @@ data class SwitchLinkingTrackLinks(
 ) {
     init {
         // linking to neither is OK; that just communicates cleaning up all links
-        check(topologyJoint == null || segmentJoints.isEmpty()) { "Switch linking track link links both to segment and topology"}
-        check(segmentJoints.zipWithNext { a, b -> a.m < b.m }.all { it }) { "Switch linking track link segment joints should be m-ordered"}
+        check(topologyJoint == null || segmentJoints.isEmpty()) {
+            "Switch linking track link links both to segment and topology"
+        }
+        check(segmentJoints.zipWithNext { a, b -> a.m < b.m }.all { it }) {
+            "Switch linking track link segment joints should be m-ordered"
+        }
     }
 
     fun isLinked(): Boolean = segmentJoints.isNotEmpty() || topologyJoint != null
@@ -146,7 +155,9 @@ data class TrackNumberSaveRequest(
 ) {
     init {
         require(description.isNotBlank()) { "TrackNumber should have a non-blank description" }
-        require(description.length < 100) { "TrackNumber description too long: ${description.length}>100" }
+        require(description.length < 100) {
+            "TrackNumber description too long: ${description.length}>100"
+        }
     }
 }
 
@@ -188,12 +199,17 @@ data class SwitchRelinkingValidationResult(
     val successfulSuggestion: SwitchRelinkingSuggestion?,
     val validationIssues: List<LayoutValidationIssue>,
 )
+
 data class SwitchRelinkingSuggestion(
     val location: Point,
     val address: TrackMeter,
 )
 
-enum class TrackSwitchRelinkingResultType { RELINKED, NOT_AUTOMATICALLY_LINKABLE }
+enum class TrackSwitchRelinkingResultType {
+    RELINKED,
+    NOT_AUTOMATICALLY_LINKABLE
+}
+
 data class TrackSwitchRelinkingResult(
     val id: IntId<TrackLayoutSwitch>,
     val outcome: TrackSwitchRelinkingResultType

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
@@ -30,7 +30,9 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 
 @GeoviiteController("/linking")
-class LinkingController @Autowired constructor(
+class LinkingController
+@Autowired
+constructor(
     private val linkingService: LinkingService,
     private val switchLinkingService: SwitchLinkingService,
 ) {
@@ -119,7 +121,8 @@ class LinkingController @Autowired constructor(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @RequestParam("id") locationTrackId: IntId<LocationTrack>,
         @RequestParam("location") location: Point,
-        @RequestParam("locationTrackPointUpdateType") locationTrackPointUpdateType: LocationTrackPointUpdateType,
+        @RequestParam("locationTrackPointUpdateType")
+        locationTrackPointUpdateType: LocationTrackPointUpdateType,
         @RequestParam("bbox") bbox: BoundingBox,
     ): List<LocationTrack> {
         return linkingService.getSuggestedAlignments(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -39,12 +39,17 @@ fun isAlignmentConnected(
     alignment: LayoutAlignment,
     distanceTolerance: Double,
 ): Boolean {
-    val comparePoint = if (updateType == END_POINT) alignment.firstSegmentStart else alignment.lastSegmentEnd
-    return comparePoint?.let { p -> calculateDistance(LAYOUT_SRID, p, location) <= distanceTolerance } ?: false
+    val comparePoint =
+        if (updateType == END_POINT) alignment.firstSegmentStart else alignment.lastSegmentEnd
+    return comparePoint?.let { p ->
+        calculateDistance(LAYOUT_SRID, p, location) <= distanceTolerance
+    } ?: false
 }
 
 @GeoviiteService
-class LinkingService @Autowired constructor(
+class LinkingService
+@Autowired
+constructor(
     private val geometryService: GeometryService,
     private val planLayoutService: PlanLayoutService,
     private val referenceLineService: ReferenceLineService,
@@ -65,7 +70,9 @@ class LinkingService @Autowired constructor(
         return locationTrackService
             .listNearWithAlignments(branch.draft, bbox)
             .filter { (first, _) -> first.id != locationTrackId }
-            .filter { (_, second) -> isAlignmentConnected(location, locationTrackPointUpdateType, second, 2.0) }
+            .filter { (_, second) ->
+                isAlignmentConnected(location, locationTrackPointUpdateType, second, 2.0)
+            }
             .map { (first, _) -> first }
     }
 
@@ -77,7 +84,8 @@ class LinkingService @Autowired constructor(
         verifyPlanNotHidden(parameters.geometryPlanId)
 
         val referenceLineId = parameters.layoutInterval.alignmentId
-        val (referenceLine, alignment) = referenceLineService.getWithAlignmentOrThrow(branch.draft, referenceLineId)
+        val (referenceLine, alignment) =
+            referenceLineService.getWithAlignmentOrThrow(branch.draft, referenceLineId)
 
         val newAlignment = linkGeometry(alignment, parameters)
         return referenceLineService.saveDraft(branch, referenceLine, newAlignment).id
@@ -89,7 +97,8 @@ class LinkingService @Autowired constructor(
         parameters: LinkingParameters<LocationTrack>,
     ): IntId<LocationTrack> {
         val locationTrackId = parameters.layoutInterval.alignmentId
-        val (locationTrack, alignment) = locationTrackService.getWithAlignmentOrThrow(branch.draft, locationTrackId)
+        val (locationTrack, alignment) =
+            locationTrackService.getWithAlignmentOrThrow(branch.draft, locationTrackId)
 
         verifyLocationTrackNotDeleted(locationTrack)
         verifyPlanNotHidden(parameters.geometryPlanId)
@@ -101,12 +110,17 @@ class LinkingService @Autowired constructor(
         return locationTrackService.saveDraft(branch, newLocationTrack, newAlignment).id
     }
 
-    private fun <T> linkGeometry(layoutAlignment: LayoutAlignment, parameters: LinkingParameters<T>): LayoutAlignment {
+    private fun <T> linkGeometry(
+        layoutAlignment: LayoutAlignment,
+        parameters: LinkingParameters<T>
+    ): LayoutAlignment {
         val geometryInterval = parameters.geometryInterval
-        val geometryAlignment = getAlignmentLayout(parameters.geometryPlanId, geometryInterval.alignmentId)
+        val geometryAlignment =
+            getAlignmentLayout(parameters.geometryPlanId, geometryInterval.alignmentId)
         val layoutRange = parameters.layoutInterval.mRange
         val geometryRange = parameters.geometryInterval.mRange
-        return linkLayoutGeometrySection(layoutAlignment, layoutRange, geometryAlignment, geometryRange)
+        return linkLayoutGeometrySection(
+            layoutAlignment, layoutRange, geometryAlignment, geometryRange)
     }
 
     private fun updateTopology(
@@ -136,7 +150,8 @@ class LinkingService @Autowired constructor(
     private fun endChanged(oldAlignment: LayoutAlignment, newAlignment: LayoutAlignment) =
         !equalsXY(oldAlignment.lastSegmentEnd, newAlignment.lastSegmentEnd)
 
-    private fun equalsXY(point1: IPoint?, point2: IPoint?) = point1?.x == point2?.x && point1?.y == point2?.y
+    private fun equalsXY(point1: IPoint?, point2: IPoint?) =
+        point1?.x == point2?.x && point1?.y == point2?.y
 
     @Transactional
     fun saveReferenceLineLinking(
@@ -148,10 +163,13 @@ class LinkingService @Autowired constructor(
         val referenceLineId = parameters.layoutAlignmentId
         val geometryInterval = parameters.geometryInterval
 
-        val (referenceLine, layoutAlignment) = referenceLineService.getWithAlignmentOrThrow(branch.draft, referenceLineId)
-        val geometryAlignment = getAlignmentLayout(parameters.geometryPlanId, geometryInterval.alignmentId)
+        val (referenceLine, layoutAlignment) =
+            referenceLineService.getWithAlignmentOrThrow(branch.draft, referenceLineId)
+        val geometryAlignment =
+            getAlignmentLayout(parameters.geometryPlanId, geometryInterval.alignmentId)
 
-        val newAlignment = replaceLayoutGeometry(layoutAlignment, geometryAlignment, geometryInterval.mRange)
+        val newAlignment =
+            replaceLayoutGeometry(layoutAlignment, geometryAlignment, geometryInterval.mRange)
 
         return referenceLineService.saveDraft(branch, referenceLine, newAlignment).id
     }
@@ -166,10 +184,13 @@ class LinkingService @Autowired constructor(
         val locationTrackId = parameters.layoutAlignmentId
         val geometryInterval = parameters.geometryInterval
 
-        val (locationTrack, alignment) = locationTrackService.getWithAlignmentOrThrow(branch.draft, locationTrackId)
-        val geometryAlignment = getAlignmentLayout(parameters.geometryPlanId, geometryInterval.alignmentId)
+        val (locationTrack, alignment) =
+            locationTrackService.getWithAlignmentOrThrow(branch.draft, locationTrackId)
+        val geometryAlignment =
+            getAlignmentLayout(parameters.geometryPlanId, geometryInterval.alignmentId)
 
-        val newAlignment = replaceLayoutGeometry(alignment, geometryAlignment, geometryInterval.mRange)
+        val newAlignment =
+            replaceLayoutGeometry(alignment, geometryAlignment, geometryInterval.mRange)
         val newLocationTrack = updateTopology(branch, locationTrack, alignment, newAlignment)
 
         return locationTrackService.saveDraft(branch, newLocationTrack, newAlignment).id
@@ -181,10 +202,12 @@ class LinkingService @Autowired constructor(
     ): PlanLayoutAlignment {
         val (geometryPlan, transformationError) = planLayoutService.getLayoutPlan(planId)
         if (geometryPlan == null) {
-            throw LinkingFailureException("Could not create plan layout: plan=$planId error=$transformationError")
+            throw LinkingFailureException(
+                "Could not create plan layout: plan=$planId error=$transformationError")
         }
         return geometryPlan.alignments.find { alignment -> alignment.id == alignmentId }
-            ?: throw LinkingFailureException("Geometry alignment not found: plan=$planId alignment=$alignmentId")
+            ?: throw LinkingFailureException(
+                "Geometry alignment not found: plan=$planId alignment=$alignmentId")
     }
 
     @Transactional
@@ -193,7 +216,8 @@ class LinkingService @Autowired constructor(
         referenceLineId: IntId<ReferenceLine>,
         mRange: Range<Double>,
     ): IntId<ReferenceLine> {
-        val (referenceLine, alignment) = referenceLineService.getWithAlignmentOrThrow(branch.draft, referenceLineId)
+        val (referenceLine, alignment) =
+            referenceLineService.getWithAlignmentOrThrow(branch.draft, referenceLineId)
         val updatedAlignment = cutLayoutGeometry(alignment, mRange)
 
         return referenceLineService.saveDraft(branch, referenceLine, updatedAlignment).id
@@ -206,14 +230,19 @@ class LinkingService @Autowired constructor(
         mRange: Range<Double>,
     ): IntId<LocationTrack> {
         verifyAllSplitsDone(branch, locationTrackId)
-        val (locationTrack, alignment) = locationTrackService.getWithAlignmentOrThrow(branch.draft, locationTrackId)
+        val (locationTrack, alignment) =
+            locationTrackService.getWithAlignmentOrThrow(branch.draft, locationTrackId)
         val updatedAlignment = cutLayoutGeometry(alignment, mRange)
-        val updatedLocationTrack = updateTopology(branch, locationTrack, alignment, updatedAlignment)
+        val updatedLocationTrack =
+            updateTopology(branch, locationTrack, alignment, updatedAlignment)
 
         return locationTrackService.saveDraft(branch, updatedLocationTrack, updatedAlignment).id
     }
 
-    fun getGeometryPlanLinkStatus(layoutContext: LayoutContext, planId: IntId<GeometryPlan>): GeometryPlanLinkStatus {
+    fun getGeometryPlanLinkStatus(
+        layoutContext: LayoutContext,
+        planId: IntId<GeometryPlan>
+    ): GeometryPlanLinkStatus {
         return linkingDao.fetchPlanLinkStatuses(layoutContext, listOf(planId))[0]
     }
 
@@ -225,31 +254,39 @@ class LinkingService @Autowired constructor(
     }
 
     @Transactional
-    fun saveKmPostLinking(branch: LayoutBranch, parameters: KmPostLinkingParameters): LayoutDaoResponse<TrackLayoutKmPost> {
+    fun saveKmPostLinking(
+        branch: LayoutBranch,
+        parameters: KmPostLinkingParameters
+    ): LayoutDaoResponse<TrackLayoutKmPost> {
         verifyPlanNotHidden(parameters.geometryPlanId)
 
         val geometryKmPost = geometryService.getKmPost(parameters.geometryKmPostId)
-        val kmPostSrid = geometryService.getKmPostSrid(parameters.geometryKmPostId)
-            ?: throw IllegalArgumentException("Cannot link a geometry km post with an unknown coordinate system!")
-        requireNotNull(geometryKmPost.location) { "Cannot link a geometry km post without a location!" }
+        val kmPostSrid =
+            geometryService.getKmPostSrid(parameters.geometryKmPostId)
+                ?: throw IllegalArgumentException(
+                    "Cannot link a geometry km post with an unknown coordinate system!")
+        requireNotNull(geometryKmPost.location) {
+            "Cannot link a geometry km post without a location!"
+        }
 
         val layoutKmPost = layoutKmPostService.getOrThrow(branch.draft, parameters.layoutKmPostId)
 
         val newGkLocation = transformToGKCoordinate(kmPostSrid, geometryKmPost.location)
-        val modifiedLayoutKmPost = layoutKmPost.copy(
-            gkLocation = newGkLocation,
-            gkLocationSource = KmPostGkLocationSource.FROM_GEOMETRY,
-            sourceId = geometryKmPost.id,
-            gkLocationConfirmed = true,
-        )
+        val modifiedLayoutKmPost =
+            layoutKmPost.copy(
+                gkLocation = newGkLocation,
+                gkLocationSource = KmPostGkLocationSource.FROM_GEOMETRY,
+                sourceId = geometryKmPost.id,
+                gkLocationConfirmed = true,
+            )
 
         return layoutKmPostService.saveDraft(branch, modifiedLayoutKmPost)
     }
 
     fun verifyPlanNotHidden(id: IntId<GeometryPlan>) {
-        if (geometryService.getPlanHeader(id).isHidden) throw LinkingFailureException(
-            message = "Cannot link a plan that is hidden", localizedMessageKey = "plan-hidden"
-        )
+        if (geometryService.getPlanHeader(id).isHidden)
+            throw LinkingFailureException(
+                message = "Cannot link a plan that is hidden", localizedMessageKey = "plan-hidden")
     }
 
     fun verifyAllSplitsDone(branch: LayoutBranch, id: IntId<LocationTrack>) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingTransformation.kt
@@ -32,11 +32,14 @@ fun linkLayoutGeometrySection(
     geometryAlignment: PlanLayoutAlignment,
     geometryMRange: Range<Double>,
 ): LayoutAlignment {
-    val segments = if (layoutMRange.min == layoutMRange.max) {
-        extendSegmentsWithGeometry(layoutAlignment, layoutMRange.min, geometryAlignment, geometryMRange)
-    } else {
-        replaceSegmentsWithGeometry(layoutAlignment, layoutMRange, geometryAlignment, geometryMRange)
-    }
+    val segments =
+        if (layoutMRange.min == layoutMRange.max) {
+            extendSegmentsWithGeometry(
+                layoutAlignment, layoutMRange.min, geometryAlignment, geometryMRange)
+        } else {
+            replaceSegmentsWithGeometry(
+                layoutAlignment, layoutMRange, geometryAlignment, geometryMRange)
+        }
     return tryCreateLinkedAlignment(layoutAlignment, segments)
 }
 
@@ -51,12 +54,15 @@ private fun extendSegmentsWithGeometry(
     geometryAlignment: PlanLayoutAlignment,
     geometryMInterval: Range<Double>,
 ): List<LayoutSegment> {
-    val addedSegments = sliceSegments(geometryAlignment.segments, geometryMInterval, ALIGNMENT_LINKING_SNAP)
+    val addedSegments =
+        sliceSegments(geometryAlignment.segments, geometryMInterval, ALIGNMENT_LINKING_SNAP)
     return if (isSame(0.0, layoutM, ALIGNMENT_LINKING_SNAP)) {
-        val gap = createLinkingSegment(lastPoint(addedSegments), firstPoint(layoutAlignment.segments))
+        val gap =
+            createLinkingSegment(lastPoint(addedSegments), firstPoint(layoutAlignment.segments))
         addedSegments + listOfNotNull(gap) + layoutAlignment.segments
     } else if (isSame(layoutAlignment.length, layoutM, ALIGNMENT_LINKING_SNAP)) {
-        val gap = createLinkingSegment(lastPoint(layoutAlignment.segments), firstPoint(addedSegments))
+        val gap =
+            createLinkingSegment(lastPoint(layoutAlignment.segments), firstPoint(addedSegments))
         layoutAlignment.segments + listOfNotNull(gap) + addedSegments
     } else {
         throw LinkingFailureException("Alignment cannot be extended with selected m-values")
@@ -71,74 +77,89 @@ private fun replaceSegmentsWithGeometry(
 ): List<LayoutSegment> {
     val startSegments = sliceSegments(layoutAlignment.segments, Range(0.0, layoutMInterval.min))
     val geometrySegments = createAlignmentGeometry(geometryAlignment, geometryMInterval)
-    val endSegments = sliceSegments(layoutAlignment.segments, Range(layoutMInterval.max, layoutAlignment.length))
+    val endSegments =
+        sliceSegments(layoutAlignment.segments, Range(layoutMInterval.max, layoutAlignment.length))
 
     val startGap = createLinkingSegment(lastPoint(startSegments), firstPoint(geometrySegments))
     val endGap = createLinkingSegment(lastPoint(geometrySegments), firstPoint(endSegments))
 
-    val combinedSegments = (
-            startSegments + listOfNotNull(startGap) + geometrySegments + listOfNotNull(endGap) + endSegments
-        )
+    val combinedSegments =
+        (startSegments +
+            listOfNotNull(startGap) +
+            geometrySegments +
+            listOfNotNull(endGap) +
+            endSegments)
     val affectedSwitchIds = getSwitchIdsInside(layoutAlignment.segments, layoutMInterval)
     return removeSwitches(combinedSegments, affectedSwitchIds)
 }
 
-private fun createLinkingSegment(start: IPoint?, end: IPoint?, tolerance: Double = LAYOUT_M_DELTA): LayoutSegment? {
+private fun createLinkingSegment(
+    start: IPoint?,
+    end: IPoint?,
+    tolerance: Double = LAYOUT_M_DELTA
+): LayoutSegment? {
     if (start == null || end == null) return null
     val length = calculateDistance(LAYOUT_SRID, start, end)
-    return if (length > tolerance) LayoutSegment(
-        geometry = SegmentGeometry(
-            resolution = max(length.toInt(), 1),
-            segmentPoints = listOf(
-                SegmentPoint(x = start.x, y = start.y, z = null, m = 0.0, cant = null),
-                SegmentPoint(x = end.x, y = end.y, z = null, m = length, cant = null),
-            ),
-        ),
-        sourceId = null,
-        sourceStart = null,
-        switchId = null,
-        startJointNumber = null,
-        endJointNumber = null,
-        source = GeometrySource.GENERATED,
-        startM = 0.0,
-    ) else null
+    return if (length > tolerance)
+        LayoutSegment(
+            geometry =
+                SegmentGeometry(
+                    resolution = max(length.toInt(), 1),
+                    segmentPoints =
+                        listOf(
+                            SegmentPoint(x = start.x, y = start.y, z = null, m = 0.0, cant = null),
+                            SegmentPoint(x = end.x, y = end.y, z = null, m = length, cant = null),
+                        ),
+                ),
+            sourceId = null,
+            sourceStart = null,
+            switchId = null,
+            startJointNumber = null,
+            endJointNumber = null,
+            source = GeometrySource.GENERATED,
+            startM = 0.0,
+        )
+    else null
 }
 
 private fun toLayoutSegment(segment: ISegment): LayoutSegment =
     if (segment is LayoutSegment) segment
-    else LayoutSegment(
-        geometry = segment.geometry,
-        sourceId = segment.sourceId,
-        sourceStart = segment.sourceStart,
-        switchId = null,
-        startJointNumber = null,
-        endJointNumber = null,
-        source = segment.source,
-        startM = segment.startM,
-    )
+    else
+        LayoutSegment(
+            geometry = segment.geometry,
+            sourceId = segment.sourceId,
+            sourceStart = segment.sourceStart,
+            switchId = null,
+            startJointNumber = null,
+            endJointNumber = null,
+            source = segment.source,
+            startM = segment.startM,
+        )
 
 private fun tryCreateLinkedAlignment(
     original: LayoutAlignment,
     newSegments: List<LayoutSegment>,
-): LayoutAlignment = try {
-    original.withSegments(fixSegmentStarts(newSegments).also(::validateSegments))
-} catch (e: IllegalArgumentException) {
-    throw LinkingFailureException(
-        message = "Linking selection produces invalid alignment",
-        cause = e,
-        localizedMessageKey = "alignment-geometry"
-    )
-}
+): LayoutAlignment =
+    try {
+        original.withSegments(fixSegmentStarts(newSegments).also(::validateSegments))
+    } catch (e: IllegalArgumentException) {
+        throw LinkingFailureException(
+            message = "Linking selection produces invalid alignment",
+            cause = e,
+            localizedMessageKey = "alignment-geometry")
+    }
 
 private fun validateSegments(newSegments: List<LayoutSegment>) =
     newSegments.forEachIndexed { index, segment ->
         newSegments.getOrNull(index - 1)?.let { previous ->
             val diff = angleDiffRads(previous.endDirection, segment.startDirection)
-            if (diff > PI / 2) throw LinkingFailureException(
-                message = "Linked geometry has over 90 degree angles between segments: " +
-                        "segment=${segment.id} m=${previous.endM} angle=${radsToDegrees(diff)}",
-                localizedMessageKey = "segments-sharp-angle",
-            )
+            if (diff > PI / 2)
+                throw LinkingFailureException(
+                    message =
+                        "Linked geometry has over 90 degree angles between segments: " +
+                            "segment=${segment.id} m=${previous.endM} angle=${radsToDegrees(diff)}",
+                    localizedMessageKey = "segments-sharp-angle",
+                )
         }
     }
 
@@ -153,24 +174,30 @@ fun sliceSegments(
     segments: List<ISegment>,
     mRange: Range<Double>,
     snapDistance: Double = ALIGNMENT_LINKING_SNAP
-): List<LayoutSegment> = segments.mapNotNull { segment ->
-    if (segment.endM <= mRange.min || segment.startM >= mRange.max) {
-        null
-    } else if (segment.startM >= mRange.min - snapDistance && segment.endM <= mRange.max + snapDistance) {
-        toLayoutSegment(segment)
-    } else {
-        toLayoutSegment(segment).slice(
-            mRange = Range(max(mRange.min, segment.startM), min(mRange.max, segment.endM)),
-            snapDistance = snapDistance,
-        )
+): List<LayoutSegment> =
+    segments.mapNotNull { segment ->
+        if (segment.endM <= mRange.min || segment.startM >= mRange.max) {
+            null
+        } else if (segment.startM >= mRange.min - snapDistance &&
+            segment.endM <= mRange.max + snapDistance) {
+            toLayoutSegment(segment)
+        } else {
+            toLayoutSegment(segment)
+                .slice(
+                    mRange = Range(max(mRange.min, segment.startM), min(mRange.max, segment.endM)),
+                    snapDistance = snapDistance,
+                )
+        }
     }
-}
 
 private fun firstPoint(segments: List<LayoutSegment>) = segments.firstOrNull()?.segmentStart
 
 private fun lastPoint(segments: List<LayoutSegment>) = segments.lastOrNull()?.segmentEnd
 
-fun removeSwitches(segments: List<LayoutSegment>, switchIds: Set<DomainId<TrackLayoutSwitch>>): List<LayoutSegment> =
+fun removeSwitches(
+    segments: List<LayoutSegment>,
+    switchIds: Set<DomainId<TrackLayoutSwitch>>
+): List<LayoutSegment> =
     segments.map { s -> if (switchIds.contains(s.switchId)) s.withoutSwitch() else s }
 
 fun getSwitchIdsInside(segments: List<LayoutSegment>, mRange: Range<Double>) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
@@ -51,21 +51,22 @@ import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.annotation.Transactional
 import java.util.stream.Collectors
 import kotlin.math.max
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
 
 private const val TOLERANCE_JOINT_LOCATION_SEGMENT_END_POINT = 0.5
 const val TOLERANCE_JOINT_LOCATION_NEW_POINT = 0.01
 
-
 /**
- * Tools for finding a fit for a switch: The positioning of the switch's joints, based on the geometry of the tracks
- * around it.
+ * Tools for finding a fit for a switch: The positioning of the switch's joints, based on the
+ * geometry of the tracks around it.
  */
 @GeoviiteService
-class SwitchFittingService @Autowired constructor(
+class SwitchFittingService
+@Autowired
+constructor(
     private val locationTrackService: LocationTrackService,
     private val locationTrackDao: LocationTrackDao,
     private val linkingDao: LinkingDao,
@@ -80,62 +81,90 @@ class SwitchFittingService @Autowired constructor(
         return missing.mapNotNull { missingLayoutSwitchLinking ->
             // Transform joints to layout space and calculate missing joints
             val geomSwitch = geometryDao.getSwitch(missingLayoutSwitchLinking.geometrySwitchId)
-            val structure = geomSwitch.switchStructureId?.let(switchLibraryService::getSwitchStructure)
+            val structure =
+                geomSwitch.switchStructureId?.let(switchLibraryService::getSwitchStructure)
             val toLayoutCoordinate =
-                coordinateTransformationService.getTransformation(missingLayoutSwitchLinking.planSrid, LAYOUT_SRID)
-            // TODO: There is a missing switch here, but current logic doesn't support non-typed suggestions
-            if (structure == null) null else calculateLayoutSwitchJoints(
-                geomSwitch, structure, toLayoutCoordinate
-            )?.let { calculatedJoints ->
-                val switchBoundingBox = boundingBoxAroundPoints(calculatedJoints.map { it.location }) * 1.5
-                val nearAlignmentIds = locationTrackDao.fetchVersionsNear(branch.draft, switchBoundingBox)
+                coordinateTransformationService.getTransformation(
+                    missingLayoutSwitchLinking.planSrid, LAYOUT_SRID)
+            // TODO: There is a missing switch here, but current logic doesn't support non-typed
+            // suggestions
+            if (structure == null) null
+            else
+                calculateLayoutSwitchJoints(geomSwitch, structure, toLayoutCoordinate)?.let {
+                    calculatedJoints ->
+                    val switchBoundingBox =
+                        boundingBoxAroundPoints(calculatedJoints.map { it.location }) * 1.5
+                    val nearAlignmentIds =
+                        locationTrackDao.fetchVersionsNear(branch.draft, switchBoundingBox)
 
-                val alignments = (nearAlignmentIds + missingLayoutSwitchLinking.locationTrackIds)
-                    .distinct()
-                    .map { id -> locationTrackService.getWithAlignment(id) }
+                    val alignments =
+                        (nearAlignmentIds + missingLayoutSwitchLinking.locationTrackIds)
+                            .distinct()
+                            .map { id -> locationTrackService.getWithAlignment(id) }
 
-                fitSwitch(
-                    jointsInLayoutSpace = calculatedJoints,
-                    switchStructure = structure,
-                    alignments = alignments,
-                    geometrySwitch = geomSwitch,
-                    alignmentEndPoint = null,
-                    geometryPlanId = missingLayoutSwitchLinking.planId,
-                    getMeasurementMethod = this::getMeasurementMethod,
-                )
-            }
+                    fitSwitch(
+                        jointsInLayoutSpace = calculatedJoints,
+                        switchStructure = structure,
+                        alignments = alignments,
+                        geometrySwitch = geomSwitch,
+                        alignmentEndPoint = null,
+                        geometryPlanId = missingLayoutSwitchLinking.planId,
+                        getMeasurementMethod = this::getMeasurementMethod,
+                    )
+                }
         }
     }
 
     @Transactional(readOnly = true)
-    fun getFitAtPoint(branch: LayoutBranch, point: IPoint, switchStructureId: IntId<SwitchStructure>): FittedSwitch? {
+    fun getFitAtPoint(
+        branch: LayoutBranch,
+        point: IPoint,
+        switchStructureId: IntId<SwitchStructure>
+    ): FittedSwitch? {
         return getFitsAtPoints(branch, listOf(point to switchStructureId))[0]
     }
 
     @Transactional(readOnly = true)
-    fun getFitsAtPoints(branch: LayoutBranch, points: List<Pair<IPoint, IntId<SwitchStructure>>>): List<FittedSwitch?> {
-        val nearbyLocationTracks = points.map { (location) ->
-            locationTrackService.getLocationTracksNear(branch.draft, location)
-        }
+    fun getFitsAtPoints(
+        branch: LayoutBranch,
+        points: List<Pair<IPoint, IntId<SwitchStructure>>>
+    ): List<FittedSwitch?> {
+        val nearbyLocationTracks =
+            points.map { (location) ->
+                locationTrackService.getLocationTracksNear(branch.draft, location)
+            }
         val switchStructures = points.map { (_, id) -> switchLibraryService.getSwitchStructure(id) }
-        return points.mapIndexed { index, point -> index to point }.parallelStream().map { (index, point) ->
-            createSuggestedSwitchByPoint(point.first, switchStructures[index], nearbyLocationTracks[index])
-        }.collect(Collectors.toList())
+        return points
+            .mapIndexed { index, point -> index to point }
+            .parallelStream()
+            .map { (index, point) ->
+                createSuggestedSwitchByPoint(
+                    point.first, switchStructures[index], nearbyLocationTracks[index])
+            }
+            .collect(Collectors.toList())
     }
 
     @Transactional(readOnly = true)
-    fun getFitAtEndpoint(branch: LayoutBranch, createParams: SuggestedSwitchCreateParams): FittedSwitch? {
+    fun getFitAtEndpoint(
+        branch: LayoutBranch,
+        createParams: SuggestedSwitchCreateParams
+    ): FittedSwitch? {
         val switchStructure =
-            createParams.switchStructureId?.let(switchLibraryService::getSwitchStructure) ?: return null
-        val locationTracks = createParams.alignmentMappings
-            .map { mapping -> mapping.locationTrackId }
-            .associateWith { id -> locationTrackService.getWithAlignmentOrThrow(branch.draft, id) }
+            createParams.switchStructureId?.let(switchLibraryService::getSwitchStructure)
+                ?: return null
+        val locationTracks =
+            createParams.alignmentMappings
+                .map { mapping -> mapping.locationTrackId }
+                .associateWith { id ->
+                    locationTrackService.getWithAlignmentOrThrow(branch.draft, id)
+                }
 
         val areaSize = switchStructure.bbox.width.coerceAtLeast(switchStructure.bbox.height) * 2.0
-        val switchAreaBbox = BoundingBox(
-            Point(0.0, 0.0), Point(areaSize, areaSize)
-        ).centerAt(createParams.locationTrackEndpoint.location)
-        val nearbyLocationTracks = locationTrackService.listNearWithAlignments(branch.draft, switchAreaBbox)
+        val switchAreaBbox =
+            BoundingBox(Point(0.0, 0.0), Point(areaSize, areaSize))
+                .centerAt(createParams.locationTrackEndpoint.location)
+        val nearbyLocationTracks =
+            locationTrackService.listNearWithAlignments(branch.draft, switchAreaBbox)
 
         return fitSwitch(
             createParams.locationTrackEndpoint,
@@ -156,18 +185,19 @@ fun calculateLayoutSwitchJoints(
     switchStructure: SwitchStructure,
     toLayoutCoordinate: Transformation,
 ): List<SwitchJoint>? {
-    val layoutJointPoints = geomSwitch.joints.map { geomJoint ->
-        SwitchJoint(
-            number = geomJoint.number,
-            location = toLayoutCoordinate.transform(geomJoint.location),
-        )
-    }
+    val layoutJointPoints =
+        geomSwitch.joints.map { geomJoint ->
+            SwitchJoint(
+                number = geomJoint.number,
+                location = toLayoutCoordinate.transform(geomJoint.location),
+            )
+        }
     val switchLocationDelta = calculateSwitchLocationDeltaOrNull(layoutJointPoints, switchStructure)
     return if (switchLocationDelta != null) {
         switchStructure.alignmentJoints.map { joint ->
             SwitchJoint(
-                number = joint.number, location = transformSwitchPoint(switchLocationDelta, joint.location)
-            )
+                number = joint.number,
+                location = transformSwitchPoint(switchLocationDelta, joint.location))
         }
     } else {
         null
@@ -183,71 +213,83 @@ fun findSuggestedSwitchJointMatches(
     val jointLocation = joint.location
 
     val closestSegmentIndex = alignment.findClosestSegmentIndex(jointLocation) ?: return listOf()
-    val possibleSegmentIndices = IntRange(
-        (closestSegmentIndex - 1).coerceAtLeast(0), (closestSegmentIndex + 1).coerceAtMost(alignment.segments.lastIndex)
-    )
+    val possibleSegmentIndices =
+        IntRange(
+            (closestSegmentIndex - 1).coerceAtLeast(0),
+            (closestSegmentIndex + 1).coerceAtMost(alignment.segments.lastIndex))
 
     val possibleSegments = alignment.segments.slice(possibleSegmentIndices)
 
-    val jointDistanceToAlignment = possibleSegments.flatMap { segment ->
-        segment.segmentPoints.mapIndexedNotNull { pIdx, point ->
-            segment.segmentPoints.getOrNull(pIdx - 1)?.let { previousPoint ->
-                val closestSegmentPoint = closestPointOnLine(previousPoint, point, jointLocation)
-                val jointDistanceToSegment = lineLength(closestSegmentPoint, jointLocation)
-                jointDistanceToSegment
+    val jointDistanceToAlignment =
+        possibleSegments
+            .flatMap { segment ->
+                segment.segmentPoints.mapIndexedNotNull { pIdx, point ->
+                    segment.segmentPoints.getOrNull(pIdx - 1)?.let { previousPoint ->
+                        val closestSegmentPoint =
+                            closestPointOnLine(previousPoint, point, jointLocation)
+                        val jointDistanceToSegment = lineLength(closestSegmentPoint, jointLocation)
+                        jointDistanceToSegment
+                    }
+                }
             }
-        }
-    }.min()
+            .min()
 
     return possibleSegments.flatMapIndexed { index, segment ->
         val segmentIndex = possibleSegmentIndices.first + index
 
-        val startMatches = segment.segmentStart.isSame(jointLocation, TOLERANCE_JOINT_LOCATION_SEGMENT_END_POINT)
-        val endMatches = segment.segmentEnd.isSame(jointLocation, TOLERANCE_JOINT_LOCATION_SEGMENT_END_POINT)
+        val startMatches =
+            segment.segmentStart.isSame(jointLocation, TOLERANCE_JOINT_LOCATION_SEGMENT_END_POINT)
+        val endMatches =
+            segment.segmentEnd.isSame(jointLocation, TOLERANCE_JOINT_LOCATION_SEGMENT_END_POINT)
 
         listOfNotNull(
             // Check if segment's start point is within tolerance
-            if (startMatches) FittedSwitchJointMatch(
-                locationTrackId = locationTrack.id as IntId,
-                m = segment.startM,
-                matchType = SuggestedSwitchJointMatchType.START,
-                switchJoint = joint,
-                distance = lineLength(segment.segmentStart, jointLocation),
-                distanceToAlignment = jointDistanceToAlignment,
-                alignmentId = locationTrack.alignmentVersion?.id,
-                segmentIndex = segmentIndex,
-            ) else null,
+            if (startMatches)
+                FittedSwitchJointMatch(
+                    locationTrackId = locationTrack.id as IntId,
+                    m = segment.startM,
+                    matchType = SuggestedSwitchJointMatchType.START,
+                    switchJoint = joint,
+                    distance = lineLength(segment.segmentStart, jointLocation),
+                    distanceToAlignment = jointDistanceToAlignment,
+                    alignmentId = locationTrack.alignmentVersion?.id,
+                    segmentIndex = segmentIndex,
+                )
+            else null,
 
             // Check if segment's end point is within tolerance
-            if (endMatches) FittedSwitchJointMatch(
-                locationTrackId = locationTrack.id as IntId,
-                m = segment.endM,
-                matchType = SuggestedSwitchJointMatchType.END,
-                switchJoint = joint,
-                distance = lineLength(segment.segmentEnd, jointLocation),
-                distanceToAlignment = jointDistanceToAlignment,
-                alignmentId = locationTrack.alignmentVersion?.id,
-                segmentIndex = segmentIndex,
-            ) else null
-        ) + segment.segmentPoints.mapIndexedNotNull { pIdx, point ->
-            segment.segmentPoints.getOrNull(pIdx - 1)?.let { previousPoint ->
-                val closestAlignmentPoint = closestPointOnLine(previousPoint, point, jointLocation)
-                val jointDistanceToSegment = lineLength(closestAlignmentPoint, jointLocation)
+            if (endMatches)
+                FittedSwitchJointMatch(
+                    locationTrackId = locationTrack.id as IntId,
+                    m = segment.endM,
+                    matchType = SuggestedSwitchJointMatchType.END,
+                    switchJoint = joint,
+                    distance = lineLength(segment.segmentEnd, jointLocation),
+                    distanceToAlignment = jointDistanceToAlignment,
+                    alignmentId = locationTrack.alignmentVersion?.id,
+                    segmentIndex = segmentIndex,
+                )
+            else null) +
+            segment.segmentPoints.mapIndexedNotNull { pIdx, point ->
+                segment.segmentPoints.getOrNull(pIdx - 1)?.let { previousPoint ->
+                    val closestAlignmentPoint =
+                        closestPointOnLine(previousPoint, point, jointLocation)
+                    val jointDistanceToSegment = lineLength(closestAlignmentPoint, jointLocation)
 
-                if (jointDistanceToSegment < tolerance) {
-                    FittedSwitchJointMatch(
-                        locationTrackId = locationTrack.id as IntId,
-                        m = segment.getClosestPointM(closestAlignmentPoint).first,
-                        matchType = SuggestedSwitchJointMatchType.LINE,
-                        switchJoint = joint,
-                        distance = jointDistanceToSegment,
-                        distanceToAlignment = jointDistanceToAlignment,
-                        alignmentId = locationTrack.alignmentVersion?.id,
-                        segmentIndex = segmentIndex,
-                    )
-                } else null
+                    if (jointDistanceToSegment < tolerance) {
+                        FittedSwitchJointMatch(
+                            locationTrackId = locationTrack.id as IntId,
+                            m = segment.getClosestPointM(closestAlignmentPoint).first,
+                            matchType = SuggestedSwitchJointMatchType.LINE,
+                            switchJoint = joint,
+                            distance = jointDistanceToSegment,
+                            distanceToAlignment = jointDistanceToAlignment,
+                            alignmentId = locationTrack.alignmentVersion?.id,
+                            segmentIndex = segmentIndex,
+                        )
+                    } else null
+                }
             }
-        }
     }
 }
 
@@ -275,31 +317,38 @@ fun fitSwitch(
     geometryPlanId: IntId<GeometryPlan>? = null,
     getMeasurementMethod: (switchId: IntId<GeometrySwitch>) -> MeasurementMethod?,
 ): FittedSwitch {
-    val jointMatchTolerance = 0.2 // TODO: There could be tolerance per joint point in switch structure
+    val jointMatchTolerance =
+        0.2 // TODO: There could be tolerance per joint point in switch structure
 
-    val matchesByLocationTrack = alignments.associate { alignment ->
-        alignment.first to findSuggestedSwitchJointMatches(
-            joints = jointsInLayoutSpace,
-            locationTrackAlignment = alignment,
-            tolerance = jointMatchTolerance,
-        )
-    }.filter { it.value.isNotEmpty() }
+    val matchesByLocationTrack =
+        alignments
+            .associate { alignment ->
+                alignment.first to
+                    findSuggestedSwitchJointMatches(
+                        joints = jointsInLayoutSpace,
+                        locationTrackAlignment = alignment,
+                        tolerance = jointMatchTolerance,
+                    )
+            }
+            .filter { it.value.isNotEmpty() }
 
     val endJoints = getEndJoints(matchesByLocationTrack)
     val matchByJoint = getBestMatchByJoint(matchesByLocationTrack, endJoints)
-    val jointsWithoutMatches = jointsInLayoutSpace
-        .filterNot { matchByJoint.containsKey(it) }
-        .associateWith { emptyList<FittedSwitchJointMatch>() }
+    val jointsWithoutMatches =
+        jointsInLayoutSpace
+            .filterNot { matchByJoint.containsKey(it) }
+            .associateWith { emptyList<FittedSwitchJointMatch>() }
 
-    val suggestedJoints = (matchByJoint + jointsWithoutMatches).map { (joint, matches) ->
-        val locationAccuracy = switchJointLocationAccuracy(getMeasurementMethod, geometrySwitch)
-        FittedSwitchJoint(
-            number = joint.number,
-            location = joint.location,
-            matches = matches,
-            locationAccuracy = locationAccuracy,
-        )
-    }
+    val suggestedJoints =
+        (matchByJoint + jointsWithoutMatches).map { (joint, matches) ->
+            val locationAccuracy = switchJointLocationAccuracy(getMeasurementMethod, geometrySwitch)
+            FittedSwitchJoint(
+                number = joint.number,
+                location = joint.location,
+                matches = matches,
+                locationAccuracy = locationAccuracy,
+            )
+        }
 
     return FittedSwitch(
         name = geometrySwitch?.name ?: SwitchName(switchStructure.baseType.name),
@@ -314,15 +363,20 @@ fun fitSwitch(
 private fun getBestMatchByJoint(
     matchesByLocationTrack: Map<LocationTrack, List<FittedSwitchJointMatch>>,
     endJoints: Map<LocationTrack, Pair<SwitchJoint, SwitchJoint>>,
-) = matchesByLocationTrack.flatMap { (lt, matches) ->
-    matches.groupBy { it.switchJoint }.map { (joint, jointMatches) ->
-        getBestMatchesForJoint(
-            jointMatches = jointMatches,
-            isFirstJoint = endJoints[lt]?.first == joint,
-            isLastJoint = endJoints[lt]?.second == joint
-        )
-    }.mapNotNull { filteredMatches -> filteredMatches.minByOrNull { it.distance } }
-}.groupBy { it.switchJoint }
+) =
+    matchesByLocationTrack
+        .flatMap { (lt, matches) ->
+            matches
+                .groupBy { it.switchJoint }
+                .map { (joint, jointMatches) ->
+                    getBestMatchesForJoint(
+                        jointMatches = jointMatches,
+                        isFirstJoint = endJoints[lt]?.first == joint,
+                        isLastJoint = endJoints[lt]?.second == joint)
+                }
+                .mapNotNull { filteredMatches -> filteredMatches.minByOrNull { it.distance } }
+        }
+        .groupBy { it.switchJoint }
 
 private fun getBestMatchesForJoint(
     jointMatches: List<FittedSwitchJointMatch>,
@@ -333,16 +387,23 @@ private fun getBestMatchesForJoint(
         // First joint should never match with the last point of a segment
         jointMatches
             .filter { it.matchType == SuggestedSwitchJointMatchType.START }
-            .ifEmpty { jointMatches.filterNot { it.matchType == SuggestedSwitchJointMatchType.END } }
+            .ifEmpty {
+                jointMatches.filterNot { it.matchType == SuggestedSwitchJointMatchType.END }
+            }
     } else if (isLastJoint) {
         // Last joint should never match with the first point of a segment
         jointMatches
             .filter { it.matchType == SuggestedSwitchJointMatchType.END }
-            .ifEmpty { jointMatches.filterNot { it.matchType == SuggestedSwitchJointMatchType.START } }
+            .ifEmpty {
+                jointMatches.filterNot { it.matchType == SuggestedSwitchJointMatchType.START }
+            }
     } else {
         // Prefer end points over "normal" ones
         jointMatches
-            .filter { it.matchType == SuggestedSwitchJointMatchType.START || it.matchType == SuggestedSwitchJointMatchType.END }
+            .filter {
+                it.matchType == SuggestedSwitchJointMatchType.START ||
+                    it.matchType == SuggestedSwitchJointMatchType.END
+            }
             .ifEmpty { jointMatches }
     }
 }
@@ -360,19 +421,22 @@ private fun switchJointLocationAccuracy(
     geometrySwitch: GeometrySwitch?,
 ): LocationAccuracy? {
     return if (geometrySwitch != null) {
-        getMeasurementMethod(geometrySwitch.id as IntId)?.let(::mapMeasurementMethodToLocationAccuracy)
+        getMeasurementMethod(geometrySwitch.id as IntId)
+            ?.let(::mapMeasurementMethodToLocationAccuracy)
     } else {
         LocationAccuracy.GEOMETRY_CALCULATED
     }
 }
 
-private fun mapMeasurementMethodToLocationAccuracy(mm: MeasurementMethod): LocationAccuracy = when (mm) {
-    MeasurementMethod.VERIFIED_DESIGNED_GEOMETRY -> LocationAccuracy.DESIGNED_GEOLOCATION
-    MeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY -> LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY
-    MeasurementMethod.TRACK_INSPECTION -> LocationAccuracy.MEASURED_GEODETICALLY
-    MeasurementMethod.DIGITIZED_AERIAL_IMAGE -> LocationAccuracy.DIGITIZED_AERIAL_IMAGE
-    MeasurementMethod.UNVERIFIED_DESIGNED_GEOMETRY -> LocationAccuracy.MEASURED_GEODETICALLY
-}
+private fun mapMeasurementMethodToLocationAccuracy(mm: MeasurementMethod): LocationAccuracy =
+    when (mm) {
+        MeasurementMethod.VERIFIED_DESIGNED_GEOMETRY -> LocationAccuracy.DESIGNED_GEOLOCATION
+        MeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY ->
+            LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY
+        MeasurementMethod.TRACK_INSPECTION -> LocationAccuracy.MEASURED_GEODETICALLY
+        MeasurementMethod.DIGITIZED_AERIAL_IMAGE -> LocationAccuracy.DIGITIZED_AERIAL_IMAGE
+        MeasurementMethod.UNVERIFIED_DESIGNED_GEOMETRY -> LocationAccuracy.MEASURED_GEODETICALLY
+    }
 
 fun inferSwitchTransformationBothDirection(
     location: IPoint,
@@ -380,11 +444,8 @@ fun inferSwitchTransformationBothDirection(
     switchAlignmentId: StringId<SwitchAlignment>,
     alignment: LayoutAlignment,
 ): SwitchPositionTransformation? {
-    return inferSwitchTransformation(
-        location, switchStructure, switchAlignmentId, alignment, true
-    ) ?: inferSwitchTransformation(
-        location, switchStructure, switchAlignmentId, alignment, false
-    )
+    return inferSwitchTransformation(location, switchStructure, switchAlignmentId, alignment, true)
+        ?: inferSwitchTransformation(location, switchStructure, switchAlignmentId, alignment, false)
 }
 
 fun inferSwitchTransformation(
@@ -396,29 +457,35 @@ fun inferSwitchTransformation(
 ): SwitchPositionTransformation? {
     val switchAlignment = switchStructure.getAlignment(switchAlignmentId)
 
-    val alignmentJointNumberPairs = switchAlignment.jointNumbers.flatMapIndexed { index1, jointNumber1 ->
-        switchAlignment.jointNumbers.mapIndexed { index2, jointNumber2 ->
-            if (index2 > index1) jointNumber1 to jointNumber2
-            else null
-        }.filterNotNull()
-    }.sortedBy { (jointNumber1, jointNumber2) ->
-        // Prefer full alignments, then alignments from the presentation point
-        if (jointNumber1 == switchAlignment.jointNumbers.first() && jointNumber2 == switchAlignment.jointNumbers.last()) 0
-        else if (jointNumber1 == switchStructure.presentationJointNumber) 1
-        else 2
-    }
+    val alignmentJointNumberPairs =
+        switchAlignment.jointNumbers
+            .flatMapIndexed { index1, jointNumber1 ->
+                switchAlignment.jointNumbers
+                    .mapIndexed { index2, jointNumber2 ->
+                        if (index2 > index1) jointNumber1 to jointNumber2 else null
+                    }
+                    .filterNotNull()
+            }
+            .sortedBy { (jointNumber1, jointNumber2) ->
+                // Prefer full alignments, then alignments from the presentation point
+                if (jointNumber1 == switchAlignment.jointNumbers.first() &&
+                    jointNumber2 == switchAlignment.jointNumbers.last())
+                    0
+                else if (jointNumber1 == switchStructure.presentationJointNumber) 1 else 2
+            }
 
     val allPoints = alignment.allSegmentPoints.toList()
     // Find the "start" point for switch joint
     // It's usually the first or the last point of alignment
-    val startPointIndex = allPoints.indexOfFirst { point ->
-        point.isSame(location, TOLERANCE_JOINT_LOCATION_NEW_POINT)
-    }
+    val startPointIndex =
+        allPoints.indexOfFirst { point ->
+            point.isSame(location, TOLERANCE_JOINT_LOCATION_NEW_POINT)
+        }
 
     if (startPointIndex == -1) return null
 
-    val switchEndPointSearchIndexes = if (ascending) (startPointIndex..allPoints.lastIndex)
-    else (startPointIndex downTo 0)
+    val switchEndPointSearchIndexes =
+        if (ascending) (startPointIndex..allPoints.lastIndex) else (startPointIndex downTo 0)
 
     val startPoint = allPoints[startPointIndex]
 
@@ -427,29 +494,33 @@ fun inferSwitchTransformation(
         val endJointLocation = switchStructure.getJointLocation(endJointNumber)
         val switchJointLength = lineLength(startJointLocation, endJointLocation)
 
-        switchEndPointSearchIndexes.firstOrNull { endPointIndex ->
-            val pointsLength = lineLength(allPoints[endPointIndex], startPoint)
-            pointsLength > switchJointLength
-        }?.let { endPointIndex ->
-            allPoints
-                .getOrNull(if (ascending) endPointIndex - 1 else endPointIndex + 1)
-                ?.let { previousEndPoint ->
+        switchEndPointSearchIndexes
+            .firstOrNull { endPointIndex ->
+                val pointsLength = lineLength(allPoints[endPointIndex], startPoint)
+                pointsLength > switchJointLength
+            }
+            ?.let { endPointIndex ->
+                allPoints.getOrNull(if (ascending) endPointIndex - 1 else endPointIndex + 1)?.let {
+                    previousEndPoint ->
                     val endPoint = allPoints[endPointIndex]
                     val lengthToPreviousEndPoint = lineLength(previousEndPoint, startPoint)
                     val lengthToEndPoint = lineLength(endPoint, startPoint)
 
                     val proportion =
-                        (switchJointLength - lengthToPreviousEndPoint) / (lengthToEndPoint - lengthToPreviousEndPoint)
+                        (switchJointLength - lengthToPreviousEndPoint) /
+                            (lengthToEndPoint - lengthToPreviousEndPoint)
                     interpolate(previousEndPoint, endPoint, proportion)
                 }
-        }?.let { endPoint ->
-            val testJoints = listOf(
-                SwitchJoint(startJointNumber, startPoint.toPoint()),
-                SwitchJoint(endJointNumber, endPoint.toPoint()),
-            )
+            }
+            ?.let { endPoint ->
+                val testJoints =
+                    listOf(
+                        SwitchJoint(startJointNumber, startPoint.toPoint()),
+                        SwitchJoint(endJointNumber, endPoint.toPoint()),
+                    )
 
-            calculateSwitchLocationDeltaOrNull(testJoints, switchStructure)
-        }
+                calculateSwitchLocationDeltaOrNull(testJoints, switchStructure)
+            }
     }
 }
 
@@ -462,9 +533,10 @@ fun hasAllMappedAlignments(
         val switchAlignmentToCheck = switchStructure.getAlignment(mappingToCheck.switchAlignmentId)
         switchAlignmentToCheck.jointNumbers.all { jointNumberToCheck ->
             switchSuggestion.joints.any { suggestedSwitchJoint ->
-                suggestedSwitchJoint.number == jointNumberToCheck && suggestedSwitchJoint.matches.any { match ->
-                    match.locationTrackId == mappingToCheck.locationTrackId
-                }
+                suggestedSwitchJoint.number == jointNumberToCheck &&
+                    suggestedSwitchJoint.matches.any { match ->
+                        match.locationTrackId == mappingToCheck.locationTrackId
+                    }
             }
         }
     }
@@ -478,46 +550,59 @@ fun fitSwitch(
     alignmentById: Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>,
     getMeasurementMethod: (switchId: IntId<GeometrySwitch>) -> MeasurementMethod?,
 ): FittedSwitch? {
-    val mappedAlignments = alignmentMappings.map { mapping ->
-        alignmentById[mapping.locationTrackId]
-            ?: throw IllegalArgumentException("Alignment with id ${mapping.locationTrackId} is not provided")
-    }
+    val mappedAlignments =
+        alignmentMappings.map { mapping ->
+            alignmentById[mapping.locationTrackId]
+                ?: throw IllegalArgumentException(
+                    "Alignment with id ${mapping.locationTrackId} is not provided")
+        }
 
     alignmentMappings.forEach { alignmentMapping ->
         val alignment = alignmentById[alignmentMapping.locationTrackId]?.second
-        require(alignment != null) { "Alignment mapping failed: id=${alignmentMapping.locationTrackId}" }
-        val switchTransformation = if (alignmentMapping.ascending == null) inferSwitchTransformationBothDirection(
-            locationTrackEndpoint.location,
-            switchStructure,
-            alignmentMapping.switchAlignmentId,
-            alignment,
-        )
-        else inferSwitchTransformation(
-            locationTrackEndpoint.location,
-            switchStructure,
-            alignmentMapping.switchAlignmentId,
-            alignment,
-            alignmentMapping.ascending,
-        )
+        require(alignment != null) {
+            "Alignment mapping failed: id=${alignmentMapping.locationTrackId}"
+        }
+        val switchTransformation =
+            if (alignmentMapping.ascending == null)
+                inferSwitchTransformationBothDirection(
+                    locationTrackEndpoint.location,
+                    switchStructure,
+                    alignmentMapping.switchAlignmentId,
+                    alignment,
+                )
+            else
+                inferSwitchTransformation(
+                    locationTrackEndpoint.location,
+                    switchStructure,
+                    alignmentMapping.switchAlignmentId,
+                    alignment,
+                    alignmentMapping.ascending,
+                )
 
         if (switchTransformation != null) {
-            val jointsInLayoutSpace = switchStructure.joints.map { joint ->
-                joint.copy(location = transformSwitchPoint(switchTransformation, joint.location))
-            }
+            val jointsInLayoutSpace =
+                switchStructure.joints.map { joint ->
+                    joint.copy(
+                        location = transformSwitchPoint(switchTransformation, joint.location))
+                }
 
-            val alignments = (nearbyAlignments + mappedAlignments).distinctBy { (locationTrack, _) -> locationTrack.id }
+            val alignments =
+                (nearbyAlignments + mappedAlignments).distinctBy { (locationTrack, _) ->
+                    locationTrack.id
+                }
 
-            val suggestedSwitch = fitSwitch(
-                jointsInLayoutSpace = jointsInLayoutSpace,
-                switchStructure = switchStructure,
-                alignments = alignments,
-                geometrySwitch = null,
-                geometryPlanId = null,
-                alignmentEndPoint = locationTrackEndpoint,
-                getMeasurementMethod = getMeasurementMethod
-            )
+            val suggestedSwitch =
+                fitSwitch(
+                    jointsInLayoutSpace = jointsInLayoutSpace,
+                    switchStructure = switchStructure,
+                    alignments = alignments,
+                    geometrySwitch = null,
+                    geometryPlanId = null,
+                    alignmentEndPoint = locationTrackEndpoint,
+                    getMeasurementMethod = getMeasurementMethod)
 
-            return if (hasAllMappedAlignments(alignmentMappings, suggestedSwitch, switchStructure)) suggestedSwitch
+            return if (hasAllMappedAlignments(alignmentMappings, suggestedSwitch, switchStructure))
+                suggestedSwitch
             else null
         }
     }
@@ -546,44 +631,53 @@ private fun findClosestIntersections(
     // that alignments are about 0 - 200 meters long, and therefore we can compare
     // angles from start to end.
     val directionDiff = alignmentStartEndDirectionDiff(alignment1, alignment2)?.let(::radsToDegrees)
-    if (directionDiff == null || directionDiff < MAX_PARALLEL_LINE_ANGLE_DIFF_IN_DEGREES) return emptyList()
+    if (directionDiff == null || directionDiff < MAX_PARALLEL_LINE_ANGLE_DIFF_IN_DEGREES)
+        return emptyList()
 
     val lines1 = lines(alignment1)
     val lines2 = lines(alignment2)
-    val intersections = lines1.flatMap { line1 ->
-        lines2.mapNotNull { line2 ->
-            val intersection = lineIntersection(line1.start, line1.end, line2.start, line2.end)
-            if (intersection != null && intersection.linesIntersect()) {
-                TrackIntersection(
-                    point = intersection.point,
-                    distance = 0.0,
-                    alignment1 = alignment1,
-                    alignment2 = alignment2,
-                    desiredLocation = desiredLocation
-                )
-            } else {
-                val linePointDistanceCheckPairs = listOf(
-                    line1 to line2.start, line1 to line2.end, line2 to line1.start, line2 to line1.end
-                )
-                val minDistanceAndPoint = linePointDistanceCheckPairs.map { (line, point) ->
-                    pointDistanceToLine(line.start, line.end, point) to point
-                }.minBy { (distance, _) -> distance }
-                if (minDistanceAndPoint.first <= MAX_LINE_INTERSECTION_DISTANCE) {
+    val intersections =
+        lines1.flatMap { line1 ->
+            lines2.mapNotNull { line2 ->
+                val intersection = lineIntersection(line1.start, line1.end, line2.start, line2.end)
+                if (intersection != null && intersection.linesIntersect()) {
                     TrackIntersection(
-                        point = minDistanceAndPoint.second,
-                        distance = minDistanceAndPoint.first,
+                        point = intersection.point,
+                        distance = 0.0,
                         alignment1 = alignment1,
                         alignment2 = alignment2,
-                        desiredLocation = desiredLocation
-                    )
-                } else null
+                        desiredLocation = desiredLocation)
+                } else {
+                    val linePointDistanceCheckPairs =
+                        listOf(
+                            line1 to line2.start,
+                            line1 to line2.end,
+                            line2 to line1.start,
+                            line2 to line1.end)
+                    val minDistanceAndPoint =
+                        linePointDistanceCheckPairs
+                            .map { (line, point) ->
+                                pointDistanceToLine(line.start, line.end, point) to point
+                            }
+                            .minBy { (distance, _) -> distance }
+                    if (minDistanceAndPoint.first <= MAX_LINE_INTERSECTION_DISTANCE) {
+                        TrackIntersection(
+                            point = minDistanceAndPoint.second,
+                            distance = minDistanceAndPoint.first,
+                            alignment1 = alignment1,
+                            alignment2 = alignment2,
+                            desiredLocation = desiredLocation)
+                    } else null
+                }
             }
         }
-    }
     return intersections.sorted().take(count)
 }
 
-private fun alignmentStartEndDirectionDiff(alignment1: IAlignment, alignment2: IAlignment): Double? {
+private fun alignmentStartEndDirectionDiff(
+    alignment1: IAlignment,
+    alignment2: IAlignment
+): Double? {
     val track1Direction = alignmentStartEndDirection(alignment1)
     val track2Direction = alignmentStartEndDirection(alignment2)
     return if (track1Direction != null && track2Direction != null) {
@@ -597,18 +691,21 @@ private fun alignmentStartEndDirection(alignment: IAlignment): Double? {
     return if (start != null && end != null) directionBetweenPoints(start, end) else null
 }
 
-private fun getClosestPointAsIntersection(track1: IAlignment, track2: IAlignment, desiredLocation: IPoint): TrackIntersection? {
+private fun getClosestPointAsIntersection(
+    track1: IAlignment,
+    track2: IAlignment,
+    desiredLocation: IPoint
+): TrackIntersection? {
     return listOf(track1, track2)
         .mapNotNull { track -> track.getClosestPoint(desiredLocation) }
-        .minByOrNull { (point, _) -> lineLength(point,desiredLocation) }
-        ?.let { (closestPoint,_) ->
+        .minByOrNull { (point, _) -> lineLength(point, desiredLocation) }
+        ?.let { (closestPoint, _) ->
             TrackIntersection(
                 alignment1 = track1,
                 alignment2 = track2,
                 point = closestPoint,
                 distance = 0.0,
-                desiredLocation = desiredLocation
-            )
+                desiredLocation = desiredLocation)
         }
 }
 
@@ -616,11 +713,13 @@ private fun findTrackIntersections(
     trackAlignments: List<IAlignment>,
     desiredLocation: IPoint,
 ): List<TrackIntersection> {
-    val trackPairs = trackAlignments.flatMapIndexed { index, track1 ->
-        trackAlignments.drop(index + 1).map { track2 -> track1 to track2 }
-    }
+    val trackPairs =
+        trackAlignments.flatMapIndexed { index, track1 ->
+            trackAlignments.drop(index + 1).map { track2 -> track1 to track2 }
+        }
     return trackPairs.flatMap { (track1, track2) ->
-        val closestPointAsIntersection = getClosestPointAsIntersection(track1, track2, desiredLocation)
+        val closestPointAsIntersection =
+            getClosestPointAsIntersection(track1, track2, desiredLocation)
 
         // Take two closest intersections instead of one because there might
         // be two points very close to each other and it is cheap to
@@ -636,9 +735,13 @@ fun findFarthestJoint(
     joint: SwitchJoint,
     switchAlignment: SwitchAlignment,
 ): SwitchJoint {
-    val jointNumber = requireNotNull(switchAlignment.jointNumbers.maxByOrNull { jointNumber ->
-        lineLength(joint.location, switchStructure.getJointLocation(jointNumber))
-    }) { "Cannot find farthest joint: joints=${switchAlignment.jointNumbers}" }
+    val jointNumber =
+        requireNotNull(
+            switchAlignment.jointNumbers.maxByOrNull { jointNumber ->
+                lineLength(joint.location, switchStructure.getJointLocation(jointNumber))
+            }) {
+                "Cannot find farthest joint: joints=${switchAlignment.jointNumbers}"
+            }
     return switchStructure.getJoint(jointNumber)
 }
 
@@ -648,37 +751,50 @@ private data class SwitchPointSeekResult(
     val pointForwards: AlignmentPoint?,
 )
 
-private fun findPointsOnTrack(from: IPoint, distance: Double, alignment: IAlignment): SwitchPointSeekResult? {
+private fun findPointsOnTrack(
+    from: IPoint,
+    distance: Double,
+    alignment: IAlignment
+): SwitchPointSeekResult? {
     val snapDistance = 0.1
-    return alignment.getClosestPointM(from)?.let { (mValue, state) ->
-        if (state == IntersectType.WITHIN) alignment.getPointAtM(mValue, snapDistance)?.let { p -> mValue to p }
-        else null
-    }?.let { (mValue, pointOnTrack) ->
-        SwitchPointSeekResult(
-            fixPoint = pointOnTrack,
-            pointBackwards = alignment.getPointAtM(mValue - distance, snapDistance),
-            pointForwards = alignment.getPointAtM(mValue + distance, snapDistance),
-        )
-    }
+    return alignment
+        .getClosestPointM(from)
+        ?.let { (mValue, state) ->
+            if (state == IntersectType.WITHIN)
+                alignment.getPointAtM(mValue, snapDistance)?.let { p -> mValue to p }
+            else null
+        }
+        ?.let { (mValue, pointOnTrack) ->
+            SwitchPointSeekResult(
+                fixPoint = pointOnTrack,
+                pointBackwards = alignment.getPointAtM(mValue - distance, snapDistance),
+                pointForwards = alignment.getPointAtM(mValue + distance, snapDistance),
+            )
+        }
 }
 
 fun findTransformations(
-    point: IPoint, alignment: IAlignment, switchAlignment: SwitchAlignment, joint: SwitchJoint,
+    point: IPoint,
+    alignment: IAlignment,
+    switchAlignment: SwitchAlignment,
+    joint: SwitchJoint,
     switchStructure: SwitchStructure,
 ): List<SwitchPositionTransformation> {
     val farthestJoint = findFarthestJoint(switchStructure, joint, switchAlignment)
     val jointDistance = lineLength(joint.location, farthestJoint.location)
     val pointsOnTrack = findPointsOnTrack(point, jointDistance, alignment)
     return listOfNotNull(
-        pointsOnTrack?.pointBackwards?.let { back -> pointsOnTrack.fixPoint to back },
-        pointsOnTrack?.pointForwards?.let { forward -> pointsOnTrack.fixPoint to forward },
-    ).mapNotNull { (from, to) ->
-        val testJoints = listOf(
-            joint.copy(location = from.toPoint()),
-            farthestJoint.copy(location = to.toPoint()),
+            pointsOnTrack?.pointBackwards?.let { back -> pointsOnTrack.fixPoint to back },
+            pointsOnTrack?.pointForwards?.let { forward -> pointsOnTrack.fixPoint to forward },
         )
-        calculateSwitchLocationDeltaOrNull(testJoints, switchStructure)
-    }
+        .mapNotNull { (from, to) ->
+            val testJoints =
+                listOf(
+                    joint.copy(location = from.toPoint()),
+                    farthestJoint.copy(location = to.toPoint()),
+                )
+            calculateSwitchLocationDeltaOrNull(testJoints, switchStructure)
+        }
 }
 
 fun findTransformations(
@@ -690,11 +806,10 @@ fun findTransformations(
     joint: SwitchJoint,
     switchStructure: SwitchStructure,
 ): List<SwitchPositionTransformation> {
-    return findTransformations(point, alignment1, switchAlignment1, joint, switchStructure) + findTransformations(
-        point, alignment1, switchAlignment2, joint, switchStructure
-    ) + findTransformations(point, alignment2, switchAlignment1, joint, switchStructure) + findTransformations(
-        point, alignment2, switchAlignment2, joint, switchStructure
-    )
+    return findTransformations(point, alignment1, switchAlignment1, joint, switchStructure) +
+        findTransformations(point, alignment1, switchAlignment2, joint, switchStructure) +
+        findTransformations(point, alignment2, switchAlignment1, joint, switchStructure) +
+        findTransformations(point, alignment2, switchAlignment2, joint, switchStructure)
 }
 
 fun fitSwitch(
@@ -702,13 +817,13 @@ fun fitSwitch(
     tracks: List<Pair<LocationTrack, LayoutAlignment>>,
     switchStructure: SwitchStructure,
 ): FittedSwitch {
-    val jointsInLayoutSpace = switchStructure.joints.map { joint ->
-        joint.copy(
-            location = transformSwitchPoint(transformation, joint.location)
-        )
-    }
+    val jointsInLayoutSpace =
+        switchStructure.joints.map { joint ->
+            joint.copy(location = transformSwitchPoint(transformation, joint.location))
+        }
 
-    return fitSwitch(jointsInLayoutSpace = jointsInLayoutSpace,
+    return fitSwitch(
+        jointsInLayoutSpace = jointsInLayoutSpace,
         switchStructure = switchStructure,
         alignments = tracks,
         geometrySwitch = null,
@@ -717,24 +832,30 @@ fun fitSwitch(
         getMeasurementMethod = { MeasurementMethod.DIGITIZED_AERIAL_IMAGE })
 }
 
-fun getSharedSwitchJoint(switchStructure: SwitchStructure): Pair<SwitchJoint, List<SwitchAlignment>> {
-    val sortedSwitchJoints = switchStructure.joints.sortedWith { jointA, jointB ->
-        when {
-            jointA.number == switchStructure.presentationJointNumber -> -1
-            jointB.number == switchStructure.presentationJointNumber -> 1
-            else -> 0
-        }
-    }
-
-    val (sharedSwitchJoint, switchAlignmentsContainingCommonJoint) = requireNotNull(
-        sortedSwitchJoints.firstNotNullOfOrNull { joint ->
-            val alignmentsContainingJoint = switchStructure.alignments.filter { alignment ->
-                alignment.jointNumbers.contains(joint.number)
+fun getSharedSwitchJoint(
+    switchStructure: SwitchStructure
+): Pair<SwitchJoint, List<SwitchAlignment>> {
+    val sortedSwitchJoints =
+        switchStructure.joints.sortedWith { jointA, jointB ->
+            when {
+                jointA.number == switchStructure.presentationJointNumber -> -1
+                jointB.number == switchStructure.presentationJointNumber -> 1
+                else -> 0
             }
-            if (alignmentsContainingJoint.size >= 2) joint to alignmentsContainingJoint
-            else null
         }
-    ) { "Switch structure ${switchStructure.type} does not contain shared switch joint and that is weird!" }
+
+    val (sharedSwitchJoint, switchAlignmentsContainingCommonJoint) =
+        requireNotNull(
+            sortedSwitchJoints.firstNotNullOfOrNull { joint ->
+                val alignmentsContainingJoint =
+                    switchStructure.alignments.filter { alignment ->
+                        alignment.jointNumbers.contains(joint.number)
+                    }
+                if (alignmentsContainingJoint.size >= 2) joint to alignmentsContainingJoint
+                else null
+            }) {
+                "Switch structure ${switchStructure.type} does not contain shared switch joint and that is weird!"
+            }
 
     return sharedSwitchJoint to switchAlignmentsContainingCommonJoint
 }
@@ -751,16 +872,19 @@ fun getSuggestedSwitchScore(
         switchSuggestion.joints.filter { joint -> alignmentJointNumbers.contains(joint.number) }
     return suggestedAlignmentJoints.sumOf { joint ->
         // Select best of each joint
-        val jointScore = (joint.matches.maxOfOrNull { match ->
-            // Smaller the match distance, better the score
-            max(1.0 - match.distanceToAlignment, 0.0)
-        } ?: 0.0)
-        val farthestJointExtraScore = if (joint.number == farthestJoint.number && maxFarthestJointDistance > 0) {
-            val distanceToFarthestJoint = lineLength(desiredLocation, joint.location)
-            val maxExtraScore = 0.5
-            val extraScore = (distanceToFarthestJoint / maxFarthestJointDistance) * maxExtraScore
-            extraScore
-        } else 0.0
+        val jointScore =
+            (joint.matches.maxOfOrNull { match ->
+                // Smaller the match distance, better the score
+                max(1.0 - match.distanceToAlignment, 0.0)
+            } ?: 0.0)
+        val farthestJointExtraScore =
+            if (joint.number == farthestJoint.number && maxFarthestJointDistance > 0) {
+                val distanceToFarthestJoint = lineLength(desiredLocation, joint.location)
+                val maxExtraScore = 0.5
+                val extraScore =
+                    (distanceToFarthestJoint / maxFarthestJointDistance) * maxExtraScore
+                extraScore
+            } else 0.0
         jointScore + farthestJointExtraScore
     }
 }
@@ -775,18 +899,22 @@ fun selectBestSuggestedSwitch(
         return null
     }
 
-    val maxFarthestJointDistance = switchSuggestions.maxOf { suggestedSwitch ->
-        suggestedSwitch.joints.maxOf { joint ->
-            if (joint.number == farthestJoint.number) {
-                lineLength(desiredLocation, joint.location)
-            } else 0.0
+    val maxFarthestJointDistance =
+        switchSuggestions.maxOf { suggestedSwitch ->
+            suggestedSwitch.joints.maxOf { joint ->
+                if (joint.number == farthestJoint.number) {
+                    lineLength(desiredLocation, joint.location)
+                } else 0.0
+            }
         }
-    }
 
     return switchSuggestions.maxBy { suggestedSwitch ->
         getSuggestedSwitchScore(
-            suggestedSwitch, switchStructure, farthestJoint, maxFarthestJointDistance, desiredLocation
-        )
+            suggestedSwitch,
+            switchStructure,
+            farthestJoint,
+            maxFarthestJointDistance,
+            desiredLocation)
     }
 }
 
@@ -800,25 +928,33 @@ fun createSuggestedSwitchByPoint(
     val croppedTracks = nearbyLocationTracks.map { (_, alignment) -> cropPoints(alignment, bbox) }
 
     val intersections = findTrackIntersections(croppedTracks, point)
-    val (sharedSwitchJoint, switchAlignmentsContainingSharedJoint) = getSharedSwitchJoint(switchStructure)
+    val (sharedSwitchJoint, switchAlignmentsContainingSharedJoint) =
+        getSharedSwitchJoint(switchStructure)
 
-    val suggestedSwitches = intersections.flatMap { intersection ->
-        val transformations = findTransformations(
-            intersection.point,
-            intersection.alignment1,
-            intersection.alignment2,
-            switchAlignmentsContainingSharedJoint[0],
-            switchAlignmentsContainingSharedJoint[1],
-            sharedSwitchJoint,
-            switchStructure
-        )
-        val suggestedSwitches = transformations.parallelStream().map { transformation ->
-            fitSwitch(transformation, nearbyLocationTracks, switchStructure)
-        }.collect(Collectors.toList())
-        suggestedSwitches
-    }
+    val suggestedSwitches =
+        intersections.flatMap { intersection ->
+            val transformations =
+                findTransformations(
+                    intersection.point,
+                    intersection.alignment1,
+                    intersection.alignment2,
+                    switchAlignmentsContainingSharedJoint[0],
+                    switchAlignmentsContainingSharedJoint[1],
+                    sharedSwitchJoint,
+                    switchStructure)
+            val suggestedSwitches =
+                transformations
+                    .parallelStream()
+                    .map { transformation ->
+                        fitSwitch(transformation, nearbyLocationTracks, switchStructure)
+                    }
+                    .collect(Collectors.toList())
+            suggestedSwitches
+        }
 
-    val farthestJoint = findFarthestJoint(switchStructure, sharedSwitchJoint, switchAlignmentsContainingSharedJoint[0])
+    val farthestJoint =
+        findFarthestJoint(
+            switchStructure, sharedSwitchJoint, switchAlignmentsContainingSharedJoint[0])
     return selectBestSuggestedSwitch(suggestedSwitches, switchStructure, farthestJoint, point)
 }
 
@@ -835,29 +971,31 @@ private data class TrackIntersection(
         return when {
             distance < other.distance -> -1
             distance > other.distance -> 1
-            else -> when {
-                distanceToDesiredLocation < other.distanceToDesiredLocation -> -1
-                distanceToDesiredLocation > other.distanceToDesiredLocation -> 1
-                else -> 0
-            }
+            else ->
+                when {
+                    distanceToDesiredLocation < other.distanceToDesiredLocation -> -1
+                    distanceToDesiredLocation > other.distanceToDesiredLocation -> 1
+                    else -> 0
+                }
         }
     }
 }
 
 /**
- * Returns a copy of the alignment filtering out points that do not locate
- * in the given bounding box.
+ * Returns a copy of the alignment filtering out points that do not locate in the given bounding
+ * box.
  */
 fun cropPoints(alignment: LayoutAlignment, bbox: BoundingBox): IAlignment {
-    val filteredSegments = alignment.segments.mapNotNull { segment ->
-        if (bbox.intersects(segment.boundingBox)) {
-            val firstMatchingPointIndex = segment.segmentPoints.indexOfFirst(bbox::contains)
-            val lastMatchingPointIndex = segment.segmentPoints.indexOfLast(bbox::contains)
-            if (firstMatchingPointIndex in 0 until lastMatchingPointIndex) {
-                segment.slice(firstMatchingPointIndex, lastMatchingPointIndex)
+    val filteredSegments =
+        alignment.segments.mapNotNull { segment ->
+            if (bbox.intersects(segment.boundingBox)) {
+                val firstMatchingPointIndex = segment.segmentPoints.indexOfFirst(bbox::contains)
+                val lastMatchingPointIndex = segment.segmentPoints.indexOfLast(bbox::contains)
+                if (firstMatchingPointIndex in 0 until lastMatchingPointIndex) {
+                    segment.slice(firstMatchingPointIndex, lastMatchingPointIndex)
+                } else null
             } else null
-        } else null
-    }
+        }
     return CroppedAlignment(filteredSegments, alignment.id)
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -68,7 +68,9 @@ private const val TOLERANCE_JOINT_LOCATION_SAME_POINT = 0.001
 private const val MAX_SWITCH_JOINT_OVERLAP_CORRECTION_AMOUNT_METERS = 5.0
 
 @GeoviiteService
-class SwitchLinkingService @Autowired constructor(
+class SwitchLinkingService
+@Autowired
+constructor(
     private val switchService: LayoutSwitchService,
     private val locationTrackService: LocationTrackService,
     private val locationTrackDao: LocationTrackDao,
@@ -82,7 +84,9 @@ class SwitchLinkingService @Autowired constructor(
 
     @Transactional(readOnly = true)
     fun getSuggestedSwitches(branch: LayoutBranch, bbox: BoundingBox): List<SuggestedSwitch> {
-        return switchFittingService.getFitsInArea(branch, bbox).map { fit -> matchFittedSwitch(branch, fit) }
+        return switchFittingService.getFitsInArea(branch, bbox).map { fit ->
+            matchFittedSwitch(branch, fit)
+        }
     }
 
     @Transactional(readOnly = true)
@@ -93,34 +97,44 @@ class SwitchLinkingService @Autowired constructor(
         return getSuggestedSwitchesWithRelevantTracks(branch, points).map { it?.first }
     }
 
-    // "relevant" = definitely includes tracks that the switches are linked to after the suggestion, but also tracks
-    // that are just within the expanded bounding box of the fitted switch joints, or that the switch was originally
+    // "relevant" = definitely includes tracks that the switches are linked to after the suggestion,
+    // but also tracks
+    // that are just within the expanded bounding box of the fitted switch joints, or that the
+    // switch was originally
     // linked to
     private fun getSuggestedSwitchesWithRelevantTracks(
         branch: LayoutBranch,
         points: List<Pair<IPoint, IntId<TrackLayoutSwitch>>>,
-    ): List<Pair<SuggestedSwitch, Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>>?> {
-        val originalSwitches = points.map { (_, switchId) -> switchService.getOrThrow(branch.draft, switchId) }
+    ): List<
+        Pair<SuggestedSwitch, Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>>?> {
+        val originalSwitches =
+            points.map { (_, switchId) -> switchService.getOrThrow(branch.draft, switchId) }
         val originallyLinkedLocationTracksBySwitch =
-            collectOriginallyLinkedLocationTracksBySwitch(branch, points.map { (_, switchId) -> switchId })
+            collectOriginallyLinkedLocationTracksBySwitch(
+                branch, points.map { (_, switchId) -> switchId })
 
-        val pointsWithStructures = points.mapIndexed { index, (point) ->
-            point to originalSwitches[index].switchStructureId
-        }
+        val pointsWithStructures =
+            points.mapIndexed { index, (point) ->
+                point to originalSwitches[index].switchStructureId
+            }
 
-        return switchFittingService.getFitsAtPoints(branch, pointsWithStructures).mapIndexed { index, fit ->
+        return switchFittingService.getFitsAtPoints(branch, pointsWithStructures).mapIndexed {
+            index,
+            fit ->
             fit?.let {
                 val tracksAroundFit = findLocationTracksForMatchingSwitchToTracks(branch, fit)
-                val originallyLinkedTracks = originallyLinkedLocationTracksBySwitch[points[index].second] ?: mapOf()
+                val originallyLinkedTracks =
+                    originallyLinkedLocationTracksBySwitch[points[index].second] ?: mapOf()
                 val relevantTracks = tracksAroundFit + originallyLinkedTracks
-                val match = matchFittedSwitchToTracks(
-                    fit,
-                    switchLibraryService.getSwitchStructure(fit.switchStructureId),
-                    relevantTracks,
-                    points[index].second,
-                    fit.geometrySwitchId?.let { id -> geometryDao.getSwitch(id).name },
-                )
-                match to relevantTracks.filterKeys { track -> match.trackLinks.containsKey(track)}
+                val match =
+                    matchFittedSwitchToTracks(
+                        fit,
+                        switchLibraryService.getSwitchStructure(fit.switchStructureId),
+                        relevantTracks,
+                        points[index].second,
+                        fit.geometrySwitchId?.let { id -> geometryDao.getSwitch(id).name },
+                    )
+                match to relevantTracks.filterKeys { track -> match.trackLinks.containsKey(track) }
             }
         }
     }
@@ -133,10 +147,13 @@ class SwitchLinkingService @Autowired constructor(
     ): SuggestedSwitch? = getSuggestedSwitches(branch, listOf(location to switchId)).getOrNull(0)
 
     @Transactional(readOnly = true)
-    fun getSuggestedSwitch(branch: LayoutBranch, createParams: SuggestedSwitchCreateParams): SuggestedSwitch? {
-        return switchFittingService
-            .getFitAtEndpoint(branch, createParams)
-            ?.let { fit -> matchFittedSwitch(branch, fit) }
+    fun getSuggestedSwitch(
+        branch: LayoutBranch,
+        createParams: SuggestedSwitchCreateParams
+    ): SuggestedSwitch? {
+        return switchFittingService.getFitAtEndpoint(branch, createParams)?.let { fit ->
+            matchFittedSwitch(branch, fit)
+        }
     }
 
     @Transactional
@@ -146,9 +163,10 @@ class SwitchLinkingService @Autowired constructor(
         switchId: IntId<TrackLayoutSwitch>,
     ): LayoutDaoResponse<TrackLayoutSwitch> {
         suggestedSwitch.geometrySwitchId?.let(::verifyPlanNotHidden)
-        val originalTracks = suggestedSwitch.trackLinks.keys.associateWith { id ->
-            locationTrackService.getWithAlignmentOrThrow(branch.draft, id)
-        }
+        val originalTracks =
+            suggestedSwitch.trackLinks.keys.associateWith { id ->
+                locationTrackService.getWithAlignmentOrThrow(branch.draft, id)
+            }
         val changedTracks = withChangesFromLinkingSwitch(suggestedSwitch, switchId, originalTracks)
         saveLocationTrackChanges(branch, changedTracks, originalTracks)
         return updateLayoutSwitch(branch, suggestedSwitch, switchId)
@@ -158,113 +176,154 @@ class SwitchLinkingService @Autowired constructor(
         branch: LayoutBranch,
         maybeChanged: List<Pair<LocationTrack, LayoutAlignment>>,
         original: Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>,
-    ) = maybeChanged.forEach { (locationTrack, alignment) ->
-        val (originalLocationTrack, originalAlignment) = original[locationTrack.id as IntId] ?: (null to null)
-        if (originalAlignment != alignment) {
-            locationTrackService.saveDraft(branch, locationTrack, alignment)
-        } else if (originalLocationTrack != locationTrack) {
-            locationTrackService.saveDraft(branch, locationTrack)
+    ) =
+        maybeChanged.forEach { (locationTrack, alignment) ->
+            val (originalLocationTrack, originalAlignment) =
+                original[locationTrack.id as IntId] ?: (null to null)
+            if (originalAlignment != alignment) {
+                locationTrackService.saveDraft(branch, locationTrack, alignment)
+            } else if (originalLocationTrack != locationTrack) {
+                locationTrackService.saveDraft(branch, locationTrack)
+            }
         }
-    }
 
     @Transactional(readOnly = true)
     fun matchFittedSwitch(
         branch: LayoutBranch,
         fittedSwitch: FittedSwitch,
         switchId: IntId<TrackLayoutSwitch>? = null,
-    ): SuggestedSwitch = matchFittedSwitchToTracks(
-        fittedSwitch,
-        switchLibraryService.getSwitchStructure(fittedSwitch.switchStructureId),
-        findLocationTracksForMatchingSwitchToTracks(branch, fittedSwitch, switchId),
-        switchId,
-        fittedSwitch.geometrySwitchId?.let { id -> geometryDao.getSwitch(id).name },
-    )
+    ): SuggestedSwitch =
+        matchFittedSwitchToTracks(
+            fittedSwitch,
+            switchLibraryService.getSwitchStructure(fittedSwitch.switchStructureId),
+            findLocationTracksForMatchingSwitchToTracks(branch, fittedSwitch, switchId),
+            switchId,
+            fittedSwitch.geometrySwitchId?.let { id -> geometryDao.getSwitch(id).name },
+        )
 
     private fun findLocationTracksForMatchingSwitchToTracks(
         branch: LayoutBranch,
         fittedSwitch: FittedSwitch,
         switchId: IntId<TrackLayoutSwitch>? = null,
     ): Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>> {
-        fun indexTracksInBounds(boundingBox: BoundingBox?) = boundingBox
-            ?.let { bounds -> locationTrackDao.fetchVersionsNear(branch.draft, bounds) }
-            ?.map(locationTrackService::getWithAlignment)
-            ?.associate { trackAndAlignment -> trackAndAlignment.first.id as IntId to trackAndAlignment } ?: mapOf()
+        fun indexTracksInBounds(boundingBox: BoundingBox?) =
+            boundingBox
+                ?.let { bounds -> locationTrackDao.fetchVersionsNear(branch.draft, bounds) }
+                ?.map(locationTrackService::getWithAlignment)
+                ?.associate { trackAndAlignment ->
+                    trackAndAlignment.first.id as IntId to trackAndAlignment
+                } ?: mapOf()
 
-        val originalTracks = if (switchId == null) emptyMap() else {
-            switchDao.findLocationTracksLinkedToSwitch(branch.draft, switchId).associate { ids ->
-                val trackAndAlignment = locationTrackService.getWithAlignment(ids.rowVersion)
-                (trackAndAlignment.first.id as IntId) to trackAndAlignment
+        val originalTracks =
+            if (switchId == null) emptyMap()
+            else {
+                switchDao.findLocationTracksLinkedToSwitch(branch.draft, switchId).associate { ids
+                    ->
+                    val trackAndAlignment = locationTrackService.getWithAlignment(ids.rowVersion)
+                    (trackAndAlignment.first.id as IntId) to trackAndAlignment
+                }
             }
-        }
         return listOfNotNull(
-            originalTracks,
-            if (switchId != null) indexTracksInBounds(getSwitchBoundsFromTracks(originalTracks.values, switchId)) else null,
-            indexTracksInBounds(getSwitchBoundsFromSwitchFit(fittedSwitch)
-        )).reduceRight { a, b -> a + b}
+                originalTracks,
+                if (switchId != null)
+                    indexTracksInBounds(getSwitchBoundsFromTracks(originalTracks.values, switchId))
+                else null,
+                indexTracksInBounds(getSwitchBoundsFromSwitchFit(fittedSwitch)))
+            .reduceRight { a, b -> a + b }
     }
 
     private fun collectOriginallyLinkedLocationTracksBySwitch(
         branch: LayoutBranch,
         switches: List<IntId<TrackLayoutSwitch>>,
-    ): Map<IntId<TrackLayoutSwitch>, Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>> =
+    ): Map<
+        IntId<TrackLayoutSwitch>, Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>> =
         switchDao
             .findLocationTracksLinkedToSwitches(branch.draft, switches)
-            .map {
-                locationTrackService.getWithAlignment(it.rowVersion)
-            }
-            // might have found both an official and a draft version of a track, we prefer the drafts
-            .sortedBy { if (it.first.isDraft) 0 else 1 }.distinct()
+            .map { locationTrackService.getWithAlignment(it.rowVersion) }
+            // might have found both an official and a draft version of a track, we prefer the
+            // drafts
+            .sortedBy { if (it.first.isDraft) 0 else 1 }
+            .distinct()
             .flatMap { trackAndAlignment ->
                 trackAndAlignment.first.switchIds.map { switchId -> switchId to trackAndAlignment }
             }
             .groupBy({ it.first }, { it.second })
-            .mapValues { (_, tracksAndAlignments) -> tracksAndAlignments.associateBy { it.first.id as IntId } }
+            .mapValues { (_, tracksAndAlignments) ->
+                tracksAndAlignments.associateBy { it.first.id as IntId }
+            }
 
     @Transactional
-    fun relinkTrack(branch: LayoutBranch, trackId: IntId<LocationTrack>): List<TrackSwitchRelinkingResult> {
+    fun relinkTrack(
+        branch: LayoutBranch,
+        trackId: IntId<LocationTrack>
+    ): List<TrackSwitchRelinkingResult> {
         val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(branch.draft, trackId)
 
-        val originalSwitches = collectAllSwitchesOnTrackAndNearby(branch, track, alignment)
-            .map { switchId -> switchId to switchService.getOrThrow(branch.draft, switchId) }
+        val originalSwitches =
+            collectAllSwitchesOnTrackAndNearby(branch, track, alignment).map { switchId ->
+                switchId to switchService.getOrThrow(branch.draft, switchId)
+            }
 
         val originallyLinkedLocationTracksBySwitch =
-            collectOriginallyLinkedLocationTracksBySwitch(branch, originalSwitches.map { (switchId) -> switchId })
+            collectOriginallyLinkedLocationTracksBySwitch(
+                branch, originalSwitches.map { (switchId) -> switchId })
 
-        val changedLocationTracks: MutableMap<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>> =
+        val changedLocationTracks:
+            MutableMap<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>> =
             mutableMapOf()
 
-        val relinkingResults = originalSwitches.map { (switchId, originalSwitch) ->
-            val switchStructure = switchLibraryService.getSwitchStructure(originalSwitch.switchStructureId)
-            val presentationJointLocation = originalSwitch.getJoint(switchStructure.presentationJointNumber)?.location
-            checkNotNull(presentationJointLocation) { "no presentation joint on switch ${originalSwitch.id}" }
-            val nearbyTracksForFit =
-                locationTrackService.getLocationTracksNear(branch.draft, presentationJointLocation).let { nearby ->
-                    val map = nearby.associateBy { it.first.id as IntId }
-                    map + changedLocationTracks.filterKeys { id -> map.containsKey(id) }
-                }.values.toList()
-
-            val fittedSwitch =
-                createSuggestedSwitchByPoint(presentationJointLocation, switchStructure, nearbyTracksForFit)
-            if (fittedSwitch == null) {
-                TrackSwitchRelinkingResult(switchId, TrackSwitchRelinkingResultType.NOT_AUTOMATICALLY_LINKABLE)
-            } else {
-                val nearbyTracksForMatch = findLocationTracksForMatchingSwitchToTracks(branch, fittedSwitch)
-                    .let { nearby ->
-                        val original = originallyLinkedLocationTracksBySwitch[switchId] ?: mapOf()
-                        nearby + original + changedLocationTracks.filterKeys { key ->
-                            nearby.containsKey(key) || original.containsKey(key)
+        val relinkingResults =
+            originalSwitches.map { (switchId, originalSwitch) ->
+                val switchStructure =
+                    switchLibraryService.getSwitchStructure(originalSwitch.switchStructureId)
+                val presentationJointLocation =
+                    originalSwitch.getJoint(switchStructure.presentationJointNumber)?.location
+                checkNotNull(presentationJointLocation) {
+                    "no presentation joint on switch ${originalSwitch.id}"
+                }
+                val nearbyTracksForFit =
+                    locationTrackService
+                        .getLocationTracksNear(branch.draft, presentationJointLocation)
+                        .let { nearby ->
+                            val map = nearby.associateBy { it.first.id as IntId }
+                            map + changedLocationTracks.filterKeys { id -> map.containsKey(id) }
                         }
-                    }
-                val match = matchFittedSwitchToTracks(fittedSwitch, switchStructure, nearbyTracksForMatch, switchId)
-                withChangesFromLinkingSwitch(
-                    match,
-                    switchId,
-                    nearbyTracksForMatch.filterKeys { track -> match.trackLinks.containsKey(track) },
-                ).forEach { track -> changedLocationTracks[track.first.id as IntId] = track }
-                updateLayoutSwitch(branch, match, switchId)
-                TrackSwitchRelinkingResult(switchId, TrackSwitchRelinkingResultType.RELINKED)
+                        .values
+                        .toList()
+
+                val fittedSwitch =
+                    createSuggestedSwitchByPoint(
+                        presentationJointLocation, switchStructure, nearbyTracksForFit)
+                if (fittedSwitch == null) {
+                    TrackSwitchRelinkingResult(
+                        switchId, TrackSwitchRelinkingResultType.NOT_AUTOMATICALLY_LINKABLE)
+                } else {
+                    val nearbyTracksForMatch =
+                        findLocationTracksForMatchingSwitchToTracks(branch, fittedSwitch).let {
+                            nearby ->
+                            val original =
+                                originallyLinkedLocationTracksBySwitch[switchId] ?: mapOf()
+                            nearby +
+                                original +
+                                changedLocationTracks.filterKeys { key ->
+                                    nearby.containsKey(key) || original.containsKey(key)
+                                }
+                        }
+                    val match =
+                        matchFittedSwitchToTracks(
+                            fittedSwitch, switchStructure, nearbyTracksForMatch, switchId)
+                    withChangesFromLinkingSwitch(
+                            match,
+                            switchId,
+                            nearbyTracksForMatch.filterKeys { track ->
+                                match.trackLinks.containsKey(track)
+                            },
+                        )
+                        .forEach { track -> changedLocationTracks[track.first.id as IntId] = track }
+                    updateLayoutSwitch(branch, match, switchId)
+                    TrackSwitchRelinkingResult(switchId, TrackSwitchRelinkingResultType.RELINKED)
+                }
             }
-        }
         changedLocationTracks.values.forEach { (track, alignment) ->
             locationTrackService.saveDraft(branch, track, alignment)
         }
@@ -282,15 +341,19 @@ class SwitchLinkingService @Autowired constructor(
 
         val switchIds = collectAllSwitchesOnTrackAndNearby(branch, track, alignment)
 
-        val replacementSwitchLocations = switchIds.map { switchId ->
-            val switch = switchService.getOrThrow(branch.draft, switchId)
-            switchService.getPresentationJointOrThrow(switch).location to switchId
-        }
+        val replacementSwitchLocations =
+            switchIds.map { switchId ->
+                val switch = switchService.getOrThrow(branch.draft, switchId)
+                switchService.getPresentationJointOrThrow(switch).location to switchId
+            }
 
-        val switchSuggestions = getSuggestedSwitchesWithRelevantTracks(branch, replacementSwitchLocations)
-        val geocodingContext = requireNotNull(geocodingService.getGeocodingContext(branch.draft, track.trackNumberId)) {
-            "Could not get geocoding context: trackNumber=${track.trackNumberId} track=$track"
-        }
+        val switchSuggestions =
+            getSuggestedSwitchesWithRelevantTracks(branch, replacementSwitchLocations)
+        val geocodingContext =
+            requireNotNull(
+                geocodingService.getGeocodingContext(branch.draft, track.trackNumberId)) {
+                    "Could not get geocoding context: trackNumber=${track.trackNumberId} track=$track"
+                }
         return switchIds.mapIndexed { index, switchId ->
             val suggestionWithTracks = switchSuggestions[index]
             if (suggestionWithTracks == null)
@@ -301,18 +364,17 @@ class SwitchLinkingService @Autowired constructor(
                         LayoutValidationIssue(
                             LayoutValidationIssueType.ERROR,
                             "$VALIDATION_SWITCH.track-linkage.relinking-failed",
-                            mapOf("switch" to switchService.getOrThrow(branch.draft, switchId).name)
-                        )
-                    )
-                )
+                            mapOf(
+                                "switch" to
+                                    switchService.getOrThrow(branch.draft, switchId).name))))
             else {
                 val (suggestedSwitch, relevantTracks) = suggestionWithTracks
-                val (validationResults, presentationJointLocation) = validateForSplit(
-                    branch, suggestedSwitch, switchId, trackId, relevantTracks
-                )
-                val address = requireNotNull(geocodingContext.getAddress(presentationJointLocation)) {
-                    "Could not geocode relinked location for switch $switchId on track $track"
-                }
+                val (validationResults, presentationJointLocation) =
+                    validateForSplit(branch, suggestedSwitch, switchId, trackId, relevantTracks)
+                val address =
+                    requireNotNull(geocodingContext.getAddress(presentationJointLocation)) {
+                        "Could not geocode relinked location for switch $switchId on track $track"
+                    }
                 SwitchRelinkingValidationResult(
                     switchId,
                     SwitchRelinkingSuggestion(presentationJointLocation, address.first),
@@ -334,11 +396,13 @@ class SwitchLinkingService @Autowired constructor(
         val alignment = track.getAlignmentVersionOrThrow().let(alignmentDao::fetch)
 
         val switchIds = collectAllSwitches(track, alignment)
-        val replacementSwitchLocations = switchIds.map { switchId ->
-            val switch = switchService.getOrThrow(layoutContext, switchId)
-            switchService.getPresentationJointOrThrow(switch).location to switchId
-        }
-        val switchSuggestions = getSuggestedSwitches(layoutContext.branch, replacementSwitchLocations)
+        val replacementSwitchLocations =
+            switchIds.map { switchId ->
+                val switch = switchService.getOrThrow(layoutContext, switchId)
+                switchService.getPresentationJointOrThrow(switch).location to switchId
+            }
+        val switchSuggestions =
+            getSuggestedSwitches(layoutContext.branch, replacementSwitchLocations)
         return switchIds.mapIndexed { index, id -> id to switchSuggestions[index] }
     }
 
@@ -347,11 +411,14 @@ class SwitchLinkingService @Autowired constructor(
         locationTrack: LocationTrack,
         alignment: LayoutAlignment,
     ): List<IntId<TrackLayoutSwitch>> {
-        val topologySwitches = listOfNotNull(
-            locationTrack.topologyStartSwitch?.switchId, locationTrack.topologyEndSwitch?.switchId
-        )
-        val segmentSwitches = alignment.segments.mapNotNull { segment -> segment.switchId as IntId? }
-        val nearbySwitches = switchDao.findSwitchesNearAlignment(branch, locationTrack.getAlignmentVersionOrThrow())
+        val topologySwitches =
+            listOfNotNull(
+                locationTrack.topologyStartSwitch?.switchId,
+                locationTrack.topologyEndSwitch?.switchId)
+        val segmentSwitches =
+            alignment.segments.mapNotNull { segment -> segment.switchId as IntId? }
+        val nearbySwitches =
+            switchDao.findSwitchesNearAlignment(branch, locationTrack.getAlignmentVersionOrThrow())
 
         return (topologySwitches + segmentSwitches + nearbySwitches).distinct()
     }
@@ -363,31 +430,39 @@ class SwitchLinkingService @Autowired constructor(
         originLocationTrackId: IntId<LocationTrack>,
         relevantLocationTracks: Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>,
     ): Pair<List<LayoutValidationIssue>, Point> {
-        val changedTracks = withChangesFromLinkingSwitch(
-            suggestedSwitch,
-            switchId,
-            relevantLocationTracks,
-        )
+        val changedTracks =
+            withChangesFromLinkingSwitch(
+                suggestedSwitch,
+                switchId,
+                relevantLocationTracks,
+            )
         val createdSwitch = createModifiedLayoutSwitchLinking(branch, suggestedSwitch, switchId)
-        val presentationJointLocation = switchService.getPresentationJointOrThrow(createdSwitch).location
-        val switchStructure = switchLibraryService.getSwitchStructure(suggestedSwitch.switchStructureId)
+        val presentationJointLocation =
+            switchService.getPresentationJointOrThrow(createdSwitch).location
+        val switchStructure =
+            switchLibraryService.getSwitchStructure(suggestedSwitch.switchStructureId)
 
         val originTrackLinkErrors =
-            validateRelinkingRetainsLocationTrackConnections(suggestedSwitch, originLocationTrackId, branch, switchId)
-        val publicationValidationErrorsMapped = validateSwitchLocationTrackLinkStructure(
-            createdSwitch,
-            switchStructure,
-            draft(changedTracks),
-        ).map { error ->
-            // Structure based issues aren't critical for splitting/relinking -> turn them into warnings
-            LayoutValidationIssue(
-                LayoutValidationIssueType.WARNING,
-                error.localizationKey,
-                error.params,
-            )
-        }
+            validateRelinkingRetainsLocationTrackConnections(
+                suggestedSwitch, originLocationTrackId, branch, switchId)
+        val publicationValidationErrorsMapped =
+            validateSwitchLocationTrackLinkStructure(
+                    createdSwitch,
+                    switchStructure,
+                    draft(changedTracks),
+                )
+                .map { error ->
+                    // Structure based issues aren't critical for splitting/relinking -> turn them
+                    // into warnings
+                    LayoutValidationIssue(
+                        LayoutValidationIssueType.WARNING,
+                        error.localizationKey,
+                        error.params,
+                    )
+                }
 
-        return (publicationValidationErrorsMapped + originTrackLinkErrors) to presentationJointLocation
+        return (publicationValidationErrorsMapped + originTrackLinkErrors) to
+            presentationJointLocation
     }
 
     private fun validateRelinkingRetainsLocationTrackConnections(
@@ -396,26 +471,27 @@ class SwitchLinkingService @Autowired constructor(
         branch: LayoutBranch,
         switchId: IntId<TrackLayoutSwitch>,
     ): List<LayoutValidationIssue> {
-        val currentConnections = switchService
-            .getSwitchJointConnections(branch.draft, switchId)
-            .flatMap { it.accurateMatches.map { it.locationTrackId } }
-            .distinct()
+        val currentConnections =
+            switchService
+                .getSwitchJointConnections(branch.draft, switchId)
+                .flatMap { it.accurateMatches.map { it.locationTrackId } }
+                .distinct()
 
-        val suggestedConnections = suggestedSwitch
-            .trackLinks
-            .filter { link -> link.value.isLinked() }
-            .keys
+        val suggestedConnections =
+            suggestedSwitch.trackLinks.filter { link -> link.value.isLinked() }.keys
 
         return listOfNotNull(
             validateWithParams(
                 suggestedConnections.containsAll(currentConnections),
-                LayoutValidationIssueType.ERROR
-            ) {
-                "$VALIDATION_SPLIT.track-links-missing-after-relinking" to localizationParams(
-                    "switchName" to switchService.getOrThrow(branch.draft, switchId).name,
-                    "sourceName" to locationTrackService.getOrThrow(branch.draft, originLocationTrackId).name
-                )
-            })
+                LayoutValidationIssueType.ERROR) {
+                    "$VALIDATION_SPLIT.track-links-missing-after-relinking" to
+                        localizationParams(
+                            "switchName" to switchService.getOrThrow(branch.draft, switchId).name,
+                            "sourceName" to
+                                locationTrackService
+                                    .getOrThrow(branch.draft, originLocationTrackId)
+                                    .name)
+                })
     }
 
     private fun createModifiedLayoutSwitchLinking(
@@ -429,7 +505,8 @@ class SwitchLinkingService @Autowired constructor(
         return layoutSwitch.copy(
             sourceId = newGeometrySwitchId,
             joints = suggestedSwitch.joints,
-            source = if (newGeometrySwitchId != null) GeometrySource.PLAN else GeometrySource.GENERATED,
+            source =
+                if (newGeometrySwitchId != null) GeometrySource.PLAN else GeometrySource.GENERATED,
         )
     }
 
@@ -438,18 +515,23 @@ class SwitchLinkingService @Autowired constructor(
         suggestedSwitch: SuggestedSwitch,
         switchId: IntId<TrackLayoutSwitch>,
     ): LayoutDaoResponse<TrackLayoutSwitch> {
-        return createModifiedLayoutSwitchLinking(branch, suggestedSwitch, switchId)
-            .let { modifiedLayoutSwitch -> switchService.saveDraft(branch, modifiedLayoutSwitch) }
+        return createModifiedLayoutSwitchLinking(branch, suggestedSwitch, switchId).let {
+            modifiedLayoutSwitch ->
+            switchService.saveDraft(branch, modifiedLayoutSwitch)
+        }
     }
 
     private fun verifyPlanNotHidden(id: IntId<GeometrySwitch>) {
-        val header = geometryDao.getSwitchPlanId(id)
-            ?.let(geometryDao::fetchPlanVersion)
-            ?.let(geometryDao::getPlanHeader)
-        if (header?.isHidden != false) throw LinkingFailureException(
-            message = "Cannot link a plan that is hidden",
-            localizedMessageKey = "plan-hidden",
-        )
+        val header =
+            geometryDao
+                .getSwitchPlanId(id)
+                ?.let(geometryDao::fetchPlanVersion)
+                ?.let(geometryDao::getPlanHeader)
+        if (header?.isHidden != false)
+            throw LinkingFailureException(
+                message = "Cannot link a plan that is hidden",
+                localizedMessageKey = "plan-hidden",
+            )
     }
 }
 
@@ -460,20 +542,30 @@ fun matchFittedSwitchToTracks(
     switchId: IntId<TrackLayoutSwitch>?,
     name: SwitchName? = null,
 ): SuggestedSwitch {
-    val segmentLinks = calculateSwitchLinkingJoints(fittedSwitch, relevantLocationTracks, switchStructure, switchId)
+    val segmentLinks =
+        calculateSwitchLinkingJoints(
+            fittedSwitch, relevantLocationTracks, switchStructure, switchId)
     val topologyLinks =
-        findTopologyLinks(relevantLocationTracks, fittedSwitch, segmentLinks, switchId ?: temporarySwitchId)
-    val trackLinks = relevantLocationTracks.entries.mapNotNull { (id, trackAndAlignment) ->
-        val segmentLink = segmentLinks[id] ?: listOf()
-        val topologyLink = topologyLinks[id]
-        val hadOriginalLink = collectAllSwitches(trackAndAlignment.first, trackAndAlignment.second).contains(switchId)
+        findTopologyLinks(
+            relevantLocationTracks, fittedSwitch, segmentLinks, switchId ?: temporarySwitchId)
+    val trackLinks =
+        relevantLocationTracks.entries
+            .mapNotNull { (id, trackAndAlignment) ->
+                val segmentLink = segmentLinks[id] ?: listOf()
+                val topologyLink = topologyLinks[id]
+                val hadOriginalLink =
+                    collectAllSwitches(trackAndAlignment.first, trackAndAlignment.second)
+                        .contains(switchId)
 
-        // "relevant" location tracks can contain tracks that are just nearby but not actually affected by linking at
-        // all; filter those out
-        if (segmentLink.isEmpty() && topologyLink == null && !hadOriginalLink) null else {
-            id to SwitchLinkingTrackLinks(segmentLink, topologyLinks[id])
-        }
-    }.associate { it }
+                // "relevant" location tracks can contain tracks that are just nearby but not
+                // actually affected by linking at
+                // all; filter those out
+                if (segmentLink.isEmpty() && topologyLink == null && !hadOriginalLink) null
+                else {
+                    id to SwitchLinkingTrackLinks(segmentLink, topologyLinks[id])
+                }
+            }
+            .associate { it }
 
     return SuggestedSwitch(
         joints = fittedSwitch.joints.map(::suggestedSwitchJointToTrackLayoutSwitchJoint),
@@ -485,9 +577,8 @@ fun matchFittedSwitchToTracks(
     )
 }
 
-private fun suggestedSwitchJointToTrackLayoutSwitchJoint(sj: FittedSwitchJoint) = TrackLayoutSwitchJoint(
-    sj.number, sj.location, sj.locationAccuracy
-)
+private fun suggestedSwitchJointToTrackLayoutSwitchJoint(sj: FittedSwitchJoint) =
+    TrackLayoutSwitchJoint(sj.number, sj.location, sj.locationAccuracy)
 
 private fun findTopologyLinks(
     nearbyLocationTracks: Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>,
@@ -502,30 +593,32 @@ private fun findTopologyLinks(
             fun tracksNear(point: IPoint) =
                 filterTracksNear(locationTrack, nearbyLocationTracks.values, point.toPoint())
 
-            val nearbyTracks = NearbyTracks(
-                alignment.firstSegmentStart?.let(::tracksNear) ?: listOf(),
-                alignment.lastSegmentEnd?.let(::tracksNear) ?: listOf()
-            )
+            val nearbyTracks =
+                NearbyTracks(
+                    alignment.firstSegmentStart?.let(::tracksNear) ?: listOf(),
+                    alignment.lastSegmentEnd?.let(::tracksNear) ?: listOf())
 
-            val locationTrackWithUpdatedTopology = calculateLocationTrackTopology(
-                locationTrack,
-                alignment,
-                startChanged = true,
-                endChanged = true,
-                nearbyTracks = nearbyTracks,
-                newSwitch = TopologyLinkFindingSwitch(fittedSwitch.joints, switchId)
-            )
+            val locationTrackWithUpdatedTopology =
+                calculateLocationTrackTopology(
+                    locationTrack,
+                    alignment,
+                    startChanged = true,
+                    endChanged = true,
+                    nearbyTracks = nearbyTracks,
+                    newSwitch = TopologyLinkFindingSwitch(fittedSwitch.joints, switchId))
             (if (locationTrackWithUpdatedTopology.topologyStartSwitch?.switchId == switchId) {
-                SwitchLinkingTopologicalTrackLink(
-                    locationTrackWithUpdatedTopology.topologyStartSwitch.jointNumber,
-                    TrackEnd.START,
-                )
-            } else if (locationTrackWithUpdatedTopology.topologyEndSwitch?.switchId == switchId) {
-                SwitchLinkingTopologicalTrackLink(
-                    locationTrackWithUpdatedTopology.topologyEndSwitch.jointNumber,
-                    TrackEnd.END,
-                )
-            } else null)?.let { locationTrackId to it }
+                    SwitchLinkingTopologicalTrackLink(
+                        locationTrackWithUpdatedTopology.topologyStartSwitch.jointNumber,
+                        TrackEnd.START,
+                    )
+                } else if (locationTrackWithUpdatedTopology.topologyEndSwitch?.switchId ==
+                    switchId) {
+                    SwitchLinkingTopologicalTrackLink(
+                        locationTrackWithUpdatedTopology.topologyEndSwitch.jointNumber,
+                        TrackEnd.END,
+                    )
+                } else null)
+                ?.let { locationTrackId to it }
         }
         .associate { it }
 }
@@ -533,20 +626,31 @@ private fun findTopologyLinks(
 fun getSwitchBoundsFromTracks(
     tracks: Collection<Pair<LocationTrack, LayoutAlignment>>,
     switchId: IntId<TrackLayoutSwitch>,
-): BoundingBox? = tracks.flatMap { (track, alignment) ->
-    listOfNotNull(
-        track.topologyStartSwitch?.let { ts -> if (ts.switchId == switchId) alignment.firstSegmentStart else null },
-        track.topologyEndSwitch?.let { ts -> if (ts.switchId == switchId) alignment.lastSegmentEnd else null }) + alignment.segments.flatMap { segment ->
-        if (segment.switchId != switchId) listOf() else listOfNotNull(
-            if (segment.startJointNumber != null) segment.segmentStart else null,
-            if (segment.endJointNumber != null) segment.segmentEnd else null
-        )
-    }
-}.let(::boundingBoxAroundPointsOrNull)
+): BoundingBox? =
+    tracks
+        .flatMap { (track, alignment) ->
+            listOfNotNull(
+                track.topologyStartSwitch?.let { ts ->
+                    if (ts.switchId == switchId) alignment.firstSegmentStart else null
+                },
+                track.topologyEndSwitch?.let { ts ->
+                    if (ts.switchId == switchId) alignment.lastSegmentEnd else null
+                }) +
+                alignment.segments.flatMap { segment ->
+                    if (segment.switchId != switchId) listOf()
+                    else
+                        listOfNotNull(
+                            if (segment.startJointNumber != null) segment.segmentStart else null,
+                            if (segment.endJointNumber != null) segment.segmentEnd else null)
+                }
+        }
+        .let(::boundingBoxAroundPointsOrNull)
 
 private fun getSwitchBoundsFromSwitchFit(
     suggestedSwitch: FittedSwitch,
-): BoundingBox? = boundingBoxAroundPointsOrNull(suggestedSwitch.joints.map { joint -> joint.location }, TRACK_SEARCH_AREA_SIZE)
+): BoundingBox? =
+    boundingBoxAroundPointsOrNull(
+        suggestedSwitch.joints.map { joint -> joint.location }, TRACK_SEARCH_AREA_SIZE)
 
 private fun calculateSwitchLinkingJoints(
     suggestedSwitch: FittedSwitch,
@@ -554,30 +658,40 @@ private fun calculateSwitchLinkingJoints(
     switchStructure: SwitchStructure,
     switchId: IntId<TrackLayoutSwitch>?,
 ): Map<IntId<LocationTrack>, List<SwitchLinkingJoint>> {
-    val switchJointsByLocationTrack = suggestedSwitch.joints
-        .flatMap { joint -> joint.matches.map { match -> match.locationTrackId } }
-        .distinct()
-        .associateWith { locationTrackId ->
-            filterMatchingJointsBySwitchAlignment(switchStructure, suggestedSwitch.joints, locationTrackId)
-        }
-        .filter { it.value.isNotEmpty() }
+    val switchJointsByLocationTrack =
+        suggestedSwitch.joints
+            .flatMap { joint -> joint.matches.map { match -> match.locationTrackId } }
+            .distinct()
+            .associateWith { locationTrackId ->
+                filterMatchingJointsBySwitchAlignment(
+                    switchStructure, suggestedSwitch.joints, locationTrackId)
+            }
+            .filter { it.value.isNotEmpty() }
 
     return switchJointsByLocationTrack.entries.associate { (locationTrackId, switchJoints) ->
-        locationTrackId to switchJoints.flatMap { suggestedSwitchJoint ->
-            suggestedSwitchJoint.matches.map { match ->
-                val alignment = tracks.getValue(locationTrackId).second
-                val segment = alignment.segments[match.segmentIndex]
-                val snappedMatch = if (segment.switchId != null && segment.switchId != switchId) {
-                    tryToSnapOverlappingSwitchSegmentToNearbySegment(tracks.getValue(locationTrackId).second, match)
-                } else match
-                SwitchLinkingJoint(
-                    suggestedSwitchJoint.number,
-                    snappedMatch.segmentIndex,
-                    snappedMatch.m,
-                    alignment.segments[snappedMatch.segmentIndex].seekPointAtSegmentM(snappedMatch.m).point.toPoint(),
-                )
-            }
-        }.sortedBy { it.m }
+        locationTrackId to
+            switchJoints
+                .flatMap { suggestedSwitchJoint ->
+                    suggestedSwitchJoint.matches.map { match ->
+                        val alignment = tracks.getValue(locationTrackId).second
+                        val segment = alignment.segments[match.segmentIndex]
+                        val snappedMatch =
+                            if (segment.switchId != null && segment.switchId != switchId) {
+                                tryToSnapOverlappingSwitchSegmentToNearbySegment(
+                                    tracks.getValue(locationTrackId).second, match)
+                            } else match
+                        SwitchLinkingJoint(
+                            suggestedSwitchJoint.number,
+                            snappedMatch.segmentIndex,
+                            snappedMatch.m,
+                            alignment.segments[snappedMatch.segmentIndex]
+                                .seekPointAtSegmentM(snappedMatch.m)
+                                .point
+                                .toPoint(),
+                        )
+                    }
+                }
+                .sortedBy { it.m }
     }
 }
 
@@ -587,7 +701,8 @@ private fun findExistingSwitchEdgeSegmentWithSwitchFreeAdjacentSegment(
     searchIndexRange: IntProgression,
 ): IndexedValue<LayoutSegment>? {
     val layoutSegmentIndicesAreValid =
-        searchIndexRange.first in layoutSegments.indices && searchIndexRange.last in layoutSegments.indices
+        searchIndexRange.first in layoutSegments.indices &&
+            searchIndexRange.last in layoutSegments.indices
 
     val step = searchIndexRange.step
     val firstAdjacentIndexIsValid = (searchIndexRange.first + step) in layoutSegments.indices
@@ -647,11 +762,12 @@ fun tryToSnapOverlappingSwitchSegmentToNearbySegment(
                 match.m - indexedExistingSwitchStartSegment.value.startM
             val hasAdjacentLayoutSegment = indexedExistingSwitchStartSegment.index > 0
 
-            if (hasAdjacentLayoutSegment && distanceToPreviousSwitchLineStart <= MAX_SWITCH_JOINT_OVERLAP_CORRECTION_AMOUNT_METERS) {
+            if (hasAdjacentLayoutSegment &&
+                distanceToPreviousSwitchLineStart <=
+                    MAX_SWITCH_JOINT_OVERLAP_CORRECTION_AMOUNT_METERS) {
                 return match.copy(
                     m = match.m - distanceToPreviousSwitchLineStart,
-                    segmentIndex = indexedExistingSwitchStartSegment.index - 1
-                )
+                    segmentIndex = indexedExistingSwitchStartSegment.index - 1)
             }
         }
 
@@ -674,15 +790,17 @@ fun tryToSnapOverlappingSwitchSegmentToNearbySegment(
             val hasAdjacentLayoutSegment =
                 indexedExistingSwitchEndSegment.index < layoutAlignment.segments.lastIndex
 
-            if (hasAdjacentLayoutSegment && distanceToPreviousSwitchLineEnd <= MAX_SWITCH_JOINT_OVERLAP_CORRECTION_AMOUNT_METERS) {
+            if (hasAdjacentLayoutSegment &&
+                distanceToPreviousSwitchLineEnd <=
+                    MAX_SWITCH_JOINT_OVERLAP_CORRECTION_AMOUNT_METERS) {
                 return match.copy(
                     m = match.m + distanceToPreviousSwitchLineEnd,
-                    segmentIndex = indexedExistingSwitchEndSegment.index + 1
-                )
+                    segmentIndex = indexedExistingSwitchEndSegment.index + 1)
             }
         }
 
-    // Couldn't snap, possibly due to too much overlap or adjacent switch segment(s) already contained another switch.
+    // Couldn't snap, possibly due to too much overlap or adjacent switch segment(s) already
+    // contained another switch.
     return match
 }
 
@@ -693,10 +811,11 @@ private fun filterTracksNear(
 ): List<Pair<LocationTrack, LayoutAlignment>> {
     val boundingBox = boundingBoxAroundPoint(point, 1.0)
     return tracksWithAlignments.filter { (track, alignment) ->
-        centerTrack.id != track.id && alignment.segments.any { segment ->
-            val bb = segment.boundingBox
-            bb != null && bb.intersects(boundingBox)
-        }
+        centerTrack.id != track.id &&
+            alignment.segments.any { segment ->
+                val bb = segment.boundingBox
+                bb != null && bb.intersects(boundingBox)
+            }
     }
 }
 
@@ -708,9 +827,14 @@ private fun withChangesFromLinkingSwitch(
     val existingLinksCleared = withExistingLinksToSwitchCleared(originalLocationTracks, switchId)
     val segmentLinksMade = withSegmentLinks(suggestedSwitch, existingLinksCleared, switchId)
     val topologicalLinksMade = withTopologicalLinks(suggestedSwitch, existingLinksCleared, switchId)
-    val onlyDelinked = existingLinksCleared.entries.filter { (id, trackAndAlignment) ->
-        !segmentLinksMade.containsKey(id) && !topologicalLinksMade.containsKey(id) && trackAndAlignment != originalLocationTracks[id]
-    }.map { it.value }
+    val onlyDelinked =
+        existingLinksCleared.entries
+            .filter { (id, trackAndAlignment) ->
+                !segmentLinksMade.containsKey(id) &&
+                    !topologicalLinksMade.containsKey(id) &&
+                    trackAndAlignment != originalLocationTracks[id]
+            }
+            .map { it.value }
 
     return segmentLinksMade.values + topologicalLinksMade.values + onlyDelinked
 }
@@ -720,13 +844,18 @@ private fun withTopologicalLinks(
     existingLinksCleared: Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>,
     switchId: IntId<TrackLayoutSwitch>,
 ): Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>> {
-    val topologicalLinksMade = suggestedSwitch.trackLinks.entries.mapNotNull { (locationTrackId, trackLink) ->
-        trackLink.topologyJoint?.let { topologyJoint ->
-            val (locationTrack, alignment) = existingLinksCleared.getValue(locationTrackId)
-            val updatedTrack = updateLocationTrackWithTopologyEndLinking(locationTrack, switchId, topologyJoint)
-            locationTrackId to (updatedTrack to alignment)
-        }
-    }.associate { it }
+    val topologicalLinksMade =
+        suggestedSwitch.trackLinks.entries
+            .mapNotNull { (locationTrackId, trackLink) ->
+                trackLink.topologyJoint?.let { topologyJoint ->
+                    val (locationTrack, alignment) = existingLinksCleared.getValue(locationTrackId)
+                    val updatedTrack =
+                        updateLocationTrackWithTopologyEndLinking(
+                            locationTrack, switchId, topologyJoint)
+                    locationTrackId to (updatedTrack to alignment)
+                }
+            }
+            .associate { it }
     return topologicalLinksMade
 }
 
@@ -735,14 +864,19 @@ private fun withSegmentLinks(
     existingLinksCleared: Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>,
     switchId: IntId<TrackLayoutSwitch>,
 ): Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>> {
-    val segmentLinksMade = suggestedSwitch.trackLinks.entries.mapNotNull { (locationTrackId, trackLink) ->
-        if (trackLink.segmentJoints.isEmpty()) null else {
-            val (locationTrack, alignment) = existingLinksCleared.getValue(locationTrackId)
-            locationTrackId to (locationTrack to updateAlignmentSegmentsWithSwitchLinking(
-                alignment, switchId, trackLink.segmentJoints
-            ))
-        }
-    }.associate { it }
+    val segmentLinksMade =
+        suggestedSwitch.trackLinks.entries
+            .mapNotNull { (locationTrackId, trackLink) ->
+                if (trackLink.segmentJoints.isEmpty()) null
+                else {
+                    val (locationTrack, alignment) = existingLinksCleared.getValue(locationTrackId)
+                    locationTrackId to
+                        (locationTrack to
+                            updateAlignmentSegmentsWithSwitchLinking(
+                                alignment, switchId, trackLink.segmentJoints))
+                }
+            }
+            .associate { it }
     return segmentLinksMade
 }
 
@@ -755,7 +889,8 @@ private fun withExistingLinksToSwitchCleared(
         clearLinksToSwitch(track, alignment, switchId)
     }
 
-// some validation logic depends on draftness state, so we need to pre-draft tracks for online validation
+// some validation logic depends on draftness state, so we need to pre-draft tracks for online
+// validation
 private fun draft(tracks: List<Pair<LocationTrack, LayoutAlignment>>) =
     tracks.map { (track, alignment) -> asDraft(track.branch, track) to alignment }
 
@@ -771,44 +906,56 @@ fun updateLocationTrackWithTopologyEndLinking(
         locationTrack.copy(topologyEndSwitch = topologySwitch)
     }
 }
+
 fun updateAlignmentSegmentsWithSwitchLinking(
     alignment: LayoutAlignment,
     layoutSwitchId: IntId<TrackLayoutSwitch>,
     matchingJoints: List<SwitchLinkingJoint>,
 ): LayoutAlignment {
-    val segmentIndexRange = matchingJoints.map { it.segmentIndex }.let { ixes -> ixes.min()..ixes.max() }
+    val segmentIndexRange =
+        matchingJoints.map { it.segmentIndex }.let { ixes -> ixes.min()..ixes.max() }
 
-    val overriddenSwitches = alignment.segments.mapIndexedNotNull { index, segment ->
-        if (index in segmentIndexRange) segment.switchId
-        else null
-    }.distinct()
-
-    val segmentsWithNewSwitch = alignment.segments.map { segment ->
-        if (overriddenSwitches.contains(segment.switchId)) segment.withoutSwitch()
-        else segment
-    }.mapIndexed { index, segment ->
-        if (index in segmentIndexRange) {
-            val switchLinkingJoints = matchingJoints
-                .filter { joint -> joint.segmentIndex == index }
-
-            if (switchLinkingJoints.isEmpty()) {
-                // Segment that is between two other segments that are linked to the switch joints
-                listOf(segment.copy(switchId = layoutSwitchId, startJointNumber = null, endJointNumber = null))
-            } else {
-                getSegmentsByLinkingJoints(
-                    switchLinkingJoints,
-                    segment,
-                    layoutSwitchId,
-                    index == segmentIndexRange.first,
-                    index == segmentIndexRange.last
-                )
+    val overriddenSwitches =
+        alignment.segments
+            .mapIndexedNotNull { index, segment ->
+                if (index in segmentIndexRange) segment.switchId else null
             }
-        } else {
-            listOf(segment)
-        }
-    }
+            .distinct()
 
-    return alignment.withSegments(combineAdjacentSegmentJointNumbers(segmentsWithNewSwitch, layoutSwitchId))
+    val segmentsWithNewSwitch =
+        alignment.segments
+            .map { segment ->
+                if (overriddenSwitches.contains(segment.switchId)) segment.withoutSwitch()
+                else segment
+            }
+            .mapIndexed { index, segment ->
+                if (index in segmentIndexRange) {
+                    val switchLinkingJoints =
+                        matchingJoints.filter { joint -> joint.segmentIndex == index }
+
+                    if (switchLinkingJoints.isEmpty()) {
+                        // Segment that is between two other segments that are linked to the switch
+                        // joints
+                        listOf(
+                            segment.copy(
+                                switchId = layoutSwitchId,
+                                startJointNumber = null,
+                                endJointNumber = null))
+                    } else {
+                        getSegmentsByLinkingJoints(
+                            switchLinkingJoints,
+                            segment,
+                            layoutSwitchId,
+                            index == segmentIndexRange.first,
+                            index == segmentIndexRange.last)
+                    }
+                } else {
+                    listOf(segment)
+                }
+            }
+
+    return alignment.withSegments(
+        combineAdjacentSegmentJointNumbers(segmentsWithNewSwitch, layoutSwitchId))
 }
 
 private fun filterMatchingJointsBySwitchAlignment(
@@ -816,28 +963,44 @@ private fun filterMatchingJointsBySwitchAlignment(
     matchingJoints: List<FittedSwitchJoint>,
     locationTrackId: DomainId<LocationTrack>,
 ): List<FittedSwitchJoint> {
-    val locationTrackSwitchJoints = matchingJoints.map { joint ->
-        joint.copy(matches = joint.matches.filter { segment -> segment.locationTrackId == locationTrackId })
-    }.filter { it.matches.isNotEmpty() }
+    val locationTrackSwitchJoints =
+        matchingJoints
+            .map { joint ->
+                joint.copy(
+                    matches =
+                        joint.matches.filter { segment ->
+                            segment.locationTrackId == locationTrackId
+                        })
+            }
+            .filter { it.matches.isNotEmpty() }
 
-    val switchStructureJointNumbers = switchStructure.alignments.firstOrNull { alignment ->
-        val frontJoint = alignment.jointNumbers.first()
-        val backJoint = alignment.jointNumbers.last()
-        val presentationJoint = switchStructure.presentationJointNumber
-        val hasFrontJoint = locationTrackSwitchJoints.any { joint -> joint.number == frontJoint }
-        val hasBackJoint = locationTrackSwitchJoints.any { joint -> joint.number == backJoint }
-        val hasSeparatePresentationJoint =
-            presentationJoint != frontJoint &&
-                presentationJoint != backJoint &&
-                alignment.jointNumbers.any { jointNumber -> jointNumber == presentationJoint } &&
-                locationTrackSwitchJoints.any { joint -> joint.number == presentationJoint }
+    val switchStructureJointNumbers =
+        switchStructure.alignments
+            .firstOrNull { alignment ->
+                val frontJoint = alignment.jointNumbers.first()
+                val backJoint = alignment.jointNumbers.last()
+                val presentationJoint = switchStructure.presentationJointNumber
+                val hasFrontJoint =
+                    locationTrackSwitchJoints.any { joint -> joint.number == frontJoint }
+                val hasBackJoint =
+                    locationTrackSwitchJoints.any { joint -> joint.number == backJoint }
+                val hasSeparatePresentationJoint =
+                    presentationJoint != frontJoint &&
+                        presentationJoint != backJoint &&
+                        alignment.jointNumbers.any { jointNumber ->
+                            jointNumber == presentationJoint
+                        } &&
+                        locationTrackSwitchJoints.any { joint -> joint.number == presentationJoint }
 
-        // Alignment must contain at least two of these ("etujatkos", "takajatkos", presentation joint)
-        listOf(hasFrontJoint, hasBackJoint, hasSeparatePresentationJoint).count { it } >= 2
-    }?.jointNumbers
+                // Alignment must contain at least two of these ("etujatkos", "takajatkos",
+                // presentation joint)
+                listOf(hasFrontJoint, hasBackJoint, hasSeparatePresentationJoint).count { it } >= 2
+            }
+            ?.jointNumbers
 
     return locationTrackSwitchJoints.filter { joint ->
-        switchStructureJointNumbers?.any { structureJoint -> structureJoint == joint.number } ?: false
+        switchStructureJointNumbers?.any { structureJoint -> structureJoint == joint.number }
+            ?: false
     }
 }
 
@@ -847,123 +1010,144 @@ private fun getSegmentsByLinkingJoints(
     layoutSwitchId: IntId<TrackLayoutSwitch>,
     isFirstSegment: Boolean,
     isLastSegment: Boolean,
-) = linkingJoints.foldIndexed(mutableListOf<LayoutSegment>()) { index, acc, linkingJoint ->
-    val jointNumber = linkingJoint.number
-    val previousSegment = acc.lastOrNull()?.also { acc.removeLast() } ?: segment
-    val suggestedPointM = linkingJoint.m
+) =
+    linkingJoints
+        .foldIndexed(mutableListOf<LayoutSegment>()) { index, acc, linkingJoint ->
+            val jointNumber = linkingJoint.number
+            val previousSegment = acc.lastOrNull()?.also { acc.removeLast() } ?: segment
+            val suggestedPointM = linkingJoint.m
 
-    if (isSame(segment.startM, suggestedPointM, TOLERANCE_JOINT_LOCATION_SAME_POINT)) {
-        // Check if suggested point is start point
-        acc.add(setStartJointNumber(segment, layoutSwitchId, jointNumber))
-    } else if (isSame(segment.endM, suggestedPointM, TOLERANCE_JOINT_LOCATION_SAME_POINT)) {
-        // Check if suggested point is end point
-        if (linkingJoints.size == 1) {
-            acc.add(setEndJointNumber(previousSegment, layoutSwitchId, jointNumber))
-        } else {
-            acc.add(previousSegment.copy(endJointNumber = jointNumber))
-        }
-    } else {
-        // Otherwise split the segment
-        // StartSplitSegment: before M-value
-        // EndSplitSegment: after M-value
-        val (startSplitSegment, endSplitSegment) = previousSegment.splitAtM(
-            suggestedPointM, TOLERANCE_JOINT_LOCATION_NEW_POINT
-        )
+            if (isSame(segment.startM, suggestedPointM, TOLERANCE_JOINT_LOCATION_SAME_POINT)) {
+                // Check if suggested point is start point
+                acc.add(setStartJointNumber(segment, layoutSwitchId, jointNumber))
+            } else if (isSame(segment.endM, suggestedPointM, TOLERANCE_JOINT_LOCATION_SAME_POINT)) {
+                // Check if suggested point is end point
+                if (linkingJoints.size == 1) {
+                    acc.add(setEndJointNumber(previousSegment, layoutSwitchId, jointNumber))
+                } else {
+                    acc.add(previousSegment.copy(endJointNumber = jointNumber))
+                }
+            } else {
+                // Otherwise split the segment
+                // StartSplitSegment: before M-value
+                // EndSplitSegment: after M-value
+                val (startSplitSegment, endSplitSegment) =
+                    previousSegment.splitAtM(suggestedPointM, TOLERANCE_JOINT_LOCATION_NEW_POINT)
 
-        // Handle cases differently when there are multiple joint matches in a single segment
-        if (linkingJoints.size == 1) {
-            acc.add(
-                if (isFirstSegment) startSplitSegment.withoutSwitch()
-                else if (isLastSegment) setEndJointNumber(startSplitSegment, layoutSwitchId, jointNumber)
-                else startSplitSegment.copy(
-                    switchId = layoutSwitchId, startJointNumber = null, endJointNumber = null
-                )
-            )
-            endSplitSegment?.let {
-                acc.add(
-                    if (isFirstSegment) setStartJointNumber(endSplitSegment, layoutSwitchId, jointNumber)
-                    else if (isLastSegment) endSplitSegment.withoutSwitch()
-                    else setStartJointNumber(endSplitSegment, layoutSwitchId, jointNumber)
-                )
-            }
-        } else {
-            when (index) {
-                // First joint match
-                0 -> {
+                // Handle cases differently when there are multiple joint matches in a single
+                // segment
+                if (linkingJoints.size == 1) {
                     acc.add(
                         if (isFirstSegment) startSplitSegment.withoutSwitch()
-                        else startSplitSegment.copy(
-                            switchId = layoutSwitchId,
-                            startJointNumber = null,
-                            endJointNumber = null,
-                        )
-                    )
-
-                    endSplitSegment?.let {
-                        acc.add(setStartJointNumber(endSplitSegment, layoutSwitchId, jointNumber))
-                    }
-                }
-                // Last joint match
-                linkingJoints.lastIndex -> {
-                    acc.add(startSplitSegment.copy(endJointNumber = jointNumber))
-
+                        else if (isLastSegment)
+                            setEndJointNumber(startSplitSegment, layoutSwitchId, jointNumber)
+                        else
+                            startSplitSegment.copy(
+                                switchId = layoutSwitchId,
+                                startJointNumber = null,
+                                endJointNumber = null))
                     endSplitSegment?.let {
                         acc.add(
-                            if (isLastSegment) endSplitSegment.withoutSwitch()
-                            else endSplitSegment.copy(
-                                switchId = layoutSwitchId, startJointNumber = null, endJointNumber = null
-                            )
-                        )
+                            if (isFirstSegment)
+                                setStartJointNumber(endSplitSegment, layoutSwitchId, jointNumber)
+                            else if (isLastSegment) endSplitSegment.withoutSwitch()
+                            else setStartJointNumber(endSplitSegment, layoutSwitchId, jointNumber))
                     }
-                }
+                } else {
+                    when (index) {
+                        // First joint match
+                        0 -> {
+                            acc.add(
+                                if (isFirstSegment) startSplitSegment.withoutSwitch()
+                                else
+                                    startSplitSegment.copy(
+                                        switchId = layoutSwitchId,
+                                        startJointNumber = null,
+                                        endJointNumber = null,
+                                    ))
 
-                else -> {
-                    acc.add(startSplitSegment.copy(endJointNumber = jointNumber))
-                    endSplitSegment?.let {
-                        acc.add(setStartJointNumber(endSplitSegment, layoutSwitchId, jointNumber))
+                            endSplitSegment?.let {
+                                acc.add(
+                                    setStartJointNumber(
+                                        endSplitSegment, layoutSwitchId, jointNumber))
+                            }
+                        }
+                        // Last joint match
+                        linkingJoints.lastIndex -> {
+                            acc.add(startSplitSegment.copy(endJointNumber = jointNumber))
+
+                            endSplitSegment?.let {
+                                acc.add(
+                                    if (isLastSegment) endSplitSegment.withoutSwitch()
+                                    else
+                                        endSplitSegment.copy(
+                                            switchId = layoutSwitchId,
+                                            startJointNumber = null,
+                                            endJointNumber = null))
+                            }
+                        }
+
+                        else -> {
+                            acc.add(startSplitSegment.copy(endJointNumber = jointNumber))
+                            endSplitSegment?.let {
+                                acc.add(
+                                    setStartJointNumber(
+                                        endSplitSegment, layoutSwitchId, jointNumber))
+                            }
+                        }
                     }
                 }
             }
+
+            acc
         }
-    }
+        .toList()
 
-    acc
-}.toList()
+private fun setStartJointNumber(
+    segment: LayoutSegment,
+    switchId: IntId<TrackLayoutSwitch>,
+    jointNumber: JointNumber
+) = segment.copy(switchId = switchId, startJointNumber = jointNumber, endJointNumber = null)
 
-private fun setStartJointNumber(segment: LayoutSegment, switchId: IntId<TrackLayoutSwitch>, jointNumber: JointNumber) =
-    segment.copy(switchId = switchId, startJointNumber = jointNumber, endJointNumber = null)
-
-private fun setEndJointNumber(segment: LayoutSegment, switchId: IntId<TrackLayoutSwitch>, jointNumber: JointNumber) =
-    segment.copy(switchId = switchId, startJointNumber = null, endJointNumber = jointNumber)
+private fun setEndJointNumber(
+    segment: LayoutSegment,
+    switchId: IntId<TrackLayoutSwitch>,
+    jointNumber: JointNumber
+) = segment.copy(switchId = switchId, startJointNumber = null, endJointNumber = jointNumber)
 
 private fun combineAdjacentSegmentJointNumbers(
     layoutSegments: List<List<LayoutSegment>>,
     switchId: IntId<TrackLayoutSwitch>,
-) = layoutSegments.fold(mutableListOf<LayoutSegment>()) { acc, segments ->
-    val currentSegment = segments.first()
-    val previousSegment = acc.lastOrNull()
+) =
+    layoutSegments.fold(mutableListOf<LayoutSegment>()) { acc, segments ->
+        val currentSegment = segments.first()
+        val previousSegment = acc.lastOrNull()
 
-    /**
-     * For instance in case of line 1-5-2
-     *      J1      J5      J2
-     * -----|-------|-------|------
-     * S0      S1      S2     S3
-     * where the first switch segment S1 has start joint number 1,
-     * and the last switch segment S2 has start joint number 5 and end joint number 2
-     * we want the S1 to have end joint number 5
-     */
-    if (currentSegment.switchId == switchId && previousSegment?.switchId == switchId) {
-        if (previousSegment.startJointNumber != null && previousSegment.endJointNumber == null && currentSegment.startJointNumber != null) {
-            acc[acc.lastIndex] = previousSegment.copy(endJointNumber = currentSegment.startJointNumber)
-            acc.addAll(segments)
-            return@fold acc
-        } else if (previousSegment.endJointNumber != null && currentSegment.startJointNumber == null && currentSegment.endJointNumber != null) {
-            acc.add(currentSegment.copy(startJointNumber = previousSegment.endJointNumber))
-            acc.addAll(segments.drop(1))
-            return@fold acc
+        /**
+         * For instance in case of line 1-5-2 J1 J5 J2
+         *
+         * -----|-------|-------|------
+         * S0 S1 S2 S3 where the first switch segment S1 has start joint number 1, and the last
+         * switch segment S2 has start joint number 5 and end joint number 2 we want the S1 to have
+         * end joint number 5
+         */
+        if (currentSegment.switchId == switchId && previousSegment?.switchId == switchId) {
+            if (previousSegment.startJointNumber != null &&
+                previousSegment.endJointNumber == null &&
+                currentSegment.startJointNumber != null) {
+                acc[acc.lastIndex] =
+                    previousSegment.copy(endJointNumber = currentSegment.startJointNumber)
+                acc.addAll(segments)
+                return@fold acc
+            } else if (previousSegment.endJointNumber != null &&
+                currentSegment.startJointNumber == null &&
+                currentSegment.endJointNumber != null) {
+                acc.add(currentSegment.copy(startJointNumber = previousSegment.endJointNumber))
+                acc.addAll(segments.drop(1))
+                return@fold acc
+            }
         }
-    }
 
-    acc.addAll(segments)
-    acc
-}
+        acc.addAll(segments)
+        acc
+    }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationController.kt
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 
 @GeoviiteController("/localization")
-class LocalizationController @Autowired constructor(
+class LocalizationController
+@Autowired
+constructor(
     val localizationService: LocalizationService,
 ) {
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
@@ -5,15 +5,16 @@ import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.databind.json.JsonMapper
 import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.util.LocalizationKey
-import org.springframework.beans.factory.annotation.Value
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import org.springframework.beans.factory.annotation.Value
 
 private val LOCALIZATION_PARAMS_KEY_REGEX = Regex("[a-zA-Z0-9_\\s\\-]*")
 private val LOCALIZATION_PARAMS_PLACEHOLDER_REGEX = Regex("\\{\\{[a-zA-Z0-9_\\s\\-]*\\}\\}")
 
-data class LocalizationParams @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    constructor(@JsonValue val params: Map<String, String>) {
+data class LocalizationParams
+@JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+constructor(@JsonValue val params: Map<String, String>) {
 
     init {
         require(params.none { LOCALIZATION_PARAMS_KEY_REGEX.matchEntire(it.key) == null }) {
@@ -33,21 +34,21 @@ data class LocalizationParams @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
 fun localizationParams(params: Map<String, Any?>): LocalizationParams =
     LocalizationParams(params.mapValues { it.value?.toString() ?: "" })
 
-fun localizationParams(vararg params: Pair<String, Any?>): LocalizationParams = localizationParams(mapOf(*params))
+fun localizationParams(vararg params: Pair<String, Any?>): LocalizationParams =
+    localizationParams(mapOf(*params))
 
 data class Translation(val lang: LocalizationLanguage, val localization: String) {
     private val jsonRoot = JsonMapper().readTree(localization)
 
     fun t(key: LocalizationKey) = t(key, LocalizationParams.empty)
+
     fun t(key: String) = t(LocalizationKey(key), LocalizationParams.empty)
+
     fun t(key: String, params: LocalizationParams) = t(LocalizationKey(key), params)
+
     fun t(key: LocalizationKey, params: LocalizationParams): String {
         var node = jsonRoot
-        key.split(".").let { keyPart ->
-            keyPart.forEach { part ->
-                node = node.path(part)
-            }
-        }
+        key.split(".").let { keyPart -> keyPart.forEach { part -> node = node.path(part) } }
 
         val nodeText = if (node.isMissingNode) key.toString() else node.asText()
         return nodeText.replace(LOCALIZATION_PARAMS_PLACEHOLDER_REGEX) {
@@ -59,19 +60,29 @@ data class Translation(val lang: LocalizationLanguage, val localization: String)
 
 class TranslationCache {
     private val translations = ConcurrentHashMap<LocalizationLanguage, Translation>()
-    fun getOrLoadTranslation(lang: LocalizationLanguage): Translation = translations.getOrPut(lang) {
-        this::class.java.classLoader.getResource("i18n/translations.${lang.lowercase()}.json")
-            .let { Translation(lang, it?.readText() ?: "") }
-    }
+
+    fun getOrLoadTranslation(lang: LocalizationLanguage): Translation =
+        translations.getOrPut(lang) {
+            this::class
+                .java
+                .classLoader
+                .getResource("i18n/translations.${lang.lowercase()}.json")
+                .let { Translation(lang, it?.readText() ?: "") }
+        }
 }
 
 @GeoviiteService
-class LocalizationService(@Value("\${geoviite.i18n.override-path:}") val overridePath: String = "") {
+class LocalizationService(
+    @Value("\${geoviite.i18n.override-path:}") val overridePath: String = ""
+) {
     val translationCache = TranslationCache()
 
-    fun getLocalization(language: LocalizationLanguage): Translation = if (overridePath.isNotEmpty()) {
-        Translation(language, File("${overridePath}translations.${language.lowercase()}.json").readText())
-    } else {
-        translationCache.getOrLoadTranslation(language)
-    }
+    fun getLocalization(language: LocalizationLanguage): Translation =
+        if (overridePath.isNotEmpty()) {
+            Translation(
+                language,
+                File("${overridePath}translations.${language.lowercase()}.json").readText())
+        } else {
+            translationCache.getOrLoadTranslation(language)
+        }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/Loggable.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/Loggable.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.logging
 
 interface Loggable {
     fun toLog(): String
+
     fun logFormat(vararg params: Pair<String, Any?>) =
         "${this::class.simpleName}[${params.joinToString(" ") { (key, value) -> "$key=$value" }}]"
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
@@ -6,12 +6,12 @@ import fi.fta.geoviite.infra.util.formatForLog
 import fi.fta.geoviite.infra.util.resetCollected
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.slf4j.Logger
-import org.springframework.web.reactive.function.client.ClientRequest
-import org.springframework.web.reactive.function.client.ClientResponse
 import java.time.Duration
 import java.time.Instant
 import kotlin.reflect.KClass
+import org.slf4j.Logger
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
 
 fun Logger.apiRequest(req: HttpServletRequest, requestIp: String) {
     if (isDebugEnabled) debug("Request: {}:{} ip={}", req.method, req.requestURL, requestIp)
@@ -43,16 +43,24 @@ private fun responseParams(
     val timeMs = Duration.between(startTime, Instant.now()).toMillis()
     val timingString = if (timingMap.isEmpty()) "[no timings]" else "[$timingMap]"
     return paramsToLog(
-        "status" to res.status,
-        "time" to "$timeMs ms",
-        "contentType" to res.contentType,
-        "ip" to requestIp,
-        "request" to "${req.method}:${req.requestURL}",
-        "timings" to timingString,
-    ).joinToString(" ")
+            "status" to res.status,
+            "time" to "$timeMs ms",
+            "contentType" to res.contentType,
+            "ip" to requestIp,
+            "request" to "${req.method}:${req.requestURL}",
+            "timings" to timingString,
+        )
+        .joinToString(" ")
 }
 
-enum class AccessType { VERSION_FETCH, FETCH, INSERT, UPDATE, UPSERT, DELETE }
+enum class AccessType {
+    VERSION_FETCH,
+    FETCH,
+    INSERT,
+    UPDATE,
+    UPSERT,
+    DELETE
+}
 
 fun Logger.daoAccess(accessType: AccessType, objectType: KClass<*>, vararg ids: Any) {
     daoAccess(accessType, objectType, ids.toList())
@@ -106,7 +114,8 @@ fun paramsToLog(params: List<Pair<String, *>>): List<String> =
     }
 
 fun returnValueToLog(returnValue: Any?): String {
-    return formatForLog(if (returnValue is Loggable) returnValue.toLog() else returnValue.toString(), 1000)
+    return formatForLog(
+        if (returnValue is Loggable) returnValue.toLog() else returnValue.toString(), 1000)
 }
 
 fun Logger.integrationCall(method: String, vararg params: Pair<String, *>) {
@@ -116,8 +125,7 @@ fun Logger.integrationCall(method: String, vararg params: Pair<String, *>) {
 fun Logger.integrationCall(request: ClientRequest) {
     info(
         "Sending API request to external service: " +
-            "${request.logPrefix()} method=${request.method()} url=${request.url()}"
-    )
+            "${request.logPrefix()} method=${request.method()} url=${request.url()}")
 }
 
 fun Logger.integrationCall(response: ClientResponse) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Angle.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Angle.kt
@@ -3,7 +3,10 @@ package fi.fta.geoviite.infra.math
 import java.math.BigDecimal
 import kotlin.math.*
 
-enum class AngularUnit { RADIANS, GRADS }
+enum class AngularUnit {
+    RADIANS,
+    GRADS
+}
 
 fun degreesToRads(degrees: Double): Double = degrees * (PI / 180)
 
@@ -20,32 +23,29 @@ fun angleAvgRads(rads1: Double, rads2: Double): Double =
     atan2(sin(rads1) + sin(rads2), cos(rads1) + cos(rads2))
 
 /**
- * Checks if an angle (agnostic of unit) is inside the closed range [start,end],
- * noting that the angle can flip (indicated by end being less than start)
+ * Checks if an angle (agnostic of unit) is inside the closed range [start,end], noting that the
+ * angle can flip (indicated by end being less than start)
  */
 fun angleIsBetween(start: Double, end: Double, value: Double): Boolean =
-    if (end < start) !(value > end && value < start)
-    else value in start..end
+    if (end < start) !(value > end && value < start) else value in start..end
 
 /**
- * The absolute difference between 2 angles, as rads, on in closed range [0,PI].
- * For all a and b, angleDiffRads(a, b) = angleDiffRads(b, a)
+ * The absolute difference between 2 angles, as rads, on in closed range [0,PI]. For all a and b,
+ * angleDiffRads(a, b) = angleDiffRads(b, a)
  */
-fun angleDiffRads(rads1: Double, rads2: Double): Double =
-    abs(relativeAngle(rads1, rads2))
+fun angleDiffRads(rads1: Double, rads2: Double): Double = abs(relativeAngle(rads1, rads2))
 
 /**
- * Relative angle, in the half-closed range [-PI,PI). For all a and b, relativeAngle(a, b) = -relativeAngle(b, a),
- * except when the difference is exactly PI.
+ * Relative angle, in the half-closed range [-PI,PI). For all a and b, relativeAngle(a, b) =
+ * -relativeAngle(b, a), except when the difference is exactly PI.
  */
-fun relativeAngle(rads1: Double, rads2: Double): Double =
-    normalizeDirectionRads(rads2 - rads1)
+fun relativeAngle(rads1: Double, rads2: Double): Double = normalizeDirectionRads(rads2 - rads1)
 
 /**
- * Rotates given angle around the origin by delta, looping around to give result at half-closed range [-PI,PI)
+ * Rotates given angle around the origin by delta, looping around to give result at half-closed
+ * range [-PI,PI)
  */
-fun rotateAngle(rads: Double, delta: Double): Double =
-    normalizeDirectionRads(rads + delta)
+fun rotateAngle(rads: Double, delta: Double): Double = normalizeDirectionRads(rads + delta)
 
 /**
  * Converts math angle (rads) to geodetic angle:
@@ -61,20 +61,14 @@ fun radsMathToGeo(rads: Double) = normalizeGeodeticRads(0.5 * PI - rads)
  */
 fun radsGeoToMath(rads: Double) = normalizeDirectionRads(0.5 * PI - rads)
 
-/**
- * Normalize radian angle value into the half-closed range [-PI,PI)
- */
+/** Normalize radian angle value into the half-closed range [-PI,PI) */
 private fun normalizeDirectionRads(rads: Double): Double =
     fract((rads - PI) / (PI * 2.0)) * (PI * 2.0) - PI
 
-/**
- * Normalize radian angle value into the half-closed range [0,2*PI)
- */
-private fun normalizeGeodeticRads(rads: Double): Double =
-    fract(rads / (PI * 2.0)) * (PI * 2.0)
+/** Normalize radian angle value into the half-closed range [0,2*PI) */
+private fun normalizeGeodeticRads(rads: Double): Double = fract(rads / (PI * 2.0)) * (PI * 2.0)
 
 private fun fract(x: Double) = x - floor(x)
-
 
 fun radsToAngle(rads: Double, unit: AngularUnit): Angle {
     return when (unit) {
@@ -95,8 +89,8 @@ sealed class Angle {
     abstract val rads: Double
 
     /**
-     * Turns an angle from typical geodetic representation (0=North & growing clockwise)
-     * into a typical math representation (0=positive-X & growing counter-clockwise).
+     * Turns an angle from typical geodetic representation (0=North & growing clockwise) into a
+     * typical math representation (0=positive-X & growing counter-clockwise).
      */
     abstract fun geoToMath(): Angle
 
@@ -109,6 +103,7 @@ sealed class Angle {
 
 data class Rads(override val original: BigDecimal) : Angle() {
     override val rads: Double by lazy { original.toDouble() }
+
     override fun geoToMath(): Angle {
         return Rads((0.5 * PI).toBigDecimal().minus(original))
     }
@@ -120,6 +115,7 @@ data class Rads(override val original: BigDecimal) : Angle() {
 
 data class Grads(override val original: BigDecimal) : Angle() {
     override val rads: Double by lazy { gradsToRads(original.toDouble()) }
+
     override fun geoToMath(): Angle {
         return Grads(BigDecimal.valueOf(100).minus(original))
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/BiquadraticParabola.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/BiquadraticParabola.kt
@@ -9,28 +9,29 @@ import kotlin.math.pow
  * https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcgeometryresource/lexical/ifctransitioncurvetype.htm
  * https://www.researchgate.net/publication/289952758_The_fourth_degree_parabola_Bi-quadratic_parabola_as_a_transition_curve
  */
-
 fun biquadraticParabolaPointAtOffset(offset: Double, R: Double, L: Double): Point {
-    val y = if (offset <= L/2.0) biquadraticY1(offset, R, L) else biquadraticY2(offset, R, L)
+    val y = if (offset <= L / 2.0) biquadraticY1(offset, R, L) else biquadraticY2(offset, R, L)
     return Point(offset, y)
 }
 
 private fun biquadraticY1(l: Double, R: Double, L: Double): Double {
-    return l.pow(4)/(6*R*L.pow(2))
+    return l.pow(4) / (6 * R * L.pow(2))
 }
 
 private fun biquadraticY2(l: Double, R: Double, L: Double): Double {
-    return -l.pow(4)/(6*R*L.pow(2)) + 2*l.pow(3)/(3*R*L) - l.pow(2)/(2*R) + L*l/(6*R) - L.pow(2)/(48*R)
+    return -l.pow(4) / (6 * R * L.pow(2)) + 2 * l.pow(3) / (3 * R * L) - l.pow(2) / (2 * R) +
+        L * l / (6 * R) - L.pow(2) / (48 * R)
 }
 
 fun biquadraticSTransition(offset: Double, D: Double, L: Double): Double {
-    return if (offset <= L/2.0) biquadraticSTransition1(offset, D, L) else biquadraticSTransition2(offset, D, L)
+    return if (offset <= L / 2.0) biquadraticSTransition1(offset, D, L)
+    else biquadraticSTransition2(offset, D, L)
 }
 
 private fun biquadraticSTransition1(offset: Double, D: Double, L: Double): Double {
-    return 2*D*offset.pow(2)/L.pow(2)
+    return 2 * D * offset.pow(2) / L.pow(2)
 }
 
 private fun biquadraticSTransition2(offset: Double, D: Double, L: Double): Double {
-    return D-(2*D*(L-offset).pow(2)/L.pow(2))
+    return D - (2 * D * (L - offset).pow(2) / L.pow(2))
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Circle.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Circle.kt
@@ -2,7 +2,6 @@ package fi.fta.geoviite.infra.math
 
 import kotlin.math.*
 
-
 fun circleArcAngle(radius: Double, chord: Double): Double {
     // Derived from law of cosines:
     // c = sqrt(a^2+b^2 - 2ab cos(alpha))
@@ -24,9 +23,10 @@ fun circleSubArcLength(radius: Double, angle: Double): Double {
 }
 
 /**
- * Calculates Y-coordinate corresponding given X-coordinate for a point on the circe arc.
- * If radius is positive, the center is assumed to be above the arc -> use lower half of the arc (negative Y).
- * If radius is negative, the center is assumed to be below the arc -> use upper half of the arc (positive Y).
+ * Calculates Y-coordinate corresponding given X-coordinate for a point on the circe arc. If radius
+ * is positive, the center is assumed to be above the arc -> use lower half of the arc (negative Y).
+ * If radius is negative, the center is assumed to be below the arc -> use upper half of the arc
+ * (positive Y).
  */
 fun circleArcYAtX(center: Point, radius: Double, x: Double): Double {
     val absRadius = abs(radius)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Clothoid.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Clothoid.kt
@@ -4,33 +4,32 @@ import kotlin.math.abs
 import kotlin.math.hypot
 import kotlin.math.pow
 
-
 /**
  * Clothoid x/y estimations are done by estimating the integral via Fresnel functions:
  *
- * C(theta) = 1/1! - theta^2/2!*5 + theta^4/4!*9 - ... + (-1)^k*theta^(2k) / (2k)!*(4k+1)
- * S(theta) = theta/1!*3 - theta^3/3!*7 + theta^5/5!*11 - ... + (-1)^k*theta^(2k+1) / (2k+1)!*(4k+3)
+ * C(theta) = 1/1! - theta^2/2!*5 + theta^4/4!*9 - ... + (-1)^k*theta^(2k) / (2k)!*(4k+1) S(theta) =
+ * theta/1!*3 - theta^3/3!*7 + theta^5/5!*11 - ... + (-1)^k*theta^(2k+1) / (2k+1)!*(4k+3)
  *
  * References:
  * <ul>
- *     <li>http://precismultipla.altervista.org/ESU2/chap08.htm</li>
- *     <li>https://pwayblog.com/2016/07/03/the-clothoid/</li>
+ * <li>http://precismultipla.altervista.org/ESU2/chap08.htm</li>
+ * <li>https://pwayblog.com/2016/07/03/the-clothoid/</li>
  * </ul>
  */
 private const val MAX_ITERATIONS = 6
 private const val ACCURACY = 0.0000001 // About 1mm on 10km long clothoid segment
 
 /**
- * Precalculated static divisor elements for Fresnel C function (x-coordinate).
- * Indexed by iteration (k: 0-based)
+ * Precalculated static divisor elements for Fresnel C function (x-coordinate). Indexed by iteration
+ * (k: 0-based)
  */
 private val fresnelDivisorsC: LongArray by lazy {
     (0..MAX_ITERATIONS).map { k -> fresnelTermSign(k) * fresnelCDivisor(k) }.toLongArray()
 }
 
 /**
- * Precalculated static divisor elements for Fresnel S function (y-coordinate).
- * Indexed by iteration (k: 0-based)
+ * Precalculated static divisor elements for Fresnel S function (y-coordinate). Indexed by iteration
+ * (k: 0-based)
  */
 private val fresnelDivisorsS: LongArray by lazy {
     (0..MAX_ITERATIONS).map { k -> fresnelTermSign(k) * fresnelSDivisor(k) }.toLongArray()
@@ -44,7 +43,9 @@ private val fresnelDivisorsS: LongArray by lazy {
  * @param radiusEnd curvature circle radius (R) for the ending point of the spiral segment
  */
 fun clothoidLength(constantA: Double, radiusStart: Double?, radiusEnd: Double?): Double {
-    return abs(clothoidLengthAtRadius(constantA, radiusEnd) - clothoidLengthAtRadius(constantA, radiusStart))
+    return abs(
+        clothoidLengthAtRadius(constantA, radiusEnd) -
+            clothoidLengthAtRadius(constantA, radiusStart))
 }
 
 /**
@@ -114,26 +115,28 @@ private fun theta(constantA: Double, offset: Double): Double {
 }
 
 /**
- * Fresnel C function single iteration.
- * Summing the results from k=0.. approaches the precise mathematical value for x offset from spiral origin.
+ * Fresnel C function single iteration. Summing the results from k=0.. approaches the precise
+ * mathematical value for x offset from spiral origin.
  *
  * @param k iteration number, starting from 0 (up to $MAX_ITERATIONS)
  * @param theta theta value, calculated for curve & desired length
  */
 private fun fresnelC(k: Int, theta: Double): Double {
-    if (k > MAX_ITERATIONS) throw IllegalArgumentException("Can't calculate iteration $k: max=$MAX_ITERATIONS")
+    if (k > MAX_ITERATIONS)
+        throw IllegalArgumentException("Can't calculate iteration $k: max=$MAX_ITERATIONS")
     return theta.pow(2 * k) / fresnelDivisorsC[k]
 }
 
 /**
- * Fresnel S function single iteration.
- * Summing the results from k=0.. approaches the precise mathematical value for y offset from spiral origin.
+ * Fresnel S function single iteration. Summing the results from k=0.. approaches the precise
+ * mathematical value for y offset from spiral origin.
  *
  * @param k iteration number, starting from 0 (up to $MAX_ITERATIONS)
  * @param theta theta value, calculated for curve & desired length
  */
 private fun fresnelS(k: Int, theta: Double): Double {
-    if (k > MAX_ITERATIONS) throw IllegalArgumentException("Can't calculate iteration $k: max=$MAX_ITERATIONS")
+    if (k > MAX_ITERATIONS)
+        throw IllegalArgumentException("Can't calculate iteration $k: max=$MAX_ITERATIONS")
     return theta.pow(2 * k + 1) / fresnelDivisorsS[k]
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Line.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Line.kt
@@ -24,7 +24,8 @@ fun closestPointProportionOnLine(start: IPoint, end: IPoint, target: IPoint): Do
     val deltaX = end.x - start.x
     val deltaY = end.y - start.y
 
-    return ((target.x - start.x) * deltaX + (target.y - start.y) * deltaY) / (deltaX * deltaX + deltaY * deltaY)
+    return ((target.x - start.x) * deltaX + (target.y - start.y) * deltaY) /
+        (deltaX * deltaX + deltaY * deltaY)
 }
 
 fun closestPointOnLine(start: IPoint, end: IPoint, target: IPoint): Point {
@@ -36,32 +37,42 @@ fun closestPointOnLine(start: IPoint, end: IPoint, target: IPoint): Point {
     }
 }
 
-
-/**
- * Derived from: https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection
- */
+/** Derived from: https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection */
 fun lineIntersection(start1: IPoint, end1: IPoint, start2: IPoint, end2: IPoint): Intersection? {
-    val denominator = (start1.x - end1.x) * (start2.y - end2.y) - (start1.y - end1.y) * (start2.x - end2.x)
+    val denominator =
+        (start1.x - end1.x) * (start2.y - end2.y) - (start1.y - end1.y) * (start2.x - end2.x)
 
     // Parallel lines -> no intersection (unless coincident)
     if (denominator == 0.0) return null
 
-    val numeratorT = (start1.x - start2.x) * (start2.y - end2.y) - (start1.y - start2.y) * (start2.x - end2.x)
-    val numeratorU = (start1.x - start2.x) * (start1.y - end1.y) - (start1.y - start2.y) * (start1.x - end1.x)
+    val numeratorT =
+        (start1.x - start2.x) * (start2.y - end2.y) - (start1.y - start2.y) * (start2.x - end2.x)
+    val numeratorU =
+        (start1.x - start2.x) * (start1.y - end1.y) - (start1.y - start2.y) * (start1.x - end1.x)
 
     val t = numeratorT / denominator
     return Intersection(
-        point = Point(
-            x = start1.x + (end1.x - start1.x) * t,
-            y = start1.y + (end1.y - start1.y) * t,
-        ),
+        point =
+            Point(
+                x = start1.x + (end1.x - start1.x) * t,
+                y = start1.y + (end1.y - start1.y) * t,
+            ),
         segment1Portion = numeratorT / denominator,
         segment2Portion = numeratorU / denominator,
     )
 }
 
-enum class IntersectType { BEFORE, WITHIN, AFTER }
-data class Intersection(val point: Point, val segment1Portion: Double, val segment2Portion: Double) {
+enum class IntersectType {
+    BEFORE,
+    WITHIN,
+    AFTER
+}
+
+data class Intersection(
+    val point: Point,
+    val segment1Portion: Double,
+    val segment2Portion: Double
+) {
     val inSegment1 by lazy { getIntersectType(segment1Portion) }
     val inSegment2 by lazy { getIntersectType(segment2Portion) }
     val relativeDistance1 by lazy { toRelativeDistance(segment1Portion) }
@@ -70,17 +81,19 @@ data class Intersection(val point: Point, val segment1Portion: Double, val segme
     fun linesIntersect() = inSegment1 == IntersectType.WITHIN && inSegment2 == IntersectType.WITHIN
 }
 
-fun getIntersectType(portion: Double): IntersectType = when {
-    portion < 0.0 -> IntersectType.BEFORE
-    portion > 1.0 -> IntersectType.AFTER
-    else -> IntersectType.WITHIN
-}
+fun getIntersectType(portion: Double): IntersectType =
+    when {
+        portion < 0.0 -> IntersectType.BEFORE
+        portion > 1.0 -> IntersectType.AFTER
+        else -> IntersectType.WITHIN
+    }
 
-private fun toRelativeDistance(portion: Double): Double = when {
-    portion < 0.0 -> abs(portion)
-    portion > 1.0 -> portion - 1.0
-    else -> 0.0
-}
+private fun toRelativeDistance(portion: Double): Double =
+    when {
+        portion < 0.0 -> abs(portion)
+        portion > 1.0 -> portion - 1.0
+        else -> 0.0
+    }
 
 fun linePointAtDistance(line: Line, distance: Double): Point =
     linePointAtDistance(line.start, line.end, distance)
@@ -101,9 +114,9 @@ fun lineYAtX(start: Point, end: Point, x: Double): Double {
 fun lineSlope(pointA: Point, pointB: Point): Double {
     val deltaY = pointB.y - pointA.y
     val deltaX = pointB.x - pointA.x
-    if (deltaX == 0.0) throw IllegalArgumentException(
-        "Cannot calculate line slope without X delta: pointA=$pointA pointB=$pointB"
-    )
+    if (deltaX == 0.0)
+        throw IllegalArgumentException(
+            "Cannot calculate line slope without X delta: pointA=$pointA pointB=$pointB")
     return (deltaY / deltaX)
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Math.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Math.kt
@@ -8,17 +8,24 @@ import kotlin.math.abs
 
 fun factorial(n: Int): Long {
     if (n < 0) throw IllegalArgumentException("Can't do factorial for $n (<0)")
-    return if (n == 0) 1 else (1..n).fold(1L) { acc, i ->
-        val result = acc * i
-        if (result / i != acc) throw IllegalArgumentException("Integer overflow in calculating factorial for $n")
-        result
-    }
+    return if (n == 0) 1
+    else
+        (1..n).fold(1L) { acc, i ->
+            val result = acc * i
+            if (result / i != acc)
+                throw IllegalArgumentException("Integer overflow in calculating factorial for $n")
+            result
+        }
 }
 
 fun roundTo1Decimal(value: Double): BigDecimal = round(value, 1)
+
 fun roundTo3Decimals(value: Double): BigDecimal = round(value, 3)
+
 fun roundTo3Decimals(value: BigDecimal): BigDecimal = round(value, 3)
+
 fun roundTo6Decimals(value: Double): BigDecimal = round(value, 6)
+
 fun round(value: Double, scale: Int): BigDecimal =
     if (!value.isFinite()) throw IllegalArgumentException("Cannot round $value")
     else round(BigDecimal.valueOf(value), scale)
@@ -26,33 +33,36 @@ fun round(value: Double, scale: Int): BigDecimal =
 fun round(value: BigDecimal, scale: Int): BigDecimal = value.setScale(scale, RoundingMode.HALF_UP)
 
 fun interpolate(value1: Double?, value2: Double?, portion: Double) =
-    if (value1 == null || value2 == null) null
-    else interpolate(value1, value2, portion)
+    if (value1 == null || value2 == null) null else interpolate(value1, value2, portion)
 
 fun interpolate(value1: Double, value2: Double, portion: Double): Double =
     if (value1.isFinite() && value2.isFinite()) value1 + (value2 - value1) * portion
     else throw IllegalArgumentException("Cannot interpolate between $value1 and $value2")
 
 fun interpolate(value1: IPoint, value2: IPoint, portion: Double): Point =
-    Point(x = interpolate(value1.x, value2.x, portion), y = interpolate(value1.y, value2.y, portion))
+    Point(
+        x = interpolate(value1.x, value2.x, portion), y = interpolate(value1.y, value2.y, portion))
 
-fun interpolate(value1: SegmentPoint, value2: SegmentPoint, portion: Double) = SegmentPoint(
-    x = interpolate(value1.x, value2.x, portion),
-    y = interpolate(value1.y, value2.y, portion),
-    z = interpolate(value1.z, value2.z, portion),
-    m = interpolate(value1.m, value2.m, portion),
-    cant = interpolate(value1.cant, value2.cant, portion),
-)
+fun interpolate(value1: SegmentPoint, value2: SegmentPoint, portion: Double) =
+    SegmentPoint(
+        x = interpolate(value1.x, value2.x, portion),
+        y = interpolate(value1.y, value2.y, portion),
+        z = interpolate(value1.z, value2.z, portion),
+        m = interpolate(value1.m, value2.m, portion),
+        cant = interpolate(value1.cant, value2.cant, portion),
+    )
 
-fun interpolate(value1: AlignmentPoint, value2: AlignmentPoint, portion: Double) = AlignmentPoint(
-    x = interpolate(value1.x, value2.x, portion),
-    y = interpolate(value1.y, value2.y, portion),
-    z = interpolate(value1.z, value2.z, portion),
-    m = interpolate(value1.m, value2.m, portion),
-    cant = interpolate(value1.cant, value2.cant, portion),
-)
+fun interpolate(value1: AlignmentPoint, value2: AlignmentPoint, portion: Double) =
+    AlignmentPoint(
+        x = interpolate(value1.x, value2.x, portion),
+        y = interpolate(value1.y, value2.y, portion),
+        z = interpolate(value1.z, value2.z, portion),
+        m = interpolate(value1.m, value2.m, portion),
+        cant = interpolate(value1.cant, value2.cant, portion),
+    )
 
 fun isSame(value1: Double?, value2: Double?, delta: Double) =
-    (value1 == null && value2 == null) || (value1 != null && value2 != null && isSame(value1, value2, delta))
+    (value1 == null && value2 == null) ||
+        (value1 != null && value2 != null && isSame(value1, value2, delta))
 
 fun isSame(value1: Double, value2: Double, delta: Double) = abs(value1 - value2) < delta

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Point.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Point.kt
@@ -3,44 +3,46 @@ package fi.fta.geoviite.infra.math
 import java.math.BigDecimal
 import kotlin.math.*
 
-
 /**
- * Returns the point that lies in the given direction (radians) at given distance from the given start-point
+ * Returns the point that lies in the given direction (radians) at given distance from the given
+ * start-point
  */
 fun pointInDirection(fromPoint: IPoint, distance: Double, direction: Double): Point {
     return fromPoint + pointInDirection(distance, direction)
 }
 
-/**
- * Returns the point that lies in the given direction (radians) at given distance from origin
- */
+/** Returns the point that lies in the given direction (radians) at given distance from origin */
 fun pointInDirection(distance: Double, direction: Double): Point {
     return Point(distance * cos(direction), distance * sin(direction))
 }
 
 /**
- * Returns the direction angle (radians, 0=direction of positive x, increasing counter-clockwise) between the given points
+ * Returns the direction angle (radians, 0=direction of positive x, increasing counter-clockwise)
+ * between the given points
  */
 fun directionBetweenPoints(fromPoint: IPoint, toPoint: IPoint): Double {
     return directionTowardsPoint(toPoint - fromPoint)
 }
 
 /**
- * Returns the direction angle (radians, 0=direction of positive x, increasing counter-clockwise) from origin to the given point
+ * Returns the direction angle (radians, 0=direction of positive x, increasing counter-clockwise)
+ * from origin to the given point
  */
 fun directionTowardsPoint(point: IPoint): Double {
     return atan2(point.y, point.x)
 }
 
 /**
- * Calculates the point received by rotating the given point around the reference point, with the given delta angle (radians)
+ * Calculates the point received by rotating the given point around the reference point, with the
+ * given delta angle (radians)
  */
 fun rotateAroundPoint(referencePoint: IPoint, deltaRad: Double, point: IPoint): Point {
     return rotateAroundOrigin(deltaRad, point - referencePoint) + referencePoint
 }
 
 /**
- * Calculates the point received by rotating the given point around origin, with the given delta angle (radians)
+ * Calculates the point received by rotating the given point around origin, with the given delta
+ * angle (radians)
  */
 fun rotateAroundOrigin(deltaRad: Double, point: IPoint): Point {
     val sin = sin(deltaRad)
@@ -59,7 +61,8 @@ interface IPoint {
     }
 
     /**
-     * Non-exact coordinate equality check, allowing for small deviations in the value and still considers the point same.
+     * Non-exact coordinate equality check, allowing for small deviations in the value and still
+     * considers the point same.
      */
     fun isSame(other: IPoint, delta: Double): Boolean {
         return isSame(x, other.x, delta) && isSame(y, other.y, delta)
@@ -100,6 +103,7 @@ interface IPoint {
 
 data class Point(override val x: Double, override val y: Double) : IPoint {
     constructor(values: Pair<Double, Double>) : this(values.first, values.second)
+
     constructor(value: String) : this(parsePointPair(value))
 
     init {
@@ -115,11 +119,15 @@ data class Point(override val x: Double, override val y: Double) : IPoint {
     }
 }
 
-data class RoundedPoint(val roundedX: BigDecimal, val roundedY: BigDecimal): IPoint {
-    override val x: Double get() = roundedX.toDouble()
-    override val y: Double get() = roundedY.toDouble()
+data class RoundedPoint(val roundedX: BigDecimal, val roundedY: BigDecimal) : IPoint {
+    override val x: Double
+        get() = roundedX.toDouble()
 
-    constructor(x: Double, y: Double, scale: Int): this(round(x, scale), round(y, scale))
+    override val y: Double
+        get() = roundedY.toDouble()
+
+    constructor(x: Double, y: Double, scale: Int) : this(round(x, scale), round(y, scale))
+
     init {
         require(roundedX.scale() == roundedY.scale()) {
             "Point X & Y must be rounded to the same scale: x=$roundedX y=$roundedY"
@@ -135,7 +143,8 @@ fun maxPoint(points: List<IPoint>): IPoint =
 
 fun parsePointPair(value: String): Pair<Double, Double> {
     val values = value.split("_").map(String::toDouble)
-    if (values.size != 2) throw IllegalArgumentException("Invalid point (expected 2 numbers): \"$value\"")
+    if (values.size != 2)
+        throw IllegalArgumentException("Invalid point (expected 2 numbers): \"$value\"")
     return values[0] to values[1]
 }
 
@@ -143,9 +152,12 @@ interface IPoint3DM : IPoint {
     val m: Double
 }
 
-data class Point3DM(override val x: Double, override val y: Double, override val m: Double) : IPoint3DM {
+data class Point3DM(override val x: Double, override val y: Double, override val m: Double) :
+    IPoint3DM {
     init {
-        require(x.isFinite() && y.isFinite() && m.isFinite()) { "Cannot create point of: x=$x y=$y m=$m" }
+        require(x.isFinite() && y.isFinite() && m.isFinite()) {
+            "Cannot create point of: x=$x y=$y m=$m"
+        }
     }
 }
 
@@ -153,13 +165,17 @@ interface IPoint3DZ : IPoint {
     val z: Double
 }
 
-data class Point3DZ(override val x: Double, override val y: Double, override val z: Double) : IPoint3DZ {
+data class Point3DZ(override val x: Double, override val y: Double, override val z: Double) :
+    IPoint3DZ {
     init {
-        require(x.isFinite() && y.isFinite() && z.isFinite()) { "Cannot create point of: x=$x y=$y z=$z" }
+        require(x.isFinite() && y.isFinite() && z.isFinite()) {
+            "Cannot create point of: x=$x y=$y z=$z"
+        }
     }
 }
 
 interface IPoint4DZM : IPoint, IPoint3DZ, IPoint3DM
+
 data class Point4DZM(
     override val x: Double,
     override val y: Double,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Range.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Range.kt
@@ -4,10 +4,13 @@ data class Range<T : Comparable<T>>(val min: T, val max: T) {
     constructor(range: ClosedFloatingPointRange<T>) : this(range.start, range.endInclusive)
 
     init {
-        if (min > max) throw IllegalArgumentException("Range min cannot be greater than max: min=$min max=$max")
+        if (min > max)
+            throw IllegalArgumentException(
+                "Range min cannot be greater than max: min=$min max=$max")
     }
 
     fun contains(value: T) = value in min..max
+
     fun overlaps(other: Range<T>) = min <= other.max && max >= other.min
 }
 
@@ -15,10 +18,9 @@ fun <T : Comparable<T>> combineContinuous(ranges: List<Range<T>>): List<Range<T>
     val result = mutableListOf<Range<T>>()
     var current: Range<T>? = null
     ranges.forEach { r ->
-        current = current?.let { c ->
-            if (r.min > c.max) r.also { result.add(c) }
-            else combine(c, r)
-        } ?: r
+        current =
+            current?.let { c -> if (r.min > c.max) r.also { result.add(c) } else combine(c, r) }
+                ?: r
     }
     current?.let(result::add)
     return result
@@ -30,13 +32,7 @@ fun <T : Comparable<T>> combine(ranges: List<Range<T>>): Range<T> =
     ranges.reduceRight { r, acc -> Range(minOf(r.min, acc.min), maxOf(r.max, acc.max)) }
 
 fun <T : Comparable<T>> maxNonNull(o1: T?, o2: T?): T? =
-    if (o1 == null) o2
-    else if (o2 == null) o1
-    else if (o1 > o2) o1
-    else o2
+    if (o1 == null) o2 else if (o2 == null) o1 else if (o1 > o2) o1 else o2
 
 fun <T : Comparable<T>> minNonNull(o1: T?, o2: T?): T? =
-    if (o1 == null) o2
-    else if (o2 == null) o1
-    else if (o1 < o2) o1
-    else o2
+    if (o1 == null) o2 else if (o2 == null) o1 else if (o1 < o2) o1 else o2

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/migration/V84__convert_km_post_locations.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/migration/V84__convert_km_post_locations.kt
@@ -27,44 +27,60 @@ class V84__convert_km_post_locations : BaseJavaMigration() {
     )
 
     private fun migrateTable(jdbcTemplate: NamedParameterJdbcTemplate, table: String) {
-        val sql = """
+        val sql =
+            """
             select id, version, postgis.st_x(location) as x, postgis.st_y(location) as y
               from $table
-        """.trimIndent()
-        val rows = jdbcTemplate.query(sql) { rs, _ ->
-            rs.getPointOrNull("x", "y")?.let { point -> rs.getRowVersion<TrackLayoutKmPost>("id", "version") to point }
-        }.filterNotNull()
+        """
+                .trimIndent()
+        val rows =
+            jdbcTemplate
+                .query(sql) { rs, _ ->
+                    rs.getPointOrNull("x", "y")?.let { point ->
+                        rs.getRowVersion<TrackLayoutKmPost>("id", "version") to point
+                    }
+                }
+                .filterNotNull()
 
-        val updateSql = """
+        val updateSql =
+            """
             update $table
             set
               location = postgis.st_point(:layout_x, :layout_y, :layout_srid),
               gk_location = postgis.st_point(:gk_x, :gk_y, :gk_srid)
             where id = :id and version = :version
-        """.trimIndent()
-        jdbcTemplate.batchUpdate(updateSql, rows.map { (version, oldLayoutLocation) ->
-            try {
-                val gkLocation = transformToGKCoordinate(LAYOUT_SRID, oldLayoutLocation)
-                val newLayoutLocation = transformNonKKJCoordinate(gkLocation.srid, LAYOUT_SRID, gkLocation)
-                mapOf(
-                    "id" to version.id.intValue,
-                    "version" to version.version,
-                    "layout_x" to newLayoutLocation.x,
-                    "layout_y" to newLayoutLocation.y,
-                    "layout_srid" to LAYOUT_SRID.code,
-                    "gk_x" to gkLocation.x,
-                    "gk_y" to gkLocation.y,
-                    "gk_srid" to gkLocation.srid.code,
-                )
-            } catch (e: CoordinateTransformationException) {
-                logger.error("Could not transform location for km post $version in $table", e)
-                throw e
-            }
-        }.toTypedArray())
+        """
+                .trimIndent()
+        jdbcTemplate.batchUpdate(
+            updateSql,
+            rows
+                .map { (version, oldLayoutLocation) ->
+                    try {
+                        val gkLocation = transformToGKCoordinate(LAYOUT_SRID, oldLayoutLocation)
+                        val newLayoutLocation =
+                            transformNonKKJCoordinate(gkLocation.srid, LAYOUT_SRID, gkLocation)
+                        mapOf(
+                            "id" to version.id.intValue,
+                            "version" to version.version,
+                            "layout_x" to newLayoutLocation.x,
+                            "layout_y" to newLayoutLocation.y,
+                            "layout_srid" to LAYOUT_SRID.code,
+                            "gk_x" to gkLocation.x,
+                            "gk_y" to gkLocation.y,
+                            "gk_srid" to gkLocation.srid.code,
+                        )
+                    } catch (e: CoordinateTransformationException) {
+                        logger.error(
+                            "Could not transform location for km post $version in $table", e)
+                        throw e
+                    }
+                }
+                .toTypedArray())
     }
 
     override fun migrate(context: Context?) {
-        val connection = requireNotNull(context?.connection) { "Can't run migrations without DB connection" }
+        val connection =
+            requireNotNull(context?.connection) { "Can't run migrations without DB connection" }
         val jdbcTemplate = NamedParameterJdbcTemplate(SingleConnectionDataSource(connection, true))
         migrateTable(jdbcTemplate, "layout.km_post")
         migrateTable(jdbcTemplate, "layout.km_post_version")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClient.kt
@@ -8,6 +8,9 @@ import fi.fta.geoviite.infra.projektivelho.PVDictionaryGroup.MATERIAL
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryGroup.PROJECT
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.*
 import fi.fta.geoviite.infra.util.formatForLog
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -18,11 +21,9 @@ import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
-import java.time.Duration
-import java.time.Instant
-import java.util.concurrent.atomic.AtomicReference
 
-val defaultBlockTimeout: Duration = fi.fta.geoviite.infra.ratko.defaultResponseTimeout.plusMinutes(1L)
+val defaultBlockTimeout: Duration =
+    fi.fta.geoviite.infra.ratko.defaultResponseTimeout.plusMinutes(1L)
 val reloginOffsetSeconds: Long = 60
 
 const val SEARCH_API_V1_PATH = "/hakupalvelu/api/v1"
@@ -46,7 +47,9 @@ const val PROJECT_GROUP_PATH = "$PROJECT_REGISTRY_V1_PATH/projektijoukko"
 
 @Component
 @ConditionalOnBean(PVClientConfiguration::class)
-class PVClient @Autowired constructor(
+class PVClient
+@Autowired
+constructor(
     val pvWebClient: PVWebClient,
     val pvLoginWebClient: PVLoginWebClient,
     val jsonMapper: ObjectMapper,
@@ -61,15 +64,15 @@ class PVClient @Autowired constructor(
             .body(BodyInserters.fromFormData("grant_type", "client_credentials"))
             .retrieve()
             .bodyToMono<PVAccessToken>()
-            .block(defaultBlockTimeout)
-            ?: throw IllegalStateException("ProjektiVelho login failed")
+            .block(defaultBlockTimeout) ?: throw IllegalStateException("ProjektiVelho login failed")
     }
 
     fun postXmlFileSearch(fetchStartTime: Instant, startOid: Oid<PVDocument>?): PVApiSearchStatus {
-        logger.integrationCall("postXmlFileSearch",
-            "fetchStartTime" to fetchStartTime, "startOid" to startOid)
+        logger.integrationCall(
+            "postXmlFileSearch", "fetchStartTime" to fetchStartTime, "startOid" to startOid)
         val json = jsonMapper.writeValueAsString(searchJson(fetchStartTime, startOid, 100))
-        return postMandatoryReturn<String, PVApiSearchStatus>("$XML_FILE_SEARCH_PATH?tagi=aineisto", json)
+        return postMandatoryReturn<String, PVApiSearchStatus>(
+            "$XML_FILE_SEARCH_PATH?tagi=aineisto", json)
     }
 
     fun fetchVelhoSearchStatus(id: PVId): PVApiSearchStatus {
@@ -94,14 +97,18 @@ class PVClient @Autowired constructor(
 
     fun fetchFileContent(oid: Oid<PVDocument>, version: PVId): String? {
         logger.integrationCall("fetchFileContent", "oid" to oid, "version" to version)
-        return getOptional<String>("$FILE_DATA_PATH/${oid}/dokumentti?versio=${version}")
-            .also { content -> if (content == null) logger.warn("File content was null! oid=$oid") }
+        return getOptional<String>("$FILE_DATA_PATH/${oid}/dokumentti?versio=${version}").also {
+            content ->
+            if (content == null) logger.warn("File content was null! oid=$oid")
+        }
     }
 
     fun fetchDictionaries(): Map<PVDictionaryType, List<PVDictionaryEntry>> =
         fetchDictionaries(MATERIAL) + fetchDictionaries(PROJECT)
 
-    fun fetchDictionaries(group: PVDictionaryGroup): Map<PVDictionaryType, List<PVDictionaryEntry>> {
+    fun fetchDictionaries(
+        group: PVDictionaryGroup
+    ): Map<PVDictionaryType, List<PVDictionaryEntry>> {
         logger.integrationCall("fetchDictionaries")
         return getJsonOptional(encodingGroupUrl(group))?.let { json ->
             json.get("info").let { infoNode ->
@@ -142,80 +149,104 @@ class PVClient @Autowired constructor(
         return getOptional<PVApiAssignment>("$ASSIGNMENT_PATH/$oid", get404toNull("oid=$oid"))
     }
 
-    private inline fun <reified T> get404toNull(message: String): (ex: WebClientResponseException) -> Mono<T> = { ex ->
+    private inline fun <reified T> get404toNull(
+        message: String
+    ): (ex: WebClientResponseException) -> Mono<T> = { ex ->
         if (ex.statusCode.value() == 404) {
-            logger.warn("Could not GET ${T::class.simpleName} from ProjektiVelho: " +
+            logger.warn(
+                "Could not GET ${T::class.simpleName} from ProjektiVelho: " +
                     "$message status=${ex.statusCode} result=${ex.message?.let(::formatForLog) ?: "" }")
             Mono.empty()
         } else Mono.error(ex)
     }
 
-    private fun getJsonOptional(uri: String): JsonNode? = getOptional<String>(uri)?.let(jsonMapper::readTree)
+    private fun getJsonOptional(uri: String): JsonNode? =
+        getOptional<String>(uri)?.let(jsonMapper::readTree)
 
     private inline fun <reified Out : Any> getMandatory(uri: String): Out =
-        requireNotNull(getOptional<Out>(uri)) { "GET failed with null result: outType=${Out::class}: uri=$uri" }
+        requireNotNull(getOptional<Out>(uri)) {
+            "GET failed with null result: outType=${Out::class}: uri=$uri"
+        }
 
     private inline fun <reified Out : Any> getOptional(
         uri: String,
-        crossinline onError: (ex: WebClientResponseException) -> Mono<Out> = { ex -> Mono.error(ex) },
-    ): Out? = pvWebClient
-        .get()
-        .uri(uri)
-        .headers(::setBearerAuth)
-        .retrieve()
-        .bodyToMono<Out>()
-        .onErrorResume(WebClientResponseException::class.java) { ex -> onError(ex) }
-        .block(defaultBlockTimeout)
+        crossinline onError: (ex: WebClientResponseException) -> Mono<Out> = { ex ->
+            Mono.error(ex)
+        },
+    ): Out? =
+        pvWebClient
+            .get()
+            .uri(uri)
+            .headers(::setBearerAuth)
+            .retrieve()
+            .bodyToMono<Out>()
+            .onErrorResume(WebClientResponseException::class.java) { ex -> onError(ex) }
+            .block(defaultBlockTimeout)
 
     private inline fun <reified In : Any, reified Out : Any> postMandatoryReturn(
         uri: String,
         body: In,
-        crossinline onError: (ex: WebClientResponseException) -> Mono<Out> = { ex -> Mono.error(ex) },
-    ): Out = requireNotNull(postOptionalReturn(uri, body, onError)) {
-        "POST failed with null result: inType=${In::class.simpleName} outType=${Out::class.simpleName} uri=$uri"
-    }
+        crossinline onError: (ex: WebClientResponseException) -> Mono<Out> = { ex ->
+            Mono.error(ex)
+        },
+    ): Out =
+        requireNotNull(postOptionalReturn(uri, body, onError)) {
+            "POST failed with null result: inType=${In::class.simpleName} outType=${Out::class.simpleName} uri=$uri"
+        }
 
     private inline fun <reified In : Any, reified Out : Any> postOptionalReturn(
         uri: String,
         body: In,
-        crossinline onError: (ex: WebClientResponseException) -> Mono<Out> = { ex -> Mono.error(ex) },
-    ): Out? = pvWebClient
-        .post()
-        .uri(uri)
-        .headers(::setBearerAuth)
-        .body(BodyInserters.fromValue(body))
-        .retrieve()
-        .bodyToMono<Out>()
-        .onErrorResume(WebClientResponseException::class.java) { ex -> onError(ex) }
-        .block(defaultBlockTimeout)
+        crossinline onError: (ex: WebClientResponseException) -> Mono<Out> = { ex ->
+            Mono.error(ex)
+        },
+    ): Out? =
+        pvWebClient
+            .post()
+            .uri(uri)
+            .headers(::setBearerAuth)
+            .body(BodyInserters.fromValue(body))
+            .retrieve()
+            .bodyToMono<Out>()
+            .onErrorResume(WebClientResponseException::class.java) { ex -> onError(ex) }
+            .block(defaultBlockTimeout)
 
-    private fun setBearerAuth(headers: HttpHeaders) = headers.setBearerAuth(fetchAccessToken(Instant.now()).toString())
+    private fun setBearerAuth(headers: HttpHeaders) =
+        headers.setBearerAuth(fetchAccessToken(Instant.now()).toString())
 
     private fun fetchAccessToken(currentTime: Instant) =
-        accessToken.updateAndGet { token ->
-            if (token == null || token.expireTime.isBefore(currentTime.plusSeconds(reloginOffsetSeconds))) {
-                login()
-            } else token
-        }?.accessToken ?: throw IllegalStateException("ProjektiVelho login token can't be null after login")
+        accessToken
+            .updateAndGet { token ->
+                if (token == null ||
+                    token.expireTime.isBefore(currentTime.plusSeconds(reloginOffsetSeconds))) {
+                    login()
+                } else token
+            }
+            ?.accessToken
+            ?: throw IllegalStateException("ProjektiVelho login token can't be null after login")
 }
 
 fun encodingTypeDictionary(type: PVDictionaryType) =
     "${encodingGroupPath(type.group)}/${encodingTypePath(type)}"
 
-fun encodingGroupUrl(group: PVDictionaryGroup) = when (group) {
-    MATERIAL -> MATERIAL_DICTIONARIES_PATH
-    PROJECT -> PROJECT_DICTIONARIES_PATH
-}
+fun encodingGroupUrl(group: PVDictionaryGroup) =
+    when (group) {
+        MATERIAL -> MATERIAL_DICTIONARIES_PATH
+        PROJECT -> PROJECT_DICTIONARIES_PATH
+    }
 
-fun encodingGroupPath(group: PVDictionaryGroup) = when(group) {
-    MATERIAL -> "aineisto"
-    PROJECT -> "projekti"
-}
-fun encodingTypePath(type: PVDictionaryType) = when(type) {
-    DOCUMENT_TYPE -> "dokumenttityyppi"
-    MATERIAL_STATE -> "aineistotila"
-    MATERIAL_CATEGORY -> "aineistolaji"
-    MATERIAL_GROUP -> "aineistoryhma"
-    TECHNICS_FIELD -> "tekniikka-ala"
-    PROJECT_STATE -> "tila"
-}
+fun encodingGroupPath(group: PVDictionaryGroup) =
+    when (group) {
+        MATERIAL -> "aineisto"
+        PROJECT -> "projekti"
+    }
+
+fun encodingTypePath(type: PVDictionaryType) =
+    when (type) {
+        DOCUMENT_TYPE -> "dokumenttityyppi"
+        MATERIAL_STATE -> "aineistotila"
+        MATERIAL_CATEGORY -> "aineistolaji"
+        MATERIAL_GROUP -> "aineistoryhma"
+        TECHNICS_FIELD -> "tekniikka-ala"
+        PROJECT_STATE -> "tila"
+    }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClientConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClientConfiguration.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.projektivelho
 
 import fi.fta.geoviite.infra.logging.integrationCall
+import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,7 +17,6 @@ import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClient
-import java.time.Duration
 
 val defaultResponseTimeout: Duration = Duration.ofMinutes(5L)
 val maxFileSize: Int = 100 * 1024 * 1024
@@ -31,7 +31,9 @@ class PVLoginWebClient(
 
 @Configuration
 @ConditionalOnProperty(prefix = "geoviite.projektivelho", name = ["enabled"], havingValue = "true")
-class PVClientConfiguration @Autowired constructor(
+class PVClientConfiguration
+@Autowired
+constructor(
     @Value("\${geoviite.projektivelho.url:}") private val projektiVelhoBaseUrl: String,
     @Value("\${geoviite.projektivelho.auth_url:}") private val projektiVelhoAuthUrl: String,
     @Value("\${geoviite.projektivelho.client_id:}") private val projektiVelhoUsername: String,
@@ -44,31 +46,34 @@ class PVClientConfiguration @Autowired constructor(
     fun pvLoginWebClient(): PVLoginWebClient {
         val httpClient = HttpClient.create().responseTimeout(defaultResponseTimeout)
 
-        val webClientBuilder = WebClient.builder()
-            .clientConnector(ReactorClientHttpConnector(httpClient))
-            .baseUrl(projektiVelhoAuthUrl)
-            .filter(logRequest())
-            .filter(logResponse())
-            .defaultHeader(CONTENT_TYPE, APPLICATION_FORM_URLENCODED_VALUE)
-            .defaultHeaders { header -> header.setBasicAuth(projektiVelhoUsername, projektiVelhoPassword) }
+        val webClientBuilder =
+            WebClient.builder()
+                .clientConnector(ReactorClientHttpConnector(httpClient))
+                .baseUrl(projektiVelhoAuthUrl)
+                .filter(logRequest())
+                .filter(logResponse())
+                .defaultHeader(CONTENT_TYPE, APPLICATION_FORM_URLENCODED_VALUE)
+                .defaultHeaders { header ->
+                    header.setBasicAuth(projektiVelhoUsername, projektiVelhoPassword)
+                }
 
         return PVLoginWebClient(webClientBuilder.build())
     }
 
     @Bean
     fun pvWebClient(): PVWebClient {
-        val httpClient = HttpClient.create().responseTimeout(defaultResponseTimeout).secure().compress(true)
+        val httpClient =
+            HttpClient.create().responseTimeout(defaultResponseTimeout).secure().compress(true)
 
         val connector = ReactorClientHttpConnector(httpClient.followRedirect(true))
-        val webClientBuilder = WebClient.builder()
-            .clientConnector(connector)
-            .baseUrl(projektiVelhoBaseUrl)
-            .filter(logRequest())
-            .filter(logResponse())
-            .defaultHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-            .codecs { codecs ->
-                codecs.defaultCodecs().maxInMemorySize(maxFileSize)
-            }
+        val webClientBuilder =
+            WebClient.builder()
+                .clientConnector(connector)
+                .baseUrl(projektiVelhoBaseUrl)
+                .filter(logRequest())
+                .filter(logResponse())
+                .defaultHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .codecs { codecs -> codecs.defaultCodecs().maxInMemorySize(maxFileSize) }
 
         return PVWebClient(webClientBuilder.build())
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDao.kt
@@ -34,11 +34,11 @@ import fi.fta.geoviite.infra.util.getPVId
 import fi.fta.geoviite.infra.util.getPVProjectName
 import fi.fta.geoviite.infra.util.getRowVersion
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.Timestamp
+import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Timestamp
-import java.time.Instant
 
 data class PVDocumentCounts(
     val suggested: Int,
@@ -58,7 +58,8 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
         projectOid: Oid<PVProject>?,
         projectGroupOid: Oid<PVProjectGroup>?,
     ): RowVersion<PVDocument> {
-        val sql = """
+        val sql =
+            """
             insert into projektivelho.document(
                 oid,
                 status,
@@ -103,36 +104,43 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
                 project_oid = :project_oid,
                 project_group_oid = :project_group_oid
               where projektivelho.document.document_version <> :document_version
-        """.trimIndent()
-        val params = mapOf(
-            "oid" to oid,
-            "status" to status.name,
-            "filename" to latestVersion.name,
-            "description" to metadata.description,
-            "document_version" to latestVersion.version,
-            "document_change_time" to Timestamp.from(latestVersion.changeTime),
-            "document_type" to metadata.documentType,
-            "material_state" to metadata.materialState,
-            "material_category" to metadata.materialCategory,
-            "material_group" to metadata.materialGroup,
-            "assignment_oid" to assignmentOid,
-            "project_oid" to projectOid,
-            "project_group_oid" to projectGroupOid,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "oid" to oid,
+                "status" to status.name,
+                "filename" to latestVersion.name,
+                "description" to metadata.description,
+                "document_version" to latestVersion.version,
+                "document_change_time" to Timestamp.from(latestVersion.changeTime),
+                "document_type" to metadata.documentType,
+                "material_state" to metadata.materialState,
+                "material_category" to metadata.materialCategory,
+                "material_group" to metadata.materialGroup,
+                "assignment_oid" to assignmentOid,
+                "project_oid" to projectOid,
+                "project_group_oid" to projectGroupOid,
+            )
         jdbcTemplate.setUser()
         jdbcTemplate.update(sql, params)
 
-        // We can't get the id via a returning clause since it won't see the row id if it's not updated
+        // We can't get the id via a returning clause since it won't see the row id if it's not
+        // updated
         val selectSql = "select id, version from projektivelho.document where oid = :oid"
         val selectParams = mapOf("oid" to oid)
-        return jdbcTemplate.query(selectSql, selectParams) { rs, _ ->
-            rs.getRowVersion<PVDocument>("id", "version")
-        }.single().also { id -> logger.daoAccess(UPSERT, PVApiDocumentMetadata::class, id) }
+        return jdbcTemplate
+            .query(selectSql, selectParams) { rs, _ ->
+                rs.getRowVersion<PVDocument>("id", "version")
+            }
+            .single()
+            .also { id -> logger.daoAccess(UPSERT, PVApiDocumentMetadata::class, id) }
     }
 
     @Transactional
     fun upsertProject(project: PVApiProject) {
-        val sql = """
+        val sql =
+            """
             insert into projektivelho.project (oid, name, state_code, created_at, modified)
             values (:oid, :name, :state_code, :created_at, :modified)
             on conflict (oid) do update 
@@ -144,14 +152,16 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
                  or projektivelho.project.state_code <> :state_code
                  or projektivelho.project.created_at <> :created_at
                  or projektivelho.project.modified <> :modified;
-        """.trimIndent()
-        val params = mapOf(
-            "oid" to project.oid,
-            "name" to project.properties.name,
-            "state_code" to project.properties.state,
-            "created_at" to Timestamp.from(project.createdAt),
-            "modified" to Timestamp.from(project.modified),
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "oid" to project.oid,
+                "name" to project.properties.name,
+                "state_code" to project.properties.state,
+                "created_at" to Timestamp.from(project.createdAt),
+                "modified" to Timestamp.from(project.modified),
+            )
         jdbcTemplate.setUser()
         jdbcTemplate.update(sql, params)
         logger.daoAccess(UPSERT, PVProject::class, project.oid)
@@ -159,7 +169,8 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
 
     @Transactional
     fun upsertProjectGroup(projectGroup: PVApiProjectGroup) {
-        val sql = """
+        val sql =
+            """
             insert into projektivelho.project_group (oid, name, state_code, created_at, modified)
             values (:oid, :name, :state_code, :created_at, :modified)
             on conflict (oid) do update 
@@ -171,14 +182,16 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
                  or projektivelho.project_group.state_code <> :state_code
                  or projektivelho.project_group.created_at <> :created_at
                  or projektivelho.project_group.modified <> :modified
-        """.trimIndent()
-        val params = mapOf(
-            "oid" to projectGroup.oid,
-            "name" to projectGroup.properties.name,
-            "state_code" to projectGroup.properties.state,
-            "created_at" to Timestamp.from(projectGroup.createdAt),
-            "modified" to Timestamp.from(projectGroup.modified),
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "oid" to projectGroup.oid,
+                "name" to projectGroup.properties.name,
+                "state_code" to projectGroup.properties.state,
+                "created_at" to Timestamp.from(projectGroup.createdAt),
+                "modified" to Timestamp.from(projectGroup.modified),
+            )
         jdbcTemplate.setUser()
         jdbcTemplate.update(sql, params)
         logger.daoAccess(UPSERT, PVProjectGroup::class, projectGroup.oid)
@@ -186,7 +199,8 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
 
     @Transactional
     fun upsertAssignment(assignment: PVApiAssignment) {
-        val sql = """
+        val sql =
+            """
             insert into projektivelho.assignment (oid, name, state_code, created_at, modified)
             values (:oid, :name, :state_code, :created_at, :modified)
             on conflict (oid) do update 
@@ -198,14 +212,16 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
                  or projektivelho.assignment.state_code <> :state_code
                  or projektivelho.assignment.created_at <> :created_at
                  or projektivelho.assignment.modified <> :modified
-        """.trimIndent()
-        val params = mapOf(
-            "oid" to assignment.oid,
-            "name" to assignment.properties.name,
-            "state_code" to assignment.properties.state,
-            "created_at" to Timestamp.from(assignment.createdAt),
-            "modified" to Timestamp.from(assignment.modified),
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "oid" to assignment.oid,
+                "name" to assignment.properties.name,
+                "state_code" to assignment.properties.state,
+                "created_at" to Timestamp.from(assignment.createdAt),
+                "modified" to Timestamp.from(assignment.modified),
+            )
         logger.daoAccess(UPSERT, PVAssignment::class, assignment.oid)
         jdbcTemplate.setUser()
         jdbcTemplate.update(sql, params)
@@ -213,7 +229,8 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
 
     @Transactional
     fun insertDocumentContent(content: String, documentId: IntId<PVDocument>) {
-        val sql = """
+        val sql =
+            """
             insert into projektivelho.document_content(
                 content,
                 document_id
@@ -221,19 +238,23 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
                 xmlparse(document :content),
                 :document_id
             )
-        """.trimIndent()
+        """
+                .trimIndent()
         jdbcTemplate.setUser()
-        val params = mapOf(
-            "document_id" to documentId.intValue,
-            "content" to content,
-        )
+        val params =
+            mapOf(
+                "document_id" to documentId.intValue,
+                "content" to content,
+            )
         jdbcTemplate.update(sql, params)
-        logger.daoAccess(INSERT, "fi.fta.geoviite.infra.projektivelho.PVDocument.content", documentId)
+        logger.daoAccess(
+            INSERT, "fi.fta.geoviite.infra.projektivelho.PVDocument.content", documentId)
     }
 
     @Transactional
     fun insertFetchInfo(searchToken: PVId, validUntil: Instant): IntId<PVSearch> {
-        val sql = """
+        val sql =
+            """
             insert into projektivelho.search(
                 status,
                 token,
@@ -243,113 +264,142 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
                 :token,
                 :valid_until
             ) returning id
-        """.trimIndent()
+        """
+                .trimIndent()
         jdbcTemplate.setUser()
-        val params = mapOf(
-            "token" to searchToken,
-            "status" to WAITING.name,
-            "valid_until" to Timestamp.from(validUntil)
-        )
-        return jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getIntId<PVSearch>("id")
-        }.single()
+        val params =
+            mapOf(
+                "token" to searchToken,
+                "status" to WAITING.name,
+                "valid_until" to Timestamp.from(validUntil))
+        return jdbcTemplate
+            .query(sql, params) { rs, _ -> rs.getIntId<PVSearch>("id") }
+            .single()
             .also { id -> logger.daoAccess(INSERT, PVSearch::class, id) }
     }
 
     @Transactional
     fun updateFetchState(id: IntId<PVSearch>, status: PVFetchStatus): IntId<PVSearch> {
-        val sql = """
+        val sql =
+            """
             update projektivelho.search 
             set status = :status::projektivelho.search_status
             where id = :id
             returning id
-        """.trimIndent()
+        """
+                .trimIndent()
         jdbcTemplate.setUser()
-        return jdbcTemplate.query(sql, mapOf<String, Any>("status" to status.name, "id" to id.intValue)) { rs, _ ->
-            rs.getIntId<PVSearch>("id")
-        }.single()
+        return jdbcTemplate
+            .query(sql, mapOf<String, Any>("status" to status.name, "id" to id.intValue)) { rs, _ ->
+                rs.getIntId<PVSearch>("id")
+            }
+            .single()
             .also { updatedId -> logger.daoAccess(UPDATE, PVSearch::class, updatedId) }
     }
 
     fun fetchLatestDocument(): Pair<Oid<PVDocument>, Instant>? {
-        val sql = """
+        val sql =
+            """
             select document_change_time, oid 
             from projektivelho.document 
             order by document_change_time desc, oid desc 
             limit 1
-        """.trimIndent()
-        return jdbcTemplate.query(sql, emptyMap<String, Any>()) { rs, _ ->
-            rs.getOid<PVDocument>("oid") to rs.getInstant("document_change_time")
-        }.firstOrNull()
-            .also { v -> logger.daoAccess(FETCH, "${PVDocument::class.simpleName}.changeTime", v ?: "null") }
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(sql, emptyMap<String, Any>()) { rs, _ ->
+                rs.getOid<PVDocument>("oid") to rs.getInstant("document_change_time")
+            }
+            .firstOrNull()
+            .also { v ->
+                logger.daoAccess(FETCH, "${PVDocument::class.simpleName}.changeTime", v ?: "null")
+            }
     }
 
     fun fetchLatestActiveSearch(): PVSearch? {
-        val sql = """
+        val sql =
+            """
             select id, token, status, valid_until 
             from projektivelho.search 
             where status not in ('ERROR', 'FINISHED')
               and valid_until >= now()
             order by valid_until desc 
             limit 1
-        """.trimIndent()
-        return jdbcTemplate.query(sql, emptyMap<String, Any>()) { rs, _ ->
-            PVSearch(
-                rs.getIntId("id"),
-                rs.getPVId("token"),
-                rs.getEnum<PVFetchStatus>("status"),
-                rs.getInstant("valid_until")
-            )
-        }.firstOrNull()
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(sql, emptyMap<String, Any>()) { rs, _ ->
+                PVSearch(
+                    rs.getIntId("id"),
+                    rs.getPVId("token"),
+                    rs.getEnum<PVFetchStatus>("status"),
+                    rs.getInstant("valid_until"))
+            }
+            .firstOrNull()
             .also { search -> logger.daoAccess(FETCH, PVSearch::class, search?.id ?: "null") }
     }
 
     @Transactional
-    fun updateDocumentsStatuses(ids: List<IntId<PVDocument>>, status: PVDocumentStatus): List<IntId<PVDocument>> {
+    fun updateDocumentsStatuses(
+        ids: List<IntId<PVDocument>>,
+        status: PVDocumentStatus
+    ): List<IntId<PVDocument>> {
         if (ids.isEmpty()) return emptyList()
-        val sql = """
+        val sql =
+            """
             update projektivelho.document
             set status = :status::projektivelho.document_status
             where id in (:ids)
             returning id
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("ids" to ids.map { it.intValue }, "status" to status.name)
         jdbcTemplate.setUser()
-        return jdbcTemplate.query<IntId<PVDocument>>(sql, params) { rs, _ ->
-            rs.getIntId("id")
-        }.also { _ -> logger.daoAccess(UPDATE, PVDocument::class, ids) }
+        return jdbcTemplate
+            .query<IntId<PVDocument>>(sql, params) { rs, _ -> rs.getIntId("id") }
+            .also { _ -> logger.daoAccess(UPDATE, PVDocument::class, ids) }
     }
 
     @Transactional
-    fun insertRejection(documentRowVersion: RowVersion<PVDocument>, reason: String): IntId<PVDocumentRejection> {
-        val sql = """
+    fun insertRejection(
+        documentRowVersion: RowVersion<PVDocument>,
+        reason: String
+    ): IntId<PVDocumentRejection> {
+        val sql =
+            """
             insert into projektivelho.document_rejection(document_id, document_version, reason)
             values (:id, :version, :reason)
             returning id
-        """.trimIndent()
-        val params = mapOf(
-            "id" to documentRowVersion.id.intValue,
-            "version" to documentRowVersion.version,
-            "reason" to reason,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "id" to documentRowVersion.id.intValue,
+                "version" to documentRowVersion.version,
+                "reason" to reason,
+            )
         jdbcTemplate.setUser()
         return getOne<PVDocument, IntId<PVDocumentRejection>>(
-            documentRowVersion.id,
-            jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId("id") },
-        ).also { id -> logger.daoAccess(INSERT, PVDocumentRejection::class, id) }
+                documentRowVersion.id,
+                jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId("id") },
+            )
+            .also { id -> logger.daoAccess(INSERT, PVDocumentRejection::class, id) }
     }
 
     fun getRejection(documentRowVersion: RowVersion<PVDocument>): PVDocumentRejection {
         logger.daoAccess(FETCH, PVDocumentRejection::class)
-        val sql = """
+        val sql =
+            """
             select id, document_id, document_version, reason 
             from projektivelho.document_rejection
             where document_id = :document_id and document_version = :document_version
-        """.trimIndent()
-        val params = mapOf(
-            "document_id" to documentRowVersion.id.intValue,
-            "document_version" to documentRowVersion.version,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "document_id" to documentRowVersion.id.intValue,
+                "document_version" to documentRowVersion.version,
+            )
         jdbcTemplate.setUser()
         return getOne<PVDocument, PVDocumentRejection>(
             documentRowVersion.id,
@@ -359,14 +409,17 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
                     documentVersion = rs.getRowVersion("document_id", "document_version"),
                     reason = LocalizationKey(rs.getString("reason")),
                 )
-            }
-        )
+            })
     }
 
     fun getDocumentHeader(id: IntId<PVDocument>) = getDocumentHeaders(id = id).single()
 
-    fun getDocumentHeaders(status: PVDocumentStatus? = null, id: IntId<PVDocument>? = null): List<PVDocumentHeader> {
-        val sql = """
+    fun getDocumentHeaders(
+        status: PVDocumentStatus? = null,
+        id: IntId<PVDocument>? = null
+    ): List<PVDocumentHeader> {
+        val sql =
+            """
             select 
               document.id,
               document.oid,
@@ -401,94 +454,119 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
               left join projektivelho.material_category on material_category.code = document.material_category_code
             where (:status::projektivelho.document_status is null or status = :status::projektivelho.document_status)
               and (:id::int is null or id = :id)
-        """.trimIndent()
-        val params = mapOf(
-            "id" to id?.intValue,
-            "status" to status?.name,
-        )
-        return jdbcTemplate.query(sql, params) { rs, _ ->
-            PVDocumentHeader(
-                project = rs.getOidOrNull<PVProject>("project_oid")?.let { oid ->
-                    PVProject(oid, rs.getPVProjectName("project_name"), rs.getPVDictionaryName("project_state"))
-                },
-                projectGroup = rs.getOidOrNull<PVProjectGroup>("project_group_oid")?.let { oid ->
-                    PVProjectGroup(
-                        oid,
-                        rs.getPVProjectName("project_group_name"),
-                        rs.getPVDictionaryName("project_state")
-                    )
-                },
-                assignment = rs.getOidOrNull<PVAssignment>("assignment_oid")?.let { oid ->
-                    PVAssignment(oid, rs.getPVProjectName("assignment_name"), rs.getPVDictionaryName("project_state"))
-                },
-                document = PVDocument(
-                    id = rs.getIntId("id"),
-                    oid = rs.getOid("oid"),
-                    name = rs.getFileName("filename"),
-                    description = rs.getFreeTextOrNull("description"),
-                    type = rs.getPVDictionaryName("document_type"),
-                    state = rs.getPVDictionaryName("material_state"),
-                    group = rs.getPVDictionaryName("material_group"),
-                    category = rs.getPVDictionaryName("material_category"),
-                    modified = rs.getInstant("change_time"),
-                    status = rs.getEnum("status"),
-                ),
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "id" to id?.intValue,
+                "status" to status?.name,
             )
-        }.also { results ->
-            logger.daoAccess(FETCH, PVDocument::class, results.map { r -> r.document.id })
-        }
+        return jdbcTemplate
+            .query(sql, params) { rs, _ ->
+                PVDocumentHeader(
+                    project =
+                        rs.getOidOrNull<PVProject>("project_oid")?.let { oid ->
+                            PVProject(
+                                oid,
+                                rs.getPVProjectName("project_name"),
+                                rs.getPVDictionaryName("project_state"))
+                        },
+                    projectGroup =
+                        rs.getOidOrNull<PVProjectGroup>("project_group_oid")?.let { oid ->
+                            PVProjectGroup(
+                                oid,
+                                rs.getPVProjectName("project_group_name"),
+                                rs.getPVDictionaryName("project_state"))
+                        },
+                    assignment =
+                        rs.getOidOrNull<PVAssignment>("assignment_oid")?.let { oid ->
+                            PVAssignment(
+                                oid,
+                                rs.getPVProjectName("assignment_name"),
+                                rs.getPVDictionaryName("project_state"))
+                        },
+                    document =
+                        PVDocument(
+                            id = rs.getIntId("id"),
+                            oid = rs.getOid("oid"),
+                            name = rs.getFileName("filename"),
+                            description = rs.getFreeTextOrNull("description"),
+                            type = rs.getPVDictionaryName("document_type"),
+                            state = rs.getPVDictionaryName("material_state"),
+                            group = rs.getPVDictionaryName("material_group"),
+                            category = rs.getPVDictionaryName("material_category"),
+                            modified = rs.getInstant("change_time"),
+                            status = rs.getEnum("status"),
+                        ),
+                )
+            }
+            .also { results ->
+                logger.daoAccess(FETCH, PVDocument::class, results.map { r -> r.document.id })
+            }
     }
 
     fun getDocumentCounts(): PVDocumentCounts {
-        val sql = """
+        val sql =
+            """
             select 
               count(*) filter (where status = 'SUGGESTED') as suggested_count, 
               count(*) filter (where status = 'REJECTED') as rejected_count
             from projektivelho.document
-        """.trimIndent()
-        return jdbcTemplate.query(sql, emptyMap<String, Any>()) { rs, _ ->
-            PVDocumentCounts(
-                suggested = rs.getInt("suggested_count"),
-                rejected = rs.getInt("rejected_count")
-            )
-        }.single()
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(sql, emptyMap<String, Any>()) { rs, _ ->
+                PVDocumentCounts(
+                    suggested = rs.getInt("suggested_count"),
+                    rejected = rs.getInt("rejected_count"))
+            }
+            .single()
     }
 
     fun fetchDocumentChangeTime(): Instant = fetchLatestChangeTime(DbTable.PROJEKTIVELHO_DOCUMENT)
 
     fun getFileContent(id: IntId<PVDocument>): InfraModelFile? {
         logger.daoAccess(FETCH, InfraModelFile::class, id)
-        val sql = """
+        val sql =
+            """
             select 
               document.filename,
               xmlserialize(document document_content.content as varchar) as file_content
             from projektivelho.document
               inner join projektivelho.document_content on document.id = document_content.document_id
             where document.id = :id
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("id" to id.intValue)
-        return getOptional(id, jdbcTemplate.query(sql, params) { rs, _ ->
-            InfraModelFile(
-                name = rs.getFileName("filename"),
-                content = rs.getString("file_content"),
-            )
-        })
+        return getOptional(
+            id,
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                InfraModelFile(
+                    name = rs.getFileName("filename"),
+                    content = rs.getString("file_content"),
+                )
+            })
     }
 
     @Transactional
     fun upsertDictionary(type: PVDictionaryType, entries: List<PVDictionaryEntry>) {
         val tableName = tableName(type)
-        val sql = """
+        val sql =
+            """
             insert into $tableName(code, name) 
               values (:code, :name) 
               on conflict (code) do update set name = :name where $tableName.name <> :name
-        """.trimIndent()
-        val params = entries.map { entry ->
-            mapOf(
-                "code" to entry.code,
-                "name" to entry.name,
-            )
-        }.toTypedArray()
+        """
+                .trimIndent()
+        val params =
+            entries
+                .map { entry ->
+                    mapOf(
+                        "code" to entry.code,
+                        "name" to entry.name,
+                    )
+                }
+                .toTypedArray()
         jdbcTemplate.setUser()
         logger.daoAccess(UPSERT, PVDictionaryEntry::class, entries.map(PVDictionaryEntry::code))
         jdbcTemplate.batchUpdate(sql, params)
@@ -496,12 +574,16 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
 
     fun fetchDictionary(type: PVDictionaryType): Map<PVDictionaryCode, PVDictionaryName> {
         val sql = "select code, name from ${tableName(type)}"
-        return jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
-            rs.getPVDictionaryCode("code") to rs.getPVDictionaryName("name")
-        }.associate { it }.also { _ -> logger.daoAccess(FETCH, PVDictionaryType::class, type) }
+        return jdbcTemplate
+            .query(sql, mapOf<String, Any>()) { rs, _ ->
+                rs.getPVDictionaryCode("code") to rs.getPVDictionaryName("name")
+            }
+            .associate { it }
+            .also { _ -> logger.daoAccess(FETCH, PVDictionaryType::class, type) }
     }
 
-    private fun tableName(type: PVDictionaryType) = "projektivelho.${
+    private fun tableName(type: PVDictionaryType) =
+        "projektivelho.${
         when (type) {
             DOCUMENT_TYPE -> "document_type"
             MATERIAL_STATE -> "material_state"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDictionary.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDictionary.kt
@@ -12,36 +12,44 @@ enum class PVDictionaryGroup {
 }
 
 enum class PVDictionaryType(val group: PVDictionaryGroup) {
-    DOCUMENT_TYPE (MATERIAL), // dokumenttityyppi
-    MATERIAL_STATE (MATERIAL), // aineistotila
-    MATERIAL_CATEGORY (MATERIAL), // aineistolaji
-    MATERIAL_GROUP (MATERIAL), // ainestoryhmä
-    TECHNICS_FIELD (MATERIAL), // teknikka-ala
-    PROJECT_STATE (PROJECT), // projektin tila
+    DOCUMENT_TYPE(MATERIAL), // dokumenttityyppi
+    MATERIAL_STATE(MATERIAL), // aineistotila
+    MATERIAL_CATEGORY(MATERIAL), // aineistolaji
+    MATERIAL_GROUP(MATERIAL), // ainestoryhmä
+    TECHNICS_FIELD(MATERIAL), // teknikka-ala
+    PROJECT_STATE(PROJECT), // projektin tila
 }
 
 val pvDictionaryCodeLength = 1..50
 val pvDictionaryCodeRegex = Regex("^[A-ZÄÖÅa-zäöå0-9\\-/]+\$")
-data class PVDictionaryCode @JsonCreator(mode = JsonCreator.Mode.DELEGATING) constructor(private val value: String)
-    : Comparable<PVDictionaryCode>, CharSequence by value {
-    init { assertSanitized<PVDictionaryCode>(value, pvDictionaryCodeRegex, pvDictionaryCodeLength) }
 
-    @JsonValue
-    override fun toString(): String = value
+data class PVDictionaryCode
+@JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+constructor(private val value: String) : Comparable<PVDictionaryCode>, CharSequence by value {
+    init {
+        assertSanitized<PVDictionaryCode>(value, pvDictionaryCodeRegex, pvDictionaryCodeLength)
+    }
+
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: PVDictionaryCode): Int = value.compareTo(other.value)
 }
 
 val pvDictionaryNameLength = 1..100
 val pvDictionaryNameRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 _\\-–+().,'/*]*\$")
-data class PVDictionaryName @JsonCreator(mode = JsonCreator.Mode.DELEGATING) constructor(private val value: String)
-    : Comparable<PVDictionaryName>, CharSequence by value {
-    init { assertSanitized<PVDictionaryName>(value, pvDictionaryNameRegex, pvDictionaryNameLength) }
 
-    @JsonValue
-    override fun toString(): String = value
+data class PVDictionaryName
+@JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+constructor(private val value: String) : Comparable<PVDictionaryName>, CharSequence by value {
+    init {
+        assertSanitized<PVDictionaryName>(value, pvDictionaryNameRegex, pvDictionaryNameLength)
+    }
+
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: PVDictionaryName): Int = value.compareTo(other.value)
 }
 
 data class PVDictionaryEntry(val code: PVDictionaryCode, val name: PVDictionaryName) {
-    constructor(code: String, name: String): this(PVDictionaryCode(code), PVDictionaryName(name))
+    constructor(code: String, name: String) : this(PVDictionaryCode(code), PVDictionaryName(name))
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocument.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocument.kt
@@ -20,20 +20,32 @@ enum class PVDocumentStatus {
 
 val pvProjectNameLength = 1..200
 val pvProjectNameRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 \t_\\\\\\-–—+().,:;'/*!@\"£#$€\\[\\]{}=?^~<>]*\$")
-data class PVProjectName @JsonCreator(mode = JsonCreator.Mode.DELEGATING) constructor(private val value: String)
-    : Comparable<PVProjectName>, CharSequence by value {
-    init { assertSanitized<PVProjectName>(value, pvProjectNameRegex, pvProjectNameLength) }
 
-    @JsonValue
-    override fun toString(): String = value
+data class PVProjectName
+@JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+constructor(private val value: String) : Comparable<PVProjectName>, CharSequence by value {
+    init {
+        assertSanitized<PVProjectName>(value, pvProjectNameRegex, pvProjectNameLength)
+    }
+
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: PVProjectName): Int = value.compareTo(other.value)
 }
 
-data class PVProjectGroup(val oid: Oid<PVProjectGroup>, val name: PVProjectName, val state: PVDictionaryName)
+data class PVProjectGroup(
+    val oid: Oid<PVProjectGroup>,
+    val name: PVProjectName,
+    val state: PVDictionaryName
+)
 
 data class PVProject(val oid: Oid<PVProject>, val name: PVProjectName, val state: PVDictionaryName)
 
-data class PVAssignment(val oid: Oid<PVAssignment>, val name: PVProjectName, val state: PVDictionaryName)
+data class PVAssignment(
+    val oid: Oid<PVAssignment>,
+    val name: PVProjectName,
+    val state: PVDictionaryName
+)
 
 data class PVDocumentRejection(
     val id: IntId<PVDocumentRejection>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocumentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocumentService.kt
@@ -4,12 +4,14 @@ import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.inframodel.*
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 @GeoviiteService
-class PVDocumentService @Autowired constructor(
+class PVDocumentService
+@Autowired
+constructor(
     private val pvDao: PVDao,
     private val infraModelService: InfraModelService,
 ) {
@@ -22,7 +24,10 @@ class PVDocumentService @Autowired constructor(
         return pvDao.updateDocumentsStatuses(listOf(id), status).first()
     }
 
-    fun updateDocumentsStatuses(ids: List<IntId<PVDocument>>, status: PVDocumentStatus): List<IntId<PVDocument>> {
+    fun updateDocumentsStatuses(
+        ids: List<IntId<PVDocument>>,
+        status: PVDocumentStatus
+    ): List<IntId<PVDocument>> {
         return pvDao.updateDocumentsStatuses(ids, status)
     }
 
@@ -36,15 +41,19 @@ class PVDocumentService @Autowired constructor(
         overrides: OverrideParameters?,
         extraInfo: ExtraInfoParameters?,
     ): IntId<GeometryPlan> {
-        val file = requireNotNull(getFile(documentId)) {
-            "ProjektiVelho document has no file to import: documentId=$documentId"
-        }
+        val file =
+            requireNotNull(getFile(documentId)) {
+                "ProjektiVelho document has no file to import: documentId=$documentId"
+            }
         val id = infraModelService.saveInfraModel(file, overrides, extraInfo).id
         updateDocumentStatus(documentId, PVDocumentStatus.ACCEPTED)
         return id
     }
 
-    fun validatePVDocument(documentId: IntId<PVDocument>, overrides: OverrideParameters?): ValidationResponse {
+    fun validatePVDocument(
+        documentId: IntId<PVDocument>,
+        overrides: OverrideParameters?
+    ): ValidationResponse {
         val file = getFile(documentId)
         return file
             ?.let { f -> infraModelService.validateInfraModelFile(f, overrides) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
@@ -13,21 +13,23 @@ import fi.fta.geoviite.infra.projektivelho.PVDocumentStatus.*
 import fi.fta.geoviite.infra.projektivelho.PVFetchStatus.*
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.formatForLog
+import java.time.Duration
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.scheduling.annotation.Scheduled
 import withUser
-import java.time.Duration
-import java.time.Instant
 
 val PROJEKTIVELHO_INTEGRATION_USERNAME = UserName.of("PROJEKTIVELHO_IMPORT")
 val PREFETCH_TIME_RANGE = Duration.ofDays(365)
 
 @GeoviiteService
 @ConditionalOnBean(PVClientConfiguration::class)
-class PVIntegrationService @Autowired constructor(
+class PVIntegrationService
+@Autowired
+constructor(
     private val pvClient: PVClient,
     private val pvDao: PVDao,
     private val lockDao: LockDao,
@@ -40,11 +42,14 @@ class PVIntegrationService @Autowired constructor(
         logger.info("Initializing ${this::class.simpleName}")
     }
 
-    private fun <T> runIntegration(op: () -> T): T? = withUser(PROJEKTIVELHO_INTEGRATION_USERNAME) {
-        lockDao.runWithLock(DatabaseLock.PROJEKTIVELHO, databaseLockDuration) { op() }
-    }
+    private fun <T> runIntegration(op: () -> T): T? =
+        withUser(PROJEKTIVELHO_INTEGRATION_USERNAME) {
+            lockDao.runWithLock(DatabaseLock.PROJEKTIVELHO, databaseLockDuration) { op() }
+        }
 
-    @Scheduled(initialDelayString="\${geoviite.projektivelho.search-poll.initial}", fixedRateString="\${geoviite.projektivelho.search-poll.rate}")
+    @Scheduled(
+        initialDelayString = "\${geoviite.projektivelho.search-poll.initial}",
+        fixedRateString = "\${geoviite.projektivelho.search-poll.rate}")
     fun search(): PVApiSearchStatus? = runIntegration {
         logger.info("Poll to launch new search")
         val currentSearch = pvDao.fetchLatestActiveSearch()
@@ -56,31 +61,35 @@ class PVIntegrationService @Autowired constructor(
                 pvDao.insertFetchInfo(status.searchId, validUntil)
             }
         } else {
-            logger.info("Not launching a new search as a previous one is still active: " +
+            logger.info(
+                "Not launching a new search as a previous one is still active: " +
                     "search=${currentSearch.token} state=${currentSearch.state} validUntil=${currentSearch.validUntil}")
             null
         }
     }
 
-    @Scheduled(initialDelayString="\${geoviite.projektivelho.result-poll.initial}", fixedRateString="\${geoviite.projektivelho.result-poll.rate}")
+    @Scheduled(
+        initialDelayString = "\${geoviite.projektivelho.result-poll.initial}",
+        fixedRateString = "\${geoviite.projektivelho.result-poll.rate}")
     fun pollAndFetchIfWaiting() = runIntegration {
         logger.info("Poll for search results")
         pvDao.fetchLatestActiveSearch()?.let { latestSearch ->
             updateDictionaries()
-            getSearchStatusIfReady(latestSearch)?.let { status -> importFilesFromProjektiVelho(latestSearch, status) }
+            getSearchStatusIfReady(latestSearch)?.let { status ->
+                importFilesFromProjektiVelho(latestSearch, status)
+            }
         }
     }
 
-    fun getSearchStatusIfReady(pvSearch: PVSearch): PVApiSearchStatus? = pvSearch
-        .takeIf { search -> search.state == WAITING }
-        ?.let { search -> pvClient.fetchVelhoSearchStatus(search.token) }
-        ?.takeIf { status -> status.state == PVApiSearchState.valmis }
+    fun getSearchStatusIfReady(pvSearch: PVSearch): PVApiSearchStatus? =
+        pvSearch
+            .takeIf { search -> search.state == WAITING }
+            ?.let { search -> pvClient.fetchVelhoSearchStatus(search.token) }
+            ?.takeIf { status -> status.state == PVApiSearchState.valmis }
 
     fun updateDictionaries() {
         val dict = pvClient.fetchDictionaries()
-        dict.forEach { (type, entries) ->
-            pvDao.upsertDictionary(type, entries)
-        }
+        dict.forEach { (type, entries) -> pvDao.upsertDictionary(type, entries) }
     }
 
     fun importFilesFromProjektiVelho(latest: PVSearch, searchResults: PVApiSearchStatus) =
@@ -89,8 +98,9 @@ class PVIntegrationService @Autowired constructor(
             val assignments = mutableMapOf<Oid<PVAssignment>, PVApiAssignment?>()
             val projects = mutableMapOf<Oid<PVProject>, PVApiProject?>()
             val projectGroups = mutableMapOf<Oid<PVProjectGroup>, PVApiProjectGroup?>()
-            pvClient.fetchSearchResults(searchResults.searchId).matches
-                .map { match -> fetchFileAndInsertToDb(match, assignments, projects, projectGroups) }
+            pvClient.fetchSearchResults(searchResults.searchId).matches.map { match ->
+                fetchFileAndInsertToDb(match, assignments, projects, projectGroups)
+            }
             pvDao.updateFetchState(latest.id, FINISHED)
         } catch (e: Exception) {
             pvDao.updateFetchState(latest.id, ERROR)
@@ -103,7 +113,8 @@ class PVIntegrationService @Autowired constructor(
         projects: MutableMap<Oid<PVProject>, PVApiProject?>,
         projectGroups: MutableMap<Oid<PVProjectGroup>, PVApiProjectGroup?>
     ) {
-        val assignmentData = fetchAndUpsertAssignmentData(match.assignmentOid, assignments, projects, projectGroups)
+        val assignmentData =
+            fetchAndUpsertAssignmentData(match.assignmentOid, assignments, projects, projectGroups)
         val fileHolder = fetchFileMetadataAndContent(match.oid)
         insertFileToDatabase(fileHolder, assignmentData)
     }
@@ -114,13 +125,18 @@ class PVIntegrationService @Autowired constructor(
         projects: MutableMap<Oid<PVProject>, PVApiProject?>,
         projectGroups: MutableMap<Oid<PVProjectGroup>, PVApiProjectGroup?>,
     ): PVAssignmentHolder {
-        val assignment = fetchIfNew(assignments, assignmentOid, pvClient::fetchAssignment, pvDao::upsertAssignment)
-        val project = assignment?.projectOid?.let { oid ->
-            fetchIfNew(projects, oid, pvClient::fetchProject, pvDao::upsertProject)
-        }
-        val projectGroup = project?.projectGroupOid?.let { oid ->
-            fetchIfNew(projectGroups, oid, pvClient::fetchProjectGroup, pvDao::upsertProjectGroup)
-        }
+        val assignment =
+            fetchIfNew(
+                assignments, assignmentOid, pvClient::fetchAssignment, pvDao::upsertAssignment)
+        val project =
+            assignment?.projectOid?.let { oid ->
+                fetchIfNew(projects, oid, pvClient::fetchProject, pvDao::upsertProject)
+            }
+        val projectGroup =
+            project?.projectGroupOid?.let { oid ->
+                fetchIfNew(
+                    projectGroups, oid, pvClient::fetchProjectGroup, pvDao::upsertProjectGroup)
+            }
         return PVAssignmentHolder(assignment, project, projectGroup)
     }
 
@@ -130,11 +146,10 @@ class PVIntegrationService @Autowired constructor(
         fetch: (oid: Oid<S>) -> T?,
         store: (T) -> Unit,
     ): T? =
-        // Can't use compute here, as that would try to re-compute nulls. If the thing doesn't exist, don't re-fetch
+        // Can't use compute here, as that would try to re-compute nulls. If the thing doesn't
+        // exist, don't re-fetch
         if (known.containsKey(oid)) known[oid]
-        else fetch(oid)
-            .also { value -> known[oid] = value }
-            ?.also { value -> store(value) }
+        else fetch(oid).also { value -> known[oid] = value }?.also { value -> store(value) }
 
     private fun fetchFileMetadataAndContent(oid: Oid<PVDocument>): PVFileHolder {
         val metadataResponse = pvClient.fetchFileMetadata(oid)
@@ -151,18 +166,21 @@ class PVIntegrationService @Autowired constructor(
     }
 
     private fun insertFileToDatabase(file: PVFileHolder, assignment: PVAssignmentHolder) {
-        val result = file.content?.let { content -> checkInfraModel(content, file.latestVersion.name) }
-            ?: InfraModelCheckResult(NOT_IM, "error.infra-model.missing-file")
-        val xmlContent = if (result.state == NOT_IM) null else file.content?.let(::censorAuthorIdentifyingInfo)
-        val pvDocumentRowVersion = pvDao.insertDocumentMetadata(
-            file.oid,
-            file.metadata,
-            file.latestVersion,
-            result.state,
-            assignment.assignment?.oid,
-            assignment.project?.oid,
-            assignment.projectGroup?.oid,
-        )
+        val result =
+            file.content?.let { content -> checkInfraModel(content, file.latestVersion.name) }
+                ?: InfraModelCheckResult(NOT_IM, "error.infra-model.missing-file")
+        val xmlContent =
+            if (result.state == NOT_IM) null else file.content?.let(::censorAuthorIdentifyingInfo)
+        val pvDocumentRowVersion =
+            pvDao.insertDocumentMetadata(
+                file.oid,
+                file.metadata,
+                file.latestVersion,
+                result.state,
+                assignment.assignment?.oid,
+                assignment.project?.oid,
+                assignment.projectGroup?.oid,
+            )
         if (xmlContent != null) {
             pvDao.insertDocumentContent(xmlContent, pvDocumentRowVersion.id)
         }
@@ -175,30 +193,38 @@ class PVIntegrationService @Autowired constructor(
         val state: PVDocumentStatus,
         val rejectionReason: String? = null,
     )
+
     fun checkInfraModel(xml: String, filename: FileName): InfraModelCheckResult =
         try {
             val parsed = infraModelService.parseInfraModel(toInfraModelFile(filename, xml))
-            if (parsed.alignments.isEmpty()) InfraModelCheckResult(REJECTED, INFRAMODEL_PARSING_KEY_GENERIC)
-            else if (parsed.alignments.any { !isRailroadAlignment(it) }) InfraModelCheckResult(
-                REJECTED,
-                "$INFRAMODEL_PARSING_KEY_PARENT.alignments.non-railroad-alignments",
-            )
+            if (parsed.alignments.isEmpty())
+                InfraModelCheckResult(REJECTED, INFRAMODEL_PARSING_KEY_GENERIC)
+            else if (parsed.alignments.any { !isRailroadAlignment(it) })
+                InfraModelCheckResult(
+                    REJECTED,
+                    "$INFRAMODEL_PARSING_KEY_PARENT.alignments.non-railroad-alignments",
+                )
             else InfraModelCheckResult(SUGGESTED)
         } catch (e: InframodelParsingException) {
-            logger.info("Rejecting XML as not-IM: file=$filename error=${e.message?.let(::formatForLog)}")
+            logger.info(
+                "Rejecting XML as not-IM: file=$filename error=${e.message?.let(::formatForLog)}")
             InfraModelCheckResult(NOT_IM, e.localizationKey.toString())
         } catch (e: Exception) {
-            logger.warn("Rejecting XML as not-IM: file=$filename error=${e.message?.let(::formatForLog)}")
+            logger.warn(
+                "Rejecting XML as not-IM: file=$filename error=${e.message?.let(::formatForLog)}")
             InfraModelCheckResult(NOT_IM, INFRAMODEL_PARSING_KEY_GENERIC)
         }
 
-    val railroadAlignmentFeatureTypes = listOf(
-        FeatureTypeCode("111"),
-        FeatureTypeCode("121"),
-        FeatureTypeCode("281"),
-    )
+    val railroadAlignmentFeatureTypes =
+        listOf(
+            FeatureTypeCode("111"),
+            FeatureTypeCode("121"),
+            FeatureTypeCode("281"),
+        )
+
     fun isRailroadAlignment(alignment: GeometryAlignment) =
-        alignment.featureTypeCode?.let { code -> railroadAlignmentFeatureTypes.contains(code) } ?: true
+        alignment.featureTypeCode?.let { code -> railroadAlignmentFeatureTypes.contains(code) }
+            ?: true
 }
 
 private data class PVAssignmentHolder(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVSearchJson.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVSearchJson.kt
@@ -54,11 +54,9 @@ fun multiArgumentOperation(operator: PVApiSearchOperator, vararg children: JsonN
         children.forEach(arrayNode::add)
     }
 
-fun and(vararg children: JsonNode) =
-    multiArgumentOperation(PVApiSearchOperator.AND, *children)
+fun and(vararg children: JsonNode) = multiArgumentOperation(PVApiSearchOperator.AND, *children)
 
-fun or(vararg children: JsonNode) =
-    multiArgumentOperation(PVApiSearchOperator.OR, *children)
+fun or(vararg children: JsonNode) = multiArgumentOperation(PVApiSearchOperator.OR, *children)
 
 fun equals(path: List<String>, value: String) =
     operationWithPath(PVApiSearchOperator.EQUALS, path, value)
@@ -79,7 +77,11 @@ fun operationWithPath(operator: PVApiSearchOperator, path: List<String>, value: 
         arrayNode.add(value)
     }
 
-fun operationWithPath(operator: PVApiSearchOperator, path: List<String>, values: List<String>): ArrayNode =
+fun operationWithPath(
+    operator: PVApiSearchOperator,
+    path: List<String>,
+    values: List<String>
+): ArrayNode =
     JsonNodeFactory.instance.arrayNode().also { arrayNode ->
         arrayNode.add(operator.apiValue)
         arrayNode.add(jsonStringArray(path))
@@ -93,83 +95,46 @@ fun ordering(path: List<String>, direction: PVApiOrderingDirection): ArrayNode =
     }
 
 fun jsonObjectArray(items: List<JsonNode>): ArrayNode =
-    JsonNodeFactory.instance.arrayNode(items.size).also { array ->
-        items.forEach(array::add)
-    }
+    JsonNodeFactory.instance.arrayNode(items.size).also { array -> items.forEach(array::add) }
 
 fun jsonStringArray(items: List<String>): ArrayNode =
-    JsonNodeFactory.instance.arrayNode(items.size).also { array ->
-        items.forEach(array::add)
-    }
+    JsonNodeFactory.instance.arrayNode(items.size).also { array -> items.forEach(array::add) }
 
 fun searchJson(cutoffDate: Instant, minOid: Oid<PVDocument>?, maxResultCount: Int) =
     searchRoot(
-        settings = settings(
-            searchType = PVApiSearchType.TARGET_SEARCH,
-            maxResultCount = maxResultCount,
-            ordering = jsonObjectArray(
-                listOf(
-                    ordering(
+        settings =
+            settings(
+                searchType = PVApiSearchType.TARGET_SEARCH,
+                maxResultCount = maxResultCount,
+                ordering =
+                    jsonObjectArray(
                         listOf(
-                            "aineisto/aineisto",
-                            "tuorein-versio",
-                            "muokattu"
-                        ), PVApiOrderingDirection.ASCENDING
-                    ),
-                    ordering(
-                        listOf(
-                            "aineisto/aineisto",
-                            "oid"
-                        ), PVApiOrderingDirection.ASCENDING
-                    )
-                )
-            )
-        ),
-        formula = and(
-            or(
-                greaterThan(
-                    path = listOf(
-                        "aineisto/aineisto",
-                        "tuorein-versio",
-                        "muokattu"
-                    ),
-                    value = cutoffDate.toString()
-                ),
-                and(
-                    equals(
-                        path = listOf(
-                            "aineisto/aineisto",
-                            "tuorein-versio",
-                            "muokattu"
-                        ),
-                        value = cutoffDate.toString()
-                    ),
+                            ordering(
+                                listOf("aineisto/aineisto", "tuorein-versio", "muokattu"),
+                                PVApiOrderingDirection.ASCENDING),
+                            ordering(
+                                listOf("aineisto/aineisto", "oid"),
+                                PVApiOrderingDirection.ASCENDING)))),
+        formula =
+            and(
+                or(
                     greaterThan(
-                        path = listOf(
-                            "aineisto/aineisto",
-                            "oid"
-                        ),
-                        value = minOid?.let { minOid.toString() } ?: ""
-                    )
-                )
-            ),
-            includesText(path = listOf("aineisto/aineisto", "tuorein-versio", "nimi"), value = ".xml"),
-            contains(
-                path = listOf(
-                    "aineisto/aineisto",
-                    "metatiedot",
-                    "tekniikka-alat"
-                ), values = listOf("tekniikka-ala/ta15")
-            ),
-            or(
-                equals(
-                    path = listOf(
-                        "aineisto/aineisto",
-                        "metatiedot",
-                        "ryhma"
-                    ), value = "aineistoryhma/ar07"
-                )
-            )
-        ),
-        targetCategories = JsonNodeFactory.instance.arrayNode().add("aineisto/aineisto")
-    )
+                        path = listOf("aineisto/aineisto", "tuorein-versio", "muokattu"),
+                        value = cutoffDate.toString()),
+                    and(
+                        equals(
+                            path = listOf("aineisto/aineisto", "tuorein-versio", "muokattu"),
+                            value = cutoffDate.toString()),
+                        greaterThan(
+                            path = listOf("aineisto/aineisto", "oid"),
+                            value = minOid?.let { minOid.toString() } ?: ""))),
+                includesText(
+                    path = listOf("aineisto/aineisto", "tuorein-versio", "nimi"), value = ".xml"),
+                contains(
+                    path = listOf("aineisto/aineisto", "metatiedot", "tekniikka-alat"),
+                    values = listOf("tekniikka-ala/ta15")),
+                or(
+                    equals(
+                        path = listOf("aineisto/aineisto", "metatiedot", "ryhma"),
+                        value = "aineistoryhma/ar07"))),
+        targetCategories = JsonNodeFactory.instance.arrayNode().add("aineisto/aineisto"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -52,7 +52,11 @@ data class ChangeValue<T>(
     val newValue: T?,
     val localizationKey: LocalizationKey? = null,
 ) {
-    constructor(oldValue: T?, newValue: T?, localizationKey: String?) : this(
+    constructor(
+        oldValue: T?,
+        newValue: T?,
+        localizationKey: String?
+    ) : this(
         oldValue,
         newValue,
         localizationKey?.let(::LocalizationKey),
@@ -69,7 +73,10 @@ data class PropKey(
     val key: LocalizationKey,
     val params: LocalizationParams = LocalizationParams.empty,
 ) {
-    constructor(key: String, params: LocalizationParams = LocalizationParams.empty) : this(LocalizationKey(key), params)
+    constructor(
+        key: String,
+        params: LocalizationParams = LocalizationParams.empty
+    ) : this(LocalizationKey(key), params)
 }
 
 open class Publication(
@@ -128,7 +135,7 @@ data class PublishedKmPost(
 )
 
 data class PublishedIndirectChanges(
-    //Currently only used by Ratko integration
+    // Currently only used by Ratko integration
     @JsonIgnore val trackNumbers: List<PublishedTrackNumber>,
     val locationTracks: List<PublishedLocationTrack>,
     val switches: List<PublishedSwitch>,
@@ -156,11 +163,19 @@ data class PublicationDetails(
 }
 
 enum class DraftChangeType {
-    TRACK_NUMBER, LOCATION_TRACK, REFERENCE_LINE, SWITCH, KM_POST,
+    TRACK_NUMBER,
+    LOCATION_TRACK,
+    REFERENCE_LINE,
+    SWITCH,
+    KM_POST,
 }
 
 enum class Operation(val priority: Int) {
-    CREATE(0), MODIFY(1), DELETE(2), RESTORE(3), CALCULATED(4),
+    CREATE(0),
+    MODIFY(1),
+    DELETE(2),
+    RESTORE(3),
+    CALCULATED(4),
 }
 
 data class ValidatedPublicationCandidates(
@@ -181,44 +196,58 @@ data class PublicationCandidates(
     val switches: List<SwitchPublicationCandidate>,
     val kmPosts: List<KmPostPublicationCandidate>,
 ) : Loggable {
-    fun ids(): PublicationRequestIds = PublicationRequestIds(
-        trackNumbers.map { candidate -> candidate.id },
-        locationTracks.map { candidate -> candidate.id },
-        referenceLines.map { candidate -> candidate.id },
-        switches.map { candidate -> candidate.id },
-        kmPosts.map { candidate -> candidate.id },
-    )
+    fun ids(): PublicationRequestIds =
+        PublicationRequestIds(
+            trackNumbers.map { candidate -> candidate.id },
+            locationTracks.map { candidate -> candidate.id },
+            referenceLines.map { candidate -> candidate.id },
+            switches.map { candidate -> candidate.id },
+            kmPosts.map { candidate -> candidate.id },
+        )
 
     fun getValidationVersions(
         branch: LayoutBranch,
         splitVersions: List<RowVersion<Split>>,
-    ) = ValidationVersions(
-        branch = branch,
-        trackNumbers = trackNumbers.map(TrackNumberPublicationCandidate::getPublicationVersion),
-        referenceLines = referenceLines.map(ReferenceLinePublicationCandidate::getPublicationVersion),
-        locationTracks = locationTracks.map(LocationTrackPublicationCandidate::getPublicationVersion),
-        switches = switches.map(SwitchPublicationCandidate::getPublicationVersion),
-        kmPosts = kmPosts.map(KmPostPublicationCandidate::getPublicationVersion),
-        splits = splitVersions,
-    )
+    ) =
+        ValidationVersions(
+            branch = branch,
+            trackNumbers = trackNumbers.map(TrackNumberPublicationCandidate::getPublicationVersion),
+            referenceLines =
+                referenceLines.map(ReferenceLinePublicationCandidate::getPublicationVersion),
+            locationTracks =
+                locationTracks.map(LocationTrackPublicationCandidate::getPublicationVersion),
+            switches = switches.map(SwitchPublicationCandidate::getPublicationVersion),
+            kmPosts = kmPosts.map(KmPostPublicationCandidate::getPublicationVersion),
+            splits = splitVersions,
+        )
 
-    fun filter(request: PublicationRequestIds) = copy(
-        trackNumbers = trackNumbers.filter { candidate -> request.trackNumbers.contains(candidate.id) },
-        referenceLines = referenceLines.filter { candidate -> request.referenceLines.contains(candidate.id) },
-        locationTracks = locationTracks.filter { candidate -> request.locationTracks.contains(candidate.id) },
-        switches = switches.filter { candidate -> request.switches.contains(candidate.id) },
-        kmPosts = kmPosts.filter { candidate -> request.kmPosts.contains(candidate.id) },
-    )
+    fun filter(request: PublicationRequestIds) =
+        copy(
+            trackNumbers =
+                trackNumbers.filter { candidate -> request.trackNumbers.contains(candidate.id) },
+            referenceLines =
+                referenceLines.filter { candidate ->
+                    request.referenceLines.contains(candidate.id)
+                },
+            locationTracks =
+                locationTracks.filter { candidate ->
+                    request.locationTracks.contains(candidate.id)
+                },
+            switches = switches.filter { candidate -> request.switches.contains(candidate.id) },
+            kmPosts = kmPosts.filter { candidate -> request.kmPosts.contains(candidate.id) },
+        )
 
-    override fun toLog(): String = logFormat(
-        "trackNumbers" to toLog(trackNumbers),
-        "locationTracks" to toLog(locationTracks),
-        "referenceLines" to toLog(referenceLines),
-        "switches" to toLog(switches),
-        "kmPosts" to toLog(kmPosts),
-    )
+    override fun toLog(): String =
+        logFormat(
+            "trackNumbers" to toLog(trackNumbers),
+            "locationTracks" to toLog(locationTracks),
+            "referenceLines" to toLog(referenceLines),
+            "switches" to toLog(switches),
+            "kmPosts" to toLog(kmPosts),
+        )
 
-    private fun <T : PublicationCandidate<*>> toLog(list: List<T>): String = "${list.map(PublicationCandidate<*>::rowVersion)}"
+    private fun <T : PublicationCandidate<*>> toLog(list: List<T>): String =
+        "${list.map(PublicationCandidate<*>::rowVersion)}"
 }
 
 data class ValidationVersions(
@@ -231,19 +260,30 @@ data class ValidationVersions(
     val splits: List<RowVersion<Split>>,
 ) {
     fun containsLocationTrack(id: IntId<LocationTrack>) = locationTracks.any { it.officialId == id }
+
     fun containsKmPost(id: IntId<TrackLayoutKmPost>) = kmPosts.any { it.officialId == id }
+
     fun containsSwitch(id: IntId<TrackLayoutSwitch>) = switches.any { it.officialId == id }
+
     fun containsSplit(id: IntId<Split>): Boolean = splits.any { it.id == id }
 
-    fun findTrackNumber(id: IntId<TrackLayoutTrackNumber>) = trackNumbers.find { it.officialId == id }
+    fun findTrackNumber(id: IntId<TrackLayoutTrackNumber>) =
+        trackNumbers.find { it.officialId == id }
+
     fun findLocationTrack(id: IntId<LocationTrack>) = locationTracks.find { it.officialId == id }
+
     fun findSwitch(id: IntId<TrackLayoutSwitch>) = switches.find { it.officialId == id }
 
     fun getTrackNumberIds() = trackNumbers.map { v -> v.officialId }
+
     fun getReferenceLineIds() = referenceLines.map { v -> v.officialId }
+
     fun getLocationTrackIds() = locationTracks.map { v -> v.officialId }
+
     fun getSwitchIds() = switches.map { v -> v.officialId }
+
     fun getKmPostIds() = kmPosts.map { v -> v.officialId }
+
     fun getSplitIds() = splits.map { v -> v.id }
 }
 
@@ -252,7 +292,10 @@ data class PublicationGroup(
 )
 
 // TODO: GVT-2629 Rename validatedAssetVersion -> rowVersion
-data class ValidationVersion<T>(val officialId: IntId<T>, val validatedAssetVersion: LayoutRowVersion<T>)
+data class ValidationVersion<T>(
+    val officialId: IntId<T>,
+    val validatedAssetVersion: LayoutRowVersion<T>
+)
 
 data class PublicationRequestIds(
     val trackNumbers: List<IntId<TrackLayoutTrackNumber>>,
@@ -261,13 +304,14 @@ data class PublicationRequestIds(
     val switches: List<IntId<TrackLayoutSwitch>>,
     val kmPosts: List<IntId<TrackLayoutKmPost>>,
 ) {
-    operator fun minus(other: PublicationRequestIds) = PublicationRequestIds(
-        trackNumbers - other.trackNumbers.toSet(),
-        locationTracks - other.locationTracks.toSet(),
-        referenceLines - other.referenceLines.toSet(),
-        switches - other.switches.toSet(),
-        kmPosts - other.kmPosts.toSet(),
-    )
+    operator fun minus(other: PublicationRequestIds) =
+        PublicationRequestIds(
+            trackNumbers - other.trackNumbers.toSet(),
+            locationTracks - other.locationTracks.toSet(),
+            referenceLines - other.referenceLines.toSet(),
+            switches - other.switches.toSet(),
+            kmPosts - other.kmPosts.toSet(),
+        )
 }
 
 data class PublicationRequest(
@@ -284,7 +328,11 @@ data class PublicationResult(
     val kmPosts: Int,
 )
 
-enum class LayoutValidationIssueType { ERROR, WARNING }
+enum class LayoutValidationIssueType {
+    ERROR,
+    WARNING
+}
+
 data class LayoutValidationIssue(
     val type: LayoutValidationIssueType,
     val localizationKey: LocalizationKey,
@@ -421,7 +469,9 @@ data class LocationTrackChanges(
 
 // Todo: Consider making TrackLayoutSwitch use this for trapPoint as well
 enum class TrapPoint {
-    Yes, No, Unknown
+    Yes,
+    No,
+    Unknown
 }
 
 data class SwitchChanges(
@@ -486,7 +536,9 @@ data class SplitTargetInPublication(
 )
 
 enum class DesignRowReferrer {
-    MAIN_DRAFT, DESIGN_DRAFT, NONE,
+    MAIN_DRAFT,
+    DESIGN_DRAFT,
+    NONE,
 }
 
 sealed class LayoutContextTransition {
@@ -497,11 +549,14 @@ sealed class LayoutContextTransition {
                 "Can't transition layout context from main-official"
             }
             return if (branch is DesignBranch) {
-                if (fromState == PublicationState.DRAFT) PublicationInDesign(branch) else MergeFromDesign(branch)
+                if (fromState == PublicationState.DRAFT) PublicationInDesign(branch)
+                else MergeFromDesign(branch)
             } else PublicationInMain
         }
+
         fun publicationIn(layoutBranch: LayoutBranch): LayoutContextTransition =
-            if (layoutBranch is DesignBranch) PublicationInDesign(layoutBranch) else PublicationInMain
+            if (layoutBranch is DesignBranch) PublicationInDesign(layoutBranch)
+            else PublicationInMain
     }
 
     abstract val candidateBranch: LayoutBranch
@@ -509,22 +564,28 @@ sealed class LayoutContextTransition {
     abstract val candidatePublicationState: PublicationState
     abstract val basePublicationState: PublicationState
 
-    val candidateContext get() = LayoutContext.of(candidateBranch, candidatePublicationState)
-    val baseContext get() = LayoutContext.of(baseBranch, basePublicationState)
+    val candidateContext
+        get() = LayoutContext.of(candidateBranch, candidatePublicationState)
+
+    val baseContext
+        get() = LayoutContext.of(baseBranch, basePublicationState)
 }
+
 data object PublicationInMain : LayoutContextTransition() {
     override val candidateBranch = MainBranch.instance
     override val baseBranch = MainBranch.instance
     override val candidatePublicationState = PublicationState.DRAFT
     override val basePublicationState = PublicationState.OFFICIAL
 }
-data class PublicationInDesign(private val branch: DesignBranch): LayoutContextTransition() {
+
+data class PublicationInDesign(private val branch: DesignBranch) : LayoutContextTransition() {
     override val candidateBranch = branch
     override val baseBranch = branch
     override val candidatePublicationState = PublicationState.DRAFT
     override val basePublicationState = PublicationState.OFFICIAL
 }
-data class MergeFromDesign(override val candidateBranch: DesignBranch): LayoutContextTransition() {
+
+data class MergeFromDesign(override val candidateBranch: DesignBranch) : LayoutContextTransition() {
     override val baseBranch = MainBranch.instance
     override val candidatePublicationState = PublicationState.OFFICIAL
     override val basePublicationState = PublicationState.DRAFT

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -34,6 +34,10 @@ import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.SortOrder
 import fi.fta.geoviite.infra.util.nullsFirstComparator
 import fi.fta.geoviite.infra.util.printCsv
+import java.time.Instant
+import java.time.ZoneId
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import org.postgresql.util.PSQLException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -41,13 +45,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.Instant
-import java.time.ZoneId
-import java.util.*
-import java.util.concurrent.ConcurrentHashMap
 
 @GeoviiteService
-class PublicationService @Autowired constructor(
+class PublicationService
+@Autowired
+constructor(
     private val publicationDao: PublicationDao,
     private val geocodingService: GeocodingService,
     private val trackNumberService: LayoutTrackNumberService,
@@ -67,29 +69,37 @@ class PublicationService @Autowired constructor(
     private val ratkoPushDao: RatkoPushDao,
     private val geocodingCacheService: GeocodingCacheService,
     private val transactionTemplate: TransactionTemplate,
-    private val publicationGeometryChangeRemarksUpdateService: PublicationGeometryChangeRemarksUpdateService,
+    private val publicationGeometryChangeRemarksUpdateService:
+        PublicationGeometryChangeRemarksUpdateService,
     private val splitService: SplitService,
     private val splitDao: SplitDao,
     private val localizationService: LocalizationService
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    private fun splitCsvColumns(translation: Translation): List<CsvEntry<Pair<LocationTrack, SplitTargetInPublication>>> =
+    private fun splitCsvColumns(
+        translation: Translation
+    ): List<CsvEntry<Pair<LocationTrack, SplitTargetInPublication>>> =
         mapOf<String, (item: Pair<LocationTrack, SplitTargetInPublication>) -> Any?>(
-            "split-details-csv.source-name" to { (lt, _) -> lt.name },
-            "split-details-csv.source-oid" to { (lt, _) -> lt.externalId },
-            "split-details-csv.target-name" to { (_, split) -> split.name },
-            "split-details-csv.target-oid" to { (_, split) -> split.oid },
-            "split-details-csv.operation" to { (_, split) ->
-                when (split.operation) {
-                    SplitTargetOperation.CREATE -> translation.t("split-details-csv.newly-created")
-                    SplitTargetOperation.OVERWRITE -> translation.t("split-details-csv.replaces-duplicate")
-                    SplitTargetOperation.TRANSFER -> translation.t("split-details-csv.transfers-assets")
-                }
-            },
-            "split-details-csv.start-address" to { (_, split) -> split.startAddress },
-            "split-details-csv.end-address" to { (_, split) -> split.endAddress },
-        ).map { (key, fn) -> CsvEntry(translation.t(key), fn) }
+                "split-details-csv.source-name" to { (lt, _) -> lt.name },
+                "split-details-csv.source-oid" to { (lt, _) -> lt.externalId },
+                "split-details-csv.target-name" to { (_, split) -> split.name },
+                "split-details-csv.target-oid" to { (_, split) -> split.oid },
+                "split-details-csv.operation" to
+                    { (_, split) ->
+                        when (split.operation) {
+                            SplitTargetOperation.CREATE ->
+                                translation.t("split-details-csv.newly-created")
+                            SplitTargetOperation.OVERWRITE ->
+                                translation.t("split-details-csv.replaces-duplicate")
+                            SplitTargetOperation.TRANSFER ->
+                                translation.t("split-details-csv.transfers-assets")
+                        }
+                    },
+                "split-details-csv.start-address" to { (_, split) -> split.startAddress },
+                "split-details-csv.end-address" to { (_, split) -> split.endAddress },
+            )
+            .map { (key, fn) -> CsvEntry(translation.t(key), fn) }
 
     @Transactional(readOnly = true)
     fun collectPublicationCandidates(transition: LayoutContextTransition): PublicationCandidates {
@@ -109,14 +119,16 @@ class PublicationService @Autowired constructor(
         request: PublicationRequestIds,
     ): ValidatedPublicationCandidates {
         return ValidatedPublicationCandidates(
-            validatedAsPublicationUnit = validateAsPublicationUnit(
-                candidates = candidates.filter(request),
-                allowMultipleSplits = false,
-            ),
-            allChangesValidated = validateAsPublicationUnit(
-                candidates = candidates,
-                allowMultipleSplits = true,
-            ),
+            validatedAsPublicationUnit =
+                validateAsPublicationUnit(
+                    candidates = candidates.filter(request),
+                    allowMultipleSplits = false,
+                ),
+            allChangesValidated =
+                validateAsPublicationUnit(
+                    candidates = candidates,
+                    allowMultipleSplits = true,
+                ),
         )
     }
 
@@ -128,17 +140,22 @@ class PublicationService @Autowired constructor(
         if (trackNumberIds.isEmpty()) return emptyList()
 
         // Switches don't affect tracknumber validity, so they are ignored
-        val validationContext = when (layoutContext.state) {
-            DRAFT -> createValidationContext(
-                branch = layoutContext.branch,
-                locationTracks = locationTrackDao.fetchPublicationVersions(layoutContext.branch),
-                kmPosts = kmPostDao.fetchPublicationVersions(layoutContext.branch),
-                trackNumbers = trackNumberDao.fetchPublicationVersions(layoutContext.branch),
-                referenceLines = referenceLineDao.fetchPublicationVersions(layoutContext.branch),
-            )
+        val validationContext =
+            when (layoutContext.state) {
+                DRAFT ->
+                    createValidationContext(
+                        branch = layoutContext.branch,
+                        locationTracks =
+                            locationTrackDao.fetchPublicationVersions(layoutContext.branch),
+                        kmPosts = kmPostDao.fetchPublicationVersions(layoutContext.branch),
+                        trackNumbers =
+                            trackNumberDao.fetchPublicationVersions(layoutContext.branch),
+                        referenceLines =
+                            referenceLineDao.fetchPublicationVersions(layoutContext.branch),
+                    )
 
-            OFFICIAL -> createValidationContext(layoutContext.branch)
-        }
+                OFFICIAL -> createValidationContext(layoutContext.branch)
+            }
         validationContext.preloadTrackNumberAndReferenceLineVersions(trackNumberIds)
         validationContext.preloadTrackNumbersByNumber(trackNumberIds)
         validationContext.preloadKmPostsByTrackNumbers(trackNumberIds)
@@ -147,9 +164,12 @@ class PublicationService @Autowired constructor(
         return trackNumberIds.mapNotNull { id ->
             val trackNumberIssues = validateTrackNumber(id, validationContext)
             val referenceLineId = validationContext.getReferenceLineIdByTrackNumber(id)
-            val referenceLineIssues = referenceLineId?.let { rlId -> validateReferenceLine(rlId, validationContext) }
+            val referenceLineIssues =
+                referenceLineId?.let { rlId -> validateReferenceLine(rlId, validationContext) }
             if (trackNumberIssues != null || referenceLineIssues != null) {
-                val allIssues = ((trackNumberIssues ?: emptyList()) + (referenceLineIssues ?: emptyList())).distinct()
+                val allIssues =
+                    ((trackNumberIssues ?: emptyList()) + (referenceLineIssues ?: emptyList()))
+                        .distinct()
                 ValidatedAsset(id, allIssues)
             } else null
         }
@@ -162,28 +182,36 @@ class PublicationService @Autowired constructor(
     ): List<ValidatedAsset<LocationTrack>> {
         if (trackIds.isEmpty()) return emptyList()
 
-        val validationContext = when (layoutContext.state) {
-            DRAFT -> createValidationContext(
-                branch = layoutContext.branch,
-                switches = switchDao.fetchPublicationVersions(layoutContext.branch),
-                locationTracks = locationTrackDao.fetchPublicationVersions(layoutContext.branch),
-                kmPosts = kmPostDao.fetchPublicationVersions(layoutContext.branch),
-                trackNumbers = trackNumberDao.fetchPublicationVersions(layoutContext.branch),
-                referenceLines = referenceLineDao.fetchPublicationVersions(layoutContext.branch),
-            )
+        val validationContext =
+            when (layoutContext.state) {
+                DRAFT ->
+                    createValidationContext(
+                        branch = layoutContext.branch,
+                        switches = switchDao.fetchPublicationVersions(layoutContext.branch),
+                        locationTracks =
+                            locationTrackDao.fetchPublicationVersions(layoutContext.branch),
+                        kmPosts = kmPostDao.fetchPublicationVersions(layoutContext.branch),
+                        trackNumbers =
+                            trackNumberDao.fetchPublicationVersions(layoutContext.branch),
+                        referenceLines =
+                            referenceLineDao.fetchPublicationVersions(layoutContext.branch),
+                    )
 
-            OFFICIAL -> createValidationContext(layoutContext.branch)
-        }
+                OFFICIAL -> createValidationContext(layoutContext.branch)
+            }
         validationContext.preloadLocationTrackVersions(trackIds)
         validationContext.preloadLocationTracksByName(trackIds)
         validationContext.preloadTrackDuplicates(trackIds)
         validationContext.preloadAssociatedTrackNumberAndReferenceLineVersions(trackIds = trackIds)
-        val linkedSwitchIds = trackIds.flatMap(validationContext::getPotentiallyAffectedSwitchIds).distinct()
+        val linkedSwitchIds =
+            trackIds.flatMap(validationContext::getPotentiallyAffectedSwitchIds).distinct()
         validationContext.preloadSwitchVersions(linkedSwitchIds)
         validationContext.preloadSwitchTrackLinks(linkedSwitchIds)
 
         return trackIds.mapNotNull { id ->
-            validateLocationTrack(id, validationContext)?.let { issues -> ValidatedAsset(id, issues) }
+            validateLocationTrack(id, validationContext)?.let { issues ->
+                ValidatedAsset(id, issues)
+            }
         }
     }
 
@@ -194,16 +222,20 @@ class PublicationService @Autowired constructor(
     ): List<ValidatedAsset<TrackLayoutSwitch>> {
         if (switchIds.isEmpty()) return emptyList()
 
-        // Only tracks and switches affect switch validation, so we can ignore the other types in the publication unit
-        val validationContext = when (layoutContext.state) {
-            DRAFT -> createValidationContext(
-                branch = layoutContext.branch,
-                switches = switchDao.fetchPublicationVersions(layoutContext.branch),
-                locationTracks = locationTrackDao.fetchPublicationVersions(layoutContext.branch),
-            )
+        // Only tracks and switches affect switch validation, so we can ignore the other types in
+        // the publication unit
+        val validationContext =
+            when (layoutContext.state) {
+                DRAFT ->
+                    createValidationContext(
+                        branch = layoutContext.branch,
+                        switches = switchDao.fetchPublicationVersions(layoutContext.branch),
+                        locationTracks =
+                            locationTrackDao.fetchPublicationVersions(layoutContext.branch),
+                    )
 
-            OFFICIAL -> createValidationContext(layoutContext.branch)
-        }
+                OFFICIAL -> createValidationContext(layoutContext.branch)
+            }
         validationContext.preloadSwitchVersions(switchIds)
         validationContext.preloadSwitchTrackLinks(switchIds)
         validationContext.preloadSwitchesByName(switchIds)
@@ -221,21 +253,24 @@ class PublicationService @Autowired constructor(
         if (kmPostIds.isEmpty()) return emptyList()
 
         // We can ignore switches and locationtracks, as they don't affect km-post validity
-        val validationContext = when (layoutContext.state) {
-            DRAFT -> createValidationContext(
-                branch = layoutContext.branch,
-                kmPosts = kmPostDao.fetchPublicationVersions(layoutContext.branch),
-                trackNumbers = trackNumberDao.fetchPublicationVersions(layoutContext.branch),
-                referenceLines = referenceLineDao.fetchPublicationVersions(layoutContext.branch),
-            )
+        val validationContext =
+            when (layoutContext.state) {
+                DRAFT ->
+                    createValidationContext(
+                        branch = layoutContext.branch,
+                        kmPosts = kmPostDao.fetchPublicationVersions(layoutContext.branch),
+                        trackNumbers =
+                            trackNumberDao.fetchPublicationVersions(layoutContext.branch),
+                        referenceLines =
+                            referenceLineDao.fetchPublicationVersions(layoutContext.branch),
+                    )
 
-            OFFICIAL -> createValidationContext(layoutContext.branch)
-        }
+                OFFICIAL -> createValidationContext(layoutContext.branch)
+            }
 
         validationContext.preloadKmPostVersions(kmPostIds)
         validationContext.preloadTrackNumberAndReferenceLineVersions(
-            validationContext.collectAssociatedTrackNumberIds(kmPostIds = kmPostIds)
-        )
+            validationContext.collectAssociatedTrackNumberIds(kmPostIds = kmPostIds))
 
         return kmPostIds.mapNotNull { id ->
             validateKmPost(id, validationContext)?.let { issues -> ValidatedAsset(id, issues) }
@@ -249,25 +284,33 @@ class PublicationService @Autowired constructor(
         referenceLines: List<ValidationVersion<ReferenceLine>> = emptyList(),
         switches: List<ValidationVersion<TrackLayoutSwitch>> = emptyList(),
         kmPosts: List<ValidationVersion<TrackLayoutKmPost>> = emptyList(),
-    ): ValidationContext = createValidationContext(
-        ValidationVersions(branch, trackNumbers, locationTracks, referenceLines, switches, kmPosts, emptyList())
-    )
+    ): ValidationContext =
+        createValidationContext(
+            ValidationVersions(
+                branch,
+                trackNumbers,
+                locationTracks,
+                referenceLines,
+                switches,
+                kmPosts,
+                emptyList()))
 
     private fun createValidationContext(
         publicationSet: ValidationVersions,
-    ): ValidationContext = ValidationContext(
-        trackNumberDao = trackNumberDao,
-        referenceLineDao = referenceLineDao,
-        kmPostDao = kmPostDao,
-        locationTrackDao = locationTrackDao,
-        switchDao = switchDao,
-        geocodingService = geocodingService,
-        alignmentDao = alignmentDao,
-        publicationDao = publicationDao,
-        switchLibraryService = switchLibraryService,
-        splitService = splitService,
-        publicationSet = publicationSet,
-    )
+    ): ValidationContext =
+        ValidationContext(
+            trackNumberDao = trackNumberDao,
+            referenceLineDao = referenceLineDao,
+            kmPostDao = kmPostDao,
+            locationTrackDao = locationTrackDao,
+            switchDao = switchDao,
+            geocodingService = geocodingService,
+            alignmentDao = alignmentDao,
+            publicationDao = publicationDao,
+            switchLibraryService = switchLibraryService,
+            splitService = splitService,
+            publicationSet = publicationSet,
+        )
 
     fun getChangeTime(): Instant {
         return publicationDao.fetchChangeTime()
@@ -278,119 +321,174 @@ class PublicationService @Autowired constructor(
         candidates: PublicationCandidates,
         allowMultipleSplits: Boolean,
     ): PublicationCandidates {
-        val splitVersions = splitService.fetchPublicationVersions(
-            branch = candidates.branch,
-            locationTracks = candidates.locationTracks.map { it.id },
-            switches = candidates.switches.map { it.id },
-        )
+        val splitVersions =
+            splitService.fetchPublicationVersions(
+                branch = candidates.branch,
+                locationTracks = candidates.locationTracks.map { it.id },
+                switches = candidates.switches.map { it.id },
+            )
         val versions = candidates.getValidationVersions(candidates.branch, splitVersions)
 
-        val validationContext = createValidationContext(versions).also { ctx -> ctx.preloadByPublicationSet() }
-        val splitIssues = splitService.validateSplit(versions, validationContext, allowMultipleSplits)
+        val validationContext =
+            createValidationContext(versions).also { ctx -> ctx.preloadByPublicationSet() }
+        val splitIssues =
+            splitService.validateSplit(versions, validationContext, allowMultipleSplits)
 
         return PublicationCandidates(
             branch = candidates.branch,
-            trackNumbers = candidates.trackNumbers.map { candidate ->
-                val trackNumberSplitIssues = splitIssues.trackNumbers[candidate.id] ?: emptyList()
-                val validationIssues = validateTrackNumber(candidate.id, validationContext) ?: emptyList()
-                candidate.copy(issues = trackNumberSplitIssues + validationIssues)
-            },
-            referenceLines = candidates.referenceLines.map { candidate ->
-                val referenceLineSplitIssues = splitIssues.referenceLines[candidate.id] ?: emptyList()
-                val validationIssues = validateReferenceLine(candidate.id, validationContext) ?: emptyList()
-                candidate.copy(issues = referenceLineSplitIssues + validationIssues)
-            },
-            locationTracks = candidates.locationTracks.map { candidate ->
-                val locationTrackSplitIssues = splitIssues.locationTracks[candidate.id] ?: emptyList()
-                val validationIssues = validateLocationTrack(candidate.id, validationContext) ?: emptyList()
-                candidate.copy(issues = validationIssues + locationTrackSplitIssues)
-            },
-            switches = candidates.switches.map { candidate ->
-                val switchSplitIssues = splitIssues.switches[candidate.id] ?: emptyList()
-                val validationIssues = validateSwitch(candidate.id, validationContext) ?: emptyList()
-                candidate.copy(issues = validationIssues + switchSplitIssues)
-            },
-            kmPosts = candidates.kmPosts.map { candidate ->
-                val kmPostSplitIssues = splitIssues.kmPosts[candidate.id] ?: emptyList()
-                val validationIssues = validateKmPost(candidate.id, validationContext) ?: emptyList()
-                candidate.copy(issues = validationIssues + kmPostSplitIssues)
-            },
+            trackNumbers =
+                candidates.trackNumbers.map { candidate ->
+                    val trackNumberSplitIssues =
+                        splitIssues.trackNumbers[candidate.id] ?: emptyList()
+                    val validationIssues =
+                        validateTrackNumber(candidate.id, validationContext) ?: emptyList()
+                    candidate.copy(issues = trackNumberSplitIssues + validationIssues)
+                },
+            referenceLines =
+                candidates.referenceLines.map { candidate ->
+                    val referenceLineSplitIssues =
+                        splitIssues.referenceLines[candidate.id] ?: emptyList()
+                    val validationIssues =
+                        validateReferenceLine(candidate.id, validationContext) ?: emptyList()
+                    candidate.copy(issues = referenceLineSplitIssues + validationIssues)
+                },
+            locationTracks =
+                candidates.locationTracks.map { candidate ->
+                    val locationTrackSplitIssues =
+                        splitIssues.locationTracks[candidate.id] ?: emptyList()
+                    val validationIssues =
+                        validateLocationTrack(candidate.id, validationContext) ?: emptyList()
+                    candidate.copy(issues = validationIssues + locationTrackSplitIssues)
+                },
+            switches =
+                candidates.switches.map { candidate ->
+                    val switchSplitIssues = splitIssues.switches[candidate.id] ?: emptyList()
+                    val validationIssues =
+                        validateSwitch(candidate.id, validationContext) ?: emptyList()
+                    candidate.copy(issues = validationIssues + switchSplitIssues)
+                },
+            kmPosts =
+                candidates.kmPosts.map { candidate ->
+                    val kmPostSplitIssues = splitIssues.kmPosts[candidate.id] ?: emptyList()
+                    val validationIssues =
+                        validateKmPost(candidate.id, validationContext) ?: emptyList()
+                    candidate.copy(issues = validationIssues + kmPostSplitIssues)
+                },
         )
     }
 
     @Transactional(readOnly = true)
     fun validatePublicationRequest(versions: ValidationVersions) {
-        val validationContext = createValidationContext(versions).also { ctx -> ctx.preloadByPublicationSet() }
-        splitService.validateSplit(versions, validationContext, allowMultipleSplits = false).also(::assertNoSplitErrors)
+        val validationContext =
+            createValidationContext(versions).also { ctx -> ctx.preloadByPublicationSet() }
+        splitService
+            .validateSplit(versions, validationContext, allowMultipleSplits = false)
+            .also(::assertNoSplitErrors)
 
         versions.trackNumbers.forEach { version ->
-            assertNoErrors(version, requireNotNull(validateTrackNumber(version.officialId, validationContext)))
+            assertNoErrors(
+                version, requireNotNull(validateTrackNumber(version.officialId, validationContext)))
         }
         versions.kmPosts.forEach { version ->
-            assertNoErrors(version, requireNotNull(validateKmPost(version.officialId, validationContext)))
+            assertNoErrors(
+                version, requireNotNull(validateKmPost(version.officialId, validationContext)))
         }
         versions.referenceLines.forEach { version ->
-            assertNoErrors(version, requireNotNull(validateReferenceLine(version.officialId, validationContext)))
+            assertNoErrors(
+                version,
+                requireNotNull(validateReferenceLine(version.officialId, validationContext)))
         }
         versions.locationTracks.forEach { version ->
-            assertNoErrors(version, requireNotNull(validateLocationTrack(version.officialId, validationContext)))
+            assertNoErrors(
+                version,
+                requireNotNull(validateLocationTrack(version.officialId, validationContext)))
         }
         versions.switches.forEach { version ->
-            assertNoErrors(version, requireNotNull(validateSwitch(version.officialId, validationContext)))
+            assertNoErrors(
+                version, requireNotNull(validateSwitch(version.officialId, validationContext)))
         }
     }
 
     @Transactional(readOnly = true)
-    fun getRevertRequestDependencies(branch: LayoutBranch, requestIds: PublicationRequestIds): PublicationRequestIds {
-        val referenceLineTrackNumberIds = referenceLineService
-            .getMany(branch.draft, requestIds.referenceLines)
-            .map { rlId -> rlId.trackNumberId }
-        val trackNumbers = trackNumberService
-            .getMany(branch.draft, referenceLineTrackNumberIds + requestIds.trackNumbers)
-        val revertTrackNumberIds = trackNumbers
-            .filter(TrackLayoutTrackNumber::isDraft)
-            .map { it.id as IntId }
+    fun getRevertRequestDependencies(
+        branch: LayoutBranch,
+        requestIds: PublicationRequestIds
+    ): PublicationRequestIds {
+        val referenceLineTrackNumberIds =
+            referenceLineService.getMany(branch.draft, requestIds.referenceLines).map { rlId ->
+                rlId.trackNumberId
+            }
+        val trackNumbers =
+            trackNumberService.getMany(
+                branch.draft, referenceLineTrackNumberIds + requestIds.trackNumbers)
+        val revertTrackNumberIds =
+            trackNumbers.filter(TrackLayoutTrackNumber::isDraft).map { it.id as IntId }
         // If revert breaks other draft row references, they should be reverted too
-        val draftOnlyTrackNumberIds = trackNumbers
-            .filter { tn -> tn.isDraft && tn.contextData.officialRowId == null }
-            .map { it.id as IntId }
+        val draftOnlyTrackNumberIds =
+            trackNumbers
+                .filter { tn -> tn.isDraft && tn.contextData.officialRowId == null }
+                .map { it.id as IntId }
 
-        val revertLocationTrackIds = requestIds.locationTracks + draftOnlyTrackNumberIds.flatMap { tnId ->
-            locationTrackDao.fetchOnlyDraftVersions(branch, includeDeleted = true, tnId).map(locationTrackDao::fetch)
-        }.map { track -> track.id as IntId }
+        val revertLocationTrackIds =
+            requestIds.locationTracks +
+                draftOnlyTrackNumberIds
+                    .flatMap { tnId ->
+                        locationTrackDao
+                            .fetchOnlyDraftVersions(branch, includeDeleted = true, tnId)
+                            .map(locationTrackDao::fetch)
+                    }
+                    .map { track -> track.id as IntId }
 
-        val revertSplits = splitService.findUnpublishedSplits(branch, revertLocationTrackIds, requestIds.switches)
+        val revertSplits =
+            splitService.findUnpublishedSplits(branch, revertLocationTrackIds, requestIds.switches)
         val revertSplitTracks = revertSplits.flatMap { s -> s.locationTracks }.distinct()
         val revertSplitSwitches = revertSplits.flatMap { s -> s.relinkedSwitches }.distinct()
 
-        val revertKmPostIds = requestIds.kmPosts.toSet() + draftOnlyTrackNumberIds.flatMap { tnId ->
-            kmPostDao.fetchOnlyDraftVersions(branch, includeDeleted = true, tnId).map(kmPostDao::fetch)
-        }.map { kmPost -> kmPost.id as IntId }
+        val revertKmPostIds =
+            requestIds.kmPosts.toSet() +
+                draftOnlyTrackNumberIds
+                    .flatMap { tnId ->
+                        kmPostDao
+                            .fetchOnlyDraftVersions(branch, includeDeleted = true, tnId)
+                            .map(kmPostDao::fetch)
+                    }
+                    .map { kmPost -> kmPost.id as IntId }
 
-        val referenceLines = requestIds.referenceLines.toSet() + requestIds.trackNumbers.mapNotNull { tnId ->
-            referenceLineService.getByTrackNumber(branch.draft, tnId)
-        }.filter(ReferenceLine::isDraft).map { line -> line.id as IntId }
+        val referenceLines =
+            requestIds.referenceLines.toSet() +
+                requestIds.trackNumbers
+                    .mapNotNull { tnId ->
+                        referenceLineService.getByTrackNumber(branch.draft, tnId)
+                    }
+                    .filter(ReferenceLine::isDraft)
+                    .map { line -> line.id as IntId }
 
         return PublicationRequestIds(
             trackNumbers = revertTrackNumberIds.toList(),
             referenceLines = referenceLines.toList(),
             locationTracks = (revertLocationTrackIds + revertSplitTracks).distinct(),
             switches = (requestIds.switches + revertSplitSwitches).distinct(),
-            kmPosts = revertKmPostIds.toList()
-        )
+            kmPosts = revertKmPostIds.toList())
     }
 
     @Transactional
-    fun revertPublicationCandidates(branch: LayoutBranch, toDelete: PublicationRequestIds): PublicationResult {
-        splitService.fetchPublicationVersions(branch, toDelete.locationTracks, toDelete.switches)
+    fun revertPublicationCandidates(
+        branch: LayoutBranch,
+        toDelete: PublicationRequestIds
+    ): PublicationResult {
+        splitService
+            .fetchPublicationVersions(branch, toDelete.locationTracks, toDelete.switches)
             .forEach { split -> splitService.deleteSplit(split.id) }
 
-        val locationTrackCount = toDelete.locationTracks.map { id -> locationTrackService.deleteDraft(branch, id) }.size
-        val referenceLineCount = toDelete.referenceLines.map { id -> referenceLineService.deleteDraft(branch, id) }.size
+        val locationTrackCount =
+            toDelete.locationTracks.map { id -> locationTrackService.deleteDraft(branch, id) }.size
+        val referenceLineCount =
+            toDelete.referenceLines.map { id -> referenceLineService.deleteDraft(branch, id) }.size
         alignmentDao.deleteOrphanedAlignments()
         val switchCount = toDelete.switches.map { id -> switchService.deleteDraft(branch, id) }.size
         val kmPostCount = toDelete.kmPosts.map { id -> kmPostService.deleteDraft(branch, id) }.size
-        val trackNumberCount = toDelete.trackNumbers.map { id -> trackNumberService.deleteDraft(branch, id) }.size
+        val trackNumberCount =
+            toDelete.trackNumbers.map { id -> trackNumberService.deleteDraft(branch, id) }.size
 
         return PublicationResult(
             publicationId = null,
@@ -403,62 +501,92 @@ class PublicationService @Autowired constructor(
     }
 
     /**
-     * Note: this is intentionally not transactional:
-     * each ID is fetched from ratko and becomes an object there -> we want to store it, even if the rest fail
+     * Note: this is intentionally not transactional: each ID is fetched from ratko and becomes an
+     * object there -> we want to store it, even if the rest fail
      */
     fun updateExternalId(branch: LayoutBranch, request: PublicationRequestIds) {
         val draftContext = branch.draft
         try {
             request.locationTracks
-                .filter { trackId -> locationTrackService.getOrThrow(draftContext, trackId).externalId == null }
+                .filter { trackId ->
+                    locationTrackService.getOrThrow(draftContext, trackId).externalId == null
+                }
                 .forEach { trackId -> updateExternalIdForLocationTrack(branch, trackId) }
             request.trackNumbers
-                .filter { trackNumberId -> trackNumberService.getOrThrow(draftContext, trackNumberId).externalId == null }
+                .filter { trackNumberId ->
+                    trackNumberService.getOrThrow(draftContext, trackNumberId).externalId == null
+                }
                 .forEach { trackNumberId -> updateExternalIdForTrackNumber(branch, trackNumberId) }
             request.switches
-                .filter { switchId -> switchService.getOrThrow(draftContext, switchId).externalId == null }
+                .filter { switchId ->
+                    switchService.getOrThrow(draftContext, switchId).externalId == null
+                }
                 .forEach { switchId -> updateExternalIdForSwitch(branch, switchId) }
         } catch (e: Exception) {
             throw PublicationFailureException(
                 message = "Failed to update external IDs for publication candidates",
                 cause = e,
-                localizedMessageKey = "external-id-update-failed"
-            )
+                localizedMessageKey = "external-id-update-failed")
         }
     }
 
     @Transactional(readOnly = true)
-    fun getValidationVersions(branch: LayoutBranch, request: PublicationRequestIds): ValidationVersions {
+    fun getValidationVersions(
+        branch: LayoutBranch,
+        request: PublicationRequestIds
+    ): ValidationVersions {
         return ValidationVersions(
             branch = branch,
             trackNumbers = trackNumberDao.fetchPublicationVersions(branch, request.trackNumbers),
-            referenceLines = referenceLineDao.fetchPublicationVersions(branch, request.referenceLines),
+            referenceLines =
+                referenceLineDao.fetchPublicationVersions(branch, request.referenceLines),
             kmPosts = kmPostDao.fetchPublicationVersions(branch, request.kmPosts),
-            locationTracks = locationTrackDao.fetchPublicationVersions(branch, request.locationTracks),
+            locationTracks =
+                locationTrackDao.fetchPublicationVersions(branch, request.locationTracks),
             switches = switchDao.fetchPublicationVersions(branch, request.switches),
-            splits = splitService.fetchPublicationVersions(branch, request.locationTracks, request.switches),
+            splits =
+                splitService.fetchPublicationVersions(
+                    branch, request.locationTracks, request.switches),
         )
     }
 
-    private fun updateExternalIdForLocationTrack(branch: LayoutBranch, locationTrackId: IntId<LocationTrack>) {
-        val locationTrackOid = ratkoClient?.let { s ->
-            requireNotNull(s.getNewLocationTrackOid()) { "No OID received from RATKO" }
+    private fun updateExternalIdForLocationTrack(
+        branch: LayoutBranch,
+        locationTrackId: IntId<LocationTrack>
+    ) {
+        val locationTrackOid =
+            ratkoClient?.let { s ->
+                requireNotNull(s.getNewLocationTrackOid()) { "No OID received from RATKO" }
+            }
+        locationTrackOid?.let { oid ->
+            locationTrackService.updateExternalId(branch, locationTrackId, Oid(oid.id))
         }
-        locationTrackOid?.let { oid -> locationTrackService.updateExternalId(branch, locationTrackId, Oid(oid.id)) }
     }
 
-    private fun updateExternalIdForTrackNumber(branch: LayoutBranch, trackNumberId: IntId<TrackLayoutTrackNumber>) {
-        val routeNumberOid = ratkoClient?.let { s ->
-            requireNotNull(s.getNewRouteNumberOid()) { "No OID received from RATKO" }
+    private fun updateExternalIdForTrackNumber(
+        branch: LayoutBranch,
+        trackNumberId: IntId<TrackLayoutTrackNumber>
+    ) {
+        val routeNumberOid =
+            ratkoClient?.let { s ->
+                requireNotNull(s.getNewRouteNumberOid()) { "No OID received from RATKO" }
+            }
+        routeNumberOid?.let { oid ->
+            trackNumberService.updateExternalId(branch, trackNumberId, Oid(oid.id))
         }
-        routeNumberOid?.let { oid -> trackNumberService.updateExternalId(branch, trackNumberId, Oid(oid.id)) }
     }
 
-    private fun updateExternalIdForSwitch(branch: LayoutBranch, switchId: IntId<TrackLayoutSwitch>) {
-        val switchOid = ratkoClient?.let { s ->
-            requireNotNull(s.getNewSwitchOid()) { "No OID received from RATKO" }
+    private fun updateExternalIdForSwitch(
+        branch: LayoutBranch,
+        switchId: IntId<TrackLayoutSwitch>
+    ) {
+        val switchOid =
+            ratkoClient?.let { s ->
+                requireNotNull(s.getNewSwitchOid()) { "No OID received from RATKO" }
+            }
+        switchOid?.let { oid ->
+            switchService.updateExternalIdForSwitch(branch, switchId, Oid(oid.id))
         }
-        switchOid?.let { oid -> switchService.updateExternalIdForSwitch(branch, switchId, Oid(oid.id)) }
     }
 
     private inline fun <reified T> assertNoErrors(
@@ -467,9 +595,11 @@ class PublicationService @Autowired constructor(
     ) {
         val errors = issues.filter { issue -> issue.type == ERROR }
         if (errors.isNotEmpty()) {
-            logger.warn("Validation errors in published ${T::class.simpleName}: item=$version errors=$errors")
+            logger.warn(
+                "Validation errors in published ${T::class.simpleName}: item=$version errors=$errors")
             throw PublicationFailureException(
-                message = "Cannot publish ${T::class.simpleName} due to validation errors: $version",
+                message =
+                    "Cannot publish ${T::class.simpleName} due to validation errors: $version",
                 localizedMessageKey = "validation-failed",
             )
         }
@@ -498,18 +628,26 @@ class PublicationService @Autowired constructor(
     ): PublicationResult {
         try {
             return requireNotNull(
-                transactionTemplate.execute { publishChangesTransaction(branch, versions, calculatedChanges, message) }
-            )
+                transactionTemplate.execute {
+                    publishChangesTransaction(branch, versions, calculatedChanges, message)
+                })
         } catch (exception: DataIntegrityViolationException) {
             enrichDuplicateNameExceptionOrRethrow(branch, exception)
         }
     }
 
     @Transactional
-    fun mergeChangesToMain(fromBranch: DesignBranch, request: PublicationRequestIds): PublicationResult {
+    fun mergeChangesToMain(
+        fromBranch: DesignBranch,
+        request: PublicationRequestIds
+    ): PublicationResult {
         request.trackNumbers.forEach { id -> trackNumberService.mergeToMainBranch(fromBranch, id) }
-        request.referenceLines.forEach { id -> referenceLineService.mergeToMainBranch(fromBranch, id) }
-        request.locationTracks.forEach { id -> locationTrackService.mergeToMainBranch(fromBranch, id) }
+        request.referenceLines.forEach { id ->
+            referenceLineService.mergeToMainBranch(fromBranch, id)
+        }
+        request.locationTracks.forEach { id ->
+            locationTrackService.mergeToMainBranch(fromBranch, id)
+        }
         request.switches.forEach { id -> switchService.mergeToMainBranch(fromBranch, id) }
         request.kmPosts.forEach { id -> kmPostService.mergeToMainBranch(fromBranch, id) }
 
@@ -532,8 +670,10 @@ class PublicationService @Autowired constructor(
         val trackNumbers = versions.trackNumbers.map { v -> trackNumberService.publish(branch, v) }
         val kmPosts = versions.kmPosts.map { v -> kmPostService.publish(branch, v) }
         val switches = versions.switches.map { v -> switchService.publish(branch, v) }
-        val referenceLines = versions.referenceLines.map { v -> referenceLineService.publish(branch, v) }
-        val locationTracks = versions.locationTracks.map { v -> locationTrackService.publish(branch, v) }
+        val referenceLines =
+            versions.referenceLines.map { v -> referenceLineService.publish(branch, v) }
+        val locationTracks =
+            versions.locationTracks.map { v -> locationTrackService.publish(branch, v) }
         val publicationId = publicationDao.createPublication(branch, message)
         publicationDao.insertCalculatedChanges(publicationId, calculatedChanges)
         publicationGeometryChangeRemarksUpdateService.processPublication(publicationId)
@@ -553,67 +693,81 @@ class PublicationService @Autowired constructor(
     private fun validateTrackNumber(
         id: IntId<TrackLayoutTrackNumber>,
         validationContext: ValidationContext,
-    ): List<LayoutValidationIssue>? = validationContext.getTrackNumber(id)?.let { trackNumber ->
-        val kmPosts = validationContext.getKmPostsByTrackNumber(id)
-        val referenceLine = validationContext.getReferenceLineByTrackNumber(id)
-        val locationTracks = validationContext.getLocationTracksByTrackNumber(id)
-        val fieldIssues = validateDraftTrackNumberFields(trackNumber)
-        val referenceIssues = validateTrackNumberReferences(trackNumber, referenceLine, kmPosts, locationTracks)
-        val geocodingIssues = if (trackNumber.exists && referenceLine != null) {
-            val geocodingContextCacheKey = validationContext.getGeocodingContextCacheKey(id)
-            validateGeocodingContext(geocodingContextCacheKey, VALIDATION_TRACK_NUMBER, trackNumber.number)
-        } else {
-            listOf()
+    ): List<LayoutValidationIssue>? =
+        validationContext.getTrackNumber(id)?.let { trackNumber ->
+            val kmPosts = validationContext.getKmPostsByTrackNumber(id)
+            val referenceLine = validationContext.getReferenceLineByTrackNumber(id)
+            val locationTracks = validationContext.getLocationTracksByTrackNumber(id)
+            val fieldIssues = validateDraftTrackNumberFields(trackNumber)
+            val referenceIssues =
+                validateTrackNumberReferences(trackNumber, referenceLine, kmPosts, locationTracks)
+            val geocodingIssues =
+                if (trackNumber.exists && referenceLine != null) {
+                    val geocodingContextCacheKey = validationContext.getGeocodingContextCacheKey(id)
+                    validateGeocodingContext(
+                        geocodingContextCacheKey, VALIDATION_TRACK_NUMBER, trackNumber.number)
+                } else {
+                    listOf()
+                }
+            val duplicateNameIssues =
+                validateTrackNumberNumberDuplication(
+                    trackNumber = trackNumber,
+                    duplicates = validationContext.getTrackNumbersByNumber(trackNumber.number),
+                )
+            return fieldIssues + referenceIssues + geocodingIssues + duplicateNameIssues
         }
-        val duplicateNameIssues = validateTrackNumberNumberDuplication(
-            trackNumber = trackNumber,
-            duplicates = validationContext.getTrackNumbersByNumber(trackNumber.number),
-        )
-        return fieldIssues + referenceIssues + geocodingIssues + duplicateNameIssues
-    }
 
     private fun validateKmPost(
         id: IntId<TrackLayoutKmPost>,
         context: ValidationContext,
-    ): List<LayoutValidationIssue>? = context.getKmPost(id)?.let { kmPost ->
-        val trackNumber = kmPost.trackNumberId?.let(context::getTrackNumber)
-        val trackNumberNumber = (trackNumber ?: kmPost.trackNumberId?.let(context::getDraftTrackNumber))?.number
-        val referenceLine = trackNumber?.referenceLineId?.let(context::getReferenceLine)
+    ): List<LayoutValidationIssue>? =
+        context.getKmPost(id)?.let { kmPost ->
+            val trackNumber = kmPost.trackNumberId?.let(context::getTrackNumber)
+            val trackNumberNumber =
+                (trackNumber ?: kmPost.trackNumberId?.let(context::getDraftTrackNumber))?.number
+            val referenceLine = trackNumber?.referenceLineId?.let(context::getReferenceLine)
 
-        val fieldIssues = validateDraftKmPostFields(kmPost)
-        val referenceIssues = validateKmPostReferences(kmPost, trackNumber, referenceLine, trackNumberNumber)
+            val fieldIssues = validateDraftKmPostFields(kmPost)
+            val referenceIssues =
+                validateKmPostReferences(kmPost, trackNumber, referenceLine, trackNumberNumber)
 
-        val geocodingIssues = if (kmPost.exists && trackNumber?.exists == true && referenceLine != null) {
-            validateGeocodingContext(
-                context.getGeocodingContextCacheKey(kmPost.trackNumberId),
-                VALIDATION_KM_POST,
-                trackNumber.number,
-            )
-        } else {
-            listOf()
+            val geocodingIssues =
+                if (kmPost.exists && trackNumber?.exists == true && referenceLine != null) {
+                    validateGeocodingContext(
+                        context.getGeocodingContextCacheKey(kmPost.trackNumberId),
+                        VALIDATION_KM_POST,
+                        trackNumber.number,
+                    )
+                } else {
+                    listOf()
+                }
+            fieldIssues + referenceIssues + geocodingIssues
         }
-        fieldIssues + referenceIssues + geocodingIssues
-    }
 
     private fun validateSwitch(
         id: IntId<TrackLayoutSwitch>,
         validationContext: ValidationContext,
-    ): List<LayoutValidationIssue>? = validationContext.getSwitch(id)?.let { switch ->
-        val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
-        val linkedTracksAndAlignments = validationContext.getSwitchTracksWithAlignments(id)
-        val linkedTracks = linkedTracksAndAlignments.map(Pair<LocationTrack, *>::first)
+    ): List<LayoutValidationIssue>? =
+        validationContext.getSwitch(id)?.let { switch ->
+            val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
+            val linkedTracksAndAlignments = validationContext.getSwitchTracksWithAlignments(id)
+            val linkedTracks = linkedTracksAndAlignments.map(Pair<LocationTrack, *>::first)
 
-        val fieldIssues = validateDraftSwitchFields(switch)
-        val referenceIssues = validateSwitchLocationTrackLinkReferences(switch, linkedTracks)
+            val fieldIssues = validateDraftSwitchFields(switch)
+            val referenceIssues = validateSwitchLocationTrackLinkReferences(switch, linkedTracks)
 
-        val locationIssues = if (switch.exists) validateSwitchLocation(switch) else emptyList()
-        val structureIssues = locationIssues.ifEmpty {
-            validateSwitchLocationTrackLinkStructure(switch, structure, linkedTracksAndAlignments)
+            val locationIssues = if (switch.exists) validateSwitchLocation(switch) else emptyList()
+            val structureIssues =
+                locationIssues.ifEmpty {
+                    validateSwitchLocationTrackLinkStructure(
+                        switch, structure, linkedTracksAndAlignments)
+                }
+
+            val duplicationIssues =
+                validateSwitchNameDuplication(
+                    switch, validationContext.getSwitchesByName(switch.name))
+            return fieldIssues + referenceIssues + structureIssues + duplicationIssues
         }
-
-        val duplicationIssues = validateSwitchNameDuplication(switch, validationContext.getSwitchesByName(switch.name))
-        return fieldIssues + referenceIssues + structureIssues + duplicationIssues
-    }
 
     private fun validateReferenceLine(
         id: IntId<ReferenceLine>,
@@ -621,29 +775,40 @@ class PublicationService @Autowired constructor(
     ): List<LayoutValidationIssue>? =
         validationContext.getReferenceLineWithAlignment(id)?.let { (referenceLine, alignment) ->
             val trackNumber = validationContext.getTrackNumber(referenceLine.trackNumberId)
-            val referenceIssues = validateReferenceLineReference(
-                referenceLine = referenceLine,
-                trackNumber = trackNumber,
-                trackNumberNumber = validationContext.getDraftTrackNumber(referenceLine.trackNumberId)?.number,
-            )
-            val alignmentIssues = if (trackNumber?.exists == true) {
-                validateReferenceLineAlignment(alignment)
-            } else {
-                listOf()
-            }
-            val geocodingIssues: List<LayoutValidationIssue> = if (trackNumber?.exists == true) {
-                val contextKey = validationContext.getGeocodingContextCacheKey(referenceLine.trackNumberId)
-                val contextIssues = validateGeocodingContext(contextKey, VALIDATION_REFERENCE_LINE, trackNumber.number)
-                val addressIssues = contextKey?.let { key ->
-                    val locationTracks = validationContext.getLocationTracksByTrackNumber(referenceLine.trackNumberId)
-                    locationTracks.flatMap { track ->
-                        validateAddressPoints(trackNumber, key, track, VALIDATION_REFERENCE_LINE)
-                    }
-                } ?: listOf()
-                contextIssues + addressIssues
-            } else {
-                listOf()
-            }
+            val referenceIssues =
+                validateReferenceLineReference(
+                    referenceLine = referenceLine,
+                    trackNumber = trackNumber,
+                    trackNumberNumber =
+                        validationContext.getDraftTrackNumber(referenceLine.trackNumberId)?.number,
+                )
+            val alignmentIssues =
+                if (trackNumber?.exists == true) {
+                    validateReferenceLineAlignment(alignment)
+                } else {
+                    listOf()
+                }
+            val geocodingIssues: List<LayoutValidationIssue> =
+                if (trackNumber?.exists == true) {
+                    val contextKey =
+                        validationContext.getGeocodingContextCacheKey(referenceLine.trackNumberId)
+                    val contextIssues =
+                        validateGeocodingContext(
+                            contextKey, VALIDATION_REFERENCE_LINE, trackNumber.number)
+                    val addressIssues =
+                        contextKey?.let { key ->
+                            val locationTracks =
+                                validationContext.getLocationTracksByTrackNumber(
+                                    referenceLine.trackNumberId)
+                            locationTracks.flatMap { track ->
+                                validateAddressPoints(
+                                    trackNumber, key, track, VALIDATION_REFERENCE_LINE)
+                            }
+                        } ?: listOf()
+                    contextIssues + addressIssues
+                } else {
+                    listOf()
+                }
 
             return referenceIssues + alignmentIssues + geocodingIssues
         }
@@ -652,81 +817,97 @@ class PublicationService @Autowired constructor(
         id: IntId<LocationTrack>,
         validationContext: ValidationContext,
     ): List<LayoutValidationIssue>? =
-        validationContext
-            .getLocationTrackWithAlignment(id)
-            ?.let { (track, alignment) ->
-                val trackNumber = validationContext.getTrackNumber(track.trackNumberId)
-                val trackNumberName = (trackNumber ?: validationContext.getDraftTrackNumber(track.trackNumberId))?.number
-                val fieldIssues = validateDraftLocationTrackFields(track)
+        validationContext.getLocationTrackWithAlignment(id)?.let { (track, alignment) ->
+            val trackNumber = validationContext.getTrackNumber(track.trackNumberId)
+            val trackNumberName =
+                (trackNumber ?: validationContext.getDraftTrackNumber(track.trackNumberId))?.number
+            val fieldIssues = validateDraftLocationTrackFields(track)
 
-                val referenceIssues = validateLocationTrackReference(track, trackNumber, trackNumberName)
-                val segmentSwitches = validationContext.getSegmentSwitches(alignment)
-                val switchSegmentIssues = validateSegmentSwitchReferences(track, segmentSwitches)
-                val topologicallyConnectedSwitchIssues = validateTopologicallyConnectedSwitchReferences(
+            val referenceIssues =
+                validateLocationTrackReference(track, trackNumber, trackNumberName)
+            val segmentSwitches = validationContext.getSegmentSwitches(alignment)
+            val switchSegmentIssues = validateSegmentSwitchReferences(track, segmentSwitches)
+            val topologicallyConnectedSwitchIssues =
+                validateTopologicallyConnectedSwitchReferences(
                     track,
                     validationContext.getTopologicallyConnectedSwitches(track),
                 )
-                val trackNetworkTopologyIssues = validationContext
+            val trackNetworkTopologyIssues =
+                validationContext
                     .getPotentiallyAffectedSwitches(id)
                     .filter(TrackLayoutSwitch::exists)
                     .flatMap { switch ->
-                        val structure = switchLibraryService.getSwitchStructure(switch.switchStructureId)
-                        val switchTracks = validationContext.getSwitchTracksWithAlignments(switch.id as IntId)
-                        validateSwitchTopologicalConnectivity(switch, structure, switchTracks, track)
+                        val structure =
+                            switchLibraryService.getSwitchStructure(switch.switchStructureId)
+                        val switchTracks =
+                            validationContext.getSwitchTracksWithAlignments(switch.id as IntId)
+                        validateSwitchTopologicalConnectivity(
+                            switch, structure, switchTracks, track)
                     }
-                val switchConnectivityIssues = if (track.exists) {
+            val switchConnectivityIssues =
+                if (track.exists) {
                     validateLocationTrackSwitchConnectivity(track, alignment)
                 } else {
                     emptyList()
                 }
 
-                val duplicatesAfterPublication = validationContext.getDuplicateTracks(id)
-                val duplicateOf = track.duplicateOf?.let(validationContext::getLocationTrack)
-                // Draft-only won't be found if it's not in the publication set -> get name from draft for validation issue
-                val duplicateOfName = track.duplicateOf?.let(validationContext::getDraftLocationTrack)?.name
-                val duplicateIssues = validateDuplicateOfState(
+            val duplicatesAfterPublication = validationContext.getDuplicateTracks(id)
+            val duplicateOf = track.duplicateOf?.let(validationContext::getLocationTrack)
+            // Draft-only won't be found if it's not in the publication set -> get name from draft
+            // for validation issue
+            val duplicateOfName =
+                track.duplicateOf?.let(validationContext::getDraftLocationTrack)?.name
+            val duplicateIssues =
+                validateDuplicateOfState(
                     track,
                     duplicateOf,
                     duplicateOfName,
                     duplicatesAfterPublication,
                 )
 
-                val alignmentIssues = if (track.exists) validateLocationTrackAlignment(alignment) else listOf()
-                val geocodingIssues = if (track.exists && trackNumber != null) {
+            val alignmentIssues =
+                if (track.exists) validateLocationTrackAlignment(alignment) else listOf()
+            val geocodingIssues =
+                if (track.exists && trackNumber != null) {
                     validationContext.getGeocodingContextCacheKey(track.trackNumberId)?.let { key ->
                         validateAddressPoints(trackNumber, key, track, VALIDATION_REFERENCE_LINE)
                     } ?: listOf(noGeocodingContext(VALIDATION_LOCATION_TRACK))
                 } else listOf()
 
-                val tracksWithSameName = validationContext.getLocationTracksByName(track.name)
-                val duplicateNameIssues = validateLocationTrackNameDuplication(
+            val tracksWithSameName = validationContext.getLocationTracksByName(track.name)
+            val duplicateNameIssues =
+                validateLocationTrackNameDuplication(
                     track,
                     trackNumberName,
                     tracksWithSameName,
                 )
 
-                (fieldIssues +
-                        referenceIssues +
-                        switchSegmentIssues +
-                        topologicallyConnectedSwitchIssues +
-                        duplicateIssues +
-                        alignmentIssues +
-                        geocodingIssues +
-                        duplicateNameIssues +
-                        trackNetworkTopologyIssues +
-                        switchConnectivityIssues)
-            }
+            (fieldIssues +
+                referenceIssues +
+                switchSegmentIssues +
+                topologicallyConnectedSwitchIssues +
+                duplicateIssues +
+                alignmentIssues +
+                geocodingIssues +
+                duplicateNameIssues +
+                trackNetworkTopologyIssues +
+                switchConnectivityIssues)
+        }
 
     @Transactional(readOnly = true)
     fun getPublicationDetails(id: IntId<Publication>): PublicationDetails {
         val publication = publicationDao.getPublication(id)
-        val ratkoStatus = ratkoPushDao.getRatkoStatus(id).sortedByDescending { it.endTime }.firstOrNull()
+        val ratkoStatus =
+            ratkoPushDao.getRatkoStatus(id).sortedByDescending { it.endTime }.firstOrNull()
 
         val publishedReferenceLines = publicationDao.fetchPublishedReferenceLines(id)
         val publishedKmPosts = publicationDao.fetchPublishedKmPosts(id)
-        val (publishedDirectTrackNumbers, publishedIndirectTrackNumbers) = publicationDao.fetchPublishedTrackNumbers(id)
-        val (publishedDirectTracks, publishedIndirectTracks) = publicationDao.fetchPublishedLocationTracks(id)
-        val (publishedDirectSwitches, publishedIndirectSwitches) = publicationDao.fetchPublishedSwitches(id)
+        val (publishedDirectTrackNumbers, publishedIndirectTrackNumbers) =
+            publicationDao.fetchPublishedTrackNumbers(id)
+        val (publishedDirectTracks, publishedIndirectTracks) =
+            publicationDao.fetchPublishedLocationTracks(id)
+        val (publishedDirectSwitches, publishedIndirectSwitches) =
+            publicationDao.fetchPublishedSwitches(id)
         val split = splitService.getSplitIdByPublicationId(id)?.let(splitService::get)
 
         return PublicationDetails(
@@ -741,11 +922,11 @@ class PublicationService @Autowired constructor(
             kmPosts = publishedKmPosts,
             ratkoPushStatus = ratkoStatus?.status,
             ratkoPushTime = ratkoStatus?.endTime,
-            indirectChanges = PublishedIndirectChanges(
-                trackNumbers = publishedIndirectTrackNumbers,
-                locationTracks = publishedIndirectTracks,
-                switches = publishedIndirectSwitches
-            ),
+            indirectChanges =
+                PublishedIndirectChanges(
+                    trackNumbers = publishedIndirectTrackNumbers,
+                    locationTracks = publishedIndirectTracks,
+                    switches = publishedIndirectSwitches),
             split = split?.let(::SplitHeader),
             layoutBranch = publication.layoutBranch,
         )
@@ -757,36 +938,56 @@ class PublicationService @Autowired constructor(
         translation: Translation,
     ): List<PublicationTableItem> {
         val geocodingContextCache =
-            ConcurrentHashMap<Instant, MutableMap<IntId<TrackLayoutTrackNumber>, Optional<GeocodingContext>>>()
+            ConcurrentHashMap<
+                Instant, MutableMap<IntId<TrackLayoutTrackNumber>, Optional<GeocodingContext>>>()
         return getPublicationDetails(id).let { publication ->
-            val previousPublication = publicationDao.fetchPublicationTimes(publication.layoutBranch).entries
-                .sortedByDescending { it.key }
-                .find { it.key < publication.publicationTime }
+            val previousPublication =
+                publicationDao
+                    .fetchPublicationTimes(publication.layoutBranch)
+                    .entries
+                    .sortedByDescending { it.key }
+                    .find { it.key < publication.publicationTime }
             mapToPublicationTableItems(
                 translation,
                 publication,
                 publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(publication.id),
                 previousPublication?.key ?: publication.publicationTime.minusMillis(1),
                 { trackNumberId: IntId<TrackLayoutTrackNumber>, timestamp: Instant ->
-                    getOrPutGeocodingContext(geocodingContextCache, publication.layoutBranch, trackNumberId, timestamp)
+                    getOrPutGeocodingContext(
+                        geocodingContextCache, publication.layoutBranch, trackNumberId, timestamp)
                 },
             )
         }
     }
 
     @Transactional(readOnly = true)
-    fun fetchPublications(layoutBranch: LayoutBranch, from: Instant? = null, to: Instant? = null): List<Publication> {
+    fun fetchPublications(
+        layoutBranch: LayoutBranch,
+        from: Instant? = null,
+        to: Instant? = null
+    ): List<Publication> {
         return publicationDao.fetchPublicationsBetween(layoutBranch, from, to)
     }
 
     @Transactional(readOnly = true)
-    fun fetchPublicationDetailsBetweenInstants(layoutBranch: LayoutBranch, from: Instant? = null, to: Instant? = null): List<PublicationDetails> {
-        return publicationDao.fetchPublicationsBetween(layoutBranch, from, to).map { getPublicationDetails(it.id) }
+    fun fetchPublicationDetailsBetweenInstants(
+        layoutBranch: LayoutBranch,
+        from: Instant? = null,
+        to: Instant? = null
+    ): List<PublicationDetails> {
+        return publicationDao.fetchPublicationsBetween(layoutBranch, from, to).map {
+            getPublicationDetails(it.id)
+        }
     }
 
     @Transactional(readOnly = true)
-    fun fetchLatestPublicationDetails(branchType: LayoutBranchType, count: Int): List<PublicationDetails> {
-        return publicationDao.fetchLatestPublications(branchType, count).map { getPublicationDetails(it.id) }
+    fun fetchLatestPublicationDetails(
+        branchType: LayoutBranchType,
+        count: Int
+    ): List<PublicationDetails> {
+        return publicationDao.fetchLatestPublications(branchType, count).map {
+            getPublicationDetails(it.id)
+        }
     }
 
     @Transactional(readOnly = true)
@@ -799,36 +1000,45 @@ class PublicationService @Autowired constructor(
         translation: Translation,
     ): List<PublicationTableItem> {
         val switchLinkChanges =
-            publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(null, layoutBranch, from, to)
+            publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(
+                null, layoutBranch, from, to)
 
         return fetchPublicationDetailsBetweenInstants(layoutBranch, from, to)
             .sortedBy { it.publicationTime }
             .let { publications ->
-            val geocodingContextCache =
-                ConcurrentHashMap<Instant, MutableMap<IntId<TrackLayoutTrackNumber>, Optional<GeocodingContext>>>()
-            val trackNumbersCache = trackNumberDao.fetchTrackNumberNames()
-            val getGeocodingContextOrNull = { trackNumberId: IntId<TrackLayoutTrackNumber>, timestamp: Instant ->
-                getOrPutGeocodingContext(geocodingContextCache, layoutBranch, trackNumberId, timestamp)
-            }
+                val geocodingContextCache =
+                    ConcurrentHashMap<
+                        Instant,
+                        MutableMap<IntId<TrackLayoutTrackNumber>, Optional<GeocodingContext>>>()
+                val trackNumbersCache = trackNumberDao.fetchTrackNumberNames()
+                val getGeocodingContextOrNull =
+                    { trackNumberId: IntId<TrackLayoutTrackNumber>, timestamp: Instant ->
+                        getOrPutGeocodingContext(
+                            geocodingContextCache, layoutBranch, trackNumberId, timestamp)
+                    }
 
-            publications.mapIndexed { index, publicationDetails ->
-                val previousPublication = publications.getOrNull(index - 1)
-                publicationDetails to (previousPublication?.publicationTime
-                    ?: publicationDetails.publicationTime.minusMillis(1))
-            }.flatMap { (publicationDetails, timeDiff) ->
-                mapToPublicationTableItems(
-                    translation,
-                    publicationDetails,
-                    switchLinkChanges[publicationDetails.id] ?: mapOf(),
-                    timeDiff,
-                    getGeocodingContextOrNull,
-                    trackNumbersCache,
-                )
+                publications
+                    .mapIndexed { index, publicationDetails ->
+                        val previousPublication = publications.getOrNull(index - 1)
+                        publicationDetails to
+                            (previousPublication?.publicationTime
+                                ?: publicationDetails.publicationTime.minusMillis(1))
+                    }
+                    .flatMap { (publicationDetails, timeDiff) ->
+                        mapToPublicationTableItems(
+                            translation,
+                            publicationDetails,
+                            switchLinkChanges[publicationDetails.id] ?: mapOf(),
+                            timeDiff,
+                            getGeocodingContextOrNull,
+                            trackNumbersCache,
+                        )
+                    }
             }
-        }.let { publications ->
-            if (sortBy == null) publications
-            else publications.sortedWith(getComparator(sortBy, order))
-        }
+            .let { publications ->
+                if (sortBy == null) publications
+                else publications.sortedWith(getComparator(sortBy, order))
+            }
     }
 
     @Transactional(readOnly = true)
@@ -837,17 +1047,22 @@ class PublicationService @Autowired constructor(
             splitService.getSplitIdByPublicationId(id)?.let { splitId ->
                 val split = splitService.getOrThrow(splitId)
                 val sourceLocationTrack = locationTrackDao.fetch(split.sourceLocationTrackVersion)
-                val targetLocationTracks = publicationDao
-                    .fetchPublishedLocationTracks(id)
-                    .let { changes -> (changes.indirectChanges + changes.directChanges).map { c -> c.version } }
-                    .distinct()
-                    .mapNotNull { v -> createSplitTargetInPublication(
-                        rowVersion = v,
-                        publicationBranch = publication.layoutBranch,
-                        publicationTime = publication.publicationTime,
-                        split = split,
-                    ) }
-                    .sortedWith { a, b -> nullsFirstComparator(a.startAddress, b.startAddress) }
+                val targetLocationTracks =
+                    publicationDao
+                        .fetchPublishedLocationTracks(id)
+                        .let { changes ->
+                            (changes.indirectChanges + changes.directChanges).map { c -> c.version }
+                        }
+                        .distinct()
+                        .mapNotNull { v ->
+                            createSplitTargetInPublication(
+                                rowVersion = v,
+                                publicationBranch = publication.layoutBranch,
+                                publicationTime = publication.publicationTime,
+                                split = split,
+                            )
+                        }
+                        .sortedWith { a, b -> nullsFirstComparator(a.startAddress, b.startAddress) }
                 SplitInPublication(
                     id = publication.id,
                     splitId = split.id,
@@ -866,11 +1081,12 @@ class PublicationService @Autowired constructor(
     ): SplitTargetInPublication? {
         val (track, alignment) = locationTrackService.getWithAlignment(rowVersion)
         return split.getTargetLocationTrack(track.id as IntId)?.let { target ->
-            val ctx = geocodingService.getGeocodingContextAtMoment(
-                publicationBranch,
-                track.trackNumberId,
-                publicationTime,
-            )
+            val ctx =
+                geocodingService.getGeocodingContextAtMoment(
+                    publicationBranch,
+                    track.trackNumberId,
+                    publicationTime,
+                )
             return SplitTargetInPublication(
                 id = track.id,
                 name = track.name,
@@ -883,13 +1099,17 @@ class PublicationService @Autowired constructor(
     }
 
     @Transactional(readOnly = true)
-    fun getSplitInPublicationCsv(id: IntId<Publication>, lang: LocalizationLanguage): Pair<String, AlignmentName?> {
+    fun getSplitInPublicationCsv(
+        id: IntId<Publication>,
+        lang: LocalizationLanguage
+    ): Pair<String, AlignmentName?> {
         return getSplitInPublication(id).let { splitInPublication ->
-            val data = splitInPublication?.targetLocationTracks?.map { lt -> splitInPublication.locationTrack to lt }
-                ?: emptyList()
-            printCsv(
-                splitCsvColumns(localizationService.getLocalization(lang)), data
-            ) to splitInPublication?.locationTrack?.name
+            val data =
+                splitInPublication?.targetLocationTracks?.map { lt ->
+                    splitInPublication.locationTrack to lt
+                } ?: emptyList()
+            printCsv(splitCsvColumns(localizationService.getLocalization(lang)), data) to
+                splitInPublication?.locationTrack?.name
         }
     }
 
@@ -903,14 +1123,15 @@ class PublicationService @Autowired constructor(
         timeZone: ZoneId? = null,
         translation: Translation,
     ): String {
-        val orderedPublishedItems = fetchPublicationDetails(
-            layoutBranch = layoutBranch,
-            from = from,
-            to = to,
-            sortBy = sortBy,
-            order = order,
-            translation = translation,
-        )
+        val orderedPublishedItems =
+            fetchPublicationDetails(
+                layoutBranch = layoutBranch,
+                from = from,
+                to = to,
+                sortBy = sortBy,
+                order = order,
+                translation = translation,
+            )
 
         return asCsvFile(orderedPublishedItems, timeZone ?: ZoneId.of("UTC"), translation)
     }
@@ -922,12 +1143,18 @@ class PublicationService @Autowired constructor(
         oldTimestamp: Instant,
         geocodingContextGetter: (IntId<TrackLayoutTrackNumber>, Instant) -> GeocodingContext?,
     ): List<PublicationChange<*>> {
-        val oldEndAddress = trackNumberChanges.endPoint.old?.let { point ->
-            geocodingContextGetter(trackNumberChanges.id, oldTimestamp)?.getAddress(point)?.first
-        }
-        val newEndAddress = trackNumberChanges.endPoint.new?.let { point ->
-            geocodingContextGetter(trackNumberChanges.id, newTimestamp)?.getAddress(point)?.first
-        }
+        val oldEndAddress =
+            trackNumberChanges.endPoint.old?.let { point ->
+                geocodingContextGetter(trackNumberChanges.id, oldTimestamp)
+                    ?.getAddress(point)
+                    ?.first
+            }
+        val newEndAddress =
+            trackNumberChanges.endPoint.new?.let { point ->
+                geocodingContextGetter(trackNumberChanges.id, newTimestamp)
+                    ?.getAddress(point)
+                    ?.first
+            }
 
         return listOfNotNull(
             compareChangeValues(
@@ -936,26 +1163,24 @@ class PublicationService @Autowired constructor(
                 PropKey("track-number"),
             ),
             compareChangeValues(
-                trackNumberChanges.state, { it }, PropKey("state"), null, "layout-state"
-            ),
-            compareChangeValues(
-                trackNumberChanges.description, { it }, PropKey("description")
-            ),
+                trackNumberChanges.state, { it }, PropKey("state"), null, "layout-state"),
+            compareChangeValues(trackNumberChanges.description, { it }, PropKey("description")),
             compareChangeValues(
                 trackNumberChanges.startAddress,
                 { it.toString() },
                 PropKey("start-address"),
-                remark = getAddressMovedRemarkOrNull(
-                    translation, trackNumberChanges.startAddress.old, trackNumberChanges.startAddress.new
-                )
-            ),
-            compareChange({ oldEndAddress != newEndAddress },
+                remark =
+                    getAddressMovedRemarkOrNull(
+                        translation,
+                        trackNumberChanges.startAddress.old,
+                        trackNumberChanges.startAddress.new)),
+            compareChange(
+                { oldEndAddress != newEndAddress },
                 oldEndAddress,
                 newEndAddress,
                 { it.toString() },
                 PropKey("end-address"),
-                remark = getAddressMovedRemarkOrNull(translation, oldEndAddress, newEndAddress)
-            ),
+                remark = getAddressMovedRemarkOrNull(translation, oldEndAddress, newEndAddress)),
         )
     }
 
@@ -972,34 +1197,40 @@ class PublicationService @Autowired constructor(
     ): List<PublicationChange<*>> {
         val oldAndTime = locationTrackChanges.duplicateOf.old to previousPublicationTime
         val newAndTime = locationTrackChanges.duplicateOf.new to publicationTime
-        val oldStartPointAndM = locationTrackChanges.startPoint.old?.let { oldStart ->
-            locationTrackChanges.trackNumberId.old?.let {
-                getGeocodingContext(it, oldAndTime.second)?.getAddressAndM(oldStart)
+        val oldStartPointAndM =
+            locationTrackChanges.startPoint.old?.let { oldStart ->
+                locationTrackChanges.trackNumberId.old?.let {
+                    getGeocodingContext(it, oldAndTime.second)?.getAddressAndM(oldStart)
+                }
             }
-        }
-        val oldEndPointAndM =locationTrackChanges.endPoint.old?.let { oldEnd ->
-            locationTrackChanges.trackNumberId.old?.let {
-                getGeocodingContext(it, oldAndTime.second)?.getAddressAndM(oldEnd)
+        val oldEndPointAndM =
+            locationTrackChanges.endPoint.old?.let { oldEnd ->
+                locationTrackChanges.trackNumberId.old?.let {
+                    getGeocodingContext(it, oldAndTime.second)?.getAddressAndM(oldEnd)
+                }
             }
-        }
-        val newStartPointAndM = locationTrackChanges.startPoint.new?.let { newStart ->
-            locationTrackChanges.trackNumberId.new?.let {
-                getGeocodingContext(it, newAndTime.second)?.getAddressAndM(newStart)
+        val newStartPointAndM =
+            locationTrackChanges.startPoint.new?.let { newStart ->
+                locationTrackChanges.trackNumberId.new?.let {
+                    getGeocodingContext(it, newAndTime.second)?.getAddressAndM(newStart)
+                }
             }
-        }
-        val newEndPointAndM = locationTrackChanges.endPoint.new?.let { newEnd ->
-            locationTrackChanges.trackNumberId.new?.let {
-                getGeocodingContext(it, newAndTime.second)?.getAddressAndM(newEnd)
+        val newEndPointAndM =
+            locationTrackChanges.endPoint.new?.let { newEnd ->
+                locationTrackChanges.trackNumberId.new?.let {
+                    getGeocodingContext(it, newAndTime.second)?.getAddressAndM(newEnd)
+                }
             }
-        }
 
         return listOfNotNull(
             compareChangeValues(
                 locationTrackChanges.trackNumberId,
                 { tnIdFromChange ->
-                    trackNumberCache.findLast { tn ->
-                        tn.id == tnIdFromChange && tn.changeTime <= publicationTime
-                    }?.number
+                    trackNumberCache
+                        .findLast { tn ->
+                            tn.id == tnIdFromChange && tn.changeTime <= publicationTime
+                        }
+                        ?.number
                 },
                 PropKey("track-number"),
             ),
@@ -1031,21 +1262,26 @@ class PublicationService @Autowired constructor(
                 locationTrackChanges.descriptionSuffix,
                 { it },
                 PropKey("description-suffix"),
-                enumLocalizationKey = "location-track-description-suffix"
-            ),
+                enumLocalizationKey = "location-track-description-suffix"),
             compareChangeValues(
                 locationTrackChanges.owner,
-                { locationTrackService.getLocationTrackOwners().find { owner -> owner.id == it }?.name },
-                PropKey("owner")
-            ),
-            compareChange({ oldAndTime.first != newAndTime.first },
+                {
+                    locationTrackService
+                        .getLocationTrackOwners()
+                        .find { owner -> owner.id == it }
+                        ?.name
+                },
+                PropKey("owner")),
+            compareChange(
+                { oldAndTime.first != newAndTime.first },
                 oldAndTime,
                 newAndTime,
                 { (duplicateOf, timestamp) ->
-                    duplicateOf?.let { locationTrackService.getOfficialAtMoment(branch, it, timestamp)?.name }
+                    duplicateOf?.let {
+                        locationTrackService.getOfficialAtMoment(branch, it, timestamp)?.name
+                    }
                 },
-                PropKey("duplicate-of")
-            ),
+                PropKey("duplicate-of")),
             compareLength(
                 locationTrackChanges.length.old,
                 locationTrackChanges.length.new,
@@ -1056,10 +1292,12 @@ class PublicationService @Autowired constructor(
                     translation,
                     locationTrackChanges.length.old,
                     locationTrackChanges.length.new,
-                )
-            ),
+                )),
             compareChange(
-                { !pointsAreSame(locationTrackChanges.startPoint.old, locationTrackChanges.startPoint.new) },
+                {
+                    !pointsAreSame(
+                        locationTrackChanges.startPoint.old, locationTrackChanges.startPoint.new)
+                },
                 locationTrackChanges.startPoint.old,
                 locationTrackChanges.startPoint.new,
                 ::formatLocation,
@@ -1068,18 +1306,19 @@ class PublicationService @Autowired constructor(
                     translation,
                     locationTrackChanges.startPoint.old,
                     locationTrackChanges.startPoint.new,
-                )
-            ),
+                )),
             compareChange(
                 { oldStartPointAndM?.address != newStartPointAndM?.address },
                 oldStartPointAndM?.address,
                 newStartPointAndM?.address,
                 { it.toString() },
                 PropKey("start-address"),
-                null
-            ),
+                null),
             compareChange(
-                { !pointsAreSame(locationTrackChanges.endPoint.old, locationTrackChanges.endPoint.new) },
+                {
+                    !pointsAreSame(
+                        locationTrackChanges.endPoint.old, locationTrackChanges.endPoint.new)
+                },
                 locationTrackChanges.endPoint.old,
                 locationTrackChanges.endPoint.new,
                 ::formatLocation,
@@ -1088,22 +1327,22 @@ class PublicationService @Autowired constructor(
                     translation,
                     locationTrackChanges.endPoint.old,
                     locationTrackChanges.endPoint.new,
-                )
-            ),
+                )),
             compareChange(
                 { oldEndPointAndM?.address != newEndPointAndM?.address },
                 oldEndPointAndM?.address,
                 newEndPointAndM?.address,
                 { it.toString() },
                 PropKey("end-address"),
-                null
-            ),
+                null),
             if (changedKmNumbers.isNotEmpty()) {
                 PublicationChange(
                     PropKey("geometry"),
                     ChangeValue(null, null),
                     getKmNumbersChangedRemarkOrNull(
-                        translation, changedKmNumbers, locationTrackChanges.geometryChangeSummaries,
+                        translation,
+                        changedKmNumbers,
+                        locationTrackChanges.geometryChangeSummaries,
                     ),
                 )
             } else {
@@ -1122,7 +1361,7 @@ class PublicationService @Autowired constructor(
                 )
             }
             // TODO owner
-        )
+            )
     }
 
     fun diffReferenceLine(
@@ -1148,23 +1387,23 @@ class PublicationService @Autowired constructor(
                 changes.startPoint.new,
                 ::formatLocation,
                 PropKey("start-location"),
-                getPointMovedRemarkOrNull(translation, changes.startPoint.old, changes.startPoint.new)
-            ),
+                getPointMovedRemarkOrNull(
+                    translation, changes.startPoint.old, changes.startPoint.new)),
             compareChange(
                 { !pointsAreSame(changes.endPoint.old, changes.endPoint.new) },
                 changes.endPoint.old,
                 changes.endPoint.new,
                 ::formatLocation,
                 PropKey("end-location"),
-                getPointMovedRemarkOrNull(translation, changes.endPoint.old, changes.endPoint.new)
-            ),
+                getPointMovedRemarkOrNull(translation, changes.endPoint.old, changes.endPoint.new)),
             if (changedKmNumbers.isNotEmpty()) {
                 PublicationChange(
                     PropKey("geometry"),
                     ChangeValue(null, null),
                     publicationChangeRemark(
                         translation,
-                        if (changedKmNumbers.size > 1) "changed-km-numbers" else "changed-km-number",
+                        if (changedKmNumbers.size > 1) "changed-km-numbers"
+                        else "changed-km-number",
                         formatChangedKmNumbers(changedKmNumbers.toList()),
                     ),
                 )
@@ -1181,39 +1420,54 @@ class PublicationService @Autowired constructor(
         oldTimestamp: Instant,
         trackNumberCache: List<TrackNumberAndChangeTime>,
         geocodingContextGetter: (IntId<TrackLayoutTrackNumber>, Instant) -> GeocodingContext?,
-    ) = listOfNotNull(
-        compareChangeValues(
-            changes.trackNumberId,
-            { tnIdFromChange ->
-                trackNumberCache.findLast { tn -> tn.id == tnIdFromChange && tn.changeTime <= newTimestamp }?.number
-            },
-            PropKey("track-number"),
-        ),
-        compareChangeValues(changes.kmNumber, { it }, PropKey("km-post")),
-        compareChangeValues(changes.state, { it }, PropKey("state"), null, "layout-state"),
-        compareChangeValues(
-            changes.location, ::formatLocation, PropKey("location"), remark = getPointMovedRemarkOrNull(
-                translation, projectPointToReferenceLineAtTime(
-                    oldTimestamp, changes.location.old, changes.trackNumberId.old, geocodingContextGetter
-                ), projectPointToReferenceLineAtTime(
-                    newTimestamp, changes.location.new, changes.trackNumberId.new, geocodingContextGetter
-                ), "moved-x-meters-on-reference-line"
-            )
-        ),
-    )
+    ) =
+        listOfNotNull(
+            compareChangeValues(
+                changes.trackNumberId,
+                { tnIdFromChange ->
+                    trackNumberCache
+                        .findLast { tn -> tn.id == tnIdFromChange && tn.changeTime <= newTimestamp }
+                        ?.number
+                },
+                PropKey("track-number"),
+            ),
+            compareChangeValues(changes.kmNumber, { it }, PropKey("km-post")),
+            compareChangeValues(changes.state, { it }, PropKey("state"), null, "layout-state"),
+            compareChangeValues(
+                changes.location,
+                ::formatLocation,
+                PropKey("location"),
+                remark =
+                    getPointMovedRemarkOrNull(
+                        translation,
+                        projectPointToReferenceLineAtTime(
+                            oldTimestamp,
+                            changes.location.old,
+                            changes.trackNumberId.old,
+                            geocodingContextGetter),
+                        projectPointToReferenceLineAtTime(
+                            newTimestamp,
+                            changes.location.new,
+                            changes.trackNumberId.new,
+                            geocodingContextGetter),
+                        "moved-x-meters-on-reference-line")),
+        )
 
     private fun projectPointToReferenceLineAtTime(
         timestamp: Instant,
         location: Point?,
         trackNumberId: IntId<TrackLayoutTrackNumber>?,
         geocodingContextGetter: (IntId<TrackLayoutTrackNumber>, Instant) -> GeocodingContext?,
-    ) = location?.let {
-        trackNumberId?.let {
-            geocodingContextGetter(trackNumberId, timestamp)?.let { context ->
-                context.getM(location)?.let { (m) -> context.referenceLineGeometry.getPointAtM(m)?.toPoint() }
+    ) =
+        location?.let {
+            trackNumberId?.let {
+                geocodingContextGetter(trackNumberId, timestamp)?.let { context ->
+                    context.getM(location)?.let { (m) ->
+                        context.referenceLineGeometry.getPointAtM(m)?.toPoint()
+                    }
+                }
             }
         }
-    }
 
     fun diffSwitch(
         translation: Translation,
@@ -1226,63 +1480,86 @@ class PublicationService @Autowired constructor(
     ): List<PublicationChange<*>> {
         val relatedJoints = changes.joints.filterNot { it.removed }.distinctBy { it.trackNumberId }
 
-        val oldLinkedLocationTracks = changes.locationTracks.associate { lt ->
-            locationTrackService.getWithAlignment(lt.oldVersion).let { (track, alignment) ->
-                track.id as IntId to (track to alignment)
+        val oldLinkedLocationTracks =
+            changes.locationTracks.associate { lt ->
+                locationTrackService.getWithAlignment(lt.oldVersion).let { (track, alignment) ->
+                    track.id as IntId to (track to alignment)
+                }
             }
-        }
-        val jointLocationChanges = relatedJoints.flatMap { joint ->
-            val oldLocation = oldLinkedLocationTracks[joint.locationTrackId]?.let { (track, alignment) ->
-                findJointPoint(track, alignment, changes.id, joint.jointNumber)
-            }?.toPoint()
-            val distance = if (oldLocation != null && !pointsAreSame(joint.point, oldLocation)) {
-                calculateDistance(listOf(joint.point, oldLocation), LAYOUT_SRID)
-            } else {
-                0.0
-            }
-            val jointPropKeyParams = localizationParams(
-                "trackNumber" to trackNumberCache.findLast {
-                    it.id == joint.trackNumberId && it.changeTime <= newTimestamp
-                }?.number?.value,
-                "switchType" to changes.type.new?.parts?.baseType?.let { switchBaseTypeToProp(translation, it) },
-            )
-            val oldAddress = oldLocation?.let {
-                geocodingContextGetter(
-                    joint.trackNumberId, oldTimestamp
-                )?.getAddress(it)?.first
-            }
+        val jointLocationChanges =
+            relatedJoints
+                .flatMap { joint ->
+                    val oldLocation =
+                        oldLinkedLocationTracks[joint.locationTrackId]
+                            ?.let { (track, alignment) ->
+                                findJointPoint(track, alignment, changes.id, joint.jointNumber)
+                            }
+                            ?.toPoint()
+                    val distance =
+                        if (oldLocation != null && !pointsAreSame(joint.point, oldLocation)) {
+                            calculateDistance(listOf(joint.point, oldLocation), LAYOUT_SRID)
+                        } else {
+                            0.0
+                        }
+                    val jointPropKeyParams =
+                        localizationParams(
+                            "trackNumber" to
+                                trackNumberCache
+                                    .findLast {
+                                        it.id == joint.trackNumberId &&
+                                            it.changeTime <= newTimestamp
+                                    }
+                                    ?.number
+                                    ?.value,
+                            "switchType" to
+                                changes.type.new?.parts?.baseType?.let {
+                                    switchBaseTypeToProp(translation, it)
+                                },
+                        )
+                    val oldAddress =
+                        oldLocation?.let {
+                            geocodingContextGetter(joint.trackNumberId, oldTimestamp)
+                                ?.getAddress(it)
+                                ?.first
+                        }
 
-            val list = listOfNotNull(
-                compareChange(
-                    { distance > DISTANCE_CHANGE_THRESHOLD },
-                    oldLocation,
-                    joint.point,
-                    ::formatLocation,
-                    PropKey("switch-joint-location", jointPropKeyParams),
-                    getPointMovedRemarkOrNull(translation, oldLocation, joint.point),
-                    null
-                ),
-                compareChange({ oldAddress != joint.address },
-                    oldAddress,
-                    joint.address,
-                    { it.toString() },
-                    PropKey("switch-track-address", jointPropKeyParams),
-                    getAddressMovedRemarkOrNull(translation, oldAddress, joint.address)
-                ),
-            )
-            list
-        }.sortedBy { it.propKey.key }
+                    val list =
+                        listOfNotNull(
+                            compareChange(
+                                { distance > DISTANCE_CHANGE_THRESHOLD },
+                                oldLocation,
+                                joint.point,
+                                ::formatLocation,
+                                PropKey("switch-joint-location", jointPropKeyParams),
+                                getPointMovedRemarkOrNull(translation, oldLocation, joint.point),
+                                null),
+                            compareChange(
+                                { oldAddress != joint.address },
+                                oldAddress,
+                                joint.address,
+                                { it.toString() },
+                                PropKey("switch-track-address", jointPropKeyParams),
+                                getAddressMovedRemarkOrNull(
+                                    translation, oldAddress, joint.address)),
+                        )
+                    list
+                }
+                .sortedBy { it.propKey.key }
 
-        val oldLinkedTrackNames = oldLinkedLocationTracks.values.mapNotNull { it.first.name }.sorted()
+        val oldLinkedTrackNames =
+            oldLinkedLocationTracks.values.mapNotNull { it.first.name }.sorted()
         val newLinkedTrackNames = changes.locationTracks.map { it.name }.sorted()
 
         return listOfNotNull(
             compareChangeValues(changes.name, { it }, PropKey("switch")),
-            compareChangeValues(changes.state, { it }, PropKey("state-category"), null, "layout-state-category"),
+            compareChangeValues(
+                changes.state, { it }, PropKey("state-category"), null, "layout-state-category"),
             compareChangeValues(changes.type, { it.typeName }, PropKey("switch-type")),
             compareChangeValues(
-                changes.trapPoint, { it }, PropKey("trap-point"), enumLocalizationKey = "trap-point"
-            ),
+                changes.trapPoint,
+                { it },
+                PropKey("trap-point"),
+                enumLocalizationKey = "trap-point"),
             compareChangeValues(changes.owner, { it }, PropKey("owner")),
             compareChange(
                 { oldLinkedTrackNames != newLinkedTrackNames },
@@ -1292,55 +1569,66 @@ class PublicationService @Autowired constructor(
                 PropKey("location-track-connectivity"),
             ),
             compareChangeValues(
-                changes.measurementMethod, { it.name }, PropKey("measurement-method"), null, "measurement-method"
-            ),
+                changes.measurementMethod,
+                { it.name },
+                PropKey("measurement-method"),
+                null,
+                "measurement-method"),
         ) + jointLocationChanges
     }
 
     private fun getOrPutGeocodingContext(
-        caches: MutableMap<Instant, MutableMap<IntId<TrackLayoutTrackNumber>, Optional<GeocodingContext>>>,
+        caches:
+            MutableMap<
+                Instant, MutableMap<IntId<TrackLayoutTrackNumber>, Optional<GeocodingContext>>>,
         branch: LayoutBranch,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         timestamp: Instant,
-    ) = caches.getOrPut(timestamp) { ConcurrentHashMap() }.getOrPut(trackNumberId) {
-        Optional.ofNullable(
-            geocodingService.getGeocodingContextAtMoment(branch, trackNumberId, timestamp)
-        )
-    }.orElse(null)
+    ) =
+        caches
+            .getOrPut(timestamp) { ConcurrentHashMap() }
+            .getOrPut(trackNumberId) {
+                Optional.ofNullable(
+                    geocodingService.getGeocodingContextAtMoment(branch, trackNumberId, timestamp))
+            }
+            .orElse(null)
 
     private fun validateGeocodingContext(
         cacheKey: GeocodingContextCacheKey?,
         localizationKey: String,
         trackNumber: TrackNumber,
-    ) = cacheKey
-        ?.let(geocodingCacheService::getGeocodingContextWithReasons)
-        ?.let { context -> validateGeocodingContext(context, trackNumber) }
-        ?: listOf(noGeocodingContext(localizationKey))
+    ) =
+        cacheKey?.let(geocodingCacheService::getGeocodingContextWithReasons)?.let { context ->
+            validateGeocodingContext(context, trackNumber)
+        } ?: listOf(noGeocodingContext(localizationKey))
 
     private fun validateAddressPoints(
         trackNumber: TrackLayoutTrackNumber,
         contextKey: GeocodingContextCacheKey,
         track: LocationTrack,
         validationTargetLocalizationPrefix: String,
-    ): List<LayoutValidationIssue> = if (!track.exists) {
-        listOf()
-    } else if (track.alignmentVersion == null) {
-        throw IllegalStateException("LocationTrack in DB should have an alignment: track=$track")
-    } else {
-        validateAddressPoints(trackNumber, track, validationTargetLocalizationPrefix) {
-            geocodingService.getAddressPoints(contextKey, track.alignmentVersion)
+    ): List<LayoutValidationIssue> =
+        if (!track.exists) {
+            listOf()
+        } else if (track.alignmentVersion == null) {
+            throw IllegalStateException(
+                "LocationTrack in DB should have an alignment: track=$track")
+        } else {
+            validateAddressPoints(trackNumber, track, validationTargetLocalizationPrefix) {
+                geocodingService.getAddressPoints(contextKey, track.alignmentVersion)
+            }
         }
-    }
 
     private fun latestTrackNumberNamesAtMoment(
         trackNumberNames: List<TrackNumberAndChangeTime>,
         trackNumberIds: Set<IntId<TrackLayoutTrackNumber>>,
         publicationTime: Instant,
-    ) = trackNumberNames
-        .filter { tn -> trackNumberIds.contains(tn.id) && tn.changeTime <= publicationTime }
-        .groupBy { it.id }
-        .map { it.value.last().number }
-        .toSet()
+    ) =
+        trackNumberNames
+            .filter { tn -> trackNumberIds.contains(tn.id) && tn.changeTime <= publicationTime }
+            .groupBy { it.id }
+            .map { it.value.last().number }
+            .toSet()
 
     private fun mapToPublicationTableItems(
         translation: Translation,
@@ -1348,188 +1636,229 @@ class PublicationService @Autowired constructor(
         switchLinkChanges: Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges>,
         previousComparisonTime: Instant,
         geocodingContextGetter: (IntId<TrackLayoutTrackNumber>, Instant) -> GeocodingContext?,
-        trackNumberNamesCache: List<TrackNumberAndChangeTime> = trackNumberDao.fetchTrackNumberNames(),
+        trackNumberNamesCache: List<TrackNumberAndChangeTime> =
+            trackNumberDao.fetchTrackNumberNames(),
     ): List<PublicationTableItem> {
-        val publicationLocationTrackChanges = publicationDao.fetchPublicationLocationTrackChanges(publication.id)
-        val publicationTrackNumberChanges = publicationDao.fetchPublicationTrackNumberChanges(
-            publication.layoutBranch,
-            publication.id,
-            previousComparisonTime,
-        )
+        val publicationLocationTrackChanges =
+            publicationDao.fetchPublicationLocationTrackChanges(publication.id)
+        val publicationTrackNumberChanges =
+            publicationDao.fetchPublicationTrackNumberChanges(
+                publication.layoutBranch,
+                publication.id,
+                previousComparisonTime,
+            )
         val publicationKmPostChanges = publicationDao.fetchPublicationKmPostChanges(publication.id)
-        val publicationReferenceLineChanges = publicationDao.fetchPublicationReferenceLineChanges(publication.id)
+        val publicationReferenceLineChanges =
+            publicationDao.fetchPublicationReferenceLineChanges(publication.id)
         val publicationSwitchChanges = publicationDao.fetchPublicationSwitchChanges(publication.id)
 
-        val trackNumbers = publication.trackNumbers.map { tn ->
-            mapToPublicationTableItem(
-                name = "${translation.t("publication-table.track-number-long")} ${tn.number}",
-                trackNumbers = setOf(tn.number),
-                changedKmNumbers = tn.changedKmNumbers,
-                operation = tn.operation,
-                publication = publication,
-                propChanges = diffTrackNumber(
-                    translation,
-                    publicationTrackNumberChanges.getOrElse(tn.id) {
-                        error("Track number changes not found: id=${tn.id} version=${tn.version}")
-                    },
-                    publication.publicationTime,
-                    previousComparisonTime,
-                    geocodingContextGetter,
-                ),
-            )
-        }
+        val trackNumbers =
+            publication.trackNumbers.map { tn ->
+                mapToPublicationTableItem(
+                    name = "${translation.t("publication-table.track-number-long")} ${tn.number}",
+                    trackNumbers = setOf(tn.number),
+                    changedKmNumbers = tn.changedKmNumbers,
+                    operation = tn.operation,
+                    publication = publication,
+                    propChanges =
+                        diffTrackNumber(
+                            translation,
+                            publicationTrackNumberChanges.getOrElse(tn.id) {
+                                error(
+                                    "Track number changes not found: id=${tn.id} version=${tn.version}")
+                            },
+                            publication.publicationTime,
+                            previousComparisonTime,
+                            geocodingContextGetter,
+                        ),
+                )
+            }
 
-        val referenceLines = publication.referenceLines.map { rl ->
-            val tn = trackNumberNamesCache.findLast {
-                it.id == rl.trackNumberId && it.changeTime <= publication.publicationTime
-            }?.number
+        val referenceLines =
+            publication.referenceLines.map { rl ->
+                val tn =
+                    trackNumberNamesCache
+                        .findLast {
+                            it.id == rl.trackNumberId &&
+                                it.changeTime <= publication.publicationTime
+                        }
+                        ?.number
 
-            mapToPublicationTableItem(
-                name = "${translation.t("publication-table.reference-line")} $tn",
-                trackNumbers = setOfNotNull(tn),
-                changedKmNumbers = rl.changedKmNumbers,
-                operation = rl.operation,
-                publication = publication,
-                propChanges = diffReferenceLine(
-                    translation,
-                    publicationReferenceLineChanges.getOrElse(rl.id) {
-                        error("Reference line changes not found: id=${rl.id} version=${rl.version}")
-                    },
-                    publication.publicationTime,
-                    previousComparisonTime,
-                    rl.changedKmNumbers,
-                    geocodingContextGetter,
-                ),
-            )
-        }
+                mapToPublicationTableItem(
+                    name = "${translation.t("publication-table.reference-line")} $tn",
+                    trackNumbers = setOfNotNull(tn),
+                    changedKmNumbers = rl.changedKmNumbers,
+                    operation = rl.operation,
+                    publication = publication,
+                    propChanges =
+                        diffReferenceLine(
+                            translation,
+                            publicationReferenceLineChanges.getOrElse(rl.id) {
+                                error(
+                                    "Reference line changes not found: id=${rl.id} version=${rl.version}")
+                            },
+                            publication.publicationTime,
+                            previousComparisonTime,
+                            rl.changedKmNumbers,
+                            geocodingContextGetter,
+                        ),
+                )
+            }
 
-        val locationTracks = publication.locationTracks.map { lt ->
-            val trackNumber = trackNumberNamesCache.findLast {
-                it.id == lt.trackNumberId && it.changeTime <= publication.publicationTime
-            }?.number
-            mapToPublicationTableItem(
-                name = "${translation.t("publication-table.location-track")} ${lt.name}",
-                trackNumbers = setOfNotNull(trackNumber),
-                changedKmNumbers = lt.changedKmNumbers,
-                operation = lt.operation,
-                publication = publication,
-                propChanges = diffLocationTrack(
-                    translation,
-                    publicationLocationTrackChanges.getOrElse(lt.id) {
-                        error("Location track changes not found: id=${lt.id} version=${lt.version}")
-                    },
-                    switchLinkChanges[lt.id],
-                    publication.layoutBranch,
-                    publication.publicationTime,
-                    previousComparisonTime,
-                    trackNumberNamesCache,
-                    lt.changedKmNumbers,
-                    geocodingContextGetter,
-                ),
-            )
-        }
+        val locationTracks =
+            publication.locationTracks.map { lt ->
+                val trackNumber =
+                    trackNumberNamesCache
+                        .findLast {
+                            it.id == lt.trackNumberId &&
+                                it.changeTime <= publication.publicationTime
+                        }
+                        ?.number
+                mapToPublicationTableItem(
+                    name = "${translation.t("publication-table.location-track")} ${lt.name}",
+                    trackNumbers = setOfNotNull(trackNumber),
+                    changedKmNumbers = lt.changedKmNumbers,
+                    operation = lt.operation,
+                    publication = publication,
+                    propChanges =
+                        diffLocationTrack(
+                            translation,
+                            publicationLocationTrackChanges.getOrElse(lt.id) {
+                                error(
+                                    "Location track changes not found: id=${lt.id} version=${lt.version}")
+                            },
+                            switchLinkChanges[lt.id],
+                            publication.layoutBranch,
+                            publication.publicationTime,
+                            previousComparisonTime,
+                            trackNumberNamesCache,
+                            lt.changedKmNumbers,
+                            geocodingContextGetter,
+                        ),
+                )
+            }
 
-        val switches = publication.switches.map { s ->
-            val tns =
-                latestTrackNumberNamesAtMoment(trackNumberNamesCache, s.trackNumberIds, publication.publicationTime)
-            mapToPublicationTableItem(
-                name = "${translation.t("publication-table.switch")} ${s.name}",
-                trackNumbers = tns,
-                operation = s.operation,
-                publication = publication,
-                propChanges = diffSwitch(
-                    translation,
-                    publicationSwitchChanges.getOrElse(s.id) {
-                        error("Switch changes not found: id=${s.id} version=${s.version}")
-                    },
-                    publication.publicationTime,
-                    previousComparisonTime,
-                    s.operation,
-                    trackNumberNamesCache,
-                    geocodingContextGetter,
-                ),
-            )
-        }
+        val switches =
+            publication.switches.map { s ->
+                val tns =
+                    latestTrackNumberNamesAtMoment(
+                        trackNumberNamesCache, s.trackNumberIds, publication.publicationTime)
+                mapToPublicationTableItem(
+                    name = "${translation.t("publication-table.switch")} ${s.name}",
+                    trackNumbers = tns,
+                    operation = s.operation,
+                    publication = publication,
+                    propChanges =
+                        diffSwitch(
+                            translation,
+                            publicationSwitchChanges.getOrElse(s.id) {
+                                error("Switch changes not found: id=${s.id} version=${s.version}")
+                            },
+                            publication.publicationTime,
+                            previousComparisonTime,
+                            s.operation,
+                            trackNumberNamesCache,
+                            geocodingContextGetter,
+                        ),
+                )
+            }
 
-        val kmPosts = publication.kmPosts.map { kp ->
-            val tn = trackNumberNamesCache.findLast {
-                it.id == kp.trackNumberId && it.changeTime <= publication.publicationTime
-            }?.number
-            mapToPublicationTableItem(
-                name = "${translation.t("publication-table.km-post")} ${kp.kmNumber}",
-                trackNumbers = setOfNotNull(tn),
-                operation = kp.operation,
-                publication = publication,
-                propChanges = diffKmPost(
-                    translation,
-                    publicationKmPostChanges.getOrElse(kp.id) {
-                        error("KM Post changes not found: id=${kp.id} version=${kp.version}")
-                    },
-                    publication.publicationTime,
-                    previousComparisonTime,
-                    trackNumberNamesCache,
-                    geocodingContextGetter,
-                ),
-            )
-        }
+        val kmPosts =
+            publication.kmPosts.map { kp ->
+                val tn =
+                    trackNumberNamesCache
+                        .findLast {
+                            it.id == kp.trackNumberId &&
+                                it.changeTime <= publication.publicationTime
+                        }
+                        ?.number
+                mapToPublicationTableItem(
+                    name = "${translation.t("publication-table.km-post")} ${kp.kmNumber}",
+                    trackNumbers = setOfNotNull(tn),
+                    operation = kp.operation,
+                    publication = publication,
+                    propChanges =
+                        diffKmPost(
+                            translation,
+                            publicationKmPostChanges.getOrElse(kp.id) {
+                                error(
+                                    "KM Post changes not found: id=${kp.id} version=${kp.version}")
+                            },
+                            publication.publicationTime,
+                            previousComparisonTime,
+                            trackNumberNamesCache,
+                            geocodingContextGetter,
+                        ),
+                )
+            }
 
-        val calculatedLocationTracks = publication.indirectChanges.locationTracks.map { lt ->
-            val tn = trackNumberNamesCache.findLast {
-                it.id == lt.trackNumberId && it.changeTime <= publication.publicationTime
-            }?.number
-            mapToPublicationTableItem(
-                name = "${translation.t("publication-table.location-track")} ${lt.name}",
-                trackNumbers = setOfNotNull(tn),
-                changedKmNumbers = lt.changedKmNumbers,
-                operation = Operation.CALCULATED,
-                publication = publication,
-                propChanges = diffLocationTrack(
-                    translation,
-                    publicationLocationTrackChanges.getOrElse(lt.id) {
-                        error("Location track changes not found: id=${lt.id} version=${lt.version}")
-                    },
-                    switchLinkChanges[lt.id],
-                    publication.layoutBranch,
-                    publication.publicationTime,
-                    previousComparisonTime,
-                    trackNumberNamesCache,
-                    lt.changedKmNumbers,
-                    geocodingContextGetter,
-                ),
-            )
-        }
+        val calculatedLocationTracks =
+            publication.indirectChanges.locationTracks.map { lt ->
+                val tn =
+                    trackNumberNamesCache
+                        .findLast {
+                            it.id == lt.trackNumberId &&
+                                it.changeTime <= publication.publicationTime
+                        }
+                        ?.number
+                mapToPublicationTableItem(
+                    name = "${translation.t("publication-table.location-track")} ${lt.name}",
+                    trackNumbers = setOfNotNull(tn),
+                    changedKmNumbers = lt.changedKmNumbers,
+                    operation = Operation.CALCULATED,
+                    publication = publication,
+                    propChanges =
+                        diffLocationTrack(
+                            translation,
+                            publicationLocationTrackChanges.getOrElse(lt.id) {
+                                error(
+                                    "Location track changes not found: id=${lt.id} version=${lt.version}")
+                            },
+                            switchLinkChanges[lt.id],
+                            publication.layoutBranch,
+                            publication.publicationTime,
+                            previousComparisonTime,
+                            trackNumberNamesCache,
+                            lt.changedKmNumbers,
+                            geocodingContextGetter,
+                        ),
+                )
+            }
 
-        val calculatedSwitches = publication.indirectChanges.switches.map { s ->
-            val tns =
-                latestTrackNumberNamesAtMoment(trackNumberNamesCache, s.trackNumberIds, publication.publicationTime)
-            mapToPublicationTableItem(
-                name = "${translation.t("publication-table.switch")} ${s.name}",
-                trackNumbers = tns,
-                operation = Operation.CALCULATED,
-                publication = publication,
-                propChanges = diffSwitch(
-                    translation,
-                    publicationSwitchChanges.getOrElse(s.id) {
-                        error("Switch changes not found: id=${s.id} version=${s.version}")
-                    },
-                    publication.publicationTime,
-                    previousComparisonTime,
-                    Operation.CALCULATED,
-                    trackNumberNamesCache,
-                    geocodingContextGetter,
-                ),
-            )
-        }
+        val calculatedSwitches =
+            publication.indirectChanges.switches.map { s ->
+                val tns =
+                    latestTrackNumberNamesAtMoment(
+                        trackNumberNamesCache, s.trackNumberIds, publication.publicationTime)
+                mapToPublicationTableItem(
+                    name = "${translation.t("publication-table.switch")} ${s.name}",
+                    trackNumbers = tns,
+                    operation = Operation.CALCULATED,
+                    publication = publication,
+                    propChanges =
+                        diffSwitch(
+                            translation,
+                            publicationSwitchChanges.getOrElse(s.id) {
+                                error("Switch changes not found: id=${s.id} version=${s.version}")
+                            },
+                            publication.publicationTime,
+                            previousComparisonTime,
+                            Operation.CALCULATED,
+                            trackNumberNamesCache,
+                            geocodingContextGetter,
+                        ),
+                )
+            }
 
         return listOf(
-            trackNumbers,
-            referenceLines,
-            locationTracks,
-            switches,
-            kmPosts,
-            calculatedLocationTracks,
-            calculatedSwitches,
-        )
+                trackNumbers,
+                referenceLines,
+                locationTracks,
+                switches,
+                kmPosts,
+                calculatedLocationTracks,
+                calculatedSwitches,
+            )
             .flatten()
             .map { publicationTableItem ->
                 addOperationClarificationsToPublicationTableItem(
@@ -1546,17 +1875,23 @@ class PublicationService @Autowired constructor(
         publication: PublicationDetails,
         changedKmNumbers: Set<KmNumber>? = null,
         propChanges: List<PublicationChange<*>>,
-    ) = PublicationTableItem(
-        name = name,
-        trackNumbers = trackNumbers.sorted(),
-        changedKmNumbers = changedKmNumbers?.let { groupChangedKmNumbers(changedKmNumbers.toList()) } ?: emptyList(),
-        operation = operation,
-        publicationTime = publication.publicationTime,
-        publicationUser = publication.publicationUser,
-        message = publication.message ?: "",
-        ratkoPushTime = if (publication.ratkoPushStatus == RatkoPushStatus.SUCCESSFUL) publication.ratkoPushTime else null,
-        propChanges = propChanges,
-    )
+    ) =
+        PublicationTableItem(
+            name = name,
+            trackNumbers = trackNumbers.sorted(),
+            changedKmNumbers =
+                changedKmNumbers?.let { groupChangedKmNumbers(changedKmNumbers.toList()) }
+                    ?: emptyList(),
+            operation = operation,
+            publicationTime = publication.publicationTime,
+            publicationUser = publication.publicationUser,
+            message = publication.message ?: "",
+            ratkoPushTime =
+                if (publication.ratkoPushStatus == RatkoPushStatus.SUCCESSFUL)
+                    publication.ratkoPushTime
+                else null,
+            propChanges = propChanges,
+        )
 
     private fun enrichDuplicateNameExceptionOrRethrow(
         branch: LayoutBranch,
@@ -1570,17 +1905,23 @@ class PublicationService @Autowired constructor(
         val (constraint, detail) = getPSQLExceptionConstraintAndDetailOrRethrow(cause)
 
         when (constraint) {
-            "switch_unique_official_name" -> maybeThrowDuplicateSwitchNameException(detail, exception)
-            "track_number_number_layout_context_unique" -> maybeThrowDuplicateTrackNumberNumberException(detail, exception)
-            "location_track_unique_official_name" -> maybeThrowDuplicateLocationTrackNameException(branch, detail, exception)
+            "switch_unique_official_name" ->
+                maybeThrowDuplicateSwitchNameException(detail, exception)
+            "track_number_number_layout_context_unique" ->
+                maybeThrowDuplicateTrackNumberNumberException(detail, exception)
+            "location_track_unique_official_name" ->
+                maybeThrowDuplicateLocationTrackNameException(branch, detail, exception)
         }
         throw exception
     }
 
     private val duplicateLocationTrackErrorRegex =
-        Regex("""Key \(track_number_id, name, layout_context_id\)=\((\d+), ([^,]+), [^)]+\) conflicts with existing key""")
-    private val duplicateTrackNumberErrorRegex = Regex("""Key \(number, layout_context_id\)=\(([^,]+), [^)]+\) already exists""")
-    private val duplicateSwitchErrorRegex = Regex("""Key \(name, layout_context_id\)=\(([^,]+), [^)]+\) conflicts with existing key""")
+        Regex(
+            """Key \(track_number_id, name, layout_context_id\)=\((\d+), ([^,]+), [^)]+\) conflicts with existing key""")
+    private val duplicateTrackNumberErrorRegex =
+        Regex("""Key \(number, layout_context_id\)=\(([^,]+), [^)]+\) already exists""")
+    private val duplicateSwitchErrorRegex =
+        Regex("""Key \(name, layout_context_id\)=\(([^,]+), [^)]+\) conflicts with existing key""")
 
     private fun maybeThrowDuplicateLocationTrackNameException(
         branch: LayoutBranch,
@@ -1596,8 +1937,7 @@ class PublicationService @Autowired constructor(
                 if (trackNumberVersion != null) {
                     val trackNumber = trackNumberDao.fetch(trackNumberVersion)
                     throw DuplicateLocationTrackNameInPublicationException(
-                        AlignmentName(nameString), trackNumber.number, exception
-                    )
+                        AlignmentName(nameString), trackNumber.number, exception)
                 }
             }
         }
@@ -1607,18 +1947,25 @@ class PublicationService @Autowired constructor(
         detail: String,
         exception: DataIntegrityViolationException,
     ) {
-        duplicateTrackNumberErrorRegex.matchAt(detail, 0)?.let { match -> match.groups[1]?.value }?.let { name ->
-            throw DuplicateNameInPublicationException(
-                DuplicateNameInPublication.TRACK_NUMBER, name, exception
-            )
-        }
+        duplicateTrackNumberErrorRegex
+            .matchAt(detail, 0)
+            ?.let { match -> match.groups[1]?.value }
+            ?.let { name ->
+                throw DuplicateNameInPublicationException(
+                    DuplicateNameInPublication.TRACK_NUMBER, name, exception)
+            }
     }
 
-    private fun maybeThrowDuplicateSwitchNameException(detail: String, exception: DataIntegrityViolationException) {
-        duplicateSwitchErrorRegex.matchAt(detail, 0)?.let { match -> match.groups[1]?.value }?.let { name ->
-            throw DuplicateNameInPublicationException(
-                DuplicateNameInPublication.SWITCH, name, exception
-            )
-        }
+    private fun maybeThrowDuplicateSwitchNameException(
+        detail: String,
+        exception: DataIntegrityViolationException
+    ) {
+        duplicateSwitchErrorRegex
+            .matchAt(detail, 0)
+            ?.let { match -> match.groups[1]?.value }
+            ?.let { name ->
+                throw DuplicateNameInPublicationException(
+                    DuplicateNameInPublication.SWITCH, name, exception)
+            }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -54,29 +54,38 @@ const val MAX_LAYOUT_POINT_ANGLE_CHANGE = PI / 2
 const val MAX_LAYOUT_METER_LENGTH = 2.0
 const val MAX_KM_POST_OFFSET = 10.0
 
-fun validateDraftTrackNumberFields(trackNumber: TrackLayoutTrackNumber): List<LayoutValidationIssue> =
-    listOfNotNull(validate(trackNumber.state.isPublishable()) { "$VALIDATION_TRACK_NUMBER.state.${trackNumber.state}" })
+fun validateDraftTrackNumberFields(
+    trackNumber: TrackLayoutTrackNumber
+): List<LayoutValidationIssue> =
+    listOfNotNull(
+        validate(trackNumber.state.isPublishable()) {
+            "$VALIDATION_TRACK_NUMBER.state.${trackNumber.state}"
+        })
 
 fun validateTrackNumberReferences(
     trackNumber: TrackLayoutTrackNumber,
     referenceLine: ReferenceLine?,
     kmPosts: List<TrackLayoutKmPost>,
     locationTracks: List<LocationTrack>,
-): List<LayoutValidationIssue> = listOfNotNull(
-    validate(referenceLine != null) { "$VALIDATION_TRACK_NUMBER.reference-line.not-published" },
-    locationTracks.filter(LocationTrack::exists).let { existingTracks ->
-        validateWithParams(trackNumber.exists || existingTracks.isEmpty()) {
-            val existingNames = existingTracks.joinToString(", ") { track -> track.name }
-            "$VALIDATION_TRACK_NUMBER.location-track.reference-deleted" to localizationParams("locationTracks" to existingNames)
-        }
-    },
-    kmPosts.filter(TrackLayoutKmPost::exists).let { existingKmPosts ->
-        validateWithParams(trackNumber.exists || existingKmPosts.isEmpty()) {
-            val existingNames = existingKmPosts.joinToString(", ") { post -> post.kmNumber.toString() }
-            "$VALIDATION_TRACK_NUMBER.km-post.reference-deleted" to localizationParams("kmPosts" to existingNames)
-        }
-    },
-)
+): List<LayoutValidationIssue> =
+    listOfNotNull(
+        validate(referenceLine != null) { "$VALIDATION_TRACK_NUMBER.reference-line.not-published" },
+        locationTracks.filter(LocationTrack::exists).let { existingTracks ->
+            validateWithParams(trackNumber.exists || existingTracks.isEmpty()) {
+                val existingNames = existingTracks.joinToString(", ") { track -> track.name }
+                "$VALIDATION_TRACK_NUMBER.location-track.reference-deleted" to
+                    localizationParams("locationTracks" to existingNames)
+            }
+        },
+        kmPosts.filter(TrackLayoutKmPost::exists).let { existingKmPosts ->
+            validateWithParams(trackNumber.exists || existingKmPosts.isEmpty()) {
+                val existingNames =
+                    existingKmPosts.joinToString(", ") { post -> post.kmNumber.toString() }
+                "$VALIDATION_TRACK_NUMBER.km-post.reference-deleted" to
+                    localizationParams("kmPosts" to existingNames)
+            }
+        },
+    )
 
 fun validateTrackNumberNumberDuplication(
     trackNumber: TrackLayoutTrackNumber,
@@ -87,62 +96,78 @@ fun validateTrackNumberNumberDuplication(
         val draftDuplicateExists = duplicates.any { d -> d.id != trackNumber.id && d.isDraft }
 
         listOfNotNull(
-            if (!draftDuplicateExists && officialDuplicateExists) LayoutValidationIssue(
-                ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-official", mapOf("trackNumber" to trackNumber.number)
-            ) else null,
-            if (draftDuplicateExists) LayoutValidationIssue(
-                ERROR, "$VALIDATION_TRACK_NUMBER.duplicate-name-draft", mapOf("trackNumber" to trackNumber.number)
-            ) else null,
+            if (!draftDuplicateExists && officialDuplicateExists)
+                LayoutValidationIssue(
+                    ERROR,
+                    "$VALIDATION_TRACK_NUMBER.duplicate-name-official",
+                    mapOf("trackNumber" to trackNumber.number))
+            else null,
+            if (draftDuplicateExists)
+                LayoutValidationIssue(
+                    ERROR,
+                    "$VALIDATION_TRACK_NUMBER.duplicate-name-draft",
+                    mapOf("trackNumber" to trackNumber.number))
+            else null,
         )
     } else {
         emptyList()
     }
 }
 
-//Location is validated by GeocodingContext
+// Location is validated by GeocodingContext
 fun validateDraftKmPostFields(kmPost: TrackLayoutKmPost): List<LayoutValidationIssue> =
-    listOfNotNull(validate(kmPost.state.isPublishable()) { "$VALIDATION_KM_POST.state.${kmPost.state}" })
+    listOfNotNull(
+        validate(kmPost.state.isPublishable()) { "$VALIDATION_KM_POST.state.${kmPost.state}" })
 
 fun validateKmPostReferences(
     kmPost: TrackLayoutKmPost,
     trackNumber: TrackLayoutTrackNumber?,
     referenceLine: ReferenceLine?,
     trackNumberNumber: TrackNumber?,
-): List<LayoutValidationIssue> = listOfNotNull(
-    validateWithParams(trackNumber != null) {
-        "$VALIDATION_KM_POST.track-number.not-published" to localizationParams("trackNumber" to trackNumberNumber)
-    },
-    validateWithParams(referenceLine != null) {
-        "$VALIDATION_KM_POST.reference-line.not-published" to localizationParams("trackNumber" to trackNumberNumber)
-    },
-    validateWithParams(!kmPost.exists || trackNumber == null || trackNumber.state.isLinkable()) {
-        "$VALIDATION_KM_POST.track-number.state.${trackNumber?.state}" to localizationParams("trackNumber" to trackNumber?.number)
-    },
-    validateWithParams(trackNumber == null || kmPost.trackNumberId == trackNumber.id) {
-        "$VALIDATION_KM_POST.track-number.not-official" to localizationParams("trackNumber" to trackNumber?.number)
-    },
-)
+): List<LayoutValidationIssue> =
+    listOfNotNull(
+        validateWithParams(trackNumber != null) {
+            "$VALIDATION_KM_POST.track-number.not-published" to
+                localizationParams("trackNumber" to trackNumberNumber)
+        },
+        validateWithParams(referenceLine != null) {
+            "$VALIDATION_KM_POST.reference-line.not-published" to
+                localizationParams("trackNumber" to trackNumberNumber)
+        },
+        validateWithParams(
+            !kmPost.exists || trackNumber == null || trackNumber.state.isLinkable()) {
+                "$VALIDATION_KM_POST.track-number.state.${trackNumber?.state}" to
+                    localizationParams("trackNumber" to trackNumber?.number)
+            },
+        validateWithParams(trackNumber == null || kmPost.trackNumberId == trackNumber.id) {
+            "$VALIDATION_KM_POST.track-number.not-official" to
+                localizationParams("trackNumber" to trackNumber?.number)
+        },
+    )
 
-fun validateDraftSwitchFields(switch: TrackLayoutSwitch): List<LayoutValidationIssue> = listOfNotNull(
-    validate(switch.stateCategory.isPublishable()) { "$VALIDATION_SWITCH.state-category.${switch.stateCategory}" },
-)
+fun validateDraftSwitchFields(switch: TrackLayoutSwitch): List<LayoutValidationIssue> =
+    listOfNotNull(
+        validate(switch.stateCategory.isPublishable()) {
+            "$VALIDATION_SWITCH.state-category.${switch.stateCategory}"
+        },
+    )
 
 fun validateSwitchLocationTrackLinkReferences(
     switch: TrackLayoutSwitch,
     locationTracks: List<LocationTrack>,
 ): List<LayoutValidationIssue> {
-    return listOfNotNull(locationTracks.filter(LocationTrack::exists).let { existingTracks ->
-        validateWithParams(switch.exists || existingTracks.isEmpty()) {
-            val existingNames = existingTracks.joinToString(", ") { track -> track.name }
-            "$VALIDATION_SWITCH.location-track.reference-deleted" to localizationParams("locationTracks" to existingNames)
-        }
-    })
+    return listOfNotNull(
+        locationTracks.filter(LocationTrack::exists).let { existingTracks ->
+            validateWithParams(switch.exists || existingTracks.isEmpty()) {
+                val existingNames = existingTracks.joinToString(", ") { track -> track.name }
+                "$VALIDATION_SWITCH.location-track.reference-deleted" to
+                    localizationParams("locationTracks" to existingNames)
+            }
+        })
 }
 
 fun validateSwitchLocation(switch: TrackLayoutSwitch): List<LayoutValidationIssue> =
-    listOfNotNull(validate(switch.joints.isNotEmpty()) {
-        "$VALIDATION_SWITCH.no-location"
-    })
+    listOfNotNull(validate(switch.joints.isNotEmpty()) { "$VALIDATION_SWITCH.no-location" })
 
 fun validateSwitchNameDuplication(
     switch: TrackLayoutSwitch,
@@ -154,10 +179,12 @@ fun validateSwitchNameDuplication(
 
         listOfNotNull(
             validateWithParams(draftDuplicateExists || !officialDuplicateExists) {
-                "$VALIDATION_SWITCH.duplicate-name-official" to localizationParams("switch" to switch.name)
+                "$VALIDATION_SWITCH.duplicate-name-official" to
+                    localizationParams("switch" to switch.name)
             },
             validateWithParams(!draftDuplicateExists) {
-                "$VALIDATION_SWITCH.duplicate-name-draft" to localizationParams("switch" to switch.name)
+                "$VALIDATION_SWITCH.duplicate-name-draft" to
+                    localizationParams("switch" to switch.name)
             },
         )
     } else {
@@ -171,16 +198,22 @@ fun validateLocationTrackNameDuplication(
     duplicates: List<LocationTrack>,
 ): List<LayoutValidationIssue> {
     return if (track.exists && duplicates.any { d -> d.id != track.id }) {
-        // Location track names must be unique within the same track number, but there can be location tracks with the
+        // Location track names must be unique within the same track number, but there can be
+        // location tracks with the
         // same name on other track numbers
         val officialDuplicateExists =
-            duplicates.any { d -> d.id != track.id && d.isOfficial && d.trackNumberId == track.trackNumberId }
+            duplicates.any { d ->
+                d.id != track.id && d.isOfficial && d.trackNumberId == track.trackNumberId
+            }
         val draftDuplicateExists =
-            duplicates.any { d -> d.id != track.id && d.isDraft && d.trackNumberId == track.trackNumberId }
-        val localizationParams = localizationParams(
-            "locationTrack" to track.name,
-            "trackNumber" to trackNumber,
-        )
+            duplicates.any { d ->
+                d.id != track.id && d.isDraft && d.trackNumberId == track.trackNumberId
+            }
+        val localizationParams =
+            localizationParams(
+                "locationTrack" to track.name,
+                "trackNumber" to trackNumber,
+            )
         return listOfNotNull(
             validateWithParams(draftDuplicateExists || !officialDuplicateExists) {
                 "$VALIDATION_LOCATION_TRACK.duplicate-name-official" to localizationParams
@@ -198,41 +231,62 @@ fun validateSwitchLocationTrackLinkStructure(
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
 ): List<LayoutValidationIssue> {
     val existingTracks = locationTracks.filter { (track, _) -> track.exists }
-    val segmentGroups = existingTracks // Only consider the non-deleted tracks for switch alignments
-        .map { (track, alignment) -> track to alignment.segments.filter { segment -> segment.switchId == switch.id } }
-        .filter { (_, segments) -> segments.isNotEmpty() }
+    val segmentGroups =
+        existingTracks // Only consider the non-deleted tracks for switch alignments
+            .map { (track, alignment) ->
+                track to alignment.segments.filter { segment -> segment.switchId == switch.id }
+            }
+            .filter { (_, segments) -> segments.isNotEmpty() }
 
     val structureJoints = collectJoints(structure)
     val segmentJoints = segmentGroups.map { (track, group) -> collectJoints(track, group) }
 
     val topologyLinks = collectTopologyEndLinks(existingTracks, switch)
 
-    return if (switch.exists) listOfNotNull(
-        segmentGroups.filterNot { (_, group) -> areSegmentsContinuous(group) }.let { errorGroups ->
-            validateWithParams(errorGroups.isEmpty()) {
-                val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                "$VALIDATION_SWITCH.location-track.not-continuous" to localizationParams("locationTracks" to errorTrackNames)
-            }
-        },
-        segmentGroups.filterNot { (_, group) -> segmentAndJointLocationsAgree(switch, group) }.let { errorGroups ->
-            validateWithParams(errorGroups.isEmpty(), WARNING) {
-                val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to localizationParams("locationTracks" to errorTrackNames)
-            }
-        },
-        topologyLinks.filterNot { (_, group) -> topologyLinkAndJointLocationsAgree(switch, group) }.let { errorGroups ->
-            validateWithParams(errorGroups.isEmpty(), WARNING) {
-                val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to localizationParams("locationTracks" to errorTrackNames)
-            }
-        },
-        segmentJoints.filterNot { (_, group) -> alignmentJointGroupFound(group, structureJoints) }.let { errorGroups ->
-            validateWithParams(errorGroups.isEmpty()) {
-                val errorTrackNames = errorGroups.joinToString(", ") { (track, _) -> track.name }
-                "$VALIDATION_SWITCH.location-track.wrong-joint-sequence" to localizationParams("locationTracks" to errorTrackNames)
-            }
-        },
-    ) + validateSwitchTopologicalConnectivity(switch, structure, locationTracks, null) else listOf()
+    return if (switch.exists)
+        listOfNotNull(
+            segmentGroups
+                .filterNot { (_, group) -> areSegmentsContinuous(group) }
+                .let { errorGroups ->
+                    validateWithParams(errorGroups.isEmpty()) {
+                        val errorTrackNames =
+                            errorGroups.joinToString(", ") { (track, _) -> track.name }
+                        "$VALIDATION_SWITCH.location-track.not-continuous" to
+                            localizationParams("locationTracks" to errorTrackNames)
+                    }
+                },
+            segmentGroups
+                .filterNot { (_, group) -> segmentAndJointLocationsAgree(switch, group) }
+                .let { errorGroups ->
+                    validateWithParams(errorGroups.isEmpty(), WARNING) {
+                        val errorTrackNames =
+                            errorGroups.joinToString(", ") { (track, _) -> track.name }
+                        "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to
+                            localizationParams("locationTracks" to errorTrackNames)
+                    }
+                },
+            topologyLinks
+                .filterNot { (_, group) -> topologyLinkAndJointLocationsAgree(switch, group) }
+                .let { errorGroups ->
+                    validateWithParams(errorGroups.isEmpty(), WARNING) {
+                        val errorTrackNames =
+                            errorGroups.joinToString(", ") { (track, _) -> track.name }
+                        "$VALIDATION_SWITCH.location-track.joint-location-mismatch" to
+                            localizationParams("locationTracks" to errorTrackNames)
+                    }
+                },
+            segmentJoints
+                .filterNot { (_, group) -> alignmentJointGroupFound(group, structureJoints) }
+                .let { errorGroups ->
+                    validateWithParams(errorGroups.isEmpty()) {
+                        val errorTrackNames =
+                            errorGroups.joinToString(", ") { (track, _) -> track.name }
+                        "$VALIDATION_SWITCH.location-track.wrong-joint-sequence" to
+                            localizationParams("locationTracks" to errorTrackNames)
+                    }
+                },
+        ) + validateSwitchTopologicalConnectivity(switch, structure, locationTracks, null)
+    else listOf()
 }
 
 fun validateLocationTrackSwitchConnectivity(
@@ -245,8 +299,11 @@ fun validateLocationTrackSwitchConnectivity(
     val topologyEndSwitch = layoutTrack.topologyEndSwitch?.switchId
 
     val hasStartSwitch =
-        (startSegment?.switchId != null && startSegment.startJointNumber != null) || topologyStartSwitch != null
-    val hasEndSwitch = (endSegment?.switchId != null && endSegment.endJointNumber != null) || topologyEndSwitch != null
+        (startSegment?.switchId != null && startSegment.startJointNumber != null) ||
+            topologyStartSwitch != null
+    val hasEndSwitch =
+        (endSegment?.switchId != null && endSegment.endJointNumber != null) ||
+            topologyEndSwitch != null
 
     return when (layoutTrack.topologicalConnectivity) {
         TopologicalConnectivityType.NONE -> {
@@ -289,8 +346,7 @@ fun validateLocationTrackSwitchConnectivity(
                 },
                 validate(hasEndSwitch, WARNING) {
                     "$VALIDATION_LOCATION_TRACK.topological-connectivity.end-switch-missing"
-                }
-            )
+                })
         }
     }
 }
@@ -302,31 +358,48 @@ fun validateSwitchTopologicalConnectivity(
     validatingTrack: LocationTrack?,
 ): List<LayoutValidationIssue> {
     val connectivity = switchConnectivity(structure)
-    val nonDuplicateTracks = locationTracks.filter { (locationTrack, _) -> locationTrack.duplicateOf == null }
-    val nonDuplicateTracksThroughJoints = getTracksThroughJoints(structure, nonDuplicateTracks, switch)
+    val nonDuplicateTracks =
+        locationTracks.filter { (locationTrack, _) -> locationTrack.duplicateOf == null }
+    val nonDuplicateTracksThroughJoints =
+        getTracksThroughJoints(structure, nonDuplicateTracks, switch)
     return listOfNotNull(
         validateFrontJointTopology(switch, structure, locationTracks, validatingTrack),
-        validateExcessTracksThroughJoint(connectivity, nonDuplicateTracksThroughJoints, switch.name, validatingTrack),
-        validateSwitchAlignmentTopology(switch.id, structure, connectivity, locationTracks, switch.name, validatingTrack),
+        validateExcessTracksThroughJoint(
+            connectivity, nonDuplicateTracksThroughJoints, switch.name, validatingTrack),
+        validateSwitchAlignmentTopology(
+            switch.id, structure, connectivity, locationTracks, switch.name, validatingTrack),
     )
 }
 
 fun switchOrTrackLinkageKey(validatingTrack: LocationTrack?) =
-    if (validatingTrack != null) "$VALIDATION_LOCATION_TRACK.switch-linkage" else "$VALIDATION_SWITCH.track-linkage"
+    if (validatingTrack != null) "$VALIDATION_LOCATION_TRACK.switch-linkage"
+    else "$VALIDATION_SWITCH.track-linkage"
 
 private fun getTracksThroughJoints(
     structure: SwitchStructure,
     tracks: List<Pair<LocationTrack, LayoutAlignment>>,
     switch: TrackLayoutSwitch,
 ): Map<JointNumber, List<LocationTrack>> {
-    val tracksThroughJoint = structure.joints.map { it.number }.associateWith { jointNumber ->
-        tracks.filter { (_, alignment) ->
-            val jointLinkedIndexRange = alignment.segments.mapIndexedNotNull { i, segment ->
-                if (segment.switchId == switch.id && (segment.startJointNumber == jointNumber || segment.endJointNumber == jointNumber)) i else null
+    val tracksThroughJoint =
+        structure.joints
+            .map { it.number }
+            .associateWith { jointNumber ->
+                tracks
+                    .filter { (_, alignment) ->
+                        val jointLinkedIndexRange =
+                            alignment.segments.mapIndexedNotNull { i, segment ->
+                                if (segment.switchId == switch.id &&
+                                    (segment.startJointNumber == jointNumber ||
+                                        segment.endJointNumber == jointNumber))
+                                    i
+                                else null
+                            }
+                        jointLinkedIndexRange.isNotEmpty() &&
+                            jointLinkedIndexRange.first() > 0 &&
+                            jointLinkedIndexRange.last() < alignment.segments.lastIndex
+                    }
+                    .map { (locationTrack, _) -> locationTrack }
             }
-            jointLinkedIndexRange.isNotEmpty() && jointLinkedIndexRange.first() > 0 && jointLinkedIndexRange.last() < alignment.segments.lastIndex
-        }.map { (locationTrack, _) -> locationTrack }
-    }
     return tracksThroughJoint
 }
 
@@ -340,12 +413,16 @@ private fun validateFrontJointTopology(
     fun tracksHaveOkFrontJointLink(tracks: List<Pair<LocationTrack, LayoutAlignment>>) =
         tracks.any { (locationTrack, _) ->
             val topoStart =
-                locationTrack.topologyStartSwitch?.switchId == switch.id && locationTrack.topologyStartSwitch.jointNumber == connectivity.frontJoint
+                locationTrack.topologyStartSwitch?.switchId == switch.id &&
+                    locationTrack.topologyStartSwitch.jointNumber == connectivity.frontJoint
             val topoEnd =
-                locationTrack.topologyEndSwitch?.switchId == switch.id && locationTrack.topologyEndSwitch.jointNumber == connectivity.frontJoint
-            val tracksThroughFrontJoint = if (connectivity.frontJoint == null) {
-                listOf()
-            } else getTracksThroughJoints(switchStructure, tracks, switch)[connectivity.frontJoint]
+                locationTrack.topologyEndSwitch?.switchId == switch.id &&
+                    locationTrack.topologyEndSwitch.jointNumber == connectivity.frontJoint
+            val tracksThroughFrontJoint =
+                if (connectivity.frontJoint == null) {
+                    listOf()
+                } else
+                    getTracksThroughJoints(switchStructure, tracks, switch)[connectivity.frontJoint]
             topoStart || topoEnd || !tracksThroughFrontJoint.isNullOrEmpty()
         }
 
@@ -354,15 +431,15 @@ private fun validateFrontJointTopology(
         tracksHaveOkFrontJointLink(locationTracks.filter { it.first.duplicateOf == null })
 
     return validateWithParams(
-        connectivity.frontJoint == null || okFrontJointLinkInNonDuplicates, WARNING
-    ) {
-        val key = "${switchOrTrackLinkageKey(validatingTrack)}.${
+        connectivity.frontJoint == null || okFrontJointLinkInNonDuplicates, WARNING) {
+            val key =
+                "${switchOrTrackLinkageKey(validatingTrack)}.${
             if (okFrontJointLinkInDuplicates) "front-joint-only-duplicate-connected"
             else "front-joint-not-connected"
         }"
 
-        key to localizationParams("switch" to switch.name.toString())
-    }
+            key to localizationParams("switch" to switch.name.toString())
+        }
 }
 
 private fun validateExcessTracksThroughJoint(
@@ -371,22 +448,25 @@ private fun validateExcessTracksThroughJoint(
     switchName: SwitchName,
     validatingTrack: LocationTrack?,
 ): LayoutValidationIssue? {
-    val excesses = tracksThroughJoint.filter { (joint, tracks) ->
-        joint != connectivity.sharedPassThroughJoint && tracks.size > 1
-    }
-    val someoneElseIsResponsible = validatingTrack?.let {
-        excesses.values.flatten().none { excess -> excess.id == validatingTrack.id }
-    } ?: false
+    val excesses =
+        tracksThroughJoint.filter { (joint, tracks) ->
+            joint != connectivity.sharedPassThroughJoint && tracks.size > 1
+        }
+    val someoneElseIsResponsible =
+        validatingTrack?.let {
+            excesses.values.flatten().none { excess -> excess.id == validatingTrack.id }
+        } ?: false
 
     return validateWithParams(excesses.isEmpty() || someoneElseIsResponsible, WARNING) {
-        val trackNames = excesses.entries
-            .sortedBy { (jointNumber, _) -> jointNumber.intValue }
-            .joinToString { (jointNumber, tracks) ->
-                "${jointNumber.intValue} (${tracks.sortedBy { it.name }.joinToString { it.name }})"
-            }
+        val trackNames =
+            excesses.entries
+                .sortedBy { (jointNumber, _) -> jointNumber.intValue }
+                .joinToString { (jointNumber, tracks) ->
+                    "${jointNumber.intValue} (${tracks.sortedBy { it.name }.joinToString { it.name }})"
+                }
 
         "${switchOrTrackLinkageKey(validatingTrack)}.multiple-tracks-through-joint" to
-                localizationParams("locationTracks" to trackNames, "switch" to switchName.toString())
+            localizationParams("locationTracks" to trackNames, "switch" to switchName.toString())
     }
 }
 
@@ -408,19 +488,22 @@ fun validateSwitchAlignmentTopology(
     switchName: SwitchName,
     validatingTrack: LocationTrack?,
 ): LayoutValidationIssue? {
-    val switchAlignmentsUnlinkedToAny = connectivity.alignmentJoints.filter { switchAlignment ->
-        locationTracks.none { (_, alignment) ->
-            alignmentsAreLinked(switchAlignment, alignment, switchId)
+    val switchAlignmentsUnlinkedToAny =
+        connectivity.alignmentJoints
+            .filter { switchAlignment ->
+                locationTracks.none { (_, alignment) ->
+                    alignmentsAreLinked(switchAlignment, alignment, switchId)
+                }
+            }
+            .toSet()
+    val allAlignmentsUnlinked =
+        connectivity.alignmentJoints.all { switchAlignment ->
+            switchAlignmentsUnlinkedToAny.contains(switchAlignment)
         }
-    }.toSet()
-    val allAlignmentsUnlinked = connectivity.alignmentJoints.all { switchAlignment ->
-        switchAlignmentsUnlinkedToAny.contains(switchAlignment)
-    }
     return if (allAlignmentsUnlinked) {
         validateWithParams(false, ERROR) {
-            "${switchOrTrackLinkageKey(validatingTrack)}.switch-no-alignments-connected" to localizationParams(
-                "switch" to switchName.toString()
-            )
+            "${switchOrTrackLinkageKey(validatingTrack)}.switch-no-alignments-connected" to
+                localizationParams("switch" to switchName.toString())
         }
     } else {
         val nonDuplicateTracks = locationTracks.filter { (lt) -> lt.duplicateOf == null }
@@ -433,31 +516,42 @@ fun validateSwitchAlignmentTopology(
         val switchAlignmentsLinkedToOnlyDuplicates =
             switchAlignmentsUnlinkedToNonduplicates.subtract(switchAlignmentsUnlinkedToAny)
 
-        // trackLinkedAlignmentsJoints splits up switch alignments going through the center on rail crossings; but it's
-        // possible that the alignment was supposed to actually go through the entire crossing. So, if the switch has any
-        // unlinked alignments, a track alignment that's only linked to a split alignment could in fact be the cause, so
+        // trackLinkedAlignmentsJoints splits up switch alignments going through the center on rail
+        // crossings; but it's
+        // possible that the alignment was supposed to actually go through the entire crossing. So,
+        // if the switch has any
+        // unlinked alignments, a track alignment that's only linked to a split alignment could in
+        // fact be the cause, so
         // we need to check the unsplit switch alignments instead.
         val trackBeingValidatedIsConnectedToFullAlignment =
-            nonDuplicateTracks.find { (lt) -> lt == validatingTrack }?.let { (_, validatingAlignment) ->
-                switchStructure.alignments.any { switchAlignment ->
-                    alignmentsAreLinked(switchAlignment.jointNumbers, validatingAlignment, switchId)
-                }
-            } ?: false
+            nonDuplicateTracks
+                .find { (lt) -> lt == validatingTrack }
+                ?.let { (_, validatingAlignment) ->
+                    switchStructure.alignments.any { switchAlignment ->
+                        alignmentsAreLinked(
+                            switchAlignment.jointNumbers, validatingAlignment, switchId)
+                    }
+                } ?: false
 
         validateWithParams(
-            switchAlignmentsUnlinkedToNonduplicates.isEmpty() || trackBeingValidatedIsConnectedToFullAlignment, WARNING
-        ) {
-            val alignmentsString = switchAlignmentsUnlinkedToNonduplicates.joinToString { alignment ->
-                alignment.joinToString("-") { joint -> joint.intValue.toString() }
-            }
-            val key = if (switchAlignmentsLinkedToOnlyDuplicates.isEmpty()) {
-                "${switchOrTrackLinkageKey(validatingTrack)}.switch-alignment-not-connected"
-            } else {
-                "${switchOrTrackLinkageKey(validatingTrack)}.switch-alignment-only-connected-to-duplicate"
-            }
+            switchAlignmentsUnlinkedToNonduplicates.isEmpty() ||
+                trackBeingValidatedIsConnectedToFullAlignment,
+            WARNING) {
+                val alignmentsString =
+                    switchAlignmentsUnlinkedToNonduplicates.joinToString { alignment ->
+                        alignment.joinToString("-") { joint -> joint.intValue.toString() }
+                    }
+                val key =
+                    if (switchAlignmentsLinkedToOnlyDuplicates.isEmpty()) {
+                        "${switchOrTrackLinkageKey(validatingTrack)}.switch-alignment-not-connected"
+                    } else {
+                        "${switchOrTrackLinkageKey(validatingTrack)}.switch-alignment-only-connected-to-duplicate"
+                    }
 
-            key to localizationParams("locationTracks" to alignmentsString, "switch" to switchName.toString())
-        }
+                key to
+                    localizationParams(
+                        "locationTracks" to alignmentsString, "switch" to switchName.toString())
+            }
     }
 }
 
@@ -465,11 +559,11 @@ private fun alignmentHasSwitchJointLink(
     alignment: LayoutAlignment,
     switchId: DomainId<TrackLayoutSwitch>,
     jointNumber: JointNumber,
-) = alignment.segments.any { segment ->
-    segment.switchId == switchId && jointNumber in listOfNotNull(
-        segment.startJointNumber, segment.endJointNumber
-    )
-}
+) =
+    alignment.segments.any { segment ->
+        segment.switchId == switchId &&
+            jointNumber in listOfNotNull(segment.startJointNumber, segment.endJointNumber)
+    }
 
 fun validateDuplicateOfState(
     locationTrack: LocationTrack,
@@ -477,51 +571,68 @@ fun validateDuplicateOfState(
     duplicateOfLocationTrackDraftName: AlignmentName?,
     duplicates: List<LocationTrack>,
 ): List<LayoutValidationIssue> {
-    val duplicateNameParams = localizationParams(
-        "duplicateTrack" to (duplicateOfLocationTrack?.name ?: duplicateOfLocationTrackDraftName)
-    )
-    val ownDuplicateOfErrors = if (duplicateOfLocationTrack == null) {
-        listOfNotNull(
-            // Non-null reference, but the duplicateOf track doesn't exist in validation context
-            validateWithParams(locationTrack.duplicateOf == null) {
-                "$VALIDATION_LOCATION_TRACK.duplicate-of.not-published" to duplicateNameParams
-            },
-        )
-    } else {
-        listOfNotNull(
-            validateWithParams(locationTrack.state.isRemoved() || duplicateOfLocationTrack.state.isLinkable()) {
-                "$VALIDATION_LOCATION_TRACK.duplicate-of.state.${duplicateOfLocationTrack.state}" to duplicateNameParams
-            },
-            validateWithParams(duplicateOfLocationTrack.duplicateOf == null) {
-                "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-of-duplicated" to duplicateNameParams
-            },
-            validateWithParams(duplicates.isEmpty()) {
-                val suffix = if (duplicates.size > 1) "-multiple" else ""
-                "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-while-duplicated${suffix}" to localizationParams(
-                    mapOf("duplicateTrack" to duplicateOfLocationTrack.name,
-                        "otherDuplicates" to duplicates.map { track -> track.name }.distinct().joinToString { it })
-                )
-            },
-        )
-    }
-    val otherDuplicateReferenceErrors = if (!locationTrack.exists) {
-        val existingDuplicates = duplicates.filter { d -> d.exists }
-        listOfNotNull(
-            validateWithParams(existingDuplicates.isEmpty()) {
-                "$VALIDATION_LOCATION_TRACK.deleted-duplicated-by-existing" to localizationParams(
-                    "duplicates" to existingDuplicates.joinToString(",") { track -> track.name },
-                )
-            },
-        )
-    } else {
-        emptyList()
-    }
+    val duplicateNameParams =
+        localizationParams(
+            "duplicateTrack" to
+                (duplicateOfLocationTrack?.name ?: duplicateOfLocationTrackDraftName))
+    val ownDuplicateOfErrors =
+        if (duplicateOfLocationTrack == null) {
+            listOfNotNull(
+                // Non-null reference, but the duplicateOf track doesn't exist in validation context
+                validateWithParams(locationTrack.duplicateOf == null) {
+                    "$VALIDATION_LOCATION_TRACK.duplicate-of.not-published" to duplicateNameParams
+                },
+            )
+        } else {
+            listOfNotNull(
+                validateWithParams(
+                    locationTrack.state.isRemoved() ||
+                        duplicateOfLocationTrack.state.isLinkable()) {
+                        "$VALIDATION_LOCATION_TRACK.duplicate-of.state.${duplicateOfLocationTrack.state}" to
+                            duplicateNameParams
+                    },
+                validateWithParams(duplicateOfLocationTrack.duplicateOf == null) {
+                    "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-of-duplicated" to
+                        duplicateNameParams
+                },
+                validateWithParams(duplicates.isEmpty()) {
+                    val suffix = if (duplicates.size > 1) "-multiple" else ""
+                    "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-while-duplicated${suffix}" to
+                        localizationParams(
+                            mapOf(
+                                "duplicateTrack" to duplicateOfLocationTrack.name,
+                                "otherDuplicates" to
+                                    duplicates
+                                        .map { track -> track.name }
+                                        .distinct()
+                                        .joinToString { it }))
+                },
+            )
+        }
+    val otherDuplicateReferenceErrors =
+        if (!locationTrack.exists) {
+            val existingDuplicates = duplicates.filter { d -> d.exists }
+            listOfNotNull(
+                validateWithParams(existingDuplicates.isEmpty()) {
+                    "$VALIDATION_LOCATION_TRACK.deleted-duplicated-by-existing" to
+                        localizationParams(
+                            "duplicates" to
+                                existingDuplicates.joinToString(",") { track -> track.name },
+                        )
+                },
+            )
+        } else {
+            emptyList()
+        }
     return ownDuplicateOfErrors + otherDuplicateReferenceErrors
 }
 
-fun validateDraftLocationTrackFields(locationTrack: LocationTrack): List<LayoutValidationIssue> = listOfNotNull(
-    validate(locationTrack.state.isPublishable()) { "$VALIDATION_LOCATION_TRACK.state.${locationTrack.state}" },
-)
+fun validateDraftLocationTrackFields(locationTrack: LocationTrack): List<LayoutValidationIssue> =
+    listOfNotNull(
+        validate(locationTrack.state.isPublishable()) {
+            "$VALIDATION_LOCATION_TRACK.state.${locationTrack.state}"
+        },
+    )
 
 fun validateReferenceLineReference(
     referenceLine: ReferenceLine,
@@ -544,9 +655,12 @@ fun validateLocationTrackReference(
     trackNumber: TrackLayoutTrackNumber?,
     trackNumberName: TrackNumber?,
 ): List<LayoutValidationIssue> {
-    return if (trackNumber == null) listOf(
-        validationError("$VALIDATION_LOCATION_TRACK.track-number.not-published", "trackNumber" to trackNumberName),
-    )
+    return if (trackNumber == null)
+        listOf(
+            validationError(
+                "$VALIDATION_LOCATION_TRACK.track-number.not-published",
+                "trackNumber" to trackNumberName),
+        )
     else {
         val numberParams = localizationParams("trackNumber" to trackNumber.number)
         listOfNotNull(
@@ -580,39 +694,50 @@ fun validateSegmentSwitchReferences(
         val nameLocalizationParams = localizationParams("switch" to segmentSwitch.switchName)
 
         if (switch == null || switchStructure == null) {
-            listOf(validationError("$VALIDATION_LOCATION_TRACK.switch.not-published", nameLocalizationParams))
+            listOf(
+                validationError(
+                    "$VALIDATION_LOCATION_TRACK.switch.not-published", nameLocalizationParams))
         } else {
-            val stateErrors: List<LayoutValidationIssue> = listOfNotNull(
-                validateWithParams(segments.all { segment -> switch.id == segment.switchId }) {
-                    "$VALIDATION_LOCATION_TRACK.switch.not-official" to nameLocalizationParams
-                },
-                validateWithParams(!locationTrack.exists || switch.stateCategory.isLinkable()) {
-                    "$VALIDATION_LOCATION_TRACK.switch.state-category.${switch.stateCategory}" to nameLocalizationParams
-                },
-            )
-
-            val geometryErrors: List<LayoutValidationIssue> = if (locationTrack.exists && switch.exists) {
-                val structureJoints = collectJoints(segmentSwitch.switchStructure)
-                val segmentJoints = collectJoints(segments)
+            val stateErrors: List<LayoutValidationIssue> =
                 listOfNotNull(
-                    validateWithParams(areSegmentsContinuous(segments)) {
-                        "$VALIDATION_LOCATION_TRACK.switch.alignment-not-continuous" to nameLocalizationParams
+                    validateWithParams(segments.all { segment -> switch.id == segment.switchId }) {
+                        "$VALIDATION_LOCATION_TRACK.switch.not-official" to nameLocalizationParams
                     },
-                    validateWithParams(segmentAndJointLocationsAgree(switch, segments), WARNING) {
-                        "$VALIDATION_LOCATION_TRACK.switch.joint-location-mismatch" to nameLocalizationParams
-                    },
-                    validateWithParams(alignmentJointGroupFound(segmentJoints, structureJoints)) {
-                        "$VALIDATION_LOCATION_TRACK.switch.wrong-joint-sequence" to localizationParams(
-                            "switch" to switch.name,
-                            "switchType" to segmentSwitch.switchStructure.baseType.name,
-                            "switchJoints" to jointSequence(segmentJoints),
-                        )
-                    },
-                    validateWithParams(segmentJoints.isNotEmpty()) {
-                        "$VALIDATION_LOCATION_TRACK.switch.wrong-links" to nameLocalizationParams
+                    validateWithParams(!locationTrack.exists || switch.stateCategory.isLinkable()) {
+                        "$VALIDATION_LOCATION_TRACK.switch.state-category.${switch.stateCategory}" to
+                            nameLocalizationParams
                     },
                 )
-            } else listOf()
+
+            val geometryErrors: List<LayoutValidationIssue> =
+                if (locationTrack.exists && switch.exists) {
+                    val structureJoints = collectJoints(segmentSwitch.switchStructure)
+                    val segmentJoints = collectJoints(segments)
+                    listOfNotNull(
+                        validateWithParams(areSegmentsContinuous(segments)) {
+                            "$VALIDATION_LOCATION_TRACK.switch.alignment-not-continuous" to
+                                nameLocalizationParams
+                        },
+                        validateWithParams(
+                            segmentAndJointLocationsAgree(switch, segments), WARNING) {
+                                "$VALIDATION_LOCATION_TRACK.switch.joint-location-mismatch" to
+                                    nameLocalizationParams
+                            },
+                        validateWithParams(
+                            alignmentJointGroupFound(segmentJoints, structureJoints)) {
+                                "$VALIDATION_LOCATION_TRACK.switch.wrong-joint-sequence" to
+                                    localizationParams(
+                                        "switch" to switch.name,
+                                        "switchType" to segmentSwitch.switchStructure.baseType.name,
+                                        "switchJoints" to jointSequence(segmentJoints),
+                                    )
+                            },
+                        validateWithParams(segmentJoints.isNotEmpty()) {
+                            "$VALIDATION_LOCATION_TRACK.switch.wrong-links" to
+                                nameLocalizationParams
+                        },
+                    )
+                } else listOf()
             stateErrors + geometryErrors
         }
     }
@@ -621,16 +746,18 @@ fun validateSegmentSwitchReferences(
 fun validateTopologicallyConnectedSwitchReferences(
     locationTrack: LocationTrack,
     topologicallyConnectedSwitches: List<Pair<SwitchName, TrackLayoutSwitch?>>,
-): List<LayoutValidationIssue> = topologicallyConnectedSwitches.mapNotNull { (name, switch) ->
-    val nameParams = localizationParams("switch" to name)
-    if (switch == null) {
-        validationError("$VALIDATION_LOCATION_TRACK.switch.not-published", nameParams)
-    } else {
-        validateWithParams(!locationTrack.exists || switch.stateCategory.isLinkable()) {
-            "$VALIDATION_LOCATION_TRACK.switch.state-category.${switch.stateCategory}" to nameParams
+): List<LayoutValidationIssue> =
+    topologicallyConnectedSwitches.mapNotNull { (name, switch) ->
+        val nameParams = localizationParams("switch" to name)
+        if (switch == null) {
+            validationError("$VALIDATION_LOCATION_TRACK.switch.not-published", nameParams)
+        } else {
+            validateWithParams(!locationTrack.exists || switch.stateCategory.isLinkable()) {
+                "$VALIDATION_LOCATION_TRACK.switch.state-category.${switch.stateCategory}" to
+                    nameParams
+            }
         }
     }
-}
 
 private fun jointSequence(joints: List<JointNumber>) =
     joints.joinToString("-") { jointNumber -> "${jointNumber.intValue}" }
@@ -644,87 +771,110 @@ fun validateGeocodingContext(
 ): List<LayoutValidationIssue> {
     val context = contextCreateResult.geocodingContext
 
-    val badStartPoint = validateWithParams(contextCreateResult.startPointRejectedReason == null) {
-        "$VALIDATION_GEOCODING.start-km-too-long" to localizationParams()
-    }
+    val badStartPoint =
+        validateWithParams(contextCreateResult.startPointRejectedReason == null) {
+            "$VALIDATION_GEOCODING.start-km-too-long" to localizationParams()
+        }
 
     val kmPostsInWrongOrder =
-        context.referencePoints.filter { point -> point.intersectType == WITHIN }.filterIndexed { index, point ->
-            val previous = context.referencePoints.getOrNull(index - 1)
-            val next = context.referencePoints.getOrNull(index + 1)
-            !isOrderOk(previous, point) || !isOrderOk(point, next)
-        }.let { invalidPoints ->
-            validateWithParams(invalidPoints.isEmpty()) {
-                "$VALIDATION_GEOCODING.km-posts-invalid" to localizationParams(
-                    "trackNumber" to context.trackNumber,
-                    "kmNumbers" to invalidPoints.joinToString(", ") { point -> point.kmNumber.toString() },
-                )
+        context.referencePoints
+            .filter { point -> point.intersectType == WITHIN }
+            .filterIndexed { index, point ->
+                val previous = context.referencePoints.getOrNull(index - 1)
+                val next = context.referencePoints.getOrNull(index + 1)
+                !isOrderOk(previous, point) || !isOrderOk(point, next)
+            }
+            .let { invalidPoints ->
+                validateWithParams(invalidPoints.isEmpty()) {
+                    "$VALIDATION_GEOCODING.km-posts-invalid" to
+                        localizationParams(
+                            "trackNumber" to context.trackNumber,
+                            "kmNumbers" to
+                                invalidPoints.joinToString(", ") { point ->
+                                    point.kmNumber.toString()
+                                },
+                        )
+                }
+            }
+
+    val kmPostsFarFromLine =
+        context.referencePoints
+            .filter { point -> point.intersectType == WITHIN }
+            .filter { point -> point.kmPostOffset > MAX_KM_POST_OFFSET }
+            .let { farAwayPoints ->
+                validateWithParams(farAwayPoints.isEmpty(), WARNING) {
+                    "$VALIDATION_GEOCODING.km-posts-far-from-line" to
+                        localizationParams(
+                            "trackNumber" to context.trackNumber,
+                            "kmNumbers" to
+                                farAwayPoints.joinToString(",") { point ->
+                                    point.kmNumber.toString()
+                                },
+                        )
+                }
+            }
+
+    val kmPostsRejected =
+        contextCreateResult.rejectedKmPosts.map { (kmPost, reason) ->
+            val kmPostLocalizationParams =
+                mapOf("trackNumber" to trackNumber, "kmNumber" to kmPost.kmNumber)
+
+            when (reason) {
+                KmPostRejectedReason.TOO_FAR_APART ->
+                    LayoutValidationIssue(
+                        ERROR, "$VALIDATION_GEOCODING.km-post-too-long", kmPostLocalizationParams)
+
+                KmPostRejectedReason.NO_LOCATION ->
+                    LayoutValidationIssue(
+                        ERROR,
+                        "$VALIDATION_GEOCODING.km-post-no-location",
+                        kmPostLocalizationParams)
+
+                KmPostRejectedReason.IS_BEFORE_START_ADDRESS ->
+                    LayoutValidationIssue(
+                        WARNING,
+                        "$VALIDATION_GEOCODING.km-post-smaller-than-track-number-start",
+                        kmPostLocalizationParams)
+
+                KmPostRejectedReason.INTERSECTS_BEFORE_REFERENCE_LINE ->
+                    LayoutValidationIssue(
+                        WARNING,
+                        "$VALIDATION_GEOCODING.km-post-outside-line-before",
+                        kmPostLocalizationParams)
+
+                KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE ->
+                    LayoutValidationIssue(
+                        WARNING,
+                        "$VALIDATION_GEOCODING.km-post-outside-line-after",
+                        kmPostLocalizationParams)
+
+                KmPostRejectedReason.DUPLICATE ->
+                    LayoutValidationIssue(
+                        ERROR, "$VALIDATION_GEOCODING.duplicate-km-posts", kmPostLocalizationParams)
             }
         }
-
-    val kmPostsFarFromLine = context.referencePoints
-        .filter { point -> point.intersectType == WITHIN }
-        .filter { point -> point.kmPostOffset > MAX_KM_POST_OFFSET }
-        .let { farAwayPoints ->
-            validateWithParams(farAwayPoints.isEmpty(), WARNING) {
-                "$VALIDATION_GEOCODING.km-posts-far-from-line" to localizationParams(
-                    "trackNumber" to context.trackNumber,
-                    "kmNumbers" to farAwayPoints.joinToString(",") { point -> point.kmNumber.toString() },
-                )
-            }
-        }
-
-    val kmPostsRejected = contextCreateResult.rejectedKmPosts.map { (kmPost, reason) ->
-        val kmPostLocalizationParams = mapOf("trackNumber" to trackNumber, "kmNumber" to kmPost.kmNumber)
-
-        when (reason) {
-            KmPostRejectedReason.TOO_FAR_APART -> LayoutValidationIssue(
-                ERROR, "$VALIDATION_GEOCODING.km-post-too-long", kmPostLocalizationParams
-            )
-
-            KmPostRejectedReason.NO_LOCATION -> LayoutValidationIssue(
-                ERROR, "$VALIDATION_GEOCODING.km-post-no-location", kmPostLocalizationParams
-            )
-
-            KmPostRejectedReason.IS_BEFORE_START_ADDRESS -> LayoutValidationIssue(
-                WARNING, "$VALIDATION_GEOCODING.km-post-smaller-than-track-number-start", kmPostLocalizationParams
-            )
-
-            KmPostRejectedReason.INTERSECTS_BEFORE_REFERENCE_LINE -> LayoutValidationIssue(
-                WARNING, "$VALIDATION_GEOCODING.km-post-outside-line-before", kmPostLocalizationParams
-            )
-
-            KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE -> LayoutValidationIssue(
-                WARNING, "$VALIDATION_GEOCODING.km-post-outside-line-after", kmPostLocalizationParams
-            )
-
-            KmPostRejectedReason.DUPLICATE -> LayoutValidationIssue(
-                ERROR, "$VALIDATION_GEOCODING.duplicate-km-posts", kmPostLocalizationParams
-            )
-        }
-    }
 
     return kmPostsRejected + listOfNotNull(kmPostsFarFromLine, kmPostsInWrongOrder, badStartPoint)
 }
 
 private fun isOrderOk(previous: GeocodingReferencePoint?, next: GeocodingReferencePoint?) =
-    if (previous == null || next == null) true
-    else previous.distance < next.distance
+    if (previous == null || next == null) true else previous.distance < next.distance
 
 fun validateAddressPoints(
     trackNumber: TrackLayoutTrackNumber,
     locationTrack: LocationTrack,
     validationTargetLocalizationPrefix: String,
     geocode: () -> AlignmentAddresses?,
-): List<LayoutValidationIssue> = try {
-    geocode()?.let { addresses ->
-        validateAddressPoints(trackNumber, locationTrack, addresses)
-    } ?: listOf(
-        LayoutValidationIssue(ERROR, "$validationTargetLocalizationPrefix.no-context", emptyMap()),
-    )
-} catch (e: ClientException) {
-    listOf(LayoutValidationIssue(ERROR, e.localizationKey))
-}
+): List<LayoutValidationIssue> =
+    try {
+        geocode()?.let { addresses -> validateAddressPoints(trackNumber, locationTrack, addresses) }
+            ?: listOf(
+                LayoutValidationIssue(
+                    ERROR, "$validationTargetLocalizationPrefix.no-context", emptyMap()),
+            )
+    } catch (e: ClientException) {
+        listOf(LayoutValidationIssue(ERROR, e.localizationKey))
+    }
 
 fun validateAddressPoints(
     trackNumber: TrackLayoutTrackNumber,
@@ -736,135 +886,184 @@ fun validateAddressPoints(
     val allAddresses = allPoints.map(AddressPoint::address)
     val maxRanges = 5
     fun describeAsAddressRanges(indices: List<ClosedRange<Int>>): String =
-        indices.take(maxRanges).joinToString(", ") { range ->
-            "${allAddresses[range.start].formatDropDecimals()}..${allAddresses[range.endInclusive].formatDropDecimals()}"
-        }.let { if (indices.size > maxRanges) "$it..." else it }
+        indices
+            .take(maxRanges)
+            .joinToString(", ") { range ->
+                "${allAddresses[range.start].formatDropDecimals()}..${allAddresses[range.endInclusive].formatDropDecimals()}"
+            }
+            .let { if (indices.size > maxRanges) "$it..." else it }
 
-    val discontinuousDirectionRanges = describeAsAddressRanges(discontinuousDirectionRangeIndices(allCoordinates))
+    val discontinuousDirectionRanges =
+        describeAsAddressRanges(discontinuousDirectionRangeIndices(allCoordinates))
     val stretchedMeterRanges = describeAsAddressRanges(stretchedMeterRangeIndices(allCoordinates))
-    val discontinuousAddressRanges = describeAsAddressRanges(discontinuousAddressRangeIndices(allAddresses))
+    val discontinuousAddressRanges =
+        describeAsAddressRanges(discontinuousAddressRangeIndices(allAddresses))
 
     return listOfNotNull(
         validateWithParams(addresses.startIntersect == WITHIN) {
-            "$VALIDATION_GEOCODING.start-outside-reference-line" to localizationParams(
-                "referenceLine" to trackNumber.number,
-                "locationTrack" to locationTrack.name,
-            )
+            "$VALIDATION_GEOCODING.start-outside-reference-line" to
+                localizationParams(
+                    "referenceLine" to trackNumber.number,
+                    "locationTrack" to locationTrack.name,
+                )
         },
         validateWithParams(addresses.endIntersect == WITHIN) {
-            "$VALIDATION_GEOCODING.end-outside-reference-line" to localizationParams(
-                "referenceLine" to trackNumber.number,
-                "locationTrack" to locationTrack.name,
-            )
+            "$VALIDATION_GEOCODING.end-outside-reference-line" to
+                localizationParams(
+                    "referenceLine" to trackNumber.number,
+                    "locationTrack" to locationTrack.name,
+                )
         },
         validateWithParams(discontinuousDirectionRanges.isEmpty()) {
-            "$VALIDATION_GEOCODING.sharp-angle" to localizationParams(
-                "trackNumber" to trackNumber.number,
-                "locationTrack" to locationTrack.name,
-                "kmNumbers" to discontinuousDirectionRanges
-            )
+            "$VALIDATION_GEOCODING.sharp-angle" to
+                localizationParams(
+                    "trackNumber" to trackNumber.number,
+                    "locationTrack" to locationTrack.name,
+                    "kmNumbers" to discontinuousDirectionRanges)
         },
         validateWithParams(stretchedMeterRanges.isEmpty()) {
-            "$VALIDATION_GEOCODING.stretched-meters" to localizationParams(
-                "trackNumber" to trackNumber.number,
-                "locationTrack" to locationTrack.name,
-                "kmNumbers" to stretchedMeterRanges
-            )
+            "$VALIDATION_GEOCODING.stretched-meters" to
+                localizationParams(
+                    "trackNumber" to trackNumber.number,
+                    "locationTrack" to locationTrack.name,
+                    "kmNumbers" to stretchedMeterRanges)
         },
         validateWithParams(discontinuousAddressRanges.isEmpty()) {
-            "$VALIDATION_GEOCODING.not-continuous" to localizationParams(
-                "trackNumber" to trackNumber.number,
-                "locationTrack" to locationTrack.name,
-                "kmNumbers" to discontinuousAddressRanges
-            )
+            "$VALIDATION_GEOCODING.not-continuous" to
+                localizationParams(
+                    "trackNumber" to trackNumber.number,
+                    "locationTrack" to locationTrack.name,
+                    "kmNumbers" to discontinuousAddressRanges)
         },
     )
 }
 
-fun validateReferenceLineAlignment(alignment: LayoutAlignment) = validateAlignment(VALIDATION_REFERENCE_LINE, alignment)
+fun validateReferenceLineAlignment(alignment: LayoutAlignment) =
+    validateAlignment(VALIDATION_REFERENCE_LINE, alignment)
 
-fun validateLocationTrackAlignment(alignment: LayoutAlignment) = validateAlignment(VALIDATION_LOCATION_TRACK, alignment)
+fun validateLocationTrackAlignment(alignment: LayoutAlignment) =
+    validateAlignment(VALIDATION_LOCATION_TRACK, alignment)
 
-private fun validateAlignment(errorParent: String, alignment: LayoutAlignment) = listOfNotNull(
-    validate(alignment.segments.isNotEmpty()) { "$errorParent.empty-segments" },
-    validate(alignment.getMaxDirectionDeltaRads() <= MAX_LAYOUT_POINT_ANGLE_CHANGE) { "$errorParent.points.not-continuous" },
-)
-
-private fun segmentAndJointLocationsAgree(switch: TrackLayoutSwitch, segmentGroup: List<LayoutSegment>): Boolean =
-    segmentGroup.all { segment -> segmentAndJointLocationsAgree(switch, segment) }
-
-private fun segmentAndJointLocationsAgree(switch: TrackLayoutSwitch, segment: LayoutSegment): Boolean {
-    val jointLocations = listOfNotNull(
-        segment.startJointNumber?.let { jn -> segment.segmentStart to jn },
-        segment.endJointNumber?.let { jn -> segment.segmentEnd to jn },
+private fun validateAlignment(errorParent: String, alignment: LayoutAlignment) =
+    listOfNotNull(
+        validate(alignment.segments.isNotEmpty()) { "$errorParent.empty-segments" },
+        validate(alignment.getMaxDirectionDeltaRads() <= MAX_LAYOUT_POINT_ANGLE_CHANGE) {
+            "$errorParent.points.not-continuous"
+        },
     )
+
+private fun segmentAndJointLocationsAgree(
+    switch: TrackLayoutSwitch,
+    segmentGroup: List<LayoutSegment>
+): Boolean = segmentGroup.all { segment -> segmentAndJointLocationsAgree(switch, segment) }
+
+private fun segmentAndJointLocationsAgree(
+    switch: TrackLayoutSwitch,
+    segment: LayoutSegment
+): Boolean {
+    val jointLocations =
+        listOfNotNull(
+            segment.startJointNumber?.let { jn -> segment.segmentStart to jn },
+            segment.endJointNumber?.let { jn -> segment.segmentEnd to jn },
+        )
     return jointLocations.all { (location, jointNumber) ->
         val joint = switch.getJoint(jointNumber)
         joint != null && joint.location.isSame(location, JOINT_LOCATION_DELTA)
     }
 }
 
-private fun topologyLinkAndJointLocationsAgree(switch: TrackLayoutSwitch, endLinks: List<TopologyEndLink>): Boolean {
+private fun topologyLinkAndJointLocationsAgree(
+    switch: TrackLayoutSwitch,
+    endLinks: List<TopologyEndLink>
+): Boolean {
     return endLinks.all { topologyEndLink ->
         val switchJoint = switch.getJoint(topologyEndLink.topologySwitch.jointNumber)
-        switchJoint != null && switchJoint.location.isSame(topologyEndLink.point, JOINT_LOCATION_DELTA)
+        switchJoint != null &&
+            switchJoint.location.isSame(topologyEndLink.point, JOINT_LOCATION_DELTA)
     }
 }
 
 private fun alignmentJointGroupFound(
     alignmentJoints: List<JointNumber>,
     structureJointGroups: List<List<JointNumber>>,
-) = structureJointGroups.any { structureJoints -> jointGroupMatches(alignmentJoints, structureJoints) }
+) =
+    structureJointGroups.any { structureJoints ->
+        jointGroupMatches(alignmentJoints, structureJoints)
+    }
 
-private fun jointGroupMatches(alignmentJoints: List<JointNumber>, structureJoints: List<JointNumber>): Boolean =
+private fun jointGroupMatches(
+    alignmentJoints: List<JointNumber>,
+    structureJoints: List<JointNumber>
+): Boolean =
     if (!structureJoints.containsAll(alignmentJoints)) false
     else if (alignmentJoints.size <= 1) true
     else {
         val alignmentStartAndEnd = listOf(alignmentJoints.first(), alignmentJoints.last())
         val structureStartAndEnd = listOf(structureJoints.first(), structureJoints.last())
-        alignmentStartAndEnd == structureStartAndEnd || alignmentStartAndEnd == structureStartAndEnd.reversed()
+        alignmentStartAndEnd == structureStartAndEnd ||
+            alignmentStartAndEnd == structureStartAndEnd.reversed()
     }
 
-private fun collectJoints(structure: SwitchStructure) = structure.alignments.flatMap { alignment ->
-    // For RR/KRV/YRV etc. structures partial alignments are also OK (like 1-5 and 5-2)
-    val firstJointNumber = alignment.jointNumbers.first()
-    val lastJointNumber = alignment.jointNumbers.last()
-    val presentationJointIndex =
-        alignment.jointNumbers.indexOfFirst { jointNumber -> jointNumber == structure.presentationJointNumber }
-    val partialAlignments =
-        if (presentationJointIndex != -1 && firstJointNumber != structure.presentationJointNumber && lastJointNumber != structure.presentationJointNumber) {
-            listOf(
-                alignment.jointNumbers.subList(0, presentationJointIndex + 1),
-                alignment.jointNumbers.subList(presentationJointIndex, alignment.jointNumbers.lastIndex + 1)
-            )
-        } else listOf()
+private fun collectJoints(structure: SwitchStructure) =
+    structure.alignments.flatMap { alignment ->
+        // For RR/KRV/YRV etc. structures partial alignments are also OK (like 1-5 and 5-2)
+        val firstJointNumber = alignment.jointNumbers.first()
+        val lastJointNumber = alignment.jointNumbers.last()
+        val presentationJointIndex =
+            alignment.jointNumbers.indexOfFirst { jointNumber ->
+                jointNumber == structure.presentationJointNumber
+            }
+        val partialAlignments =
+            if (presentationJointIndex != -1 &&
+                firstJointNumber != structure.presentationJointNumber &&
+                lastJointNumber != structure.presentationJointNumber) {
+                listOf(
+                    alignment.jointNumbers.subList(0, presentationJointIndex + 1),
+                    alignment.jointNumbers.subList(
+                        presentationJointIndex, alignment.jointNumbers.lastIndex + 1))
+            } else listOf()
 
-    listOf(alignment.jointNumbers) + partialAlignments
-}
+        listOf(alignment.jointNumbers) + partialAlignments
+    }
 
-private fun collectJoints(track: LocationTrack, segments: List<LayoutSegment>): Pair<LocationTrack, List<JointNumber>> =
-    track to collectJoints(segments)
+private fun collectJoints(
+    track: LocationTrack,
+    segments: List<LayoutSegment>
+): Pair<LocationTrack, List<JointNumber>> = track to collectJoints(segments)
 
 private fun collectJoints(segments: List<LayoutSegment>): List<JointNumber> {
-    val allJoints = segments.flatMap { segment -> listOfNotNull(segment.startJointNumber, segment.endJointNumber) }
-    return allJoints.filterIndexed { index, jointNumber -> index == 0 || allJoints[index - 1] != jointNumber }
+    val allJoints =
+        segments.flatMap { segment ->
+            listOfNotNull(segment.startJointNumber, segment.endJointNumber)
+        }
+    return allJoints.filterIndexed { index, jointNumber ->
+        index == 0 || allJoints[index - 1] != jointNumber
+    }
 }
 
-private fun areSegmentsContinuous(segments: List<LayoutSegment>): Boolean = segments.mapIndexed { index, segment ->
-    index == 0 || segments[index - 1].segmentEnd.isSame(segment.segmentStart, LAYOUT_COORDINATE_DELTA)
-}.all { it }
+private fun areSegmentsContinuous(segments: List<LayoutSegment>): Boolean =
+    segments
+        .mapIndexed { index, segment ->
+            index == 0 ||
+                segments[index - 1].segmentEnd.isSame(segment.segmentStart, LAYOUT_COORDINATE_DELTA)
+        }
+        .all { it }
 
 private fun discontinuousDirectionRangeIndices(points: List<AlignmentPoint>) =
-    rangesOfConsecutiveIndicesOf(false, points.zipWithNext(::directionBetweenPoints).zipWithNext(::isAngleDiffOk), 2)
+    rangesOfConsecutiveIndicesOf(
+        false, points.zipWithNext(::directionBetweenPoints).zipWithNext(::isAngleDiffOk), 2)
 
 private fun stretchedMeterRangeIndices(points: List<AlignmentPoint>) =
-    rangesOfConsecutiveIndicesOf(false, points.zipWithNext(::lineLength).map { it <= MAX_LAYOUT_METER_LENGTH }, 1)
+    rangesOfConsecutiveIndicesOf(
+        false, points.zipWithNext(::lineLength).map { it <= MAX_LAYOUT_METER_LENGTH }, 1)
 
 private fun discontinuousAddressRangeIndices(addresses: List<TrackMeter>): List<ClosedRange<Int>> =
     rangesOfConsecutiveIndicesOf(false, addresses.zipWithNext(::isAddressDiffOk), 1)
 
 private fun isAngleDiffOk(direction1: Double?, direction2: Double?) =
-    direction1 == null || direction2 == null || angleDiffRads(direction1, direction2) <= MAX_LAYOUT_POINT_ANGLE_CHANGE
+    direction1 == null ||
+        direction2 == null ||
+        angleDiffRads(direction1, direction2) <= MAX_LAYOUT_POINT_ANGLE_CHANGE
 
 private fun isAddressDiffOk(address1: TrackMeter?, address2: TrackMeter?): Boolean =
     if (address1 == null || address2 == null) true
@@ -879,11 +1078,12 @@ fun validateWithParams(
     valid: Boolean,
     type: LayoutValidationIssueType = ERROR,
     issue: () -> Pair<String, LocalizationParams>,
-): LayoutValidationIssue? = if (!valid) {
-    issue().let { (key, params) -> LayoutValidationIssue(type, LocalizationKey(key), params) }
-} else {
-    null
-}
+): LayoutValidationIssue? =
+    if (!valid) {
+        issue().let { (key, params) -> LayoutValidationIssue(type, LocalizationKey(key), params) }
+    } else {
+        null
+    }
 
 data class TopologyEndLink(
     val topologySwitch: TopologyLocationTrackSwitch,
@@ -893,25 +1093,32 @@ data class TopologyEndLink(
 private fun collectTopologyEndLinks(
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
     switch: TrackLayoutSwitch,
-): List<Pair<LocationTrack, List<TopologyEndLink>>> = locationTracks.map { (track, alignment) ->
-    track to listOfNotNull(
-        track.topologyStartSwitch
-            ?.takeIf { topologySwitch -> topologySwitch.switchId == switch.id }
-            ?.let { topologySwitch -> alignment.start?.let { p -> TopologyEndLink(topologySwitch, p) } },
-        track.topologyEndSwitch
-            ?.takeIf { topologySwitch -> topologySwitch.switchId == switch.id }
-            ?.let { topologySwitch -> alignment.end?.let { p -> TopologyEndLink(topologySwitch, p) }
+): List<Pair<LocationTrack, List<TopologyEndLink>>> =
+    locationTracks
+        .map { (track, alignment) ->
+            track to
+                listOfNotNull(
+                    track.topologyStartSwitch
+                        ?.takeIf { topologySwitch -> topologySwitch.switchId == switch.id }
+                        ?.let { topologySwitch ->
+                            alignment.start?.let { p -> TopologyEndLink(topologySwitch, p) }
+                        },
+                    track.topologyEndSwitch
+                        ?.takeIf { topologySwitch -> topologySwitch.switchId == switch.id }
+                        ?.let { topologySwitch ->
+                            alignment.end?.let { p -> TopologyEndLink(topologySwitch, p) }
+                        })
         }
-    )
-}.filter { (_, ends) -> ends.isNotEmpty() }
+        .filter { (_, ends) -> ends.isNotEmpty() }
 
 fun <T> combineVersions(
     officials: List<LayoutDaoResponse<T>>,
     validations: List<ValidationVersion<T>>,
 ): Collection<LayoutRowVersion<T>> {
-    val officialVersions = officials
-        .filterNot { official -> validations.any { v -> v.officialId == official.id } }
-        .map { official -> official.rowVersion }
+    val officialVersions =
+        officials
+            .filterNot { official -> validations.any { v -> v.officialId == official.id } }
+            .map { official -> official.rowVersion }
     val validationVersions = validations.map { it.validatedAssetVersion }
     return (officialVersions + validationVersions).distinct()
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.module.kotlin.kotlinModule
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.TrackMeter
-import fi.fta.geoviite.infra.integration.RatkoAssetType
 import fi.fta.geoviite.infra.integration.RatkoOperation
 import fi.fta.geoviite.infra.integration.RatkoPushErrorType
 import fi.fta.geoviite.infra.logging.integrationCall
@@ -18,6 +17,7 @@ import fi.fta.geoviite.infra.ratko.model.*
 import fi.fta.geoviite.infra.split.BulkTransfer
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.split.Split
+import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -29,7 +29,6 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
-import java.time.Duration
 
 val defaultBlockTimeout: Duration = defaultResponseTimeout.plusMinutes(1L)
 
@@ -52,7 +51,9 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     private val ratkoJsonMapper =
-        jsonMapper { addModule(kotlinModule { configure(KotlinFeature.NullIsSameAsDefault, true) }) }
+        jsonMapper {
+                addModule(kotlinModule { configure(KotlinFeature.NullIsSameAsDefault, true) })
+            }
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
     data class RatkoStatus(val isOnline: Boolean)
@@ -74,7 +75,8 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             ?.let { response ->
                 ratkoJsonMapper.readTree(response).firstOrNull()?.let { locationTrackJsonNode ->
                     replaceKmM(locationTrackJsonNode.get("nodecollection"))
-                    ratkoJsonMapper.treeToValue(locationTrackJsonNode, RatkoLocationTrack::class.java)
+                    ratkoJsonMapper.treeToValue(
+                        locationTrackJsonNode, RatkoLocationTrack::class.java)
                 }
             }
     }
@@ -87,25 +89,22 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
     fun deleteLocationTrackPoints(locationTrackOid: RatkoOid<RatkoLocationTrack>, km: KmNumber?) {
         logger.integrationCall(
-            "deleteLocationTrackPoints",
-            "locationTrackOid" to locationTrackOid,
-            "km" to km
-        )
+            "deleteLocationTrackPoints", "locationTrackOid" to locationTrackOid, "km" to km)
 
         deletePoints(combinePaths(LOCATION_TRACK_POINTS_PATH, locationTrackOid, km))
     }
 
     fun deleteRouteNumberPoints(routeNumberOid: RatkoOid<RatkoRouteNumber>, km: KmNumber?) {
         logger.integrationCall(
-            "deleteRouteNumberPoints",
-            "routeNumberOid" to routeNumberOid,
-            "km" to km
-        )
+            "deleteRouteNumberPoints", "routeNumberOid" to routeNumberOid, "km" to km)
 
         deletePoints(combinePaths(ROUTE_NUMBER_POINTS_PATH, routeNumberOid, km))
     }
 
-    fun updateRouteNumberPoints(routeNumberOid: RatkoOid<RatkoRouteNumber>, points: List<RatkoPoint>) {
+    fun updateRouteNumberPoints(
+        routeNumberOid: RatkoOid<RatkoRouteNumber>,
+        points: List<RatkoPoint>
+    ) {
         logger.integrationCall(
             "updateRouteNumberPoints",
             "routeNumberOid" to routeNumberOid,
@@ -124,12 +123,14 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         }
     }
 
-    fun createRouteNumberPoints(routeNumberOid: RatkoOid<RatkoRouteNumber>, points: List<RatkoPoint>) {
+    fun createRouteNumberPoints(
+        routeNumberOid: RatkoOid<RatkoRouteNumber>,
+        points: List<RatkoPoint>
+    ) {
         logger.integrationCall(
             "createRouteNumberPoints",
             "routeNumberOid" to routeNumberOid,
-            "points" to "${points.first().kmM}..${points.last().kmM}"
-        )
+            "points" to "${points.first().kmM}..${points.last().kmM}")
 
         points.chunked(1000).mapIndexed { index, chunk ->
             logger.integrationCall(
@@ -146,12 +147,14 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         }
     }
 
-    fun updateLocationTrackPoints(locationTrackOid: RatkoOid<RatkoLocationTrack>, points: List<RatkoPoint>) {
+    fun updateLocationTrackPoints(
+        locationTrackOid: RatkoOid<RatkoLocationTrack>,
+        points: List<RatkoPoint>
+    ) {
         logger.integrationCall(
             "updateLocationTrackPoints",
             "locationTrackOid" to locationTrackOid,
-            "points" to "${points.first().kmM}..${points.last().kmM}"
-        )
+            "points" to "${points.first().kmM}..${points.last().kmM}")
 
         points.chunked(1000).mapIndexed { index, chunk ->
             logger.integrationCall(
@@ -161,16 +164,19 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                 "points" to "${chunk.first().kmM}..${chunk.last().kmM}",
             )
 
-            patchWithoutResponseBody(combinePaths(LOCATION_TRACK_POINTS_PATH, locationTrackOid), chunk)
+            patchWithoutResponseBody(
+                combinePaths(LOCATION_TRACK_POINTS_PATH, locationTrackOid), chunk)
         }
     }
 
-    fun createLocationTrackPoints(locationTrackOid: RatkoOid<RatkoLocationTrack>, points: List<RatkoPoint>) {
+    fun createLocationTrackPoints(
+        locationTrackOid: RatkoOid<RatkoLocationTrack>,
+        points: List<RatkoPoint>
+    ) {
         logger.integrationCall(
             "createLocationTrackPoints",
             "locationTrackOid" to locationTrackOid,
-            "points" to "${points.first().kmM}..${points.last().kmM}"
-        )
+            "points" to "${points.first().kmM}..${points.last().kmM}")
 
         points.chunked(1000).mapIndexed { index, chunk ->
             logger.integrationCall(
@@ -189,9 +195,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
     fun forceRatkoToRedrawLocationTrack(locationTrackOids: Set<RatkoOid<RatkoLocationTrack>>) {
         logger.integrationCall(
-            "updateLocationTrackGeometryMValues",
-            "locationTrackOids" to locationTrackOids
-        )
+            "updateLocationTrackGeometryMValues", "locationTrackOids" to locationTrackOids)
 
         patchSpec(combinePaths(LOCATION_TRACK_PATH, "geom"), locationTrackOids.map { it.id })
             .toBodilessEntity()
@@ -208,24 +212,33 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         logger.integrationCall("newAsset", "asset" to asset)
 
         return postWithResponseBody<String>(ASSET_PATH, asset.withoutGeometries())
-            ?.let { response -> ratkoJsonMapper.readTree(response).firstOrNull()?.get("id")?.textValue() }
+            ?.let { response ->
+                ratkoJsonMapper.readTree(response).firstOrNull()?.get("id")?.textValue()
+            }
             ?.let(::RatkoOid)
     }
 
-    fun <T : RatkoAsset> replaceAssetLocations(assetOid: RatkoOid<T>, locations: List<RatkoAssetLocation>) {
-        logger.integrationCall("replaceAssetLocations", "assetOid" to assetOid, "locations" to locations)
+    fun <T : RatkoAsset> replaceAssetLocations(
+        assetOid: RatkoOid<T>,
+        locations: List<RatkoAssetLocation>
+    ) {
+        logger.integrationCall(
+            "replaceAssetLocations", "assetOid" to assetOid, "locations" to locations)
 
         putWithoutResponseBody(
             combinePaths(ASSET_PATH, assetOid, "locations"),
             locations.map { it.withoutGeometries() },
-            RatkoPushErrorType.LOCATION
-        )
+            RatkoPushErrorType.LOCATION)
     }
 
-    fun <T : RatkoAsset> replaceAssetGeoms(assetOid: RatkoOid<T>, geoms: Collection<RatkoAssetGeometry>) {
+    fun <T : RatkoAsset> replaceAssetGeoms(
+        assetOid: RatkoOid<T>,
+        geoms: Collection<RatkoAssetGeometry>
+    ) {
         logger.integrationCall("replaceAssetGeoms", "assetOid" to assetOid, "geoms" to geoms)
 
-        putWithoutResponseBody(combinePaths(ASSET_PATH, assetOid, "geoms"), geoms, RatkoPushErrorType.GEOMETRY)
+        putWithoutResponseBody(
+            combinePaths(ASSET_PATH, assetOid, "geoms"), geoms, RatkoPushErrorType.GEOMETRY)
     }
 
     fun <T : RatkoAsset> getSwitchAsset(assetOid: RatkoOid<T>): RatkoSwitchAsset? {
@@ -255,7 +268,10 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun <T : RatkoAsset> updateAssetState(assetOid: RatkoOid<T>, state: RatkoAssetState) {
         logger.integrationCall("updateAssetState", "assetOid" to assetOid, "state" to state)
 
-        val responseJson = getSpec(combinePaths(ASSET_PATH, assetOid)).bodyToMono<String>().block(defaultBlockTimeout)
+        val responseJson =
+            getSpec(combinePaths(ASSET_PATH, assetOid))
+                .bodyToMono<String>()
+                .block(defaultBlockTimeout)
 
         val switchJsonObject = ObjectMapper().readTree(responseJson) as ObjectNode
         switchJsonObject.put("state", state.value)
@@ -282,10 +298,12 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             (location.get("nodecollection") as ObjectNode?)?.let { nodeCollection ->
                 replaceKmM(nodeCollection)
 
-                val validJoints = nodeCollection.get("nodes")?.filter { node ->
-                    val point = node.get("point") as ObjectNode?
-                    (point?.get("state") as ObjectNode?)?.get("name")?.textValue() == RatkoPointStates.VALID.state
-                } ?: emptyList()
+                val validJoints =
+                    nodeCollection.get("nodes")?.filter { node ->
+                        val point = node.get("point") as ObjectNode?
+                        (point?.get("state") as ObjectNode?)?.get("name")?.textValue() ==
+                            RatkoPointStates.VALID.state
+                    } ?: emptyList()
 
                 if (validJoints.isNotEmpty()) {
                     val nodes = nodeCollection.putArray("nodes")
@@ -309,16 +327,15 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         putWithoutResponseBody(
             combinePaths(ASSET_PATH, assetOid),
             switchJsonObject.toString(),
-            RatkoPushErrorType.STATE
-        )
+            RatkoPushErrorType.STATE)
     }
 
-    fun <T : RatkoAsset> updateAssetProperties(assetOid: RatkoOid<T>, properties: Collection<RatkoAssetProperty>) {
+    fun <T : RatkoAsset> updateAssetProperties(
+        assetOid: RatkoOid<T>,
+        properties: Collection<RatkoAssetProperty>
+    ) {
         logger.integrationCall(
-            "updateAssetProperties",
-            "assetOid" to assetOid,
-            "properties" to properties
-        )
+            "updateAssetProperties", "assetOid" to assetOid, "properties" to properties)
 
         putWithoutResponseBody(combinePaths(ASSET_PATH, assetOid, "properties"), properties)
     }
@@ -340,7 +357,8 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
         val body = "{\"type\":\"turnout\"}"
 
-        return postWithResponseBody<List<RatkoOid<RatkoSwitchAsset>>>(ASSET_PATH, body)?.firstOrNull()
+        return postWithResponseBody<List<RatkoOid<RatkoSwitchAsset>>>(ASSET_PATH, body)
+            ?.firstOrNull()
     }
 
     fun getRouteNumber(routeNumberOid: RatkoOid<RatkoRouteNumber>): RatkoRouteNumber? {
@@ -368,7 +386,8 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     }
 
     fun forceRatkoToRedrawRouteNumber(routeNumberOids: Set<RatkoOid<RatkoRouteNumber>>) {
-        logger.integrationCall("updateRouteNumberGeometryMValues", "routeNumberOids" to routeNumberOids)
+        logger.integrationCall(
+            "updateRouteNumberGeometryMValues", "routeNumberOids" to routeNumberOids)
 
         patchSpec(combinePaths(ROUTE_NUMBER_PATH, "geom"), routeNumberOids.map { it.id })
             .toBodilessEntity()
@@ -387,17 +406,19 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         var pageNumber = 0
         do {
             logger.info("fetching operating points for page $pageNumber")
-            val body = (postWithResponseBody<String>(
-                "$ASSET_PATH/search?fields=summary", mapOf(
-                    "assetType" to "railway_traffic_operating_point",
-                    "pageNumber" to pageNumber++,
-                    "size" to 100,
-                    "sortOrder" to "ASC",
-                    "secondarySortOrder" to "ASC"
-                )
-            ))
+            val body =
+                (postWithResponseBody<String>(
+                    "$ASSET_PATH/search?fields=summary",
+                    mapOf(
+                        "assetType" to "railway_traffic_operating_point",
+                        "pageNumber" to pageNumber++,
+                        "size" to 100,
+                        "sortOrder" to "ASC",
+                        "secondarySortOrder" to "ASC")))
             val allAssetsInPage =
-                ratkoJsonMapper.readValue(body, RatkoOperatingPointAssetsResponse::class.java)?.assets ?: listOf()
+                ratkoJsonMapper
+                    .readValue(body, RatkoOperatingPointAssetsResponse::class.java)
+                    ?.assets ?: listOf()
             val validOperatingPointsInPage = allAssetsInPage.mapNotNull(::parseAsset)
             allPoints.addAll(validOperatingPointsInPage)
         } while (allAssetsInPage.size == 100)
@@ -407,17 +428,17 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun startNewBulkTransfer(split: Split): Pair<IntId<BulkTransfer>, BulkTransferState> {
         logger.integrationCall("startNewBulkTransfer", "splitId" to split.id)
 
-        val body = postWithResponseBody<String>(
-            url = "$BULK_TRANSFER_PATH/start",
-            content = mapOf(
-                "this-is-something-that-should-be-defined" to "in-the-future",
-            )
-        )
+        val body =
+            postWithResponseBody<String>(
+                url = "$BULK_TRANSFER_PATH/start",
+                content =
+                    mapOf(
+                        "this-is-something-that-should-be-defined" to "in-the-future",
+                    ))
 
-        val bulkTransferId = ratkoJsonMapper.readValue(body, RatkoBulkTransferResponse::class.java)?.id
-        checkNotNull(bulkTransferId) {
-            "Received bulk transfer id was null"
-        }
+        val bulkTransferId =
+            ratkoJsonMapper.readValue(body, RatkoBulkTransferResponse::class.java)?.id
+        checkNotNull(bulkTransferId) { "Received bulk transfer id was null" }
 
         // The state may also be received from the api regarding how it is created in Ratko's end.
         return bulkTransferId to BulkTransferState.IN_PROGRESS
@@ -426,18 +447,22 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun pollBulkTransferState(bulkTransferId: IntId<BulkTransfer>): BulkTransferState {
         logger.integrationCall("pollBulkTransferState", "bulkTransferId" to bulkTransferId)
 
-        return getSpec(url = "$BULK_TRANSFER_PATH/$bulkTransferId/state") // Should be changed when the URL is known
+        return getSpec(
+                url =
+                    "$BULK_TRANSFER_PATH/$bulkTransferId/state") // Should be changed when the URL
+                                                                 // is known
             .bodyToMono<String>()
             .block(defaultBlockTimeout)
             .let { response ->
-                val bulkTransferState = ratkoJsonMapper.readValue(
-                    response,
-                    RatkoBulkTransferResponse::class.java,
-                )?.state
+                val bulkTransferState =
+                    ratkoJsonMapper
+                        .readValue(
+                            response,
+                            RatkoBulkTransferResponse::class.java,
+                        )
+                        ?.state
 
-                checkNotNull(bulkTransferState) {
-                    "Received bulk transfer id was null!"
-                }
+                checkNotNull(bulkTransferState) { "Received bulk transfer id was null!" }
 
                 bulkTransferState
             }
@@ -484,15 +509,16 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         deleteSpec(url)
             .toBodilessEntity()
             .onErrorResume(WebClientResponseException::class.java) {
-                if (HttpStatus.NOT_FOUND == it.statusCode || HttpStatus.BAD_REQUEST == it.statusCode) Mono.empty()
-                else Mono.error(
-                    RatkoPushException(
-                        RatkoPushErrorType.GEOMETRY,
-                        RatkoOperation.DELETE,
-                        it.responseBodyAsString,
-                        it
-                    )
-                )
+                if (HttpStatus.NOT_FOUND == it.statusCode ||
+                    HttpStatus.BAD_REQUEST == it.statusCode)
+                    Mono.empty()
+                else
+                    Mono.error(
+                        RatkoPushException(
+                            RatkoPushErrorType.GEOMETRY,
+                            RatkoOperation.DELETE,
+                            it.responseBodyAsString,
+                            it))
             }
             .block(defaultBlockTimeout)
     }
@@ -506,26 +532,32 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         client.post().uri(url).contentType(MediaType.APPLICATION_JSON).bodyValue(content).retrieve()
 
     private fun patchSpec(url: String, content: Any) =
-        client.patch().uri(url).contentType(MediaType.APPLICATION_JSON).bodyValue(content).retrieve()
+        client
+            .patch()
+            .uri(url)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(content)
+            .retrieve()
 
     private fun getSpec(url: String) = client.get().uri(url).retrieve()
 
     private fun WebClient.ResponseSpec.defaultErrorHandler(
         errorType: RatkoPushErrorType,
         operation: RatkoOperation
-    ) = onStatus(
-        { !it.is2xxSuccessful },
-        { response ->
-            response.bodyToMono<String>().switchIfEmpty(Mono.just("")).flatMap { body ->
-                logger.error("Error during Ratko push! HTTP Status code: ${response.statusCode()}, body: $body")
-                Mono.error(RatkoPushException(errorType, operation, body))
-            }
-        }
-    )
+    ) =
+        onStatus(
+            { !it.is2xxSuccessful },
+            { response ->
+                response.bodyToMono<String>().switchIfEmpty(Mono.just("")).flatMap { body ->
+                    logger.error(
+                        "Error during Ratko push! HTTP Status code: ${response.statusCode()}, body: $body")
+                    Mono.error(RatkoPushException(errorType, operation, body))
+                }
+            })
 }
 
 fun combinePaths(vararg paths: Any?) =
     paths
-        .mapNotNull { it?.toString() } //otherwise null will toString() to "null"
+        .mapNotNull { it?.toString() } // otherwise null will toString() to "null"
         .joinToString("/")
         .replace(Regex("/+"), "/")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientConfiguration.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.logging.integrationCall
+import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,17 +17,16 @@ import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClient
-import java.time.Duration
 
 val defaultResponseTimeout: Duration = Duration.ofMinutes(5L)
 
-class RatkoWebClient(
-    val client: WebClient
-) : WebClient by client
+class RatkoWebClient(val client: WebClient) : WebClient by client
 
 @Configuration
 @ConditionalOnProperty(prefix = "geoviite.ratko", name = ["enabled"], havingValue = "true")
-class RatkoClientConfiguration @Autowired constructor(
+class RatkoClientConfiguration
+@Autowired
+constructor(
     @Value("\${geoviite.ratko.url:}") private val ratkoBaseUrl: String,
     @Value("\${geoviite.ratko.username:}") private val basicAuthUsername: String,
     @Value("\${geoviite.ratko.password:}") private val basicAuthPassword: String,
@@ -39,16 +39,19 @@ class RatkoClientConfiguration @Autowired constructor(
     fun webClient(): RatkoWebClient {
         val httpClient = HttpClient.create().responseTimeout(defaultResponseTimeout)
 
-        val webClientBuilder = WebClient.builder()
-            .clientConnector(ReactorClientHttpConnector(httpClient))
-            .baseUrl(ratkoBaseUrl)
-            .filter(logRequest())
-            .filter(logResponse())
-            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .codecs { it.defaultCodecs().maxInMemorySize(10 * 1024 * 1024) }
+        val webClientBuilder =
+            WebClient.builder()
+                .clientConnector(ReactorClientHttpConnector(httpClient))
+                .baseUrl(ratkoBaseUrl)
+                .filter(logRequest())
+                .filter(logResponse())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .codecs { it.defaultCodecs().maxInMemorySize(10 * 1024 * 1024) }
 
         if (basicAuthUsername.isNotBlank() && basicAuthPassword.isNotBlank()) {
-            webClientBuilder.defaultHeaders { header -> header.setBasicAuth(basicAuthUsername, basicAuthPassword) }
+            webClientBuilder.defaultHeaders { header ->
+                header.setBasicAuth(basicAuthUsername, basicAuthPassword)
+            }
         }
 
         return RatkoWebClient(webClientBuilder.build())

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
@@ -49,7 +49,9 @@ class RatkoController(
 
     @PreAuthorize(AUTH_VIEW_LAYOUT)
     @PostMapping("/push-location-tracks")
-    fun pushLocationTracksToRatko(@RequestBody changes: List<LocationTrackChange>): ResponseEntity<String> {
+    fun pushLocationTracksToRatko(
+        @RequestBody changes: List<LocationTrackChange>
+    ): ResponseEntity<String> {
         ratkoService.pushLocationTracksToRatko(LayoutBranch.main, changes)
         return ResponseEntity(HttpStatus.OK)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -23,7 +23,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
 
 @GeoviiteService
-class RatkoLocalService @Autowired constructor(
+class RatkoLocalService
+@Autowired
+constructor(
     private val ratkoClient: RatkoClient?,
     private val ratkoPushDao: RatkoPushDao,
     private val ratkoOperatingPointDao: RatkoOperatingPointDao,
@@ -39,12 +41,23 @@ class RatkoLocalService @Autowired constructor(
 
     fun getRatkoPushError(publicationId: IntId<Publication>): RatkoPushErrorWithAsset? {
         return ratkoPushDao.getLatestRatkoPushErrorFor(publicationId)?.let { ratkoError ->
-            val asset = when (ratkoError.assetType) {
-                TRACK_NUMBER -> trackNumberService.get(MainLayoutContext.official, ratkoError.assetId as IntId<TrackLayoutTrackNumber>)
-                LOCATION_TRACK -> locationTrackService.get(MainLayoutContext.official, ratkoError.assetId as IntId<LocationTrack>)
-                SWITCH -> switchService.get(MainLayoutContext.official, ratkoError.assetId as IntId<TrackLayoutSwitch>)
+            val asset =
+                when (ratkoError.assetType) {
+                    TRACK_NUMBER ->
+                        trackNumberService.get(
+                            MainLayoutContext.official,
+                            ratkoError.assetId as IntId<TrackLayoutTrackNumber>)
+                    LOCATION_TRACK ->
+                        locationTrackService.get(
+                            MainLayoutContext.official, ratkoError.assetId as IntId<LocationTrack>)
+                    SWITCH ->
+                        switchService.get(
+                            MainLayoutContext.official,
+                            ratkoError.assetId as IntId<TrackLayoutSwitch>)
+                }
+            checkNotNull(asset) {
+                "No asset found for id! ${ratkoError.assetType} ${ratkoError.assetId}"
             }
-            checkNotNull(asset) { "No asset found for id! ${ratkoError.assetType} ${ratkoError.assetId}" }
 
             RatkoPushErrorWithAsset(
                 ratkoError.id,
@@ -52,8 +65,7 @@ class RatkoLocalService @Autowired constructor(
                 ratkoError.errorType,
                 ratkoError.operation,
                 ratkoError.assetType,
-                asset
-            )
+                asset)
         }
     }
 
@@ -61,7 +73,10 @@ class RatkoLocalService @Autowired constructor(
         return ratkoOperatingPointDao.getOperatingPoints(bbox)
     }
 
-    fun searchOperatingPoints(searchTerm: FreeText, resultLimit: Int = 10): List<RatkoOperatingPoint> {
+    fun searchOperatingPoints(
+        searchTerm: FreeText,
+        resultLimit: Int = 10
+    ): List<RatkoOperatingPoint> {
         return ratkoOperatingPointDao.searchOperatingPoints(searchTerm, resultLimit)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -26,13 +26,15 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import java.time.Instant
 
 @GeoviiteService
 @ConditionalOnBean(RatkoClientConfiguration::class)
-class RatkoLocationTrackService @Autowired constructor(
+class RatkoLocationTrackService
+@Autowired
+constructor(
     private val ratkoClient: RatkoClient,
     private val locationTrackService: LocationTrackService,
     private val locationTrackDao: LocationTrackDao,
@@ -46,42 +48,47 @@ class RatkoLocationTrackService @Autowired constructor(
         publishedLocationTracks: Collection<PublishedLocationTrack>,
         publicationTime: Instant,
     ): List<Oid<LocationTrack>> {
-        return publishedLocationTracks.groupBy { it.id }.map { (_, locationTracks) ->
-            val newestVersion = locationTracks.maxBy { it.version.version }.version
-            locationTrackDao.fetch(newestVersion) to locationTracks.flatMap { it.changedKmNumbers }.toSet()
-        }.sortedWith(
-            compareBy(
-                { sortByNullDuplicateOfFirst(it.first.duplicateOf) },
-                { sortByDeletedStateFirst(it.first.state) },
-            )
-        ).map { (layoutLocationTrack, changedKmNumbers) ->
-            val externalId = requireNotNull(layoutLocationTrack.externalId) {
-                "OID required for location track, lt=${layoutLocationTrack.id}"
+        return publishedLocationTracks
+            .groupBy { it.id }
+            .map { (_, locationTracks) ->
+                val newestVersion = locationTracks.maxBy { it.version.version }.version
+                locationTrackDao.fetch(newestVersion) to
+                    locationTracks.flatMap { it.changedKmNumbers }.toSet()
             }
-            try {
-                ratkoClient.getLocationTrack(RatkoOid(externalId))?.let { existingLocationTrack ->
-                    if (layoutLocationTrack.state == LocationTrackState.DELETED) {
-                        deleteLocationTrack(
-                            branch = branch,
-                            layoutLocationTrack = layoutLocationTrack,
-                            existingRatkoLocationTrack = existingLocationTrack,
-                            moment = publicationTime,
-                        )
-                    } else {
-                        updateLocationTrack(
-                            branch = branch,
-                            layoutLocationTrack = layoutLocationTrack,
-                            existingRatkoLocationTrack = existingLocationTrack,
-                            changedKmNumbers = changedKmNumbers,
-                            moment = publicationTime
-                        )
+            .sortedWith(
+                compareBy(
+                    { sortByNullDuplicateOfFirst(it.first.duplicateOf) },
+                    { sortByDeletedStateFirst(it.first.state) },
+                ))
+            .map { (layoutLocationTrack, changedKmNumbers) ->
+                val externalId =
+                    requireNotNull(layoutLocationTrack.externalId) {
+                        "OID required for location track, lt=${layoutLocationTrack.id}"
                     }
-                } ?: createLocationTrack(branch, layoutLocationTrack, publicationTime)
-            } catch (ex: RatkoPushException) {
-                throw RatkoLocationTrackPushException(ex, layoutLocationTrack)
+                try {
+                    ratkoClient.getLocationTrack(RatkoOid(externalId))?.let { existingLocationTrack
+                        ->
+                        if (layoutLocationTrack.state == LocationTrackState.DELETED) {
+                            deleteLocationTrack(
+                                branch = branch,
+                                layoutLocationTrack = layoutLocationTrack,
+                                existingRatkoLocationTrack = existingLocationTrack,
+                                moment = publicationTime,
+                            )
+                        } else {
+                            updateLocationTrack(
+                                branch = branch,
+                                layoutLocationTrack = layoutLocationTrack,
+                                existingRatkoLocationTrack = existingLocationTrack,
+                                changedKmNumbers = changedKmNumbers,
+                                moment = publicationTime)
+                        }
+                    } ?: createLocationTrack(branch, layoutLocationTrack, publicationTime)
+                } catch (ex: RatkoPushException) {
+                    throw RatkoLocationTrackPushException(ex, layoutLocationTrack)
+                }
+                externalId
             }
-            externalId
-        }
     }
 
     private fun getTrackNumberOid(
@@ -89,7 +96,8 @@ class RatkoLocationTrackService @Autowired constructor(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         moment: Instant,
     ): Oid<TrackLayoutTrackNumber> {
-        return trackNumberDao.fetchOfficialVersionAtMomentOrThrow(branch, trackNumberId, moment)
+        return trackNumberDao
+            .fetchOfficialVersionAtMomentOrThrow(branch, trackNumberId, moment)
             .let { version -> trackNumberDao.fetch(version) }
             .let { layoutTrackNumber ->
                 checkNotNull(layoutTrackNumber.externalId) {
@@ -103,7 +111,8 @@ class RatkoLocationTrackService @Autowired constructor(
         locationTrackId: IntId<LocationTrack>,
         moment: Instant,
     ): Oid<LocationTrack>? {
-        return locationTrackDao.fetchOfficialVersionAtMomentOrThrow(branch, locationTrackId, moment)
+        return locationTrackDao
+            .fetchOfficialVersionAtMomentOrThrow(branch, locationTrackId, moment)
             .let { version -> locationTrackDao.fetch(version).externalId }
     }
 
@@ -113,45 +122,59 @@ class RatkoLocationTrackService @Autowired constructor(
         }
     }
 
-    private fun createLocationTrack(branch: LayoutBranch, layoutLocationTrack: LocationTrack, moment: Instant) {
+    private fun createLocationTrack(
+        branch: LayoutBranch,
+        layoutLocationTrack: LocationTrack,
+        moment: Instant
+    ) {
         val (addresses, jointPoints) = getLocationTrackPoints(branch, layoutLocationTrack, moment)
 
         val ratkoNodes = convertToRatkoNodeCollection(addresses)
         val trackNumberOid = getTrackNumberOid(branch, layoutLocationTrack.trackNumberId, moment)
 
-        val duplicateOfOidLocationTrack = layoutLocationTrack.duplicateOf?.let { duplicateId ->
-            getExternalId(branch, duplicateId, moment)
-        }
+        val duplicateOfOidLocationTrack =
+            layoutLocationTrack.duplicateOf?.let { duplicateId ->
+                getExternalId(branch, duplicateId, moment)
+            }
 
-        val ratkoLocationTrack = convertToRatkoLocationTrack(locationTrack = layoutLocationTrack,
-            trackNumberOid = trackNumberOid,
-            nodeCollection = ratkoNodes,
-            duplicateOfOid = duplicateOfOidLocationTrack,
-            descriptionGetter = { locationTrack ->
-                locationTrackService.getFullDescription(branch.official, locationTrack, LocalizationLanguage.FI).toString()
-            })
+        val ratkoLocationTrack =
+            convertToRatkoLocationTrack(
+                locationTrack = layoutLocationTrack,
+                trackNumberOid = trackNumberOid,
+                nodeCollection = ratkoNodes,
+                duplicateOfOid = duplicateOfOidLocationTrack,
+                descriptionGetter = { locationTrack ->
+                    locationTrackService
+                        .getFullDescription(branch.official, locationTrack, LocalizationLanguage.FI)
+                        .toString()
+                })
         val locationTrackOid = ratkoClient.newLocationTrack(ratkoLocationTrack)
         checkNotNull(locationTrackOid) {
             "Did not receive oid from Ratko for location track $ratkoLocationTrack"
         }
 
-        val switchPoints = jointPoints.filterNot { jp ->
-            jp.address == addresses.startPoint.address || jp.address == addresses.endPoint.address
-        }
+        val switchPoints =
+            jointPoints.filterNot { jp ->
+                jp.address == addresses.startPoint.address ||
+                    jp.address == addresses.endPoint.address
+            }
 
         val midPoints = (addresses.midPoints + switchPoints).sortedBy { p -> p.address }
         createLocationTrackPoints(locationTrackOid, midPoints)
-        val layoutLocationTrackWithOid = layoutLocationTrack.copy(externalId = Oid(locationTrackOid.id))
+        val layoutLocationTrackWithOid =
+            layoutLocationTrack.copy(externalId = Oid(locationTrackOid.id))
         val allPoints = listOf(addresses.startPoint) + midPoints + listOf(addresses.endPoint)
-        createLocationTrackMetadata(branch, layoutLocationTrackWithOid, allPoints, trackNumberOid, moment)
+        createLocationTrackMetadata(
+            branch, layoutLocationTrackWithOid, allPoints, trackNumberOid, moment)
     }
 
     private fun createLocationTrackPoints(
         locationTrackOid: RatkoOid<RatkoLocationTrack>,
         addressPoints: Collection<AddressPoint>,
-    ) = toRatkoPointsGroupedByKm(addressPoints).forEach { points ->
-        ratkoClient.createLocationTrackPoints(locationTrackOid, points)
-    }
+    ) =
+        toRatkoPointsGroupedByKm(addressPoints).forEach { points ->
+            ratkoClient.createLocationTrackPoints(locationTrackOid, points)
+        }
 
     private fun createLocationTrackMetadata(
         branch: LayoutBranch,
@@ -165,13 +188,18 @@ class RatkoLocationTrackService @Autowired constructor(
             "Cannot update location track metadata without location track oid, id=${layoutLocationTrack.id}"
         }
 
-        val geocodingContext = geocodingService.getGeocodingContextAtMoment(branch, layoutLocationTrack.trackNumberId, moment)
+        val geocodingContext =
+            geocodingService.getGeocodingContextAtMoment(
+                branch, layoutLocationTrack.trackNumberId, moment)
 
-        alignmentDao.fetchMetadata(layoutLocationTrack.getAlignmentVersionOrThrow())
+        alignmentDao
+            .fetchMetadata(layoutLocationTrack.getAlignmentVersionOrThrow())
             .fold(mutableListOf<LayoutSegmentMetadata>()) { acc, metadata ->
                 val previousMetadata = acc.lastOrNull()
 
-                if (previousMetadata == null || previousMetadata.isEmpty() || !previousMetadata.hasSameMetadata(metadata)) {
+                if (previousMetadata == null ||
+                    previousMetadata.isEmpty() ||
+                    !previousMetadata.hasSameMetadata(metadata)) {
                     acc.add(metadata)
                 } else {
                     acc[acc.lastIndex] = previousMetadata.copy(endPoint = metadata.endPoint)
@@ -185,36 +213,44 @@ class RatkoLocationTrackService @Autowired constructor(
 
                 if (startTrackMeter != null && endTrackMeter != null) {
                     val origMetaDataRange = startTrackMeter..endTrackMeter
-                    val splitAddressRanges = if (changedKmNumbers == null) listOf(origMetaDataRange)
-                    else geocodingContext.cutRangeByKms(origMetaDataRange, changedKmNumbers)
+                    val splitAddressRanges =
+                        if (changedKmNumbers == null) listOf(origMetaDataRange)
+                        else geocodingContext.cutRangeByKms(origMetaDataRange, changedKmNumbers)
 
-                    val splitMetaDataAssets = splitAddressRanges.mapNotNull { addressRange ->
-                        val startPoint = findAddressPoint(
-                            points = alignmentPoints,
-                            seek = addressRange.start,
-                            rounding = AddressRounding.UP,
-                        )
+                    val splitMetaDataAssets =
+                        splitAddressRanges.mapNotNull { addressRange ->
+                            val startPoint =
+                                findAddressPoint(
+                                    points = alignmentPoints,
+                                    seek = addressRange.start,
+                                    rounding = AddressRounding.UP,
+                                )
 
-                        val endPoint = findAddressPoint(
-                            points = alignmentPoints,
-                            seek = addressRange.endInclusive,
-                            rounding = AddressRounding.DOWN,
-                        )
+                            val endPoint =
+                                findAddressPoint(
+                                    points = alignmentPoints,
+                                    seek = addressRange.endInclusive,
+                                    rounding = AddressRounding.DOWN,
+                                )
 
-                        val splitMetaData = metadata.copy(
-                            startPoint = startPoint.point.toPoint(),
-                            endPoint = endPoint.point.toPoint(),
-                        )
+                            val splitMetaData =
+                                metadata.copy(
+                                    startPoint = startPoint.point.toPoint(),
+                                    endPoint = endPoint.point.toPoint(),
+                                )
 
-                        // Ignore metadata where the address range is under 1m, since there are no address points for it
-                        if (startPoint.address + 1 <= endPoint.address) convertToRatkoMetadataAsset(
-                            trackNumberOid = trackNumberOid,
-                            locationTrackOid = layoutLocationTrack.externalId,
-                            segmentMetadata = splitMetaData,
-                            startTrackMeter = startPoint.address,
-                            endTrackMeter = endPoint.address,
-                        ) else null
-                    }
+                            // Ignore metadata where the address range is under 1m, since there are
+                            // no address points for it
+                            if (startPoint.address + 1 <= endPoint.address)
+                                convertToRatkoMetadataAsset(
+                                    trackNumberOid = trackNumberOid,
+                                    locationTrackOid = layoutLocationTrack.externalId,
+                                    segmentMetadata = splitMetaData,
+                                    startTrackMeter = startPoint.address,
+                                    endTrackMeter = endPoint.address,
+                                )
+                            else null
+                        }
 
                     splitMetaDataAssets.forEach { metadataAsset ->
                         ratkoClient.newAsset<RatkoMetadataAsset>(metadataAsset)
@@ -223,16 +259,20 @@ class RatkoLocationTrackService @Autowired constructor(
             }
     }
 
-    private enum class AddressRounding { UP, DOWN }
+    private enum class AddressRounding {
+        UP,
+        DOWN
+    }
 
     private fun findAddressPoint(
         points: List<AddressPoint>,
         seek: TrackMeter,
         rounding: AddressRounding,
-    ): AddressPoint = when (rounding) {
-        AddressRounding.UP -> points.find { p -> p.address >= seek }
-        AddressRounding.DOWN -> points.findLast { p -> p.address <= seek }
-    } ?: error("No address point found: seek=$seek rounding=$rounding")
+    ): AddressPoint =
+        when (rounding) {
+            AddressRounding.UP -> points.find { p -> p.address >= seek }
+            AddressRounding.DOWN -> points.findLast { p -> p.address <= seek }
+        } ?: error("No address point found: seek=$seek rounding=$rounding")
 
     private fun deleteLocationTrack(
         branch: LayoutBranch,
@@ -245,7 +285,8 @@ class RatkoLocationTrackService @Autowired constructor(
         }
 
         val deletedEndsPoints =
-            existingRatkoLocationTrack.nodecollection?.let(::toNodeCollectionMarkingEndpointsNotInUse)
+            existingRatkoLocationTrack.nodecollection?.let(
+                ::toNodeCollectionMarkingEndpointsNotInUse)
 
         updateLocationTrackProperties(
             branch = branch,
@@ -275,22 +316,27 @@ class RatkoLocationTrackService @Autowired constructor(
         val existingStartNode = existingRatkoLocationTrack.nodecollection?.getStartNode()
         val existingEndNode = existingRatkoLocationTrack.nodecollection?.getEndNode()
 
-        val updatedEndPointNodeCollection = getEndPointNodeCollection(
-            alignmentAddresses = addresses,
-            changedKmNumbers = changedKmNumbers,
-            existingStartNode = existingStartNode,
-            existingEndNode = existingEndNode,
-        )
+        val updatedEndPointNodeCollection =
+            getEndPointNodeCollection(
+                alignmentAddresses = addresses,
+                changedKmNumbers = changedKmNumbers,
+                existingStartNode = existingStartNode,
+                existingEndNode = existingEndNode,
+            )
 
-        val switchPoints = jointPoints.filterNot { jp ->
-            jp.address == addresses.startPoint.address || jp.address == addresses.endPoint.address
-        }
+        val switchPoints =
+            jointPoints.filterNot { jp ->
+                jp.address == addresses.startPoint.address ||
+                    jp.address == addresses.endPoint.address
+            }
 
         val changedMidPoints =
-            (addresses.midPoints + switchPoints).filter { p -> changedKmNumbers.contains(p.address.kmNumber) }
+            (addresses.midPoints + switchPoints)
+                .filter { p -> changedKmNumbers.contains(p.address.kmNumber) }
                 .sortedBy { p -> p.address }
 
-        // Update location track end points before deleting anything, otherwise old end points will stay in use
+        // Update location track end points before deleting anything, otherwise old end points will
+        // stay in use
         updateLocationTrackProperties(
             branch = branch,
             layoutLocationTrack = layoutLocationTrack,
@@ -308,7 +354,8 @@ class RatkoLocationTrackService @Autowired constructor(
         createLocationTrackMetadata(
             branch = branch,
             layoutLocationTrack = layoutLocationTrack,
-            alignmentPoints = listOf(addresses.startPoint) + changedMidPoints + listOf(addresses.endPoint),
+            alignmentPoints =
+                listOf(addresses.startPoint) + changedMidPoints + listOf(addresses.endPoint),
             trackNumberOid = trackNumberOid,
             moment = moment,
             changedKmNumbers = changedKmNumbers,
@@ -327,9 +374,10 @@ class RatkoLocationTrackService @Autowired constructor(
     private fun updateLocationTrackGeometry(
         locationTrackOid: RatkoOid<RatkoLocationTrack>,
         newPoints: Collection<AddressPoint>,
-    ) = toRatkoPointsGroupedByKm(newPoints).forEach { points ->
-        ratkoClient.updateLocationTrackPoints(locationTrackOid, points)
-    }
+    ) =
+        toRatkoPointsGroupedByKm(newPoints).forEach { points ->
+            ratkoClient.updateLocationTrackPoints(locationTrackOid, points)
+        }
 
     private fun updateLocationTrackProperties(
         branch: LayoutBranch,
@@ -338,17 +386,22 @@ class RatkoLocationTrackService @Autowired constructor(
         changedNodeCollection: RatkoNodes? = null,
     ) {
         val trackNumberOid = getTrackNumberOid(branch, layoutLocationTrack.trackNumberId, moment)
-        val duplicateOfOidLocationTrack = layoutLocationTrack.duplicateOf?.let { duplicateId ->
-            getExternalId(branch, duplicateId, moment)
-        }
+        val duplicateOfOidLocationTrack =
+            layoutLocationTrack.duplicateOf?.let { duplicateId ->
+                getExternalId(branch, duplicateId, moment)
+            }
 
-        val ratkoLocationTrack = convertToRatkoLocationTrack(locationTrack = layoutLocationTrack,
-            trackNumberOid = trackNumberOid,
-            nodeCollection = changedNodeCollection,
-            duplicateOfOid = duplicateOfOidLocationTrack,
-            descriptionGetter = { locationTrack ->
-                locationTrackService.getFullDescription(branch.official, locationTrack, LocalizationLanguage.FI).toString()
-            })
+        val ratkoLocationTrack =
+            convertToRatkoLocationTrack(
+                locationTrack = layoutLocationTrack,
+                trackNumberOid = trackNumberOid,
+                nodeCollection = changedNodeCollection,
+                duplicateOfOid = duplicateOfOidLocationTrack,
+                descriptionGetter = { locationTrack ->
+                    locationTrackService
+                        .getFullDescription(branch.official, locationTrack, LocalizationLanguage.FI)
+                        .toString()
+                })
 
         ratkoClient.updateLocationTrackProperties(ratkoLocationTrack)
     }
@@ -358,20 +411,24 @@ class RatkoLocationTrackService @Autowired constructor(
         locationTrack: LocationTrack,
         moment: Instant,
     ): Pair<AlignmentAddresses, List<AddressPoint>> {
-        val geocodingContext = geocodingService.getGeocodingContextCacheKey(
-            branch,
-            locationTrack.trackNumberId,
-            moment,
-        )?.let(geocodingService::getGeocodingContext)
+        val geocodingContext =
+            geocodingService
+                .getGeocodingContextCacheKey(
+                    branch,
+                    locationTrack.trackNumberId,
+                    moment,
+                )
+                ?.let(geocodingService::getGeocodingContext)
 
         checkNotNull(geocodingContext) {
             "Missing geocoding context, trackNumberId=${locationTrack.trackNumberId} moment=$moment"
         }
 
         val alignment = alignmentDao.fetch(locationTrack.getAlignmentVersionOrThrow())
-        val addresses = checkNotNull(geocodingContext.getAddressPoints(alignment)) {
-            "Cannot calculate addresses for location track, id=${locationTrack.id}"
-        }
+        val addresses =
+            checkNotNull(geocodingContext.getAddressPoints(alignment)) {
+                "Cannot calculate addresses for location track, id=${locationTrack.id}"
+            }
 
         return addresses to geocodingContext.getSwitchPoints(alignment)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointDao.kt
@@ -5,12 +5,12 @@ import fi.fta.geoviite.infra.ratko.model.RatkoOperatingPoint
 import fi.fta.geoviite.infra.ratko.model.RatkoOperatingPointParse
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.util.*
+import java.sql.ResultSet
+import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
-import java.time.Instant
 
 fun toRatkoOperatingPoint(rs: ResultSet): RatkoOperatingPoint {
     return RatkoOperatingPoint(
@@ -26,7 +26,8 @@ fun toRatkoOperatingPoint(rs: ResultSet): RatkoOperatingPoint {
 
 @Service
 @Component
-class RatkoOperatingPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTemplateParam) {
+class RatkoOperatingPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
+    DaoBase(jdbcTemplateParam) {
     @Transactional
     fun updateOperatingPoints(newPoints: List<RatkoOperatingPointParse>) {
         logger.info("Writing ${newPoints.size} operating points")
@@ -37,16 +38,22 @@ class RatkoOperatingPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : D
     }
 
     private fun deleteRemovedPoints(newPoints: List<RatkoOperatingPointParse>) {
-        val oldPointsIds = jdbcTemplate.query("""select external_id from layout.operating_point""") { rs, _ ->
-            rs.getOid<RatkoOperatingPoint>("external_id")
-        }
+        val oldPointsIds =
+            jdbcTemplate.query("""select external_id from layout.operating_point""") { rs, _ ->
+                rs.getOid<RatkoOperatingPoint>("external_id")
+            }
         val newPointsIds = newPoints.map { point -> point.externalId }.toSet()
-        jdbcTemplate.batchUpdate("""delete from layout.operating_point where external_id = :id""",
-            oldPointsIds.filter { id -> !newPointsIds.contains(id) }.map { id -> mapOf("id" to id.toString()) }.toTypedArray())
+        jdbcTemplate.batchUpdate(
+            """delete from layout.operating_point where external_id = :id""",
+            oldPointsIds
+                .filter { id -> !newPointsIds.contains(id) }
+                .map { id -> mapOf("id" to id.toString()) }
+                .toTypedArray())
     }
 
     private fun upsertPoints(newPoints: List<RatkoOperatingPointParse>) {
-        val sql = """
+        val sql =
+            """
                 insert into layout.operating_point
                   (external_id, name, abbreviation, uic_code, type, location, track_number_id)
                   (select
@@ -74,30 +81,36 @@ class RatkoOperatingPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : D
                     or operating_point.type != excluded.type
                     or not postgis.st_equals(operating_point.location, excluded.location)
                     or operating_point.track_number_id != excluded.track_number_id
-                """.trimIndent()
+                """
+                .trimIndent()
 
-        jdbcTemplate.batchUpdate(sql, newPoints.map { point ->
-            mapOf(
-                "externalId" to point.externalId.toString(),
-                "name" to point.name,
-                "abbreviation" to point.abbreviation,
-                "uicCode" to point.uicCode,
-                "type" to point.type.name,
-                "x" to point.location.x,
-                "y" to point.location.y,
-                "srid" to LAYOUT_SRID.code,
-                "trackNumberExternalId" to point.trackNumberExternalId.toString(),
-            )
-        }.toTypedArray())
+        jdbcTemplate.batchUpdate(
+            sql,
+            newPoints
+                .map { point ->
+                    mapOf(
+                        "externalId" to point.externalId.toString(),
+                        "name" to point.name,
+                        "abbreviation" to point.abbreviation,
+                        "uicCode" to point.uicCode,
+                        "type" to point.type.name,
+                        "x" to point.location.x,
+                        "y" to point.location.y,
+                        "srid" to LAYOUT_SRID.code,
+                        "trackNumberExternalId" to point.trackNumberExternalId.toString(),
+                    )
+                }
+                .toTypedArray())
     }
 
     fun getChangeTime(): Instant {
         return fetchLatestChangeTime(DbTable.OPERATING_POINT)
     }
 
-    @Transactional(readOnly=true)
+    @Transactional(readOnly = true)
     fun getOperatingPoints(bbox: BoundingBox): List<RatkoOperatingPoint> {
-        val sql = """
+        val sql =
+            """
             select
               external_id,
               name,
@@ -109,24 +122,25 @@ class RatkoOperatingPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : D
               track_number_id
               from layout.operating_point
               where postgis.st_contains(postgis.st_makeenvelope (:x_min, :y_min, :x_max, :y_max, :layout_srid), location)
-        """.trimIndent()
+        """
+                .trimIndent()
 
         return jdbcTemplate.query(
-            sql, mapOf(
+            sql,
+            mapOf(
                 "x_min" to bbox.x.min,
                 "x_max" to bbox.x.max,
                 "y_min" to bbox.y.min,
                 "y_max" to bbox.y.max,
-                "layout_srid" to LAYOUT_SRID.code
-            )
-        ) { rs, _ ->
-            toRatkoOperatingPoint(rs)
-        }
+                "layout_srid" to LAYOUT_SRID.code)) { rs, _ ->
+                toRatkoOperatingPoint(rs)
+            }
     }
 
     @Transactional(readOnly = true)
     fun searchOperatingPoints(searchTerm: FreeText, resultLimit: Int): List<RatkoOperatingPoint> {
-        val sql = """
+        val sql =
+            """
             select
               external_id,
               name,
@@ -142,16 +156,16 @@ class RatkoOperatingPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : D
               or external_id = :searchTerm
             order by name
             limit :resultLimit
-        """.trimIndent()
+        """
+                .trimIndent()
 
         return jdbcTemplate.query(
             sql,
             mapOf(
                 "searchTerm" to searchTerm,
                 "resultLimit" to resultLimit,
-            )
-        ) { rs, _ ->
-            toRatkoOperatingPoint(rs)
-        }
+            )) { rs, _ ->
+                toRatkoOperatingPoint(rs)
+            }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
@@ -22,10 +22,10 @@ import fi.fta.geoviite.infra.util.getIntIdOrNull
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
+import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 @Transactional(readOnly = true)
 @Component
@@ -33,25 +33,28 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
 
     @Transactional
     fun startPushing(layoutPublicationIds: List<IntId<Publication>>): IntId<RatkoPush> {
-        val sql = """
+        val sql =
+            """
             insert into integrations.ratko_push(start_time, status)
             values (now(), 'IN_PROGRESS')
             returning id
-        """.trimIndent()
+        """
+                .trimIndent()
 
         jdbcTemplate.setUser()
-        val ratkoPushId = jdbcTemplate.query(sql) { rs, _ ->
-            rs.getIntId<RatkoPush>("id")
-        }.first()
+        val ratkoPushId = jdbcTemplate.query(sql) { rs, _ -> rs.getIntId<RatkoPush>("id") }.first()
 
         updatePushContent(ratkoPushId, publicationIds = layoutPublicationIds)
 
-        return ratkoPushId.also { logger.daoAccess(AccessType.INSERT, "${RatkoPush::class}.id", ratkoPushId) }
+        return ratkoPushId.also {
+            logger.daoAccess(AccessType.INSERT, "${RatkoPush::class}.id", ratkoPushId)
+        }
     }
 
     @Transactional
     fun finishStuckPushes() {
-        val sql = """
+        val sql =
+            """
             update integrations.ratko_push
             set 
                 end_time = now(),
@@ -62,28 +65,34 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                 end
             where end_time is null
             returning id
-        """.trimIndent()
+        """
+                .trimIndent()
 
         jdbcTemplate.setUser()
-        jdbcTemplate.query(sql) { rs, _ -> rs.getIntId<RatkoPush>("id") }.also { updatedPushes ->
-            logger.daoAccess(AccessType.UPDATE, RatkoPush::class, updatedPushes)
-        }
+        jdbcTemplate
+            .query(sql) { rs, _ -> rs.getIntId<RatkoPush>("id") }
+            .also { updatedPushes ->
+                logger.daoAccess(AccessType.UPDATE, RatkoPush::class, updatedPushes)
+            }
     }
 
     @Transactional
     fun updatePushStatus(pushId: IntId<RatkoPush>, status: RatkoPushStatus) {
-        val sql = """
+        val sql =
+            """
             update integrations.ratko_push
             set 
               end_time = case when :status = 'IN_PROGRESS_M_VALUES' then null else now() end,
               status = :status::integrations.ratko_push_status
             where id = :push_id
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "push_id" to pushId.intValue,
-            "status" to status.name,
-        )
+        val params =
+            mapOf(
+                "push_id" to pushId.intValue,
+                "status" to status.name,
+            )
 
         jdbcTemplate.setUser()
         check(jdbcTemplate.update(sql, params) == 1)
@@ -91,7 +100,8 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
     }
 
     fun fetchPreviousPush(): RatkoPush {
-        val sql = """
+        val sql =
+            """
             select
               id,
               start_time,
@@ -100,18 +110,20 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
             from integrations.ratko_push
             order by end_time desc
             limit 1
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        return jdbcTemplate.query(sql) { rs, _ ->
-            RatkoPush(
-                id = rs.getIntId("id"),
-                startTime = rs.getInstant("start_time"),
-                endTime = rs.getInstantOrNull("end_time"),
-                status = rs.getEnum("status"),
-            )
-        }.first().also {
-            logger.daoAccess(AccessType.FETCH, RatkoPush::class, it.id)
-        }
+        return jdbcTemplate
+            .query(sql) { rs, _ ->
+                RatkoPush(
+                    id = rs.getIntId("id"),
+                    startTime = rs.getInstant("start_time"),
+                    endTime = rs.getInstantOrNull("end_time"),
+                    status = rs.getEnum("status"),
+                )
+            }
+            .first()
+            .also { logger.daoAccess(AccessType.FETCH, RatkoPush::class, it.id) }
     }
 
     private fun updatePushContent(
@@ -120,19 +132,24 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
     ) {
         require(publicationIds.isNotEmpty())
 
-        val sql = """
+        val sql =
+            """
             insert into integrations.ratko_push_content
               values (:publication_id, :ratko_push_id)
             on conflict (publication_id) 
               do update set ratko_push_id = :ratko_push_id
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = publicationIds.map { id ->
-            mapOf(
-                "ratko_push_id" to pushId.intValue,
-                "publication_id" to id.intValue,
-            )
-        }.toTypedArray()
+        val params =
+            publicationIds
+                .map { id ->
+                    mapOf(
+                        "ratko_push_id" to pushId.intValue,
+                        "publication_id" to id.intValue,
+                    )
+                }
+                .toTypedArray()
 
         check(jdbcTemplate.batchUpdate(sql, params).isNotEmpty())
 
@@ -148,8 +165,9 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
         assetId: IntId<T>,
         responseBody: String,
     ): IntId<RatkoPushError<T>> {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             insert into integrations.ratko_push_error(
               ratko_push_id,
               track_number_id,
@@ -169,25 +187,32 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
               :response_body
             )
             returning id
-        """.trimIndent()
-        val params = mapOf(
-            "ratko_push_id" to ratkoPushId.intValue,
-            "error_type" to ratkoPushErrorType.name,
-            "operation" to operation.name,
-            "track_number_id" to if (assetType == RatkoAssetType.TRACK_NUMBER) assetId.intValue else null,
-            "location_track_id" to if (assetType == RatkoAssetType.LOCATION_TRACK) assetId.intValue else null,
-            "switch_id" to if (assetType == RatkoAssetType.SWITCH) assetId.intValue else null,
-            "response_body" to responseBody,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "ratko_push_id" to ratkoPushId.intValue,
+                "error_type" to ratkoPushErrorType.name,
+                "operation" to operation.name,
+                "track_number_id" to
+                    if (assetType == RatkoAssetType.TRACK_NUMBER) assetId.intValue else null,
+                "location_track_id" to
+                    if (assetType == RatkoAssetType.LOCATION_TRACK) assetId.intValue else null,
+                "switch_id" to if (assetType == RatkoAssetType.SWITCH) assetId.intValue else null,
+                "response_body" to responseBody,
+            )
 
-        return jdbcTemplate.queryOne<IntId<RatkoPushError<T>>>(sql, params, ratkoPushId.toString()) { rs, _ ->
-            rs.getIntId("id")
-        }.also { errorId -> logger.daoAccess(AccessType.INSERT, RatkoPushError::class, errorId) }
+        return jdbcTemplate
+            .queryOne<IntId<RatkoPushError<T>>>(sql, params, ratkoPushId.toString()) { rs, _ ->
+                rs.getIntId("id")
+            }
+            .also { errorId -> logger.daoAccess(AccessType.INSERT, RatkoPushError::class, errorId) }
     }
 
     fun getLatestRatkoPushErrorFor(publicationId: IntId<Publication>): RatkoPushError<*>? {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select 
               ratko_push_error.id, 
               error_type, 
@@ -203,57 +228,70 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
             where ratko_push_content.publication_id = :id
             order by ratko_push_error.id desc
             limit 1;
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        return jdbcTemplate.queryOptional(sql, mapOf("id" to publicationId.intValue)) { rs, _ ->
-            val errorId = rs.getIntId<RatkoPushError<*>>("id")
-            val trackNumberId = rs.getIntIdOrNull<TrackLayoutTrackNumber>("track_number_id")
-            val locationTrackId = rs.getIntIdOrNull<LocationTrack>("location_track_id")
-            val switchId = rs.getIntIdOrNull<TrackLayoutSwitch>("switch_id")
-            RatkoPushError(
-                id = errorId,
-                ratkoPushId = rs.getIntId("ratko_push_id"),
-                errorType = rs.getEnum("error_type"),
-                operation = rs.getEnum("operation"),
-                assetId = trackNumberId
-                    ?: locationTrackId
-                    ?: switchId
-                    ?: error("Encountered Ratko push error without asset! id: $errorId"),
-                assetType = trackNumberId?.let { RatkoAssetType.TRACK_NUMBER }
-                    ?: locationTrackId?.let { RatkoAssetType.LOCATION_TRACK }
-                    ?: switchId.let { RatkoAssetType.SWITCH },
-            )
-        }?.also { pushError -> logger.daoAccess(AccessType.FETCH, RatkoPushError::class, pushError) }
+        return jdbcTemplate
+            .queryOptional(sql, mapOf("id" to publicationId.intValue)) { rs, _ ->
+                val errorId = rs.getIntId<RatkoPushError<*>>("id")
+                val trackNumberId = rs.getIntIdOrNull<TrackLayoutTrackNumber>("track_number_id")
+                val locationTrackId = rs.getIntIdOrNull<LocationTrack>("location_track_id")
+                val switchId = rs.getIntIdOrNull<TrackLayoutSwitch>("switch_id")
+                RatkoPushError(
+                    id = errorId,
+                    ratkoPushId = rs.getIntId("ratko_push_id"),
+                    errorType = rs.getEnum("error_type"),
+                    operation = rs.getEnum("operation"),
+                    assetId =
+                        trackNumberId
+                            ?: locationTrackId
+                            ?: switchId
+                            ?: error("Encountered Ratko push error without asset! id: $errorId"),
+                    assetType =
+                        trackNumberId?.let { RatkoAssetType.TRACK_NUMBER }
+                            ?: locationTrackId?.let { RatkoAssetType.LOCATION_TRACK }
+                            ?: switchId.let { RatkoAssetType.SWITCH },
+                )
+            }
+            ?.also { pushError ->
+                logger.daoAccess(AccessType.FETCH, RatkoPushError::class, pushError)
+            }
     }
 
     fun getLatestPushedPublicationMoment(): Instant {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select 
               coalesce(max(publication.publication_time), '2000-01-01 00:00:00'::timestamptz) as latest_publication_time
             from integrations.ratko_push
             inner join integrations.ratko_push_content on ratko_push_content.ratko_push_id = ratko_push.id
             inner join publication.publication on publication.id = ratko_push_content.publication_id
             where ratko_push.status = 'SUCCESSFUL'
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        return jdbcTemplate.queryOne(sql) { rs, _ ->
-            rs.getInstant("latest_publication_time")
-        }.also { logger.daoAccess(AccessType.FETCH, "${Publication::class}.publicationTime") }
+        return jdbcTemplate
+            .queryOne(sql) { rs, _ -> rs.getInstant("latest_publication_time") }
+            .also { logger.daoAccess(AccessType.FETCH, "${Publication::class}.publicationTime") }
     }
 
     fun getLatestPublicationMoment(): Instant {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select coalesce(max(publication.publication_time), now()) as latest_publication_time
             from publication.publication
-        """.trimIndent()
-        return jdbcTemplate.queryOne(sql) { rs, _ -> rs.getInstant("latest_publication_time") }
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .queryOne(sql) { rs, _ -> rs.getInstant("latest_publication_time") }
             .also { logger.daoAccess(AccessType.FETCH, "${Publication::class}.publicationTime") }
     }
 
     fun getRatkoPushChangeTime(): Instant {
-        val sql = """
+        val sql =
+            """
             select coalesce(
                 greatest(
                     max(ratko_push.end_time), 
@@ -262,13 +300,18 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                 now()
             ) as latest_ratko_push_time
             from integrations.ratko_push
-        """.trimIndent()
-        return jdbcTemplate.queryOne(sql) { rs, _ -> rs.getInstant("latest_ratko_push_time") }
-            .also { logger.daoAccess(AccessType.FETCH, "${RatkoPush::class.simpleName}.changeTime") }
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .queryOne(sql) { rs, _ -> rs.getInstant("latest_ratko_push_time") }
+            .also {
+                logger.daoAccess(AccessType.FETCH, "${RatkoPush::class.simpleName}.changeTime")
+            }
     }
 
     fun getRatkoStatus(publicationId: IntId<Publication>): List<RatkoPush> {
-        val sql = """
+        val sql =
+            """
             select
               ratko_push.id,
               ratko_push.start_time,
@@ -278,15 +321,18 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
             inner join integrations.ratko_push_content on ratko_push_content.ratko_push_id = ratko_push.id
             inner join publication.publication on publication.id = ratko_push_content.publication_id
             where publication.id = :publication_id
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        return jdbcTemplate.query(sql, mapOf("publication_id" to publicationId.intValue)) { rs, _ ->
-            RatkoPush(
-                id = rs.getIntId("id"),
-                startTime = rs.getInstant("start_time"),
-                endTime = rs.getInstantOrNull("end_time"),
-                status = rs.getEnum("status"),
-            )
-        }.onEach { push -> logger.daoAccess(AccessType.FETCH, RatkoPush::class, push.id) }
+        return jdbcTemplate
+            .query(sql, mapOf("publication_id" to publicationId.intValue)) { rs, _ ->
+                RatkoPush(
+                    id = rs.getIntId("id"),
+                    startTime = rs.getInstant("start_time"),
+                    endTime = rs.getInstantOrNull("end_time"),
+                    status = rs.getEnum("status"),
+                )
+            }
+            .onEach { push -> logger.daoAccess(AccessType.FETCH, RatkoPush::class, push.id) }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
@@ -31,14 +31,14 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import java.time.Duration
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.scheduling.annotation.Scheduled
 import withUser
-import java.time.Duration
-import java.time.Instant
 
 open class RatkoPushException(
     val type: RatkoPushErrorType,
@@ -50,15 +50,21 @@ open class RatkoPushException(
 class RatkoSwitchPushException(exception: RatkoPushException, val switch: TrackLayoutSwitch) :
     RatkoPushException(exception.type, exception.operation, exception.responseBody, exception)
 
-class RatkoLocationTrackPushException(exception: RatkoPushException, val locationTrack: LocationTrack) :
-    RatkoPushException(exception.type, exception.operation, exception.responseBody, exception)
+class RatkoLocationTrackPushException(
+    exception: RatkoPushException,
+    val locationTrack: LocationTrack
+) : RatkoPushException(exception.type, exception.operation, exception.responseBody, exception)
 
-class RatkoTrackNumberPushException(exception: RatkoPushException, val trackNumber: TrackLayoutTrackNumber) :
-    RatkoPushException(exception.type, exception.operation, exception.responseBody, exception)
+class RatkoTrackNumberPushException(
+    exception: RatkoPushException,
+    val trackNumber: TrackLayoutTrackNumber
+) : RatkoPushException(exception.type, exception.operation, exception.responseBody, exception)
 
 @GeoviiteService
 @ConditionalOnBean(RatkoClientConfiguration::class)
-class RatkoService @Autowired constructor(
+class RatkoService
+@Autowired
+constructor(
     private val ratkoClient: RatkoClient,
     private val ratkoLocationTrackService: RatkoLocationTrackService,
     private val ratkoRouteNumberService: RatkoRouteNumberService,
@@ -91,9 +97,7 @@ class RatkoService @Autowired constructor(
     }
 
     fun updateOperatingPointsFromRatko() {
-        lockDao.runWithLock(
-            DatabaseLock.RATKO_OPERATING_POINTS_FETCH, databaseLockDuration
-        ) {
+        lockDao.runWithLock(DatabaseLock.RATKO_OPERATING_POINTS_FETCH, databaseLockDuration) {
             val points = ratkoClient.fetchOperatingPoints()
             ratkoOperatingPointDao.updateOperatingPoints(points)
         }
@@ -104,7 +108,8 @@ class RatkoService @Autowired constructor(
 
         lockDao.runWithLock(DatabaseLock.RATKO, databaseLockDuration) {
 
-            // Kill off any pushes that have been stuck for too long, as it's likely failed and state is hanging in DB
+            // Kill off any pushes that have been stuck for too long, as it's likely failed and
+            // state is hanging in DB
             ratkoPushDao.finishStuckPushes()
 
             if (!retryFailed && previousPushStateIn(RatkoPushStatus.FAILED)) {
@@ -115,9 +120,11 @@ class RatkoService @Autowired constructor(
                 val lastPublicationMoment = ratkoPushDao.getLatestPushedPublicationMoment()
 
                 // Inclusive search, therefore the already pushed one is also returned
-                val publications = publicationService.fetchPublications(layoutBranch, lastPublicationMoment)
-                    .filter { it.publicationTime > lastPublicationMoment }
-                    .map { publicationService.getPublicationDetails(it.id) }
+                val publications =
+                    publicationService
+                        .fetchPublications(layoutBranch, lastPublicationMoment)
+                        .filter { it.publicationTime > lastPublicationMoment }
+                        .map { publicationService.getPublicationDetails(it.id) }
 
                 if (publications.isNotEmpty()) {
                     pushChanges(layoutBranch, publications)
@@ -138,31 +145,28 @@ class RatkoService @Autowired constructor(
             .filter { split -> split.publicationId != null && split.publicationTime != null }
             .sortedWith(compareBy { split -> split.publicationTime ?: Instant.MAX })
             .firstOrNull()
-            ?.let { split ->
-                pollBulkTransferStateUpdate(branch, split)
-            }
+            ?.let { split -> pollBulkTransferStateUpdate(branch, split) }
             .takeIf { split ->
-                split?.bulkTransferState in listOf(
-                    BulkTransferState.PENDING,
-                    BulkTransferState.TEMPORARY_FAILURE,
-                )
+                split?.bulkTransferState in
+                    listOf(
+                        BulkTransferState.PENDING,
+                        BulkTransferState.TEMPORARY_FAILURE,
+                    )
             }
-            ?.let { split ->
-                beginNewBulkTransfer(branch, split)
-            }
+            ?.let { split -> beginNewBulkTransfer(branch, split) }
     }
 
     fun pollBulkTransferStateUpdate(branch: LayoutBranch, split: Split): Split {
         if (split.bulkTransferState != BulkTransferState.IN_PROGRESS) {
             logger.info(
-                "Skipping bulk transfer state poll: split is not in progress (current state=${split.bulkTransferState})"
-            )
+                "Skipping bulk transfer state poll: split is not in progress (current state=${split.bulkTransferState})")
 
             return split
         }
 
         checkNotNull(split.bulkTransferId) {
-            error("Was about to poll bulk transfer state for split=${split.id}, but bulkTransferId was null!")
+            error(
+                "Was about to poll bulk transfer state for split=${split.id}, but bulkTransferId was null!")
         }
 
         val oldState = split.bulkTransferState
@@ -188,7 +192,10 @@ class RatkoService @Autowired constructor(
         }
     }
 
-    fun pushLocationTracksToRatko(branch: LayoutBranch, locationTrackChanges: Collection<LocationTrackChange>) {
+    fun pushLocationTracksToRatko(
+        branch: LayoutBranch,
+        locationTrackChanges: Collection<LocationTrackChange>
+    ) {
         assertMainBranch(branch)
 
         lockDao.runWithLock(DatabaseLock.RATKO, databaseLockDuration) {
@@ -197,39 +204,45 @@ class RatkoService @Autowired constructor(
                 "Push all publications before pushing location track point manually"
             }
 
-            check(ratkoClient.getRatkoOnlineStatus().isOnline) {
-                "Ratko is offline"
-            }
+            check(ratkoClient.getRatkoOnlineStatus().isOnline) { "Ratko is offline" }
 
-            // Here, we only care about current moment, but fix it to the latest publication DB time, pushed or not
+            // Here, we only care about current moment, but fix it to the latest publication DB
+            // time, pushed or not
             val latestPublicationMoment = ratkoPushDao.getLatestPublicationMoment()
-            val switchChanges = locationTrackChanges
-                .flatMap { locationTrackChange ->
-                    getSwitchChangesByLocationTrack(
-                        layoutBranch = branch,
-                        locationTrackId = locationTrackChange.locationTrackId,
-                        filterByKmNumbers = locationTrackChange.changedKmNumbers,
-                        moment = latestPublicationMoment,
-                    )
-                }.map { switchChange -> toFakePublishedSwitch(branch, switchChange, latestPublicationMoment) }
+            val switchChanges =
+                locationTrackChanges
+                    .flatMap { locationTrackChange ->
+                        getSwitchChangesByLocationTrack(
+                            layoutBranch = branch,
+                            locationTrackId = locationTrackChange.locationTrackId,
+                            filterByKmNumbers = locationTrackChange.changedKmNumbers,
+                            moment = latestPublicationMoment,
+                        )
+                    }
+                    .map { switchChange ->
+                        toFakePublishedSwitch(branch, switchChange, latestPublicationMoment)
+                    }
 
-            val publishedLocationTrackChanges = locationTrackChanges
-                .map { locationTrackChange ->
-                    val locationTrack = locationTrackService.getOfficialAtMoment(
-                        branch = branch,
-                        id = locationTrackChange.locationTrackId,
-                        moment = latestPublicationMoment,
-                    )
+            val publishedLocationTrackChanges =
+                locationTrackChanges.map { locationTrackChange ->
+                    val locationTrack =
+                        locationTrackService.getOfficialAtMoment(
+                            branch = branch,
+                            id = locationTrackChange.locationTrackId,
+                            moment = latestPublicationMoment,
+                        )
                     checkNotNull(locationTrack) {
                         "No location track exists with id ${locationTrackChange.locationTrackId} and timestamp $latestPublicationMoment"
                     }
 
-                    //Fake PublishedLocationTrack, Ratko integration is built around published items
+                    // Fake PublishedLocationTrack, Ratko integration is built around published
+                    // items
                     PublishedLocationTrack(
                         id = locationTrack.id as IntId,
-                        version = checkNotNull(locationTrack.version) {
-                            "Location track missing version, id=${locationTrackChange.locationTrackId}"
-                        },
+                        version =
+                            checkNotNull(locationTrack.version) {
+                                "Location track missing version, id=${locationTrackChange.locationTrackId}"
+                            },
                         name = locationTrack.name,
                         trackNumberId = locationTrack.trackNumberId,
                         operation = Operation.MODIFY,
@@ -237,25 +250,27 @@ class RatkoService @Autowired constructor(
                     )
                 }
 
-            val pushedLocationTrackOids = ratkoLocationTrackService.pushLocationTrackChangesToRatko(
-                branch,
-                publishedLocationTrackChanges,
-                latestPublicationMoment,
-            )
-
-            val distinctJoints = switchChanges.map { switchChange ->
-                switchChange.copy(
-                    changedJoints = switchChange.changedJoints.distinctBy { changedJoint ->
-                        changedJoint.number
-                    }
+            val pushedLocationTrackOids =
+                ratkoLocationTrackService.pushLocationTrackChangesToRatko(
+                    branch,
+                    publishedLocationTrackChanges,
+                    latestPublicationMoment,
                 )
-            }
-            ratkoAssetService.pushSwitchChangesToRatko(branch, distinctJoints, latestPublicationMoment)
+
+            val distinctJoints =
+                switchChanges.map { switchChange ->
+                    switchChange.copy(
+                        changedJoints =
+                            switchChange.changedJoints.distinctBy { changedJoint ->
+                                changedJoint.number
+                            })
+                }
+            ratkoAssetService.pushSwitchChangesToRatko(
+                branch, distinctJoints, latestPublicationMoment)
 
             try {
                 ratkoLocationTrackService.forceRedraw(
-                    pushedLocationTrackOids.map { RatkoOid<RatkoLocationTrack>(it) }.toSet()
-                )
+                    pushedLocationTrackOids.map { RatkoOid<RatkoLocationTrack>(it) }.toSet())
             } catch (_: Exception) {
                 logger.warn("Failed to push M values for location tracks $pushedLocationTrackOids")
             }
@@ -273,17 +288,19 @@ class RatkoService @Autowired constructor(
         val ratkoPushId = ratkoPushDao.startPushing(publications.map { it.id })
         val lastPublicationTime = publications.maxOf { it.publicationTime }
         try {
-            val pushedRouteNumberOids = ratkoRouteNumberService.pushTrackNumberChangesToRatko(
-                layoutBranch,
-                publications.flatMap { it.allPublishedTrackNumbers },
-                lastPublicationTime,
-            )
+            val pushedRouteNumberOids =
+                ratkoRouteNumberService.pushTrackNumberChangesToRatko(
+                    layoutBranch,
+                    publications.flatMap { it.allPublishedTrackNumbers },
+                    lastPublicationTime,
+                )
 
-            val pushedLocationTrackOids = ratkoLocationTrackService.pushLocationTrackChangesToRatko(
-                layoutBranch,
-                publications.flatMap { it.allPublishedLocationTracks },
-                lastPublicationTime,
-            )
+            val pushedLocationTrackOids =
+                ratkoLocationTrackService.pushLocationTrackChangesToRatko(
+                    layoutBranch,
+                    publications.flatMap { it.allPublishedLocationTracks },
+                    lastPublicationTime,
+                )
 
             pushSwitchChanges(
                 layoutBranch = layoutBranch,
@@ -296,16 +313,14 @@ class RatkoService @Autowired constructor(
 
             try {
                 ratkoRouteNumberService.forceRedraw(
-                    pushedRouteNumberOids.map { RatkoOid<RatkoRouteNumber>(it) }.toSet()
-                )
+                    pushedRouteNumberOids.map { RatkoOid<RatkoRouteNumber>(it) }.toSet())
             } catch (_: Exception) {
                 logger.warn("Failed to push M values for route numbers $pushedRouteNumberOids")
             }
 
             try {
                 ratkoLocationTrackService.forceRedraw(
-                    pushedLocationTrackOids.map { RatkoOid<RatkoLocationTrack>(it) }.toSet()
-                )
+                    pushedLocationTrackOids.map { RatkoOid<RatkoLocationTrack>(it) }.toSet())
             } catch (_: Exception) {
                 logger.warn("Failed to push M values for location tracks $pushedLocationTrackOids")
             }
@@ -344,9 +359,10 @@ class RatkoService @Autowired constructor(
                     )
             }
 
-            //dummy check if Ratko is online
-            val pushStatus = if (ratkoClient.getRatkoOnlineStatus().isOnline) RatkoPushStatus.FAILED
-            else RatkoPushStatus.CONNECTION_ISSUE
+            // dummy check if Ratko is online
+            val pushStatus =
+                if (ratkoClient.getRatkoOnlineStatus().isOnline) RatkoPushStatus.FAILED
+                else RatkoPushStatus.CONNECTION_ISSUE
 
             ratkoPushDao.updatePushStatus(ratkoPushId, pushStatus)
 
@@ -360,19 +376,22 @@ class RatkoService @Autowired constructor(
         publishedLocationTracks: List<PublishedLocationTrack>,
         publicationTime: Instant,
     ) {
-        //Location track points are always removed per kilometre.
-        //However, there is a slight chance that points used by switches (according to Geoviite)
+        // Location track points are always removed per kilometre.
+        // However, there is a slight chance that points used by switches (according to Geoviite)
         // will not match with the ones in Ratko.
-        //Therefore, Geoviite will also update all switches with joints in the danger zone.
-        val locationTrackSwitchChanges = publishedLocationTracks
-            .flatMap { locationTrack ->
-                getSwitchChangesByLocationTrack(
-                    layoutBranch = layoutBranch,
-                    locationTrackId = locationTrack.id,
-                    filterByKmNumbers = locationTrack.changedKmNumbers,
-                    moment = publicationTime
-                )
-            }.map { switchChange -> toFakePublishedSwitch(layoutBranch, switchChange, publicationTime) }
+        // Therefore, Geoviite will also update all switches with joints in the danger zone.
+        val locationTrackSwitchChanges =
+            publishedLocationTracks
+                .flatMap { locationTrack ->
+                    getSwitchChangesByLocationTrack(
+                        layoutBranch = layoutBranch,
+                        locationTrackId = locationTrack.id,
+                        filterByKmNumbers = locationTrack.changedKmNumbers,
+                        moment = publicationTime)
+                }
+                .map { switchChange ->
+                    toFakePublishedSwitch(layoutBranch, switchChange, publicationTime)
+                }
 
         val switchChanges = publishedSwitches + locationTrackSwitchChanges
         ratkoAssetService.pushSwitchChangesToRatko(layoutBranch, switchChanges, publicationTime)
@@ -383,14 +402,17 @@ class RatkoService @Autowired constructor(
         locationTrackId: IntId<LocationTrack>,
         filterByKmNumbers: Collection<KmNumber>,
         moment: Instant,
-    ) = calculatedChangesService.getAllSwitchChangesByLocationTrackAtMoment(layoutBranch, locationTrackId, moment)
-        .map { switchChanges ->
-            switchChanges.copy(
-                changedJoints = switchChanges.changedJoints.filter { changedJoint ->
-                    filterByKmNumbers.contains(changedJoint.address.kmNumber)
-                }
-            )
-        }.filter { it.changedJoints.isNotEmpty() }
+    ) =
+        calculatedChangesService
+            .getAllSwitchChangesByLocationTrackAtMoment(layoutBranch, locationTrackId, moment)
+            .map { switchChanges ->
+                switchChanges.copy(
+                    changedJoints =
+                        switchChanges.changedJoints.filter { changedJoint ->
+                            filterByKmNumbers.contains(changedJoint.address.kmNumber)
+                        })
+            }
+            .filter { it.changedJoints.isNotEmpty() }
 
     private fun toFakePublishedSwitch(
         layoutBranch: LayoutBranch,
@@ -398,16 +420,20 @@ class RatkoService @Autowired constructor(
         moment: Instant,
     ): PublishedSwitch {
         val switch = switchService.getOfficialAtMoment(layoutBranch, switchChange.switchId, moment)
-        checkNotNull(switch) { "No switch exists with id ${switchChange.switchId} and timestamp $moment" }
+        checkNotNull(switch) {
+            "No switch exists with id ${switchChange.switchId} and timestamp $moment"
+        }
 
-        //Fake PublishedSwitch, Ratko integration is built around published items
+        // Fake PublishedSwitch, Ratko integration is built around published items
         return PublishedSwitch(
             id = switch.id as IntId,
-            version = checkNotNull(switch.version) { "Switch missing version, id=${switchChange.switchId}" },
-            trackNumberIds = emptySet(), //Ratko integration doesn't care about this field
+            version =
+                checkNotNull(switch.version) {
+                    "Switch missing version, id=${switchChange.switchId}"
+                },
+            trackNumberIds = emptySet(), // Ratko integration doesn't care about this field
             name = switch.name,
             operation = Operation.MODIFY,
-            changedJoints = switchChange.changedJoints
-        )
+            changedJoints = switchChange.changedJoints)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtils.kt
@@ -17,27 +17,31 @@ fun getEndPointNodeCollection(
     existingStartNode: RatkoNode? = null,
     existingEndNode: RatkoNode? = null,
 ): RatkoNodes? {
-    val layoutStartNode = convertToRatkoNode(
-        addressPoint = alignmentAddresses.startPoint,
-        nodeType = RatkoNodeType.START_POINT,
-        state = RatkoPointStates.VALID,
-    )
+    val layoutStartNode =
+        convertToRatkoNode(
+            addressPoint = alignmentAddresses.startPoint,
+            nodeType = RatkoNodeType.START_POINT,
+            state = RatkoPointStates.VALID,
+        )
 
-    val layoutEndNode = convertToRatkoNode(
-        addressPoint = alignmentAddresses.endPoint,
-        nodeType = RatkoNodeType.END_POINT,
-        state = RatkoPointStates.VALID,
-    )
+    val layoutEndNode =
+        convertToRatkoNode(
+            addressPoint = alignmentAddresses.endPoint,
+            nodeType = RatkoNodeType.END_POINT,
+            state = RatkoPointStates.VALID,
+        )
 
     val startHasChanged = changedKmNumbers.contains(alignmentAddresses.startPoint.address.kmNumber)
     val endHasChanged = changedKmNumbers.contains(alignmentAddresses.endPoint.address.kmNumber)
 
     return if (startHasChanged || endHasChanged) {
-        val newStartNode = if (startHasChanged || existingStartNode == null) layoutStartNode
-        else existingStartNode.withoutGeometry()
+        val newStartNode =
+            if (startHasChanged || existingStartNode == null) layoutStartNode
+            else existingStartNode.withoutGeometry()
 
-        val newEndNode = if (endHasChanged || existingEndNode == null) layoutEndNode
-        else existingEndNode.withoutGeometry()
+        val newEndNode =
+            if (endHasChanged || existingEndNode == null) layoutEndNode
+            else existingEndNode.withoutGeometry()
 
         return convertToRatkoNodeCollection(listOf(newStartNode, newEndNode))
     } else null
@@ -46,24 +50,25 @@ fun getEndPointNodeCollection(
 fun asSwitchTypeString(switchType: SwitchType): String {
     val radius = switchType.parts.curveRadius
     val spread = switchType.parts.spread ?: ""
-    val curveRadius = radius
-        .mapIndexed { i, r ->
-            //Adds N/P version to the first curve radius
-            if (i == 0) "$r$spread"
-            else "$r"
-        }.let { radii ->
-            if (radii.isEmpty()) ""
-            else "-${radii.joinToString("/")}"
-        }
+    val curveRadius =
+        radius
+            .mapIndexed { i, r ->
+                // Adds N/P version to the first curve radius
+                if (i == 0) "$r$spread" else "$r"
+            }
+            .let { radii -> if (radii.isEmpty()) "" else "-${radii.joinToString("/")}" }
 
     return "${switchType.parts.baseType}${switchType.parts.railWeight}${curveRadius}-${switchType.parts.ratio}"
 }
 
-fun sortByDeletedStateFirst(layoutState: LayoutState) = if (layoutState == LayoutState.DELETED) 0 else 1
+fun sortByDeletedStateFirst(layoutState: LayoutState) =
+    if (layoutState == LayoutState.DELETED) 0 else 1
+
 fun sortByDeletedStateFirst(locationTrackState: LocationTrackState) =
     if (locationTrackState == LocationTrackState.DELETED) 0 else 1
 
-fun sortByNullDuplicateOfFirst(duplicateOf: IntId<LocationTrack>?) = if (duplicateOf == null) 0 else 1
+fun sortByNullDuplicateOfFirst(duplicateOf: IntId<LocationTrack>?) =
+    if (duplicateOf == null) 0 else 1
 
 fun sortByDeletedStateFirst(layoutStateCategory: LayoutStateCategory) =
     if (layoutStateCategory == LayoutStateCategory.NOT_EXISTING) 0 else 1
@@ -74,19 +79,26 @@ fun toRatkoPointsGroupedByKm(addressPoints: Collection<AddressPoint>) =
         .map { (_, addressPointsForKm) ->
             addressPointsForKm
                 .map(::convertToRatkoPoint)
-                .distinctBy { it.kmM.meters } //track meters 0000+0000.010 and 0000+0000.01 are considered the same
+                .distinctBy {
+                    it.kmM.meters
+                } // track meters 0000+0000.010 and 0000+0000.01 are considered the same
                 .sortedBy { it.kmM }
         }
         .filter { ratkoPoints -> ratkoPoints.isNotEmpty() }
 
-
-fun toNodeCollectionMarkingEndpointsNotInUse(ratkoNodes: RatkoNodes): RatkoNodes = convertToRatkoNodeCollection(
-    listOfNotNull(
-        ratkoNodes.getStartNode()?.point?.withoutGeometry()?.copy(
-            state = RatkoPointState(RatkoPointStates.NOT_IN_USE)
-        )?.let { point -> RatkoNode(RatkoNodeType.START_POINT, point) },
-        ratkoNodes.getEndNode()?.point?.withoutGeometry()?.copy(
-            state = RatkoPointState(RatkoPointStates.NOT_IN_USE)
-        )?.let { point -> RatkoNode(RatkoNodeType.END_POINT, point) },
-    )
-)
+fun toNodeCollectionMarkingEndpointsNotInUse(ratkoNodes: RatkoNodes): RatkoNodes =
+    convertToRatkoNodeCollection(
+        listOfNotNull(
+            ratkoNodes
+                .getStartNode()
+                ?.point
+                ?.withoutGeometry()
+                ?.copy(state = RatkoPointState(RatkoPointStates.NOT_IN_USE))
+                ?.let { point -> RatkoNode(RatkoNodeType.START_POINT, point) },
+            ratkoNodes
+                .getEndNode()
+                ?.point
+                ?.withoutGeometry()
+                ?.copy(state = RatkoPointState(RatkoPointStates.NOT_IN_USE))
+                ?.let { point -> RatkoNode(RatkoNodeType.END_POINT, point) },
+        ))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
@@ -22,32 +22,35 @@ data class RatkoMetadataAsset(
     override val properties: Collection<RatkoAssetProperty>,
     override val rowMetadata: RatkoMetadata = RatkoMetadata(),
     override val locations: List<RatkoAssetLocation>,
-) : RatkoAsset(
-    state = RatkoAssetState.IN_USE,
-    type = RatkoAssetType.METADATA,
-    rowMetadata = rowMetadata,
-    properties = properties,
-    locations = locations
-) {
-    override fun withoutGeometries() = this.copy(locations = locations.map { it.withoutGeometries() })
+) :
+    RatkoAsset(
+        state = RatkoAssetState.IN_USE,
+        type = RatkoAssetType.METADATA,
+        rowMetadata = rowMetadata,
+        properties = properties,
+        locations = locations) {
+    override fun withoutGeometries() =
+        this.copy(locations = locations.map { it.withoutGeometries() })
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class RatkoSwitchAsset constructor(
+data class RatkoSwitchAsset
+constructor(
     val id: String?,
     override val state: RatkoAssetState,
     override val properties: Collection<RatkoAssetProperty>,
     override val rowMetadata: RatkoMetadata = RatkoMetadata(),
     override val locations: List<RatkoAssetLocation>?,
     val assetGeoms: Collection<RatkoAssetGeometry>?,
-) : RatkoAsset(
-    state = state,
-    type = RatkoAssetType.TURNOUT,
-    rowMetadata = rowMetadata,
-    properties = properties,
-    locations = locations
-) {
-    override fun withoutGeometries() = this.copy(locations = locations?.map { it.withoutGeometries() })
+) :
+    RatkoAsset(
+        state = state,
+        type = RatkoAssetType.TURNOUT,
+        rowMetadata = rowMetadata,
+        properties = properties,
+        locations = locations) {
+    override fun withoutGeometries() =
+        this.copy(locations = locations?.map { it.withoutGeometries() })
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -81,52 +84,39 @@ enum class RatkoAssetGeometryType(@get:JsonValue val value: String) {
     MATH_POINT_AB("MATH_POINT_AB"),
     MATH_POINT_AC("MATH_POINT_AC"),
     MATH_POINT_AD("MATH_POINT_AD"),
-
-    @Suppress("unused")
-    CACHE_POINT("CACHE_POINT")
+    @Suppress("unused") CACHE_POINT("CACHE_POINT")
 }
 
-enum class RatkoAssetState(@get:JsonValue val value: String, val category: LayoutStateCategory? = null) {
-    PLANNED("PLANNED", LayoutStateCategory.FUTURE_EXISTING), // RATAVAGE -prosessin kautta suunniteltu
+enum class RatkoAssetState(
+    @get:JsonValue val value: String,
+    val category: LayoutStateCategory? = null
+) {
+    PLANNED(
+        "PLANNED", LayoutStateCategory.FUTURE_EXISTING), // RATAVAGE -prosessin kautta suunniteltu
     IN_USE(
         "IN USE",
-        LayoutStateCategory.EXISTING
-    ), // liikennöinti ilman rajoituksia, kunnossapitäjä kunnossapitourakoitsija
-
-    @Suppress("unused")
-    SUGGESTED("SUGGESTED", LayoutStateCategory.FUTURE_EXISTING),
-
+        LayoutStateCategory
+            .EXISTING), // liikennöinti ilman rajoituksia, kunnossapitäjä kunnossapitourakoitsija
+    @Suppress("unused") SUGGESTED("SUGGESTED", LayoutStateCategory.FUTURE_EXISTING),
     BUILT("BUILT", LayoutStateCategory.EXISTING), // rakennettu
-
     @Suppress("unused")
     IN_TRAFFIC(
         "IN TRAFFIC",
-        LayoutStateCategory.EXISTING
-    ), // liikennöinti voi alkaa rajoituksin, kunnossapitäjä rakennusurakoitsija
-
-    @Suppress("unused")
-    REPLACED("REPLACED", LayoutStateCategory.NOT_EXISTING),
+        LayoutStateCategory
+            .EXISTING), // liikennöinti voi alkaa rajoituksin, kunnossapitäjä rakennusurakoitsija
+    @Suppress("unused") REPLACED("REPLACED", LayoutStateCategory.NOT_EXISTING),
     NOT_IN_USE("NOT IN USE", LayoutStateCategory.EXISTING), // olemassa, mutta ei käytössä
-
     @Suppress("unused")
     REMOVED("REMOVED", LayoutStateCategory.NOT_EXISTING), // olemassa, mutta irti radasta
     DELETED("DELETED", LayoutStateCategory.NOT_EXISTING), // purettu maastossa
-
+    @Suppress("unused") TRANSITION("TRANSITION"),
+    @Suppress("unused") CANCELED("CANCELED"), // muutospyyntö peruttu
+    @Suppress("unused") COMPLETED("COMPLETED"), // muutospyyntö käsitelty
     @Suppress("unused")
-
-    TRANSITION("TRANSITION"),
-
-    @Suppress("unused")
-    CANCELED("CANCELED"), // muutospyyntö peruttu
-
-    @Suppress("unused")
-    COMPLETED("COMPLETED"), // muutospyyntö käsitelty
-
-    @Suppress("unused")
-    REJECTED("REJECTED"), // Hylätyn RYHTI toimenpide-ehdotuksen tai RATKO UI:n kautta tehty muutosilmoitus
-
-    @Suppress("unused")
-    OLD("OLD"),
+    REJECTED(
+        "REJECTED"), // Hylätyn RYHTI toimenpide-ehdotuksen tai RATKO UI:n kautta tehty
+                     // muutosilmoitus
+    @Suppress("unused") OLD("OLD"),
 }
 
 enum class RatkoAssetType(@get:JsonValue val value: String) {
@@ -135,25 +125,39 @@ enum class RatkoAssetType(@get:JsonValue val value: String) {
     RAILWAY_TRAFFIC_OPERATING_POINT("railway_traffic_operating_point"),
 }
 
-
 data class RatkoOperatingPointAssetsResponse(val assets: List<RatkoOperatingPointAsset>)
+
 data class RatkoOperatingPointAsset(
     val id: String,
     val properties: Collection<RatkoAssetProperty>,
     val locations: List<IncomingRatkoAssetLocation>?,
 ) {
     fun getIntProperty(name: String): Int? = properties.find { it.name == name }?.integerValue
+
     fun getStringProperty(name: String): String? = properties.find { it.name == name }?.stringValue
+
     inline fun <reified T : Enum<T>> getEnumProperty(name: String): T? =
-        properties.find { it.name == name }?.enumValue?.let { v ->
-            T::class.java.enumConstants.find { c -> c.name == v }
-        }
+        properties
+            .find { it.name == name }
+            ?.enumValue
+            ?.let { v -> T::class.java.enumConstants.find { c -> c.name == v } }
 }
 
 data class IncomingRatkoAssetLocation(val nodecollection: IncomingRatkoNodes)
+
 data class IncomingRatkoNodes(val nodes: Collection<IncomingRatkoNode> = listOf())
+
 data class IncomingRatkoNode(val point: IncomingRatkoPoint, val nodeType: RatkoNodeType)
-data class IncomingRatkoPoint(val geometry: IncomingRatkoGeometry, val routenumber: RatkoOid<RatkoRouteNumber>)
-data class IncomingRatkoGeometry(val type: RatkoGeometryType, val coordinates: List<Double>, val crs: RatkoCrs)
+
+data class IncomingRatkoPoint(
+    val geometry: IncomingRatkoGeometry,
+    val routenumber: RatkoOid<RatkoRouteNumber>
+)
+
+data class IncomingRatkoGeometry(
+    val type: RatkoGeometryType,
+    val coordinates: List<Double>,
+    val crs: RatkoCrs
+)
 
 data class RatkoBulkTransferResponse(val id: IntId<BulkTransfer>, val state: BulkTransferState)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
@@ -37,11 +37,9 @@ data class RatkoNodes(
     val nodes: Collection<RatkoNode> = listOf(),
     val type: RatkoNodesType,
 ) {
-    @JsonIgnore
-    fun getStartNode() = nodes.find { it.nodeType == RatkoNodeType.START_POINT }
+    @JsonIgnore fun getStartNode() = nodes.find { it.nodeType == RatkoNodeType.START_POINT }
 
-    @JsonIgnore
-    fun getEndNode() = nodes.find { it.nodeType == RatkoNodeType.END_POINT }
+    @JsonIgnore fun getEndNode() = nodes.find { it.nodeType == RatkoNodeType.END_POINT }
 
     fun withoutGeometries() = this.copy(nodes = nodes.map { it.withoutGeometry() })
 }
@@ -73,8 +71,9 @@ private fun limitScale(meters: BigDecimal) =
     else if (meters.scale() > MAX_METERS_SCALE) meters.setScale(MAX_METERS_SCALE, RoundingMode.DOWN)
     else meters
 
-//^[0-9]{4}\+[0-9]{4}(\.[0-9]{1,15})?$
-class RatkoTrackMeter private constructor(
+// ^[0-9]{4}\+[0-9]{4}(\.[0-9]{1,15})?$
+class RatkoTrackMeter
+private constructor(
     override val kmNumber: KmNumber,
     override val meters: BigDecimal,
 ) : ITrackMeter {
@@ -86,12 +85,13 @@ class RatkoTrackMeter private constructor(
             val trackMeter = TrackMeter(kmM)
             return RatkoTrackMeter(
                 kmNumber = trackMeter.kmNumber,
-                meters = limitScale(trackMeter.meters.stripTrailingZeros())
-            )
+                meters = limitScale(trackMeter.meters.stripTrailingZeros()))
         }
     }
 
-    constructor(trackMeter: TrackMeter) : this(trackMeter.kmNumber, limitScale(trackMeter.meters.stripTrailingZeros()))
+    constructor(
+        trackMeter: TrackMeter
+    ) : this(trackMeter.kmNumber, limitScale(trackMeter.meters.stripTrailingZeros()))
 
     init {
         require(meters.scale() in 0..MAX_METERS_SCALE) {
@@ -99,24 +99,28 @@ class RatkoTrackMeter private constructor(
         }
     }
 
-    @JsonValue
-    override fun toString() = formatTrackMeter(kmNumber, meters)
+    @JsonValue override fun toString() = formatTrackMeter(kmNumber, meters)
 }
 
 class RatkoGeometry(val type: RatkoGeometryType, coordinates: List<Double>, crs: RatkoCrs) {
     val coordinates: List<Double> =
         if (crs.properties.name != RATKO_SRID)
-            transformNonKKJCoordinate(crs.properties.name, RATKO_SRID, Point(coordinates[0], coordinates[1]))
+            transformNonKKJCoordinate(
+                    crs.properties.name, RATKO_SRID, Point(coordinates[0], coordinates[1]))
                 .let { listOf(it.x, it.y) }
         else coordinates
 
     val crs: RatkoCrs = RatkoCrs()
 
-    constructor(point: IPoint) : this(
+    constructor(
+        point: IPoint
+    ) : this(
         type = RatkoGeometryType.POINT,
-        coordinates = transformNonKKJCoordinate(LAYOUT_SRID, RATKO_SRID, Point(point.x, point.y)).let { listOf(it.x, it.y) },
-        crs = RatkoCrs()
-    )
+        coordinates =
+            transformNonKKJCoordinate(LAYOUT_SRID, RATKO_SRID, Point(point.x, point.y)).let {
+                listOf(it.x, it.y)
+            },
+        crs = RatkoCrs())
 }
 
 data class RatkoPointState(val name: RatkoPointStates)
@@ -132,12 +136,8 @@ enum class RatkoNodeType(@get:JsonValue val value: String) {
     JOINT_B("joint_point_B"),
     JOINT_C("joint_point_C"),
     JOINT_D("joint_point_D"),
-
-    @Suppress("unused")
-    MIDDLE_POINT("middle_point"),
-
-    @Suppress("unused")
-    SOLO_POINT("solo_point"),
+    @Suppress("unused") MIDDLE_POINT("middle_point"),
+    @Suppress("unused") SOLO_POINT("solo_point"),
 }
 
 enum class RatkoPointStates(@get:JsonValue val state: String) {
@@ -153,15 +153,9 @@ enum class RatkoNodesType(@get:JsonValue val value: String) {
     JOINTS("joint_points"),
     START_AND_END("start_and_end"),
     END("end"),
-
-    @Suppress("unused")
-    START("start"),
-
-    @Suppress("unused")
-    START_MIDDLE_END("start_middle_end"),
-
-    @Suppress("unused")
-    POINT("point"),
+    @Suppress("unused") START("start"),
+    @Suppress("unused") START_MIDDLE_END("start_middle_end"),
+    @Suppress("unused") POINT("point"),
 }
 
 enum class RatkoMeasurementMethod(@get:JsonValue val value: String) {
@@ -184,22 +178,10 @@ enum class RatkoAssetGeomAccuracyType(@get:JsonValue val value: String) {
 
 enum class RatkoAccuracyType(@get:JsonValue val value: String) {
     GEOMETRY_CALCULATED("GEOMETRY CALCULATED"),
-
-    @Suppress("unused")
-    DESIGNED_TRACK_ADDRESS("DESIGNED TRACKADDRESS"),
-
-    @Suppress("unused")
-    MEASURED_TRACK_ADDRESS("MEASURED TRACKADDRESS"),
-
-    @Suppress("unused")
-    OFFICIALLY_MEASURED_GEODETICALLY("OFFICIALLY MEASURED GEODETICALLY"),
-
-    @Suppress("unused")
-    MEASURED_GEODETICALLY("MEASURED GEODETICALLY"),
-
-    @Suppress("unused")
-    DIGITALIZED_AERIAL_IMAGE("DIGITIZED AERIAL IMAGE"),
-
-    @Suppress("unused")
-    ESTIMATED_TRACK_ADDRESS("ESTIMATED TRACKADDRESS"),
+    @Suppress("unused") DESIGNED_TRACK_ADDRESS("DESIGNED TRACKADDRESS"),
+    @Suppress("unused") MEASURED_TRACK_ADDRESS("MEASURED TRACKADDRESS"),
+    @Suppress("unused") OFFICIALLY_MEASURED_GEODETICALLY("OFFICIALLY MEASURED GEODETICALLY"),
+    @Suppress("unused") MEASURED_GEODETICALLY("MEASURED GEODETICALLY"),
+    @Suppress("unused") DIGITALIZED_AERIAL_IMAGE("DIGITIZED AERIAL IMAGE"),
+    @Suppress("unused") ESTIMATED_TRACK_ADDRESS("ESTIMATED TRACKADDRESS"),
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
@@ -12,144 +12,164 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.*
 import java.time.ZoneId
 
-fun mapToRatkoLocationTrackState(layoutState: LocationTrackState) = when (layoutState) {
-    LocationTrackState.BUILT -> RatkoLocationTrackState.BUILT
-    LocationTrackState.DELETED -> RatkoLocationTrackState.DELETED
-    LocationTrackState.NOT_IN_USE -> RatkoLocationTrackState.NOT_IN_USE
-    LocationTrackState.PLANNED -> RatkoLocationTrackState.PLANNED
-    LocationTrackState.IN_USE -> RatkoLocationTrackState.IN_USE
-}
+fun mapToRatkoLocationTrackState(layoutState: LocationTrackState) =
+    when (layoutState) {
+        LocationTrackState.BUILT -> RatkoLocationTrackState.BUILT
+        LocationTrackState.DELETED -> RatkoLocationTrackState.DELETED
+        LocationTrackState.NOT_IN_USE -> RatkoLocationTrackState.NOT_IN_USE
+        LocationTrackState.PLANNED -> RatkoLocationTrackState.PLANNED
+        LocationTrackState.IN_USE -> RatkoLocationTrackState.IN_USE
+    }
 
-fun mapToRatkoRouteNumberState(layoutState: LayoutState) = when (layoutState) {
-    LayoutState.NOT_IN_USE -> RatkoRouteNumberState(RatkoRouteNumberStateType.NOT_IN_USE)
-    LayoutState.PLANNED -> RatkoRouteNumberState(RatkoRouteNumberStateType.VALID)
-    LayoutState.IN_USE -> RatkoRouteNumberState(RatkoRouteNumberStateType.VALID)
-    // There is no DELETED or corresponding state in Ratko, so it will be NOT_VALID
-    LayoutState.DELETED -> RatkoRouteNumberState(RatkoRouteNumberStateType.NOT_VALID)
-}
+fun mapToRatkoRouteNumberState(layoutState: LayoutState) =
+    when (layoutState) {
+        LayoutState.NOT_IN_USE -> RatkoRouteNumberState(RatkoRouteNumberStateType.NOT_IN_USE)
+        LayoutState.PLANNED -> RatkoRouteNumberState(RatkoRouteNumberStateType.VALID)
+        LayoutState.IN_USE -> RatkoRouteNumberState(RatkoRouteNumberStateType.VALID)
+        // There is no DELETED or corresponding state in Ratko, so it will be NOT_VALID
+        LayoutState.DELETED -> RatkoRouteNumberState(RatkoRouteNumberStateType.NOT_VALID)
+    }
 
-fun mapToRatkoLocationTrackType(trackType: LocationTrackType?) = when (trackType) {
-    LocationTrackType.MAIN -> RatkoLocationTrackType.MAIN
-    LocationTrackType.TRAP -> RatkoLocationTrackType.TRAP
-    LocationTrackType.CHORD -> RatkoLocationTrackType.CHORD
-    LocationTrackType.SIDE -> RatkoLocationTrackType.SIDE
-    null -> RatkoLocationTrackType.NULL
-}
+fun mapToRatkoLocationTrackType(trackType: LocationTrackType?) =
+    when (trackType) {
+        LocationTrackType.MAIN -> RatkoLocationTrackType.MAIN
+        LocationTrackType.TRAP -> RatkoLocationTrackType.TRAP
+        LocationTrackType.CHORD -> RatkoLocationTrackType.CHORD
+        LocationTrackType.SIDE -> RatkoLocationTrackType.SIDE
+        null -> RatkoLocationTrackType.NULL
+    }
 
-fun mapToRatkoTopologicalConnectivityType(type: TopologicalConnectivityType) = when (type) {
-    TopologicalConnectivityType.NONE -> RatkoTopologicalConnectivityType.NONE
-    TopologicalConnectivityType.START -> RatkoTopologicalConnectivityType.START
-    TopologicalConnectivityType.END -> RatkoTopologicalConnectivityType.END
-    TopologicalConnectivityType.START_AND_END -> RatkoTopologicalConnectivityType.START_AND_END
-}
+fun mapToRatkoTopologicalConnectivityType(type: TopologicalConnectivityType) =
+    when (type) {
+        TopologicalConnectivityType.NONE -> RatkoTopologicalConnectivityType.NONE
+        TopologicalConnectivityType.START -> RatkoTopologicalConnectivityType.START
+        TopologicalConnectivityType.END -> RatkoTopologicalConnectivityType.END
+        TopologicalConnectivityType.START_AND_END -> RatkoTopologicalConnectivityType.START_AND_END
+    }
 
-fun mapToRatkoMeasurementMethod(layoutMeasurementMethod: MeasurementMethod?) = when (layoutMeasurementMethod) {
-    MeasurementMethod.VERIFIED_DESIGNED_GEOMETRY -> RatkoMeasurementMethod.VERIFIED_DESIGNED_GEOMETRY
-    MeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY -> RatkoMeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY
-    MeasurementMethod.TRACK_INSPECTION -> RatkoMeasurementMethod.TRACK_INSPECTION
-    MeasurementMethod.DIGITIZED_AERIAL_IMAGE -> RatkoMeasurementMethod.DIGITALIZED_AERIAL_IMAGE
-    MeasurementMethod.UNVERIFIED_DESIGNED_GEOMETRY -> RatkoMeasurementMethod.UNVERIFIED_DESIGNED_GEOMETRY
-    null -> RatkoMeasurementMethod.UNKNOWN
-}
+fun mapToRatkoMeasurementMethod(layoutMeasurementMethod: MeasurementMethod?) =
+    when (layoutMeasurementMethod) {
+        MeasurementMethod.VERIFIED_DESIGNED_GEOMETRY ->
+            RatkoMeasurementMethod.VERIFIED_DESIGNED_GEOMETRY
+        MeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY ->
+            RatkoMeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY
+        MeasurementMethod.TRACK_INSPECTION -> RatkoMeasurementMethod.TRACK_INSPECTION
+        MeasurementMethod.DIGITIZED_AERIAL_IMAGE -> RatkoMeasurementMethod.DIGITALIZED_AERIAL_IMAGE
+        MeasurementMethod.UNVERIFIED_DESIGNED_GEOMETRY ->
+            RatkoMeasurementMethod.UNVERIFIED_DESIGNED_GEOMETRY
+        null -> RatkoMeasurementMethod.UNKNOWN
+    }
 
 fun mapToRatkoSwitchState(
     layoutStateCategory: LayoutStateCategory,
     ratkoSwitchState: RatkoAssetState?,
-) = if (ratkoSwitchState == null || layoutStateCategory != ratkoSwitchState.category) when (layoutStateCategory) {
-    LayoutStateCategory.FUTURE_EXISTING -> RatkoAssetState.PLANNED
-    LayoutStateCategory.EXISTING -> RatkoAssetState.IN_USE
-    LayoutStateCategory.NOT_EXISTING -> RatkoAssetState.DELETED
-}
-else ratkoSwitchState
+) =
+    if (ratkoSwitchState == null || layoutStateCategory != ratkoSwitchState.category)
+        when (layoutStateCategory) {
+            LayoutStateCategory.FUTURE_EXISTING -> RatkoAssetState.PLANNED
+            LayoutStateCategory.EXISTING -> RatkoAssetState.IN_USE
+            LayoutStateCategory.NOT_EXISTING -> RatkoAssetState.DELETED
+        }
+    else ratkoSwitchState
 
 fun convertToRatkoAssetGeometries(
     joints: Collection<TrackLayoutSwitchJoint>,
     switchType: SwitchBaseType,
-) = joints.map { joint ->
-    RatkoAssetGeometry(
-        geometry = RatkoGeometry(joint.location),
-        geomType = mapJointNumberToGeometryType(joint.number, switchType),
-        assetGeomAccuracyType = mapLocationAccuracyToRatkoLocationAccuracy(joint.locationAccuracy)
-    )
-}
+) =
+    joints.map { joint ->
+        RatkoAssetGeometry(
+            geometry = RatkoGeometry(joint.location),
+            geomType = mapJointNumberToGeometryType(joint.number, switchType),
+            assetGeomAccuracyType =
+                mapLocationAccuracyToRatkoLocationAccuracy(joint.locationAccuracy))
+    }
 
-fun mapLocationAccuracyToRatkoLocationAccuracy(locationAccuracy: LocationAccuracy?) = when (locationAccuracy) {
-    LocationAccuracy.DESIGNED_GEOLOCATION -> RatkoAssetGeomAccuracyType.DESIGNED_GEOLOCATION
-    LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY -> RatkoAssetGeomAccuracyType.OFFICIALLY_MEASURED_GEODETICALLY
-    LocationAccuracy.MEASURED_GEODETICALLY -> RatkoAssetGeomAccuracyType.MEASURED_GEODETICALLY
-    LocationAccuracy.DIGITIZED_AERIAL_IMAGE -> RatkoAssetGeomAccuracyType.DIGITALIZED_AERIAL_IMAGE
-    LocationAccuracy.GEOMETRY_CALCULATED -> RatkoAssetGeomAccuracyType.GEOMETRY_CALCULATED
-    else -> RatkoAssetGeomAccuracyType.UNKNOWN
-}
+fun mapLocationAccuracyToRatkoLocationAccuracy(locationAccuracy: LocationAccuracy?) =
+    when (locationAccuracy) {
+        LocationAccuracy.DESIGNED_GEOLOCATION -> RatkoAssetGeomAccuracyType.DESIGNED_GEOLOCATION
+        LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY ->
+            RatkoAssetGeomAccuracyType.OFFICIALLY_MEASURED_GEODETICALLY
+        LocationAccuracy.MEASURED_GEODETICALLY -> RatkoAssetGeomAccuracyType.MEASURED_GEODETICALLY
+        LocationAccuracy.DIGITIZED_AERIAL_IMAGE ->
+            RatkoAssetGeomAccuracyType.DIGITALIZED_AERIAL_IMAGE
+        LocationAccuracy.GEOMETRY_CALCULATED -> RatkoAssetGeomAccuracyType.GEOMETRY_CALCULATED
+        else -> RatkoAssetGeomAccuracyType.UNKNOWN
+    }
 
-fun mapGeometryTypeToNodeType(geometryType: RatkoAssetGeometryType) = when (geometryType) {
-    RatkoAssetGeometryType.JOINT_A -> RatkoNodeType.JOINT_A
-    RatkoAssetGeometryType.JOINT_B -> RatkoNodeType.JOINT_B
-    RatkoAssetGeometryType.JOINT_C -> RatkoNodeType.JOINT_C
-    RatkoAssetGeometryType.JOINT_D -> RatkoNodeType.JOINT_D
-    else -> null
-}
+fun mapGeometryTypeToNodeType(geometryType: RatkoAssetGeometryType) =
+    when (geometryType) {
+        RatkoAssetGeometryType.JOINT_A -> RatkoNodeType.JOINT_A
+        RatkoAssetGeometryType.JOINT_B -> RatkoNodeType.JOINT_B
+        RatkoAssetGeometryType.JOINT_C -> RatkoNodeType.JOINT_C
+        RatkoAssetGeometryType.JOINT_D -> RatkoNodeType.JOINT_D
+        else -> null
+    }
 
 fun mapJointNumberToGeometryType(
     number: JointNumber,
     baseType: SwitchBaseType,
 ): RatkoAssetGeometryType {
-    val geometryType = if (baseType === SwitchBaseType.YV || baseType === SwitchBaseType.TYV) {
-        when (number.intValue) {
-            1 -> RatkoAssetGeometryType.JOINT_A
-            2 -> RatkoAssetGeometryType.JOINT_B
-            3 -> RatkoAssetGeometryType.JOINT_C
-            5 -> RatkoAssetGeometryType.MATH_POINT
-            else -> null
-        }
-    } else if (baseType === SwitchBaseType.KV) {
-        when (number.intValue) {
-            1 -> RatkoAssetGeometryType.JOINT_A
-            2 -> RatkoAssetGeometryType.JOINT_B
-            3 -> RatkoAssetGeometryType.JOINT_C
-            4 -> RatkoAssetGeometryType.JOINT_D
-            5 -> RatkoAssetGeometryType.MATH_POINT_AC
-            6 -> RatkoAssetGeometryType.MATH_POINT_AD
-            else -> null
-        }
-    } else if (baseType === SwitchBaseType.KRV || baseType === SwitchBaseType.YRV || baseType === SwitchBaseType.RR) {
-        when (number.intValue) {
-            1 -> RatkoAssetGeometryType.JOINT_A
-            2 -> RatkoAssetGeometryType.JOINT_B
-            3 -> RatkoAssetGeometryType.JOINT_C
-            4 -> RatkoAssetGeometryType.JOINT_D
-            5 -> RatkoAssetGeometryType.MATH_POINT
-            else -> null
-        }
-    } else if (baseType === SwitchBaseType.UKV) {
-        when (number.intValue) {
-            1 -> RatkoAssetGeometryType.JOINT_A
-            7 -> RatkoAssetGeometryType.MATH_POINT_AC
-            8 -> RatkoAssetGeometryType.MATH_POINT_AB
-            10 -> RatkoAssetGeometryType.JOINT_C
-            11 -> RatkoAssetGeometryType.JOINT_B
-            else -> null
-        }
-    } else if (baseType === SwitchBaseType.SKV) {
-        when (number.intValue) {
-            1 -> RatkoAssetGeometryType.JOINT_A
-            13 -> RatkoAssetGeometryType.MATH_POINT_AC
-            16 -> RatkoAssetGeometryType.JOINT_B
-            17 -> RatkoAssetGeometryType.JOINT_C
-            else -> null
-        }
-    } else if (baseType === SwitchBaseType.SRR) {
-        when (number.intValue) {
-            1 -> RatkoAssetGeometryType.JOINT_A
-            2 -> RatkoAssetGeometryType.JOINT_B
-            3 -> RatkoAssetGeometryType.JOINT_C
-            4 -> RatkoAssetGeometryType.JOINT_D
-            5 -> RatkoAssetGeometryType.MATH_POINT
-            else -> null
-        }
-    } else null
+    val geometryType =
+        if (baseType === SwitchBaseType.YV || baseType === SwitchBaseType.TYV) {
+            when (number.intValue) {
+                1 -> RatkoAssetGeometryType.JOINT_A
+                2 -> RatkoAssetGeometryType.JOINT_B
+                3 -> RatkoAssetGeometryType.JOINT_C
+                5 -> RatkoAssetGeometryType.MATH_POINT
+                else -> null
+            }
+        } else if (baseType === SwitchBaseType.KV) {
+            when (number.intValue) {
+                1 -> RatkoAssetGeometryType.JOINT_A
+                2 -> RatkoAssetGeometryType.JOINT_B
+                3 -> RatkoAssetGeometryType.JOINT_C
+                4 -> RatkoAssetGeometryType.JOINT_D
+                5 -> RatkoAssetGeometryType.MATH_POINT_AC
+                6 -> RatkoAssetGeometryType.MATH_POINT_AD
+                else -> null
+            }
+        } else if (baseType === SwitchBaseType.KRV ||
+            baseType === SwitchBaseType.YRV ||
+            baseType === SwitchBaseType.RR) {
+            when (number.intValue) {
+                1 -> RatkoAssetGeometryType.JOINT_A
+                2 -> RatkoAssetGeometryType.JOINT_B
+                3 -> RatkoAssetGeometryType.JOINT_C
+                4 -> RatkoAssetGeometryType.JOINT_D
+                5 -> RatkoAssetGeometryType.MATH_POINT
+                else -> null
+            }
+        } else if (baseType === SwitchBaseType.UKV) {
+            when (number.intValue) {
+                1 -> RatkoAssetGeometryType.JOINT_A
+                7 -> RatkoAssetGeometryType.MATH_POINT_AC
+                8 -> RatkoAssetGeometryType.MATH_POINT_AB
+                10 -> RatkoAssetGeometryType.JOINT_C
+                11 -> RatkoAssetGeometryType.JOINT_B
+                else -> null
+            }
+        } else if (baseType === SwitchBaseType.SKV) {
+            when (number.intValue) {
+                1 -> RatkoAssetGeometryType.JOINT_A
+                13 -> RatkoAssetGeometryType.MATH_POINT_AC
+                16 -> RatkoAssetGeometryType.JOINT_B
+                17 -> RatkoAssetGeometryType.JOINT_C
+                else -> null
+            }
+        } else if (baseType === SwitchBaseType.SRR) {
+            when (number.intValue) {
+                1 -> RatkoAssetGeometryType.JOINT_A
+                2 -> RatkoAssetGeometryType.JOINT_B
+                3 -> RatkoAssetGeometryType.JOINT_C
+                4 -> RatkoAssetGeometryType.JOINT_D
+                5 -> RatkoAssetGeometryType.MATH_POINT
+                else -> null
+            }
+        } else null
 
-    return checkNotNull(geometryType) { "Unknown switch joint number ${number.intValue} for switch type $baseType" }
+    return checkNotNull(geometryType) {
+        "Unknown switch joint number ${number.intValue} for switch type $baseType"
+    }
 }
 
 fun convertToRatkoLocationTrack(
@@ -158,46 +178,50 @@ fun convertToRatkoLocationTrack(
     nodeCollection: RatkoNodes? = null,
     duplicateOfOid: Oid<LocationTrack>?,
     descriptionGetter: (LocationTrack) -> String,
-) = RatkoLocationTrack(
-    id = locationTrack.externalId?.toString(),
-    name = locationTrack.name.toString(),
-    routenumber = trackNumberOid?.let(::RatkoOid),
-    description = descriptionGetter(locationTrack),
-    state = mapToRatkoLocationTrackState(locationTrack.state),
-    type = mapToRatkoLocationTrackType(locationTrack.type),
-    nodecollection = nodeCollection,
-    duplicateOf = duplicateOfOid?.toString(),
-    topologicalConnectivity = mapToRatkoTopologicalConnectivityType(locationTrack.topologicalConnectivity),
-)
+) =
+    RatkoLocationTrack(
+        id = locationTrack.externalId?.toString(),
+        name = locationTrack.name.toString(),
+        routenumber = trackNumberOid?.let(::RatkoOid),
+        description = descriptionGetter(locationTrack),
+        state = mapToRatkoLocationTrackState(locationTrack.state),
+        type = mapToRatkoLocationTrackType(locationTrack.type),
+        nodecollection = nodeCollection,
+        duplicateOf = duplicateOfOid?.toString(),
+        topologicalConnectivity =
+            mapToRatkoTopologicalConnectivityType(locationTrack.topologicalConnectivity),
+    )
 
 fun convertToRatkoRouteNumber(
     trackNumber: TrackLayoutTrackNumber,
     nodeCollection: RatkoNodes? = null,
-) = RatkoRouteNumber(
-    id = trackNumber.externalId?.toString(),
-    name = trackNumber.number.toString(),
-    description = trackNumber.description.toString(),
-    state = mapToRatkoRouteNumberState(trackNumber.state),
-    nodecollection = nodeCollection,
-)
+) =
+    RatkoRouteNumber(
+        id = trackNumber.externalId?.toString(),
+        name = trackNumber.number.toString(),
+        description = trackNumber.description.toString(),
+        state = mapToRatkoRouteNumberState(trackNumber.state),
+        nodecollection = nodeCollection,
+    )
 
 fun convertToRatkoPoint(
     point: AddressPoint,
     state: RatkoPointStates = RatkoPointStates.VALID,
-) = RatkoPoint(
-    state = RatkoPointState(state),
-    kmM = RatkoTrackMeter(point.address),
-    geometry = RatkoGeometry(point.point),
-)
-
-fun convertToRatkoNodeCollection(addresses: AlignmentAddresses) = convertToRatkoNodeCollection(
-    listOf(
-        convertToRatkoNode(addresses.startPoint, RatkoNodeType.START_POINT),
-        convertToRatkoNode(addresses.endPoint, RatkoNodeType.END_POINT)
+) =
+    RatkoPoint(
+        state = RatkoPointState(state),
+        kmM = RatkoTrackMeter(point.address),
+        geometry = RatkoGeometry(point.point),
     )
-)
 
-fun convertToRatkoNodeCollection(nodes: Collection<RatkoNode>) = RatkoNodes(nodes, RatkoNodesType.START_AND_END)
+fun convertToRatkoNodeCollection(addresses: AlignmentAddresses) =
+    convertToRatkoNodeCollection(
+        listOf(
+            convertToRatkoNode(addresses.startPoint, RatkoNodeType.START_POINT),
+            convertToRatkoNode(addresses.endPoint, RatkoNodeType.END_POINT)))
+
+fun convertToRatkoNodeCollection(nodes: Collection<RatkoNode>) =
+    RatkoNodes(nodes, RatkoNodesType.START_AND_END)
 
 fun convertToRatkoNode(
     addressPoint: AddressPoint,
@@ -211,125 +235,150 @@ fun convertToRatkoMetadataAsset(
     segmentMetadata: LayoutSegmentMetadata,
     startTrackMeter: TrackMeter,
     endTrackMeter: TrackMeter,
-) = RatkoMetadataAsset(
-    properties = listOf(
-        RatkoAssetProperty(
-            name = "filename", stringValue = segmentMetadata.fileName?.toString() ?: ""
-        ),
-        RatkoAssetProperty(
-            name = "measurement_method",
-            enumValue = mapToRatkoMeasurementMethod(segmentMetadata.measurementMethod).value,
-        ),
-        RatkoAssetProperty(
-            name = "created_year", integerValue = segmentMetadata.planTime?.atZone(ZoneId.systemDefault())?.year ?: 1800
-        ),
-        RatkoAssetProperty(
-            name = "original_crs", stringValue = segmentMetadata.originalSrid?.toString() ?: ""
-        ),
-        RatkoAssetProperty(
-            name = "alignment", stringValue = segmentMetadata.alignmentName?.toString() ?: ""
-        ),
-    ),
-    locations = listOf(
-        RatkoAssetLocation(
-            priority = 1, accuracyType = RatkoAccuracyType.GEOMETRY_CALCULATED, nodecollection = RatkoNodes(
-                type = RatkoNodesType.START_AND_END,
-                nodes = listOf(
-                    RatkoNode(
-                        nodeType = RatkoNodeType.START_POINT,
-                        point = RatkoPoint(
-                            kmM = RatkoTrackMeter(startTrackMeter),
-                            locationtrack = RatkoOid(locationTrackOid),
-                            routenumber = RatkoOid(trackNumberOid),
-                            geometry = RatkoGeometry(segmentMetadata.startPoint),
-                            state = RatkoPointState(RatkoPointStates.VALID),
-                            rowMetadata = null,
-                        ),
-                    ),
-                    RatkoNode(
-                        nodeType = RatkoNodeType.END_POINT,
-                        point = RatkoPoint(
-                            kmM = RatkoTrackMeter(endTrackMeter),
-                            locationtrack = RatkoOid(locationTrackOid),
-                            routenumber = RatkoOid(trackNumberOid),
-                            geometry = RatkoGeometry(segmentMetadata.endPoint),
-                            state = RatkoPointState(RatkoPointStates.VALID),
-                            rowMetadata = null,
-                        ),
-                    ),
+) =
+    RatkoMetadataAsset(
+        properties =
+            listOf(
+                RatkoAssetProperty(
+                    name = "filename", stringValue = segmentMetadata.fileName?.toString() ?: ""),
+                RatkoAssetProperty(
+                    name = "measurement_method",
+                    enumValue =
+                        mapToRatkoMeasurementMethod(segmentMetadata.measurementMethod).value,
                 ),
-            )
-        ),
-    ),
-)
+                RatkoAssetProperty(
+                    name = "created_year",
+                    integerValue =
+                        segmentMetadata.planTime?.atZone(ZoneId.systemDefault())?.year ?: 1800),
+                RatkoAssetProperty(
+                    name = "original_crs",
+                    stringValue = segmentMetadata.originalSrid?.toString() ?: ""),
+                RatkoAssetProperty(
+                    name = "alignment",
+                    stringValue = segmentMetadata.alignmentName?.toString() ?: ""),
+            ),
+        locations =
+            listOf(
+                RatkoAssetLocation(
+                    priority = 1,
+                    accuracyType = RatkoAccuracyType.GEOMETRY_CALCULATED,
+                    nodecollection =
+                        RatkoNodes(
+                            type = RatkoNodesType.START_AND_END,
+                            nodes =
+                                listOf(
+                                    RatkoNode(
+                                        nodeType = RatkoNodeType.START_POINT,
+                                        point =
+                                            RatkoPoint(
+                                                kmM = RatkoTrackMeter(startTrackMeter),
+                                                locationtrack = RatkoOid(locationTrackOid),
+                                                routenumber = RatkoOid(trackNumberOid),
+                                                geometry =
+                                                    RatkoGeometry(segmentMetadata.startPoint),
+                                                state = RatkoPointState(RatkoPointStates.VALID),
+                                                rowMetadata = null,
+                                            ),
+                                    ),
+                                    RatkoNode(
+                                        nodeType = RatkoNodeType.END_POINT,
+                                        point =
+                                            RatkoPoint(
+                                                kmM = RatkoTrackMeter(endTrackMeter),
+                                                locationtrack = RatkoOid(locationTrackOid),
+                                                routenumber = RatkoOid(trackNumberOid),
+                                                geometry = RatkoGeometry(segmentMetadata.endPoint),
+                                                state = RatkoPointState(RatkoPointStates.VALID),
+                                                rowMetadata = null,
+                                            ),
+                                    ),
+                                ),
+                        )),
+            ),
+    )
 
 fun convertToRatkoSwitch(
     layoutSwitch: TrackLayoutSwitch,
     switchStructure: SwitchStructure,
     switchOwner: SwitchOwner?,
     existingRatkoSwitch: RatkoSwitchAsset? = null,
-) = RatkoSwitchAsset(
-    id = layoutSwitch.externalId?.toString(),
-    state = mapToRatkoSwitchState(layoutSwitch.stateCategory, existingRatkoSwitch?.state),
-    properties = listOf(RatkoAssetProperty(
-        name = "name",
-        stringValue = layoutSwitch.name.toString(),
-    ), RatkoAssetProperty(
-        name = "turnout_id",
-        stringValue = layoutSwitch.name.toString(),
-    ), RatkoAssetProperty(
-        name = "turnout_type",
-        enumValue = asSwitchTypeString(switchStructure.type),
-    ), RatkoAssetProperty(name = "safety_turnout",
-        enumValue = layoutSwitch.trapPoint?.let { if (it) "Kyllä" else "Ei" } ?: "Ei tiedossa"), RatkoAssetProperty(
-        name = "owner", enumValue = switchOwner?.name?.toString() ?: "Ei tiedossa"
-    ), RatkoAssetProperty(name = "handedness", enumValue = switchStructure.hand.let { hand ->
-        when (hand) {
-            SwitchHand.LEFT -> "Vasenkätinen"
-            SwitchHand.RIGHT -> "Oikeakätinen"
-            else -> "Ei kätisyyttä"
-        }
-    })
-    ),
-    locations = null,
-    assetGeoms = null,
-)
+) =
+    RatkoSwitchAsset(
+        id = layoutSwitch.externalId?.toString(),
+        state = mapToRatkoSwitchState(layoutSwitch.stateCategory, existingRatkoSwitch?.state),
+        properties =
+            listOf(
+                RatkoAssetProperty(
+                    name = "name",
+                    stringValue = layoutSwitch.name.toString(),
+                ),
+                RatkoAssetProperty(
+                    name = "turnout_id",
+                    stringValue = layoutSwitch.name.toString(),
+                ),
+                RatkoAssetProperty(
+                    name = "turnout_type",
+                    enumValue = asSwitchTypeString(switchStructure.type),
+                ),
+                RatkoAssetProperty(
+                    name = "safety_turnout",
+                    enumValue =
+                        layoutSwitch.trapPoint?.let { if (it) "Kyllä" else "Ei" } ?: "Ei tiedossa"),
+                RatkoAssetProperty(
+                    name = "owner", enumValue = switchOwner?.name?.toString() ?: "Ei tiedossa"),
+                RatkoAssetProperty(
+                    name = "handedness",
+                    enumValue =
+                        switchStructure.hand.let { hand ->
+                            when (hand) {
+                                SwitchHand.LEFT -> "Vasenkätinen"
+                                SwitchHand.RIGHT -> "Oikeakätinen"
+                                else -> "Ei kätisyyttä"
+                            }
+                        })),
+        locations = null,
+        assetGeoms = null,
+    )
 
 fun convertToRatkoAssetLocations(
     jointChanges: List<SwitchJointChange>,
     switchType: SwitchBaseType,
 ): List<RatkoAssetLocation> {
-    return jointChanges.groupBy { it.locationTrackId }.map { (_, jointChange) ->
-        jointChange.mapNotNull { change ->
-            val nodeType = mapGeometryTypeToNodeType(
-                mapJointNumberToGeometryType(change.number, switchType)
-            )
+    return jointChanges
+        .groupBy { it.locationTrackId }
+        .map { (_, jointChange) ->
+            jointChange.mapNotNull { change ->
+                val nodeType =
+                    mapGeometryTypeToNodeType(
+                        mapJointNumberToGeometryType(change.number, switchType))
 
-            nodeType?.let {
-                checkNotNull(change.locationTrackExternalId) {
-                    "Cannot push switch changes with missing location track oid $change"
+                nodeType?.let {
+                    checkNotNull(change.locationTrackExternalId) {
+                        "Cannot push switch changes with missing location track oid $change"
+                    }
+
+                    checkNotNull(change.trackNumberExternalId) {
+                        "Cannot push switch changes with missing route number oid $change"
+                    }
+
+                    RatkoNode(
+                        nodeType = nodeType,
+                        point =
+                            RatkoPoint(
+                                state = RatkoPointState(RatkoPointStates.VALID),
+                                locationtrack = RatkoOid(change.locationTrackExternalId),
+                                routenumber = RatkoOid(change.trackNumberExternalId),
+                                kmM = RatkoTrackMeter(change.address),
+                                geometry = RatkoGeometry(change.point),
+                            ))
                 }
-
-                checkNotNull(change.trackNumberExternalId) {
-                    "Cannot push switch changes with missing route number oid $change"
-                }
-
-                RatkoNode(
-                    nodeType = nodeType, point = RatkoPoint(
-                        state = RatkoPointState(RatkoPointStates.VALID),
-                        locationtrack = RatkoOid(change.locationTrackExternalId),
-                        routenumber = RatkoOid(change.trackNumberExternalId),
-                        kmM = RatkoTrackMeter(change.address),
-                        geometry = RatkoGeometry(change.point),
-                    )
-                )
             }
         }
-    }.filter { it.isNotEmpty() }.mapIndexed { index, locationNodes ->
-        RatkoAssetLocation(
-            nodecollection = RatkoNodes(
-                type = RatkoNodesType.JOINTS, nodes = locationNodes
-            ), priority = index + 1, accuracyType = RatkoAccuracyType.GEOMETRY_CALCULATED
-        )
-    }
+        .filter { it.isNotEmpty() }
+        .mapIndexed { index, locationNodes ->
+            RatkoAssetLocation(
+                nodecollection = RatkoNodes(type = RatkoNodesType.JOINTS, nodes = locationNodes),
+                priority = index + 1,
+                accuracyType = RatkoAccuracyType.GEOMETRY_CALCULATED)
+        }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoLocationTrackModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoLocationTrackModel.kt
@@ -31,9 +31,7 @@ enum class RatkoLocationTrackState(@get:JsonValue val value: String) {
     NOT_IN_USE("NOT IN USE"),
     PLANNED("PLANNED"),
     IN_USE("IN USE"),
-
-    @Suppress("unused")
-    OLD("OLD"),
+    @Suppress("unused") OLD("OLD"),
 }
 
 enum class RatkoTopologicalConnectivityType(@get:JsonValue val value: String) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
@@ -10,7 +10,8 @@ enum class OperationalPointType {
     LPO, // Liikennepaikan osa
     OLP, // Osiin jaettu liikennepaikka
     SEIS, // Seisake
-    LVH; // Linjavaihde
+    LVH
+    // Linjavaihde
 }
 
 abstract class AbstractRatkoOperatingPoint(
@@ -44,19 +45,24 @@ data class RatkoOperatingPoint(
 fun parseAsset(asset: RatkoOperatingPointAsset): RatkoOperatingPointParse? {
     val externalId = Oid<RatkoOperatingPoint>(asset.id)
     val type = asset.getEnumProperty<OperationalPointType>("operational_point_type")
-    val soloPoint = asset.locations?.get(0)?.nodecollection?.nodes?.find { node ->
-        node.nodeType == RatkoNodeType.SOLO_POINT
-    }?.point
+    val soloPoint =
+        asset.locations
+            ?.get(0)
+            ?.nodecollection
+            ?.nodes
+            ?.find { node -> node.nodeType == RatkoNodeType.SOLO_POINT }
+            ?.point
     val location = soloPoint?.geometry?.coordinates?.let { cs -> Point(cs[0], cs[1]) }
-    val trackNumberExternalId: Oid<RatkoRouteNumber>? = soloPoint?.routenumber?.toString()?.let(::Oid)
-    return if (type == null || location == null || trackNumberExternalId == null) null else RatkoOperatingPointParse(
-        externalId = externalId,
-        name = asset.getStringProperty("name") ?: "",
-        abbreviation = asset.getStringProperty("operational_point_abbreviation") ?: "",
-        uicCode = asset.getStringProperty("operational_point_code") ?: "",
-        type = type,
-        location = location,
-        trackNumberExternalId = trackNumberExternalId
-    )
+    val trackNumberExternalId: Oid<RatkoRouteNumber>? =
+        soloPoint?.routenumber?.toString()?.let(::Oid)
+    return if (type == null || location == null || trackNumberExternalId == null) null
+    else
+        RatkoOperatingPointParse(
+            externalId = externalId,
+            name = asset.getStringProperty("name") ?: "",
+            abbreviation = asset.getStringProperty("operational_point_abbreviation") ?: "",
+            uicCode = asset.getStringProperty("operational_point_code") ?: "",
+            type = type,
+            location = location,
+            trackNumberExternalId = trackNumberExternalId)
 }
-

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoRouteNumberModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoRouteNumberModel.kt
@@ -3,7 +3,6 @@ package fi.fta.geoviite.infra.ratko.model
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
 
-
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class RatkoRouteNumber(
     val id: String?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -32,7 +32,9 @@ data class SplitHeader(
     val bulkTransferState: BulkTransferState,
     val publicationId: IntId<Publication>?,
 ) {
-    constructor(split: Split) : this(
+    constructor(
+        split: Split
+    ) : this(
         id = split.id,
         locationTrackId = split.sourceLocationTrackId,
         bulkTransferState = split.bulkTransferState,
@@ -55,10 +57,14 @@ data class Split(
 ) {
     init {
         if (publicationId != null) {
-            require(id == rowVersion.id) { "Split source row version must refer to official row, once published" }
+            require(id == rowVersion.id) {
+                "Split source row version must refer to official row, once published"
+            }
         }
         if (publicationId == null) {
-            require(bulkTransferState == BulkTransferState.PENDING) { "Split must be pending if not published" }
+            require(bulkTransferState == BulkTransferState.PENDING) {
+                "Split must be pending if not published"
+            }
         }
 
         if (bulkTransferState == BulkTransferState.IN_PROGRESS) {
@@ -69,29 +75,42 @@ data class Split(
     }
 
     @get:JsonIgnore
-    val locationTracks by lazy { targetLocationTracks.map { it.locationTrackId } + sourceLocationTrackId }
+    val locationTracks by lazy {
+        targetLocationTracks.map { it.locationTrackId } + sourceLocationTrackId
+    }
 
     @JsonIgnore
-    val isPublishedAndWaitingTransfer: Boolean = bulkTransferState != BulkTransferState.DONE && publicationId != null
+    val isPublishedAndWaitingTransfer: Boolean =
+        bulkTransferState != BulkTransferState.DONE && publicationId != null
 
     fun containsTargetTrack(trackId: IntId<LocationTrack>): Boolean =
         targetLocationTracks.any { tlt -> tlt.locationTrackId == trackId }
-    fun containsLocationTrack(trackId: IntId<LocationTrack>): Boolean = locationTracks.contains(trackId)
+
+    fun containsLocationTrack(trackId: IntId<LocationTrack>): Boolean =
+        locationTracks.contains(trackId)
+
     fun getTargetLocationTrack(trackId: IntId<LocationTrack>): SplitTarget? =
         targetLocationTracks.find { track -> track.locationTrackId == trackId }
 
-    fun containsSwitch(switchId: IntId<TrackLayoutSwitch>): Boolean = relinkedSwitches.contains(switchId)
+    fun containsSwitch(switchId: IntId<TrackLayoutSwitch>): Boolean =
+        relinkedSwitches.contains(switchId)
 }
 
-enum class SplitTargetOperation { CREATE, OVERWRITE, TRANSFER }
+enum class SplitTargetOperation {
+    CREATE,
+    OVERWRITE,
+    TRANSFER
+}
 
 enum class SplitTargetDuplicateOperation {
     TRANSFER,
     OVERWRITE;
-    fun toSplitTargetOperation(): SplitTargetOperation = when (this) {
-        TRANSFER -> SplitTargetOperation.TRANSFER
-        OVERWRITE -> SplitTargetOperation.OVERWRITE
-    }
+
+    fun toSplitTargetOperation(): SplitTargetOperation =
+        when (this) {
+            TRANSFER -> SplitTargetOperation.TRANSFER
+            OVERWRITE -> SplitTargetOperation.OVERWRITE
+        }
 }
 
 data class SplitTarget(
@@ -108,7 +127,12 @@ data class SplitLayoutValidationIssues(
     val switches: Map<IntId<TrackLayoutSwitch>, List<LayoutValidationIssue>>,
 ) {
     fun allIssues(): List<LayoutValidationIssue> =
-        (trackNumbers.values + referenceLines.values + kmPosts.values + locationTracks.values + switches.values).flatten()
+        (trackNumbers.values +
+                referenceLines.values +
+                kmPosts.values +
+                locationTracks.values +
+                switches.values)
+            .flatten()
 }
 
 data class SplitRequestTargetDuplicate(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -22,27 +22,29 @@ import fi.fta.geoviite.infra.util.getOne
 import fi.fta.geoviite.infra.util.getOptional
 import fi.fta.geoviite.infra.util.getRowVersion
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.ResultSet
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
 
-private fun toSplit(rs: ResultSet, targetLocationTracks: List<SplitTarget>) = Split(
-    id = rs.getIntId("id"),
-    rowVersion = rs.getRowVersion("id", "version"),
-    sourceLocationTrackId = rs.getIntId("source_location_track_official_id"),
-    sourceLocationTrackVersion = rs.getLayoutRowVersion(
-        "source_location_track_row_id",
-        "source_location_track_row_version",
-    ),
-    bulkTransferState = rs.getEnum("bulk_transfer_state"),
-    bulkTransferId = rs.getIntIdOrNull("bulk_transfer_id"),
-    publicationId = rs.getIntIdOrNull("publication_id"),
-    publicationTime = rs.getInstantOrNull("publication_time"),
-    targetLocationTracks = targetLocationTracks,
-    relinkedSwitches = rs.getIntIdArray("switch_ids"),
-    updatedDuplicates = rs.getIntIdArray("updated_duplicate_ids"),
-)
+private fun toSplit(rs: ResultSet, targetLocationTracks: List<SplitTarget>) =
+    Split(
+        id = rs.getIntId("id"),
+        rowVersion = rs.getRowVersion("id", "version"),
+        sourceLocationTrackId = rs.getIntId("source_location_track_official_id"),
+        sourceLocationTrackVersion =
+            rs.getLayoutRowVersion(
+                "source_location_track_row_id",
+                "source_location_track_row_version",
+            ),
+        bulkTransferState = rs.getEnum("bulk_transfer_state"),
+        bulkTransferId = rs.getIntIdOrNull("bulk_transfer_id"),
+        publicationId = rs.getIntIdOrNull("publication_id"),
+        publicationTime = rs.getInstantOrNull("publication_time"),
+        targetLocationTracks = targetLocationTracks,
+        relinkedSwitches = rs.getIntIdArray("switch_ids"),
+        updatedDuplicates = rs.getIntIdArray("updated_duplicate_ids"),
+    )
 
 @Transactional(readOnly = true)
 @Component
@@ -57,7 +59,8 @@ class SplitDao(
         relinkedSwitches: Collection<IntId<TrackLayoutSwitch>>,
         updatedDuplicates: Collection<IntId<LocationTrack>>,
     ): IntId<Split> {
-        val sql = """
+        val sql =
+            """
             insert into publication.split(
               source_location_track_row_id,
               source_location_track_row_version,
@@ -73,16 +76,19 @@ class SplitDao(
               null
             )
             returning id
-        """.trimIndent()
+        """
+                .trimIndent()
 
         jdbcTemplate.setUser()
-        val params = mapOf(
-            "source_location_track_row_id" to sourceLocationTrackVersion.rowId.intValue,
-            "source_location_track_row_version" to sourceLocationTrackVersion.version,
-        )
-        val splitId = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getIntId<Split>("id")
-        } ?: error("Failed to save split for location track: version=$sourceLocationTrackVersion")
+        val params =
+            mapOf(
+                "source_location_track_row_id" to sourceLocationTrackVersion.rowId.intValue,
+                "source_location_track_row_version" to sourceLocationTrackVersion.version,
+            )
+        val splitId =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getIntId<Split>("id") }
+                ?: error(
+                    "Failed to save split for location track: version=$sourceLocationTrackVersion")
 
         logger.daoAccess(AccessType.INSERT, Split::class, splitId)
 
@@ -93,34 +99,46 @@ class SplitDao(
         return splitId
     }
 
-    private fun saveRelinkedSwitches(splitId: IntId<Split>, relinkedSwitches: Collection<IntId<TrackLayoutSwitch>>) {
-        val sql = """
+    private fun saveRelinkedSwitches(
+        splitId: IntId<Split>,
+        relinkedSwitches: Collection<IntId<TrackLayoutSwitch>>
+    ) {
+        val sql =
+            """
             insert into publication.split_relinked_switch(split_id, switch_id)
             values (:splitId, :switchId)
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = relinkedSwitches.map { switchId ->
-            mapOf(
-                "splitId" to splitId.intValue,
-                "switchId" to switchId.intValue,
-            )
-        }
+        val params =
+            relinkedSwitches.map { switchId ->
+                mapOf(
+                    "splitId" to splitId.intValue,
+                    "switchId" to switchId.intValue,
+                )
+            }
 
         jdbcTemplate.batchUpdate(sql, params.toTypedArray())
     }
 
-    private fun saveUpdatedDuplicates(splitId: IntId<Split>, updatedDuplicates: Collection<IntId<LocationTrack>>) {
-        val sql = """
+    private fun saveUpdatedDuplicates(
+        splitId: IntId<Split>,
+        updatedDuplicates: Collection<IntId<LocationTrack>>
+    ) {
+        val sql =
+            """
             insert into publication.split_updated_duplicate(split_id, duplicate_location_track_id)
             values (:splitId, :duplicateLocationTrackId)
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = updatedDuplicates.map { duplicateId ->
-            mapOf(
-                "splitId" to splitId.intValue,
-                "duplicateLocationTrackId" to duplicateId.intValue,
-            )
-        }
+        val params =
+            updatedDuplicates.map { duplicateId ->
+                mapOf(
+                    "splitId" to splitId.intValue,
+                    "duplicateLocationTrackId" to duplicateId.intValue,
+                )
+            }
 
         jdbcTemplate.batchUpdate(sql, params.toTypedArray())
     }
@@ -136,7 +154,8 @@ class SplitDao(
     }
 
     private fun saveSplitTargets(splitId: IntId<Split>, splitTargets: Collection<SplitTarget>) {
-        val sql = """
+        val sql =
+            """
             insert into publication.split_target_location_track(
                 split_id,
                 location_track_id,
@@ -151,25 +170,29 @@ class SplitDao(
                 :segmentEnd,
                 :operation::publication.split_target_operaton
             )
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = splitTargets.map { st ->
-            mapOf(
-                "splitId" to splitId.intValue,
-                "trackId" to st.locationTrackId.intValue,
-                "segmentStart" to st.segmentIndices.first,
-                "segmentEnd" to st.segmentIndices.last,
-                "operation" to st.operation.name,
-            )
-        }
+        val params =
+            splitTargets.map { st ->
+                mapOf(
+                    "splitId" to splitId.intValue,
+                    "trackId" to st.locationTrackId.intValue,
+                    "segmentStart" to st.segmentIndices.first,
+                    "segmentEnd" to st.segmentIndices.last,
+                    "operation" to st.operation.name,
+                )
+            }
 
         jdbcTemplate.batchUpdate(sql, params.toTypedArray())
     }
 
-    fun getOrThrow(splitId: IntId<Split>): Split = get(splitId) ?: throw NoSuchEntityException(Split::class, splitId)
+    fun getOrThrow(splitId: IntId<Split>): Split =
+        get(splitId) ?: throw NoSuchEntityException(Split::class, splitId)
 
     fun get(splitId: IntId<Split>): Split? {
-        val sql = """
+        val sql =
+            """
           select
               split.id,
               split.version,
@@ -191,16 +214,21 @@ class SplitDao(
               left join publication.split_updated_duplicate on split.id = split_updated_duplicate.split_id
           where split.id = :id
           group by split.id, source_track.official_row_id, source_track.id, publication.publication_time
-        """.trimIndent()
+        """
+                .trimIndent()
 
         return getOptional(
-            splitId,
-            jdbcTemplate.query(sql, mapOf("id" to splitId.intValue)) { rs, _ -> toSplit(rs, getSplitTargets(splitId)) },
-        ).also { logger.daoAccess(AccessType.FETCH, Split::class, splitId) }
+                splitId,
+                jdbcTemplate.query(sql, mapOf("id" to splitId.intValue)) { rs, _ ->
+                    toSplit(rs, getSplitTargets(splitId))
+                },
+            )
+            .also { logger.daoAccess(AccessType.FETCH, Split::class, splitId) }
     }
 
     fun getSplitHeader(splitId: IntId<Split>): SplitHeader {
-        val sql = """
+        val sql =
+            """
           select
               split.id,
               split.bulk_transfer_state,
@@ -211,18 +239,20 @@ class SplitDao(
                   on split.source_location_track_row_id = ltv.id
                    and split.source_location_track_row_version = ltv.version
           where split.id = :id
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        return getOne(splitId, jdbcTemplate.query(sql, mapOf("id" to splitId.intValue)) { rs, _ ->
-            SplitHeader(
-                id = splitId,
-                locationTrackId = rs.getIntId("source_location_track_official_id"),
-                bulkTransferState = rs.getEnum("bulk_transfer_state"),
-                publicationId = rs.getIntIdOrNull("publication_id"),
-            )
-        }).also {
-            logger.daoAccess(AccessType.FETCH, SplitHeader::class, splitId)
-        }
+        return getOne(
+                splitId,
+                jdbcTemplate.query(sql, mapOf("id" to splitId.intValue)) { rs, _ ->
+                    SplitHeader(
+                        id = splitId,
+                        locationTrackId = rs.getIntId("source_location_track_official_id"),
+                        bulkTransferState = rs.getEnum("bulk_transfer_state"),
+                        publicationId = rs.getIntIdOrNull("publication_id"),
+                    )
+                })
+            .also { logger.daoAccess(AccessType.FETCH, SplitHeader::class, splitId) }
     }
 
     @Transactional
@@ -233,7 +263,8 @@ class SplitDao(
         publicationId: IntId<Publication>? = null,
         sourceTrackVersion: LayoutRowVersion<LocationTrack>? = null,
     ): RowVersion<Split> {
-        val sql = """
+        val sql =
+            """
             update publication.split
             set 
                 bulk_transfer_state = coalesce(:bulk_transfer_state::publication.bulk_transfer_state, bulk_transfer_state),
@@ -243,25 +274,31 @@ class SplitDao(
                 source_location_track_row_version = coalesce(:source_track_row_version, source_location_track_row_version)
             where id = :split_id
             returning id, version
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "bulk_transfer_state" to bulkTransferState?.name,
-            "bulk_transfer_id" to bulkTransferId?.intValue,
-            "publication_id" to publicationId?.intValue,
-            "split_id" to splitId.intValue,
-            "source_track_row_id" to sourceTrackVersion?.rowId?.intValue,
-            "source_track_row_version" to sourceTrackVersion?.version,
-        )
+        val params =
+            mapOf(
+                "bulk_transfer_state" to bulkTransferState?.name,
+                "bulk_transfer_id" to bulkTransferId?.intValue,
+                "publication_id" to publicationId?.intValue,
+                "split_id" to splitId.intValue,
+                "source_track_row_id" to sourceTrackVersion?.rowId?.intValue,
+                "source_track_row_version" to sourceTrackVersion?.version,
+            )
 
         jdbcTemplate.setUser()
-        return getOne(splitId, jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getRowVersion<Split>("id", "version")
-        }).also { logger.daoAccess(AccessType.UPDATE, Split::class, splitId) }
+        return getOne(
+                splitId,
+                jdbcTemplate.query(sql, params) { rs, _ ->
+                    rs.getRowVersion<Split>("id", "version")
+                })
+            .also { logger.daoAccess(AccessType.UPDATE, Split::class, splitId) }
     }
 
     private fun getSplitTargets(splitId: IntId<Split>): List<SplitTarget> {
-        val sql = """
+        val sql =
+            """
           select
               location_track_id,
               source_start_segment_index,
@@ -269,19 +306,22 @@ class SplitDao(
               operation
           from publication.split_target_location_track
           where split_id = :id
-        """.trimIndent()
+        """
+                .trimIndent()
 
         return jdbcTemplate.query(sql, mapOf("id" to splitId.intValue)) { rs, _ ->
             SplitTarget(
                 locationTrackId = rs.getIntId("location_track_id"),
-                segmentIndices = rs.getInt("source_start_segment_index")..rs.getInt("source_end_segment_index"),
+                segmentIndices =
+                    rs.getInt("source_start_segment_index")..rs.getInt("source_end_segment_index"),
                 operation = rs.getEnum("operation"),
             )
         }
     }
 
     fun fetchUnfinishedSplits(branch: LayoutBranch): List<Split> {
-        val sql = """
+        val sql =
+            """
           select
               split.id,
               split.version,
@@ -304,14 +344,17 @@ class SplitDao(
           where split.bulk_transfer_state != 'DONE'
             and (ltv.design_id is null or ltv.design_id = :design_id)
           group by split.id, ltv.official_row_id, ltv.design_row_id, ltv.id, publication.publication_time
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        return jdbcTemplate.query(sql, mapOf("design_id" to branch.designId?.intValue)) { rs, _ ->
-            val splitId = rs.getIntId<Split>("id")
-            toSplit(rs, getSplitTargets(splitId))
-        }.also { ids ->
-            logger.daoAccess(AccessType.FETCH, SplitTarget::class, ids.map { it.id })
-        }
+        return jdbcTemplate
+            .query(sql, mapOf("design_id" to branch.designId?.intValue)) { rs, _ ->
+                val splitId = rs.getIntId<Split>("id")
+                toSplit(rs, getSplitTargets(splitId))
+            }
+            .also { ids ->
+                logger.daoAccess(AccessType.FETCH, SplitTarget::class, ids.map { it.id })
+            }
     }
 
     fun fetchChangeTime() = fetchLatestChangeTime(DbTable.PUBLICATION_SPLIT)
@@ -320,11 +363,18 @@ class SplitDao(
         val sql = "select id from publication.split where publication_id = :publication_id"
         val params = mapOf("publication_id" to publicationId.intValue)
 
-        return getOptional(publicationId, jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId<Split>("id") })
-            .also { _ -> logger.daoAccess(AccessType.FETCH, Split::class, "publicationId" to publicationId) }
+        return getOptional(
+                publicationId,
+                jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId<Split>("id") })
+            .also { _ ->
+                logger.daoAccess(AccessType.FETCH, Split::class, "publicationId" to publicationId)
+            }
     }
 
-    fun locationTracksPartOfAnyUnfinishedSplit(branch: LayoutBranch, locationTrackIds: Collection<IntId<LocationTrack>>) =
+    fun locationTracksPartOfAnyUnfinishedSplit(
+        branch: LayoutBranch,
+        locationTrackIds: Collection<IntId<LocationTrack>>
+    ) =
         fetchUnfinishedSplits(branch).filter { split ->
             locationTrackIds.any { lt -> split.containsLocationTrack(lt) }
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -38,9 +38,9 @@ import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.topologicalConnectivityTypeOf
 import fi.fta.geoviite.infra.util.produceIf
+import java.time.Instant
 import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 @GeoviiteService
 class SplitService(
@@ -60,26 +60,28 @@ class SplitService(
     }
 
     /**
-     * Fetches all splits that are not published. Can be filtered by location tracks or switches. If both filters
-     * are defined, the result is combined by OR (match by either).
+     * Fetches all splits that are not published. Can be filtered by location tracks or switches. If
+     * both filters are defined, the result is combined by OR (match by either).
      */
     fun findUnpublishedSplits(
         branch: LayoutBranch,
         locationTrackIds: List<IntId<LocationTrack>>? = null,
         switchIds: List<IntId<TrackLayoutSwitch>>? = null,
-    ): List<Split> = findUnfinishedSplits(branch, locationTrackIds, switchIds)
-        .filter { split -> split.publicationId == null }
+    ): List<Split> =
+        findUnfinishedSplits(branch, locationTrackIds, switchIds).filter { split ->
+            split.publicationId == null
+        }
 
     /**
-     * Fetches all splits that are not marked as DONE. Can be filtered by location tracks or switches. If both filters
-     * are defined, the result is combined by OR (match by either).
+     * Fetches all splits that are not marked as DONE. Can be filtered by location tracks or
+     * switches. If both filters are defined, the result is combined by OR (match by either).
      */
     fun findUnfinishedSplits(
         branch: LayoutBranch,
         locationTrackIds: List<IntId<LocationTrack>>? = null,
         switchIds: List<IntId<TrackLayoutSwitch>>? = null,
-    ): List<Split> = splitDao.fetchUnfinishedSplits(branch)
-        .filter { split ->
+    ): List<Split> =
+        splitDao.fetchUnfinishedSplits(branch).filter { split ->
             val containsTrack = locationTrackIds?.any(split::containsLocationTrack)
             val containsSwitch = switchIds?.any(split::containsSwitch)
             when {
@@ -94,8 +96,8 @@ class SplitService(
         branch: LayoutBranch,
         locationTracks: List<IntId<LocationTrack>>,
         switches: List<IntId<TrackLayoutSwitch>>,
-    ): List<RowVersion<Split>> = findUnpublishedSplits(branch, locationTracks, switches)
-        .map { split -> split.rowVersion }
+    ): List<RowVersion<Split>> =
+        findUnpublishedSplits(branch, locationTracks, switches).map { split -> split.rowVersion }
 
     @Transactional
     fun publishSplit(
@@ -105,23 +107,28 @@ class SplitService(
     ): List<RowVersion<Split>> {
         return validatedSplitVersions.map { splitVersion ->
             val split = splitDao.getOrThrow(splitVersion.id)
-            val track = requireNotNull(locationTracks.find { t -> t.id == split.sourceLocationTrackId }) {
-                "Source track must be part of the same publication as the split: split=$split"
-            }
-            splitDao.updateSplit(
-                splitId = split.id,
-                publicationId = publicationId,
-                sourceTrackVersion = track.rowVersion,
-            ).also { updatedVersion ->
-                // Sanity-check the version for conflicting update, though this should not be possible
-                if (updatedVersion != splitVersion.next()) {
-                    throw PublicationFailureException(
-                        message = "Split version has changed between validation and publication: split=${split.id}",
-                        localizedMessageKey = "split-version-changed",
-                        status = HttpStatus.CONFLICT,
-                    )
+            val track =
+                requireNotNull(locationTracks.find { t -> t.id == split.sourceLocationTrackId }) {
+                    "Source track must be part of the same publication as the split: split=$split"
                 }
-            }
+            splitDao
+                .updateSplit(
+                    splitId = split.id,
+                    publicationId = publicationId,
+                    sourceTrackVersion = track.rowVersion,
+                )
+                .also { updatedVersion ->
+                    // Sanity-check the version for conflicting update, though this should not be
+                    // possible
+                    if (updatedVersion != splitVersion.next()) {
+                        throw PublicationFailureException(
+                            message =
+                                "Split version has changed between validation and publication: split=${split.id}",
+                            localizedMessageKey = "split-version-changed",
+                            status = HttpStatus.CONFLICT,
+                        )
+                    }
+                }
         }
     }
 
@@ -136,40 +143,61 @@ class SplitService(
         context: ValidationContext,
         allowMultipleSplits: Boolean,
     ): SplitLayoutValidationIssues {
-        val splitIssues = validateSplitContent(
-            trackVersions = candidates.locationTracks,
-            switchVersions = candidates.switches,
-            publicationSplits = context.getPublicationSplits(),
-            allowMultipleSplits = allowMultipleSplits,
-        )
+        val splitIssues =
+            validateSplitContent(
+                trackVersions = candidates.locationTracks,
+                switchVersions = candidates.switches,
+                publicationSplits = context.getPublicationSplits(),
+                allowMultipleSplits = allowMultipleSplits,
+            )
 
-        val tnSplitIssues = candidates.trackNumbers.associate { (id, _) ->
-            id to listOfNotNull(validateSplitReferencesByTrackNumber(id, context))
-        }.filterValues { it.isNotEmpty() }
+        val tnSplitIssues =
+            candidates.trackNumbers
+                .associate { (id, _) ->
+                    id to listOfNotNull(validateSplitReferencesByTrackNumber(id, context))
+                }
+                .filterValues { it.isNotEmpty() }
 
-        val rlSplitIssues = candidates.referenceLines.associate { (id, version) ->
-            val trackNumberId = referenceLineDao.fetch(version).trackNumberId
-            id to listOfNotNull(validateSplitReferencesByTrackNumber(trackNumberId, context))
-        }.filterValues { it.isNotEmpty() }
+        val rlSplitIssues =
+            candidates.referenceLines
+                .associate { (id, version) ->
+                    val trackNumberId = referenceLineDao.fetch(version).trackNumberId
+                    id to
+                        listOfNotNull(validateSplitReferencesByTrackNumber(trackNumberId, context))
+                }
+                .filterValues { it.isNotEmpty() }
 
-        val kpSplitIssues = candidates.kmPosts.associate { (id, version) ->
-            val trackNumberId = kmPostDao.fetch(version).trackNumberId
-            id to listOfNotNull(trackNumberId?.let { tnId -> validateSplitReferencesByTrackNumber(tnId, context) })
-        }.filterValues { it.isNotEmpty() }
+        val kpSplitIssues =
+            candidates.kmPosts
+                .associate { (id, version) ->
+                    val trackNumberId = kmPostDao.fetch(version).trackNumberId
+                    id to
+                        listOfNotNull(
+                            trackNumberId?.let { tnId ->
+                                validateSplitReferencesByTrackNumber(tnId, context)
+                            })
+                }
+                .filterValues { it.isNotEmpty() }
 
-        val trackSplitIssues = candidates.locationTracks.associate { (id, _) ->
-            val ltSplitIssues = validateSplitForLocationTrack(id, context)
-            val contentIssues = splitIssues.mapNotNull { (split, error) ->
-                if (split.containsLocationTrack(id)) error else null
+        val trackSplitIssues =
+            candidates.locationTracks
+                .associate { (id, _) ->
+                    val ltSplitIssues = validateSplitForLocationTrack(id, context)
+                    val contentIssues =
+                        splitIssues.mapNotNull { (split, error) ->
+                            if (split.containsLocationTrack(id)) error else null
+                        }
+                    id to ltSplitIssues + contentIssues
+                }
+                .filterValues { it.isNotEmpty() }
+
+        val switchSplitIssues =
+            candidates.switches.associate { (id, _) ->
+                id to
+                    splitIssues.mapNotNull { (split, error) ->
+                        if (split.containsSwitch(id)) error else null
+                    }
             }
-            id to ltSplitIssues + contentIssues
-        }.filterValues { it.isNotEmpty() }
-
-        val switchSplitIssues = candidates.switches.associate { (id, _) ->
-            id to splitIssues.mapNotNull { (split, error) ->
-                if (split.containsSwitch(id)) error else null
-            }
-        }
 
         return SplitLayoutValidationIssues(
             tnSplitIssues,
@@ -196,46 +224,64 @@ class SplitService(
         trackId: IntId<LocationTrack>,
         context: ValidationContext,
     ): List<LayoutValidationIssue> {
-        val splits = context.getUnfinishedSplits()
-            .filter { split -> split.locationTracks.contains(trackId) }
-            .map { split -> split to locationTrackDao.fetch(split.sourceLocationTrackVersion) }
-        val track = requireNotNull(context.getLocationTrack(trackId)) {
-            "The track to validate must exist in the validation context: id=$trackId"
-        }
+        val splits =
+            context
+                .getUnfinishedSplits()
+                .filter { split -> split.locationTracks.contains(trackId) }
+                .map { split -> split to locationTrackDao.fetch(split.sourceLocationTrackVersion) }
+        val track =
+            requireNotNull(context.getLocationTrack(trackId)) {
+                "The track to validate must exist in the validation context: id=$trackId"
+            }
 
-        val splitSourceLocationTrackErrors = splits.flatMap { (split, _) ->
-            if (split.sourceLocationTrackId == trackId) validateSplitSourceLocationTrack(track, split) else emptyList()
-        }
+        val splitSourceLocationTrackErrors =
+            splits.flatMap { (split, _) ->
+                if (split.sourceLocationTrackId == trackId)
+                    validateSplitSourceLocationTrack(track, split)
+                else emptyList()
+            }
 
-        val statusErrors = splits.mapNotNull { (split, sourceTrack) -> validateSplitStatus(track, sourceTrack, split) }
+        val statusErrors =
+            splits.mapNotNull { (split, sourceTrack) ->
+                validateSplitStatus(track, sourceTrack, split)
+            }
 
-        // Note: we only check draft splits from here on, since the situation cannot change after publication:
+        // Note: we only check draft splits from here on, since the situation cannot change after
+        // publication:
         // - Official tracks are already validated and published
-        // - The above status check will not allow draft tracks to be involved in published pending splits
+        // - The above status check will not allow draft tracks to be involved in published pending
+        // splits
         // - Published DONE splits don't matter and shouldn't affect future changes
         // - Changes to the geocoding context are blocked for any tracks associated with a split
         val draftSplits = splits.filter { (split, _) -> split.publicationId == null }
 
-        val trackNumberMismatchErrors = draftSplits.mapNotNull { (split, sourceTrack) ->
-            produceIf(split.containsTargetTrack(trackId)) {
-                validateTargetTrackNumberIsUnchanged(sourceTrack, track)
+        val trackNumberMismatchErrors =
+            draftSplits.mapNotNull { (split, sourceTrack) ->
+                produceIf(split.containsTargetTrack(trackId)) {
+                    validateTargetTrackNumberIsUnchanged(sourceTrack, track)
+                }
             }
-        }
 
-        // Geometry error checking is skipped if the track numbers are different between any source & target tracks,
-        // The geometry check will rarely if ever succeed for differing track numbers on source & target tracks, and
-        // differing track number for any source & target track is already a considered a publication-blocking error.
-        val splitGeometryErrors = when {
-            trackNumberMismatchErrors.isEmpty() -> validateSplitGeometries(trackId, draftSplits, context)
-            else -> emptyList()
-        }
+        // Geometry error checking is skipped if the track numbers are different between any source
+        // & target tracks,
+        // The geometry check will rarely if ever succeed for differing track numbers on source &
+        // target tracks, and
+        // differing track number for any source & target track is already a considered a
+        // publication-blocking error.
+        val splitGeometryErrors =
+            when {
+                trackNumberMismatchErrors.isEmpty() ->
+                    validateSplitGeometries(trackId, draftSplits, context)
+                else -> emptyList()
+            }
 
         return listOf(
-            statusErrors,
-            splitSourceLocationTrackErrors,
-            trackNumberMismatchErrors,
-            splitGeometryErrors,
-        ).flatten()
+                statusErrors,
+                splitSourceLocationTrackErrors,
+                trackNumberMismatchErrors,
+                splitGeometryErrors,
+            )
+            .flatten()
     }
 
     private fun validateSplitGeometries(
@@ -243,24 +289,31 @@ class SplitService(
         splits: List<Pair<Split, LocationTrack>>,
         context: ValidationContext,
     ): List<LayoutValidationIssue> {
-        // Target address validation ensures that all split target addresspoints match the source addresspoints in
-        // the validation context (that is: draft target geometry is a subset of draft source geometry)
-        val targetGeometryErrors = splits.mapNotNull { (split, sourceTrack) ->
-            split.getTargetLocationTrack(trackId)?.let { target ->
-                val (sourceAddresses, targetAddresses) = getTargetValidationAddressPoints(sourceTrack, target, context)
-                validateTargetGeometry(target.operation, targetAddresses, sourceAddresses)
+        // Target address validation ensures that all split target addresspoints match the source
+        // addresspoints in
+        // the validation context (that is: draft target geometry is a subset of draft source
+        // geometry)
+        val targetGeometryErrors =
+            splits.mapNotNull { (split, sourceTrack) ->
+                split.getTargetLocationTrack(trackId)?.let { target ->
+                    val (sourceAddresses, targetAddresses) =
+                        getTargetValidationAddressPoints(sourceTrack, target, context)
+                    validateTargetGeometry(target.operation, targetAddresses, sourceAddresses)
+                }
             }
-        }
 
-        // Source address validation ensures that the in-validationcontext source addresspoints are unchanged from the
+        // Source address validation ensures that the in-validationcontext source addresspoints are
+        // unchanged from the
         // official ones (that is: draft source geometry == official source geometry)
-        val sourceGeometryErrors = splits.mapNotNull { (_, sourceTrack) ->
-            produceIf(trackId == sourceTrack.id) {
-                val draftAddresses = context.getAddressPoints(sourceTrack)
-                val officialAddresses = geocodingService.getAddressPoints(context.branch.official, trackId)
-                validateSourceGeometry(draftAddresses, officialAddresses)
+        val sourceGeometryErrors =
+            splits.mapNotNull { (_, sourceTrack) ->
+                produceIf(trackId == sourceTrack.id) {
+                    val draftAddresses = context.getAddressPoints(sourceTrack)
+                    val officialAddresses =
+                        geocodingService.getAddressPoints(context.branch.official, trackId)
+                    validateSourceGeometry(draftAddresses, officialAddresses)
+                }
             }
-        }
 
         return targetGeometryErrors + sourceGeometryErrors
     }
@@ -270,28 +323,30 @@ class SplitService(
         target: SplitTarget,
         context: ValidationContext,
     ): Pair<List<AddressPoint>?, List<AddressPoint>?> {
-        val sourceMRange = getMRange(sourceTrack.getAlignmentVersionOrThrow(), target.segmentIndices)
-        val sourceAddresses = sourceMRange?.let { range ->
-            context.getAddressPoints(sourceTrack)
-                ?.integerPrecisionPoints
-                ?.filter { p -> p.point.m in range }
-        }
+        val sourceMRange =
+            getMRange(sourceTrack.getAlignmentVersionOrThrow(), target.segmentIndices)
+        val sourceAddresses =
+            sourceMRange?.let { range ->
+                context.getAddressPoints(sourceTrack)?.integerPrecisionPoints?.filter { p ->
+                    p.point.m in range
+                }
+            }
 
         val targetAddressStart = sourceAddresses?.firstOrNull()?.address
         val targetAddressEnd = sourceAddresses?.lastOrNull()?.address
-        val targetAddresses = if (targetAddressStart != null && targetAddressEnd != null) {
-            context.getAddressPoints(target.locationTrackId)
-                ?.integerPrecisionPoints
-                ?.let { points ->
+        val targetAddresses =
+            if (targetAddressStart != null && targetAddressEnd != null) {
+                context.getAddressPoints(target.locationTrackId)?.integerPrecisionPoints?.let {
+                    points ->
                     if (target.operation == SplitTargetOperation.TRANSFER) {
                         points.filter { p -> p.address in targetAddressStart..targetAddressEnd }
                     } else {
                         points
                     }
                 }
-        } else {
-            null
-        }
+            } else {
+                null
+            }
 
         return sourceAddresses to targetAddresses
     }
@@ -315,12 +370,17 @@ class SplitService(
         context: ValidationContext,
     ): LayoutValidationIssue? {
         val affectedTracks = context.getLocationTracksByTrackNumber(trackNumberId)
-        val affectedSplits = context.getUnfinishedSplits()
-            .filter { split -> split.locationTracks.any { ltId -> affectedTracks.any { a -> a.id == ltId } } }
+        val affectedSplits =
+            context.getUnfinishedSplits().filter { split ->
+                split.locationTracks.any { ltId -> affectedTracks.any { a -> a.id == ltId } }
+            }
         return if (affectedSplits.isNotEmpty()) {
-            val sourceTrackNames = affectedSplits
-                .mapNotNull { split -> context.getLocationTrack(split.sourceLocationTrackId)?.name }
-                .joinToString(", ")
+            val sourceTrackNames =
+                affectedSplits
+                    .mapNotNull { split ->
+                        context.getLocationTrack(split.sourceLocationTrackId)?.name
+                    }
+                    .joinToString(", ")
             validationError(
                 "$VALIDATION_SPLIT.affected-split-in-progress",
                 "sourceName" to sourceTrackNames,
@@ -349,11 +409,14 @@ class SplitService(
     fun split(branch: LayoutBranch, request: SplitRequest): IntId<Split> {
         // Original duplicate ids to be stored in split data before updating the location track
         // references which they referenced before the split (request source track).
-        // If the references are not updated, the duplicate-of reference will be removed entirely when the
+        // If the references are not updated, the duplicate-of reference will be removed entirely
+        // when the
         // source track's layout state is set to "DELETED".
-        val sourceTrackDuplicateIds = locationTrackService
-            .fetchDuplicates(branch.draft, request.sourceTrackId)
-            .map { duplicateTrack -> duplicateTrack.id as IntId }
+        val sourceTrackDuplicateIds =
+            locationTrackService.fetchDuplicates(branch.draft, request.sourceTrackId).map {
+                duplicateTrack ->
+                duplicateTrack.id as IntId
+            }
 
         val sourceTrack = locationTrackDao.getOrThrow(branch.draft, request.sourceTrackId)
         if (sourceTrack.state != LocationTrackState.IN_USE) {
@@ -363,28 +426,37 @@ class SplitService(
             )
         }
 
-        val suggestions = switchLinkingService.getTrackSwitchSuggestions(branch.draft, sourceTrack)
-            .let(::verifySwitchSuggestions)
-        val relinkedSwitches = switchLinkingService.relinkTrack(branch, request.sourceTrackId).map { it.id }
+        val suggestions =
+            switchLinkingService
+                .getTrackSwitchSuggestions(branch.draft, sourceTrack)
+                .let(::verifySwitchSuggestions)
+        val relinkedSwitches =
+            switchLinkingService.relinkTrack(branch, request.sourceTrackId).map { it.id }
 
         // Fetch post-re-linking track & alignment
-        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(branch.draft, request.sourceTrackId)
-        val targetResults = splitLocationTrack(
-            track = track,
-            alignment = alignment,
-            targets = collectSplitTargetParams(branch, request.targetTracks, suggestions),
-        )
+        val (track, alignment) =
+            locationTrackService.getWithAlignmentOrThrow(branch.draft, request.sourceTrackId)
+        val targetResults =
+            splitLocationTrack(
+                track = track,
+                alignment = alignment,
+                targets = collectSplitTargetParams(branch, request.targetTracks, suggestions),
+            )
 
-        val savedSplitTargetLocationTracks = targetResults.map { result ->
-            val response = saveTargetTrack(branch, result)
-            val (resultTrack, resultAlignment) = locationTrackService.getWithAlignment(response.rowVersion)
-            result.copy(locationTrack = resultTrack, alignment = resultAlignment)
-        }
-
-        geocodingService.getGeocodingContext(branch.draft, sourceTrack.trackNumberId)?.let { geocodingContext ->
-            val splitTargetTracksWithAlignments = savedSplitTargetLocationTracks.map { splitTargetResult ->
-                splitTargetResult.locationTrack to splitTargetResult.alignment
+        val savedSplitTargetLocationTracks =
+            targetResults.map { result ->
+                val response = saveTargetTrack(branch, result)
+                val (resultTrack, resultAlignment) =
+                    locationTrackService.getWithAlignment(response.rowVersion)
+                result.copy(locationTrack = resultTrack, alignment = resultAlignment)
             }
+
+        geocodingService.getGeocodingContext(branch.draft, sourceTrack.trackNumberId)?.let {
+            geocodingContext ->
+            val splitTargetTracksWithAlignments =
+                savedSplitTargetLocationTracks.map { splitTargetResult ->
+                    splitTargetResult.locationTrack to splitTargetResult.alignment
+                }
 
             updateUnusedDuplicateReferencesToSplitTargetTracks(
                 branch,
@@ -392,13 +464,16 @@ class SplitService(
                 request,
                 splitTargetTracksWithAlignments,
             )
-        } ?: throw SplitFailureException(
-            message = "Geocoding context creation failed: trackNumber=${sourceTrack.trackNumberId}",
-            localizedMessageKey = "geocoding-failed",
-            localizationParams = localizationParams("trackName" to sourceTrack.name)
-        )
+        }
+            ?: throw SplitFailureException(
+                message =
+                    "Geocoding context creation failed: trackNumber=${sourceTrack.trackNumberId}",
+                localizedMessageKey = "geocoding-failed",
+                localizationParams = localizationParams("trackName" to sourceTrack.name))
 
-        val savedSource = locationTrackService.updateState(branch, request.sourceTrackId, LocationTrackState.DELETED)
+        val savedSource =
+            locationTrackService.updateState(
+                branch, request.sourceTrackId, LocationTrackState.DELETED)
 
         return savedSplitTargetLocationTracks
             .map { splitTargetResult ->
@@ -409,7 +484,8 @@ class SplitService(
                 )
             }
             .let { splitTargets ->
-                splitDao.saveSplit(savedSource.rowVersion, splitTargets, relinkedSwitches, sourceTrackDuplicateIds)
+                splitDao.saveSplit(
+                    savedSource.rowVersion, splitTargets, relinkedSwitches, sourceTrackDuplicateIds)
             }
     }
 
@@ -419,33 +495,42 @@ class SplitService(
         splitRequest: SplitRequest,
         splitTargetLocationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
     ) {
-        val unusedDuplicates = locationTrackService.fetchDuplicates(branch.draft, splitRequest.sourceTrackId)
-            .filter { locationTrackDuplicate ->
-                !splitRequest.targetTracks.any { targetTrack ->
-                    targetTrack.duplicateTrack?.id == locationTrackDuplicate.id
+        val unusedDuplicates =
+            locationTrackService
+                .fetchDuplicates(branch.draft, splitRequest.sourceTrackId)
+                .filter { locationTrackDuplicate ->
+                    !splitRequest.targetTracks.any { targetTrack ->
+                        targetTrack.duplicateTrack?.id == locationTrackDuplicate.id
+                    }
                 }
-            }
-            .let { unusedDuplicateTracks ->
-                locationTrackService.getAlignmentsForTracks(unusedDuplicateTracks)
-            }
+                .let { unusedDuplicateTracks ->
+                    locationTrackService.getAlignmentsForTracks(unusedDuplicateTracks)
+                }
 
         findNewLocationTracksForUnusedDuplicates(
-            geocodingContext,
-            unusedDuplicates,
-            splitTargetLocationTracks,
-        ).forEach { updatedDuplicate -> locationTrackService.saveDraft(branch, updatedDuplicate) }
+                geocodingContext,
+                unusedDuplicates,
+                splitTargetLocationTracks,
+            )
+            .forEach { updatedDuplicate ->
+                locationTrackService.saveDraft(branch, updatedDuplicate)
+            }
     }
 
-    private fun saveTargetTrack(branch: LayoutBranch, target: SplitTargetResult): LayoutDaoResponse<LocationTrack> =
+    private fun saveTargetTrack(
+        branch: LayoutBranch,
+        target: SplitTargetResult
+    ): LayoutDaoResponse<LocationTrack> =
         locationTrackService.saveDraft(
             branch = branch,
-            draftAsset = locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
-                layoutContext = branch.draft,
-                track = target.locationTrack,
-                alignment = target.alignment,
-                startChanged = true,
-                endChanged = true,
-            ),
+            draftAsset =
+                locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                    layoutContext = branch.draft,
+                    track = target.locationTrack,
+                    alignment = target.alignment,
+                    startChanged = true,
+                    endChanged = true,
+                ),
             alignment = target.alignment,
         )
 
@@ -455,24 +540,30 @@ class SplitService(
         suggestions: List<Pair<IntId<TrackLayoutSwitch>, SuggestedSwitch>>,
     ): List<SplitTargetParams> {
         return targets.map { target ->
-            val startSwitch = target.startAtSwitchId?.let { switchId ->
-                val (jointNumber, name) = suggestions
-                    .find { (id, _) -> id == switchId }
-                    ?.let { (_, suggestion) ->
-                        val joint = switchLibraryService.getPresentationJointNumber(suggestion.switchStructureId)
-                        val name = switchService.getOrThrow(branch.draft, switchId).name
-                        joint to name
-                    }
-                    ?: throw SplitFailureException(
-                        message = "No re-linked switch for switch: id=$switchId",
-                        localizedMessageKey = "no-switch-suggestion",
-                    )
-                SplitPointSwitch(switchId, jointNumber, name)
-            }
-            val duplicate = target.duplicateTrack?.let { d ->
-                val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(branch.draft, d.id)
-                SplitTargetDuplicate(d.operation, track, alignment)
-            }
+            val startSwitch =
+                target.startAtSwitchId?.let { switchId ->
+                    val (jointNumber, name) =
+                        suggestions
+                            .find { (id, _) -> id == switchId }
+                            ?.let { (_, suggestion) ->
+                                val joint =
+                                    switchLibraryService.getPresentationJointNumber(
+                                        suggestion.switchStructureId)
+                                val name = switchService.getOrThrow(branch.draft, switchId).name
+                                joint to name
+                            }
+                            ?: throw SplitFailureException(
+                                message = "No re-linked switch for switch: id=$switchId",
+                                localizedMessageKey = "no-switch-suggestion",
+                            )
+                    SplitPointSwitch(switchId, jointNumber, name)
+                }
+            val duplicate =
+                target.duplicateTrack?.let { d ->
+                    val (track, alignment) =
+                        locationTrackService.getWithAlignmentOrThrow(branch.draft, d.id)
+                    SplitTargetDuplicate(d.operation, track, alignment)
+                }
             SplitTargetParams(target, startSwitch, duplicate)
         }
     }
@@ -511,34 +602,40 @@ fun splitLocationTrack(
     alignment: LayoutAlignment,
     targets: List<SplitTargetParams>,
 ): List<SplitTargetResult> {
-    return targets.mapIndexed { index, target ->
-        val nextSwitch = targets.getOrNull(index + 1)?.startSwitch
-        val segmentIndices = findSplitIndices(alignment, target.startSwitch, nextSwitch)
-        val segments = cutSegments(alignment, segmentIndices)
-        val connectivityType = calculateTopologicalConnectivity(track, alignment.segments.size, segmentIndices)
-        val (newTrack, newAlignment) = target.duplicate?.let { d ->
-            when (d.operation) {
-                SplitTargetDuplicateOperation.TRANSFER -> updateSplitTargetForTransferAssets(
-                    duplicateTrack = d.track,
-                    topologicalConnectivityType = connectivityType,
-                ) to d.alignment
-                SplitTargetDuplicateOperation.OVERWRITE -> updateSplitTargetForOverwriteDuplicate(
-                    sourceTrack = track,
-                    duplicateTrack = d.track,
-                    duplicateAlignment = d.alignment,
-                    request = target.request,
-                    segments = segments,
-                    topologicalConnectivityType = connectivityType,
-                )
-            }
-        } ?: createSplitTarget(track, target.request, segments, connectivityType)
-        SplitTargetResult(
-            locationTrack = newTrack,
-            alignment = newAlignment,
-            indices = segmentIndices,
-            operation = target.getOperation(),
-        )
-    }.also { result -> validateSplitResult(result, alignment) }
+    return targets
+        .mapIndexed { index, target ->
+            val nextSwitch = targets.getOrNull(index + 1)?.startSwitch
+            val segmentIndices = findSplitIndices(alignment, target.startSwitch, nextSwitch)
+            val segments = cutSegments(alignment, segmentIndices)
+            val connectivityType =
+                calculateTopologicalConnectivity(track, alignment.segments.size, segmentIndices)
+            val (newTrack, newAlignment) =
+                target.duplicate?.let { d ->
+                    when (d.operation) {
+                        SplitTargetDuplicateOperation.TRANSFER ->
+                            updateSplitTargetForTransferAssets(
+                                duplicateTrack = d.track,
+                                topologicalConnectivityType = connectivityType,
+                            ) to d.alignment
+                        SplitTargetDuplicateOperation.OVERWRITE ->
+                            updateSplitTargetForOverwriteDuplicate(
+                                sourceTrack = track,
+                                duplicateTrack = d.track,
+                                duplicateAlignment = d.alignment,
+                                request = target.request,
+                                segments = segments,
+                                topologicalConnectivityType = connectivityType,
+                            )
+                    }
+                } ?: createSplitTarget(track, target.request, segments, connectivityType)
+            SplitTargetResult(
+                locationTrack = newTrack,
+                alignment = newAlignment,
+                indices = segmentIndices,
+                operation = target.getOperation(),
+            )
+        }
+        .also { result -> validateSplitResult(result, alignment) }
 }
 
 fun validateSplitResult(results: List<SplitTargetResult>, alignment: LayoutAlignment) {
@@ -547,20 +644,24 @@ fun validateSplitResult(results: List<SplitTargetResult>, alignment: LayoutAlign
         val previousEndIndex = previousIndices?.last ?: -1
         if (previousEndIndex + 1 != result.indices.first) {
             throw SplitFailureException(
-                message = "Not all segments were allocated in the split: last=${previousIndices?.last} first=${result.indices.first}",
+                message =
+                    "Not all segments were allocated in the split: last=${previousIndices?.last} first=${result.indices.first}",
                 localizedMessageKey = "segment-allocation-failed",
             )
         }
-        if (result.operation != SplitTargetOperation.TRANSFER && result.alignment.segments.size != result.indices.count()) {
+        if (result.operation != SplitTargetOperation.TRANSFER &&
+            result.alignment.segments.size != result.indices.count()) {
             throw SplitFailureException(
-                message = "Split target segments don't match calculated indices: segments=${result.alignment.segments.size} indices=${result.indices.count()}",
+                message =
+                    "Split target segments don't match calculated indices: segments=${result.alignment.segments.size} indices=${result.indices.count()}",
                 localizedMessageKey = "segment-allocation-failed",
             )
         }
     }
     if (results.last().indices.last != alignment.segments.lastIndex) {
         throw SplitFailureException(
-            message = "Not all segments were allocated in the split: lastIndex=${results.last().indices.last} lastAlignmentIndex=${alignment.segments.lastIndex}",
+            message =
+                "Not all segments were allocated in the split: lastIndex=${results.last().indices.last} lastAlignmentIndex=${alignment.segments.lastIndex}",
             localizedMessageKey = "segment-allocation-failed",
         )
     }
@@ -589,29 +690,29 @@ private fun updateSplitTargetForOverwriteDuplicate(
     topologicalConnectivityType: TopologicalConnectivityType,
 ): Pair<LocationTrack, LayoutAlignment> {
     val newAlignment = duplicateAlignment.withSegments(segments)
-    val newTrack = duplicateTrack.copy(
-        name = request.name,
-        descriptionBase = request.descriptionBase,
-        descriptionSuffix = request.descriptionSuffix,
+    val newTrack =
+        duplicateTrack.copy(
+            name = request.name,
+            descriptionBase = request.descriptionBase,
+            descriptionSuffix = request.descriptionSuffix,
 
-        // After split, the track is no longer duplicate
-        duplicateOf = null,
-        // Topology is re-resolved after tracks and switches are updated
-        topologyStartSwitch = null,
-        topologyEndSwitch = null,
-        topologicalConnectivity = topologicalConnectivityType,
+            // After split, the track is no longer duplicate
+            duplicateOf = null,
+            // Topology is re-resolved after tracks and switches are updated
+            topologyStartSwitch = null,
+            topologyEndSwitch = null,
+            topologicalConnectivity = topologicalConnectivityType,
+            state = sourceTrack.state,
+            trackNumberId = sourceTrack.trackNumberId,
+            sourceId = sourceTrack.sourceId,
+            // owner remains that of the duplicate
+            type = sourceTrack.type,
 
-        state = sourceTrack.state,
-        trackNumberId = sourceTrack.trackNumberId,
-        sourceId = sourceTrack.sourceId,
-        // owner remains that of the duplicate
-        type = sourceTrack.type,
-
-        // Geometry fields come from alignment
-        segmentCount = newAlignment.segments.size,
-        length = newAlignment.length,
-        boundingBox = newAlignment.boundingBox,
-    )
+            // Geometry fields come from alignment
+            segmentCount = newAlignment.segments.size,
+            length = newAlignment.length,
+            boundingBox = newAlignment.boundingBox,
+        )
     return newTrack to newAlignment
 }
 
@@ -622,33 +723,33 @@ private fun createSplitTarget(
     topologicalConnectivityType: TopologicalConnectivityType,
 ): Pair<LocationTrack, LayoutAlignment> {
     val newAlignment = LayoutAlignment(segments)
-    val newTrack = LocationTrack(
-        name = request.name,
-        descriptionBase = request.descriptionBase,
-        descriptionSuffix = request.descriptionSuffix,
+    val newTrack =
+        LocationTrack(
+            name = request.name,
+            descriptionBase = request.descriptionBase,
+            descriptionSuffix = request.descriptionSuffix,
 
-        // New track -> no external ID
-        externalId = null,
-        // After split, tracks are not duplicates
-        duplicateOf = null,
-        // Topology is re-resolved after tracks and switches are updated
-        topologyStartSwitch = null,
-        topologyEndSwitch = null,
-        topologicalConnectivity = topologicalConnectivityType,
+            // New track -> no external ID
+            externalId = null,
+            // After split, tracks are not duplicates
+            duplicateOf = null,
+            // Topology is re-resolved after tracks and switches are updated
+            topologyStartSwitch = null,
+            topologyEndSwitch = null,
+            topologicalConnectivity = topologicalConnectivityType,
+            state = sourceTrack.state,
+            trackNumberId = sourceTrack.trackNumberId,
+            sourceId = sourceTrack.sourceId,
+            ownerId = sourceTrack.ownerId,
+            type = sourceTrack.type,
 
-        state = sourceTrack.state,
-        trackNumberId = sourceTrack.trackNumberId,
-        sourceId = sourceTrack.sourceId,
-        ownerId = sourceTrack.ownerId,
-        type = sourceTrack.type,
-
-        // Geometry fields come from alignment
-        segmentCount = newAlignment.segments.size,
-        length = newAlignment.length,
-        boundingBox = newAlignment.boundingBox,
-        // TODO: GVT-2399
-        contextData = LayoutContextData.newDraft(LayoutBranch.main),
-    )
+            // Geometry fields come from alignment
+            segmentCount = newAlignment.segments.size,
+            length = newAlignment.length,
+            boundingBox = newAlignment.boundingBox,
+            // TODO: GVT-2399
+            contextData = LayoutContextData.newDraft(LayoutBranch.main),
+        )
     return newTrack to newAlignment
 }
 
@@ -657,16 +758,18 @@ private fun calculateTopologicalConnectivity(
     sourceSegments: Int,
     segmentIndices: ClosedRange<Int>,
 ): TopologicalConnectivityType {
-    val startConnected = if (0 == segmentIndices.start) {
-        sourceTrack.topologicalConnectivity.isStartConnected()
-    } else {
-        true
-    }
-    val endConnected = if (sourceSegments == segmentIndices.endInclusive + 1) {
-        sourceTrack.topologicalConnectivity.isEndConnected()
-    } else {
-        true
-    }
+    val startConnected =
+        if (0 == segmentIndices.start) {
+            sourceTrack.topologicalConnectivity.isStartConnected()
+        } else {
+            true
+        }
+    val endConnected =
+        if (sourceSegments == segmentIndices.endInclusive + 1) {
+            sourceTrack.topologicalConnectivity.isEndConnected()
+        } else {
+            true
+        }
     return topologicalConnectivityTypeOf(startConnected, endConnected)
 }
 
@@ -676,7 +779,8 @@ private fun findSplitIndices(
     endSwitch: SplitPointSwitch?,
 ): IntRange {
     val startIndex = startSwitch?.let { (s, j) -> findIndex(alignment, s, j) } ?: 0
-    val endIndex = endSwitch?.let { (s, j) -> findIndex(alignment, s, j) - 1 } ?: alignment.segments.lastIndex
+    val endIndex =
+        endSwitch?.let { (s, j) -> findIndex(alignment, s, j) - 1 } ?: alignment.segments.lastIndex
 
     return if (startIndex < 0) {
         throwSwitchSegmentMappingFailure(alignment, startSwitch)
@@ -687,16 +791,26 @@ private fun findSplitIndices(
     }
 }
 
-private fun throwSwitchSegmentMappingFailure(alignment: LayoutAlignment, switch: SplitPointSwitch?): Nothing {
-    val aligmentDesc = alignment.segments.map { s -> s.switchId to "${s.startJointNumber}..${s.endJointNumber}" }
+private fun throwSwitchSegmentMappingFailure(
+    alignment: LayoutAlignment,
+    switch: SplitPointSwitch?
+): Nothing {
+    val aligmentDesc =
+        alignment.segments.map { s -> s.switchId to "${s.startJointNumber}..${s.endJointNumber}" }
     throw SplitFailureException(
-        message = "Failed to map split switches to segment indices: switch=$switch alignment=$aligmentDesc",
+        message =
+            "Failed to map split switches to segment indices: switch=$switch alignment=$aligmentDesc",
         localizedMessageKey = "switch-segment-mapping-failed",
-        localizationParams = localizationParams("switchName" to switch?.name, "joint" to switch?.jointNumber),
+        localizationParams =
+            localizationParams("switchName" to switch?.name, "joint" to switch?.jointNumber),
     )
 }
 
-private fun findIndex(alignment: LayoutAlignment, switchId: IntId<TrackLayoutSwitch>, joint: JointNumber): Int {
+private fun findIndex(
+    alignment: LayoutAlignment,
+    switchId: IntId<TrackLayoutSwitch>,
+    joint: JointNumber
+): Int {
     alignment.segments.forEachIndexed { index, segment ->
         if (segment.switchId == switchId && segment.startJointNumber == joint) {
             return index
@@ -705,64 +819,71 @@ private fun findIndex(alignment: LayoutAlignment, switchId: IntId<TrackLayoutSwi
     return -1
 }
 
-private fun cutSegments(alignment: LayoutAlignment, segmentIndices: ClosedRange<Int>): List<LayoutSegment> =
-    fixSegmentStarts(alignment.segments.subList(segmentIndices.start, segmentIndices.endInclusive + 1))
+private fun cutSegments(
+    alignment: LayoutAlignment,
+    segmentIndices: ClosedRange<Int>
+): List<LayoutSegment> =
+    fixSegmentStarts(
+        alignment.segments.subList(segmentIndices.start, segmentIndices.endInclusive + 1))
 
 private fun verifySwitchSuggestions(
     suggestions: List<Pair<IntId<TrackLayoutSwitch>, SuggestedSwitch?>>,
-): List<Pair<IntId<TrackLayoutSwitch>, SuggestedSwitch>> = suggestions.map { (id, suggestion) ->
-    if (suggestion == null) {
-        throw SplitFailureException(
-            message = "Switch re-linking failed to produce a suggestion: switch=$id",
-            localizedMessageKey = "switch-linking-failed",
-        )
-    } else {
-        id to suggestion
+): List<Pair<IntId<TrackLayoutSwitch>, SuggestedSwitch>> =
+    suggestions.map { (id, suggestion) ->
+        if (suggestion == null) {
+            throw SplitFailureException(
+                message = "Switch re-linking failed to produce a suggestion: switch=$id",
+                localizedMessageKey = "switch-linking-failed",
+            )
+        } else {
+            id to suggestion
+        }
     }
-}
 
 private fun findNewLocationTracksForUnusedDuplicates(
     geocodingContext: GeocodingContext,
     unusedDuplicates: List<Pair<LocationTrack, LayoutAlignment>>,
     splitTargetLocationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
 ): List<LocationTrack> {
-    val geocodedUnusedDuplicates = unusedDuplicates
-        .mapNotNull { (unusedDuplicate, alignment) ->
+    val geocodedUnusedDuplicates =
+        unusedDuplicates.mapNotNull { (unusedDuplicate, alignment) ->
             getAlignmentStartAndEndM(geocodingContext, alignment)?.let { startAndEnd ->
                 unusedDuplicate to startAndEnd
             }
         }
 
-    val geocodedSplitTargets = splitTargetLocationTracks
-        .mapNotNull { (locationTrack, alignment) ->
+    val geocodedSplitTargets =
+        splitTargetLocationTracks.mapNotNull { (locationTrack, alignment) ->
             getAlignmentStartAndEndM(geocodingContext, alignment)?.let { startEnd ->
                 locationTrack to startEnd
             }
         }
 
     return geocodedUnusedDuplicates.map { (duplicate, duplicateStartAndEnd) ->
-        geocodedSplitTargets.fold(
-            LocationTrackOverlapReference()
-        ) { currentHighestOverlap, (splitTarget, splitTargetStartEnd) ->
-
-            if (currentHighestOverlap.percentage > 99.9) {
-                currentHighestOverlap
-            } else {
-                calculateDuplicateLocationTrackOverlap(splitTarget, splitTargetStartEnd, duplicateStartAndEnd)
-                    .takeIf { calculatedOverlap ->
-                        calculatedOverlap.percentage > currentHighestOverlap.percentage
-                    }
-                    ?: currentHighestOverlap
+        geocodedSplitTargets
+            .fold(LocationTrackOverlapReference()) {
+                currentHighestOverlap,
+                (splitTarget, splitTargetStartEnd) ->
+                if (currentHighestOverlap.percentage > 99.9) {
+                    currentHighestOverlap
+                } else {
+                    calculateDuplicateLocationTrackOverlap(
+                            splitTarget, splitTargetStartEnd, duplicateStartAndEnd)
+                        .takeIf { calculatedOverlap ->
+                            calculatedOverlap.percentage > currentHighestOverlap.percentage
+                        } ?: currentHighestOverlap
+                }
             }
-        }.let { bestNewLocationTrackReference ->
-            bestNewLocationTrackReference.locationTrack?.id as IntId?
-        }?.let { newReferenceTrackId ->
-            duplicate.copy(duplicateOf = newReferenceTrackId)
-        } ?: throw SplitFailureException(
-            message = "Could not find a new reference for duplicate location track: duplicateId=${duplicate.id}",
-            localizedMessageKey = "new-duplicate-reference-assignment-failed",
-            localizationParams = localizationParams("duplicate" to duplicate.name),
-        )
+            .let { bestNewLocationTrackReference ->
+                bestNewLocationTrackReference.locationTrack?.id as IntId?
+            }
+            ?.let { newReferenceTrackId -> duplicate.copy(duplicateOf = newReferenceTrackId) }
+            ?: throw SplitFailureException(
+                message =
+                    "Could not find a new reference for duplicate location track: duplicateId=${duplicate.id}",
+                localizedMessageKey = "new-duplicate-reference-assignment-failed",
+                localizationParams = localizationParams("duplicate" to duplicate.name),
+            )
     }
 }
 
@@ -783,9 +904,7 @@ private fun calculateDuplicateLocationTrackOverlap(
     val intervalLength = duplicateStartAndEnd.end - duplicateStartAndEnd.start
 
     return LocationTrackOverlapReference(
-        locationTrack = splitTarget,
-        percentage = overlap / intervalLength * 100
-    )
+        locationTrack = splitTarget, percentage = overlap / intervalLength * 100)
 }
 
 private data class AlignmentStartAndEndMeters(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchLibraryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchLibraryService.kt
@@ -16,12 +16,11 @@ class SwitchLibraryService(
     }
 
     private val structuresById: Map<IntId<SwitchStructure>, SwitchStructure> by lazy {
-        structures.associateBy { switchStructure ->
-            switchStructure.id as IntId
-        }
+        structures.associateBy { switchStructure -> switchStructure.id as IntId }
     }
 
     fun getSwitchStructures(): List<SwitchStructure> = structures
+
     fun getSwitchStructuresById(): Map<IntId<SwitchStructure>, SwitchStructure> = structuresById
 
     fun getSwitchStructure(id: IntId<SwitchStructure>): SwitchStructure {
@@ -48,11 +47,15 @@ class SwitchLibraryService(
         structuresById[id] ?: throw NoSuchEntityException(SwitchStructure::class, id)
 
     @Transactional
-    fun upsertSwitchStructure(newSwitchStructure: SwitchStructure, existingSwitchStructure: SwitchStructure?) {
+    fun upsertSwitchStructure(
+        newSwitchStructure: SwitchStructure,
+        existingSwitchStructure: SwitchStructure?
+    ) {
         if (existingSwitchStructure == null) {
             switchStructureDao.insertSwitchStructure(newSwitchStructure)
         } else {
-            val switchStructureWithExistingId = newSwitchStructure.copy(id =existingSwitchStructure.id)
+            val switchStructureWithExistingId =
+                newSwitchStructure.copy(id = existingSwitchStructure.id)
             if (!existingSwitchStructure.isSame(switchStructureWithExistingId)) {
                 switchStructureDao.updateSwitchStructure(switchStructureWithExistingId)
             }
@@ -63,16 +66,18 @@ class SwitchLibraryService(
     fun replaceExistingSwitchStructures(newSwitchStructures: List<SwitchStructure>) {
         val existingSwitchStructures = switchStructureDao.fetchSwitchStructures()
         existingSwitchStructures.forEach { existingSwitchStructure ->
-            val existsInNewSet = newSwitchStructures.any { newSwitchStructure ->
-                newSwitchStructure.type == existingSwitchStructure.type
-            }
+            val existsInNewSet =
+                newSwitchStructures.any { newSwitchStructure ->
+                    newSwitchStructure.type == existingSwitchStructure.type
+                }
             if (!existsInNewSet) {
                 switchStructureDao.delete(existingSwitchStructure.id as IntId)
             }
         }
 
         newSwitchStructures.forEach { newSwitchStructure ->
-            val existingSwitchStructure = existingSwitchStructures.find { it.type == newSwitchStructure.type }
+            val existingSwitchStructure =
+                existingSwitchStructures.find { it.type == newSwitchStructure.type }
             upsertSwitchStructure(newSwitchStructure, existingSwitchStructure)
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchOwnerDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchOwnerDao.kt
@@ -17,18 +17,21 @@ class SwitchOwnerDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(j
 
     @Cacheable(CACHE_COMMON_SWITCH_OWNER, sync = true)
     fun fetchSwitchOwners(): List<SwitchOwner> {
-        val sql = """
+        val sql =
+            """
             select
                 id,
                 name
             from common.switch_owner
-        """.trimIndent()
-        val switchOwners = jdbcTemplate.query(sql) { rs, _ ->
-            SwitchOwner(
-                id = rs.getIntId("id"),
-                name = MetaDataName(rs.getString("name")),
-            )
-        }
+        """
+                .trimIndent()
+        val switchOwners =
+            jdbcTemplate.query(sql) { rs, _ ->
+                SwitchOwner(
+                    id = rs.getIntId("id"),
+                    name = MetaDataName(rs.getString("name")),
+                )
+            }
         logger.daoAccess(AccessType.FETCH, SwitchOwner::class, switchOwners.map { it.id })
         return switchOwners
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructureDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructureDao.kt
@@ -19,42 +19,47 @@ import fi.fta.geoviite.infra.util.getPoint
 import fi.fta.geoviite.infra.util.getRowVersion
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.setUser
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional(readOnly = true)
 @Component
-class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTemplateParam) {
+class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
+    DaoBase(jdbcTemplateParam) {
 
-    fun fetchSwitchStructureVersion(id: IntId<SwitchStructure>) = fetchRowVersion(id, DbTable.COMMON_SWITCH_STRUCTURE)
+    fun fetchSwitchStructureVersion(id: IntId<SwitchStructure>) =
+        fetchRowVersion(id, DbTable.COMMON_SWITCH_STRUCTURE)
 
     fun fetchSwitchStructures(): List<SwitchStructure> {
-        val sql = """
+        val sql =
+            """
             select
                 id,
                 type,
                 presentation_joint_number
             from common.switch_structure
-        """.trimIndent()
-        val switchStructures = jdbcTemplate.query(sql) { rs, _ ->
-            val switchTypeId = rs.getIntId<SwitchStructure>("id")
-            val switchType = SwitchStructure(
-                id = switchTypeId,
-                type = SwitchType(rs.getString("type")),
-                presentationJointNumber = rs.getJointNumber("presentation_joint_number"),
-                joints = fetchSwitchTypeJoints(switchTypeId),
-                alignments = fetchSwitchTypeAlignments(switchTypeId)
-            )
-            switchType
-        }
+        """
+                .trimIndent()
+        val switchStructures =
+            jdbcTemplate.query(sql) { rs, _ ->
+                val switchTypeId = rs.getIntId<SwitchStructure>("id")
+                val switchType =
+                    SwitchStructure(
+                        id = switchTypeId,
+                        type = SwitchType(rs.getString("type")),
+                        presentationJointNumber = rs.getJointNumber("presentation_joint_number"),
+                        joints = fetchSwitchTypeJoints(switchTypeId),
+                        alignments = fetchSwitchTypeAlignments(switchTypeId))
+                switchType
+            }
         logger.daoAccess(FETCH, SwitchStructure::class, switchStructures.map { it.id })
         return switchStructures
     }
 
     fun fetchSwitchStructure(version: RowVersion<SwitchStructure>): SwitchStructure {
-        val sql = """
+        val sql =
+            """
             select
                 id,
                 type,
@@ -62,34 +67,38 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
             from common.switch_structure
             where
               id = :id
-        """.trimIndent()
-        val params = mapOf(
-            "id" to version.id.intValue
-        )
-        val switchStructure = jdbcTemplate.queryOne(sql, params, version.toString()) { rs, _ ->
-            val switchTypeId = rs.getIntId<SwitchStructure>("id")
-            val switchType = SwitchStructure(
-                id = switchTypeId,
-                type = SwitchType(rs.getString("type")),
-                presentationJointNumber = rs.getJointNumber("presentation_joint_number"),
-                joints = fetchSwitchTypeJoints(switchTypeId),
-                alignments = fetchSwitchTypeAlignments(switchTypeId)
-            )
-            switchType
-        }
+        """
+                .trimIndent()
+        val params = mapOf("id" to version.id.intValue)
+        val switchStructure =
+            jdbcTemplate.queryOne(sql, params, version.toString()) { rs, _ ->
+                val switchTypeId = rs.getIntId<SwitchStructure>("id")
+                val switchType =
+                    SwitchStructure(
+                        id = switchTypeId,
+                        type = SwitchType(rs.getString("type")),
+                        presentationJointNumber = rs.getJointNumber("presentation_joint_number"),
+                        joints = fetchSwitchTypeJoints(switchTypeId),
+                        alignments = fetchSwitchTypeAlignments(switchTypeId))
+                switchType
+            }
         logger.daoAccess(FETCH, SwitchStructure::class, version)
         return switchStructure
     }
 
-    private fun fetchSwitchTypeJoints(switchStructureId: IntId<SwitchStructure>): List<SwitchJoint> {
-        val sql = """
+    private fun fetchSwitchTypeJoints(
+        switchStructureId: IntId<SwitchStructure>
+    ): List<SwitchJoint> {
+        val sql =
+            """
             select
               number,
               postgis.st_x(location) as x,
               postgis.st_y(location) as y
             from common.switch_joint
             where switch_structure_id = :switch_structure_id
-        """.trimIndent()
+        """
+                .trimIndent()
 
         val params = mapOf("switch_structure_id" to switchStructureId.intValue)
 
@@ -101,8 +110,11 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
         }
     }
 
-    private fun fetchSwitchTypeElements(switchAlignmentId: IntId<SwitchAlignment>): List<SwitchElement> {
-        val sql = """
+    private fun fetchSwitchTypeElements(
+        switchAlignmentId: IntId<SwitchAlignment>
+    ): List<SwitchElement> {
+        val sql =
+            """
             select
               alignment_id,
               element_index,
@@ -115,41 +127,49 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
             from common.switch_element
             where alignment_id = :alignment_id
             order by element_index
-        """.trimIndent()
+        """
+                .trimIndent()
 
         val params = mapOf("alignment_id" to switchAlignmentId.intValue)
 
         return jdbcTemplate.query(sql, params) { rs, _ ->
             val elementId = rs.getIndexedId<SwitchElement>("alignment_id", "element_index")
             when (rs.getEnum<SwitchElementType>("type")) {
-                SwitchElementType.LINE -> SwitchElementLine(
-                    id = elementId,
-                    start = rs.getPoint("start_x", "start_y"),
-                    end = rs.getPoint("end_x", "end_y"),
-                )
-                SwitchElementType.CURVE -> SwitchElementCurve(
-                    id = elementId,
-                    start = rs.getPoint("start_x", "start_y"),
-                    end = rs.getPoint("end_x", "end_y"),
-                    radius = rs.getDouble("curve_radius"),
-                )
+                SwitchElementType.LINE ->
+                    SwitchElementLine(
+                        id = elementId,
+                        start = rs.getPoint("start_x", "start_y"),
+                        end = rs.getPoint("end_x", "end_y"),
+                    )
+                SwitchElementType.CURVE ->
+                    SwitchElementCurve(
+                        id = elementId,
+                        start = rs.getPoint("start_x", "start_y"),
+                        end = rs.getPoint("end_x", "end_y"),
+                        radius = rs.getDouble("curve_radius"),
+                    )
             }
         }
     }
 
-    private fun fetchSwitchTypeAlignments(switchStructureId: IntId<SwitchStructure>): List<SwitchAlignment> {
-        val sql = """
+    private fun fetchSwitchTypeAlignments(
+        switchStructureId: IntId<SwitchStructure>
+    ): List<SwitchAlignment> {
+        val sql =
+            """
             select
               id,
               joint_numbers
             from common.switch_alignment
             where switch_structure_id = :switch_structure_id
-        """.trimIndent()
+        """
+                .trimIndent()
         val params = mapOf("switch_structure_id" to switchStructureId.intValue)
         return jdbcTemplate.query(sql, params) { rs, _ ->
             val switchAlignmentId = rs.getIntId<SwitchAlignment>("id")
             SwitchAlignment(
-                jointNumbers = rs.getIntArray("joint_numbers").map { number -> JointNumber(number) },
+                jointNumbers =
+                    rs.getIntArray("joint_numbers").map { number -> JointNumber(number) },
                 elements = fetchSwitchTypeElements(switchAlignmentId),
             )
         }
@@ -157,7 +177,8 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
 
     @Transactional
     fun insertSwitchStructure(switchStructure: SwitchStructure): RowVersion<SwitchStructure> {
-        val sql = """
+        val sql =
+            """
             insert into common.switch_structure(
                   type,
                   presentation_joint_number
@@ -168,12 +189,13 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                   :presentation_joint_number
                 )
             returning id, version
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "type" to switchStructure.type.typeName,
-            "presentation_joint_number" to switchStructure.presentationJointNumber.intValue
-        )
+        val params =
+            mapOf(
+                "type" to switchStructure.type.typeName,
+                "presentation_joint_number" to switchStructure.presentationJointNumber.intValue)
 
         jdbcTemplate.setUser()
         val version: RowVersion<SwitchStructure> =
@@ -188,7 +210,8 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
 
     @Transactional
     fun updateSwitchStructure(switchStructure: SwitchStructure): RowVersion<SwitchStructure> {
-        val sql = """
+        val sql =
+            """
             update common.switch_structure
             set
                 type = :type,
@@ -196,13 +219,14 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
             where
                 id = :id
             returning id, version
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "id" to (switchStructure.id as IntId).intValue,
-            "type" to switchStructure.type.typeName,
-            "presentation_joint_number" to switchStructure.presentationJointNumber.intValue
-        )
+        val params =
+            mapOf(
+                "id" to (switchStructure.id as IntId).intValue,
+                "type" to switchStructure.type.typeName,
+                "presentation_joint_number" to switchStructure.presentationJointNumber.intValue)
 
         jdbcTemplate.setUser()
         val version: RowVersion<SwitchStructure> =
@@ -218,49 +242,56 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
 
     @Transactional
     fun insertInframodelAlias(alias: String, type: String) {
-        val sql = """
+        val sql =
+            """
             insert into common.inframodel_switch_type_name_alias (alias, type)
             values (:alias, :type)
-        """.trimIndent()
+        """
+                .trimIndent()
         jdbcTemplate.setUser()
         val params = mapOf("alias" to alias, "type" to type)
         jdbcTemplate.update(sql, params)
     }
 
     fun getInframodelAliases(): Map<String, String> {
-        val sql = """
+        val sql =
+            """
             select alias, type from common.inframodel_switch_type_name_alias
-        """.trimIndent()
-        return jdbcTemplate.query(sql) { rs, _ ->
-            rs.getString("alias") to rs.getString("type")
-        }.associate { it }
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(sql) { rs, _ -> rs.getString("alias") to rs.getString("type") }
+            .associate { it }
     }
 
-
-    private fun insertJoints(switchStructureId: RowVersion<SwitchStructure>, joints: List<SwitchJoint>) {
+    private fun insertJoints(
+        switchStructureId: RowVersion<SwitchStructure>,
+        joints: List<SwitchJoint>
+    ) {
         joints.forEach { joint -> insertJoint(switchStructureId, joint) }
     }
 
     private fun deleteJoints(
         switchStructureId: IntId<SwitchStructure>,
     ) {
-        val sql = """
+        val sql =
+            """
             delete from common.switch_joint
             where switch_structure_id=:switch_structure_id
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "switch_structure_id" to switchStructureId.intValue,
-        )
+        val params =
+            mapOf(
+                "switch_structure_id" to switchStructureId.intValue,
+            )
 
         jdbcTemplate.update(sql, params)
     }
 
-    private fun insertJoint(
-        switchStructureId: RowVersion<SwitchStructure>,
-        joint: SwitchJoint
-    ) {
-        val sql = """
+    private fun insertJoint(switchStructureId: RowVersion<SwitchStructure>, joint: SwitchJoint) {
+        val sql =
+            """
             insert into common.switch_joint
                 (
                   switch_structure_id,
@@ -278,27 +309,32 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                     :srid
                   )
                 )
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "switch_structure_id" to switchStructureId.id.intValue,
-            "joint_number" to joint.number.intValue,
-            "location_x" to joint.location.x,
-            "location_y" to joint.location.y,
-            "srid" to LAYOUT_SRID.code
-        )
+        val params =
+            mapOf(
+                "switch_structure_id" to switchStructureId.id.intValue,
+                "joint_number" to joint.number.intValue,
+                "location_x" to joint.location.x,
+                "location_y" to joint.location.y,
+                "srid" to LAYOUT_SRID.code)
 
         jdbcTemplate.update(sql, params)
     }
 
-    private fun insertAlignments(switchStructureId: RowVersion<SwitchStructure>, alignments: List<SwitchAlignment>) {
+    private fun insertAlignments(
+        switchStructureId: RowVersion<SwitchStructure>,
+        alignments: List<SwitchAlignment>
+    ) {
         alignments.forEach { alignment -> insertAlignment(switchStructureId, alignment) }
     }
 
     private fun deleteAlignments(
         switchStructureId: IntId<SwitchStructure>,
     ) {
-        val deleteElementsSql = """
+        val deleteElementsSql =
+            """
             delete from common.switch_element
             where alignment_id in (
                 select 
@@ -307,16 +343,20 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                     common.switch_alignment
                 where switch_structure_id=:switch_structure_id
             )
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val deleteAlignmentsSql = """
+        val deleteAlignmentsSql =
+            """
             delete from common.switch_alignment
             where switch_structure_id=:switch_structure_id
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "switch_structure_id" to switchStructureId.intValue,
-        )
+        val params =
+            mapOf(
+                "switch_structure_id" to switchStructureId.intValue,
+            )
 
         jdbcTemplate.update(deleteElementsSql, params)
         jdbcTemplate.update(deleteAlignmentsSql, params)
@@ -326,7 +366,8 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
         switchStructureId: RowVersion<SwitchStructure>,
         alignment: SwitchAlignment
     ): RowVersion<SwitchAlignment> {
-        val sql = """
+        val sql =
+            """
             insert into common.switch_alignment
                 (
                   switch_structure_id,
@@ -338,22 +379,30 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                   array[ :joint_numbers ]
                 )
             returning id, version
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "switch_structure_id" to switchStructureId.id.intValue,
-            "joint_numbers" to alignment.jointNumbers.map { it.intValue },
-        )
+        val params =
+            mapOf(
+                "switch_structure_id" to switchStructureId.id.intValue,
+                "joint_numbers" to alignment.jointNumbers.map { it.intValue },
+            )
 
         val version: RowVersion<SwitchAlignment> =
             jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
-                ?: throw IllegalStateException("Failed to generate ID for new switch structure alignment")
+                ?: throw IllegalStateException(
+                    "Failed to generate ID for new switch structure alignment")
         insertElements(version, alignment.elements)
         return version
     }
 
-    private fun insertElements(switchAlignmentId: RowVersion<SwitchAlignment>, elements: List<SwitchElement>) {
-        elements.forEachIndexed { index, element -> insertElement(switchAlignmentId, element, index) }
+    private fun insertElements(
+        switchAlignmentId: RowVersion<SwitchAlignment>,
+        elements: List<SwitchElement>
+    ) {
+        elements.forEachIndexed { index, element ->
+            insertElement(switchAlignmentId, element, index)
+        }
     }
 
     private fun insertElement(
@@ -361,7 +410,8 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
         element: SwitchElement,
         index: Int
     ) {
-        val sql = """
+        val sql =
+            """
             insert into common.switch_element
                 (
                   alignment_id,
@@ -390,19 +440,20 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                   ),
                   :curve_radius
                 )
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "alignment_id" to switchAlignmentId.id.intValue,
-            "element_index" to index,
-            "type" to element.type.name,
-            "start_point_x" to element.start.x,
-            "start_point_y" to element.start.y,
-            "end_point_x" to element.end.x,
-            "end_point_y" to element.end.y,
-            "curve_radius" to (element as? SwitchElementCurve)?.radius,
-            "srid" to LAYOUT_SRID.code
-        )
+        val params =
+            mapOf(
+                "alignment_id" to switchAlignmentId.id.intValue,
+                "element_index" to index,
+                "type" to element.type.name,
+                "start_point_x" to element.start.x,
+                "start_point_y" to element.start.y,
+                "end_point_x" to element.end.x,
+                "end_point_y" to element.end.y,
+                "curve_radius" to (element as? SwitchElementCurve)?.radius,
+                "srid" to LAYOUT_SRID.code)
 
         jdbcTemplate.update(sql, params)
     }
@@ -415,11 +466,10 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
 
         val sql = "delete from common.switch_structure where id = :id returning id"
         val params = mapOf("id" to id.intValue)
-        val deletedRowId = getOne(id, jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getIntId<SwitchStructure>("id")
-        })
+        val deletedRowId =
+            getOne(
+                id, jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId<SwitchStructure>("id") })
         logger.daoAccess(AccessType.DELETE, SwitchStructure::class, deletedRowId)
         return deletedRowId
     }
-
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_233_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_233_1_9.kt
@@ -4,101 +4,72 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun KRV43_233_1_9() = SwitchStructure(
-    type = SwitchType("KRV43-233-1:9"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(16.846, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(33.692, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(0.103, 1.86)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(33.589, -1.86)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(16.846, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(16.846, 0.0),
-                    end = Point(33.692, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.103, 1.86),
-                    end = Point(16.846, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(16.846, 0.0),
-                    end = Point(33.692, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                // NOTE:
-                // Most probably there should be line elements before and after the curve,
-                // but did not have information about those elements and therefore this
-                // is simplified. This does not affect current functionality, joint point
-                // locations are the most important information.
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(33.589, -1.86),
-                    radius = 233.0
-                ),
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                // NOTE:
-                // Most probably there should be line elements before and after the curve,
-                // but did not have information about those elements and therefore this
-                // is simplified. This does not affect current functionality, joint point
-                // locations are the most important information.
-                SwitchElementCurve(
-                    start = Point(0.103, 1.86),
-                    end = Point(33.692, 0.0),
-                    radius = 233.0
-                ),
-            )
-        )
-    )
-)
+fun KRV43_233_1_9() =
+    SwitchStructure(
+        type = SwitchType("KRV43-233-1:9"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(16.846, 0.0)),
+                SwitchJoint(JointNumber(2), Point(33.692, 0.0)),
+                SwitchJoint(JointNumber(4), Point(0.103, 1.86)),
+                SwitchJoint(JointNumber(3), Point(33.589, -1.86))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(16.846, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(16.846, 0.0),
+                                end = Point(33.692, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.103, 1.86),
+                                end = Point(16.846, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(16.846, 0.0),
+                                end = Point(33.692, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            // NOTE:
+                            // Most probably there should be line elements before and after the
+                            // curve,
+                            // but did not have information about those elements and therefore this
+                            // is simplified. This does not affect current functionality, joint
+                            // point
+                            // locations are the most important information.
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(33.589, -1.86),
+                                radius = 233.0),
+                        )),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(2)),
+                    elements =
+                        listOf(
+                            // NOTE:
+                            // Most probably there should be line elements before and after the
+                            // curve,
+                            // but did not have information about those elements and therefore this
+                            // is simplified. This does not affect current functionality, joint
+                            // point
+                            // locations are the most important information.
+                            SwitchElementCurve(
+                                start = Point(0.103, 1.86),
+                                end = Point(33.692, 0.0),
+                                radius = 233.0),
+                        ))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_270_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_270_1_9_514.kt
@@ -4,107 +4,74 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun KRV43_270_1_9_514() = SwitchStructure(
-    type = SwitchType("KRV43-270-1:9,514"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(17.540, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(35.080, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(0.096, 1.833)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(34.984, -1.833)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.540, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(17.540, 0.0),
-                    end = Point(35.080, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.096, 1.833),
-                    end = Point(17.540, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(17.540, 0.0),
-                    end = Point(35.080, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(6.010, 0.0),
-                ),
-                SwitchElementCurve(
-                    start = Point(6.010, 0.0),
-                    end = Point(29.006, -1.206),
-                    radius = 220.0
-                ),
-                SwitchElementLine(
-                    start = Point(29.006, -1.206),
-                    end = Point(34.984, -1.833),
-                ),
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.096, 1.833),
-                    end = Point(6.0734, 1.206),
-                ),
-                SwitchElementCurve(
-                    start = Point(6.0734, 1.206),
-                    end = Point(29.07, 0.0),
-                    radius = 220.0
-                ),
-                SwitchElementLine(
-                    start = Point(29.07, 0.0),
-                    end = Point(35.080, 0.0),
-                ),
-            )
-        )
-    )
-)
+fun KRV43_270_1_9_514() =
+    SwitchStructure(
+        type = SwitchType("KRV43-270-1:9,514"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(17.540, 0.0)),
+                SwitchJoint(JointNumber(2), Point(35.080, 0.0)),
+                SwitchJoint(JointNumber(4), Point(0.096, 1.833)),
+                SwitchJoint(JointNumber(3), Point(34.984, -1.833))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.540, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(17.540, 0.0),
+                                end = Point(35.080, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.096, 1.833),
+                                end = Point(17.540, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(17.540, 0.0),
+                                end = Point(35.080, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(6.010, 0.0),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(6.010, 0.0),
+                                end = Point(29.006, -1.206),
+                                radius = 220.0),
+                            SwitchElementLine(
+                                start = Point(29.006, -1.206),
+                                end = Point(34.984, -1.833),
+                            ),
+                        )),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.096, 1.833),
+                                end = Point(6.0734, 1.206),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(6.0734, 1.206),
+                                end = Point(29.07, 0.0),
+                                radius = 220.0),
+                            SwitchElementLine(
+                                start = Point(29.07, 0.0),
+                                end = Point(35.080, 0.0),
+                            ),
+                        ))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV54_200_1_9.kt
@@ -4,109 +4,72 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun KRV54_200_1_9() = SwitchStructure(
-    type = SwitchType("KRV54-200-1:9"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(17.223, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(34.446, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(0.105, 1.902)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(34.341, -1.902)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.223, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(17.223, 0.0),
-                    end = Point(34.446, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.105, 1.902),
-                    end = Point(17.223, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(17.223, 0.0),
-                    end = Point(34.446, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(6.15, 0.0),
-                ),
-
-                SwitchElementCurve(
-                    start = Point(6.15, 0.0),
-                    end = Point(28.232, -1.223),
-                    radius = 200.0
-                ),
-                SwitchElementLine(
-                    start = Point(28.232, -1.223),
-                    end = Point(34.341, -1.902),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.105, 1.902),
-                    end = Point(6.214, 1.223),
-                ),
-
-                SwitchElementCurve(
-                    start = Point(6.214, 1.223),
-                    end = Point(28.300, 0.0),
-                    radius = 200.0
-                ),
-                SwitchElementLine(
-                    start = Point(28.300, 0.0),
-                    end = Point(34.446, 0.0),
-                )
-            )
-        )
-    )
-)
+fun KRV54_200_1_9() =
+    SwitchStructure(
+        type = SwitchType("KRV54-200-1:9"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(17.223, 0.0)),
+                SwitchJoint(JointNumber(2), Point(34.446, 0.0)),
+                SwitchJoint(JointNumber(4), Point(0.105, 1.902)),
+                SwitchJoint(JointNumber(3), Point(34.341, -1.902))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.223, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(17.223, 0.0),
+                                end = Point(34.446, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.105, 1.902),
+                                end = Point(17.223, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(17.223, 0.0),
+                                end = Point(34.446, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(6.15, 0.0),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(6.15, 0.0),
+                                end = Point(28.232, -1.223),
+                                radius = 200.0),
+                            SwitchElementLine(
+                                start = Point(28.232, -1.223),
+                                end = Point(34.341, -1.902),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.105, 1.902),
+                                end = Point(6.214, 1.223),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(6.214, 1.223),
+                                end = Point(28.300, 0.0),
+                                radius = 200.0),
+                            SwitchElementLine(
+                                start = Point(28.300, 0.0),
+                                end = Point(34.446, 0.0),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV30_270_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV30_270_1_9_514.kt
@@ -4,102 +4,66 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-
-fun KV30_270_1_9_514_O() = SwitchStructure(
-    type = SwitchType("KV30-270-1:9,514-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(10.42, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(6),
-            Point(20.42, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(37.96, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(27.864, -1.833)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(37.96, 1.833)
-        ),
-
-        ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(6),
-                JointNumber(2)
+fun KV30_270_1_9_514_O() =
+    SwitchStructure(
+        type = SwitchType("KV30-270-1:9,514-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(10.42, 0.0)),
+                SwitchJoint(JointNumber(6), Point(20.42, 0.0)),
+                SwitchJoint(JointNumber(2), Point(37.96, 0.0)),
+                SwitchJoint(JointNumber(3), Point(27.864, -1.833)),
+                SwitchJoint(JointNumber(4), Point(37.96, 1.833)),
             ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(10.42, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(10.42, 0.0),
-                    end = Point(20.42, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(20.42, 0.0),
-                    end = Point(37.96, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(20.783, -1.089),
-                    radius = 198.825
-                ),
-                SwitchElementLine(
-                    start = Point(20.783, -1.089),
-                    end = Point(27.864, -1.833),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(4)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(10.0, 0.0),
-                ),
-                SwitchElementCurve(
-                    start = Point(10.0, 0.0),
-                    end = Point(30.783, 1.089),
-                    radius = 198.825
-                ),
-                SwitchElementLine(
-                    start = Point(30.783, 1.089),
-                    end = Point(37.864, 1.833),
-                )
-            )
-        )
-    )
-)
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers =
+                        listOf(JointNumber(1), JointNumber(5), JointNumber(6), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(10.42, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(10.42, 0.0),
+                                end = Point(20.42, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(20.42, 0.0),
+                                end = Point(37.96, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(20.783, -1.089),
+                                radius = 198.825),
+                            SwitchElementLine(
+                                start = Point(20.783, -1.089),
+                                end = Point(27.864, -1.833),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(4)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(10.0, 0.0),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(10.0, 0.0),
+                                end = Point(30.783, 1.089),
+                                radius = 198.825),
+                            SwitchElementLine(
+                                start = Point(30.783, 1.089),
+                                end = Point(37.864, 1.833),
+                            )))))
 
-fun KV30_270_1_9_514_V() = KV30_270_1_9_514_O().flipAlongYAxis().copy(
-    type = SwitchType("KV30-270-1:9,514-V")
-)
-
+fun KV30_270_1_9_514_V() =
+    KV30_270_1_9_514_O().flipAlongYAxis().copy(type = SwitchType("KV30-270-1:9,514-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV43_300_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV43_300_1_9_514.kt
@@ -4,101 +4,64 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-
-fun KV43_300_1_9_514_V() = SwitchStructure(
-    type = SwitchType("KV43-300-1:9,514-V"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(11.31, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(6),
-            Point(23.38, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(40.92, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(28.754, 1.834)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(40.92, -1.834)
-        ),
-
-        ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(6),
-                JointNumber(2)
+fun KV43_300_1_9_514_V() =
+    SwitchStructure(
+        type = SwitchType("KV43-300-1:9,514-V"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(11.31, 0.0)),
+                SwitchJoint(JointNumber(6), Point(23.38, 0.0)),
+                SwitchJoint(JointNumber(2), Point(40.92, 0.0)),
+                SwitchJoint(JointNumber(3), Point(28.754, 1.834)),
+                SwitchJoint(JointNumber(4), Point(40.92, -1.834)),
             ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(11.31, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(11.31, 0.0),
-                    end = Point(23.38, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(23.38, 0.0),
-                    end = Point(40.92, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(23.35, 1.265),
-                    radius = 231.0
-                ),
-                SwitchElementLine(
-                    start = Point(23.35, 1.265),
-                    end = Point(28.754, 1.834),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(4)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(11.274, 0.0),
-                ),
-                SwitchElementCurve(
-                    start = Point(11.274, 0.0),
-                    end = Point(35.42, -1.266),
-                    radius = 231.0
-                ),
-                SwitchElementLine(
-                    start = Point(35.42, -1.266),
-                    end = Point(40.824, -1.834),
-                )
-            )
-        )
-    )
-)
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers =
+                        listOf(JointNumber(1), JointNumber(5), JointNumber(6), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(11.31, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(11.31, 0.0),
+                                end = Point(23.38, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(23.38, 0.0),
+                                end = Point(40.92, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0), end = Point(23.35, 1.265), radius = 231.0),
+                            SwitchElementLine(
+                                start = Point(23.35, 1.265),
+                                end = Point(28.754, 1.834),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(4)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(11.274, 0.0),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(11.274, 0.0),
+                                end = Point(35.42, -1.266),
+                                radius = 231.0),
+                            SwitchElementLine(
+                                start = Point(35.42, -1.266),
+                                end = Point(40.824, -1.834),
+                            )))))
 
-fun KV43_300_1_9_514_O() = KV43_300_1_9_514_V().flipAlongYAxis().copy(
-    type = SwitchType("KV43-300-1:9,514-O")
-)
+fun KV43_300_1_9_514_O() =
+    KV43_300_1_9_514_V().flipAlongYAxis().copy(type = SwitchType("KV43-300-1:9,514-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV54_200_1_9.kt
@@ -4,108 +4,68 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun KV54_200_1_9_O() = SwitchStructure(
-    type = SwitchType("KV54-200-1:9-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(11.077, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(6),
-            Point(22.4, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(39.623, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(28.195, -1.902)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(39.518, 1.902)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(6),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(11.077, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(11.077, 0.0),
-                    end = Point(22.4, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(22.4, 0.0),
-                    end = Point(39.623, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(22.086, -1.223),
-                    radius = 200.0
-                ),
-                SwitchElementLine(
-                    start = Point(22.086, -1.223),
-                    end = Point(28.195, -1.902),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(4)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(11.323, 0.0),
-                ),
-                SwitchElementCurve(
-                    start = Point(11.323, 0.0),
-                    end = Point(33.406, 1.223),
-                    radius = 200.0
-                ),
-                SwitchElementLine(
-                    start = Point(33.406, 1.223),
-                    end = Point(39.518, 1.902),
-                )
-            )
-        )
-    )
-)
+fun KV54_200_1_9_O() =
+    SwitchStructure(
+        type = SwitchType("KV54-200-1:9-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(11.077, 0.0)),
+                SwitchJoint(JointNumber(6), Point(22.4, 0.0)),
+                SwitchJoint(JointNumber(2), Point(39.623, 0.0)),
+                SwitchJoint(JointNumber(3), Point(28.195, -1.902)),
+                SwitchJoint(JointNumber(4), Point(39.518, 1.902))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers =
+                        listOf(JointNumber(1), JointNumber(5), JointNumber(6), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(11.077, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(11.077, 0.0),
+                                end = Point(22.4, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(22.4, 0.0),
+                                end = Point(39.623, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(22.086, -1.223),
+                                radius = 200.0),
+                            SwitchElementLine(
+                                start = Point(22.086, -1.223),
+                                end = Point(28.195, -1.902),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(4)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(11.323, 0.0),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(11.323, 0.0),
+                                end = Point(33.406, 1.223),
+                                radius = 200.0),
+                            SwitchElementLine(
+                                start = Point(33.406, 1.223),
+                                end = Point(39.518, 1.902),
+                            )))))
 
-fun KV54_200_1_9_V() = KV54_200_1_9_O().flipAlongYAxis().copy(
-    type = SwitchType("KV54-200-1:9-V")
-)
+fun KV54_200_1_9_V() = KV54_200_1_9_O().flipAlongYAxis().copy(type = SwitchType("KV54-200-1:9-V"))
 
-fun KV54_200N_1_9_O() = KV54_200_1_9_O().copy(
-    type = SwitchType("KV54-200N-1:9-O")
-)
+fun KV54_200N_1_9_O() = KV54_200_1_9_O().copy(type = SwitchType("KV54-200N-1:9-O"))
 
-fun KV54_200N_1_9_V() = KV54_200_1_9_V().copy(
-    type = SwitchType("KV54-200N-1:9-V")
-)
-
+fun KV54_200N_1_9_V() = KV54_200_1_9_V().copy(type = SwitchType("KV54-200N-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR43_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR43_1_9_514.kt
@@ -8,65 +8,40 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
-fun RR43_1_9_514() = SwitchStructure(
-    type = SwitchType("RR43-1:9,514"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(5),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(1),
-            Point(-17.44, 1.84)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(17.44, -1.84)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(-17.44, -1.84)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(17.44, 1.84)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-17.44, 1.84),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.44, -1.84),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-17.44, -1.84),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.44, 1.84),
-                )
-            )
-        )
-    )
-)
+fun RR43_1_9_514() =
+    SwitchStructure(
+        type = SwitchType("RR43-1:9,514"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(1), Point(-17.44, 1.84)),
+                SwitchJoint(JointNumber(2), Point(17.44, -1.84)),
+                SwitchJoint(JointNumber(4), Point(-17.44, -1.84)),
+                SwitchJoint(JointNumber(3), Point(17.44, 1.84))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-17.44, 1.84),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.44, -1.84),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-17.44, -1.84),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.44, 1.84),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_9.kt
@@ -4,65 +4,40 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun RR54_1_9() = SwitchStructure(
-    type = SwitchType("RR54-1:9"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(17.223, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(34.446, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(0.105, 1.902)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(34.341, -1.902)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.223, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(17.223, 0.0),
-                    end = Point(34.446, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.105, 1.902),
-                    end = Point(17.223, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(17.223, 0.0),
-                    end = Point(34.446, 0.0),
-                )
-            )
-        )
-    )
-)
+fun RR54_1_9() =
+    SwitchStructure(
+        type = SwitchType("RR54-1:9"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(17.223, 0.0)),
+                SwitchJoint(JointNumber(2), Point(34.446, 0.0)),
+                SwitchJoint(JointNumber(4), Point(0.105, 1.902)),
+                SwitchJoint(JointNumber(3), Point(34.341, -1.902))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.223, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(17.223, 0.0),
+                                end = Point(34.446, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.105, 1.902),
+                                end = Point(17.223, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(17.223, 0.0),
+                                end = Point(34.446, 0.0),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_2x1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_2x1_9.kt
@@ -4,65 +4,40 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun RR54_2x1_9() = SwitchStructure(
-    type = SwitchType("RR54-2x1:9"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(-11.148, -1.239)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(11.148, 1.239)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(-11.148, 1.239)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(11.148, -1.239)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-11.148, -1.239),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(11.148, 1.239),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-11.148, 1.239),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(11.148, -1.239),
-                )
-            )
-        )
-    )
-)
+fun RR54_2x1_9() =
+    SwitchStructure(
+        type = SwitchType("RR54-2x1:9"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(-11.148, -1.239)),
+                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(2), Point(11.148, 1.239)),
+                SwitchJoint(JointNumber(4), Point(-11.148, 1.239)),
+                SwitchJoint(JointNumber(3), Point(11.148, -1.239))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-11.148, -1.239),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(11.148, 1.239),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-11.148, 1.239),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(11.148, -1.239),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_4x1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_4x1_9.kt
@@ -4,65 +4,40 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun RR54_4x1_9() = SwitchStructure(
-    type = SwitchType("RR54-4x1:9"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(-5.075, -1.142)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(5.075, 1.142)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(-5.075, 1.142)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(5.075, -1.142)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-5.075, -1.142),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(5.075, 1.142),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-5.075, 1.142),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(5.075, -1.142),
-                )
-            )
-        )
-    )
-)
+fun RR54_4x1_9() =
+    SwitchStructure(
+        type = SwitchType("RR54-4x1:9"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(-5.075, -1.142)),
+                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(2), Point(5.075, 1.142)),
+                SwitchJoint(JointNumber(4), Point(-5.075, 1.142)),
+                SwitchJoint(JointNumber(3), Point(5.075, -1.142))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-5.075, -1.142),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(5.075, 1.142),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-5.075, 1.142),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(5.075, -1.142),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_1000_474_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_1000_474_1_15_5.kt
@@ -4,58 +4,41 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun SKV60_1000_474_1_15_5_O() = SwitchStructure(
-    type = SwitchType("SKV60-1000/474-1:15,5-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(13),
-            Point(29.555, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(16),
-            Point(59.058, -1.745)
-        ),
-        SwitchJoint(
-            JointNumber(17),
-            Point(58.896, -3.553)
-        ),
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(16),
+fun SKV60_1000_474_1_15_5_O() =
+    SwitchStructure(
+        type = SwitchType("SKV60-1000/474-1:15,5-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(13), Point(29.555, 0.0)),
+                SwitchJoint(JointNumber(16), Point(59.058, -1.745)),
+                SwitchJoint(JointNumber(17), Point(58.896, -3.553)),
             ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(59.058, -1.745),
-                    radius = 1000.0
-                ),
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(17)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(58.896, -3.553),
-                    radius = 474.0
-                ),
-            )
-        )
-    )
-)
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers =
+                        listOf(
+                            JointNumber(1),
+                            JointNumber(16),
+                        ),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(59.058, -1.745),
+                                radius = 1000.0),
+                        )),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(17)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(58.896, -3.553),
+                                radius = 474.0),
+                        ))))
 
-
-fun SKV60_1000_474_1_15_5_V() = SKV60_1000_474_1_15_5_O().flipAlongYAxis().copy(
-    type = SwitchType("SKV60-1000/474-1:15,5-V")
-)
+fun SKV60_1000_474_1_15_5_V() =
+    SKV60_1000_474_1_15_5_O().flipAlongYAxis().copy(type = SwitchType("SKV60-1000/474-1:15,5-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_800_423_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_800_423_1_15_5.kt
@@ -9,54 +9,40 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // as this model is constructed with insufficient information from Ratko DB and
 // with limited understanding of the domain.
 
-fun SKV60_800_423_1_15_5_O() = SwitchStructure(
-    type = SwitchType("SKV60-800/423-1:15,5-V"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(16),
-            Point(59.003, 2.105)
-        ),
-        SwitchJoint(
-            JointNumber(17),
-            Point(58.807, 3.967)
-        ),
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(16),
+fun SKV60_800_423_1_15_5_O() =
+    SwitchStructure(
+        type = SwitchType("SKV60-800/423-1:15,5-V"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(16), Point(59.003, 2.105)),
+                SwitchJoint(JointNumber(17), Point(58.807, 3.967)),
             ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(59.003, 2.105),
-                    radius = 800.0
-                ),
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(17)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(58.807, 3.967),
-                    radius = 423.0
-                ),
-            )
-        )
-    )
-)
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers =
+                        listOf(
+                            JointNumber(1),
+                            JointNumber(16),
+                        ),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(59.003, 2.105),
+                                radius = 800.0),
+                        )),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(17)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(58.807, 3.967),
+                                radius = 423.0),
+                        ))))
 
-
-fun SKV60_800_423_1_15_5_V() = SKV60_800_423_1_15_5_O().flipAlongYAxis().copy(
-    type = SwitchType("SKV60-800/423-1:15,5-O")
-)
+fun SKV60_800_423_1_15_5_V() =
+    SKV60_800_423_1_15_5_O().flipAlongYAxis().copy(type = SwitchType("SKV60-800/423-1:15,5-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_4_8.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_4_8.kt
@@ -7,65 +7,41 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // NOTE: Joint point locations are inferred from geometry elements with just a little domain
 // knowledge and therefore this switch model may be somewhat wrong.
 
-fun SRR54_2x1_9_4_8() = SwitchStructure(
-    type = SwitchType("SRR54-2x1:9-4,8"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(-4.482, -4.482 / 9.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(4.482, 4.482 / 9.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(4.482, -4.482 / 9.0)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(-4.482, 4.482 / 9.0)
-        ),
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
+fun SRR54_2x1_9_4_8() =
+    SwitchStructure(
+        type = SwitchType("SRR54-2x1:9-4,8"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(-4.482, -4.482 / 9.0)),
+                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(2), Point(4.482, 4.482 / 9.0)),
+                SwitchJoint(JointNumber(3), Point(4.482, -4.482 / 9.0)),
+                SwitchJoint(JointNumber(4), Point(-4.482, 4.482 / 9.0)),
             ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-4.482, -4.482 / 9.0),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(4.482, 4.482 / 9.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-4.482, 4.482 / 9.0),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(4.482, -4.482 / 9.0),
-                )
-            )
-        )
-    )
-)
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-4.482, -4.482 / 9.0),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(4.482, 4.482 / 9.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-4.482, 4.482 / 9.0),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(4.482, -4.482 / 9.0),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_6_0.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_6_0.kt
@@ -7,65 +7,41 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // NOTE: Joint point locations are inferred from geometry elements with just a little domain
 // knowledge and therefore this switch model may be somewhat wrong.
 
-fun SRR54_2x1_9_6_0() = SwitchStructure(
-    type = SwitchType("SRR54-2x1:9-6,0"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(-9.927, -9.927 / 9.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(9.927, 9.927 / 9.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(9.927, -9.927 / 9.0)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(-9.927, 9.927 / 9.0)
-        ),
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
+fun SRR54_2x1_9_6_0() =
+    SwitchStructure(
+        type = SwitchType("SRR54-2x1:9-6,0"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(-9.927, -9.927 / 9.0)),
+                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(2), Point(9.927, 9.927 / 9.0)),
+                SwitchJoint(JointNumber(3), Point(9.927, -9.927 / 9.0)),
+                SwitchJoint(JointNumber(4), Point(-9.927, 9.927 / 9.0)),
             ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-9.927, -9.927 / 9.0),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(9.927, 9.927 / 9.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-9.927, 9.927 / 9.0),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(9.927, -9.927 / 9.0),
-                )
-            )
-        )
-    )
-)
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-9.927, -9.927 / 9.0),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(9.927, 9.927 / 9.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-9.927, 9.927 / 9.0),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(9.927, -9.927 / 9.0),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR60_2x1_9_4_8.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR60_2x1_9_4_8.kt
@@ -7,65 +7,41 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // NOTE: Joint point locations are inferred from geometry elements with just a little domain
 // knowledge and therefore this switch model may be somewhat wrong.
 
-fun SRR60_2x1_9_4_8() = SwitchStructure(
-    type = SwitchType("SRR60-2x1:9-4,8"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(-5.087, -5.087 / 9.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(5.087, 5.087 / 9.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(5.087, -5.087 / 9.0)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(-5.087, 5.087 / 9.0)
-        ),
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
+fun SRR60_2x1_9_4_8() =
+    SwitchStructure(
+        type = SwitchType("SRR60-2x1:9-4,8"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(-5.087, -5.087 / 9.0)),
+                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(2), Point(5.087, 5.087 / 9.0)),
+                SwitchJoint(JointNumber(3), Point(5.087, -5.087 / 9.0)),
+                SwitchJoint(JointNumber(4), Point(-5.087, 5.087 / 9.0)),
             ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-5.087, -5.087 / 9.0),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(5.087, 5.087 / 9.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(-5.087, 5.087 / 9.0),
-                    end = Point(0.0, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(5.087, -5.087 / 9.0),
-                )
-            )
-        )
-    )
-)
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-5.087, -5.087 / 9.0),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(5.087, 5.087 / 9.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(-5.087, 5.087 / 9.0),
+                                end = Point(0.0, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(5.087, -5.087 / 9.0),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44.kt
@@ -4,53 +4,31 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun TYV54_200_1_4_44() = SwitchStructure(
-    type = SwitchType("TYV54-200-1:4,44"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(11.077, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(22.086, 1.223)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(22.086, -1.223)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(22.086, 1.223),
-                    radius = 200.0
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(22.086, -1.223),
-                    radius = 200.0
-                )
-            )
-        )
-    )
-)
+fun TYV54_200_1_4_44() =
+    SwitchStructure(
+        type = SwitchType("TYV54-200-1:4,44"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(11.077, 0.0)),
+                SwitchJoint(JointNumber(2), Point(22.086, 1.223)),
+                SwitchJoint(JointNumber(3), Point(22.086, -1.223))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(22.086, 1.223),
+                                radius = 200.0))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(22.086, -1.223),
+                                radius = 200.0)))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44TPE.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44TPE.kt
@@ -9,54 +9,31 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // "TYV54-200-1:4.44", but in most cases this won't cause
 // any problems.
 
-
-fun TYV54_200_1_4_44TPE() = SwitchStructure(
-    type = SwitchType("TYV54-200-1:4,44TPE"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(11.077, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(22.305, 1.236)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(22.305, -1.236)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(22.305, 1.236),
-                    radius = 200.0
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(22.305, -1.236),
-                    radius = 200.0
-                )
-            )
-        )
-    )
-)
+fun TYV54_200_1_4_44TPE() =
+    SwitchStructure(
+        type = SwitchType("TYV54-200-1:4,44TPE"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(11.077, 0.0)),
+                SwitchJoint(JointNumber(2), Point(22.305, 1.236)),
+                SwitchJoint(JointNumber(3), Point(22.305, -1.236))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(22.305, 1.236),
+                                radius = 200.0))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(22.305, -1.236),
+                                radius = 200.0)))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46.kt
@@ -4,61 +4,39 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun TYV54_225_1_6_46() = SwitchStructure(
-    type = SwitchType("TYV54-225-1:6,46"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(8.706, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(20.942, 0.941)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(20.942, -0.941)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.322, 0.663),
-                    radius = 225.0
-                ),
-                SwitchElementLine(
-                    start = Point(17.322, 0.663),
-                    end = Point(20.942, 0.941),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.322, -0.663),
-                    radius = 225.0
-                ),
-                SwitchElementLine(
-                    start = Point(17.322, 0.663),
-                    end = Point(20.942, -0.941),
-                )
-            )
-        )
-    )
-)
+fun TYV54_225_1_6_46() =
+    SwitchStructure(
+        type = SwitchType("TYV54-225-1:6,46"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(8.706, 0.0)),
+                SwitchJoint(JointNumber(2), Point(20.942, 0.941)),
+                SwitchJoint(JointNumber(3), Point(20.942, -0.941))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.322, 0.663),
+                                radius = 225.0),
+                            SwitchElementLine(
+                                start = Point(17.322, 0.663),
+                                end = Point(20.942, 0.941),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.322, -0.663),
+                                radius = 225.0),
+                            SwitchElementLine(
+                                start = Point(17.322, 0.663),
+                                end = Point(20.942, -0.941),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46TPE.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46TPE.kt
@@ -9,62 +9,39 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // "TYV54-225-1:6.46", but in most cases this won't cause
 // any problems.
 
-fun TYV54_225_1_6_46TPE() = SwitchStructure(
-    type = SwitchType("TYV54-225-1:6,46TPE"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(8.706, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(21.140, 0.949)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(21.140, -0.949)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.421, 0.663),
-                    radius = 225.0
-                ),
-                SwitchElementLine(
-                    start = Point(17.421, 0.663),
-                    end = Point(21.140, 0.949),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.421, -0.663),
-                    radius = 225.0
-                ),
-                SwitchElementLine(
-                    start = Point(17.421, 0.663),
-                    end = Point(21.140, -0.949),
-                )
-            )
-        )
-    )
-)
-
+fun TYV54_225_1_6_46TPE() =
+    SwitchStructure(
+        type = SwitchType("TYV54-225-1:6,46TPE"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(8.706, 0.0)),
+                SwitchJoint(JointNumber(2), Point(21.140, 0.949)),
+                SwitchJoint(JointNumber(3), Point(21.140, -0.949))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.421, 0.663),
+                                radius = 225.0),
+                            SwitchElementLine(
+                                start = Point(17.421, 0.663),
+                                end = Point(21.140, 0.949),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.421, -0.663),
+                                radius = 225.0),
+                            SwitchElementLine(
+                                start = Point(17.421, 0.663),
+                                end = Point(21.140, -0.949),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1000_244_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1000_244_1_9.kt
@@ -2,11 +2,11 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
-fun UKV54_1000_244_1_9_O() = UKV60_1000_244_1_9_O().copy(
-    type = SwitchType("UKV54-1000/244-1:9-O"),
-)
+fun UKV54_1000_244_1_9_O() =
+    UKV60_1000_244_1_9_O()
+        .copy(
+            type = SwitchType("UKV54-1000/244-1:9-O"),
+        )
 
-
-fun UKV54_1000_244_1_9_V() = UKV54_1000_244_1_9_O().flipAlongYAxis().copy(
-    type = SwitchType("UKV54-1000/244-1:9-V")
-)
+fun UKV54_1000_244_1_9_V() =
+    UKV54_1000_244_1_9_O().flipAlongYAxis().copy(type = SwitchType("UKV54-1000/244-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1500_228_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1500_228_1_9.kt
@@ -9,70 +9,48 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // as this model is constructed with insufficient information from IM models and
 // with limited understanding of domain.
 
-fun UKV54_1500_228_1_9_O() = SwitchStructure(
-    type = SwitchType("UKV54-1500/228-1:9-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(7),
-            Point(10.476, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(8),
-            Point(14.143, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(10),
-            Point(28.228, -1.480)
-        ),
-        SwitchJoint(
-            JointNumber(11),
-            Point(28.284, 0.256)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(10),
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(1.054, 0.0),
-                ),
-                SwitchElementCurve(
-                    start = Point(1.054, 0.0),
-                    end = Point(19.865, 0.785),
-                    radius = 228.0
-                ),
-                SwitchElementLine(
-                    start = Point(19.865, 0.785),
-                    end = Point(28.228, -1.480),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(11)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(28.284, 0.256),
-                    radius = 1500.0
-                ),
-            )
-        )
-    )
-)
+fun UKV54_1500_228_1_9_O() =
+    SwitchStructure(
+        type = SwitchType("UKV54-1500/228-1:9-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(7), Point(10.476, 0.0)),
+                SwitchJoint(JointNumber(8), Point(14.143, 0.0)),
+                SwitchJoint(JointNumber(10), Point(28.228, -1.480)),
+                SwitchJoint(JointNumber(11), Point(28.284, 0.256))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers =
+                        listOf(
+                            JointNumber(1),
+                            JointNumber(10),
+                        ),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(1.054, 0.0),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(1.054, 0.0),
+                                end = Point(19.865, 0.785),
+                                radius = 228.0),
+                            SwitchElementLine(
+                                start = Point(19.865, 0.785),
+                                end = Point(28.228, -1.480),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(11)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(28.284, 0.256),
+                                radius = 1500.0),
+                        ))))
 
-
-fun UKV54_1500_228_1_9_V() = UKV54_1500_228_1_9_O().flipAlongYAxis().copy(
-    type = SwitchType("UKV54-1500/228-1:9-V")
-)
+fun UKV54_1500_228_1_9_V() =
+    UKV54_1500_228_1_9_O().flipAlongYAxis().copy(type = SwitchType("UKV54-1500/228-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_800_258_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_800_258_1_9.kt
@@ -9,66 +9,44 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // as this model is constructed with insufficient information from IM models and
 // with limited understanding of domain.
 
-fun UKV54_800_258_1_9_V() = SwitchStructure(
-    type = SwitchType("UKV54-800/258-1:9-V"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(7),
-            Point(9.709, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(8),
-            Point(14.138, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(10),
-            Point(28.230, 1.398)
-        ),
-        SwitchJoint(
-            JointNumber(11),
-            Point(28.268, -0.499)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(10),
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(19.403, 0.731),
-                    radius = 258.0
-                ),
-                SwitchElementLine(
-                    start = Point(19.403, 0.731),
-                    end = Point(28.230, 1.398),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(11)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(28.268, -0.499),
-                    radius = 800.0
-                ),
-            )
-        )
-    )
-)
+fun UKV54_800_258_1_9_V() =
+    SwitchStructure(
+        type = SwitchType("UKV54-800/258-1:9-V"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(7), Point(9.709, 0.0)),
+                SwitchJoint(JointNumber(8), Point(14.138, 0.0)),
+                SwitchJoint(JointNumber(10), Point(28.230, 1.398)),
+                SwitchJoint(JointNumber(11), Point(28.268, -0.499))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers =
+                        listOf(
+                            JointNumber(1),
+                            JointNumber(10),
+                        ),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(19.403, 0.731),
+                                radius = 258.0),
+                            SwitchElementLine(
+                                start = Point(19.403, 0.731),
+                                end = Point(28.230, 1.398),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(11)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(28.268, -0.499),
+                                radius = 800.0),
+                        ))))
 
-
-fun UKV54_800_258_1_9_O() = UKV54_800_258_1_9_V().flipAlongYAxis().copy(
-    type = SwitchType("UKV54-800/258-1:9-O")
-)
+fun UKV54_800_258_1_9_O() =
+    UKV54_800_258_1_9_V().flipAlongYAxis().copy(type = SwitchType("UKV54-800/258-1:9-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_1000_244_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_1000_244_1_9.kt
@@ -4,62 +4,42 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun UKV60_1000_244_1_9_O() = SwitchStructure(
-    type = SwitchType("UKV60-1000/244-1:9-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(7),
-            Point(10.074, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(8),
-            Point(14.141, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(10),
-            Point(28.290, -0.400)
-        ),
-        SwitchJoint(
-            JointNumber(11),
-            Point(28.217, 1.498)
-        ),
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(10),
+fun UKV60_1000_244_1_9_O() =
+    SwitchStructure(
+        type = SwitchType("UKV60-1000/244-1:9-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(7), Point(10.074, 0.0)),
+                SwitchJoint(JointNumber(8), Point(14.141, 0.0)),
+                SwitchJoint(JointNumber(10), Point(28.290, -0.400)),
+                SwitchJoint(JointNumber(11), Point(28.217, 1.498)),
             ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(28.290, -0.400),
-                    radius = 1000.0
-                ),
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(11)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(28.217, 1.498),
-                    radius = 244.45
-                ),
-            )
-        )
-    )
-)
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers =
+                        listOf(
+                            JointNumber(1),
+                            JointNumber(10),
+                        ),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(28.290, -0.400),
+                                radius = 1000.0),
+                        )),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(11)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(28.217, 1.498),
+                                radius = 244.45),
+                        ))))
 
-
-fun UKV60_1000_244_1_9_V() = UKV60_1000_244_1_9_O().flipAlongYAxis().copy(
-    type = SwitchType("UKV60-1000/244-1:9-V")
-)
+fun UKV60_1000_244_1_9_V() =
+    UKV60_1000_244_1_9_O().flipAlongYAxis().copy(type = SwitchType("UKV60-1000/244-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_600_281_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_600_281_1_9.kt
@@ -4,62 +4,42 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun UKV60_600_281_1_9_O() = SwitchStructure(
-    type = SwitchType("UKV60-600/281-1:9-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(7),
-            Point(8.921, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(8),
-            Point(14.135, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(10),
-            Point(28.254, -0.666)
-        ),
-        SwitchJoint(
-            JointNumber(11),
-            Point(28.234, 1.229)
-        ),
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(10),
+fun UKV60_600_281_1_9_O() =
+    SwitchStructure(
+        type = SwitchType("UKV60-600/281-1:9-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(7), Point(8.921, 0.0)),
+                SwitchJoint(JointNumber(8), Point(14.135, 0.0)),
+                SwitchJoint(JointNumber(10), Point(28.254, -0.666)),
+                SwitchJoint(JointNumber(11), Point(28.234, 1.229)),
             ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(28.254, -0.666),
-                    radius = 600.0
-                ),
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(11)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(28.234, 1.229),
-                    radius = 281.0
-                ),
-            )
-        )
-    )
-)
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers =
+                        listOf(
+                            JointNumber(1),
+                            JointNumber(10),
+                        ),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(28.254, -0.666),
+                                radius = 600.0),
+                        )),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(11)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(28.234, 1.229),
+                                radius = 281.0),
+                        ))))
 
-
-fun UKV60_600_281_1_9_V() = UKV60_600_281_1_9_O().flipAlongYAxis().copy(
-    type = SwitchType("UKV60-600/281-1:9-V")
-)
+fun UKV60_600_281_1_9_V() =
+    UKV60_600_281_1_9_O().flipAlongYAxis().copy(type = SwitchType("UKV60-600/281-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YRV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YRV54_200_1_9.kt
@@ -4,109 +4,72 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YRV54_200_1_9() = SwitchStructure(
-    type = SwitchType("YRV54-200-1:9"),
-    presentationJointNumber = JointNumber(5),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(17.223, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(34.446, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(4),
-            Point(0.105, 1.902)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(34.341, -1.902)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.223, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(17.223, 0.0),
-                    end = Point(34.446, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(5),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.105, 1.902),
-                    end = Point(17.223, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(17.223, 0.0),
-                    end = Point(34.446, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(6.15, 0.0),
-                ),
-
-                SwitchElementCurve(
-                    start = Point(6.15, 0.0),
-                    end = Point(28.232, -1.223),
-                    radius = 200.0
-                ),
-                SwitchElementLine(
-                    start = Point(28.232, -1.223),
-                    end = Point(34.341, -1.902),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(4),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.105, 1.902),
-                    end = Point(6.214, 1.223),
-                ),
-
-                SwitchElementCurve(
-                    start = Point(6.214, 1.223),
-                    end = Point(28.300, 0.0),
-                    radius = 200.0
-                ),
-                SwitchElementLine(
-                    start = Point(28.300, 0.0),
-                    end = Point(34.446, 0.0),
-                )
-            )
-        )
-    )
-)
+fun YRV54_200_1_9() =
+    SwitchStructure(
+        type = SwitchType("YRV54-200-1:9"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(17.223, 0.0)),
+                SwitchJoint(JointNumber(2), Point(34.446, 0.0)),
+                SwitchJoint(JointNumber(4), Point(0.105, 1.902)),
+                SwitchJoint(JointNumber(3), Point(34.341, -1.902))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.223, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(17.223, 0.0),
+                                end = Point(34.446, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.105, 1.902),
+                                end = Point(17.223, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(17.223, 0.0),
+                                end = Point(34.446, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(6.15, 0.0),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(6.15, 0.0),
+                                end = Point(28.232, -1.223),
+                                radius = 200.0),
+                            SwitchElementLine(
+                                start = Point(28.232, -1.223),
+                                end = Point(34.341, -1.902),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.105, 1.902),
+                                end = Point(6.214, 1.223),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(6.214, 1.223),
+                                end = Point(28.300, 0.0),
+                                radius = 200.0),
+                            SwitchElementLine(
+                                start = Point(28.300, 0.0),
+                                end = Point(34.446, 0.0),
+                            )))))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_7.kt
@@ -4,66 +4,41 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
+fun YV30_270_1_7_V() =
+    SwitchStructure(
+        type = SwitchType("YV30-270-1:7-V"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(12.685, 0.0)),
+                SwitchJoint(JointNumber(2), Point(25.928, 0.0)),
+                SwitchJoint(JointNumber(3), Point(25.795, 1.872))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(12.685, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(12.685, 0.0),
+                                end = Point(25.928, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(25.701, 1.859),
+                                radius = 185.0),
+                            SwitchElementLine(
+                                start = Point(25.701, 1.859),
+                                end = Point(25.795, 1.872),
+                            )))))
 
-fun YV30_270_1_7_V() = SwitchStructure(
-    type = SwitchType("YV30-270-1:7-V"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(12.685, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(25.928, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(25.795, 1.872)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(12.685, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(12.685, 0.0),
-                    end = Point(25.928, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(25.701, 1.859),
-                    radius = 185.0
-                ),
-                SwitchElementLine(
-                    start = Point(25.701, 1.859),
-                    end = Point(25.795, 1.872),
-                )
-            )
-        )
-    )
-)
-
-fun YV30_270_1_7_O() = YV30_270_1_7_V().flipAlongYAxis().copy(
-    type = SwitchType("YV30-270-1:7-O")
-)
+fun YV30_270_1_7_O() = YV30_270_1_7_V().flipAlongYAxis().copy(type = SwitchType("YV30-270-1:7-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_9_514.kt
@@ -4,66 +4,42 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
+fun YV30_270_1_9_514_V() =
+    SwitchStructure(
+        type = SwitchType("YV30-270-1:9,514-V"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(10.422, 0.0)),
+                SwitchJoint(JointNumber(2), Point(27.962, 0.0)),
+                SwitchJoint(JointNumber(3), Point(27.866, 1.833))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(10.422, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(10.422, 0.0),
+                                end = Point(27.962, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(22.722, 1.293),
+                                radius = 236.0),
+                            SwitchElementLine(
+                                start = Point(22.722, 1.293),
+                                end = Point(27.866, 1.833),
+                            )))))
 
-fun YV30_270_1_9_514_V() = SwitchStructure(
-    type = SwitchType("YV30-270-1:9,514-V"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(10.422, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(27.962, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(27.866, 1.833)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(10.422, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(10.422, 0.0),
-                    end = Point(27.962, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(22.722, 1.293),
-                    radius = 236.0
-                ),
-                SwitchElementLine(
-                    start = Point(22.722, 1.293),
-                    end = Point(27.866, 1.833),
-                )
-            )
-        )
-    )
-)
-
-fun YV30_270_1_9_514_O() = YV30_270_1_9_514_V().flipAlongYAxis().copy(
-    type = SwitchType("YV30-270-1:9,514-O")
-)
+fun YV30_270_1_9_514_O() =
+    YV30_270_1_9_514_V().flipAlongYAxis().copy(type = SwitchType("YV30-270-1:9,514-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_205_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_205_1_9.kt
@@ -2,10 +2,6 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
-fun YV43_205_1_9_O() = YV43_300_1_9_O().copy(
-    type = SwitchType("YV43-205-1:9-O")
-)
+fun YV43_205_1_9_O() = YV43_300_1_9_O().copy(type = SwitchType("YV43-205-1:9-O"))
 
-fun YV43_205_1_9_V() = YV43_300_1_9_V().copy(
-    type = SwitchType("YV43-205-1:9-V")
-)
+fun YV43_205_1_9_V() = YV43_300_1_9_V().copy(type = SwitchType("YV43-205-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_205_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_205_1_9_514.kt
@@ -2,10 +2,6 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
-fun YV43_205_1_9_514_O() = YV43_300_1_9_514_O().copy(
-    type = SwitchType("YV43-205-1:9,514-O")
-)
+fun YV43_205_1_9_514_O() = YV43_300_1_9_514_O().copy(type = SwitchType("YV43-205-1:9,514-O"))
 
-fun YV43_205_1_9_514_V() = YV43_300_1_9_514_V().copy(
-    type = SwitchType("YV43-205-1:9,514-V")
-)
+fun YV43_205_1_9_514_V() = YV43_300_1_9_514_V().copy(type = SwitchType("YV43-205-1:9,514-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_7.kt
@@ -4,66 +4,41 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
+fun YV43_300_1_7_O() =
+    SwitchStructure(
+        type = SwitchType("YV43-300-1:7-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(13.481, 0.0)),
+                SwitchJoint(JointNumber(2), Point(26.506, 0.0)),
+                SwitchJoint(JointNumber(3), Point(26.375, -1.842))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(13.481, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(13.481, 0.0),
+                                end = Point(26.506, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(26.145, -1.809),
+                                radius = 180.0),
+                            SwitchElementLine(
+                                start = Point(26.145, -1.809),
+                                end = Point(26.375, -1.842),
+                            )))))
 
-fun YV43_300_1_7_O() = SwitchStructure(
-    type = SwitchType("YV43-300-1:7-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(13.481, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(26.506, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(26.375, -1.842)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(13.481, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(13.481, 0.0),
-                    end = Point(26.506, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(26.145, -1.809),
-                    radius = 180.0
-                ),
-                SwitchElementLine(
-                    start = Point(26.145, -1.809),
-                    end = Point(26.375, -1.842),
-                )
-            )
-        )
-    )
-)
-
-fun YV43_300_1_7_V() = YV43_300_1_7_O().flipAlongYAxis().copy(
-    type = SwitchType("YV43-300-1:7-V")
-)
+fun YV43_300_1_7_V() = YV43_300_1_7_O().flipAlongYAxis().copy(type = SwitchType("YV43-300-1:7-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9.kt
@@ -4,65 +4,41 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV43_300_1_9_O() = SwitchStructure(
-    type = SwitchType("YV43-300-1:9-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(12.004, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(28.85, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(28.747, -1.86)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(12.004, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(12.004, 0.0),
-                    end = Point(28.85, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(23.935, -1.326),
-                    radius = 216.737
-                ),
-                SwitchElementLine(
-                    start = Point(23.935, -1.326),
-                    end = Point(28.747, -1.86),
-                )
-            )
-        )
-    )
-)
+fun YV43_300_1_9_O() =
+    SwitchStructure(
+        type = SwitchType("YV43-300-1:9-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(12.004, 0.0)),
+                SwitchJoint(JointNumber(2), Point(28.85, 0.0)),
+                SwitchJoint(JointNumber(3), Point(28.747, -1.86))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(12.004, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(12.004, 0.0),
+                                end = Point(28.85, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(23.935, -1.326),
+                                radius = 216.737),
+                            SwitchElementLine(
+                                start = Point(23.935, -1.326),
+                                end = Point(28.747, -1.86),
+                            )))))
 
-fun YV43_300_1_9_V() = YV43_300_1_9_O().flipAlongYAxis().copy(
-    type = SwitchType("YV43-300-1:9-V")
-)
+fun YV43_300_1_9_V() = YV43_300_1_9_O().flipAlongYAxis().copy(type = SwitchType("YV43-300-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9_514.kt
@@ -4,75 +4,48 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
+fun YV43_300_1_9_514_O() =
+    SwitchStructure(
+        type = SwitchType("YV43-300-1:9,514-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(11.31, 0.0)),
+                SwitchJoint(JointNumber(2), Point(28.85, 0.0)),
+                SwitchJoint(JointNumber(3), Point(28.754, -1.833))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(11.31, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(11.31, 0.0),
+                                end = Point(28.85, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(23.35, -1.265),
+                                radius = 231.0),
+                            SwitchElementLine(
+                                start = Point(23.35, -1.265),
+                                end = Point(28.754, -1.833),
+                            )))))
 
-fun YV43_300_1_9_514_O() = SwitchStructure(
-    type = SwitchType("YV43-300-1:9,514-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(11.31, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(28.85, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(28.754, -1.833)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(11.31, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(11.31, 0.0),
-                    end = Point(28.85, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(23.35, -1.265),
-                    radius = 231.0
-                ),
-                SwitchElementLine(
-                    start = Point(23.35, -1.265),
-                    end = Point(28.754, -1.833),
-                )
-            )
-        )
-    )
-)
+fun YV43_300_1_9_514_V() =
+    YV43_300_1_9_514_O().flipAlongYAxis().copy(type = SwitchType("YV43-300-1:9,514-V"))
 
-fun YV43_300_1_9_514_V() = YV43_300_1_9_514_O().flipAlongYAxis().copy(
-    type = SwitchType("YV43-300-1:9,514-V")
-)
+fun YV43_300_1_9_514_1435_O() =
+    YV43_300_1_9_514_O().copy(type = SwitchType("YV43-300-1:9,514-1435-O"))
 
-fun YV43_300_1_9_514_1435_O() = YV43_300_1_9_514_O().copy(
-    type = SwitchType("YV43-300-1:9,514-1435-O")
-)
-
-fun YV43_300_1_9_514_1435_V() = YV43_300_1_9_514_V().copy(
-    type = SwitchType("YV43-300-1:9,514-1435-V")
-)
-
+fun YV43_300_1_9_514_1435_V() =
+    YV43_300_1_9_514_V().copy(type = SwitchType("YV43-300-1:9,514-1435-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_530_1_15.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_530_1_15.kt
@@ -8,65 +8,42 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // This switch may contain inaccurate location for joint point 3 as
 // that point was not marked in the IM file but was reasoned by a developer.
 
-fun YV43_530_1_15_O() = SwitchStructure(
-    type = SwitchType("YV43-530-1:15-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(15.802, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(43.195, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(42.984, -1.689)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(15.802, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(15.802, 0.0),
-                    end = Point(43.195, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(35.256, -1.174),
-                    radius = 530.0
-                ),
-                SwitchElementLine(
-                    start = Point(35.256, -1.174),
-                    end = Point(42.984, -1.689),
-                )
-            )
-        )
-    )
-)
+fun YV43_530_1_15_O() =
+    SwitchStructure(
+        type = SwitchType("YV43-530-1:15-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(15.802, 0.0)),
+                SwitchJoint(JointNumber(2), Point(43.195, 0.0)),
+                SwitchJoint(JointNumber(3), Point(42.984, -1.689))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(15.802, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(15.802, 0.0),
+                                end = Point(43.195, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(35.256, -1.174),
+                                radius = 530.0),
+                            SwitchElementLine(
+                                start = Point(35.256, -1.174),
+                                end = Point(42.984, -1.689),
+                            )))))
 
-fun YV43_530_1_15_V() = YV43_530_1_15_O().flipAlongYAxis().copy(
-    type = SwitchType("YV43-530-1:15-V")
-)
+fun YV43_530_1_15_V() =
+    YV43_530_1_15_O().flipAlongYAxis().copy(type = SwitchType("YV43-530-1:15-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_165_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_165_1_7.kt
@@ -4,66 +4,39 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
+fun YV54_165_1_7_V() =
+    SwitchStructure(
+        type = SwitchType("YV54-165-1:7-V"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(13.482, 0.0)),
+                SwitchJoint(JointNumber(2), Point(26.506, 0.0)),
+                SwitchJoint(JointNumber(3), Point(26.376, 1.842))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(13.482, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(13.482, 0.0),
+                                end = Point(26.506, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0), end = Point(25.09, 1.658), radius = 165.0),
+                            SwitchElementLine(
+                                start = Point(25.09, 1.658),
+                                end = Point(26.376, 1.842),
+                            )))))
 
-fun YV54_165_1_7_V() = SwitchStructure(
-    type = SwitchType("YV54-165-1:7-V"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(13.482, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(26.506, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(26.376, 1.842)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(13.482, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(13.482, 0.0),
-                    end = Point(26.506, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(25.09, 1.658),
-                    radius = 165.0
-                ),
-                SwitchElementLine(
-                    start = Point(25.09, 1.658),
-                    end = Point(26.376, 1.842),
-                )
-            )
-        )
-    )
-)
-
-fun YV54_165_1_7_O() = YV54_165_1_7_V().flipAlongYAxis().copy(
-    type = SwitchType("YV54-165-1:7-O")
-)
+fun YV54_165_1_7_O() = YV54_165_1_7_V().flipAlongYAxis().copy(type = SwitchType("YV54-165-1:7-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_190_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_190_1_7.kt
@@ -7,61 +7,37 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // NOTE:
 // This switch is not in RATO4 but found from IM models
 
-fun YV54_190_1_7_O() = SwitchStructure(
-    type = SwitchType("YV54-190-1:7-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(13.504, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(27.006, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(26.87, -1.91)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(13.504, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(13.504, 0.0),
-                    end = Point(27.006, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(26.87, -1.91),
-                    radius = 190.0
-                )
-            )
-        )
-    )
-)
+fun YV54_190_1_7_O() =
+    SwitchStructure(
+        type = SwitchType("YV54-190-1:7-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(13.504, 0.0)),
+                SwitchJoint(JointNumber(2), Point(27.006, 0.0)),
+                SwitchJoint(JointNumber(3), Point(26.87, -1.91))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(13.504, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(13.504, 0.0),
+                                end = Point(27.006, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(26.87, -1.91),
+                                radius = 190.0)))))
 
-fun YV54_190_1_7_V() = YV54_190_1_7_O().flipAlongYAxis().copy(
-    type = SwitchType("YV54-190-1:7-V")
-)
+fun YV54_190_1_7_V() = YV54_190_1_7_O().flipAlongYAxis().copy(type = SwitchType("YV54-190-1:7-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_200_1_9.kt
@@ -4,101 +4,59 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV54_200_1_9_O() = SwitchStructure(
-    type = SwitchType("YV54-200-1:9-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(11.077, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(28.300, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(28.195, -1.902)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(11.077, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(11.077, 0.0),
-                    end = Point(28.300, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(22.086, -1.223),
-                    radius = 300.0
-                ),
-                SwitchElementLine(
-                    start = Point(22.086, -1.223),
-                    end = Point(28.195, -1.902),
-                )
-            )
-        )
-    )
-)
+fun YV54_200_1_9_O() =
+    SwitchStructure(
+        type = SwitchType("YV54-200-1:9-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(11.077, 0.0)),
+                SwitchJoint(JointNumber(2), Point(28.300, 0.0)),
+                SwitchJoint(JointNumber(3), Point(28.195, -1.902))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(11.077, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(11.077, 0.0),
+                                end = Point(28.300, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(22.086, -1.223),
+                                radius = 300.0),
+                            SwitchElementLine(
+                                start = Point(22.086, -1.223),
+                                end = Point(28.195, -1.902),
+                            )))))
 
+fun YV54_200_1_9_V() = YV54_200_1_9_O().flipAlongYAxis().copy(type = SwitchType("YV54-200-1:9-V"))
 
-fun YV54_200_1_9_V() = YV54_200_1_9_O().flipAlongYAxis().copy(
-    type = SwitchType("YV54-200-1:9-V")
-)
+fun YV54_200N_1_9_O() = YV54_200_1_9_O().copy(type = SwitchType("YV54-200N-1:9-O"))
 
-fun YV54_200N_1_9_O() = YV54_200_1_9_O().copy(
-    type = SwitchType("YV54-200N-1:9-O")
-)
+fun YV54_200N_1_9_V() = YV54_200_1_9_V().copy(type = SwitchType("YV54-200N-1:9-V"))
 
-fun YV54_200N_1_9_V() = YV54_200_1_9_V().copy(
-    type = SwitchType("YV54-200N-1:9-V")
-)
+fun YV54_200_1_9_1435_O() = YV54_200_1_9_O().copy(type = SwitchType("YV54-200-1:9-1435-O"))
 
+fun YV54_200_1_9_1435_V() = YV54_200_1_9_V().copy(type = SwitchType("YV54-200-1:9-1435-V"))
 
-fun YV54_200_1_9_1435_O() = YV54_200_1_9_O().copy(
-    type = SwitchType("YV54-200-1:9-1435-O")
-)
+fun YV54_200N_1_9_1435_O() = YV54_200_1_9_O().copy(type = SwitchType("YV54-200N-1:9-1435-O"))
 
-fun YV54_200_1_9_1435_V() = YV54_200_1_9_V().copy(
-    type = SwitchType("YV54-200-1:9-1435-V")
-)
+fun YV54_200N_1_9_1435_V() = YV54_200_1_9_V().copy(type = SwitchType("YV54-200N-1:9-1435-V"))
 
-fun YV54_200N_1_9_1435_O() = YV54_200_1_9_O().copy(
-    type = SwitchType("YV54-200N-1:9-1435-O")
-)
+fun YV54_200_1_9_1524_1435_O() =
+    YV54_200_1_9_O().copy(type = SwitchType("YV54-200-1:9-1524/1435-O"))
 
-fun YV54_200N_1_9_1435_V() = YV54_200_1_9_V().copy(
-    type = SwitchType("YV54-200N-1:9-1435-V")
-)
-
-fun YV54_200_1_9_1524_1435_O() = YV54_200_1_9_O().copy(
-    type = SwitchType("YV54-200-1:9-1524/1435-O")
-)
-
-fun YV54_200_1_9_1524_1435_V() = YV54_200_1_9_V().copy(
-    type = SwitchType("YV54-200-1:9-1524/1435-V")
-)
-
-
+fun YV54_200_1_9_1524_1435_V() =
+    YV54_200_1_9_V().copy(type = SwitchType("YV54-200-1:9-1524/1435-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_900_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_900_1_15_5.kt
@@ -4,64 +4,38 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
+fun YV54_900_1_15_5_V() =
+    SwitchStructure(
+        type = SwitchType("YV54-900-1:15,5-V"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(30.06, 0.0)),
+                SwitchJoint(JointNumber(2), Point(59.1, 0.0)),
+                SwitchJoint(JointNumber(3), Point(59.04, 1.872))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(30.06, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(30.06, 0.0),
+                                end = Point(59.1, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(59.04, 1.872),
+                                radius = 900.0)))))
 
-fun YV54_900_1_15_5_V() = SwitchStructure(
-    type = SwitchType("YV54-900-1:15,5-V"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(30.06, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(59.1, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(59.04, 1.872)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(30.06, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(30.06, 0.0),
-                    end = Point(59.1, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(59.04, 1.872),
-                    radius = 900.0
-                )
-            )
-        )
-    )
-)
-
-fun YV54_900_1_15_5_O() = YV54_900_1_15_5_V().flipAlongYAxis().copy(
-    type = SwitchType("YV54-900-1:15,5-O")
-)
-
-
+fun YV54_900_1_15_5_O() =
+    YV54_900_1_15_5_V().flipAlongYAxis().copy(type = SwitchType("YV54-900-1:15,5-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300P_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300P_1_9.kt
@@ -9,61 +9,38 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // as this model is constructed with insufficient information from IM models and
 // with limited understanding of domain.
 
-fun YV60_300P_1_9_O() = SwitchStructure(
-    type = SwitchType("YV60-300P-1:9-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(16.615, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(33.23, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(33.128, -1.835)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(16.615, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(16.615, 0.0),
-                    end = Point(33.23, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(33.128, -1.835),
-                    radius = 300.0
-                )
-            )
-        )
-    )
-)
+fun YV60_300P_1_9_O() =
+    SwitchStructure(
+        type = SwitchType("YV60-300P-1:9-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(16.615, 0.0)),
+                SwitchJoint(JointNumber(2), Point(33.23, 0.0)),
+                SwitchJoint(JointNumber(3), Point(33.128, -1.835))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(16.615, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(16.615, 0.0),
+                                end = Point(33.23, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(33.128, -1.835),
+                                radius = 300.0)))))
 
-fun YV60_300P_1_9_V() = YV60_300P_1_9_O().flipAlongYAxis().copy(
-    type = SwitchType("YV60-300P-1:9-V")
-)
+fun YV60_300P_1_9_V() =
+    YV60_300P_1_9_O().flipAlongYAxis().copy(type = SwitchType("YV60-300P-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_10.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_10.kt
@@ -5,66 +5,43 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV60_300_1_10_V() = SwitchStructure(
-    type = SwitchType("YV60-300-1:10-V"),
-    id = IntId(123456),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(12.97, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(32.008, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(31.914, 1.894)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(12.97, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(12.97, 0.0),
-                    end = Point(32.008, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(25.876, 1.291),
-                    radius = 260.047
-                ),
-                SwitchElementLine(
-                    start = Point(25.876, 1.291),
-                    end = Point(31.914, 1.894),
-                )
-            )
-        )
-    )
-)
+fun YV60_300_1_10_V() =
+    SwitchStructure(
+        type = SwitchType("YV60-300-1:10-V"),
+        id = IntId(123456),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(12.97, 0.0)),
+                SwitchJoint(JointNumber(2), Point(32.008, 0.0)),
+                SwitchJoint(JointNumber(3), Point(31.914, 1.894))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(12.97, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(12.97, 0.0),
+                                end = Point(32.008, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(25.876, 1.291),
+                                radius = 260.047),
+                            SwitchElementLine(
+                                start = Point(25.876, 1.291),
+                                end = Point(31.914, 1.894),
+                            )))))
 
-fun YV60_300_1_10_O() = YV60_300_1_10_V().flipAlongYAxis().copy(
-    type = SwitchType("YV60-300-1:10-O")
-)
+fun YV60_300_1_10_O() =
+    YV60_300_1_10_V().flipAlongYAxis().copy(type = SwitchType("YV60-300-1:10-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_9.kt
@@ -4,82 +4,49 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV60_300_1_9_O() = SwitchStructure(
-    type = SwitchType("YV60-300-1:9-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(16.615, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(34.430, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(34.321, -1.967)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(16.615, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(16.615, 0.0),
-                    end = Point(34.430, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(33.128, -1.835),
-                    radius = 300.0
-                ),
-                SwitchElementLine(
-                    start = Point(33.128, -1.835),
-                    end = Point(34.321, -1.967),
-                )
-            )
-        )
-    )
-)
+fun YV60_300_1_9_O() =
+    SwitchStructure(
+        type = SwitchType("YV60-300-1:9-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(16.615, 0.0)),
+                SwitchJoint(JointNumber(2), Point(34.430, 0.0)),
+                SwitchJoint(JointNumber(3), Point(34.321, -1.967))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(16.615, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(16.615, 0.0),
+                                end = Point(34.430, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(33.128, -1.835),
+                                radius = 300.0),
+                            SwitchElementLine(
+                                start = Point(33.128, -1.835),
+                                end = Point(34.321, -1.967),
+                            )))))
 
+fun YV60_300_1_9_V() = YV60_300_1_9_O().flipAlongYAxis().copy(type = SwitchType("YV60-300-1:9-V"))
 
-fun YV60_300_1_9_V() = YV60_300_1_9_O().flipAlongYAxis().copy(
-    type = SwitchType("YV60-300-1:9-V")
-)
+fun YV60_300A_1_9_O() = YV60_300_1_9_O().copy(type = SwitchType("YV60-300A-1:9-O"))
 
-fun YV60_300A_1_9_O() = YV60_300_1_9_O().copy(
-    type = SwitchType("YV60-300A-1:9-O")
-)
+fun YV60_300A_1_9_V() = YV60_300_1_9_V().copy(type = SwitchType("YV60-300A-1:9-V"))
 
-fun YV60_300A_1_9_V() = YV60_300_1_9_V().copy(
-    type = SwitchType("YV60-300A-1:9-V")
-)
+fun YV60_300E_1_9_O() = YV60_300_1_9_O().copy(type = SwitchType("YV60-300E-1:9-O"))
 
-fun YV60_300E_1_9_O() = YV60_300_1_9_O().copy(
-    type = SwitchType("YV60-300E-1:9-O")
-)
-
-fun YV60_300E_1_9_V() = YV60_300_1_9_V().copy(
-    type = SwitchType("YV60-300E-1:9-V")
-)
+fun YV60_300E_1_9_V() = YV60_300_1_9_V().copy(type = SwitchType("YV60-300E-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_2500_1_26.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_2500_1_26.kt
@@ -4,72 +4,46 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV60_5000_2500_1_26_O() = SwitchStructure(
-    type = SwitchType("YV60-5000/2500-1:26-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(56.563, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(107.180, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(107.143, -1.945)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(56.563, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(56.563, 0.0),
-                    end = Point(107.180, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(36.979, -0.182),
-                    radius = 5000.0
-                ),
+fun YV60_5000_2500_1_26_O() =
+    SwitchStructure(
+        type = SwitchType("YV60-5000/2500-1:26-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(56.563, 0.0)),
+                SwitchJoint(JointNumber(2), Point(107.180, 0.0)),
+                SwitchJoint(JointNumber(3), Point(107.143, -1.945))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(56.563, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(56.563, 0.0),
+                                end = Point(107.180, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(36.979, -0.182),
+                                radius = 5000.0),
+                            SwitchElementCurve(
+                                start = Point(36.979, -0.182),
+                                end = Point(105.327, -1.876),
+                                radius = 2500.0),
+                            SwitchElementLine(
+                                start = Point(105.327, -1.876),
+                                end = Point(107.143, -1.945),
+                            )))))
 
-                SwitchElementCurve(
-                    start = Point(36.979, -0.182),
-                    end = Point(105.327, -1.876),
-                    radius = 2500.0
-                ),
-                SwitchElementLine(
-                    start = Point(105.327, -1.876),
-                    end = Point(107.143, -1.945),
-                )
-            )
-        )
-    )
-)
-
-
-fun YV60_5000_2500_1_26_V() = YV60_5000_2500_1_26_O().flipAlongYAxis().copy(
-    type = SwitchType("YV60-5000/2500-1:26-V")
-)
+fun YV60_5000_2500_1_26_V() =
+    YV60_5000_2500_1_26_O().flipAlongYAxis().copy(type = SwitchType("YV60-5000/2500-1:26-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_3000_1_28.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_3000_1_28.kt
@@ -4,68 +4,42 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV60_5000_3000_1_28_O() = SwitchStructure(
-    type = SwitchType("YV60-5000/3000-1:28-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(58.220, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(112.039, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(112.005, -1.921)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(58.220, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(58.220, 0.0),
-                    end = Point(112.039, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(24.653, -0.074),
-                    radius = 5000.0
-                ),
+fun YV60_5000_3000_1_28_O() =
+    SwitchStructure(
+        type = SwitchType("YV60-5000/3000-1:28-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(58.220, 0.0)),
+                SwitchJoint(JointNumber(2), Point(112.039, 0.0)),
+                SwitchJoint(JointNumber(3), Point(112.005, -1.921))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(58.220, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(58.220, 0.0),
+                                end = Point(112.039, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(24.653, -0.074),
+                                radius = 5000.0),
+                            SwitchElementCurve(
+                                start = Point(24.653, -0.074),
+                                end = Point(112.005, -1.921),
+                                radius = 3000.0)))))
 
-                SwitchElementCurve(
-                    start = Point(24.653, -0.074),
-                    end = Point(112.005, -1.921),
-                    radius = 3000.0
-                )
-            )
-        )
-    )
-)
-
-
-fun YV60_5000_3000_1_28_V() = YV60_5000_3000_1_28_O().flipAlongYAxis().copy(
-    type = SwitchType("YV60-5000/3000-1:28-V")
-)
+fun YV60_5000_3000_1_28_V() =
+    YV60_5000_3000_1_28_O().flipAlongYAxis().copy(type = SwitchType("YV60-5000/3000-1:28-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_11_1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_11_1.kt
@@ -4,70 +4,42 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV60_500_1_11_1_O() = SwitchStructure(
-    type = SwitchType("YV60-500-1:11,1-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(22.471, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(44.943, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(44.852, -2.016)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(22.471, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(22.471, 0.0),
-                    end = Point(44.943, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(44.852, -2.016),
-                    radius = 500.0
-                )
-            )
-        )
-    )
-)
+fun YV60_500_1_11_1_O() =
+    SwitchStructure(
+        type = SwitchType("YV60-500-1:11,1-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(22.471, 0.0)),
+                SwitchJoint(JointNumber(2), Point(44.943, 0.0)),
+                SwitchJoint(JointNumber(3), Point(44.852, -2.016))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(22.471, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(22.471, 0.0),
+                                end = Point(44.943, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(44.852, -2.016),
+                                radius = 500.0)))))
 
+fun YV60_500_1_11_1_V() =
+    YV60_500_1_11_1_O().flipAlongYAxis().copy(type = SwitchType("YV60-500-1:11,1-V"))
 
-fun YV60_500_1_11_1_V() = YV60_500_1_11_1_O().flipAlongYAxis().copy(
-    type = SwitchType("YV60-500-1:11,1-V")
-)
+fun YV60_500A_1_11_1_O() = YV60_500_1_11_1_O().copy(type = SwitchType("YV60-500A-1:11,1-O"))
 
-fun YV60_500A_1_11_1_O() = YV60_500_1_11_1_O().copy(
-    type = SwitchType("YV60-500A-1:11,1-O")
-)
-
-fun YV60_500A_1_11_1_V() = YV60_500_1_11_1_V().copy(
-    type = SwitchType("YV60-500A-1:11,1-V")
-)
+fun YV60_500A_1_11_1_V() = YV60_500_1_11_1_V().copy(type = SwitchType("YV60-500A-1:11,1-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_14.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_14.kt
@@ -4,74 +4,46 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV60_500_1_14_O() = SwitchStructure(
-    type = SwitchType("YV60-500-1:14-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(17.834, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(44.943, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(44.874, -1.931)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(17.834, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(17.834, 0.0),
-                    end = Point(44.943, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(35.623, -1.271),
-                    radius = 500.0
-                ),
-                SwitchElementLine(
-                    start = Point(35.623, -1.271),
-                    end = Point(44.874, -1.931),
-                )
-            )
-        )
-    )
-)
+fun YV60_500_1_14_O() =
+    SwitchStructure(
+        type = SwitchType("YV60-500-1:14-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(17.834, 0.0)),
+                SwitchJoint(JointNumber(2), Point(44.943, 0.0)),
+                SwitchJoint(JointNumber(3), Point(44.874, -1.931))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(17.834, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(17.834, 0.0),
+                                end = Point(44.943, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(35.623, -1.271),
+                                radius = 500.0),
+                            SwitchElementLine(
+                                start = Point(35.623, -1.271),
+                                end = Point(44.874, -1.931),
+                            )))))
 
+fun YV60_500_1_14_V() =
+    YV60_500_1_14_O().flipAlongYAxis().copy(type = SwitchType("YV60-500-1:14-V"))
 
-fun YV60_500_1_14_V() = YV60_500_1_14_O().flipAlongYAxis().copy(
-    type = SwitchType("YV60-500-1:14-V")
-)
+fun YV60_500A_1_14_O() = YV60_500_1_14_O().copy(type = SwitchType("YV60-500A-1:14-O"))
 
-fun YV60_500A_1_14_O() = YV60_500_1_14_O().copy(
-    type = SwitchType("YV60-500A-1:14-O")
-)
-
-fun YV60_500A_1_14_V() = YV60_500_1_14_V().copy(
-    type = SwitchType("YV60-500A-1:14-V")
-)
+fun YV60_500A_1_14_V() = YV60_500_1_14_V().copy(type = SwitchType("YV60-500A-1:14-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_15_5.kt
@@ -4,87 +4,54 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV60_900_1_15_5_O() = SwitchStructure(
-    type = SwitchType("YV60-900-1:15,5-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(30.060, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(59.100, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(59.040, -1.870)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(30.060, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(30.060, 0.0),
-                    end = Point(59.100, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(1.058, 0.0),
-                ),
+fun YV60_900_1_15_5_O() =
+    SwitchStructure(
+        type = SwitchType("YV60-900-1:15,5-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(30.060, 0.0)),
+                SwitchJoint(JointNumber(2), Point(59.100, 0.0)),
+                SwitchJoint(JointNumber(3), Point(59.040, -1.870))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(30.060, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(30.060, 0.0),
+                                end = Point(59.100, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(1.058, 0.0),
+                            ),
+                            SwitchElementCurve(
+                                start = Point(1.058, 0.0),
+                                end = Point(59.002, -1.867),
+                                radius = 900.0),
+                            SwitchElementLine(
+                                start = Point(59.002, -1.867),
+                                end = Point(59.040, -1.870),
+                            )))))
 
-                SwitchElementCurve(
-                    start = Point(1.058, 0.0),
-                    end = Point(59.002, -1.867),
-                    radius = 900.0
-                ),
-                SwitchElementLine(
-                    start = Point(59.002, -1.867),
-                    end = Point(59.040, -1.870),
-                )
-            )
-        )
-    )
-)
+fun YV60_900_1_15_5_V() =
+    YV60_900_1_15_5_O().flipAlongYAxis().copy(type = SwitchType("YV60-900-1:15,5-V"))
 
+fun YV60_900A_1_15_5_O() = YV60_900_1_15_5_O().copy(type = SwitchType("YV60-900A-1:15,5-O"))
 
-fun YV60_900_1_15_5_V() = YV60_900_1_15_5_O().flipAlongYAxis().copy(
-    type = SwitchType("YV60-900-1:15,5-V")
-)
+fun YV60_900A_1_15_5_V() = YV60_900_1_15_5_V().copy(type = SwitchType("YV60-900A-1:15,5-V"))
 
-fun YV60_900A_1_15_5_O() = YV60_900_1_15_5_O().copy(
-    type = SwitchType("YV60-900A-1:15,5-O")
-)
+fun YV60_900E_1_15_5_O() = YV60_900_1_15_5_O().copy(type = SwitchType("YV60-900E-1:15,5-O"))
 
-fun YV60_900A_1_15_5_V() = YV60_900_1_15_5_V().copy(
-    type = SwitchType("YV60-900A-1:15,5-V")
-)
-
-fun YV60_900E_1_15_5_O() = YV60_900_1_15_5_O().copy(
-    type = SwitchType("YV60-900E-1:15,5-O")
-)
-
-fun YV60_900E_1_15_5_V() = YV60_900_1_15_5_V().copy(
-    type = SwitchType("YV60-900E-1:15,5-V")
-)
+fun YV60_900E_1_15_5_V() = YV60_900_1_15_5_V().copy(type = SwitchType("YV60-900E-1:15,5-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_18.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_18.kt
@@ -4,82 +4,50 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
-fun YV60_900_1_18_O() = SwitchStructure(
-    type = SwitchType("YV60-900-1:18-O"),
-    presentationJointNumber = JointNumber(1),
-    joints = listOf(
-        SwitchJoint(
-            JointNumber(1),
-            Point(0.0, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(5),
-            Point(25.999, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(2),
-            Point(59.700, 0.0)
-        ),
-        SwitchJoint(
-            JointNumber(3),
-            Point(59.648, -1.869)
-        )
-    ),
-    alignments = listOf(
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(5),
-                JointNumber(2)
-            ),
-            elements = listOf(
-                SwitchElementLine(
-                    start = Point(0.0, 0.0),
-                    end = Point(25.999, 0.0),
-                ),
-                SwitchElementLine(
-                    start = Point(25.999, 0.0),
-                    end = Point(59.700, 0.0),
-                )
-            )
-        ),
-        SwitchAlignment(
-            jointNumbers = listOf(
-                JointNumber(1),
-                JointNumber(3)
-            ),
-            elements = listOf(
-                SwitchElementCurve(
-                    start = Point(0.0, 0.0),
-                    end = Point(50.941, -1.386),
-                    radius = 900.0
-                ),
-                SwitchElementLine(
-                    start = Point(50.941, -1.386),
-                    end = Point(59.648, -1.869),
-                )
-            )
-        )
-    )
-)
+fun YV60_900_1_18_O() =
+    SwitchStructure(
+        type = SwitchType("YV60-900-1:18-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(25.999, 0.0)),
+                SwitchJoint(JointNumber(2), Point(59.700, 0.0)),
+                SwitchJoint(JointNumber(3), Point(59.648, -1.869))),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(
+                                start = Point(0.0, 0.0),
+                                end = Point(25.999, 0.0),
+                            ),
+                            SwitchElementLine(
+                                start = Point(25.999, 0.0),
+                                end = Point(59.700, 0.0),
+                            ))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(50.941, -1.386),
+                                radius = 900.0),
+                            SwitchElementLine(
+                                start = Point(50.941, -1.386),
+                                end = Point(59.648, -1.869),
+                            )))))
 
+fun YV60_900_1_18_V() =
+    YV60_900_1_18_O().flipAlongYAxis().copy(type = SwitchType("YV60-900-1:18-V"))
 
-fun YV60_900_1_18_V() = YV60_900_1_18_O().flipAlongYAxis().copy(
-    type = SwitchType("YV60-900-1:18-V")
-)
+fun YV60_900A_1_18_O() = YV60_900_1_18_O().copy(type = SwitchType("YV60-900A-1:18-O"))
 
-fun YV60_900A_1_18_O() = YV60_900_1_18_O().copy(
-    type = SwitchType("YV60-900A-1:18-O")
-)
+fun YV60_900A_1_18_V() = YV60_900_1_18_V().copy(type = SwitchType("YV60-900A-1:18-V"))
 
-fun YV60_900A_1_18_V() = YV60_900_1_18_V().copy(
-    type = SwitchType("YV60-900A-1:18-V")
-)
+fun YV60_900P_1_18_O() = YV60_900_1_18_O().copy(type = SwitchType("YV60-900P-1:18-O"))
 
-fun YV60_900P_1_18_O() = YV60_900_1_18_O().copy(
-    type = SwitchType("YV60-900P-1:18-O")
-)
-
-fun YV60_900P_1_18_V() = YV60_900_1_18_V().copy(
-    type = SwitchType("YV60-900P-1:18-V")
-)
+fun YV60_900P_1_18_V() = YV60_900_1_18_V().copy(type = SwitchType("YV60-900P-1:18-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ElementListingFileDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ElementListingFileDao.kt
@@ -3,23 +3,26 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.util.*
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 data class ElementListingFile(val name: FileName, val content: String)
 
 @Transactional(readOnly = true)
 @Component
-class ElementListingFileDao @Autowired constructor(
+class ElementListingFileDao
+@Autowired
+constructor(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
 ) : DaoBase(jdbcTemplateParam) {
 
     @Transactional
     fun upsertElementListingFile(file: ElementListingFile) {
-        val sql = """
+        val sql =
+            """
             insert into layout.element_listing_file(
               name,
               content,
@@ -37,11 +40,13 @@ class ElementListingFileDao @Autowired constructor(
               content = :content,
               change_time = now(),
               change_user = current_setting('geoviite.edit_user')
-        """.trimIndent()
-        val params = mapOf(
-            "name" to file.name,
-            "content" to file.content,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "name" to file.name,
+                "content" to file.content,
+            )
         jdbcTemplate.setUser()
         jdbcTemplate.update(sql, params).also {
             logger.daoAccess(AccessType.UPSERT, ElementListingFile::class, file.name)
@@ -49,26 +54,39 @@ class ElementListingFileDao @Autowired constructor(
     }
 
     fun getElementListingFile(): ElementListingFile? {
-        val sql = """
+        val sql =
+            """
             select name, content
             from layout.element_listing_file
             where id = 1
-        """.trimIndent()
-        return jdbcTemplate.query(sql, mapOf<String,Any>()) { rs, _ -> ElementListingFile(
-            name = rs.getFileName("name"),
-            content = rs.getString("content"),
-        ) }
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(sql, mapOf<String, Any>()) { rs, _ ->
+                ElementListingFile(
+                    name = rs.getFileName("name"),
+                    content = rs.getString("content"),
+                )
+            }
             .firstOrNull()
-            .also { file -> logger.daoAccess(AccessType.FETCH, ElementListingFile::class, "${file?.name}") }
+            .also { file ->
+                logger.daoAccess(AccessType.FETCH, ElementListingFile::class, "${file?.name}")
+            }
     }
 
     fun getLastFileListingTime(): Instant {
-        val sql = """
+        val sql =
+            """
             select max(change_time) change_time 
             from layout.element_listing_file
-        """.trimIndent()
-        return jdbcTemplate.query(sql, mapOf<String,Any>()) { rs, _ -> rs.getInstantOrNull("change_time") }
-            .also { logger.daoAccess(AccessType.FETCH, "${ElementListingFile::class.simpleName}.changeTime") }
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(sql, mapOf<String, Any>()) { rs, _ -> rs.getInstantOrNull("change_time") }
+            .also {
+                logger.daoAccess(
+                    AccessType.FETCH, "${ElementListingFile::class.simpleName}.changeTime")
+            }
             .firstOrNull() ?: Instant.EPOCH
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
@@ -26,23 +26,32 @@ data class GeometryPlanLayout(
     val planDataType: DataType,
     val startAddress: TrackMeter?,
 ) : Loggable {
-    val boundingBox: BoundingBox? = boundingBoxCombining(alignments.mapNotNull { a -> a.boundingBox })
+    val boundingBox: BoundingBox? =
+        boundingBoxCombining(alignments.mapNotNull { a -> a.boundingBox })
 
-    fun withLayoutGeometry(resolution: Int? = null) = copy(
-        alignments = alignments.map { alignment ->
-            alignment.copy(
-                polyLine = toAlignmentPolyLine(alignment.id, alignment.header.alignmentType, alignment, resolution),
-                segmentMValues = getSegmentBorderMValues(alignment),
-            )
-        },
-    )
+    fun withLayoutGeometry(resolution: Int? = null) =
+        copy(
+            alignments =
+                alignments.map { alignment ->
+                    alignment.copy(
+                        polyLine =
+                            toAlignmentPolyLine(
+                                alignment.id,
+                                alignment.header.alignmentType,
+                                alignment,
+                                resolution),
+                        segmentMValues = getSegmentBorderMValues(alignment),
+                    )
+                },
+        )
 
-    override fun toLog(): String = logFormat(
-        "plan" to id,
-        "alignments" to alignments.map(PlanLayoutAlignment::toLog),
-        "switches" to switches.map(TrackLayoutSwitch::toLog),
-        "kmPosts" to kmPosts.map(TrackLayoutKmPost::toLog),
-    )
+    override fun toLog(): String =
+        logFormat(
+            "plan" to id,
+            "alignments" to alignments.map(PlanLayoutAlignment::toLog),
+            "switches" to switches.map(TrackLayoutSwitch::toLog),
+            "kmPosts" to kmPosts.map(TrackLayoutKmPost::toLog),
+        )
 }
 
 data class PlanLayoutAlignment(
@@ -52,17 +61,20 @@ data class PlanLayoutAlignment(
     val segmentMValues: List<Double> = listOf(),
 ) : IAlignment {
     @get:JsonIgnore
-    override val id: DomainId<GeometryAlignment> get() = header.id
+    override val id: DomainId<GeometryAlignment>
+        get() = header.id
 
     @get:JsonIgnore
-    override val boundingBox: BoundingBox? get() = header.boundingBox
+    override val boundingBox: BoundingBox?
+        get() = header.boundingBox
 
-    override fun toLog(): String = logFormat(
-        "id" to id,
-        "name" to header.name,
-        "segments" to segments.size,
-        "points" to polyLine?.points?.size,
-    )
+    override fun toLog(): String =
+        logFormat(
+            "id" to id,
+            "name" to header.name,
+            "segments" to segments.size,
+            "points" to polyLine?.points?.size,
+        )
 }
 
 data class PlanLayoutSegment(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -11,14 +11,14 @@ import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.util.*
 import fi.fta.geoviite.infra.util.DbTable.LAYOUT_ALIGNMENT
+import java.sql.ResultSet
+import java.util.stream.Collectors
+import kotlin.math.abs
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
-import java.util.stream.Collectors
-import kotlin.math.abs
 
 const val ALIGNMENT_CACHE_SIZE = 10000L
 const val GEOMETRY_CACHE_SIZE = 500000L
@@ -39,10 +39,16 @@ class LayoutAlignmentDao(
 ) : DaoBase(jdbcTemplateParam) {
 
     private val alignmentsCache: Cache<RowVersion<LayoutAlignment>, LayoutAlignment> =
-        Caffeine.newBuilder().maximumSize(ALIGNMENT_CACHE_SIZE).expireAfterAccess(layoutCacheDuration).build()
+        Caffeine.newBuilder()
+            .maximumSize(ALIGNMENT_CACHE_SIZE)
+            .expireAfterAccess(layoutCacheDuration)
+            .build()
 
     private val segmentGeometryCache: Cache<IntId<SegmentGeometry>, SegmentGeometry> =
-        Caffeine.newBuilder().maximumSize(GEOMETRY_CACHE_SIZE).expireAfterAccess(layoutCacheDuration).build()
+        Caffeine.newBuilder()
+            .maximumSize(GEOMETRY_CACHE_SIZE)
+            .expireAfterAccess(layoutCacheDuration)
+            .build()
 
     fun fetchVersions() = fetchRowVersions<LayoutAlignment>(LAYOUT_ALIGNMENT)
 
@@ -52,34 +58,42 @@ class LayoutAlignmentDao(
         else fetchInternal(alignmentVersion)
 
     @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-    fun fetchMany(versions: List<RowVersion<LayoutAlignment>>): Map<RowVersion<LayoutAlignment>, LayoutAlignment> =
-        versions.associateWith(::fetch)
+    fun fetchMany(
+        versions: List<RowVersion<LayoutAlignment>>
+    ): Map<RowVersion<LayoutAlignment>, LayoutAlignment> = versions.associateWith(::fetch)
 
     private fun fetchInternal(alignmentVersion: RowVersion<LayoutAlignment>): LayoutAlignment {
-        val sql = """
+        val sql =
+            """
             select id, version
             from layout.alignment_version
             where id = :id 
               and version = :version
               and deleted = false
-        """.trimIndent()
-        val params = mapOf(
-            "id" to alignmentVersion.id.intValue,
-            "version" to alignmentVersion.version,
-        )
-        return getOne(alignmentVersion.id, jdbcTemplate.query(sql, params) { rs, _ ->
-            LayoutAlignment(
-                dataType = DataType.STORED,
-                id = rs.getIntId("id"),
-                segments = fetchSegments(alignmentVersion),
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "id" to alignmentVersion.id.intValue,
+                "version" to alignmentVersion.version,
             )
-        }).also { alignment ->
-            logger.daoAccess(AccessType.FETCH, LayoutAlignment::class, alignment.id)
-        }
+        return getOne(
+                alignmentVersion.id,
+                jdbcTemplate.query(sql, params) { rs, _ ->
+                    LayoutAlignment(
+                        dataType = DataType.STORED,
+                        id = rs.getIntId("id"),
+                        segments = fetchSegments(alignmentVersion),
+                    )
+                })
+            .also { alignment ->
+                logger.daoAccess(AccessType.FETCH, LayoutAlignment::class, alignment.id)
+            }
     }
 
     fun preloadAlignmentCache() {
-        val sql = """
+        val sql =
+            """
           select 
             sv.alignment_id,
             sv.alignment_version,
@@ -97,40 +111,53 @@ class LayoutAlignmentDao(
             left join layout.segment_version sv on sv.alignment_id = a.id and sv.alignment_version = a.version
           where sv.segment_index is not null
           order by sv.alignment_id, sv.segment_index
-        """.trimIndent()
+        """
+                .trimIndent()
 
         data class AlignmentData(val version: RowVersion<LayoutAlignment>)
 
-        val dataTriple = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
-            val alignmentData = AlignmentData(
-                version = rs.getRowVersion("alignment_id", "alignment_version"),
-            )
-            val segmentData = SegmentData(
-                id = rs.getIndexedId("alignment_id", "segment_index"),
-                start = rs.getDouble("start"),
-                sourceId = rs.getIndexedIdOrNull("geometry_alignment_id", "geometry_element_index"),
-                sourceStart = rs.getDoubleOrNull("source_start"),
-                switchId = rs.getIntIdOrNull("switch_id"),
-                startJointNumber = rs.getJointNumberOrNull("switch_start_joint_number"),
-                endJointNumber = rs.getJointNumberOrNull("switch_end_joint_number"),
-                source = rs.getEnum("source"),
-            )
-            val geometryId = rs.getIntId<SegmentGeometry>("geometry_id")
-            Triple(alignmentData, segmentData, geometryId)
-        }
+        val dataTriple =
+            jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
+                val alignmentData =
+                    AlignmentData(
+                        version = rs.getRowVersion("alignment_id", "alignment_version"),
+                    )
+                val segmentData =
+                    SegmentData(
+                        id = rs.getIndexedId("alignment_id", "segment_index"),
+                        start = rs.getDouble("start"),
+                        sourceId =
+                            rs.getIndexedIdOrNull(
+                                "geometry_alignment_id", "geometry_element_index"),
+                        sourceStart = rs.getDoubleOrNull("source_start"),
+                        switchId = rs.getIntIdOrNull("switch_id"),
+                        startJointNumber = rs.getJointNumberOrNull("switch_start_joint_number"),
+                        endJointNumber = rs.getJointNumberOrNull("switch_end_joint_number"),
+                        source = rs.getEnum("source"),
+                    )
+                val geometryId = rs.getIntId<SegmentGeometry>("geometry_id")
+                Triple(alignmentData, segmentData, geometryId)
+            }
         val groupedByAlignment = dataTriple.groupBy({ (a, _, _) -> a }, { (_, s, gId) -> s to gId })
-        val alignments = groupedByAlignment.entries.parallelStream().map { (alignmentData, segmentDatas) ->
-            alignmentData.version to LayoutAlignment(
-                id = alignmentData.version.id,
-                segments = createSegments(segmentDatas),
-            )
-        }.collect(Collectors.toList()).associate { it }
+        val alignments =
+            groupedByAlignment.entries
+                .parallelStream()
+                .map { (alignmentData, segmentDatas) ->
+                    alignmentData.version to
+                        LayoutAlignment(
+                            id = alignmentData.version.id,
+                            segments = createSegments(segmentDatas),
+                        )
+                }
+                .collect(Collectors.toList())
+                .associate { it }
         alignmentsCache.putAll(alignments)
     }
 
     @Transactional
     fun insert(alignment: LayoutAlignment): RowVersion<LayoutAlignment> {
-        val sql = """
+        val sql =
+            """
             insert into layout.alignment(
                 bounding_box,
                 segment_count,
@@ -142,16 +169,22 @@ class LayoutAlignmentDao(
                 :length
             )
             returning id, version
-        """.trimIndent()
-        val params = mapOf(
-            "polygon_string" to alignment.boundingBox?.let { bbox -> create2DPolygonString(bbox.polygonFromCorners) },
-            "segment_count" to alignment.segments.size,
-            "length" to alignment.length,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "polygon_string" to
+                    alignment.boundingBox?.let { bbox ->
+                        create2DPolygonString(bbox.polygonFromCorners)
+                    },
+                "segment_count" to alignment.segments.size,
+                "length" to alignment.length,
+            )
         jdbcTemplate.setUser()
         val id: RowVersion<LayoutAlignment> =
             jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
-                ?: throw IllegalStateException("Failed to generate ID for new Track Layout Alignment")
+                ?: throw IllegalStateException(
+                    "Failed to generate ID for new Track Layout Alignment")
         upsertSegments(id, alignment.segments)
         logger.daoAccess(AccessType.INSERT, LayoutAlignment::class, id)
         return id
@@ -160,8 +193,12 @@ class LayoutAlignmentDao(
     @Transactional
     fun update(alignment: LayoutAlignment): RowVersion<LayoutAlignment> {
         val alignmentId =
-            if (alignment.id is IntId) alignment.id else throw IllegalArgumentException("Cannot update an alignment that isn't in DB already")
-        val sql = """
+            if (alignment.id is IntId) alignment.id
+            else
+                throw IllegalArgumentException(
+                    "Cannot update an alignment that isn't in DB already")
+        val sql =
+            """
             update layout.alignment 
             set 
                 bounding_box = postgis.st_polygonfromtext(:polygon_string, 3067),
@@ -169,17 +206,23 @@ class LayoutAlignmentDao(
                 length = :length
             where id = :id
             returning id, version
-        """.trimIndent()
-        val params = mapOf(
-            "id" to alignmentId.intValue,
-            "polygon_string" to alignment.boundingBox?.let { bbox -> create2DPolygonString(bbox.polygonFromCorners) },
-            "segment_count" to alignment.segments.size,
-            "length" to alignment.length,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "id" to alignmentId.intValue,
+                "polygon_string" to
+                    alignment.boundingBox?.let { bbox ->
+                        create2DPolygonString(bbox.polygonFromCorners)
+                    },
+                "segment_count" to alignment.segments.size,
+                "length" to alignment.length,
+            )
         jdbcTemplate.setUser()
-        val result: RowVersion<LayoutAlignment> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getRowVersion("id", "version")
-        } ?: throw IllegalStateException("Failed to get new version for Track Layout Alignment")
+        val result: RowVersion<LayoutAlignment> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getRowVersion("id", "version") }
+                ?: throw IllegalStateException(
+                    "Failed to get new version for Track Layout Alignment")
         logger.daoAccess(AccessType.UPDATE, LayoutAlignment::class, result.id)
         upsertSegments(result, alignment.segments)
         return result
@@ -190,32 +233,36 @@ class LayoutAlignmentDao(
         val sql = "delete from layout.alignment where id = :id returning id"
         val params = mapOf("id" to id.intValue)
         jdbcTemplate.setUser()
-        val deletedRowId = getOne(id, jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getIntId<LayoutAlignment>("id")
-        })
+        val deletedRowId =
+            getOne(
+                id, jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId<LayoutAlignment>("id") })
         logger.daoAccess(AccessType.DELETE, LayoutAlignment::class, deletedRowId)
         return deletedRowId
     }
 
     @Transactional
     fun deleteOrphanedAlignments(): List<IntId<LayoutAlignment>> {
-        val sql = """
+        val sql =
+            """
            delete
            from layout.alignment alignment
            where not exists(select 1 from layout.reference_line where reference_line.alignment_id = alignment.id)
              and not exists(select 1 from layout.location_track where location_track.alignment_id = alignment.id)
            returning alignment.id
-       """.trimIndent()
+       """
+                .trimIndent()
         jdbcTemplate.setUser()
-        val deletedAlignments = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
-            rs.getIntId<LayoutAlignment>("id")
-        }
+        val deletedAlignments =
+            jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
+                rs.getIntId<LayoutAlignment>("id")
+            }
         logger.daoAccess(AccessType.DELETE, LayoutAlignment::class, deletedAlignments)
         return deletedAlignments
     }
 
     private fun fetchSegments(alignmentVersion: RowVersion<LayoutAlignment>): List<LayoutSegment> {
-        val sql = """
+        val sql =
+            """
             select 
               alignment_id,
               segment_index,
@@ -232,50 +279,57 @@ class LayoutAlignmentDao(
             where alignment_id = :alignment_id
               and alignment_version = :alignment_version
             order by alignment_id, segment_index
-        """.trimIndent()
-        val params = mapOf(
-            "alignment_id" to alignmentVersion.id.intValue,
-            "alignment_version" to alignmentVersion.version,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "alignment_id" to alignmentVersion.id.intValue,
+                "alignment_version" to alignmentVersion.version,
+            )
 
-        return createSegments(jdbcTemplate.query(sql, params) { rs, _ ->
-            SegmentData(
-                id = rs.getIndexedId("alignment_id", "segment_index"),
-                start = rs.getDouble("start"),
-                sourceId = rs.getIndexedIdOrNull("geometry_alignment_id", "geometry_element_index"),
-                sourceStart = rs.getDoubleOrNull("source_start"),
-                switchId = rs.getIntIdOrNull("switch_id"),
-                startJointNumber = rs.getJointNumberOrNull("switch_start_joint_number"),
-                endJointNumber = rs.getJointNumberOrNull("switch_end_joint_number"),
-                source = rs.getEnum("source"),
-            ) to rs.getIntId("geometry_id")
-        })
+        return createSegments(
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                SegmentData(
+                    id = rs.getIndexedId("alignment_id", "segment_index"),
+                    start = rs.getDouble("start"),
+                    sourceId =
+                        rs.getIndexedIdOrNull("geometry_alignment_id", "geometry_element_index"),
+                    sourceStart = rs.getDoubleOrNull("source_start"),
+                    switchId = rs.getIntIdOrNull("switch_id"),
+                    startJointNumber = rs.getJointNumberOrNull("switch_start_joint_number"),
+                    endJointNumber = rs.getJointNumberOrNull("switch_end_joint_number"),
+                    source = rs.getEnum("source"),
+                ) to rs.getIntId("geometry_id")
+            })
     }
 
-    private fun createSegments(segmentResults: List<Pair<SegmentData, IntId<SegmentGeometry>>>): List<LayoutSegment> {
-        val geometries = fetchSegmentGeometries(segmentResults.map { (_, geometryId) -> geometryId }.distinct())
+    private fun createSegments(
+        segmentResults: List<Pair<SegmentData, IntId<SegmentGeometry>>>
+    ): List<LayoutSegment> {
+        val geometries =
+            fetchSegmentGeometries(segmentResults.map { (_, geometryId) -> geometryId }.distinct())
 
         var start = 0.0
         return segmentResults.map { (data, geometryId) ->
             require(abs(start - data.start) < LAYOUT_M_DELTA) {
                 "Segment start value does not match the calculated one: stored=${data.start} calc=$start"
             }
-            val geometry = requireNotNull(geometries[geometryId]) {
-                "Fetching geometry failed for segment: id=${data.id} geometryId=$geometryId"
-            }
+            val geometry =
+                requireNotNull(geometries[geometryId]) {
+                    "Fetching geometry failed for segment: id=${data.id} geometryId=$geometryId"
+                }
             LayoutSegment(
-                id = data.id,
-                sourceId = data.sourceId,
-                sourceStart = data.sourceStart,
-                switchId = data.switchId,
-                startJointNumber = data.startJointNumber,
-                endJointNumber = data.endJointNumber,
-                source = data.source,
-                geometry = geometry,
-                startM = start,
-            ).also {
-                start += geometry.length
-            }
+                    id = data.id,
+                    sourceId = data.sourceId,
+                    sourceStart = data.sourceStart,
+                    switchId = data.switchId,
+                    startJointNumber = data.startJointNumber,
+                    endJointNumber = data.endJointNumber,
+                    source = data.source,
+                    geometry = geometry,
+                    startM = start,
+                )
+                .also { start += geometry.length }
         }
     }
 
@@ -284,8 +338,9 @@ class LayoutAlignmentDao(
         metadataExternalId: Oid<*>?,
         boundingBox: BoundingBox?,
     ): List<SegmentGeometryAndMetadata> {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             with
               segment_range as (
                 select
@@ -407,47 +462,54 @@ class LayoutAlignmentDao(
             where range.max_index >= segment.from_segment
               and range.min_index <= segment.to_segment
             order by segment.from_segment, segment.to_segment
-        """.trimIndent()
-        val params = mapOf(
-            "alignment_id" to alignmentVersion.id.intValue,
-            "alignment_version" to alignmentVersion.version,
-            "external_id" to metadataExternalId,
-            "use_bounding_box" to (boundingBox != null),
-            "x_min" to boundingBox?.min?.x,
-            "y_min" to boundingBox?.min?.y,
-            "x_max" to boundingBox?.max?.x,
-            "y_max" to boundingBox?.max?.y,
-            "layout_srid" to LAYOUT_SRID.code,
-        )
-        val result = jdbcTemplate.query(sql, params) { rs, _ ->
-            val fromSegment = rs.getInt("from_segment")
-            val toSegment = rs.getInt("to_segment")
-            val startPoint = rs.getDoubleOrNull("start_m")?.let { m ->
-                rs.getPointOrNull("start_x", "start_y")?.let { point ->
-                    AlignmentPoint(point.x, point.y, 0.0, m, 0.0) }
-            }
-            val endPoint = rs.getDoubleOrNull("end_m")?.let { m ->
-                rs.getPointOrNull("end_x", "end_y")?.let { point ->
-                    AlignmentPoint(point.x, point.y, 0.0, m, 0.0) }
-            }
-            SegmentGeometryAndMetadata(
-                planId = rs.getIntIdOrNull("plan_id"),
-                fileName = rs.getFileNameOrNull("file_name"),
-                alignmentId = rs.getIntIdOrNull("geom_alignment_id"),
-                alignmentName = rs.getString("alignment_name")?.let(::AlignmentName),
-                startPoint = startPoint,
-                endPoint = endPoint,
-                isLinked = rs.getBoolean("is_linked"),
-                id = StringId("${alignmentVersion.id.intValue}_${fromSegment}_${toSegment}")
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "alignment_id" to alignmentVersion.id.intValue,
+                "alignment_version" to alignmentVersion.version,
+                "external_id" to metadataExternalId,
+                "use_bounding_box" to (boundingBox != null),
+                "x_min" to boundingBox?.min?.x,
+                "y_min" to boundingBox?.min?.y,
+                "x_max" to boundingBox?.max?.x,
+                "y_max" to boundingBox?.max?.y,
+                "layout_srid" to LAYOUT_SRID.code,
             )
-        }
+        val result =
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                val fromSegment = rs.getInt("from_segment")
+                val toSegment = rs.getInt("to_segment")
+                val startPoint =
+                    rs.getDoubleOrNull("start_m")?.let { m ->
+                        rs.getPointOrNull("start_x", "start_y")?.let { point ->
+                            AlignmentPoint(point.x, point.y, 0.0, m, 0.0)
+                        }
+                    }
+                val endPoint =
+                    rs.getDoubleOrNull("end_m")?.let { m ->
+                        rs.getPointOrNull("end_x", "end_y")?.let { point ->
+                            AlignmentPoint(point.x, point.y, 0.0, m, 0.0)
+                        }
+                    }
+                SegmentGeometryAndMetadata(
+                    planId = rs.getIntIdOrNull("plan_id"),
+                    fileName = rs.getFileNameOrNull("file_name"),
+                    alignmentId = rs.getIntIdOrNull("geom_alignment_id"),
+                    alignmentName = rs.getString("alignment_name")?.let(::AlignmentName),
+                    startPoint = startPoint,
+                    endPoint = endPoint,
+                    isLinked = rs.getBoolean("is_linked"),
+                    id = StringId("${alignmentVersion.id.intValue}_${fromSegment}_${toSegment}"))
+            }
         logger.daoAccess(AccessType.UPDATE, SegmentGeometryAndMetadata::class, alignmentVersion)
         return result
     }
 
     fun fetchMetadata(alignmentVersion: RowVersion<LayoutAlignment>): List<LayoutSegmentMetadata> {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select
               postgis.st_x(postgis.st_startpoint(segment_geometry.geometry)) as start_point_x,
               postgis.st_y(postgis.st_startpoint(segment_geometry.geometry)) as start_point_y,
@@ -466,12 +528,14 @@ class LayoutAlignmentDao(
             where segment_version.alignment_id = :alignment_id 
               and segment_version.alignment_version = :alignment_version
             order by alignment.id, segment_version.segment_index
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "alignment_id" to alignmentVersion.id.intValue,
-            "alignment_version" to alignmentVersion.version,
-        )
+        val params =
+            mapOf(
+                "alignment_id" to alignmentVersion.id.intValue,
+                "alignment_version" to alignmentVersion.version,
+            )
 
         return jdbcTemplate.query(sql, params) { rs, _ ->
             LayoutSegmentMetadata(
@@ -481,8 +545,7 @@ class LayoutAlignmentDao(
                 planTime = rs.getInstantOrNull("plan_time"),
                 measurementMethod = rs.getEnumOrNull<MeasurementMethod>("measurement_method"),
                 fileName = rs.getString("file_name")?.let(::FileName),
-                originalSrid = rs.getSridOrNull("srid")
-            )
+                originalSrid = rs.getSridOrNull("srid"))
         }
     }
 
@@ -490,8 +553,9 @@ class LayoutAlignmentDao(
         layoutContext: LayoutContext,
         bbox: BoundingBox,
     ): List<MapSegmentProfileInfo<T>> {
-        //language=SQL
-        val sql = """
+        // language=SQL
+        val sql =
+            """
             select
               location_track_v.official_id,
               segment_version.alignment_id,
@@ -512,17 +576,19 @@ class LayoutAlignmentDao(
                   segment_geometry.bounding_box
                 )
               order by segment_version.segment_index
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "x_min" to bbox.min.x,
-            "y_min" to bbox.min.y,
-            "x_max" to bbox.max.x,
-            "y_max" to bbox.max.y,
-            "layout_srid" to LAYOUT_SRID.code,
-            "publication_state" to layoutContext.state.name,
-            "design_id" to layoutContext.branch.designId?.intValue,
-        )
+        val params =
+            mapOf(
+                "x_min" to bbox.min.x,
+                "y_min" to bbox.min.y,
+                "x_max" to bbox.max.x,
+                "y_max" to bbox.max.y,
+                "layout_srid" to LAYOUT_SRID.code,
+                "publication_state" to layoutContext.state.name,
+                "design_id" to layoutContext.branch.designId?.intValue,
+            )
 
         return jdbcTemplate.query(sql, params) { rs, _ ->
             val startM = rs.getDouble("start")
@@ -531,18 +597,25 @@ class LayoutAlignmentDao(
                 alignmentId = rs.getIndexedId("alignment_id", "segment_index"),
                 segmentStartM = startM,
                 segmentEndM = startM + rs.getDouble("max_m"),
-                hasProfile = rs.getEnumOrNull<VerticalCoordinateSystem>("vertical_coordinate_system") != null
-            )
+                hasProfile =
+                    rs.getEnumOrNull<VerticalCoordinateSystem>("vertical_coordinate_system") !=
+                        null)
         }
     }
 
-    private fun upsertSegments(alignmentId: RowVersion<LayoutAlignment>, segments: List<LayoutSegment>) {
+    private fun upsertSegments(
+        alignmentId: RowVersion<LayoutAlignment>,
+        segments: List<LayoutSegment>
+    ) {
         if (segments.isNotEmpty()) {
-            val newGeometryIds = insertSegmentGeometries(segments.mapNotNull { s ->
-                if (s.geometry.id is StringId) s.geometry else null
-            })
-            //language=SQL
-            val sqlIndexed = """
+            val newGeometryIds =
+                insertSegmentGeometries(
+                    segments.mapNotNull { s ->
+                        if (s.geometry.id is StringId) s.geometry else null
+                    })
+            // language=SQL
+            val sqlIndexed =
+                """
                 insert into layout.segment_version(
                   alignment_id,
                   alignment_version,
@@ -558,7 +631,8 @@ class LayoutAlignmentDao(
                   geometry_id
                 )
                 values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::layout.geometry_source, ?) 
-              """.trimIndent()
+              """
+                    .trimIndent()
             // This uses indexed parameters (rather than named ones),
             // since named parameter template's batch-method is considerably slower
             jdbcTemplate.batchUpdateIndexed(sqlIndexed, segments) { ps, (index, s) ->
@@ -573,8 +647,12 @@ class LayoutAlignmentDao(
                 ps.setNullableInt(9, s.endJointNumber?.intValue)
                 ps.setNullableDouble(10, s.sourceStart)
                 ps.setString(11, s.source.name)
-                val geometryId = if (s.geometry.id is IntId) s.geometry.id
-                else requireNotNull(newGeometryIds[s.geometry.id]) { "SegmentGeometry not stored: id=${s.id}" }
+                val geometryId =
+                    if (s.geometry.id is IntId) s.geometry.id
+                    else
+                        requireNotNull(newGeometryIds[s.geometry.id]) {
+                            "SegmentGeometry not stored: id=${s.id}"
+                        }
                 ps.setInt(12, geometryId.intValue)
             }
         }
@@ -589,13 +667,17 @@ class LayoutAlignmentDao(
         require(geometries.all { geom -> geom.segmentStart.m == 0.0 }) {
             "Geometries in DB must be set to startM=0.0, so they remain valid if an earlier segment changes"
         }
-        require(geometries.all { geom ->
-            val calculatedLength = calculateDistance(geom.segmentPoints, LAYOUT_SRID)
-            val maxDelta = calculatedLength * 0.01
-            abs(calculatedLength - geom.segmentEnd.m) <= maxDelta
-        }) { "Geometries in DB should have (approximately) endM=length" }
-        //language=SQL
-        val sql = """
+        require(
+            geometries.all { geom ->
+                val calculatedLength = calculateDistance(geom.segmentPoints, LAYOUT_SRID)
+                val maxDelta = calculatedLength * 0.01
+                abs(calculatedLength - geom.segmentEnd.m) <= maxDelta
+            }) {
+                "Geometries in DB should have (approximately) endM=length"
+            }
+        // language=SQL
+        val sql =
+            """
           insert into layout.segment_geometry(
             resolution,
             geometry,
@@ -611,32 +693,39 @@ class LayoutAlignmentDao(
           on conflict (hash) do update
           set resolution = segment_geometry.resolution -- no-op update so that returns clause works on conflict as well
           returning id
-        """.trimIndent()
+        """
+                .trimIndent()
         return geometries.associate { geometry ->
-            val params = mapOf(
-                "resolution" to geometry.resolution,
-                "line_string" to create3DMLineString(geometry.segmentPoints),
-                "srid" to LAYOUT_SRID.code,
-                "height_values" to createListString(geometry.segmentPoints) { p -> p.z },
-                "cant_values" to createListString(geometry.segmentPoints) { p -> p.cant },
-            )
-            jdbcTemplate.query(sql, params) { rs, _ ->
-                geometry.id as StringId to rs.getIntId<SegmentGeometry>("id")
-            }.first()
+            val params =
+                mapOf(
+                    "resolution" to geometry.resolution,
+                    "line_string" to create3DMLineString(geometry.segmentPoints),
+                    "srid" to LAYOUT_SRID.code,
+                    "height_values" to createListString(geometry.segmentPoints) { p -> p.z },
+                    "cant_values" to createListString(geometry.segmentPoints) { p -> p.cant },
+                )
+            jdbcTemplate
+                .query(sql, params) { rs, _ ->
+                    geometry.id as StringId to rs.getIntId<SegmentGeometry>("id")
+                }
+                .first()
         }
     }
 
     private fun fetchSegmentGeometries(
         ids: List<IntId<SegmentGeometry>>,
     ): Map<IntId<SegmentGeometry>, SegmentGeometry> {
-        return segmentGeometryCache.getAll(ids) { fetchIds -> fetchSegmentGeometriesInternal(fetchIds) }
+        return segmentGeometryCache.getAll(ids) { fetchIds ->
+            fetchSegmentGeometriesInternal(fetchIds)
+        }
     }
 
     private fun fetchSegmentGeometriesInternal(
         ids: Set<IntId<SegmentGeometry>>,
     ): Map<IntId<SegmentGeometry>, SegmentGeometry> {
         return if (ids.isNotEmpty()) {
-            val sql = """
+            val sql =
+                """
                   select 
                     id,
                     postgis.st_astext(geometry) as geometry_wkt,
@@ -651,23 +740,26 @@ class LayoutAlignmentDao(
                     end as cant_values
                   from layout.segment_geometry
                   where id in (:ids)
-                """.trimIndent()
+                """
+                    .trimIndent()
             val params = mapOf("ids" to ids.map(IntId<SegmentGeometry>::intValue))
-            val rowResults = jdbcTemplate.query(sql, params) { rs, _ ->
-                GeometryRowResult(
-                    id = rs.getIntId("id"),
-                    wktString = rs.getString("geometry_wkt"),
-                    heightString = rs.getString("height_values"),
-                    cantString = rs.getString("cant_values"),
-                    resolution = rs.getInt("resolution"),
-                )
-            }
+            val rowResults =
+                jdbcTemplate.query(sql, params) { rs, _ ->
+                    GeometryRowResult(
+                        id = rs.getIntId("id"),
+                        wktString = rs.getString("geometry_wkt"),
+                        heightString = rs.getString("height_values"),
+                        cantString = rs.getString("cant_values"),
+                        resolution = rs.getInt("resolution"),
+                    )
+                }
             parseGeometries(rowResults)
         } else mapOf()
     }
 
     fun preloadSegmentGeometries() {
-        val sql = """
+        val sql =
+            """
           select 
             geom.id,
             postgis.st_astext(geom.geometry) as geometry_wkt,
@@ -685,17 +777,19 @@ class LayoutAlignmentDao(
             left join layout.segment_geometry geom on geom.id = sv.geometry_id
           where geom.id is not null
           group by geom.id
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val rowResults = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
-            GeometryRowResult(
-                id = rs.getIntId("id"),
-                wktString = rs.getString("geometry_wkt"),
-                heightString = rs.getString("height_values"),
-                cantString = rs.getString("cant_values"),
-                resolution = rs.getInt("resolution"),
-            )
-        }
+        val rowResults =
+            jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
+                GeometryRowResult(
+                    id = rs.getIntId("id"),
+                    wktString = rs.getString("geometry_wkt"),
+                    heightString = rs.getString("height_values"),
+                    cantString = rs.getString("cant_values"),
+                    resolution = rs.getInt("resolution"),
+                )
+            }
         segmentGeometryCache.putAll(parseGeometries(rowResults))
     }
 }
@@ -708,23 +802,31 @@ data class GeometryRowResult(
     val resolution: Int,
 )
 
-private fun parseGeometries(rowResults: List<GeometryRowResult>): Map<IntId<SegmentGeometry>, SegmentGeometry> =
-    rowResults.parallelStream().map { row ->
-        SegmentGeometry(
-            id = row.id,
-            segmentPoints = parseSegmentPointsWkt(row.wktString, row.heightString, row.cantString),
-            resolution = row.resolution,
-        )
-    }.collect(Collectors.toMap({ g -> g.id as IntId }, { it }))
+private fun parseGeometries(
+    rowResults: List<GeometryRowResult>
+): Map<IntId<SegmentGeometry>, SegmentGeometry> =
+    rowResults
+        .parallelStream()
+        .map { row ->
+            SegmentGeometry(
+                id = row.id,
+                segmentPoints =
+                    parseSegmentPointsWkt(row.wktString, row.heightString, row.cantString),
+                resolution = row.resolution,
+            )
+        }
+        .collect(Collectors.toMap({ g -> g.id as IntId }, { it }))
 
 private fun getSegmentPointsWkt(
     rs: ResultSet,
     geometryColumn: String,
     heightColumn: String? = null,
     cantColumn: String? = null,
-): List<SegmentPoint> = rs.getString(geometryColumn)?.let { wktString ->
-    parseSegmentPointsWkt(wktString, heightColumn?.let(rs::getString), cantColumn?.let(rs::getString))
-} ?: emptyList()
+): List<SegmentPoint> =
+    rs.getString(geometryColumn)?.let { wktString ->
+        parseSegmentPointsWkt(
+            wktString, heightColumn?.let(rs::getString), cantColumn?.let(rs::getString))
+    } ?: emptyList()
 
 private fun parseSegmentPointsWkt(
     geometryWkt: String,
@@ -740,15 +842,16 @@ fun parseSegmentPointLineString(
     lineString: String,
     heights: List<Double?>?,
     cants: List<Double?>?,
-): List<SegmentPoint> = get3DMLineStringContent(lineString).let { pointStrings ->
-    require(heights == null || heights.size == pointStrings.size) {
-        "Height value count should match point count: points=${pointStrings.size} heights=${heights?.size}"
+): List<SegmentPoint> =
+    get3DMLineStringContent(lineString).let { pointStrings ->
+        require(heights == null || heights.size == pointStrings.size) {
+            "Height value count should match point count: points=${pointStrings.size} heights=${heights?.size}"
+        }
+        require(cants == null || cants.size == pointStrings.size) {
+            "Cant value count should match point count: points=${pointStrings.size} cants=${cants?.size}"
+        }
+        pointStrings.mapIndexed { i, p -> parseSegmentPoint(p, heights?.get(i), cants?.get(i)) }
     }
-    require(cants == null || cants.size == pointStrings.size) {
-        "Cant value count should match point count: points=${pointStrings.size} cants=${cants?.size}"
-    }
-    pointStrings.mapIndexed { i, p -> parseSegmentPoint(p, heights?.get(i), cants?.get(i)) }
-}
 
 private fun parseNullableDoubleList(listString: String?): List<Double?>? =
     listString?.split(",")?.map(String::toDoubleOrNull)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentService.kt
@@ -20,16 +20,16 @@ class LayoutAlignmentService(
     fun saveAsNew(alignment: LayoutAlignment): RowVersion<LayoutAlignment> = save(asNew(alignment))
 
     @Transactional
-    fun duplicateOrNew(alignmentVersion: RowVersion<LayoutAlignment>?): RowVersion<LayoutAlignment> =
-        alignmentVersion?.let(::duplicate) ?: newEmpty().second
+    fun duplicateOrNew(
+        alignmentVersion: RowVersion<LayoutAlignment>?
+    ): RowVersion<LayoutAlignment> = alignmentVersion?.let(::duplicate) ?: newEmpty().second
 
     @Transactional
     fun duplicate(alignmentVersion: RowVersion<LayoutAlignment>): RowVersion<LayoutAlignment> =
         save(asNew(dao.fetch(alignmentVersion)))
 
     fun save(alignment: LayoutAlignment): RowVersion<LayoutAlignment> =
-        if (alignment.dataType == DataType.STORED) dao.update(alignment)
-        else dao.insert(alignment)
+        if (alignment.dataType == DataType.STORED) dao.update(alignment) else dao.insert(alignment)
 
     fun newEmpty(): Pair<LayoutAlignment, RowVersion<LayoutAlignment>> {
         val alignment = emptyAlignment()
@@ -42,7 +42,8 @@ class LayoutAlignmentService(
         boundingBox: BoundingBox?,
         context: GeocodingContext,
     ): List<AlignmentPlanSection> {
-        val sections = dao.fetchSegmentGeometriesAndPlanMetadata(alignmentVersion, externalId, boundingBox)
+        val sections =
+            dao.fetchSegmentGeometriesAndPlanMetadata(alignmentVersion, externalId, boundingBox)
         val alignment = dao.fetch(alignmentVersion)
         return sections.mapNotNull { section ->
             val start = section.startPoint?.let { p -> toPlanSectionPoint(p, alignment, context) }
@@ -66,17 +67,20 @@ class LayoutAlignmentService(
     }
 }
 
-private fun toPlanSectionPoint(point: IPoint, alignment: LayoutAlignment, context: GeocodingContext) =
+private fun toPlanSectionPoint(
+    point: IPoint,
+    alignment: LayoutAlignment,
+    context: GeocodingContext
+) =
     context.getAddress(point)?.let { (address, _) ->
         PlanSectionPoint(
             address = address,
             location = point,
-            m = alignment.getClosestPointM(point)?.first ?: throw IllegalArgumentException(
-                "Could not find closest point for $point"
-            ),
+            m =
+                alignment.getClosestPointM(point)?.first
+                    ?: throw IllegalArgumentException("Could not find closest point for $point"),
         )
     }
 
 private fun asNew(alignment: LayoutAlignment): LayoutAlignment =
-    if (alignment.dataType == TEMP) alignment
-    else alignment.copy(id = StringId(), dataType = TEMP)
+    if (alignment.dataType == TEMP) alignment else alignment.copy(id = StringId(), dataType = TEMP)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
@@ -9,13 +9,14 @@ import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.util.FreeText
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 @GeoviiteService
-abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType : ILayoutAssetDao<ObjectType>>(
+abstract class LayoutAssetService<
+    ObjectType : LayoutAsset<ObjectType>, DaoType : ILayoutAssetDao<ObjectType>>(
     protected open val dao: DaoType,
 ) {
 
@@ -33,7 +34,11 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
         return dao.getMany(context, ids)
     }
 
-    fun getOfficialAtMoment(branch: LayoutBranch, id: IntId<ObjectType>, moment: Instant): ObjectType? {
+    fun getOfficialAtMoment(
+        branch: LayoutBranch,
+        id: IntId<ObjectType>,
+        moment: Instant
+    ): ObjectType? {
         return dao.getOfficialAtMoment(branch, id, moment)
     }
 
@@ -45,7 +50,10 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
         return dao.fetchChangeTime()
     }
 
-    fun getLayoutAssetChangeInfo(context: LayoutContext, id: IntId<ObjectType>): LayoutAssetChangeInfo? {
+    fun getLayoutAssetChangeInfo(
+        context: LayoutContext,
+        id: IntId<ObjectType>
+    ): LayoutAssetChangeInfo? {
         return dao.fetchLayoutAssetChangeInfo(context, id)
     }
 
@@ -59,11 +67,17 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
     protected open fun contentMatches(term: String, item: ObjectType): Boolean = false
 
     @Transactional
-    open fun saveDraft(branch: LayoutBranch, draftAsset: ObjectType): LayoutDaoResponse<ObjectType> {
+    open fun saveDraft(
+        branch: LayoutBranch,
+        draftAsset: ObjectType
+    ): LayoutDaoResponse<ObjectType> {
         return saveDraftInternal(branch, draftAsset)
     }
 
-    protected fun saveDraftInternal(branch: LayoutBranch, draftAsset: ObjectType): LayoutDaoResponse<ObjectType> {
+    protected fun saveDraftInternal(
+        branch: LayoutBranch,
+        draftAsset: ObjectType
+    ): LayoutDaoResponse<ObjectType> {
         val draft = asDraft(branch, draftAsset)
         require(draft.isDraft) { "Item is not a draft: id=${draft.id}" }
         val officialId = if (draftAsset.id is IntId) draftAsset.id as IntId else null
@@ -73,38 +87,62 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
         } else {
             requireNotNull(officialId) { "Updating item that has no known official ID" }
             verifyObjectIsExisting(draft)
-            val previousVersion = requireNotNull(draft.version) { "Updating item without rowVersion: $draftAsset" }
-            dao.update(draft).also { response -> verifyDraftUpdateResponse(officialId, previousVersion, response) }
+            val previousVersion =
+                requireNotNull(draft.version) { "Updating item without rowVersion: $draftAsset" }
+            dao.update(draft).also { response ->
+                verifyDraftUpdateResponse(officialId, previousVersion, response)
+            }
         }
     }
 
     @Transactional
-    open fun deleteDraft(branch: LayoutBranch, id: IntId<ObjectType>): LayoutDaoResponse<ObjectType> {
+    open fun deleteDraft(
+        branch: LayoutBranch,
+        id: IntId<ObjectType>
+    ): LayoutDaoResponse<ObjectType> {
         return dao.deleteDraft(branch, id)
     }
 
     @Transactional
-    open fun publish(branch: LayoutBranch, version: ValidationVersion<ObjectType>): LayoutDaoResponse<ObjectType> {
+    open fun publish(
+        branch: LayoutBranch,
+        version: ValidationVersion<ObjectType>
+    ): LayoutDaoResponse<ObjectType> {
         return publishInternal(branch, version.validatedAssetVersion)
     }
 
-    protected fun publishInternal(branch: LayoutBranch, version: LayoutRowVersion<ObjectType>): LayoutDaoResponse<ObjectType> {
+    protected fun publishInternal(
+        branch: LayoutBranch,
+        version: LayoutRowVersion<ObjectType>
+    ): LayoutDaoResponse<ObjectType> {
         val draft = dao.fetch(version)
-        require(branch == draft.branch) { "Draft branch does not match the publishing operation: branch=$branch draft=$draft" }
-        require(draft.isDraft) { "Object to publish is not a draft: version=$version context=${draft.contextData}" }
+        require(branch == draft.branch) {
+            "Draft branch does not match the publishing operation: branch=$branch draft=$draft"
+        }
+        require(draft.isDraft) {
+            "Object to publish is not a draft: version=$version context=${draft.contextData}"
+        }
         val published = asOfficial(branch, draft)
-        require(!published.isDraft) { "Published object is still a draft: context=${published.contextData}" }
+        require(!published.isDraft) {
+            "Published object is still a draft: context=${published.contextData}"
+        }
         verifyObjectIsExisting(published)
 
-        val publicationResponse = dao.update(published).also { r ->
-            require(r.id == draft.id) { "Publication response ID doesn't match object: id=${draft.id} updated=$r" }
-        }
-        // If draft row-id changed, the data was updated to the official row -> delete the now-redundant draft row
+        val publicationResponse =
+            dao.update(published).also { r ->
+                require(r.id == draft.id) {
+                    "Publication response ID doesn't match object: id=${draft.id} updated=$r"
+                }
+            }
+        // If draft row-id changed, the data was updated to the official row -> delete the
+        // now-redundant draft row
         if (version.rowId != publicationResponse.rowVersion.rowId) {
             dao.deleteRow(version.rowId)
         }
-        // If main-draft was published and it came from a design row that wasn't updated, then that row is redundant too
-        if (draft.branch == LayoutBranch.main && draft.contextData.designRowId != publicationResponse.rowVersion.rowId) {
+        // If main-draft was published and it came from a design row that wasn't updated, then that
+        // row is redundant too
+        if (draft.branch == LayoutBranch.main &&
+            draft.contextData.designRowId != publicationResponse.rowVersion.rowId) {
             draft.contextData.designRowId?.let(dao::deleteRow)
         }
         return publicationResponse
@@ -135,10 +173,14 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
         require(dao.fetchVersion(fromBranch.draft, id) == branchOfficialVersion) {
             "Object must not have branch-draft version when merging to main: fromBranch=$fromBranch id=$id"
         }
-        return VersionsForMerging(branchOfficialVersion, mainOfficialVersion, mainDraftVersion) to branchObject
+        return VersionsForMerging(branchOfficialVersion, mainOfficialVersion, mainDraftVersion) to
+            branchObject
     }
 
-    fun mergeToMainBranch(fromBranch: DesignBranch, id: IntId<ObjectType>): LayoutDaoResponse<ObjectType> =
+    fun mergeToMainBranch(
+        fromBranch: DesignBranch,
+        id: IntId<ObjectType>
+    ): LayoutDaoResponse<ObjectType> =
         fetchAndCheckVersionsForMerging(fromBranch, id).let { (versions, branchObject) ->
             mergeToMainBranchInternal(versions, branchObject)
         }
@@ -147,19 +189,27 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
         versions: VersionsForMerging,
         objectFromBranch: ObjectType,
     ): LayoutDaoResponse<ObjectType> =
-        // The merge should overwrite any pre-existing main-draft row, or otherwise be saved as a new one
-        if (versions.mainDraftVersion == null || versions.mainDraftVersion == versions.mainOfficialVersion) {
+        // The merge should overwrite any pre-existing main-draft row, or otherwise be saved as a
+        // new one
+        if (versions.mainDraftVersion == null ||
+            versions.mainDraftVersion == versions.mainOfficialVersion) {
             dao.insert(asMainDraft(objectFromBranch))
         } else {
             dao.update(asOverwritingMainDraft(objectFromBranch, versions.mainDraftVersion.rowId))
         }
 
-    private fun verifyInsertResponse(officialId: IntId<ObjectType>?, response: LayoutDaoResponse<ObjectType>) {
-        if (officialId != null) require(response.id == officialId) {
-            "Insert response ID doesn't match object: officialId=$officialId updated=$response"
-        } else require(response.id.intValue == response.rowVersion.rowId.intValue) {
-            "Inserted new object refers to another official row: inserted=$response"
-        }
+    private fun verifyInsertResponse(
+        officialId: IntId<ObjectType>?,
+        response: LayoutDaoResponse<ObjectType>
+    ) {
+        if (officialId != null)
+            require(response.id == officialId) {
+                "Insert response ID doesn't match object: officialId=$officialId updated=$response"
+            }
+        else
+            require(response.id.intValue == response.rowVersion.rowId.intValue) {
+                "Inserted new object refers to another official row: inserted=$response"
+            }
         require(response.rowVersion.version == 1) {
             "Inserted new row has a version over 1: inserted=$response"
         }
@@ -180,8 +230,7 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
             // We could do optimistic locking here by throwing
             logger.warn(
                 "Updated version isn't the next one: a concurrent change may have been overwritten: " +
-                        "id=$id previous=$previousVersion updated=$response"
-            )
+                    "id=$id previous=$previousVersion updated=$response")
         }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -15,7 +15,11 @@ import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.logging.Loggable
 
-enum class EditState { UNEDITED, EDITED, CREATED }
+enum class EditState {
+    UNEDITED,
+    EDITED,
+    CREATED
+}
 
 interface LayoutContextAware<T> {
     val id: DomainId<T>
@@ -25,13 +29,16 @@ interface LayoutContextAware<T> {
     val branch: LayoutBranch
 
     @get:JsonIgnore
-    val isDraft: Boolean get() = false
+    val isDraft: Boolean
+        get() = false
 
     @get:JsonIgnore
-    val isOfficial: Boolean get() = false
+    val isOfficial: Boolean
+        get() = false
 
     @get:JsonIgnore
-    val isDesign: Boolean get() = false
+    val isDesign: Boolean
+        get() = false
 }
 
 sealed class ContextIdHolder<T> {
@@ -42,65 +49,72 @@ data class UnstoredContextIdHolder<T>(
     val sourceRowVersion: LayoutRowVersion<T>?,
     val tempId: StringId<T> = StringId(),
 ) : ContextIdHolder<T>() {
-    override val rowId: LayoutRowId<T>? get() = null
+    override val rowId: LayoutRowId<T>?
+        get() = null
 }
 
-data class StoredContextIdHolder<T>(
-    val version: LayoutRowVersion<T>
-) : ContextIdHolder<T>() {
-    override val rowId: LayoutRowId<T> get() = version.rowId
+data class StoredContextIdHolder<T>(val version: LayoutRowVersion<T>) : ContextIdHolder<T>() {
+    override val rowId: LayoutRowId<T>
+        get() = version.rowId
 }
 
 data class OverwritingContextIdHolder<T>(
     val targetRowId: LayoutRowId<T>,
     val sourceRowVersion: LayoutRowVersion<T>
 ) : ContextIdHolder<T>() {
-    override val rowId: LayoutRowId<T> get() = targetRowId
+    override val rowId: LayoutRowId<T>
+        get() = targetRowId
 }
 
 sealed class LayoutAsset<T : LayoutAsset<T>>(contextData: LayoutContextData<T>) :
     LayoutContextAware<T> by contextData, Loggable {
-    @get:JsonIgnore
-    abstract val contextData: LayoutContextData<T>
+    @get:JsonIgnore abstract val contextData: LayoutContextData<T>
 
     abstract fun withContext(contextData: LayoutContextData<T>): T
 }
 
 sealed class LayoutContextData<T> : LayoutContextAware<T> {
 
-    @get:JsonIgnore
-    abstract val contextIdHolder: ContextIdHolder<T>
+    @get:JsonIgnore abstract val contextIdHolder: ContextIdHolder<T>
 
     @get:JsonIgnore
-    open val officialRowId: LayoutRowId<T>? get() = null
+    open val officialRowId: LayoutRowId<T>?
+        get() = null
 
     @get:JsonIgnore
-    open val designRowId: LayoutRowId<T>? get() = null
+    open val designRowId: LayoutRowId<T>?
+        get() = null
 
     @get:JsonIgnore
-    val rowId: LayoutRowId<T>? get() = contextIdHolder.rowId
+    val rowId: LayoutRowId<T>?
+        get() = contextIdHolder.rowId
 
-    override val version: LayoutRowVersion<T>? get() = (contextIdHolder as? StoredContextIdHolder)?.version
+    override val version: LayoutRowVersion<T>?
+        get() = (contextIdHolder as? StoredContextIdHolder)?.version
 
     final override val id: DomainId<T> by lazy {
-        (officialRowId ?: designRowId ?: rowId)
-            ?.let { rowId -> IntId(rowId.intValue) }
+        (officialRowId ?: designRowId ?: rowId)?.let { rowId -> IntId(rowId.intValue) }
             ?: (contextIdHolder as UnstoredContextIdHolder).tempId
     }
 
-    final override val dataType get() = if (rowId == null) TEMP else STORED
+    final override val dataType
+        get() = if (rowId == null) TEMP else STORED
 
-    override val branch get() = designId?.let(LayoutBranch::design) ?: LayoutBranch.main
+    override val branch
+        get() = designId?.let(LayoutBranch::design) ?: LayoutBranch.main
 
     @get:JsonIgnore
-    open val designId: IntId<LayoutDesign>? get() = null
+    open val designId: IntId<LayoutDesign>?
+        get() = null
 
-    protected fun requireStoredRowVersion() = contextIdHolder.let { current ->
-        if (current is StoredContextIdHolder) current.version
-        else error {
-            "Only $STORED rows can transition to a different context: context=${this::class.simpleName} dataType=$dataType"
+    protected fun requireStoredRowVersion() =
+        contextIdHolder.let { current ->
+            if (current is StoredContextIdHolder) current.version
+            else
+                error {
+                    "Only $STORED rows can transition to a different context: context=${this::class.simpleName} dataType=$dataType"
+                }
         }
-    }
 
     companion object {
         fun <T : LayoutAsset<T>> new(context: LayoutContext): LayoutContextData<T> =
@@ -109,30 +123,36 @@ sealed class LayoutContextData<T> : LayoutContextAware<T> {
                 OFFICIAL -> newOfficial(context.branch)
             }
 
-        fun <T : LayoutAsset<T>> newDraft(branch: LayoutBranch): LayoutContextData<T> = when (branch) {
-            is MainBranch -> MainDraftContextData(
-                contextIdHolder = UnstoredContextIdHolder(null),
-                officialRowId = null,
-                designRowId = null,
-            )
-            is DesignBranch -> DesignDraftContextData(
-                contextIdHolder = UnstoredContextIdHolder(null),
-                designRowId = null,
-                officialRowId = null,
-                designId = branch.designId,
-            )
-        }
+        fun <T : LayoutAsset<T>> newDraft(branch: LayoutBranch): LayoutContextData<T> =
+            when (branch) {
+                is MainBranch ->
+                    MainDraftContextData(
+                        contextIdHolder = UnstoredContextIdHolder(null),
+                        officialRowId = null,
+                        designRowId = null,
+                    )
+                is DesignBranch ->
+                    DesignDraftContextData(
+                        contextIdHolder = UnstoredContextIdHolder(null),
+                        designRowId = null,
+                        officialRowId = null,
+                        designId = branch.designId,
+                    )
+            }
 
-        fun <T : LayoutAsset<T>> newOfficial(branch: LayoutBranch): LayoutContextData<T> = when (branch) {
-            is MainBranch -> MainOfficialContextData(
-                contextIdHolder = UnstoredContextIdHolder(null),
-            )
-            is DesignBranch -> DesignOfficialContextData(
-                contextIdHolder = UnstoredContextIdHolder(null),
-                officialRowId = null,
-                designId = branch.designId,
-            )
-        }
+        fun <T : LayoutAsset<T>> newOfficial(branch: LayoutBranch): LayoutContextData<T> =
+            when (branch) {
+                is MainBranch ->
+                    MainOfficialContextData(
+                        contextIdHolder = UnstoredContextIdHolder(null),
+                    )
+                is DesignBranch ->
+                    DesignOfficialContextData(
+                        contextIdHolder = UnstoredContextIdHolder(null),
+                        officialRowId = null,
+                        designId = branch.designId,
+                    )
+            }
     }
 }
 
@@ -146,8 +166,11 @@ data class MainOfficialContextData<T>(
     override val contextIdHolder: ContextIdHolder<T>,
 ) : MainContextData<T>() {
 
-    override val editState: EditState get() = EditState.UNEDITED
-    override val isOfficial: Boolean get() = true
+    override val editState: EditState
+        get() = EditState.UNEDITED
+
+    override val isOfficial: Boolean
+        get() = true
 
     fun asMainDraft(): MainDraftContextData<T> {
         val ownRowVersion = requireStoredRowVersion()
@@ -174,8 +197,11 @@ data class MainDraftContextData<T>(
     override val officialRowId: LayoutRowId<T>?,
     override val designRowId: LayoutRowId<T>?,
 ) : MainContextData<T>() {
-    override val editState: EditState get() = if (officialRowId != null) EditState.EDITED else EditState.CREATED
-    override val isDraft: Boolean get() = true
+    override val editState: EditState
+        get() = if (officialRowId != null) EditState.EDITED else EditState.CREATED
+
+    override val isDraft: Boolean
+        get() = true
 
     init {
         requireUniqueRowIds(this)
@@ -185,11 +211,11 @@ data class MainDraftContextData<T>(
         val ownRowVersion = requireStoredRowVersion()
         return MainOfficialContextData(
             OverwritingContextIdHolder(
-                // At publish, we update the first known row for the asset, making it main-official if it wasn't
+                // At publish, we update the first known row for the asset, making it main-official
+                // if it wasn't
                 targetRowId = officialRowId ?: designRowId ?: ownRowVersion.rowId,
                 sourceRowVersion = ownRowVersion,
-            )
-        )
+            ))
     }
 }
 
@@ -198,9 +224,14 @@ data class DesignOfficialContextData<T>(
     override val officialRowId: LayoutRowId<T>?,
     override val designId: IntId<LayoutDesign>,
 ) : DesignContextData<T>() {
-    override val editState: EditState get() = EditState.UNEDITED
-    override val isOfficial: Boolean get() = true
-    override val isDesign: Boolean get() = true
+    override val editState: EditState
+        get() = EditState.UNEDITED
+
+    override val isOfficial: Boolean
+        get() = true
+
+    override val isDesign: Boolean
+        get() = true
 
     init {
         requireUniqueRowIds(this)
@@ -209,11 +240,13 @@ data class DesignOfficialContextData<T>(
     fun asMainDraft(overwriteRowId: LayoutRowId<T>?): MainDraftContextData<T> {
         val ownRowVersion = requireStoredRowVersion()
         return MainDraftContextData(
-            contextIdHolder = if (overwriteRowId == null) {
-                UnstoredContextIdHolder(ownRowVersion)
-            } else {
-                OverwritingContextIdHolder(targetRowId = overwriteRowId, sourceRowVersion = ownRowVersion)
-            },
+            contextIdHolder =
+                if (overwriteRowId == null) {
+                    UnstoredContextIdHolder(ownRowVersion)
+                } else {
+                    OverwritingContextIdHolder(
+                        targetRowId = overwriteRowId, sourceRowVersion = ownRowVersion)
+                },
             officialRowId = officialRowId,
             designRowId = ownRowVersion.rowId,
         )
@@ -236,9 +269,14 @@ data class DesignDraftContextData<T>(
     override val officialRowId: LayoutRowId<T>?,
     override val designId: IntId<LayoutDesign>,
 ) : DesignContextData<T>() {
-    override val editState: EditState get() = if (designRowId != null) EditState.EDITED else EditState.CREATED
-    override val isDraft: Boolean get() = true
-    override val isDesign: Boolean get() = true
+    override val editState: EditState
+        get() = if (designRowId != null) EditState.EDITED else EditState.CREATED
+
+    override val isDraft: Boolean
+        get() = true
+
+    override val isDesign: Boolean
+        get() = true
 
     init {
         requireUniqueRowIds(this)
@@ -247,83 +285,91 @@ data class DesignDraftContextData<T>(
     fun asDesignOfficial(): DesignOfficialContextData<T> {
         val ownRowVersion = requireStoredRowVersion()
         return DesignOfficialContextData(
-            contextIdHolder = OverwritingContextIdHolder(
-                // The publishing should update either the official or the draft row in the design (not main official)
-                targetRowId = designRowId ?: ownRowVersion.rowId,
-                sourceRowVersion = ownRowVersion,
-            ),
+            contextIdHolder =
+                OverwritingContextIdHolder(
+                    // The publishing should update either the official or the draft row in the
+                    // design (not main official)
+                    targetRowId = designRowId ?: ownRowVersion.rowId,
+                    sourceRowVersion = ownRowVersion,
+                ),
             officialRowId = officialRowId,
             designId = designId,
         )
     }
 }
 
-fun <T : LayoutAsset<T>> asDraft(branch: LayoutBranch, item: T): T = when (branch) {
-    is MainBranch -> asMainDraft(item)
-    is DesignBranch -> asDesignDraft(item, branch.designId)
-}
-
-fun <T : LayoutAsset<T>> asMainDraft(item: T): T = item.contextData.let { ctx ->
-    when (ctx) {
-        is MainDraftContextData -> item
-        is MainOfficialContextData -> item.withContext(ctx.asMainDraft())
-        is DesignOfficialContextData -> item.withContext(ctx.asMainDraft(null))
-        is DesignDraftContextData -> error(
-            "Creating a main-draft from a design-draft is not supported (publish the design first): item=$item"
-        )
+fun <T : LayoutAsset<T>> asDraft(branch: LayoutBranch, item: T): T =
+    when (branch) {
+        is MainBranch -> asMainDraft(item)
+        is DesignBranch -> asDesignDraft(item, branch.designId)
     }
-}
 
-fun <T : LayoutAsset<T>> asOverwritingMainDraft(item: T, overwriteRowId: LayoutRowId<T>): T = item.contextData.let { ctx ->
-    when (ctx) {
-        is DesignOfficialContextData -> item.withContext(ctx.asMainDraft(overwriteRowId))
-        else -> error(
-            "Creating an overwriting main-draft (a merge of drafts) is only possible from an official design: item=$item"
-        )
+fun <T : LayoutAsset<T>> asMainDraft(item: T): T =
+    item.contextData.let { ctx ->
+        when (ctx) {
+            is MainDraftContextData -> item
+            is MainOfficialContextData -> item.withContext(ctx.asMainDraft())
+            is DesignOfficialContextData -> item.withContext(ctx.asMainDraft(null))
+            is DesignDraftContextData ->
+                error(
+                    "Creating a main-draft from a design-draft is not supported (publish the design first): item=$item")
+        }
     }
-}
 
-fun <T : LayoutAsset<T>> asOfficial(branch: LayoutBranch, item: T): T = when (branch) {
-    is MainBranch -> asMainOfficial(item)
-    is DesignBranch -> asDesignOfficial(item, branch.designId)
-}
+fun <T : LayoutAsset<T>> asOverwritingMainDraft(item: T, overwriteRowId: LayoutRowId<T>): T =
+    item.contextData.let { ctx ->
+        when (ctx) {
+            is DesignOfficialContextData -> item.withContext(ctx.asMainDraft(overwriteRowId))
+            else ->
+                error(
+                    "Creating an overwriting main-draft (a merge of drafts) is only possible from an official design: item=$item")
+        }
+    }
+
+fun <T : LayoutAsset<T>> asOfficial(branch: LayoutBranch, item: T): T =
+    when (branch) {
+        is MainBranch -> asMainOfficial(item)
+        is DesignBranch -> asDesignOfficial(item, branch.designId)
+    }
 
 fun <T : LayoutAsset<T>> asMainOfficial(item: T): T =
     item.contextData.let { ctx ->
         when (ctx) {
             is MainOfficialContextData -> item
             is MainDraftContextData -> item.withContext(ctx.asMainOfficial())
-            else -> error(
-                "Creating a main-official from a design is not supported (create a main-draft first): item=$item"
-            )
+            else ->
+                error(
+                    "Creating a main-official from a design is not supported (create a main-draft first): item=$item")
         }
     }
 
-fun <T : LayoutAsset<T>> asDesignOfficial(item: T, designId: IntId<LayoutDesign>): T = item.contextData.let { ctx ->
-    require(ctx.designId == null || ctx.designId == designId) {
-        "Creating a design-official from another design is not supported: item=$item designId=$designId"
+fun <T : LayoutAsset<T>> asDesignOfficial(item: T, designId: IntId<LayoutDesign>): T =
+    item.contextData.let { ctx ->
+        require(ctx.designId == null || ctx.designId == designId) {
+            "Creating a design-official from another design is not supported: item=$item designId=$designId"
+        }
+        when (ctx) {
+            is DesignDraftContextData -> item.withContext(ctx.asDesignOfficial())
+            else ->
+                error(
+                    "Creating a design-official from the main branch is not supported (create a design draft first): item=$item designId=$designId")
+        }
     }
-    when (ctx) {
-        is DesignDraftContextData -> item.withContext(ctx.asDesignOfficial())
-        else -> error(
-            "Creating a design-official from the main branch is not supported (create a design draft first): item=$item designId=$designId"
-        )
-    }
-}
 
-fun <T : LayoutAsset<T>> asDesignDraft(item: T, designId: IntId<LayoutDesign>): T = item.contextData.let { ctx ->
-    require(ctx.designId == null || ctx.designId == designId) {
-        "Creating a design-draft from another design is not supported: item=$item designId=$designId"
+fun <T : LayoutAsset<T>> asDesignDraft(item: T, designId: IntId<LayoutDesign>): T =
+    item.contextData.let { ctx ->
+        require(ctx.designId == null || ctx.designId == designId) {
+            "Creating a design-draft from another design is not supported: item=$item designId=$designId"
+        }
+        when (ctx) {
+            is DesignDraftContextData -> item
+            is MainOfficialContextData -> item.withContext(ctx.asDesignDraft(designId))
+            is DesignOfficialContextData -> item.withContext(ctx.asDesignDraft())
+            is MainDraftContextData ->
+                error(
+                    "Creating a design-draft from a main-draft is not supported (publish the draft first): item=$item designId=$designId")
+        }
     }
-    when (ctx) {
-        is DesignDraftContextData -> item
-        is MainOfficialContextData -> item.withContext(ctx.asDesignDraft(designId))
-        is DesignOfficialContextData -> item.withContext(ctx.asDesignDraft())
-        is MainDraftContextData -> error(
-            "Creating a design-draft from a main-draft is not supported (publish the draft first): item=$item designId=$designId"
-        )
-    }
-}
 
 private fun requireUniqueRowIds(contextData: LayoutContextData<*>) {
     contextData.rowId?.let { r ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
@@ -5,7 +5,9 @@ import fi.fta.geoviite.infra.util.FreeText
 import java.time.LocalDate
 
 enum class DesignState {
-    ACTIVE, DELETED, COMPLETED
+    ACTIVE,
+    DELETED,
+    COMPLETED
 }
 
 data class LayoutDesign(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
@@ -8,7 +8,6 @@ import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.util.DaoBase
 import fi.fta.geoviite.infra.util.DbTable
-import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.getEnum
 import fi.fta.geoviite.infra.util.getFreeText
 import fi.fta.geoviite.infra.util.getIntId
@@ -17,12 +16,12 @@ import fi.fta.geoviite.infra.util.getRowVersion
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.setUser
 import fi.fta.geoviite.infra.util.toDbId
+import java.time.Instant
 import org.postgresql.util.PSQLException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 @Component
 @Transactional(readOnly = true)
@@ -31,11 +30,13 @@ class LayoutDesignDao(
 ) : DaoBase(jdbcTemplateParam) {
 
     fun fetch(id: IntId<LayoutDesign>): LayoutDesign {
-        val sql = """
+        val sql =
+            """
             select id, name, estimated_completion, design_state
             from layout.design
             where id = :id
-        """.trimIndent()
+        """
+                .trimIndent()
         return jdbcTemplate.queryOne(sql, mapOf("id" to id.intValue)) { rs, _ ->
             LayoutDesign(
                 rs.getIntId("id"),
@@ -46,49 +47,60 @@ class LayoutDesignDao(
         }
     }
 
-    fun list(includeCompleted: Boolean = false, includeDeleted: Boolean = false): List<LayoutDesign> {
-        val sql = """
+    fun list(
+        includeCompleted: Boolean = false,
+        includeDeleted: Boolean = false
+    ): List<LayoutDesign> {
+        val sql =
+            """
             select id, name, estimated_completion, design_state
             from layout.design
             where design_state = 'ACTIVE'::layout.design_state 
               or :include_completed is true and design_state = 'COMPLETED'::layout.design_state
               or :include_deleted is true and design_state = 'DELETED'::layout.design_state
-        """.trimIndent()
+        """
+                .trimIndent()
         return jdbcTemplate.query(
             sql,
-            mapOf("include_completed" to includeCompleted, "include_deleted" to includeDeleted)
-        ) { rs, _ ->
-            LayoutDesign(
-                rs.getIntId("id"),
-                rs.getFreeText("name"),
-                rs.getLocalDate("estimated_completion"),
-                rs.getEnum("design_state"),
-            )
-        }
+            mapOf("include_completed" to includeCompleted, "include_deleted" to includeDeleted)) {
+                rs,
+                _ ->
+                LayoutDesign(
+                    rs.getIntId("id"),
+                    rs.getFreeText("name"),
+                    rs.getLocalDate("estimated_completion"),
+                    rs.getEnum("design_state"),
+                )
+            }
     }
 
     @Transactional
     fun update(id: DomainId<LayoutDesign>, design: LayoutDesignSaveRequest): IntId<LayoutDesign> {
         jdbcTemplate.setUser()
-        val params = mapOf(
-            "id" to toDbId(id).intValue,
-            "name" to design.name,
-            "estimated_completion" to design.estimatedCompletion,
-            "design_state" to design.designState.name,
-        )
+        val params =
+            mapOf(
+                "id" to toDbId(id).intValue,
+                "name" to design.name,
+                "estimated_completion" to design.estimatedCompletion,
+                "design_state" to design.designState.name,
+            )
 
-        val sql = """
+        val sql =
+            """
             update layout.design
             set name = :name,
                 estimated_completion = :estimated_completion,
                 design_state = :design_state::layout.design_state
             where id = :id
             returning id, version
-        """.trimIndent()
-        val response = jdbcTemplate.queryForObject(
-            sql, params
-        ) { rs, _ -> rs.getRowVersion<LayoutDesign>("id", "version") }
-            ?: throw IllegalStateException("Failed to generate ID for new row version of updated layout design")
+        """
+                .trimIndent()
+        val response =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+                rs.getRowVersion<LayoutDesign>("id", "version")
+            }
+                ?: throw IllegalStateException(
+                    "Failed to generate ID for new row version of updated layout design")
         logger.daoAccess(AccessType.UPDATE, LayoutDesign::class, response)
         return response.id
     }
@@ -96,19 +108,23 @@ class LayoutDesignDao(
     @Transactional
     fun insert(design: LayoutDesignSaveRequest): IntId<LayoutDesign> {
         jdbcTemplate.setUser()
-        val sql = """
+        val sql =
+            """
             insert into layout.design (name, estimated_completion, design_state)
             values (:name, :estimated_completion, :design_state::layout.design_state)
             returning id, version
-        """.trimIndent()
-        val response = jdbcTemplate.queryForObject(
-            sql, mapOf(
-                "name" to design.name,
-                "estimated_completion" to design.estimatedCompletion,
-                "design_state" to design.designState.name,
-            )
-        ) { rs, _ -> rs.getRowVersion<LayoutDesign>("id", "version") }
-            ?: throw IllegalStateException("Failed to generate ID for new layout design")
+        """
+                .trimIndent()
+        val response =
+            jdbcTemplate.queryForObject(
+                sql,
+                mapOf(
+                    "name" to design.name,
+                    "estimated_completion" to design.estimatedCompletion,
+                    "design_state" to design.designState.name,
+                )) { rs, _ ->
+                    rs.getRowVersion<LayoutDesign>("id", "version")
+                } ?: throw IllegalStateException("Failed to generate ID for new layout design")
         logger.daoAccess(AccessType.INSERT, LayoutDesign::class, response)
         return response.id
     }
@@ -118,21 +134,23 @@ class LayoutDesignDao(
     }
 }
 
-private val duplicateSwitchErrorRegex = Regex("""Key \(lower\(name\)\)=\(([^,]+)\) conflicts with existing key""")
+private val duplicateSwitchErrorRegex =
+    Regex("""Key \(lower\(name\)\)=\(([^,]+)\) conflicts with existing key""")
 
-fun asDuplicateNameException(e: DataIntegrityViolationException): DuplicateDesignNameException? = e.cause
-    .let { cause -> cause as? PSQLException }
-    ?.let { cause -> getPSQLExceptionConstraintAndDetailOrRethrow(cause) }
-    ?.let { (constraint, detail) ->
-        duplicateSwitchErrorRegex
-            .matchAt(detail, 0)
-            ?.let { match -> match.groups[1]?.value }
-            ?.let { name -> constraint to name }
-    }
-    ?.let { (constraint, name) ->
-        if (constraint == "layout_design_unique_name") {
-            DuplicateDesignNameException(name, e)
-        } else {
-            null
+fun asDuplicateNameException(e: DataIntegrityViolationException): DuplicateDesignNameException? =
+    e.cause
+        .let { cause -> cause as? PSQLException }
+        ?.let { cause -> getPSQLExceptionConstraintAndDetailOrRethrow(cause) }
+        ?.let { (constraint, detail) ->
+            duplicateSwitchErrorRegex
+                .matchAt(detail, 0)
+                ?.let { match -> match.groups[1]?.value }
+                ?.let { name -> constraint to name }
         }
-    }
+        ?.let { (constraint, name) ->
+            if (constraint == "layout_design_unique_name") {
+                DuplicateDesignNameException(name, e)
+            } else {
+                null
+            }
+        }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
@@ -18,16 +18,18 @@ class LayoutDesignService(
     }
 
     @Transactional
-    fun update(id: IntId<LayoutDesign>, request: LayoutDesignSaveRequest): IntId<LayoutDesign> = try {
-        dao.update(id, request)
-    } catch (e: DataIntegrityViolationException) {
-        throw asDuplicateNameException(e) ?: e
-    }
+    fun update(id: IntId<LayoutDesign>, request: LayoutDesignSaveRequest): IntId<LayoutDesign> =
+        try {
+            dao.update(id, request)
+        } catch (e: DataIntegrityViolationException) {
+            throw asDuplicateNameException(e) ?: e
+        }
 
     @Transactional
-    fun insert(request: LayoutDesignSaveRequest): IntId<LayoutDesign> = try {
-        dao.insert(request)
-    } catch (e: DataIntegrityViolationException) {
-        throw asDuplicateNameException(e) ?: e
-    }
+    fun insert(request: LayoutDesignSaveRequest): IntId<LayoutDesign> =
+        try {
+            dao.insert(request)
+        } catch (e: DataIntegrityViolationException) {
+            throw asDuplicateNameException(e) ?: e
+        }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -47,7 +47,9 @@ import kotlin.math.min
 const val POINT_SEEK_TOLERANCE = 1.0
 
 enum class GeometrySource {
-    IMPORTED, PLAN, GENERATED,
+    IMPORTED,
+    PLAN,
+    GENERATED,
 }
 
 fun emptyAlignment() = LayoutAlignment(segments = listOf())
@@ -85,25 +87,46 @@ interface IAlignment : Loggable {
     val id: DomainId<*>
     val boundingBox: BoundingBox?
 
-    val length: Double get() = segments.lastOrNull()?.let(ISegment::endM) ?: 0.0
-    val firstSegmentStart: SegmentPoint? get() = segments.firstOrNull()?.segmentStart
-    val lastSegmentEnd: SegmentPoint? get() = segments.lastOrNull()?.segmentEnd
-    val start: AlignmentPoint? get() = segments.firstOrNull()?.alignmentStart
-    val end: AlignmentPoint? get() = segments.lastOrNull()?.alignmentEnd
+    val length: Double
+        get() = segments.lastOrNull()?.let(ISegment::endM) ?: 0.0
+
+    val firstSegmentStart: SegmentPoint?
+        get() = segments.firstOrNull()?.segmentStart
+
+    val lastSegmentEnd: SegmentPoint?
+        get() = segments.lastOrNull()?.segmentEnd
+
+    val start: AlignmentPoint?
+        get() = segments.firstOrNull()?.alignmentStart
+
+    val end: AlignmentPoint?
+        get() = segments.lastOrNull()?.alignmentEnd
 
     private fun getSegmentPoints(downward: Boolean): Sequence<Pair<SegmentPoint, ISegment>> =
-        (if (downward) segments.asReversed() else segments).asSequence().flatMapIndexed { index, segment ->
-            (if (downward && index == 0 || !downward && index == segments.lastIndex) segment.segmentPoints
-            else segment.segmentPoints.subList(0, segment.segmentPoints.size - 1))
+        (if (downward) segments.asReversed() else segments).asSequence().flatMapIndexed {
+            index,
+            segment ->
+            (if (downward && index == 0 || !downward && index == segments.lastIndex)
+                    segment.segmentPoints
+                else segment.segmentPoints.subList(0, segment.segmentPoints.size - 1))
                 .let { if (downward) it.asReversed() else it }
                 .map { it to segment }
         }
 
-    val allSegmentPoints: Sequence<SegmentPoint> get() = getSegmentPoints(false).map { (point) -> point }
+    val allSegmentPoints: Sequence<SegmentPoint>
+        get() = getSegmentPoints(false).map { (point) -> point }
+
     val allAlignmentPoints: Sequence<AlignmentPoint>
-        get() = getSegmentPoints(false).map { (point, segment) -> point.toAlignmentPoint(segment.startM) }
+        get() =
+            getSegmentPoints(false).map { (point, segment) ->
+                point.toAlignmentPoint(segment.startM)
+            }
+
     val allAlignmentPointsDownward: Sequence<AlignmentPoint>
-        get() = getSegmentPoints(true).map { (point, segment) -> point.toAlignmentPoint(segment.startM) }
+        get() =
+            getSegmentPoints(true).map { (point, segment) ->
+                point.toAlignmentPoint(segment.startM)
+            }
 
     fun filterSegmentsByBbox(bbox: BoundingBox): List<ISegment> {
         return if (!bbox.intersects(boundingBox)) {
@@ -113,8 +136,13 @@ interface IAlignment : Loggable {
         }
     }
 
-    fun getClosestPoint(target: IPoint, snapDistance: Double = 0.0): Pair<AlignmentPoint, IntersectType>? =
-        getClosestPointM(target)?.let { (m, type) -> getPointAtM(m, snapDistance)?.let { p -> p to type } }
+    fun getClosestPoint(
+        target: IPoint,
+        snapDistance: Double = 0.0
+    ): Pair<AlignmentPoint, IntersectType>? =
+        getClosestPointM(target)?.let { (m, type) ->
+            getPointAtM(m, snapDistance)?.let { p -> p to type }
+        }
 
     fun getClosestPointM(target: IPoint): Pair<Double, IntersectType>? =
         findClosestSegmentIndex(target)?.let { segmentIndex ->
@@ -123,7 +151,8 @@ interface IAlignment : Loggable {
                 val proportion = closestPointProportionOnGeneratedSegment(segmentIndex, target)
                 val interpolatedInternalM = proportion * segment.length
                 if (interpolatedInternalM < -POINT_SEEK_TOLERANCE) segment.startM to BEFORE
-                else if (interpolatedInternalM > segment.length + POINT_SEEK_TOLERANCE) segment.endM to AFTER
+                else if (interpolatedInternalM > segment.length + POINT_SEEK_TOLERANCE)
+                    segment.endM to AFTER
                 else if (interpolatedInternalM < 0.0) segment.startM to WITHIN
                 else if (interpolatedInternalM > segment.length) segment.endM to WITHIN
                 else segment.startM + interpolatedInternalM to WITHIN
@@ -134,17 +163,15 @@ interface IAlignment : Loggable {
 
     fun getPointAtM(m: Double, snapDistance: Double = 0.0): AlignmentPoint? =
         if (m <= 0.0) start
-        else if (m >= length) end
-        else getSegmentAtM(m)?.seekPointAtM(m, snapDistance)?.point
+        else if (m >= length) end else getSegmentAtM(m)?.seekPointAtM(m, snapDistance)?.point
 
     fun getSegmentIndexAtM(m: Double) =
-        if (m < 0 || m > length + LAYOUT_M_DELTA) throw IllegalArgumentException("m of $m out of range 0..${length + LAYOUT_M_DELTA}") else m
-            .coerceAtMost(length)
-            .let { clampedM ->
+        if (m < 0 || m > length + LAYOUT_M_DELTA)
+            throw IllegalArgumentException("m of $m out of range 0..${length + LAYOUT_M_DELTA}")
+        else
+            m.coerceAtMost(length).let { clampedM ->
                 segments.binarySearch { s ->
-                    if (clampedM < s.startM) 1
-                    else if (clampedM > s.endM) -1
-                    else 0
+                    if (clampedM < s.startM) 1 else if (clampedM > s.endM) -1 else 0
                 }
             }
 
@@ -168,7 +195,8 @@ interface IAlignment : Loggable {
         return if (segment.source == GENERATED) {
             closestPointProportionOnGeneratedSegment(segmentIndex, target) < 0.0
         } else {
-            closestPointProportionOnLine(segment.segmentPoints[0], segment.segmentPoints[1], target) < 0.0
+            closestPointProportionOnLine(
+                segment.segmentPoints[0], segment.segmentPoints[1], target) < 0.0
         }
     }
 
@@ -186,15 +214,20 @@ interface IAlignment : Loggable {
     }
 
     // For generated segments, we use projections based on next/prev segment directions
-    // Similarly, when finding the closest point on an alignment, we assume the segment going with that angle
-    private fun closestPointProportionOnGeneratedSegment(segmentIndex: Int, target: IPoint): Double {
+    // Similarly, when finding the closest point on an alignment, we assume the segment going with
+    // that angle
+    private fun closestPointProportionOnGeneratedSegment(
+        segmentIndex: Int,
+        target: IPoint
+    ): Double {
         val segment = segments[segmentIndex]
         val start = segment.segmentStart
         val end = segment.segmentEnd
         val prevDir = segments.getOrNull(segmentIndex - 1)?.endDirection
         val nextDir = segments.getOrNull(segmentIndex + 1)?.startDirection
-        val fakeDir = if (prevDir != null && nextDir != null) angleAvgRads(prevDir, nextDir)
-        else prevDir ?: nextDir
+        val fakeDir =
+            if (prevDir != null && nextDir != null) angleAvgRads(prevDir, nextDir)
+            else prevDir ?: nextDir
 
         return if (fakeDir != null) {
             val segmentDir = directionBetweenPoints(start, end)
@@ -211,21 +244,28 @@ interface IAlignment : Loggable {
      * - Basic geometry, not geographic calc but in TM35FIN the difference is small
      * - Finds the closest by start/end, ignoring curvature
      */
-    private fun approximateClosestSegmentIndex(target: IPoint): Int? = segments
-        .mapIndexed { idx, seg -> pointDistanceToLine(seg.segmentStart, seg.segmentEnd, target) to idx }
-        .minByOrNull { (distance, _) -> distance }
-        ?.let { (_, index) -> index }
+    private fun approximateClosestSegmentIndex(target: IPoint): Int? =
+        segments
+            .mapIndexed { idx, seg ->
+                pointDistanceToLine(seg.segmentStart, seg.segmentEnd, target) to idx
+            }
+            .minByOrNull { (distance, _) -> distance }
+            ?.let { (_, index) -> index }
 
     fun getMaxDirectionDeltaRads(): Double =
-        allSegmentPoints.zipWithNext(::directionBetweenPoints).zipWithNext(::angleDiffRads).maxOrNull() ?: 0.0
+        allSegmentPoints
+            .zipWithNext(::directionBetweenPoints)
+            .zipWithNext(::angleDiffRads)
+            .maxOrNull() ?: 0.0
 
     fun isWithinDistanceOfPoint(point: Point, distance: Double): Boolean =
-        (boundingBox?.intersects(boundingBoxAroundPoint(point, distance))
-            ?: false) && getClosestPoint(point)?.let { closestPoint ->
-            lineLength(point, closestPoint.first.toPoint()) <= distance
-        } ?: false
+        (boundingBox?.intersects(boundingBoxAroundPoint(point, distance)) ?: false) &&
+            getClosestPoint(point)?.let { closestPoint ->
+                lineLength(point, closestPoint.first.toPoint()) <= distance
+            } ?: false
 
-    override fun toLog(): String = logFormat("id" to id, "segments" to segments.size, "length" to round(length, 3))
+    override fun toLog(): String =
+        logFormat("id" to id, "segments" to segments.size, "length" to round(length, 3))
 }
 
 data class LayoutAlignment(
@@ -233,7 +273,8 @@ data class LayoutAlignment(
     override val id: DomainId<LayoutAlignment> = StringId(),
     val dataType: DataType = DataType.TEMP,
 ) : IAlignment {
-    override val boundingBox: BoundingBox? = boundingBoxCombining(segments.mapNotNull { s -> s.boundingBox })
+    override val boundingBox: BoundingBox? =
+        boundingBoxCombining(segments.mapNotNull { s -> s.boundingBox })
 
     init {
         segments.forEachIndexed { index, segment ->
@@ -245,13 +286,13 @@ data class LayoutAlignment(
                 val previous = segments[index - 1]
                 require(previous.segmentEnd.isSame(segment.segmentStart, LAYOUT_COORDINATE_DELTA)) {
                     "Alignment segment doesn't start where the previous one ended: " +
-                            "alignment=$id segment=$index length=${segment.length} prevLength=${previous.length} " +
-                            "diff=${lineLength(previous.segmentEnd, segment.segmentStart)}"
+                        "alignment=$id segment=$index length=${segment.length} prevLength=${previous.length} " +
+                        "diff=${lineLength(previous.segmentEnd, segment.segmentStart)}"
                 }
                 require(isSame(previous.startM + previous.length, segment.startM, LAYOUT_M_DELTA)) {
                     "Alignment segment m-calculation should be continuous: " +
-                            "alignment=$id segment=$index " +
-                            "prevStart=${previous.startM} prevLength=${previous.length} nextStart=${segment.startM}"
+                        "alignment=$id segment=$index " +
+                        "prevStart=${previous.startM} prevLength=${previous.length} nextStart=${segment.startM}"
                 }
             }
         }
@@ -261,7 +302,8 @@ data class LayoutAlignment(
 
     fun takeFirst(count: Int): List<AlignmentPoint> = allAlignmentPoints.take(count).toList()
 
-    fun takeLast(count: Int): List<AlignmentPoint> = allAlignmentPointsDownward.take(count).toList().asReversed()
+    fun takeLast(count: Int): List<AlignmentPoint> =
+        allAlignmentPointsDownward.take(count).toList().asReversed()
 }
 
 data class LayoutSegmentMetadata(
@@ -274,40 +316,52 @@ data class LayoutSegmentMetadata(
     val originalSrid: Srid?,
 ) {
     fun isEmpty() =
-        alignmentName == null && planTime == null && measurementMethod == null && fileName == null && originalSrid == null
+        alignmentName == null &&
+            planTime == null &&
+            measurementMethod == null &&
+            fileName == null &&
+            originalSrid == null
 
     fun hasSameMetadata(other: LayoutSegmentMetadata): Boolean =
-        alignmentName == other.alignmentName && planTime == other.planTime && measurementMethod == other.measurementMethod && fileName == other.fileName && originalSrid == other.originalSrid
+        alignmentName == other.alignmentName &&
+            planTime == other.planTime &&
+            measurementMethod == other.measurementMethod &&
+            fileName == other.fileName &&
+            originalSrid == other.originalSrid
 }
 
 interface ISegmentGeometry {
     val resolution: Int
 
-    @get:JsonIgnore
-    val segmentPoints: List<SegmentPoint>
+    @get:JsonIgnore val segmentPoints: List<SegmentPoint>
 
-    @get:JsonIgnore
-    val startDirection: Double
+    @get:JsonIgnore val startDirection: Double
 
-    @get:JsonIgnore
-    val endDirection: Double
+    @get:JsonIgnore val endDirection: Double
 
-    @get:JsonIgnore
-    val boundingBox: BoundingBox?
+    @get:JsonIgnore val boundingBox: BoundingBox?
 
-    val segmentStart: SegmentPoint get() = segmentPoints.first()
-    val segmentEnd: SegmentPoint get() = segmentPoints.last()
-    val length: Double get() = segmentPoints.last().m
+    val segmentStart: SegmentPoint
+        get() = segmentPoints.first()
+
+    val segmentEnd: SegmentPoint
+        get() = segmentPoints.last()
+
+    val length: Double
+        get() = segmentPoints.last().m
 
     fun includes(searchPoint: IPoint): Boolean {
         return segmentPoints.any { point -> point.isSame(searchPoint, LAYOUT_COORDINATE_DELTA) }
     }
 
     /**
-     * Finds a point on the line at given in-segment m-value
-     * Snaps to actual segment points at snapDistance, if provided and greater than zero.
+     * Finds a point on the line at given in-segment m-value Snaps to actual segment points at
+     * snapDistance, if provided and greater than zero.
      */
-    fun seekPointAtSegmentM(segmentM: Double, snapDistance: Double = 0.0): PointSeekResult<SegmentPoint> {
+    fun seekPointAtSegmentM(
+        segmentM: Double,
+        snapDistance: Double = 0.0
+    ): PointSeekResult<SegmentPoint> {
         return if (segmentM <= 0.0) {
             PointSeekResult(segmentStart, 0, true)
         } else if (segmentM >= length) {
@@ -324,7 +378,8 @@ interface ISegmentGeometry {
                     PointSeekResult(pointAfter, indexAfter, true)
                 } else {
                     val portion = (segmentM - pointBefore.m) / (pointAfter.m - pointBefore.m)
-                    PointSeekResult(interpolate(pointBefore, pointAfter, portion), indexAfter, false)
+                    PointSeekResult(
+                        interpolate(pointBefore, pointAfter, portion), indexAfter, false)
                 }
             } ?: PointSeekResult(pointAfter, indexAfter, true)
         }
@@ -343,22 +398,28 @@ data class SegmentGeometry(
         directionBetweenPoints(segmentPoints[0], segmentPoints[1])
     }
     override val endDirection: Double by lazy {
-        directionBetweenPoints(segmentPoints[segmentPoints.lastIndex - 1], segmentPoints[segmentPoints.lastIndex])
+        directionBetweenPoints(
+            segmentPoints[segmentPoints.lastIndex - 1], segmentPoints[segmentPoints.lastIndex])
     }
 
     init {
         require(resolution > 0) { "Invalid segment geometry resolution: $resolution" }
-        require(segmentPoints.size >= 2) { "Segment geometry must have at least 2 points: points=${segmentPoints.size}" }
+        require(segmentPoints.size >= 2) {
+            "Segment geometry must have at least 2 points: points=${segmentPoints.size}"
+        }
         require(length.isFinite() && length >= 0.0) { "Invalid length: $length" }
         require(segmentPoints.first().m == 0.0) { "Segment geometry m-values should start at 0.0" }
         segmentPoints.forEachIndexed { index, point ->
-            require(index == 0 || point.x != segmentPoints[index - 1].x || point.y != segmentPoints[index - 1].y) {
-                "There should be no duplicate points in segment geometry:" +
+            require(
+                index == 0 ||
+                    point.x != segmentPoints[index - 1].x ||
+                    point.y != segmentPoints[index - 1].y) {
+                    "There should be no duplicate points in segment geometry:" +
                         " id=$id ${index - 1}=${segmentPoints[index - 1]} ${index}=${segmentPoints[index]}"
-            }
+                }
             require(index == 0 || point.m > segmentPoints[index - 1].m) {
                 "Segment geometry m-values should be increasing:" +
-                        " id=$id ${index - 1}=${segmentPoints[index - 1].m} $index=${point.m}"
+                    " id=$id ${index - 1}=${segmentPoints[index - 1].m} $index=${point.m}"
             }
         }
     }
@@ -366,19 +427,26 @@ data class SegmentGeometry(
     fun withPoints(segmentPoints: List<SegmentPoint>): SegmentGeometry =
         copy(segmentPoints = fixSegmentGeometryMValues(segmentPoints), id = StringId())
 
-    fun splitAtSegmentM(segmentM: Double, tolerance: Double): Pair<SegmentGeometry, SegmentGeometry?> =
+    fun splitAtSegmentM(
+        segmentM: Double,
+        tolerance: Double
+    ): Pair<SegmentGeometry, SegmentGeometry?> =
         if (segmentM !in 0.0..length) this to null
         else {
             val pointAtM = seekPointAtSegmentM(segmentM, tolerance)
-            if (pointAtM.isSnapped && (pointAtM.index <= 0 || pointAtM.index >= segmentPoints.lastIndex)) {
+            if (pointAtM.isSnapped &&
+                (pointAtM.index <= 0 || pointAtM.index >= segmentPoints.lastIndex)) {
                 this to null
             } else {
                 val firstPoints =
                     if (pointAtM.isSnapped) segmentPoints.slice(0..pointAtM.index)
                     else segmentPoints.slice(0 until pointAtM.index) + pointAtM.point
                 val secondPoints =
-                    if (pointAtM.isSnapped) segmentPoints.slice(pointAtM.index..segmentPoints.lastIndex)
-                    else listOf(pointAtM.point) + segmentPoints.slice(pointAtM.index..segmentPoints.lastIndex)
+                    if (pointAtM.isSnapped)
+                        segmentPoints.slice(pointAtM.index..segmentPoints.lastIndex)
+                    else
+                        listOf(pointAtM.point) +
+                            segmentPoints.slice(pointAtM.index..segmentPoints.lastIndex)
                 withPoints(firstPoints) to withPoints(secondPoints)
             }
         }
@@ -398,20 +466,29 @@ interface ISegmentFields {
 }
 
 interface ISegment : ISegmentGeometry, ISegmentFields {
-    @get:JsonIgnore
-    val geometry: SegmentGeometry
+    @get:JsonIgnore val geometry: SegmentGeometry
     val startM: Double
-    val endM: Double get() = startM + segmentPoints.last().m
-    val alignmentStart: AlignmentPoint get() = segmentStart.let(::toAlignmentPoint)
-    val alignmentEnd: AlignmentPoint get() = segmentEnd.let(::toAlignmentPoint)
-    val alignmentPoints: List<AlignmentPoint> get() = segmentPoints.map(::toAlignmentPoint)
+    val endM: Double
+        get() = startM + segmentPoints.last().m
+
+    val alignmentStart: AlignmentPoint
+        get() = segmentStart.let(::toAlignmentPoint)
+
+    val alignmentEnd: AlignmentPoint
+        get() = segmentEnd.let(::toAlignmentPoint)
+
+    val alignmentPoints: List<AlignmentPoint>
+        get() = segmentPoints.map(::toAlignmentPoint)
 
     fun getClosestPointM(target: IPoint): Pair<Double, IntersectType> =
         findClosestSegmentPointM(0..segmentPoints.lastIndex, target).let { (segmentM, intersect) ->
             segmentM + startM to intersect
         }
 
-    private fun findClosestSegmentPointM(range: ClosedRange<Int>, target: IPoint): Pair<Double, IntersectType> {
+    private fun findClosestSegmentPointM(
+        range: ClosedRange<Int>,
+        target: IPoint
+    ): Pair<Double, IntersectType> {
         if (range.start == range.endInclusive) {
             return segmentPoints[range.start].m to WITHIN
         } else {
@@ -421,35 +498,43 @@ interface ISegment : ISegmentGeometry, ISegmentFields {
             val first = segmentPoints[firstIndex]
             val second = segmentPoints[secondIndex]
             // Note: Basic geometry, not geographic calc, but the difference is small in TM35FIN.
-            val proportionOnLine = closestPointProportionOnLine(first, second, target).also { prop ->
-                require(prop.isFinite()) { "Invalid proportion: prop=$prop first=$first second=$second target=$target" }
-            }
+            val proportionOnLine =
+                closestPointProportionOnLine(first, second, target).also { prop ->
+                    require(prop.isFinite()) {
+                        "Invalid proportion: prop=$prop first=$first second=$second target=$target"
+                    }
+                }
 
             val interpolatedM = interpolate(first.m, second.m, proportionOnLine)
             return if (firstIndex == 0 && interpolatedM < first.m - POINT_SEEK_TOLERANCE) {
                 // If in beginning & target is over 1m farther in negative direction
                 first.m to BEFORE
-            } else if (secondIndex == segmentPoints.lastIndex && interpolatedM > second.m + POINT_SEEK_TOLERANCE) {
+            } else if (secondIndex == segmentPoints.lastIndex &&
+                interpolatedM > second.m + POINT_SEEK_TOLERANCE) {
                 // If in the end & target is over 1m farther in positive direction
                 second.m to AFTER
             } else if (proportionOnLine < 0.0) {
                 // Target in the negative direction (towards start)
                 findClosestSegmentPointM(range.start..firstIndex, target)
-            } else if (proportionOnLine > 1.0) {
-                // Target in the positive direction (towards end)
-                findClosestSegmentPointM(secondIndex..range.endInclusive, target)
-            } else {
-                // Found target between the points
-                interpolatedM to WITHIN
-            }.also { (length, _) ->
-                require(length.isFinite()) { "Invalid length value: length=$length target=$target" }
-            }
+            } else
+                if (proportionOnLine > 1.0) {
+                        // Target in the positive direction (towards end)
+                        findClosestSegmentPointM(secondIndex..range.endInclusive, target)
+                    } else {
+                        // Found target between the points
+                        interpolatedM to WITHIN
+                    }
+                    .also { (length, _) ->
+                        require(length.isFinite()) {
+                            "Invalid length value: length=$length target=$target"
+                        }
+                    }
         }
     }
 
     /**
-     * Finds a point on the line at given alignment m-value (segment start + in-segment m).
-     * Snaps to actual segment points at snapDistance, if provided and greater than zero.
+     * Finds a point on the line at given alignment m-value (segment start + in-segment m). Snaps to
+     * actual segment points at snapDistance, if provided and greater than zero.
      */
     fun seekPointAtM(m: Double, snapDistance: Double = 0.0): PointSeekResult<AlignmentPoint> =
         seekPointAtSegmentM(m - startM, snapDistance).let { r ->
@@ -492,7 +577,9 @@ data class LayoutSegment(
 ) : ISegmentGeometry by geometry, ISegment, Loggable {
 
     init {
-        require(source != GENERATED || segmentPoints.size == 2) { "Generated segment can't have more than 2 points" }
+        require(source != GENERATED || segmentPoints.size == 2) {
+            "Generated segment can't have more than 2 points"
+        }
         require(sourceStart?.isFinite() != false) { "Invalid source start length: $sourceStart" }
         require(startM.isFinite() && startM >= 0.0) { "Invalid start m: $startM" }
         require(endM.isFinite() && endM >= startM) { "Invalid end m: $endM" }
@@ -503,14 +590,15 @@ data class LayoutSegment(
 
     fun slice(fromIndex: Int, toIndex: Int, newStart: Double? = null): LayoutSegment? {
         return if (fromIndex >= toIndex) null
-        else segmentPoints.slice(fromIndex..toIndex).let { newPoints ->
-            val offset = newPoints.first().m
-            withPoints(
-                points = fixSegmentGeometryMValues(newPoints),
-                newStart = newStart ?: (startM + offset),
-                newSourceStart = sourceStart?.plus(offset),
-            )
-        }
+        else
+            segmentPoints.slice(fromIndex..toIndex).let { newPoints ->
+                val offset = newPoints.first().m
+                withPoints(
+                    points = fixSegmentGeometryMValues(newPoints),
+                    newStart = newStart ?: (startM + offset),
+                    newSourceStart = sourceStart?.plus(offset),
+                )
+            }
     }
 
     fun slice(mRange: Range<Double>, snapDistance: Double = 0.0): LayoutSegment {
@@ -518,7 +606,8 @@ data class LayoutSegment(
             "Slice m-range must be at least as long as snap distance: range=$mRange snapDistance=$snapDistance"
         }
         require(mRange.min + snapDistance >= startM && mRange.max - startM <= endM) {
-            "Slice m-range ends must be within segment (with snapDistance tolerance):" + " range=$mRange snapDistance=$snapDistance segment=${startM..endM}"
+            "Slice m-range ends must be within segment (with snapDistance tolerance):" +
+                " range=$mRange snapDistance=$snapDistance segment=${startM..endM}"
         }
         val start = seekPointAtSegmentM(mRange.min - startM, snapDistance)
         val end = seekPointAtSegmentM(mRange.max - startM, snapDistance)
@@ -531,13 +620,20 @@ data class LayoutSegment(
         return withPoints(newPoints, startM + startCutLength, sourceStart?.plus(startCutLength))
     }
 
-    fun withPoints(points: List<SegmentPoint>, newStart: Double, newSourceStart: Double?): LayoutSegment =
-        withGeometry(geometry.withPoints(points), newStart, newSourceStart)
+    fun withPoints(
+        points: List<SegmentPoint>,
+        newStart: Double,
+        newSourceStart: Double?
+    ): LayoutSegment = withGeometry(geometry.withPoints(points), newStart, newSourceStart)
 
-    private fun withGeometry(geometry: SegmentGeometry, newStart: Double, newSourceStart: Double?): LayoutSegment =
-        copy(geometry = geometry, startM = newStart, sourceStart = newSourceStart)
+    private fun withGeometry(
+        geometry: SegmentGeometry,
+        newStart: Double,
+        newSourceStart: Double?
+    ): LayoutSegment = copy(geometry = geometry, startM = newStart, sourceStart = newSourceStart)
 
-    fun withStartM(newStartM: Double): LayoutSegment = if (newStartM == startM) this else copy(startM = newStartM)
+    fun withStartM(newStartM: Double): LayoutSegment =
+        if (newStartM == startM) this else copy(startM = newStartM)
 
     fun splitAtM(m: Double, tolerance: Double): Pair<LayoutSegment, LayoutSegment?> {
         val (startGeom, endGeom) = geometry.splitAtSegmentM(m - startM, tolerance)
@@ -546,7 +642,8 @@ data class LayoutSegment(
         } else {
             val splitLength = startGeom.length
             val startSegment = withGeometry(startGeom, startM, sourceStart)
-            val endSegment = withGeometry(endGeom, startM + splitLength, sourceStart?.plus(splitLength))
+            val endSegment =
+                withGeometry(endGeom, startM + splitLength, sourceStart?.plus(splitLength))
             startSegment to endSegment
         }
     }
@@ -555,7 +652,8 @@ data class LayoutSegment(
         if (switchId == null && startJointNumber == null && endJointNumber == null) this
         else copy(switchId = null, startJointNumber = null, endJointNumber = null)
 
-    override fun toLog(): String = logFormat("id" to id, "source" to source, "geometry" to geometry.toLog())
+    override fun toLog(): String =
+        logFormat("id" to id, "source" to source, "geometry" to geometry.toLog())
 }
 
 const val LAYOUT_COORDINATE_DELTA = 0.001
@@ -569,18 +667,18 @@ interface LayoutPoint : IPoint3DM {
 
     fun isSame(other: LayoutPoint) =
         this::class == other::class &&
-                super.isSame(other, LAYOUT_COORDINATE_DELTA) &&
-                isSame(z, other.z, LAYOUT_HEIGHT_DELTA) &&
-                isSame(cant, other.cant, LAYOUT_CANT_DELTA)
+            super.isSame(other, LAYOUT_COORDINATE_DELTA) &&
+            isSame(z, other.z, LAYOUT_HEIGHT_DELTA) &&
+            isSame(cant, other.cant, LAYOUT_CANT_DELTA)
+
     fun isSame(other: IPoint) = super.isSame(other, LAYOUT_COORDINATE_DELTA)
 }
+
 data class SegmentPoint(
     override val x: Double,
     override val y: Double,
     override val z: Double?,
-    /**
-     * Length (in meters) along the segment, from start to this point.
-     */
+    /** Length (in meters) along the segment, from start to this point. */
     override val m: Double,
     override val cant: Double?,
 ) : LayoutPoint {
@@ -596,9 +694,7 @@ data class AlignmentPoint(
     override val x: Double,
     override val y: Double,
     override val z: Double?,
-    /**
-     * Length (in meters) along the alignment, from start to this point.
-     */
+    /** Length (in meters) along the alignment, from start to this point. */
     override val m: Double,
     override val cant: Double?,
 ) : LayoutPoint {
@@ -611,7 +707,9 @@ data class AlignmentPoint(
 }
 
 fun verifyPointValues(x: Double, y: Double, m: Double, z: Double?, cant: Double?) {
-    require(x.isFinite() && y.isFinite() && m.isFinite()) { "Cannot create layout point of: x=$x y=$y m=$m" }
+    require(x.isFinite() && y.isFinite() && m.isFinite()) {
+        "Cannot create layout point of: x=$x y=$y m=$m"
+    }
     require(z?.isFinite() != false) { "Invalid Z value: $z" }
     require(cant?.isFinite() != false) { "Invalid cant value: $cant" }
     require(m >= 0.0) { "Layout point m-value must be positive" }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -107,7 +107,9 @@ class LayoutKmPostController(
         @RequestParam("includeDeleted") includeDeleted: Boolean,
     ): ResponseEntity<TrackLayoutKmPost> {
         val context = LayoutContext.of(branch, publicationState)
-        return kmPostService.getByKmNumber(context, trackNumberId, kmNumber, includeDeleted).let(::toResponse)
+        return kmPostService
+            .getByKmNumber(context, trackNumberId, kmNumber, includeDeleted)
+            .let(::toResponse)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
@@ -118,7 +120,10 @@ class LayoutKmPostController(
         @PathVariable("id") id: IntId<TrackLayoutKmPost>,
     ): ResponseEntity<ValidatedAsset<TrackLayoutKmPost>> {
         val context = LayoutContext.of(branch, publicationState)
-        return publicationService.validateKmPosts(context, listOf(id)).firstOrNull().let(::toResponse)
+        return publicationService
+            .validateKmPosts(context, listOf(id))
+            .firstOrNull()
+            .let(::toResponse)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -18,15 +18,14 @@ import fi.fta.geoviite.infra.util.getIntIdOrNull
 import fi.fta.geoviite.infra.util.getKmNumber
 import fi.fta.geoviite.infra.util.getLayoutContextData
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
-import fi.fta.geoviite.infra.util.getPointOrNull
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
 import fi.fta.geoviite.infra.util.toDbId
+import java.sql.ResultSet
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
 
 const val KM_POST_CACHE_SIZE = 10000L
 
@@ -35,7 +34,12 @@ const val KM_POST_CACHE_SIZE = 10000L
 class LayoutKmPostDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
     @Value("\${geoviite.cache.enabled}") cacheEnabled: Boolean,
-) : LayoutAssetDao<TrackLayoutKmPost>(jdbcTemplateParam, LayoutAssetTable.LAYOUT_ASSET_KM_POST, cacheEnabled, KM_POST_CACHE_SIZE) {
+) :
+    LayoutAssetDao<TrackLayoutKmPost>(
+        jdbcTemplateParam,
+        LayoutAssetTable.LAYOUT_ASSET_KM_POST,
+        cacheEnabled,
+        KM_POST_CACHE_SIZE) {
 
     override fun fetchVersions(layoutContext: LayoutContext, includeDeleted: Boolean) =
         fetchVersions(layoutContext, includeDeleted, null, null)
@@ -45,8 +49,10 @@ class LayoutKmPostDao(
         includeDeleted: Boolean,
         trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
         bbox: BoundingBox? = null,
-    ): List<TrackLayoutKmPost> = fetchVersions(layoutContext, includeDeleted, trackNumberId, bbox)
-        .map { r -> fetch(r.rowVersion) }
+    ): List<TrackLayoutKmPost> =
+        fetchVersions(layoutContext, includeDeleted, trackNumberId, bbox).map { r ->
+            fetch(r.rowVersion)
+        }
 
     fun fetchVersions(
         layoutContext: LayoutContext,
@@ -54,7 +60,8 @@ class LayoutKmPostDao(
         trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
         bbox: BoundingBox? = null,
     ): List<LayoutDaoResponse<TrackLayoutKmPost>> {
-        val sql = """
+        val sql =
+            """
             select km_post.official_id, km_post.row_id, km_post.row_version 
             from layout.km_post_in_layout_context(:publication_state::layout.publication_state, :design_id) km_post
             where (:include_deleted = true or km_post.state != 'DELETED')
@@ -64,7 +71,8 @@ class LayoutKmPostDao(
                 postgis.st_polygonfromtext(:polygon_wkt::varchar, :map_srid)
               ))
             order by km_post.track_number_id, km_post.km_number
-        """.trimIndent()
+        """
+                .trimIndent()
         return jdbcTemplate.query(
             sql,
             mapOf(
@@ -86,7 +94,8 @@ class LayoutKmPostDao(
         kmPostIdsToPublish: List<IntId<TrackLayoutKmPost>>,
     ): Map<IntId<TrackLayoutTrackNumber>, List<LayoutDaoResponse<TrackLayoutKmPost>>> {
         if (trackNumberIds.isEmpty()) return emptyMap()
-        val sql = """
+        val sql =
+            """
             select km_post.track_number_id, km_post.official_id, km_post.row_id, km_post.row_version
             from (
               select * from layout.km_post_in_layout_context('DRAFT', :design_id)
@@ -98,21 +107,29 @@ class LayoutKmPostDao(
             where track_number_id in (:track_number_ids)
               and km_post.state != 'DELETED'
             order by km_post.track_number_id, km_post.km_number
-        """.trimIndent()
-        val params = mapOf(
-            "track_number_ids" to trackNumberIds.map { id -> id.intValue },
-            "design_id" to branch.designId?.intValue,
-            // listOf(null) to indicate an empty list due to SQL syntax limitations; the "is distinct from true" checks
-            // explicitly for false or null, since "foo in (null)" in SQL is null
-            "km_post_ids_to_publish" to (kmPostIdsToPublish.map { id -> id.intValue }.ifEmpty { listOf(null) }),
-        )
-        val versions = jdbcTemplate.query(sql, params) { rs, _ ->
-            val trackNumberId = rs.getIntId<TrackLayoutTrackNumber>("track_number_id")
-            val version = rs.getDaoResponse<TrackLayoutKmPost>("official_id", "row_id", "row_version")
-            trackNumberId to version
-        }
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "track_number_ids" to trackNumberIds.map { id -> id.intValue },
+                "design_id" to branch.designId?.intValue,
+                // listOf(null) to indicate an empty list due to SQL syntax limitations; the "is
+                // distinct from true" checks
+                // explicitly for false or null, since "foo in (null)" in SQL is null
+                "km_post_ids_to_publish" to
+                    (kmPostIdsToPublish.map { id -> id.intValue }.ifEmpty { listOf(null) }),
+            )
+        val versions =
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                val trackNumberId = rs.getIntId<TrackLayoutTrackNumber>("track_number_id")
+                val version =
+                    rs.getDaoResponse<TrackLayoutKmPost>("official_id", "row_id", "row_version")
+                trackNumberId to version
+            }
         return trackNumberIds.associateWith { trackNumberId ->
-            versions.filter { (tnId, _) -> tnId == trackNumberId }.map { (_, kmPostVersions) -> kmPostVersions }
+            versions
+                .filter { (tnId, _) -> tnId == trackNumberId }
+                .map { (_, kmPostVersions) -> kmPostVersions }
         }
     }
 
@@ -122,28 +139,33 @@ class LayoutKmPostDao(
         kmNumber: KmNumber,
         includeDeleted: Boolean,
     ): LayoutRowVersion<TrackLayoutKmPost>? {
-        val sql = """
+        val sql =
+            """
             select km_post.row_id, km_post.row_version 
             from layout.km_post_in_layout_context(:publication_state::layout.publication_state, :design_id) km_post
             where (:include_deleted or km_post.state != 'DELETED')
               and km_post.track_number_id = :track_number_id
               and km_post.km_number = :km_number
-        """.trimIndent()
-        val params = mapOf(
-            "track_number_id" to trackNumberId.intValue,
-            "km_number" to kmNumber.toString(),
-            "publication_state" to layoutContext.state.name,
-            "design_id" to layoutContext.branch.designId?.intValue,
-            "include_deleted" to includeDeleted,
-        )
-        val result = jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getLayoutRowVersion<TrackLayoutKmPost>("row_id", "row_version")
-        }
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "track_number_id" to trackNumberId.intValue,
+                "km_number" to kmNumber.toString(),
+                "publication_state" to layoutContext.state.name,
+                "design_id" to layoutContext.branch.designId?.intValue,
+                "include_deleted" to includeDeleted,
+            )
+        val result =
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                rs.getLayoutRowVersion<TrackLayoutKmPost>("row_id", "row_version")
+            }
         return result.firstOrNull()
     }
 
     override fun fetchInternal(version: LayoutRowVersion<TrackLayoutKmPost>): TrackLayoutKmPost {
-        val sql = """
+        val sql =
+            """
             select 
               id as row_id,
               version as row_version,
@@ -164,18 +186,20 @@ class LayoutKmPostDao(
             where id = :id 
               and version = :version
               and deleted = false
-        """.trimIndent()
-        val params = mapOf(
-            "id" to version.rowId.intValue,
-            "version" to version.version,
-        )
-        return getOne(version, jdbcTemplate.query(sql, params) { rs, _ -> getLayoutKmPost(rs) }).also {
-            logger.daoAccess(AccessType.FETCH, TrackLayoutKmPost::class, version)
-        }
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "id" to version.rowId.intValue,
+                "version" to version.version,
+            )
+        return getOne(version, jdbcTemplate.query(sql, params) { rs, _ -> getLayoutKmPost(rs) })
+            .also { logger.daoAccess(AccessType.FETCH, TrackLayoutKmPost::class, version) }
     }
 
     override fun preloadCache() {
-        val sql = """
+        val sql =
+            """
             select 
               id as row_id,
               version as row_version,
@@ -193,40 +217,46 @@ class LayoutKmPostDao(
               gk_location_confirmed,
               state
             from layout.km_post
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val posts = jdbcTemplate
-            .query(sql, mapOf<String, Any>()) { rs, _ -> getLayoutKmPost(rs) }
-            .associateBy(TrackLayoutKmPost::version)
+        val posts =
+            jdbcTemplate
+                .query(sql, mapOf<String, Any>()) { rs, _ -> getLayoutKmPost(rs) }
+                .associateBy(TrackLayoutKmPost::version)
         logger.daoAccess(AccessType.FETCH, TrackLayoutKmPost::class, posts.keys)
         cache.putAll(posts)
     }
 
-    private fun getLayoutKmPost(rs: ResultSet): TrackLayoutKmPost = TrackLayoutKmPost(
-        trackNumberId = rs.getIntId("track_number_id"),
-        kmNumber = rs.getKmNumber("km_number"),
-        gkLocation = rs.getGeometryPointOrNull("gk_point_x", "gk_point_y", "gk_srid"),
-        gkLocationSource = rs.getEnumOrNull<KmPostGkLocationSource>("gk_location_source"),
-        gkLocationConfirmed = rs.getBoolean("gk_location_confirmed"),
-        state = rs.getEnum("state"),
-        sourceId = rs.getIntIdOrNull("geometry_km_post_id"),
-
-        contextData = rs.getLayoutContextData(
-            "official_row_id",
-            "design_row_id",
-            "design_id",
-            "row_id",
-            "row_version",
-            "draft",
-        ),
-    )
+    private fun getLayoutKmPost(rs: ResultSet): TrackLayoutKmPost =
+        TrackLayoutKmPost(
+            trackNumberId = rs.getIntId("track_number_id"),
+            kmNumber = rs.getKmNumber("km_number"),
+            gkLocation = rs.getGeometryPointOrNull("gk_point_x", "gk_point_y", "gk_srid"),
+            gkLocationSource = rs.getEnumOrNull<KmPostGkLocationSource>("gk_location_source"),
+            gkLocationConfirmed = rs.getBoolean("gk_location_confirmed"),
+            state = rs.getEnum("state"),
+            sourceId = rs.getIntIdOrNull("geometry_km_post_id"),
+            contextData =
+                rs.getLayoutContextData(
+                    "official_row_id",
+                    "design_row_id",
+                    "design_id",
+                    "row_id",
+                    "row_version",
+                    "draft",
+                ),
+        )
 
     @Transactional
     override fun insert(newItem: TrackLayoutKmPost): LayoutDaoResponse<TrackLayoutKmPost> {
-        val trackNumberId = toDbId(requireNotNull(newItem.trackNumberId) {
-            "KM post not linked to TrackNumber: kmPost=$newItem"
-        })
-        val sql = """
+        val trackNumberId =
+            toDbId(
+                requireNotNull(newItem.trackNumberId) {
+                    "KM post not linked to TrackNumber: kmPost=$newItem"
+                })
+        val sql =
+            """
             insert into layout.km_post(
               track_number_id, 
               geometry_km_post_id, 
@@ -259,42 +289,49 @@ class LayoutKmPostDao(
               coalesce(official_row_id, id) as official_id,
               id as row_id,
               version as row_version
-        """.trimIndent()
-        val params = mapOf(
-            "track_number_id" to trackNumberId.intValue,
-            "geometry_km_post_id" to newItem.sourceId?.let(::toDbId)?.intValue,
-            "km_number" to newItem.kmNumber.toString(),
-            "layout_x" to newItem.layoutLocation?.x,
-            "layout_y" to newItem.layoutLocation?.y,
-            "layout_srid" to LAYOUT_SRID.code,
-            "gk_x" to newItem.gkLocation?.x,
-            "gk_y" to newItem.gkLocation?.y,
-            "gk_srid" to newItem.gkLocation?.srid?.code,
-            "gk_location_confirmed" to newItem.gkLocationConfirmed,
-            "gk_location_source" to newItem.gkLocationSource?.name,
-            "state" to newItem.state.name,
-            "draft" to newItem.contextData.isDraft,
-            "official_row_id" to newItem.contextData.officialRowId?.intValue,
-            "design_row_id" to newItem.contextData.designRowId?.intValue,
-            "design_id" to newItem.contextData.designId?.intValue,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "track_number_id" to trackNumberId.intValue,
+                "geometry_km_post_id" to newItem.sourceId?.let(::toDbId)?.intValue,
+                "km_number" to newItem.kmNumber.toString(),
+                "layout_x" to newItem.layoutLocation?.x,
+                "layout_y" to newItem.layoutLocation?.y,
+                "layout_srid" to LAYOUT_SRID.code,
+                "gk_x" to newItem.gkLocation?.x,
+                "gk_y" to newItem.gkLocation?.y,
+                "gk_srid" to newItem.gkLocation?.srid?.code,
+                "gk_location_confirmed" to newItem.gkLocationConfirmed,
+                "gk_location_source" to newItem.gkLocationSource?.name,
+                "state" to newItem.state.name,
+                "draft" to newItem.contextData.isDraft,
+                "official_row_id" to newItem.contextData.officialRowId?.intValue,
+                "design_row_id" to newItem.contextData.designRowId?.intValue,
+                "design_id" to newItem.contextData.designId?.intValue,
+            )
         jdbcTemplate.setUser()
-        val response: LayoutDaoResponse<TrackLayoutKmPost> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getDaoResponse("official_id", "row_id", "row_version")
-        } ?: throw IllegalStateException("Failed to generate ID for new km-post")
+        val response: LayoutDaoResponse<TrackLayoutKmPost> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+                rs.getDaoResponse("official_id", "row_id", "row_version")
+            } ?: throw IllegalStateException("Failed to generate ID for new km-post")
         logger.daoAccess(AccessType.INSERT, TrackLayoutKmPost::class, response)
         return response
     }
 
     @Transactional
     override fun update(updatedItem: TrackLayoutKmPost): LayoutDaoResponse<TrackLayoutKmPost> {
-        val trackNumberId = toDbId(requireNotNull(updatedItem.trackNumberId) {
-            "KM post not linked to TrackNumber: kmPost=$updatedItem"
-        })
-        val rowId = requireNotNull(updatedItem.contextData.rowId) {
-            "Cannot update a row that doesn't have a DB ID: kmPost=$updatedItem"
-        }
-        val sql = """
+        val trackNumberId =
+            toDbId(
+                requireNotNull(updatedItem.trackNumberId) {
+                    "KM post not linked to TrackNumber: kmPost=$updatedItem"
+                })
+        val rowId =
+            requireNotNull(updatedItem.contextData.rowId) {
+                "Cannot update a row that doesn't have a DB ID: kmPost=$updatedItem"
+            }
+        val sql =
+            """
             update layout.km_post 
             set
               track_number_id = :track_number_id, 
@@ -314,30 +351,35 @@ class LayoutKmPostDao(
               coalesce(official_row_id, design_row_id, id) as official_id,
               id as row_id,
               version as row_version
-        """.trimIndent()
-        val params = mapOf(
-            "km_post_id" to rowId.intValue,
-            "track_number_id" to trackNumberId.intValue,
-            "geometry_km_post_id" to updatedItem.sourceId?.let(::toDbId)?.intValue,
-            "km_number" to updatedItem.kmNumber.toString(),
-            "layout_x" to updatedItem.layoutLocation?.x,
-            "layout_y" to updatedItem.layoutLocation?.y,
-            "layout_srid" to LAYOUT_SRID.code,
-            "gk_x" to updatedItem.gkLocation?.x,
-            "gk_y" to updatedItem.gkLocation?.y,
-            "gk_srid" to updatedItem.gkLocation?.srid?.code,
-            "gk_location_confirmed" to updatedItem.gkLocationConfirmed,
-            "gk_location_source" to updatedItem.gkLocationSource?.name,
-            "state" to updatedItem.state.name,
-            "draft" to updatedItem.isDraft,
-            "official_row_id" to updatedItem.contextData.officialRowId?.intValue,
-            "design_row_id" to updatedItem.contextData.designRowId?.intValue,
-            "design_id" to updatedItem.contextData.designId?.intValue,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "km_post_id" to rowId.intValue,
+                "track_number_id" to trackNumberId.intValue,
+                "geometry_km_post_id" to updatedItem.sourceId?.let(::toDbId)?.intValue,
+                "km_number" to updatedItem.kmNumber.toString(),
+                "layout_x" to updatedItem.layoutLocation?.x,
+                "layout_y" to updatedItem.layoutLocation?.y,
+                "layout_srid" to LAYOUT_SRID.code,
+                "gk_x" to updatedItem.gkLocation?.x,
+                "gk_y" to updatedItem.gkLocation?.y,
+                "gk_srid" to updatedItem.gkLocation?.srid?.code,
+                "gk_location_confirmed" to updatedItem.gkLocationConfirmed,
+                "gk_location_source" to updatedItem.gkLocationSource?.name,
+                "state" to updatedItem.state.name,
+                "draft" to updatedItem.isDraft,
+                "official_row_id" to updatedItem.contextData.officialRowId?.intValue,
+                "design_row_id" to updatedItem.contextData.designRowId?.intValue,
+                "design_id" to updatedItem.contextData.designId?.intValue,
+            )
         jdbcTemplate.setUser()
-        val response: LayoutDaoResponse<TrackLayoutKmPost> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getDaoResponse("official_id", "row_id", "row_version")
-        } ?: throw IllegalStateException("Failed to generate ID for new row version of updated km-post")
+        val response: LayoutDaoResponse<TrackLayoutKmPost> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+                rs.getDaoResponse("official_id", "row_id", "row_version")
+            }
+                ?: throw IllegalStateException(
+                    "Failed to generate ID for new row version of updated km-post")
         logger.daoAccess(AccessType.UPDATE, TrackLayoutKmPost::class, response)
         return response
     }
@@ -347,26 +389,28 @@ class LayoutKmPostDao(
         includeDeleted: Boolean,
         trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
     ): List<LayoutRowVersion<TrackLayoutKmPost>> {
-        val sql = """
+        val sql =
+            """
             select id, version
             from layout.km_post
             where draft
               and (:include_deleted or state != 'DELETED')
               and (:trackNumberId::int is null or track_number_id = :trackNumberId)
               and design_id is not distinct from :design_id
-        """.trimIndent()
-        return jdbcTemplate.query(
-            sql,
-            mapOf(
-                "include_deleted" to includeDeleted,
-                "trackNumberId" to trackNumberId?.intValue,
-                "design_id" to branch.designId?.intValue
-            )
-        ) { rs, _ ->
-            rs.getLayoutRowVersion<TrackLayoutKmPost>("id", "version")
-        }.also { ids ->
-            logger.daoAccess(AccessType.VERSION_FETCH, "fetchOnlyDraftVersions", ids)
-        }
+        """
+                .trimIndent()
+        return jdbcTemplate
+            .query(
+                sql,
+                mapOf(
+                    "include_deleted" to includeDeleted,
+                    "trackNumberId" to trackNumberId?.intValue,
+                    "design_id" to branch.designId?.intValue)) { rs, _ ->
+                    rs.getLayoutRowVersion<TrackLayoutKmPost>("id", "version")
+                }
+            .also { ids ->
+                logger.daoAccess(AccessType.VERSION_FETCH, "fetchOnlyDraftVersions", ids)
+            }
     }
 
     fun fetchNextWithLocationAfter(
@@ -375,7 +419,8 @@ class LayoutKmPostDao(
         kmNumber: KmNumber,
         state: LayoutState,
     ): LayoutRowVersion<TrackLayoutKmPost>? {
-        val sql = """
+        val sql =
+            """
             select row_id, row_version
             from layout.km_post_in_layout_context(:publication_state::layout.publication_state, :design_id)
             where track_number_id = :track_number_id
@@ -384,15 +429,17 @@ class LayoutKmPostDao(
               and km_number > :km_number
             order by km_number asc
             limit 1
-        """.trimIndent()
+        """
+                .trimIndent()
         return jdbcTemplate.queryOptional(
-            sql, mapOf(
+            sql,
+            mapOf(
                 "track_number_id" to trackNumberId.intValue,
                 "state" to state.name,
                 "publication_state" to layoutContext.state.name,
                 "design_id" to layoutContext.branch.designId?.intValue,
-                "km_number" to kmNumber.toString()
-            )
-        ) { rs, _ -> rs.getLayoutRowVersion("row_id", "row_version") }
+                "km_number" to kmNumber.toString())) { rs, _ ->
+                rs.getLayoutRowVersion("row_id", "row_version")
+            }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -21,17 +21,21 @@ class LayoutKmPostService(
 ) : LayoutAssetService<TrackLayoutKmPost, LayoutKmPostDao>(dao) {
 
     @Transactional
-    fun insertKmPost(branch: LayoutBranch, request: TrackLayoutKmPostSaveRequest): IntId<TrackLayoutKmPost> {
-        val kmPost = TrackLayoutKmPost(
-            kmNumber = request.kmNumber,
-            state = request.state,
-            trackNumberId = request.trackNumberId,
-            sourceId = null,
-            gkLocation = request.gkLocation,
-            gkLocationSource = request.gkLocationSource,
-            gkLocationConfirmed = request.gkLocationConfirmed,
-            contextData = LayoutContextData.newDraft(branch),
-        )
+    fun insertKmPost(
+        branch: LayoutBranch,
+        request: TrackLayoutKmPostSaveRequest
+    ): IntId<TrackLayoutKmPost> {
+        val kmPost =
+            TrackLayoutKmPost(
+                kmNumber = request.kmNumber,
+                state = request.state,
+                trackNumberId = request.trackNumberId,
+                sourceId = null,
+                gkLocation = request.gkLocation,
+                gkLocationSource = request.gkLocationSource,
+                gkLocationConfirmed = request.gkLocationConfirmed,
+                contextData = LayoutContextData.newDraft(branch),
+            )
         return saveDraftInternal(branch, kmPost).id
     }
 
@@ -41,29 +45,41 @@ class LayoutKmPostService(
         id: IntId<TrackLayoutKmPost>,
         kmPost: TrackLayoutKmPostSaveRequest,
     ): IntId<TrackLayoutKmPost> {
-        val trackLayoutKmPost = dao.getOrThrow(branch.draft, id).copy(
-            kmNumber = kmPost.kmNumber,
-            state = kmPost.state,
-            gkLocationConfirmed = kmPost.gkLocationConfirmed,
-            gkLocationSource = kmPost.gkLocationSource,
-            gkLocation = kmPost.gkLocation,
-        )
+        val trackLayoutKmPost =
+            dao.getOrThrow(branch.draft, id)
+                .copy(
+                    kmNumber = kmPost.kmNumber,
+                    state = kmPost.state,
+                    gkLocationConfirmed = kmPost.gkLocationConfirmed,
+                    gkLocationSource = kmPost.gkLocationSource,
+                    gkLocation = kmPost.gkLocation,
+                )
         return saveDraftInternal(branch, trackLayoutKmPost).id
     }
 
-    fun list(layoutContext: LayoutContext, filter: ((kmPost: TrackLayoutKmPost) -> Boolean)?): List<TrackLayoutKmPost> {
+    fun list(
+        layoutContext: LayoutContext,
+        filter: ((kmPost: TrackLayoutKmPost) -> Boolean)?
+    ): List<TrackLayoutKmPost> {
         val all = dao.list(layoutContext, false)
         return filter?.let(all::filter) ?: all
     }
 
-    fun list(layoutContext: LayoutContext, trackNumberId: IntId<TrackLayoutTrackNumber>): List<TrackLayoutKmPost> {
+    fun list(
+        layoutContext: LayoutContext,
+        trackNumberId: IntId<TrackLayoutTrackNumber>
+    ): List<TrackLayoutKmPost> {
         return dao.list(layoutContext, false, trackNumberId)
     }
 
-    fun list(layoutContext: LayoutContext, boundingBox: BoundingBox, step: Int): List<TrackLayoutKmPost> {
-        return dao
-            .list(layoutContext, false, bbox = boundingBox)
-            .filter { p -> (step <= 1 || (p.kmNumber.isPrimary() && p.kmNumber.number % step == 0)) }
+    fun list(
+        layoutContext: LayoutContext,
+        boundingBox: BoundingBox,
+        step: Int
+    ): List<TrackLayoutKmPost> {
+        return dao.list(layoutContext, false, bbox = boundingBox).filter { p ->
+            (step <= 1 || (p.kmNumber.isPrimary() && p.kmNumber.number % step == 0))
+        }
     }
 
     fun getByKmNumber(
@@ -72,7 +88,8 @@ class LayoutKmPostService(
         kmNumber: KmNumber,
         includeDeleted: Boolean,
     ): TrackLayoutKmPost? {
-        return dao.fetchVersion(layoutContext, trackNumberId, kmNumber, includeDeleted)?.let(dao::fetch)
+        return dao.fetchVersion(layoutContext, trackNumberId, kmNumber, includeDeleted)
+            ?.let(dao::fetch)
     }
 
     fun listNearbyOnTrackPaged(
@@ -84,24 +101,33 @@ class LayoutKmPostService(
     ): List<TrackLayoutKmPost> {
         val allPosts = dao.list(layoutContext, false, trackNumberId)
         val postsByDistance = allPosts.map { post -> associateByDistance(post, location) }
-        return pageToList(postsByDistance, offset, limit, ::compareByDistanceNullsFirst).map { (kmPost, _) -> kmPost }
+        return pageToList(postsByDistance, offset, limit, ::compareByDistanceNullsFirst).map {
+            (kmPost, _) ->
+            kmPost
+        }
     }
 
     @Transactional(readOnly = true)
-    fun getKmPostInfoboxExtras(layoutContext: LayoutContext, id: IntId<TrackLayoutKmPost>): KmPostInfoboxExtras {
+    fun getKmPostInfoboxExtras(
+        layoutContext: LayoutContext,
+        id: IntId<TrackLayoutKmPost>
+    ): KmPostInfoboxExtras {
         val kmPost = dao.get(layoutContext, id)
         val length = getSingleKmPostLength(layoutContext, id)
-        val geometryPlanId = if (kmPost?.sourceId is IntId) geometryDao.getPlanIdForKmPost(kmPost.sourceId) else null
+        val geometryPlanId =
+            if (kmPost?.sourceId is IntId) geometryDao.getPlanIdForKmPost(kmPost.sourceId) else null
 
         return KmPostInfoboxExtras(length, geometryPlanId)
     }
 
     fun getSingleKmPostLength(layoutContext: LayoutContext, id: IntId<TrackLayoutKmPost>): Double? {
         return dao.get(layoutContext, id)?.getAsIntegral()?.let { kmPost ->
-            referenceLineService.getByTrackNumberWithAlignment(layoutContext, kmPost.trackNumberId)
+            referenceLineService
+                .getByTrackNumberWithAlignment(layoutContext, kmPost.trackNumberId)
                 ?.let { (_, alignment) ->
                     val kmPostM = alignment.getClosestPointM(kmPost.location)?.first
-                    val kmEndM = getKmEndM(layoutContext, kmPost.trackNumberId, kmPost.kmNumber, alignment)
+                    val kmEndM =
+                        getKmEndM(layoutContext, kmPost.trackNumberId, kmPost.kmNumber, alignment)
                     if (kmPostM == null || kmEndM == null) null else kmEndM - kmPostM
                 }
         }
@@ -113,10 +139,11 @@ class LayoutKmPostService(
         kmNumber: KmNumber,
         referenceLineAlignment: LayoutAlignment,
     ): Double? {
-        val nextKmPost = dao
-            .fetchNextWithLocationAfter(layoutContext, trackNumberId, kmNumber, LayoutState.IN_USE)
-            ?.let(dao::fetch)
-            ?.getAsIntegral()
+        val nextKmPost =
+            dao.fetchNextWithLocationAfter(
+                    layoutContext, trackNumberId, kmNumber, LayoutState.IN_USE)
+                ?.let(dao::fetch)
+                ?.getAsIntegral()
         return if (nextKmPost == null) {
             referenceLineAlignment.length
         } else {
@@ -125,5 +152,8 @@ class LayoutKmPostService(
     }
 }
 
-fun associateByDistance(kmPost: TrackLayoutKmPost, comparisonPoint: Point): Pair<TrackLayoutKmPost, Double?> =
+fun associateByDistance(
+    kmPost: TrackLayoutKmPost,
+    comparisonPoint: Point
+): Pair<TrackLayoutKmPost, Double?> =
     kmPost to kmPost.layoutLocation?.let { l -> calculateDistance(LAYOUT_SRID, comparisonPoint, l) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutRowVersion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutRowVersion.kt
@@ -12,29 +12,36 @@ private val intLength = 1..(Int.MAX_VALUE.toString().length)
 
 data class LayoutRowId<T>(val intValue: Int)
 
-data class LayoutRowVersion<T> @JsonCreator(mode = DISABLED) constructor(
+data class LayoutRowVersion<T>
+@JsonCreator(mode = DISABLED)
+constructor(
     val rowId: LayoutRowId<T>,
     val version: Int,
 ) {
     private constructor(values: Pair<LayoutRowId<T>, Int>) : this(values.first, values.second)
 
-    @JsonCreator(mode = DELEGATING)
-    constructor(value: String) : this(parseVersionValues(value))
+    @JsonCreator(mode = DELEGATING) constructor(value: String) : this(parseVersionValues(value))
 
-    init { require(version > 0) { "Version numbers start at 1: version=$version" } }
+    init {
+        require(version > 0) { "Version numbers start at 1: version=$version" }
+    }
 
-    @JsonValue
-    override fun toString(): String = "${rowId.intValue}$VERSION_SEPARATOR$version"
+    @JsonValue override fun toString(): String = "${rowId.intValue}$VERSION_SEPARATOR$version"
 
     fun next() = LayoutRowVersion(rowId, version + 1)
+
     fun previous() = if (version > 1) LayoutRowVersion(rowId, version - 1) else null
 }
 
 private fun <T> parseVersionValues(stringVersion: String): Pair<LayoutRowId<T>, Int> {
     val split = stringVersion.split(VERSION_SEPARATOR)
-    require(split.size == 2) { "${LayoutRowVersion::class.simpleName} must contain 2 numbers: found ${split.size}" }
+    require(split.size == 2) {
+        "${LayoutRowVersion::class.simpleName} must contain 2 numbers: found ${split.size}"
+    }
     split.forEach { i ->
-        require(i.length in intLength) { "Invalid ${LayoutRowVersion::class.simpleName} number: ${formatForException(i)}" }
+        require(i.length in intLength) {
+            "Invalid ${LayoutRowVersion::class.simpleName} number: ${formatForException(i)}"
+        }
     }
     return LayoutRowId<T>(split[1].toInt()) to split[2].toInt()
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
@@ -28,15 +28,18 @@ class LayoutSearchController(
 ) {
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["searchTerm", "limitPerResultType"])
+    @GetMapping(
+        "/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["searchTerm", "limitPerResultType"])
     fun searchAssets(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("searchTerm", required = true) searchTerm: FreeText,
         @RequestParam("limitPerResultType", required = true) limitPerResultType: Int,
-        @RequestParam("locationTrackSearchScope", required = false) locationTrackSearchScope: IntId<LocationTrack>?,
+        @RequestParam("locationTrackSearchScope", required = false)
+        locationTrackSearchScope: IntId<LocationTrack>?,
     ): TrackLayoutSearchResult {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        return searchService.searchAssets(layoutContext, searchTerm, limitPerResultType, locationTrackSearchScope)
+        return searchService.searchAssets(
+            layoutContext, searchTerm, limitPerResultType, locationTrackSearchScope)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
@@ -8,7 +8,9 @@ import fi.fta.geoviite.infra.util.FreeText
 import org.springframework.beans.factory.annotation.Autowired
 
 @GeoviiteService
-class LayoutSearchService @Autowired constructor(
+class LayoutSearchService
+@Autowired
+constructor(
     private val switchService: LayoutSwitchService,
     private val locationTrackService: LocationTrackService,
     private val trackNumberService: LayoutTrackNumberService,
@@ -22,14 +24,20 @@ class LayoutSearchService @Autowired constructor(
         locationTrackSearchScope: IntId<LocationTrack>?,
     ): TrackLayoutSearchResult {
         return if (locationTrackSearchScope != null) {
-            searchByLocationTrackSearchScope(layoutContext, locationTrackSearchScope, searchTerm, limitPerResultType)
+            searchByLocationTrackSearchScope(
+                layoutContext, locationTrackSearchScope, searchTerm, limitPerResultType)
         } else {
             searchFromEntireRailwayNetwork(layoutContext, searchTerm, limitPerResultType)
         }
     }
 
-    fun searchAllLocationTracks(layoutContext: LayoutContext, searchTerm: FreeText, limit: Int): List<LocationTrack> {
-        return locationTrackService.list(layoutContext, true)
+    fun searchAllLocationTracks(
+        layoutContext: LayoutContext,
+        searchTerm: FreeText,
+        limit: Int
+    ): List<LocationTrack> {
+        return locationTrackService
+            .list(layoutContext, true)
             .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
             .sortedBy(LocationTrack::name)
             .take(limit)
@@ -40,14 +48,20 @@ class LayoutSearchService @Autowired constructor(
         searchTerm: FreeText,
         limit: Int,
     ): List<TrackLayoutSwitch> {
-        return switchService.list(layoutContext, true)
+        return switchService
+            .list(layoutContext, true)
             .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
             .sortedBy(TrackLayoutSwitch::name)
             .take(limit)
     }
 
-    fun searchAllTrackNumbers(layoutContext: LayoutContext, searchTerm: FreeText, limit: Int): List<TrackLayoutTrackNumber> {
-        return trackNumberService.list(layoutContext, true)
+    fun searchAllTrackNumbers(
+        layoutContext: LayoutContext,
+        searchTerm: FreeText,
+        limit: Int
+    ): List<TrackLayoutTrackNumber> {
+        return trackNumberService
+            .list(layoutContext, true)
             .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
             .sortedBy(TrackLayoutTrackNumber::number)
             .take(limit)
@@ -57,12 +71,14 @@ class LayoutSearchService @Autowired constructor(
         layoutContext: LayoutContext,
         searchTerm: FreeText,
         limitPerResultType: Int,
-    ) = TrackLayoutSearchResult(
-        switches = searchAllSwitches(layoutContext, searchTerm, limitPerResultType),
-        locationTracks = searchAllLocationTracks(layoutContext, searchTerm, limitPerResultType),
-        trackNumbers = searchAllTrackNumbers(layoutContext, searchTerm, limitPerResultType),
-        operatingPoints = ratkoLocalService.searchOperatingPoints(searchTerm, limitPerResultType),
-    )
+    ) =
+        TrackLayoutSearchResult(
+            switches = searchAllSwitches(layoutContext, searchTerm, limitPerResultType),
+            locationTracks = searchAllLocationTracks(layoutContext, searchTerm, limitPerResultType),
+            trackNumbers = searchAllTrackNumbers(layoutContext, searchTerm, limitPerResultType),
+            operatingPoints =
+                ratkoLocalService.searchOperatingPoints(searchTerm, limitPerResultType),
+        )
 
     private fun searchByLocationTrackSearchScope(
         layoutContext: LayoutContext,
@@ -70,35 +86,41 @@ class LayoutSearchService @Autowired constructor(
         searchTerm: FreeText,
         limit: Int,
     ): TrackLayoutSearchResult {
-        val switches = locationTrackService
-            .getSwitchesForLocationTrack(layoutContext, locationTrackSearchScope)
-            .let { ids -> switchService.getMany(layoutContext, ids) }
-        val locationTracks = getLocationTrackAndDuplicatesByScope(layoutContext, locationTrackSearchScope)
+        val switches =
+            locationTrackService
+                .getSwitchesForLocationTrack(layoutContext, locationTrackSearchScope)
+                .let { ids -> switchService.getMany(layoutContext, ids) }
+        val locationTracks =
+            getLocationTrackAndDuplicatesByScope(layoutContext, locationTrackSearchScope)
         val trackNumbers = emptyList<TrackLayoutTrackNumber>()
 
         return TrackLayoutSearchResult(
-            switches = switches
-                .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
-                .take(limit),
-            locationTracks = locationTracks
-                .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
-                .take(limit),
-            trackNumbers = trackNumbers
-                .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
-                .take(limit),
-            operatingPoints = ratkoLocalService.searchOperatingPoints(searchTerm, limit)
-        )
+            switches =
+                switches
+                    .let { list -> switchService.filterBySearchTerm(list, searchTerm) }
+                    .take(limit),
+            locationTracks =
+                locationTracks
+                    .let { list -> locationTrackService.filterBySearchTerm(list, searchTerm) }
+                    .take(limit),
+            trackNumbers =
+                trackNumbers
+                    .let { list -> trackNumberService.filterBySearchTerm(list, searchTerm) }
+                    .take(limit),
+            operatingPoints = ratkoLocalService.searchOperatingPoints(searchTerm, limit))
     }
 
     private fun getLocationTrackAndDuplicatesByScope(
         layoutContext: LayoutContext,
         locationTrackSearchScope: IntId<LocationTrack>,
-    ): List<LocationTrack> = locationTrackService
-        .getWithAlignmentOrThrow(layoutContext, locationTrackSearchScope)
-        .let { (lt, alignment) ->
-            lt to locationTrackService.getLocationTrackDuplicates(layoutContext, lt, alignment)
-        }
-        .let { (locationTrack, duplicates) ->
-            listOf(locationTrack) + locationTrackService.getMany(layoutContext, duplicates.map { d -> d.id })
-        }
+    ): List<LocationTrack> =
+        locationTrackService
+            .getWithAlignmentOrThrow(layoutContext, locationTrackSearchScope)
+            .let { (lt, alignment) ->
+                lt to locationTrackService.getLocationTrackDuplicates(layoutContext, lt, alignment)
+            }
+            .let { (locationTrack, duplicates) ->
+                listOf(locationTrack) +
+                    locationTrackService.getMany(layoutContext, duplicates.map { d -> d.id })
+            }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -48,7 +48,8 @@ class LayoutSwitchController(
         @RequestParam("includeDeleted") includeDeleted: Boolean = false,
     ): List<TrackLayoutSwitch> {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        val filter = switchFilter(namePart, exactName, switchType, bbox, includeSwitchesWithNoJoints)
+        val filter =
+            switchFilter(namePart, exactName, switchType, bbox, includeSwitchesWithNoJoints)
         val switches = switchService.listWithStructure(layoutContext, includeDeleted).filter(filter)
         return pageSwitches(switches, offset ?: 0, limit, comparisonPoint).items
     }
@@ -95,14 +96,16 @@ class LayoutSwitchController(
         @RequestParam("bbox") bbox: BoundingBox?,
     ): List<ValidatedAsset<TrackLayoutSwitch>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        val switches = if (ids != null) {
-            switchService.getMany(layoutContext, ids)
-        } else {
-            switchService.list(layoutContext, false)
-        }
-        val switchIds = switches
-            .filter { switch -> switchMatchesBbox(switch, bbox, false) }
-            .map { sw -> sw.id as IntId }
+        val switches =
+            if (ids != null) {
+                switchService.getMany(layoutContext, ids)
+            } else {
+                switchService.list(layoutContext, false)
+            }
+        val switchIds =
+            switches
+                .filter { switch -> switchMatchesBbox(switch, bbox, false) }
+                .map { sw -> sw.id as IntId }
         return publicationService.validateSwitches(layoutContext, switchIds)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -21,6 +21,9 @@ import fi.fta.geoviite.infra.publication.ValidatedAsset
 import fi.fta.geoviite.infra.publication.getCsvResponseEntity
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.toResponse
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -30,9 +33,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 
 @GeoviiteController("/track-layout/track-numbers")
 class LayoutTrackNumberController(
@@ -141,19 +141,21 @@ class LayoutTrackNumberController(
     ): ResponseEntity<ByteArray> {
         val context = LayoutContext.of(branch, publicationState)
 
-        val csv = trackNumberService.getKmLengthsAsCsv(
-            layoutContext = context,
-            trackNumberId = id,
-            startKmNumber = startKmNumber,
-            endKmNumber = endKmNumber,
-            precision = precision,
-            lang = lang,
-        )
+        val csv =
+            trackNumberService.getKmLengthsAsCsv(
+                layoutContext = context,
+                trackNumberId = id,
+                startKmNumber = startKmNumber,
+                endKmNumber = endKmNumber,
+                precision = precision,
+                lang = lang,
+            )
 
         val trackNumber = trackNumberService.getOrThrow(context, id)
 
         val fileName =
-            FileName("ratakilometrien-pituudet_${trackNumber.number}${kmLengthsPrecisionSuffix(precision)}.csv")
+            FileName(
+                "ratakilometrien-pituudet_${trackNumber.number}${kmLengthsPrecisionSuffix(precision)}.csv")
         return getCsvResponseEntity(csv, fileName)
     }
 
@@ -166,17 +168,21 @@ class LayoutTrackNumberController(
     ): ResponseEntity<ByteArray> {
         val layoutContext = LayoutContext.of(branch, publicationState)
 
-        val csv = trackNumberService.getAllKmLengthsAsCsv(
-            layoutContext = layoutContext,
-            trackNumberIds = trackNumberService.list(layoutContext).map { tn -> tn.id as IntId },
-            lang = lang,
-        )
+        val csv =
+            trackNumberService.getAllKmLengthsAsCsv(
+                layoutContext = layoutContext,
+                trackNumberIds =
+                    trackNumberService.list(layoutContext).map { tn -> tn.id as IntId },
+                lang = lang,
+            )
 
         val localization = localizationService.getLocalization(lang)
-        val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneId.of("Europe/Helsinki"))
+        val dateFormatter =
+            DateTimeFormatter.ofPattern("dd.MM.yyyy").withZone(ZoneId.of("Europe/Helsinki"))
 
         val fileDescription =
-            localization.t("data-products.km-lengths.entire-rail-network-km-lengths-file-name-without-date")
+            localization.t(
+                "data-products.km-lengths.entire-rail-network-km-lengths-file-name-without-date")
         val fileDate = dateFormatter.format(Instant.now())
 
         return getCsvResponseEntity(csv, FileName("$fileDescription $fileDate.csv"))
@@ -194,7 +200,8 @@ class LayoutTrackNumberController(
     }
 }
 
-private fun kmLengthsPrecisionSuffix(precision: KmLengthsLocationPrecision): String = when (precision) {
-    KmLengthsLocationPrecision.PRECISE_LOCATION -> ""
-    KmLengthsLocationPrecision.APPROXIMATION_IN_LAYOUT -> "-paikannuspohjan-tarkkuus"
-}
+private fun kmLengthsPrecisionSuffix(precision: KmLengthsLocationPrecision): String =
+    when (precision) {
+        KmLengthsLocationPrecision.PRECISE_LOCATION -> ""
+        KmLengthsLocationPrecision.APPROXIMATION_IN_LAYOUT -> "-paikannuspohjan-tarkkuus"
+    }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -16,11 +16,11 @@ import fi.fta.geoviite.infra.util.getLayoutContextData
 import fi.fta.geoviite.infra.util.getOidOrNull
 import fi.fta.geoviite.infra.util.getTrackNumber
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.ResultSet
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
 
 const val TRACK_NUMBER_CACHE_SIZE = 1000L
 
@@ -29,12 +29,13 @@ const val TRACK_NUMBER_CACHE_SIZE = 1000L
 class LayoutTrackNumberDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
     @Value("\${geoviite.cache.enabled}") cacheEnabled: Boolean,
-) : LayoutAssetDao<TrackLayoutTrackNumber>(
-    jdbcTemplateParam,
-    LayoutAssetTable.LAYOUT_ASSET_TRACK_NUMBER,
-    cacheEnabled,
-    TRACK_NUMBER_CACHE_SIZE,
-) {
+) :
+    LayoutAssetDao<TrackLayoutTrackNumber>(
+        jdbcTemplateParam,
+        LayoutAssetTable.LAYOUT_ASSET_TRACK_NUMBER,
+        cacheEnabled,
+        TRACK_NUMBER_CACHE_SIZE,
+    ) {
 
     override fun fetchVersions(layoutContext: LayoutContext, includeDeleted: Boolean) =
         fetchVersions(layoutContext, includeDeleted, null)
@@ -47,26 +48,32 @@ class LayoutTrackNumberDao(
         includeDeleted: Boolean,
         number: TrackNumber?,
     ): List<LayoutDaoResponse<TrackLayoutTrackNumber>> {
-        val sql = """
+        val sql =
+            """
             select official_id, row_id, row_version
             from layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id)
             where (:number::varchar is null or :number = number)
               and (:include_deleted = true or state != 'DELETED')
             order by number
-        """.trimIndent()
-        val params = mapOf(
-            "publication_state" to layoutContext.state.name,
-            "design_id" to layoutContext.branch.designId?.intValue,
-            "include_deleted" to includeDeleted,
-            "number" to number,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "publication_state" to layoutContext.state.name,
+                "design_id" to layoutContext.branch.designId?.intValue,
+                "include_deleted" to includeDeleted,
+                "number" to number,
+            )
         return jdbcTemplate.query(sql, params) { rs, _ ->
             rs.getDaoResponse("official_id", "row_id", "row_version")
         }
     }
 
-    override fun fetchInternal(version: LayoutRowVersion<TrackLayoutTrackNumber>): TrackLayoutTrackNumber {
-        val sql = """
+    override fun fetchInternal(
+        version: LayoutRowVersion<TrackLayoutTrackNumber>
+    ): TrackLayoutTrackNumber {
+        val sql =
+            """
             -- Draft vs Official reference line might duplicate the row, but results will be the same. Just pick one.
             select distinct on (tn.id, tn.version)
               tn.id as row_id,
@@ -88,18 +95,21 @@ class LayoutTrackNumberDao(
               and tn.version = :version
               and tn.deleted = false
             order by tn.id, tn.version, rl.id
-        """.trimIndent()
-        val params = mapOf(
-            "id" to version.rowId.intValue,
-            "version" to version.version,
-        )
-        return getOne(version, jdbcTemplate.query(sql, params) { rs, _ -> getLayoutTrackNumber(rs) }).also {
-            logger.daoAccess(AccessType.FETCH, TrackLayoutTrackNumber::class, version)
-        }
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "id" to version.rowId.intValue,
+                "version" to version.version,
+            )
+        return getOne(
+                version, jdbcTemplate.query(sql, params) { rs, _ -> getLayoutTrackNumber(rs) })
+            .also { logger.daoAccess(AccessType.FETCH, TrackLayoutTrackNumber::class, version) }
     }
 
     override fun preloadCache() {
-        val sql = """
+        val sql =
+            """
             -- Draft vs Official reference line might duplicate the row, but results will be the same. Just pick one.
             select distinct on (tn.id)
               tn.id as row_id,
@@ -116,33 +126,42 @@ class LayoutTrackNumberDao(
             from layout.track_number tn
               left join layout.reference_line rl on rl.track_number_id = coalesce(tn.official_row_id, tn.id)
             order by tn.id, rl.id
-        """.trimIndent()
-        val trackNumbers = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ -> getLayoutTrackNumber(rs) }
-            .associateBy(TrackLayoutTrackNumber::version)
+        """
+                .trimIndent()
+        val trackNumbers =
+            jdbcTemplate
+                .query(sql, mapOf<String, Any>()) { rs, _ -> getLayoutTrackNumber(rs) }
+                .associateBy(TrackLayoutTrackNumber::version)
         logger.daoAccess(AccessType.FETCH, TrackLayoutTrackNumber::class, trackNumbers.keys)
         cache.putAll(trackNumbers)
     }
 
-    private fun getLayoutTrackNumber(rs: ResultSet): TrackLayoutTrackNumber = TrackLayoutTrackNumber(
-        number = rs.getTrackNumber("number"),
-        description = rs.getFreeText("description"),
-        state = rs.getEnum("state"),
-        externalId = rs.getOidOrNull("external_id"),
-        // TODO: GVT-2442 This should be non-null but we have a lot of tests that produce broken data
-        referenceLineId = rs.getIntIdOrNull("reference_line_id"),
-        contextData = rs.getLayoutContextData(
-            "official_row_id",
-            "design_row_id",
-            "design_id",
-            "row_id",
-            "row_version",
-            "draft",
-        ),
-    )
+    private fun getLayoutTrackNumber(rs: ResultSet): TrackLayoutTrackNumber =
+        TrackLayoutTrackNumber(
+            number = rs.getTrackNumber("number"),
+            description = rs.getFreeText("description"),
+            state = rs.getEnum("state"),
+            externalId = rs.getOidOrNull("external_id"),
+            // TODO: GVT-2442 This should be non-null but we have a lot of tests that produce broken
+            // data
+            referenceLineId = rs.getIntIdOrNull("reference_line_id"),
+            contextData =
+                rs.getLayoutContextData(
+                    "official_row_id",
+                    "design_row_id",
+                    "design_id",
+                    "row_id",
+                    "row_version",
+                    "draft",
+                ),
+        )
 
     @Transactional
-    override fun insert(newItem: TrackLayoutTrackNumber): LayoutDaoResponse<TrackLayoutTrackNumber> {
-        val sql = """
+    override fun insert(
+        newItem: TrackLayoutTrackNumber
+    ): LayoutDaoResponse<TrackLayoutTrackNumber> {
+        val sql =
+            """
             insert into layout.track_number(
               external_id, 
               number, 
@@ -167,31 +186,38 @@ class LayoutTrackNumberDao(
               coalesce(official_row_id, id) as official_id,
               id as row_id,
               version as row_version
-        """.trimIndent()
-        val params = mapOf(
-            "external_id" to newItem.externalId,
-            "number" to newItem.number,
-            "description" to newItem.description,
-            "state" to newItem.state.name,
-            "draft" to newItem.isDraft,
-            "official_row_id" to newItem.contextData.officialRowId?.intValue,
-            "design_row_id" to newItem.contextData.designRowId?.intValue,
-            "design_id" to newItem.contextData.designId?.intValue,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "external_id" to newItem.externalId,
+                "number" to newItem.number,
+                "description" to newItem.description,
+                "state" to newItem.state.name,
+                "draft" to newItem.isDraft,
+                "official_row_id" to newItem.contextData.officialRowId?.intValue,
+                "design_row_id" to newItem.contextData.designRowId?.intValue,
+                "design_id" to newItem.contextData.designId?.intValue,
+            )
         jdbcTemplate.setUser()
-        val response: LayoutDaoResponse<TrackLayoutTrackNumber> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getDaoResponse("official_id", "row_id", "row_version")
-        } ?: throw IllegalStateException("Failed to generate ID for new TrackNumber")
+        val response: LayoutDaoResponse<TrackLayoutTrackNumber> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+                rs.getDaoResponse("official_id", "row_id", "row_version")
+            } ?: throw IllegalStateException("Failed to generate ID for new TrackNumber")
         logger.daoAccess(AccessType.INSERT, TrackLayoutTrackNumber::class, response)
         return response
     }
 
     @Transactional
-    override fun update(updatedItem: TrackLayoutTrackNumber): LayoutDaoResponse<TrackLayoutTrackNumber> {
-        val rowId = requireNotNull(updatedItem.contextData.rowId) {
-            "Cannot update a row that doesn't have a DB ID: kmPost=$updatedItem"
-        }
-        val sql = """
+    override fun update(
+        updatedItem: TrackLayoutTrackNumber
+    ): LayoutDaoResponse<TrackLayoutTrackNumber> {
+        val rowId =
+            requireNotNull(updatedItem.contextData.rowId) {
+                "Cannot update a row that doesn't have a DB ID: kmPost=$updatedItem"
+            }
+        val sql =
+            """
             update layout.track_number
             set
               external_id = :external_id,
@@ -207,41 +233,50 @@ class LayoutTrackNumberDao(
               coalesce(official_row_id, design_row_id, id) as official_id,
               id as row_id,
               version as row_version
-        """.trimIndent()
-        val params = mapOf(
-            "id" to rowId.intValue,
-            "external_id" to updatedItem.externalId,
-            "number" to updatedItem.number,
-            "description" to updatedItem.description,
-            "state" to updatedItem.state.name,
-            "draft" to updatedItem.isDraft,
-            "official_row_id" to updatedItem.contextData.officialRowId?.intValue,
-            "design_row_id" to updatedItem.contextData.designRowId?.intValue,
-            "design_id" to updatedItem.contextData.designId?.intValue,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "id" to rowId.intValue,
+                "external_id" to updatedItem.externalId,
+                "number" to updatedItem.number,
+                "description" to updatedItem.description,
+                "state" to updatedItem.state.name,
+                "draft" to updatedItem.isDraft,
+                "official_row_id" to updatedItem.contextData.officialRowId?.intValue,
+                "design_row_id" to updatedItem.contextData.designRowId?.intValue,
+                "design_id" to updatedItem.contextData.designId?.intValue,
+            )
         jdbcTemplate.setUser()
-        val response: LayoutDaoResponse<TrackLayoutTrackNumber> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getDaoResponse("official_id", "row_id", "row_version")
-        } ?: throw IllegalStateException("Failed to get new version for Track Layout TrackNumber")
+        val response: LayoutDaoResponse<TrackLayoutTrackNumber> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+                rs.getDaoResponse("official_id", "row_id", "row_version")
+            }
+                ?: throw IllegalStateException(
+                    "Failed to get new version for Track Layout TrackNumber")
         logger.daoAccess(AccessType.UPDATE, TrackLayoutTrackNumber::class, response)
         return response
     }
 
     fun fetchTrackNumberNames(): List<TrackNumberAndChangeTime> {
-        val sql = """
+        val sql =
+            """
             select tn.id, tn.number, tn.change_time
             from layout.track_number_version tn
             where tn.draft = false
             order by tn.change_time
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        return jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
-            TrackNumberAndChangeTime(
-                rs.getIntId("id"),
-                rs.getTrackNumber("number"),
-                rs.getInstant("change_time"),
-            )
-        }.also { logger.daoAccess(AccessType.FETCH, "track_number_version") }
+        return jdbcTemplate
+            .query(sql, mapOf<String, Any>()) { rs, _ ->
+                TrackNumberAndChangeTime(
+                    rs.getIntId("id"),
+                    rs.getTrackNumber("number"),
+                    rs.getInstant("change_time"),
+                )
+            }
+            .also { logger.daoAccess(AccessType.FETCH, "track_number_version") }
     }
 
     fun findOfficialNumberDuplicates(
@@ -251,22 +286,29 @@ class LayoutTrackNumberDao(
         return if (numbers.isEmpty()) {
             emptyMap()
         } else {
-            val sql = """
+            val sql =
+                """
                 select official_id, row_id, row_version, number
                 from layout.track_number_in_layout_context('OFFICIAL', :design_id)
                 where number in (:numbers)
                   and draft = false
                   and state != 'DELETED'
-            """.trimIndent()
+            """
+                    .trimIndent()
             val params = mapOf("numbers" to numbers, "design_id" to layoutBranch.designId?.intValue)
             val found =
-                jdbcTemplate.query<Pair<TrackNumber, LayoutDaoResponse<TrackLayoutTrackNumber>>>(sql, params) { rs, _ ->
-                    val daoResponse = rs.getDaoResponse<TrackLayoutTrackNumber>("official_id", "row_id", "row_version")
-                    val name = rs.getString("number").let(::TrackNumber)
-                    name to daoResponse
-                }
+                jdbcTemplate.query<Pair<TrackNumber, LayoutDaoResponse<TrackLayoutTrackNumber>>>(
+                    sql, params) { rs, _ ->
+                        val daoResponse =
+                            rs.getDaoResponse<TrackLayoutTrackNumber>(
+                                "official_id", "row_id", "row_version")
+                        val name = rs.getString("number").let(::TrackNumber)
+                        name to daoResponse
+                    }
             // Ensure that the result contains all asked-for numbers, even if there are no matches
-            numbers.associateWith { n -> found.filter { (number, _) -> number == n }.map { (_, v) -> v } }
+            numbers.associateWith { n ->
+                found.filter { (number, _) -> number == n }.map { (_, v) -> v }
+            }
         }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -54,7 +54,8 @@ class LocationTrackController(
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/location-tracks/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["searchTerm", "limit"])
+    @GetMapping(
+        "/location-tracks/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}", params = ["searchTerm", "limit"])
     fun searchLocationTracks(
         @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
@@ -96,10 +97,14 @@ class LocationTrackController(
     ): ResponseEntity<AlignmentStartAndEndWithId<*>> {
         val context = LayoutContext.of(layoutBranch, publicationState)
         val locationTrackAndAlignment = locationTrackService.getWithAlignment(context, id)
-        return toResponse(locationTrackAndAlignment?.let { (locationTrack, alignment) ->
-            geocodingService.getLocationTrackStartAndEnd(context, locationTrack, alignment)
-                ?.let { AlignmentStartAndEndWithId(locationTrack.id as IntId, it.start, it.end) }
-        })
+        return toResponse(
+            locationTrackAndAlignment?.let { (locationTrack, alignment) ->
+                geocodingService
+                    .getLocationTrackStartAndEnd(context, locationTrack, alignment)
+                    ?.let {
+                        AlignmentStartAndEndWithId(locationTrack.id as IntId, it.start, it.end)
+                    }
+            })
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
@@ -112,8 +117,11 @@ class LocationTrackController(
         val context = LayoutContext.of(layoutBranch, publicationState)
         return ids.mapNotNull { id ->
             locationTrackService.getWithAlignment(context, id)?.let { (locationTrack, alignment) ->
-                geocodingService.getLocationTrackStartAndEnd(context, locationTrack, alignment)
-                    ?.let { AlignmentStartAndEndWithId(locationTrack.id as IntId, it.start, it.end) }
+                geocodingService
+                    .getLocationTrackStartAndEnd(context, locationTrack, alignment)
+                    ?.let {
+                        AlignmentStartAndEndWithId(locationTrack.id as IntId, it.start, it.end)
+                    }
             }
         }
     }
@@ -130,7 +138,8 @@ class LocationTrackController(
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/location-tracks/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}/relinkable-switches-count")
+    @GetMapping(
+        "/location-tracks/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}/relinkable-switches-count")
     fun getRelinkableSwitchesCount(
         @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
@@ -150,9 +159,11 @@ class LocationTrackController(
     ): List<LocationTrackDescription> {
         val context = LayoutContext.of(layoutBranch, publicationState)
         return ids.mapNotNull { id ->
-            id.let { locationTrackService.get(context, it) }?.let { lt ->
-                LocationTrackDescription(id, locationTrackService.getFullDescription(context, lt, lang))
-            }
+            id.let { locationTrackService.get(context, it) }
+                ?.let { lt ->
+                    LocationTrackDescription(
+                        id, locationTrackService.getFullDescription(context, lt, lang))
+                }
         }
     }
 
@@ -175,7 +186,10 @@ class LocationTrackController(
         @PathVariable("id") id: IntId<LocationTrack>,
     ): ResponseEntity<ValidatedAsset<LocationTrack>> {
         val context = LayoutContext.of(layoutBranch, publicationState)
-        return publicationService.validateLocationTracks(context, listOf(id)).firstOrNull().let(::toResponse)
+        return publicationService
+            .validateLocationTracks(context, listOf(id))
+            .firstOrNull()
+            .let(::toResponse)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
@@ -187,7 +201,8 @@ class LocationTrackController(
     ): List<SwitchValidationWithSuggestedSwitch> {
         val context = LayoutContext.of(layoutBranch, publicationState)
         val switchSuggestions = switchLinkingService.getTrackSwitchSuggestions(context, id)
-        val switchValidation = publicationService.validateSwitches(context, switchSuggestions.map { (id, _) -> id })
+        val switchValidation =
+            publicationService.validateSwitches(context, switchSuggestions.map { (id, _) -> id })
         return switchValidation.map { validatedAsset ->
             SwitchValidationWithSuggestedSwitch(
                 validatedAsset.id,
@@ -257,7 +272,8 @@ class LocationTrackController(
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/track-numbers/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{trackNumberId}/location-tracks")
+    @GetMapping(
+        "/track-numbers/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{trackNumberId}/location-tracks")
     fun getTrackNumberTracksByName(
         @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
@@ -275,7 +291,8 @@ class LocationTrackController(
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/location-tracks/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}/splitting-initialization-parameters")
+    @GetMapping(
+        "/location-tracks/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}/splitting-initialization-parameters")
     fun getSplittingInitializationParameters(
         @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -23,12 +23,12 @@ import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.getOidOrNull
 import fi.fta.geoviite.infra.util.getRowVersion
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.ResultSet
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
 
 const val LOCATIONTRACK_CACHE_SIZE = 10000L
 
@@ -37,33 +37,38 @@ const val LOCATIONTRACK_CACHE_SIZE = 10000L
 class LocationTrackDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
     @Value("\${geoviite.cache.enabled}") cacheEnabled: Boolean,
-) : LayoutAssetDao<LocationTrack>(
-    jdbcTemplateParam,
-    LayoutAssetTable.LAYOUT_ASSET_LOCATION_TRACK,
-    cacheEnabled,
-    LOCATIONTRACK_CACHE_SIZE,
-) {
+) :
+    LayoutAssetDao<LocationTrack>(
+        jdbcTemplateParam,
+        LayoutAssetTable.LAYOUT_ASSET_LOCATION_TRACK,
+        cacheEnabled,
+        LOCATIONTRACK_CACHE_SIZE,
+    ) {
 
     fun fetchDuplicateVersions(
         layoutContext: LayoutContext,
         id: IntId<LocationTrack>,
         includeDeleted: Boolean = false,
     ): List<LayoutRowVersion<LocationTrack>> {
-        val sql = """
+        val sql =
+            """
             select row_id, row_version
             from layout.location_track_in_layout_context(:publication_state::layout.publication_state, :design_id)
             where duplicate_of_location_track_id = :id
               and (:include_deleted or state != 'DELETED')
-        """.trimIndent()
-        val params = mapOf(
-            "id" to id.intValue,
-            "publication_state" to layoutContext.state.name,
-            "design_id" to layoutContext.branch.designId?.intValue,
-            "include_deleted" to includeDeleted,
-        )
-        val versions = jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getLayoutRowVersion<LocationTrack>("row_id", "row_version")
-        }
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "id" to id.intValue,
+                "publication_state" to layoutContext.state.name,
+                "design_id" to layoutContext.branch.designId?.intValue,
+                "include_deleted" to includeDeleted,
+            )
+        val versions =
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                rs.getLayoutRowVersion<LocationTrack>("row_id", "row_version")
+            }
         logger.daoAccess(AccessType.FETCH, LocationTrack::class, id)
         return versions
     }
@@ -75,25 +80,31 @@ class LocationTrackDao(
         return if (names.isEmpty()) {
             emptyMap()
         } else {
-            val sql = """
+            val sql =
+                """
                 select official_id, row_id, row_version, name
                 from layout.location_track_in_layout_context('OFFICIAL', :design_id)
                 where name in (:names)
                   and state != 'DELETED'
-            """.trimIndent()
+            """
+                    .trimIndent()
             val params = mapOf("names" to names, "design_id" to layoutBranch.designId?.intValue)
-            val found = jdbcTemplate.query<Pair<AlignmentName, LayoutDaoResponse<LocationTrack>>>(sql, params) { rs, _ ->
-                val daoResponse = rs.getDaoResponse<LocationTrack>("official_id", "row_id", "row_version")
-                val name = rs.getString("name").let(::AlignmentName)
-                name to daoResponse
-            }
+            val found =
+                jdbcTemplate.query<Pair<AlignmentName, LayoutDaoResponse<LocationTrack>>>(
+                    sql, params) { rs, _ ->
+                        val daoResponse =
+                            rs.getDaoResponse<LocationTrack>("official_id", "row_id", "row_version")
+                        val name = rs.getString("name").let(::AlignmentName)
+                        name to daoResponse
+                    }
             // Ensure that the result contains all asked-for names, even if there are no matches
             names.associateWith { n -> found.filter { (name, _) -> name == n }.map { (_, v) -> v } }
         }
     }
 
     override fun fetchInternal(version: LayoutRowVersion<LocationTrack>): LocationTrack {
-        val sql = """
+        val sql =
+            """
             select 
               ltv.id as row_id,
               ltv.version as row_version,
@@ -133,19 +144,21 @@ class LocationTrackDao(
             where ltv.id = :id
               and ltv.version = :version
               and ltv.deleted = false
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "id" to version.rowId.intValue,
-            "version" to version.version,
-        )
-        return getOne(version, jdbcTemplate.query(sql, params) { rs, _ -> getLocationTrack(rs) }).also {
-            logger.daoAccess(AccessType.FETCH, LocationTrack::class, version)
-        }
+        val params =
+            mapOf(
+                "id" to version.rowId.intValue,
+                "version" to version.version,
+            )
+        return getOne(version, jdbcTemplate.query(sql, params) { rs, _ -> getLocationTrack(rs) })
+            .also { logger.daoAccess(AccessType.FETCH, LocationTrack::class, version) }
     }
 
     override fun preloadCache() {
-        val sql = """
+        val sql =
+            """
             select 
               lt.id as row_id,
               lt.version as row_version,
@@ -182,57 +195,64 @@ class LocationTrackDao(
               ) as segment_switch_ids
             from layout.location_track lt
               left join layout.alignment_version av on lt.alignment_id = av.id and lt.alignment_version = av.version
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val tracks = jdbcTemplate
-            .query(sql, mapOf<String, Any>()) { rs, _ -> getLocationTrack(rs) }
-            .associateBy(LocationTrack::version)
+        val tracks =
+            jdbcTemplate
+                .query(sql, mapOf<String, Any>()) { rs, _ -> getLocationTrack(rs) }
+                .associateBy(LocationTrack::version)
         logger.daoAccess(AccessType.FETCH, LocationTrack::class, tracks.keys)
         cache.putAll(tracks)
     }
 
-    private fun getLocationTrack(rs: ResultSet): LocationTrack = LocationTrack(
-        alignmentVersion = rs.getRowVersion("alignment_id", "alignment_version"),
-        sourceId = null,
-        externalId = rs.getOidOrNull("external_id"),
-        trackNumberId = rs.getIntId("track_number_id"),
-        name = rs.getString("name").let(::AlignmentName),
-        descriptionBase = rs.getFreeText("description_base"),
-        descriptionSuffix = rs.getEnum<DescriptionSuffixType>("description_suffix"),
-        type = rs.getEnum("type"),
-        state = rs.getEnum("state"),
-        boundingBox = rs.getBboxOrNull("bounding_box"),
-        length = rs.getDouble("length"),
-        segmentCount = rs.getInt("segment_count"),
-        duplicateOf = rs.getIntIdOrNull("duplicate_of_location_track_id"),
-        topologicalConnectivity = rs.getEnum("topological_connectivity"),
-        ownerId = rs.getIntId("owner_id"),
-        topologyStartSwitch = rs.getIntIdOrNull<TrackLayoutSwitch>("topology_start_switch_id")?.let { id ->
-            TopologyLocationTrackSwitch(
-                id,
-                rs.getJointNumber("topology_start_switch_joint_number"),
-            )
-        },
-        topologyEndSwitch = rs.getIntIdOrNull<TrackLayoutSwitch>("topology_end_switch_id")?.let { id ->
-            TopologyLocationTrackSwitch(
-                id,
-                rs.getJointNumber("topology_end_switch_joint_number"),
-            )
-        },
-        segmentSwitchIds = rs.getIntIdArray("segment_switch_ids"),
-        contextData = rs.getLayoutContextData(
-            "official_row_id",
-            "design_row_id",
-            "design_id",
-            "row_id",
-            "row_version",
-            "draft",
-        ),
-    )
+    private fun getLocationTrack(rs: ResultSet): LocationTrack =
+        LocationTrack(
+            alignmentVersion = rs.getRowVersion("alignment_id", "alignment_version"),
+            sourceId = null,
+            externalId = rs.getOidOrNull("external_id"),
+            trackNumberId = rs.getIntId("track_number_id"),
+            name = rs.getString("name").let(::AlignmentName),
+            descriptionBase = rs.getFreeText("description_base"),
+            descriptionSuffix = rs.getEnum<DescriptionSuffixType>("description_suffix"),
+            type = rs.getEnum("type"),
+            state = rs.getEnum("state"),
+            boundingBox = rs.getBboxOrNull("bounding_box"),
+            length = rs.getDouble("length"),
+            segmentCount = rs.getInt("segment_count"),
+            duplicateOf = rs.getIntIdOrNull("duplicate_of_location_track_id"),
+            topologicalConnectivity = rs.getEnum("topological_connectivity"),
+            ownerId = rs.getIntId("owner_id"),
+            topologyStartSwitch =
+                rs.getIntIdOrNull<TrackLayoutSwitch>("topology_start_switch_id")?.let { id ->
+                    TopologyLocationTrackSwitch(
+                        id,
+                        rs.getJointNumber("topology_start_switch_joint_number"),
+                    )
+                },
+            topologyEndSwitch =
+                rs.getIntIdOrNull<TrackLayoutSwitch>("topology_end_switch_id")?.let { id ->
+                    TopologyLocationTrackSwitch(
+                        id,
+                        rs.getJointNumber("topology_end_switch_joint_number"),
+                    )
+                },
+            segmentSwitchIds = rs.getIntIdArray("segment_switch_ids"),
+            contextData =
+                rs.getLayoutContextData(
+                    "official_row_id",
+                    "design_row_id",
+                    "design_id",
+                    "row_id",
+                    "row_version",
+                    "draft",
+                ),
+        )
 
     @Transactional
     override fun insert(newItem: LocationTrack): LayoutDaoResponse<LocationTrack> {
-        val sql = """
+        val sql =
+            """
             insert into layout.location_track(
               track_number_id,
               external_id,
@@ -281,44 +301,51 @@ class LocationTrackDao(
               coalesce(official_row_id, id) as official_id,
               id as row_id,
               version as row_version
-        """.trimIndent()
-        val params = mapOf(
-            "track_number_id" to newItem.trackNumberId.intValue,
-            "external_id" to newItem.externalId,
-            "alignment_id" to newItem.getAlignmentVersionOrThrow().id.intValue,
-            "alignment_version" to newItem.getAlignmentVersionOrThrow().version,
-            "name" to newItem.name,
-            "description_base" to newItem.descriptionBase,
-            "description_suffix" to newItem.descriptionSuffix.name,
-            "type" to newItem.type.name,
-            "state" to newItem.state.name,
-            "draft" to newItem.isDraft,
-            "official_row_id" to newItem.contextData.officialRowId?.intValue,
-            "design_row_id" to newItem.contextData.designRowId?.intValue,
-            "design_id" to newItem.contextData.designId?.intValue,
-            "duplicate_of_location_track_id" to newItem.duplicateOf?.intValue,
-            "topological_connectivity" to newItem.topologicalConnectivity.name,
-            "topology_start_switch_id" to newItem.topologyStartSwitch?.switchId?.intValue,
-            "topology_start_switch_joint_number" to newItem.topologyStartSwitch?.jointNumber?.intValue,
-            "topology_end_switch_id" to newItem.topologyEndSwitch?.switchId?.intValue,
-            "topology_end_switch_joint_number" to newItem.topologyEndSwitch?.jointNumber?.intValue,
-            "owner_id" to newItem.ownerId.intValue,
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "track_number_id" to newItem.trackNumberId.intValue,
+                "external_id" to newItem.externalId,
+                "alignment_id" to newItem.getAlignmentVersionOrThrow().id.intValue,
+                "alignment_version" to newItem.getAlignmentVersionOrThrow().version,
+                "name" to newItem.name,
+                "description_base" to newItem.descriptionBase,
+                "description_suffix" to newItem.descriptionSuffix.name,
+                "type" to newItem.type.name,
+                "state" to newItem.state.name,
+                "draft" to newItem.isDraft,
+                "official_row_id" to newItem.contextData.officialRowId?.intValue,
+                "design_row_id" to newItem.contextData.designRowId?.intValue,
+                "design_id" to newItem.contextData.designId?.intValue,
+                "duplicate_of_location_track_id" to newItem.duplicateOf?.intValue,
+                "topological_connectivity" to newItem.topologicalConnectivity.name,
+                "topology_start_switch_id" to newItem.topologyStartSwitch?.switchId?.intValue,
+                "topology_start_switch_joint_number" to
+                    newItem.topologyStartSwitch?.jointNumber?.intValue,
+                "topology_end_switch_id" to newItem.topologyEndSwitch?.switchId?.intValue,
+                "topology_end_switch_joint_number" to
+                    newItem.topologyEndSwitch?.jointNumber?.intValue,
+                "owner_id" to newItem.ownerId.intValue,
+            )
 
         jdbcTemplate.setUser()
-        val response: LayoutDaoResponse<LocationTrack> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getDaoResponse("official_id", "row_id", "row_version")
-        } ?: throw IllegalStateException("Failed to generate ID for new Location Track")
+        val response: LayoutDaoResponse<LocationTrack> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+                rs.getDaoResponse("official_id", "row_id", "row_version")
+            } ?: throw IllegalStateException("Failed to generate ID for new Location Track")
         logger.daoAccess(AccessType.INSERT, LocationTrack::class, response)
         return response
     }
 
     @Transactional
     override fun update(updatedItem: LocationTrack): LayoutDaoResponse<LocationTrack> {
-        val rowId = requireNotNull(updatedItem.contextData.rowId) {
-            "Cannot update a row that doesn't have a DB ID: kmPost=$updatedItem"
-        }
-        val sql = """
+        val rowId =
+            requireNotNull(updatedItem.contextData.rowId) {
+                "Cannot update a row that doesn't have a DB ID: kmPost=$updatedItem"
+            }
+        val sql =
+            """
             update layout.location_track
             set
               track_number_id = :track_number_id,
@@ -346,35 +373,39 @@ class LocationTrackDao(
               coalesce(official_row_id, design_row_id, id) as official_id,
               id as row_id,
               version as row_version
-        """.trimIndent()
+        """
+                .trimIndent()
         val alignmentVersion = updatedItem.getAlignmentVersionOrThrow()
-        val params = mapOf(
-            "id" to rowId.intValue,
-            "track_number_id" to updatedItem.trackNumberId.intValue,
-            "external_id" to updatedItem.externalId,
-            "alignment_id" to alignmentVersion.id.intValue,
-            "alignment_version" to alignmentVersion.version,
-            "name" to updatedItem.name,
-            "description_base" to updatedItem.descriptionBase,
-            "description_suffix" to updatedItem.descriptionSuffix.name,
-            "type" to updatedItem.type.name,
-            "state" to updatedItem.state.name,
-            "draft" to updatedItem.isDraft,
-            "official_row_id" to updatedItem.contextData.officialRowId?.intValue,
-            "design_row_id" to updatedItem.contextData.designRowId?.intValue,
-            "design_id" to updatedItem.contextData.designId?.intValue,
-            "duplicate_of_location_track_id" to updatedItem.duplicateOf?.intValue,
-            "topological_connectivity" to updatedItem.topologicalConnectivity.name,
-            "topology_start_switch_id" to updatedItem.topologyStartSwitch?.switchId?.intValue,
-            "topology_start_switch_joint_number" to updatedItem.topologyStartSwitch?.jointNumber?.intValue,
-            "topology_end_switch_id" to updatedItem.topologyEndSwitch?.switchId?.intValue,
-            "topology_end_switch_joint_number" to updatedItem.topologyEndSwitch?.jointNumber?.intValue,
-            "owner_id" to updatedItem.ownerId.intValue
-        )
+        val params =
+            mapOf(
+                "id" to rowId.intValue,
+                "track_number_id" to updatedItem.trackNumberId.intValue,
+                "external_id" to updatedItem.externalId,
+                "alignment_id" to alignmentVersion.id.intValue,
+                "alignment_version" to alignmentVersion.version,
+                "name" to updatedItem.name,
+                "description_base" to updatedItem.descriptionBase,
+                "description_suffix" to updatedItem.descriptionSuffix.name,
+                "type" to updatedItem.type.name,
+                "state" to updatedItem.state.name,
+                "draft" to updatedItem.isDraft,
+                "official_row_id" to updatedItem.contextData.officialRowId?.intValue,
+                "design_row_id" to updatedItem.contextData.designRowId?.intValue,
+                "design_id" to updatedItem.contextData.designId?.intValue,
+                "duplicate_of_location_track_id" to updatedItem.duplicateOf?.intValue,
+                "topological_connectivity" to updatedItem.topologicalConnectivity.name,
+                "topology_start_switch_id" to updatedItem.topologyStartSwitch?.switchId?.intValue,
+                "topology_start_switch_joint_number" to
+                    updatedItem.topologyStartSwitch?.jointNumber?.intValue,
+                "topology_end_switch_id" to updatedItem.topologyEndSwitch?.switchId?.intValue,
+                "topology_end_switch_joint_number" to
+                    updatedItem.topologyEndSwitch?.jointNumber?.intValue,
+                "owner_id" to updatedItem.ownerId.intValue)
         jdbcTemplate.setUser()
-        val response: LayoutDaoResponse<LocationTrack> = jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-            rs.getDaoResponse("official_id", "row_id", "row_version")
-        } ?: throw IllegalStateException("Failed to get new version for Location Track")
+        val response: LayoutDaoResponse<LocationTrack> =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+                rs.getDaoResponse("official_id", "row_id", "row_version")
+            } ?: throw IllegalStateException("Failed to get new version for Location Track")
         logger.daoAccess(AccessType.UPDATE, LocationTrack::class, response)
         return response
     }
@@ -387,8 +418,10 @@ class LocationTrackDao(
         includeDeleted: Boolean,
         trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
         names: List<AlignmentName> = emptyList(),
-    ): List<LocationTrack> = fetchVersions(layoutContext, includeDeleted, trackNumberId, names)
-        .map { r -> fetch(r.rowVersion) }
+    ): List<LocationTrack> =
+        fetchVersions(layoutContext, includeDeleted, trackNumberId, names).map { r ->
+            fetch(r.rowVersion)
+        }
 
     fun fetchVersions(
         layoutContext: LayoutContext,
@@ -396,21 +429,24 @@ class LocationTrackDao(
         trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
         names: List<AlignmentName> = emptyList(),
     ): List<LayoutDaoResponse<LocationTrack>> {
-        val sql = """
+        val sql =
+            """
             select lt.official_id, lt.row_id, lt.row_version 
             from layout.location_track_in_layout_context(:publication_state::layout.publication_state, :design_id) lt
             where 
               (cast(:track_number_id as int) is null or lt.track_number_id = :track_number_id) 
               and (:names = '' or lower(lt.name) = any(string_to_array(:names, ',')::varchar[]))
               and (:include_deleted = true or state != 'DELETED')
-        """.trimIndent()
-        val params = mapOf(
-            "track_number_id" to trackNumberId?.intValue,
-            "publication_state" to layoutContext.state.name,
-            "design_id" to layoutContext.branch.designId?.intValue,
-            "include_deleted" to includeDeleted,
-            "names" to names.map { name -> name.toString().lowercase() }.joinToString(","),
-        )
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "track_number_id" to trackNumberId?.intValue,
+                "publication_state" to layoutContext.state.name,
+                "design_id" to layoutContext.branch.designId?.intValue,
+                "include_deleted" to includeDeleted,
+                "names" to names.map { name -> name.toString().lowercase() }.joinToString(","),
+            )
         return jdbcTemplate.query(sql, params) { rs, _ ->
             rs.getDaoResponse("official_id", "row_id", "row_version")
         }
@@ -419,8 +455,12 @@ class LocationTrackDao(
     fun listNear(context: LayoutContext, bbox: BoundingBox): List<LocationTrack> =
         fetchVersionsNear(context, bbox).map(::fetch)
 
-    fun fetchVersionsNear(context: LayoutContext, bbox: BoundingBox): List<LayoutRowVersion<LocationTrack>> {
-        val sql = """
+    fun fetchVersionsNear(
+        context: LayoutContext,
+        bbox: BoundingBox
+    ): List<LayoutRowVersion<LocationTrack>> {
+        val sql =
+            """
             select row_id, row_version
               from (
                 select coalesce(official_row_id, design_row_id, id) as official_id, id as row_id, version as row_version
@@ -444,17 +484,19 @@ class LocationTrackDao(
                   from layout.location_track_in_layout_context(:publication_state::layout.publication_state,
                                                                :design_id, location_track.official_id)
                   where state != 'DELETED') in_layout_context using (row_id, row_version);
-        """.trimIndent()
+        """
+                .trimIndent()
 
-        val params = mapOf(
-            "x_min" to bbox.min.x,
-            "y_min" to bbox.min.y,
-            "x_max" to bbox.max.x,
-            "y_max" to bbox.max.y,
-            "layout_srid" to LAYOUT_SRID.code,
-            "publication_state" to context.state.name,
-            "design_id" to context.branch.designId?.intValue,
-        )
+        val params =
+            mapOf(
+                "x_min" to bbox.min.x,
+                "y_min" to bbox.min.y,
+                "x_max" to bbox.max.x,
+                "y_max" to bbox.max.y,
+                "layout_srid" to LAYOUT_SRID.code,
+                "publication_state" to context.state.name,
+                "design_id" to context.branch.designId?.intValue,
+            )
 
         return jdbcTemplate.query(sql, params) { rs, _ ->
             rs.getLayoutRowVersion("row_id", "row_version")
@@ -463,21 +505,25 @@ class LocationTrackDao(
 
     @Cacheable(CACHE_COMMON_LOCATION_TRACK_OWNER, sync = true)
     fun fetchLocationTrackOwners(): List<LocationTrackOwner> {
-        val sql = """
+        val sql =
+            """
         select
             id,
             name
         from common.location_track_owner
         order by sort_priority, name
-    """.trimIndent()
+    """
+                .trimIndent()
 
-        val locationTrackOwners = jdbcTemplate.query(sql) { rs, _ ->
-            LocationTrackOwner(
-                id = rs.getIntId("id"),
-                name = MetaDataName(rs.getString("name")),
-            )
-        }
-        logger.daoAccess(AccessType.FETCH, LocationTrackOwner::class, locationTrackOwners.map { it.id })
+        val locationTrackOwners =
+            jdbcTemplate.query(sql) { rs, _ ->
+                LocationTrackOwner(
+                    id = rs.getIntId("id"),
+                    name = MetaDataName(rs.getString("name")),
+                )
+            }
+        logger.daoAccess(
+            AccessType.FETCH, LocationTrackOwner::class, locationTrackOwners.map { it.id })
         return locationTrackOwners
     }
 
@@ -486,24 +532,27 @@ class LocationTrackDao(
         includeDeleted: Boolean,
         trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
     ): List<LayoutRowVersion<LocationTrack>> {
-        val sql = """
+        val sql =
+            """
             select id, version
             from layout.location_track
             where draft
               and (:includeDeleted or state != 'DELETED')
               and (:trackNumberId::int is null or track_number_id = :trackNumberId)
               and design_id is not distinct from :design_id
-        """.trimIndent()
-        val params = mapOf(
-            "includeDeleted" to includeDeleted,
-            "trackNumberId" to trackNumberId?.intValue,
-            "design_id" to branch.designId?.intValue,
-        )
-        return jdbcTemplate.query(sql, params) { rs, _ ->
-            rs.getLayoutRowVersion<LocationTrack>("id", "version")
-        }.also { ids ->
-            logger.daoAccess(AccessType.VERSION_FETCH, "fetchOnlyDraftVersions", ids)
-        }
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "includeDeleted" to includeDeleted,
+                "trackNumberId" to trackNumberId?.intValue,
+                "design_id" to branch.designId?.intValue,
+            )
+        return jdbcTemplate
+            .query(sql, params) { rs, _ -> rs.getLayoutRowVersion<LocationTrack>("id", "version") }
+            .also { ids ->
+                logger.daoAccess(AccessType.VERSION_FETCH, "fetchOnlyDraftVersions", ids)
+            }
     }
 
     fun fetchVersionsForPublication(
@@ -513,7 +562,8 @@ class LocationTrackDao(
     ): Map<IntId<TrackLayoutTrackNumber>, List<LayoutDaoResponse<LocationTrack>>> {
         if (trackNumberIds.isEmpty()) return emptyMap()
 
-        val sql = """
+        val sql =
+            """
             select track.track_number_id, track.official_id, track.row_id, track.row_version
             from (
             select state, track_number_id, official_id, row_id, row_version
@@ -527,21 +577,29 @@ class LocationTrackDao(
             where track_number_id in (:track_number_ids)
               and track.state != 'DELETED'
             order by track.track_number_id, track.row_id
-        """.trimIndent()
-        val params = mapOf(
-            "track_number_ids" to trackNumberIds.map { id -> id.intValue },
-            "design_id" to branch.designId?.intValue,
-            // listOf(null) to indicate an empty list due to SQL syntax limitations; the "is distinct from true" checks
-            // explicitly for false or null, since "foo in (null)" in SQL is null
-            "track_ids_to_publish" to (trackIdsToPublish.map { id -> id.intValue }.ifEmpty { listOf(null) }),
-        )
-        val versions = jdbcTemplate.query(sql, params) { rs, _ ->
-            val trackNumberId = rs.getIntId<TrackLayoutTrackNumber>("track_number_id")
-            val daoResponse = rs.getDaoResponse<LocationTrack>("official_id", "row_id", "row_version")
-            trackNumberId to daoResponse
-        }
+        """
+                .trimIndent()
+        val params =
+            mapOf(
+                "track_number_ids" to trackNumberIds.map { id -> id.intValue },
+                "design_id" to branch.designId?.intValue,
+                // listOf(null) to indicate an empty list due to SQL syntax limitations; the "is
+                // distinct from true" checks
+                // explicitly for false or null, since "foo in (null)" in SQL is null
+                "track_ids_to_publish" to
+                    (trackIdsToPublish.map { id -> id.intValue }.ifEmpty { listOf(null) }),
+            )
+        val versions =
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                val trackNumberId = rs.getIntId<TrackLayoutTrackNumber>("track_number_id")
+                val daoResponse =
+                    rs.getDaoResponse<LocationTrack>("official_id", "row_id", "row_version")
+                trackNumberId to daoResponse
+            }
         return trackNumberIds.associateWith { trackNumberId ->
-            versions.filter { (tnId, _) -> tnId == trackNumberId }.map { (_, trackVersions) -> trackVersions }
+            versions
+                .filter { (tnId, _) -> tnId == trackNumberId }
+                .map { (_, trackVersions) -> trackVersions }
         }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -35,11 +35,11 @@ import fi.fta.geoviite.infra.ratko.model.OperationalPointType
 import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.util.FreeText
+import java.time.Instant
 import org.postgresql.util.PSQLException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.Instant
 
 const val TRACK_SEARCH_AREA_SIZE = 2.0
 const val OPERATING_POINT_AROUND_SWITCH_SEARCH_AREA_SIZE = 1000.0
@@ -59,28 +59,32 @@ class LocationTrackService(
 ) : LayoutAssetService<LocationTrack, LocationTrackDao>(locationTrackDao) {
 
     @Transactional
-    fun insert(branch: LayoutBranch, request: LocationTrackSaveRequest): LayoutDaoResponse<LocationTrack> {
+    fun insert(
+        branch: LayoutBranch,
+        request: LocationTrackSaveRequest
+    ): LayoutDaoResponse<LocationTrack> {
         val (alignment, alignmentVersion) = alignmentService.newEmpty()
-        val locationTrack = LocationTrack(
-            alignmentVersion = alignmentVersion,
-            name = request.name,
-            descriptionBase = request.descriptionBase,
-            descriptionSuffix = request.descriptionSuffix,
-            type = request.type,
-            state = request.state,
-            externalId = null,
-            trackNumberId = request.trackNumberId,
-            sourceId = null,
-            length = alignment.length,
-            segmentCount = alignment.segments.size,
-            boundingBox = alignment.boundingBox,
-            duplicateOf = request.duplicateOf,
-            topologicalConnectivity = request.topologicalConnectivity,
-            topologyStartSwitch = null,
-            topologyEndSwitch = null,
-            ownerId = request.ownerId,
-            contextData = LayoutContextData.newDraft(branch),
-        )
+        val locationTrack =
+            LocationTrack(
+                alignmentVersion = alignmentVersion,
+                name = request.name,
+                descriptionBase = request.descriptionBase,
+                descriptionSuffix = request.descriptionSuffix,
+                type = request.type,
+                state = request.state,
+                externalId = null,
+                trackNumberId = request.trackNumberId,
+                sourceId = null,
+                length = alignment.length,
+                segmentCount = alignment.segments.size,
+                boundingBox = alignment.boundingBox,
+                duplicateOf = request.duplicateOf,
+                topologicalConnectivity = request.topologicalConnectivity,
+                topologyStartSwitch = null,
+                topologyEndSwitch = null,
+                ownerId = request.ownerId,
+                contextData = LayoutContextData.newDraft(branch),
+            )
         return saveDraftInternal(branch, locationTrack)
     }
 
@@ -91,8 +95,7 @@ class LocationTrackService(
     ): LayoutDaoResponse<LocationTrack> {
         try {
             return requireNotNull(
-                transactionTemplate.execute { updateLocationTrackTransaction(branch, id, request) }
-            )
+                transactionTemplate.execute { updateLocationTrackTransaction(branch, id, request) })
         } catch (dataIntegrityException: DataIntegrityViolationException) {
             throw if (isSplitSourceReferenceError(dataIntegrityException)) {
                 SplitSourceLocationTrackUpdateException(request.name, dataIntegrityException)
@@ -108,28 +111,31 @@ class LocationTrackService(
         request: LocationTrackSaveRequest,
     ): LayoutDaoResponse<LocationTrack> {
         val (originalTrack, originalAlignment) = getWithAlignmentInternalOrThrow(branch.draft, id)
-        val locationTrack = originalTrack.copy(
-            name = request.name,
-            descriptionBase = request.descriptionBase,
-            descriptionSuffix = request.descriptionSuffix,
-            type = request.type,
-            state = request.state,
-            trackNumberId = request.trackNumberId,
-            duplicateOf = request.duplicateOf,
-            topologicalConnectivity = request.topologicalConnectivity,
-            ownerId = request.ownerId,
-        )
+        val locationTrack =
+            originalTrack.copy(
+                name = request.name,
+                descriptionBase = request.descriptionBase,
+                descriptionSuffix = request.descriptionSuffix,
+                type = request.type,
+                state = request.state,
+                trackNumberId = request.trackNumberId,
+                duplicateOf = request.duplicateOf,
+                topologicalConnectivity = request.topologicalConnectivity,
+                ownerId = request.ownerId,
+            )
 
         return if (locationTrack.state != LocationTrackState.DELETED) {
             saveDraft(
                 branch,
-                fetchNearbyTracksAndCalculateLocationTrackTopology(branch.draft, locationTrack, originalAlignment)
-            )
+                fetchNearbyTracksAndCalculateLocationTrackTopology(
+                    branch.draft, locationTrack, originalAlignment))
         } else {
             clearDuplicateReferences(branch, id)
             val segmentsWithoutSwitch = originalAlignment.segments.map(LayoutSegment::withoutSwitch)
             val newAlignment = originalAlignment.withSegments(segmentsWithoutSwitch)
-            val newTrack = fetchNearbyTracksAndCalculateLocationTrackTopology(branch.draft, locationTrack, newAlignment)
+            val newTrack =
+                fetchNearbyTracksAndCalculateLocationTrackTopology(
+                    branch.draft, locationTrack, newAlignment)
             saveDraft(branch, newTrack, newAlignment)
         }
     }
@@ -149,18 +155,26 @@ class LocationTrackService(
             clearDuplicateReferences(branch, id)
             val segmentsWithoutSwitch = originalAlignment.segments.map(LayoutSegment::withoutSwitch)
             val newAlignment = originalAlignment.withSegments(segmentsWithoutSwitch)
-            val newTrack = fetchNearbyTracksAndCalculateLocationTrackTopology(branch.draft, locationTrack, newAlignment)
+            val newTrack =
+                fetchNearbyTracksAndCalculateLocationTrackTopology(
+                    branch.draft, locationTrack, newAlignment)
             saveDraft(branch, newTrack, newAlignment)
         }
     }
 
     @Transactional
-    override fun saveDraft(branch: LayoutBranch, draftAsset: LocationTrack): LayoutDaoResponse<LocationTrack> =
-        super.saveDraft(branch, draftAsset.copy(alignmentVersion = updatedAlignmentVersion(draftAsset)))
+    override fun saveDraft(
+        branch: LayoutBranch,
+        draftAsset: LocationTrack
+    ): LayoutDaoResponse<LocationTrack> =
+        super.saveDraft(
+            branch, draftAsset.copy(alignmentVersion = updatedAlignmentVersion(draftAsset)))
 
     private fun updatedAlignmentVersion(track: LocationTrack): RowVersion<LayoutAlignment>? =
-        // If we're creating a new row or starting a draft, we duplicate the alignment to not edit any original
-        if (track.dataType == TEMP || track.isOfficial) alignmentService.duplicateOrNew(track.alignmentVersion)
+        // If we're creating a new row or starting a draft, we duplicate the alignment to not edit
+        // any original
+        if (track.dataType == TEMP || track.isOfficial)
+            alignmentService.duplicateOrNew(track.alignmentVersion)
         else track.alignmentVersion
 
     @Transactional
@@ -170,14 +184,16 @@ class LocationTrackService(
         alignment: LayoutAlignment,
     ): LayoutDaoResponse<LocationTrack> {
         val alignmentVersion =
-            // If we're creating a new row or starting a draft, we duplicate the alignment to not edit any original
+            // If we're creating a new row or starting a draft, we duplicate the alignment to not
+            // edit any original
             if (draftAsset.dataType == TEMP || draftAsset.isOfficial) {
                 alignmentService.saveAsNew(alignment)
             }
             // Ensure that we update the correct one.
             else if (draftAsset.getAlignmentVersionOrThrow().id != alignment.id) {
                 alignmentService.save(
-                    alignment.copy(id = draftAsset.getAlignmentVersionOrThrow().id, dataType = STORED),
+                    alignment.copy(
+                        id = draftAsset.getAlignmentVersionOrThrow().id, dataType = STORED),
                 )
             } else {
                 alignmentService.save(alignment)
@@ -197,20 +213,26 @@ class LocationTrackService(
             original.copy(
                 externalId = oid,
                 alignmentVersion = updatedAlignmentVersion(original),
-            )
-        )
+            ))
     }
 
     @Transactional
-    override fun publish(branch: LayoutBranch, version: ValidationVersion<LocationTrack>): LayoutDaoResponse<LocationTrack> {
+    override fun publish(
+        branch: LayoutBranch,
+        version: ValidationVersion<LocationTrack>
+    ): LayoutDaoResponse<LocationTrack> {
         val publishedVersion = publishInternal(branch, version.validatedAssetVersion)
-        // Some of the versions may get deleted in publication -> delete any alignments they left behind
+        // Some of the versions may get deleted in publication -> delete any alignments they left
+        // behind
         alignmentDao.deleteOrphanedAlignments()
         return publishedVersion
     }
 
     @Transactional
-    override fun deleteDraft(branch: LayoutBranch, id: IntId<LocationTrack>): LayoutDaoResponse<LocationTrack> {
+    override fun deleteDraft(
+        branch: LayoutBranch,
+        id: IntId<LocationTrack>
+    ): LayoutDaoResponse<LocationTrack> {
         val draft = dao.getOrThrow(branch.draft, id)
         // If removal also breaks references, clear them out first
         if (draft.contextData.officialRowId == null) {
@@ -222,16 +244,19 @@ class LocationTrackService(
     }
 
     @Transactional
-    fun fetchDuplicates(layoutContext: LayoutContext, id: IntId<LocationTrack>): List<LocationTrack> {
+    fun fetchDuplicates(
+        layoutContext: LayoutContext,
+        id: IntId<LocationTrack>
+    ): List<LocationTrack> {
         return dao.fetchDuplicateVersions(layoutContext, id).map(dao::fetch)
     }
 
     @Transactional
-    fun clearDuplicateReferences(branch: LayoutBranch, id: IntId<LocationTrack>) = dao
-        .fetchDuplicateVersions(branch.draft, id, includeDeleted = true)
-        .map(dao::fetch)
-        .map { dup -> asDraft(branch, dup) }
-        .forEach { duplicate -> saveDraft(branch, duplicate.copy(duplicateOf = null)) }
+    fun clearDuplicateReferences(branch: LayoutBranch, id: IntId<LocationTrack>) =
+        dao.fetchDuplicateVersions(branch.draft, id, includeDeleted = true)
+            .map(dao::fetch)
+            .map { dup -> asDraft(branch, dup) }
+            .forEach { duplicate -> saveDraft(branch, duplicate.copy(duplicateOf = null)) }
 
     fun listNonLinked(branch: LayoutBranch): List<LocationTrack> {
         return dao.list(branch.draft, false).filter { a -> a.segmentCount == 0 }
@@ -266,8 +291,7 @@ class LocationTrackService(
         includeDeleted: Boolean = false,
         boundingBox: BoundingBox? = null,
     ): List<Pair<LocationTrack, LayoutAlignment>> {
-        return dao
-            .list(layoutContext, includeDeleted, trackNumberId)
+        return dao.list(layoutContext, includeDeleted, trackNumberId)
             .let { list -> filterByBoundingBox(list, boundingBox) }
             .let(::associateWithAlignments)
     }
@@ -318,12 +342,16 @@ class LocationTrackService(
     }
 
     @Transactional(readOnly = true)
-    fun getWithAlignment(version: LayoutDaoResponse<LocationTrack>): Pair<LocationTrack, LayoutAlignment> {
+    fun getWithAlignment(
+        version: LayoutDaoResponse<LocationTrack>
+    ): Pair<LocationTrack, LayoutAlignment> {
         return getWithAlignmentInternal(version.rowVersion)
     }
 
     @Transactional(readOnly = true)
-    fun getWithAlignment(version: LayoutRowVersion<LocationTrack>): Pair<LocationTrack, LayoutAlignment> {
+    fun getWithAlignment(
+        version: LayoutRowVersion<LocationTrack>
+    ): Pair<LocationTrack, LayoutAlignment> {
         return getWithAlignmentInternal(version)
     }
 
@@ -340,13 +368,16 @@ class LocationTrackService(
         layoutContext: LayoutContext,
         location: IPoint,
     ): List<Pair<LocationTrack, LayoutAlignment>> {
-        val searchArea = BoundingBox(
-            Point(0.0, 0.0),
-            Point(TRACK_SEARCH_AREA_SIZE, TRACK_SEARCH_AREA_SIZE),
-        ).centerAt(location)
+        val searchArea =
+            BoundingBox(
+                    Point(0.0, 0.0),
+                    Point(TRACK_SEARCH_AREA_SIZE, TRACK_SEARCH_AREA_SIZE),
+                )
+                .centerAt(location)
         return listNearWithAlignments(layoutContext, searchArea).filter { (_, alignment) ->
             alignment.segments.any { segment ->
-                searchArea.intersects(segment.boundingBox) && segment.segmentPoints.any(searchArea::contains)
+                searchArea.intersects(segment.boundingBox) &&
+                    segment.segmentPoints.any(searchArea::contains)
             }
         }
     }
@@ -358,9 +389,10 @@ class LocationTrackService(
         boundingBox: BoundingBox?,
     ): List<AlignmentPlanSection> {
         val locationTrack = get(layoutContext, locationTrackId)
-        val geocodingContext = locationTrack?.let {
-            geocodingService.getGeocodingContext(layoutContext, locationTrack.trackNumberId)
-        }
+        val geocodingContext =
+            locationTrack?.let {
+                geocodingService.getGeocodingContext(layoutContext, locationTrack.trackNumberId)
+            }
 
         return if (geocodingContext != null && locationTrack.alignmentVersion != null) {
             alignmentService.getGeometryMetadataSections(
@@ -373,22 +405,28 @@ class LocationTrackService(
     }
 
     private fun getSwitchIdAtStart(alignment: LayoutAlignment, locationTrack: LocationTrack) =
-        if (alignment.segments.firstOrNull()?.startJointNumber == null) locationTrack.topologyStartSwitch?.switchId
+        if (alignment.segments.firstOrNull()?.startJointNumber == null)
+            locationTrack.topologyStartSwitch?.switchId
         else alignment.segments.firstOrNull()?.switchId as IntId?
 
     private fun getSwitchIdAtEnd(alignment: LayoutAlignment, locationTrack: LocationTrack) =
-        if (alignment.segments.lastOrNull()?.endJointNumber == null) locationTrack.topologyEndSwitch?.switchId
+        if (alignment.segments.lastOrNull()?.endJointNumber == null)
+            locationTrack.topologyEndSwitch?.switchId
         else alignment.segments.lastOrNull()?.switchId as IntId?
 
     @Transactional(readOnly = true)
-    fun getFullDescription(layoutContext: LayoutContext, locationTrack: LocationTrack, lang: LocalizationLanguage): FreeText {
+    fun getFullDescription(
+        layoutContext: LayoutContext,
+        locationTrack: LocationTrack,
+        lang: LocalizationLanguage
+    ): FreeText {
         val alignmentVersion = locationTrack.alignmentVersion
-        val (startSwitch, endSwitch) = alignmentVersion?.let {
-            val alignment = alignmentDao.fetch(alignmentVersion)
-            getSwitchIdAtStart(alignment, locationTrack) to getSwitchIdAtEnd(
-                alignment, locationTrack
-            )
-        } ?: (null to null)
+        val (startSwitch, endSwitch) =
+            alignmentVersion?.let {
+                val alignment = alignmentDao.fetch(alignmentVersion)
+                getSwitchIdAtStart(alignment, locationTrack) to
+                    getSwitchIdAtEnd(alignment, locationTrack)
+            } ?: (null to null)
 
         fun getSwitchShortName(switchId: IntId<TrackLayoutSwitch>) =
             switchDao.get(layoutContext, switchId)?.shortName
@@ -400,17 +438,17 @@ class LocationTrackService(
         return when (locationTrack.descriptionSuffix) {
             DescriptionSuffixType.NONE -> locationTrack.descriptionBase
 
-            DescriptionSuffixType.SWITCH_TO_BUFFER -> FreeText(
-                "${locationTrack.descriptionBase} ${startSwitchName ?: endSwitchName ?: "???"} - ${translation.t("location-track-dialog.buffer")}"
-            )
+            DescriptionSuffixType.SWITCH_TO_BUFFER ->
+                FreeText(
+                    "${locationTrack.descriptionBase} ${startSwitchName ?: endSwitchName ?: "???"} - ${translation.t("location-track-dialog.buffer")}")
 
-            DescriptionSuffixType.SWITCH_TO_SWITCH -> FreeText(
-                "${locationTrack.descriptionBase} ${startSwitchName ?: "???"} - ${endSwitchName ?: "???"}"
-            )
+            DescriptionSuffixType.SWITCH_TO_SWITCH ->
+                FreeText(
+                    "${locationTrack.descriptionBase} ${startSwitchName ?: "???"} - ${endSwitchName ?: "???"}")
 
-            DescriptionSuffixType.SWITCH_TO_OWNERSHIP_BOUNDARY -> FreeText(
-                "${locationTrack.descriptionBase} ${startSwitchName ?: endSwitchName ?: "???"} - ${translation.t("location-track-dialog.ownership-boundary")}"
-            )
+            DescriptionSuffixType.SWITCH_TO_OWNERSHIP_BOUNDARY ->
+                FreeText(
+                    "${locationTrack.descriptionBase} ${startSwitchName ?: endSwitchName ?: "???"} - ${translation.t("location-track-dialog.ownership-boundary")}")
         }
     }
 
@@ -421,78 +459,99 @@ class LocationTrackService(
         return getWithAlignmentInternal(dao.fetchVersionOrThrow(layoutContext, id))
     }
 
-    private fun getWithAlignmentInternal(version: LayoutRowVersion<LocationTrack>): Pair<LocationTrack, LayoutAlignment> =
-        locationTrackWithAlignment(dao, alignmentDao, version)
+    private fun getWithAlignmentInternal(
+        version: LayoutRowVersion<LocationTrack>
+    ): Pair<LocationTrack, LayoutAlignment> = locationTrackWithAlignment(dao, alignmentDao, version)
 
-    private fun associateWithAlignments(lines: List<LocationTrack>): List<Pair<LocationTrack, LayoutAlignment>> {
-        // This is a little convoluted to avoid extra passes of transaction annotation handling in alignmentDao.fetch
-        val alignments = alignmentDao.fetchMany(lines.map(LocationTrack::getAlignmentVersionOrThrow))
+    private fun associateWithAlignments(
+        lines: List<LocationTrack>
+    ): List<Pair<LocationTrack, LayoutAlignment>> {
+        // This is a little convoluted to avoid extra passes of transaction annotation handling in
+        // alignmentDao.fetch
+        val alignments =
+            alignmentDao.fetchMany(lines.map(LocationTrack::getAlignmentVersionOrThrow))
         return lines.map { line -> line to alignments.getValue(line.getAlignmentVersionOrThrow()) }
     }
 
-    fun fillTrackAddress(splitPoint:SplitPoint, geocodingContext: GeocodingContext): SplitPoint {
+    fun fillTrackAddress(splitPoint: SplitPoint, geocodingContext: GeocodingContext): SplitPoint {
         val address = geocodingContext.getAddress(splitPoint.location)?.first
         return when (splitPoint) {
-            is SwitchSplitPoint -> splitPoint.copy( address = address)
-            is EndpointSplitPoint -> splitPoint.copy( address = address)
+            is SwitchSplitPoint -> splitPoint.copy(address = address)
+            is EndpointSplitPoint -> splitPoint.copy(address = address)
         }
     }
 
-    fun fillTrackAddresses(duplicates: List<LocationTrackDuplicate>, geocodingContext:GeocodingContext) : List<LocationTrackDuplicate> {
+    fun fillTrackAddresses(
+        duplicates: List<LocationTrackDuplicate>,
+        geocodingContext: GeocodingContext
+    ): List<LocationTrackDuplicate> {
         return duplicates.map { duplicate ->
             duplicate.copy(
-                duplicateStatus = duplicate.duplicateStatus.copy(
-                    startSplitPoint = duplicate.duplicateStatus.startSplitPoint?.let { splitPoint ->
-                        fillTrackAddress(splitPoint, geocodingContext)
-                        },
-                    endSplitPoint = duplicate.duplicateStatus.endSplitPoint?.let { splitPoint ->
-                        fillTrackAddress(splitPoint, geocodingContext)
-                    }
-                )
-            )
+                duplicateStatus =
+                    duplicate.duplicateStatus.copy(
+                        startSplitPoint =
+                            duplicate.duplicateStatus.startSplitPoint?.let { splitPoint ->
+                                fillTrackAddress(splitPoint, geocodingContext)
+                            },
+                        endSplitPoint =
+                            duplicate.duplicateStatus.endSplitPoint?.let { splitPoint ->
+                                fillTrackAddress(splitPoint, geocodingContext)
+                            }))
         }
     }
 
     @Transactional(readOnly = true)
-    fun getInfoboxExtras(layoutContext: LayoutContext, id: IntId<LocationTrack>): LocationTrackInfoboxExtras? {
+    fun getInfoboxExtras(
+        layoutContext: LayoutContext,
+        id: IntId<LocationTrack>
+    ): LocationTrackInfoboxExtras? {
         return getWithAlignment(layoutContext, id)?.let { (locationTrack, alignment) ->
             val start = alignment.start ?: return null
             val end = alignment.end ?: return null
-            val geocodingContext = geocodingService.getGeocodingContext(layoutContext, locationTrack.trackNumberId)
-                ?: return null
+            val geocodingContext =
+                geocodingService.getGeocodingContext(layoutContext, locationTrack.trackNumberId)
+                    ?: return null
 
             val duplicateOf = getDuplicateTrackParent(layoutContext, locationTrack)
-            val duplicates = fillTrackAddresses(
-                getLocationTrackDuplicates(layoutContext, locationTrack, alignment),
-                geocodingContext
-            )
-            val sortedDuplicates = duplicates.sortedBy { duplicate ->
-                duplicate.duplicateStatus.startSplitPoint?.address
-            }
+            val duplicates =
+                fillTrackAddresses(
+                    getLocationTrackDuplicates(layoutContext, locationTrack, alignment),
+                    geocodingContext)
+            val sortedDuplicates =
+                duplicates.sortedBy { duplicate ->
+                    duplicate.duplicateStatus.startSplitPoint?.address
+                }
 
             val startAddress = geocodingContext?.getAddress(start)?.first
-            val startSwitchId = alignment.segments.firstOrNull()?.switchId as IntId?
-                ?: locationTrack.topologyStartSwitch?.switchId
-            val startSplitPoint = if (startSwitchId!=null)
-                    SwitchSplitPoint( start, startAddress, startSwitchId, JointNumber(0))
-                else
-                    EndpointSplitPoint( start, startAddress, DuplicateEndPointType.START)
+            val startSwitchId =
+                alignment.segments.firstOrNull()?.switchId as IntId?
+                    ?: locationTrack.topologyStartSwitch?.switchId
+            val startSplitPoint =
+                if (startSwitchId != null)
+                    SwitchSplitPoint(start, startAddress, startSwitchId, JointNumber(0))
+                else EndpointSplitPoint(start, startAddress, DuplicateEndPointType.START)
 
             val endAddress = geocodingContext?.getAddress(end)?.first
-            val endSwitchId = alignment.segments.lastOrNull()?.switchId as IntId?
-                ?: locationTrack.topologyEndSwitch?.switchId
-            val endSplitPoint = if (endSwitchId!=null)
+            val endSwitchId =
+                alignment.segments.lastOrNull()?.switchId as IntId?
+                    ?: locationTrack.topologyEndSwitch?.switchId
+            val endSplitPoint =
+                if (endSwitchId != null)
                     SwitchSplitPoint(end, endAddress, endSwitchId, JointNumber(0))
-                else
-                    EndpointSplitPoint(end, endAddress, DuplicateEndPointType.END)
+                else EndpointSplitPoint(end, endAddress, DuplicateEndPointType.END)
 
-            val startSwitch = (alignment.segments.firstOrNull()?.switchId as IntId?
-                ?: locationTrack.topologyStartSwitch?.switchId)?.let { id -> fetchSwitchAtEndById(layoutContext, id) }
-            val endSwitch = (alignment.segments.lastOrNull()?.switchId as IntId?
-                ?: locationTrack.topologyEndSwitch?.switchId)?.let { id -> fetchSwitchAtEndById(layoutContext, id) }
-            val partOfUnfinishedSplit = splitDao
-                .locationTracksPartOfAnyUnfinishedSplit(layoutContext.branch , listOf(id))
-                .isNotEmpty()
+            val startSwitch =
+                (alignment.segments.firstOrNull()?.switchId as IntId?
+                        ?: locationTrack.topologyStartSwitch?.switchId)
+                    ?.let { id -> fetchSwitchAtEndById(layoutContext, id) }
+            val endSwitch =
+                (alignment.segments.lastOrNull()?.switchId as IntId?
+                        ?: locationTrack.topologyEndSwitch?.switchId)
+                    ?.let { id -> fetchSwitchAtEndById(layoutContext, id) }
+            val partOfUnfinishedSplit =
+                splitDao
+                    .locationTracksPartOfAnyUnfinishedSplit(layoutContext.branch, listOf(id))
+                    .isNotEmpty()
 
             LocationTrackInfoboxExtras(
                 duplicateOf,
@@ -501,25 +560,30 @@ class LocationTrackService(
                 endSwitch,
                 partOfUnfinishedSplit,
                 startSplitPoint,
-                endSplitPoint
-            )
+                endSplitPoint)
         }
     }
 
     @Transactional(readOnly = true)
     fun getRelinkableSwitchesCount(layoutContext: LayoutContext, id: IntId<LocationTrack>): Int? =
-        getWithAlignment(layoutContext, id)
-            ?.let { (track, alignment) -> countRelinkableSwitches(layoutContext.branch, track, alignment) }
+        getWithAlignment(layoutContext, id)?.let { (track, alignment) ->
+            countRelinkableSwitches(layoutContext.branch, track, alignment)
+        }
 
     private fun countRelinkableSwitches(
         branch: LayoutBranch,
         locationTrack: LocationTrack,
         alignment: LayoutAlignment,
     ): Int =
-        (alignment.segments.mapNotNull { it.switchId } + listOfNotNull(
-            locationTrack.topologyStartSwitch?.switchId,
-            locationTrack.topologyEndSwitch?.switchId,
-        ) + switchDao.findSwitchesNearAlignment(branch, locationTrack.getAlignmentVersionOrThrow())).distinct().size
+        (alignment.segments.mapNotNull { it.switchId } +
+                listOfNotNull(
+                    locationTrack.topologyStartSwitch?.switchId,
+                    locationTrack.topologyEndSwitch?.switchId,
+                ) +
+                switchDao.findSwitchesNearAlignment(
+                    branch, locationTrack.getAlignmentVersionOrThrow()))
+            .distinct()
+            .size
 
     @Transactional(readOnly = true)
     fun getLocationTrackDuplicates(
@@ -528,39 +592,46 @@ class LocationTrackService(
         alignment: LayoutAlignment,
     ): List<LocationTrackDuplicate> {
         val markedDuplicateVersions = dao.fetchDuplicateVersions(layoutContext, track.id as IntId)
-        val tracksLinkedThroughSwitch = switchDao
-            .findLocationTracksLinkedToSwitches(layoutContext, track.switchIds)
-            .map(LayoutSwitchDao.LocationTrackIdentifiers::rowVersion)
-        val duplicateTracksAndAlignments = (markedDuplicateVersions + tracksLinkedThroughSwitch)
-            .distinct()
-            .map(::getWithAlignmentInternal)
-            .filter { (duplicateTrack, _) -> duplicateTrack.id != track.id && duplicateTrack.id != track.duplicateOf }
-        return getLocationTrackDuplicatesBySplitPoints(track, alignment, duplicateTracksAndAlignments)
+        val tracksLinkedThroughSwitch =
+            switchDao
+                .findLocationTracksLinkedToSwitches(layoutContext, track.switchIds)
+                .map(LayoutSwitchDao.LocationTrackIdentifiers::rowVersion)
+        val duplicateTracksAndAlignments =
+            (markedDuplicateVersions + tracksLinkedThroughSwitch)
+                .distinct()
+                .map(::getWithAlignmentInternal)
+                .filter { (duplicateTrack, _) ->
+                    duplicateTrack.id != track.id && duplicateTrack.id != track.duplicateOf
+                }
+        return getLocationTrackDuplicatesBySplitPoints(
+            track, alignment, duplicateTracksAndAlignments)
     }
 
     private fun getDuplicateTrackParent(
         layoutContext: LayoutContext,
         childTrack: LocationTrack,
-    ): LocationTrackDuplicate? = childTrack.duplicateOf?.let { parentId ->
-        getWithAlignment(layoutContext, parentId)?.let { (parentTrack, parentTrackAlignment) ->
-            val childAlignment = alignmentDao.fetch(childTrack.getAlignmentVersionOrThrow())
-            getDuplicateTrackParentStatus(parentTrack, parentTrackAlignment, childTrack, childAlignment)
+    ): LocationTrackDuplicate? =
+        childTrack.duplicateOf?.let { parentId ->
+            getWithAlignment(layoutContext, parentId)?.let { (parentTrack, parentTrackAlignment) ->
+                val childAlignment = alignmentDao.fetch(childTrack.getAlignmentVersionOrThrow())
+                getDuplicateTrackParentStatus(
+                    parentTrack, parentTrackAlignment, childTrack, childAlignment)
+            }
         }
-    }
 
-    private fun fetchSwitchAtEndById(layoutContext: LayoutContext, id: IntId<TrackLayoutSwitch>): LayoutSwitchIdAndName? =
+    private fun fetchSwitchAtEndById(
+        layoutContext: LayoutContext,
+        id: IntId<TrackLayoutSwitch>
+    ): LayoutSwitchIdAndName? =
         switchDao.get(layoutContext, id)?.let { switch -> LayoutSwitchIdAndName(id, switch.name) }
 
     fun fetchNearbyLocationTracksWithAlignments(
         layoutContext: LayoutContext,
         targetPoint: LayoutPoint,
     ): List<Pair<LocationTrack, LayoutAlignment>> {
-        return dao
-            .fetchVersionsNear(layoutContext, boundingBoxAroundPoint(targetPoint, 1.0))
+        return dao.fetchVersionsNear(layoutContext, boundingBoxAroundPoint(targetPoint, 1.0))
             .map { version -> getWithAlignmentInternal(version) }
-            .filter { (track, alignment) ->
-                alignment.segments.isNotEmpty() && track.exists
-            }
+            .filter { (track, alignment) -> alignment.segments.isNotEmpty() && track.exists }
     }
 
     @Transactional
@@ -571,30 +642,36 @@ class LocationTrackService(
         startChanged: Boolean = false,
         endChanged: Boolean = false,
     ): LocationTrack {
-        val nearbyTracksAroundStart = alignment.start
-            ?.let { point -> fetchNearbyLocationTracksWithAlignments(layoutContext, point) }
-            ?.filter { (nearbyLocationTrack, _) -> nearbyLocationTrack.id != track.id }
-            ?: listOf()
+        val nearbyTracksAroundStart =
+            alignment.start
+                ?.let { point -> fetchNearbyLocationTracksWithAlignments(layoutContext, point) }
+                ?.filter { (nearbyLocationTrack, _) -> nearbyLocationTrack.id != track.id }
+                ?: listOf()
 
-        val nearbyTracksAroundEnd = alignment.end
-            ?.let { point -> fetchNearbyLocationTracksWithAlignments(layoutContext, point) }
-            ?.filter { (nearbyLocationTrack, _) -> nearbyLocationTrack.id != track.id }
-            ?: listOf()
+        val nearbyTracksAroundEnd =
+            alignment.end
+                ?.let { point -> fetchNearbyLocationTracksWithAlignments(layoutContext, point) }
+                ?.filter { (nearbyLocationTrack, _) -> nearbyLocationTrack.id != track.id }
+                ?: listOf()
 
         return calculateLocationTrackTopology(
             track = track,
             alignment = alignment,
             startChanged = startChanged,
             endChanged = endChanged,
-            nearbyTracks = NearbyTracks(
-                aroundStart = nearbyTracksAroundStart,
-                aroundEnd = nearbyTracksAroundEnd,
-            ),
+            nearbyTracks =
+                NearbyTracks(
+                    aroundStart = nearbyTracksAroundStart,
+                    aroundEnd = nearbyTracksAroundEnd,
+                ),
         )
     }
 
     @Transactional(readOnly = true)
-    fun getLocationTrackEndpoints(layoutContext: LayoutContext, bbox: BoundingBox): List<LocationTrackEndpoint> {
+    fun getLocationTrackEndpoints(
+        layoutContext: LayoutContext,
+        bbox: BoundingBox
+    ): List<LocationTrackEndpoint> {
         return getLocationTrackEndpoints(listWithAlignments(layoutContext), bbox)
     }
 
@@ -608,91 +685,115 @@ class LocationTrackService(
         trackId: IntId<LocationTrack>,
     ): SplittingInitializationParameters? {
         return getWithAlignment(layoutContext, trackId)?.let { (locationTrack, alignment) ->
-            val switches = getSwitchesForLocationTrack(layoutContext, trackId)
-                .mapNotNull { id -> switchDao.get(layoutContext, id) }
-                .mapNotNull { switch ->
-                    switchLibraryService.getSwitchStructure(switch.switchStructureId).let { structure ->
-                        val presentationJointLocation = switch.getJoint(structure.presentationJointNumber)?.location
-                        if (presentationJointLocation != null) {
-                            switch to presentationJointLocation
-                        } else {
-                            null
+            val switches =
+                getSwitchesForLocationTrack(layoutContext, trackId)
+                    .mapNotNull { id -> switchDao.get(layoutContext, id) }
+                    .mapNotNull { switch ->
+                        switchLibraryService.getSwitchStructure(switch.switchStructureId).let {
+                            structure ->
+                            val presentationJointLocation =
+                                switch.getJoint(structure.presentationJointNumber)?.location
+                            if (presentationJointLocation != null) {
+                                switch to presentationJointLocation
+                            } else {
+                                null
+                            }
                         }
                     }
-                }
-                .map { (switch, location) ->
-                    val address = geocodingService
-                        .getGeocodingContext(layoutContext, locationTrack.trackNumberId)
-                        ?.getAddressAndM(location)
-                    val mAlongAlignment = alignment.getClosestPointM(location)?.first
-                    SwitchOnLocationTrack(
-                        switch.id as IntId,
-                        switch.name,
-                        address?.address,
-                        location,
-                        mAlongAlignment,
-                        getNearestOperatingPoint(location),
-                    )
-                }
+                    .map { (switch, location) ->
+                        val address =
+                            geocodingService
+                                .getGeocodingContext(layoutContext, locationTrack.trackNumberId)
+                                ?.getAddressAndM(location)
+                        val mAlongAlignment = alignment.getClosestPointM(location)?.first
+                        SwitchOnLocationTrack(
+                            switch.id as IntId,
+                            switch.name,
+                            address?.address,
+                            location,
+                            mAlongAlignment,
+                            getNearestOperatingPoint(location),
+                        )
+                    }
 
-            val duplicateTracks = getLocationTrackDuplicates(layoutContext, locationTrack, alignment)
-                .mapNotNull { duplicate ->
-                    getWithAlignmentOrThrow(layoutContext, duplicate.id).let { (dupe, alignment) ->
-                        geocodingService.getLocationTrackStartAndEnd(layoutContext, dupe, alignment)
-                    }?.let { (start, end) ->
-                        if (start != null && end != null) {
-                            SplitDuplicateTrack(duplicate.id, duplicate.name, start, end, duplicate.duplicateStatus)
-                        } else {
-                            null
+            val duplicateTracks =
+                getLocationTrackDuplicates(layoutContext, locationTrack, alignment).mapNotNull {
+                    duplicate ->
+                    getWithAlignmentOrThrow(layoutContext, duplicate.id)
+                        .let { (dupe, alignment) ->
+                            geocodingService.getLocationTrackStartAndEnd(
+                                layoutContext, dupe, alignment)
                         }
-                    }
+                        ?.let { (start, end) ->
+                            if (start != null && end != null) {
+                                SplitDuplicateTrack(
+                                    duplicate.id,
+                                    duplicate.name,
+                                    start,
+                                    end,
+                                    duplicate.duplicateStatus)
+                            } else {
+                                null
+                            }
+                        }
                 }
 
             SplittingInitializationParameters(trackId, switches, duplicateTracks)
         }
     }
 
-    private fun getNearestOperatingPoint(location: Point) = ratkoOperatingPointDao
-        .getOperatingPoints(
-            boundingBoxAroundPoint(
-                location, OPERATING_POINT_AROUND_SWITCH_SEARCH_AREA_SIZE
-            )
-        )
-        .filter { op -> op.type == OperationalPointType.LPO || op.type == OperationalPointType.LP }
-        .minByOrNull { operatingPoint -> lineLength(operatingPoint.location, location) }
+    private fun getNearestOperatingPoint(location: Point) =
+        ratkoOperatingPointDao
+            .getOperatingPoints(
+                boundingBoxAroundPoint(location, OPERATING_POINT_AROUND_SWITCH_SEARCH_AREA_SIZE))
+            .filter { op ->
+                op.type == OperationalPointType.LPO || op.type == OperationalPointType.LP
+            }
+            .minByOrNull { operatingPoint -> lineLength(operatingPoint.location, location) }
 
     @Transactional(readOnly = true)
     fun getSwitchesForLocationTrack(
         layoutContext: LayoutContext,
         locationTrackId: IntId<LocationTrack>,
     ): List<IntId<TrackLayoutSwitch>> {
-        return getWithAlignment(layoutContext, locationTrackId)
-            ?.let { (track, alignment) -> collectAllSwitches(track, alignment) }
-            ?: emptyList()
+        return getWithAlignment(layoutContext, locationTrackId)?.let { (track, alignment) ->
+            collectAllSwitches(track, alignment)
+        } ?: emptyList()
     }
 
     @Transactional(readOnly = true)
-    fun getAlignmentsForTracks(tracks: List<LocationTrack>): List<Pair<LocationTrack, LayoutAlignment>> {
+    fun getAlignmentsForTracks(
+        tracks: List<LocationTrack>
+    ): List<Pair<LocationTrack, LayoutAlignment>> {
         return tracks.map { track ->
-            val alignment = track.alignmentVersion?.let(alignmentDao::fetch)
-                ?: error("All location tracks should have an alignment. Alignment was not found for track=${track.id}")
+            val alignment =
+                track.alignmentVersion?.let(alignmentDao::fetch)
+                    ?: error(
+                        "All location tracks should have an alignment. Alignment was not found for track=${track.id}")
             track to alignment
         }
     }
 
-    override fun mergeToMainBranch(fromBranch: DesignBranch, id: IntId<LocationTrack>): LayoutDaoResponse<LocationTrack> {
+    override fun mergeToMainBranch(
+        fromBranch: DesignBranch,
+        id: IntId<LocationTrack>
+    ): LayoutDaoResponse<LocationTrack> {
         val (versions, track) = fetchAndCheckVersionsForMerging(fromBranch, id)
         return mergeToMainBranchInternal(
             versions,
-            track.copy(alignmentVersion = alignmentService.duplicate(track.getAlignmentVersionOrThrow())),
+            track.copy(
+                alignmentVersion = alignmentService.duplicate(track.getAlignmentVersionOrThrow())),
         )
     }
 }
 
-fun collectAllSwitches(locationTrack: LocationTrack, alignment: LayoutAlignment): List<IntId<TrackLayoutSwitch>> {
-    val topologySwitches = listOfNotNull(
-        locationTrack.topologyStartSwitch?.switchId, locationTrack.topologyEndSwitch?.switchId
-    )
+fun collectAllSwitches(
+    locationTrack: LocationTrack,
+    alignment: LayoutAlignment
+): List<IntId<TrackLayoutSwitch>> {
+    val topologySwitches =
+        listOfNotNull(
+            locationTrack.topologyStartSwitch?.switchId, locationTrack.topologyEndSwitch?.switchId)
     val segmentSwitches = alignment.segments.mapNotNull { segment -> segment.switchId as IntId? }
     return (topologySwitches + segmentSwitches).distinct()
 }
@@ -714,20 +815,30 @@ fun calculateLocationTrackTopology(
     val endPoint = alignment.lastSegmentEnd
     val ownSwitches = alignment.segments.mapNotNull { segment -> segment.switchId }.toSet()
 
-    val startSwitch = if (!track.exists || startPoint == null) null
-    else if (startChanged) {
-        findBestTopologySwitchMatch(startPoint, ownSwitches, nearbyTracks.aroundStart, null, newSwitch)
-    } else {
-        findBestTopologySwitchMatch(startPoint, ownSwitches, nearbyTracks.aroundStart, track.topologyStartSwitch, newSwitch)
-    }
+    val startSwitch =
+        if (!track.exists || startPoint == null) null
+        else if (startChanged) {
+            findBestTopologySwitchMatch(
+                startPoint, ownSwitches, nearbyTracks.aroundStart, null, newSwitch)
+        } else {
+            findBestTopologySwitchMatch(
+                startPoint,
+                ownSwitches,
+                nearbyTracks.aroundStart,
+                track.topologyStartSwitch,
+                newSwitch)
+        }
 
-    val endSwitch = if (!track.exists || endPoint == null) {
-        null
-    } else if (endChanged) {
-        findBestTopologySwitchMatch(endPoint, ownSwitches, nearbyTracks.aroundEnd, null, newSwitch)
-    } else {
-        findBestTopologySwitchMatch(endPoint, ownSwitches, nearbyTracks.aroundEnd, track.topologyEndSwitch, newSwitch)
-    }
+    val endSwitch =
+        if (!track.exists || endPoint == null) {
+            null
+        } else if (endChanged) {
+            findBestTopologySwitchMatch(
+                endPoint, ownSwitches, nearbyTracks.aroundEnd, null, newSwitch)
+        } else {
+            findBestTopologySwitchMatch(
+                endPoint, ownSwitches, nearbyTracks.aroundEnd, track.topologyEndSwitch, newSwitch)
+        }
 
     return if (track.topologyStartSwitch == startSwitch && track.topologyEndSwitch == endSwitch) {
         track
@@ -747,11 +858,12 @@ fun findBestTopologySwitchMatch(
     currentTopologySwitch: TopologyLocationTrackSwitch?,
     newSwitch: TopologyLinkFindingSwitch?,
 ): TopologyLocationTrackSwitch? {
-    val defaultSwitch = if (currentTopologySwitch?.switchId?.let(ownSwitches::contains) != false) {
-        null
-    } else {
-        currentTopologySwitch
-    }
+    val defaultSwitch =
+        if (currentTopologySwitch?.switchId?.let(ownSwitches::contains) != false) {
+            null
+        } else {
+            currentTopologySwitch
+        }
     return findBestTopologySwitchFromSegments(target, ownSwitches, nearbyTracksForSearch, newSwitch)
         ?: defaultSwitch
         ?: findBestTopologySwitchFromOtherTopology(target, ownSwitches, nearbyTracksForSearch)
@@ -762,35 +874,54 @@ private fun findBestTopologySwitchFromSegments(
     ownSwitches: Set<DomainId<TrackLayoutSwitch>>,
     nearbyTracks: List<Pair<LocationTrack, LayoutAlignment>>,
     newSwitch: TopologyLinkFindingSwitch?,
-): TopologyLocationTrackSwitch? = nearbyTracks.flatMap { (_, otherAlignment) ->
-    otherAlignment.segments.flatMap { segment ->
-        if (segment.switchId !is IntId || ownSwitches.contains(segment.switchId) || segment.switchId == newSwitch?.id) {
-            listOf()
-        } else {
-            listOfNotNull(
-                segment.startJointNumber?.let { number ->
-                    pickIfClose(segment.switchId, number, target, segment.segmentStart)
-                },
-                segment.endJointNumber?.let { number ->
-                    pickIfClose(segment.switchId, number, target, segment.segmentEnd)
-                },
-            )
+): TopologyLocationTrackSwitch? =
+    nearbyTracks
+        .flatMap { (_, otherAlignment) ->
+            otherAlignment.segments.flatMap { segment ->
+                if (segment.switchId !is IntId ||
+                    ownSwitches.contains(segment.switchId) ||
+                    segment.switchId == newSwitch?.id) {
+                    listOf()
+                } else {
+                    listOfNotNull(
+                        segment.startJointNumber?.let { number ->
+                            pickIfClose(segment.switchId, number, target, segment.segmentStart)
+                        },
+                        segment.endJointNumber?.let { number ->
+                            pickIfClose(segment.switchId, number, target, segment.segmentEnd)
+                        },
+                    )
+                }
+            } +
+                (newSwitch?.joints?.mapNotNull { sj ->
+                    pickIfClose(newSwitch.id, sj.number, target, sj.location)
+                } ?: listOf())
         }
-    } + (newSwitch?.joints?.mapNotNull { sj ->
-        pickIfClose(newSwitch.id, sj.number, target, sj.location)
-    } ?: listOf())
-}.minByOrNull { (_, distance) -> distance }?.first
+        .minByOrNull { (_, distance) -> distance }
+        ?.first
 
 private fun findBestTopologySwitchFromOtherTopology(
     target: IPoint,
     ownSwitches: Set<DomainId<TrackLayoutSwitch>>,
     nearbyTracks: List<Pair<LocationTrack, LayoutAlignment>>,
-): TopologyLocationTrackSwitch? = nearbyTracks.flatMap { (otherTrack, otherAlignment) ->
-    listOfNotNull(
-        pickIfClose(otherTrack.topologyStartSwitch, target, otherAlignment.firstSegmentStart, ownSwitches),
-        pickIfClose(otherTrack.topologyEndSwitch, target, otherAlignment.lastSegmentEnd, ownSwitches),
-    )
-}.minByOrNull { (_, distance) -> distance }?.first
+): TopologyLocationTrackSwitch? =
+    nearbyTracks
+        .flatMap { (otherTrack, otherAlignment) ->
+            listOfNotNull(
+                pickIfClose(
+                    otherTrack.topologyStartSwitch,
+                    target,
+                    otherAlignment.firstSegmentStart,
+                    ownSwitches),
+                pickIfClose(
+                    otherTrack.topologyEndSwitch,
+                    target,
+                    otherAlignment.lastSegmentEnd,
+                    ownSwitches),
+            )
+        }
+        .minByOrNull { (_, distance) -> distance }
+        ?.first
 
 private fun pickIfClose(
     switchId: IntId<TrackLayoutSwitch>,
@@ -805,7 +936,9 @@ private fun pickIfClose(
     reference: IPoint?,
     ownSwitches: Set<DomainId<TrackLayoutSwitch>>,
 ): Pair<TopologyLocationTrackSwitch, Double>? =
-    if (reference != null && topologyMatch != null && !ownSwitches.contains(topologyMatch.switchId)) {
+    if (reference != null &&
+        topologyMatch != null &&
+        !ownSwitches.contains(topologyMatch.switchId)) {
         val distance = lineLength(target, reference)
         if (distance < 1.0) topologyMatch to distance else null
     } else {
@@ -815,42 +948,42 @@ private fun pickIfClose(
 fun getLocationTrackEndpoints(
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
     bbox: BoundingBox,
-): List<LocationTrackEndpoint> = locationTracks.flatMap { (locationTrack, alignment) ->
-    val trackId = locationTrack.id as IntId
-    listOfNotNull(
-        alignment.firstSegmentStart?.takeIf(bbox::contains)?.let { p ->
-            LocationTrackEndpoint(trackId, p.toPoint(), START_POINT)
-        },
-        alignment.lastSegmentEnd?.takeIf(bbox::contains)?.let { p ->
-            LocationTrackEndpoint(trackId, p.toPoint(), END_POINT)
-        },
-    )
-}
+): List<LocationTrackEndpoint> =
+    locationTracks.flatMap { (locationTrack, alignment) ->
+        val trackId = locationTrack.id as IntId
+        listOfNotNull(
+            alignment.firstSegmentStart?.takeIf(bbox::contains)?.let { p ->
+                LocationTrackEndpoint(trackId, p.toPoint(), START_POINT)
+            },
+            alignment.lastSegmentEnd?.takeIf(bbox::contains)?.let { p ->
+                LocationTrackEndpoint(trackId, p.toPoint(), END_POINT)
+            },
+        )
+    }
 
 fun locationTrackWithAlignment(
     locationTrackDao: LocationTrackDao,
     alignmentDao: LayoutAlignmentDao,
     rowVersion: LayoutRowVersion<LocationTrack>,
-) = locationTrackDao.fetch(rowVersion).let { track ->
-    track to alignmentDao.fetch(track.getAlignmentVersionOrThrow())
-}
+) =
+    locationTrackDao.fetch(rowVersion).let { track ->
+        track to alignmentDao.fetch(track.getAlignmentVersionOrThrow())
+    }
 
 fun filterByBoundingBox(list: List<LocationTrack>, boundingBox: BoundingBox?): List<LocationTrack> =
-    if (boundingBox != null) list.filter { t -> boundingBox.intersects(t.boundingBox) }
-    else list
+    if (boundingBox != null) list.filter { t -> boundingBox.intersects(t.boundingBox) } else list
 
 fun isSplitSourceReferenceError(exception: DataIntegrityViolationException): Boolean {
     val constraint = "split_source_location_track_fkey"
     val trackIsSplitSourceTrackError = "is still referenced from table \"split\""
 
-    return (exception.cause as? PSQLException)
-        ?.serverErrorMessage
-        .let { msg ->
-            when {
-                msg == null -> false
-                msg.constraint == constraint && msg.detail?.contains(trackIsSplitSourceTrackError) == true -> true
+    return (exception.cause as? PSQLException)?.serverErrorMessage.let { msg ->
+        when {
+            msg == null -> false
+            msg.constraint == constraint &&
+                msg.detail?.contains(trackIsSplitSourceTrackError) == true -> true
 
-                else -> false
-            }
+            else -> false
         }
+    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
@@ -30,7 +30,8 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @RequestParam("type") type: AlignmentFetchType? = null,
     ): List<AlignmentPolyLine<*>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        return mapAlignmentService.getAlignmentPolyLines(layoutContext, bbox, resolution, type ?: ALL)
+        return mapAlignmentService.getAlignmentPolyLines(
+            layoutContext, bbox, resolution, type ?: ALL)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
@@ -43,7 +44,8 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @RequestParam("resolution") resolution: Int,
     ): AlignmentPolyLine<LocationTrack>? {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        return mapAlignmentService.getAlignmentPolyline(layoutContext, locationTrackId, bbox, resolution)
+        return mapAlignmentService.getAlignmentPolyline(
+            layoutContext, locationTrackId, bbox, resolution)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -54,15 +54,15 @@ fun toTrackLayout(
 ): GeometryPlanLayout {
     val switches = toTrackLayoutSwitches(geometryPlan.switches, planToLayout)
 
-    val alignments: List<PlanLayoutAlignment> = toMapAlignments(
-        trackNumberId,
-        geometryPlan.alignments,
-        planToLayout,
-        pointListStepLength,
-        heightTriangles,
-        geometryPlan.units.verticalCoordinateSystem,
-        includeGeometryData
-    )
+    val alignments: List<PlanLayoutAlignment> =
+        toMapAlignments(
+            trackNumberId,
+            geometryPlan.alignments,
+            planToLayout,
+            pointListStepLength,
+            heightTriangles,
+            geometryPlan.units.verticalCoordinateSystem,
+            includeGeometryData)
 
     val kmPosts = toTrackLayoutKmPosts(trackNumberId, geometryPlan.kmPosts, planToLayout, planSrid)
     val startAddress = getPlanStartAddress(geometryPlan.kmPosts)
@@ -75,8 +75,7 @@ fun toTrackLayout(
         alignments = alignments,
         switches = switches.values.toList(),
         kmPosts = kmPosts,
-        startAddress = startAddress
-    )
+        startAddress = startAddress)
 }
 
 fun toTrackLayoutKmPosts(
@@ -101,32 +100,39 @@ fun toTrackLayoutKmPosts(
     }
 }
 
-fun toTrackLayoutSwitch(switch: GeometrySwitch, toMapCoordinate: Transformation): TrackLayoutSwitch? =
+fun toTrackLayoutSwitch(
+    switch: GeometrySwitch,
+    toMapCoordinate: Transformation
+): TrackLayoutSwitch? =
     if (switch.switchStructureId == null) null
-    else TrackLayoutSwitch(
-        name = switch.name,
-        switchStructureId = switch.switchStructureId,
-        stateCategory = getLayoutStateOrDefault(switch.state).category,
-        joints = switch.joints.map { j ->
-            TrackLayoutSwitchJoint(
-                number = j.number,
-                location = toMapCoordinate.transform(j.location),
-                locationAccuracy = LocationAccuracy.DESIGNED_GEOLOCATION,
-            )
-        },
-        sourceId = switch.id,
-        externalId = null,
-        trapPoint = null,
-        ownerId = null,
-        source = GeometrySource.PLAN,
-        contextData = LayoutContextData.newDraft(LayoutBranch.main),
-    )
+    else
+        TrackLayoutSwitch(
+            name = switch.name,
+            switchStructureId = switch.switchStructureId,
+            stateCategory = getLayoutStateOrDefault(switch.state).category,
+            joints =
+                switch.joints.map { j ->
+                    TrackLayoutSwitchJoint(
+                        number = j.number,
+                        location = toMapCoordinate.transform(j.location),
+                        locationAccuracy = LocationAccuracy.DESIGNED_GEOLOCATION,
+                    )
+                },
+            sourceId = switch.id,
+            externalId = null,
+            trapPoint = null,
+            ownerId = null,
+            source = GeometrySource.PLAN,
+            contextData = LayoutContextData.newDraft(LayoutBranch.main),
+        )
 
 fun toTrackLayoutSwitches(
     geometrySwitches: List<GeometrySwitch>,
     planToLayout: Transformation,
 ): Map<DomainId<GeometrySwitch>, TrackLayoutSwitch> =
-    geometrySwitches.mapNotNull { s -> toTrackLayoutSwitch(s, planToLayout)?.let { s.id to it } }.associate { it }
+    geometrySwitches
+        .mapNotNull { s -> toTrackLayoutSwitch(s, planToLayout)?.let { s.id to it } }
+        .associate { it }
 
 fun toMapAlignments(
     trackNumberId: IntId<TrackLayoutTrackNumber>?,
@@ -138,19 +144,22 @@ fun toMapAlignments(
     includeGeometryData: Boolean = true,
 ): List<PlanLayoutAlignment> {
     return geometryAlignments.map { alignment ->
-        val mapSegments = toMapSegments(
-            alignment = alignment,
-            planToLayoutTransformation = planToLayout,
-            pointListStepLength = pointListStepLength,
-            heightTriangles = heightTriangles,
-            verticalCoordinateSystem = verticalCoordinateSystem,
-            includeGeometryData = includeGeometryData,
-        )
+        val mapSegments =
+            toMapSegments(
+                alignment = alignment,
+                planToLayoutTransformation = planToLayout,
+                pointListStepLength = pointListStepLength,
+                heightTriangles = heightTriangles,
+                verticalCoordinateSystem = verticalCoordinateSystem,
+                includeGeometryData = includeGeometryData,
+            )
 
-        val boundingBoxInLayoutSpace = alignment.bounds?.let {
-            val cornersInLayoutSpace = it.corners.map { corner -> planToLayout.transform(corner) }
-            boundingBoxAroundPoints(cornersInLayoutSpace)
-        }
+        val boundingBoxInLayoutSpace =
+            alignment.bounds?.let {
+                val cornersInLayoutSpace =
+                    it.corners.map { corner -> planToLayout.transform(corner) }
+                boundingBoxAroundPoints(cornersInLayoutSpace)
+            }
 
         PlanLayoutAlignment(
             header = toAlignmentHeader(trackNumberId, alignment, boundingBoxInLayoutSpace),
@@ -163,21 +172,21 @@ fun toAlignmentHeader(
     trackNumberId: IntId<TrackLayoutTrackNumber>?,
     alignment: GeometryAlignment,
     boundingBoxInLayoutSpace: BoundingBox? = null,
-) = AlignmentHeader(
-    id = alignment.id,
-    name = alignment.name,
-    alignmentSource = MapAlignmentSource.GEOMETRY,
-    alignmentType = getAlignmentType(alignment.featureTypeCode),
-    state = getLayoutStateOrDefault(alignment.state),
-    trackNumberId = trackNumberId,
-    boundingBox = boundingBoxInLayoutSpace,
-    length = alignment.elements.sumOf(GeometryElement::calculatedLength),
-    segmentCount = alignment.elements.size,
-    version = null,
-    duplicateOf = null,
-    trackType = null,
-)
-
+) =
+    AlignmentHeader(
+        id = alignment.id,
+        name = alignment.name,
+        alignmentSource = MapAlignmentSource.GEOMETRY,
+        alignmentType = getAlignmentType(alignment.featureTypeCode),
+        state = getLayoutStateOrDefault(alignment.state),
+        trackNumberId = trackNumberId,
+        boundingBox = boundingBoxInLayoutSpace,
+        length = alignment.elements.sumOf(GeometryElement::calculatedLength),
+        segmentCount = alignment.elements.size,
+        version = null,
+        duplicateOf = null,
+        trackType = null,
+    )
 
 private fun toMapSegments(
     alignment: GeometryAlignment,
@@ -189,55 +198,66 @@ private fun toMapSegments(
 ): List<PlanLayoutSegment> {
     val alignmentStationStart = alignment.staStart.toDouble()
     var segmentStartLength = 0.0
-    val elements = alignment.elements.map { element ->
-        val startLength = segmentStartLength
-        segmentStartLength += element.calculatedLength
-        element to startLength
-    }.filter { (e, _) -> e.calculatedLength >= 0.001 }
-    val segments = if (!includeGeometryData) listOf()
-    else elements.map { (element, segmentStartLength) ->
-        val segmentPoints = toPointList(element, pointListStepLength).map { p ->
-            toSegmentGeometryPoint(
-                point = planToLayoutTransformation.transform(p),
-                mValue = p.m,
-                profile = alignment.profile,
-                cant = alignment.cant,
-                alignmentStartStation = alignmentStationStart,
-                segmentStart = segmentStartLength,
-                heightTriangles = heightTriangles,
-                verticalCoordinateSystem = verticalCoordinateSystem,
-            )
-        }
+    val elements =
+        alignment.elements
+            .map { element ->
+                val startLength = segmentStartLength
+                segmentStartLength += element.calculatedLength
+                element to startLength
+            }
+            .filter { (e, _) -> e.calculatedLength >= 0.001 }
+    val segments =
+        if (!includeGeometryData) listOf()
+        else
+            elements.map { (element, segmentStartLength) ->
+                val segmentPoints =
+                    toPointList(element, pointListStepLength).map { p ->
+                        toSegmentGeometryPoint(
+                            point = planToLayoutTransformation.transform(p),
+                            mValue = p.m,
+                            profile = alignment.profile,
+                            cant = alignment.cant,
+                            alignmentStartStation = alignmentStationStart,
+                            segmentStart = segmentStartLength,
+                            heightTriangles = heightTriangles,
+                            verticalCoordinateSystem = verticalCoordinateSystem,
+                        )
+                    }
 
-        PlanLayoutSegment(
-            id = deriveFromSourceId("AS", element.id),
-            geometry = SegmentGeometry(
-                resolution = pointListStepLength,
-                segmentPoints = segmentPoints,
-            ),
-            startM = segmentStartLength,
-            sourceId = element.id,
-            sourceStart = 0.0,
-            source = GeometrySource.PLAN,
-            pointCount = segmentPoints.size,
-        )
-    }
+                PlanLayoutSegment(
+                    id = deriveFromSourceId("AS", element.id),
+                    geometry =
+                        SegmentGeometry(
+                            resolution = pointListStepLength,
+                            segmentPoints = segmentPoints,
+                        ),
+                    startM = segmentStartLength,
+                    sourceId = element.id,
+                    sourceStart = 0.0,
+                    source = GeometrySource.PLAN,
+                    pointCount = segmentPoints.size,
+                )
+            }
 
     return segments
 }
 
-fun getAlignmentType(typeCode: FeatureTypeCode?): MapAlignmentType = when (typeCode) {
-    REFERENCE_LINE_TYPE_CODE -> MapAlignmentType.REFERENCE_LINE
-    else -> MapAlignmentType.LOCATION_TRACK
-}
+fun getAlignmentType(typeCode: FeatureTypeCode?): MapAlignmentType =
+    when (typeCode) {
+        REFERENCE_LINE_TYPE_CODE -> MapAlignmentType.REFERENCE_LINE
+        else -> MapAlignmentType.LOCATION_TRACK
+    }
 
-fun getLayoutStateOrDefault(planState: PlanState?) = planState?.let { state -> getLayoutState(state) } ?: PLANNED
-fun getLayoutState(planState: PlanState): LayoutState = when (planState) {
-    ABANDONED -> DELETED
-    DESTROYED -> DELETED
-    EXISTING -> IN_USE
-    PROPOSED -> NOT_IN_USE
-}
+fun getLayoutStateOrDefault(planState: PlanState?) =
+    planState?.let { state -> getLayoutState(state) } ?: PLANNED
+
+fun getLayoutState(planState: PlanState): LayoutState =
+    when (planState) {
+        ABANDONED -> DELETED
+        DESTROYED -> DELETED
+        EXISTING -> IN_USE
+        PROPOSED -> NOT_IN_USE
+    }
 
 fun toSegmentGeometryPoint(
     point: Point,
@@ -250,13 +270,16 @@ fun toSegmentGeometryPoint(
     verticalCoordinateSystem: VerticalCoordinateSystem?,
 ): SegmentPoint {
     // Profile station values are alignment m-values calculated from given station-start
-    val heightValue = verticalCoordinateSystem?.let { vcs ->
-        if (vcs == VerticalCoordinateSystem.N43) null
-        else profile
-            ?.getHeightAt(alignmentStartStation + segmentStart + mValue)
-            ?.let { value -> transformHeightValue(value, point, heightTriangles, vcs) }
-    }
-    // Cant station values are alignment m-values, calculated from 0 (ignoring alignment station-start)
+    val heightValue =
+        verticalCoordinateSystem?.let { vcs ->
+            if (vcs == VerticalCoordinateSystem.N43) null
+            else
+                profile?.getHeightAt(alignmentStartStation + segmentStart + mValue)?.let { value ->
+                    transformHeightValue(value, point, heightTriangles, vcs)
+                }
+        }
+    // Cant station values are alignment m-values, calculated from 0 (ignoring alignment
+    // station-start)
     val cantValue = cant?.getCantValue(segmentStart + mValue)
     return SegmentPoint(
         x = point.x,
@@ -270,22 +293,26 @@ fun toSegmentGeometryPoint(
 /**
  * Generates the list of points at stepLength interval along the element. Special rules:
  * - Always include the first and last point as-is, rather than calculated.
- *   - This ensures the result alignment is continuous (next segment starts where previous ends), despite less-than perfect parameter accuracy
- * - Avoid generating a point very close to the end-point, even if total length would have it due to step length
- *   - Inaccuracy in parameters could cause the point to be in any direction -> could create a short zig-zag with the actual end-point
+ *     - This ensures the result alignment is continuous (next segment starts where previous ends),
+ *       despite less-than perfect parameter accuracy
+ * - Avoid generating a point very close to the end-point, even if total length would have it due to
+ *   step length
+ *     - Inaccuracy in parameters could cause the point to be in any direction -> could create a
+ *       short zig-zag with the actual end-point
  */
 fun toPointList(element: GeometryElement, stepLength: Int): List<Point3DM> {
     return lengthPoints(element.calculatedLength, stepLength).map { length ->
-        val point = if (length <= 0.0) element.start
-        else if (length > element.calculatedLength - MIN_POINT_DISTANCE) element.end
-        else element.getCoordinateAt(length)
+        val point =
+            if (length <= 0.0) element.start
+            else if (length > element.calculatedLength - MIN_POINT_DISTANCE) element.end
+            else element.getCoordinateAt(length)
         Point3DM(point.x, point.y, length)
     }
 }
 
 fun lengthPoints(length: Double, stepSize: Int): List<Double> {
-    val last1mPoint = if (length % 1.0 > MIN_POINT_DISTANCE) length.toInt()
-    else max(length.toInt() - 1, 0)
+    val last1mPoint =
+        if (length % 1.0 > MIN_POINT_DISTANCE) length.toInt() else max(length.toInt() - 1, 0)
     val midPoints = (0..last1mPoint step stepSize).map(Int::toDouble)
     return midPoints + length
 }
@@ -294,17 +321,19 @@ fun <T> deriveFromSourceId(prefix: String, source: DomainId<*>?): StringId<T> =
     if (source != null) StringId("${prefix}_$source") else StringId()
 
 private fun getPlanStartAddress(planKmPosts: List<GeometryKmPost>): TrackMeter? {
-    val minimumKmNumber = planKmPosts.mapNotNull(GeometryKmPost::kmNumber).minOrNull() ?: return null
+    val minimumKmNumber =
+        planKmPosts.mapNotNull(GeometryKmPost::kmNumber).minOrNull() ?: return null
     val minimumKmNumberPosts = planKmPosts.filter { kmPost -> kmPost.kmNumber == minimumKmNumber }
     return if (minimumKmNumberPosts.size == 1) {
         val precedingKmPost = minimumKmNumberPosts[0]
         // safety: minimumKmNumberPosts was filtered for equality with a known-not-null kmNumber
-        // Negative or zero staInternals are assumed to be the distance of the preceding km post from the plan's
+        // Negative or zero staInternals are assumed to be the distance of the preceding km post
+        // from the plan's
         // reference line's start; for anything else, let's not assume we know what to do with it.
-        // Round to 6 decimals to make sure TrackNumber creation doesn't fail due to too many decimals
-        if (precedingKmPost.staInternal <= BigDecimal.ZERO) TrackMeter(
-            precedingKmPost.kmNumber!!, round(-precedingKmPost.staInternal, 6)
-        )
+        // Round to 6 decimals to make sure TrackNumber creation doesn't fail due to too many
+        // decimals
+        if (precedingKmPost.staInternal <= BigDecimal.ZERO)
+            TrackMeter(precedingKmPost.kmNumber!!, round(-precedingKmPost.staInternal, 6))
         else null
     } else null
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
@@ -77,14 +77,19 @@ class ReferenceLineController(
         @PathVariable("id") id: IntId<ReferenceLine>,
     ): ResponseEntity<AlignmentStartAndEnd> {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        return toResponse(referenceLineService.getWithAlignment(layoutContext, id)?.let { (referenceLine, alignment) ->
-            geocodingService.getReferenceLineStartAndEnd(layoutContext, referenceLine, alignment)
-        })
+        return toResponse(
+            referenceLineService.getWithAlignment(layoutContext, id)?.let {
+                (referenceLine, alignment) ->
+                geocodingService.getReferenceLineStartAndEnd(
+                    layoutContext, referenceLine, alignment)
+            })
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
     @GetMapping("/{$LAYOUT_BRANCH}/draft/non-linked")
-    fun getNonLinkedReferenceLines(@PathVariable(LAYOUT_BRANCH) branch: LayoutBranch): List<ReferenceLine> {
+    fun getNonLinkedReferenceLines(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch
+    ): List<ReferenceLine> {
         return referenceLineService.listNonLinked(branch)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -45,7 +45,9 @@ enum class LocationTrackState(val category: LayoutStateCategory) {
     DELETED(LayoutStateCategory.NOT_EXISTING);
 
     fun isPublishable() = this != PLANNED
+
     fun isLinkable() = this == IN_USE || this == BUILT || this == NOT_IN_USE
+
     fun isRemoved() = this == DELETED
 }
 
@@ -56,31 +58,42 @@ enum class LayoutState(val category: LayoutStateCategory) {
     DELETED(LayoutStateCategory.NOT_EXISTING);
 
     fun isPublishable() = this != PLANNED
+
     fun isLinkable() = this == IN_USE || this == NOT_IN_USE
+
     fun isRemoved() = this == DELETED
 }
 
 enum class LayoutStateCategory {
-    FUTURE_EXISTING, EXISTING, NOT_EXISTING;
+    FUTURE_EXISTING,
+    EXISTING,
+    NOT_EXISTING;
 
     fun isPublishable() = this != FUTURE_EXISTING
+
     fun isLinkable() = this == EXISTING
+
     fun isRemoved() = this == NOT_EXISTING
 }
 
 enum class TopologicalConnectivityType {
-    NONE, START, END, START_AND_END;
+    NONE,
+    START,
+    END,
+    START_AND_END;
 
     fun isStartConnected() = this == START || this == START_AND_END
 
     fun isEndConnected() = this == END || this == START_AND_END
 }
 
-fun topologicalConnectivityTypeOf(startConnected: Boolean, endConnected: Boolean): TopologicalConnectivityType =
+fun topologicalConnectivityTypeOf(
+    startConnected: Boolean,
+    endConnected: Boolean
+): TopologicalConnectivityType =
     if (startConnected && endConnected) TopologicalConnectivityType.START_AND_END
     else if (startConnected) TopologicalConnectivityType.START
-    else if (endConnected) TopologicalConnectivityType.END
-    else TopologicalConnectivityType.NONE
+    else if (endConnected) TopologicalConnectivityType.END else TopologicalConnectivityType.NONE
 
 data class LocationTrackDuplicate(
     val id: IntId<LocationTrack>,
@@ -103,35 +116,39 @@ data class TrackLayoutTrackNumber(
     @JsonIgnore override val contextData: LayoutContextData<TrackLayoutTrackNumber>,
     @JsonIgnore val referenceLineId: IntId<ReferenceLine>? = null,
 ) : LayoutAsset<TrackLayoutTrackNumber>(contextData) {
-    @JsonIgnore
-    val exists = !state.isRemoved()
+    @JsonIgnore val exists = !state.isRemoved()
 
     init {
         require(description.isNotBlank()) { "TrackNumber should have a non-blank description" }
-        require(description.length < 100) { "TrackNumber description too long: ${description.length}>100" }
+        require(description.length < 100) {
+            "TrackNumber description too long: ${description.length}>100"
+        }
     }
 
-    override fun toLog(): String = logFormat(
-        "id" to id,
-        "version" to version,
-        "context" to contextData::class.simpleName,
-        "number" to number,
-    )
+    override fun toLog(): String =
+        logFormat(
+            "id" to id,
+            "version" to version,
+            "context" to contextData::class.simpleName,
+            "number" to number,
+        )
 
-    override fun withContext(contextData: LayoutContextData<TrackLayoutTrackNumber>): TrackLayoutTrackNumber =
-        copy(contextData = contextData)
+    override fun withContext(
+        contextData: LayoutContextData<TrackLayoutTrackNumber>
+    ): TrackLayoutTrackNumber = copy(contextData = contextData)
 }
 
 enum class LocationTrackType {
     MAIN, // Pääraide
     SIDE, // Sivuraide
-    TRAP, // Turvaraide: Turvaraide on raide, jonka tarkoitus on ohjata liikkuva kalusto riittävän etäälle siitä raiteesta, jota turvaraide suojaa. https://fi.wikipedia.org/wiki/Turvavaihde
+    TRAP, // Turvaraide: Turvaraide on raide, jonka tarkoitus on ohjata liikkuva kalusto riittävän
+          // etäälle siitä raiteesta, jota turvaraide suojaa.
+          // https://fi.wikipedia.org/wiki/Turvavaihde
     CHORD, // Kujaraide: Kujaraide on raide, joka ei ole sivu-, eikä pääraide.
 }
 
-sealed class PolyLineLayoutAsset<T : PolyLineLayoutAsset<T>>(
-    contextData: LayoutContextData<T>
-) : LayoutAsset<T>(contextData) {
+sealed class PolyLineLayoutAsset<T : PolyLineLayoutAsset<T>>(contextData: LayoutContextData<T>) :
+    LayoutAsset<T>(contextData) {
     @get:JsonIgnore abstract val alignmentVersion: RowVersion<LayoutAlignment>?
 
     fun getAlignmentVersionOrThrow(): RowVersion<LayoutAlignment> =
@@ -155,13 +172,14 @@ data class ReferenceLine(
         }
     }
 
-    override fun toLog(): String = logFormat(
-        "id" to id,
-        "version" to version,
-        "context" to contextData::class.simpleName,
-        "trackNumber" to trackNumberId,
-        "alignment" to alignmentVersion,
-    )
+    override fun toLog(): String =
+        logFormat(
+            "id" to id,
+            "version" to version,
+            "context" to contextData::class.simpleName,
+            "trackNumber" to trackNumberId,
+            "alignment" to alignmentVersion,
+        )
 
     override fun withContext(contextData: LayoutContextData<ReferenceLine>): ReferenceLine =
         copy(contextData = contextData)
@@ -175,7 +193,10 @@ data class TopologyLocationTrackSwitch(
 val locationTrackDescriptionLength = 4..256
 
 enum class DescriptionSuffixType {
-    NONE, SWITCH_TO_SWITCH, SWITCH_TO_BUFFER, SWITCH_TO_OWNERSHIP_BOUNDARY
+    NONE,
+    SWITCH_TO_SWITCH,
+    SWITCH_TO_BUFFER,
+    SWITCH_TO_OWNERSHIP_BOUNDARY
 }
 
 data class LayoutSwitchIdAndName(val id: IntId<TrackLayoutSwitch>, val name: SwitchName)
@@ -207,14 +228,22 @@ data class SwitchOnLocationTrack(
 
 const val EndpointSplitPointLocationToleranceInMeters = 2
 
-enum class DuplicateMatch { FULL, PARTIAL, NONE }
-enum class DuplicateEndPointType { START, END }
+enum class DuplicateMatch {
+    FULL,
+    PARTIAL,
+    NONE
+}
+
+enum class DuplicateEndPointType {
+    START,
+    END
+}
 
 sealed class SplitPoint {
     abstract val location: AlignmentPoint
     abstract val address: TrackMeter?
 
-    abstract fun isSame(other:SplitPoint):Boolean
+    abstract fun isSame(other: SplitPoint): Boolean
 }
 
 data class SwitchSplitPoint(
@@ -222,10 +251,13 @@ data class SwitchSplitPoint(
     override val address: TrackMeter?,
     val switchId: IntId<TrackLayoutSwitch>,
     val jointNumber: JointNumber,
-): SplitPoint() {
+) : SplitPoint() {
     val type = "SWITCH_SPLIT_POINT"
-    override fun isSame(other:SplitPoint):Boolean {
-        return other is SwitchSplitPoint && switchId==other.switchId && jointNumber==other.jointNumber
+
+    override fun isSame(other: SplitPoint): Boolean {
+        return other is SwitchSplitPoint &&
+            switchId == other.switchId &&
+            jointNumber == other.jointNumber
     }
 }
 
@@ -233,12 +265,13 @@ data class EndpointSplitPoint(
     override val location: AlignmentPoint,
     override val address: TrackMeter?,
     val endPointType: DuplicateEndPointType
-): SplitPoint() {
+) : SplitPoint() {
     val type = "ENDPOINT_SPLIT_POINT"
-    override fun isSame(other:SplitPoint):Boolean {
-        return other is EndpointSplitPoint
-            && endPointType==other.endPointType
-            && lineLength(location, other.location)<=EndpointSplitPointLocationToleranceInMeters
+
+    override fun isSame(other: SplitPoint): Boolean {
+        return other is EndpointSplitPoint &&
+            endPointType == other.endPointType &&
+            lineLength(location, other.location) <= EndpointSplitPointLocationToleranceInMeters
     }
 }
 
@@ -285,12 +318,13 @@ data class LocationTrack(
     @JsonIgnore val segmentSwitchIds: List<IntId<TrackLayoutSwitch>> = listOf(),
 ) : PolyLineLayoutAsset<LocationTrack>(contextData) {
 
-    @JsonIgnore
-    val exists = !state.isRemoved()
+    @JsonIgnore val exists = !state.isRemoved()
 
     @get:JsonIgnore
     val switchIds: List<IntId<TrackLayoutSwitch>> by lazy {
-        (listOfNotNull(topologyStartSwitch?.switchId) + segmentSwitchIds + listOfNotNull(topologyEndSwitch?.switchId))
+        (listOfNotNull(topologyStartSwitch?.switchId) +
+                segmentSwitchIds +
+                listOfNotNull(topologyEndSwitch?.switchId))
             .distinct()
     }
 
@@ -305,23 +339,25 @@ data class LocationTrack(
             "LocationTrack in DB must have an alignment: id=$id"
         }
         require(
-            topologyStartSwitch?.switchId == null || topologyStartSwitch.switchId != topologyEndSwitch?.switchId
-        ) {
-            "LocationTrack cannot topologically connect to the same switch at both ends: " +
-                "trackId=$id " + "switchId=${topologyStartSwitch?.switchId} " +
-                "startJoint=${topologyStartSwitch?.jointNumber} " +
-                "endJoint=${topologyEndSwitch?.jointNumber}"
-        }
+            topologyStartSwitch?.switchId == null ||
+                topologyStartSwitch.switchId != topologyEndSwitch?.switchId) {
+                "LocationTrack cannot topologically connect to the same switch at both ends: " +
+                    "trackId=$id " +
+                    "switchId=${topologyStartSwitch?.switchId} " +
+                    "startJoint=${topologyStartSwitch?.jointNumber} " +
+                    "endJoint=${topologyEndSwitch?.jointNumber}"
+            }
     }
 
-    override fun toLog(): String = logFormat(
-        "id" to id,
-        "version" to version,
-        "context" to contextData::class.simpleName,
-        "name" to name,
-        "trackNumber" to trackNumberId,
-        "alignment" to alignmentVersion,
-    )
+    override fun toLog(): String =
+        logFormat(
+            "id" to id,
+            "version" to version,
+            "context" to contextData::class.simpleName,
+            "name" to name,
+            "trackNumber" to trackNumberId,
+            "alignment" to alignmentVersion,
+        )
 
     override fun withContext(contextData: LayoutContextData<LocationTrack>): LocationTrack =
         copy(contextData = contextData)
@@ -339,19 +375,18 @@ data class TrackLayoutSwitch(
     val source: GeometrySource,
     @JsonIgnore override val contextData: LayoutContextData<TrackLayoutSwitch>,
 ) : LayoutAsset<TrackLayoutSwitch>(contextData) {
-    @JsonIgnore
-    val exists = !stateCategory.isRemoved()
-    val shortName = name.split(" ").lastOrNull()?.let { last ->
-        if (last.startsWith("V")) {
-            last.substring(1)
-                .toIntOrNull(10)
-                ?.toString()
-                ?.padStart(3, '0')
-                ?.let { switchNumber -> "V$switchNumber" }
-        } else {
-            null
+    @JsonIgnore val exists = !stateCategory.isRemoved()
+    val shortName =
+        name.split(" ").lastOrNull()?.let { last ->
+            if (last.startsWith("V")) {
+                last.substring(1).toIntOrNull(10)?.toString()?.padStart(3, '0')?.let { switchNumber
+                    ->
+                    "V$switchNumber"
+                }
+            } else {
+                null
+            }
         }
-    }
 
     fun getJoint(location: AlignmentPoint, delta: Double): TrackLayoutSwitchJoint? =
         getJoint(Point(location.x, location.y), delta)
@@ -359,24 +394,34 @@ data class TrackLayoutSwitch(
     fun getJoint(location: Point, delta: Double): TrackLayoutSwitchJoint? =
         joints.find { j -> j.location.isSame(location, delta) }
 
-    fun getJoint(number: JointNumber): TrackLayoutSwitchJoint? = joints.find { j -> j.number == number }
+    fun getJoint(number: JointNumber): TrackLayoutSwitchJoint? =
+        joints.find { j -> j.number == number }
 
-    override fun toLog(): String = logFormat(
-        "id" to id,
-        "version" to version,
-        "context" to contextData::class.simpleName,
-        "source" to source,
-        "name" to name,
-        "joints" to joints.map { j -> j.number.intValue },
-    )
+    override fun toLog(): String =
+        logFormat(
+            "id" to id,
+            "version" to version,
+            "context" to contextData::class.simpleName,
+            "source" to source,
+            "name" to name,
+            "joints" to joints.map { j -> j.number.intValue },
+        )
 
     override fun withContext(contextData: LayoutContextData<TrackLayoutSwitch>): TrackLayoutSwitch =
         copy(contextData = contextData)
 }
 
-data class TrackLayoutSwitchJoint(val number: JointNumber, val location: Point, val locationAccuracy: LocationAccuracy?)
+data class TrackLayoutSwitchJoint(
+    val number: JointNumber,
+    val location: Point,
+    val locationAccuracy: LocationAccuracy?
+)
 
-enum class KmPostGkLocationSource { FROM_GEOMETRY, FROM_LAYOUT, MANUAL }
+enum class KmPostGkLocationSource {
+    FROM_GEOMETRY,
+    FROM_LAYOUT,
+    MANUAL
+}
 
 data class TrackLayoutKmPost(
     val kmNumber: KmNumber,
@@ -388,23 +433,24 @@ data class TrackLayoutKmPost(
     val sourceId: DomainId<GeometryKmPost>?,
     @JsonIgnore override val contextData: LayoutContextData<TrackLayoutKmPost>,
 ) : LayoutAsset<TrackLayoutKmPost>(contextData) {
-    @JsonIgnore
-    val exists = !state.isRemoved()
+    @JsonIgnore val exists = !state.isRemoved()
 
     val layoutLocation =
-        if (gkLocation == null) null else transformNonKKJCoordinate(gkLocation.srid, LAYOUT_SRID, gkLocation.toPoint())
+        if (gkLocation == null) null
+        else transformNonKKJCoordinate(gkLocation.srid, LAYOUT_SRID, gkLocation.toPoint())
 
     fun getAsIntegral(): IntegralTrackLayoutKmPost? =
         if (state != LayoutState.IN_USE || layoutLocation == null || trackNumberId == null) null
         else IntegralTrackLayoutKmPost(kmNumber, layoutLocation, trackNumberId)
 
-    override fun toLog(): String = logFormat(
-        "id" to id,
-        "version" to version,
-        "context" to contextData::class.simpleName,
-        "kmNumber" to kmNumber,
-        "trackNumber" to trackNumberId,
-    )
+    override fun toLog(): String =
+        logFormat(
+            "id" to id,
+            "version" to version,
+            "context" to contextData::class.simpleName,
+            "kmNumber" to kmNumber,
+            "trackNumber" to trackNumberId,
+        )
 
     override fun withContext(contextData: LayoutContextData<TrackLayoutKmPost>): TrackLayoutKmPost =
         copy(contextData = contextData)
@@ -442,7 +488,9 @@ data class TrackLayoutSwitchJointConnection(
     val locationAccuracy: LocationAccuracy?,
 ) {
     fun merge(other: TrackLayoutSwitchJointConnection): TrackLayoutSwitchJointConnection {
-        check(number == other.number) { "expected $number == $other.number in TrackLayoutSwitchJointConnection#merge" }
+        check(number == other.number) {
+            "expected $number == $other.number in TrackLayoutSwitchJointConnection#merge"
+        }
         // location accuracy comes from the joint and hence can't differ
         check(locationAccuracy == other.locationAccuracy) {
             "expected $locationAccuracy == ${other.locationAccuracy} in TrackLayoutSwitchJointConnection#merge"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/CSVPrintingUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/CSVPrintingUtils.kt
@@ -1,10 +1,10 @@
 package fi.fta.geoviite.infra.util
 
-import org.apache.commons.csv.CSVFormat
-import org.apache.commons.csv.CSVPrinter
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVPrinter
 
 data class CsvEntry<T>(
     val header: String,
@@ -12,11 +12,14 @@ data class CsvEntry<T>(
 )
 
 val csvDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
-fun toCsvDate(date: Instant): String = csvDateFormatter
-    // Default to Finnish time. Stored dates are at midnight Finnish time (21/22:00 UTC the previous day),
-    // so a timezone offset is added to make sure the correct date is shown
-    .withZone(ZoneId.of("Europe/Helsinki"))
-    .format(date)
+
+fun toCsvDate(date: Instant): String =
+    csvDateFormatter
+        // Default to Finnish time. Stored dates are at midnight Finnish time (21/22:00 UTC the
+        // previous day),
+        // so a timezone offset is added to make sure the correct date is shown
+        .withZone(ZoneId.of("Europe/Helsinki"))
+        .format(date)
 
 fun <T> printCsv(columns: List<CsvEntry<T>>, data: List<T>): String {
     val csvBuilder = StringBuilder()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/FileName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/FileName.kt
@@ -6,9 +6,8 @@ import com.fasterxml.jackson.annotation.JsonValue
 import org.springframework.web.multipart.MultipartFile
 
 /**
- * Bytes of character in canonical decomposition form differ from the default form
- * (precomposed). We encountered these in some IM files, probably produced by
- * some 3D design software.
+ * Bytes of character in canonical decomposition form differ from the default form (precomposed). We
+ * encountered these in some IM files, probably produced by some 3D design software.
  *
  * https://www.ibm.com/docs/en/cobol-zos/6.3?topic=functions-ulength
  */
@@ -22,21 +21,25 @@ enum class KnownFileSuffix {
     XML,
 }
 
-data class FileName @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<FileName>, CharSequence by value {
+data class FileName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<FileName>, CharSequence by value {
     init {
         assertSanitized<FileName>(value, fileNameRegex, fileNameLength)
     }
 
-    constructor(file: MultipartFile) : this(file.originalFilename?.takeIf(String::isNotBlank) ?: file.name)
+    constructor(
+        file: MultipartFile
+    ) : this(file.originalFilename?.takeIf(String::isNotBlank) ?: file.name)
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: FileName): Int = value.compareTo(other.value)
 
     fun withSuffix(suffix: KnownFileSuffix): FileName =
-        suffix.name.lowercase().let { suffixName ->
-            if (value.endsWith(".$suffixName", true)) value
-            else "$value.$suffixName"
-        }.let(::FileName)
+        suffix.name
+            .lowercase()
+            .let { suffixName ->
+                if (value.endsWith(".$suffixName", true)) value else "$value.$suffixName"
+            }
+            .let(::FileName)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Functional.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Functional.kt
@@ -3,5 +3,4 @@ package fi.fta.geoviite.infra.util
 fun <T> produceIfNot(condition: Boolean, producer: () -> T): T? =
     if (!condition) producer() else null
 
-fun <T> produceIf(condition: Boolean, producer: () -> T): T? =
-    if (condition) producer() else null
+fun <T> produceIf(condition: Boolean, producer: () -> T): T? = if (condition) producer() else null

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/HttpsUrl.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/HttpsUrl.kt
@@ -3,14 +3,16 @@ package fi.fta.geoviite.infra.util
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
-import org.apache.commons.validator.routines.UrlValidator
 import java.net.URL
+import org.apache.commons.validator.routines.UrlValidator
 
 val urlLength = 1..2000
 val httpsValidator = UrlValidator(arrayOf("https"))
-data class HttpsUrl @JsonCreator(mode = DELEGATING) constructor(private val value: URL)
-    : Comparable<HttpsUrl>, CharSequence by value.toString() {
-    constructor(stringValue: String): this(URL(stringValue))
+
+data class HttpsUrl @JsonCreator(mode = DELEGATING) constructor(private val value: URL) :
+    Comparable<HttpsUrl>, CharSequence by value.toString() {
+    constructor(stringValue: String) : this(URL(stringValue))
+
     init {
         assertLength<HttpsUrl>(value.toString(), urlLength)
         require(httpsValidator.isValid(value.toString())) {
@@ -18,7 +20,7 @@ data class HttpsUrl @JsonCreator(mode = DELEGATING) constructor(private val valu
         }
     }
 
-    @JsonValue
-    override fun toString(): String = value.toString()
+    @JsonValue override fun toString(): String = value.toString()
+
     override fun compareTo(other: HttpsUrl): Int = toString().compareTo(other.toString())
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
@@ -1,24 +1,22 @@
 package fi.fta.geoviite.infra.util
 
-//Nulls are "last", e.g., 0, 1, 2, null
+// Nulls are "last", e.g., 0, 1, 2, null
 fun <T : Comparable<T>> nullsLastComparator(a: T?, b: T?) =
-    if (a == null && b == null) 0
-    else if (a == null) 1
-    else if (b == null) -1
-    else a.compareTo(b)
+    if (a == null && b == null) 0 else if (a == null) 1 else if (b == null) -1 else a.compareTo(b)
 
 fun <T : Comparable<T>> nullsFirstComparator(a: T?, b: T?) =
-    if (a == null && b == null) 0
-    else if (a == null) -1
-    else if (b == null) 1
-    else a.compareTo(b)
+    if (a == null && b == null) 0 else if (a == null) -1 else if (b == null) 1 else a.compareTo(b)
 
 fun rangesOfConsecutiveIndicesOf(
     value: Boolean,
     ts: List<Boolean>,
     offsetRangeEndsBy: Int = 0,
 ): List<ClosedRange<Int>> =
-    sequence { yield(!value); yieldAll(ts.asSequence()); yield(!value) }
+    sequence {
+            yield(!value)
+            yieldAll(ts.asSequence())
+            yield(!value)
+        }
         .zipWithNext()
         .mapIndexedNotNull { i, (a, b) -> if (a != b) i else null }
         .chunked(2)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/LocalizationKey.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/LocalizationKey.kt
@@ -7,11 +7,13 @@ import com.fasterxml.jackson.annotation.JsonValue
 val localizationKeyRegex = Regex("^[A-Za-z0-9_\\-.]+\$")
 val localizationKeyLength = 1..100
 
-data class LocalizationKey @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<LocalizationKey>, CharSequence by value {
-    init { assertSanitized<LocalizationKey>(value, localizationKeyRegex, localizationKeyLength) }
+data class LocalizationKey @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<LocalizationKey>, CharSequence by value {
+    init {
+        assertSanitized<LocalizationKey>(value, localizationKeyRegex, localizationKeyLength)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: LocalizationKey): Int = value.compareTo(other.value)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/NamedParameterJdbcTemplateExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/NamedParameterJdbcTemplateExternal.kt
@@ -3,9 +3,9 @@ package fi.fta.geoviite.infra.util
 import currentUser
 import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.error.NoSuchEntityException
+import java.sql.ResultSet
 import org.springframework.jdbc.core.ParameterizedPreparedStatementSetter
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import java.sql.ResultSet
 
 inline fun <reified T> NamedParameterJdbcTemplate.queryNotNull(
     sql: String,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Paging.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Paging.kt
@@ -1,7 +1,8 @@
 package fi.fta.geoviite.infra.util
 
 enum class SortOrder {
-    ASCENDING, DESCENDING,
+    ASCENDING,
+    DESCENDING,
 }
 
 data class Page<T>(
@@ -18,7 +19,10 @@ data class PageAndRest<T>(
 )
 
 fun <T> page(items: List<T>, offset: Int, limit: Int?, comparator: Comparator<T>): Page<T> =
-    Page(totalCount = items.size, items = pageToList(items, offset, limit, comparator), start = offset)
+    Page(
+        totalCount = items.size,
+        items = pageToList(items, offset, limit, comparator),
+        start = offset)
 
 fun <T> pageToList(items: List<T>, offset: Int, limit: Int?, comparator: Comparator<T>): List<T> {
     val endIndex = getEndIndex(limit, offset, items)
@@ -28,11 +32,15 @@ fun <T> pageToList(items: List<T>, offset: Int, limit: Int?, comparator: Compara
 private fun getEndIndex(limit: Int?, offset: Int, items: List<*>) =
     limit?.let { lim -> minOf(offset + lim - 1, items.lastIndex) } ?: items.lastIndex
 
-fun <T> pageAndRest(items: List<T>, offset: Int, limit: Int?, comparator: Comparator<T>): PageAndRest<T> {
+fun <T> pageAndRest(
+    items: List<T>,
+    offset: Int,
+    limit: Int?,
+    comparator: Comparator<T>
+): PageAndRest<T> {
     val endIndex = getEndIndex(limit, offset, items)
     val sorted = items.sortedWith(comparator)
     return PageAndRest(
         Page(totalCount = items.size, items = sorted.slice(offset..endIndex), start = offset),
-        sorted.slice(0 until offset) + sorted.slice(endIndex + 1 until sorted.size)
-    )
+        sorted.slice(0 until offset) + sorted.slice(endIndex + 1 until sorted.size))
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/PreparedStatementExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/PreparedStatementExternal.kt
@@ -3,11 +3,9 @@ package fi.fta.geoviite.infra.util
 import java.sql.JDBCType
 import java.sql.PreparedStatement
 
-fun PreparedStatement.setNullInt(index: Int) =
-    setNull(index, JDBCType.INTEGER.vendorTypeNumber)
+fun PreparedStatement.setNullInt(index: Int) = setNull(index, JDBCType.INTEGER.vendorTypeNumber)
 
-fun PreparedStatement.setNullDouble(index: Int) =
-    setNull(index, JDBCType.DOUBLE.vendorTypeNumber)
+fun PreparedStatement.setNullDouble(index: Int) = setNull(index, JDBCType.DOUBLE.vendorTypeNumber)
 
 fun PreparedStatement.setNullableInt(index: Int, getter: () -> Int?) =
     setNullableInt(index, getter())
@@ -16,9 +14,7 @@ fun PreparedStatement.setNullableDouble(index: Int, getter: () -> Double?) =
     setNullableDouble(index, getter())
 
 fun PreparedStatement.setNullableInt(index: Int, value: Int?) =
-    if (value != null) setInt(index, value)
-    else setNullInt(index)
+    if (value != null) setInt(index, value) else setNullInt(index)
 
 fun PreparedStatement.setNullableDouble(index: Int, value: Double?) =
-    if (value != null) setDouble(index, value)
-    else setNullDouble(index)
+    if (value != null) setDouble(index, value) else setNullDouble(index)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResponseEntity.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResponseEntity.kt
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus.OK
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 
-fun <T> toResponse(value: T?) = value?.let { v -> ResponseEntity(v, OK) } ?: ResponseEntity(NO_CONTENT)
+fun <T> toResponse(value: T?) =
+    value?.let { v -> ResponseEntity(v, OK) } ?: ResponseEntity(NO_CONTENT)
 
 fun toFileDownloadResponse(file: InfraModelFile): ResponseEntity<ByteArray> =
     toFileDownloadResponse(file.name.withSuffix(XML), file.content.toByteArray())
@@ -19,6 +20,9 @@ fun toFileDownloadResponse(fileName: FileName, content: ByteArray): ResponseEnti
     headers.contentType = MediaType.APPLICATION_OCTET_STREAM
     headers.set(
         HttpHeaders.CONTENT_DISPOSITION,
-        ContentDisposition.attachment().filename(fileName.toString(), Charsets.UTF_8).build().toString())
+        ContentDisposition.attachment()
+            .filename(fileName.toString(), Charsets.UTF_8)
+            .build()
+            .toString())
     return ResponseEntity.ok().headers(headers).body(content)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -73,9 +73,12 @@ fun <T> ResultSet.getIndexedIdOrNull(parent: String, index: String): IndexedId<T
         null
     }
 }
-fun <T> ResultSet.getLayoutRowId(name: String): LayoutRowId<T> = verifyNotNull(name, ::getLayoutRowIdOrNull)
 
-fun <T> ResultSet.getLayoutRowIdOrNull(name: String): LayoutRowId<T>? = getIntOrNull(name)?.let(::LayoutRowId)
+fun <T> ResultSet.getLayoutRowId(name: String): LayoutRowId<T> =
+    verifyNotNull(name, ::getLayoutRowIdOrNull)
+
+fun <T> ResultSet.getLayoutRowIdOrNull(name: String): LayoutRowId<T>? =
+    getIntOrNull(name)?.let(::LayoutRowId)
 
 fun <T> ResultSet.getIntId(name: String): IntId<T> = verifyNotNull(name, ::getIntIdOrNull)
 
@@ -93,9 +96,8 @@ fun ResultSet.getSrid(name: String): Srid = verifyNotNull(name, ::getSridOrNull)
 
 fun ResultSet.getSridOrNull(name: String): Srid? = getIntOrNull(name)?.let(::Srid)
 
-fun ResultSet.getTrackNumber(name: String): TrackNumber = requireNotNull(getTrackNumberOrNull(name)) {
-    "Track number was null"
-}
+fun ResultSet.getTrackNumber(name: String): TrackNumber =
+    requireNotNull(getTrackNumberOrNull(name)) { "Track number was null" }
 
 fun ResultSet.getTrackNumberOrNull(name: String): TrackNumber? = getString(name)?.let(::TrackNumber)
 
@@ -107,26 +109,33 @@ fun ResultSet.getTrackMeter(name: String): TrackMeter = verifyNotNull(name, ::ge
 
 fun ResultSet.getTrackMeterOrNull(name: String): TrackMeter? = getString(name)?.let(::TrackMeter)
 
-fun ResultSet.getJointNumber(name: String): JointNumber = verifyNotNull(name, ::getJointNumberOrNull)
+fun ResultSet.getJointNumber(name: String): JointNumber =
+    verifyNotNull(name, ::getJointNumberOrNull)
 
-fun ResultSet.getJointNumberOrNull(name: String): JointNumber? = getIntOrNull(name)?.let(::JointNumber)
+fun ResultSet.getJointNumberOrNull(name: String): JointNumber? =
+    getIntOrNull(name)?.let(::JointNumber)
 
-fun ResultSet.getFeatureTypeCode(name: String): FeatureTypeCode = verifyNotNull(name, ::getFeatureTypeCodeOrNull)
+fun ResultSet.getFeatureTypeCode(name: String): FeatureTypeCode =
+    verifyNotNull(name, ::getFeatureTypeCodeOrNull)
 
-fun ResultSet.getFeatureTypeCodeOrNull(name: String): FeatureTypeCode? = getString(name)?.let(::FeatureTypeCode)
+fun ResultSet.getFeatureTypeCodeOrNull(name: String): FeatureTypeCode? =
+    getString(name)?.let(::FeatureTypeCode)
 
-fun ResultSet.getPoint(nameX: String, nameY: String): Point = requireNotNull(getPointOrNull(nameX, nameY)) {
-    "Point does not exist in result set: nameX=$nameX nameY=$nameY"
-}
+fun ResultSet.getPoint(nameX: String, nameY: String): Point =
+    requireNotNull(getPointOrNull(nameX, nameY)) {
+        "Point does not exist in result set: nameX=$nameX nameY=$nameY"
+    }
 
 fun ResultSet.getGeometryPoint(nameX: String, nameY: String, nameSrid: String): GeometryPoint =
     getPoint(nameX, nameY).let { point -> GeometryPoint(point.x, point.y, getSrid(nameSrid)) }
 
-fun ResultSet.getGeometryPointOrNull(nameX: String, nameY: String, nameSrid: String): GeometryPoint? =
+fun ResultSet.getGeometryPointOrNull(
+    nameX: String,
+    nameY: String,
+    nameSrid: String
+): GeometryPoint? =
     getPointOrNull(nameX, nameY)?.let { point ->
-        getSridOrNull(nameSrid)?.let { srid ->
-            GeometryPoint(point.x, point.y, srid)
-        }
+        getSridOrNull(nameSrid)?.let { srid -> GeometryPoint(point.x, point.y, srid) }
     }
 
 fun ResultSet.getPointOrNull(nameX: String, nameY: String): Point? {
@@ -146,9 +155,11 @@ inline fun <reified T : Enum<T>> ResultSet.getEnumOrNull(name: String): T? {
 fun ResultSet.getStringListFromString(name: String): List<String> =
     verifyNotNull(name, ::getStringsListOrNullFromString)
 
-fun ResultSet.getStringsListOrNullFromString(name: String): List<String>? = getString(name)?.split(",")
+fun ResultSet.getStringsListOrNullFromString(name: String): List<String>? =
+    getString(name)?.split(",")
 
-fun ResultSet.getDoubleListFromString(name: String): List<Double> = verifyNotNull(name, ::getDoubleListOrNullFromString)
+fun ResultSet.getDoubleListFromString(name: String): List<Double> =
+    verifyNotNull(name, ::getDoubleListOrNullFromString)
 
 fun ResultSet.getDoubleListOrNullFromString(name: String): List<Double>? =
     getStringsListOrNullFromString(name)?.map { s -> s.toDouble() }
@@ -156,11 +167,14 @@ fun ResultSet.getDoubleListOrNullFromString(name: String): List<Double>? =
 fun ResultSet.getNullableDoubleListOrNullFromString(name: String): List<Double?>? =
     getStringsListOrNullFromString(name)?.map { s -> s.toDoubleOrNull() }
 
-fun ResultSet.getIntListFromString(name: String): List<Int> = verifyNotNull(name, ::getIntListOrNullFromString)
+fun ResultSet.getIntListFromString(name: String): List<Int> =
+    verifyNotNull(name, ::getIntListOrNullFromString)
 
-fun ResultSet.getIntListOrNullFromString(name: String): List<Int>? = getString(name)?.split(",")?.map { s -> s.toInt() }
+fun ResultSet.getIntListOrNullFromString(name: String): List<Int>? =
+    getString(name)?.split(",")?.map { s -> s.toInt() }
 
-fun <T> ResultSet.getIntIdArray(name: String): List<IntId<T>> = getListOrNull<Int>(name)?.map(::IntId) ?: emptyList()
+fun <T> ResultSet.getIntIdArray(name: String): List<IntId<T>> =
+    getListOrNull<Int>(name)?.map(::IntId) ?: emptyList()
 
 fun <T> ResultSet.getLayoutRowIdArray(name: String): List<LayoutRowId<T>> =
     getListOrNull<Int>(name)?.map(::LayoutRowId) ?: emptyList()
@@ -169,7 +183,8 @@ fun ResultSet.getIntArray(name: String): List<Int> = verifyNotNull(name, ::getIn
 
 fun ResultSet.getIntArrayOrNull(name: String): List<Int>? = getListOrNull(name)
 
-fun ResultSet.getDoubleArray(name: String): List<Double> = verifyNotNull(name, ::getDoubleArrayOrNull)
+fun ResultSet.getDoubleArray(name: String): List<Double> =
+    verifyNotNull(name, ::getDoubleArrayOrNull)
 
 fun ResultSet.getDoubleArrayOrNull(name: String): List<Double>? = getListOrNull(name)
 
@@ -177,17 +192,22 @@ fun ResultSet.getStringArray(name: String): List<String> = verifyNotNull(name, :
 
 fun ResultSet.getStringArrayOrNull(name: String): List<String>? = getListOrNull(name)
 
-fun ResultSet.getNullableIntArray(name: String): List<Int?> = verifyNotNull(name, ::getNullableIntArrayOrNull)
+fun ResultSet.getNullableIntArray(name: String): List<Int?> =
+    verifyNotNull(name, ::getNullableIntArrayOrNull)
 
 fun ResultSet.getNullableIntArrayOrNull(name: String): List<Int?>? = getNullableListOrNull(name)
 
-fun ResultSet.getNullableDoubleArray(name: String): List<Double?> = verifyNotNull(name, ::getNullableDoubleArrayOrNull)
+fun ResultSet.getNullableDoubleArray(name: String): List<Double?> =
+    verifyNotNull(name, ::getNullableDoubleArrayOrNull)
 
-fun ResultSet.getNullableDoubleArrayOrNull(name: String): List<Double?>? = getNullableListOrNull(name)
+fun ResultSet.getNullableDoubleArrayOrNull(name: String): List<Double?>? =
+    getNullableListOrNull(name)
 
-fun ResultSet.getNullableStringArray(name: String): List<String?> = verifyNotNull(name, ::getNullableStringArrayOrNull)
+fun ResultSet.getNullableStringArray(name: String): List<String?> =
+    verifyNotNull(name, ::getNullableStringArrayOrNull)
 
-fun ResultSet.getNullableStringArrayOrNull(name: String): List<String?>? = getNullableListOrNull(name)
+fun ResultSet.getNullableStringArrayOrNull(name: String): List<String?>? =
+    getNullableListOrNull(name)
 
 inline fun <reified T : Enum<T>> ResultSet.getNullableEnumArray(name: String): List<T?> =
     verifyNotNull(name) { getNullableEnumArrayOrNull<T>(name) }
@@ -198,22 +218,28 @@ inline fun <reified T : Enum<T>> ResultSet.getNullableEnumArrayOrNull(name: Stri
 fun ResultSet.getIntArrayOfArrayOrNull(name: String): List<List<Int>>? =
     getListOrNull<Array<Int>>(name)?.map { it.toList() }
 
-inline fun <reified T> ResultSet.getList(name: String): List<T> = verifyNotNull(name, ::getListOrNull)
+inline fun <reified T> ResultSet.getList(name: String): List<T> =
+    verifyNotNull(name, ::getListOrNull)
 
-inline fun <reified T> ResultSet.getListOrNull(name: String): List<T>? = getArray(name)?.array?.let { arr ->
-    if (arr is Array<*>) (arr as Array<out Any?>).mapNotNull(::verifyType)
-    else null
-}
+inline fun <reified T> ResultSet.getListOrNull(name: String): List<T>? =
+    getArray(name)?.array?.let { arr ->
+        if (arr is Array<*>) (arr as Array<out Any?>).mapNotNull(::verifyType) else null
+    }
 
-inline fun <reified T> ResultSet.getNullableListOrNull(name: String): List<T?>? = getArray(name)?.array?.let { arr ->
-    if (arr is Array<*>) (arr as Array<out Any?>).map { it?.let(::verifyType) }
-    else null
-}
+inline fun <reified T> ResultSet.getNullableListOrNull(name: String): List<T?>? =
+    getArray(name)?.array?.let { arr ->
+        if (arr is Array<*>) (arr as Array<out Any?>).map { it?.let(::verifyType) } else null
+    }
 
-fun <T> ResultSet.getDaoResponse(officialIdName: String, versionIdName: String, versionName: String) = LayoutDaoResponse<T>(
-    id = getIntId(officialIdName),
-    rowVersion = getLayoutRowVersion(versionIdName, versionName),
-)
+fun <T> ResultSet.getDaoResponse(
+    officialIdName: String,
+    versionIdName: String,
+    versionName: String
+) =
+    LayoutDaoResponse<T>(
+        id = getIntId(officialIdName),
+        rowVersion = getLayoutRowVersion(versionIdName, versionName),
+    )
 
 fun <T> ResultSet.getRowVersion(idName: String, versionName: String): RowVersion<T> =
     RowVersion(getIntId(idName), getIntNonNull(versionName))
@@ -227,7 +253,10 @@ fun <T> ResultSet.getRowVersionOrNull(idName: String, versionName: String): RowV
 fun <T> ResultSet.getLayoutRowVersion(rowIdName: String, versionName: String): LayoutRowVersion<T> =
     LayoutRowVersion(getLayoutRowId(rowIdName), getIntNonNull(versionName))
 
-fun <T> ResultSet.getLayoutRowVersionOrNull(rowIdName: String, versionName: String): LayoutRowVersion<T>? {
+fun <T> ResultSet.getLayoutRowVersionOrNull(
+    rowIdName: String,
+    versionName: String
+): LayoutRowVersion<T>? {
     val rowId = getLayoutRowIdOrNull<T>(rowIdName)
     val version = getIntOrNull(versionName)
     return if (rowId != null && version != null) LayoutRowVersion(rowId, version) else null
@@ -243,7 +272,8 @@ fun ResultSet.getFreeText(name: String): FreeText = verifyNotNull(name, ::getFre
 
 fun ResultSet.getFreeTextOrNull(name: String): FreeText? = getString(name)?.let(::FreeText)
 
-fun ResultSet.getFreeTextWithNewLinesOrNull(name: String): FreeTextWithNewLines? = getString(name)?.let(::FreeTextWithNewLines)
+fun ResultSet.getFreeTextWithNewLinesOrNull(name: String): FreeTextWithNewLines? =
+    getString(name)?.let(::FreeTextWithNewLines)
 
 fun ResultSet.getFileName(name: String): FileName = verifyNotNull(name, ::getFileNameOrNull)
 
@@ -254,21 +284,29 @@ fun ResultSet.getBbox(name: String): BoundingBox = verifyNotNull(name, ::getBbox
 fun ResultSet.getBboxOrNull(name: String): BoundingBox? =
     getPolygonPointListOrNull(name)?.let(::boundingBoxAroundPoints)
 
-fun ResultSet.getPolygonPointList(name: String): List<Point> = verifyNotNull(name, ::getPolygonPointListOrNull)
+fun ResultSet.getPolygonPointList(name: String): List<Point> =
+    verifyNotNull(name, ::getPolygonPointListOrNull)
 
-fun ResultSet.getPolygonPointListOrNull(name: String): List<Point>? = getString(name)?.let(::parse2DPolygon)
+fun ResultSet.getPolygonPointListOrNull(name: String): List<Point>? =
+    getString(name)?.let(::parse2DPolygon)
 
-fun ResultSet.getPVProjectName(name: String): PVProjectName = verifyNotNull(name, ::getPVProjectNameOrNull)
+fun ResultSet.getPVProjectName(name: String): PVProjectName =
+    verifyNotNull(name, ::getPVProjectNameOrNull)
 
-fun ResultSet.getPVProjectNameOrNull(name: String): PVProjectName? = getString(name)?.let(::PVProjectName)
+fun ResultSet.getPVProjectNameOrNull(name: String): PVProjectName? =
+    getString(name)?.let(::PVProjectName)
 
-fun ResultSet.getPVDictionaryName(name: String): PVDictionaryName = verifyNotNull(name, ::getPVDictionaryNameOrNull)
+fun ResultSet.getPVDictionaryName(name: String): PVDictionaryName =
+    verifyNotNull(name, ::getPVDictionaryNameOrNull)
 
-fun ResultSet.getPVDictionaryNameOrNull(name: String): PVDictionaryName? = getString(name)?.let(::PVDictionaryName)
+fun ResultSet.getPVDictionaryNameOrNull(name: String): PVDictionaryName? =
+    getString(name)?.let(::PVDictionaryName)
 
-fun ResultSet.getPVDictionaryCode(name: String): PVDictionaryCode = verifyNotNull(name, ::getPVDictionaryCodeOrNull)
+fun ResultSet.getPVDictionaryCode(name: String): PVDictionaryCode =
+    verifyNotNull(name, ::getPVDictionaryCodeOrNull)
 
-fun ResultSet.getPVDictionaryCodeOrNull(name: String): PVDictionaryCode? = getString(name)?.let(::PVDictionaryCode)
+fun ResultSet.getPVDictionaryCodeOrNull(name: String): PVDictionaryCode? =
+    getString(name)?.let(::PVDictionaryCode)
 
 fun ResultSet.getPVId(name: String): PVId = verifyNotNull(name, ::getPVIdOrNull)
 
@@ -281,18 +319,28 @@ fun ResultSet.getChangePoint(nameX: String, nameY: String) =
     Change(getPointOrNull("old_$nameX", "old_$nameY"), getPointOrNull(nameX, nameY))
 
 fun <T> ResultSet.getChangeRowVersion(idName: String, versionName: String): Change<RowVersion<T>> =
-    Change(getRowVersionOrNull("old_$idName", "old_$versionName"), getRowVersionOrNull(idName, versionName))
+    Change(
+        getRowVersionOrNull("old_$idName", "old_$versionName"),
+        getRowVersionOrNull(idName, versionName))
 
 fun ResultSet.getLayoutContext(designIdName: String, draftFlagName: String): LayoutContext =
     toLayoutContext(getPublicationState(draftFlagName), getIntIdOrNull(designIdName))
 
 fun ResultSet.getLayoutContextOrNull(designIdName: String, draftFlagName: String): LayoutContext? =
-    getPublicationStateOrNull(draftFlagName)?.let { state -> toLayoutContext(state, getIntIdOrNull(designIdName)) }
+    getPublicationStateOrNull(draftFlagName)?.let { state ->
+        toLayoutContext(state, getIntIdOrNull(designIdName))
+    }
 
-fun ResultSet.getDesignLayoutContext(designIdName: String, draftFlagName: String): DesignLayoutContext =
+fun ResultSet.getDesignLayoutContext(
+    designIdName: String,
+    draftFlagName: String
+): DesignLayoutContext =
     DesignLayoutContext.of(getIntId(designIdName), getPublicationState(draftFlagName))
 
-fun ResultSet.getDesignLayoutContextOrNull(designIdName: String, draftFlagName: String): DesignLayoutContext? =
+fun ResultSet.getDesignLayoutContextOrNull(
+    designIdName: String,
+    draftFlagName: String
+): DesignLayoutContext? =
     getIntIdOrNull<LayoutDesign>(designIdName)
         ?.let { id -> id to getPublicationState(draftFlagName) }
         ?.let { (id, state) -> DesignLayoutContext.of(id, state) }
@@ -303,25 +351,39 @@ fun ResultSet.getMainLayoutContext(draftFlagName: String): MainLayoutContext =
 fun ResultSet.getMainLayoutContextOrNull(draftFlagName: String): MainLayoutContext? =
     getPublicationStateOrNull(draftFlagName)?.let(MainLayoutContext::of)
 
-private fun toLayoutContext(state: PublicationState, designId: IntId<LayoutDesign>?): LayoutContext =
+private fun toLayoutContext(
+    state: PublicationState,
+    designId: IntId<LayoutDesign>?
+): LayoutContext =
     designId?.let { id -> DesignLayoutContext.of(id, state) } ?: MainLayoutContext.of(state)
 
 fun ResultSet.getPublicationState(draftFlagName: String): PublicationState =
-    requireNotNull(getPublicationStateOrNull(draftFlagName)) { "Value was null: type=Boolean column=$draftFlagName" }
+    requireNotNull(getPublicationStateOrNull(draftFlagName)) {
+        "Value was null: type=Boolean column=$draftFlagName"
+    }
 
 fun ResultSet.getPublicationStateOrNull(draftFlagName: String): PublicationState? =
-    getBooleanOrNull(draftFlagName)?.let { draft -> if (draft) PublicationState.DRAFT else PublicationState.OFFICIAL }
+    getBooleanOrNull(draftFlagName)?.let { draft ->
+        if (draft) PublicationState.DRAFT else PublicationState.OFFICIAL
+    }
 
 fun ResultSet.getLayoutBranch(designIdName: String): LayoutBranch =
-    getIntIdOrNull<LayoutDesign>(designIdName).let { id -> if (id == null) LayoutBranch.main else DesignBranch.of(id) }
+    getIntIdOrNull<LayoutDesign>(designIdName).let { id ->
+        if (id == null) LayoutBranch.main else DesignBranch.of(id)
+    }
 
 inline fun <reified T> verifyNotNull(column: String, nullableGet: (column: String) -> T?): T =
-    requireNotNull(nullableGet(column)) { "Value was null: type=${T::class.simpleName} column=$column" }
+    requireNotNull(nullableGet(column)) {
+        "Value was null: type=${T::class.simpleName} column=$column"
+    }
 
-inline fun <reified T> verifyType(value: Any?): T = value.let { v ->
-    require(v is T) { "Value is of unexpected type: expected=${T::class.simpleName} value=${v}" }
-    v
-}
+inline fun <reified T> verifyType(value: Any?): T =
+    value.let { v ->
+        require(v is T) {
+            "Value is of unexpected type: expected=${T::class.simpleName} value=${v}"
+        }
+        v
+    }
 
 fun <T> ResultSet.getLayoutContextData(
     officialRowIdName: String,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/SanitizedString.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/SanitizedString.kt
@@ -13,33 +13,42 @@ const val freeTextWithNewLineCharacters = freeTextCharacters + newLineCharacter
 val freeTextRegex = Regex("^[$freeTextCharacters]*\$")
 val freeTextWithNewLinesRegex = Regex("^[$freeTextWithNewLineCharacters]*\$")
 
-data class Code @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<Code>, CharSequence by value {
-    init { assertSanitized<Code>(value, codeRegex) }
+data class Code @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<Code>, CharSequence by value {
+    init {
+        assertSanitized<Code>(value, codeRegex)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: Code): Int = value.compareTo(other.value)
 }
 
 fun isValidCode(source: String): Boolean = isSanitized(source, codeRegex, allowBlank = false)
 
-data class FreeText @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<FreeText>, CharSequence by value {
-    init { assertSanitized<FreeText>(value, freeTextRegex) }
+data class FreeText @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<FreeText>, CharSequence by value {
+    init {
+        assertSanitized<FreeText>(value, freeTextRegex)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: FreeText): Int = value.compareTo(other.value)
+
     operator fun plus(addition: String) = FreeText("$value$addition")
 }
 
-data class FreeTextWithNewLines @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<FreeTextWithNewLines>, CharSequence by value {
-    init { assertSanitized<FreeTextWithNewLines>(value, freeTextWithNewLinesRegex) }
+data class FreeTextWithNewLines
+@JsonCreator(mode = DELEGATING)
+constructor(private val value: String) : Comparable<FreeTextWithNewLines>, CharSequence by value {
+    init {
+        assertSanitized<FreeTextWithNewLines>(value, freeTextWithNewLinesRegex)
+    }
 
-    @JsonValue
-    override fun toString(): String = value
+    @JsonValue override fun toString(): String = value
+
     override fun compareTo(other: FreeTextWithNewLines): Int = value.compareTo(other.value)
+
     operator fun plus(addition: String) = FreeTextWithNewLines("$value$addition")
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
@@ -6,10 +6,12 @@ val lineBreakRegex = Regex("[\n\r\t]")
 const val UNSAFE_LOG_CHARACTERS = "[^A-Za-zäöÄÖåÅ0-9_-+!?.:;', �/]"
 
 const val UNIX_LINEBREAK = "\n"
-const val LEGACY_LINEBREAK = "\r" // Possibly used in older files were text may be copied and pasted from.
+const val LEGACY_LINEBREAK =
+    "\r" // Possibly used in older files were text may be copied and pasted from.
 const val WINDOWS_LINEBREAK = "\r\n"
 
-// Order matters due to both Windows style & legacy linebreaks containing the same special character.
+// Order matters due to both Windows style & legacy linebreaks containing the same special
+// character.
 val linebreakNormalizationRegex = Regex("$WINDOWS_LINEBREAK|$LEGACY_LINEBREAK")
 
 const val UNSAFE_REPLACEMENT = "�"
@@ -20,16 +22,22 @@ const val DEFAULT_EXCEPTION_MAX_LENGTH = 100
 
 inline fun <reified T> parsePrefixedInt(prefix: String, value: String): Int =
     parsePrefixed<T>(prefix, value).toIntOrNull()
-        ?: failInput<T>(value) { "Invalid string value: prefix=$prefix value=${formatForException(value)}" }
+        ?: failInput<T>(value) {
+            "Invalid string value: prefix=$prefix value=${formatForException(value)}"
+        }
 
 inline fun <reified T> parsePrefixed(prefix: String, value: String): String =
     if (value.startsWith(prefix)) value.substring(prefix.length)
-    else failInput<T>(value) { "Invalid string prefix: prefix=$prefix value=${formatForException(value)}" }
+    else
+        failInput<T>(value) {
+            "Invalid string prefix: prefix=$prefix value=${formatForException(value)}"
+        }
 
 fun equalsIgnoreCaseAndWhitespace(s1: String, s2: String) =
     s1.filterNot(Char::isWhitespace).equals(s2.filterNot(Char::isWhitespace), ignoreCase = false)
 
-fun formatForException(input: String, maxLength: Int = DEFAULT_EXCEPTION_MAX_LENGTH) = formatForLog(input, maxLength)
+fun formatForException(input: String, maxLength: Int = DEFAULT_EXCEPTION_MAX_LENGTH) =
+    formatForLog(input, maxLength)
 
 fun formatForLog(input: String, maxLength: Int = DEFAULT_LOG_MAX_LENGTH): String =
     "\"${limitLength(input, maxLength).let(::removeLogUnsafe).let(::removeLinebreaks)}\""
@@ -41,7 +49,9 @@ fun removeLogUnsafe(input: String) = input.replace(UNSAFE_LOG_CHARACTERS, UNSAFE
 
 fun removeLinebreaks(input: String) = input.replace(lineBreakRegex, LINE_BREAK_REPLACEMENT)
 
-fun normalizeLinebreaksToUnixFormat(input: String) = input.replace(linebreakNormalizationRegex, UNIX_LINEBREAK)
+fun normalizeLinebreaksToUnixFormat(input: String) =
+    input.replace(linebreakNormalizationRegex, UNIX_LINEBREAK)
+
 fun normalizeLinebreaksToUnixFormat(input: FreeTextWithNewLines) =
     FreeTextWithNewLines(normalizeLinebreaksToUnixFormat(input.toString()))
 
@@ -50,9 +60,10 @@ fun isSanitized(
     regex: Regex,
     length: ClosedRange<Int>? = null,
     allowBlank: Boolean = true,
-) = (length == null || stringValue.length in length)
-        && (allowBlank || stringValue.isNotBlank())
-        && stringValue.matches(regex)
+) =
+    (length == null || stringValue.length in length) &&
+        (allowBlank || stringValue.isNotBlank()) &&
+        stringValue.matches(regex)
 
 inline fun <reified T> assertSanitized(
     stringValue: String,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Timer.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Timer.kt
@@ -1,20 +1,23 @@
 package fi.fta.geoviite.infra.util
 
 import correlationId
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 private class Timer
+
 val logger: Logger = LoggerFactory.getLogger(Timer::class.java)
 
 fun <T> measureAndPrintLength(function: () -> T, title: String): T =
     measureLength({ duration -> printDuration(title, duration) }, function)
 
 fun operationId() = correlationId.getOrNull() ?: "DEFAULT"
+
 val collectedTimes: MutableMap<String, MutableMap<String, Duration>> = ConcurrentHashMap()
+
 fun logAndResetCollected() {
     val map = collectedTimes.remove(operationId())
     map?.forEach { (key: String, value: Duration) -> printDuration(key, value) }
@@ -38,7 +41,7 @@ fun <T> measureLength(timeConsumer: (duration: Duration) -> Unit, function: () -
 fun collectDuration(title: String, duration: Duration) {
     collectedTimes.compute(operationId()) { _, previousMap ->
         val map = previousMap ?: ConcurrentHashMap()
-        map.compute(title) { _, previousDuration -> previousDuration?.plus(duration) ?: duration}
+        map.compute(title) { _, previousDuration -> previousDuration?.plus(duration) ?: duration }
         map
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/VersionLogger.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/VersionLogger.kt
@@ -13,14 +13,18 @@ class VersionLogger(val jdbcTemplate: NamedParameterJdbcTemplate?) {
 
     @PostConstruct
     fun logVersion() {
-        val sql = """
+        val sql =
+            """
            select 
              version() as postgres_version,
              postgis.postgis_full_version() as postgis_version;
-       """.trimIndent()
-        jdbcTemplate?.let { jdbc -> jdbc.queryForObject(sql, mapOf<String, Any>()) { rs, _ ->
-            logger.info("PostgreSQL Version: ${rs.getString("postgres_version")}")
-            logger.info("PostGIS Version: ${rs.getString("postgis_version")}")
-        } }
+       """
+                .trimIndent()
+        jdbcTemplate?.let { jdbc ->
+            jdbc.queryForObject(sql, mapOf<String, Any>()) { rs, _ ->
+                logger.info("PostgreSQL Version: ${rs.getString("postgres_version")}")
+                logger.info("PostGIS Version: ${rs.getString("postgis_version")}")
+            }
+        }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/XmlUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/XmlUtils.kt
@@ -1,12 +1,12 @@
 package fi.fta.geoviite.infra.util
 
-import org.apache.commons.io.ByteOrderMark
-import org.apache.commons.io.input.BOMInputStream
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import javax.xml.stream.XMLInputFactory
+import org.apache.commons.io.ByteOrderMark
+import org.apache.commons.io.input.BOMInputStream
 
 enum class XmlCharset(val charset: Charset) {
     UTF_8(StandardCharsets.UTF_8),
@@ -17,12 +17,13 @@ enum class XmlCharset(val charset: Charset) {
     ISO_8859_1(StandardCharsets.ISO_8859_1),
 }
 
-fun mapBomToCharset(bom: ByteOrderMark): Charset? = when (bom) {
-    ByteOrderMark.UTF_8 -> StandardCharsets.UTF_8
-    ByteOrderMark.UTF_16BE -> StandardCharsets.UTF_16BE
-    ByteOrderMark.UTF_16LE -> StandardCharsets.UTF_16LE
-    else -> null
-}
+fun mapBomToCharset(bom: ByteOrderMark): Charset? =
+    when (bom) {
+        ByteOrderMark.UTF_8 -> StandardCharsets.UTF_8
+        ByteOrderMark.UTF_16BE -> StandardCharsets.UTF_16BE
+        ByteOrderMark.UTF_16LE -> StandardCharsets.UTF_16LE
+        else -> null
+    }
 
 fun encodingsFromXmlStream(stream: InputStream): Pair<String?, String?> =
     XMLInputFactory.newInstance().createXMLStreamReader(stream).let { xmlStreamReader ->
@@ -36,9 +37,10 @@ fun getEncodingAndBom(bytes: ByteArray): Pair<Charset, Boolean> {
     BOMInputStream.builder().setInputStream(ByteArrayInputStream(bytes)).get().use { stream ->
         val encodingFromBOM = stream.bom?.let { bom -> mapBomToCharset(bom) }
         val (fileEncoding, encodingFromXMLDeclaration) = encodingsFromXmlStream(stream)
-        val encoding = encodingFromBOM
-            ?: (encodingFromXMLDeclaration ?: fileEncoding)?.let(::findXmlCharset)
-            ?: StandardCharsets.UTF_8
+        val encoding =
+            encodingFromBOM
+                ?: (encodingFromXMLDeclaration ?: fileEncoding)?.let(::findXmlCharset)
+                ?: StandardCharsets.UTF_8
         return encoding to (stream.bom != null)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
@@ -4,7 +4,6 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.TestApi
 import fi.fta.geoviite.infra.TestLayoutContext
-import fi.fta.geoviite.infra.authorization.AuthorizationService
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutContext
@@ -24,19 +23,18 @@ import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndAlignment
 import fi.fta.geoviite.infra.tracklayout.segment
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import java.util.UUID
-import kotlin.test.assertTrue
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 private const val API_URL = "/rata-vkm/v1"
 
@@ -64,9 +62,10 @@ private data class GeocodableTrack(
     classes = [InfraApplication::class],
 )
 @AutoConfigureMockMvc
-class CoordinateToTrackAddressIT @Autowired constructor(
+class CoordinateToTrackAddressIT
+@Autowired
+constructor(
     mockMvc: MockMvc,
-
     val trackNumberDao: LayoutTrackNumberDao,
     val referenceLineDao: ReferenceLineDao,
     val locationTrackService: LocationTrackService,
@@ -74,9 +73,8 @@ class CoordinateToTrackAddressIT @Autowired constructor(
     val layoutKmPostDao: LayoutKmPostDao,
 ) : DBTestBase() {
 
-    private val mapper = ObjectMapper().apply {
-        setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    }
+    private val mapper =
+        ObjectMapper().apply { setSerializationInclusion(JsonInclude.Include.NON_NULL) }
 
     val testApi = TestApi(mapper, mockMvc)
 
@@ -89,14 +87,17 @@ class CoordinateToTrackAddressIT @Autowired constructor(
     fun `Partially valid request should result in a descriptive error`() {
         val params = mapOf("x" to "0.0")
 
-        val requests = listOf(
-            testApi.doGetWithParams(API_URL, params, HttpStatus.OK),
-            testApi.doPostWithParams(API_URL, params, HttpStatus.OK),
-        )
+        val requests =
+            listOf(
+                testApi.doGetWithParams(API_URL, params, HttpStatus.OK),
+                testApi.doPostWithParams(API_URL, params, HttpStatus.OK),
+            )
 
         requests.forEach { request ->
-            val featureCollection = request
-                .let { body -> mapper.readValue(body, TestGeoJsonFeatureCollection::class.java) }
+            val featureCollection =
+                request.let { body ->
+                    mapper.readValue(body, TestGeoJsonFeatureCollection::class.java)
+                }
 
             assertNotNull(featureCollection.features[0].properties?.get("virheet"))
         }
@@ -112,14 +113,16 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Missing x-coordinate in a request should result in an error`() {
-        val request = TestCoordinateToTrackAddressRequest(
-            y = 0.0,
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                y = 0.0,
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(request),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(request),
+            )
 
         assertEquals("FeatureCollection", featureCollection.type)
         assertEquals(1, featureCollection.features.size)
@@ -136,14 +139,16 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Missing y-coordinate in a request should result in an error`() {
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(request),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(request),
+            )
 
         assertEquals("FeatureCollection", featureCollection.type)
         assertEquals(1, featureCollection.features.size)
@@ -162,14 +167,17 @@ class CoordinateToTrackAddressIT @Autowired constructor(
     fun `Missing x- and y-coordinates in a request should result in two errors`() {
         val params = emptyMap<String, String>()
 
-        val requests = listOf(
-            testApi.doGetWithParams(API_URL, params, HttpStatus.OK),
-            testApi.doPostWithParams(API_URL, params, HttpStatus.OK),
-        )
+        val requests =
+            listOf(
+                testApi.doGetWithParams(API_URL, params, HttpStatus.OK),
+                testApi.doPostWithParams(API_URL, params, HttpStatus.OK),
+            )
 
         requests.forEach { request ->
-            val featureCollection = request
-                .let { body -> mapper.readValue(body, TestGeoJsonFeatureCollection::class.java) }
+            val featureCollection =
+                request.let { body ->
+                    mapper.readValue(body, TestGeoJsonFeatureCollection::class.java)
+                }
 
             assertNotNull(featureCollection.features[0].properties?.get("virheet"))
 
@@ -189,15 +197,17 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Valid single request without any matching tracks should succeed but return error feature`() {
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 0.0,
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 0.0,
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(request),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(request),
+            )
 
         assertEquals("FeatureCollection", featureCollection.type)
         assertEquals(1, featureCollection.features.size)
@@ -216,21 +226,22 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Valid multi request without any matches should succeed but return error features`() {
-        val requests = listOf(
-            TestCoordinateToTrackAddressRequest(
-                x = 0.0,
-                y = 0.0,
-            ),
-            TestCoordinateToTrackAddressRequest(
-                x = 15.0,
-                y = 15.0,
-            )
-        )
+        val requests =
+            listOf(
+                TestCoordinateToTrackAddressRequest(
+                    x = 0.0,
+                    y = 0.0,
+                ),
+                TestCoordinateToTrackAddressRequest(
+                    x = 15.0,
+                    y = 15.0,
+                ))
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(requests),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(requests),
+            )
 
         assertEquals("FeatureCollection", featureCollection.type)
         assertEquals(2, featureCollection.features.size)
@@ -251,60 +262,62 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Valid multi request with some matches should succeed but return error features`() {
-        insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
-        val requests = listOf(
-            TestCoordinateToTrackAddressRequest(
-                tunniste = "unmatching request",
-                x = -15.0,
-                y = 0.0,
-                sade = 2.0,
-            ),
-            TestCoordinateToTrackAddressRequest(
-                tunniste = "matching request",
-                x = 0.0,
-                y = 0.0,
-            ),
-            TestCoordinateToTrackAddressRequest(
-                tunniste = "unmatching request 2",
-                x = 15.0,
-                y = 0.0,
-                sade = 3.0,
-            ),
-        )
+        val requests =
+            listOf(
+                TestCoordinateToTrackAddressRequest(
+                    tunniste = "unmatching request",
+                    x = -15.0,
+                    y = 0.0,
+                    sade = 2.0,
+                ),
+                TestCoordinateToTrackAddressRequest(
+                    tunniste = "matching request",
+                    x = 0.0,
+                    y = 0.0,
+                ),
+                TestCoordinateToTrackAddressRequest(
+                    tunniste = "unmatching request 2",
+                    x = 15.0,
+                    y = 0.0,
+                    sade = 3.0,
+                ),
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(requests),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(requests),
+            )
 
         assertEquals("FeatureCollection", featureCollection.type)
         assertEquals(3, featureCollection.features.size)
 
         val expectedErrorMessage = "Annetun (alku)pisteen parametreilla ei löytynyt tietoja."
 
-        assertEquals(requests[0].tunniste, featureCollection.features[0].properties?.get("tunniste"))
+        assertEquals(
+            requests[0].tunniste, featureCollection.features[0].properties?.get("tunniste"))
         assertEquals(expectedErrorMessage, featureCollection.features[0].properties?.get("virheet"))
 
-        assertEquals(requests[1].tunniste, featureCollection.features[1].properties?.get("tunniste"))
+        assertEquals(
+            requests[1].tunniste, featureCollection.features[1].properties?.get("tunniste"))
         assertEquals(null, featureCollection.features[1].properties?.get("virheet"))
 
-        assertEquals(requests[2].tunniste, featureCollection.features[2].properties?.get("tunniste"))
+        assertEquals(
+            requests[2].tunniste, featureCollection.features[2].properties?.get("tunniste"))
         assertEquals(expectedErrorMessage, featureCollection.features[2].properties?.get("virheet"))
     }
 
     @Test
     fun `Valid single request using request params should succeed`() {
-        insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
-        val params = mapOf(
-            "x" to "0.0",
-            "y" to "0.0",
-        )
+        val params =
+            mapOf(
+                "x" to "0.0",
+                "y" to "0.0",
+            )
 
         testApi.doGetWithParams(API_URL, params, HttpStatus.OK)
         testApi.doPostWithParams(API_URL, params, HttpStatus.OK)
@@ -312,14 +325,13 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Valid single request with JSON should succeed`() {
-        insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 0.0,
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 0.0,
+            )
 
         testApi.doGetWithParams(API_URL, createJsonRequestParams(request), HttpStatus.OK)
         testApi.doPostWithParams(API_URL, createJsonRequestParams(request), HttpStatus.OK)
@@ -327,20 +339,19 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Valid JSON request with multiple transformations should succeed`() {
-        insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
-        val requests = listOf(
-            TestCoordinateToTrackAddressRequest(
-                x = 0.0,
-                y = 0.0,
-            ),
-            TestCoordinateToTrackAddressRequest(
-                x = 1.0,
-                y = 1.0,
-            ),
-        )
+        val requests =
+            listOf(
+                TestCoordinateToTrackAddressRequest(
+                    x = 0.0,
+                    y = 0.0,
+                ),
+                TestCoordinateToTrackAddressRequest(
+                    x = 1.0,
+                    y = 1.0,
+                ),
+            )
 
         testApi.doGetWithParams(API_URL, createJsonRequestParams(requests), HttpStatus.OK)
         testApi.doPostWithParams(API_URL, createJsonRequestParams(requests), HttpStatus.OK)
@@ -348,71 +359,75 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Response feature should include identifier of the request if submitted`() {
-        insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
-        val identifiers = listOf(
-            "some-identifier-${UUID.randomUUID()}",
-            "some-identifier-${UUID.randomUUID()}"
-        )
+        val identifiers =
+            listOf("some-identifier-${UUID.randomUUID()}", "some-identifier-${UUID.randomUUID()}")
 
-        val requests = listOf(
-            TestCoordinateToTrackAddressRequest(
-                tunniste = identifiers[0],
-                x = 0.0,
-                y = 0.0,
-            ),
-            TestCoordinateToTrackAddressRequest(
-                tunniste = identifiers[1],
-                x = 1.0,
-                y = 1.0,
-            )
-        )
+        val requests =
+            listOf(
+                TestCoordinateToTrackAddressRequest(
+                    tunniste = identifiers[0],
+                    x = 0.0,
+                    y = 0.0,
+                ),
+                TestCoordinateToTrackAddressRequest(
+                    tunniste = identifiers[1],
+                    x = 1.0,
+                    y = 1.0,
+                ))
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(requests)
-        )
+        val featureCollection = fetchFeatureCollection(API_URL, createJsonRequestParams(requests))
 
-        assertEquals(identifiers[0], featureCollection.features[0].properties?.get("tunniste"), "key=tunniste")
-        assertEquals(identifiers[1], featureCollection.features[1].properties?.get("tunniste"), "key=tunniste")
+        assertEquals(
+            identifiers[0],
+            featureCollection.features[0].properties?.get("tunniste"),
+            "key=tunniste")
+        assertEquals(
+            identifiers[1],
+            featureCollection.features[1].properties?.get("tunniste"),
+            "key=tunniste")
     }
 
     @Test
     fun `Basic request should default to return data with responseSettings 1 and 10`() {
-        val geocodableTrack = insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        val geocodableTrack =
+            insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
         val yDifferenceToTargetLocation = 5.0
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = yDifferenceToTargetLocation,
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = yDifferenceToTargetLocation,
+            )
 
-        val expectedProperties = mapOf(
-            "x" to 0.0,
-            "y" to 0.0,
-            "valimatka" to yDifferenceToTargetLocation,
-            "ratanumero" to geocodableTrack.trackNumber.number.toString(),
-            "sijaintiraide" to geocodableTrack.locationTrack.name.toString(),
-            "sijaintiraide_kuvaus" to locationTrackService.getFullDescription(
-                layoutContext = geocodableTrack.layoutContext,
-                locationTrack = geocodableTrack.locationTrack,
-                lang = LocalizationLanguage.FI,
-            ).toString(),
-            "sijaintiraide_tyyppi" to "pääraide",
-            "ratakilometri" to 0,
-            "ratametri" to 10,
-            "ratametri_desimaalit" to 0,
-        )
+        val expectedProperties =
+            mapOf(
+                "x" to 0.0,
+                "y" to 0.0,
+                "valimatka" to yDifferenceToTargetLocation,
+                "ratanumero" to geocodableTrack.trackNumber.number.toString(),
+                "sijaintiraide" to geocodableTrack.locationTrack.name.toString(),
+                "sijaintiraide_kuvaus" to
+                    locationTrackService
+                        .getFullDescription(
+                            layoutContext = geocodableTrack.layoutContext,
+                            locationTrack = geocodableTrack.locationTrack,
+                            lang = LocalizationLanguage.FI,
+                        )
+                        .toString(),
+                "sijaintiraide_tyyppi" to "pääraide",
+                "ratakilometri" to 0,
+                "ratametri" to 10,
+                "ratametri_desimaalit" to 0,
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(request),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(request),
+            )
 
         assertEquals("FeatureCollection", featureCollection.type)
         assertEquals(1, featureCollection.features.size)
@@ -428,20 +443,20 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Request with empty but assigned responseSettings should succeed but not return any actual data`() {
-        insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 0.0,
-            palautusarvot = emptyList(),
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 0.0,
+                palautusarvot = emptyList(),
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(request),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(request),
+            )
 
         assertEquals("FeatureCollection", featureCollection.type)
         assertEquals(1, featureCollection.features.size)
@@ -454,37 +469,35 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Basic filtering with radius works`() {
-        insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
-        val requestsToExpectedError = mapOf(
-            TestCoordinateToTrackAddressRequest(
-                tunniste = "requestWithoutRadius",
-                x = 0.0,
-                y = 0.0,
-            ) to null,
-
-            TestCoordinateToTrackAddressRequest(
-                tunniste = "requestInsideRadius",
-                x = 0.0,
-                y = 0.0,
-                sade = 1.0,
-            ) to null,
-
-            TestCoordinateToTrackAddressRequest(
-                tunniste = "requestOutsideRadius",
-                x = 0.0,
-                y = 3.0,
-                sade = 2.0,
-            ) to "Annetun (alku)pisteen parametreilla ei löytynyt tietoja.",
-        )
+        val requestsToExpectedError =
+            mapOf(
+                TestCoordinateToTrackAddressRequest(
+                    tunniste = "requestWithoutRadius",
+                    x = 0.0,
+                    y = 0.0,
+                ) to null,
+                TestCoordinateToTrackAddressRequest(
+                    tunniste = "requestInsideRadius",
+                    x = 0.0,
+                    y = 0.0,
+                    sade = 1.0,
+                ) to null,
+                TestCoordinateToTrackAddressRequest(
+                    tunniste = "requestOutsideRadius",
+                    x = 0.0,
+                    y = 3.0,
+                    sade = 2.0,
+                ) to "Annetun (alku)pisteen parametreilla ei löytynyt tietoja.",
+            )
 
         requestsToExpectedError.forEach { (request, expectedError) ->
-            val featureCollection = fetchFeatureCollection(
-                API_URL,
-                createJsonRequestParams(request),
-            )
+            val featureCollection =
+                fetchFeatureCollection(
+                    API_URL,
+                    createJsonRequestParams(request),
+                )
 
             assertEquals(1, featureCollection.features.size, "request=${request.tunniste}")
 
@@ -495,33 +508,34 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Filtering with track number works`() {
-        val trackNumberIds = (0..2).map { _ ->
-            mainOfficialContext.createLayoutTrackNumber().id
-        }
+        val trackNumberIds = (0..2).map { _ -> mainOfficialContext.createLayoutTrackNumber().id }
 
         // Purposefully uses the same segments for overlap in order to determine
         // that the filtering works based on the track number.
         val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        val tracks = trackNumberIds.map { trackNumberId ->
-            insertGeocodableTrack(
-                trackNumberId = trackNumberId,
-                segments = segments,
-            )
-        }
+        val tracks =
+            trackNumberIds.map { trackNumberId ->
+                insertGeocodableTrack(
+                    trackNumberId = trackNumberId,
+                    segments = segments,
+                )
+            }
 
         tracks.forEach { geocodableTrack ->
             val trackNumberName = geocodableTrack.trackNumber.number.toString()
 
-            val request = TestCoordinateToTrackAddressRequest(
-                x = 0.0,
-                y = 0.0,
-                ratanumero = trackNumberName,
-            )
+            val request =
+                TestCoordinateToTrackAddressRequest(
+                    x = 0.0,
+                    y = 0.0,
+                    ratanumero = trackNumberName,
+                )
 
-            val featureCollection = fetchFeatureCollection(
-                API_URL,
-                createJsonRequestParams(request),
-            )
+            val featureCollection =
+                fetchFeatureCollection(
+                    API_URL,
+                    createJsonRequestParams(request),
+                )
 
             val properties = featureCollection.features[0].properties
             assertEquals(trackNumberName, properties?.get("ratanumero"))
@@ -533,26 +547,29 @@ class CoordinateToTrackAddressIT @Autowired constructor(
         // Purposefully uses the same segments for overlap in order to determine
         // that the filtering works based on the location track name.
         val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        val tracks = (0..2).map { _ ->
-            insertGeocodableTrack(
-                locationTrackName = "Test track-${UUID.randomUUID()}",
-                segments = segments,
-            )
-        }
+        val tracks =
+            (0..2).map { _ ->
+                insertGeocodableTrack(
+                    locationTrackName = "Test track-${UUID.randomUUID()}",
+                    segments = segments,
+                )
+            }
 
         tracks.forEach { geocodableTrack ->
             val locationTrackName = geocodableTrack.locationTrack.name.toString()
 
-            val request = TestCoordinateToTrackAddressRequest(
-                x = 0.0,
-                y = 0.0,
-                sijaintiraide = locationTrackName,
-            )
+            val request =
+                TestCoordinateToTrackAddressRequest(
+                    x = 0.0,
+                    y = 0.0,
+                    sijaintiraide = locationTrackName,
+                )
 
-            val featureCollection = fetchFeatureCollection(
-                API_URL,
-                createJsonRequestParams(request),
-            )
+            val featureCollection =
+                fetchFeatureCollection(
+                    API_URL,
+                    createJsonRequestParams(request),
+                )
 
             val properties = featureCollection.features[0].properties
             assertEquals(locationTrackName, properties?.get("sijaintiraide"))
@@ -572,22 +589,19 @@ class CoordinateToTrackAddressIT @Autowired constructor(
             )
         }
 
-        listOf(
-            "pääraide",
-            "sivuraide",
-            "kujaraide",
-            "turvaraide"
-        ).forEach { trackType ->
-            val request = TestCoordinateToTrackAddressRequest(
-                x = 0.0,
-                y = 0.0,
-                sijaintiraide_tyyppi = trackType,
-            )
+        listOf("pääraide", "sivuraide", "kujaraide", "turvaraide").forEach { trackType ->
+            val request =
+                TestCoordinateToTrackAddressRequest(
+                    x = 0.0,
+                    y = 0.0,
+                    sijaintiraide_tyyppi = trackType,
+                )
 
-            val featureCollection = fetchFeatureCollection(
-                API_URL,
-                createJsonRequestParams(request),
-            )
+            val featureCollection =
+                fetchFeatureCollection(
+                    API_URL,
+                    createJsonRequestParams(request),
+                )
 
             val properties = featureCollection.features[0].properties
             assertEquals(trackType, properties?.get("sijaintiraide_tyyppi"))
@@ -596,21 +610,21 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Response output data setting 1 works`() {
-        insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
         val yDifference = 1.0
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = yDifference,
-            palautusarvot = listOf(1), // This is the parameter being tested.
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = yDifference,
+                palautusarvot = listOf(1), // This is the parameter being tested.
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(request),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(request),
+            )
 
         assertEquals(1, featureCollection.features.size)
         assertEquals("Point", featureCollection.features[0].geometry?.type)
@@ -633,20 +647,20 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Response output data setting 5 works`() {
-        insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        )
+        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 1.0,
-            palautusarvot = listOf(5), // This is the parameter being tested.
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 1.0,
+                palautusarvot = listOf(5), // This is the parameter being tested.
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(request),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(request),
+            )
 
         assertEquals(1, featureCollection.features.size)
         assertEquals("Point", featureCollection.features[0].geometry?.type)
@@ -675,27 +689,33 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     @Test
     fun `Response output data setting 10 works`() {
-        val geocodableTrack = insertGeocodableTrack(
-            segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))),
-            locationTrackType = LocationTrackType.CHORD,
-        )
+        val geocodableTrack =
+            insertGeocodableTrack(
+                segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))),
+                locationTrackType = LocationTrackType.CHORD,
+            )
 
-        val trackDescription = locationTrackService.getFullDescription(
-            layoutContext = geocodableTrack.layoutContext,
-            locationTrack = geocodableTrack.locationTrack,
-            lang = LocalizationLanguage.FI,
-        ).toString()
+        val trackDescription =
+            locationTrackService
+                .getFullDescription(
+                    layoutContext = geocodableTrack.layoutContext,
+                    locationTrack = geocodableTrack.locationTrack,
+                    lang = LocalizationLanguage.FI,
+                )
+                .toString()
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 1.0,
-            palautusarvot = listOf(10), // This is the parameter being tested.
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 1.0,
+                palautusarvot = listOf(10), // This is the parameter being tested.
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(request),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(request),
+            )
 
         assertEquals(1, featureCollection.features.size)
         assertEquals("Point", featureCollection.features[0].geometry?.type)
@@ -708,7 +728,8 @@ class CoordinateToTrackAddressIT @Autowired constructor(
         assertEquals(null, properties?.get("valimatka"))
 
         assertEquals(geocodableTrack.trackNumber.number.toString(), properties?.get("ratanumero"))
-        assertEquals(geocodableTrack.locationTrack.name.toString(), properties?.get("sijaintiraide"))
+        assertEquals(
+            geocodableTrack.locationTrack.name.toString(), properties?.get("sijaintiraide"))
         assertEquals(trackDescription, properties?.get("sijaintiraide_kuvaus"))
         assertEquals("kujaraide", properties?.get("sijaintiraide_tyyppi"))
         assertEquals(0, properties?.get("ratakilometri"))
@@ -720,32 +741,38 @@ class CoordinateToTrackAddressIT @Autowired constructor(
     fun `Response output data setting combination works`() {
         val layoutContext = mainOfficialContext
 
-        val geocodableTrack = insertGeocodableTrack(
-            layoutContext = layoutContext,
-            segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-            locationTrackType = LocationTrackType.TRAP,
-        )
+        val geocodableTrack =
+            insertGeocodableTrack(
+                layoutContext = layoutContext,
+                segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+                locationTrackType = LocationTrackType.TRAP,
+            )
 
-        val trackDescription = locationTrackService.getFullDescription(
-            layoutContext = geocodableTrack.layoutContext,
-            locationTrack = geocodableTrack.locationTrack,
-            lang = LocalizationLanguage.FI,
-        ).toString()
+        val trackDescription =
+            locationTrackService
+                .getFullDescription(
+                    layoutContext = geocodableTrack.layoutContext,
+                    locationTrack = geocodableTrack.locationTrack,
+                    lang = LocalizationLanguage.FI,
+                )
+                .toString()
 
         val xPositionOnTrack = 3.0
         val yPositionOnTrack = 0.0
 
         val yDifference = 5.0
-        val request = TestCoordinateToTrackAddressRequest(
-            x = xPositionOnTrack,
-            y = yPositionOnTrack + yDifference,
-            palautusarvot = listOf(10, 1, 5), // This is the parameter being tested.
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = xPositionOnTrack,
+                y = yPositionOnTrack + yDifference,
+                palautusarvot = listOf(10, 1, 5), // This is the parameter being tested.
+            )
 
-        val featureCollection = fetchFeatureCollection(
-            API_URL,
-            createJsonRequestParams(request),
-        )
+        val featureCollection =
+            fetchFeatureCollection(
+                API_URL,
+                createJsonRequestParams(request),
+            )
 
         assertEquals(1, featureCollection.features.size)
         assertEquals("Point", featureCollection.features[0].geometry?.type)
@@ -776,11 +803,12 @@ class CoordinateToTrackAddressIT @Autowired constructor(
     fun `Track km position is returned correctly`() {
         val layoutContext = mainOfficialContext
 
-        val geocodableTrack = insertGeocodableTrack(
-            layoutContext = layoutContext,
-            segments = listOf(segment(Point(0.0, 0.0), Point(3000.0, 0.0))),
-            locationTrackType = LocationTrackType.TRAP,
-        )
+        val geocodableTrack =
+            insertGeocodableTrack(
+                layoutContext = layoutContext,
+                segments = listOf(segment(Point(0.0, 0.0), Point(3000.0, 0.0))),
+                locationTrackType = LocationTrackType.TRAP,
+            )
 
         val secondKmNumberXLocation = 2000.0 - 50
 
@@ -792,22 +820,22 @@ class CoordinateToTrackAddressIT @Autowired constructor(
         val expectedTrackMeters = xPositionOnTrack - secondKmNumberXLocation
         val expectedTrackDecimals = 456
 
-        listOf(
-            Point(900.0, 0.0),
-            Point(secondKmNumberXLocation, 0.0)
-        ).mapIndexed { index, kmPostLocation ->
-            kmPost(
-                trackNumberId = geocodableTrack.trackNumber.id as IntId,
-                km = KmNumber(index + 1),
-                roughLayoutLocation = kmPostLocation,
-                draft = false,
-            )
-        }.forEach(layoutKmPostDao::insert)
+        listOf(Point(900.0, 0.0), Point(secondKmNumberXLocation, 0.0))
+            .mapIndexed { index, kmPostLocation ->
+                kmPost(
+                    trackNumberId = geocodableTrack.trackNumber.id as IntId,
+                    km = KmNumber(index + 1),
+                    roughLayoutLocation = kmPostLocation,
+                    draft = false,
+                )
+            }
+            .forEach(layoutKmPostDao::insert)
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = xPositionOnTrack,
-            y = yPositionOnTrack + yRequestDifference,
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = xPositionOnTrack,
+                y = yPositionOnTrack + yRequestDifference,
+            )
 
         val featureCollection = fetchFeatureCollection(API_URL, createJsonRequestParams(request))
 
@@ -828,11 +856,12 @@ class CoordinateToTrackAddressIT @Autowired constructor(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 0.0,
-            sade = 0.9,
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 0.0,
+                sade = 0.9,
+            )
 
         val featureCollection = fetchFeatureCollection(API_URL, createJsonRequestParams(request))
 
@@ -850,11 +879,12 @@ class CoordinateToTrackAddressIT @Autowired constructor(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 0.0,
-            sade = 1000.1,
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 0.0,
+                sade = 1000.1,
+            )
 
         val featureCollection = fetchFeatureCollection(API_URL, createJsonRequestParams(request))
 
@@ -872,11 +902,12 @@ class CoordinateToTrackAddressIT @Autowired constructor(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 0.0,
-            palautusarvot = listOf(3), // This is the parameter under test.
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 0.0,
+                palautusarvot = listOf(3), // This is the parameter under test.
+            )
 
         val featureCollection = fetchFeatureCollection(API_URL, createJsonRequestParams(request))
 
@@ -894,11 +925,12 @@ class CoordinateToTrackAddressIT @Autowired constructor(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 0.0,
-            sijaintiraide_tyyppi = "something",
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 0.0,
+                sijaintiraide_tyyppi = "something",
+            )
 
         val featureCollection = fetchFeatureCollection(API_URL, createJsonRequestParams(request))
 
@@ -916,11 +948,12 @@ class CoordinateToTrackAddressIT @Autowired constructor(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 0.0,
-            sijaintiraide = "@",
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 0.0,
+                sijaintiraide = "@",
+            )
 
         val featureCollection = fetchFeatureCollection(API_URL, createJsonRequestParams(request))
 
@@ -938,11 +971,12 @@ class CoordinateToTrackAddressIT @Autowired constructor(
             segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val request = TestCoordinateToTrackAddressRequest(
-            x = 0.0,
-            y = 0.0,
-            ratanumero = "alsjkdhkajlshdljkahsdljkahsldjkhaslkjdhalkjsdhlkjashdjklasdhj",
-        )
+        val request =
+            TestCoordinateToTrackAddressRequest(
+                x = 0.0,
+                y = 0.0,
+                ratanumero = "alsjkdhkajlshdljkahsdljkahsldjkhaslkjdhalkjsdhlkjashdjklasdhj",
+            )
 
         val featureCollection = fetchFeatureCollection(API_URL, createJsonRequestParams(request))
 
@@ -956,26 +990,31 @@ class CoordinateToTrackAddressIT @Autowired constructor(
 
     private fun insertGeocodableTrack(
         layoutContext: TestLayoutContext = mainOfficialContext,
-        trackNumberId: IntId<TrackLayoutTrackNumber> = mainOfficialContext.createLayoutTrackNumber().id,
+        trackNumberId: IntId<TrackLayoutTrackNumber> =
+            mainOfficialContext.createLayoutTrackNumber().id,
         locationTrackName: String = "Test location track",
         locationTrackType: LocationTrackType = LocationTrackType.MAIN,
         segments: List<LayoutSegment> = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
     ): GeocodableTrack {
-        val referenceLineId = layoutContext.insert(
-            referenceLineAndAlignment(
-                trackNumberId = trackNumberId,
-                segments = segments,
-            )
-        ).id
+        val referenceLineId =
+            layoutContext
+                .insert(
+                    referenceLineAndAlignment(
+                        trackNumberId = trackNumberId,
+                        segments = segments,
+                    ))
+                .id
 
-        val locationTrackId = layoutContext.insert(
-            locationTrackAndAlignment(
-                trackNumberId = trackNumberId,
-                name = locationTrackName,
-                type = locationTrackType,
-                segments = segments,
-            )
-        ).id
+        val locationTrackId =
+            layoutContext
+                .insert(
+                    locationTrackAndAlignment(
+                        trackNumberId = trackNumberId,
+                        name = locationTrackName,
+                        type = locationTrackType,
+                        segments = segments,
+                    ))
+                .id
 
         return GeocodableTrack(
             layoutContext = layoutContext.context,
@@ -989,17 +1028,20 @@ class CoordinateToTrackAddressIT @Autowired constructor(
         url: String,
         params: Map<String, String>,
     ): TestGeoJsonFeatureCollection {
-        return testApi
-            .doPostWithParams(url, params, HttpStatus.OK)
-            .let { body -> mapper.readValue(body, TestGeoJsonFeatureCollection::class.java) }
+        return testApi.doPostWithParams(url, params, HttpStatus.OK).let { body ->
+            mapper.readValue(body, TestGeoJsonFeatureCollection::class.java)
+        }
     }
 
-    private fun createJsonRequestParams(request: TestCoordinateToTrackAddressRequest): Map<String, String> {
+    private fun createJsonRequestParams(
+        request: TestCoordinateToTrackAddressRequest
+    ): Map<String, String> {
         return mapOf("json" to mapper.writeValueAsString(listOf(request)))
     }
 
-    private fun createJsonRequestParams(requests: List<TestCoordinateToTrackAddressRequest>): Map<String, String> {
+    private fun createJsonRequestParams(
+        requests: List<TestCoordinateToTrackAddressRequest>
+    ): Map<String, String> {
         return mapOf("json" to mapper.writeValueAsString(requests))
     }
 }
-

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterAuthIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterAuthIT.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.TestApi
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -14,7 +15,6 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import kotlin.test.assertNotNull
 
 private const val API_URI = "/rata-vkm/v1"
 
@@ -24,12 +24,13 @@ private const val API_URI = "/rata-vkm/v1"
     properties = ["geoviite.skip-auth=false"],
 )
 @AutoConfigureMockMvc
-class FrameConverterAuthIT @Autowired constructor(
+class FrameConverterAuthIT
+@Autowired
+constructor(
     mockMvc: MockMvc,
 ) {
-    private val mapper = ObjectMapper().apply {
-        setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    }
+    private val mapper =
+        ObjectMapper().apply { setSerializationInclusion(JsonInclude.Include.NON_NULL) }
 
     val testApi = TestApi(mapper, mockMvc)
 
@@ -88,14 +89,12 @@ class FrameConverterAuthIT @Autowired constructor(
         apiUri: String = API_URI,
         expectedStatus: HttpStatus = HttpStatus.OK,
     ): TestGeoJsonFeatureCollection? {
-        return testApi
-            .doPostWithParams(apiUri, emptyMap(), expectedStatus, headers)
-            .let { body ->
-                try {
-                    mapper.readValue(body, TestGeoJsonFeatureCollection::class.java)
-                } catch (e: ValueInstantiationException) {
-                    null
-                }
+        return testApi.doPostWithParams(apiUri, emptyMap(), expectedStatus, headers).let { body ->
+            try {
+                mapper.readValue(body, TestGeoJsonFeatureCollection::class.java)
+            } catch (e: ValueInstantiationException) {
+                null
             }
+        }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/DBTestBase.kt
@@ -13,14 +13,21 @@ const val TEST_USER = "TEST_USER"
 
 abstract class DBTestBase(val testUser: String = TEST_USER) {
 
-    @Autowired
-    var testDBServiceIn: TestDBService? = null
+    @Autowired var testDBServiceIn: TestDBService? = null
 
     val testDBService by lazy { testDBServiceIn ?: error("Test data service not initialized") }
-    val jdbc: NamedParameterJdbcTemplate get() = testDBService.jdbc
-    val transaction: TransactionTemplate get() = testDBService.transaction
-    val mainDraftContext by lazy { testDBService.testContext(LayoutBranch.main, PublicationState.DRAFT) }
-    val mainOfficialContext by lazy { testDBService.testContext(LayoutBranch.main, PublicationState.OFFICIAL) }
+    val jdbc: NamedParameterJdbcTemplate
+        get() = testDBService.jdbc
+
+    val transaction: TransactionTemplate
+        get() = testDBService.transaction
+
+    val mainDraftContext by lazy {
+        testDBService.testContext(LayoutBranch.main, PublicationState.DRAFT)
+    }
+    val mainOfficialContext by lazy {
+        testDBService.testContext(LayoutBranch.main, PublicationState.OFFICIAL)
+    }
 
     val trackNumberDescription by lazy { "Test track number ${this::class.simpleName}" }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/MetaDataIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/MetaDataIT.kt
@@ -2,19 +2,19 @@ package fi.fta.geoviite.infra
 
 import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.util.setUser
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import withUser
-import kotlin.test.assertTrue
 
 const val TEST_ROLE_CODE = "it_tst"
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class MetaDataIT: DBTestBase() {
+class MetaDataIT : DBTestBase() {
 
     private data class VersionData(
         val changeUser: String,
@@ -59,19 +59,23 @@ class MetaDataIT: DBTestBase() {
 
     private fun getUserGroup(code: String): String? {
         val sql = "select user_group from common.role where code = :code"
-        val userGroups = jdbc.query(sql, mapOf("code" to code)) { rs, _ -> rs.getString("user_group") }
+        val userGroups =
+            jdbc.query(sql, mapOf("code" to code)) { rs, _ -> rs.getString("user_group") }
         assertTrue(userGroups.size <= 1)
         return userGroups.firstOrNull()
     }
 
     private fun getRoleVersionData(code: String): Map<Int, VersionData> {
         val sql = "select version, change_user, deleted from common.role_version where code = :code"
-        return jdbc.query(sql, mapOf("code" to code)) { rs, _ ->
-            rs.getInt("version") to VersionData(
-                changeUser = rs.getString("change_user"),
-                deleted = rs.getBoolean("deleted"),
-            )
-        }.associate { it }
+        return jdbc
+            .query(sql, mapOf("code" to code)) { rs, _ ->
+                rs.getInt("version") to
+                    VersionData(
+                        changeUser = rs.getString("change_user"),
+                        deleted = rs.getBoolean("deleted"),
+                    )
+            }
+            .associate { it }
     }
 
     private fun insertRole(code: String, userGroup: String) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/NoTransactionTemplate.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/NoTransactionTemplate.kt
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
 
-
 @Profile("nodb")
 @Component
 class NoTransactionTemplate : TransactionTemplate() {
@@ -13,6 +12,5 @@ class NoTransactionTemplate : TransactionTemplate() {
         throw Exception("No transaction template in nodb tests")
     }
 
-    override fun afterPropertiesSet() {
-    }
+    override fun afterPropertiesSet() {}
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestApi.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestApi.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import fi.fta.geoviite.infra.error.ApiErrorResponse
+import kotlin.test.assertTrue
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON
@@ -12,7 +13,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.result.isEqualTo
-import kotlin.test.assertTrue
 
 class TestApi(val mapper: ObjectMapper, val mockMvc: MockMvc) {
 
@@ -25,7 +25,9 @@ class TestApi(val mapper: ObjectMapper, val mockMvc: MockMvc) {
             .perform(requestBuilder)
             .andExpect(status().isEqualTo(expectedStatus.value()))
             .andExpect(content().contentType(APPLICATION_JSON))
-            .andReturn().response.getContentAsString(Charsets.UTF_8)
+            .andReturn()
+            .response
+            .getContentAsString(Charsets.UTF_8)
     }
 
     fun doGetWithParams(
@@ -60,16 +62,23 @@ class TestApi(val mapper: ObjectMapper, val mockMvc: MockMvc) {
             .perform(request)
             .andExpect(status().isEqualTo(expectedStatus.value()))
             .andExpect(content().contentType(APPLICATION_JSON))
-            .andReturn().response.getContentAsString(Charsets.UTF_8)
+            .andReturn()
+            .response
+            .getContentAsString(Charsets.UTF_8)
     }
 
     fun doPostWithString(url: String, body: String?, expectedStatus: HttpStatus): String {
-        val request = MockMvcRequestBuilders.post(url).characterEncoding(Charsets.UTF_8).contentType(APPLICATION_JSON)
+        val request =
+            MockMvcRequestBuilders.post(url)
+                .characterEncoding(Charsets.UTF_8)
+                .contentType(APPLICATION_JSON)
         return mockMvc
             .perform(if (body != null) request.content(body) else request)
             .andExpect(status().isEqualTo(expectedStatus.value()))
             .andExpect(content().contentType(APPLICATION_JSON))
-            .andReturn().response.getContentAsString(Charsets.UTF_8)
+            .andReturn()
+            .response
+            .getContentAsString(Charsets.UTF_8)
     }
 
     fun doPut(url: String, body: Any?, expectedStatus: HttpStatus): String {
@@ -78,18 +87,24 @@ class TestApi(val mapper: ObjectMapper, val mockMvc: MockMvc) {
     }
 
     fun doPutWithString(url: String, body: String?, expectedStatus: HttpStatus): String {
-        val request = MockMvcRequestBuilders.put(url).characterEncoding(Charsets.UTF_8).contentType(APPLICATION_JSON)
+        val request =
+            MockMvcRequestBuilders.put(url)
+                .characterEncoding(Charsets.UTF_8)
+                .contentType(APPLICATION_JSON)
         return mockMvc
             .perform(if (body != null) request.content(body) else request)
             .andExpect(status().isEqualTo(expectedStatus.value()))
             .andExpect(content().contentType(APPLICATION_JSON))
-            .andReturn().response.getContentAsString(Charsets.UTF_8)
+            .andReturn()
+            .response
+            .getContentAsString(Charsets.UTF_8)
     }
 
     fun assertErrorResult(result: String, vararg messages: String) {
         val parsed = mapper.readValue<ApiErrorResponse>(result)
         for (message in messages) {
-            assertTrue(parsed.messageRows.contains(message),
+            assertTrue(
+                parsed.messageRows.contains(message),
                 "Response should contain \"$message\" actual=${parsed.messageRows}")
         }
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -64,13 +64,13 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.DbTable
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.setUser
+import java.time.Instant
+import kotlin.reflect.KClass
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.Instant
-import kotlin.reflect.KClass
-import kotlin.test.assertEquals
 
 interface TestDB {
     val jdbc: NamedParameterJdbcTemplate
@@ -82,28 +82,34 @@ interface TestDB {
     val alignmentDao: LayoutAlignmentDao
     val geometryDao: GeometryDao
 
-    fun getDbTime(): Instant = requireNotNull(
-        jdbc.queryForObject("select now() as now", mapOf<String, Any>()) { rs, _ -> rs.getInstant("now") }
-    )
+    fun getDbTime(): Instant =
+        requireNotNull(
+            jdbc.queryForObject("select now() as now", mapOf<String, Any>()) { rs, _ ->
+                rs.getInstant("now")
+            })
 
     @Suppress("UNCHECKED_CAST")
-    fun <T : LayoutAsset<T>> getDao(clazz: KClass<T>): LayoutAssetDao<T> = when (clazz) {
-        LocationTrack::class -> locationTrackDao
-        TrackLayoutSwitch::class -> switchDao
-        TrackLayoutTrackNumber::class -> trackNumberDao
-        ReferenceLine::class -> referenceLineDao
-        TrackLayoutKmPost::class -> kmPostDao
-        else -> error("Unsupported asset type: ${clazz.simpleName}")
-    } as LayoutAssetDao<T>
+    fun <T : LayoutAsset<T>> getDao(clazz: KClass<T>): LayoutAssetDao<T> =
+        when (clazz) {
+            LocationTrack::class -> locationTrackDao
+            TrackLayoutSwitch::class -> switchDao
+            TrackLayoutTrackNumber::class -> trackNumberDao
+            ReferenceLine::class -> referenceLineDao
+            TrackLayoutKmPost::class -> kmPostDao
+            else -> error("Unsupported asset type: ${clazz.simpleName}")
+        }
+            as LayoutAssetDao<T>
 
     @Suppress("UNCHECKED_CAST")
-    fun <T : LayoutAsset<T>> getDao(asset: LayoutAsset<T>): LayoutAssetDao<T> = when (asset) {
-        is LocationTrack -> locationTrackDao
-        is TrackLayoutSwitch -> switchDao
-        is TrackLayoutTrackNumber -> trackNumberDao
-        is ReferenceLine -> referenceLineDao
-        is TrackLayoutKmPost -> kmPostDao
-    } as LayoutAssetDao<T>
+    fun <T : LayoutAsset<T>> getDao(asset: LayoutAsset<T>): LayoutAssetDao<T> =
+        when (asset) {
+            is LocationTrack -> locationTrackDao
+            is TrackLayoutSwitch -> switchDao
+            is TrackLayoutTrackNumber -> trackNumberDao
+            is ReferenceLine -> referenceLineDao
+            is TrackLayoutKmPost -> kmPostDao
+        }
+            as LayoutAssetDao<T>
 }
 
 @GeoviiteService
@@ -136,99 +142,104 @@ class TestDBService(
     fun clearLayoutTables() {
         deleteFromTables(
             schema = "layout",
-            tables = arrayOf(
-                "design",
-                "alignment",
-                "km_post",
-                "location_track",
-                "reference_line",
-                "switch",
-                "switch_version",
-                "switch_joint",
-                "track_number",
-                "segment_version",
-                "segment_geometry",
-            ),
+            tables =
+                arrayOf(
+                    "design",
+                    "alignment",
+                    "km_post",
+                    "location_track",
+                    "reference_line",
+                    "switch",
+                    "switch_version",
+                    "switch_joint",
+                    "track_number",
+                    "segment_version",
+                    "segment_geometry",
+                ),
         )
     }
 
     fun clearGeometryTables() {
         deleteFromTables(
             schema = "geometry",
-            tables = arrayOf(
-                "alignment",
-                "cant_point",
-                "element",
-                "plan",
-                "plan_application",
-                "plan_file",
-                "plan_project",
-                "plan_author",
-                "plan_version",
-                "switch",
-                "switch_joint",
-                "vertical_intersection",
-            )
-        )
+            tables =
+                arrayOf(
+                    "alignment",
+                    "cant_point",
+                    "element",
+                    "plan",
+                    "plan_application",
+                    "plan_file",
+                    "plan_project",
+                    "plan_author",
+                    "plan_version",
+                    "switch",
+                    "switch_joint",
+                    "vertical_intersection",
+                ))
     }
 
     fun clearPublicationTables() {
         deleteFromTables(
             schema = "publication",
-            tables = arrayOf(
-                "km_post",
-                "location_track",
-                "location_track_km",
-                "publication",
-                "reference_line",
-                "switch",
-                "switch_joint",
-                "switch_location_tracks",
-                "track_number",
-                "track_number_km",
-            ),
+            tables =
+                arrayOf(
+                    "km_post",
+                    "location_track",
+                    "location_track_km",
+                    "publication",
+                    "reference_line",
+                    "switch",
+                    "switch_joint",
+                    "switch_location_tracks",
+                    "track_number",
+                    "track_number_km",
+                ),
         )
     }
 
     fun clearSplitTables() {
         deleteFromTables(
             schema = "publication",
-            tables = arrayOf(
-                "split",
-                "split_version",
-                "split_relinked_switch",
-                "split_target_location_track",
-            ),
+            tables =
+                arrayOf(
+                    "split",
+                    "split_version",
+                    "split_relinked_switch",
+                    "split_target_location_track",
+                ),
         )
     }
 
     fun clearProjektivelhoTables() {
         deleteFromTables(
             schema = "projektivelho",
-            tables = arrayOf(
-                "document_content",
-                "document_rejection",
-                "document",
-                "document_type",
-                "material_category",
-                "material_group",
-                "material_state",
-                "technics_field",
-                "project_state",
-                "assignment",
-                "project",
-                "project_group",
-                "search",
-            ),
+            tables =
+                arrayOf(
+                    "document_content",
+                    "document_rejection",
+                    "document",
+                    "document_type",
+                    "material_category",
+                    "material_group",
+                    "material_state",
+                    "technics_field",
+                    "project_state",
+                    "assignment",
+                    "project",
+                    "project_group",
+                    "search",
+                ),
         )
     }
 
     fun clearRatkoTables() {
         deleteFromTables(
             schema = "integrations",
-            tables = arrayOf(
-                "ratko_push_content",
-            ),
+            tables =
+                arrayOf(
+                    "ratko_push_content",
+                ),
         )
     }
 
@@ -240,13 +251,11 @@ class TestDBService(
         return SwitchName(getUniqueName(DbTable.LAYOUT_SWITCH, switchNameLength.last))
     }
 
-    fun getUnusedProjectName(): ProjectName = ProjectName(
-        getUniqueName(DbTable.GEOMETRY_PLAN_PROJECT, 100)
-    )
+    fun getUnusedProjectName(): ProjectName =
+        ProjectName(getUniqueName(DbTable.GEOMETRY_PLAN_PROJECT, 100))
 
-    fun getUnusedAuthorCompanyName(): CompanyName = CompanyName(
-        getUniqueName(DbTable.GEOMETRY_PLAN_AUTHOR, 100)
-    )
+    fun getUnusedAuthorCompanyName(): CompanyName =
+        CompanyName(getUniqueName(DbTable.GEOMETRY_PLAN_AUTHOR, 100))
 
     fun getUnusedBulkTransferId(): IntId<BulkTransfer> {
         return getUniqueId(DbTable.PUBLICATION_SPLIT, "bulk_transfer_id")
@@ -254,11 +263,14 @@ class TestDBService(
 
     private fun getUniqueName(table: DbTable, maxLength: Int): String {
         val sql = "select max(id) max_id from ${table.versionTable}"
-        val maxId = jdbc.queryForObject(sql, mapOf<String, Any>()) { rs, _ -> rs.getInt("max_id") }!!
+        val maxId =
+            jdbc.queryForObject(sql, mapOf<String, Any>()) { rs, _ -> rs.getInt("max_id") }!!
         val baseNameLength = maxLength - 8 // allow 7 unique digits + space
-        val baseName = this::class.simpleName!!.let { className ->
-            if (className.length > baseNameLength) className.substring(0, baseNameLength) else className
-        }
+        val baseName =
+            this::class.simpleName!!.let { className ->
+                if (className.length > baseNameLength) className.substring(0, baseNameLength)
+                else className
+            }
         return "$baseName ${maxId + 1}"
     }
 
@@ -281,7 +293,8 @@ class TestDBService(
         fetch(rowVersion).let { a -> a to alignmentDao.fetch(a.getAlignmentVersionOrThrow()) }
 
     fun deleteFromTables(schema: String, vararg tables: String) {
-        // We don't actually need transactionality, but we do need everything to be run in one session
+        // We don't actually need transactionality, but we do need everything to be run in one
+        // session
         transactional {
             // Temporarily disable all triggers
             jdbc.execute("set session_replication_role = replica") { it.execute() }
@@ -295,21 +308,28 @@ class TestDBService(
         }
     }
 
-    fun <T> transactional(op: () -> T): T = transaction.execute {
-        jdbc.setUser()
-        op()
-    } ?: error("Transaction returned nothing")
+    fun <T> transactional(op: () -> T): T =
+        transaction.execute {
+            jdbc.setUser()
+            op()
+        } ?: error("Transaction returned nothing")
 
-    fun testContext(branch: LayoutBranch = LayoutBranch.main, state: PublicationState = OFFICIAL): TestLayoutContext =
-        TestLayoutContext(LayoutContext.of(branch, state), this)
+    fun testContext(
+        branch: LayoutBranch = LayoutBranch.main,
+        state: PublicationState = OFFICIAL
+    ): TestLayoutContext = TestLayoutContext(LayoutContext.of(branch, state), this)
 
-    fun <T : LayoutAsset<T>> updateContext(original: T, context: LayoutContext): T = original
-        .takeIf { o -> o.contextData.designId == context.branch.designId && o.isDraft == (context.state == DRAFT) }
-        ?: original.withContext(LayoutContextData.new(context))
+    fun <T : LayoutAsset<T>> updateContext(original: T, context: LayoutContext): T =
+        original.takeIf { o ->
+            o.contextData.designId == context.branch.designId &&
+                o.isDraft == (context.state == DRAFT)
+        } ?: original.withContext(LayoutContextData.new(context))
 
-    fun insertProject(): RowVersion<Project> = geometryDao.insertProject(project(getUnusedProjectName().toString()))
+    fun insertProject(): RowVersion<Project> =
+        geometryDao.insertProject(project(getUnusedProjectName().toString()))
 
-    fun insertAuthor(): RowVersion<Author> = geometryDao.insertAuthor(Author(getUnusedAuthorCompanyName()))
+    fun insertAuthor(): RowVersion<Author> =
+        geometryDao.insertAuthor(Author(getUnusedAuthorCompanyName()))
 
     final inline fun <reified T : LayoutAsset<T>> update(
         rowVersion: LayoutRowVersion<T>,
@@ -323,18 +343,21 @@ class TestDBService(
 
     fun createDesignBranch(): DesignBranch = LayoutBranch.design(createLayoutDesign())
 
-    fun layoutChangeTime(): Instant = listOf(
-        trackNumberDao.fetchChangeTime(),
-        referenceLineDao.fetchChangeTime(),
-        locationTrackDao.fetchChangeTime(),
-        switchDao.fetchChangeTime(),
-        kmPostDao.fetchChangeTime(),
-    ).max()
+    fun layoutChangeTime(): Instant =
+        listOf(
+                trackNumberDao.fetchChangeTime(),
+                referenceLineDao.fetchChangeTime(),
+                locationTrackDao.fetchChangeTime(),
+                switchDao.fetchChangeTime(),
+                kmPostDao.fetchChangeTime(),
+            )
+            .max()
 
     /**
-     * This function can be used to create a draft-version of an official asset, creating the appropriate backwards
-     * linking as necessary. Optionally, a target branch can be given to create the draft in a different branch
-     * (main-official -> design-draft or design-official -> main-draft). If not given, the current branch is used.
+     * This function can be used to create a draft-version of an official asset, creating the
+     * appropriate backwards linking as necessary. Optionally, a target branch can be given to
+     * create the draft in a different branch (main-official -> design-draft or design-official ->
+     * main-draft). If not given, the current branch is used.
      */
     final inline fun <reified S : LayoutAsset<S>> createDraft(
         officialVersion: LayoutRowVersion<S>,
@@ -346,7 +369,9 @@ class TestDBService(
         val targetContext = testContext(targetBranch ?: original.branch, DRAFT)
         return targetContext.copyFrom(
             officialVersion,
-            officialRowId = if (!original.isDesign) original.contextData.rowId else original.contextData.officialRowId,
+            officialRowId =
+                if (!original.isDesign) original.contextData.rowId
+                else original.contextData.officialRowId,
             designRowId = if (original.isDesign) original.contextData.rowId else null,
             mutate = mutate,
         )
@@ -361,11 +386,13 @@ data class TestLayoutContext(
     inline fun <reified T : LayoutAsset<T>> fetch(id: IntId<T>): T? =
         getDao(T::class).let { dao -> dao.fetchVersion(context, id)?.let(dao::fetch) }
 
-    inline fun <reified T : PolyLineLayoutAsset<T>> fetchWithAlignment(id: IntId<T>): Pair<T, LayoutAlignment>? =
+    inline fun <reified T : PolyLineLayoutAsset<T>> fetchWithAlignment(
+        id: IntId<T>
+    ): Pair<T, LayoutAlignment>? =
         fetch(id)?.let { a -> a to alignmentDao.fetch(a.getAlignmentVersionOrThrow()) }
 
-    fun <T : LayoutAsset<T>> insert(asset: T): LayoutDaoResponse<T> = testService.getDao(asset)
-        .insert(testService.updateContext(asset, context))
+    fun <T : LayoutAsset<T>> insert(asset: T): LayoutDaoResponse<T> =
+        testService.getDao(asset).insert(testService.updateContext(asset, context))
 
     fun <T : PolyLineLayoutAsset<T>> insert(
         assetAndAlignment: Pair<PolyLineLayoutAsset<T>, LayoutAlignment>
@@ -379,17 +406,19 @@ data class TestLayoutContext(
 
     inline fun <reified T : LayoutAsset<T>> getAssetOriginContext(id: IntId<T>): LayoutContext {
         val assetInContext = getDao(T::class).getOrThrow(context, id)
-        return LayoutContext.of(assetInContext.branch, if(assetInContext.isDraft) DRAFT else OFFICIAL)
+        return LayoutContext.of(
+            assetInContext.branch, if (assetInContext.isDraft) DRAFT else OFFICIAL)
     }
 
     /**
-     * Copies the asset identified by [rowVersion] to the current context. Note, that this does not create linking
-     * to the original asset, so calling this for draft context on an official asset creates a new draft with same
-     * data, not a draft of the official. You can provide [officialRowId] and [designRowId] to link the new asset if
-     * desired.
+     * Copies the asset identified by [rowVersion] to the current context. Note, that this does not
+     * create linking to the original asset, so calling this for draft context on an official asset
+     * creates a new draft with same data, not a draft of the official. You can provide
+     * [officialRowId] and [designRowId] to link the new asset if desired.
+     *
      * <p>
-     * If desired, you can also mutate the asset before moving it to the new context by providing a [mutate] function.
-     * </p>
+     * If desired, you can also mutate the asset before moving it to the new context by providing a
+     * [mutate] function. </p>
      */
     @Suppress("UNCHECKED_CAST")
     inline fun <reified T : LayoutAsset<T>> copyFrom(
@@ -400,22 +429,33 @@ data class TestLayoutContext(
     ): LayoutDaoResponse<T> {
         val dao = getDao(T::class)
         val original = mutate(dao.fetch(rowVersion))
-        val withNewContext = original.withContext(createContextData(UnstoredContextIdHolder(rowVersion), officialRowId, designRowId))
+        val withNewContext =
+            original.withContext(
+                createContextData(UnstoredContextIdHolder(rowVersion), officialRowId, designRowId))
         return when (withNewContext) {
-            // Also copy alignment: the types won't play nice unless we use the final ones, so this duplicates
-            is LocationTrack -> insert(withNewContext, alignmentDao.fetch(withNewContext.getAlignmentVersionOrThrow()))
-            is ReferenceLine -> insert(withNewContext, alignmentDao.fetch(withNewContext.getAlignmentVersionOrThrow()))
-            is PolyLineLayoutAsset<*> -> error("Unhandled PolyLineAsset type: ${T::class.simpleName}")
+            // Also copy alignment: the types won't play nice unless we use the final ones, so this
+            // duplicates
+            is LocationTrack ->
+                insert(
+                    withNewContext, alignmentDao.fetch(withNewContext.getAlignmentVersionOrThrow()))
+            is ReferenceLine ->
+                insert(
+                    withNewContext, alignmentDao.fetch(withNewContext.getAlignmentVersionOrThrow()))
+            is PolyLineLayoutAsset<*> ->
+                error("Unhandled PolyLineAsset type: ${T::class.simpleName}")
             else -> insert(withNewContext)
-        } as LayoutDaoResponse<T>
+        }
+            as LayoutDaoResponse<T>
     }
 
     /**
-     * Moves the asset identified by [rowVersion] to the current context, maintaining the row itself.
-     * Links to official/design row are kept where possible, noting the rules of which contexts actually have them.
+     * Moves the asset identified by [rowVersion] to the current context, maintaining the row
+     * itself. Links to official/design row are kept where possible, noting the rules of which
+     * contexts actually have them.
+     *
      * <p>
-     * If desired, you can also mutate the asset before moving it to the new context by providing a [mutate] function.
-     * </p>
+     * If desired, you can also mutate the asset before moving it to the new context by providing a
+     * [mutate] function. </p>
      */
     inline fun <reified T : LayoutAsset<T>> moveFrom(
         rowVersion: LayoutRowVersion<T>,
@@ -423,13 +463,16 @@ data class TestLayoutContext(
     ): LayoutDaoResponse<T> {
         val dao = getDao(T::class)
         val original = mutate(dao.fetch(rowVersion))
-        val withNewContext = original.withContext(original.contextData.let { origCtx ->
-            createContextData(
-                rowContextId = OverwritingContextIdHolder(rowVersion.rowId, rowVersion),
-                officialRowId = origCtx.officialRowId.takeIf { context !is MainLayoutContext },
-                designRowId = origCtx.designRowId.takeIf { context.state == DRAFT },
-            )
-        })
+        val withNewContext =
+            original.withContext(
+                original.contextData.let { origCtx ->
+                    createContextData(
+                        rowContextId = OverwritingContextIdHolder(rowVersion.rowId, rowVersion),
+                        officialRowId =
+                            origCtx.officialRowId.takeIf { context !is MainLayoutContext },
+                        designRowId = origCtx.designRowId.takeIf { context.state == DRAFT },
+                    )
+                })
         return dao.update(withNewContext)
     }
 
@@ -437,17 +480,24 @@ data class TestLayoutContext(
     fun <T : PolyLineLayoutAsset<T>> insert(
         asset: PolyLineLayoutAsset<T>,
         alignment: LayoutAlignment,
-    ): LayoutDaoResponse<T> = when (asset) {
-        is LocationTrack -> insert(asset.copy(alignmentVersion = alignmentDao.insert(alignment)))
-        is ReferenceLine -> insert(asset.copy(alignmentVersion = alignmentDao.insert(alignment)))
-    } as LayoutDaoResponse<T>
+    ): LayoutDaoResponse<T> =
+        when (asset) {
+            is LocationTrack ->
+                insert(asset.copy(alignmentVersion = alignmentDao.insert(alignment)))
+            is ReferenceLine ->
+                insert(asset.copy(alignmentVersion = alignmentDao.insert(alignment)))
+        }
+            as LayoutDaoResponse<T>
 
-    fun <T : LayoutAsset<T>> insertMany(vararg asset: T): List<LayoutDaoResponse<T>> = asset.map(::insert)
+    fun <T : LayoutAsset<T>> insertMany(vararg asset: T): List<LayoutDaoResponse<T>> =
+        asset.map(::insert)
+
     fun <T : PolyLineLayoutAsset<T>> insertMany(
         vararg assets: Pair<PolyLineLayoutAsset<T>, LayoutAlignment>,
     ): List<LayoutDaoResponse<T>> = assets.map(::insert)
 
-    fun <T : LayoutAsset<T>> insertAndFetch(asset: T): T = getDao(asset).fetch(insert(asset).rowVersion)
+    fun <T : LayoutAsset<T>> insertAndFetch(asset: T): T =
+        getDao(asset).fetch(insert(asset).rowVersion)
 
     fun <T : PolyLineLayoutAsset<T>> insertAndFetch(
         assetAndAlignment: Pair<PolyLineLayoutAsset<T>, LayoutAlignment>,
@@ -456,11 +506,13 @@ data class TestLayoutContext(
     fun <T : PolyLineLayoutAsset<T>> insertAndFetch(
         asset: PolyLineLayoutAsset<T>,
         alignment: LayoutAlignment,
-    ): Pair<T, LayoutAlignment> = getDao(asset)
-        .fetch(insert(asset, alignment).rowVersion)
-        .let { a -> a to alignmentDao.fetch(a.getAlignmentVersionOrThrow()) }
+    ): Pair<T, LayoutAlignment> =
+        getDao(asset).fetch(insert(asset, alignment).rowVersion).let { a ->
+            a to alignmentDao.fetch(a.getAlignmentVersionOrThrow())
+        }
 
-    fun <T : LayoutAsset<T>> insertAndFetchMany(vararg asset: T): List<T> = asset.map(::insertAndFetch)
+    fun <T : LayoutAsset<T>> insertAndFetchMany(vararg asset: T): List<T> =
+        asset.map(::insertAndFetch)
 
     fun <T : PolyLineLayoutAsset<T>> insertAndFetchMany(
         vararg assets: Pair<PolyLineLayoutAsset<T>, LayoutAlignment>,
@@ -474,15 +526,18 @@ data class TestLayoutContext(
 
     fun createLayoutTrackNumberAndReferenceLine(
         lineAlignment: LayoutAlignment = alignment()
-    ): LayoutDaoResponse<TrackLayoutTrackNumber> = createLayoutTrackNumber()
-        .also { tnResponse -> insert(referenceLine(trackNumberId = tnResponse.id), lineAlignment) }
+    ): LayoutDaoResponse<TrackLayoutTrackNumber> =
+        createLayoutTrackNumber().also { tnResponse ->
+            insert(referenceLine(trackNumberId = tnResponse.id), lineAlignment)
+        }
 
     fun createLayoutTrackNumbers(count: Int): List<LayoutDaoResponse<TrackLayoutTrackNumber>> =
         (1..count).map { createLayoutTrackNumber() }
 
     fun getOrCreateLayoutTrackNumber(trackNumber: TrackNumber): TrackLayoutTrackNumber {
-        val response = trackNumberDao.fetchVersions(context, true, trackNumber).firstOrNull()
-            ?: insert(trackNumber(trackNumber))
+        val response =
+            trackNumberDao.fetchVersions(context, true, trackNumber).firstOrNull()
+                ?: insert(trackNumber(trackNumber))
         return response.let { r -> trackNumberDao.fetch(r.rowVersion) }
     }
 
@@ -491,40 +546,49 @@ data class TestLayoutContext(
 
     fun createSwitch(
         stateCategory: LayoutStateCategory = LayoutStateCategory.EXISTING,
-    ): LayoutDaoResponse<TrackLayoutSwitch> = insert(
-        switch(
-            name = testService.getUnusedSwitchName().toString(),
-            stateCategory = stateCategory,
-        )
-    )
+    ): LayoutDaoResponse<TrackLayoutSwitch> =
+        insert(
+            switch(
+                name = testService.getUnusedSwitchName().toString(),
+                stateCategory = stateCategory,
+            ))
 
     fun createSwitchWithInnerTracks(
         name: String,
         vararg alignmentJointPositions: List<Pair<JointNumber, Point>>,
     ): Pair<IntId<TrackLayoutSwitch>, List<IntId<LocationTrack>>> {
-        val switchId = insert(switch(
-            name = name,
-            joints = alignmentJointPositions
-                .flatMap { it }
-                .map { (jointNumber, position) ->
-                    TrackLayoutSwitchJoint(number = jointNumber, location = position, locationAccuracy = null)
-                },
-        )).id
-        val innerTrackIds = alignmentJointPositions.map { jointPositions ->
+        val switchId =
             insert(
-                locationTrackAndAlignment(
-                    createLayoutTrackNumber().id,
-                    segments = jointPositions.zipWithNext().map { (from, to) ->
-                        segment(
-                            points = arrayOf(from.second, to.second),
-                            switchId = switchId,
-                            startJointNumber = from.first,
-                            endJointNumber = to.first,
-                        )
-                    },
-                )
-            ).id
-        }
+                    switch(
+                        name = name,
+                        joints =
+                            alignmentJointPositions
+                                .flatMap { it }
+                                .map { (jointNumber, position) ->
+                                    TrackLayoutSwitchJoint(
+                                        number = jointNumber,
+                                        location = position,
+                                        locationAccuracy = null)
+                                },
+                    ))
+                .id
+        val innerTrackIds =
+            alignmentJointPositions.map { jointPositions ->
+                insert(
+                        locationTrackAndAlignment(
+                            createLayoutTrackNumber().id,
+                            segments =
+                                jointPositions.zipWithNext().map { (from, to) ->
+                                    segment(
+                                        points = arrayOf(from.second, to.second),
+                                        switchId = switchId,
+                                        startJointNumber = from.first,
+                                        endJointNumber = to.first,
+                                    )
+                                },
+                        ))
+                    .id
+            }
         return switchId to innerTrackIds
     }
 
@@ -532,21 +596,36 @@ data class TestLayoutContext(
         rowContextId: ContextIdHolder<T>,
         officialRowId: LayoutRowId<T>? = null,
         designRowId: LayoutRowId<T>? = null,
-    ): LayoutContextData<T> = context.branch.let { branch ->
-        when (context.state) {
-            OFFICIAL -> when (branch) {
-                is MainBranch -> MainOfficialContextData(rowContextId).also {
-                    require(officialRowId == null) { "Can't set official row reference on official row itself" }
-                    require(designRowId == null) { "Can't set design row reference on main-official row" }
-                }
-                is DesignBranch -> DesignOfficialContextData(rowContextId, officialRowId, branch.designId).also {
-                    require(designRowId == null) { "Can't set design row reference on official design itself" }
-                }
-            }
-            DRAFT -> when (branch) {
-                is MainBranch -> MainDraftContextData(rowContextId, officialRowId, designRowId)
-                is DesignBranch -> DesignDraftContextData(rowContextId, designRowId, officialRowId, branch.designId)
+    ): LayoutContextData<T> =
+        context.branch.let { branch ->
+            when (context.state) {
+                OFFICIAL ->
+                    when (branch) {
+                        is MainBranch ->
+                            MainOfficialContextData(rowContextId).also {
+                                require(officialRowId == null) {
+                                    "Can't set official row reference on official row itself"
+                                }
+                                require(designRowId == null) {
+                                    "Can't set design row reference on main-official row"
+                                }
+                            }
+                        is DesignBranch ->
+                            DesignOfficialContextData(rowContextId, officialRowId, branch.designId)
+                                .also {
+                                    require(designRowId == null) {
+                                        "Can't set design row reference on official design itself"
+                                    }
+                                }
+                    }
+                DRAFT ->
+                    when (branch) {
+                        is MainBranch ->
+                            MainDraftContextData(rowContextId, officialRowId, designRowId)
+                        is DesignBranch ->
+                            DesignDraftContextData(
+                                rowContextId, designRowId, officialRowId, branch.designId)
+                    }
             }
         }
-    }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDataGeneration.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDataGeneration.kt
@@ -13,6 +13,5 @@ inline fun <reified T : Enum<T>> getSomeNullableValue(index: Int): T? {
     return values[index % values.size]
 }
 
-fun <T> getSomeOid(seed: Int): Oid<T> = Oid(
-    "${abs(seed % 1000)}.${abs(seed * 2 % 1000)}.${abs(seed * 3 % 1000)}"
-)
+fun <T> getSomeOid(seed: Int): Oid<T> =
+    Oid("${abs(seed % 1000)}.${abs(seed * 2 % 1000)}.${abs(seed * 3 % 1000)}")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationIT.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.TestApi
 import fi.fta.geoviite.infra.configuration.HTTP_HEADER_JWT_DATA
 import fi.fta.geoviite.infra.util.Code
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -14,8 +15,6 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import kotlin.test.assertEquals
-
 
 /*
 Generated via jwt.io
@@ -51,7 +50,9 @@ const val TOKEN =
 @ActiveProfiles("dev", "test", "backend")
 @SpringBootTest(properties = ["geoviite.jwt.validation.enabled=false", "geoviite.skip-auth=false"])
 @AutoConfigureMockMvc
-class AuthorizationIT @Autowired constructor(
+class AuthorizationIT
+@Autowired
+constructor(
     authorizationDao: AuthorizationDao,
     authorizationService: AuthorizationService,
     mapper: ObjectMapper,
@@ -63,12 +64,13 @@ class AuthorizationIT @Autowired constructor(
     val availableRoles = authorizationDao.getRolesByRoleCodes(listOf(Code("browser")))
     val user by lazy {
         User(
-            details = UserDetails(
-                userName = UserName.of("A123456"),
-                firstName = AuthName.of("John"),
-                lastName = AuthName.of("Doe"),
-                organization = AuthName.of("Test Oy"),
-            ),
+            details =
+                UserDetails(
+                    userName = UserName.of("A123456"),
+                    firstName = AuthName.of("John"),
+                    lastName = AuthName.of("Doe"),
+                    organization = AuthName.of("Test Oy"),
+                ),
             role = authorizationService.getDefaultRole(availableRoles),
             availableRoles = availableRoles,
         )
@@ -122,10 +124,9 @@ class AuthorizationIT @Autowired constructor(
         )
     }
 
-    private fun getRequest(url: String) = MockMvcRequestBuilders
-        .get(url)
-        .header(HTTP_HEADER_JWT_DATA, TOKEN)
-        .characterEncoding(Charsets.UTF_8)
-        .contentType(MediaType.APPLICATION_JSON)
-
+    private fun getRequest(url: String) =
+        MockMvcRequestBuilders.get(url)
+            .header(HTTP_HEADER_JWT_DATA, TOKEN)
+            .characterEncoding(Charsets.UTF_8)
+            .contentType(MediaType.APPLICATION_JSON)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationTestController.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationTestController.kt
@@ -9,16 +9,11 @@ const val OK = "OK"
 @GeoviiteController("/test-auth")
 class AuthorizationTestController {
 
-    @GetMapping("/public")
-    fun testPublic() = OK
+    @GetMapping("/public") fun testPublic() = OK
 
-    @PreAuthorize(AUTH_BASIC)
-    @GetMapping("/read")
-    fun testRead() = OK
+    @PreAuthorize(AUTH_BASIC) @GetMapping("/read") fun testRead() = OK
 
-    @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @GetMapping("/write")
-    fun testWrite() = OK
+    @PreAuthorize(AUTH_EDIT_LAYOUT) @GetMapping("/write") fun testWrite() = OK
 
     @PreAuthorize("hasAuthority('there-is-no-such-privilege')")
     @GetMapping("/fail")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/cloudfront/CookieSignerTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/cloudfront/CookieSignerTest.kt
@@ -1,21 +1,22 @@
 package fi.fta.geoviite.infra.cloudfront
 
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test", "nodb")
 @SpringBootTest
 @Disabled
-class CookieSignerTest @Autowired constructor(
+class CookieSignerTest
+@Autowired
+constructor(
     private val cookieSigner: CookieSigner,
     @Value("\${geoviite.cloudfront.key-pair-id}") private val keyPairId: String,
 ) {
-
 
     @Test
     fun signedCookieContainsConfiguredKeyPairId() {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/cloudfront/KeyUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/cloudfront/KeyUtilsTest.kt
@@ -1,42 +1,38 @@
-package fi.fta.geoviite.infra.cloudfront;
+package fi.fta.geoviite.infra.cloudfront
 
+import kotlin.test.*
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import kotlin.test.*
 
 class KeyUtilsTest {
 
-    /**
-     * These are dummy keys, not in use anywhere except in this class.
-     */
+    /** These are dummy keys, not in use anywhere except in this class. */
     val base64EncodedDerKey =
-        "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDdfHVQyiLKz8Zb5pVxbKaLJPs6jN287bMrc2NBDmFfbHspsPg2kFYWFlQns6NpwzZF7HaF+WZNeZfeVBjYDzJA1os62JroNF6+cYrpIsIpjr0jdA0am19Kai3+MYt3d1qi4ILp2I/4LX/axiFnK4Gfe430jN7o4Ud0hFl6vRbbWfr9D3OOxHjLRprf2N3gPZE/D3m2HAwAUy1tX1My88ItFlDynmGQm/bpywTOgxEeeXRmsZ6FoigNgNpMh5wp/Sdf6rMC0XtxbDng/PgzWhA5i7Z6R0VNGds06zuadsF/izqtV92iveCb/BDGAq3mYXjvWUw/MD6A3Ddb1qfgabq9AgMBAAECggEAZxEAgqzdjeUsGB3wEw0NXxjBc9iTYtR2GNUkLeTkOQSBN8BrcPCvrq2LUcJNW+0Ed3t3GBcbnRflLQeTXA+OQg/UUHj1dPLR1+t8Scrr8WzD5Rie9G+y4y0P5AboMJqw6bRyFyG4tTNvGL40Uw8yzaUwRMm8/T/AAZ+JCA2v8jhJ3i4yHGiiHUnjY1CRLaUDpkycxRaGgA9q7JnDzfp8CCh88pFFr5nKEGWhoJq6noNm/rh9OpYgXx9byylTE9lGq8GQtlfRo1kQP9h1lsZztQ4rP+MKQhCOBsyQrCJn1GIjmv1utqxTipcgukQxtIzykbSXBsykufblozFjfikeIQKBgQD/wa2G9I1PuBmmY7NVj8cuPbMqYGGOshzeRuz/aYuOo7ajw6i6YgutP3Qvq0Ix99cvLru/tcDbR9+xfmKwoA/uSK1wOazusikskrnA8phJUkpeEnjumGhtqWRpXvM0P5MU3oFj+poSVjoZYScLgbHnF1pS/Fm0fzI17rr2CAJeKQKBgQDdsm3zZY1OcmRK8beUiNqAsXY0pMQ0gWjTdeJYbCtif0Vkpem0tMRm9bbA8Gora1DKlfBHuzopdq8HBbi/4PSY4so4zkJB3EZnmGDEthEF8KZEXi8KGU7v6/0ViCcjujCsvqdAZgsGKYfRDdXRPm17Chd2Rg5KFmJhcGgrTCFidQKBgADZyhP62EV9nUg6aKxOMCFtPx1S+MAaw5HRtpQa68XrsX3V9se378YBwgcukKfN5T9Y7nLyzdNs58eVXgqsXaEzSLBo4LRij1SAoHGN3QfRaEHr2c8hXqeOurDHChQQahLVsqR8fuq0srjG4/Rb2BWmtDw2bq31Blu7kY+j8y4RAoGBAJkWaDRl0LD17umNho5L/k5VvOFXUaFMJ122DomukDrg1cNNilddaC4MyJjsqvO2lECATz7JO718FhrMSao+JckY+jlFvJ0MBZXttAzCCHlIlxeozeS0WzzzgX0H2rciEBCJSqb+j+g+b2ndmuN1r1YCPvdOIvnoASF15IjZdkgtAoGASUm2gEr3mtoRFh1Q0xJwRNM3hV0dvderUv2k3Hyv+qM/3LValLimy7NSwSyrIkIB2NoXW/zsWTXrcQ8jkpmvACnXAdkVcYyidxeRzzshQjioQaIO8IY3Wtc8Jhnq7Qi8g0FPn2Hc/Q8eee0M5+gf68f/N9z88R3I1bsSIwrvU6U=";
+        "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDdfHVQyiLKz8Zb5pVxbKaLJPs6jN287bMrc2NBDmFfbHspsPg2kFYWFlQns6NpwzZF7HaF+WZNeZfeVBjYDzJA1os62JroNF6+cYrpIsIpjr0jdA0am19Kai3+MYt3d1qi4ILp2I/4LX/axiFnK4Gfe430jN7o4Ud0hFl6vRbbWfr9D3OOxHjLRprf2N3gPZE/D3m2HAwAUy1tX1My88ItFlDynmGQm/bpywTOgxEeeXRmsZ6FoigNgNpMh5wp/Sdf6rMC0XtxbDng/PgzWhA5i7Z6R0VNGds06zuadsF/izqtV92iveCb/BDGAq3mYXjvWUw/MD6A3Ddb1qfgabq9AgMBAAECggEAZxEAgqzdjeUsGB3wEw0NXxjBc9iTYtR2GNUkLeTkOQSBN8BrcPCvrq2LUcJNW+0Ed3t3GBcbnRflLQeTXA+OQg/UUHj1dPLR1+t8Scrr8WzD5Rie9G+y4y0P5AboMJqw6bRyFyG4tTNvGL40Uw8yzaUwRMm8/T/AAZ+JCA2v8jhJ3i4yHGiiHUnjY1CRLaUDpkycxRaGgA9q7JnDzfp8CCh88pFFr5nKEGWhoJq6noNm/rh9OpYgXx9byylTE9lGq8GQtlfRo1kQP9h1lsZztQ4rP+MKQhCOBsyQrCJn1GIjmv1utqxTipcgukQxtIzykbSXBsykufblozFjfikeIQKBgQD/wa2G9I1PuBmmY7NVj8cuPbMqYGGOshzeRuz/aYuOo7ajw6i6YgutP3Qvq0Ix99cvLru/tcDbR9+xfmKwoA/uSK1wOazusikskrnA8phJUkpeEnjumGhtqWRpXvM0P5MU3oFj+poSVjoZYScLgbHnF1pS/Fm0fzI17rr2CAJeKQKBgQDdsm3zZY1OcmRK8beUiNqAsXY0pMQ0gWjTdeJYbCtif0Vkpem0tMRm9bbA8Gora1DKlfBHuzopdq8HBbi/4PSY4so4zkJB3EZnmGDEthEF8KZEXi8KGU7v6/0ViCcjujCsvqdAZgsGKYfRDdXRPm17Chd2Rg5KFmJhcGgrTCFidQKBgADZyhP62EV9nUg6aKxOMCFtPx1S+MAaw5HRtpQa68XrsX3V9se378YBwgcukKfN5T9Y7nLyzdNs58eVXgqsXaEzSLBo4LRij1SAoHGN3QfRaEHr2c8hXqeOurDHChQQahLVsqR8fuq0srjG4/Rb2BWmtDw2bq31Blu7kY+j8y4RAoGBAJkWaDRl0LD17umNho5L/k5VvOFXUaFMJ122DomukDrg1cNNilddaC4MyJjsqvO2lECATz7JO718FhrMSao+JckY+jlFvJ0MBZXttAzCCHlIlxeozeS0WzzzgX0H2rciEBCJSqb+j+g+b2ndmuN1r1YCPvdOIvnoASF15IjZdkgtAoGASUm2gEr3mtoRFh1Q0xJwRNM3hV0dvderUv2k3Hyv+qM/3LValLimy7NSwSyrIkIB2NoXW/zsWTXrcQ8jkpmvACnXAdkVcYyidxeRzzshQjioQaIO8IY3Wtc8Jhnq7Qi8g0FPn2Hc/Q8eee0M5+gf68f/N9z88R3I1bsSIwrvU6U="
+
     val base64EncodedDerKeyWithExtraChars =
         "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDdfHVQyiLKz8Zb5pVxbKaLJPs6\n" +
-                "jN287bMrc2NBDmFfbHspsPg2kFYWFlQns6NpwzZF7HaF+WZNeZfeVBjYDzJA1os62JroNF6+cYrp\n" +
-                "IsIpjr0jdA0am19Kai3+MYt3d1qi4ILp2I/4LX/axiFnK4Gfe430jN7o4Ud0hFl6vRbbWfr9D3OO\n" +
-                "xHjLRprf2N3gPZE/D3m2HAwAUy1tX1My88ItFlDynmGQm/bpywTOgxEeeXRmsZ6FoigNgNpMh5wp\n" +
-                "/Sdf6rMC0XtxbDng/PgzWhA5i7Z6R0VNGds06zuadsF/izqtV92iveCb/BDGAq3mYXjvWUw/MD6A\n" +
-                "3Ddb1qfgabq9AgMBAAECggEAZxEAgqzdjeUsGB3wEw0NXxjBc9iTYtR2GNUkLeTkOQSBN8BrcPCv\n" +
-                "rq2LUcJNW+0Ed3t3GBcbnRflLQeTXA+OQg/UUHj1dPLR1+t8Scrr8WzD5Rie9G+y4y0P5AboMJqw\n" +
-                "6bRyFyG4tTNvGL40Uw8yzaUwRMm8/T/AAZ+JCA2v8jhJ3i4yHGiiHUnjY1CRLaUDpkycxRaGgA9q\n" +
-                "7JnDzfp8CCh88pFFr5nKEGWhoJq6noNm/rh9OpYgXx9byylTE9lGq8GQtlfRo1kQP9h1lsZztQ4r\n" +
-                "P+MKQhCOBsyQrCJn1GIjmv1utqxTipcgukQxtIzykbSXBsykufblozFjfikeIQKBgQD/wa2G9I1P\n" +
-                "uBmmY7NVj8cuPbMqYGGOshzeRuz/aYuOo7ajw6i6YgutP3Qvq0Ix99cvLru/tcDbR9+xfmKwoA/u\n" +
-                "SK1wOazusikskrnA8phJUkpeEnjumGhtqWRpXvM0P5MU3oFj+poSVjoZYScLgbHnF1pS/Fm0fzI1\n" +
-                "7rr2CAJeKQKBgQDdsm3zZY1OcmRK8beUiNqAsXY0pMQ0gWjTdeJYbCtif0Vkpem0tMRm9bbA8Gor\n" +
-                "a1DKlfBHuzopdq8HBbi/4PSY4so4zkJB3EZnmGDEthEF8KZEXi8KGU7v6/0ViCcjujCsvqdAZgsG\n" +
-                "KYfRDdXRPm17Chd2Rg5KFmJhcGgrTCFidQKBgADZyhP62EV9nUg6aKxOMCFtPx1S+MAaw5HRtpQa\n" +
-                "68XrsX3V9se378YBwgcukKfN5T9Y7nLyzdNs58eVXgqsXaEzSLBo4LRij1SAoHGN3QfRaEHr2c8h\n" +
-                "XqeOurDHChQQahLVsqR8fuq0srjG4/Rb2BWmtDw2bq31Blu7kY+j8y4RAoGBAJkWaDRl0LD17umN\n" +
-                "ho5L/k5VvOFXUaFMJ122DomukDrg1cNNilddaC4MyJjsqvO2lECATz7JO718FhrMSao+JckY+jlF\n" +
-                "vJ0MBZXttAzCCHlIlxeozeS0WzzzgX0H2rciEBCJSqb+j+g+b2ndmuN1r1YCPvdOIvnoASF15IjZ\n" +
-                "dkgtAoGASUm2gEr3mtoRFh1Q0xJwRNM3hV0dvderUv2k3Hyv+qM/3LValLimy7NSwSyrIkIB2NoX\n" +
-                "W/zsWTXrcQ8jkpmvACnXAdkVcYyidxeRzzshQjioQaIO8IY3Wtc8Jhnq7Qi8g0FPn2Hc/Q8eee0M\n" +
-                "5+gf68f/N9z88R3I1bsSIwrvU6U=";
-
+            "jN287bMrc2NBDmFfbHspsPg2kFYWFlQns6NpwzZF7HaF+WZNeZfeVBjYDzJA1os62JroNF6+cYrp\n" +
+            "IsIpjr0jdA0am19Kai3+MYt3d1qi4ILp2I/4LX/axiFnK4Gfe430jN7o4Ud0hFl6vRbbWfr9D3OO\n" +
+            "xHjLRprf2N3gPZE/D3m2HAwAUy1tX1My88ItFlDynmGQm/bpywTOgxEeeXRmsZ6FoigNgNpMh5wp\n" +
+            "/Sdf6rMC0XtxbDng/PgzWhA5i7Z6R0VNGds06zuadsF/izqtV92iveCb/BDGAq3mYXjvWUw/MD6A\n" +
+            "3Ddb1qfgabq9AgMBAAECggEAZxEAgqzdjeUsGB3wEw0NXxjBc9iTYtR2GNUkLeTkOQSBN8BrcPCv\n" +
+            "rq2LUcJNW+0Ed3t3GBcbnRflLQeTXA+OQg/UUHj1dPLR1+t8Scrr8WzD5Rie9G+y4y0P5AboMJqw\n" +
+            "6bRyFyG4tTNvGL40Uw8yzaUwRMm8/T/AAZ+JCA2v8jhJ3i4yHGiiHUnjY1CRLaUDpkycxRaGgA9q\n" +
+            "7JnDzfp8CCh88pFFr5nKEGWhoJq6noNm/rh9OpYgXx9byylTE9lGq8GQtlfRo1kQP9h1lsZztQ4r\n" +
+            "P+MKQhCOBsyQrCJn1GIjmv1utqxTipcgukQxtIzykbSXBsykufblozFjfikeIQKBgQD/wa2G9I1P\n" +
+            "uBmmY7NVj8cuPbMqYGGOshzeRuz/aYuOo7ajw6i6YgutP3Qvq0Ix99cvLru/tcDbR9+xfmKwoA/u\n" +
+            "SK1wOazusikskrnA8phJUkpeEnjumGhtqWRpXvM0P5MU3oFj+poSVjoZYScLgbHnF1pS/Fm0fzI1\n" +
+            "7rr2CAJeKQKBgQDdsm3zZY1OcmRK8beUiNqAsXY0pMQ0gWjTdeJYbCtif0Vkpem0tMRm9bbA8Gor\n" +
+            "a1DKlfBHuzopdq8HBbi/4PSY4so4zkJB3EZnmGDEthEF8KZEXi8KGU7v6/0ViCcjujCsvqdAZgsG\n" +
+            "KYfRDdXRPm17Chd2Rg5KFmJhcGgrTCFidQKBgADZyhP62EV9nUg6aKxOMCFtPx1S+MAaw5HRtpQa\n" +
+            "68XrsX3V9se378YBwgcukKfN5T9Y7nLyzdNs58eVXgqsXaEzSLBo4LRij1SAoHGN3QfRaEHr2c8h\n" +
+            "XqeOurDHChQQahLVsqR8fuq0srjG4/Rb2BWmtDw2bq31Blu7kY+j8y4RAoGBAJkWaDRl0LD17umN\n" +
+            "ho5L/k5VvOFXUaFMJ122DomukDrg1cNNilddaC4MyJjsqvO2lECATz7JO718FhrMSao+JckY+jlF\n" +
+            "vJ0MBZXttAzCCHlIlxeozeS0WzzzgX0H2rciEBCJSqb+j+g+b2ndmuN1r1YCPvdOIvnoASF15IjZ\n" +
+            "dkgtAoGASUm2gEr3mtoRFh1Q0xJwRNM3hV0dvderUv2k3Hyv+qM/3LValLimy7NSwSyrIkIB2NoX\n" +
+            "W/zsWTXrcQ8jkpmvACnXAdkVcYyidxeRzzshQjioQaIO8IY3Wtc8Jhnq7Qi8g0FPn2Hc/Q8eee0M\n" +
+            "5+gf68f/N9z88R3I1bsSIwrvU6U="
 
     @Test
     fun decodedResultIsNotNull() {
@@ -50,9 +46,7 @@ class KeyUtilsTest {
         Assertions.assertFalse(decoded.isEmpty())
     }
 
-    /**
-     * AWS Requires the resulting key to be in PKCS#8 format
-     */
+    /** AWS Requires the resulting key to be in PKCS#8 format */
     @Test
     fun privateKeyFormatEqualsPKCS8() {
         val decoded = KeyUtils.decodeBase64ToByteArray(base64EncodedDerKeyWithExtraChars)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/codeDictionary/CodeDictionaryControllerIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/codeDictionary/CodeDictionaryControllerIT.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.codeDictionary
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import fi.fta.geoviite.infra.DBTestBase
+import kotlin.text.Charsets.UTF_8
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -13,23 +14,26 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import kotlin.text.Charsets.UTF_8
 
 @ActiveProfiles("dev", "test", "backend")
 @SpringBootTest
 @AutoConfigureMockMvc
-class CodeDictionaryControllerIT @Autowired constructor(
+class CodeDictionaryControllerIT
+@Autowired
+constructor(
     val objectMapper: ObjectMapper,
     val mockMvc: MockMvc,
-): DBTestBase() {
+) : DBTestBase() {
 
     @Test
     fun getFeatureTypesWorks() {
-        val result: MvcResult = mockMvc
-            .perform(get("/code-dictionary/feature-types"))
-            .andExpect(status().isOk)
-            .andReturn()
-        val responseAsObject: List<FeatureType> = objectMapper.readValue(result.response.getContentAsString(UTF_8))
+        val result: MvcResult =
+            mockMvc
+                .perform(get("/code-dictionary/feature-types"))
+                .andExpect(status().isOk)
+                .andReturn()
+        val responseAsObject: List<FeatureType> =
+            objectMapper.readValue(result.response.getContentAsString(UTF_8))
         assertTrue(responseAsObject.isNotEmpty())
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/codeDictionary/CodeDictionaryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/codeDictionary/CodeDictionaryServiceIT.kt
@@ -9,12 +9,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 
-
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class CodeDictionaryServiceIT @Autowired constructor(
-    private val codeDictionaryService: CodeDictionaryService
-): DBTestBase() {
+class CodeDictionaryServiceIT
+@Autowired
+constructor(private val codeDictionaryService: CodeDictionaryService) : DBTestBase() {
 
     @Test
     fun fetchFeatureTypesWorks() {
@@ -23,8 +22,11 @@ class CodeDictionaryServiceIT @Autowired constructor(
 
     @Test
     fun fetchFeatureTypeHasValues() {
-        assertTrue(codeDictionaryService.getFeatureTypes().any { t -> t.code == FeatureTypeCode("111") })
-        assertTrue(codeDictionaryService.getFeatureTypes().any { t -> t.code == FeatureTypeCode("121") })
-        assertTrue(codeDictionaryService.getFeatureTypes().any { t -> t.code == FeatureTypeCode("281") })
+        assertTrue(
+            codeDictionaryService.getFeatureTypes().any { t -> t.code == FeatureTypeCode("111") })
+        assertTrue(
+            codeDictionaryService.getFeatureTypes().any { t -> t.code == FeatureTypeCode("121") })
+        assertTrue(
+            codeDictionaryService.getFeatureTypes().any { t -> t.code == FeatureTypeCode("281") })
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/FileNameTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/FileNameTest.kt
@@ -16,5 +16,4 @@ class FileNameTest {
         // Three byte version of umlauts, these may exist in some file names
         assertDoesNotThrow { FileName("aaäöåÄÖÅ") }
     }
-
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/IdConversionTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/IdConversionTest.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.common
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.fta.geoviite.infra.TestApi
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -11,12 +12,13 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.OK
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "nodb", "backend")
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
-class IdConversionTest @Autowired constructor(
+class IdConversionTest
+@Autowired
+constructor(
     mapper: ObjectMapper,
     mockMvc: MockMvc,
 ) {
@@ -37,7 +39,8 @@ class IdConversionTest @Autowired constructor(
 
     @Test
     fun getWithTypedStringIdInPathSucceeds() {
-        assertEquals(successResponse(StringId("asdf")), testApi.doGet("$ID_TEST_URL/string/STR_asdf", OK))
+        assertEquals(
+            successResponse(StringId("asdf")), testApi.doGet("$ID_TEST_URL/string/STR_asdf", OK))
     }
 
     @Test
@@ -52,22 +55,26 @@ class IdConversionTest @Autowired constructor(
 
     @Test
     fun getWithIndexIdInPathSucceeds() {
-        assertEquals(successResponse(IndexedId(12, 34)), testApi.doGet("$ID_TEST_URL/IDX_12_34", OK))
+        assertEquals(
+            successResponse(IndexedId(12, 34)), testApi.doGet("$ID_TEST_URL/IDX_12_34", OK))
     }
 
     @Test
     fun getWithTypedIndexIdInPathSucceeds() {
-        assertEquals(successResponse(IndexedId(12, 34)), testApi.doGet("$ID_TEST_URL/indexed/IDX_12_34", OK))
+        assertEquals(
+            successResponse(IndexedId(12, 34)), testApi.doGet("$ID_TEST_URL/indexed/IDX_12_34", OK))
     }
 
     @Test
     fun getWithOidInPathSucceeds() {
-        assertEquals(successResponse(Oid("123.456.789")), testApi.doGet("$ID_TEST_URL/oid/123.456.789", OK))
+        assertEquals(
+            successResponse(Oid("123.456.789")), testApi.doGet("$ID_TEST_URL/oid/123.456.789", OK))
     }
 
     @Test
     fun getWithSridInPathSucceeds() {
-        assertEquals(successResponse(Srid(12345)), testApi.doGet("$ID_TEST_URL/srid/EPSG:12345", OK))
+        assertEquals(
+            successResponse(Srid(12345)), testApi.doGet("$ID_TEST_URL/srid/EPSG:12345", OK))
     }
 
     @Test
@@ -99,17 +106,22 @@ class IdConversionTest @Autowired constructor(
 
     @Test
     fun getWithStringIdInArgumentSucceeds() {
-        assertEquals(successResponse(StringId("asdf")), testApi.doGet("$ID_TEST_URL/id-test-arg?id=STR_asdf", OK))
+        assertEquals(
+            successResponse(StringId("asdf")),
+            testApi.doGet("$ID_TEST_URL/id-test-arg?id=STR_asdf", OK))
     }
 
     @Test
     fun getWithIntIdInArgumentSucceeds() {
-        assertEquals(successResponse(IntId(123)), testApi.doGet("$ID_TEST_URL/id-test-arg?id=INT_123", OK))
+        assertEquals(
+            successResponse(IntId(123)), testApi.doGet("$ID_TEST_URL/id-test-arg?id=INT_123", OK))
     }
 
     @Test
     fun getWithIndexIdInArgumentSucceeds() {
-        assertEquals(successResponse(IndexedId(12, 34)), testApi.doGet("$ID_TEST_URL/id-test-arg?id=IDX_12_34", OK))
+        assertEquals(
+            successResponse(IndexedId(12, 34)),
+            testApi.doGet("$ID_TEST_URL/id-test-arg?id=IDX_12_34", OK))
     }
 
     @Test
@@ -122,7 +134,9 @@ class IdConversionTest @Autowired constructor(
 
     @Test
     fun getWithTypedIntIdInArgumentSucceeds() {
-        assertEquals(successResponse(IntId(123)), testApi.doGet("$ID_TEST_URL/id-test-arg/int?id=INT_123", OK))
+        assertEquals(
+            successResponse(IntId(123)),
+            testApi.doGet("$ID_TEST_URL/id-test-arg/int?id=INT_123", OK))
     }
 
     @Test
@@ -197,19 +211,22 @@ class IdConversionTest @Autowired constructor(
     @Test
     fun postWithTypedStringIdInBodySucceeds() {
         val body = StringIdTestObject(StringId("asdf"))
-        assertEquals(testApi.response(body), testApi.doPost("$ID_TEST_URL/id-test-body/string", body, OK))
+        assertEquals(
+            testApi.response(body), testApi.doPost("$ID_TEST_URL/id-test-body/string", body, OK))
     }
 
     @Test
     fun postWithTypedIntIdInBodySucceeds() {
         val body = IntIdTestObject(IntId(123))
-        assertEquals(testApi.response(body), testApi.doPost("$ID_TEST_URL/id-test-body/int", body, OK))
+        assertEquals(
+            testApi.response(body), testApi.doPost("$ID_TEST_URL/id-test-body/int", body, OK))
     }
 
     @Test
     fun postWithTypedIndexIdInBodySucceeds() {
         val body = IndexedIdTestObject(IndexedId(12, 34))
-        assertEquals(testApi.response(body), testApi.doPost("$ID_TEST_URL/id-test-body/indexed", body, OK))
+        assertEquals(
+            testApi.response(body), testApi.doPost("$ID_TEST_URL/id-test-body/indexed", body, OK))
     }
 
     @Test
@@ -221,13 +238,15 @@ class IdConversionTest @Autowired constructor(
     @Test
     fun postWithSridInBodySucceeds() {
         val body = SridTestObject(Srid(12345))
-        assertEquals(testApi.response(body), testApi.doPost("$ID_TEST_URL/srid-test-body", body, OK))
+        assertEquals(
+            testApi.response(body), testApi.doPost("$ID_TEST_URL/srid-test-body", body, OK))
     }
 
     @Test
     fun postWithUnparseableIdInBodyIs400() {
         testApi.assertErrorResult(
-            testApi.doPostWithString("$ID_TEST_URL/id-test-body", "{\"id\":\"asdf\"}", HttpStatus.BAD_REQUEST),
+            testApi.doPostWithString(
+                "$ID_TEST_URL/id-test-body", "{\"id\":\"asdf\"}", HttpStatus.BAD_REQUEST),
             "Request body not readable",
             "Failed to instantiate Lfi/fta/geoviite/infra/common/DomainId;",
             "Invalid DomainId: \"asdf\"",
@@ -237,7 +256,8 @@ class IdConversionTest @Autowired constructor(
     @Test
     fun postWithUnparseableOidInBodyIs400() {
         testApi.assertErrorResult(
-            testApi.doPostWithString("$ID_TEST_URL/oid-test-body", "{\"id\":\"1.2.3.a\"}", HttpStatus.BAD_REQUEST),
+            testApi.doPostWithString(
+                "$ID_TEST_URL/oid-test-body", "{\"id\":\"1.2.3.a\"}", HttpStatus.BAD_REQUEST),
             "Request body not readable",
             "Failed to instantiate Lfi/fta/geoviite/infra/common/Oid;",
             "Input validation failed: Invalid characters in Oid: \"1.2.3.a\"",
@@ -247,7 +267,8 @@ class IdConversionTest @Autowired constructor(
     @Test
     fun postWithUnparseableSridInBodyIs400() {
         testApi.assertErrorResult(
-            testApi.doPostWithString("$ID_TEST_URL/srid-test-body", "{\"id\":\"1a\"}", HttpStatus.BAD_REQUEST),
+            testApi.doPostWithString(
+                "$ID_TEST_URL/srid-test-body", "{\"id\":\"1a\"}", HttpStatus.BAD_REQUEST),
             "Request body not readable",
             "Failed to instantiate Lfi/fta/geoviite/infra/common/Srid;",
             "Input validation failed: Invalid string prefix: prefix=EPSG: value=\"1a\"",
@@ -290,7 +311,8 @@ class IdConversionTest @Autowired constructor(
     @Test
     fun `Overlong StringIds are rejected`() {
         assertThrows<IllegalArgumentException> {
-            StringId.parse<IdConversionTest>(StringId<IdConversionTest>("a".repeat(96)).toString() + "a")
+            StringId.parse<IdConversionTest>(
+                StringId<IdConversionTest>("a".repeat(96)).toString() + "a")
         }
     }
 
@@ -304,11 +326,16 @@ class IdConversionTest @Autowired constructor(
     @Test
     fun `Overlong IndexedIds are rejected`() {
         assertThrows<IllegalArgumentException> {
-            IndexedId.parse<IdConversionTest>(IndexedId<IdConversionTest>(Int.MAX_VALUE, Int.MAX_VALUE).toString() + "0")
+            IndexedId.parse<IdConversionTest>(
+                IndexedId<IdConversionTest>(Int.MAX_VALUE, Int.MAX_VALUE).toString() + "0")
         }
     }
 
-    private fun successResponse(id: DomainId<IdTestObject>): String = testApi.response(IdTestObject(id))
-    private fun successResponse(id: Oid<OidTestObject>): String = testApi.response(OidTestObject(id))
+    private fun successResponse(id: DomainId<IdTestObject>): String =
+        testApi.response(IdTestObject(id))
+
+    private fun successResponse(id: Oid<OidTestObject>): String =
+        testApi.response(OidTestObject(id))
+
     private fun successResponse(id: Srid): String = testApi.response(SridTestObject(id))
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/IdTestController.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/IdTestController.kt
@@ -68,7 +68,9 @@ class IdTestController {
     }
 
     @GetMapping("/id-test-arg/indexed")
-    fun requestWithIdArgument(@RequestParam("id") id: IndexedId<IdTestObject>): IndexedIdTestObject {
+    fun requestWithIdArgument(
+        @RequestParam("id") id: IndexedId<IdTestObject>
+    ): IndexedIdTestObject {
         return IndexedIdTestObject(id)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/KmNumberTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/KmNumberTest.kt
@@ -1,11 +1,11 @@
 package fi.fta.geoviite.infra.common
 
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class KmNumberTest {
 
@@ -95,6 +95,7 @@ class KmNumberTest {
             TrackMeter(123, 1.50, 2).ceil(1),
         )
     }
+
     @Test
     fun roundDecimalsWork() {
         assertEquals(
@@ -105,14 +106,10 @@ class KmNumberTest {
 
     @Test
     fun addressesWorkInRanges() {
-        assertTrue(TrackMeter(704, 87) in
-                TrackMeter(704, 85.123, 3)..TrackMeter(704, 87.123, 3))
-        assertTrue(TrackMeter(704, 87) in
-                TrackMeter(704, 87)..TrackMeter(704, 87))
-        assertTrue(TrackMeter(704, 87) in
-                TrackMeter(704, 9)..TrackMeter(704, 123))
-        assertTrue(TrackMeter(704, 87) in
-                TrackMeter(703, 999.123, 3)..TrackMeter(705, 7.123, 3))
+        assertTrue(TrackMeter(704, 87) in TrackMeter(704, 85.123, 3)..TrackMeter(704, 87.123, 3))
+        assertTrue(TrackMeter(704, 87) in TrackMeter(704, 87)..TrackMeter(704, 87))
+        assertTrue(TrackMeter(704, 87) in TrackMeter(704, 9)..TrackMeter(704, 123))
+        assertTrue(TrackMeter(704, 87) in TrackMeter(703, 999.123, 3)..TrackMeter(705, 7.123, 3))
     }
 
     @Test
@@ -134,13 +131,17 @@ class KmNumberTest {
         assertTrue(TrackMeter("0001+0002.0") in TrackMeter("0001+0002")..TrackMeter("0001+0003"))
         assertTrue(TrackMeter("0001+0002.521") in TrackMeter("0001+0002")..TrackMeter("0001+0003"))
         assertTrue(TrackMeter("0001+0003.0") in TrackMeter("0001+0002")..TrackMeter("0001+0003"))
-        assertTrue(TrackMeter("0001+0002") in TrackMeter("0001+0002.000")..TrackMeter("0001+0003.000"))
-        assertTrue(TrackMeter("0001+0003") in TrackMeter("0001+0002.000")..TrackMeter("0001+0003.000"))
+        assertTrue(
+            TrackMeter("0001+0002") in TrackMeter("0001+0002.000")..TrackMeter("0001+0003.000"))
+        assertTrue(
+            TrackMeter("0001+0003") in TrackMeter("0001+0002.000")..TrackMeter("0001+0003.000"))
 
         assertFalse(TrackMeter("0001+0001.999") in TrackMeter("0001+0002")..TrackMeter("0001+0003"))
         assertFalse(TrackMeter("0001+0003.001") in TrackMeter("0001+0002")..TrackMeter("0001+0003"))
-        assertFalse(TrackMeter("0001+0001.999") in TrackMeter("0001+0002.0")..TrackMeter("0001+0003.0"))
-        assertFalse(TrackMeter("0001+0003.001") in TrackMeter("0001+0002.0")..TrackMeter("0001+0003.0"))
+        assertFalse(
+            TrackMeter("0001+0001.999") in TrackMeter("0001+0002.0")..TrackMeter("0001+0003.0"))
+        assertFalse(
+            TrackMeter("0001+0003.001") in TrackMeter("0001+0002.0")..TrackMeter("0001+0003.0"))
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/LayoutBranchConversionTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/LayoutBranchConversionTest.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra.common
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.fta.geoviite.infra.TestApi
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -9,12 +10,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "nodb", "backend")
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
-class LayoutBranchConversionTest @Autowired constructor(
+class LayoutBranchConversionTest
+@Autowired
+constructor(
     mapper: ObjectMapper,
     mockMvc: MockMvc,
 ) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/LayoutBranchTestController.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/LayoutBranchTestController.kt
@@ -30,20 +30,24 @@ class LayoutBranchTestController {
     fun requestWithBranchPath(@PathVariable("branch") branch: DesignBranch): DesignBranch = branch
 
     @GetMapping("/arg")
-    fun requestWithBranchArgument(@RequestParam("branch") branch: LayoutBranch): LayoutBranch = branch
+    fun requestWithBranchArgument(@RequestParam("branch") branch: LayoutBranch): LayoutBranch =
+        branch
 
     @GetMapping("/arg/main")
     fun requestWithBranchArgument(@RequestParam("branch") branch: MainBranch): MainBranch = branch
 
     @GetMapping("/arg/design")
-    fun requestWithBranchArgument(@RequestParam("branch") branch: DesignBranch): DesignBranch = branch
+    fun requestWithBranchArgument(@RequestParam("branch") branch: DesignBranch): DesignBranch =
+        branch
 
     @PostMapping("/body")
-    fun requestWithBranchBody(@RequestBody body: LayoutBranchTestObject): LayoutBranchTestObject = body
+    fun requestWithBranchBody(@RequestBody body: LayoutBranchTestObject): LayoutBranchTestObject =
+        body
 
     @PostMapping("/body/main")
     fun requestWithBranchBody(@RequestBody body: MainBranchTestObject): MainBranchTestObject = body
 
     @PostMapping("/body/design")
-    fun requestWithBranchBody(@RequestBody body: DesignBranchTestObject): DesignBranchTestObject = body
+    fun requestWithBranchBody(@RequestBody body: DesignBranchTestObject): DesignBranchTestObject =
+        body
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/MetaDataNameTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/MetaDataNameTest.kt
@@ -20,5 +20,4 @@ class MetaDataNameTest {
         assertDoesNotThrow { MetaDataName("ÄÖ") }
         assertDoesNotThrow { MetaDataName("21.2 / (Jan 31 2022 16:48:38)") }
     }
-
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureIT.kt
@@ -14,19 +14,21 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 import fi.fta.geoviite.infra.switchLibrary.data.RR54_2x1_9
 import fi.fta.geoviite.infra.switchLibrary.data.YV60_300A_1_9_O
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class SwitchStructureIT @Autowired constructor(
+class SwitchStructureIT
+@Autowired
+constructor(
     val switchStructureDao: SwitchStructureDao,
     val switchLibraryService: SwitchLibraryService
-): DBTestBase() {
+) : DBTestBase() {
 
     @Test
     fun shouldGetSwitchStructures() {
@@ -37,126 +39,94 @@ class SwitchStructureIT @Autowired constructor(
     fun insertAndFetchSwitchStructureShouldWork() {
         val seq = System.currentTimeMillis()
         val uniqueSwitchType = SwitchType("YV60-$seq-1:10")
-        val switchStructure = SwitchStructure(
-            id = IntId(0), // can be any ID
-            type = uniqueSwitchType,
-            presentationJointNumber = JointNumber(5),
-            joints = listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(10.0, 0.0)),
-                SwitchJoint(JointNumber(2), Point(20.0, 0.0)),
-                SwitchJoint(JointNumber(3), Point(20.0, 2.0)),
-            ),
-            alignments = listOf(
-                SwitchAlignment(
-                    jointNumbers = listOf(
-                        JointNumber(1),
-                        JointNumber(5),
-                        JointNumber(2)
+        val switchStructure =
+            SwitchStructure(
+                id = IntId(0), // can be any ID
+                type = uniqueSwitchType,
+                presentationJointNumber = JointNumber(5),
+                joints =
+                    listOf(
+                        SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                        SwitchJoint(JointNumber(5), Point(10.0, 0.0)),
+                        SwitchJoint(JointNumber(2), Point(20.0, 0.0)),
+                        SwitchJoint(JointNumber(3), Point(20.0, 2.0)),
                     ),
-                    elements = listOf(
-                        SwitchElementLine(
-                            id = IndexedId(0, 0), // can be any ID
-                            start = Point(0.0, 0.0),
-                            end = Point(10.0, 0.0)
-                        ),
-                        SwitchElementLine(
-                            id = IndexedId(0, 0), // can be any ID
-                            start = Point(10.0, 0.0),
-                            end = Point(20.0, 0.0)
-                        )
-                    )
-                ),
-                SwitchAlignment(
-                    jointNumbers = listOf(
-                        JointNumber(1),
-                        JointNumber(3)
-                    ),
-                    elements = listOf(
-                        SwitchElementCurve(
-                            id = IndexedId(0, 0), // can be any ID
-                            start = Point(0.0, 0.0),
-                            end = Point(20.0, 2.0),
-                            radius = 200.0
-                        )
-                    )
-                )
-            )
-        )
+                alignments =
+                    listOf(
+                        SwitchAlignment(
+                            jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                            elements =
+                                listOf(
+                                    SwitchElementLine(
+                                        id = IndexedId(0, 0), // can be any ID
+                                        start = Point(0.0, 0.0),
+                                        end = Point(10.0, 0.0)),
+                                    SwitchElementLine(
+                                        id = IndexedId(0, 0), // can be any ID
+                                        start = Point(10.0, 0.0),
+                                        end = Point(20.0, 0.0)))),
+                        SwitchAlignment(
+                            jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                            elements =
+                                listOf(
+                                    SwitchElementCurve(
+                                        id = IndexedId(0, 0), // can be any ID
+                                        start = Point(0.0, 0.0),
+                                        end = Point(20.0, 2.0),
+                                        radius = 200.0)))))
 
-
-        val version = switchStructureDao.insertSwitchStructure(
-            switchStructure
-        )
+        val version = switchStructureDao.insertSwitchStructure(switchStructure)
         val loadedSwitchStructure = switchStructureDao.fetchSwitchStructure(version)
 
-        switchStructuresEqual(
-            switchStructure,
-            loadedSwitchStructure
-        )
+        switchStructuresEqual(switchStructure, loadedSwitchStructure)
     }
 
     @Test
     fun `Update switch structure should work as described`() {
         val seq = System.currentTimeMillis()
         val originalSwitchType = SwitchType("YV60-$seq-1:9")
-        val originalSwitchStructure = YV60_300A_1_9_O().copy(
-            type = originalSwitchType
-        )
-        val originalVersionId = switchStructureDao.insertSwitchStructure(
-            originalSwitchStructure
-        )
-        val originalLoadedSwitchStructure = switchStructureDao.fetchSwitchStructure(originalVersionId)
+        val originalSwitchStructure = YV60_300A_1_9_O().copy(type = originalSwitchType)
+        val originalVersionId = switchStructureDao.insertSwitchStructure(originalSwitchStructure)
+        val originalLoadedSwitchStructure =
+            switchStructureDao.fetchSwitchStructure(originalVersionId)
 
         val updatedSwitchType = SwitchType("RR54-$seq-1:9")
-        val updatedSwitchStructure = RR54_2x1_9().copy(
-            type = updatedSwitchType,
-            id = originalLoadedSwitchStructure.id
-        )
-        val updatedVersionId = switchStructureDao.updateSwitchStructure(
-            updatedSwitchStructure
-        )
+        val updatedSwitchStructure =
+            RR54_2x1_9().copy(type = updatedSwitchType, id = originalLoadedSwitchStructure.id)
+        val updatedVersionId = switchStructureDao.updateSwitchStructure(updatedSwitchStructure)
         val updatedLoadedSwitchStructure = switchStructureDao.fetchSwitchStructure(updatedVersionId)
 
         assertEquals(originalLoadedSwitchStructure.id, updatedLoadedSwitchStructure.id)
-        switchStructuresEqual(
-            updatedSwitchStructure,
-            updatedLoadedSwitchStructure
-        )
+        switchStructuresEqual(updatedSwitchStructure, updatedLoadedSwitchStructure)
     }
 
     @Test
     fun `Upsert should update modified switch structure`() {
         val seq = System.currentTimeMillis()
         val switchType = SwitchType("YV60-$seq-1:9")
-        val switchStructure = YV60_300A_1_9_O().copy(
-            type = switchType
-        )
-        val versionId = switchStructureDao.insertSwitchStructure(
-            switchStructure
-        )
+        val switchStructure = YV60_300A_1_9_O().copy(type = switchType)
+        val versionId = switchStructureDao.insertSwitchStructure(switchStructure)
 
-        val modifiedSwitchStructure = YV60_300A_1_9_O().let { struct ->
-            struct.copy(
-                type = switchType,
-                alignments = struct.alignments.mapIndexed{index, alignment ->
-                    if (index==0)
-                        alignment.copy(
-                            elements = alignment.elements.mapIndexed{index, element ->
-                                if (index==0)
-                                    SwitchElementLine(
-                                        id = element.id,
-                                        start = element.start + 10.0,
-                                        end = element.end)
-                                else
-                                    element
-                            }
-                        )
-                    else
-                        alignment
-                }
-            )
-        }
+        val modifiedSwitchStructure =
+            YV60_300A_1_9_O().let { struct ->
+                struct.copy(
+                    type = switchType,
+                    alignments =
+                        struct.alignments.mapIndexed { index, alignment ->
+                            if (index == 0)
+                                alignment.copy(
+                                    elements =
+                                        alignment.elements.mapIndexed { index, element ->
+                                            if (index == 0)
+                                                SwitchElementLine(
+                                                    id = element.id,
+                                                    start = element.start + 10.0,
+                                                    end = element.end)
+                                            else element
+                                        })
+                            else alignment
+                        })
+            }
 
         val versionBeforeUpsert = switchStructureDao.fetchSwitchStructureVersion(versionId.id)
         val existingSwitchStructure = switchStructureDao.fetchSwitchStructure(versionBeforeUpsert)
@@ -169,16 +139,10 @@ class SwitchStructureIT @Autowired constructor(
     fun `Upsert should not update unmodified switch structure`() {
         val seq = System.currentTimeMillis()
         val switchType = SwitchType("YV60-$seq-1:9")
-        val switchStructure = YV60_300A_1_9_O().copy(
-            type = switchType
-        )
-        val versionId = switchStructureDao.insertSwitchStructure(
-            switchStructure
-        )
+        val switchStructure = YV60_300A_1_9_O().copy(type = switchType)
+        val versionId = switchStructureDao.insertSwitchStructure(switchStructure)
 
-        val similarSwitchStructure = YV60_300A_1_9_O().copy(
-            type = switchType
-        )
+        val similarSwitchStructure = YV60_300A_1_9_O().copy(type = switchType)
 
         val versionBeforeUpsert = switchStructureDao.fetchSwitchStructureVersion(versionId.id)
         val existingSwitchStructure = switchStructureDao.fetchSwitchStructure(versionBeforeUpsert)
@@ -193,17 +157,14 @@ class SwitchStructureIT @Autowired constructor(
 
         val seq = System.currentTimeMillis()
         val newSwitchType = SwitchType("YV60-$seq-1:9")
-        val newSwitchStructure = YV60_300A_1_9_O().copy(
-            type = newSwitchType
-        )
+        val newSwitchStructure = YV60_300A_1_9_O().copy(type = newSwitchType)
 
         switchLibraryService.replaceExistingSwitchStructures(
-            existingSwitchStructuresBeforeUpdate + newSwitchStructure
-        )
+            existingSwitchStructuresBeforeUpdate + newSwitchStructure)
 
         val existingSwitchStructuresAfterUpdate = switchStructureDao.fetchSwitchStructures()
-        assert(existingSwitchStructuresBeforeUpdate.none { s -> s.type==newSwitchType })
-        assert(existingSwitchStructuresAfterUpdate.any { s -> s.type==newSwitchType })
+        assert(existingSwitchStructuresBeforeUpdate.none { s -> s.type == newSwitchType })
+        assert(existingSwitchStructuresAfterUpdate.any { s -> s.type == newSwitchType })
     }
 
     @Test
@@ -212,23 +173,18 @@ class SwitchStructureIT @Autowired constructor(
 
         val seq = System.currentTimeMillis()
         val newSwitchType = SwitchType("YV60-$seq-1:9")
-        val newSwitchStructure = YV60_300A_1_9_O().copy(
-            type = newSwitchType
-        )
+        val newSwitchStructure = YV60_300A_1_9_O().copy(type = newSwitchType)
 
         switchLibraryService.replaceExistingSwitchStructures(
-            existingSwitchStructuresBeforeUpdate + newSwitchStructure
-        )
+            existingSwitchStructuresBeforeUpdate + newSwitchStructure)
         val existingSwitchStructuresAfterFirstUpdate = switchStructureDao.fetchSwitchStructures()
 
-        switchLibraryService.replaceExistingSwitchStructures(
-            existingSwitchStructuresBeforeUpdate
-        )
+        switchLibraryService.replaceExistingSwitchStructures(existingSwitchStructuresBeforeUpdate)
         val existingSwitchStructuresAfterSecondUpdate = switchStructureDao.fetchSwitchStructures()
 
-        assert(existingSwitchStructuresBeforeUpdate.none { s -> s.type==newSwitchType })
-        assert(existingSwitchStructuresAfterFirstUpdate.any { s -> s.type==newSwitchType })
-        assert(existingSwitchStructuresAfterSecondUpdate.none { s -> s.type==newSwitchType })
+        assert(existingSwitchStructuresBeforeUpdate.none { s -> s.type == newSwitchType })
+        assert(existingSwitchStructuresAfterFirstUpdate.any { s -> s.type == newSwitchType })
+        assert(existingSwitchStructuresAfterSecondUpdate.none { s -> s.type == newSwitchType })
     }
 
     fun switchStructuresEqual(s1: SwitchStructure, s2: SwitchStructure) {
@@ -265,47 +221,40 @@ class SwitchStructureIT @Autowired constructor(
     @Test
     fun `Should produce different hashcode when switch structures are modified`() {
         val firstSet = switchStructures
-        val modifiedSet = firstSet.mapIndexed { index, struct ->
-            if (index>0)
-                struct
-            else
-                struct.copy(
-                    alignments = struct.alignments.mapIndexed{index, alignment ->
-                        if (index==0)
-                            alignment.copy(
-                                elements = alignment.elements.mapIndexed{index, element ->
-                                    if (index==0)
-                                        SwitchElementLine(
-                                            id = element.id,
-                                            start = element.start + 10.0,
-                                            end = element.end)
-                                    else
-                                        element
-                                }
-                            )
-                        else
-                            alignment
-                    }
-                )
-        }
+        val modifiedSet =
+            firstSet.mapIndexed { index, struct ->
+                if (index > 0) struct
+                else
+                    struct.copy(
+                        alignments =
+                            struct.alignments.mapIndexed { index, alignment ->
+                                if (index == 0)
+                                    alignment.copy(
+                                        elements =
+                                            alignment.elements.mapIndexed { index, element ->
+                                                if (index == 0)
+                                                    SwitchElementLine(
+                                                        id = element.id,
+                                                        start = element.start + 10.0,
+                                                        end = element.end)
+                                                else element
+                                            })
+                                else alignment
+                            })
+            }
 
         assertNotEquals(
             firstSet.map { s -> s.stripUniqueIdentifiers() }.hashCode(),
-            modifiedSet.map { s -> s.stripUniqueIdentifiers() }.hashCode()
-        )
+            modifiedSet.map { s -> s.stripUniqueIdentifiers() }.hashCode())
     }
 
     @Test
     fun `Should produce same hashcode when switch structures are not modified`() {
         val firstSet = switchStructures
-        val similarSet = firstSet.map {struct ->
-            struct.copy()
-        }
+        val similarSet = firstSet.map { struct -> struct.copy() }
 
         assertEquals(
             firstSet.map { s -> s.stripUniqueIdentifiers() }.hashCode(),
-            similarSet.map { s -> s.stripUniqueIdentifiers() }.hashCode()
-        )
+            similarSet.map { s -> s.stripUniqueIdentifiers() }.hashCode())
     }
-
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureTest.kt
@@ -2,179 +2,153 @@ package fi.fta.geoviite.infra.common
 
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import kotlin.test.assertEquals
 
 class SwitchStructureTest {
-    private val knownSwitchTypes = listOf(
-        "KRV43-233-1:9",
-        "KRV43-270-1:9,514",
-        "KRV54-200-1:9",
-        "KRV54-200-1:9-O",
-        "KV30-270-1:9,514",
-        "KV30-270-1:9,514-V",
-        "KV43-300-1:9,514",
-        "KV43-300-1:9,514-O",
-        "KV43-300-1:9,514-V",
-        "KV54-200-1:9",
-        "KV54-200-1:9-O",
-        "KV54-200-1:9-V",
-        "KV54-200N-1:9",
-        "KV54-200N-1:9-O",
-        "KV54-200N-1:9-V",
-        "RR54-2x1:9",
-        "RR54-4x1:9",
-        "SKV60-1000/474-1:15,5-O",
-        "SKV60-800/423-1:15,5-V",
-        "SRR54-2x1:9-4,8",
-        "SRR54-2x1:9-6,0",
-        "SRR60-2x1:9-4.8",
-        "TYV54-200-1:4,44",
-        "TYV54-225-1:6,46",
-        "TYV54-225-1:6,46TPE",
-        "UKV54-1000/244-1:9-V",
-        "UKV54-1500/228-1:9-O",
-        "UKV54-800/258-1:9-V",
-        "UKV60-600/281-1:9-O",
-        "YRV54-200-1:9",
-        "YV30-270-1:7-V",
-        "YV30-270-1:9,514",
-        "YV30-270-1:9,514-O",
-        "YV30-270-1:9,514-V",
-        "YV43-205-1:9",
-        "YV43-205-1:9,514",
-        "YV43-205-1:9,514-O",
-        "YV43-205-1:9,514-V",
-        "YV43-205-1:9-O",
-        "YV43-205-1:9-V",
-        "YV43-300-1:7",
-        "YV43-300-1:7-O",
-        "YV43-300-1:7-V",
-        "YV43-300-1:9",
-        "YV43-300-1:9,514",
-        "YV43-300-1:9,514-O",
-        "YV43-300-1:9,514-V",
-        "YV43-300-1:9-O",
-        "YV43-300-1:9-V",
-        "YV43-530-1:15",
-        "YV54-165-1:7",
-        "YV54-165-1:7-O",
-        "YV54-165-1:7-V",
-        "YV54-200-1:9",
-        "YV54-200-1:9-O",
-        "YV54-200-1:9-V",
-        "YV54-200N-1:9",
-        "YV54-200N-1:9-O",
-        "YV54-200N-1:9-V",
-        "YV60-300-1:10",
-        "YV60-300-1:10-O",
-        "YV60-300-1:9",
-        "YV60-300-1:9-O",
-        "YV60-300-1:9-V",
-        "YV60-300A-1:9-O",
-        "YV60-300A-1:9-V",
-        "YV60-300E-1:9-O",
-        "YV60-300E-1:9-V",
-        "YV60-300P-1:9",
-        "YV60-300P-1:9-O",
-        "YV60-300P-1:9-V",
-        "YV60-5000/2500-1:26",
-        "YV60-5000/2500-1:26-O",
-        "YV60-5000/2500-1:26-V",
-        "YV60-5000/3000-1:28-O",
-        "YV60-5000/3000-1:28-V",
-        "YV60-500-1:11,1",
-        "YV60-500-1:11,1-O",
-        "YV60-500-1:11,1-V",
-        "YV60-500-1:14",
-        "YV60-500-1:14-O",
-        "YV60-500-1:14-V",
-        "YV60-500A-1:14-V",
-        "YV60-500E-1:14-O",
-        "YV60-900-1:15,5",
-        "YV60-900-1:15,5-O",
-        "YV60-900-1:15,5-V",
-        "YV60-900-1:18",
-        "YV60-900-1:18-O",
-        "YV60-900-1:18-V",
-        "YV60-900A-1:15,5-O",
-        "YV60-900A-1:18-O",
-        "YV60-900A-1:18-V",
-        "YV60-900P-1:18",
-        "YV60-900P-1:18-O",
-        "YV60-900P-1:18-V"
-    )
+    private val knownSwitchTypes =
+        listOf(
+            "KRV43-233-1:9",
+            "KRV43-270-1:9,514",
+            "KRV54-200-1:9",
+            "KRV54-200-1:9-O",
+            "KV30-270-1:9,514",
+            "KV30-270-1:9,514-V",
+            "KV43-300-1:9,514",
+            "KV43-300-1:9,514-O",
+            "KV43-300-1:9,514-V",
+            "KV54-200-1:9",
+            "KV54-200-1:9-O",
+            "KV54-200-1:9-V",
+            "KV54-200N-1:9",
+            "KV54-200N-1:9-O",
+            "KV54-200N-1:9-V",
+            "RR54-2x1:9",
+            "RR54-4x1:9",
+            "SKV60-1000/474-1:15,5-O",
+            "SKV60-800/423-1:15,5-V",
+            "SRR54-2x1:9-4,8",
+            "SRR54-2x1:9-6,0",
+            "SRR60-2x1:9-4.8",
+            "TYV54-200-1:4,44",
+            "TYV54-225-1:6,46",
+            "TYV54-225-1:6,46TPE",
+            "UKV54-1000/244-1:9-V",
+            "UKV54-1500/228-1:9-O",
+            "UKV54-800/258-1:9-V",
+            "UKV60-600/281-1:9-O",
+            "YRV54-200-1:9",
+            "YV30-270-1:7-V",
+            "YV30-270-1:9,514",
+            "YV30-270-1:9,514-O",
+            "YV30-270-1:9,514-V",
+            "YV43-205-1:9",
+            "YV43-205-1:9,514",
+            "YV43-205-1:9,514-O",
+            "YV43-205-1:9,514-V",
+            "YV43-205-1:9-O",
+            "YV43-205-1:9-V",
+            "YV43-300-1:7",
+            "YV43-300-1:7-O",
+            "YV43-300-1:7-V",
+            "YV43-300-1:9",
+            "YV43-300-1:9,514",
+            "YV43-300-1:9,514-O",
+            "YV43-300-1:9,514-V",
+            "YV43-300-1:9-O",
+            "YV43-300-1:9-V",
+            "YV43-530-1:15",
+            "YV54-165-1:7",
+            "YV54-165-1:7-O",
+            "YV54-165-1:7-V",
+            "YV54-200-1:9",
+            "YV54-200-1:9-O",
+            "YV54-200-1:9-V",
+            "YV54-200N-1:9",
+            "YV54-200N-1:9-O",
+            "YV54-200N-1:9-V",
+            "YV60-300-1:10",
+            "YV60-300-1:10-O",
+            "YV60-300-1:9",
+            "YV60-300-1:9-O",
+            "YV60-300-1:9-V",
+            "YV60-300A-1:9-O",
+            "YV60-300A-1:9-V",
+            "YV60-300E-1:9-O",
+            "YV60-300E-1:9-V",
+            "YV60-300P-1:9",
+            "YV60-300P-1:9-O",
+            "YV60-300P-1:9-V",
+            "YV60-5000/2500-1:26",
+            "YV60-5000/2500-1:26-O",
+            "YV60-5000/2500-1:26-V",
+            "YV60-5000/3000-1:28-O",
+            "YV60-5000/3000-1:28-V",
+            "YV60-500-1:11,1",
+            "YV60-500-1:11,1-O",
+            "YV60-500-1:11,1-V",
+            "YV60-500-1:14",
+            "YV60-500-1:14-O",
+            "YV60-500-1:14-V",
+            "YV60-500A-1:14-V",
+            "YV60-500E-1:14-O",
+            "YV60-900-1:15,5",
+            "YV60-900-1:15,5-O",
+            "YV60-900-1:15,5-V",
+            "YV60-900-1:18",
+            "YV60-900-1:18-O",
+            "YV60-900-1:18-V",
+            "YV60-900A-1:15,5-O",
+            "YV60-900A-1:18-O",
+            "YV60-900A-1:18-V",
+            "YV60-900P-1:18",
+            "YV60-900P-1:18-O",
+            "YV60-900P-1:18-V")
 
     private val validSwitchStructure by lazy {
         SwitchStructure(
             id = IntId(0),
             type = SwitchType("YV60-300-1:9-O"),
             presentationJointNumber = JointNumber(1),
-            joints = listOf(
-                SwitchJoint(
-                    number = JointNumber(1),
-                    location = Point(0.0, 0.0)
+            joints =
+                listOf(
+                    SwitchJoint(number = JointNumber(1), location = Point(0.0, 0.0)),
+                    SwitchJoint(number = JointNumber(5), location = Point(16.615, 0.0)),
+                    SwitchJoint(number = JointNumber(2), location = Point(34.430, 0.0)),
+                    SwitchJoint(number = JointNumber(3), location = Point(34.430, 3.825)),
                 ),
-                SwitchJoint(
-                    number = JointNumber(5),
-                    location = Point(16.615, 0.0)
-                ),
-                SwitchJoint(
-                    number = JointNumber(2),
-                    location = Point(34.430, 0.0)
-                ),
-                SwitchJoint(
-                    number = JointNumber(3),
-                    location = Point(34.430, 3.825)
-                ),
-            ),
-            alignments = listOf(
-                SwitchAlignment(
-                    jointNumbers = listOf(
-                        JointNumber(1),
-                        JointNumber(5),
-                        JointNumber(2)
-                    ),
-                    elements = listOf(
-                        SwitchElementLine(
-                            id = IndexedId(0, 0),
-                            start = Point(0.0, 0.0),
-                            end = Point(16.615, 0.0)
-                        ),
-                        SwitchElementLine(
-                            id = IndexedId(0, 0),
-                            start = Point(16.615, 0.0),
-                            end = Point(34.430, 0.0)
-                        )
-                    )
-                ),
-                SwitchAlignment(
-                    jointNumbers = listOf(
-                        JointNumber(1),
-                        JointNumber(3)
-                    ),
-                    elements = listOf(
-                        SwitchElementCurve(
-                            id = IndexedId(0, 0),
-                            start = Point(0.0, 0.0),
-                            end = Point(34.0, 3.777),
-                            radius = 300.0
-                        ),
-                        SwitchElementLine(
-                            id = IndexedId(0, 0),
-                            start = Point(34.0, 3.5),
-                            end = Point(34.430, 3.825)
-                        )
-                    )
-                )
-            )
-        )
+            alignments =
+                listOf(
+                    SwitchAlignment(
+                        jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                        elements =
+                            listOf(
+                                SwitchElementLine(
+                                    id = IndexedId(0, 0),
+                                    start = Point(0.0, 0.0),
+                                    end = Point(16.615, 0.0)),
+                                SwitchElementLine(
+                                    id = IndexedId(0, 0),
+                                    start = Point(16.615, 0.0),
+                                    end = Point(34.430, 0.0)))),
+                    SwitchAlignment(
+                        jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                        elements =
+                            listOf(
+                                SwitchElementCurve(
+                                    id = IndexedId(0, 0),
+                                    start = Point(0.0, 0.0),
+                                    end = Point(34.0, 3.777),
+                                    radius = 300.0),
+                                SwitchElementLine(
+                                    id = IndexedId(0, 0),
+                                    start = Point(34.0, 3.5),
+                                    end = Point(34.430, 3.825))))))
     }
 
-    private val nonExistingJointNumber = JointNumber(999);
-
+    private val nonExistingJointNumber = JointNumber(999)
 
     @Test
     fun switchTypeParsingAllowsKnownTypes() {
@@ -185,20 +159,17 @@ class SwitchStructureTest {
     fun switchTypeParsingFindsExpectedParts() {
         assertEquals(
             SwitchTypeParts(SwitchBaseType.YV, 60, listOf(900), "P", "1:18", SwitchHand.RIGHT),
-            SwitchType("YV60-900P-1:18-O").parts
-        )
+            SwitchType("YV60-900P-1:18-O").parts)
         assertEquals(
             SwitchTypeParts(SwitchBaseType.KRV, 43, listOf(270), null, "1:9,514", SwitchHand.NONE),
-            SwitchType("KRV43-270-1:9,514").parts
-        )
+            SwitchType("KRV43-270-1:9,514").parts)
         assertEquals(
-            SwitchTypeParts(SwitchBaseType.YV, 60, listOf(5000, 2500), null, "1:26", SwitchHand.LEFT),
-            SwitchType("YV60-5000/2500-1:26-V").parts
-        )
+            SwitchTypeParts(
+                SwitchBaseType.YV, 60, listOf(5000, 2500), null, "1:26", SwitchHand.LEFT),
+            SwitchType("YV60-5000/2500-1:26-V").parts)
         assertEquals(
             SwitchTypeParts(SwitchBaseType.SRR, 54, listOf(), null, "2x1:9-6,0", SwitchHand.NONE),
-            SwitchType("SRR54-2x1:9-6,0").parts
-        )
+            SwitchType("SRR54-2x1:9-6,0").parts)
     }
 
     @Test
@@ -219,8 +190,7 @@ class SwitchStructureTest {
                 validSwitchStructure.type,
                 presentationJointNumber = nonExistingJointNumber,
                 validSwitchStructure.joints,
-                validSwitchStructure.alignments
-            )
+                validSwitchStructure.alignments)
         }
     }
 
@@ -232,8 +202,7 @@ class SwitchStructureTest {
                 validSwitchStructure.type,
                 validSwitchStructure.presentationJointNumber,
                 validSwitchStructure.joints,
-                listOf()
-            )
+                listOf())
         }
     }
 
@@ -250,13 +219,9 @@ class SwitchStructureTest {
     @Test
     fun switchAlignmentDeniesEmptyElements() {
         assertThrows<IllegalArgumentException> {
-            SwitchAlignment(
-                validSwitchStructure.alignments[0].jointNumbers,
-                elements = listOf()
-            )
+            SwitchAlignment(validSwitchStructure.alignments[0].jointNumbers, elements = listOf())
         }
     }
-
 
     @Test
     fun switchStructureDeniesInvalidAlignmentJointNumber() {
@@ -269,10 +234,8 @@ class SwitchStructureTest {
                 validSwitchStructure.alignments.map {
                     it.copy(
                         // make alignment joint numbers invalid
-                        jointNumbers = listOf(nonExistingJointNumber)
-                    )
-                }
-            )
+                        jointNumbers = listOf(nonExistingJointNumber))
+                })
         }
     }
 
@@ -280,42 +243,31 @@ class SwitchStructureTest {
     fun flipAlongYAxisProducesValidValues() {
         val flipped = validSwitchStructure.flipAlongYAxis()
         validSwitchStructure.joints.forEachIndexed { index, switchJoint ->
-            assertEquals(
-                switchJoint.location.x,
-                flipped.joints[index].location.x
-            )
-            assertEquals(
-                switchJoint.location.y,
-                -flipped.joints[index].location.y
-            )
+            assertEquals(switchJoint.location.x, flipped.joints[index].location.x)
+            assertEquals(switchJoint.location.y, -flipped.joints[index].location.y)
         }
         validSwitchStructure.alignments.forEachIndexed { alignmentIndex, alignment ->
             alignment.elements.forEachIndexed { elementIndex, switchElement ->
                 assertEquals(
                     switchElement.start.x,
-                    flipped.alignments[alignmentIndex].elements[elementIndex].start.x
-                )
+                    flipped.alignments[alignmentIndex].elements[elementIndex].start.x)
                 assertEquals(
                     switchElement.start.y,
-                    -flipped.alignments[alignmentIndex].elements[elementIndex].start.y
-                )
+                    -flipped.alignments[alignmentIndex].elements[elementIndex].start.y)
                 assertEquals(
                     switchElement.end.x,
-                    flipped.alignments[alignmentIndex].elements[elementIndex].end.x
-                )
+                    flipped.alignments[alignmentIndex].elements[elementIndex].end.x)
                 assertEquals(
                     switchElement.end.y,
-                    -flipped.alignments[alignmentIndex].elements[elementIndex].end.y
-                )
+                    -flipped.alignments[alignmentIndex].elements[elementIndex].end.y)
             }
         }
     }
 
     @Test
     fun allBaseTypesAreValidAsSwitchName() {
-        // For suggestions without name, we generate a temp-name from the basetype. Ensure that works
-        SwitchBaseType.values().forEach { type ->
-            assertDoesNotThrow { SwitchName(type.name) }
-        }
+        // For suggestions without name, we generate a temp-name from the basetype. Ensure that
+        // works
+        SwitchBaseType.values().forEach { type -> assertDoesNotThrow { SwitchName(type.name) } }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/dataImport/FrozenMigrationsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/dataImport/FrozenMigrationsTest.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.dataImport
 
+import kotlin.test.assertEquals
 import org.flywaydb.core.internal.resolver.ChecksumCalculator
 import org.flywaydb.core.internal.resource.StringResource
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -8,86 +9,150 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.core.io.support.ResourcePatternResolver
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "nodb")
 @SpringBootTest
-class FrozenMigrationsTest @Autowired constructor(
-    val resourceResolver: ResourcePatternResolver
-) {
+class FrozenMigrationsTest @Autowired constructor(val resourceResolver: ResourcePatternResolver) {
     private data class MigrationFile(val fileName: String, val checksum: Int)
 
     @Test
     fun initMigrationsHaveNotChanged() {
         // This test is a sanity-check to give early warning for developers if they
         // accidentally edit the un-editable: the initial migrations
-        val expectedMigrations: List<MigrationFile> = listOf(
-            MigrationFile(fileName = "V00.01__install_postgis.sql", checksum = 1412735420),
-            MigrationFile(fileName = "V00.10__common_utility_functions.sql", checksum = 1115603267),
-            MigrationFile(fileName = "V00.11__common_metadata_functions.sql", checksum = 1301034460),
-            MigrationFile(fileName = "V01.01__common_unit_type.sql", checksum = -407838513),
-            MigrationFile(fileName = "V01.02__common_feature_type.sql", checksum = 2106249120),
-            MigrationFile(fileName = "V01.03.01__common_switch_type.sql", checksum = -43494992),
-            MigrationFile(fileName = "V01.03.02__common_switch_structure.sql", checksum = -1109698266),
-            MigrationFile(fileName = "V01.03.03__common_switch_alignment.sql", checksum = 487568140),
-            MigrationFile(fileName = "V01.03.04__common_switch_element.sql", checksum = 1028870762),
-            MigrationFile(fileName = "V01.03.05__common_switch_joint.sql", checksum = 1959336719),
-            MigrationFile(fileName = "V01.03.06__common_switch_owner.sql", checksum = -39678304),
-            MigrationFile(fileName = "V01.04__common_coordinate_system.sql", checksum = 1752767082),
-            MigrationFile(fileName = "V01.05__common_location_accuracy.sql", checksum = -999072516),
-            MigrationFile(fileName = "V01.06__common_vertical_coordinate_system.sql", checksum = 1647683084),
-            MigrationFile(fileName = "V01.03.07__common_inframodel_switch_type_name_alias.sql", checksum = 144978698),
-            MigrationFile(fileName = "V01.07.01__common_role.sql", checksum = -410660863),
-            MigrationFile(fileName = "V01.07.02__common_privilege.sql", checksum = 899063532),
-            MigrationFile(fileName = "V01.07.03__common_role_privilege.sql", checksum = -1711975293),
-            MigrationFile(fileName = "V01.08.01__layout_state.sql", checksum = 1058871688),
-            MigrationFile(fileName = "V01.08.02__layout_track_number.sql", checksum = -1293075289),
-            MigrationFile(fileName = "V01.08.03__layout_category.sql", checksum = -654332391),
-            MigrationFile(fileName = "V02.00.01__geometry_plan_state.sql", checksum = 494877868),
-            MigrationFile(fileName = "V02.00.02__geometry_plan_source.sql", checksum = -1657379807),
-            MigrationFile(fileName = "V02.01.01__geometry_plan_project.sql", checksum = -1922121912),
-            MigrationFile(fileName = "V02.01.02__geometry_plan_application.sql", checksum = 626252729),
-            MigrationFile(fileName = "V02.01.03__geometry_plan_author.sql", checksum = -1281457289),
-            MigrationFile(fileName = "V02.01.04__geometry_plan.sql", checksum = 978092024),
-            MigrationFile(fileName = "V02.01.05__geometry_plan_file.sql", checksum = -1529850039),
-            MigrationFile(fileName = "V02.02.01__geometry_km_post.sql", checksum = -311372319),
-            MigrationFile(fileName = "V02.03.01__geometry_switch.sql", checksum = 273160783),
-            MigrationFile(fileName = "V02.03.02__geometry_switch_joint.sql", checksum = 1912952394),
-            MigrationFile(fileName = "V02.04.01__geometry_alignment.sql", checksum = 1326585480),
-            MigrationFile(fileName = "V02.04.02__geometry_element.sql", checksum = -1328250198),
-            MigrationFile(fileName = "V02.04.03__geometry_vertical_intersection.sql", checksum = 502980499),
-            MigrationFile(fileName = "V02.04.04__geometry_cant_point.sql", checksum = -1255272875),
-            MigrationFile(fileName = "V03.02.01__layout_switch.sql", checksum = 886649753),
-            MigrationFile(fileName = "V03.02.02__layout_switch_joint.sql", checksum = 838150452),
-            MigrationFile(fileName = "V03.03.01__layout_km_post.sql", checksum = 605416016),
-            MigrationFile(fileName = "V03.04.01__layout_alignment.sql", checksum = 1616389042),
-            MigrationFile(fileName = "V03.04.02__layout_segment.sql", checksum = 190129497),
-            MigrationFile(fileName = "V03.05.01__layout_location_track.sql", checksum = -1925261205),
-            MigrationFile(fileName = "V03.05.02__layout_reference_line.sql", checksum = 1815023431),
-            MigrationFile(fileName = "V04.01.01__layout_initial_import_metadata.sql", checksum = 51863216),
-            MigrationFile(fileName = "V10.01__common_feature_type_values.sql", checksum = 1021841055),
-            MigrationFile(fileName = "V10.02__common_coordinate_system_values.sql", checksum = 1382442814),
-            MigrationFile(fileName = "V10.03.04__common_switch_owner_values.sql", checksum = 1821224761),
-            MigrationFile(fileName = "V10.04.01__common_n60_n200_triangulation_network.sql", checksum = -801851226),
-            MigrationFile(fileName = "V10.04.02__common_inserts_for_n60_n2000_triangle_corner_point_table.sql", checksum = -1896455933),
-            MigrationFile(fileName = "V10.04.03__common_inserts_for_n60_n2000_triangulation_network_table.sql", checksum = 1910613803),
-            MigrationFile(fileName = "V10.05.01__common_kkj_etrs_triangulation_network.sql", checksum = -1040194410),
-            MigrationFile(fileName = "V10.05.02__common_inserts_for_kkj_etrs_triangle_corner_point_table.sql", checksum = -294904538),
-            MigrationFile(fileName = "V10.05.03__common_inserts_for_kkj_etrs_triangulation_network.sql", checksum = 571127275),
-            MigrationFile(fileName = "V11.00.00__layout_track_number_imports_in_code.sql", checksum = 465780583),
-            MigrationFile(fileName = "V12.00.00__geometry_inframodel_imports_in_code.sql", checksum = 1765353731),
-            MigrationFile(fileName = "V13.01.01__finalize_geometry_tables.sql", checksum = 4829361),
-            MigrationFile(fileName = "V14.00.00__layout_imports_in_code.sql", checksum = 1185536260),
-            MigrationFile(fileName = "V15.01.01__finalize_layout_tables.sql", checksum = 493331486),
-            MigrationFile(fileName = "V16.01.01__publication.sql", checksum = -257379860),
-            MigrationFile(fileName = "V16.02.01__publication_calculated_changes.sql", checksum = 640208248),
-            MigrationFile(fileName = "V17.01.01__integrations_enums.sql", checksum = 332715753),
-            MigrationFile(fileName = "V17.01.02__integrations_lock.sql", checksum = -316859793),
-            MigrationFile(fileName = "V17.01.03__integrations_ratko_push.sql", checksum = -1142466586),
-            MigrationFile(fileName = "V17.01.04__integrations_ratko_push_content.sql", checksum = 485117446),
-            MigrationFile(fileName = "V17.01.05__integrations_ratko_push_error.sql", checksum = 578997775),
-            MigrationFile(fileName = "V17.02.00__publication_add_first_publication.sql", checksum = -1157951969),
-        )
+        val expectedMigrations: List<MigrationFile> =
+            listOf(
+                MigrationFile(fileName = "V00.01__install_postgis.sql", checksum = 1412735420),
+                MigrationFile(
+                    fileName = "V00.10__common_utility_functions.sql", checksum = 1115603267),
+                MigrationFile(
+                    fileName = "V00.11__common_metadata_functions.sql", checksum = 1301034460),
+                MigrationFile(fileName = "V01.01__common_unit_type.sql", checksum = -407838513),
+                MigrationFile(fileName = "V01.02__common_feature_type.sql", checksum = 2106249120),
+                MigrationFile(fileName = "V01.03.01__common_switch_type.sql", checksum = -43494992),
+                MigrationFile(
+                    fileName = "V01.03.02__common_switch_structure.sql", checksum = -1109698266),
+                MigrationFile(
+                    fileName = "V01.03.03__common_switch_alignment.sql", checksum = 487568140),
+                MigrationFile(
+                    fileName = "V01.03.04__common_switch_element.sql", checksum = 1028870762),
+                MigrationFile(
+                    fileName = "V01.03.05__common_switch_joint.sql", checksum = 1959336719),
+                MigrationFile(
+                    fileName = "V01.03.06__common_switch_owner.sql", checksum = -39678304),
+                MigrationFile(
+                    fileName = "V01.04__common_coordinate_system.sql", checksum = 1752767082),
+                MigrationFile(
+                    fileName = "V01.05__common_location_accuracy.sql", checksum = -999072516),
+                MigrationFile(
+                    fileName = "V01.06__common_vertical_coordinate_system.sql",
+                    checksum = 1647683084),
+                MigrationFile(
+                    fileName = "V01.03.07__common_inframodel_switch_type_name_alias.sql",
+                    checksum = 144978698),
+                MigrationFile(fileName = "V01.07.01__common_role.sql", checksum = -410660863),
+                MigrationFile(fileName = "V01.07.02__common_privilege.sql", checksum = 899063532),
+                MigrationFile(
+                    fileName = "V01.07.03__common_role_privilege.sql", checksum = -1711975293),
+                MigrationFile(fileName = "V01.08.01__layout_state.sql", checksum = 1058871688),
+                MigrationFile(
+                    fileName = "V01.08.02__layout_track_number.sql", checksum = -1293075289),
+                MigrationFile(fileName = "V01.08.03__layout_category.sql", checksum = -654332391),
+                MigrationFile(
+                    fileName = "V02.00.01__geometry_plan_state.sql", checksum = 494877868),
+                MigrationFile(
+                    fileName = "V02.00.02__geometry_plan_source.sql", checksum = -1657379807),
+                MigrationFile(
+                    fileName = "V02.01.01__geometry_plan_project.sql", checksum = -1922121912),
+                MigrationFile(
+                    fileName = "V02.01.02__geometry_plan_application.sql", checksum = 626252729),
+                MigrationFile(
+                    fileName = "V02.01.03__geometry_plan_author.sql", checksum = -1281457289),
+                MigrationFile(fileName = "V02.01.04__geometry_plan.sql", checksum = 978092024),
+                MigrationFile(
+                    fileName = "V02.01.05__geometry_plan_file.sql", checksum = -1529850039),
+                MigrationFile(fileName = "V02.02.01__geometry_km_post.sql", checksum = -311372319),
+                MigrationFile(fileName = "V02.03.01__geometry_switch.sql", checksum = 273160783),
+                MigrationFile(
+                    fileName = "V02.03.02__geometry_switch_joint.sql", checksum = 1912952394),
+                MigrationFile(
+                    fileName = "V02.04.01__geometry_alignment.sql", checksum = 1326585480),
+                MigrationFile(fileName = "V02.04.02__geometry_element.sql", checksum = -1328250198),
+                MigrationFile(
+                    fileName = "V02.04.03__geometry_vertical_intersection.sql",
+                    checksum = 502980499),
+                MigrationFile(
+                    fileName = "V02.04.04__geometry_cant_point.sql", checksum = -1255272875),
+                MigrationFile(fileName = "V03.02.01__layout_switch.sql", checksum = 886649753),
+                MigrationFile(
+                    fileName = "V03.02.02__layout_switch_joint.sql", checksum = 838150452),
+                MigrationFile(fileName = "V03.03.01__layout_km_post.sql", checksum = 605416016),
+                MigrationFile(fileName = "V03.04.01__layout_alignment.sql", checksum = 1616389042),
+                MigrationFile(fileName = "V03.04.02__layout_segment.sql", checksum = 190129497),
+                MigrationFile(
+                    fileName = "V03.05.01__layout_location_track.sql", checksum = -1925261205),
+                MigrationFile(
+                    fileName = "V03.05.02__layout_reference_line.sql", checksum = 1815023431),
+                MigrationFile(
+                    fileName = "V04.01.01__layout_initial_import_metadata.sql",
+                    checksum = 51863216),
+                MigrationFile(
+                    fileName = "V10.01__common_feature_type_values.sql", checksum = 1021841055),
+                MigrationFile(
+                    fileName = "V10.02__common_coordinate_system_values.sql",
+                    checksum = 1382442814),
+                MigrationFile(
+                    fileName = "V10.03.04__common_switch_owner_values.sql", checksum = 1821224761),
+                MigrationFile(
+                    fileName = "V10.04.01__common_n60_n200_triangulation_network.sql",
+                    checksum = -801851226),
+                MigrationFile(
+                    fileName =
+                        "V10.04.02__common_inserts_for_n60_n2000_triangle_corner_point_table.sql",
+                    checksum = -1896455933),
+                MigrationFile(
+                    fileName =
+                        "V10.04.03__common_inserts_for_n60_n2000_triangulation_network_table.sql",
+                    checksum = 1910613803),
+                MigrationFile(
+                    fileName = "V10.05.01__common_kkj_etrs_triangulation_network.sql",
+                    checksum = -1040194410),
+                MigrationFile(
+                    fileName =
+                        "V10.05.02__common_inserts_for_kkj_etrs_triangle_corner_point_table.sql",
+                    checksum = -294904538),
+                MigrationFile(
+                    fileName = "V10.05.03__common_inserts_for_kkj_etrs_triangulation_network.sql",
+                    checksum = 571127275),
+                MigrationFile(
+                    fileName = "V11.00.00__layout_track_number_imports_in_code.sql",
+                    checksum = 465780583),
+                MigrationFile(
+                    fileName = "V12.00.00__geometry_inframodel_imports_in_code.sql",
+                    checksum = 1765353731),
+                MigrationFile(
+                    fileName = "V13.01.01__finalize_geometry_tables.sql", checksum = 4829361),
+                MigrationFile(
+                    fileName = "V14.00.00__layout_imports_in_code.sql", checksum = 1185536260),
+                MigrationFile(
+                    fileName = "V15.01.01__finalize_layout_tables.sql", checksum = 493331486),
+                MigrationFile(fileName = "V16.01.01__publication.sql", checksum = -257379860),
+                MigrationFile(
+                    fileName = "V16.02.01__publication_calculated_changes.sql",
+                    checksum = 640208248),
+                MigrationFile(fileName = "V17.01.01__integrations_enums.sql", checksum = 332715753),
+                MigrationFile(fileName = "V17.01.02__integrations_lock.sql", checksum = -316859793),
+                MigrationFile(
+                    fileName = "V17.01.03__integrations_ratko_push.sql", checksum = -1142466586),
+                MigrationFile(
+                    fileName = "V17.01.04__integrations_ratko_push_content.sql",
+                    checksum = 485117446),
+                MigrationFile(
+                    fileName = "V17.01.05__integrations_ratko_push_error.sql",
+                    checksum = 578997775),
+                MigrationFile(
+                    fileName = "V17.02.00__publication_add_first_publication.sql",
+                    checksum = -1157951969),
+            )
         val allMigrations = collectAllMigrations("init")
 
         // Verify one-by-one for clearer error message
@@ -100,19 +165,20 @@ class FrozenMigrationsTest @Autowired constructor(
 
         // New migrations cannot be added to init directory
         allMigrations.forEach { actual ->
-            val expectedExists = expectedMigrations.any { expected -> expected.fileName == actual.fileName }
+            val expectedExists =
+                expectedMigrations.any { expected -> expected.fileName == actual.fileName }
             assertTrue(expectedExists, "New migration found in init: new=$actual")
         }
 
         // Code migrations must also retain their versions, names and checksums
-        val csvMigrations = listOf(
-            V11_01__Csv_import_track_numbers() to "V11_01__Csv_import_track_numbers",
-            V14_01__Csv_import_km_posts() to "V14_01__Csv_import_km_posts",
-            V14_02__Csv_import_switches() to "V14_02__Csv_import_switches",
-            V14_03__Csv_import_reference_lines() to "V14_03__Csv_import_reference_lines",
-            V14_04__Csv_import_location_tracks() to "V14_04__Csv_import_location_tracks",
-
-        )
+        val csvMigrations =
+            listOf(
+                V11_01__Csv_import_track_numbers() to "V11_01__Csv_import_track_numbers",
+                V14_01__Csv_import_km_posts() to "V14_01__Csv_import_km_posts",
+                V14_02__Csv_import_switches() to "V14_02__Csv_import_switches",
+                V14_03__Csv_import_reference_lines() to "V14_03__Csv_import_reference_lines",
+                V14_04__Csv_import_location_tracks() to "V14_04__Csv_import_location_tracks",
+            )
         csvMigrations.forEach { (migration, name) ->
             assertEquals(migration.checksum, 9)
             assertEquals(name, migration::class.simpleName)
@@ -120,15 +186,15 @@ class FrozenMigrationsTest @Autowired constructor(
         assertEquals(V12_01__InfraModelMigration().checksum, null)
         assertEquals("V12_01__InfraModelMigration", V12_01__InfraModelMigration::class.simpleName)
         assertEquals(V10_03_06__SwitchLibraryDataMigration().checksum, 6)
-        assertEquals("V10_03_06__SwitchLibraryDataMigration", V10_03_06__SwitchLibraryDataMigration::class.simpleName)
+        assertEquals(
+            "V10_03_06__SwitchLibraryDataMigration",
+            V10_03_06__SwitchLibraryDataMigration::class.simpleName)
     }
 
     private fun collectAllMigrations(folder: String): List<MigrationFile> =
-        resourceResolver.getResources("classpath:db/migration/$folder/*.sql")
-            .map { resource ->
-                MigrationFile(
-                    fileName = resource.filename!!,
-                    checksum = ChecksumCalculator.calculate(StringResource(resource.file.readText()))
-                )
-            }
+        resourceResolver.getResources("classpath:db/migration/$folder/*.sql").map { resource ->
+            MigrationFile(
+                fileName = resource.filename!!,
+                checksum = ChecksumCalculator.calculate(StringResource(resource.file.readText())))
+        }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/error/ApiErrorHandlerTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/error/ApiErrorHandlerTest.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.TestApi
 import fi.fta.geoviite.infra.hello.ERROR_TEST_URL
 import fi.fta.geoviite.infra.hello.ErrorTestBody
 import fi.fta.geoviite.infra.hello.ErrorTestResponse
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -12,12 +13,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus.*
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "nodb", "backend")
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
-class ApiErrorHandlerTest @Autowired constructor(
+class ApiErrorHandlerTest
+@Autowired
+constructor(
     mapper: ObjectMapper,
     mockMvc: MockMvc,
 ) {
@@ -130,7 +132,8 @@ class ApiErrorHandlerTest @Autowired constructor(
     @Test
     fun invalidBodyIs400() {
         testApi.assertErrorResult(
-            testApi.doPostWithString("$ERROR_TEST_URL/body", "{\"name\":\"name\",\"value\":0}", BAD_REQUEST),
+            testApi.doPostWithString(
+                "$ERROR_TEST_URL/body", "{\"name\":\"name\",\"value\":0}", BAD_REQUEST),
             "Request body not readable",
             "Failed to instantiate Lfi/fta/geoviite/infra/hello/ErrorTestBody;",
             "Input validation failed: ErrorTestBody value too small",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/error/ErrorTestController.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/error/ErrorTestController.kt
@@ -7,15 +7,20 @@ import fi.fta.geoviite.infra.error.ServerException
 import org.springframework.web.bind.annotation.*
 
 data class ErrorTestParam(val value: Int) {
-    @JsonCreator constructor(stringValue: String): this(stringValue.toInt())
+    @JsonCreator constructor(stringValue: String) : this(stringValue.toInt())
+
     init {
-        if (value <= 0) throw InputValidationException("ErrorTestParam value too small", ErrorTestParam::class, "test")
+        if (value <= 0)
+            throw InputValidationException(
+                "ErrorTestParam value too small", ErrorTestParam::class, "test")
     }
 }
 
 data class ErrorTestBody @JsonCreator constructor(val name: String, val value: Int) {
     init {
-        if (value <= 0) throw InputValidationException("ErrorTestBody value too small", ErrorTestParam::class, "test")
+        if (value <= 0)
+            throw InputValidationException(
+                "ErrorTestBody value too small", ErrorTestParam::class, "test")
     }
 }
 
@@ -27,17 +32,19 @@ const val ERROR_TEST_URL = "/error-test"
 class ErrorTestController {
 
     @GetMapping("/path/{variable}")
-    fun requestWithPathVariable(@PathVariable("variable") value: ErrorTestParam) : ErrorTestResponse {
+    fun requestWithPathVariable(
+        @PathVariable("variable") value: ErrorTestParam
+    ): ErrorTestResponse {
         return ErrorTestResponse()
     }
 
     @GetMapping("/param")
-    fun requestWithParam(@RequestParam("param") value: ErrorTestParam) : ErrorTestResponse {
+    fun requestWithParam(@RequestParam("param") value: ErrorTestParam): ErrorTestResponse {
         return ErrorTestResponse()
     }
 
     @PostMapping("/body")
-    fun requestWithBody(@RequestBody body: ErrorTestBody) : ErrorTestResponse {
+    fun requestWithBody(@RequestBody body: ErrorTestBody): ErrorTestResponse {
         return ErrorTestResponse()
     }
 
@@ -47,22 +54,23 @@ class ErrorTestController {
     }
 
     @GetMapping("/illegal-java")
-    fun illegalJava() : ErrorTestResponse {
+    fun illegalJava(): ErrorTestResponse {
         throw java.lang.IllegalStateException("Unhandled error")
     }
 
     @GetMapping("/client")
-    fun clientException() : ErrorTestResponse {
+    fun clientException(): ErrorTestResponse {
         throw InputValidationException("Client error", ErrorTestParam::class, "test")
     }
 
     @GetMapping("/server")
-    fun serverException() : ErrorTestResponse {
+    fun serverException(): ErrorTestResponse {
         throw ServerException("Server error")
     }
 
     @GetMapping("/wrapped")
     fun serverExceptionWrappedInClientException(): ErrorTestResponse {
-        throw InputValidationException("Client error", ErrorTestParam::class, "test", ServerException("Server error"))
+        throw InputValidationException(
+            "Client error", ErrorTestParam::class, "test", ServerException("Server error"))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
@@ -31,7 +31,9 @@ import validationVersions
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class GeocodingDaoIT @Autowired constructor(
+class GeocodingDaoIT
+@Autowired
+constructor(
     val geocodingDao: GeocodingDao,
     val trackNumberDao: LayoutTrackNumberDao,
     val referenceLineDao: ReferenceLineDao,
@@ -53,9 +55,11 @@ class GeocodingDaoIT @Autowired constructor(
     fun trackNumberWithoutKmPostsHasAContext() {
         val id = mainOfficialContext.createLayoutTrackNumber().id
         val alignmentVersion = alignmentDao.insert(alignment())
-        referenceLineDao.insert(referenceLine(id, alignmentVersion = alignmentVersion, draft = false))
+        referenceLineDao.insert(
+            referenceLine(id, alignmentVersion = alignmentVersion, draft = false))
         assertNotNull(geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.draft, id))
-        assertNotNull(geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, id))
+        assertNotNull(
+            geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, id))
     }
 
     @Test
@@ -74,28 +78,31 @@ class GeocodingDaoIT @Autowired constructor(
         // Add a deleted post - should not appear in results
         mainOfficialContext.insert(kmPost(tnId, KmNumber(4), state = LayoutState.DELETED))
 
-        val officialKey = geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId)!!
+        val officialKey =
+            geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId)!!
         assertEquals(
             LayoutGeocodingContextCacheKey(
                 trackNumberId = tnId,
                 trackNumberVersion = tnOfficialVersion,
                 referenceLineVersion = rlOfficial.rowVersion,
-                kmPostVersions = listOf(kmPost1Official.rowVersion, kmPost3OnlyOfficial.rowVersion)
-            ),
+                kmPostVersions =
+                    listOf(kmPost1Official.rowVersion, kmPost3OnlyOfficial.rowVersion)),
             officialKey,
         )
 
-        val draftKey = geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.draft, tnId)!!
+        val draftKey =
+            geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.draft, tnId)!!
         assertEquals(
             LayoutGeocodingContextCacheKey(
                 trackNumberId = tnId,
                 trackNumberVersion = tnDraft.rowVersion,
                 referenceLineVersion = rlDraft.rowVersion,
-                kmPostVersions = listOf(
-                    kmPost1Draft.rowVersion,
-                    kmPost2OnlyDraft.rowVersion,
-                    kmPost3OnlyOfficial.rowVersion,
-                ),
+                kmPostVersions =
+                    listOf(
+                        kmPost1Draft.rowVersion,
+                        kmPost2OnlyDraft.rowVersion,
+                        kmPost3OnlyOfficial.rowVersion,
+                    ),
             ),
             draftKey,
         )
@@ -109,41 +116,54 @@ class GeocodingDaoIT @Autowired constructor(
         // Publishing everything is the same as regular draft
         assertEquals(
             draftKey,
-            geocodingDao.getLayoutGeocodingContextCacheKey(tnId, validationVersions(
-                trackNumbers = listOf(tnDraft),
-                referenceLines = listOf(rlDraft),
-                kmPosts = listOf(kmPost1Draft, kmPost2OnlyDraft),
-            )),
+            geocodingDao.getLayoutGeocodingContextCacheKey(
+                tnId,
+                validationVersions(
+                    trackNumbers = listOf(tnDraft),
+                    referenceLines = listOf(rlDraft),
+                    kmPosts = listOf(kmPost1Draft, kmPost2OnlyDraft),
+                )),
         )
 
         // Publishing partial combines official with requested draft parts
         assertEquals(
             officialKey.copy(trackNumberVersion = tnDraft.rowVersion),
-            geocodingDao.getLayoutGeocodingContextCacheKey(tnId, validationVersions(
-                trackNumbers = listOf(tnDraft),
-            )),
+            geocodingDao.getLayoutGeocodingContextCacheKey(
+                tnId,
+                validationVersions(
+                    trackNumbers = listOf(tnDraft),
+                )),
         )
         assertEquals(
             officialKey.copy(referenceLineVersion = rlDraft.rowVersion),
-            geocodingDao.getLayoutGeocodingContextCacheKey(tnId, validationVersions(
-                referenceLines = listOf(rlDraft),
-            )),
+            geocodingDao.getLayoutGeocodingContextCacheKey(
+                tnId,
+                validationVersions(
+                    referenceLines = listOf(rlDraft),
+                )),
         )
         assertEquals(
-            officialKey.copy(kmPostVersions = listOf(
-                kmPost1Draft.rowVersion,
-                kmPost2OnlyDraft.rowVersion,
-                kmPost3OnlyOfficial.rowVersion,
-            )),
-            geocodingDao.getLayoutGeocodingContextCacheKey(tnId, validationVersions(
-                kmPosts = listOf(kmPost1Draft, kmPost2OnlyDraft),
-            )),
+            officialKey.copy(
+                kmPostVersions =
+                    listOf(
+                        kmPost1Draft.rowVersion,
+                        kmPost2OnlyDraft.rowVersion,
+                        kmPost3OnlyOfficial.rowVersion,
+                    )),
+            geocodingDao.getLayoutGeocodingContextCacheKey(
+                tnId,
+                validationVersions(
+                    kmPosts = listOf(kmPost1Draft, kmPost2OnlyDraft),
+                )),
         )
         assertEquals(
-            officialKey.copy(kmPostVersions = listOf(kmPost1Draft.rowVersion, kmPost3OnlyOfficial.rowVersion)),
-            geocodingDao.getLayoutGeocodingContextCacheKey(tnId, validationVersions(
-                kmPosts = listOf(kmPost1Draft),
-            )),
+            officialKey.copy(
+                kmPostVersions = listOf(kmPost1Draft.rowVersion, kmPost3OnlyOfficial.rowVersion)),
+            geocodingDao.getLayoutGeocodingContextCacheKey(
+                tnId,
+                validationVersions(
+                    kmPosts = listOf(kmPost1Draft),
+                )),
         )
     }
 
@@ -168,9 +188,12 @@ class GeocodingDaoIT @Autowired constructor(
         mainDraftContext.insert(kmPost(tnId, KmNumber(10)))
 
         // Add some design changes
-        val tnDesignV1 = officialDesignContext.copyFrom(tnMainV1, officialRowId = tnMainV1.rowId).rowVersion
-        val rlDesignV1 = officialDesignContext.copyFrom(rlMainV1, officialRowId = rlMainV1.rowId).rowVersion
-        val kmp1DesignV1 = officialDesignContext.copyFrom(kmp1MainV1, officialRowId = kmp1MainV1.rowId).rowVersion
+        val tnDesignV1 =
+            officialDesignContext.copyFrom(tnMainV1, officialRowId = tnMainV1.rowId).rowVersion
+        val rlDesignV1 =
+            officialDesignContext.copyFrom(rlMainV1, officialRowId = rlMainV1.rowId).rowVersion
+        val kmp1DesignV1 =
+            officialDesignContext.copyFrom(kmp1MainV1, officialRowId = kmp1MainV1.rowId).rowVersion
         val kmp3DesignV1 = officialDesignContext.insert(kmPost(tnId, KmNumber(3))).rowVersion
 
         // Design-draft changes should not affect results either
@@ -179,15 +202,24 @@ class GeocodingDaoIT @Autowired constructor(
         designDraftContext.insert(kmPost(tnId, KmNumber(11)))
 
         val version1Time = testDBService.layoutChangeTime()
-        Thread.sleep(1) // Ensure that later objects get a new changetime so that moment-fetch makes sense
+        Thread.sleep(
+            1) // Ensure that later objects get a new changetime so that moment-fetch makes sense
 
-        val mainKeyV1 = geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId).also { key ->
-            assertEquals(geocodingContextCacheKey(tnId, tnMainV1, rlMainV1, kmp1MainV1, kmp2MainV1), key)
-        }
+        val mainKeyV1 =
+            geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId).also {
+                key ->
+                assertEquals(
+                    geocodingContextCacheKey(tnId, tnMainV1, rlMainV1, kmp1MainV1, kmp2MainV1), key)
+            }
 
-        val designKeyV1 = geocodingDao.getLayoutGeocodingContextCacheKey(designBranch.official, tnId).also { key ->
-            assertEquals(geocodingContextCacheKey(tnId, tnDesignV1, rlDesignV1, kmp1DesignV1, kmp2MainV1, kmp3DesignV1), key)
-        }
+        val designKeyV1 =
+            geocodingDao.getLayoutGeocodingContextCacheKey(designBranch.official, tnId).also { key
+                ->
+                assertEquals(
+                    geocodingContextCacheKey(
+                        tnId, tnDesignV1, rlDesignV1, kmp1DesignV1, kmp2MainV1, kmp3DesignV1),
+                    key)
+            }
 
         // --- Version 2
 
@@ -207,15 +239,26 @@ class GeocodingDaoIT @Autowired constructor(
         val kmp3DesignV2 = testDBService.update(kmp3DesignV1).rowVersion
 
         val version2Time = testDBService.layoutChangeTime()
-        Thread.sleep(1) // Ensure that later objects get a new changetime so that moment-fetch makes sense
+        Thread.sleep(
+            1) // Ensure that later objects get a new changetime so that moment-fetch makes sense
 
-        val mainKeyV2 = geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId).also { key ->
-            assertEquals(geocodingContextCacheKey(tnId, tnMainV2, rlMainV2, kmp1MainV2, kmp2MainV1, kmp4MainV2), key)
-        }
+        val mainKeyV2 =
+            geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId).also {
+                key ->
+                assertEquals(
+                    geocodingContextCacheKey(
+                        tnId, tnMainV2, rlMainV2, kmp1MainV2, kmp2MainV1, kmp4MainV2),
+                    key)
+            }
 
-        val designKeyV2 = geocodingDao.getLayoutGeocodingContextCacheKey(designBranch.official, tnId).also { key ->
-            assertEquals(geocodingContextCacheKey(tnId, tnDesignV2, rlDesignV2, kmp2MainV1, kmp3DesignV2, kmp4MainV2), key)
-        }
+        val designKeyV2 =
+            geocodingDao.getLayoutGeocodingContextCacheKey(designBranch.official, tnId).also { key
+                ->
+                assertEquals(
+                    geocodingContextCacheKey(
+                        tnId, tnDesignV2, rlDesignV2, kmp2MainV1, kmp3DesignV2, kmp4MainV2),
+                    key)
+            }
 
         // --- Version 3
 
@@ -229,19 +272,41 @@ class GeocodingDaoIT @Autowired constructor(
 
         val version3Time = testDBService.layoutChangeTime()
 
-        val mainKeyV3 = geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId).also { key ->
-            assertEquals(geocodingContextCacheKey(tnId, tnMainV2, rlMainV2, kmp1MainV2, kmp3MainV3, kmp4MainV2), key)
-        }
-        val designKeyV3 = geocodingDao.getLayoutGeocodingContextCacheKey(designBranch.official, tnId).also { key ->
-            assertEquals(geocodingContextCacheKey(tnId, tnDesignV2, rlMainV2, kmp1MainV2, kmp3MainV3, kmp4MainV2), key)
-        }
+        val mainKeyV3 =
+            geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId).also {
+                key ->
+                assertEquals(
+                    geocodingContextCacheKey(
+                        tnId, tnMainV2, rlMainV2, kmp1MainV2, kmp3MainV3, kmp4MainV2),
+                    key)
+            }
+        val designKeyV3 =
+            geocodingDao.getLayoutGeocodingContextCacheKey(designBranch.official, tnId).also { key
+                ->
+                assertEquals(
+                    geocodingContextCacheKey(
+                        tnId, tnDesignV2, rlMainV2, kmp1MainV2, kmp3MainV3, kmp4MainV2),
+                    key)
+            }
 
         // Verify fetching each key with time
-        assertEquals(mainKeyV1, geocodingDao.getLayoutGeocodingContextCacheKey(LayoutBranch.main, tnId, version1Time))
-        assertEquals(designKeyV1, geocodingDao.getLayoutGeocodingContextCacheKey(designBranch, tnId, version1Time))
-        assertEquals(mainKeyV2, geocodingDao.getLayoutGeocodingContextCacheKey(LayoutBranch.main, tnId, version2Time))
-        assertEquals(designKeyV2, geocodingDao.getLayoutGeocodingContextCacheKey(designBranch, tnId, version2Time))
-        assertEquals(mainKeyV3, geocodingDao.getLayoutGeocodingContextCacheKey(LayoutBranch.main, tnId, version3Time))
-        assertEquals(designKeyV3, geocodingDao.getLayoutGeocodingContextCacheKey(designBranch, tnId, version3Time))
+        assertEquals(
+            mainKeyV1,
+            geocodingDao.getLayoutGeocodingContextCacheKey(LayoutBranch.main, tnId, version1Time))
+        assertEquals(
+            designKeyV1,
+            geocodingDao.getLayoutGeocodingContextCacheKey(designBranch, tnId, version1Time))
+        assertEquals(
+            mainKeyV2,
+            geocodingDao.getLayoutGeocodingContextCacheKey(LayoutBranch.main, tnId, version2Time))
+        assertEquals(
+            designKeyV2,
+            geocodingDao.getLayoutGeocodingContextCacheKey(designBranch, tnId, version2Time))
+        assertEquals(
+            mainKeyV3,
+            geocodingDao.getLayoutGeocodingContextCacheKey(LayoutBranch.main, tnId, version3Time))
+        assertEquals(
+            designKeyV3,
+            geocodingDao.getLayoutGeocodingContextCacheKey(designBranch, tnId, version3Time))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingServiceIT.kt
@@ -8,73 +8,82 @@ import fi.fta.geoviite.infra.math.AngularUnit
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.ui.testdata.createGeometryKmPost
+import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class GeocodingServiceIT @Autowired constructor(
+class GeocodingServiceIT
+@Autowired
+constructor(
     private val geocodingService: GeocodingService,
     private val geometryDao: GeometryDao,
 ) : DBTestBase() {
 
     @Test
     fun `geocoding context can be generated from geometry plan`() {
-        val plan = minimalPlan().copy(
-            units = GeometryUnits(
-                coordinateSystemSrid = LAYOUT_SRID,
-                coordinateSystemName = null,
-                verticalCoordinateSystem = null,
-                directionUnit = AngularUnit.GRADS,
-                linearUnit = LinearUnit.METER,
-            ),
-            alignments = listOf(
-                geometryAlignment(
-                    listOf(
-                        // reference line goes straight up
-                        line(Point(450000.0, 7000000.0), Point(450000.0, 7000020.0)),
-                    ),
-                    featureTypeCode = FeatureTypeCode("111"),
+        val plan =
+            minimalPlan()
+                .copy(
+                    units =
+                        GeometryUnits(
+                            coordinateSystemSrid = LAYOUT_SRID,
+                            coordinateSystemName = null,
+                            verticalCoordinateSystem = null,
+                            directionUnit = AngularUnit.GRADS,
+                            linearUnit = LinearUnit.METER,
+                        ),
+                    alignments =
+                        listOf(
+                            geometryAlignment(
+                                listOf(
+                                    // reference line goes straight up
+                                    line(Point(450000.0, 7000000.0), Point(450000.0, 7000020.0)),
+                                ),
+                                featureTypeCode = FeatureTypeCode("111"),
+                            ),
+                            geometryAlignment(
+                                listOf(
+                                    // location track goes somewhere that doesn't matter (but
+                                    // actually just goes diagonally)
+                                    line(Point(450000.0, 7000000.0), Point(450020.0, 7000020.0)),
+                                ),
+                                featureTypeCode = FeatureTypeCode("121"),
+                            ),
+                        ),
+                    kmPosts =
+                        listOf(
+                            createGeometryKmPost(
+                                null, "0140", staInternal = BigDecimal.valueOf(-100L)),
+                            createGeometryKmPost(Point(450000.0, 7000010.0), "0141")),
+                )
+        val planVersion =
+            geometryDao.insertPlan(
+                plan,
+                InfraModelFile(plan.fileName, "<plan />"),
+                listOf(
+                    Point(450000.0, 7000000.0),
+                    Point(460000.0, 7000000.0),
+                    Point(460000.0, 7100000.0),
+                    Point(450000.0, 7100000.0),
+                    Point(450000.0, 7000000.0),
                 ),
-                geometryAlignment(
-                    listOf(
-                        // location track goes somewhere that doesn't matter (but actually just goes diagonally)
-                        line(Point(450000.0, 7000000.0), Point(450020.0, 7000020.0)),
-                    ),
-                    featureTypeCode = FeatureTypeCode("121"),
-                ),
-            ),
-            kmPosts = listOf(
-                createGeometryKmPost(null, "0140", staInternal = BigDecimal.valueOf(-100L)),
-                createGeometryKmPost(Point(450000.0, 7000010.0), "0141")
-            ),
-        )
-        val planVersion = geometryDao.insertPlan(
-            plan, InfraModelFile(plan.fileName, "<plan />"),
-            listOf(
-                Point(450000.0, 7000000.0),
-                Point(460000.0, 7000000.0),
-                Point(460000.0, 7100000.0),
-                Point(450000.0, 7100000.0),
-                Point(450000.0, 7000000.0),
-            ),
-        )
+            )
         val context = geocodingService.getGeocodingContext(TrackNumber("foo"), planVersion)
         assertNotNull(context)
         context!!
         assertEquals(
-            // alignment started 100 meters in per the preceding km post, and we're 5 meters up of the start
+            // alignment started 100 meters in per the preceding km post, and we're 5 meters up of
+            // the start
             TrackMeter(KmNumber("0140"), BigDecimal.valueOf(105)),
-            context.getAddress(Point(450000.0, 7000005.0), 0)!!.first
-        )
+            context.getAddress(Point(450000.0, 7000005.0), 0)!!.first)
         assertEquals(
             TrackMeter(KmNumber("0141"), BigDecimal.valueOf(5)),
-            context.getAddress(Point(450000.0, 7000015.0), 0)!!.first
-        )
+            context.getAddress(Point(450000.0, 7000015.0), 0)!!.first)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -25,95 +25,123 @@ import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 import kotlin.math.PI
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 const val DELTA = 0.000001
 
-val segment1 = segment(
-    Point(x = 385757.97156912443, y = 6672279.269578109),
-    Point(x = 385711.5357118625, y = 6672843.197750405),
-    Point(x = 385626.95239453146, y = 6673453.008328755),
-    Point(x = 385565.58700583136, y = 6673780.854820957),
-    Point(x = 385493.5620447163, y = 6674327.448223977),
-    Point(x = 385482.9024723013, y = 6674546.195134795),
-    Point(x = 385424.6330188301, y = 6674981.630668635),
-    Point(x = 385377.0231377738, y = 6675198.319291654),
-    Point(x = 385273.0397969192, y = 6675558.0948048225),
-    Point(x = 385216.6663371209, y = 6675701.1816949705),
-    Point(x = 385081.84688330034, y = 6675970.204397376),
-    startM = 0.0,
-)
-val segment2 = segment(
-    Point(x = 385081.84688330034, y = 6675970.204397376),
-    Point(x = 385003.4008892781, y = 6676096.140209634),
-    Point(x = 384824.43636700965, y = 6676330.8607562585),
-    Point(x = 384723.9178387635, y = 6676439.645490625),
-    Point(x = 384461.0552224484, y = 6676692.609084033),
-    Point(x = 384298.7111343796, y = 6676836.7879430745),
-    Point(x = 383962.4566625423, y = 6677106.147418647),
-    Point(x = 383614.6358950054, y = 6677356.508651709),
-    Point(x = 383257.66521149303, y = 6677624.701901384),
-    Point(x = 383079.07071553095, y = 6677746.511026372),
-    Point(x = 382959.97133348766, y = 6677823.621276415),
-    Point(x = 382900.3670653631, y = 6677856.032651512),
-    Point(x = 382761.2176702685, y = 6677923.467526838),
-    Point(x = 382711.47467736073, y = 6677942.28533952),
-    startM = segment1.startM + segment1.length
-)
-val segment3 = segment(
-    Point(x = 382711.47467736073, y = 6677942.28533952),
-    Point(x = 382616.9193291537, y = 6677973.124183675),
-    Point(x = 382572.1069738545, y = 6677985.145215148),
-    Point(x = 382487.4129008643, y = 6678002.390496888),
-    Point(x = 382447.5311831734, y = 6678007.614747154),
-    Point(x = 382239.6534347426, y = 6678014.43348008),
-    Point(x = 381903.6613732627, y = 6678017.6224454),
-    Point(x = 381500.8788447162, y = 6677988.736686744),
-    Point(x = 381098.351281938, y = 6677939.405604937),
-    Point(x = 380696.0786849283, y = 6677869.629199982),
-    Point(x = 380075.3780522702, y = 6677812.131510135),
-    Point(x = 379546.59970029286, y = 6677795.661380321),
-    Point(x = 379109.7436289962, y = 6677820.218810541),
-    startM = segment2.startM + segment2.length
-)
+val segment1 =
+    segment(
+        Point(x = 385757.97156912443, y = 6672279.269578109),
+        Point(x = 385711.5357118625, y = 6672843.197750405),
+        Point(x = 385626.95239453146, y = 6673453.008328755),
+        Point(x = 385565.58700583136, y = 6673780.854820957),
+        Point(x = 385493.5620447163, y = 6674327.448223977),
+        Point(x = 385482.9024723013, y = 6674546.195134795),
+        Point(x = 385424.6330188301, y = 6674981.630668635),
+        Point(x = 385377.0231377738, y = 6675198.319291654),
+        Point(x = 385273.0397969192, y = 6675558.0948048225),
+        Point(x = 385216.6663371209, y = 6675701.1816949705),
+        Point(x = 385081.84688330034, y = 6675970.204397376),
+        startM = 0.0,
+    )
+val segment2 =
+    segment(
+        Point(x = 385081.84688330034, y = 6675970.204397376),
+        Point(x = 385003.4008892781, y = 6676096.140209634),
+        Point(x = 384824.43636700965, y = 6676330.8607562585),
+        Point(x = 384723.9178387635, y = 6676439.645490625),
+        Point(x = 384461.0552224484, y = 6676692.609084033),
+        Point(x = 384298.7111343796, y = 6676836.7879430745),
+        Point(x = 383962.4566625423, y = 6677106.147418647),
+        Point(x = 383614.6358950054, y = 6677356.508651709),
+        Point(x = 383257.66521149303, y = 6677624.701901384),
+        Point(x = 383079.07071553095, y = 6677746.511026372),
+        Point(x = 382959.97133348766, y = 6677823.621276415),
+        Point(x = 382900.3670653631, y = 6677856.032651512),
+        Point(x = 382761.2176702685, y = 6677923.467526838),
+        Point(x = 382711.47467736073, y = 6677942.28533952),
+        startM = segment1.startM + segment1.length)
+val segment3 =
+    segment(
+        Point(x = 382711.47467736073, y = 6677942.28533952),
+        Point(x = 382616.9193291537, y = 6677973.124183675),
+        Point(x = 382572.1069738545, y = 6677985.145215148),
+        Point(x = 382487.4129008643, y = 6678002.390496888),
+        Point(x = 382447.5311831734, y = 6678007.614747154),
+        Point(x = 382239.6534347426, y = 6678014.43348008),
+        Point(x = 381903.6613732627, y = 6678017.6224454),
+        Point(x = 381500.8788447162, y = 6677988.736686744),
+        Point(x = 381098.351281938, y = 6677939.405604937),
+        Point(x = 380696.0786849283, y = 6677869.629199982),
+        Point(x = 380075.3780522702, y = 6677812.131510135),
+        Point(x = 379546.59970029286, y = 6677795.661380321),
+        Point(x = 379109.7436289962, y = 6677820.218810541),
+        startM = segment2.startM + segment2.length)
 val alignment = alignment(segment1, segment2, segment3)
 val startAddress = TrackMeter(KmNumber(2), 150)
-val addressPoints = listOf(
-    GeocodingReferencePoint(startAddress.kmNumber, startAddress.meters, 0.0, 0.0, WITHIN),
-    GeocodingReferencePoint(KmNumber(3), BigDecimal.ZERO, alignment.length / 5, 0.0, WITHIN),
-    GeocodingReferencePoint(KmNumber(4), BigDecimal.ZERO, 2 * alignment.length / 5, 0.0, WITHIN),
-    GeocodingReferencePoint(KmNumber(5, "A"), BigDecimal.ZERO, 3 * alignment.length / 5, 0.0, WITHIN),
-    GeocodingReferencePoint(KmNumber(5, "B"), BigDecimal.ZERO, 4 * alignment.length / 5, 0.0, WITHIN),
-)
+val addressPoints =
+    listOf(
+        GeocodingReferencePoint(startAddress.kmNumber, startAddress.meters, 0.0, 0.0, WITHIN),
+        GeocodingReferencePoint(KmNumber(3), BigDecimal.ZERO, alignment.length / 5, 0.0, WITHIN),
+        GeocodingReferencePoint(
+            KmNumber(4), BigDecimal.ZERO, 2 * alignment.length / 5, 0.0, WITHIN),
+        GeocodingReferencePoint(
+            KmNumber(5, "A"), BigDecimal.ZERO, 3 * alignment.length / 5, 0.0, WITHIN),
+        GeocodingReferencePoint(
+            KmNumber(5, "B"), BigDecimal.ZERO, 4 * alignment.length / 5, 0.0, WITHIN),
+    )
 val trackNumber: TrackNumber = TrackNumber("T001")
-val kmPostLocations = (0..5).map { i ->
-    val alignmentPoint = alignment.getPointAtM(i * alignment.length / 5)
-    checkNotNull(alignmentPoint?.toPoint())
-}
+val kmPostLocations =
+    (0..5).map { i ->
+        val alignmentPoint = alignment.getPointAtM(i * alignment.length / 5)
+        checkNotNull(alignmentPoint?.toPoint())
+    }
 
-val kmPosts = listOf(
-    kmPost(trackNumberId = null, km = startAddress.kmNumber, roughLayoutLocation = kmPostLocations[0], draft = false),
-    kmPost(trackNumberId = null, km = KmNumber(3), roughLayoutLocation = kmPostLocations[1], draft = false),
-    kmPost(trackNumberId = null, km = KmNumber(4), roughLayoutLocation = kmPostLocations[2], draft = false),
-    kmPost(trackNumberId = null, km = KmNumber(5, "A"), roughLayoutLocation = kmPostLocations[3], draft = false),
-    kmPost(trackNumberId = null, km = KmNumber(5, "B"), roughLayoutLocation = kmPostLocations[4], draft = false),
-)
-val context = GeocodingContext(
-    trackNumber,
-    startAddress,
-    alignment,
-    addressPoints,
-    // test-data is inaccurate so allow more delta in validation
-    projectionLineDistanceDeviation = 0.05,
-    projectionLineMaxAngleDelta = PI / 16,
-)
+val kmPosts =
+    listOf(
+        kmPost(
+            trackNumberId = null,
+            km = startAddress.kmNumber,
+            roughLayoutLocation = kmPostLocations[0],
+            draft = false),
+        kmPost(
+            trackNumberId = null,
+            km = KmNumber(3),
+            roughLayoutLocation = kmPostLocations[1],
+            draft = false),
+        kmPost(
+            trackNumberId = null,
+            km = KmNumber(4),
+            roughLayoutLocation = kmPostLocations[2],
+            draft = false),
+        kmPost(
+            trackNumberId = null,
+            km = KmNumber(5, "A"),
+            roughLayoutLocation = kmPostLocations[3],
+            draft = false),
+        kmPost(
+            trackNumberId = null,
+            km = KmNumber(5, "B"),
+            roughLayoutLocation = kmPostLocations[4],
+            draft = false),
+    )
+val context =
+    GeocodingContext(
+        trackNumber,
+        startAddress,
+        alignment,
+        addressPoints,
+        // test-data is inaccurate so allow more delta in validation
+        projectionLineDistanceDeviation = 0.05,
+        projectionLineMaxAngleDelta = PI / 16,
+    )
 
 class GeocodingTest {
 
@@ -122,11 +150,13 @@ class GeocodingTest {
         val endAddress = context.projectionLines.last().address
         assertEquals(
             listOf(startAddress..endAddress),
-            context.cutRangeByKms((startAddress - 100.0)..(endAddress + 100.0), context.allKms.toSet()),
+            context.cutRangeByKms(
+                (startAddress - 100.0)..(endAddress + 100.0), context.allKms.toSet()),
         )
         assertEquals(
             listOf(),
-            context.cutRangeByKms((endAddress + 100.0)..(endAddress + 200.0), context.allKms.toSet()),
+            context.cutRangeByKms(
+                (endAddress + 100.0)..(endAddress + 200.0), context.allKms.toSet()),
         )
     }
 
@@ -223,12 +253,16 @@ class GeocodingTest {
 
     @Test
     fun projectionLinesAndReverseGeocodingAgree() {
-        val projections = (listOf(context.startProjection) + context.projectionLines + listOf(context.endProjection))
+        val projections =
+            (listOf(context.startProjection) +
+                context.projectionLines +
+                listOf(context.endProjection))
         projections.forEachIndexed { index, proj ->
-            if (index > 0) assertTrue(
-                projections[index - 1].address <= proj.address,
-                "Projections should be in increasing order: index=$index prev=${projections[index-1].address} next=${proj.address}",
-            )
+            if (index > 0)
+                assertTrue(
+                    projections[index - 1].address <= proj.address,
+                    "Projections should be in increasing order: index=$index prev=${projections[index-1].address} next=${proj.address}",
+                )
             val decimals = proj.address.decimalCount()
             assertEquals(proj.address, context.getAddress(proj.projection.start, decimals)!!.first)
             val pointAside = linePointAtDistance(proj.projection, 1.0)
@@ -239,47 +273,54 @@ class GeocodingTest {
     @Test
     fun projectionIsFoundForAddress() {
         listOf(
-            TrackMeter(KmNumber(5, "A"), 0),
-            TrackMeter(KmNumber(5, "A"), 10),
-            TrackMeter(KmNumber(5, "A"), 10.6, 1),
-            TrackMeter(KmNumber(5, "A"), 10.152, 3),
-        ).forEach { address ->
-            val projection = context.getProjectionLine(address)
-            assertNotNull(projection)
-            assertEquals(address, projection.address)
-        }
+                TrackMeter(KmNumber(5, "A"), 0),
+                TrackMeter(KmNumber(5, "A"), 10),
+                TrackMeter(KmNumber(5, "A"), 10.6, 1),
+                TrackMeter(KmNumber(5, "A"), 10.152, 3),
+            )
+            .forEach { address ->
+                val projection = context.getProjectionLine(address)
+                assertNotNull(projection)
+                assertEquals(address, projection.address)
+            }
     }
 
     @Test
     fun generatedSegmentsProjectWithSurroundingDirection() {
-        val startSegment = segment(
-            Point(-0.7, 0.0),
-            Point(1.0, 2.0),
-            Point(3.0, 4.0),
-            startM = 10.0,
-            source = PLAN,
-        )
-        val connectSegment = segment(
-            Point(3.0, 4.0),
-            Point(3.0, 6.0),
-            startM = startSegment.startM + startSegment.length,
-            source = GENERATED,
-        )
-        val endSegment = segment(
-            Point(3.0, 6.0),
-            Point(7.0, 10.0),
-            startM = connectSegment.startM + connectSegment.length,
-            source = PLAN,
-        )
+        val startSegment =
+            segment(
+                Point(-0.7, 0.0),
+                Point(1.0, 2.0),
+                Point(3.0, 4.0),
+                startM = 10.0,
+                source = PLAN,
+            )
+        val connectSegment =
+            segment(
+                Point(3.0, 4.0),
+                Point(3.0, 6.0),
+                startM = startSegment.startM + startSegment.length,
+                source = GENERATED,
+            )
+        val endSegment =
+            segment(
+                Point(3.0, 6.0),
+                Point(7.0, 10.0),
+                startM = connectSegment.startM + connectSegment.length,
+                source = PLAN,
+            )
         val startAddress = TrackMeter(KmNumber(2), 100)
-        val ctx = GeocodingContext.create(
-            trackNumber = TrackNumber("T001"),
-            startAddress = startAddress,
-            referenceLineGeometry = alignment(startSegment, connectSegment, endSegment),
-            kmPosts = listOf(),
-        ).geocodingContext
+        val ctx =
+            GeocodingContext.create(
+                    trackNumber = TrackNumber("T001"),
+                    startAddress = startAddress,
+                    referenceLineGeometry = alignment(startSegment, connectSegment, endSegment),
+                    kmPosts = listOf(),
+                )
+                .geocodingContext
 
-        val addressPoints = ctx.getAddressPoints(alignment(segment(Point(7.0, -2.0), Point(7.0, 8.0))))
+        val addressPoints =
+            ctx.getAddressPoints(alignment(segment(Point(7.0, -2.0), Point(7.0, 8.0))))
         assertNotNull(addressPoints)
 
         assertTrue((Point(7.0, -2.0)).isSame(addressPoints.startPoint.point, 0.0001))
@@ -302,30 +343,35 @@ class GeocodingTest {
         val projection1 = Line(Point(100.0, 100.0), Point(0.0, 200.0))
         val projection2 = Line(Point(60.0, 175.0), Point(80.0, 195.0))
         val projection3 = Line(Point(195.0, 200.0), Point(145.0, 250.0))
-        val points1 = toSegmentPoints(
-            Point(0.0, 0.0),
-            Point(20.0, 50.0),
-            Point(20.0, 100.0),
-            // This interval is where projection1 should hit at 50,150 = 0.5
-            Point(80.0, 200.0),
-            // This interval is where projection2 should hit at 90,205 = 0.25
-            Point(120.0, 220.0),
-        )
-        val points2 = toSegmentPoints(
-            Point(140.0, 220.0),
-            Point(160.0, 230.0),
-            // This interval is where projection3 should hit at 170,225 = 0.5
-            Point(180.0, 220.0),
-        )
-        val points = points1 + points2
-        val edges = points.mapIndexedNotNull { index: Int, point: SegmentPoint ->
-            if (index == 0) null else PolyLineEdge(
-                start = points[index - 1],
-                end = point,
-                segmentStart = if (index <= points1.lastIndex) 0.0 else points1.last().m,
-                projectionDirection = directionBetweenPoints(points[index - 1], point),
+        val points1 =
+            toSegmentPoints(
+                Point(0.0, 0.0),
+                Point(20.0, 50.0),
+                Point(20.0, 100.0),
+                // This interval is where projection1 should hit at 50,150 = 0.5
+                Point(80.0, 200.0),
+                // This interval is where projection2 should hit at 90,205 = 0.25
+                Point(120.0, 220.0),
             )
-        }
+        val points2 =
+            toSegmentPoints(
+                Point(140.0, 220.0),
+                Point(160.0, 230.0),
+                // This interval is where projection3 should hit at 170,225 = 0.5
+                Point(180.0, 220.0),
+            )
+        val points = points1 + points2
+        val edges =
+            points.mapIndexedNotNull { index: Int, point: SegmentPoint ->
+                if (index == 0) null
+                else
+                    PolyLineEdge(
+                        start = points[index - 1],
+                        end = point,
+                        segmentStart = if (index <= points1.lastIndex) 0.0 else points1.last().m,
+                        projectionDirection = directionBetweenPoints(points[index - 1], point),
+                    )
+            }
 
         val intersection1 = getIntersection(projection1, edges)
         assertNotNull(intersection1)
@@ -358,21 +404,23 @@ class GeocodingTest {
     fun projectionLinesAreCreatedCorrectly() {
         val start = Point(385757.97, 6672279.26)
         // Points along rising Y-axis for understandable test calculations
-        val alignment = alignmentFromPoints(
-            start,
-            start + Point(0.0, 2.0),
-            start + Point(0.0, 4.0),
-            start + Point(0.0, 6.0),
-        )
-        val projectionContext = GeocodingContext(
-            trackNumber = trackNumber,
-            startAddress = startAddress,
-            referenceLineGeometry = alignment,
-            referencePoints = listOf(
-                GeocodingReferencePoint(KmNumber(2), BigDecimal("100.0"), 0.0, 0.0, WITHIN),
-                GeocodingReferencePoint(KmNumber(3), BigDecimal("0.0"), 3.0, 0.0, WITHIN),
+        val alignment =
+            alignmentFromPoints(
+                start,
+                start + Point(0.0, 2.0),
+                start + Point(0.0, 4.0),
+                start + Point(0.0, 6.0),
             )
-        )
+        val projectionContext =
+            GeocodingContext(
+                trackNumber = trackNumber,
+                startAddress = startAddress,
+                referenceLineGeometry = alignment,
+                referencePoints =
+                    listOf(
+                        GeocodingReferencePoint(KmNumber(2), BigDecimal("100.0"), 0.0, 0.0, WITHIN),
+                        GeocodingReferencePoint(KmNumber(3), BigDecimal("0.0"), 3.0, 0.0, WITHIN),
+                    ))
         // As lines go straight up, projections should go 100m to the left from there
         val projectionOffset = Point(-100.0, 0.0)
         fun projectionLine(point: Point): Line = Line(point, point + projectionOffset)
@@ -391,59 +439,65 @@ class GeocodingTest {
 
         // Dynamically created projections between even meters
         listOf(
-            TrackMeter(2, 101.000, 3) to start + Point(0.0, 1.0),
-            TrackMeter(2, 101.1, 1) to start + Point(0.0, 1.1),
-            TrackMeter(2, 101.92, 2) to start + Point(0.0, 1.92),
-            TrackMeter(2, 101.456, 3) to start + Point(0.0, 1.456),
-            TrackMeter(3, 0.12, 2) to start + Point(0.0, 3.12),
-        ).forEach { (address, point) ->
-            val projectionLine = projectionContext.getProjectionLine(address)
-            assertNotNull(projectionLine)
-            assertProjectionLineMatches(projectionLine, address, projectionLine(point))
-        }
+                TrackMeter(2, 101.000, 3) to start + Point(0.0, 1.0),
+                TrackMeter(2, 101.1, 1) to start + Point(0.0, 1.1),
+                TrackMeter(2, 101.92, 2) to start + Point(0.0, 1.92),
+                TrackMeter(2, 101.456, 3) to start + Point(0.0, 1.456),
+                TrackMeter(3, 0.12, 2) to start + Point(0.0, 3.12),
+            )
+            .forEach { (address, point) ->
+                val projectionLine = projectionContext.getProjectionLine(address)
+                assertNotNull(projectionLine)
+                assertProjectionLineMatches(projectionLine, address, projectionLine(point))
+            }
     }
 
     @Test
     fun geocodingWorks() {
         // Straight horizontal reference line for understandable calc
-        val context = createContext(
-            geometryPoints = listOf(Point(0.0, 0.0), Point(10.0, 0.0)),
-            startAddress = TrackMeter(1, "51.4"),
-            referencePoints = listOf(TrackMeter(2, "0.0") to 5.0),
-        )
+        val context =
+            createContext(
+                geometryPoints = listOf(Point(0.0, 0.0), Point(10.0, 0.0)),
+                startAddress = TrackMeter(1, "51.4"),
+                referencePoints = listOf(TrackMeter(2, "0.0") to 5.0),
+            )
         // Geocode on 45deg diagonal alignment above the reference line
         val trackAlignment = alignment(segment(Point(1.1, 1.1), Point(8.9, 8.9)))
 
         // Verify basic ends + 1m points
         val addressPoints = context.getAddressPoints(trackAlignment)
-        assertAddressPoint(addressPoints?.startPoint, TrackMeter(1, "52.500"), trackAlignment.start!!)
+        assertAddressPoint(
+            addressPoints?.startPoint, TrackMeter(1, "52.500"), trackAlignment.start!!)
         assertAddressPoint(addressPoints?.endPoint, TrackMeter(2, "3.900"), trackAlignment.end!!)
         listOf(
-            TrackMeter(1, "53") to Point(1.6, 1.6),
-            TrackMeter(1, "54") to Point(2.6, 2.6),
-            TrackMeter(1, "55") to Point(3.6, 3.6),
-            TrackMeter(1, "56") to Point(4.6, 4.6),
-            TrackMeter(2, "0") to Point(5.0, 5.0),
-            TrackMeter(2, "1") to Point(6.0, 6.0),
-            TrackMeter(2, "2") to Point(7.0, 7.0),
-            TrackMeter(2, "3") to Point(8.0, 8.0),
-        ).forEachIndexed { index, (address, location) ->
-            assertAddressPoint(addressPoints?.midPoints?.getOrNull(index), address, location)
-        }
+                TrackMeter(1, "53") to Point(1.6, 1.6),
+                TrackMeter(1, "54") to Point(2.6, 2.6),
+                TrackMeter(1, "55") to Point(3.6, 3.6),
+                TrackMeter(1, "56") to Point(4.6, 4.6),
+                TrackMeter(2, "0") to Point(5.0, 5.0),
+                TrackMeter(2, "1") to Point(6.0, 6.0),
+                TrackMeter(2, "2") to Point(7.0, 7.0),
+                TrackMeter(2, "3") to Point(8.0, 8.0),
+            )
+            .forEachIndexed { index, (address, location) ->
+                assertAddressPoint(addressPoints?.midPoints?.getOrNull(index), address, location)
+            }
 
         // Verify individual, accurately requested points
         listOf(
-            TrackMeter(1, "52.500") to Point(1.1, 1.1), // start
-            TrackMeter(2, "3.900") to Point(8.9, 8.9), // end
-            TrackMeter(1, "52.501") to Point(1.101, 1.101),
-            TrackMeter(2, "3.899") to Point(8.899, 8.899),
-            TrackMeter(1, "54.132") to Point(2.732, 2.732),
-            TrackMeter(1, "56.1") to Point(4.7, 4.7),
-            TrackMeter(2, "0.1") to Point(5.1, 5.1),
-            TrackMeter(2, "3.12") to Point(8.12, 8.12),
-        ).forEach { (address, location) ->
-            assertAddressPoint(context.getTrackLocation(trackAlignment, address), address, location)
-        }
+                TrackMeter(1, "52.500") to Point(1.1, 1.1), // start
+                TrackMeter(2, "3.900") to Point(8.9, 8.9), // end
+                TrackMeter(1, "52.501") to Point(1.101, 1.101),
+                TrackMeter(2, "3.899") to Point(8.899, 8.899),
+                TrackMeter(1, "54.132") to Point(2.732, 2.732),
+                TrackMeter(1, "56.1") to Point(4.7, 4.7),
+                TrackMeter(2, "0.1") to Point(5.1, 5.1),
+                TrackMeter(2, "3.12") to Point(8.12, 8.12),
+            )
+            .forEach { (address, location) ->
+                assertAddressPoint(
+                    context.getTrackLocation(trackAlignment, address), address, location)
+            }
     }
 
     private fun assertAddressPoint(point: AddressPoint?, address: TrackMeter, location: IPoint) {
@@ -458,22 +512,23 @@ class GeocodingTest {
         referencePoints: List<Pair<TrackMeter, Double>>,
     ): GeocodingContext {
         val alignment = alignment(segment(*geometryPoints.toTypedArray()))
-        val startRefPoint = GeocodingReferencePoint(
-            kmNumber = startAddress.kmNumber,
-            meters = startAddress.meters,
-            distance = 0.0,
-            kmPostOffset = 0.0,
-            intersectType = WITHIN
-        )
-        val combinedReferencePoints = listOf(startRefPoint) + referencePoints.map { (address, distance) ->
+        val startRefPoint =
             GeocodingReferencePoint(
-                kmNumber = address.kmNumber,
-                meters = address.meters,
-                distance = distance,
+                kmNumber = startAddress.kmNumber,
+                meters = startAddress.meters,
+                distance = 0.0,
                 kmPostOffset = 0.0,
-                intersectType = WITHIN
-            )
-        }
+                intersectType = WITHIN)
+        val combinedReferencePoints =
+            listOf(startRefPoint) +
+                referencePoints.map { (address, distance) ->
+                    GeocodingReferencePoint(
+                        kmNumber = address.kmNumber,
+                        meters = address.meters,
+                        distance = distance,
+                        kmPostOffset = 0.0,
+                        intersectType = WITHIN)
+                }
 
         return GeocodingContext(
             trackNumber = trackNumber,
@@ -487,37 +542,42 @@ class GeocodingTest {
     fun projectionsWorkOnVerticalVsDiagonal() {
         val start = Point(428123.459, 7208379.993)
 
-        val verticalPoints = toSegmentPoints((0..3).map { n ->
-            Point3DM(start.x + 0.0, start.y + 3 * n.toDouble(), 3 * n.toDouble())
-        })
+        val verticalPoints =
+            toSegmentPoints(
+                (0..3).map { n ->
+                    Point3DM(start.x + 0.0, start.y + 3 * n.toDouble(), 3 * n.toDouble())
+                })
         val verticalAlignment = alignment(segment(verticalPoints))
-        val verticalContext = GeocodingContext(
-            trackNumber,
-            startAddress,
-            verticalAlignment,
-            listOf(
-                GeocodingReferencePoint(
-                    kmNumber = startAddress.kmNumber,
-                    meters = startAddress.meters,
-                    distance = 0.0,
-                    kmPostOffset = 0.0,
-                    intersectType = WITHIN
-                )
-            ),
-        )
-        val diagonalLine = alignmentFromPoints(
-            start + Point(-52.5, 2.5),
-            start + Point(-47.5, 7.5),
-        )
+        val verticalContext =
+            GeocodingContext(
+                trackNumber,
+                startAddress,
+                verticalAlignment,
+                listOf(
+                    GeocodingReferencePoint(
+                        kmNumber = startAddress.kmNumber,
+                        meters = startAddress.meters,
+                        distance = 0.0,
+                        kmPostOffset = 0.0,
+                        intersectType = WITHIN)),
+            )
+        val diagonalLine =
+            alignmentFromPoints(
+                start + Point(-52.5, 2.5),
+                start + Point(-47.5, 7.5),
+            )
 
         val diagonalCenter = start + Point(-50.0, 5.0)
         assertEquals(5.0, verticalContext.getM(diagonalCenter)!!.first, 0.000001)
-        assertEquals(startAddress + 5.0, verticalContext.getAddress(5.0, startAddress.decimalCount()))
+        assertEquals(
+            startAddress + 5.0, verticalContext.getAddress(5.0, startAddress.decimalCount()))
 
         val projectionLine = verticalContext.getProjectionLine(startAddress + 5.0)
         assertEquals(startAddress + 5.0, projectionLine!!.address)
-        assertApproximatelyEquals(start + Point(0.0, 5.0), projectionLine.projection.start, 0.000001)
-        assertApproximatelyEquals(start + Point(-100.0, 5.0), projectionLine.projection.end, 0.000001)
+        assertApproximatelyEquals(
+            start + Point(0.0, 5.0), projectionLine.projection.start, 0.000001)
+        assertApproximatelyEquals(
+            start + Point(-100.0, 5.0), projectionLine.projection.end, 0.000001)
         assertEquals(PI, projectionLine.projection.angle, 0.000001)
 
         val geocoded = getProjectedAddressPoint(projectionLine, diagonalLine)
@@ -527,73 +587,116 @@ class GeocodingTest {
 
     @Test
     fun sublistForRange() {
-        assertEquals(listOf(2, 3, 4), getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..4), Integer::compare))
-        assertEquals(listOf(2, 3   ), getSublistForRangeInOrderedList(listOf(1, 2, 3,    5), (2..4), Integer::compare))
-        assertEquals(listOf(   3, 4), getSublistForRangeInOrderedList(listOf(1,    3, 4, 5), (2..4), Integer::compare))
-        assertEquals(listOf(2, 3, 4, 5), getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..5), Integer::compare))
-        assertEquals(listOf(2, 3, 4, 5), getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..6), Integer::compare))
-        assertEquals(listOf(1, 2, 3, 4), getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (1..4), Integer::compare))
-        assertEquals(listOf(1, 2, 3, 4), getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (0..4), Integer::compare))
-        assertEquals(listOf(), getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (0..0), Integer::compare))
-        assertEquals(listOf(), getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (6..6), Integer::compare))
-        assertEquals(listOf(), getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..0), Integer::compare))
-        assertEquals(listOf(), getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..1), Integer::compare))
+        assertEquals(
+            listOf(2, 3, 4),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..4), Integer::compare))
+        assertEquals(
+            listOf(2, 3),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 5), (2..4), Integer::compare))
+        assertEquals(
+            listOf(3, 4),
+            getSublistForRangeInOrderedList(listOf(1, 3, 4, 5), (2..4), Integer::compare))
+        assertEquals(
+            listOf(2, 3, 4, 5),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..5), Integer::compare))
+        assertEquals(
+            listOf(2, 3, 4, 5),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..6), Integer::compare))
+        assertEquals(
+            listOf(1, 2, 3, 4),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (1..4), Integer::compare))
+        assertEquals(
+            listOf(1, 2, 3, 4),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (0..4), Integer::compare))
+        assertEquals(
+            listOf(),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (0..0), Integer::compare))
+        assertEquals(
+            listOf(),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (6..6), Integer::compare))
+        assertEquals(
+            listOf(),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..0), Integer::compare))
+        assertEquals(
+            listOf(),
+            getSublistForRangeInOrderedList(listOf(1, 2, 3, 4, 5), (2..1), Integer::compare))
     }
 
     @Test
     fun switchPointsAreFetchedCorrectly() {
         val start = Point(385757.97, 6672279.26)
         val referenceLineAlignment = alignment(segment(start, start + Point(0.0, 100.0)))
-        val referenceLine = referenceLine(
-            trackNumberId = IntId(1),
-            alignment = referenceLineAlignment,
-            startAddress = TrackMeter(10, 0),
-            draft = false,
-        )
-        val testContext = GeocodingContext.create(
-            trackNumber = trackNumber,
-            startAddress = referenceLine.startAddress,
-            referenceLineGeometry = referenceLineAlignment,
-            kmPosts = listOf(),
-        ).geocodingContext
+        val referenceLine =
+            referenceLine(
+                trackNumberId = IntId(1),
+                alignment = referenceLineAlignment,
+                startAddress = TrackMeter(10, 0),
+                draft = false,
+            )
+        val testContext =
+            GeocodingContext.create(
+                    trackNumber = trackNumber,
+                    startAddress = referenceLine.startAddress,
+                    referenceLineGeometry = referenceLineAlignment,
+                    kmPosts = listOf(),
+                )
+                .geocodingContext
 
-        val result = testContext.getSwitchPoints(alignment(
-            segment(start + Point(0.0, 1.0), start + Point(0.0, 5.5)),
+        val result =
+            testContext.getSwitchPoints(
+                alignment(
+                    segment(start + Point(0.0, 1.0), start + Point(0.0, 5.5)),
+                    segment(start + Point(0.0, 5.5), start + Point(0.0, 15.5))
+                        .copy(
+                            switchId = IntId(1),
+                            startJointNumber = JointNumber(1),
+                            endJointNumber = JointNumber(5)),
+                    segment(start + Point(0.0, 15.5), start + Point(0.0, 25.5))
+                        .copy(
+                            switchId = IntId(1),
+                            startJointNumber = JointNumber(5),
+                            endJointNumber = null),
+                    segment(start + Point(0.0, 25.5), start + Point(0.0, 35.5))
+                        .copy(switchId = IntId(1), startJointNumber = null, endJointNumber = null),
+                    segment(start + Point(0.0, 35.5), start + Point(0.0, 45.5))
+                        .copy(
+                            switchId = IntId(1),
+                            startJointNumber = null,
+                            endJointNumber = JointNumber(2)),
+                    segment(start + Point(0.0, 45.5), start + Point(0.0, 55.5)),
+                    segment(start + Point(0.0, 55.5), start + Point(0.0, 65.5))
+                        .copy(
+                            switchId = IntId(2),
+                            startJointNumber = JointNumber(1),
+                            endJointNumber = JointNumber(5)),
+                    segment(start + Point(0.0, 65.5), start + Point(0.0, 75.5))
+                        .copy(
+                            switchId = IntId(2),
+                            startJointNumber = JointNumber(5),
+                            endJointNumber = null),
+                    segment(start + Point(0.0, 75.5), start + Point(0.0, 85.5))
+                        .copy(
+                            switchId = IntId(2),
+                            startJointNumber = null,
+                            endJointNumber = JointNumber(2)),
+                    segment(start + Point(0.0, 85.5), start + Point(0.0, 95.5)),
+                ))
 
-            segment(start + Point(0.0, 5.5), start + Point(0.0, 15.5))
-                .copy(switchId = IntId(1), startJointNumber = JointNumber(1), endJointNumber = JointNumber(5)),
-            segment(start + Point(0.0, 15.5), start + Point(0.0, 25.5))
-                .copy(switchId = IntId(1), startJointNumber = JointNumber(5), endJointNumber = null),
-            segment(start + Point(0.0, 25.5), start + Point(0.0, 35.5))
-                .copy(switchId = IntId(1), startJointNumber = null, endJointNumber = null),
-            segment(start + Point(0.0, 35.5), start + Point(0.0, 45.5))
-                .copy(switchId = IntId(1), startJointNumber = null, endJointNumber = JointNumber(2)),
-
-            segment(start + Point(0.0, 45.5), start + Point(0.0, 55.5)),
-
-            segment(start + Point(0.0, 55.5), start + Point(0.0, 65.5))
-                .copy(switchId = IntId(2), startJointNumber = JointNumber(1), endJointNumber = JointNumber(5)),
-            segment(start + Point(0.0, 65.5), start + Point(0.0, 75.5))
-                .copy(switchId = IntId(2), startJointNumber = JointNumber(5), endJointNumber = null),
-            segment(start + Point(0.0, 75.5), start + Point(0.0, 85.5))
-                .copy(switchId = IntId(2), startJointNumber = null, endJointNumber = JointNumber(2)),
-
-            segment(start + Point(0.0, 85.5), start + Point(0.0, 95.5)),
-        ))
-
-        assertEquals(listOf(
-            start + Point(0.0, 5.5), // switch 1, joint 1
-            start + Point(0.0, 15.5), // switch 1, joint 5
-            start + Point(0.0, 45.5), // switch 1, joint 2
-            start + Point(0.0, 55.5), // switch 2, joint 1
-            start + Point(0.0, 65.5), // switch 2, joint 5
-            start + Point(0.0, 85.5), // switch 2, joint 2
-        ), result.map { p -> p.point.toPoint() })
+        assertEquals(
+            listOf(
+                start + Point(0.0, 5.5), // switch 1, joint 1
+                start + Point(0.0, 15.5), // switch 1, joint 5
+                start + Point(0.0, 45.5), // switch 1, joint 2
+                start + Point(0.0, 55.5), // switch 2, joint 1
+                start + Point(0.0, 65.5), // switch 2, joint 5
+                start + Point(0.0, 85.5), // switch 2, joint 2
+            ),
+            result.map { p -> p.point.toPoint() })
 
         result.forEachIndexed { index, jointPoint ->
             assertEquals(3, jointPoint.address.decimalCount())
             if (index > 0) {
-                assertTrue(jointPoint.address > result[index-1].address)
+                assertTrue(jointPoint.address > result[index - 1].address)
             }
         }
     }
@@ -602,47 +705,48 @@ class GeocodingTest {
     fun `should throw an exception with empty reference line geometry`() {
         val startAlignment = LayoutAlignment(segments = emptyList())
 
-        assertThrows<IllegalArgumentException>("Geocoding context was created with empty reference line") {
-            GeocodingContext(
-                trackNumber = TrackNumber("T001"),
-                startAddress = TrackMeter(KmNumber(10), 100),
-                referenceLineGeometry = startAlignment,
-                referencePoints = emptyList(),
-            )
-        }
+        assertThrows<IllegalArgumentException>(
+            "Geocoding context was created with empty reference line") {
+                GeocodingContext(
+                    trackNumber = TrackNumber("T001"),
+                    startAddress = TrackMeter(KmNumber(10), 100),
+                    referenceLineGeometry = startAlignment,
+                    referencePoints = emptyList(),
+                )
+            }
     }
 
     @Test
     fun `should throw an exception when there are no reference points`() {
-        val startAlignment = LayoutAlignment(
-            segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        )
+        val startAlignment =
+            LayoutAlignment(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
 
-        assertThrows<IllegalArgumentException>("Geocoding context was created without reference points") {
-            GeocodingContext(
-                trackNumber = TrackNumber("T001"),
-                startAddress = TrackMeter(KmNumber(10), 100),
-                referenceLineGeometry = startAlignment,
-                referencePoints = emptyList(),
-            )
-        }
+        assertThrows<IllegalArgumentException>(
+            "Geocoding context was created without reference points") {
+                GeocodingContext(
+                    trackNumber = TrackNumber("T001"),
+                    startAddress = TrackMeter(KmNumber(10), 100),
+                    referenceLineGeometry = startAlignment,
+                    referencePoints = emptyList(),
+                )
+            }
     }
 
     @Test
     fun `should reject km posts without location`() {
         val trackNumber = TrackNumber("T001")
-        val startAlignment = LayoutAlignment(
-            segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        )
+        val startAlignment =
+            LayoutAlignment(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
 
         val kmPost = kmPost(IntId(1), KmNumber(11), null, draft = false)
 
-        val result = GeocodingContext.create(
-            trackNumber = trackNumber,
-            startAddress = TrackMeter(KmNumber(10), 100),
-            referenceLineGeometry = startAlignment,
-            kmPosts = listOf(kmPost),
-        )
+        val result =
+            GeocodingContext.create(
+                trackNumber = trackNumber,
+                startAddress = TrackMeter(KmNumber(10), 100),
+                referenceLineGeometry = startAlignment,
+                kmPosts = listOf(kmPost),
+            )
 
         assertTrue("Km post without location was not rejected") {
             result.rejectedKmPosts.all { kp ->
@@ -658,22 +762,23 @@ class GeocodingTest {
     @Test
     fun `should reject km posts that are before start address`() {
         val trackNumber = TrackNumber("T001")
-        val startAlignment = LayoutAlignment(
-            segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        )
+        val startAlignment =
+            LayoutAlignment(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
 
         val kmPost = kmPost(IntId(1), KmNumber(10), Point(5.0, 0.0), draft = false)
 
-        val result = GeocodingContext.create(
-            trackNumber = trackNumber,
-            startAddress = TrackMeter(KmNumber(10), 100),
-            referenceLineGeometry = startAlignment,
-            kmPosts = listOf(kmPost),
-        )
+        val result =
+            GeocodingContext.create(
+                trackNumber = trackNumber,
+                startAddress = TrackMeter(KmNumber(10), 100),
+                referenceLineGeometry = startAlignment,
+                kmPosts = listOf(kmPost),
+            )
 
         assertTrue("Km post with too small km number was not rejected") {
             result.rejectedKmPosts.all { kp ->
-                kp.kmPost == kmPost && kp.rejectedReason == KmPostRejectedReason.IS_BEFORE_START_ADDRESS
+                kp.kmPost == kmPost &&
+                    kp.rejectedReason == KmPostRejectedReason.IS_BEFORE_START_ADDRESS
             }
         }
     }
@@ -681,22 +786,23 @@ class GeocodingTest {
     @Test
     fun `should reject km posts that intersects before reference line`() {
         val trackNumber = TrackNumber("T001")
-        val startAlignment = LayoutAlignment(
-            segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        )
+        val startAlignment =
+            LayoutAlignment(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
 
         val kmPost = kmPost(IntId(1), KmNumber(11), Point(-5.0, 0.0), draft = false)
 
-        val result = GeocodingContext.create(
-            trackNumber = trackNumber,
-            startAddress = TrackMeter(KmNumber(10), 100),
-            referenceLineGeometry = startAlignment,
-            kmPosts = listOf(kmPost),
-        )
+        val result =
+            GeocodingContext.create(
+                trackNumber = trackNumber,
+                startAddress = TrackMeter(KmNumber(10), 100),
+                referenceLineGeometry = startAlignment,
+                kmPosts = listOf(kmPost),
+            )
 
         assertTrue("Km post that intersected before reference line was not rejected") {
             result.rejectedKmPosts.all { kp ->
-                kp.kmPost == kmPost && kp.rejectedReason == KmPostRejectedReason.INTERSECTS_BEFORE_REFERENCE_LINE
+                kp.kmPost == kmPost &&
+                    kp.rejectedReason == KmPostRejectedReason.INTERSECTS_BEFORE_REFERENCE_LINE
             }
         }
     }
@@ -704,22 +810,23 @@ class GeocodingTest {
     @Test
     fun `should reject km posts that intersects after reference line`() {
         val trackNumber = TrackNumber("T001")
-        val startAlignment = LayoutAlignment(
-            segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        )
+        val startAlignment =
+            LayoutAlignment(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
 
         val kmPost = kmPost(IntId(1), KmNumber(11), Point(50.0, 0.0), draft = false)
 
-        val result = GeocodingContext.create(
-            trackNumber = trackNumber,
-            startAddress = TrackMeter(KmNumber(10), 100),
-            referenceLineGeometry = startAlignment,
-            kmPosts = listOf(kmPost),
-        )
+        val result =
+            GeocodingContext.create(
+                trackNumber = trackNumber,
+                startAddress = TrackMeter(KmNumber(10), 100),
+                referenceLineGeometry = startAlignment,
+                kmPosts = listOf(kmPost),
+            )
 
         assertTrue("Km post that intersected after reference line was not rejected") {
             result.rejectedKmPosts.all { kp ->
-                kp.kmPost == kmPost && kp.rejectedReason == KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE
+                kp.kmPost == kmPost &&
+                    kp.rejectedReason == KmPostRejectedReason.INTERSECTS_AFTER_REFERENCE_LINE
             }
         }
     }
@@ -727,18 +834,18 @@ class GeocodingTest {
     @Test
     fun `should reject km posts that are too far apart`() {
         val trackNumber = TrackNumber("T001")
-        val startAlignment = LayoutAlignment(
-            segments = listOf(segment(Point(0.0, 0.0), Point(40000.0, 0.0)))
-        )
+        val startAlignment =
+            LayoutAlignment(segments = listOf(segment(Point(0.0, 0.0), Point(40000.0, 0.0))))
 
         val kmPost = kmPost(IntId(1), KmNumber(11), Point(20000.0, 0.0), draft = false)
 
-        val result = GeocodingContext.create(
-            trackNumber = trackNumber,
-            startAddress = TrackMeter(KmNumber(10), 100),
-            referenceLineGeometry = startAlignment,
-            kmPosts = listOf(kmPost),
-        )
+        val result =
+            GeocodingContext.create(
+                trackNumber = trackNumber,
+                startAddress = TrackMeter(KmNumber(10), 100),
+                referenceLineGeometry = startAlignment,
+                kmPosts = listOf(kmPost),
+            )
 
         assertTrue("Km post that had over 10000 m in distance was not rejected") {
             result.rejectedKmPosts.all { kp ->
@@ -750,16 +857,16 @@ class GeocodingTest {
     @Test
     fun `should require start km to have sane length`() {
         val trackNumber = TrackNumber("T001")
-        val startAlignment = LayoutAlignment(
-            segments = listOf(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
-        )
+        val startAlignment =
+            LayoutAlignment(segments = listOf(segment(Point(0.0, 0.0), Point(100.0, 0.0))))
         val kmPost = kmPost(IntId(1), KmNumber(1), Point(15.0, 0.0), draft = false)
-        val result = GeocodingContext.create(
-            trackNumber = trackNumber,
-            startAddress = TrackMeter(KmNumber(0), 9990),
-            referenceLineGeometry = startAlignment,
-            kmPosts = listOf(kmPost),
-        )
+        val result =
+            GeocodingContext.create(
+                trackNumber = trackNumber,
+                startAddress = TrackMeter(KmNumber(0), 9990),
+                referenceLineGeometry = startAlignment,
+                kmPosts = listOf(kmPost),
+            )
 
         assertEquals(null, result.geocodingContext.getAddress(Point(14.0, 0.0)))
         assertEquals(StartPointRejectedReason.TOO_LONG, result.startPointRejectedReason)
@@ -779,18 +886,26 @@ class GeocodingTest {
         assertNull(AddressPoint(point, TrackMeter("1234+1234.123")).withIntegerPrecision())
     }
 
-    private fun assertProjectionLinesMatch(result: List<ProjectionLine>, vararg expected: Pair<TrackMeter, Line>) {
+    private fun assertProjectionLinesMatch(
+        result: List<ProjectionLine>,
+        vararg expected: Pair<TrackMeter, Line>
+    ) {
         assertEquals(
             expected.size,
             result.size,
             "expectedSize=${expected.size} actualSize=${result.size} expected=$expected actual=$result",
         )
         result.forEachIndexed { index, projectionLine ->
-            assertProjectionLineMatches(projectionLine, expected[index].first, expected[index].second)
+            assertProjectionLineMatches(
+                projectionLine, expected[index].first, expected[index].second)
         }
     }
 
-    private fun assertProjectionLineMatches(projectionLine: ProjectionLine, address: TrackMeter, line: Line) {
+    private fun assertProjectionLineMatches(
+        projectionLine: ProjectionLine,
+        address: TrackMeter,
+        line: Line
+    ) {
         assertEquals(address, projectionLine.address)
         assertEquals(line.start.x, projectionLine.projection.start.x, 2 * DELTA)
         assertEquals(line.start.y, projectionLine.projection.start.y, 2 * DELTA)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geography/GeographyServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geography/GeographyServiceIT.kt
@@ -11,9 +11,8 @@ import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class GeographyServiceIT @Autowired constructor(
-    private val geographyService: GeographyService
-): DBTestBase() {
+class GeographyServiceIT @Autowired constructor(private val geographyService: GeographyService) :
+    DBTestBase() {
 
     @Test
     fun someCoordinateSystemsAreReturnedAsDefault() {
@@ -42,6 +41,7 @@ class GeographyServiceIT @Autowired constructor(
         assertEquals(Srid(2393), mapping[CoordinateSystemName("KKJ3")])
         assertEquals(Srid(2393), mapping[CoordinateSystemName("KKJ / Finland zone 3")])
         assertEquals(Srid(2393), mapping[CoordinateSystemName("KKJ")])
-        assertEquals(Srid(2393), mapping[CoordinateSystemName("KKJ / Finland Uniform Coordinate System")])
+        assertEquals(
+            Srid(2393), mapping[CoordinateSystemName("KKJ / Finland Uniform Coordinate System")])
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geography/KkjToEtrsTriangulationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geography/KkjToEtrsTriangulationDaoIT.kt
@@ -11,64 +11,95 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 
-
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class KkjToEtrsTriangulationDaoIT @Autowired constructor(
+class KkjToEtrsTriangulationDaoIT
+@Autowired
+constructor(
     val kkjTm35FinTriangulationDao: KkjTm35finTriangulationDao,
-): DBTestBase() {
+) : DBTestBase() {
 
     @Test
     fun fetchesTriangleInsideTriangulationNetwork() {
         // Point is in Hervanta, Tampere
-        val triangles = kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.KKJ_TO_TM35FIN)
+        val triangles =
+            kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                TriangulationDirection.KKJ_TO_TM35FIN)
         val point = toJtsPoint(Point(3332494.083, 6819936.144), YKJ_CRS)
-        val triangle = triangles.search(Geometries.point(point.x, point.y)).find { it.value().intersects(point) }
+        val triangle =
+            triangles.search(Geometries.point(point.x, point.y)).find {
+                it.value().intersects(point)
+            }
         assertNotNull(triangle)
     }
 
     @Test
     fun fetchesTriangleAtCornerPoint() {
         // Point is in a triangulation network corner point
-        val triangles = kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.KKJ_TO_TM35FIN)
+        val triangles =
+            kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                TriangulationDirection.KKJ_TO_TM35FIN)
         val point = toJtsPoint(Point(3199159.097, 6747800.979), YKJ_CRS)
-        val triangle = triangles.search(Geometries.point(point.x, point.y)).find { it.value().intersects(point) }
+        val triangle =
+            triangles.search(Geometries.point(point.x, point.y)).find {
+                it.value().intersects(point)
+            }
         assertNotNull(triangle)
     }
 
     @Test
     fun doesntFetchTriangleOutsideTriangulationNetwork() {
         // Point is in Norway
-        val triangles = kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.KKJ_TO_TM35FIN)
+        val triangles =
+            kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                TriangulationDirection.KKJ_TO_TM35FIN)
         val point = toJtsPoint(Point(2916839.212, 7227390.743), YKJ_CRS)
-        val triangle = triangles.search(Geometries.point(point.x, point.y)).find { it.value().intersects(point) }
+        val triangle =
+            triangles.search(Geometries.point(point.x, point.y)).find {
+                it.value().intersects(point)
+            }
         assertNull(triangle)
     }
 
     @Test
     fun `Fetches ETRS to KKJ triangulation triangle correctly`() {
         // Point is in Hervanta, Tampere
-        val triangles = kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.TM35FIN_TO_KKJ)
-        val point = toJtsPoint( Point(332391.7884, 6817075.2561), LAYOUT_CRS)
-        val triangle = triangles.search(Geometries.point(point.x, point.y)).find { it.value().intersects(point) }
+        val triangles =
+            kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                TriangulationDirection.TM35FIN_TO_KKJ)
+        val point = toJtsPoint(Point(332391.7884, 6817075.2561), LAYOUT_CRS)
+        val triangle =
+            triangles.search(Geometries.point(point.x, point.y)).find {
+                it.value().intersects(point)
+            }
         assertNotNull(triangle)
     }
 
     @Test
     fun `Fetches ETRS to KKJ triangulation triangle at network corner point correctly`() {
         // Point is in a triangulation network corner point
-        val triangles = kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.TM35FIN_TO_KKJ)
+        val triangles =
+            kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                TriangulationDirection.TM35FIN_TO_KKJ)
         val point = toJtsPoint(Point(538905.047, 6707957.789), LAYOUT_CRS)
-        val triangle = triangles.search(Geometries.point(point.x, point.y)).find { it.value().intersects(point) }
+        val triangle =
+            triangles.search(Geometries.point(point.x, point.y)).find {
+                it.value().intersects(point)
+            }
         assertNotNull(triangle)
     }
 
     @Test
     fun `Doesn't fetch a triangle outside of the triangulation network`() {
         // Point is in Norway
-        val triangles = kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.TM35FIN_TO_KKJ)
+        val triangles =
+            kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                TriangulationDirection.TM35FIN_TO_KKJ)
         val point = toJtsPoint(Point(-33121.0, 7455239.0), LAYOUT_CRS)
-        val triangle = triangles.search(Geometries.point(point.x, point.y)).find { it.value().intersects(point) }
+        val triangle =
+            triangles.search(Geometries.point(point.x, point.y)).find {
+                it.value().intersects(point)
+            }
         assertNull(triangle)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/CoordinateTransformServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/CoordinateTransformServiceIT.kt
@@ -12,33 +12,40 @@ import fi.fta.geoviite.infra.geography.KKJ5_SRID
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.ratko.model.RATKO_SRID
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class CoordinateTransformServiceIT @Autowired constructor(
-    private val coordinateTransformationService: CoordinateTransformationService
-) : DBTestBase() {
+class CoordinateTransformServiceIT
+@Autowired
+constructor(private val coordinateTransformationService: CoordinateTransformationService) :
+    DBTestBase() {
     @Test
     fun `Creates KKJ to TM35FIn transformation`() {
-        assertDoesNotThrow { coordinateTransformationService.getTransformation(Srid(2392) /* KKJ2 */, LAYOUT_SRID) }
+        assertDoesNotThrow {
+            coordinateTransformationService.getTransformation(Srid(2392) /* KKJ2 */, LAYOUT_SRID)
+        }
     }
 
     @Test
     fun `Creates TM35FIN to WGS84 transformation`() {
-        assertDoesNotThrow { coordinateTransformationService.getTransformation(LAYOUT_SRID, RATKO_SRID) }
+        assertDoesNotThrow {
+            coordinateTransformationService.getTransformation(LAYOUT_SRID, RATKO_SRID)
+        }
     }
 
     @Test
     fun `Caches transformations properly`() {
-        val kkj2ToEtrsTransformation = coordinateTransformationService.getTransformation(Srid(2392), LAYOUT_SRID)
-        val kkj2ToEtrsTransformation2 = coordinateTransformationService.getTransformation(Srid(2392), LAYOUT_SRID)
+        val kkj2ToEtrsTransformation =
+            coordinateTransformationService.getTransformation(Srid(2392), LAYOUT_SRID)
+        val kkj2ToEtrsTransformation2 =
+            coordinateTransformationService.getTransformation(Srid(2392), LAYOUT_SRID)
 
         assertEquals(kkj2ToEtrsTransformation, kkj2ToEtrsTransformation2)
     }
@@ -47,7 +54,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     fun `Transforms YKJ (KKJ3) to TM35FIN accurately`() {
         // Point is in Hervanta, Tampere
         val point = Point(3332494.083, 6819936.144)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ3_YKJ_SRID, LAYOUT_SRID, point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(KKJ3_YKJ_SRID, LAYOUT_SRID, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(332391.7884, transformedPoint.x, 0.001)
         Assertions.assertEquals(6817075.2561, transformedPoint.y, 0.001)
@@ -56,7 +64,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms KKJ0 to TM35FIN accurately`() {
         val kkj0point = Point(585436.3916, 6679828.4162)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ0_SRID, LAYOUT_SRID, kkj0point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(KKJ0_SRID, LAYOUT_SRID, kkj0point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(87158.652, transformedPoint.x, 0.001)
         Assertions.assertEquals(6699388.278, transformedPoint.y, 0.001)
@@ -65,7 +74,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms KKJ1 to TM35FIN accurately`() {
         val kkj1point = Point(1541730.796, 6818539.1569)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ1_SRID, LAYOUT_SRID, kkj1point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(KKJ1_SRID, LAYOUT_SRID, kkj1point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(222053.674, transformedPoint.x, 0.001)
         Assertions.assertEquals(6826549.907, transformedPoint.y, 0.001)
@@ -74,7 +84,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms KKJ2 to TM35FIN accurately`() {
         val kkj2point = Point(2488027.6005, 6820948.9609)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ2_SRID, LAYOUT_SRID, kkj2point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(KKJ2_SRID, LAYOUT_SRID, kkj2point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(328183.073, transformedPoint.x, 0.001)
         Assertions.assertEquals(6822313.526, transformedPoint.y, 0.001)
@@ -83,7 +94,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms KKJ4 to TM35FIN accurately`() {
         val kkj4point = Point(4488552.946177, 6943595.611588)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ4_SRID, LAYOUT_SRID, kkj4point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(KKJ4_SRID, LAYOUT_SRID, kkj4point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(642412.7448, transformedPoint.x, 0.001)
         Assertions.assertEquals(6943735.9093, transformedPoint.y, 0.001)
@@ -92,7 +104,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms KKJ5 to TM35FIN accurately`() {
         val kkj5point = Point(5426728.7305, 6978302.5687)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(KKJ5_SRID, LAYOUT_SRID, kkj5point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(KKJ5_SRID, LAYOUT_SRID, kkj5point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(731400.669, transformedPoint.x, 0.001)
         Assertions.assertEquals(6982768.023, transformedPoint.y, 0.001)
@@ -102,7 +115,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     fun `Transforms TM35FIN to YKJ (KKJ3) accurately`() {
         // Point is in Hervanta, Tampere
         val point = Point(332391.7884, 6817075.2561)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ3_YKJ_SRID, point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ3_YKJ_SRID, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(3332494.083, transformedPoint.x, 0.001)
         Assertions.assertEquals(6819936.144, transformedPoint.y, 0.001)
@@ -112,8 +126,10 @@ class CoordinateTransformServiceIT @Autowired constructor(
     fun `Transforms TM35FIN to KKJ0 accurately`() {
         // Point is in western Åland, in case anybody decides to build a track there
         val point = Point(87158.652, 6699388.278)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ0_SRID, point)
-        // Expected values are from paikkatietoikkuna. The KKJ0 transform is less accurate than the rest,
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ0_SRID, point)
+        // Expected values are from paikkatietoikkuna. The KKJ0 transform is less accurate than the
+        // rest,
         // hence the larger delta
         Assertions.assertEquals(585436.3916, transformedPoint.x, 0.01)
         Assertions.assertEquals(6679828.4162, transformedPoint.y, 0.01)
@@ -123,7 +139,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     fun `Transforms TM35FIN to KKJ1 accurately`() {
         // Point is at Pori railway station
         val point = Point(222053.674, 6826549.907)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ1_SRID, point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ1_SRID, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(1541730.796, transformedPoint.x, 0.001)
         Assertions.assertEquals(6818539.1569, transformedPoint.y, 0.001)
@@ -132,7 +149,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms TM35FIN to KKJ2 accurately`() {
         val point = Point(328183.073, 6822313.526)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ2_SRID, point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ2_SRID, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(2488027.6005, transformedPoint.x, 0.001)
         Assertions.assertEquals(6820948.9609, transformedPoint.y, 0.001)
@@ -141,7 +159,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms TM35FIN to KKJ4 accurately`() {
         val point = Point(642412.7448, 6943735.9093)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ4_SRID, point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ4_SRID, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(4488552.946177, transformedPoint.x, 0.001)
         Assertions.assertEquals(6943595.611588, transformedPoint.y, 0.001)
@@ -150,7 +169,8 @@ class CoordinateTransformServiceIT @Autowired constructor(
     @Test
     fun `Transforms TM35FIN to KKJ5 accurately`() {
         val point = Point(731400.669, 6982768.023)
-        val transformedPoint = coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ5_SRID, point)
+        val transformedPoint =
+            coordinateTransformationService.transformCoordinate(LAYOUT_SRID, KKJ5_SRID, point)
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(5426728.7305, transformedPoint.x, 0.001)
         Assertions.assertEquals(6978302.5687, transformedPoint.y, 0.001)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/DataProductsTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/DataProductsTestData.kt
@@ -6,31 +6,36 @@ import fi.fta.geoviite.infra.math.Point
 
 fun createAlignment(
     vararg elementTypes: GeometryElementType,
-) = geometryAlignment(
-    id = IntId(1),
-    elements = createElements(1, *elementTypes),
-)
+) =
+    geometryAlignment(
+        id = IntId(1),
+        elements = createElements(1, *elementTypes),
+    )
 
-fun createElements(parentId: Int, vararg types: GeometryElementType) = types.mapIndexed { index, t ->
-    when (t) {
-        GeometryElementType.LINE -> minimalLine(
-            id = IndexedId(parentId, index),
-            start = Point(index.toDouble(), index.toDouble()),
-            end = Point((index + 1).toDouble(), (index + 1).toDouble()),
-        )
+fun createElements(parentId: Int, vararg types: GeometryElementType) =
+    types.mapIndexed { index, t ->
+        when (t) {
+            GeometryElementType.LINE ->
+                minimalLine(
+                    id = IndexedId(parentId, index),
+                    start = Point(index.toDouble(), index.toDouble()),
+                    end = Point((index + 1).toDouble(), (index + 1).toDouble()),
+                )
 
-        GeometryElementType.CURVE -> minimalCurve(
-            id = IndexedId(parentId, index),
-            start = Point(index.toDouble(), index.toDouble()),
-            end = Point((index + 1).toDouble(), (index + 1).toDouble()),
-        )
+            GeometryElementType.CURVE ->
+                minimalCurve(
+                    id = IndexedId(parentId, index),
+                    start = Point(index.toDouble(), index.toDouble()),
+                    end = Point((index + 1).toDouble(), (index + 1).toDouble()),
+                )
 
-        GeometryElementType.CLOTHOID -> minimalClothoid(
-            id = IndexedId(parentId, index),
-            start = Point(index.toDouble(), index.toDouble()),
-            end = Point((index + 1).toDouble(), (index + 1).toDouble()),
-        )
+            GeometryElementType.CLOTHOID ->
+                minimalClothoid(
+                    id = IndexedId(parentId, index),
+                    start = Point(index.toDouble(), index.toDouble()),
+                    end = Point((index + 1).toDouble(), (index + 1).toDouble()),
+                )
 
-        else -> throw IllegalStateException("element $t not supported by this test method")
+            else -> throw IllegalStateException("element $t not supported by this test method")
+        }
     }
-}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ElementListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ElementListingTest.kt
@@ -29,43 +29,49 @@ import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndAlignment
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.util.FileName
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
 
 private val allElementTypes = GeometryElementType.values().toList()
 private val allTrackElementTypes = TrackGeometryElementType.values().toList()
-private val getTransformation = { srid: Srid -> Transformation.nonTriangulableTransform(srid, LAYOUT_SRID) }
+private val getTransformation = { srid: Srid ->
+    Transformation.nonTriangulableTransform(srid, LAYOUT_SRID)
+}
 
 class ElementListingTest {
 
     @Test
     fun `Basic info is filled from LocationTrack & GeometryPlanHeader`() {
         val trackNumber = TrackNumber("12345")
-        val alignment = geometryAlignment(
-            id = IntId(1),
-            elements = createElements(
-                1,
-                GeometryElementType.LINE,
-                GeometryElementType.CURVE,
-                GeometryElementType.CLOTHOID,
-            ),
-            name = "TSTTrack002",
-        )
-        val planHeader = planHeader(
-            source = PlanSource.PAIKANNUSPALVELU,
-            id = IntId(2),
-            trackNumber = trackNumber,
-            fileName = FileName("test-file 002.xml"),
-            srid = LAYOUT_SRID,
-            coordinateSystemName = CoordinateSystemName("KKJ test-name"),
-        )
-        val (locationTrack, layoutAlignment) = locationTrackAndAlignment(
-            trackNumberId = IntId(1),
-            segments = createSegments(alignment),
-            draft = false,
-        )
+        val alignment =
+            geometryAlignment(
+                id = IntId(1),
+                elements =
+                    createElements(
+                        1,
+                        GeometryElementType.LINE,
+                        GeometryElementType.CURVE,
+                        GeometryElementType.CLOTHOID,
+                    ),
+                name = "TSTTrack002",
+            )
+        val planHeader =
+            planHeader(
+                source = PlanSource.PAIKANNUSPALVELU,
+                id = IntId(2),
+                trackNumber = trackNumber,
+                fileName = FileName("test-file 002.xml"),
+                srid = LAYOUT_SRID,
+                coordinateSystemName = CoordinateSystemName("KKJ test-name"),
+            )
+        val (locationTrack, layoutAlignment) =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(1),
+                segments = createSegments(alignment),
+                draft = false,
+            )
         val listing = getListing(locationTrack, layoutAlignment, planHeader, alignment)
         listing.forEach { l ->
             assertEquals(PlanSource.PAIKANNUSPALVELU, l.planSource)
@@ -78,32 +84,41 @@ class ElementListingTest {
             assertEquals(AlignmentName("TSTTrack002"), l.alignmentName)
         }
         assertEquals(listOf(LINE, CURVE, CLOTHOID), listing.map { l -> l.elementType })
-        assertEquals(alignment.elements.map(GeometryElement::id), listing.map(ElementListing::elementId))
+        assertEquals(
+            alignment.elements.map(GeometryElement::id), listing.map(ElementListing::elementId))
         assertEquals(
             alignment.elements.map { e -> roundTo3Decimals(e.calculatedLength) },
             listing.map { l -> l.lengthMeters },
         )
-        assertEquals(alignment.elements.map { e -> e.start.round(3) }, listing.map { l -> l.start.coordinate })
-        assertEquals(alignment.elements.map { e -> e.end.round(3) }, listing.map { l -> l.end.coordinate })
+        assertEquals(
+            alignment.elements.map { e -> e.start.round(3) },
+            listing.map { l -> l.start.coordinate })
+        assertEquals(
+            alignment.elements.map { e -> e.end.round(3) }, listing.map { l -> l.end.coordinate })
     }
 
     @Test
     fun `Basic info is filled from GeometryPlan`() {
         val trackNumber = TrackNumber("45675")
-        val alignment = geometryAlignment(
-            elements = listOf(minimalLine(), minimalCurve(), minimalClothoid()),
-            name = "TSTTrack001",
-        )
-        val plan = plan(
-            source = PlanSource.GEOMETRIAPALVELU,
-            trackNumber = trackNumber,
-            trackNumberDesc = PlanElementName("test track number"),
-            alignments = listOf(alignment),
-            fileName = FileName("test-file 001.xml"),
-            srid = LAYOUT_SRID,
-            coordinateSystemName = CoordinateSystemName("KKJ testname"),
-        )
-        val listing = toElementListing(null, getTransformation, plan, allElementTypes) { _ -> SwitchName("Test") }
+        val alignment =
+            geometryAlignment(
+                elements = listOf(minimalLine(), minimalCurve(), minimalClothoid()),
+                name = "TSTTrack001",
+            )
+        val plan =
+            plan(
+                source = PlanSource.GEOMETRIAPALVELU,
+                trackNumber = trackNumber,
+                trackNumberDesc = PlanElementName("test track number"),
+                alignments = listOf(alignment),
+                fileName = FileName("test-file 001.xml"),
+                srid = LAYOUT_SRID,
+                coordinateSystemName = CoordinateSystemName("KKJ testname"),
+            )
+        val listing =
+            toElementListing(null, getTransformation, plan, allElementTypes) { _ ->
+                SwitchName("Test")
+            }
         listing.forEach { l ->
             assertEquals(PlanSource.GEOMETRIAPALVELU, l.planSource)
             assertEquals(plan.id, l.planId)
@@ -116,13 +131,17 @@ class ElementListingTest {
             assertEquals(AlignmentName("TSTTrack001"), l.alignmentName)
         }
         assertEquals(listOf(LINE, CURVE, CLOTHOID), listing.map { l -> l.elementType })
-        assertEquals(alignment.elements.map(GeometryElement::id), listing.map(ElementListing::elementId))
+        assertEquals(
+            alignment.elements.map(GeometryElement::id), listing.map(ElementListing::elementId))
         assertEquals(
             alignment.elements.map { e -> roundTo3Decimals(e.calculatedLength) },
             listing.map { l -> l.lengthMeters },
         )
-        assertEquals(alignment.elements.map { e -> e.start.round(3) }, listing.map { l -> l.start.coordinate })
-        assertEquals(alignment.elements.map { e -> e.end.round(3) }, listing.map { l -> l.end.coordinate })
+        assertEquals(
+            alignment.elements.map { e -> e.start.round(3) },
+            listing.map { l -> l.start.coordinate })
+        assertEquals(
+            alignment.elements.map { e -> e.end.round(3) }, listing.map { l -> l.end.coordinate })
     }
 
     @Test
@@ -133,43 +152,52 @@ class ElementListingTest {
 
         val trackNumberId = IntId<TrackLayoutTrackNumber>(1)
         val trackNumber = TrackNumber("4646")
-        val (referenceLine, alignment) = referenceLineAndAlignment(
-            trackNumberId = trackNumberId,
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0) + layoutCoordinateBase,
-                    Point(50.0, 0.0) + layoutCoordinateBase,
-                ),
-            ),
-            startAddress = TrackMeter(KmNumber(1), 100),
-            draft = false,
-        )
+        val (referenceLine, alignment) =
+            referenceLineAndAlignment(
+                trackNumberId = trackNumberId,
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0) + layoutCoordinateBase,
+                            Point(50.0, 0.0) + layoutCoordinateBase,
+                        ),
+                    ),
+                startAddress = TrackMeter(KmNumber(1), 100),
+                draft = false,
+            )
         val geocodingContext =
-            GeocodingContext.create(trackNumber, referenceLine.startAddress, alignment, listOf()).geocodingContext
-        val clothoid = minimalClothoid(
-            start = Point(10.0, 10.0) + gk27CoordinateBase,
-            end = Point(20.0, 20.0) + gk27CoordinateBase,
-            pi = Point(18.0, 19.0) + gk27CoordinateBase,
-            rotation = CW,
-        )
+            GeocodingContext.create(trackNumber, referenceLine.startAddress, alignment, listOf())
+                .geocodingContext
+        val clothoid =
+            minimalClothoid(
+                start = Point(10.0, 10.0) + gk27CoordinateBase,
+                end = Point(20.0, 20.0) + gk27CoordinateBase,
+                pi = Point(18.0, 19.0) + gk27CoordinateBase,
+                rotation = CW,
+            )
         val cant = linearCant(0.0, clothoid.calculatedLength, 0.001, 0.005)
-        val plan = plan(
-            trackNumber = TrackNumber("6767"),
-            alignments = listOf(geometryAlignment(elements = listOf(clothoid), cant = cant)),
-            srid = gk27,
-        )
-        val elementListing = toElementListing(
-            geocodingContext,
-            getTransformation,
-            plan,
-            GeometryElementType.entries,
-        ) { _ -> SwitchName("Test") }
+        val plan =
+            plan(
+                trackNumber = TrackNumber("6767"),
+                alignments = listOf(geometryAlignment(elements = listOf(clothoid), cant = cant)),
+                srid = gk27,
+            )
+        val elementListing =
+            toElementListing(
+                geocodingContext,
+                getTransformation,
+                plan,
+                GeometryElementType.entries,
+            ) { _ ->
+                SwitchName("Test")
+            }
         assertEquals(1, elementListing.size)
         val element1 = elementListing[0]
 
         assertEquals((Point(10.0, 10.0) + gk27CoordinateBase).round(3), element1.start.coordinate)
         // Geocoding is not 1mm accurate so round decimals
-        assertEquals(TrackMeter(KmNumber(1), BigDecimal("110.0")), element1.start.address!!.round(1))
+        assertEquals(
+            TrackMeter(KmNumber(1), BigDecimal("110.0")), element1.start.address!!.round(1))
         // Direction in grads (geodetic) from start to pi
         assertEquals(BigDecimal("46.259488"), element1.start.directionGrads)
         assertEquals(clothoid.radiusStart, element1.start.radiusMeters)
@@ -187,45 +215,52 @@ class ElementListingTest {
     @Test
     fun `Plan element listing is filtered by types`() {
         val trackNumber = TrackNumber("001")
-        val geometryAlignment = createAlignment(
-            GeometryElementType.LINE,
-            GeometryElementType.CURVE,
-            GeometryElementType.CLOTHOID,
-            GeometryElementType.CLOTHOID,
-            GeometryElementType.CURVE,
-            GeometryElementType.LINE,
-        )
+        val geometryAlignment =
+            createAlignment(
+                GeometryElementType.LINE,
+                GeometryElementType.CURVE,
+                GeometryElementType.CLOTHOID,
+                GeometryElementType.CLOTHOID,
+                GeometryElementType.CURVE,
+                GeometryElementType.LINE,
+            )
         val plan = plan(trackNumber = trackNumber, alignments = listOf(geometryAlignment))
         assertEquals(listOf(LINE, LINE), getElementListingTypes(plan, GeometryElementType.LINE))
         assertEquals(listOf(CURVE, CURVE), getElementListingTypes(plan, GeometryElementType.CURVE))
-        assertEquals(listOf(CLOTHOID, CLOTHOID), getElementListingTypes(plan, GeometryElementType.CLOTHOID))
+        assertEquals(
+            listOf(CLOTHOID, CLOTHOID), getElementListingTypes(plan, GeometryElementType.CLOTHOID))
         assertEquals(
             listOf(LINE, CLOTHOID, CLOTHOID, LINE),
             getElementListingTypes(plan, GeometryElementType.LINE, GeometryElementType.CLOTHOID),
         )
         assertEquals(
             listOf(LINE, CURVE, CLOTHOID, CLOTHOID, CURVE, LINE),
-            getElementListingTypes(plan, GeometryElementType.LINE, GeometryElementType.CURVE, GeometryElementType.CLOTHOID),
+            getElementListingTypes(
+                plan,
+                GeometryElementType.LINE,
+                GeometryElementType.CURVE,
+                GeometryElementType.CLOTHOID),
         )
     }
-
 
     @Test
     fun `Track element listing is filtered by types`() {
         val plan = planHeader(trackNumber = TrackNumber("001"))
-        val geometryAlignment = createAlignment(
-            GeometryElementType.LINE,
-            GeometryElementType.CURVE,
-            GeometryElementType.CLOTHOID,
-            GeometryElementType.CLOTHOID,
-            GeometryElementType.CURVE,
-            GeometryElementType.LINE,
-        )
-        val (track, layoutAlignment) = locationTrackAndAlignment(
-            trackNumberId = IntId(12345),
-            segments = createSegments(geometryAlignment),
-            draft = false,
-        )
+        val geometryAlignment =
+            createAlignment(
+                GeometryElementType.LINE,
+                GeometryElementType.CURVE,
+                GeometryElementType.CLOTHOID,
+                GeometryElementType.CLOTHOID,
+                GeometryElementType.CURVE,
+                GeometryElementType.LINE,
+            )
+        val (track, layoutAlignment) =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(12345),
+                segments = createSegments(geometryAlignment),
+                draft = false,
+            )
         assertEquals(
             getElementTypes(geometryAlignment).filter { t -> t == LINE },
             getListingTypes(track, layoutAlignment, plan, geometryAlignment, listOf(LINE)),
@@ -240,60 +275,87 @@ class ElementListingTest {
         )
         assertEquals(
             getElementTypes(geometryAlignment).filter { t -> t == CLOTHOID || t == LINE },
-            getListingTypes(track, layoutAlignment, plan, geometryAlignment, listOf(LINE, CLOTHOID)),
+            getListingTypes(
+                track, layoutAlignment, plan, geometryAlignment, listOf(LINE, CLOTHOID)),
         )
         assertEquals(
-            getElementTypes(geometryAlignment).filter { t -> t == CLOTHOID || t == LINE || t == CURVE },
-            getListingTypes(track, layoutAlignment, plan, geometryAlignment, listOf(LINE, CURVE, CLOTHOID)),
+            getElementTypes(geometryAlignment).filter { t ->
+                t == CLOTHOID || t == LINE || t == CURVE
+            },
+            getListingTypes(
+                track, layoutAlignment, plan, geometryAlignment, listOf(LINE, CURVE, CLOTHOID)),
         )
     }
 
     @Test
     fun `Track element listing is filtered by linking and track meters`() {
         val trackNumber = TrackNumber("001")
-        val alignment1 = geometryAlignment(
-            id = IntId(1),
-            elements = listOf(
-                minimalLine(id = IndexedId(1,1)),
-                minimalCurve(id = IndexedId(1,2)),
-                minimalClothoid(id = IndexedId(1,3)),
-            ),
-        )
-        val alignment2 = geometryAlignment(
-            id = IntId(2),
-            elements = listOf(
-                minimalCurve(id = IndexedId(2,1)),
-                minimalClothoid(id = IndexedId(2,2)),
-                minimalLine(id = IndexedId(2,3)),
-            ),
-        )
-        val (track, layoutAlignment) = locationTrackAndAlignment(
-            IntId(1),
-            segment(Point(10.0, 1.0), Point(20.0, 2.0), source = PLAN, sourceId = alignment1.elements[1].id),
-            segment(Point(20.0, 2.0), Point(30.0, 3.0), source = PLAN, sourceId = alignment1.elements[2].id),
-            segment(Point(30.0, 3.0), Point(40.0, 4.0), source = PLAN, sourceId = alignment2.elements[0].id),
-            segment(Point(40.0, 4.0), Point(50.0, 5.0), source = PLAN, sourceId = alignment2.elements[1].id),
-            draft = false,
-        )
+        val alignment1 =
+            geometryAlignment(
+                id = IntId(1),
+                elements =
+                    listOf(
+                        minimalLine(id = IndexedId(1, 1)),
+                        minimalCurve(id = IndexedId(1, 2)),
+                        minimalClothoid(id = IndexedId(1, 3)),
+                    ),
+            )
+        val alignment2 =
+            geometryAlignment(
+                id = IntId(2),
+                elements =
+                    listOf(
+                        minimalCurve(id = IndexedId(2, 1)),
+                        minimalClothoid(id = IndexedId(2, 2)),
+                        minimalLine(id = IndexedId(2, 3)),
+                    ),
+            )
+        val (track, layoutAlignment) =
+            locationTrackAndAlignment(
+                IntId(1),
+                segment(
+                    Point(10.0, 1.0),
+                    Point(20.0, 2.0),
+                    source = PLAN,
+                    sourceId = alignment1.elements[1].id),
+                segment(
+                    Point(20.0, 2.0),
+                    Point(30.0, 3.0),
+                    source = PLAN,
+                    sourceId = alignment1.elements[2].id),
+                segment(
+                    Point(30.0, 3.0),
+                    Point(40.0, 4.0),
+                    source = PLAN,
+                    sourceId = alignment2.elements[0].id),
+                segment(
+                    Point(40.0, 4.0),
+                    Point(50.0, 5.0),
+                    source = PLAN,
+                    sourceId = alignment2.elements[1].id),
+                draft = false,
+            )
         val planHeader = planHeader(trackNumber = trackNumber, srid = LAYOUT_SRID)
         val alignments = listOf(planHeader to alignment1, planHeader to alignment2)
 
-        val context = geocodingContext(
-            referenceLinePoints = listOf(Point(0.0, 0.0), Point(100.0, 0.0)),
-            trackNumber = trackNumber,
-        )
-        val listing = toElementListing(
-            context,
-            getTransformation,
-            track,
-            layoutAlignment,
-            trackNumber,
-            allTrackElementTypes,
-            TrackMeter(KmNumber.ZERO, 25),
-            TrackMeter(KmNumber.ZERO, 35),
-            { id -> alignments.find { a -> a.second.id == id }!! },
-            { _ -> SwitchName("Test") },
-        )
+        val context =
+            geocodingContext(
+                referenceLinePoints = listOf(Point(0.0, 0.0), Point(100.0, 0.0)),
+                trackNumber = trackNumber,
+            )
+        val listing =
+            toElementListing(
+                context,
+                getTransformation,
+                track,
+                layoutAlignment,
+                trackNumber,
+                allTrackElementTypes,
+                TrackMeter(KmNumber.ZERO, 25),
+                TrackMeter(KmNumber.ZERO, 35),
+                { id -> alignments.find { a -> a.second.id == id }!! },
+                { _ -> SwitchName("Test") },
+            )
 
         // Linked: alignment1 elements 1 & 2 (not 0) + alignment2 elements 0 & 1 (not 2)
         // Address range includes only alignment1 element 2 & alignment2 element 0
@@ -304,39 +366,53 @@ class ElementListingTest {
     @Test
     fun `Track element listing contains switch names`() {
         val trackNumber = TrackNumber("001")
-        val alignment = geometryAlignment(
-            id = IntId(1),
-            elements = listOf(
-                minimalLine(id = IndexedId(1,1)),
-                minimalLine(id = IndexedId(1,2)),
-            ),
-        )
-        val (track, layoutAlignment) = locationTrackAndAlignment(
-            IntId(1),
-            segment(Point(10.0, 1.0), Point(20.0, 2.0), source = PLAN, sourceId = alignment.elements[0].id),
-            segment(Point(20.0, 2.0), Point(25.0, 2.5), source = PLAN, sourceId = alignment.elements[1].id, switchId = IntId(1)),
-            draft = false,
-        )
+        val alignment =
+            geometryAlignment(
+                id = IntId(1),
+                elements =
+                    listOf(
+                        minimalLine(id = IndexedId(1, 1)),
+                        minimalLine(id = IndexedId(1, 2)),
+                    ),
+            )
+        val (track, layoutAlignment) =
+            locationTrackAndAlignment(
+                IntId(1),
+                segment(
+                    Point(10.0, 1.0),
+                    Point(20.0, 2.0),
+                    source = PLAN,
+                    sourceId = alignment.elements[0].id),
+                segment(
+                    Point(20.0, 2.0),
+                    Point(25.0, 2.5),
+                    source = PLAN,
+                    sourceId = alignment.elements[1].id,
+                    switchId = IntId(1)),
+                draft = false,
+            )
 
         val planHeader = planHeader(id = IntId(1), trackNumber = trackNumber, srid = LAYOUT_SRID)
         val alignments = listOf(planHeader to alignment)
 
-        val context = geocodingContext(
-            referenceLinePoints = listOf(Point(0.0, 0.0), Point(100.0, 0.0)),
-            trackNumber = trackNumber,
-        )
-        val listing = toElementListing(
-            context,
-            getTransformation,
-            track,
-            layoutAlignment,
-            trackNumber,
-            allTrackElementTypes,
-            null,
-            null,
-            { id -> alignments.find { a -> a.second.id == id }!! },
-            { _ -> SwitchName("Test") },
-        )
+        val context =
+            geocodingContext(
+                referenceLinePoints = listOf(Point(0.0, 0.0), Point(100.0, 0.0)),
+                trackNumber = trackNumber,
+            )
+        val listing =
+            toElementListing(
+                context,
+                getTransformation,
+                track,
+                layoutAlignment,
+                trackNumber,
+                allTrackElementTypes,
+                null,
+                null,
+                { id -> alignments.find { a -> a.second.id == id }!! },
+                { _ -> SwitchName("Test") },
+            )
 
         assertNull(listing[0].connectedSwitchName)
         assertEquals(SwitchName("Test"), listing[1].connectedSwitchName)
@@ -345,61 +421,92 @@ class ElementListingTest {
     @Test
     fun `Elements linked through multiple segments are listed once`() {
         val trackNumber = TrackNumber("001")
-        val alignment = geometryAlignment(
-            id = IntId(1),
-            elements = listOf(
-                minimalLine(id = IndexedId(1,1)),
-                minimalLine(id = IndexedId(1,2)),
-                minimalLine(id = IndexedId(1,3)),
-            ),
-        )
-        val (track, layoutAlignment) = locationTrackAndAlignment(
-            IntId(1),
-            segment(Point(0.0, 0.0), Point(10.0, 1.0), source = PLAN, sourceId = alignment.elements[2].id),
-            segment(Point(10.0, 1.0), Point(20.0, 2.0), source = PLAN, sourceId = alignment.elements[0].id),
-            segment(Point(20.0, 2.0), Point(30.0, 3.0), source = PLAN, sourceId = alignment.elements[0].id),
-            segment(Point(30.0, 3.0), Point(40.0, 4.0), source = PLAN, sourceId = alignment.elements[1].id),
-            segment(Point(40.0, 4.0), Point(50.0, 5.0), source = PLAN, sourceId = alignment.elements[0].id),
-            draft = false,
-        )
+        val alignment =
+            geometryAlignment(
+                id = IntId(1),
+                elements =
+                    listOf(
+                        minimalLine(id = IndexedId(1, 1)),
+                        minimalLine(id = IndexedId(1, 2)),
+                        minimalLine(id = IndexedId(1, 3)),
+                    ),
+            )
+        val (track, layoutAlignment) =
+            locationTrackAndAlignment(
+                IntId(1),
+                segment(
+                    Point(0.0, 0.0),
+                    Point(10.0, 1.0),
+                    source = PLAN,
+                    sourceId = alignment.elements[2].id),
+                segment(
+                    Point(10.0, 1.0),
+                    Point(20.0, 2.0),
+                    source = PLAN,
+                    sourceId = alignment.elements[0].id),
+                segment(
+                    Point(20.0, 2.0),
+                    Point(30.0, 3.0),
+                    source = PLAN,
+                    sourceId = alignment.elements[0].id),
+                segment(
+                    Point(30.0, 3.0),
+                    Point(40.0, 4.0),
+                    source = PLAN,
+                    sourceId = alignment.elements[1].id),
+                segment(
+                    Point(40.0, 4.0),
+                    Point(50.0, 5.0),
+                    source = PLAN,
+                    sourceId = alignment.elements[0].id),
+                draft = false,
+            )
 
         val planHeader = planHeader(id = IntId(1), trackNumber = trackNumber, srid = LAYOUT_SRID)
         val alignments = listOf(planHeader to alignment)
 
-        val context = geocodingContext(
-            referenceLinePoints = listOf(Point(0.0, 0.0), Point(100.0, 0.0)),
-            trackNumber = trackNumber,
-        )
-        val listing = toElementListing(
-            context,
-            getTransformation,
-            track,
-            layoutAlignment,
-            trackNumber,
-            allTrackElementTypes,
-            null,
-            null,
-            { id -> alignments.find { a -> a.second.id == id }!! },
-            { _ -> SwitchName("Test") },
-        )
+        val context =
+            geocodingContext(
+                referenceLinePoints = listOf(Point(0.0, 0.0), Point(100.0, 0.0)),
+                trackNumber = trackNumber,
+            )
+        val listing =
+            toElementListing(
+                context,
+                getTransformation,
+                track,
+                layoutAlignment,
+                trackNumber,
+                allTrackElementTypes,
+                null,
+                null,
+                { id -> alignments.find { a -> a.second.id == id }!! },
+                { _ -> SwitchName("Test") },
+            )
         assertEquals(3, listing.size)
         assertEquals(listOf(3, 1, 2), listing.map { l -> (l.elementId as IndexedId).index })
     }
 
     private fun createSegments(alignment: GeometryAlignment) =
-        if (alignment.id !is IntId) throw IllegalStateException("Alignment must have int-id for element seeking to work")
-        else if (alignment.elements.isEmpty()) throw IllegalStateException("Must have elements to generate the segments for")
+        if (alignment.id !is IntId)
+            throw IllegalStateException("Alignment must have int-id for element seeking to work")
+        else if (alignment.elements.isEmpty())
+            throw IllegalStateException("Must have elements to generate the segments for")
         else alignment.elements.map { e -> segment(e.start, e.end, sourceId = e.id) }
 
     private fun getElementListingTypes(
         plan: GeometryPlan,
         vararg types: GeometryElementType,
-    ): List<TrackGeometryElementType> = toElementListing(
-        null,
-        getTransformation,
-        plan,
-        types.toList(),
-    ) { SwitchName("Test") }.map { e -> e.elementType }
+    ): List<TrackGeometryElementType> =
+        toElementListing(
+                null,
+                getTransformation,
+                plan,
+                types.toList(),
+            ) {
+                SwitchName("Test")
+            }
+            .map { e -> e.elementType }
 
     private fun getListingTypes(
         locationTrack: LocationTrack,
@@ -407,8 +514,9 @@ class ElementListingTest {
         planHeader: GeometryPlanHeader,
         geometryAlignment: GeometryAlignment,
         elementTypes: List<TrackGeometryElementType> = allTrackElementTypes,
-    ) = getListing(locationTrack, layoutAlignment, planHeader, geometryAlignment, elementTypes)
-        .map { l -> l.elementType }
+    ) =
+        getListing(locationTrack, layoutAlignment, planHeader, geometryAlignment, elementTypes)
+            .map { l -> l.elementType }
 
     private fun getListing(
         locationTrack: LocationTrack,
@@ -416,18 +524,19 @@ class ElementListingTest {
         planHeader: GeometryPlanHeader,
         geometryAlignment: GeometryAlignment,
         elementTypes: List<TrackGeometryElementType> = allTrackElementTypes,
-    ): List<ElementListing> = toElementListing(
-        null,
-        getTransformation,
-        locationTrack,
-        layoutAlignment,
-        planHeader.trackNumber,
-        elementTypes,
-        null,
-        null,
-        { _ -> planHeader to geometryAlignment },
-        { SwitchName("Test") },
-    )
+    ): List<ElementListing> =
+        toElementListing(
+            null,
+            getTransformation,
+            locationTrack,
+            layoutAlignment,
+            planHeader.trackNumber,
+            elementTypes,
+            null,
+            null,
+            { _ -> planHeader to geometryAlignment },
+            { SwitchName("Test") },
+        )
 
     private fun getElementTypes(alignment: GeometryAlignment) =
         alignment.elements.map { e -> TrackGeometryElementType.of(e.type) }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryAssertions.kt
@@ -85,7 +85,6 @@ fun assertMatches(original: GeometryAlignment, fromDb: GeometryAlignment) {
         val elementFromDb = fromDb.elements[index]
         assertTrue(
             convertedElement.contentEquals(elementFromDb),
-            "Contents should be equal: \n\texpect=$convertedElement. \n\tactual=$elementFromDb"
-        )
+            "Contents should be equal: \n\texpect=$convertedElement. \n\tactual=$elementFromDb")
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryCantTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryCantTest.kt
@@ -5,10 +5,10 @@ import fi.fta.geoviite.infra.geometry.CantRotationPoint.INSIDE_RAIL
 import fi.fta.geoviite.infra.geometry.CantTransitionType.BIQUADRATIC_PARABOLA
 import fi.fta.geoviite.infra.geometry.CantTransitionType.LINEAR
 import fi.fta.geoviite.infra.inframodel.PlanElementName
+import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
 
 class GeometryCantTest {
 
@@ -21,30 +21,37 @@ class GeometryCantTest {
 
     @Test
     fun shouldReturnLastValueIfStationIsGreaterThanStationPoints() {
-        val dummyCant = createCant(listOf(
-            createCantPoint(station = 509.117345, cant = 0.046),
-            createCantPoint(station = 539.117345, cant = 0.0),
-        ))
+        val dummyCant =
+            createCant(
+                listOf(
+                    createCantPoint(station = 509.117345, cant = 0.046),
+                    createCantPoint(station = 539.117345, cant = 0.0),
+                ))
         val stationLength = 1166.108648
         assertEquals(0.00, dummyCant.getCantValue(stationLength))
     }
 
     @Test
     fun shouldReturnFirstValueIfStationIsLessThanStationPoints() {
-        val dummyCant = createCant(listOf(
-            createCantPoint(station = 509.117345, cant = 0.046),
-            createCantPoint(station = 539.117345, cant = 0.0),
-        ))
+        val dummyCant =
+            createCant(
+                listOf(
+                    createCantPoint(station = 509.117345, cant = 0.046),
+                    createCantPoint(station = 539.117345, cant = 0.0),
+                ))
         val stationLength = 500.0
         assertEquals(0.046, dummyCant.getCantValue(stationLength))
     }
 
     @Test
     fun biquadraticSCurveCantsMakeSense() {
-        val cant = createCant(listOf(
-            createCantPoint(station = 100.0, cant = 0.0, transitionType = BIQUADRATIC_PARABOLA),
-            createCantPoint(station = 200.0, cant = 0.2),
-        ))
+        val cant =
+            createCant(
+                listOf(
+                    createCantPoint(
+                        station = 100.0, cant = 0.0, transitionType = BIQUADRATIC_PARABOLA),
+                    createCantPoint(station = 200.0, cant = 0.2),
+                ))
         assertEquals(0.0, cant.getCantValue(100.0)!!, 0.000001)
         assertEquals(0.1, cant.getCantValue(150.0)!!, 0.000001)
         assertEquals(0.2, cant.getCantValue(200.0)!!, 0.000001)
@@ -65,18 +72,26 @@ class GeometryCantTest {
         val firstCantPoint = createCantPoint(station = 509.117345, cant = 0.046)
         val secondCantPoint = createCantPoint(station = 539.117345, cant = 0.0)
         val station = 532.234724
-        assertEquals(0.010553, calculateGeometryPointCantValue(firstCantPoint, secondCantPoint, station), 0.000001)
+        assertEquals(
+            0.010553,
+            calculateGeometryPointCantValue(firstCantPoint, secondCantPoint, station),
+            0.000001)
     }
 
-    private fun createCant(cantPoints: List<GeometryCantPoint>): GeometryCant = GeometryCant(
-        name = PlanElementName("dummyCantObject"),
-        description = PlanElementName("for testing purposes"),
-        gauge = BigDecimal("1.524"),
-        rotationPoint = INSIDE_RAIL,
-        points = cantPoints,
-    )
+    private fun createCant(cantPoints: List<GeometryCantPoint>): GeometryCant =
+        GeometryCant(
+            name = PlanElementName("dummyCantObject"),
+            description = PlanElementName("for testing purposes"),
+            gauge = BigDecimal("1.524"),
+            rotationPoint = INSIDE_RAIL,
+            points = cantPoints,
+        )
 
-    private fun createCantPoint(station: Double, cant: Double, transitionType: CantTransitionType = LINEAR) =
+    private fun createCantPoint(
+        station: Double,
+        cant: Double,
+        transitionType: CantTransitionType = LINEAR
+    ) =
         GeometryCantPoint(
             station = station.toBigDecimal(),
             appliedCant = cant.toBigDecimal(),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
@@ -12,6 +12,8 @@ import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
 import fi.fta.geoviite.infra.tracklayout.segment
+import kotlin.test.assertContains
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
@@ -20,14 +22,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
-import kotlin.test.assertNotNull
 
 const val TEST_NAME_PREFIX = "GEOM_DAO_IT_"
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class GeometryDaoIT @Autowired constructor(
+class GeometryDaoIT
+@Autowired
+constructor(
     val geometryDao: GeometryDao,
     val locationTrackService: LocationTrackService,
 ) : DBTestBase() {
@@ -35,7 +37,8 @@ class GeometryDaoIT @Autowired constructor(
     @BeforeEach
     fun init() {
         transactional {
-            val selectPlanIds = """
+            val selectPlanIds =
+                """
                 select plan.id 
                 from geometry.plan 
                   left join geometry.plan_project project on plan.plan_project_id = project.id
@@ -44,12 +47,14 @@ class GeometryDaoIT @Autowired constructor(
                 where project.name like '$TEST_NAME_PREFIX%'
                    or author.company_name like '$TEST_NAME_PREFIX%'
                    or application.name like '$TEST_NAME_PREFIX%'
-            """.trimIndent()
+            """
+                    .trimIndent()
             val ids = jdbc.query(selectPlanIds, mapOf<String, Unit>()) { rs, _ -> rs.getInt("id") }
             val idReferenceCondition = if (ids.isEmpty()) "0=1" else "plan_id in (:plan_ids)"
             val idCondition = if (ids.isEmpty()) "0=1" else "id in (:plan_ids)"
 
-            val deleteSql = """
+            val deleteSql =
+                """
                 delete from geometry.alignment where $idReferenceCondition;
                 delete from geometry.km_post where $idReferenceCondition;
                 delete from geometry.switch where $idReferenceCondition;
@@ -57,7 +62,8 @@ class GeometryDaoIT @Autowired constructor(
                 delete from geometry.plan_project where name like '$TEST_NAME_PREFIX%';
                 delete from geometry.plan_author where company_name like '$TEST_NAME_PREFIX%';
                 delete from geometry.plan_application where name like '$TEST_NAME_PREFIX%';
-            """.trimIndent()
+            """
+                    .trimIndent()
 
             jdbc.update(deleteSql, mapOf("plan_ids" to ids))
         }
@@ -84,7 +90,8 @@ class GeometryDaoIT @Autowired constructor(
         geometryDao.insertProject(project1)
         geometryDao.insertProject(project2)
 
-        val fetchedProject = geometryDao.findProject(ProjectName("${TEST_NAME_PREFIX}pRojEcT           MaTCh"))
+        val fetchedProject =
+            geometryDao.findProject(ProjectName("${TEST_NAME_PREFIX}pRojEcT           MaTCh"))
 
         assertNotNull(fetchedProject)
         assertEquals(ProjectName("${TEST_NAME_PREFIX}Project match"), fetchedProject.name)
@@ -111,7 +118,8 @@ class GeometryDaoIT @Autowired constructor(
         geometryDao.insertAuthor(author1)
         geometryDao.insertAuthor(author2)
 
-        val author = geometryDao.findAuthor(CompanyName("${TEST_NAME_PREFIX}COMPANY            mAtCH"))
+        val author =
+            geometryDao.findAuthor(CompanyName("${TEST_NAME_PREFIX}COMPANY            mAtCH"))
 
         assertNotNull(author)
         assertEquals(CompanyName("${TEST_NAME_PREFIX}Company match"), author.companyName)
@@ -119,12 +127,16 @@ class GeometryDaoIT @Autowired constructor(
 
     @Test
     fun findsApplicationById() {
-        val application1 = application(
-            name = "${TEST_NAME_PREFIX}Application 1", manufacturer = "Solita Ab/Oy", version = "0.1"
-        )
-        val application2 = application(
-            name = "${TEST_NAME_PREFIX}Application 2", manufacturer = "Solita Ab/Oy", version = "0.2"
-        )
+        val application1 =
+            application(
+                name = "${TEST_NAME_PREFIX}Application 1",
+                manufacturer = "Solita Ab/Oy",
+                version = "0.1")
+        val application2 =
+            application(
+                name = "${TEST_NAME_PREFIX}Application 2",
+                manufacturer = "Solita Ab/Oy",
+                version = "0.2")
 
         val applicationId = geometryDao.insertApplication(application1)
         geometryDao.insertApplication(application2)
@@ -178,15 +190,16 @@ class GeometryDaoIT @Autowired constructor(
     fun minimalElementInsertsWork() {
         val file = infraModelFile("${TEST_NAME_PREFIX}_file_min_elem.xml")
         val trackNumber = mainOfficialContext.createAndFetchLayoutTrackNumber().number
-        val plan = plan(
-            trackNumber = trackNumber,
-            fileName = file.name,
-            alignments = listOf(
-                geometryAlignment(
-                    elements = listOf(minimalLine(), minimalCurve(), minimalClothoid()),
-                )
-            ),
-        )
+        val plan =
+            plan(
+                trackNumber = trackNumber,
+                fileName = file.name,
+                alignments =
+                    listOf(
+                        geometryAlignment(
+                            elements = listOf(minimalLine(), minimalCurve(), minimalClothoid()),
+                        )),
+            )
         val version = geometryDao.insertPlan(plan, file, null)
         assertPlansMatch(plan, geometryDao.fetchPlan(version))
     }
@@ -195,30 +208,38 @@ class GeometryDaoIT @Autowired constructor(
     fun getLinkingSummariesHappyCase() {
         val file = infraModelFile("${TEST_NAME_PREFIX}_file_min_elem.xml")
         val (trackNumber, trackNumberId) = mainOfficialContext.createTrackNumberAndId()
-        val plan = plan(
-            trackNumber = trackNumber,
-            fileName = file.name,
-            alignments = listOf(
-                geometryAlignment(
-                    elements = listOf(
-                        minimalLine(),
-                    ),
-                )
-            ),
-        )
+        val plan =
+            plan(
+                trackNumber = trackNumber,
+                fileName = file.name,
+                alignments =
+                    listOf(
+                        geometryAlignment(
+                            elements =
+                                listOf(
+                                    minimalLine(),
+                                ),
+                        )),
+            )
         val planVersion = geometryDao.insertPlan(plan, file, null)
         val element = geometryDao.fetchPlan(planVersion).alignments[0].elements[0]
-        val track = locationTrackAndAlignment(
-            trackNumberId,
-            segment(Point(0.0, 0.0), Point(1.0, 1.0)).copy(sourceId = element.id),
-            draft = true,
-        )
-        val trackVersion = locationTrackService.saveDraft(LayoutBranch.main, track.first, track.second)
-        locationTrackService.publish(LayoutBranch.main, ValidationVersion(trackVersion.id, trackVersion.rowVersion))
+        val track =
+            locationTrackAndAlignment(
+                trackNumberId,
+                segment(Point(0.0, 0.0), Point(1.0, 1.0)).copy(sourceId = element.id),
+                draft = true,
+            )
+        val trackVersion =
+            locationTrackService.saveDraft(LayoutBranch.main, track.first, track.second)
+        locationTrackService.publish(
+            LayoutBranch.main, ValidationVersion(trackVersion.id, trackVersion.rowVersion))
         val trackChangeTime =
-            locationTrackService.getLayoutAssetChangeInfo(MainLayoutContext.official, trackVersion.id)?.changed
+            locationTrackService
+                .getLayoutAssetChangeInfo(MainLayoutContext.official, trackVersion.id)
+                ?.changed
 
-        val expectedSummary = GeometryPlanLinkingSummary(trackChangeTime, listOf(UserName.of("TEST_USER")), true)
+        val expectedSummary =
+            GeometryPlanLinkingSummary(trackChangeTime, listOf(UserName.of("TEST_USER")), true)
         val summaries = geometryDao.getLinkingSummaries(listOf(planVersion.id))
         val allSummaries = geometryDao.getLinkingSummaries(null)
         assertEquals(mapOf(planVersion.id to expectedSummary), summaries)
@@ -230,28 +251,32 @@ class GeometryDaoIT @Autowired constructor(
         val file1 = infraModelFile("${TEST_NAME_PREFIX}_file_min_elem_1.xml")
         val file2 = infraModelFile("${TEST_NAME_PREFIX}_file_min_elem_2.xml")
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val plan1 = plan(
-            trackNumber = trackNumber,
-            fileName = file1.name,
-            alignments = listOf(
-                geometryAlignment(
-                    elements = listOf(
-                        minimalLine(),
-                    ),
-                )
-            ),
-        )
-        val plan2 = plan(
-            trackNumber = trackNumber,
-            fileName = file1.name,
-            alignments = listOf(
-                geometryAlignment(
-                    elements = listOf(
-                        minimalCurve(),
-                    ),
-                )
-            ),
-        )
+        val plan1 =
+            plan(
+                trackNumber = trackNumber,
+                fileName = file1.name,
+                alignments =
+                    listOf(
+                        geometryAlignment(
+                            elements =
+                                listOf(
+                                    minimalLine(),
+                                ),
+                        )),
+            )
+        val plan2 =
+            plan(
+                trackNumber = trackNumber,
+                fileName = file1.name,
+                alignments =
+                    listOf(
+                        geometryAlignment(
+                            elements =
+                                listOf(
+                                    minimalCurve(),
+                                ),
+                        )),
+            )
         val plan1Version = geometryDao.insertPlan(plan1, file1, null)
         val plan2Version = geometryDao.insertPlan(plan2, file2, null)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
@@ -48,9 +48,11 @@ import java.math.RoundingMode
 import java.time.Instant
 import kotlin.math.PI
 
-fun lineFromOrigin(dirStartGrads: Double) = line(Point(0.0, 0.0), pointInDirection(50.0, gradsToRads(dirStartGrads)))
+fun lineFromOrigin(dirStartGrads: Double) =
+    line(Point(0.0, 0.0), pointInDirection(50.0, gradsToRads(dirStartGrads)))
 
-fun lineToOrigin(dirEndGrads: Double) = line(pointInDirection(50.0, gradsToRads(dirEndGrads - 200)), Point(0.0, 0.0))
+fun lineToOrigin(dirEndGrads: Double) =
+    line(pointInDirection(50.0, gradsToRads(dirEndGrads - 200)), Point(0.0, 0.0))
 
 fun curveFromOrigin(rotation: RotationDirection, dirStartGrads: Double): GeometryCurve {
     // For simple math, make it a 90-degree turn: chord = radius & end-point is in a 45-degree angle
@@ -63,7 +65,8 @@ fun curveFromOrigin(rotation: RotationDirection, dirStartGrads: Double): Geometr
 }
 
 fun curveToOrigin(rotation: RotationDirection, dirEndGrads: Double): GeometryCurve {
-    // For simple math, make it a 90-degree turn: chord = radius & start-point is in a 45-degree angle
+    // For simple math, make it a 90-degree turn: chord = radius & start-point is in a 45-degree
+    // angle
     val radius = 50.0
     val centerDirection = if (rotation == CW) dirEndGrads - 100 else dirEndGrads + 100
     val center = pointInDirection(radius, gradsToRads(centerDirection))
@@ -72,49 +75,65 @@ fun curveToOrigin(rotation: RotationDirection, dirEndGrads: Double): GeometryCur
     return curve(rotation, radius, start, end = Point(0.0, 0.0), center)
 }
 
-fun clothoidFromOrigin(rotation: RotationDirection, dirStartGrads: Double) = clothoid(
-    constant = 200.0,
-    rotation = rotation, dirStartGrads = dirStartGrads,
-    // Steepening: start straight, get a curvature in the end
-    radiusStart = null, radiusEnd = 1000.0,
-    start = Point(0.0, 0.0),
-    // End point doesn't matter as the spiral is steepening (calculated from the start)
-    dirEndGrads = 0.0, end = Point(1.0, 1.0),
-    pi = pointInDirection(0.5, gradsToRads(dirStartGrads)),
-)
+fun clothoidFromOrigin(rotation: RotationDirection, dirStartGrads: Double) =
+    clothoid(
+        constant = 200.0,
+        rotation = rotation,
+        dirStartGrads = dirStartGrads,
+        // Steepening: start straight, get a curvature in the end
+        radiusStart = null,
+        radiusEnd = 1000.0,
+        start = Point(0.0, 0.0),
+        // End point doesn't matter as the spiral is steepening (calculated from the start)
+        dirEndGrads = 0.0,
+        end = Point(1.0, 1.0),
+        pi = pointInDirection(0.5, gradsToRads(dirStartGrads)),
+    )
 
-fun clothoidToOrigin(rotation: RotationDirection, dirEndGrads: Double) = clothoid(
-    constant = 200.0,
-    rotation = rotation, dirEndGrads = dirEndGrads,
-    // Non-steepening: start curved, straighten out in the end
-    radiusStart = 1000.0, radiusEnd = null,
-    end = Point(0.0, 0.0),
-    // Start point doesn't matter as the spiral is flattening (calculated from the end)
-    dirStartGrads = 0.0, start = Point(1.0, 1.0),
-    pi = Point(0.0, 0.0) - pointInDirection(0.5, gradsToRads(dirEndGrads)),
-)
+fun clothoidToOrigin(rotation: RotationDirection, dirEndGrads: Double) =
+    clothoid(
+        constant = 200.0,
+        rotation = rotation,
+        dirEndGrads = dirEndGrads,
+        // Non-steepening: start curved, straighten out in the end
+        radiusStart = 1000.0,
+        radiusEnd = null,
+        end = Point(0.0, 0.0),
+        // Start point doesn't matter as the spiral is flattening (calculated from the end)
+        dirStartGrads = 0.0,
+        start = Point(1.0, 1.0),
+        pi = Point(0.0, 0.0) - pointInDirection(0.5, gradsToRads(dirEndGrads)),
+    )
 
-fun biquadraticParabolaFromOrigin(rotation: RotationDirection, dirStartGrads: Double) = biquadraticParabola(
-    length = 100.0,
-    rotation = rotation, dirStartGrads = dirStartGrads,
-    // Steepening: start straight, get a curvature in the end
-    radiusStart = null, radiusEnd = 1000.0,
-    start = Point(0.0, 0.0),
-    // End point doesn't matter as the spiral is steepening (calculated from the start)
-    dirEndGrads = 0.0, end = Point(1.0, 1.0),
-    pi = pointInDirection(0.5, gradsToRads(dirStartGrads)),
-)
+fun biquadraticParabolaFromOrigin(rotation: RotationDirection, dirStartGrads: Double) =
+    biquadraticParabola(
+        length = 100.0,
+        rotation = rotation,
+        dirStartGrads = dirStartGrads,
+        // Steepening: start straight, get a curvature in the end
+        radiusStart = null,
+        radiusEnd = 1000.0,
+        start = Point(0.0, 0.0),
+        // End point doesn't matter as the spiral is steepening (calculated from the start)
+        dirEndGrads = 0.0,
+        end = Point(1.0, 1.0),
+        pi = pointInDirection(0.5, gradsToRads(dirStartGrads)),
+    )
 
-fun biquadraticParabolaToOrigin(rotation: RotationDirection, dirEndGrads: Double) = biquadraticParabola(
-    length = 100.0,
-    rotation = rotation, dirEndGrads = dirEndGrads,
-    // Non-steepening: start curved, straighten out in the end
-    radiusStart = 1000.0, radiusEnd = null,
-    end = Point(0.0, 0.0),
-    // Start point doesn't matter as the spiral is flattening (calculated from the end)
-    dirStartGrads = 0.0, start = Point(1.0, 1.0),
-    pi = Point(0.0, 0.0) - pointInDirection(0.5, gradsToRads(dirEndGrads)),
-)
+fun biquadraticParabolaToOrigin(rotation: RotationDirection, dirEndGrads: Double) =
+    biquadraticParabola(
+        length = 100.0,
+        rotation = rotation,
+        dirEndGrads = dirEndGrads,
+        // Non-steepening: start curved, straighten out in the end
+        radiusStart = 1000.0,
+        radiusEnd = null,
+        end = Point(0.0, 0.0),
+        // Start point doesn't matter as the spiral is flattening (calculated from the end)
+        dirStartGrads = 0.0,
+        start = Point(1.0, 1.0),
+        pi = Point(0.0, 0.0) - pointInDirection(0.5, gradsToRads(dirEndGrads)),
+    )
 
 fun line(
     start: Point,
@@ -129,18 +148,20 @@ fun minimalLine(
     start: Point = Point(0.0, 0.0),
     end: Point = Point(1.0, 1.0),
     id: DomainId<GeometryElement> = StringId(),
-) = GeometryLine(
-    elementData = ElementData(
-        name = null,
-        oidPart = null,
-        start = start,
-        end = end,
-        staStart = BigDecimal.ZERO.setScale(6),
-        length = lineLength(start, end).toBigDecimal().setScale(6, RoundingMode.HALF_UP),
-    ),
-    switchData = emptySwitchData(),
-    id = id,
-)
+) =
+    GeometryLine(
+        elementData =
+            ElementData(
+                name = null,
+                oidPart = null,
+                start = start,
+                end = end,
+                staStart = BigDecimal.ZERO.setScale(6),
+                length = lineLength(start, end).toBigDecimal().setScale(6, RoundingMode.HALF_UP),
+            ),
+        switchData = emptySwitchData(),
+        id = id,
+    )
 
 fun minimalCurve(
     start: Point = Point(0.0, 0.0),
@@ -148,24 +169,30 @@ fun minimalCurve(
     center: Point = Point(0.0, 1.0),
     rotation: RotationDirection = CCW,
     id: DomainId<GeometryElement> = StringId(),
-) = GeometryCurve(
-    elementData = ElementData(
-        name = null,
-        oidPart = null,
-        start = start,
-        end = end,
-        staStart = BigDecimal.ZERO.setScale(6),
-        length = circleArcLength(lineLength(center, start)).toBigDecimal().setScale(6, RoundingMode.HALF_UP),
-    ),
-    switchData = emptySwitchData(),
-    curveData = CurveData(
-        rotation = rotation,
-        center = center,
-        radius = lineLength(center, start).toBigDecimal().setScale(6, RoundingMode.HALF_UP),
-        chord = lineLength(start, end).toBigDecimal().setScale(6, RoundingMode.HALF_UP),
-    ),
-    id = id,
-)
+) =
+    GeometryCurve(
+        elementData =
+            ElementData(
+                name = null,
+                oidPart = null,
+                start = start,
+                end = end,
+                staStart = BigDecimal.ZERO.setScale(6),
+                length =
+                    circleArcLength(lineLength(center, start))
+                        .toBigDecimal()
+                        .setScale(6, RoundingMode.HALF_UP),
+            ),
+        switchData = emptySwitchData(),
+        curveData =
+            CurveData(
+                rotation = rotation,
+                center = center,
+                radius = lineLength(center, start).toBigDecimal().setScale(6, RoundingMode.HALF_UP),
+                chord = lineLength(start, end).toBigDecimal().setScale(6, RoundingMode.HALF_UP),
+            ),
+        id = id,
+    )
 
 fun minimalClothoid(
     start: Point = Point(0.0, 0.0),
@@ -186,14 +213,17 @@ fun minimalClothoid(
             length = length.toBigDecimal().setScale(6, RoundingMode.HALF_UP),
         ),
         switchData = emptySwitchData(),
-        spiralData = SpiralData(
-            rotation = rotation,
-            pi = pi,
-            directionEnd = null,
-            directionStart = null,
-            radiusStart = null,
-            radiusEnd = BigDecimal(clothoidRadiusAtLength(constant, length)).setScale(6, RoundingMode.HALF_UP),
-        ),
+        spiralData =
+            SpiralData(
+                rotation = rotation,
+                pi = pi,
+                directionEnd = null,
+                directionStart = null,
+                radiusStart = null,
+                radiusEnd =
+                    BigDecimal(clothoidRadiusAtLength(constant, length))
+                        .setScale(6, RoundingMode.HALF_UP),
+            ),
         constant = constant.toBigDecimal().setScale(6, RoundingMode.HALF_UP),
         id = id,
     )
@@ -206,16 +236,17 @@ fun line(
     staStart: Double = 0.0,
     name: PlanElementName,
     switchData: SwitchData = emptySwitchData(),
-) = GeometryLine(
-    ElementData(
-        name = name,
-        oidPart = PlanElementName("1"),
-        start = start,
-        end = end,
-        staStart = staStart.toBigDecimal(),
-        length = length.toBigDecimal(),
-    ), switchData = switchData
-)
+) =
+    GeometryLine(
+        ElementData(
+            name = name,
+            oidPart = PlanElementName("1"),
+            start = start,
+            end = end,
+            staStart = staStart.toBigDecimal(),
+            length = length.toBigDecimal(),
+        ),
+        switchData = switchData)
 
 fun emptySwitchData() = SwitchData(null, null, null)
 
@@ -227,23 +258,24 @@ fun curve(
     center: Point,
     chord: Double = lineLength(start, end),
     length: Double = circleArcLength(radius, chord),
-) = GeometryCurve(
-    ElementData(
-        name = PlanElementName("Test"),
-        oidPart = PlanElementName("1"),
-        start = start,
-        end = end,
-        staStart = BigDecimal("0.0"),
-        length = length.toBigDecimal(),
-    ),
-    CurveData(
-        rotation = rotation,
-        radius = radius.toBigDecimal(),
-        chord = chord.toBigDecimal(),
-        center = center,
-    ),
-    switchData = emptySwitchData(),
-)
+) =
+    GeometryCurve(
+        ElementData(
+            name = PlanElementName("Test"),
+            oidPart = PlanElementName("1"),
+            start = start,
+            end = end,
+            staStart = BigDecimal("0.0"),
+            length = length.toBigDecimal(),
+        ),
+        CurveData(
+            rotation = rotation,
+            radius = radius.toBigDecimal(),
+            chord = chord.toBigDecimal(),
+            center = center,
+        ),
+        switchData = emptySwitchData(),
+    )
 
 fun clothoidSteepening(
     constant: Double,
@@ -260,19 +292,26 @@ fun clothoidSteepening(
     val endPoint = startPoint + offset
     val piPoint = piPoint(startPoint, endPoint, startAngle, endAngle)
     return clothoid(
-        constant = constant, rotation = rotation,
-        radiusStart = null, dirStartGrads = radsToGrads(startAngle), start = startPoint,
-        radiusEnd = endRadius, dirEndGrads = radsToGrads(endAngle), end = endPoint,
+        constant = constant,
+        rotation = rotation,
+        radiusStart = null,
+        dirStartGrads = radsToGrads(startAngle),
+        start = startPoint,
+        radiusEnd = endRadius,
+        dirEndGrads = radsToGrads(endAngle),
+        end = endPoint,
         pi = piPoint,
     )
 }
 
-fun piPoint(start: Point, end: Point, startDir: Double, endDir: Double): Point = lineIntersection(
-    start1 = start,
-    end1 = start + pointInDirection(10.0, startDir),
-    start2 = end - pointInDirection(10.0, endDir),
-    end2 = end,
-)!!.point
+fun piPoint(start: Point, end: Point, startDir: Double, endDir: Double): Point =
+    lineIntersection(
+            start1 = start,
+            end1 = start + pointInDirection(10.0, startDir),
+            start2 = end - pointInDirection(10.0, endDir),
+            end2 = end,
+        )!!
+        .point
 
 fun clothoidFlattening(
     constant: Double,
@@ -289,9 +328,14 @@ fun clothoidFlattening(
     val startPoint = endPoint + offset
     val piPoint = piPoint(startPoint, endPoint, startAngle, endAngle)
     return clothoid(
-        constant = constant, rotation = rotation,
-        radiusStart = startRadius, dirStartGrads = radsToGrads(startAngle), start = startPoint,
-        radiusEnd = null, dirEndGrads = radsToGrads(endAngle), end = endPoint,
+        constant = constant,
+        rotation = rotation,
+        radiusStart = startRadius,
+        dirStartGrads = radsToGrads(startAngle),
+        start = startPoint,
+        radiusEnd = null,
+        dirEndGrads = radsToGrads(endAngle),
+        end = endPoint,
         pi = piPoint,
     )
 }
@@ -299,101 +343,118 @@ fun clothoidFlattening(
 fun clothoid(
     constant: Double,
     rotation: RotationDirection,
-    radiusStart: Double?, radiusEnd: Double?,
-    start: Point, end: Point,
+    radiusStart: Double?,
+    radiusEnd: Double?,
+    start: Point,
+    end: Point,
     dirStartGrads: Double,
     dirEndGrads: Double,
     length: Double = clothoidLength(constant, radiusStart, radiusEnd),
-) = clothoid(
-    constant = constant,
-    rotation = rotation,
-    radiusStart = radiusStart,
-    radiusEnd = radiusEnd,
-    start = start,
-    end = end,
-    pi = piPoint(start, end, gradsToRads(dirStartGrads), gradsToRads(dirEndGrads)),
-    dirStartGrads = dirStartGrads,
-    dirEndGrads = dirEndGrads,
-    length = length,
-)
-
+) =
+    clothoid(
+        constant = constant,
+        rotation = rotation,
+        radiusStart = radiusStart,
+        radiusEnd = radiusEnd,
+        start = start,
+        end = end,
+        pi = piPoint(start, end, gradsToRads(dirStartGrads), gradsToRads(dirEndGrads)),
+        dirStartGrads = dirStartGrads,
+        dirEndGrads = dirEndGrads,
+        length = length,
+    )
 
 fun clothoid(
     constant: Double,
     rotation: RotationDirection,
-    radiusStart: Double?, radiusEnd: Double?,
-    start: Point, end: Point, pi: Point,
+    radiusStart: Double?,
+    radiusEnd: Double?,
+    start: Point,
+    end: Point,
+    pi: Point,
     length: Double = clothoidLength(constant, radiusStart, radiusEnd),
     dirStartGrads: Double? = null,
     dirEndGrads: Double? = null,
-) = GeometryClothoid(
-    ElementData(
-        name = PlanElementName("Test"),
-        oidPart = PlanElementName("1"),
-        start = start,
-        end = end,
-        staStart = BigDecimal("0.0"),
-        length = length.toBigDecimal(),
-    ),
-    SpiralData(
-        rotation = rotation,
-        directionStart = dirStartGrads?.let { d -> Grads(d.toBigDecimal()) },
-        directionEnd = dirEndGrads?.let { d -> Grads(d.toBigDecimal()) },
-        radiusStart = radiusStart?.toBigDecimal(), radiusEnd = radiusEnd?.toBigDecimal(),
-        pi = pi,
-    ),
-    constant = constant.toBigDecimal(),
-    switchData = emptySwitchData(),
-)
+) =
+    GeometryClothoid(
+        ElementData(
+            name = PlanElementName("Test"),
+            oidPart = PlanElementName("1"),
+            start = start,
+            end = end,
+            staStart = BigDecimal("0.0"),
+            length = length.toBigDecimal(),
+        ),
+        SpiralData(
+            rotation = rotation,
+            directionStart = dirStartGrads?.let { d -> Grads(d.toBigDecimal()) },
+            directionEnd = dirEndGrads?.let { d -> Grads(d.toBigDecimal()) },
+            radiusStart = radiusStart?.toBigDecimal(),
+            radiusEnd = radiusEnd?.toBigDecimal(),
+            pi = pi,
+        ),
+        constant = constant.toBigDecimal(),
+        switchData = emptySwitchData(),
+    )
 
 fun biquadraticParabola(
     length: Double,
     rotation: RotationDirection,
-    radiusStart: Double?, radiusEnd: Double?,
-    start: Point, end: Point,
+    radiusStart: Double?,
+    radiusEnd: Double?,
+    start: Point,
+    end: Point,
     dirStartGrads: Double,
     dirEndGrads: Double,
-) = biquadraticParabola(
-    length = length,
-    rotation = rotation,
-    radiusStart = radiusStart,
-    radiusEnd = radiusEnd,
-    start = start, end = end,
-    pi = piPoint(start, end, gradsToRads(dirStartGrads), gradsToRads(dirEndGrads)),
-    dirStartGrads = dirStartGrads,
-    dirEndGrads = dirEndGrads,
-)
+) =
+    biquadraticParabola(
+        length = length,
+        rotation = rotation,
+        radiusStart = radiusStart,
+        radiusEnd = radiusEnd,
+        start = start,
+        end = end,
+        pi = piPoint(start, end, gradsToRads(dirStartGrads), gradsToRads(dirEndGrads)),
+        dirStartGrads = dirStartGrads,
+        dirEndGrads = dirEndGrads,
+    )
 
 fun biquadraticParabola(
     length: Double,
     rotation: RotationDirection,
-    radiusStart: Double?, radiusEnd: Double?,
-    start: Point, end: Point, pi: Point,
+    radiusStart: Double?,
+    radiusEnd: Double?,
+    start: Point,
+    end: Point,
+    pi: Point,
     dirStartGrads: Double? = null,
     dirEndGrads: Double? = null,
-) = BiquadraticParabola(
-    ElementData(
-        name = PlanElementName("Test"),
-        oidPart = PlanElementName("1"),
-        start = start,
-        end = end,
-        staStart = BigDecimal("0.0"),
-        length = length.toBigDecimal(),
-    ),
-    SpiralData(
-        rotation = rotation,
-        directionStart = dirStartGrads?.let { d -> Grads(d.toBigDecimal()) },
-        directionEnd = dirEndGrads?.let { d -> Grads(d.toBigDecimal()) },
-        radiusStart = radiusStart?.toBigDecimal(), radiusEnd = radiusEnd?.toBigDecimal(),
-        pi = pi,
-    ),
-    switchData = emptySwitchData(),
-)
+) =
+    BiquadraticParabola(
+        ElementData(
+            name = PlanElementName("Test"),
+            oidPart = PlanElementName("1"),
+            start = start,
+            end = end,
+            staStart = BigDecimal("0.0"),
+            length = length.toBigDecimal(),
+        ),
+        SpiralData(
+            rotation = rotation,
+            directionStart = dirStartGrads?.let { d -> Grads(d.toBigDecimal()) },
+            directionEnd = dirEndGrads?.let { d -> Grads(d.toBigDecimal()) },
+            radiusStart = radiusStart?.toBigDecimal(),
+            radiusEnd = radiusEnd?.toBigDecimal(),
+            pi = pi,
+        ),
+        switchData = emptySwitchData(),
+    )
 
-fun infraModelFile(name: String = "test_file.xml") = InfraModelFile(
-    name = FileName(name),
-    content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><LandXml></LandXml>",
-)
+fun infraModelFile(name: String = "test_file.xml") =
+    InfraModelFile(
+        name = FileName(name),
+        content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><LandXml></LandXml>",
+    )
 
 fun plan(
     trackNumber: TrackNumber = TrackNumber("001"),
@@ -407,7 +468,8 @@ fun plan(
     alignments: List<GeometryAlignment> = listOf(geometryAlignment()),
     switches: List<GeometrySwitch> = listOf(),
     measurementMethod: MeasurementMethod? = MeasurementMethod.VERIFIED_DESIGNED_GEOMETRY,
-    elevationMeasurementMethod: ElevationMeasurementMethod? = ElevationMeasurementMethod.TOP_OF_SLEEPER,
+    elevationMeasurementMethod: ElevationMeasurementMethod? =
+        ElevationMeasurementMethod.TOP_OF_SLEEPER,
     trackNumberDesc: PlanElementName = PlanElementName("TNDesc"),
     fileName: FileName = FileName("test_file.xml"),
     coordinateSystemName: CoordinateSystemName? = null,
@@ -445,71 +507,77 @@ fun planHeader(
     id: IntId<GeometryPlan> = IntId(1),
     fileName: FileName = FileName("test_file.xml"),
     measurementMethod: MeasurementMethod? = MeasurementMethod.VERIFIED_DESIGNED_GEOMETRY,
-    elevationMeasurementMethod: ElevationMeasurementMethod? = ElevationMeasurementMethod.TOP_OF_SLEEPER,
+    elevationMeasurementMethod: ElevationMeasurementMethod? =
+        ElevationMeasurementMethod.TOP_OF_SLEEPER,
     srid: Srid = Srid(3879),
     coordinateSystemName: CoordinateSystemName? = null,
     trackNumber: TrackNumber = TrackNumber("001"),
     verticalCoordinateSystem: VerticalCoordinateSystem? = null,
     source: PlanSource = PlanSource.GEOMETRIAPALVELU,
-) = GeometryPlanHeader(
-    id = id,
-    version = RowVersion(id, 1),
-    fileName = fileName,
-    project = project(),
-    units = geometryUnits(srid, coordinateSystemName, verticalCoordinateSystem),
-    planPhase = PlanPhase.RAILWAY_PLAN,
-    decisionPhase = PlanDecisionPhase.APPROVED_PLAN,
-    measurementMethod = measurementMethod,
-    elevationMeasurementMethod = elevationMeasurementMethod,
-    kmNumberRange = null,
-    planTime = Instant.EPOCH,
-    trackNumber = trackNumber,
-    linkedAsPlanId = null,
-    message = FreeTextWithNewLines("test text \n description"),
-    uploadTime = Instant.now(),
-    source = source,
-    hasCant = false,
-    hasProfile = false,
-    author = "Test Company",
-    isHidden = false,
-)
+) =
+    GeometryPlanHeader(
+        id = id,
+        version = RowVersion(id, 1),
+        fileName = fileName,
+        project = project(),
+        units = geometryUnits(srid, coordinateSystemName, verticalCoordinateSystem),
+        planPhase = PlanPhase.RAILWAY_PLAN,
+        decisionPhase = PlanDecisionPhase.APPROVED_PLAN,
+        measurementMethod = measurementMethod,
+        elevationMeasurementMethod = elevationMeasurementMethod,
+        kmNumberRange = null,
+        planTime = Instant.EPOCH,
+        trackNumber = trackNumber,
+        linkedAsPlanId = null,
+        message = FreeTextWithNewLines("test text \n description"),
+        uploadTime = Instant.now(),
+        source = source,
+        hasCant = false,
+        hasProfile = false,
+        author = "Test Company",
+        isHidden = false,
+    )
 
 fun minimalPlan(
     fileName: FileName = FileName("TEST_FILE.xml"),
-) = GeometryPlan(
-    source = PlanSource.GEOMETRIAPALVELU,
-    fileName = fileName,
-    units = GeometryUnits(
-        null,
-        null,
-        null,
-        AngularUnit.GRADS,
-        LinearUnit.METER,
-    ),
-    trackNumberDescription = PlanElementName("TEST_TN_DESC"),
-    project = Project(
-        name = ProjectName("TEST Project"),
-        description = null,
-    ),
-    application = Application(
-        name = MetaDataName("TEST Application"),
-        manufacturer = MetaDataName("TEST APP Company"),
-        version = MetaDataName("v1.0.0"),
-    ),
-    author = null,
-    message = null,
-    planPhase = null,
-    decisionPhase = null,
-    planTime = null,
-    switches = listOf(),
-    alignments = listOf(),
-    kmPosts = listOf(),
-    pvDocumentId = null,
-    measurementMethod = null,
-    elevationMeasurementMethod = null,
-    trackNumber = null,
-    uploadTime = null,
-)
+) =
+    GeometryPlan(
+        source = PlanSource.GEOMETRIAPALVELU,
+        fileName = fileName,
+        units =
+            GeometryUnits(
+                null,
+                null,
+                null,
+                AngularUnit.GRADS,
+                LinearUnit.METER,
+            ),
+        trackNumberDescription = PlanElementName("TEST_TN_DESC"),
+        project =
+            Project(
+                name = ProjectName("TEST Project"),
+                description = null,
+            ),
+        application =
+            Application(
+                name = MetaDataName("TEST Application"),
+                manufacturer = MetaDataName("TEST APP Company"),
+                version = MetaDataName("v1.0.0"),
+            ),
+        author = null,
+        message = null,
+        planPhase = null,
+        decisionPhase = null,
+        planTime = null,
+        switches = listOf(),
+        alignments = listOf(),
+        kmPosts = listOf(),
+        pvDocumentId = null,
+        measurementMethod = null,
+        elevationMeasurementMethod = null,
+        trackNumber = null,
+        uploadTime = null,
+    )
 
 fun geometryLine(
     name: String,
@@ -519,19 +587,21 @@ fun geometryLine(
     staStart: BigDecimal,
     length: BigDecimal,
     elementSwitchData: SwitchData? = null,
-) = GeometryLine(
-    elementData = ElementData(
-        name = PlanElementName(name),
-        oidPart = PlanElementName(oidPart),
-        start = start,
-        end = end,
-        staStart = staStart,
-        length = length,
-    ),
-    switchData = elementSwitchData ?: SwitchData(
-        switchId = null, startJointNumber = null, endJointNumber = null
-    ),
-)
+) =
+    GeometryLine(
+        elementData =
+            ElementData(
+                name = PlanElementName(name),
+                oidPart = PlanElementName(oidPart),
+                start = start,
+                end = end,
+                staStart = staStart,
+                length = length,
+            ),
+        switchData =
+            elementSwitchData
+                ?: SwitchData(switchId = null, startJointNumber = null, endJointNumber = null),
+    )
 
 fun geometryElements(): List<GeometryElement> {
     val start = Point(x = 385372.582, y = 6673712.000614)
@@ -559,88 +629,102 @@ fun geometryAlignment(
     name: String = "001",
     id: DomainId<GeometryAlignment> = StringId(),
     featureTypeCode: FeatureTypeCode = FeatureTypeCode("281"),
-): GeometryAlignment = GeometryAlignment(
-    id = id,
-    name = AlignmentName(name),
-    description = FreeText("test-alignment 001"),
-    oidPart = null,
-    state = PlanState.PROPOSED,
-    featureTypeCode = featureTypeCode,
-    staStart = BigDecimal("0.000000"),
-    elements = elements,
-    profile = profile,
-    cant = cant,
-)
+): GeometryAlignment =
+    GeometryAlignment(
+        id = id,
+        name = AlignmentName(name),
+        description = FreeText("test-alignment 001"),
+        oidPart = null,
+        state = PlanState.PROPOSED,
+        featureTypeCode = featureTypeCode,
+        staStart = BigDecimal("0.000000"),
+        elements = elements,
+        profile = profile,
+        cant = cant,
+    )
 
-fun linearCant(startDistance: Double, endDistance: Double, startValue: Double, endValue: Double): GeometryCant {
-    val point1 = GeometryCantPoint(
-        station = round(startDistance, 6),
-        appliedCant = round(startValue, 6),
-        curvature = CW,
-        transitionType = LINEAR,
-    )
-    val point2 = GeometryCantPoint(
-        station = round(endDistance, 6),
-        appliedCant = round(endValue, 6),
-        curvature = CW,
-        transitionType = LINEAR,
-    )
+fun linearCant(
+    startDistance: Double,
+    endDistance: Double,
+    startValue: Double,
+    endValue: Double
+): GeometryCant {
+    val point1 =
+        GeometryCantPoint(
+            station = round(startDistance, 6),
+            appliedCant = round(startValue, 6),
+            curvature = CW,
+            transitionType = LINEAR,
+        )
+    val point2 =
+        GeometryCantPoint(
+            station = round(endDistance, 6),
+            appliedCant = round(endValue, 6),
+            curvature = CW,
+            transitionType = LINEAR,
+        )
     return geometryCant(points = listOf(point1, point2))
 }
 
-fun geometryCant(points: List<GeometryCantPoint>) = GeometryCant(
-    name = PlanElementName("TST Cant"),
-    description = PlanElementName("Test alignment cant"),
-    gauge = FINNISH_RAIL_GAUGE,
-    rotationPoint = CantRotationPoint.INSIDE_RAIL,
-    points = points,
-)
+fun geometryCant(points: List<GeometryCantPoint>) =
+    GeometryCant(
+        name = PlanElementName("TST Cant"),
+        description = PlanElementName("Test alignment cant"),
+        gauge = FINNISH_RAIL_GAUGE,
+        rotationPoint = CantRotationPoint.INSIDE_RAIL,
+        points = points,
+    )
 
 fun geometrySwitch(
     name: String = "TEST V001",
     switchStructureId: IntId<SwitchStructure>? = null,
-) = GeometrySwitch(
-    name = SwitchName(name),
-    state = PlanState.EXISTING,
-    switchStructureId = switchStructureId,
-    joints = listOf(
-        GeometrySwitchJoint(JointNumber(1), Point(1.0, 1.0)),
-        GeometrySwitchJoint(JointNumber(2), Point(2.0, 2.0)),
-    ),
-    typeName = GeometrySwitchTypeName("TestSwitchType"),
-)
-
-fun kmPosts(srid: Srid) = listOf(
-    GeometryKmPost(
-        staBack = null,
-        staAhead = BigDecimal("-148.729000"),
-        staInternal = BigDecimal("-148.729000"),
-        kmNumber = KmNumber.ZERO,
-        description = PlanElementName("0"),
-        state = PlanState.PROPOSED,
-        location = null,
-    ), GeometryKmPost(
-        staBack = BigDecimal("1003.440894"),
-        staAhead = BigDecimal("854.711894"),
-        staInternal = BigDecimal("854.711894"),
-        kmNumber = KmNumber(1),
-        description = PlanElementName("1"),
-        state = PlanState.PROPOSED,
-        location = transformNonKKJCoordinate(Srid(3879), srid, Point(x = 25496284.448063374, y = 6674885.339042075))
+) =
+    GeometrySwitch(
+        name = SwitchName(name),
+        state = PlanState.EXISTING,
+        switchStructureId = switchStructureId,
+        joints =
+            listOf(
+                GeometrySwitchJoint(JointNumber(1), Point(1.0, 1.0)),
+                GeometrySwitchJoint(JointNumber(2), Point(2.0, 2.0)),
+            ),
+        typeName = GeometrySwitchTypeName("TestSwitchType"),
     )
-)
+
+fun kmPosts(srid: Srid) =
+    listOf(
+        GeometryKmPost(
+            staBack = null,
+            staAhead = BigDecimal("-148.729000"),
+            staInternal = BigDecimal("-148.729000"),
+            kmNumber = KmNumber.ZERO,
+            description = PlanElementName("0"),
+            state = PlanState.PROPOSED,
+            location = null,
+        ),
+        GeometryKmPost(
+            staBack = BigDecimal("1003.440894"),
+            staAhead = BigDecimal("854.711894"),
+            staInternal = BigDecimal("854.711894"),
+            kmNumber = KmNumber(1),
+            description = PlanElementName("1"),
+            state = PlanState.PROPOSED,
+            location =
+                transformNonKKJCoordinate(
+                    Srid(3879), srid, Point(x = 25496284.448063374, y = 6674885.339042075))))
 
 fun geometryUnits(
     srid: Srid,
     coordinateSystemName: CoordinateSystemName? = null,
     verticalCoordinateSystem: VerticalCoordinateSystem? = VerticalCoordinateSystem.N2000,
-) = GeometryUnits(
-    coordinateSystemSrid = srid,
-    coordinateSystemName = coordinateSystemName,
-    verticalCoordinateSystem = verticalCoordinateSystem,
-    directionUnit = AngularUnit.GRADS,
-    linearUnit = LinearUnit.METER,
-)
+) =
+    GeometryUnits(
+        coordinateSystemSrid = srid,
+        coordinateSystemName = coordinateSystemName,
+        verticalCoordinateSystem = verticalCoordinateSystem,
+        directionUnit = AngularUnit.GRADS,
+        linearUnit = LinearUnit.METER,
+    )
 
 fun project(name: String = "TEST Project", description: String? = null) =
     Project(ProjectName(name), description?.let(::FreeText))
@@ -655,10 +739,11 @@ fun application(
 
 fun testFile() = InfraModelFile(FileName("testfile_empty_xml.xml"), "<a></a>")
 
-fun someBoundingPolygon() = listOf(
-    Point(494585.0, 6710975.0),
-    Point(494791.0, 6711265.0),
-    Point(495074.0, 6711718.0),
-    Point(494786.0, 6711281.0),
-    Point(494585.0, 6710975.0),
-)
+fun someBoundingPolygon() =
+    listOf(
+        Point(494585.0, 6710975.0),
+        Point(494791.0, 6711265.0),
+        Point(495074.0, 6711718.0),
+        Point(494786.0, 6711281.0),
+        Point(494585.0, 6710975.0),
+    )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryElementTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryElementTest.kt
@@ -3,11 +3,11 @@ package fi.fta.geoviite.infra.geometry
 import fi.fta.geoviite.infra.common.RotationDirection.CCW
 import fi.fta.geoviite.infra.common.RotationDirection.CW
 import fi.fta.geoviite.infra.math.*
+import kotlin.math.*
+import kotlin.test.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.math.*
-import kotlin.test.assertFalse
 
 const val COMPARE_DELTA = 0.000001
 
@@ -15,11 +15,13 @@ class GeometryElementTest {
 
     @Test
     fun lineCalculationWorks() {
-        assertGeometryValid(line(
-            length = 121.133,
-            start = Point(x = 2497947.988500, y = 6661582.954000),
-            end = Point(x = 2497847.364500, y = 6661515.514000),
-        ), accuracy = 0.001)
+        assertGeometryValid(
+            line(
+                length = 121.133,
+                start = Point(x = 2497947.988500, y = 6661582.954000),
+                end = Point(x = 2497847.364500, y = 6661515.514000),
+            ),
+            accuracy = 0.001)
     }
 
     @Test
@@ -37,24 +39,32 @@ class GeometryElementTest {
 
     @Test
     fun curveCalculationWorksCcw() {
-        assertGeometryValid(curve(
-            length = 37.654, rotation = CCW,
-            radius = 1070.0, chord = 37.651564,
-            start = Point(x = 2499138.729000, y = 6662277.682000),
-            end = Point(x = 2499109.274000, y = 6662254.229000),
-            center = Point(x = 2499790.389000, y = 6661429.013000),
-        ), accuracy = 0.001)
+        assertGeometryValid(
+            curve(
+                length = 37.654,
+                rotation = CCW,
+                radius = 1070.0,
+                chord = 37.651564,
+                start = Point(x = 2499138.729000, y = 6662277.682000),
+                end = Point(x = 2499109.274000, y = 6662254.229000),
+                center = Point(x = 2499790.389000, y = 6661429.013000),
+            ),
+            accuracy = 0.001)
     }
 
     @Test
     fun curveCalculationWorksCw() {
-        assertGeometryValid(curve(
-            length = 204.018, rotation = CW,
-            radius = 806.0, chord = 203.473678,
-            start = Point(x = 2498762.696000, y = 6661941.804000),
-            end = Point(x = 2498585.977000, y = 6661840.948000),
-            center = Point(x = 2498278.021000, y = 6662585.797000),
-        ), accuracy = 0.001)
+        assertGeometryValid(
+            curve(
+                length = 204.018,
+                rotation = CW,
+                radius = 806.0,
+                chord = 203.473678,
+                start = Point(x = 2498762.696000, y = 6661941.804000),
+                end = Point(x = 2498585.977000, y = 6661840.948000),
+                center = Point(x = 2498278.021000, y = 6662585.797000),
+            ),
+            accuracy = 0.001)
     }
 
     @Test
@@ -80,38 +90,50 @@ class GeometryElementTest {
 
     @Test
     fun clothoidCalculationWorksFlatteningBetweenCurvesCw() {
-        assertGeometryValid(clothoid(
-            constant = 404.795,
-            length = 103.0, rotation = CW,
-            dirStartGrads = 100.0 - 290.647958, dirEndGrads = 100.0 - 295.27125,
-            radiusStart = 2559.0, radiusEnd = 981.0,
-            start = Point(x = 2485163.625000, y = 6663015.781500),
-            end = Point(x = 2485061.340000, y = 6663003.865000)
-        ), accuracy = 0.001)
+        assertGeometryValid(
+            clothoid(
+                constant = 404.795,
+                length = 103.0,
+                rotation = CW,
+                dirStartGrads = 100.0 - 290.647958,
+                dirEndGrads = 100.0 - 295.27125,
+                radiusStart = 2559.0,
+                radiusEnd = 981.0,
+                start = Point(x = 2485163.625000, y = 6663015.781500),
+                end = Point(x = 2485061.340000, y = 6663003.865000)),
+            accuracy = 0.001)
     }
 
     @Test
     fun clothoidCalculationWorksFlatteningCw() {
-        assertGeometryValid(clothoid(
-            constant = 377.831,
-            length = 178.0, rotation = CW,
-            dirStartGrads = 100.0 - 255.173986, dirEndGrads = 100.0 - 262.238719,
-            radiusStart = 802.0, radiusEnd = null,
-            start = Point(x = 2500648.286000, y = 6663306.527500),
-            end = Point(x = 2500504.550000, y = 6663201.697000)
-        ), accuracy = 0.001)
+        assertGeometryValid(
+            clothoid(
+                constant = 377.831,
+                length = 178.0,
+                rotation = CW,
+                dirStartGrads = 100.0 - 255.173986,
+                dirEndGrads = 100.0 - 262.238719,
+                radiusStart = 802.0,
+                radiusEnd = null,
+                start = Point(x = 2500648.286000, y = 6663306.527500),
+                end = Point(x = 2500504.550000, y = 6663201.697000)),
+            accuracy = 0.001)
     }
 
     @Test
     fun clothoidCalculationWorksSteepeningCcw() {
-        assertGeometryValid(clothoid(
-            constant = 375.819,
-            length = 132.0, rotation = CCW,
-            dirStartGrads = 100.0 - 262.238719, dirEndGrads = 100.0 - 258.311905,
-            radiusStart = null, radiusEnd = 1070.0,
-            start = Point(x = 2499246.623000, y = 6662353.689000),
-            end = Point(x = 2499138.729000, y = 6662277.682000)
-        ), accuracy = 0.001)
+        assertGeometryValid(
+            clothoid(
+                constant = 375.819,
+                length = 132.0,
+                rotation = CCW,
+                dirStartGrads = 100.0 - 262.238719,
+                dirEndGrads = 100.0 - 258.311905,
+                radiusStart = null,
+                radiusEnd = 1070.0,
+                start = Point(x = 2499246.623000, y = 6662353.689000),
+                end = Point(x = 2499138.729000, y = 6662277.682000)),
+            accuracy = 0.001)
     }
 
     @Test
@@ -122,14 +144,16 @@ class GeometryElementTest {
         assertGrowsConsistently(clothoidFromOrigin(CW, 100.0), positiveX = true, positiveY = true)
         assertGrowsConsistently(clothoidFromOrigin(CCW, 100.0), positiveX = false, positiveY = true)
         assertGrowsConsistently(clothoidFromOrigin(CW, 200.0), positiveX = false, positiveY = true)
-        assertGrowsConsistently(clothoidFromOrigin(CCW, 200.0), positiveX = false, positiveY = false)
+        assertGrowsConsistently(
+            clothoidFromOrigin(CCW, 200.0), positiveX = false, positiveY = false)
         assertGrowsConsistently(clothoidFromOrigin(CW, 300.0), positiveX = false, positiveY = false)
         assertGrowsConsistently(clothoidFromOrigin(CCW, 300.0), positiveX = true, positiveY = false)
     }
 
     @Test
     fun clothoidFlatteningVariationsCalculationWorks() {
-        // Flattening curves: start curved outside origin, straighten out as it heads in, ending at origin
+        // Flattening curves: start curved outside origin, straighten out as it heads in, ending at
+        // origin
         assertGrowsConsistently(clothoidToOrigin(CW, 0.0), positiveX = true, positiveY = true)
         assertGrowsConsistently(clothoidToOrigin(CCW, 0.0), positiveX = true, positiveY = false)
         assertGrowsConsistently(clothoidToOrigin(CW, 100.0), positiveX = false, positiveY = true)
@@ -142,50 +166,75 @@ class GeometryElementTest {
 
     @Test
     fun biquadraticParabolaCalculationWorksL162FlatteningCcw() {
-        assertGeometryValid(biquadraticParabola(
-            length = 162.0, rotation = CCW,
-            dirStartGrads = 100.0 - 283.253815, dirEndGrads = 100.0 - 279.117589,
-            radiusStart = 1244.0, radiusEnd = null,
-            start = Point(x = 2485815.150000, y = 6663189.957500),
-            end = Point(x = 2485660.856000, y = 6663140.695000)
-        ), accuracy = 0.1) // Poor accuracy in this calculation type
+        assertGeometryValid(
+            biquadraticParabola(
+                length = 162.0,
+                rotation = CCW,
+                dirStartGrads = 100.0 - 283.253815,
+                dirEndGrads = 100.0 - 279.117589,
+                radiusStart = 1244.0,
+                radiusEnd = null,
+                start = Point(x = 2485815.150000, y = 6663189.957500),
+                end = Point(x = 2485660.856000, y = 6663140.695000)),
+            accuracy = 0.1) // Poor accuracy in this calculation type
     }
 
     @Test
     fun biquadraticParabolaCalculationWorksL100SteepeningCw() {
-        assertGeometryValid(biquadraticParabola(
-            length = 100.0, rotation = CW,
-            dirStartGrads = 100.0 - 279.117589, dirEndGrads = 100.0 - 280.361230,
-            radiusStart = null, radiusEnd = 2559.0,
-            start = Point(x = 2485660.856000, y = 6663140.695000),
-            end = Point(x = 2485566.007000, y = 6663109.018500)
-        ), accuracy = 0.1) // Poor accuracy in this calculation type
+        assertGeometryValid(
+            biquadraticParabola(
+                length = 100.0,
+                rotation = CW,
+                dirStartGrads = 100.0 - 279.117589,
+                dirEndGrads = 100.0 - 280.361230,
+                radiusStart = null,
+                radiusEnd = 2559.0,
+                start = Point(x = 2485660.856000, y = 6663140.695000),
+                end = Point(x = 2485566.007000, y = 6663109.018500)),
+            accuracy = 0.1) // Poor accuracy in this calculation type
     }
 
     @Test
     fun biquadraticParabolaVariationsCalculationWorks() {
         // Steepening curves: start straight in origin, curve as it heads outwards
-        assertGrowsConsistently(biquadraticParabolaFromOrigin(CCW, 0.0), positiveX = true, positiveY = true)
-        assertGrowsConsistently(biquadraticParabolaFromOrigin(CW, 0.0), positiveX = true, positiveY = false)
-        assertGrowsConsistently(biquadraticParabolaFromOrigin(CW, 100.0), positiveX = true, positiveY = true)
-        assertGrowsConsistently(biquadraticParabolaFromOrigin(CCW, 100.0), positiveX = false, positiveY = true)
-        assertGrowsConsistently(biquadraticParabolaFromOrigin(CW, 200.0), positiveX = false, positiveY = true)
-        assertGrowsConsistently(biquadraticParabolaFromOrigin(CCW, 200.0), positiveX = false, positiveY = false)
-        assertGrowsConsistently(biquadraticParabolaFromOrigin(CW, 300.0), positiveX = false, positiveY = false)
-        assertGrowsConsistently(biquadraticParabolaFromOrigin(CCW, 300.0), positiveX = true, positiveY = false)
+        assertGrowsConsistently(
+            biquadraticParabolaFromOrigin(CCW, 0.0), positiveX = true, positiveY = true)
+        assertGrowsConsistently(
+            biquadraticParabolaFromOrigin(CW, 0.0), positiveX = true, positiveY = false)
+        assertGrowsConsistently(
+            biquadraticParabolaFromOrigin(CW, 100.0), positiveX = true, positiveY = true)
+        assertGrowsConsistently(
+            biquadraticParabolaFromOrigin(CCW, 100.0), positiveX = false, positiveY = true)
+        assertGrowsConsistently(
+            biquadraticParabolaFromOrigin(CW, 200.0), positiveX = false, positiveY = true)
+        assertGrowsConsistently(
+            biquadraticParabolaFromOrigin(CCW, 200.0), positiveX = false, positiveY = false)
+        assertGrowsConsistently(
+            biquadraticParabolaFromOrigin(CW, 300.0), positiveX = false, positiveY = false)
+        assertGrowsConsistently(
+            biquadraticParabolaFromOrigin(CCW, 300.0), positiveX = true, positiveY = false)
     }
 
     @Test
     fun biquadraticParabolaFlatteningVariationsCalculationWorks() {
-        // Flattening curves: start curved outside origin, straighten out as it heads in, ending at origin
-        assertGrowsConsistently(biquadraticParabolaToOrigin(CW, 0.0), positiveX = true, positiveY = true)
-        assertGrowsConsistently(biquadraticParabolaToOrigin(CCW, 0.0), positiveX = true, positiveY = false)
-        assertGrowsConsistently(biquadraticParabolaToOrigin(CW, 100.0), positiveX = false, positiveY = true)
-        assertGrowsConsistently(biquadraticParabolaToOrigin(CCW, 100.0), positiveX = true, positiveY = true)
-        assertGrowsConsistently(biquadraticParabolaToOrigin(CW, 200.0), positiveX = false, positiveY = false)
-        assertGrowsConsistently(biquadraticParabolaToOrigin(CCW, 200.0), positiveX = false, positiveY = true)
-        assertGrowsConsistently(biquadraticParabolaToOrigin(CW, 300.0), positiveX = true, positiveY = false)
-        assertGrowsConsistently(biquadraticParabolaToOrigin(CCW, 300.0), positiveX = false, positiveY = false)
+        // Flattening curves: start curved outside origin, straighten out as it heads in, ending at
+        // origin
+        assertGrowsConsistently(
+            biquadraticParabolaToOrigin(CW, 0.0), positiveX = true, positiveY = true)
+        assertGrowsConsistently(
+            biquadraticParabolaToOrigin(CCW, 0.0), positiveX = true, positiveY = false)
+        assertGrowsConsistently(
+            biquadraticParabolaToOrigin(CW, 100.0), positiveX = false, positiveY = true)
+        assertGrowsConsistently(
+            biquadraticParabolaToOrigin(CCW, 100.0), positiveX = true, positiveY = true)
+        assertGrowsConsistently(
+            biquadraticParabolaToOrigin(CW, 200.0), positiveX = false, positiveY = false)
+        assertGrowsConsistently(
+            biquadraticParabolaToOrigin(CCW, 200.0), positiveX = false, positiveY = true)
+        assertGrowsConsistently(
+            biquadraticParabolaToOrigin(CW, 300.0), positiveX = true, positiveY = false)
+        assertGrowsConsistently(
+            biquadraticParabolaToOrigin(CCW, 300.0), positiveX = false, positiveY = false)
     }
 
     @Test
@@ -312,12 +361,14 @@ class GeometryElementTest {
     @Test
     fun curveLengthUntilWorksCw() {
         val radius = 100.0
-        val curve = curve(
-            rotation = CW, radius = radius,
-            start = Point(x = 200.0, y = 100.0),
-            end = Point(x = 100.0, y = 0.0),
-            center = Point(x = 100.0, y = 100.0),
-        )
+        val curve =
+            curve(
+                rotation = CW,
+                radius = radius,
+                start = Point(x = 200.0, y = 100.0),
+                end = Point(x = 100.0, y = 0.0),
+                center = Point(x = 100.0, y = 100.0),
+            )
 
         assertLengthUntilExact(curve, curve.start, 0.0)
         assertLengthUntilExact(curve, curve.end, circleArcLength(radius) / 4)
@@ -326,19 +377,22 @@ class GeometryElementTest {
         assertLengthUntilExact(curve, quarterTarget, circleArcLength(radius) / 8)
 
         val distantQuarterTarget = pointInDirection(curve.center, radius * 2, -PI / 4)
-        assertEquals(circleArcLength(radius) / 8, curve.getLengthUntil(distantQuarterTarget), COMPARE_DELTA)
+        assertEquals(
+            circleArcLength(radius) / 8, curve.getLengthUntil(distantQuarterTarget), COMPARE_DELTA)
     }
 
     @Test
     fun curveLengthUntilWorksCcw() {
         val radius = 100.0
         val center = Point(x = 100.0, y = 100.0)
-        val curve = curve(
-            rotation = CCW, radius = radius,
-            start = pointInDirection(center, radius, 3 * PI / 4),
-            end = pointInDirection(center, radius, -3 * PI / 4),
-            center = center,
-        )
+        val curve =
+            curve(
+                rotation = CCW,
+                radius = radius,
+                start = pointInDirection(center, radius, 3 * PI / 4),
+                end = pointInDirection(center, radius, -3 * PI / 4),
+                center = center,
+            )
 
         assertLengthUntilExact(curve, curve.start, 0.0)
         assertLengthUntilExact(curve, curve.end, circleArcLength(radius) / 4)
@@ -347,18 +401,23 @@ class GeometryElementTest {
         assertLengthUntilExact(curve, quarterTarget, circleArcLength(radius) / 8)
 
         val distantQuarterTarget = Point(x = -100.0, y = 100.0)
-        assertEquals(circleArcLength(radius) / 8, curve.getLengthUntil(distantQuarterTarget), COMPARE_DELTA)
+        assertEquals(
+            circleArcLength(radius) / 8, curve.getLengthUntil(distantQuarterTarget), COMPARE_DELTA)
     }
 
     @Test
     fun biquadraticParabolaLengthUntilWorksCw() {
-        val parabola = biquadraticParabola(
-            length = 100.0, rotation = CW,
-            dirStartGrads = 100.0 - 279.117589, dirEndGrads = 100.0 - 280.361230,
-            radiusStart = null, radiusEnd = 2559.0,
-            start = Point(x = 2485660.856000, y = 6663140.695000),
-            end = Point(x = 2485566.007000, y = 6663109.018500),
-        )
+        val parabola =
+            biquadraticParabola(
+                length = 100.0,
+                rotation = CW,
+                dirStartGrads = 100.0 - 279.117589,
+                dirEndGrads = 100.0 - 280.361230,
+                radiusStart = null,
+                radiusEnd = 2559.0,
+                start = Point(x = 2485660.856000, y = 6663140.695000),
+                end = Point(x = 2485566.007000, y = 6663109.018500),
+            )
         assertEquals(0.0, parabola.getLengthUntil(parabola.start), COMPARE_DELTA)
         assertEquals(parabola.calculatedLength, parabola.getLengthUntil(parabola.end), 0.1)
         assertLengthUntilAlongElement(parabola, 0.1)
@@ -366,13 +425,17 @@ class GeometryElementTest {
 
     @Test
     fun biquadraticParabolaLengthUntilWorksCcw() {
-        val parabola = biquadraticParabola(
-            length = 162.0, rotation = CCW,
-            dirStartGrads = 100.0 - 283.253815, dirEndGrads = 100.0 - 279.117589,
-            radiusStart = 1244.0, radiusEnd = null,
-            start = Point(x = 2485815.150000, y = 6663189.957500),
-            end = Point(x = 2485660.856000, y = 6663140.695000),
-        )
+        val parabola =
+            biquadraticParabola(
+                length = 162.0,
+                rotation = CCW,
+                dirStartGrads = 100.0 - 283.253815,
+                dirEndGrads = 100.0 - 279.117589,
+                radiusStart = 1244.0,
+                radiusEnd = null,
+                start = Point(x = 2485815.150000, y = 6663189.957500),
+                end = Point(x = 2485660.856000, y = 6663140.695000),
+            )
         assertEquals(0.0, parabola.getLengthUntil(parabola.start), COMPARE_DELTA)
         assertEquals(parabola.calculatedLength, parabola.getLengthUntil(parabola.end), 0.1)
         assertLengthUntilAlongElement(parabola, 0.1)
@@ -380,13 +443,17 @@ class GeometryElementTest {
 
     @Test
     fun clothoidLengthUntilWorksCw() {
-        val clothoid = clothoid(
-            constant = 404.795, rotation = CW,
-            dirStartGrads = 100.0 - 290.647958, dirEndGrads = 100.0 - 295.27125,
-            radiusStart = 2559.0, radiusEnd = 981.0,
-            start = Point(x = 2485163.625000, y = 6663015.781500),
-            end = Point(x = 2485061.340000, y = 6663003.865000),
-        )
+        val clothoid =
+            clothoid(
+                constant = 404.795,
+                rotation = CW,
+                dirStartGrads = 100.0 - 290.647958,
+                dirEndGrads = 100.0 - 295.27125,
+                radiusStart = 2559.0,
+                radiusEnd = 981.0,
+                start = Point(x = 2485163.625000, y = 6663015.781500),
+                end = Point(x = 2485061.340000, y = 6663003.865000),
+            )
         assertEquals(0.0, clothoid.getLengthUntil(clothoid.start), COMPARE_DELTA)
         assertEquals(clothoid.calculatedLength, clothoid.getLengthUntil(clothoid.end), 0.001)
         assertLengthUntilAlongElement(clothoid, 0.001)
@@ -394,13 +461,17 @@ class GeometryElementTest {
 
     @Test
     fun clothoidLengthUntilWorksCcw() {
-        val clothoid = clothoid(
-            constant = 375.819, rotation = CCW,
-            dirStartGrads = 100.0 - 262.238719, dirEndGrads = 100.0 - 258.311905,
-            radiusStart = null, radiusEnd = 1070.0,
-            start = Point(x = 2499246.623000, y = 6662353.689000),
-            end = Point(x = 2499138.729000, y = 6662277.682000),
-        )
+        val clothoid =
+            clothoid(
+                constant = 375.819,
+                rotation = CCW,
+                dirStartGrads = 100.0 - 262.238719,
+                dirEndGrads = 100.0 - 258.311905,
+                radiusStart = null,
+                radiusEnd = 1070.0,
+                start = Point(x = 2499246.623000, y = 6662353.689000),
+                end = Point(x = 2499138.729000, y = 6662277.682000),
+            )
         assertEquals(0.0, clothoid.getLengthUntil(clothoid.start), COMPARE_DELTA)
         assertEquals(clothoid.calculatedLength, clothoid.getLengthUntil(clothoid.end), 0.001)
         assertLengthUntilAlongElement(clothoid, 0.001)
@@ -409,35 +480,46 @@ class GeometryElementTest {
     private fun assertGeometryValid(element: GeometryElement, accuracy: Double) {
         assertEquals(element.length.toDouble(), element.calculatedLength, accuracy)
         assertApproximatelyEquals(element.start, element.getCoordinateAt(0.0), accuracy)
-        assertApproximatelyEquals(element.end, element.getCoordinateAt(element.length.toDouble()), accuracy)
+        assertApproximatelyEquals(
+            element.end, element.getCoordinateAt(element.length.toDouble()), accuracy)
     }
 
-    private fun assertGrowsConsistently(element: GeometryElement, positiveX: Boolean, positiveY: Boolean) {
+    private fun assertGrowsConsistently(
+        element: GeometryElement,
+        positiveX: Boolean,
+        positiveY: Boolean
+    ) {
         var previous: Point = element.getCoordinateAt(0.0)
         val totalLength = element.calculatedLength.toInt()
         for (dist in 1..totalLength step 1) {
             val current: Point = element.getCoordinateAt(dist.toDouble())
             if (positiveX) {
-                assertTrue(current.x > previous.x, "X should grow: current=${current.x} previous=${previous.x}")
+                assertTrue(
+                    current.x > previous.x,
+                    "X should grow: current=${current.x} previous=${previous.x}")
             } else {
-                assertTrue(current.x < previous.x, "X should shrink: current=${current.x} previous=${previous.x}")
+                assertTrue(
+                    current.x < previous.x,
+                    "X should shrink: current=${current.x} previous=${previous.x}")
             }
             if (positiveY) {
-                assertTrue(current.y > previous.y, "Y should grow: current=${current.y} previous=${previous.y}")
+                assertTrue(
+                    current.y > previous.y,
+                    "Y should grow: current=${current.y} previous=${previous.y}")
             } else {
-                assertTrue(current.y < previous.y, "Y should shrink: current=${current.y} previous=${previous.y}")
+                assertTrue(
+                    current.y < previous.y,
+                    "Y should shrink: current=${current.y} previous=${previous.y}")
             }
             val portion = dist.toDouble() / totalLength.toDouble()
             val maxDist = element.length.toDouble() * portion + 0.2 // Allow for accuracy deviation
             val offsetFromStart = current - element.getCoordinateAt(0.0)
             assertTrue(
                 abs(offsetFromStart.x) <= maxDist,
-                "Step $dist: X-offset=abs(${current.x}) should be less than ${element.length.toDouble()}*$portion=$maxDist"
-            )
+                "Step $dist: X-offset=abs(${current.x}) should be less than ${element.length.toDouble()}*$portion=$maxDist")
             assertTrue(
                 abs(offsetFromStart.y) <= maxDist,
-                "Step $dist: Y-offset=abs(${current.y}) should be less than ${element.length.toDouble()}*$portion=$maxDist"
-            )
+                "Step $dist: Y-offset=abs(${current.y}) should be less than ${element.length.toDouble()}*$portion=$maxDist")
             previous = current
         }
     }
@@ -449,16 +531,19 @@ class GeometryElementTest {
         var distance = 0.0
         while (distance <= element.calculatedLength) {
             val point = element.getCoordinateAt(distance)
-            assertTrue(bbox.contains(point),
+            assertTrue(
+                bbox.contains(point),
                 "Bounding box should contain all element points: bbox=$bbox point=$point element=$element")
             distance += step
         }
 
-        val minPoint = Point(min(element.start.x, element.end.x), min(element.start.y, element.end.y))
+        val minPoint =
+            Point(min(element.start.x, element.end.x), min(element.start.y, element.end.y))
         assertFalse(bbox.contains(minPoint - Point(testOffset, 0.0)))
         assertFalse(bbox.contains(minPoint - Point(0.0, testOffset)))
 
-        val maxPoint = Point(max(element.start.x, element.end.x), max(element.start.y, element.end.y))
+        val maxPoint =
+            Point(max(element.start.x, element.end.x), max(element.start.y, element.end.y))
         assertFalse(bbox.contains(maxPoint + Point(testOffset, 0.0)))
         assertFalse(bbox.contains(maxPoint + Point(0.0, testOffset)))
     }
@@ -469,7 +554,10 @@ class GeometryElementTest {
         assertTrue(target.isSame(element.getCoordinateAt(lengthUntil), COMPARE_DELTA))
     }
 
-    private fun assertLengthUntilAlongElement(element: GeometryElement, delta: Double = COMPARE_DELTA) {
+    private fun assertLengthUntilAlongElement(
+        element: GeometryElement,
+        delta: Double = COMPARE_DELTA
+    ) {
         val steps = 5
         for (i in 0..steps) {
             val length = (i / steps) * element.calculatedLength

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfileTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfileTest.kt
@@ -3,11 +3,10 @@ package fi.fta.geoviite.infra.geometry
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
+import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
-
 
 class GeometryProfileTest {
 
@@ -15,23 +14,27 @@ class GeometryProfileTest {
     fun shouldReturnPVITangentPoints() {
         val accuracy = 0.000000001
 
-        val tangentPoints1 = tangentPointsOfPvi(
-            leftPvi = Point(4.0, 2.0),
-            middlePvi = Point(9.5, 12.0),
-            rightPvi = Point(13.0, 3.0),
-            radius = -3.0
-        )
-        assertApproximatelyEquals(Point(6.403890888228156, 6.370710705869375), tangentPoints1.first, accuracy)
-        assertApproximatelyEquals(Point(11.828552628881985, 6.012293240017755), tangentPoints1.second, accuracy)
+        val tangentPoints1 =
+            tangentPointsOfPvi(
+                leftPvi = Point(4.0, 2.0),
+                middlePvi = Point(9.5, 12.0),
+                rightPvi = Point(13.0, 3.0),
+                radius = -3.0)
+        assertApproximatelyEquals(
+            Point(6.403890888228156, 6.370710705869375), tangentPoints1.first, accuracy)
+        assertApproximatelyEquals(
+            Point(11.828552628881985, 6.012293240017755), tangentPoints1.second, accuracy)
 
-        val tangentPoints2 = tangentPointsOfPvi(
-            leftPvi = Point(60.0, 19.65),
-            middlePvi = Point(304.394100, 18.052),
-            rightPvi = Point(400.0002, 18.5302),
-            radius = 3000.0
-        )
-        assertApproximatelyEquals(Point(287.08389182585677, 18.165184862737195), tangentPoints2.first, accuracy)
-        assertApproximatelyEquals(Point(321.7044616749155, 18.13858249790489), tangentPoints2.second, accuracy)
+        val tangentPoints2 =
+            tangentPointsOfPvi(
+                leftPvi = Point(60.0, 19.65),
+                middlePvi = Point(304.394100, 18.052),
+                rightPvi = Point(400.0002, 18.5302),
+                radius = 3000.0)
+        assertApproximatelyEquals(
+            Point(287.08389182585677, 18.165184862737195), tangentPoints2.first, accuracy)
+        assertApproximatelyEquals(
+            Point(321.7044616749155, 18.13858249790489), tangentPoints2.second, accuracy)
     }
 
     @Test
@@ -39,12 +42,12 @@ class GeometryProfileTest {
         val accuracy = 0.0001
 
         // Top-of-hill, centered
-        val tangentPoints1 = tangentPointsOfPvi(
-            leftPvi = Point(1.0, -1.0),
-            middlePvi = Point(3.5, 2.0),
-            rightPvi = Point(7.0, -1.0),
-            radius = -2.0
-        )
+        val tangentPoints1 =
+            tangentPointsOfPvi(
+                leftPvi = Point(1.0, -1.0),
+                middlePvi = Point(3.5, 2.0),
+                rightPvi = Point(7.0, -1.0),
+                radius = -2.0)
         assertApproximatelyEquals(Point(2.2017, 0.4421), tangentPoints1.first, accuracy)
         assertApproximatelyEquals(Point(5.0397, 0.6802), tangentPoints1.second, accuracy)
         assertApproximatelyEquals(
@@ -54,12 +57,12 @@ class GeometryProfileTest {
         )
 
         // Top-of-hill, left-tilted
-        val tangentPoints2 = tangentPointsOfPvi(
-            leftPvi = Point(1.0, -1.0),
-            middlePvi = Point(2.5, 1.5),
-            rightPvi = Point(6.0, 3.0),
-            radius = -2.0
-        )
+        val tangentPoints2 =
+            tangentPointsOfPvi(
+                leftPvi = Point(1.0, -1.0),
+                middlePvi = Point(2.5, 1.5),
+                rightPvi = Point(6.0, 3.0),
+                radius = -2.0)
         assertApproximatelyEquals(Point(2.1673, 0.9455), tangentPoints2.first, accuracy)
         assertApproximatelyEquals(Point(3.0944, 1.7548), tangentPoints2.second, accuracy)
         assertApproximatelyEquals(
@@ -69,12 +72,12 @@ class GeometryProfileTest {
         )
 
         // Top-of-hill, right-tilted
-        val tangentPoints3 = tangentPointsOfPvi(
-            leftPvi = Point(2.0, 2.5),
-            middlePvi = Point(5.5, 2.0),
-            rightPvi = Point(7.0, -1.0),
-            radius = -2.0
-        )
+        val tangentPoints3 =
+            tangentPointsOfPvi(
+                leftPvi = Point(2.0, 2.5),
+                middlePvi = Point(5.5, 2.0),
+                rightPvi = Point(7.0, -1.0),
+                radius = -2.0)
         assertApproximatelyEquals(Point(4.4626, 2.1482), tangentPoints3.first, accuracy)
         assertApproximatelyEquals(Point(5.9686, 1.0627), tangentPoints3.second, accuracy)
         assertApproximatelyEquals(
@@ -84,12 +87,12 @@ class GeometryProfileTest {
         )
 
         // Bottom-of-pit, centered
-        val tangentPoints4 = tangentPointsOfPvi(
-            leftPvi = Point(1.0, -1.0),
-            middlePvi = Point(4.5, -2.5),
-            rightPvi = Point(8.0, 0.0),
-            radius = 2.0
-        )
+        val tangentPoints4 =
+            tangentPointsOfPvi(
+                leftPvi = Point(1.0, -1.0),
+                middlePvi = Point(4.5, -2.5),
+                rightPvi = Point(8.0, 0.0),
+                radius = 2.0)
         assertApproximatelyEquals(Point(3.4655, -2.0567), tangentPoints4.first, accuracy)
         assertApproximatelyEquals(Point(5.4158, -1.8458), tangentPoints4.second, accuracy)
         assertApproximatelyEquals(
@@ -99,12 +102,12 @@ class GeometryProfileTest {
         )
 
         // Bottom-of-pit, left-tilted
-        val tangentPoints5 = tangentPointsOfPvi(
-            leftPvi = Point(1.0, 1.0),
-            middlePvi = Point(2.0, -2.0),
-            rightPvi = Point(5.0, -3.0),
-            radius = 2.0
-        )
+        val tangentPoints5 =
+            tangentPointsOfPvi(
+                leftPvi = Point(1.0, 1.0),
+                middlePvi = Point(2.0, -2.0),
+                rightPvi = Point(5.0, -3.0),
+                radius = 2.0)
         assertApproximatelyEquals(Point(1.6838, -1.0513), tangentPoints5.first, accuracy)
         assertApproximatelyEquals(Point(2.9487, -2.3162), tangentPoints5.second, accuracy)
         assertApproximatelyEquals(
@@ -114,12 +117,12 @@ class GeometryProfileTest {
         )
 
         // Bottom-of-pit, right-tilted
-        val tangentPoints6 = tangentPointsOfPvi(
-            leftPvi = Point(2.0, -2.0),
-            middlePvi = Point(5.0, -1.5),
-            rightPvi = Point(5.5, 1.0),
-            radius = 2.0
-        )
+        val tangentPoints6 =
+            tangentPointsOfPvi(
+                leftPvi = Point(2.0, -2.0),
+                middlePvi = Point(5.0, -1.5),
+                rightPvi = Point(5.5, 1.0),
+                radius = 2.0)
         assertApproximatelyEquals(Point(3.6383, -1.7269), tangentPoints6.first, accuracy)
         assertApproximatelyEquals(Point(5.2707, -0.1464), tangentPoints6.second, accuracy)
         assertApproximatelyEquals(
@@ -133,18 +136,27 @@ class GeometryProfileTest {
     fun shouldReturnProfilePointAtGivenDistance() {
         val point3 = VIPoint(PlanElementName("first"), Point(1.82, 19.09))
         val point4 =
-            VICircularCurve(PlanElementName("mid1"), Point(60.0, 19.65), BigDecimal(-3000.0), BigDecimal(48.490589))
+            VICircularCurve(
+                PlanElementName("mid1"),
+                Point(60.0, 19.65),
+                BigDecimal(-3000.0),
+                BigDecimal(48.490589))
         val point5 =
-            VICircularCurve(PlanElementName("mid2"), Point(304.3941, 18.052), BigDecimal(3500.0), BigDecimal(40.390901))
-        val point6 = VICircularCurve(
-            PlanElementName("mid3"),
-            Point(400.0002, 18.5302),
-            BigDecimal(-3000.0),
-            BigDecimal(29.900281)
-        )
+            VICircularCurve(
+                PlanElementName("mid2"),
+                Point(304.3941, 18.052),
+                BigDecimal(3500.0),
+                BigDecimal(40.390901))
+        val point6 =
+            VICircularCurve(
+                PlanElementName("mid3"),
+                Point(400.0002, 18.5302),
+                BigDecimal(-3000.0),
+                BigDecimal(29.900281))
         val point7 = VIPoint(PlanElementName("last"), Point(505.318, 17.92))
         val listOfVerticalIntersectionPoints2 = listOf(point3, point4, point5, point6, point7)
-        val profile = GeometryProfile(PlanElementName("test profile 2"), listOfVerticalIntersectionPoints2)
+        val profile =
+            GeometryProfile(PlanElementName("test profile 2"), listOfVerticalIntersectionPoints2)
 
         // Exact PVI points
         assertEquals(19.09, profile.getHeightAt(1.82))
@@ -170,69 +182,70 @@ class GeometryProfileTest {
         val pointAccuracy = 0.000000001
         val angleAccuracy = 0.000000001
 
-        val profileElements = listOf(
-            VIPoint(
-                description = PlanElementName("831_profAlign/2"),
-                point = Point(x = 0.0, y = 106.800011),
-            ),
-            VICircularCurve(
-                description = PlanElementName("831_profAlign/3"),
-                point = Point(x = 26.641, y = 106.95),
-                radius = BigDecimal(-5000.000000),
-                length = BigDecimal(14.059082),
-            ),
-            VICircularCurve(
-                description = PlanElementName("831_profAlign/6"),
-                point = Point(x = 136.641, y = 107.26),
-                radius = BigDecimal(-20000.000000),
-                length = BigDecimal(60.113591),
-            ),
-            VICircularCurve(
-                description = PlanElementName("831_profAlign/9"),
-                point = Point(x = 296.641, y = 107.23),
-                radius = BigDecimal(-10000.000000),
-                length = BigDecimal(14.791664),
-            ),
-            VICircularCurve(
-                description = PlanElementName("831_profAlign/12"),
-                point = Point(x = 416.641, y = 107.03),
-                radius = BigDecimal(10000.000000),
-                length = BigDecimal(20.784306),
-            ),
-            VICircularCurve(
-                description = PlanElementName("831_profAlign/15"),
-                point = Point(x = 756.641, y = 107.17),
-                radius = BigDecimal(10000.000000),
-                length = BigDecimal(83.970546),
-            ),
-            VICircularCurve(
-                description = PlanElementName("831_profAlign/18"),
-                point = Point(x = 925.788714, y = 108.66),
-                radius = BigDecimal(-10000.000000),
-                length = BigDecimal(0.720266),
-            ),
-            VICircularCurve(
-                description = PlanElementName("831_profAlign/21"),
-                point = Point(x = 1020.788714, y = 109.49),
-                radius = BigDecimal(5000.000000),
-                length = BigDecimal(7.030074),
-            ),
-            VICircularCurve(
-                description = PlanElementName("831_profAlign/24"),
-                point = Point(x = 1090.788714, y = 110.2),
-                radius = BigDecimal(5000.000000),
-                length = BigDecimal(6.785713),
-            ),
-            VIPoint(
-                description = PlanElementName("831_profAlign/25"),
-                point = Point(x = 1102.624711, y = 110.336114),
-            ),
-        )
+        val profileElements =
+            listOf(
+                VIPoint(
+                    description = PlanElementName("831_profAlign/2"),
+                    point = Point(x = 0.0, y = 106.800011),
+                ),
+                VICircularCurve(
+                    description = PlanElementName("831_profAlign/3"),
+                    point = Point(x = 26.641, y = 106.95),
+                    radius = BigDecimal(-5000.000000),
+                    length = BigDecimal(14.059082),
+                ),
+                VICircularCurve(
+                    description = PlanElementName("831_profAlign/6"),
+                    point = Point(x = 136.641, y = 107.26),
+                    radius = BigDecimal(-20000.000000),
+                    length = BigDecimal(60.113591),
+                ),
+                VICircularCurve(
+                    description = PlanElementName("831_profAlign/9"),
+                    point = Point(x = 296.641, y = 107.23),
+                    radius = BigDecimal(-10000.000000),
+                    length = BigDecimal(14.791664),
+                ),
+                VICircularCurve(
+                    description = PlanElementName("831_profAlign/12"),
+                    point = Point(x = 416.641, y = 107.03),
+                    radius = BigDecimal(10000.000000),
+                    length = BigDecimal(20.784306),
+                ),
+                VICircularCurve(
+                    description = PlanElementName("831_profAlign/15"),
+                    point = Point(x = 756.641, y = 107.17),
+                    radius = BigDecimal(10000.000000),
+                    length = BigDecimal(83.970546),
+                ),
+                VICircularCurve(
+                    description = PlanElementName("831_profAlign/18"),
+                    point = Point(x = 925.788714, y = 108.66),
+                    radius = BigDecimal(-10000.000000),
+                    length = BigDecimal(0.720266),
+                ),
+                VICircularCurve(
+                    description = PlanElementName("831_profAlign/21"),
+                    point = Point(x = 1020.788714, y = 109.49),
+                    radius = BigDecimal(5000.000000),
+                    length = BigDecimal(7.030074),
+                ),
+                VICircularCurve(
+                    description = PlanElementName("831_profAlign/24"),
+                    point = Point(x = 1090.788714, y = 110.2),
+                    radius = BigDecimal(5000.000000),
+                    length = BigDecimal(6.785713),
+                ),
+                VIPoint(
+                    description = PlanElementName("831_profAlign/25"),
+                    point = Point(x = 1102.624711, y = 110.336114),
+                ),
+            )
 
         val profile = GeometryProfile(PlanElementName("831_profAlign"), profileElements)
         profile.segments.forEachIndexed { index, segment ->
             assertFalse(segment is LinearProfileSegment && !segment.valid)
-            val previous = profile.segments.getOrNull(index-1)
+            val previous = profile.segments.getOrNull(index - 1)
             if (previous != null) {
                 assertApproximatelyEquals(previous.end, segment.start, pointAccuracy)
                 assertEquals(previous.endAngle, segment.startAngle, angleAccuracy)
@@ -243,26 +256,35 @@ class GeometryProfileTest {
         val curveSegments = profile.segments.count { e -> e is CurvedProfileSegment }
         val lineSegments = profile.segments.count { e -> e is LinearProfileSegment }
         assertEquals(curveElements, curveSegments)
-        assertEquals(curveElements+1, lineSegments)
+        assertEquals(curveElements + 1, lineSegments)
     }
 
     // Enable to generate a CSV curve to inspect visually
-//    @Test
+    //    @Test
     fun printProfileCoordinatesInCsvForm() {
         val point1 = VIPoint(PlanElementName("first"), Point(1.82, 19.09))
         val point2 =
-            VICircularCurve(PlanElementName("mid1"), Point(60.0, 19.65), BigDecimal(-3000.0), BigDecimal(48.490589))
+            VICircularCurve(
+                PlanElementName("mid1"),
+                Point(60.0, 19.65),
+                BigDecimal(-3000.0),
+                BigDecimal(48.490589))
         val point3 =
-            VICircularCurve(PlanElementName("mid2"), Point(304.3941, 18.052), BigDecimal(3500.0), BigDecimal(40.390901))
-        val point4 = VICircularCurve(
-            PlanElementName("mid3"),
-            Point(400.0002, 18.5302),
-            BigDecimal(-3000.0),
-            BigDecimal(29.900281)
-        )
+            VICircularCurve(
+                PlanElementName("mid2"),
+                Point(304.3941, 18.052),
+                BigDecimal(3500.0),
+                BigDecimal(40.390901))
+        val point4 =
+            VICircularCurve(
+                PlanElementName("mid3"),
+                Point(400.0002, 18.5302),
+                BigDecimal(-3000.0),
+                BigDecimal(29.900281))
         val point5 = VIPoint(PlanElementName("last"), Point(505.318, 17.92))
         val listOfVerticalIntersectionPoints = listOf(point1, point2, point3, point4, point5)
-        val profile = GeometryProfile(PlanElementName("test profile 2"), listOfVerticalIntersectionPoints)
+        val profile =
+            GeometryProfile(PlanElementName("test profile 2"), listOfVerticalIntersectionPoints)
 
         val distance = (point5.point.x - point1.point.x).toInt()
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -25,18 +25,20 @@ import fi.fta.geoviite.infra.tracklayout.to3DMPoints
 import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FileName
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class GeometryServiceIT @Autowired constructor(
+class GeometryServiceIT
+@Autowired
+constructor(
     private val layoutTrackNumberDao: LayoutTrackNumberDao,
     private val referenceLineService: ReferenceLineService,
     private val locationTrackService: LocationTrackService,
@@ -55,18 +57,25 @@ class GeometryServiceIT @Autowired constructor(
         val planId = geometryDao.insertPlan(plan, file, polygon).id
         val searchBbox = boundingBoxAroundPoints(polygon)
 
-        assertEquals(planId, geometryService.fetchDuplicateGeometryPlanHeader(file, plan.source)?.id)
-        assertEquals(listOf(planId), geometryService.getGeometryPlanAreas(searchBbox).map(GeometryPlanArea::id))
+        assertEquals(
+            planId, geometryService.fetchDuplicateGeometryPlanHeader(file, plan.source)?.id)
+        assertEquals(
+            listOf(planId),
+            geometryService.getGeometryPlanAreas(searchBbox).map(GeometryPlanArea::id))
 
         geometryService.setPlanHidden(planId, true)
         assertFalse(geometryService.getPlanHeaders().any { p -> p.id == planId })
         assertEquals(null, geometryService.fetchDuplicateGeometryPlanHeader(file, plan.source)?.id)
-        assertEquals(listOf(), geometryService.getGeometryPlanAreas(searchBbox).map(GeometryPlanArea::id))
+        assertEquals(
+            listOf(), geometryService.getGeometryPlanAreas(searchBbox).map(GeometryPlanArea::id))
 
         geometryService.setPlanHidden(planId, false)
         assertTrue(geometryService.getPlanHeaders().any { p -> p.id == planId })
-        assertEquals(planId, geometryService.fetchDuplicateGeometryPlanHeader(file, plan.source)?.id)
-        assertEquals(listOf(planId), geometryService.getGeometryPlanAreas(searchBbox).map(GeometryPlanArea::id))
+        assertEquals(
+            planId, geometryService.fetchDuplicateGeometryPlanHeader(file, plan.source)?.id)
+        assertEquals(
+            listOf(planId),
+            geometryService.getGeometryPlanAreas(searchBbox).map(GeometryPlanArea::id))
     }
 
     @Test
@@ -82,11 +91,14 @@ class GeometryServiceIT @Autowired constructor(
             ),
             alignment(segment(Point(0.0, 0.0), Point(0.0, 100.0))),
         )
-        val locationTrackId = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(yRangeToSegmentPoints(1..29))),
-        ).id
+        val locationTrackId =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumberId, draft = true),
+                    alignment(segment(yRangeToSegmentPoints(1..29))),
+                )
+                .id
 
         kmPostService.saveDraft(
             LayoutBranch.main,
@@ -98,50 +110,60 @@ class GeometryServiceIT @Autowired constructor(
         )
 
         // tickLength = 5 => normal ticks less than 2.5 distance apart from a neighbor get dropped
-        val actual = geometryService.getLocationTrackHeights(
-            MainLayoutContext.draft,
-            locationTrackId,
-            0.0,
-            30.0,
-            5,
-        )!!
+        val actual =
+            geometryService.getLocationTrackHeights(
+                MainLayoutContext.draft,
+                locationTrackId,
+                0.0,
+                30.0,
+                5,
+            )!!
 
-        // location track starts 1 m after reference line start; reference line start address is 123.4; so first address
-        // is 124.4. First km post is at m 14.5 -> 13.5 in location track. Ordinary ticks always start at track meter 0
-        // so we get nice addresses for all of them, we just skip the ones coming before the track start.
-        val expectedData = listOf(
-            "0154" to listOf(
-                124.4 to 0.0,
-                125.0 to 0.6,
-                130.0 to 5.6,
-                135.0 to 10.6,
-            ),
-            "0155" to listOf(
-                0.0 to 13.5,
-                5.0 to 18.5,
-                10.0 to 23.5,
-            ),
-            "0156" to listOf(
-                0.0 to 26.6,
-                1.4 to 28.0,
-            ),
-        )
+        // location track starts 1 m after reference line start; reference line start address is
+        // 123.4; so first address
+        // is 124.4. First km post is at m 14.5 -> 13.5 in location track. Ordinary ticks always
+        // start at track meter 0
+        // so we get nice addresses for all of them, we just skip the ones coming before the track
+        // start.
+        val expectedData =
+            listOf(
+                "0154" to
+                    listOf(
+                        124.4 to 0.0,
+                        125.0 to 0.6,
+                        130.0 to 5.6,
+                        135.0 to 10.6,
+                    ),
+                "0155" to
+                    listOf(
+                        0.0 to 13.5,
+                        5.0 to 18.5,
+                        10.0 to 23.5,
+                    ),
+                "0156" to
+                    listOf(
+                        0.0 to 26.6,
+                        1.4 to 28.0,
+                    ),
+            )
 
         actual.forEachIndexed { kmIndex, actualKm ->
             val expectedKm = expectedData[kmIndex]
             assertEquals(KmNumber(expectedKm.first), actualKm.kmNumber)
-            // last lastM needs to be exactly correct, because it specifies the end of the track, and the front-end code
-            // depends on that being clean; the km post locations can slightly wobble due the GK coordinate
+            // last lastM needs to be exactly correct, because it specifies the end of the track,
+            // and the front-end code
+            // depends on that being clean; the km post locations can slightly wobble due the GK
+            // coordinate
             // transformation though
             if (kmIndex == expectedData.lastIndex) {
-                assertEquals(expectedData.last().second.last().second, actualKm.endM, "endM at track end")
+                assertEquals(
+                    expectedData.last().second.last().second, actualKm.endM, "endM at track end")
             } else {
                 assertEquals(
                     expectedData[kmIndex + 1].second.first().second,
                     actualKm.endM,
                     0.00001,
-                    "endM at index $kmIndex"
-                )
+                    "endM at index $kmIndex")
             }
             assertEquals(expectedKm.second.size, actualKm.trackMeterHeights.size)
 
@@ -165,44 +187,68 @@ class GeometryServiceIT @Autowired constructor(
         val p1 = insertPlanWithGeometry("plan1.xml", trackNumber.number)
         val p2 = insertPlanWithGeometry("plan2.xml", trackNumber.number)
         val p3 = insertPlanWithGeometry("plan3.xml", trackNumber.number)
-        val locationTrackId = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(yRangeToSegmentPoints(0..6), sourceId = p1.alignments[0].elements[0].id, sourceStart = 0.0),
-                segment(yRangeToSegmentPoints(6..10)),
-                segment(yRangeToSegmentPoints(10..12), sourceId = p2.alignments[0].elements[0].id, sourceStart = 0.0),
-                segment(yRangeToSegmentPoints(12..13)),
-                segment(yRangeToSegmentPoints(13..15), sourceId = p3.alignments[0].elements[0].id, sourceStart = 0.0),
-                segment(yRangeToSegmentPoints(15..17), sourceId = p1.alignments[0].elements[0].id, sourceStart = 0.0),
-            ),
-        ).id
-        val kmHeights = geometryService.getLocationTrackHeights(
-            MainLayoutContext.draft,
-            locationTrackId,
-            0.0,
-            20.0,
-            5,
-        )!!
-        // this track is exactly straight on the reference line, so m-values and track meters coincide perfectly; also,
+        val locationTrackId =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumberId, draft = true),
+                    alignment(
+                        segment(
+                            yRangeToSegmentPoints(0..6),
+                            sourceId = p1.alignments[0].elements[0].id,
+                            sourceStart = 0.0),
+                        segment(yRangeToSegmentPoints(6..10)),
+                        segment(
+                            yRangeToSegmentPoints(10..12),
+                            sourceId = p2.alignments[0].elements[0].id,
+                            sourceStart = 0.0),
+                        segment(yRangeToSegmentPoints(12..13)),
+                        segment(
+                            yRangeToSegmentPoints(13..15),
+                            sourceId = p3.alignments[0].elements[0].id,
+                            sourceStart = 0.0),
+                        segment(
+                            yRangeToSegmentPoints(15..17),
+                            sourceId = p1.alignments[0].elements[0].id,
+                            sourceStart = 0.0),
+                    ),
+                )
+                .id
+        val kmHeights =
+            geometryService.getLocationTrackHeights(
+                MainLayoutContext.draft,
+                locationTrackId,
+                0.0,
+                20.0,
+                5,
+            )!!
+        // this track is exactly straight on the reference line, so m-values and track meters
+        // coincide perfectly; also,
         // the profile is at exactly 50 meters height at every point where it's linked
-        val expected = listOf(
-            0 to 50,
-            // 5 to 50, // should be filtered due to being less than a half-tick distance from nearest
-            6 to 50,
-            6 to null,
-            10 to null,
-            10 to 50,
-            12 to 50,
-            12 to null,
-            13 to null,
-            13 to 50,
-            15 to 50,
-            17 to 50,
-        ).map { (m, h) -> TrackMeterHeight(m.toDouble(), m.toDouble(), h?.toDouble(), Point(0.0, m.toDouble())) }
+        val expected =
+            listOf(
+                    0 to 50,
+                    // 5 to 50, // should be filtered due to being less than a half-tick distance
+                    // from nearest
+                    6 to 50,
+                    6 to null,
+                    10 to null,
+                    10 to 50,
+                    12 to 50,
+                    12 to null,
+                    13 to null,
+                    13 to 50,
+                    15 to 50,
+                    17 to 50,
+                )
+                .map { (m, h) ->
+                    TrackMeterHeight(
+                        m.toDouble(), m.toDouble(), h?.toDouble(), Point(0.0, m.toDouble()))
+                }
         assertEquals(expected, kmHeights[0].trackMeterHeights)
         val linkingSummary =
-            geometryService.getLocationTrackGeometryLinkingSummary(MainLayoutContext.draft, locationTrackId)!!
+            geometryService.getLocationTrackGeometryLinkingSummary(
+                MainLayoutContext.draft, locationTrackId)!!
         assertEquals(
             listOf(
                 Triple(0.0, 6.0, FileName("plan1.xml")),
@@ -225,47 +271,59 @@ class GeometryServiceIT @Autowired constructor(
             referenceLine(trackNumberId, startAddress = TrackMeter("0154", 400), draft = true),
             alignment(segment(Point(0.0, 0.0), Point(0.0, 100.0))),
         )
-        val sourceId = insertPlanWithGeometry("plan1.xml", trackNumber.number).alignments[0].elements[0].id
-        val locationTrackId = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(yRangeToSegmentPoints(0..2)),
-                segment(yRangeToSegmentPoints(2..9), sourceId = sourceId, sourceStart = 0.0),
-                segment(yRangeToSegmentPoints(9..10)),
-                segment(yRangeToSegmentPoints(10..20), sourceId = sourceId, sourceStart = 0.0),
-            ),
-        ).id
-        // geocoding rounds m-values to three decimals half-up, so placing the km post juuuuuuuust here in fact rounds
-        // its position back to exactly 10, causing the 9..10 connection segment's end address to also be in
+        val sourceId =
+            insertPlanWithGeometry("plan1.xml", trackNumber.number).alignments[0].elements[0].id
+        val locationTrackId =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumberId, draft = true),
+                    alignment(
+                        segment(yRangeToSegmentPoints(0..2)),
+                        segment(
+                            yRangeToSegmentPoints(2..9), sourceId = sourceId, sourceStart = 0.0),
+                        segment(yRangeToSegmentPoints(9..10)),
+                        segment(
+                            yRangeToSegmentPoints(10..20), sourceId = sourceId, sourceStart = 0.0),
+                    ),
+                )
+                .id
+        // geocoding rounds m-values to three decimals half-up, so placing the km post juuuuuuuust
+        // here in fact rounds
+        // its position back to exactly 10, causing the 9..10 connection segment's end address to
+        // also be in
         // track km 0155
         val post = kmPost(trackNumberId, KmNumber("0155"), Point(0.0, 10.00001), draft = true)
         kmPostService.saveDraft(LayoutBranch.main, post)
 
-        val actual = geometryService.getLocationTrackHeights(
-            MainLayoutContext.draft,
-            locationTrackId,
-            0.0,
-            20.0,
-            5,
-        )!!
+        val actual =
+            geometryService.getLocationTrackHeights(
+                MainLayoutContext.draft,
+                locationTrackId,
+                0.0,
+                20.0,
+                5,
+            )!!
 
-        val expected = listOf(
-            "0154" to listOf(
-                400.0 to null,
-                402.0 to null,
-                402.0 to 50.0,
-                405.0 to 50.0,
-                409.0 to 50.0,
-                409.0 to null,
-            ),
-            "0155" to listOf(
-                0.0 to null,
-                0.0 to 50.0,
-                5.0 to 50.0,
-                10.0 to 50.0,
-            ),
-        )
+        val expected =
+            listOf(
+                "0154" to
+                    listOf(
+                        400.0 to null,
+                        402.0 to null,
+                        402.0 to 50.0,
+                        405.0 to 50.0,
+                        409.0 to 50.0,
+                        409.0 to null,
+                    ),
+                "0155" to
+                    listOf(
+                        0.0 to null,
+                        0.0 to 50.0,
+                        5.0 to 50.0,
+                        10.0 to 50.0,
+                    ),
+            )
         assertEquals(expected.size, actual.size)
         actual.forEachIndexed { kmIndex, actualKm ->
             val expectedKm = expected[kmIndex]
@@ -285,13 +343,15 @@ class GeometryServiceIT @Autowired constructor(
         referenceLineService.saveDraft(
             LayoutBranch.main,
             referenceLine(trackNumberId, startAddress = TrackMeter("0154", 0), draft = true),
-            alignment(segment(Point(0.0, 0.0), Point(0.0, 100.0)))
-        )
-        val locationTrackId = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(yRangeToSegmentPoints(0..10))),
-        ).id
+            alignment(segment(Point(0.0, 0.0), Point(0.0, 100.0))))
+        val locationTrackId =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumberId, draft = true),
+                    alignment(segment(yRangeToSegmentPoints(0..10))),
+                )
+                .id
         kmPostService.saveDraft(
             LayoutBranch.main,
             kmPost(trackNumberId, KmNumber("0155"), Point(0.0, 8.0), draft = true),
@@ -300,13 +360,14 @@ class GeometryServiceIT @Autowired constructor(
             LayoutBranch.main,
             kmPost(trackNumberId, KmNumber("0156"), Point(0.0, 9.0), draft = true),
         )
-        val actual = geometryService.getLocationTrackHeights(
-            MainLayoutContext.draft,
-            locationTrackId,
-            0.0,
-            20.0,
-            5,
-        )!!
+        val actual =
+            geometryService.getLocationTrackHeights(
+                MainLayoutContext.draft,
+                locationTrackId,
+                0.0,
+                20.0,
+                5,
+            )!!
         assertEquals(3, actual.size)
         assertEquals(2, actual[0].trackMeterHeights.size)
         assertEquals(1, actual[1].trackMeterHeights.size)
@@ -317,38 +378,44 @@ class GeometryServiceIT @Autowired constructor(
         toSegmentPoints(to3DMPoints(range.map { i -> Point(0.0, i.toDouble()) }))
 
     fun insertPlanWithGeometry(filename: String, trackNumber: TrackNumber): GeometryPlan {
-        val version = geometryDao.insertPlan(
-            planWithGeometryAndHeights(trackNumber), InfraModelFile(FileName(filename), "<a></a>"), null
-        )
+        val version =
+            geometryDao.insertPlan(
+                planWithGeometryAndHeights(trackNumber),
+                InfraModelFile(FileName(filename), "<a></a>"),
+                null)
         return geometryDao.fetchPlan(version)
     }
 
-    fun planWithGeometryAndHeights(trackNumber: TrackNumber): GeometryPlan = plan(
-        trackNumber,
-        srid = LAYOUT_SRID,
-        verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
-        alignments = listOf(
-            geometryAlignment(
-                elements = listOf(lineFromOrigin(1.0)),
-                name = "foo",
-                profile = GeometryProfile(
-                    PlanElementName("aoeu"),
-                    listOf(
-                        // profile originally inspired by geometry alignment 2466 in order to make the numbers plausible;
-                        // but simplified and rounded
-                        VIPoint(PlanElementName("startpoint"), Point(0.0, 50.0)),
-                        VICircularCurve(
-                            PlanElementName("rounding"),
-                            Point(500.0, 50.0),
-                            BigDecimal(20000),
-                            BigDecimal(155),
-                        ),
-                        VIPoint(PlanElementName("endpoint"), Point(600.0, 51.0)),
+    fun planWithGeometryAndHeights(trackNumber: TrackNumber): GeometryPlan =
+        plan(
+            trackNumber,
+            srid = LAYOUT_SRID,
+            verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
+            alignments =
+                listOf(
+                    geometryAlignment(
+                        elements = listOf(lineFromOrigin(1.0)),
+                        name = "foo",
+                        profile =
+                            GeometryProfile(
+                                PlanElementName("aoeu"),
+                                listOf(
+                                    // profile originally inspired by geometry alignment 2466 in
+                                    // order to make the numbers plausible;
+                                    // but simplified and rounded
+                                    VIPoint(PlanElementName("startpoint"), Point(0.0, 50.0)),
+                                    VICircularCurve(
+                                        PlanElementName("rounding"),
+                                        Point(500.0, 50.0),
+                                        BigDecimal(20000),
+                                        BigDecimal(155),
+                                    ),
+                                    VIPoint(PlanElementName("endpoint"), Point(600.0, 51.0)),
+                                ),
+                            ),
                     ),
                 ),
-            ),
-        ),
-    )
+        )
 
     private fun deletePlans() {
         jdbc.update("truncate geometry.plan cascade;", mapOf<String, Any>())

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TransformationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TransformationTest.kt
@@ -15,10 +15,10 @@ import fi.fta.geoviite.infra.ratko.model.RATKO_SRID
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.lengthPoints
 import fi.fta.geoviite.infra.tracklayout.toPointList
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import kotlin.test.assertEquals
 
 val DummyTriangulationNetwork = RTree.create<KkjTm35finTriangle, Rectangle>()
 
@@ -29,16 +29,21 @@ class TransformationTest {
         val originalHeight = 3.2267
         val expectedHeight = 3.48
         val pointToTransform = Point(2776456.160, 8437996.456)
-        val triangle = HeightTriangle(
-            corner1 = Point(2736945.03516908, 8441109.719913667),
-            corner2 = Point(2775850.2241459107, 8434428.120915797),
-            corner3 = Point(2793936.116042787, 8504341.156241765),
-            corner1Diff = 0.253170,
-            corner2Diff = 0.253090,
-            corner3Diff = 0.256790
-        )
+        val triangle =
+            HeightTriangle(
+                corner1 = Point(2736945.03516908, 8441109.719913667),
+                corner2 = Point(2775850.2241459107, 8434428.120915797),
+                corner3 = Point(2793936.116042787, 8504341.156241765),
+                corner1Diff = 0.253170,
+                corner2Diff = 0.253090,
+                corner3Diff = 0.256790)
         val listOfHeightTriangles = listOf(triangle)
-        val transformedHeight = transformHeightValue(originalHeight, pointToTransform, listOfHeightTriangles, VerticalCoordinateSystem.N60)
+        val transformedHeight =
+            transformHeightValue(
+                originalHeight,
+                pointToTransform,
+                listOfHeightTriangles,
+                VerticalCoordinateSystem.N60)
         assertHeightEquals(expectedHeight, transformedHeight)
     }
 
@@ -52,23 +57,24 @@ class TransformationTest {
 
     @Test
     fun transformingShortElementSucceeds() {
-        val curve = curve(
-            rotation = CCW,
-            length = 0.003,
-            radius = 300.0,
-            chord = 0.00364,
-            start = Point(4436238.519000, 6789010.552000),
-            end = Point( 4436238.520000, 6789010.555500),
-            center = Point( 4435942.847000, 6789061.329000),
-        )
+        val curve =
+            curve(
+                rotation = CCW,
+                length = 0.003,
+                radius = 300.0,
+                chord = 0.00364,
+                start = Point(4436238.519000, 6789010.552000),
+                end = Point(4436238.520000, 6789010.555500),
+                center = Point(4435942.847000, 6789061.329000),
+            )
         assertEquals(
             listOf(0.0, 0.003640000000022328),
             lengthPoints(curve.calculatedLength, 1),
         )
         assertEquals(
             listOf(
-                Point3DM(x=4436238.519, y=6789010.552, m=0.0),
-                Point3DM(x=4436238.52, y=6789010.5555, m=0.003640000000022328),
+                Point3DM(x = 4436238.519, y = 6789010.552, m = 0.0),
+                Point3DM(x = 4436238.52, y = 6789010.5555, m = 0.003640000000022328),
             ),
             toPointList(curve, 1),
         )
@@ -83,20 +89,19 @@ class TransformationTest {
 
     @Test
     fun `Creating LAYOUT_SRID to RATKO_SRID transformation works without triangulation network`() {
-        assertDoesNotThrow {
-            Transformation.nonTriangulableTransform(LAYOUT_SRID, RATKO_SRID)
-        }
+        assertDoesNotThrow { Transformation.nonTriangulableTransform(LAYOUT_SRID, RATKO_SRID) }
     }
 
     @Test
     fun `Creating KKJ to TM35 transform works with triangulation network`() {
         assertDoesNotThrow {
-            Transformation.possiblyTriangulableTransform(LAYOUT_SRID, RATKO_SRID, DummyTriangulationNetwork, DummyTriangulationNetwork)
+            Transformation.possiblyTriangulableTransform(
+                LAYOUT_SRID, RATKO_SRID, DummyTriangulationNetwork, DummyTriangulationNetwork)
         }
     }
 }
 
-fun assertHeightEquals(expectedHeight:Double, actualHeight:Double ){
-    val actualHeightTo2Digits = String.format("%.2f", actualHeight).replace(",",".").toDouble()
+fun assertHeightEquals(expectedHeight: Double, actualHeight: Double) {
+    val actualHeightTo2Digits = String.format("%.2f", actualHeight).replace(",", ".").toDouble()
     assertEquals(expectedHeight, actualHeightTo2Digits)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
@@ -12,10 +12,10 @@ import fi.fta.geoviite.infra.math.rotateAroundOrigin
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.util.LocalizationKey
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import kotlin.math.PI
 import kotlin.math.hypot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 private const val JOINT_LOCATION_DELTA = 0.01
 
@@ -25,17 +25,13 @@ class ValidationTest {
 
     @Test
     fun validationFindsNothingInValidGeometry() {
-        val alignment = geometryAlignment(
-            elements = lines(Point(1.0, 2.0), 4, 12.34)
-        )
+        val alignment = geometryAlignment(elements = lines(Point(1.0, 2.0), 4, 12.34))
         assertEquals(listOf<GeometryValidationIssue>(), validateAlignmentGeometry(alignment))
     }
 
     @Test
     fun validationFindsIncorrectLineLength() {
-        val alignment = geometryAlignment(
-            elements = lines(Point(1.0, 2.0), 1, 12.34, 1.0)
-        )
+        val alignment = geometryAlignment(elements = lines(Point(1.0, 2.0), 1, 12.34, 1.0))
         assertGeometryValidationIssues(
             validateAlignmentGeometry(alignment),
             listOf("$VALIDATION_ELEMENT.field-incorrect-length"),
@@ -47,15 +43,12 @@ class ValidationTest {
         val lines = lines(Point(1.0, 2.0), 3, 12.34).filterIndexed { i, _ -> i % 2 == 0 }
         assertGeometryValidationIssues(
             validateAlignmentGeometry(geometryAlignment(elements = lines)),
-            listOf("$VALIDATION_ELEMENT.coordinates-not-continuous")
-        )
+            listOf("$VALIDATION_ELEMENT.coordinates-not-continuous"))
     }
 
     @Test
     fun validationFindsMissingCant() {
-        val alignment = geometryAlignment(
-            elements = lines(Point(1.0, 2.0), 1, 12.34, 1.0)
-        )
+        val alignment = geometryAlignment(elements = lines(Point(1.0, 2.0), 1, 12.34, 1.0))
         assertGeometryValidationIssues(
             validateAlignmentCant(alignment),
             listOf("$VALIDATION_ALIGNMENT.no-cant"),
@@ -64,10 +57,11 @@ class ValidationTest {
 
     @Test
     fun validationFindsMissingProfile() {
-        val alignment = geometryAlignment(
-            elements = lines(Point(1.0, 2.0), 1, 12.34, 1.0),
-            profile = null,
-        )
+        val alignment =
+            geometryAlignment(
+                elements = lines(Point(1.0, 2.0), 1, 12.34, 1.0),
+                profile = null,
+            )
         assertGeometryValidationIssues(
             validateAlignmentProfile(alignment),
             listOf("$VALIDATION_ALIGNMENT.no-profile"),
@@ -76,34 +70,38 @@ class ValidationTest {
 
     @Test
     fun validationFindsNothingInValidProfile() {
-        val points = listOf(
-            viPoint(0.0, 2.0),
-            viPoint(10.1, 1.0),
-        )
+        val points =
+            listOf(
+                viPoint(0.0, 2.0),
+                viPoint(10.1, 1.0),
+            )
         val alignment = geometryAlignment(profile = profile(points))
         assertEquals(listOf<GeometryValidationIssue>(), validateAlignmentProfile(alignment))
     }
 
     @Test
     fun validationFindsProfileStationNonContinuous() {
-        val points = listOf(
-            viPoint(1.0, 0.02),
-            viPoint(0.1, 0.01),
-            viPoint(3.0, 0.04),
-        )
+        val points =
+            listOf(
+                viPoint(1.0, 0.02),
+                viPoint(0.1, 0.01),
+                viPoint(3.0, 0.04),
+            )
         val alignment = geometryAlignment(profile = profile(points))
         assertGeometryValidationIssues(
             validateAlignmentProfile(alignment),
-            listOf("$VALIDATION_PROFILE.incorrect-station", "$VALIDATION_PROFILE.calculation-failed"),
+            listOf(
+                "$VALIDATION_PROFILE.incorrect-station", "$VALIDATION_PROFILE.calculation-failed"),
         )
     }
 
     @Test
     fun validationFindsProfileToSteep() {
-        val points = listOf(
-            viPoint(1.0, 1.0),
-            viPoint(2.0, 2.0),
-        )
+        val points =
+            listOf(
+                viPoint(1.0, 1.0),
+                viPoint(2.0, 2.0),
+            )
         val alignment = geometryAlignment(profile = profile(points))
         assertGeometryValidationIssues(
             validateAlignmentProfile(alignment),
@@ -113,22 +111,24 @@ class ValidationTest {
 
     @Test
     fun validationFindsNothingInValidCant() {
-        val points = listOf(
-            cantPoint(0.0, 0.2, CW),
-            cantPoint(1.1, 0.1, CW),
-            cantPoint(2.1, 0.15, CCW),
-        )
+        val points =
+            listOf(
+                cantPoint(0.0, 0.2, CW),
+                cantPoint(1.1, 0.1, CW),
+                cantPoint(2.1, 0.15, CCW),
+            )
         val alignment = geometryAlignment(cant = cant(points))
         assertEquals(listOf<GeometryValidationIssue>(), validateAlignmentCant(alignment))
     }
 
     @Test
     fun validationFindsCantStationNonContinuous() {
-        val points = listOf(
-            cantPoint(1.0, 0.1, CCW),
-            cantPoint(0.5, 0.2, CCW),
-            cantPoint(3.0, 0.3, CCW),
-        )
+        val points =
+            listOf(
+                cantPoint(1.0, 0.1, CCW),
+                cantPoint(0.5, 0.2, CCW),
+                cantPoint(3.0, 0.3, CCW),
+            )
         val alignment = geometryAlignment(cant = cant(points))
         assertGeometryValidationIssues(
             validateAlignmentCant(alignment),
@@ -138,17 +138,20 @@ class ValidationTest {
 
     @Test
     fun `validation finds cant missing from track`() {
-        val alignment = geometryAlignment(
-            cant = cant(
-                points = listOf(
-                    cantPoint(0.0, 0.2, CW),
-                    cantPoint(1.1, 0.1, CW),
-                    cantPoint(2.1, 0.15, CCW),
-                ),
-                rotationPoint = null,
-            ),
-            featureTypeCode = FeatureTypeCode("281"), // cant should exist on tracks
-        )
+        val alignment =
+            geometryAlignment(
+                cant =
+                    cant(
+                        points =
+                            listOf(
+                                cantPoint(0.0, 0.2, CW),
+                                cantPoint(1.1, 0.1, CW),
+                                cantPoint(2.1, 0.15, CCW),
+                            ),
+                        rotationPoint = null,
+                    ),
+                featureTypeCode = FeatureTypeCode("281"), // cant should exist on tracks
+            )
 
         assertGeometryValidationIssues(
             validateAlignmentCant(alignment),
@@ -158,11 +161,12 @@ class ValidationTest {
 
     @Test
     fun validationFindsCantOverGauge() {
-        val points = listOf(
-            cantPoint(1.0, 0.1, CCW),
-            cantPoint(2.0, 2.0, CCW),
-            cantPoint(3.0, 0.3, CCW),
-        )
+        val points =
+            listOf(
+                cantPoint(1.0, 0.1, CCW),
+                cantPoint(2.0, 2.0, CCW),
+                cantPoint(3.0, 0.3, CCW),
+            )
         val alignment = geometryAlignment(cant = cant(points))
         assertGeometryValidationIssues(
             validateAlignmentCant(alignment),
@@ -176,31 +180,38 @@ class ValidationTest {
         val angle = PI / 4
         val switch = createSwitch(yvStructure, location, angle)
         val alignments = createSwitchAlignments(switch, yvStructure)
-        val alignmentSwitches = alignments.mapNotNull { alignment ->
-            collectAlignmentSwitchJoints(switch.id, alignment)
-        }
-        assertEquals(listOf<GeometryValidationIssue>(), validateSwitch(switch, yvStructure, alignmentSwitches))
+        val alignmentSwitches =
+            alignments.mapNotNull { alignment ->
+                collectAlignmentSwitchJoints(switch.id, alignment)
+            }
+        assertEquals(
+            listOf<GeometryValidationIssue>(),
+            validateSwitch(switch, yvStructure, alignmentSwitches))
     }
 
     @Test
     fun validationNoticesSwitchJointPointsNotMeeting() {
         val validSwitch = createSwitch(yvStructure, Point(100.0, 150.0), PI / 4)
-        val invalidSwitch = validSwitch.copy(
-            joints = validSwitch.joints.map { joint ->
-                // Move first joint a bit off
-                if (joint.number == JointNumber(1)) {
-                    joint.copy(
-                        location = joint.location.copy(x = joint.location.x + JOINT_LOCATION_DELTA * 1.1)
-                    )
-                } else {
-                    joint
-                }
-            },
-        )
+        val invalidSwitch =
+            validSwitch.copy(
+                joints =
+                    validSwitch.joints.map { joint ->
+                        // Move first joint a bit off
+                        if (joint.number == JointNumber(1)) {
+                            joint.copy(
+                                location =
+                                    joint.location.copy(
+                                        x = joint.location.x + JOINT_LOCATION_DELTA * 1.1))
+                        } else {
+                            joint
+                        }
+                    },
+            )
         val alignments = createSwitchAlignments(invalidSwitch, yvStructure)
-        val alignmentSwitches = alignments.mapNotNull { alignment ->
-            collectAlignmentSwitchJoints(invalidSwitch.id, alignment)
-        }
+        val alignmentSwitches =
+            alignments.mapNotNull { alignment ->
+                collectAlignmentSwitchJoints(invalidSwitch.id, alignment)
+            }
         assertGeometryValidationIssues(
             validateSwitch(invalidSwitch, yvStructure, alignmentSwitches),
             listOf("$VALIDATION_SWITCH.incorrect-joint-locations"),
@@ -210,22 +221,26 @@ class ValidationTest {
     @Test
     fun validationNoticesSwitchJointPointsInaccuracy() {
         val validSwitch = createSwitch(yvStructure, Point(100.0, 150.0), PI / 4)
-        val inaccurateSwitch = validSwitch.copy(
-            joints = validSwitch.joints.map { joint ->
-                // Move first joint a bit off
-                if (joint.number == JointNumber(1)) {
-                    joint.copy(
-                        location = joint.location.copy(x = joint.location.x + JOINT_LOCATION_DELTA * 0.9)
-                    )
-                } else {
-                    joint
-                }
-            },
-        )
+        val inaccurateSwitch =
+            validSwitch.copy(
+                joints =
+                    validSwitch.joints.map { joint ->
+                        // Move first joint a bit off
+                        if (joint.number == JointNumber(1)) {
+                            joint.copy(
+                                location =
+                                    joint.location.copy(
+                                        x = joint.location.x + JOINT_LOCATION_DELTA * 0.9))
+                        } else {
+                            joint
+                        }
+                    },
+            )
         val alignments = createSwitchAlignments(inaccurateSwitch, yvStructure)
-        val alignmentSwitches = alignments.mapNotNull { alignment ->
-            collectAlignmentSwitchJoints(inaccurateSwitch.id, alignment)
-        }
+        val alignmentSwitches =
+            alignments.mapNotNull { alignment ->
+                collectAlignmentSwitchJoints(inaccurateSwitch.id, alignment)
+            }
         assertGeometryValidationIssues(
             validateSwitch(inaccurateSwitch, yvStructure, alignmentSwitches),
             listOf("$VALIDATION_SWITCH.inaccurate-joint-locations"),
@@ -267,59 +282,70 @@ class ValidationTest {
         )
     }
 
-    private fun cantPoint(station: Double, appliedCant: Double, curvature: RotationDirection): GeometryCantPoint {
-        return GeometryCantPoint(station.toBigDecimal(), appliedCant.toBigDecimal(), curvature, LINEAR)
+    private fun cantPoint(
+        station: Double,
+        appliedCant: Double,
+        curvature: RotationDirection
+    ): GeometryCantPoint {
+        return GeometryCantPoint(
+            station.toBigDecimal(), appliedCant.toBigDecimal(), curvature, LINEAR)
     }
 
     private fun createSwitch(
         structure: SwitchStructure,
         locationOffset: Point,
         angle: Double,
-    ) = GeometrySwitch(
-        name = SwitchName("T001"),
-        switchStructureId = structure.id as IntId,
-        typeName = GeometrySwitchTypeName(structure.type.typeName),
-        state = PlanState.PROPOSED,
-        joints = listOf(
-            geometrySwitchJoint(1, structure, locationOffset, angle),
-            geometrySwitchJoint(5, structure, locationOffset, angle),
-            geometrySwitchJoint(2, structure, locationOffset, angle),
-            geometrySwitchJoint(3, structure, locationOffset, angle),
-        )
-    )
+    ) =
+        GeometrySwitch(
+            name = SwitchName("T001"),
+            switchStructureId = structure.id as IntId,
+            typeName = GeometrySwitchTypeName(structure.type.typeName),
+            state = PlanState.PROPOSED,
+            joints =
+                listOf(
+                    geometrySwitchJoint(1, structure, locationOffset, angle),
+                    geometrySwitchJoint(5, structure, locationOffset, angle),
+                    geometrySwitchJoint(2, structure, locationOffset, angle),
+                    geometrySwitchJoint(3, structure, locationOffset, angle),
+                ))
 
     private fun createSwitchAlignments(
         switch: GeometrySwitch,
         structure: SwitchStructure,
-    ) = structure.alignments.map { structureAlignment ->
-        geometryAlignment(
-            elements = structureAlignment.jointNumbers.mapIndexedNotNull { index, jointNumber ->
-                structureAlignment.jointNumbers.getOrNull(index + 1)?.let { nextJointNumber ->
-                    val startPoint = switch.getJoint(jointNumber)!!.location
-                    val endPoint = switch.getJoint(nextJointNumber)!!.location
-                    line(
-                        start = startPoint,
-                        end = endPoint,
-                        name = switch.name.toString(),
-                        switchData = SwitchData(
-                            switchId = switch.id,
-                            startJointNumber = jointNumber,
-                            endJointNumber = null,
-                        ),
-                    )
-                }
-            },
-        )
-    }
+    ) =
+        structure.alignments.map { structureAlignment ->
+            geometryAlignment(
+                elements =
+                    structureAlignment.jointNumbers.mapIndexedNotNull { index, jointNumber ->
+                        structureAlignment.jointNumbers.getOrNull(index + 1)?.let { nextJointNumber
+                            ->
+                            val startPoint = switch.getJoint(jointNumber)!!.location
+                            val endPoint = switch.getJoint(nextJointNumber)!!.location
+                            line(
+                                start = startPoint,
+                                end = endPoint,
+                                name = switch.name.toString(),
+                                switchData =
+                                    SwitchData(
+                                        switchId = switch.id,
+                                        startJointNumber = jointNumber,
+                                        endJointNumber = null,
+                                    ),
+                            )
+                        }
+                    },
+            )
+        }
 
     private fun geometrySwitchJoint(
         number: Int,
         structure: SwitchStructure,
         locationOffset: Point,
         angle: Double,
-    ) = JointNumber(number).let { jn ->
-        GeometrySwitchJoint(jn, getTransformedPoint(jn, structure, locationOffset, angle))
-    }
+    ) =
+        JointNumber(number).let { jn ->
+            GeometrySwitchJoint(jn, getTransformedPoint(jn, structure, locationOffset, angle))
+        }
 
     private fun getTransformedPoint(
         number: JointNumber,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingFileDaoIT.kt
@@ -2,25 +2,28 @@ package fi.fta.geoviite.infra.geometry
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.util.FileName
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class VerticalGeometryListingFileDaoIT @Autowired constructor(
+class VerticalGeometryListingFileDaoIT
+@Autowired
+constructor(
     private val verticalGeometryListingFileDao: VerticalGeometryListingFileDao,
-): DBTestBase() {
+) : DBTestBase() {
 
     @BeforeEach
     fun setUp() {
-        jdbc.update("delete from layout.vertical_geometry_listing_file where id = 1", mapOf<String, Any>())
+        jdbc.update(
+            "delete from layout.vertical_geometry_listing_file where id = 1", mapOf<String, Any>())
     }
 
     @Test
@@ -28,27 +31,31 @@ class VerticalGeometryListingFileDaoIT @Autowired constructor(
         assertNull(verticalGeometryListingFileDao.getVerticalGeometryListingFile())
         assertEquals(Instant.EPOCH, verticalGeometryListingFileDao.getLastFileListingTime())
 
-        val originalFile = VerticalGeometryListingFile(
-            name = FileName("vertical geometry test file name 1"),
-            content = """
+        val originalFile =
+            VerticalGeometryListingFile(
+                name = FileName("vertical geometry test file name 1"),
+                content =
+                    """
                 vert_geom_header1, vert_geom_header2, vert_geom_header3
                 vert_geom_col1_val1, vert_geom_col2_val1, vert_geom_col3_val1
                 vert_geom_col1_val2, vert_geom_col2_val2, vert_geom_col3_val2
-            """.trimIndent()
-        )
+            """
+                        .trimIndent())
         verticalGeometryListingFileDao.upsertVerticalGeometryListingFile(originalFile)
         assertEquals(originalFile, verticalGeometryListingFileDao.getVerticalGeometryListingFile())
         val originalChangeTime = verticalGeometryListingFileDao.getLastFileListingTime()
         assertTrue(originalChangeTime > Instant.EPOCH)
 
-        val updatedFile = VerticalGeometryListingFile(
-            name = FileName("vertical geometry test file name 2"),
-            content = """
+        val updatedFile =
+            VerticalGeometryListingFile(
+                name = FileName("vertical geometry test file name 2"),
+                content =
+                    """
                 vert_geom_header1, vert_geom_header2, vert_geom_header3
                 vert_geom_col1_val1_new, vert_geom_col2_val1_new, vert_geom_col3_val1_new
                 vert_geom_col1_val2_new, vert_geom_col2_val2_new, vert_geom_col3_val2_new
-            """.trimIndent()
-        )
+            """
+                        .trimIndent())
         verticalGeometryListingFileDao.upsertVerticalGeometryListingFile(updatedFile)
         assertEquals(updatedFile, verticalGeometryListingFileDao.getVerticalGeometryListingFile())
         val updatedChangeTime = verticalGeometryListingFileDao.getLastFileListingTime()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListingTest.kt
@@ -8,23 +8,19 @@ import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import kotlin.math.sqrt
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class VerticalGeometryListingTest {
     @Test
     fun `Station point is calculated correctly when other line goes straight up`() {
-        val curve = CurvedProfileSegment(
-            PlanElementName(""),
-            Point(0.0, 0.0),
-            Point(2.0, 2.0),
-            Point(0.0, 2.0),
-            2.0
-        )
+        val curve =
+            CurvedProfileSegment(
+                PlanElementName(""), Point(0.0, 0.0), Point(2.0, 2.0), Point(0.0, 2.0), 2.0)
 
         val tangentPoint = circCurveStationPoint(curve)
         assertNotNull(tangentPoint)
@@ -34,13 +30,9 @@ class VerticalGeometryListingTest {
 
     @Test
     fun `Station point is calculated correctly when centerpoint is below`() {
-        val curve = CurvedProfileSegment(
-            PlanElementName(""),
-            Point(6.0, 0.0),
-            Point(8.0, 0.0),
-            Point(7.0, 1.0),
-            sqrt(2.0)
-        )
+        val curve =
+            CurvedProfileSegment(
+                PlanElementName(""), Point(6.0, 0.0), Point(8.0, 0.0), Point(7.0, 1.0), sqrt(2.0))
 
         val tangentPoint = circCurveStationPoint(curve)
         assertNotNull(tangentPoint)
@@ -50,13 +42,9 @@ class VerticalGeometryListingTest {
 
     @Test
     fun `Station point is calculated correctly when centerpoint is above`() {
-        val curve = CurvedProfileSegment(
-            PlanElementName(""),
-            Point(0.0, 0.0),
-            Point(2.0, 0.0),
-            Point(1.0, -1.0),
-            sqrt(2.0)
-        )
+        val curve =
+            CurvedProfileSegment(
+                PlanElementName(""), Point(0.0, 0.0), Point(2.0, 0.0), Point(1.0, -1.0), sqrt(2.0))
 
         val tangentPoint = circCurveStationPoint(curve)
         assertNotNull(tangentPoint)
@@ -106,14 +94,17 @@ class VerticalGeometryListingTest {
     @Test
     fun `Backwards linear section to previous curve is calculated correctly`() {
         val segment = curvedSegment(Point(4.0, 0.0), Point(6.0, 0.0), Point(5.0, -1.0))
-        val entireProfile = listOf(
-            curvedSegment(Point(0.0, 0.0), Point(2.0, 0.0), Point(1.0, -1.0)),
-            linearSegment(Point(2.0, 0.0), Point(4.0, 0.0)),
-            segment,
-        )
+        val entireProfile =
+            listOf(
+                curvedSegment(Point(0.0, 0.0), Point(2.0, 0.0), Point(1.0, -1.0)),
+                linearSegment(Point(2.0, 0.0), Point(4.0, 0.0)),
+                segment,
+            )
         val (curved, linear) = entireProfile.partition { it is CurvedProfileSegment }
 
-        val previous = previousLinearSection(segment, curved as List<CurvedProfileSegment>, linear as List<LinearProfileSegment>)
+        val previous =
+            previousLinearSection(
+                segment, curved as List<CurvedProfileSegment>, linear as List<LinearProfileSegment>)
         assertEquals(previous.linearSegmentLength!!.toDouble(), 2.0, 0.001)
         assertEquals(previous.stationValueDistance!!.toDouble(), 4.0, 0.001)
     }
@@ -121,13 +112,12 @@ class VerticalGeometryListingTest {
     @Test
     fun `Backwards linear section is calculated correctly if no previous curved section`() {
         val segment = curvedSegment(Point(4.0, 0.0), Point(6.0, 0.0), Point(5.0, -1.0))
-        val entireProfile = listOf(
-            linearSegment(Point(2.0, 0.0), Point(4.0, 0.0)),
-            segment
-        )
+        val entireProfile = listOf(linearSegment(Point(2.0, 0.0), Point(4.0, 0.0)), segment)
         val (curved, linear) = entireProfile.partition { it is CurvedProfileSegment }
 
-        val previous = previousLinearSection(segment, curved as List<CurvedProfileSegment>, linear as List<LinearProfileSegment>)
+        val previous =
+            previousLinearSection(
+                segment, curved as List<CurvedProfileSegment>, linear as List<LinearProfileSegment>)
         assertEquals(previous.linearSegmentLength!!.toDouble(), 2.0, 0.001)
         assertEquals(previous.stationValueDistance!!.toDouble(), 3.0, 0.001)
     }
@@ -135,10 +125,11 @@ class VerticalGeometryListingTest {
     @Test
     fun `Backwards linear section has no values if there is no linear section`() {
         val segment = curvedSegment(Point(4.0, 0.0), Point(6.0, 0.0), Point(5.0, -1.0))
-        val entireProfile = listOf(
-            curvedSegment(Point(0.0, 0.0), Point(2.0, 0.0), Point(1.0, -1.0)),
-            segment,
-        )
+        val entireProfile =
+            listOf(
+                curvedSegment(Point(0.0, 0.0), Point(2.0, 0.0), Point(1.0, -1.0)),
+                segment,
+            )
 
         val previous = previousLinearSection(segment, entireProfile, emptyList())
         assertNull(previous.linearSegmentLength)
@@ -148,14 +139,17 @@ class VerticalGeometryListingTest {
     @Test
     fun `Forwards linear section to next curve is calculated correctly`() {
         val segment = curvedSegment(Point(4.0, 0.0), Point(6.0, 0.0), Point(5.0, -1.0))
-        val entireProfile = listOf(
-            segment,
-            linearSegment(Point(6.0, 0.0), Point(8.0, 0.0)),
-            curvedSegment(Point(8.0, 0.0), Point(10.0, 0.0), Point(9.0, -1.0)),
-        )
+        val entireProfile =
+            listOf(
+                segment,
+                linearSegment(Point(6.0, 0.0), Point(8.0, 0.0)),
+                curvedSegment(Point(8.0, 0.0), Point(10.0, 0.0), Point(9.0, -1.0)),
+            )
         val (curved, linear) = entireProfile.partition { it is CurvedProfileSegment }
 
-        val next = nextLinearSection(segment, curved as List<CurvedProfileSegment>, linear as List<LinearProfileSegment>)
+        val next =
+            nextLinearSection(
+                segment, curved as List<CurvedProfileSegment>, linear as List<LinearProfileSegment>)
         assertEquals(next.linearSegmentLength!!.toDouble(), 2.0, 0.001)
         assertEquals(next.stationValueDistance!!.toDouble(), 4.0, 0.001)
     }
@@ -163,13 +157,16 @@ class VerticalGeometryListingTest {
     @Test
     fun `Forwards linear section is calculated correctly if no next curved section`() {
         val segment = curvedSegment(Point(4.0, 0.0), Point(6.0, 0.0), Point(5.0, -1.0))
-        val entireProfile = listOf(
-            segment,
-            linearSegment(Point(6.0, 0.0), Point(8.0, 0.0)),
-        )
+        val entireProfile =
+            listOf(
+                segment,
+                linearSegment(Point(6.0, 0.0), Point(8.0, 0.0)),
+            )
         val (curved, linear) = entireProfile.partition { it is CurvedProfileSegment }
 
-        val next = nextLinearSection(segment, curved as List<CurvedProfileSegment>, linear as List<LinearProfileSegment>)
+        val next =
+            nextLinearSection(
+                segment, curved as List<CurvedProfileSegment>, linear as List<LinearProfileSegment>)
         assertEquals(next.linearSegmentLength!!.toDouble(), 2.0, 0.001)
         assertEquals(next.stationValueDistance!!.toDouble(), 3.0, 0.001)
     }
@@ -177,10 +174,11 @@ class VerticalGeometryListingTest {
     @Test
     fun `Forwards linear section is null if no next linear section`() {
         val segment = curvedSegment(Point(4.0, 0.0), Point(6.0, 0.0), Point(5.0, -1.0))
-        val entireProfile = listOf(
-            segment,
-            curvedSegment(Point(8.0, 0.0), Point(10.0, 0.0), Point(9.0, -1.0)),
-        )
+        val entireProfile =
+            listOf(
+                segment,
+                curvedSegment(Point(8.0, 0.0), Point(10.0, 0.0), Point(9.0, -1.0)),
+            )
 
         val next = nextLinearSection(segment, entireProfile, emptyList())
         assertNull(next.linearSegmentLength)
@@ -190,35 +188,37 @@ class VerticalGeometryListingTest {
     @Test
     fun `Simpler value calculations work`() {
         val segment = curvedSegment(Point(4.0, 0.0), Point(6.0, 0.0), Point(5.0, -1.0), 1.0)
-        val entireProfile = listOf(
-            curvedSegment(Point(0.0, 0.0), Point(2.0, 0.0), Point(1.0, -1.0), 1.0),
-            linearSegment(Point(2.0, 0.0), Point(4.0, 0.0)),
-            segment,
-            linearSegment(Point(6.0, 0.0), Point(8.0, 0.0)),
-            curvedSegment(Point(8.0, 0.0), Point(10.0, 0.0), Point(9.0, -1.0), 1.0),
-        )
+        val entireProfile =
+            listOf(
+                curvedSegment(Point(0.0, 0.0), Point(2.0, 0.0), Point(1.0, -1.0), 1.0),
+                linearSegment(Point(2.0, 0.0), Point(4.0, 0.0)),
+                segment,
+                linearSegment(Point(6.0, 0.0), Point(8.0, 0.0)),
+                curvedSegment(Point(8.0, 0.0), Point(10.0, 0.0), Point(9.0, -1.0), 1.0),
+            )
         val (curved, linear) = entireProfile.partition { it is CurvedProfileSegment }
 
-        val verticalGeometryEntry = toVerticalGeometryListing(
-            segment,
-            GeometryAlignment(
-                AlignmentName("test-alignment"),
-                description = FreeText(""),
-                staStart = BigDecimal(0.0),
-                elements = emptyList(),
-                featureTypeCode = FeatureTypeCode("111"),
-                oidPart = FreeText("123"),
-                state = PlanState.EXISTING,
-            ),
-            null,
-            null,
-            planHeader(fileName = FileName("test")),
-            null,
-            curved as List<CurvedProfileSegment>,
-            linear as List<LinearProfileSegment>,
-            TrackMeter.ZERO,
-            TrackMeter.ZERO,
-        )
+        val verticalGeometryEntry =
+            toVerticalGeometryListing(
+                segment,
+                GeometryAlignment(
+                    AlignmentName("test-alignment"),
+                    description = FreeText(""),
+                    staStart = BigDecimal(0.0),
+                    elements = emptyList(),
+                    featureTypeCode = FeatureTypeCode("111"),
+                    oidPart = FreeText("123"),
+                    state = PlanState.EXISTING,
+                ),
+                null,
+                null,
+                planHeader(fileName = FileName("test")),
+                null,
+                curved as List<CurvedProfileSegment>,
+                linear as List<LinearProfileSegment>,
+                TrackMeter.ZERO,
+                TrackMeter.ZERO,
+            )
 
         assertEquals(verticalGeometryEntry.start.station.toDouble(), 4.0, 0.001)
         assertEquals(verticalGeometryEntry.start.angle!!.toDouble(), 1.0, 0.000001)
@@ -237,10 +237,11 @@ class VerticalGeometryListingTest {
 
     @Test
     fun `Returns right coordinate at the intersection of elements`() {
-        val alignment = createAlignment(
-            GeometryElementType.LINE,
-            GeometryElementType.LINE,
-        )
+        val alignment =
+            createAlignment(
+                GeometryElementType.LINE,
+                GeometryElementType.LINE,
+            )
         val element = alignment.elements.get(0)
         val coordinate = alignment.getCoordinateAt(element.calculatedLength)!!
         assertEquals(coordinate.x, element.end.x, 0.0001)
@@ -249,9 +250,10 @@ class VerticalGeometryListingTest {
 
     @Test
     fun `Returns right coordinate at the beginning of alignment`() {
-        val alignment = createAlignment(
-            GeometryElementType.LINE,
-        )
+        val alignment =
+            createAlignment(
+                GeometryElementType.LINE,
+            )
         val element = alignment.elements.get(0)
         val coordinate = alignment.getCoordinateAt(0.0)!!
         assertEquals(coordinate.x, element.start.x, 0.0001)
@@ -260,23 +262,25 @@ class VerticalGeometryListingTest {
 
     @Test
     fun `Returns right coordinate mid-element`() {
-        val alignment = createAlignment(
-            GeometryElementType.LINE,
-            GeometryElementType.LINE,
-        )
+        val alignment =
+            createAlignment(
+                GeometryElementType.LINE,
+                GeometryElementType.LINE,
+            )
         val element = alignment.elements.get(1)
-        val coordinate = alignment.getCoordinateAt(
-            alignment.elements.first().calculatedLength + element.calculatedLength*0.5
-        )!!
+        val coordinate =
+            alignment.getCoordinateAt(
+                alignment.elements.first().calculatedLength + element.calculatedLength * 0.5)!!
         assertEquals(coordinate.x, 1.5, 0.0001)
         assertEquals(coordinate.y, 1.5, 0.0001)
     }
 
     @Test
     fun `Returns right coordinate at the end of alignment`() {
-        val alignment = createAlignment(
-            GeometryElementType.LINE,
-        )
+        val alignment =
+            createAlignment(
+                GeometryElementType.LINE,
+            )
         val coordinate = alignment.getCoordinateAt(alignment.elements.first().calculatedLength)!!
         assertEquals(coordinate.x, 1.0, 0.0001)
         assertEquals(coordinate.y, 1.0, 0.0001)
@@ -284,13 +288,19 @@ class VerticalGeometryListingTest {
 
     @Test
     fun `Throws if distance is past the end of alignment`() {
-        val alignment = createAlignment(
-            GeometryElementType.LINE,
-        )
+        val alignment =
+            createAlignment(
+                GeometryElementType.LINE,
+            )
         assertNull(alignment.getCoordinateAt(alignment.elements.first().calculatedLength + 0.5))
     }
 
-    private fun curvedSegment(start: Point, end: Point, center: Point, radius: Double = start.x - end.x / 2.0) =
+    private fun curvedSegment(
+        start: Point,
+        end: Point,
+        center: Point,
+        radius: Double = start.x - end.x / 2.0
+    ) =
         CurvedProfileSegment(
             PlanElementName(""),
             start,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/DummyFileContent.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/DummyFileContent.kt
@@ -8,7 +8,6 @@ object DummyFileContent {
     fun dummyValidFileXmlAsInputStream(): InputStream {
         val resource = InfraModel::class.java.getResource("/inframodel/testfile_simple.xml")!!
         return File(resource.toURI()).inputStream()
-
     }
 
     fun dummyInvalidFileXmlAsInputStream(): InputStream {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelControllerIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelControllerIT.kt
@@ -2,6 +2,9 @@ package fi.fta.geoviite.infra.inframodel
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.util.LocalizationKey
+import java.io.InputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -9,25 +12,16 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.context.ActiveProfiles
-import java.io.InputStream
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-internal class InfraModelControllerIT @Autowired constructor(
-    val infraModelService: InfraModelService
-): DBTestBase() {
+internal class InfraModelControllerIT
+@Autowired
+constructor(val infraModelService: InfraModelService) : DBTestBase() {
 
     @Test
     fun shouldFailIfFileIsEmpty() {
-        val emptyFile = MockMultipartFile(
-            "file",
-            null,
-            null,
-            null
-        )
+        val emptyFile = MockMultipartFile("file", null, null, null)
         val result = infraModelService.validateInfraModelFile(emptyFile, null)
         assertNull(result.geometryPlan)
         assertEquals(1, result.geometryValidationIssues.size)
@@ -40,23 +34,16 @@ internal class InfraModelControllerIT @Autowired constructor(
     @Test
     fun shouldReturnNotNullPlanIdIfValidXmlIsPosted() {
         val dummyXmlFile: InputStream = DummyFileContent.dummyValidFileXmlAsInputStream()
-        val validFile = MockMultipartFile(
-            "file",
-            "dummy.xml",
-            MediaType.TEXT_XML_VALUE,
-            dummyXmlFile
-        )
+        val validFile =
+            MockMultipartFile("file", "dummy.xml", MediaType.TEXT_XML_VALUE, dummyXmlFile)
         assertNotNull(infraModelService.validateInfraModelFile(validFile, null))
     }
 
     @Test
     fun shouldFailIfNoXmlFileIsSent() {
-        val textFile = MockMultipartFile(
-            "file",
-            "dummy.txt",
-            MediaType.TEXT_PLAIN_VALUE,
-            "Hello World".toByteArray()
-        )
+        val textFile =
+            MockMultipartFile(
+                "file", "dummy.txt", MediaType.TEXT_PLAIN_VALUE, "Hello World".toByteArray())
         val result = infraModelService.validateInfraModelFile(textFile, null)
         assertNull(result.geometryPlan)
         assertEquals(1, result.geometryValidationIssues.size)
@@ -69,12 +56,8 @@ internal class InfraModelControllerIT @Autowired constructor(
     @Test
     fun shouldFailIfInvalidXmlFileIsSent() {
         val dummyXmlFile: InputStream = DummyFileContent.dummyInvalidFileXmlAsInputStream()
-        val invalidFile = MockMultipartFile(
-            "file",
-            "dummy.xml",
-            MediaType.TEXT_XML_VALUE,
-            dummyXmlFile
-        )
+        val invalidFile =
+            MockMultipartFile("file", "dummy.xml", MediaType.TEXT_XML_VALUE, dummyXmlFile)
         val result = infraModelService.validateInfraModelFile(invalidFile, null)
         assertNull(result.geometryPlan)
         assertEquals(1, result.geometryValidationIssues.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelFileTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelFileTest.kt
@@ -1,8 +1,8 @@
 package fi.fta.geoviite.infra.inframodel
 
+import kotlin.test.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFalse
 
 class InfraModelFileTest {
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelParsingIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelParsingIT.kt
@@ -22,6 +22,8 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
+import java.io.StringWriter
+import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -30,22 +32,24 @@ import org.junit.jupiter.api.fail
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.io.StringWriter
-import java.math.BigDecimal
 
 const val TESTFILE_SIMPLE = "/inframodel/testfile_simple.xml"
 const val TESTFILE_CLOTHOID_AND_PARABOLA = "/inframodel/testfile_clothoid_and_parabola.xml"
-const val TESTFILE_SIMPLE_WITHOUT_CANT_ROTATION_POINT = "/inframodel/testfile_simple_without_cant_rotation_point.xml"
+const val TESTFILE_SIMPLE_WITHOUT_CANT_ROTATION_POINT =
+    "/inframodel/testfile_simple_without_cant_rotation_point.xml"
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class InfraModelParsingIT @Autowired constructor(
+class InfraModelParsingIT
+@Autowired
+constructor(
     geographyService: GeographyService,
     switchStructureDao: SwitchStructureDao,
     val trackNumberDao: LayoutTrackNumberDao,
 ) : DBTestBase() {
     private val coordinateSystemNameToSrid = geographyService.getCoordinateSystemNameToSridMapping()
-    private val switchStructuresByType = switchStructureDao.fetchSwitchStructures().associateBy { it.type }
+    private val switchStructuresByType =
+        switchStructureDao.fetchSwitchStructures().associateBy { it.type }
     private val switchTypeNameAliases = switchStructureDao.getInframodelAliases()
 
     @Test
@@ -61,14 +65,15 @@ class InfraModelParsingIT @Autowired constructor(
         assertEquals("meter", infraModel.units?.metric?.linearUnit)
         assertEquals("ETRS89 / GK25FIN", infraModel.coordinateSystem?.name)
         assertEquals("2392", infraModel.coordinateSystem?.epsgCode)
-        val converted = toGvtPlan(
-            PlanSource.GEOMETRIAPALVELU,
-            FileName(TESTFILE_SIMPLE),
-            infraModel,
-            coordinateSystemNameToSrid,
-            switchStructuresByType,
-            switchTypeNameAliases,
-        )
+        val converted =
+            toGvtPlan(
+                PlanSource.GEOMETRIAPALVELU,
+                FileName(TESTFILE_SIMPLE),
+                infraModel,
+                coordinateSystemNameToSrid,
+                switchStructuresByType,
+                switchTypeNameAliases,
+            )
         val allAlignments = infraModel.alignmentGroups.flatMap { ag -> ag.alignments }
         assertTrackNumbersMatch(infraModel.alignmentGroups, trackNumber)
         assertAlignmentsMatch(allAlignments, converted.alignments)
@@ -78,168 +83,230 @@ class InfraModelParsingIT @Autowired constructor(
     @Test
     fun differentSpiralsCanBeParsed() {
         val imFile = classPathToInfraModelFile(TESTFILE_CLOTHOID_AND_PARABOLA)
-        val parsed = parseInfraModelFile(
-            PlanSource.GEOMETRIAPALVELU,
-            imFile,
-            coordinateSystemNameToSrid,
-            switchStructuresByType,
-            switchTypeNameAliases,
-        )
+        val parsed =
+            parseInfraModelFile(
+                PlanSource.GEOMETRIAPALVELU,
+                imFile,
+                coordinateSystemNameToSrid,
+                switchStructuresByType,
+                switchTypeNameAliases,
+            )
         val allElements = parsed.alignments.flatMap { a -> a.elements }
         assertEquals(29, allElements.filterIsInstance<GeometryClothoid>().size)
         assertEquals(8, allElements.filterIsInstance<BiquadraticParabola>().size)
 
         val allCantPoints = parsed.alignments.mapNotNull { a -> a.cant }.flatMap { c -> c.points }
-        assertEquals(8, allCantPoints.filter { cp -> cp.transitionType == CantTransitionType.BIQUADRATIC_PARABOLA }.size)
+        assertEquals(
+            8,
+            allCantPoints
+                .filter { cp -> cp.transitionType == CantTransitionType.BIQUADRATIC_PARABOLA }
+                .size)
     }
 
     @Test
     fun encodeAndDecodeWorks403() {
-        val infraModelObject = InfraModel403(
-            language = "finnish",
-            featureDictionary = InfraModelFeatureDictionary403("featureDictName"),
-            units = InfraModelUnits403(InfraModelMetric403("meter", "squareMeter", "cubicMeter", "grads", "radians")),
-            coordinateSystem = InfraModelCoordinateSystem403("coordsys", "epsg1234"),
-            alignmentGroups = listOf(
-                InfraModelAlignmentGroup403(
-                    name = "name1",
-                    desc = "desc1",
-                    state = "proposed",
-                    alignments = listOf(
-                        InfraModelAlignment403(
-                            name = "alignment1",
+        val infraModelObject =
+            InfraModel403(
+                language = "finnish",
+                featureDictionary = InfraModelFeatureDictionary403("featureDictName"),
+                units =
+                    InfraModelUnits403(
+                        InfraModelMetric403(
+                            "meter", "squareMeter", "cubicMeter", "grads", "radians")),
+                coordinateSystem = InfraModelCoordinateSystem403("coordsys", "epsg1234"),
+                alignmentGroups =
+                    listOf(
+                        InfraModelAlignmentGroup403(
+                            name = "name1",
                             desc = "desc1",
                             state = "proposed",
-                            oid = "11",
-                            staStart = "0.0",
-                            elements = listOf(
-                                InfraModelLine403("l1", "o01", "123.123", "10.000", "start start", "end end"),
-                                InfraModelCurve403(
-                                    "c1",
-                                    "o11",
-                                    "123.124",
-                                    "11.000",
-                                    "cw",
-                                    "101.000",
-                                    "1001.000",
-                                    "start start",
-                                    "center center",
-                                    "end end",
-                                ),
-                                InfraModelSpiral403(
-                                    "s1",
-                                    "o21",
-                                    "123.125",
-                                    "12.000",
-                                    "clothoid",
-                                    "ab",
-                                    "2001.000",
-                                    "3001.000",
-                                    "3002.000",
-                                    "4001.000",
-                                    "INF",
-                                    "start start",
-                                    "pi pi",
-                                    "end end",
-                                ),
-                                InfraModelLine403("l2", "o02", "123.126", "13.000", "start start", "end end"),
-                            ),
-                            cant = InfraModelCant403(
-                                "tc", "test cant", "1.01", "insideRail",
+                            alignments =
                                 listOf(
-                                    InfraModelCantStation403("12.12", "0.045000", "cw"),
-                                    InfraModelCantStation403("123.123", "0.055000", "ccw"),
-                                    InfraModelCantStation403("1234.1234", "0.065000", "cw"),
-                                ),
-                            ),
-                            profile = InfraModelProfile403(
-                                InfraModelProfAlign403(
-                                    "tp",
-                                    listOf(
-                                        InfraModelPvi403("test start PVI", "100.001"),
-                                        InfraModelCircCurve403("test circcurve 1", "12.3", "654321", "123.321 456.654"),
-                                        InfraModelCircCurve403("test circcurve 2", "21.3", "123456", "321.123 654.456"),
-                                        InfraModelPvi403("test end PVI", "1000.5"),
+                                    InfraModelAlignment403(
+                                        name = "alignment1",
+                                        desc = "desc1",
+                                        state = "proposed",
+                                        oid = "11",
+                                        staStart = "0.0",
+                                        elements =
+                                            listOf(
+                                                InfraModelLine403(
+                                                    "l1",
+                                                    "o01",
+                                                    "123.123",
+                                                    "10.000",
+                                                    "start start",
+                                                    "end end"),
+                                                InfraModelCurve403(
+                                                    "c1",
+                                                    "o11",
+                                                    "123.124",
+                                                    "11.000",
+                                                    "cw",
+                                                    "101.000",
+                                                    "1001.000",
+                                                    "start start",
+                                                    "center center",
+                                                    "end end",
+                                                ),
+                                                InfraModelSpiral403(
+                                                    "s1",
+                                                    "o21",
+                                                    "123.125",
+                                                    "12.000",
+                                                    "clothoid",
+                                                    "ab",
+                                                    "2001.000",
+                                                    "3001.000",
+                                                    "3002.000",
+                                                    "4001.000",
+                                                    "INF",
+                                                    "start start",
+                                                    "pi pi",
+                                                    "end end",
+                                                ),
+                                                InfraModelLine403(
+                                                    "l2",
+                                                    "o02",
+                                                    "123.126",
+                                                    "13.000",
+                                                    "start start",
+                                                    "end end"),
+                                            ),
+                                        cant =
+                                            InfraModelCant403(
+                                                "tc",
+                                                "test cant",
+                                                "1.01",
+                                                "insideRail",
+                                                listOf(
+                                                    InfraModelCantStation403(
+                                                        "12.12", "0.045000", "cw"),
+                                                    InfraModelCantStation403(
+                                                        "123.123", "0.055000", "ccw"),
+                                                    InfraModelCantStation403(
+                                                        "1234.1234", "0.065000", "cw"),
+                                                ),
+                                            ),
+                                        profile =
+                                            InfraModelProfile403(
+                                                InfraModelProfAlign403(
+                                                    "tp",
+                                                    listOf(
+                                                        InfraModelPvi403(
+                                                            "test start PVI", "100.001"),
+                                                        InfraModelCircCurve403(
+                                                            "test circcurve 1",
+                                                            "12.3",
+                                                            "654321",
+                                                            "123.321 456.654"),
+                                                        InfraModelCircCurve403(
+                                                            "test circcurve 2",
+                                                            "21.3",
+                                                            "123456",
+                                                            "321.123 654.456"),
+                                                        InfraModelPvi403("test end PVI", "1000.5"),
+                                                    ),
+                                                    listOf(
+                                                        InfraModelFeature403(
+                                                            "profalignfeature",
+                                                            listOf(
+                                                                InfraModelProperty403(
+                                                                    "testprop", "testvalue")),
+                                                        ),
+                                                    ),
+                                                ),
+                                                listOf(
+                                                    InfraModelFeature403(
+                                                        "profilefeature",
+                                                        listOf(
+                                                            InfraModelProperty403(
+                                                                "testprop", "testvalue")),
+                                                    ),
+                                                ),
+                                            ),
+                                        features =
+                                            listOf(
+                                                InfraModelFeature403(
+                                                    "alignmentfeature",
+                                                    listOf(
+                                                        InfraModelProperty403(
+                                                            "testprop", "testvalue")),
+                                                ),
+                                            ),
+                                        staEquations =
+                                            listOf(
+                                                InfraModelStaEquation403(
+                                                    staBack = "1003.440785",
+                                                    staAhead = "304.954785",
+                                                    staInternal = "304.954785",
+                                                    desc = "1",
+                                                    InfraModelFeature403(
+                                                        code = "IM_kmPostCoords",
+                                                        listOf(
+                                                            InfraModelProperty403(
+                                                                label = "northing",
+                                                                value = "6674007.758000"),
+                                                            InfraModelProperty403(
+                                                                label = "easting",
+                                                                value = "25496599.876000"),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
                                     ),
-                                    listOf(
-                                        InfraModelFeature403(
-                                            "profalignfeature",
-                                            listOf(InfraModelProperty403("testprop", "testvalue")),
-                                        ),
+                                    InfraModelAlignment403(
+                                        name = "alignment2",
+                                        desc = "desc2",
+                                        state = "proposed",
+                                        oid = "12",
+                                        staStart = "10.0",
+                                        elements =
+                                            listOf(
+                                                InfraModelLine403(
+                                                    "l3",
+                                                    "o03",
+                                                    "123.127",
+                                                    "20.000",
+                                                    "start start",
+                                                    "end end"),
+                                                InfraModelCurve403(
+                                                    "c2",
+                                                    "o12",
+                                                    "123.128",
+                                                    "21.000",
+                                                    "ccw",
+                                                    "101.000",
+                                                    "1001.000",
+                                                    "start start",
+                                                    "center center",
+                                                    "end end"),
+                                                InfraModelSpiral403(
+                                                    "s2",
+                                                    "o22",
+                                                    "123.129",
+                                                    "22.000",
+                                                    "clothoid",
+                                                    "ac",
+                                                    "2002.000",
+                                                    "3011.000",
+                                                    "3012.000",
+                                                    "4002.000",
+                                                    "INF",
+                                                    "start start",
+                                                    "pi pi",
+                                                    "end end"),
+                                                InfraModelLine403(
+                                                    "l4",
+                                                    "o04",
+                                                    "123.130",
+                                                    "23.000",
+                                                    "start start",
+                                                    "end end"),
+                                            ),
                                     ),
                                 ),
-                                listOf(
-                                    InfraModelFeature403(
-                                        "profilefeature",
-                                        listOf(InfraModelProperty403("testprop", "testvalue")),
-                                    ),
-                                ),
-                            ),
-                            features = listOf(
-                                InfraModelFeature403(
-                                    "alignmentfeature",
-                                    listOf(InfraModelProperty403("testprop", "testvalue")),
-                                ),
-                            ),
-                            staEquations = listOf(
-                                InfraModelStaEquation403(
-                                    staBack = "1003.440785",
-                                    staAhead = "304.954785",
-                                    staInternal = "304.954785",
-                                    desc = "1",
-                                    InfraModelFeature403(
-                                        code = "IM_kmPostCoords",
-                                        listOf(
-                                            InfraModelProperty403(label = "northing", value = "6674007.758000"),
-                                            InfraModelProperty403(label = "easting", value = "25496599.876000"),
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                        InfraModelAlignment403(
-                            name = "alignment2",
-                            desc = "desc2",
-                            state = "proposed",
-                            oid = "12",
-                            staStart = "10.0",
-                            elements = listOf(
-                                InfraModelLine403("l3", "o03", "123.127", "20.000", "start start", "end end"),
-                                InfraModelCurve403(
-                                    "c2",
-                                    "o12",
-                                    "123.128",
-                                    "21.000",
-                                    "ccw",
-                                    "101.000",
-                                    "1001.000",
-                                    "start start",
-                                    "center center",
-                                    "end end"
-                                ),
-                                InfraModelSpiral403(
-                                    "s2",
-                                    "o22",
-                                    "123.129",
-                                    "22.000",
-                                    "clothoid",
-                                    "ac",
-                                    "2002.000",
-                                    "3011.000",
-                                    "3012.000",
-                                    "4002.000",
-                                    "INF",
-                                    "start start",
-                                    "pi pi",
-                                    "end end"
-                                ),
-                                InfraModelLine403("l4", "o04", "123.130", "23.000", "start start", "end end"),
-                            ),
-                        ),
-                    ),
-                )
-            )
-        )
+                        )))
         assertEquals("meter", infraModelObject.units?.metric?.linearUnit)
         val sw = StringWriter()
         marshaller.marshal(infraModelObject, sw)
@@ -263,149 +330,197 @@ class InfraModelParsingIT @Autowired constructor(
 
     @Test
     fun encodeAndDecodeWorks404() {
-        val infraModelObject = InfraModel404(
-            language = "finnish",
-            featureDictionary = InfraModelFeatureDictionary404("featureDictName"),
-            units = InfraModelUnits404(InfraModelMetric404("meter", "squareMeter", "cubicMeter", "grads", "radians")),
-            coordinateSystem = InfraModelCoordinateSystem404("coordsys", "epsg1234"),
-            alignmentGroups = listOf(
-                InfraModelAlignmentGroup404(
-                    name = "name1",
-                    desc = "desc1",
-                    state = "proposed",
-                    alignments = listOf(
-                        InfraModelAlignment404(
-                            name = "alignment1",
+        val infraModelObject =
+            InfraModel404(
+                language = "finnish",
+                featureDictionary = InfraModelFeatureDictionary404("featureDictName"),
+                units =
+                    InfraModelUnits404(
+                        InfraModelMetric404(
+                            "meter", "squareMeter", "cubicMeter", "grads", "radians")),
+                coordinateSystem = InfraModelCoordinateSystem404("coordsys", "epsg1234"),
+                alignmentGroups =
+                    listOf(
+                        InfraModelAlignmentGroup404(
+                            name = "name1",
                             desc = "desc1",
                             state = "proposed",
-                            oid = "11",
-                            staStart = "0.0",
-                            elements = listOf(
-                                InfraModelLine404("l1", "o01", "123.123", "10.000", "start start", "end end"),
-                                InfraModelCurve404(
-                                    "c1",
-                                    "o11",
-                                    "123.124",
-                                    "11.000",
-                                    "cw",
-                                    "101.000",
-                                    "1001.000",
-                                    "start start",
-                                    "center center",
-                                    "end end"
-                                ),
-                                InfraModelSpiral404(
-                                    "s1",
-                                    "o21",
-                                    "123.125",
-                                    "12.000",
-                                    "clothoid",
-                                    "ab",
-                                    "2001.000",
-                                    "3001.000",
-                                    "3002.000",
-                                    "4001.000",
-                                    "INF",
-                                    "start start",
-                                    "pi pi",
-                                    "end end"
-                                ),
-                                InfraModelLine404("l2", "o02", "123.126", "13.000", "start start", "end end")
-                            ),
-                            cant = InfraModelCant404(
-                                "tc", "test cant", "1.01", "insideRail", listOf(
-                                    InfraModelCantStation404("12.12", "0.045000", "cw"),
-                                    InfraModelCantStation404("123.123", "0.055000", "ccw"),
-                                    InfraModelCantStation404("1234.1234", "0.065000", "cw"),
-                                )
-                            ),
-                            profile = InfraModelProfile404(
-                                InfraModelProfAlign404(
-                                    "tp",
-                                    listOf(
-                                        InfraModelPvi404("test start PVI", "100.001"),
-                                        InfraModelCircCurve404("test circcurve 1", "12.3", "654321", "123.321 456.654"),
-                                        InfraModelCircCurve404("test circcurve 2", "21.3", "123456", "321.123 654.456"),
-                                        InfraModelPvi404("test end PVI", "1000.5")
-                                    ),
-                                    listOf(
-                                        InfraModelFeature404(
-                                            "profalignfeature",
-                                            listOf(InfraModelProperty404("testprop", "testvalue")),
-                                        ),
-                                    ),
-                                ),
+                            alignments =
                                 listOf(
-                                    InfraModelFeature404(
-                                        "profilefeature",
-                                        listOf(InfraModelProperty404("testprop", "testvalue")),
+                                    InfraModelAlignment404(
+                                        name = "alignment1",
+                                        desc = "desc1",
+                                        state = "proposed",
+                                        oid = "11",
+                                        staStart = "0.0",
+                                        elements =
+                                            listOf(
+                                                InfraModelLine404(
+                                                    "l1",
+                                                    "o01",
+                                                    "123.123",
+                                                    "10.000",
+                                                    "start start",
+                                                    "end end"),
+                                                InfraModelCurve404(
+                                                    "c1",
+                                                    "o11",
+                                                    "123.124",
+                                                    "11.000",
+                                                    "cw",
+                                                    "101.000",
+                                                    "1001.000",
+                                                    "start start",
+                                                    "center center",
+                                                    "end end"),
+                                                InfraModelSpiral404(
+                                                    "s1",
+                                                    "o21",
+                                                    "123.125",
+                                                    "12.000",
+                                                    "clothoid",
+                                                    "ab",
+                                                    "2001.000",
+                                                    "3001.000",
+                                                    "3002.000",
+                                                    "4001.000",
+                                                    "INF",
+                                                    "start start",
+                                                    "pi pi",
+                                                    "end end"),
+                                                InfraModelLine404(
+                                                    "l2",
+                                                    "o02",
+                                                    "123.126",
+                                                    "13.000",
+                                                    "start start",
+                                                    "end end")),
+                                        cant =
+                                            InfraModelCant404(
+                                                "tc",
+                                                "test cant",
+                                                "1.01",
+                                                "insideRail",
+                                                listOf(
+                                                    InfraModelCantStation404(
+                                                        "12.12", "0.045000", "cw"),
+                                                    InfraModelCantStation404(
+                                                        "123.123", "0.055000", "ccw"),
+                                                    InfraModelCantStation404(
+                                                        "1234.1234", "0.065000", "cw"),
+                                                )),
+                                        profile =
+                                            InfraModelProfile404(
+                                                InfraModelProfAlign404(
+                                                    "tp",
+                                                    listOf(
+                                                        InfraModelPvi404(
+                                                            "test start PVI", "100.001"),
+                                                        InfraModelCircCurve404(
+                                                            "test circcurve 1",
+                                                            "12.3",
+                                                            "654321",
+                                                            "123.321 456.654"),
+                                                        InfraModelCircCurve404(
+                                                            "test circcurve 2",
+                                                            "21.3",
+                                                            "123456",
+                                                            "321.123 654.456"),
+                                                        InfraModelPvi404("test end PVI", "1000.5")),
+                                                    listOf(
+                                                        InfraModelFeature404(
+                                                            "profalignfeature",
+                                                            listOf(
+                                                                InfraModelProperty404(
+                                                                    "testprop", "testvalue")),
+                                                        ),
+                                                    ),
+                                                ),
+                                                listOf(
+                                                    InfraModelFeature404(
+                                                        "profilefeature",
+                                                        listOf(
+                                                            InfraModelProperty404(
+                                                                "testprop", "testvalue")),
+                                                    ),
+                                                ),
+                                            ),
+                                        features =
+                                            listOf(
+                                                InfraModelFeature404(
+                                                    "alignmentfeature",
+                                                    listOf(
+                                                        InfraModelProperty404(
+                                                            "testprop", "testvalue")),
+                                                )),
+                                        staEquations =
+                                            listOf(
+                                                InfraModelStaEquation404(
+                                                    staBack = "1003.440785",
+                                                    staAhead = "304.954785",
+                                                    staInternal = "304.954785",
+                                                    desc = "1",
+                                                    InfraModelFeature404(
+                                                        code = "IM_kmPostCoords",
+                                                        listOf(
+                                                            InfraModelProperty404(
+                                                                label = "northing",
+                                                                value = "6674007.758000"),
+                                                            InfraModelProperty404(
+                                                                label = "easting",
+                                                                value = "25496599.876000"),
+                                                        )))),
                                     ),
+                                    InfraModelAlignment404(
+                                        name = "alignment2",
+                                        desc = "desc2",
+                                        state = "proposed",
+                                        oid = "12",
+                                        staStart = "10.0",
+                                        elements =
+                                            listOf(
+                                                InfraModelLine404(
+                                                    "l3",
+                                                    "o03",
+                                                    "123.127",
+                                                    "20.000",
+                                                    "start start",
+                                                    "end end"),
+                                                InfraModelCurve404(
+                                                    "c2",
+                                                    "o12",
+                                                    "123.128",
+                                                    "21.000",
+                                                    "ccw",
+                                                    "101.000",
+                                                    "1001.000",
+                                                    "start start",
+                                                    "center center",
+                                                    "end end"),
+                                                InfraModelSpiral404(
+                                                    "s2",
+                                                    "o22",
+                                                    "123.129",
+                                                    "22.000",
+                                                    "clothoid",
+                                                    "ac",
+                                                    "2002.000",
+                                                    "3011.000",
+                                                    "3012.000",
+                                                    "4002.000",
+                                                    "INF",
+                                                    "start start",
+                                                    "pi pi",
+                                                    "end end"),
+                                                InfraModelLine404(
+                                                    "l4",
+                                                    "o04",
+                                                    "123.130",
+                                                    "23.000",
+                                                    "start start",
+                                                    "end end"))),
                                 ),
-                            ),
-                            features = listOf(
-                                InfraModelFeature404(
-                                    "alignmentfeature",
-                                    listOf(InfraModelProperty404("testprop", "testvalue")),
-                                )
-                            ),
-                            staEquations = listOf(
-                                InfraModelStaEquation404(
-                                    staBack = "1003.440785",
-                                    staAhead = "304.954785",
-                                    staInternal = "304.954785",
-                                    desc = "1",
-                                    InfraModelFeature404(
-                                        code = "IM_kmPostCoords", listOf(
-                                            InfraModelProperty404(label = "northing", value = "6674007.758000"),
-                                            InfraModelProperty404(label = "easting", value = "25496599.876000"),
-                                        )
-                                    )
-                                )
-                            ),
-                        ),
-                        InfraModelAlignment404(
-                            name = "alignment2",
-                            desc = "desc2",
-                            state = "proposed",
-                            oid = "12",
-                            staStart = "10.0",
-                            elements = listOf(
-                                InfraModelLine404("l3", "o03", "123.127", "20.000", "start start", "end end"),
-                                InfraModelCurve404(
-                                    "c2",
-                                    "o12",
-                                    "123.128",
-                                    "21.000",
-                                    "ccw",
-                                    "101.000",
-                                    "1001.000",
-                                    "start start",
-                                    "center center",
-                                    "end end"
-                                ),
-                                InfraModelSpiral404(
-                                    "s2",
-                                    "o22",
-                                    "123.129",
-                                    "22.000",
-                                    "clothoid",
-                                    "ac",
-                                    "2002.000",
-                                    "3011.000",
-                                    "3012.000",
-                                    "4002.000",
-                                    "INF",
-                                    "start start",
-                                    "pi pi",
-                                    "end end"
-                                ),
-                                InfraModelLine404("l4", "o04", "123.130", "23.000", "start start", "end end")
-                            )
-                        ),
-                    ),
-                )
-            )
-        )
+                        )))
         assertEquals("meter", infraModelObject.units?.metric?.linearUnit)
         val sw = StringWriter()
         marshaller.marshal(infraModelObject, sw)
@@ -432,7 +547,8 @@ class InfraModelParsingIT @Autowired constructor(
     fun `InfraModel Cant-field is allowed to have missing rotationPoint-attribute`() {
         val xmlString = classpathResourceToString(TESTFILE_SIMPLE_WITHOUT_CANT_ROTATION_POINT)
         val infraModel =
-            toInfraModel(toInfraModelFile(FileName("testfile_without_cant_rotation_point.xml"), xmlString))
+            toInfraModel(
+                toInfraModelFile(FileName("testfile_without_cant_rotation_point.xml"), xmlString))
 
         toGvtPlan(
             PlanSource.GEOMETRIAPALVELU,
@@ -490,10 +606,14 @@ class InfraModelParsingIT @Autowired constructor(
         }
     }
 
-    private fun assertFeatureTypeCodeMatch(features: List<InfraModelFeature>, featureTypeCode: FeatureTypeCode?) {
-        val xmlCodeProperty = features
-            .find { imFeature -> imFeature.code == "IM_coding" }
-            ?.getPropertyAnyMatch(listOf("terrainCoding", "infraCoding"))
+    private fun assertFeatureTypeCodeMatch(
+        features: List<InfraModelFeature>,
+        featureTypeCode: FeatureTypeCode?
+    ) {
+        val xmlCodeProperty =
+            features
+                .find { imFeature -> imFeature.code == "IM_coding" }
+                ?.getPropertyAnyMatch(listOf("terrainCoding", "infraCoding"))
         assertEquals(xmlCodeProperty?.let(::FeatureTypeCode), featureTypeCode)
     }
 
@@ -520,13 +640,19 @@ class InfraModelParsingIT @Autowired constructor(
         }
     }
 
-    private fun assertKmPostsMatch(xmlKmPosts: List<InfraModelStaEquation>, gvtKmPost: List<GeometryKmPost>) {
+    private fun assertKmPostsMatch(
+        xmlKmPosts: List<InfraModelStaEquation>,
+        gvtKmPost: List<GeometryKmPost>
+    ) {
         if (xmlKmPosts.isNotEmpty()) {
             gvtKmPost.forEachIndexed { i, gvtKmPostElement ->
-
-                assertEquals(parseNullableBigDecimal(xmlKmPosts[i].staBack), gvtKmPostElement.staBack)
-                assertEquals(parseNullableBigDecimal(xmlKmPosts[i].staAhead), gvtKmPostElement.staAhead)
-                assertEquals(parseNullableBigDecimal(xmlKmPosts[i].staInternal), gvtKmPostElement.staInternal)
+                assertEquals(
+                    parseNullableBigDecimal(xmlKmPosts[i].staBack), gvtKmPostElement.staBack)
+                assertEquals(
+                    parseNullableBigDecimal(xmlKmPosts[i].staAhead), gvtKmPostElement.staAhead)
+                assertEquals(
+                    parseNullableBigDecimal(xmlKmPosts[i].staInternal),
+                    gvtKmPostElement.staInternal)
                 assertEquals(KmNumber(xmlKmPosts[i].desc), gvtKmPostElement.kmNumber)
 
                 val gvtKmPostLocation: Point? = gvtKmPostElement.location

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
@@ -13,6 +13,9 @@ import fi.fta.geoviite.infra.geometry.PlanDecisionPhase
 import fi.fta.geoviite.infra.geometry.PlanPhase
 import fi.fta.geoviite.infra.geometry.PlanSource
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -22,16 +25,15 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.context.ActiveProfiles
-import java.time.Duration
-import java.time.Instant
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class InfraModelServiceIT @Autowired constructor(
+class InfraModelServiceIT
+@Autowired
+constructor(
     val infraModelService: InfraModelService,
     val geometryDao: GeometryDao,
-): DBTestBase() {
+) : DBTestBase() {
 
     @BeforeEach
     fun clearPlanFiles() {
@@ -63,9 +65,10 @@ class InfraModelServiceIT @Autowired constructor(
         val file = getMockedMultipartFile(TESTFILE_CLOTHOID_AND_PARABOLA)
 
         infraModelService.saveInfraModel(file, null, null)
-        val exception = assertThrows<InframodelParsingException> {
-            infraModelService.saveInfraModel(file, null, null)
-        }
+        val exception =
+            assertThrows<InframodelParsingException> {
+                infraModelService.saveInfraModel(file, null, null)
+            }
         assertTrue(exception.message?.contains("InfraModel file exists already") ?: false)
     }
 
@@ -83,41 +86,45 @@ class InfraModelServiceIT @Autowired constructor(
     fun `InfraModel update works`() {
         val file = getMockedMultipartFile(TESTFILE_SIMPLE)
 
-        val overrides1 = OverrideParameters(
-            encoding = null,
-            coordinateSystemSrid = null,
-            verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
-            projectId = testDBService.insertProject().id,
-            authorId = testDBService.insertAuthor().id,
-            trackNumber = mainDraftContext.createAndFetchLayoutTrackNumber().number,
-            createdDate = Instant.now().minusSeconds(Duration.ofDays(5L).toSeconds()),
-            source = PlanSource.GEOMETRIAPALVELU,
-        )
-        val extraInfo1 = ExtraInfoParameters(
-            planPhase = PlanPhase.RAILWAY_PLAN,
-            decisionPhase = PlanDecisionPhase.APPROVED_PLAN,
-            measurementMethod = MeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY,
-            elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_RAIL,
-            message = FreeTextWithNewLines("test message 1"),
-        )
+        val overrides1 =
+            OverrideParameters(
+                encoding = null,
+                coordinateSystemSrid = null,
+                verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
+                projectId = testDBService.insertProject().id,
+                authorId = testDBService.insertAuthor().id,
+                trackNumber = mainDraftContext.createAndFetchLayoutTrackNumber().number,
+                createdDate = Instant.now().minusSeconds(Duration.ofDays(5L).toSeconds()),
+                source = PlanSource.GEOMETRIAPALVELU,
+            )
+        val extraInfo1 =
+            ExtraInfoParameters(
+                planPhase = PlanPhase.RAILWAY_PLAN,
+                decisionPhase = PlanDecisionPhase.APPROVED_PLAN,
+                measurementMethod = MeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY,
+                elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_RAIL,
+                message = FreeTextWithNewLines("test message 1"),
+            )
 
-        val overrides2 = OverrideParameters(
-            encoding = null,
-            coordinateSystemSrid = null,
-            verticalCoordinateSystem = VerticalCoordinateSystem.N60,
-            projectId = testDBService.insertProject().id,
-            authorId = testDBService.insertAuthor().id,
-            trackNumber = mainDraftContext.createAndFetchLayoutTrackNumber().number,
-            createdDate = Instant.now(),
-            source = PlanSource.PAIKANNUSPALVELU,
-        )
-        val extraInfo2 = ExtraInfoParameters(
-            planPhase = PlanPhase.RENOVATION_PLAN,
-            decisionPhase = PlanDecisionPhase.UNDER_CONSTRUCTION,
-            measurementMethod = MeasurementMethod.DIGITIZED_AERIAL_IMAGE,
-            elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_SLEEPER,
-            message = FreeTextWithNewLines("test message 2"),
-        )
+        val overrides2 =
+            OverrideParameters(
+                encoding = null,
+                coordinateSystemSrid = null,
+                verticalCoordinateSystem = VerticalCoordinateSystem.N60,
+                projectId = testDBService.insertProject().id,
+                authorId = testDBService.insertAuthor().id,
+                trackNumber = mainDraftContext.createAndFetchLayoutTrackNumber().number,
+                createdDate = Instant.now(),
+                source = PlanSource.PAIKANNUSPALVELU,
+            )
+        val extraInfo2 =
+            ExtraInfoParameters(
+                planPhase = PlanPhase.RENOVATION_PLAN,
+                decisionPhase = PlanDecisionPhase.UNDER_CONSTRUCTION,
+                measurementMethod = MeasurementMethod.DIGITIZED_AERIAL_IMAGE,
+                elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_SLEEPER,
+                message = FreeTextWithNewLines("test message 2"),
+            )
 
         val planId = infraModelService.saveInfraModel(file, overrides1, extraInfo1).id
         assertOverrides(planId, overrides1, extraInfo1)
@@ -125,12 +132,13 @@ class InfraModelServiceIT @Autowired constructor(
         assertOverrides(planId, overrides2, extraInfo2)
     }
 
-    fun getMockedMultipartFile(fileLocation: String): MockMultipartFile = MockMultipartFile(
-        "file",
-        "file.xml",
-        MediaType.TEXT_XML_VALUE,
-        classpathResourceToString(fileLocation).byteInputStream(),
-    )
+    fun getMockedMultipartFile(fileLocation: String): MockMultipartFile =
+        MockMultipartFile(
+            "file",
+            "file.xml",
+            MediaType.TEXT_XML_VALUE,
+            classpathResourceToString(fileLocation).byteInputStream(),
+        )
 
     private fun assertOverrides(
         planId: IntId<GeometryPlan>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
@@ -43,20 +43,22 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.splitSegment
 import fi.fta.geoviite.infra.tracklayout.toAlignmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackNumber
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import java.time.Instant
 import kotlin.math.ceil
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class AddressChangesServiceIT @Autowired constructor(
+class AddressChangesServiceIT
+@Autowired
+constructor(
     val geocodingService: GeocodingService,
     val geocodingDao: GeocodingDao,
     val locationTrackDao: LocationTrackDao,
@@ -73,76 +75,85 @@ class AddressChangesServiceIT @Autowired constructor(
     fun addressChangesAreEmptyIfNothingCanBeGeocoded() {
         val setupData1 = createAndInsertTrackNumberAndLocationTrack()
         val setupData2 = createAndInsertTrackNumberAndLocationTrack()
-        val changes = addressChangesService.getAddressChanges(
-            beforeTrack = setupData1.locationTrack,
-            afterTrack = setupData2.locationTrack,
-            beforeContextKey = null,
-            afterContextKey = null,
-        )
+        val changes =
+            addressChangesService.getAddressChanges(
+                beforeTrack = setupData1.locationTrack,
+                afterTrack = setupData2.locationTrack,
+                beforeContextKey = null,
+                afterContextKey = null,
+            )
         assertFalse(changes.isChanged())
     }
 
     @Test
     fun addressChangesAreEmptyIfNothingIsChanged() {
         val setupData = createAndInsertTrackNumberAndLocationTrack()
-        val contextKey = geocodingDao.getLayoutGeocodingContextCacheKey(
-            MainLayoutContext.official,
-            setupData.locationTrack.trackNumberId,
-        )!!
-        val changes = addressChangesService.getAddressChanges(
-            beforeTrack = setupData.locationTrack,
-            afterTrack = setupData.locationTrack,
-            beforeContextKey = contextKey,
-            afterContextKey = contextKey,
-        )
+        val contextKey =
+            geocodingDao.getLayoutGeocodingContextCacheKey(
+                MainLayoutContext.official,
+                setupData.locationTrack.trackNumberId,
+            )!!
+        val changes =
+            addressChangesService.getAddressChanges(
+                beforeTrack = setupData.locationTrack,
+                afterTrack = setupData.locationTrack,
+                beforeContextKey = contextKey,
+                afterContextKey = contextKey,
+            )
         assertFalse(changes.isChanged())
     }
 
     @Test
     fun addressChangesContainAllAddressesIfThereIsNoBeforeVersion() {
         val setupData = createAndInsertTrackNumberAndLocationTrack()
-        val contextKey = geocodingDao.getLayoutGeocodingContextCacheKey(
-            MainLayoutContext.official,
-            setupData.locationTrack.trackNumberId,
-        )!!
-        val changes = addressChangesService.getAddressChanges(
-            beforeTrack = null,
-            afterTrack = setupData.locationTrack,
-            beforeContextKey = null,
-            afterContextKey = contextKey,
-        )
+        val contextKey =
+            geocodingDao.getLayoutGeocodingContextCacheKey(
+                MainLayoutContext.official,
+                setupData.locationTrack.trackNumberId,
+            )!!
+        val changes =
+            addressChangesService.getAddressChanges(
+                beforeTrack = null,
+                afterTrack = setupData.locationTrack,
+                beforeContextKey = null,
+                afterContextKey = contextKey,
+            )
         assertTrue(changes.isChanged())
         assertTrue(changes.startPointChanged)
         assertTrue(changes.endPointChanged)
-        val allKms = getAllKms(
-            contextKey,
-            setupData.locationTrackGeometry.start!!,
-            setupData.locationTrackGeometry.end!!,
-        )
+        val allKms =
+            getAllKms(
+                contextKey,
+                setupData.locationTrackGeometry.start!!,
+                setupData.locationTrackGeometry.end!!,
+            )
         assertEquals(allKms, changes.changedKmNumbers)
     }
 
     @Test
     fun addressChangesContainAllAddressesIfTrackIsBeingRestoredFromBeingDeleted() {
         val setupData = createAndInsertTrackNumberAndLocationTrack()
-        val contextKey = geocodingDao.getLayoutGeocodingContextCacheKey(
-            MainLayoutContext.official,
-            setupData.locationTrack.trackNumberId,
-        )!!
-        val changes = addressChangesService.getAddressChanges(
-            beforeTrack = setupData.locationTrack.copy(state = LocationTrackState.DELETED),
-            afterTrack = setupData.locationTrack,
-            beforeContextKey = contextKey,
-            afterContextKey = contextKey,
-        )
+        val contextKey =
+            geocodingDao.getLayoutGeocodingContextCacheKey(
+                MainLayoutContext.official,
+                setupData.locationTrack.trackNumberId,
+            )!!
+        val changes =
+            addressChangesService.getAddressChanges(
+                beforeTrack = setupData.locationTrack.copy(state = LocationTrackState.DELETED),
+                afterTrack = setupData.locationTrack,
+                beforeContextKey = contextKey,
+                afterContextKey = contextKey,
+            )
         assertTrue(changes.isChanged())
         assertTrue(changes.startPointChanged)
         assertTrue(changes.endPointChanged)
-        val allKms = getAllKms(
-            contextKey,
-            setupData.locationTrackGeometry.start!!,
-            setupData.locationTrackGeometry.end!!,
-        )
+        val allKms =
+            getAllKms(
+                contextKey,
+                setupData.locationTrackGeometry.start!!,
+                setupData.locationTrackGeometry.end!!,
+            )
         assertEquals(allKms, changes.changedKmNumbers)
     }
 
@@ -152,28 +163,31 @@ class AddressChangesServiceIT @Autowired constructor(
         val initialLocationTrack = setupData.locationTrack
         val locationTrackId = initialLocationTrack.id as IntId
         val initialChangeMoment = locationTrackDao.fetchChangeTime()
-        val contextKey = geocodingDao.getLayoutGeocodingContextCacheKey(
-            MainLayoutContext.official,
-            setupData.locationTrack.trackNumberId,
-        )!!
+        val contextKey =
+            geocodingDao.getLayoutGeocodingContextCacheKey(
+                MainLayoutContext.official,
+                setupData.locationTrack.trackNumberId,
+            )!!
 
         removeLocationTrackGeometryAndUpdate(initialLocationTrack, setupData.locationTrackGeometry)
         val updateMoment = locationTrackDao.fetchChangeTime()
 
-        val changes = addressChangesService.getAddressChanges(
-            getTrackAtMoment(locationTrackId, initialChangeMoment),
-            getTrackAtMoment(locationTrackId, updateMoment)!!,
-            getContextKeyAtMoment(initialLocationTrack.trackNumberId, initialChangeMoment),
-            getContextKeyAtMoment(initialLocationTrack.trackNumberId, updateMoment),
-        )
+        val changes =
+            addressChangesService.getAddressChanges(
+                getTrackAtMoment(locationTrackId, initialChangeMoment),
+                getTrackAtMoment(locationTrackId, updateMoment)!!,
+                getContextKeyAtMoment(initialLocationTrack.trackNumberId, initialChangeMoment),
+                getContextKeyAtMoment(initialLocationTrack.trackNumberId, updateMoment),
+            )
         assertTrue(changes.isChanged())
         assertTrue(changes.startPointChanged)
         assertTrue(changes.endPointChanged)
-        val allKms = getAllKms(
-            contextKey,
-            setupData.locationTrackGeometry.start!!,
-            setupData.locationTrackGeometry.end!!,
-        )
+        val allKms =
+            getAllKms(
+                contextKey,
+                setupData.locationTrackGeometry.start!!,
+                setupData.locationTrackGeometry.end!!,
+            )
         assertEquals(allKms, changes.changedKmNumbers)
     }
 
@@ -189,32 +203,42 @@ class AddressChangesServiceIT @Autowired constructor(
         updateAndPublish(
             initialLocationTrack,
             setupData.locationTrackGeometry.copy(
-                segments = fixSegmentStarts(setupData.locationTrackGeometry.segments.mapIndexed { index, segment ->
-                    if (index == 0) segment.copy(
-                        geometry = segment.geometry.withPoints(
-                            fixMValues(listOf(movePoint(segment.segmentPoints.first(), -1.0)) + segment.segmentPoints.drop(1)),
-                        )
-                    )
-                    else segment
-                }),
+                segments =
+                    fixSegmentStarts(
+                        setupData.locationTrackGeometry.segments.mapIndexed { index, segment ->
+                            if (index == 0)
+                                segment.copy(
+                                    geometry =
+                                        segment.geometry.withPoints(
+                                            fixMValues(
+                                                listOf(
+                                                    movePoint(
+                                                        segment.segmentPoints.first(), -1.0)) +
+                                                    segment.segmentPoints.drop(1)),
+                                        ))
+                            else segment
+                        }),
             ),
         )
         val updateMoment = locationTrackDao.fetchChangeTime()
 
-        val changes = addressChangesService.getAddressChanges(
-            getTrackAtMoment(locationTrackId, initialChangeMoment),
-            getTrackAtMoment(locationTrackId, updateMoment)!!,
-            getContextKeyAtMoment(trackNumberId, initialChangeMoment),
-            getContextKeyAtMoment(trackNumberId, updateMoment),
-        )
+        val changes =
+            addressChangesService.getAddressChanges(
+                getTrackAtMoment(locationTrackId, initialChangeMoment),
+                getTrackAtMoment(locationTrackId, updateMoment)!!,
+                getContextKeyAtMoment(trackNumberId, initialChangeMoment),
+                getContextKeyAtMoment(trackNumberId, updateMoment),
+            )
         assertTrue(changes.isChanged())
         assertTrue(changes.startPointChanged)
         assertFalse(changes.endPointChanged)
-        val startAddress = geocodingService.getAddress(
-            MainLayoutContext.official,
-            trackNumberId,
-            setupData.locationTrackGeometry.start!!
-        )!!.first
+        val startAddress =
+            geocodingService
+                .getAddress(
+                    MainLayoutContext.official,
+                    trackNumberId,
+                    setupData.locationTrackGeometry.start!!)!!
+                .first
         assertEquals(setOf(startAddress.kmNumber), changes.changedKmNumbers)
     }
 
@@ -227,31 +251,32 @@ class AddressChangesServiceIT @Autowired constructor(
         val initialChangeMoment = locationTrackDao.fetchChangeTime()
 
         moveReferenceLineGeometryPointsAndUpdate(
-            setupData.referenceLine,
-            setupData.referenceLineGeometry
-        ) { index, point ->
-            // The reference-line is parallel to track, so alter the shape a bit to force all addresses changing
-            point + if (index % 2 == 0) Point(0.5, 0.5) else Point(0.5, 0.4)
-        }
+            setupData.referenceLine, setupData.referenceLineGeometry) { index, point ->
+                // The reference-line is parallel to track, so alter the shape a bit to force all
+                // addresses changing
+                point + if (index % 2 == 0) Point(0.5, 0.5) else Point(0.5, 0.4)
+            }
         val updateMoment = referenceLineDao.fetchChangeTime()
 
-        val changes = addressChangesService.getAddressChanges(
-            getTrackAtMoment(locationTrackId, initialChangeMoment),
-            getTrackAtMoment(locationTrackId, updateMoment)!!,
-            getContextKeyAtMoment(trackNumberId, initialChangeMoment),
-            getContextKeyAtMoment(trackNumberId, updateMoment),
-        )
+        val changes =
+            addressChangesService.getAddressChanges(
+                getTrackAtMoment(locationTrackId, initialChangeMoment),
+                getTrackAtMoment(locationTrackId, updateMoment)!!,
+                getContextKeyAtMoment(trackNumberId, initialChangeMoment),
+                getContextKeyAtMoment(trackNumberId, updateMoment),
+            )
         assertTrue(changes.isChanged())
         assertTrue(changes.startPointChanged, "Start should change: changes=$changes")
         assertTrue(changes.endPointChanged, "End should change: changes=$changes")
-        val allKms = getAllKms(
-            geocodingDao.getLayoutGeocodingContextCacheKey(
-                MainLayoutContext.official,
-                setupData.locationTrack.trackNumberId,
-            )!!,
-            setupData.locationTrackGeometry.start!!,
-            setupData.locationTrackGeometry.end!!,
-        )
+        val allKms =
+            getAllKms(
+                geocodingDao.getLayoutGeocodingContextCacheKey(
+                    MainLayoutContext.official,
+                    setupData.locationTrack.trackNumberId,
+                )!!,
+                setupData.locationTrackGeometry.start!!,
+                setupData.locationTrackGeometry.end!!,
+            )
         assertEquals(allKms, changes.changedKmNumbers)
     }
 
@@ -266,12 +291,13 @@ class AddressChangesServiceIT @Autowired constructor(
         moveKmPostGkLocationAndUpdate(setupData.kmPosts[0]) { point -> point + 0.5 }
         val updateMoment = layoutKmPostDao.fetchChangeTime()
 
-        val changes = addressChangesService.getAddressChanges(
-            getTrackAtMoment(locationTrackId, initialChangeMoment),
-            getTrackAtMoment(locationTrackId, updateMoment)!!,
-            getContextKeyAtMoment(trackNumberId, initialChangeMoment),
-            getContextKeyAtMoment(trackNumberId, updateMoment),
-        )
+        val changes =
+            addressChangesService.getAddressChanges(
+                getTrackAtMoment(locationTrackId, initialChangeMoment),
+                getTrackAtMoment(locationTrackId, updateMoment)!!,
+                getContextKeyAtMoment(trackNumberId, initialChangeMoment),
+                getContextKeyAtMoment(trackNumberId, updateMoment),
+            )
         assertTrue(changes.isChanged())
         assertFalse(changes.startPointChanged)
         assertFalse(changes.endPointChanged)
@@ -280,36 +306,42 @@ class AddressChangesServiceIT @Autowired constructor(
 
     @Test
     fun shouldFindDifferencesWhenEitherHasNoMidPoints() {
-        assertEquals(setOf(), resolveChangedGeometryKilometers(
-            createEmptyAddresses(
-                Point(100.0, 100.0) to TrackMeter(2, 1),
-                Point(100.0, 200.0) to TrackMeter(2, 101),
-            ),
-            createEmptyAddresses(
-                Point(100.0, 100.0) to TrackMeter(2, 1),
-                Point(100.0, 200.0) to TrackMeter(2, 101),
-            ),
-        ))
-        assertEquals(setOf(KmNumber(3)), resolveChangedGeometryKilometers(
-            createAddresses(
-                Point(100.0, 100.0) to TrackMeter(3, 1),
-                Point(100.0, 200.0) to TrackMeter(3, 101),
-            ),
-            createEmptyAddresses(
-                Point(100.0, 100.0) to TrackMeter(3, 1),
-                Point(100.0, 200.0) to TrackMeter(3, 101),
-            ),
-        ))
-        assertEquals(setOf(KmNumber(2)), resolveChangedGeometryKilometers(
-            createEmptyAddresses(
-                Point(100.0, 100.0) to TrackMeter(2, 1),
-                Point(100.0, 200.0) to TrackMeter(2, 101),
-            ),
-            createAddresses(
-                Point(100.0, 100.0) to TrackMeter(2, 1),
-                Point(100.0, 200.0) to TrackMeter(2, 101),
-            ),
-        ))
+        assertEquals(
+            setOf(),
+            resolveChangedGeometryKilometers(
+                createEmptyAddresses(
+                    Point(100.0, 100.0) to TrackMeter(2, 1),
+                    Point(100.0, 200.0) to TrackMeter(2, 101),
+                ),
+                createEmptyAddresses(
+                    Point(100.0, 100.0) to TrackMeter(2, 1),
+                    Point(100.0, 200.0) to TrackMeter(2, 101),
+                ),
+            ))
+        assertEquals(
+            setOf(KmNumber(3)),
+            resolveChangedGeometryKilometers(
+                createAddresses(
+                    Point(100.0, 100.0) to TrackMeter(3, 1),
+                    Point(100.0, 200.0) to TrackMeter(3, 101),
+                ),
+                createEmptyAddresses(
+                    Point(100.0, 100.0) to TrackMeter(3, 1),
+                    Point(100.0, 200.0) to TrackMeter(3, 101),
+                ),
+            ))
+        assertEquals(
+            setOf(KmNumber(2)),
+            resolveChangedGeometryKilometers(
+                createEmptyAddresses(
+                    Point(100.0, 100.0) to TrackMeter(2, 1),
+                    Point(100.0, 200.0) to TrackMeter(2, 101),
+                ),
+                createAddresses(
+                    Point(100.0, 100.0) to TrackMeter(2, 1),
+                    Point(100.0, 200.0) to TrackMeter(2, 101),
+                ),
+            ))
     }
 
     @Test
@@ -317,22 +349,24 @@ class AddressChangesServiceIT @Autowired constructor(
         //
         //      -------------
         // 0    1     2     3    4
-        val origAddresses = createAddresses(
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-        )
+        val origAddresses =
+            createAddresses(
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+            )
 
         //
         // -----------------------
         // 0    1     2     3    4
-        val newAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
@@ -351,22 +385,24 @@ class AddressChangesServiceIT @Autowired constructor(
         //
         // -----------------------
         // 0    1     2     3    4
-        val origAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val origAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         //
         //      -------------
         // 0    1     2     3    4
-        val newAddresses = createAddresses(
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+            )
 
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
@@ -385,20 +421,22 @@ class AddressChangesServiceIT @Autowired constructor(
         //
         // ------------
         // 0    1     2     3    4
-        val origAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-        )
+        val origAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+            )
 
         //
         //            ------------
         // 0    1     2     3    4
-        val newAddresses = createAddresses(
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
@@ -419,20 +457,22 @@ class AddressChangesServiceIT @Autowired constructor(
         //
         //            ------------
         // 0    1     2     3    4
-        val origAddresses = createAddresses(
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val origAddresses =
+            createAddresses(
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         //
         // ------------
         // 0    1     2     3    4
-        val newAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+            )
 
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
@@ -453,31 +493,30 @@ class AddressChangesServiceIT @Autowired constructor(
         //
         // -----------------------
         // 0    1     2     3    4
-        val origAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val origAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         //         /-----\
         // -------/       \-------
         // 0    1     2     3    4
-        val newAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(1200.0, 0.0) to TrackMeter(1, 200),
-            Point(1500.0, 100.0) to TrackMeter(1, 500),
-
-            Point(2000.0, 100.0) to TrackMeter(2, 0),
-            Point(2500.0, 100.0) to TrackMeter(2, 500),
-            Point(2800.0, 0.0) to TrackMeter(2, 800),
-
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(1200.0, 0.0) to TrackMeter(1, 200),
+                Point(1500.0, 100.0) to TrackMeter(1, 500),
+                Point(2000.0, 100.0) to TrackMeter(2, 0),
+                Point(2500.0, 100.0) to TrackMeter(2, 500),
+                Point(2800.0, 0.0) to TrackMeter(2, 800),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
@@ -496,30 +535,29 @@ class AddressChangesServiceIT @Autowired constructor(
         //         /-----\
         // -------/       \-------
         // 0    1     2     3    4
-        val origAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(1200.0, 0.0) to TrackMeter(1, 200),
-            Point(1500.0, 100.0) to TrackMeter(1, 500),
-
-            Point(2000.0, 100.0) to TrackMeter(2, 0),
-            Point(2500.0, 100.0) to TrackMeter(2, 500),
-            Point(2800.0, 0.0) to TrackMeter(2, 800),
-
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val origAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(1200.0, 0.0) to TrackMeter(1, 200),
+                Point(1500.0, 100.0) to TrackMeter(1, 500),
+                Point(2000.0, 100.0) to TrackMeter(2, 0),
+                Point(2500.0, 100.0) to TrackMeter(2, 500),
+                Point(2800.0, 0.0) to TrackMeter(2, 800),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         //
         // -----------------------
         // 0    1           3    4
-        val newAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
@@ -538,22 +576,24 @@ class AddressChangesServiceIT @Autowired constructor(
         //
         //      ------------------
         //      1     2     3    4
-        val origAddresses = createAddresses(
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val origAddresses =
+            createAddresses(
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         //
         // -----------------------
         // 0          2     3    4
-        val newAddresses = createAddresses(
-            Point(1000.0, 0.0) to TrackMeter(0, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(1000.0, 0.0) to TrackMeter(0, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
@@ -572,32 +612,30 @@ class AddressChangesServiceIT @Autowired constructor(
         //
         // -------------------------------
         // 0    1         2     3        4
-        val origAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val origAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         //         /--\            /--\
         // -------/    \----------/    \--
         // 0    1         2     3        4
-        val newAddresses = createAddresses(
-            Point(0.0, 0.0) to TrackMeter(0, 0),
-
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(1300.0, 100.0) to TrackMeter(1, 300),
-            Point(1600.0, 0.0) to TrackMeter(1, 600),
-
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-            Point(3300.0, 100.0) to TrackMeter(3, 300),
-            Point(3600.0, 0.0) to TrackMeter(3, 600),
-
-            Point(4000.0, 0.0) to TrackMeter(4, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(0.0, 0.0) to TrackMeter(0, 0),
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(1300.0, 100.0) to TrackMeter(1, 300),
+                Point(1600.0, 0.0) to TrackMeter(1, 600),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+                Point(3300.0, 100.0) to TrackMeter(3, 300),
+                Point(3600.0, 0.0) to TrackMeter(3, 600),
+                Point(4000.0, 0.0) to TrackMeter(4, 0),
+            )
 
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
@@ -616,20 +654,22 @@ class AddressChangesServiceIT @Autowired constructor(
         //
         //      -------------
         // 0    1     2     3    4
-        val origAddresses = createAddresses(
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-        )
+        val origAddresses =
+            createAddresses(
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+            )
 
         //
         //      -------------
         // 0    1     2     3    4
-        val newAddresses = createAddresses(
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+            )
 
         val differences = resolveChangedGeometryKilometers(origAddresses, newAddresses)
 
@@ -645,11 +685,12 @@ class AddressChangesServiceIT @Autowired constructor(
         //
         //      -------------
         // 0    1     2     3    4
-        val newAddresses = createAddresses(
-            Point(1000.0, 0.0) to TrackMeter(1, 0),
-            Point(2000.0, 0.0) to TrackMeter(2, 0),
-            Point(3000.0, 0.0) to TrackMeter(3, 0),
-        )
+        val newAddresses =
+            createAddresses(
+                Point(1000.0, 0.0) to TrackMeter(1, 0),
+                Point(2000.0, 0.0) to TrackMeter(2, 0),
+                Point(3000.0, 0.0) to TrackMeter(3, 0),
+            )
 
         val addressChanges = getAddressChanges(null, newAddresses)
 
@@ -673,64 +714,66 @@ class AddressChangesServiceIT @Autowired constructor(
     fun createAndInsertTrackNumberAndLocationTrack(): SetupData {
         val sequence = System.currentTimeMillis().toString().takeLast(8)
         val refPoint = Point(370000.0, 7100000.0) // any point in Finland
-        val trackNumber = layoutTrackNumberDao.fetch(
-            layoutTrackNumberDao.insert(trackNumber(TrackNumber("TEST TN $sequence"), draft = false)).rowVersion
-        )
-        val kmPost1 = layoutKmPostDao.fetch(
-            layoutKmPostDao.insert(
-                kmPost(
-                    trackNumberId = trackNumber.id as IntId,
-                    km = KmNumber(1),
-                    roughLayoutLocation = refPoint + 5.0,
-                    draft = false,
-                )
-            ).rowVersion
-        )
-        val kmPost2 = layoutKmPostDao.fetch(
-            layoutKmPostDao.insert(
-                kmPost(
-                    trackNumberId = trackNumber.id as IntId,
-                    km = KmNumber(2),
-                    roughLayoutLocation = refPoint + 10.0,
-                    draft = false,
-                )
-            ).rowVersion
-        )
+        val trackNumber =
+            layoutTrackNumberDao.fetch(
+                layoutTrackNumberDao
+                    .insert(trackNumber(TrackNumber("TEST TN $sequence"), draft = false))
+                    .rowVersion)
+        val kmPost1 =
+            layoutKmPostDao.fetch(
+                layoutKmPostDao
+                    .insert(
+                        kmPost(
+                            trackNumberId = trackNumber.id as IntId,
+                            km = KmNumber(1),
+                            roughLayoutLocation = refPoint + 5.0,
+                            draft = false,
+                        ))
+                    .rowVersion)
+        val kmPost2 =
+            layoutKmPostDao.fetch(
+                layoutKmPostDao
+                    .insert(
+                        kmPost(
+                            trackNumberId = trackNumber.id as IntId,
+                            km = KmNumber(2),
+                            roughLayoutLocation = refPoint + 10.0,
+                            draft = false,
+                        ))
+                    .rowVersion)
         val referenceLinePoints = (0..15).map { i -> refPoint + i.toDouble() }
-        val referenceLineGeometryVersion = layoutAlignmentDao.insert(
-            alignment(
-                splitSegment(segment(*referenceLinePoints.toTypedArray()), 4)
-            )
-        )
+        val referenceLineGeometryVersion =
+            layoutAlignmentDao.insert(
+                alignment(splitSegment(segment(*referenceLinePoints.toTypedArray()), 4)))
         val referenceLineGeometry = layoutAlignmentDao.fetch(referenceLineGeometryVersion)
-        val referenceLine = referenceLineDao.fetch(
-            referenceLineDao.insert(
-                referenceLine(
-                    trackNumber.id as IntId<TrackLayoutTrackNumber>,
-                    alignment = referenceLineGeometry,
-                    alignmentVersion = referenceLineGeometryVersion,
-                    draft = false,
-                )
-            ).rowVersion
-        )
+        val referenceLine =
+            referenceLineDao.fetch(
+                referenceLineDao
+                    .insert(
+                        referenceLine(
+                            trackNumber.id as IntId<TrackLayoutTrackNumber>,
+                            alignment = referenceLineGeometry,
+                            alignmentVersion = referenceLineGeometryVersion,
+                            draft = false,
+                        ))
+                    .rowVersion)
         val alignmentPoints = referenceLinePoints.subList(2, referenceLinePoints.count() - 2)
-        val locationTrackGeometryVersion = layoutAlignmentDao.insert(
-            alignment(
-                splitSegment(segment(*alignmentPoints.toTypedArray()), 3)
-            )
-        )
+        val locationTrackGeometryVersion =
+            layoutAlignmentDao.insert(
+                alignment(splitSegment(segment(*alignmentPoints.toTypedArray()), 3)))
         val locationTrackGeometry = layoutAlignmentDao.fetch(locationTrackGeometryVersion)
-        val locationTrack = locationTrackDao.fetch(
-            locationTrackDao.insert(
-                locationTrack(
-                    trackNumberId = trackNumber.id as IntId,
-                    alignment = locationTrackGeometry,
-                    name = "TEST LocTr $sequence",
-                    alignmentVersion = locationTrackGeometryVersion,
-                    draft = false,
-                )
-            ).rowVersion
-        )
+        val locationTrack =
+            locationTrackDao.fetch(
+                locationTrackDao
+                    .insert(
+                        locationTrack(
+                            trackNumberId = trackNumber.id as IntId,
+                            alignment = locationTrackGeometry,
+                            name = "TEST LocTr $sequence",
+                            alignmentVersion = locationTrackGeometryVersion,
+                            draft = false,
+                        ))
+                    .rowVersion)
 
         return SetupData(
             locationTrack,
@@ -741,12 +784,15 @@ class AddressChangesServiceIT @Autowired constructor(
         )
     }
 
-    fun removeLocationTrackGeometryAndUpdate(locationTrack: LocationTrack, alignment: LayoutAlignment) =
-        updateAndPublish(locationTrack, alignment.copy(segments = listOf()))
+    fun removeLocationTrackGeometryAndUpdate(
+        locationTrack: LocationTrack,
+        alignment: LayoutAlignment
+    ) = updateAndPublish(locationTrack, alignment.copy(segments = listOf()))
 
     fun updateAndPublish(locationTrack: LocationTrack, alignment: LayoutAlignment) {
         val version = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
-        locationTrackService.publish(LayoutBranch.main, ValidationVersion(version.id, version.rowVersion))
+        locationTrackService.publish(
+            LayoutBranch.main, ValidationVersion(version.id, version.rowVersion))
     }
 
     fun moveReferenceLineGeometryPointsAndUpdate(
@@ -755,24 +801,34 @@ class AddressChangesServiceIT @Autowired constructor(
         moveFunc: (index: Int, point: IPoint) -> IPoint,
     ) {
         var index = 0
-        val version = referenceLineService.saveDraft(
-            LayoutBranch.main,
-            referenceLine,
-            alignment.copy(
-                segments = fixSegmentStarts(alignment.segments.map { segment ->
-                    segment.copy(
-                        geometry = segment.geometry.withPoints(
-                            fixMValues(segment.segmentPoints.mapIndexed { inSegmentIndex, point ->
-                                val newPoint = moveFunc(index, point)
-                                if (inSegmentIndex < segment.alignmentPoints.lastIndex) index++
-                                point.copy(x = newPoint.x, y = newPoint.y)
+        val version =
+            referenceLineService.saveDraft(
+                LayoutBranch.main,
+                referenceLine,
+                alignment.copy(
+                    segments =
+                        fixSegmentStarts(
+                            alignment.segments.map { segment ->
+                                segment.copy(
+                                    geometry =
+                                        segment.geometry.withPoints(
+                                            fixMValues(
+                                                segment.segmentPoints.mapIndexed {
+                                                    inSegmentIndex,
+                                                    point ->
+                                                    val newPoint = moveFunc(index, point)
+                                                    if (inSegmentIndex <
+                                                        segment.alignmentPoints.lastIndex)
+                                                        index++
+                                                    point.copy(x = newPoint.x, y = newPoint.y)
+                                                }),
+                                        ),
+                                )
                             }),
-                        ),
-                    )
-                }),
-            ),
-        )
-        referenceLineService.publish(LayoutBranch.main, ValidationVersion(version.id, version.rowVersion))
+                ),
+            )
+        referenceLineService.publish(
+            LayoutBranch.main, ValidationVersion(version.id, version.rowVersion))
     }
 
     fun moveKmPostGkLocationAndUpdate(
@@ -780,39 +836,47 @@ class AddressChangesServiceIT @Autowired constructor(
         moveFunc: (point: IPoint) -> Point,
     ): TrackLayoutKmPost {
         return layoutKmPostDao.fetch(
-            layoutKmPostDao.update(
-                kmPost.copy(
-                    gkLocation = GeometryPoint(moveFunc(kmPost.gkLocation!!), kmPost.gkLocation!!.srid)
-                )
-            ).rowVersion
-        )
+            layoutKmPostDao
+                .update(
+                    kmPost.copy(
+                        gkLocation =
+                            GeometryPoint(moveFunc(kmPost.gkLocation!!), kmPost.gkLocation!!.srid)))
+                .rowVersion)
     }
 
     fun createLineString(vararg transitPoints: Point): List<Point> {
-        return transitPoints.flatMapIndexed { index, from ->
-            val to = transitPoints.getOrNull(index + 1)
-            if (to != null) {
-                val length = ceil(lineLength(from, to)).toInt()
-                (0..length).map { i ->
-                    val ratio = i / length.toDouble()
-                    (from * (1 - ratio) + to * ratio) / 2.0
+        return transitPoints
+            .flatMapIndexed { index, from ->
+                val to = transitPoints.getOrNull(index + 1)
+                if (to != null) {
+                    val length = ceil(lineLength(from, to)).toInt()
+                    (0..length).map { i ->
+                        val ratio = i / length.toDouble()
+                        (from * (1 - ratio) + to * ratio) / 2.0
+                    }
+                } else {
+                    emptyList()
                 }
-            } else {
-                emptyList()
             }
-        }.distinct()
+            .distinct()
     }
 
-    fun createEmptyAddresses(start: Pair<Point, TrackMeter>, end: Pair<Point, TrackMeter>): AlignmentAddresses =
+    fun createEmptyAddresses(
+        start: Pair<Point, TrackMeter>,
+        end: Pair<Point, TrackMeter>
+    ): AlignmentAddresses =
         AlignmentAddresses(
-            startPoint = AddressPoint(
-                AlignmentPoint(start.first.x, start.first.y, null, 0.0, null),
-                start.second,
-            ),
-            endPoint = AddressPoint(
-                AlignmentPoint(end.first.x, end.first.y, null, lineLength(start.first, end.first), null),
-                start.second,
-            ),
+            startPoint =
+                AddressPoint(
+                    AlignmentPoint(start.first.x, start.first.y, null, 0.0, null),
+                    start.second,
+                ),
+            endPoint =
+                AddressPoint(
+                    AlignmentPoint(
+                        end.first.x, end.first.y, null, lineLength(start.first, end.first), null),
+                    start.second,
+                ),
             startIntersect = IntersectType.WITHIN,
             endIntersect = IntersectType.WITHIN,
             midPoints = listOf(),
@@ -821,25 +885,27 @@ class AddressChangesServiceIT @Autowired constructor(
     fun createAddresses(
         vararg transitionPoints: Pair<Point, TrackMeter>,
     ): AlignmentAddresses {
-        val addressPoints = transitionPoints.flatMapIndexed { index, transitionPoint ->
-            val from = transitionPoint.first
-            val fromAddress = transitionPoint.second
-            val nextTransitionPoint = transitionPoints.getOrNull(index + 1)
-            if (nextTransitionPoint != null) {
-                val to = nextTransitionPoint.first
-                val points = createLineString(from, to)
-                val alignmentPoints = toAlignmentPoints(points = points.toTypedArray())
-                val addressPoints = alignmentPoints.map { alignmentPoint: AlignmentPoint ->
-                    AddressPoint(
-                        point = alignmentPoint,
-                        address = fromAddress + alignmentPoint.m,
-                    )
+        val addressPoints =
+            transitionPoints.flatMapIndexed { index, transitionPoint ->
+                val from = transitionPoint.first
+                val fromAddress = transitionPoint.second
+                val nextTransitionPoint = transitionPoints.getOrNull(index + 1)
+                if (nextTransitionPoint != null) {
+                    val to = nextTransitionPoint.first
+                    val points = createLineString(from, to)
+                    val alignmentPoints = toAlignmentPoints(points = points.toTypedArray())
+                    val addressPoints =
+                        alignmentPoints.map { alignmentPoint: AlignmentPoint ->
+                            AddressPoint(
+                                point = alignmentPoint,
+                                address = fromAddress + alignmentPoint.m,
+                            )
+                        }
+                    addressPoints
+                } else {
+                    emptyList()
                 }
-                addressPoints
-            } else {
-                emptyList()
             }
-        }
         return AlignmentAddresses(
             startPoint = addressPoints.firstOrNull() ?: someAddressPoint(),
             endPoint = addressPoints.lastOrNull() ?: someAddressPoint(),
@@ -849,25 +915,34 @@ class AddressChangesServiceIT @Autowired constructor(
         )
     }
 
-    fun someAddressPoint() = AddressPoint(
-        AlignmentPoint(0.0, 0.0, null, 0.0, null),
-        TrackMeter(0, 0),
-    )
+    fun someAddressPoint() =
+        AddressPoint(
+            AlignmentPoint(0.0, 0.0, null, 0.0, null),
+            TrackMeter(0, 0),
+        )
 
-    fun getAllKms(geocodingContextCacheKey: GeocodingContextCacheKey, start: IPoint, end: IPoint): Set<KmNumber> {
+    fun getAllKms(
+        geocodingContextCacheKey: GeocodingContextCacheKey,
+        start: IPoint,
+        end: IPoint
+    ): Set<KmNumber> {
         val context = geocodingService.getGeocodingContext(geocodingContextCacheKey)!!
         val startKm = context.getAddress(start)!!.first.kmNumber
         val endKm = context.getAddress(end)!!.first.kmNumber
-        return context.referencePoints.map { r -> r.kmNumber }.filter { km -> km in startKm..endKm }.toSet()
+        return context.referencePoints
+            .map { r -> r.kmNumber }
+            .filter { km -> km in startKm..endKm }
+            .toSet()
     }
 
-    fun movePoint(point: SegmentPoint, delta: Double) = SegmentPoint(
-        x = point.x + delta,
-        y = point.y + delta,
-        z = point.z,
-        m = point.m,
-        cant = point.cant,
-    )
+    fun movePoint(point: SegmentPoint, delta: Double) =
+        SegmentPoint(
+            x = point.x + delta,
+            y = point.y + delta,
+            z = point.z,
+            m = point.m,
+            cant = point.cant,
+        )
 
     fun getTrackAtMoment(locationTrackId: IntId<LocationTrack>, moment: Instant) =
         locationTrackService.getOfficialAtMoment(LayoutBranch.main, locationTrackId, moment)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -53,11 +53,6 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkingAtEnd
 import fi.fta.geoviite.infra.tracklayout.switchLinkingAtStart
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FreeText
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.*
@@ -67,10 +62,17 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class CalculatedChangesServiceIT @Autowired constructor(
+class CalculatedChangesServiceIT
+@Autowired
+constructor(
     val calculatedChangesService: CalculatedChangesService,
     val switchDao: LayoutSwitchDao,
     val locationTrackDao: LocationTrackDao,
@@ -128,19 +130,21 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrackService = locationTrackService,
         )
 
-        val changes = getCalculatedChanges(
-            locationTrackIds = listOf(locationTrack3.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                locationTrackIds = listOf(locationTrack3.id as IntId),
+            )
 
         assertContains(
             changes.directChanges.locationTrackChanges,
             LocationTrackChange(
                 locationTrackId = locationTrack3.id as IntId<LocationTrack>,
-                changedKmNumbers = setOf(
-                    KmNumber(6),
-                    KmNumber(7),
-                    KmNumber(8),
-                ),
+                changedKmNumbers =
+                    setOf(
+                        KmNumber(6),
+                        KmNumber(7),
+                        KmNumber(8),
+                    ),
                 isStartChanged = true,
                 isEndChanged = true,
             ),
@@ -155,38 +159,45 @@ class CalculatedChangesServiceIT @Autowired constructor(
 
     @Test
     fun addingTopologyEndSwitchGeneratesIndirectlySwitchChanges() {
-        val testData = insertTestData(
-            kmPostData = listOf(
-                KmNumber(0) to Point(0.0, 0.0),
-                KmNumber(1) to Point(1000.0, 0.0),
-            ),
-            locationTrackData = listOf(
-                Line(Point(0.0, 0.0), Point(100.0, 0.0)),
+        val testData =
+            insertTestData(
+                kmPostData =
+                    listOf(
+                        KmNumber(0) to Point(0.0, 0.0),
+                        KmNumber(1) to Point(1000.0, 0.0),
+                    ),
+                locationTrackData =
+                    listOf(
+                        Line(Point(0.0, 0.0), Point(100.0, 0.0)),
 
-                // tracks for YV switch
-                Line(Point(100.0, 0.0), Point(200.0, 0.0)),
-                Line(Point(100.0, 0.0), Point(200.0, 20.0)),
-            ),
-            switchData = listOf(
-                SwitchData(
-                    Point(100.0, 0.0),
-                    locationTrackIndexA = 1,
-                    locationTrackIndexB = 2,
-                )
-            ),
-        )
+                        // tracks for YV switch
+                        Line(Point(100.0, 0.0), Point(200.0, 0.0)),
+                        Line(Point(100.0, 0.0), Point(200.0, 20.0)),
+                    ),
+                switchData =
+                    listOf(
+                        SwitchData(
+                            Point(100.0, 0.0),
+                            locationTrackIndexA = 1,
+                            locationTrackIndexB = 2,
+                        )),
+            )
         val (locationTrack1, alignment1) = testData.locationTracksAndAlignments[0]
         val switch = testData.switches[0]
 
         // Manually remove topology switch as it is automatically added when creating test data
-        val (updatedLocationTrack, updatedAlignment) = removeTopologySwitchesFromLocationTrackAndUpdate(
-            locationTrack1,
-            alignment1,
-            locationTrackService,
-        ).let { (id, version) ->
-            val (_, publishedVersion) = locationTrackService.publish(LayoutBranch.main, ValidationVersion(id, version))
-            locationTrackService.getWithAlignment(publishedVersion)
-        }
+        val (updatedLocationTrack, updatedAlignment) =
+            removeTopologySwitchesFromLocationTrackAndUpdate(
+                    locationTrack1,
+                    alignment1,
+                    locationTrackService,
+                )
+                .let { (id, version) ->
+                    val (_, publishedVersion) =
+                        locationTrackService.publish(
+                            LayoutBranch.main, ValidationVersion(id, version))
+                    locationTrackService.getWithAlignment(publishedVersion)
+                }
 
         // Set topology switch info
         addTopologyEndSwitchIntoLocationTrackAndUpdate(
@@ -194,12 +205,12 @@ class CalculatedChangesServiceIT @Autowired constructor(
             updatedAlignment,
             switch.id as IntId,
             JointNumber(1),
-            locationTrackService = locationTrackService
-        )
+            locationTrackService = locationTrackService)
 
-        val changes = getCalculatedChanges(
-            locationTrackIds = listOf(locationTrack1.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                locationTrackIds = listOf(locationTrack1.id as IntId),
+            )
 
         assertContains(
             changes.directChanges.locationTrackChanges,
@@ -207,8 +218,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 locationTrackId = locationTrack1.id as IntId,
                 changedKmNumbers = setOf(KmNumber(0)),
                 isStartChanged = false,
-                isEndChanged = true
-            ),
+                isEndChanged = true),
         )
 
         assertEquals(1, changes.indirectChanges.switchChanges.size)
@@ -232,40 +242,47 @@ class CalculatedChangesServiceIT @Autowired constructor(
 
     @Test
     fun addingTopologyStartSwitchGeneratesIndirectlySwitchChanges() {
-        val testData = insertTestData(
-            kmPostData = listOf(
-                KmNumber(0) to Point(0.0, 0.0),
-                KmNumber(1) to Point(1000.0, 0.0),
-            ),
-            locationTrackData = listOf(
-                // NOTICE: This track starts from the switch. It is not aligned properly
-                // but should be OK for this test.
-                Line(Point(100.0, 0.0), Point(150.0, 50.0)),
+        val testData =
+            insertTestData(
+                kmPostData =
+                    listOf(
+                        KmNumber(0) to Point(0.0, 0.0),
+                        KmNumber(1) to Point(1000.0, 0.0),
+                    ),
+                locationTrackData =
+                    listOf(
+                        // NOTICE: This track starts from the switch. It is not aligned properly
+                        // but should be OK for this test.
+                        Line(Point(100.0, 0.0), Point(150.0, 50.0)),
 
-                // tracks for YV switch
-                Line(Point(100.0, 0.0), Point(200.0, 0.0)),
-                Line(Point(100.0, 0.0), Point(200.0, 20.0)),
-            ),
-            switchData = listOf(
-                SwitchData(
-                    Point(100.0, 0.0),
-                    locationTrackIndexA = 1,
-                    locationTrackIndexB = 2,
-                )
-            ),
-        )
+                        // tracks for YV switch
+                        Line(Point(100.0, 0.0), Point(200.0, 0.0)),
+                        Line(Point(100.0, 0.0), Point(200.0, 20.0)),
+                    ),
+                switchData =
+                    listOf(
+                        SwitchData(
+                            Point(100.0, 0.0),
+                            locationTrackIndexA = 1,
+                            locationTrackIndexB = 2,
+                        )),
+            )
         val (locationTrack1, alignment1) = testData.locationTracksAndAlignments[0]
         val switch = testData.switches[0]
 
         // Manually remove topology switch as it is automatically added when creating test data
-        val (updatedLocationTrack, updatedAlignment) = removeTopologySwitchesFromLocationTrackAndUpdate(
-            locationTrack1,
-            alignment1,
-            locationTrackService,
-        ).let { (id, version) ->
-            val (_, publishedVersion) = locationTrackService.publish(LayoutBranch.main, ValidationVersion(id, version))
-            locationTrackService.getWithAlignment(publishedVersion)
-        }
+        val (updatedLocationTrack, updatedAlignment) =
+            removeTopologySwitchesFromLocationTrackAndUpdate(
+                    locationTrack1,
+                    alignment1,
+                    locationTrackService,
+                )
+                .let { (id, version) ->
+                    val (_, publishedVersion) =
+                        locationTrackService.publish(
+                            LayoutBranch.main, ValidationVersion(id, version))
+                    locationTrackService.getWithAlignment(publishedVersion)
+                }
 
         // Set topology switch info
         addTopologyStartSwitchIntoLocationTrackAndUpdate(
@@ -273,12 +290,12 @@ class CalculatedChangesServiceIT @Autowired constructor(
             updatedAlignment,
             switch.id as IntId,
             JointNumber(1),
-            locationTrackService = locationTrackService
-        )
+            locationTrackService = locationTrackService)
 
-        val changes = getCalculatedChanges(
-            locationTrackIds = listOf(locationTrack1.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                locationTrackIds = listOf(locationTrack1.id as IntId),
+            )
 
         assertContains(
             changes.directChanges.locationTrackChanges,
@@ -286,8 +303,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 locationTrackId = locationTrack1.id as IntId,
                 changedKmNumbers = setOf(KmNumber(0)),
                 isStartChanged = true,
-                isEndChanged = false
-            ),
+                isEndChanged = false),
         )
 
         assertEquals(1, changes.indirectChanges.switchChanges.size)
@@ -313,45 +329,50 @@ class CalculatedChangesServiceIT @Autowired constructor(
     fun addingNonPresentationPointTopologySwitchesShouldNotGenerateSwitchChanges() {
         val sequence = System.currentTimeMillis().toString().takeLast(8)
 
-        val testData = insertTestData(
-            kmPostData = listOf(
-                KmNumber(0) to Point(0.0, 0.0),
-                KmNumber(1) to Point(1000.0, 0.0),
-            ),
-            locationTrackData = listOf(
-                // NOTICE: This track does not locate near to the switch
-                // but topology switch link is added manually afterwards
-                Line(Point(0.0, 0.0), Point(85.0, 0.0)),
+        val testData =
+            insertTestData(
+                kmPostData =
+                    listOf(
+                        KmNumber(0) to Point(0.0, 0.0),
+                        KmNumber(1) to Point(1000.0, 0.0),
+                    ),
+                locationTrackData =
+                    listOf(
+                        // NOTICE: This track does not locate near to the switch
+                        // but topology switch link is added manually afterwards
+                        Line(Point(0.0, 0.0), Point(85.0, 0.0)),
 
-                // tracks for YV switch
-                Line(Point(100.0, 0.0), Point(200.0, 0.0)),
-                Line(Point(100.0, 0.0), Point(200.0, 20.0)),
-            ),
-            switchData = listOf(
-                SwitchData(
-                    Point(100.0, 0.0),
-                    locationTrackIndexA = 1,
-                    locationTrackIndexB = 2,
-                    name = "switch-A $sequence",
-                ),
-                SwitchData(
-                    Point(100.0, 0.0),
-                    locationTrackIndexA = 1,
-                    locationTrackIndexB = 2,
-                    name = "switch-B $sequence",
-                ),
-            ),
-        )
+                        // tracks for YV switch
+                        Line(Point(100.0, 0.0), Point(200.0, 0.0)),
+                        Line(Point(100.0, 0.0), Point(200.0, 20.0)),
+                    ),
+                switchData =
+                    listOf(
+                        SwitchData(
+                            Point(100.0, 0.0),
+                            locationTrackIndexA = 1,
+                            locationTrackIndexB = 2,
+                            name = "switch-A $sequence",
+                        ),
+                        SwitchData(
+                            Point(100.0, 0.0),
+                            locationTrackIndexA = 1,
+                            locationTrackIndexB = 2,
+                            name = "switch-B $sequence",
+                        ),
+                    ),
+            )
         val (locationTrack1, alignment1) = testData.locationTracksAndAlignments[0]
 
         // Set topology switch info
-        val (updatedLocationTrack, updatedAlignment) = addTopologyStartSwitchIntoLocationTrackAndUpdate(
-            locationTrack1,
-            alignment1,
-            testData.switches[0].id as IntId,
-            JointNumber(5), // Use non-presentation joint number
-            locationTrackService = locationTrackService
-        ).let { locationTrackService.getWithAlignment(it.rowVersion) }
+        val (updatedLocationTrack, updatedAlignment) =
+            addTopologyStartSwitchIntoLocationTrackAndUpdate(
+                    locationTrack1,
+                    alignment1,
+                    testData.switches[0].id as IntId,
+                    JointNumber(5), // Use non-presentation joint number
+                    locationTrackService = locationTrackService)
+                .let { locationTrackService.getWithAlignment(it.rowVersion) }
 
         addTopologyEndSwitchIntoLocationTrackAndUpdate(
             updatedLocationTrack,
@@ -361,9 +382,10 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrackService = locationTrackService,
         )
 
-        val changes = getCalculatedChanges(
-            locationTrackIds = listOf(locationTrack1.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                locationTrackIds = listOf(locationTrack1.id as IntId),
+            )
 
         assertContains(
             changes.directChanges.locationTrackChanges,
@@ -379,40 +401,47 @@ class CalculatedChangesServiceIT @Autowired constructor(
 
     @Test
     fun removingTopologyEndSwitchGeneratesIndirectlySwitchChanges() {
-        val testData = insertTestData(
-            kmPostData = listOf(
-                KmNumber(0) to Point(0.0, 0.0),
-                KmNumber(1) to Point(1000.0, 0.0),
-            ),
-            locationTrackData = listOf(
-                Line(Point(0.0, 0.0), Point(100.0, 0.0)),
+        val testData =
+            insertTestData(
+                kmPostData =
+                    listOf(
+                        KmNumber(0) to Point(0.0, 0.0),
+                        KmNumber(1) to Point(1000.0, 0.0),
+                    ),
+                locationTrackData =
+                    listOf(
+                        Line(Point(0.0, 0.0), Point(100.0, 0.0)),
 
-                // tracks for YV switch
-                Line(Point(100.0, 0.0), Point(200.0, 0.0)),
-                Line(Point(100.0, 0.0), Point(200.0, 20.0)),
-            ),
-            switchData = listOf(
-                SwitchData(
-                    Point(100.0, 0.0),
-                    locationTrackIndexA = 1,
-                    locationTrackIndexB = 2,
-                )
-            ),
-        )
+                        // tracks for YV switch
+                        Line(Point(100.0, 0.0), Point(200.0, 0.0)),
+                        Line(Point(100.0, 0.0), Point(200.0, 20.0)),
+                    ),
+                switchData =
+                    listOf(
+                        SwitchData(
+                            Point(100.0, 0.0),
+                            locationTrackIndexA = 1,
+                            locationTrackIndexB = 2,
+                        )),
+            )
         val (locationTrack1, alignment1) = testData.locationTracksAndAlignments[0]
         val switch = testData.switches[0]
 
         // Add a topology switch to generate base state
-        val (updatedLocationTrack, updatedAlignment) = addTopologyEndSwitchIntoLocationTrackAndUpdate(
-            locationTrack1,
-            alignment1,
-            switch.id as IntId,
-            JointNumber(1),
-            locationTrackService = locationTrackService,
-        ).let { (id, version) ->
-            val (_, publishedVersion) = locationTrackService.publish(LayoutBranch.main, ValidationVersion(id, version))
-            locationTrackService.getWithAlignment(publishedVersion)
-        }
+        val (updatedLocationTrack, updatedAlignment) =
+            addTopologyEndSwitchIntoLocationTrackAndUpdate(
+                    locationTrack1,
+                    alignment1,
+                    switch.id as IntId,
+                    JointNumber(1),
+                    locationTrackService = locationTrackService,
+                )
+                .let { (id, version) ->
+                    val (_, publishedVersion) =
+                        locationTrackService.publish(
+                            LayoutBranch.main, ValidationVersion(id, version))
+                    locationTrackService.getWithAlignment(publishedVersion)
+                }
 
         // Then remove the topology switch info
         removeTopologySwitchesFromLocationTrackAndUpdate(
@@ -421,11 +450,10 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrackService = locationTrackService,
         )
 
-        val changes = getCalculatedChanges(
-            locationTrackIds = listOf(
-                locationTrack1.id as IntId
-            ),
-        )
+        val changes =
+            getCalculatedChanges(
+                locationTrackIds = listOf(locationTrack1.id as IntId),
+            )
 
         assertContains(
             changes.directChanges.locationTrackChanges,
@@ -433,8 +461,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 locationTrackId = locationTrack1.id as IntId,
                 changedKmNumbers = setOf(),
                 isStartChanged = false,
-                isEndChanged = false
-            ),
+                isEndChanged = false),
         )
 
         assertEquals(1, changes.indirectChanges.switchChanges.size)
@@ -478,19 +505,21 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrackService = locationTrackService,
         )
 
-        val changes = getCalculatedChanges(
-            locationTrackIds = listOf(locationTrack3.id as IntId, locationTrack4.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                locationTrackIds = listOf(locationTrack3.id as IntId, locationTrack4.id as IntId),
+            )
 
         assertContains(
             changes.directChanges.locationTrackChanges,
             LocationTrackChange(
                 locationTrackId = locationTrack3.id as IntId<LocationTrack>,
-                changedKmNumbers = setOf(
-                    KmNumber(6),
-                    KmNumber(7),
-                    KmNumber(8),
-                ),
+                changedKmNumbers =
+                    setOf(
+                        KmNumber(6),
+                        KmNumber(7),
+                        KmNumber(8),
+                    ),
                 isStartChanged = true,
                 isEndChanged = true,
             ),
@@ -499,9 +528,10 @@ class CalculatedChangesServiceIT @Autowired constructor(
             changes.directChanges.locationTrackChanges,
             LocationTrackChange(
                 locationTrackId = locationTrack4.id as IntId<LocationTrack>,
-                changedKmNumbers = setOf(
-                    KmNumber(7),
-                ),
+                changedKmNumbers =
+                    setOf(
+                        KmNumber(7),
+                    ),
                 isStartChanged = true,
                 isEndChanged = true,
             ),
@@ -531,12 +561,12 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrack3,
             alignment3,
             { point -> if (point.m < 200) point + 2.0 else point },
-            locationTrackService = locationTrackService
-        )
+            locationTrackService = locationTrackService)
 
-        val changes = getCalculatedChanges(
-            locationTrackIds = listOf(locationTrack3.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                locationTrackIds = listOf(locationTrack3.id as IntId),
+            )
 
         assertEquals(
             changes.directChanges.locationTrackChanges,
@@ -545,8 +575,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                     locationTrackId = locationTrack3.id as IntId<LocationTrack>,
                     changedKmNumbers = setOf(KmNumber(6)),
                     isStartChanged = true,
-                    isEndChanged = false
-                ),
+                    isEndChanged = false),
             ),
         )
         assertTrue(changes.indirectChanges.switchChanges.isEmpty())
@@ -564,12 +593,12 @@ class CalculatedChangesServiceIT @Autowired constructor(
             referenceLine,
             referenceLineAlignment,
             { point -> if (point.m < 900) point - 2.0 else point },
-            referenceLineService = referenceLineService
-        )
+            referenceLineService = referenceLineService)
 
-        val changes = getCalculatedChanges(
-            referenceLineIds = listOf(referenceLine.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                referenceLineIds = listOf(referenceLine.id as IntId),
+            )
 
         assertContains(changes.directChanges.referenceLineChanges, referenceLine.id)
 
@@ -579,8 +608,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 trackNumberId = referenceLine.trackNumberId,
                 changedKmNumbers = setOf(KmNumber(5)),
                 isStartChanged = true,
-                isEndChanged = false
-            ),
+                isEndChanged = false),
         )
         assertContains(
             changes.indirectChanges.locationTrackChanges,
@@ -588,8 +616,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 locationTrackId = locationTrack1.id as IntId<LocationTrack>,
                 changedKmNumbers = setOf(KmNumber(5)),
                 isStartChanged = true,
-                isEndChanged = false
-            ),
+                isEndChanged = false),
         )
     }
 
@@ -619,9 +646,10 @@ class CalculatedChangesServiceIT @Autowired constructor(
             referenceLineService = referenceLineService,
         )
 
-        val changes = getCalculatedChanges(
-            referenceLineIds = listOf(referenceLine.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                referenceLineIds = listOf(referenceLine.id as IntId),
+            )
 
         assertContains(changes.directChanges.referenceLineChanges, referenceLine.id)
 
@@ -629,10 +657,11 @@ class CalculatedChangesServiceIT @Autowired constructor(
             changes.indirectChanges.trackNumberChanges,
             TrackNumberChange(
                 trackNumberId = referenceLine.trackNumberId,
-                changedKmNumbers = setOf(
-                    KmNumber(6),
-                    KmNumber(7),
-                ),
+                changedKmNumbers =
+                    setOf(
+                        KmNumber(6),
+                        KmNumber(7),
+                    ),
                 isStartChanged = false,
                 isEndChanged = false,
             ),
@@ -641,9 +670,10 @@ class CalculatedChangesServiceIT @Autowired constructor(
             changes.indirectChanges.locationTrackChanges,
             LocationTrackChange(
                 locationTrackId = locationTrack1.id as IntId,
-                changedKmNumbers = setOf(
-                    KmNumber(6),
-                ),
+                changedKmNumbers =
+                    setOf(
+                        KmNumber(6),
+                    ),
                 isStartChanged = false,
                 isEndChanged = true,
             ),
@@ -652,10 +682,11 @@ class CalculatedChangesServiceIT @Autowired constructor(
             changes.indirectChanges.locationTrackChanges,
             LocationTrackChange(
                 locationTrackId = locationTrack3.id as IntId<LocationTrack>,
-                changedKmNumbers = setOf(
-                    KmNumber(6),
-                    KmNumber(7),
-                ),
+                changedKmNumbers =
+                    setOf(
+                        KmNumber(6),
+                        KmNumber(7),
+                    ),
                 isStartChanged = true,
                 isEndChanged = false,
             ),
@@ -664,9 +695,10 @@ class CalculatedChangesServiceIT @Autowired constructor(
             changes.indirectChanges.locationTrackChanges,
             LocationTrackChange(
                 locationTrackId = locationTrack4.id as IntId<LocationTrack>,
-                changedKmNumbers = setOf(
-                    KmNumber(7),
-                ),
+                changedKmNumbers =
+                    setOf(
+                        KmNumber(7),
+                    ),
                 isStartChanged = true,
                 isEndChanged = true,
             ),
@@ -704,10 +736,11 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrackService = locationTrackService,
         )
 
-        val changes = getCalculatedChanges(
-            switchIds = listOf(switch.id as IntId),
-            locationTrackIds = listOf(locationTrack3.id as IntId<LocationTrack>),
-        )
+        val changes =
+            getCalculatedChanges(
+                switchIds = listOf(switch.id as IntId),
+                locationTrackIds = listOf(locationTrack3.id as IntId<LocationTrack>),
+            )
 
         assertEquals(1, changes.directChanges.switchChanges.size)
 
@@ -729,11 +762,15 @@ class CalculatedChangesServiceIT @Autowired constructor(
             switchService,
         )
 
-        val changes = getCalculatedChanges(
-            switchIds = listOf(switch.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                switchIds = listOf(switch.id as IntId),
+            )
 
-        assertTrue(changes.directChanges.switchChanges.all { it.switchId == switch.id && it.changedJoints.isEmpty() })
+        assertTrue(
+            changes.directChanges.switchChanges.all {
+                it.switchId == switch.id && it.changedJoints.isEmpty()
+            })
         assertTrue(changes.indirectChanges.switchChanges.isEmpty())
         assertTrue(changes.indirectChanges.locationTrackChanges.isEmpty())
     }
@@ -747,8 +784,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
             referenceLine = referenceLine,
             alignment = alignment,
             moveFunc = { point -> if (point.m < 900) point - 2.0 else point },
-            referenceLineService = referenceLineService
-        )
+            referenceLineService = referenceLineService)
 
         val changes = getCalculatedChanges()
 
@@ -768,17 +804,14 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val testData = insertTestData()
         val kmPost = testData.kmPosts.first()
         kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost.copy(
-                kmNumber = KmNumber(kmPost.kmNumber.number, "A")
-            )
-        )
+            LayoutBranch.main, kmPost.copy(kmNumber = KmNumber(kmPost.kmNumber.number, "A")))
         val changes = getCalculatedChanges(kmPostIds = listOf(kmPost.id as IntId))
 
         assertEquals(1, changes.directChanges.kmPostChanges.size)
         assertContains(changes.directChanges.kmPostChanges, kmPost.id)
         assertEquals(1, changes.indirectChanges.trackNumberChanges.size)
-        assertEquals(kmPost.trackNumberId, changes.indirectChanges.trackNumberChanges[0].trackNumberId)
+        assertEquals(
+            kmPost.trackNumberId, changes.indirectChanges.trackNumberChanges[0].trackNumberId)
         assertEquals(0, changes.directChanges.trackNumberChanges.size)
     }
 
@@ -797,7 +830,8 @@ class CalculatedChangesServiceIT @Autowired constructor(
 
         val changes = getCalculatedChanges(kmPostIds = listOf(kmPost.id as IntId))
         assertEquals(1, changes.indirectChanges.trackNumberChanges.size)
-        assertEquals(kmPost.trackNumberId, changes.indirectChanges.trackNumberChanges[0].trackNumberId)
+        assertEquals(
+            kmPost.trackNumberId, changes.indirectChanges.trackNumberChanges[0].trackNumberId)
         assertEquals(0, changes.directChanges.trackNumberChanges.size)
     }
 
@@ -864,18 +898,16 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val testData = insertTestData()
         val (referenceLine, _) = testData.referenceLineAndAlignment
         referenceLineService.saveDraft(
-            LayoutBranch.main,
-            referenceLine.copy(
-                startAddress = TrackMeter(0, 500)
-            )
-        )
+            LayoutBranch.main, referenceLine.copy(startAddress = TrackMeter(0, 500)))
 
         val changes = getCalculatedChanges(referenceLineIds = listOf(referenceLine.id as IntId))
 
         assertEquals(1, changes.directChanges.referenceLineChanges.size)
         assertContains(changes.directChanges.referenceLineChanges, referenceLine.id)
         assertEquals(1, changes.indirectChanges.trackNumberChanges.size)
-        assertEquals(referenceLine.trackNumberId, changes.indirectChanges.trackNumberChanges[0].trackNumberId)
+        assertEquals(
+            referenceLine.trackNumberId,
+            changes.indirectChanges.trackNumberChanges[0].trackNumberId)
         assertEquals(0, changes.directChanges.trackNumberChanges.size)
     }
 
@@ -888,12 +920,13 @@ class CalculatedChangesServiceIT @Autowired constructor(
             referenceLine = referenceLine,
             alignment = alignment,
             moveFunc = { point -> if (point.m < 900) point - 2.0 else point },
-            referenceLineService = referenceLineService
-        )
+            referenceLineService = referenceLineService)
 
         val changes = getCalculatedChanges(referenceLineIds = listOf(referenceLine.id as IntId))
         assertEquals(1, changes.indirectChanges.trackNumberChanges.size)
-        assertEquals(changes.indirectChanges.trackNumberChanges[0].trackNumberId, referenceLine.trackNumberId)
+        assertEquals(
+            changes.indirectChanges.trackNumberChanges[0].trackNumberId,
+            referenceLine.trackNumberId)
         assertEquals(0, changes.directChanges.trackNumberChanges.size)
     }
 
@@ -907,12 +940,12 @@ class CalculatedChangesServiceIT @Autowired constructor(
             referenceLine = referenceLine,
             alignment = alignment,
             moveFunc = { point -> if (point.m < 900) point - 2.0 else point },
-            referenceLineService = referenceLineService
-        )
+            referenceLineService = referenceLineService)
 
         val changes = getCalculatedChanges(referenceLineIds = listOf(referenceLine.id as IntId))
         assertEquals(1, changes.indirectChanges.locationTrackChanges.size)
-        assertEquals(locationTrack.id, changes.indirectChanges.locationTrackChanges[0].locationTrackId)
+        assertEquals(
+            locationTrack.id, changes.indirectChanges.locationTrackChanges[0].locationTrackId)
         assertEquals(0, changes.directChanges.locationTrackChanges.size)
     }
 
@@ -922,10 +955,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val trackNumber = testData.trackNumber
         trackNumberservice.saveDraft(
             LayoutBranch.main,
-            trackNumber.copy(
-                description = FreeText(UUID.randomUUID().toString())
-            )
-        )
+            trackNumber.copy(description = FreeText(UUID.randomUUID().toString())))
 
         val changes = getCalculatedChanges(trackNumberIds = listOf(trackNumber.id as IntId))
         assertEquals(1, changes.directChanges.trackNumberChanges.size)
@@ -942,12 +972,12 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrack = locationTrack,
             alignment = alignment,
             moveFunc = { point -> point + 2.0 },
-            locationTrackService = locationTrackService
-        )
+            locationTrackService = locationTrackService)
 
         val changes = getCalculatedChanges(locationTrackIds = listOf(locationTrack.id as IntId))
         assertEquals(1, changes.directChanges.locationTrackChanges.size)
-        assertEquals(locationTrack.id, changes.directChanges.locationTrackChanges[0].locationTrackId)
+        assertEquals(
+            locationTrack.id, changes.directChanges.locationTrackChanges[0].locationTrackId)
         assertEquals(0, changes.indirectChanges.locationTrackChanges.size)
     }
 
@@ -961,8 +991,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrack = locationTrack,
             alignment = alignment,
             moveFunc = { point -> point + 2.0 },
-            locationTrackService = locationTrackService
-        )
+            locationTrackService = locationTrackService)
 
         val changes = getCalculatedChanges(locationTrackIds = listOf(locationTrack.id as IntId))
         assertEquals(1, changes.indirectChanges.switchChanges.size)
@@ -979,11 +1008,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val testData = insertTestData()
         val switch = testData.switches.first()
         switchService.saveDraft(
-            LayoutBranch.main,
-            switch.copy(
-                name = SwitchName(UUID.randomUUID().toString())
-            )
-        )
+            LayoutBranch.main, switch.copy(name = SwitchName(UUID.randomUUID().toString())))
 
         val changes = getCalculatedChanges(switchIds = listOf(switch.id as IntId))
         assertEquals(1, changes.directChanges.switchChanges.size)
@@ -999,10 +1024,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val trackNumber = testData.trackNumber
         trackNumberservice.saveDraft(
             LayoutBranch.main,
-            trackNumber.copy(
-                description = FreeText(UUID.randomUUID().toString())
-            )
-        )
+            trackNumber.copy(description = FreeText(UUID.randomUUID().toString())))
 
         moveReferenceLineGeometryPointsAndUpdate(
             referenceLine,
@@ -1011,10 +1033,11 @@ class CalculatedChangesServiceIT @Autowired constructor(
             referenceLineService,
         )
 
-        val changes = getCalculatedChanges(
-            trackNumberIds = listOf(trackNumber.id as IntId),
-            referenceLineIds = listOf(referenceLine.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                trackNumberIds = listOf(trackNumber.id as IntId),
+                referenceLineIds = listOf(referenceLine.id as IntId),
+            )
 
         assertEquals(1, changes.directChanges.trackNumberChanges.size)
         assertContains(
@@ -1023,8 +1046,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 trackNumberId = trackNumber.id as IntId,
                 changedKmNumbers = setOf(KmNumber(5)),
                 isStartChanged = true,
-                isEndChanged = false
-            ),
+                isEndChanged = false),
         )
 
         assertEquals(0, changes.indirectChanges.trackNumberChanges.size)
@@ -1040,20 +1062,19 @@ class CalculatedChangesServiceIT @Autowired constructor(
             locationTrack = locationTrack,
             alignment = locationTrackAlignment,
             moveFunc = { point -> point + 2.0 },
-            locationTrackService = locationTrackService
-        )
+            locationTrackService = locationTrackService)
 
         moveReferenceLineGeometryPointsAndUpdate(
             referenceLine = referenceLine,
             alignment = referenceLineAlignment,
             moveFunc = { point -> if (point.m < 900) point - 2.0 else point },
-            referenceLineService = referenceLineService
-        )
+            referenceLineService = referenceLineService)
 
-        val changes = getCalculatedChanges(
-            locationTrackIds = listOf(locationTrack.id as IntId),
-            referenceLineIds = listOf(referenceLine.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                locationTrackIds = listOf(locationTrack.id as IntId),
+                referenceLineIds = listOf(referenceLine.id as IntId),
+            )
 
         assertEquals(1, changes.directChanges.locationTrackChanges.size)
         assertContains(
@@ -1062,8 +1083,7 @@ class CalculatedChangesServiceIT @Autowired constructor(
                 locationTrackId = locationTrack.id as IntId,
                 changedKmNumbers = setOf(KmNumber(5), KmNumber(6)),
                 isStartChanged = true,
-                isEndChanged = true
-            ),
+                isEndChanged = true),
         )
 
         assertEquals(0, changes.indirectChanges.locationTrackChanges.size)
@@ -1076,23 +1096,19 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val switch = testData.switches.first()
 
         switchService.saveDraft(
-            LayoutBranch.main,
-            switch.copy(
-                name = SwitchName(UUID.randomUUID().toString())
-            )
-        )
+            LayoutBranch.main, switch.copy(name = SwitchName(UUID.randomUUID().toString())))
 
         moveLocationTrackGeometryPointsAndUpdate(
             locationTrack = locationTrack,
             alignment = alignment,
             moveFunc = { point -> point + 2.0 },
-            locationTrackService = locationTrackService
-        )
+            locationTrackService = locationTrackService)
 
-        val changes = getCalculatedChanges(
-            switchIds = listOf(switch.id as IntId),
-            locationTrackIds = listOf(locationTrack.id as IntId),
-        )
+        val changes =
+            getCalculatedChanges(
+                switchIds = listOf(switch.id as IntId),
+                locationTrackIds = listOf(locationTrack.id as IntId),
+            )
 
         assertEquals(1, changes.directChanges.switchChanges.size)
         assertContainsSwitchJoint152Change(
@@ -1107,30 +1123,35 @@ class CalculatedChangesServiceIT @Autowired constructor(
     @Test
     fun `switch change with joint linked to segment gap should still be reported as only one change`() {
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
-        val referenceLineId = referenceLineService.saveDraft(
-            LayoutBranch.main,
-            referenceLine(trackNumberId, draft = true),
-            alignment(segment(Point(0.0, 0.0), Point(0.0, 20.0))),
-        ).id
+        val referenceLineId =
+            referenceLineService
+                .saveDraft(
+                    LayoutBranch.main,
+                    referenceLine(trackNumberId, draft = true),
+                    alignment(segment(Point(0.0, 0.0), Point(0.0, 20.0))),
+                )
+                .id
         val switch = switchService.saveDraft(LayoutBranch.main, switch(123, draft = true)).id
-        val wibblyTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 10.0))
-                    .copy(switchId = switch, endJointNumber = JointNumber(5)),
-                segment(Point(0.0, 10.00001), Point(0.0, 20.0))
-                    .copy(switchId = switch, startJointNumber = JointNumber(5))
-            ),
-        )
-        val changes = getCalculatedChanges(
-            locationTrackIds = listOf(wibblyTrack.id),
-            switchIds = listOf(switch),
-            trackNumberIds = listOf(trackNumberId),
-            referenceLineIds = listOf(referenceLineId)
-        )
+        val wibblyTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, draft = true),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 10.0))
+                        .copy(switchId = switch, endJointNumber = JointNumber(5)),
+                    segment(Point(0.0, 10.00001), Point(0.0, 20.0))
+                        .copy(switchId = switch, startJointNumber = JointNumber(5))),
+            )
+        val changes =
+            getCalculatedChanges(
+                locationTrackIds = listOf(wibblyTrack.id),
+                switchIds = listOf(switch),
+                trackNumberIds = listOf(trackNumberId),
+                referenceLineIds = listOf(referenceLineId))
         assertEquals(1, changes.directChanges.switchChanges.size)
-        assertEquals(1, changes.directChanges.switchChanges.find { it.switchId == switch }?.changedJoints?.size)
+        assertEquals(
+            1,
+            changes.directChanges.switchChanges.find { it.switchId == switch }?.changedJoints?.size)
     }
 
     data class TestData(
@@ -1152,45 +1173,40 @@ class CalculatedChangesServiceIT @Autowired constructor(
     /**
      * Reference line
      * -----------------------------
-     *
-     * Km posts
-     * 5      6      7      8      9
+     * Km posts 5 6 7 8 9
      *
      * Location track 1
-     *    --------
-     *
+     * --------
      * Location track 2
-     *                        ----
-     *
+     * ----
      * Location track 3 (switch 1-5-2)
-     *            ---------------
-     *
+     * ---------------
      * Location track 4 (switch 1-3)
-     *                   --
-     *
+     * --
      */
     fun insertTestData(): TestData {
         return insertTestData(
-            kmPostData = listOf(
-                KmNumber(5) to Point(0.0, 0.0),
-                KmNumber(6) to Point(1000.0, 0.0),
-                KmNumber(7) to Point(2000.0, 0.0),
-                KmNumber(8) to Point(3000.0, 0.0),
-                KmNumber(9) to Point(4000.0, 0.0)
-            ),
-            locationTrackData = listOf(
-                Line(Point(500.0, 0.0), Point(1500.0, 0.0)),
-                Line(Point(3200.0, 0.0), Point(3800.0, 0.0)),
-                Line(Point(1500.0, 0.0), Point(3500.0, 0.0)),
-                Line(Point(2490.0, 0.0), Point(2700.0, 20.0)),
-            ),
-            switchData = listOf(
-                SwitchData(
-                    Point(2500.0, 0.0),
-                    locationTrackIndexA = 2,
-                    locationTrackIndexB = 3,
-                )
-            ),
+            kmPostData =
+                listOf(
+                    KmNumber(5) to Point(0.0, 0.0),
+                    KmNumber(6) to Point(1000.0, 0.0),
+                    KmNumber(7) to Point(2000.0, 0.0),
+                    KmNumber(8) to Point(3000.0, 0.0),
+                    KmNumber(9) to Point(4000.0, 0.0)),
+            locationTrackData =
+                listOf(
+                    Line(Point(500.0, 0.0), Point(1500.0, 0.0)),
+                    Line(Point(3200.0, 0.0), Point(3800.0, 0.0)),
+                    Line(Point(1500.0, 0.0), Point(3500.0, 0.0)),
+                    Line(Point(2490.0, 0.0), Point(2700.0, 20.0)),
+                ),
+            switchData =
+                listOf(
+                    SwitchData(
+                        Point(2500.0, 0.0),
+                        locationTrackIndexA = 2,
+                        locationTrackIndexB = 3,
+                    )),
         )
     }
 
@@ -1202,105 +1218,112 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val sequence = System.currentTimeMillis().toString().takeLast(8)
         val refPoint = Point(350000.0, 7000000.0) // any point in Finland
 
-        val trackNumber = layoutTrackNumberDao.fetch(
-            layoutTrackNumberDao.insert(
-                trackNumber(TrackNumber("TEST TN $sequence"), draft = false)
-            ).rowVersion
-        )
-        val kmPosts = kmPostData.map { (kmNumber, location) ->
-            layoutKmPostDao.fetch(
-                layoutKmPostDao.insert(
-                    kmPost(
-                        trackNumberId = trackNumber.id as IntId,
-                        km = kmNumber,
-                        roughLayoutLocation = refPoint + location,
-                        draft = false,
-                    )
-                ).rowVersion
-            )
-        }
-        val referenceLineGeometryVersion = layoutAlignmentDao.insert(
-            alignment(
-                segment(
-                    kmPosts.first().layoutLocation as Point,
-                    kmPosts.last().layoutLocation as Point,
-                )
-            )
-        )
+        val trackNumber =
+            layoutTrackNumberDao.fetch(
+                layoutTrackNumberDao
+                    .insert(trackNumber(TrackNumber("TEST TN $sequence"), draft = false))
+                    .rowVersion)
+        val kmPosts =
+            kmPostData.map { (kmNumber, location) ->
+                layoutKmPostDao.fetch(
+                    layoutKmPostDao
+                        .insert(
+                            kmPost(
+                                trackNumberId = trackNumber.id as IntId,
+                                km = kmNumber,
+                                roughLayoutLocation = refPoint + location,
+                                draft = false,
+                            ))
+                        .rowVersion)
+            }
+        val referenceLineGeometryVersion =
+            layoutAlignmentDao.insert(
+                alignment(
+                    segment(
+                        kmPosts.first().layoutLocation as Point,
+                        kmPosts.last().layoutLocation as Point,
+                    )))
         val referenceLineGeometry = layoutAlignmentDao.fetch(referenceLineGeometryVersion)
-        val referenceLine = referenceLineDao.fetch(
-            referenceLineDao.insert(
-                referenceLine(
-                    trackNumber.id as IntId<TrackLayoutTrackNumber>,
-                    alignment = referenceLineGeometry,
-                    startAddress = TrackMeter(
-                        kmNumber = kmPosts.first().kmNumber,
-                        meters = BigDecimal.ZERO,
-                    ),
-                    draft = false,
-                ).copy(
-                    alignmentVersion = referenceLineGeometryVersion
-                )
-            ).rowVersion
-        )
+        val referenceLine =
+            referenceLineDao.fetch(
+                referenceLineDao
+                    .insert(
+                        referenceLine(
+                                trackNumber.id as IntId<TrackLayoutTrackNumber>,
+                                alignment = referenceLineGeometry,
+                                startAddress =
+                                    TrackMeter(
+                                        kmNumber = kmPosts.first().kmNumber,
+                                        meters = BigDecimal.ZERO,
+                                    ),
+                                draft = false,
+                            )
+                            .copy(alignmentVersion = referenceLineGeometryVersion))
+                    .rowVersion)
 
         var locationTrackSequence = 0
-        val locationTracksAndAlignments = locationTrackData.map { line ->
-            val locationTrackGeometryVersion = layoutAlignmentDao.insert(
-                alignment(
-                    segments(
-                        refPoint + line.start,
-                        refPoint + line.end,
-                        10.0,
-                    )
+        val locationTracksAndAlignments =
+            locationTrackData.map { line ->
+                val locationTrackGeometryVersion =
+                    layoutAlignmentDao.insert(
+                        alignment(
+                            segments(
+                                refPoint + line.start,
+                                refPoint + line.end,
+                                10.0,
+                            )))
+                val locationTrackGeometry = layoutAlignmentDao.fetch(locationTrackGeometryVersion)
+                val locationTrack =
+                    locationTrackDao.fetch(
+                        locationTrackDao
+                            .insert(
+                                locationTrack(
+                                    trackNumberId = trackNumber.id as IntId,
+                                    alignment = locationTrackGeometry,
+                                    name = "TEST LocTr $sequence ${locationTrackSequence++}",
+                                    alignmentVersion = locationTrackGeometryVersion,
+                                    draft = false))
+                            .rowVersion)
+                locationTrack to locationTrackGeometry
+            }
+
+        val switches =
+            switchData.map { switch ->
+                linkTestSwitch(
+                    refPoint + switch.location,
+                    locationTracksAndAlignments[switch.locationTrackIndexA],
+                    locationTracksAndAlignments[switch.locationTrackIndexB],
+                    switch.name,
                 )
-            )
-            val locationTrackGeometry = layoutAlignmentDao.fetch(locationTrackGeometryVersion)
-            val locationTrack = locationTrackDao.fetch(
-                locationTrackDao.insert(
-                    locationTrack(
-                        trackNumberId = trackNumber.id as IntId,
-                        alignment = locationTrackGeometry,
-                        name = "TEST LocTr $sequence ${locationTrackSequence++}",
-                        alignmentVersion = locationTrackGeometryVersion,
-                        draft = false
-                    )
-                ).rowVersion
-            )
-            locationTrack to locationTrackGeometry
-        }
-
-        val switches = switchData.map { switch ->
-            linkTestSwitch(
-                refPoint + switch.location,
-                locationTracksAndAlignments[switch.locationTrackIndexA],
-                locationTracksAndAlignments[switch.locationTrackIndexB],
-                switch.name,
-            )
-        }
-
-        val publishedLocationTracksAndAlignments = locationTracksAndAlignments.map { (locationTrack, _) ->
-            val id = locationTrack.id as IntId
-            val rowVersion = locationTrackDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
-            val (edited, editedAlignment) = locationTrackService.getWithAlignment(rowVersion)
-            if (edited.isDraft) {
-                val publicationResponse = locationTrackService.publish(LayoutBranch.main, ValidationVersion(id, rowVersion))
-                locationTrackService.getWithAlignment(publicationResponse.rowVersion)
-            } else {
-                edited to editedAlignment
             }
-        }
-        val publishedSwitches = switches.map { switch ->
-            val id = switch.id as IntId
-            val rowVersion = switchDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
-            val edited = switchDao.fetch(rowVersion)
-            if (edited.isDraft) {
-                val publicationResponse = switchService.publish(LayoutBranch.main, ValidationVersion(id, rowVersion))
-                switchDao.fetch(publicationResponse.rowVersion)
-            } else {
-                edited
+
+        val publishedLocationTracksAndAlignments =
+            locationTracksAndAlignments.map { (locationTrack, _) ->
+                val id = locationTrack.id as IntId
+                val rowVersion = locationTrackDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
+                val (edited, editedAlignment) = locationTrackService.getWithAlignment(rowVersion)
+                if (edited.isDraft) {
+                    val publicationResponse =
+                        locationTrackService.publish(
+                            LayoutBranch.main, ValidationVersion(id, rowVersion))
+                    locationTrackService.getWithAlignment(publicationResponse.rowVersion)
+                } else {
+                    edited to editedAlignment
+                }
             }
-        }
+        val publishedSwitches =
+            switches.map { switch ->
+                val id = switch.id as IntId
+                val rowVersion = switchDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
+                val edited = switchDao.fetch(rowVersion)
+                if (edited.isDraft) {
+                    val publicationResponse =
+                        switchService.publish(LayoutBranch.main, ValidationVersion(id, rowVersion))
+                    switchDao.fetch(publicationResponse.rowVersion)
+                } else {
+                    edited
+                }
+            }
 
         return TestData(
             trackNumber = trackNumber,
@@ -1318,65 +1341,75 @@ class CalculatedChangesServiceIT @Autowired constructor(
         trackB: Pair<LocationTrack, LayoutAlignment>,
         name: String?,
     ): TrackLayoutSwitch {
-        val switch = switchDao.fetch(
-            switchDao.insert(
-                switch(
-                    name = name ?: "${trackA.first.name}-${trackB.first.name}",
-                    joints = listOf(),
-                    draft = false,
-                )
-            ).rowVersion
-        )
+        val switch =
+            switchDao.fetch(
+                switchDao
+                    .insert(
+                        switch(
+                            name = name ?: "${trackA.first.name}-${trackB.first.name}",
+                            joints = listOf(),
+                            draft = false,
+                        ))
+                    .rowVersion)
 
         val (locationTrackA, alignmentA) = trackA
         val (locationTrackB, alignmentB) = trackB
         val segIndexA = alignmentA.findClosestSegmentIndex(switchLocation) as Int
         val segIndexB = alignmentB.findClosestSegmentIndex(switchLocation) as Int
 
-        val suggestedFitting = FittedSwitch(
-            joints = listOf(
-                FittedSwitchJoint(
-                    number = JointNumber(1),
-                    location = firstPoint(alignmentA, segIndexA).toPoint(),
-                    matches = listOf(
-                        switchLinkingAtStart(locationTrackA.id, alignmentA, segIndexA),
-                        switchLinkingAtStart(locationTrackB.id, alignmentB, segIndexB),
+        val suggestedFitting =
+            FittedSwitch(
+                joints =
+                    listOf(
+                        FittedSwitchJoint(
+                            number = JointNumber(1),
+                            location = firstPoint(alignmentA, segIndexA).toPoint(),
+                            matches =
+                                listOf(
+                                    switchLinkingAtStart(locationTrackA.id, alignmentA, segIndexA),
+                                    switchLinkingAtStart(locationTrackB.id, alignmentB, segIndexB),
+                                ),
+                            locationAccuracy = null,
+                        ),
+                        FittedSwitchJoint(
+                            number = JointNumber(5),
+                            location = lastPoint(alignmentA, segIndexA).toPoint(),
+                            matches =
+                                listOf(
+                                    switchLinkingAtEnd(locationTrackA.id, alignmentA, segIndexA),
+                                ),
+                            locationAccuracy = null,
+                        ),
+                        FittedSwitchJoint(
+                            number = JointNumber(2),
+                            location = lastPoint(alignmentA, segIndexA + 2).toPoint(),
+                            matches =
+                                listOf(
+                                    switchLinkingAtEnd(
+                                        locationTrackA.id, alignmentA, segIndexA + 2),
+                                ),
+                            locationAccuracy = null,
+                        ),
+                        FittedSwitchJoint(
+                            number = JointNumber(3),
+                            location = lastPoint(alignmentB, segIndexB + 1).toPoint(),
+                            matches =
+                                listOf(
+                                    switchLinkingAtEnd(
+                                        locationTrackB.id, alignmentB, segIndexB + 1),
+                                ),
+                            locationAccuracy = null,
+                        ),
                     ),
-                    locationAccuracy = null,
-                ),
-                FittedSwitchJoint(
-                    number = JointNumber(5),
-                    location = lastPoint(alignmentA, segIndexA).toPoint(),
-                    matches = listOf(
-                        switchLinkingAtEnd(locationTrackA.id, alignmentA, segIndexA),
-                    ),
-                    locationAccuracy = null,
-                ),
-                FittedSwitchJoint(
-                    number = JointNumber(2),
-                    location = lastPoint(alignmentA, segIndexA + 2).toPoint(),
-                    matches = listOf(
-                        switchLinkingAtEnd(locationTrackA.id, alignmentA, segIndexA + 2),
-                    ),
-                    locationAccuracy = null,
-                ),
-                FittedSwitchJoint(
-                    number = JointNumber(3),
-                    location = lastPoint(alignmentB, segIndexB + 1).toPoint(),
-                    matches = listOf(
-                        switchLinkingAtEnd(locationTrackB.id, alignmentB, segIndexB + 1),
-                    ),
-                    locationAccuracy = null,
-                ),
-            ),
-            geometrySwitchId = null,
-            switchStructureId = switch.switchStructureId,
-            alignmentEndPoint = null,
-            name = SwitchName("abc"),
-        )
+                geometrySwitchId = null,
+                switchStructureId = switch.switchStructureId,
+                alignmentEndPoint = null,
+                name = SwitchName("abc"),
+            )
         switchLinkingService.saveSwitchLinking(
             LayoutBranch.main,
-            switchLinkingService.matchFittedSwitch(LayoutBranch.main, suggestedFitting, switch.id as IntId),
+            switchLinkingService.matchFittedSwitch(
+                LayoutBranch.main, suggestedFitting, switch.id as IntId),
             switch.id as IntId,
         )
         return switch
@@ -1396,9 +1429,11 @@ class CalculatedChangesServiceIT @Autowired constructor(
         val switchChange = changes.find { it.switchId == switchId }
         assertNotNull(switchChange)
         listOf(1, 5, 2).forEach { jointNumber ->
-            val joint = switchChange.changedJoints.find { change ->
-                change.number == JointNumber(jointNumber) && change.locationTrackId == locationTrackId
-            }
+            val joint =
+                switchChange.changedJoints.find { change ->
+                    change.number == JointNumber(jointNumber) &&
+                        change.locationTrackId == locationTrackId
+                }
 
             assertNotNull(joint)
         }
@@ -1413,9 +1448,11 @@ class CalculatedChangesServiceIT @Autowired constructor(
         assertNotNull(switchChange)
 
         listOf(1, 3).forEach { jointNumber ->
-            val joint = switchChange.changedJoints.find { change ->
-                change.number == JointNumber(jointNumber) && change.locationTrackId == locationTrackId
-            }
+            val joint =
+                switchChange.changedJoints.find { change ->
+                    change.number == JointNumber(jointNumber) &&
+                        change.locationTrackId == locationTrackId
+                }
 
             assertNotNull(joint)
         }
@@ -1428,15 +1465,20 @@ class CalculatedChangesServiceIT @Autowired constructor(
         switchIds: List<IntId<TrackLayoutSwitch>> = emptyList(),
         trackNumberIds: List<IntId<TrackLayoutTrackNumber>> = emptyList(),
     ): CalculatedChanges {
-        val publicationVersions = ValidationVersions(
-            branch = LayoutBranch.main,
-            locationTracks = locationTrackDao.fetchPublicationVersions(LayoutBranch.main, locationTrackIds),
-            kmPosts = layoutKmPostDao.fetchPublicationVersions(LayoutBranch.main, kmPostIds),
-            referenceLines = referenceLineDao.fetchPublicationVersions(LayoutBranch.main, referenceLineIds),
-            switches = switchDao.fetchPublicationVersions(LayoutBranch.main, switchIds),
-            trackNumbers = layoutTrackNumberDao.fetchPublicationVersions(LayoutBranch.main, trackNumberIds),
-            splits = listOf(),
-        )
+        val publicationVersions =
+            ValidationVersions(
+                branch = LayoutBranch.main,
+                locationTracks =
+                    locationTrackDao.fetchPublicationVersions(LayoutBranch.main, locationTrackIds),
+                kmPosts = layoutKmPostDao.fetchPublicationVersions(LayoutBranch.main, kmPostIds),
+                referenceLines =
+                    referenceLineDao.fetchPublicationVersions(LayoutBranch.main, referenceLineIds),
+                switches = switchDao.fetchPublicationVersions(LayoutBranch.main, switchIds),
+                trackNumbers =
+                    layoutTrackNumberDao.fetchPublicationVersions(
+                        LayoutBranch.main, trackNumberIds),
+                splits = listOf(),
+            )
 
         return calculatedChangesService.getCalculatedChanges(publicationVersions)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/jsonFormatting/JsonFormattingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/jsonFormatting/JsonFormattingTest.kt
@@ -3,6 +3,8 @@ package fi.fta.geoviite.infra.jsonFormatting
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import fi.fta.geoviite.infra.TestApi
+import java.time.Instant
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -10,13 +12,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import java.time.Instant
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "nodb", "backend")
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
-class JsonFormattingTest @Autowired constructor(
+class JsonFormattingTest
+@Autowired
+constructor(
     val mapper: ObjectMapper,
     mockMvc: MockMvc,
 ) {
@@ -25,7 +27,8 @@ class JsonFormattingTest @Autowired constructor(
     @Test
     fun `Instants as response body work`() {
         assertEquals("\"2021-06-14T12:30:50Z\"", successResponse(Instant.ofEpochSecond(1623673850)))
-        assertEquals("\"2021-06-14T12:30:50.999Z\"", successResponse(Instant.ofEpochMilli(1623673850999)))
+        assertEquals(
+            "\"2021-06-14T12:30:50.999Z\"", successResponse(Instant.ofEpochMilli(1623673850999)))
     }
 
     @Test
@@ -38,17 +41,21 @@ class JsonFormattingTest @Autowired constructor(
 
     @Test
     fun `Instants in path arguments work`() {
-        assertEquals("\"1623673850000\"",
+        assertEquals(
+            "\"1623673850000\"",
             testApi.doGet("/json-test-path/to-millis/2021-06-14T12:30:50Z", HttpStatus.OK))
-        assertEquals("\"1623673850999\"",
+        assertEquals(
+            "\"1623673850999\"",
             testApi.doGet("/json-test-path/to-millis/2021-06-14T12:30:50.999Z", HttpStatus.OK))
     }
 
     @Test
     fun `Instants in return values work`() {
-        assertEquals("\"2021-06-14T12:30:50Z\"",
+        assertEquals(
+            "\"2021-06-14T12:30:50Z\"",
             testApi.doGet("/json-test-path/to-instant/1623673850000", HttpStatus.OK))
-        assertEquals("\"2021-06-14T12:30:50.999Z\"",
+        assertEquals(
+            "\"2021-06-14T12:30:50.999Z\"",
             testApi.doGet("/json-test-path/to-instant/1623673850999", HttpStatus.OK))
     }
 
@@ -56,31 +63,33 @@ class JsonFormattingTest @Autowired constructor(
     fun `Null is read as default value`() {
         assertEquals(
             TestData("argument value 1", "argument value 2"),
-            mapper.readValue<TestData>("""{
+            mapper.readValue<TestData>(
+                """{
                 "value1":"argument value 1",
                 "value2":"argument value 2"
-            }""".trimIndent()),
+            }"""
+                    .trimIndent()),
         )
         assertEquals(
             TestData("argument value 1"),
-            mapper.readValue<TestData>("""{"value1":"argument value 1"}""")
-        )
+            mapper.readValue<TestData>("""{"value1":"argument value 1"}"""))
     }
 
     @Test
     fun `Deserialization doesn't care about extra arguments`() {
         assertEquals(
             TestData("argument value 1", "argument value 2"),
-            mapper.readValue<TestData>("""{
+            mapper.readValue<TestData>(
+                """{
                "value1":"argument value 1", 
                "value2":"argument value 2", 
                "extraValue":"something useless"
-            }""".trimIndent()),
+            }"""
+                    .trimIndent()),
         )
     }
 
     private fun successResponse(instant: Any): String = testApi.response(instant)
-
 }
 
 data class TestData(val value1: String, val value2: String = "default value")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/jsonFormatting/JsonFormattingTestController.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/jsonFormatting/JsonFormattingTestController.kt
@@ -1,9 +1,9 @@
 package fi.fta.geoviite.infra.jsonFormatting
 
 import fi.fta.geoviite.infra.aspects.GeoviiteController
+import java.time.Instant
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import java.time.Instant
 
 @GeoviiteController("/json-test-path")
 class JsonFormattingTestController {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/FittedSwitchTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/FittedSwitchTest.kt
@@ -18,16 +18,17 @@ import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
-import org.junit.jupiter.api.Test
 import kotlin.math.absoluteValue
 import kotlin.test.assertEquals
 import kotlin.test.fail
+import org.junit.jupiter.api.Test
 
 class FittedSwitchTest {
     private val switchStructure = switchStructureYV60_300_1_9()
-    private val switchAlignment_1_5_2 = switchStructure.alignments.find { alignment ->
-        alignment.jointNumbers.contains(JointNumber(5))
-    } ?: error("Invalid switch structure")
+    private val switchAlignment_1_5_2 =
+        switchStructure.alignments.find { alignment ->
+            alignment.jointNumbers.contains(JointNumber(5))
+        } ?: error("Invalid switch structure")
 
     private fun transformPoint(
         point: IPoint,
@@ -42,7 +43,8 @@ class FittedSwitchTest {
         translation: Point,
         rotation: Double,
     ): LayoutAlignment {
-        val points = listOf<Point>() +
+        val points =
+            listOf<Point>() +
                 Point(-300.0, 0.0) +
                 switchAlignment.elements.map { element -> element.start } +
                 switchAlignment.elements.last().end +
@@ -50,12 +52,13 @@ class FittedSwitchTest {
         val transformedPoints = points.map { point -> transformPoint(point, translation, rotation) }
 
         return alignment(
-            segments = (0 until transformedPoints.lastIndex).map { index ->
-                segment(
-                    transformedPoints[index],
-                    transformedPoints[index + 1],
-                )
-            },
+            segments =
+                (0 until transformedPoints.lastIndex).map { index ->
+                    segment(
+                        transformedPoints[index],
+                        transformedPoints[index + 1],
+                    )
+                },
         )
     }
 
@@ -64,20 +67,22 @@ class FittedSwitchTest {
         val rotation = degreesToRads(45.0)
         val translation = Point(2000.0, 3000.0)
 
-        val alignmentContainingSwitchSegments = createAlignmentBySwitchAlignment(
-            switchAlignment_1_5_2,
-            translation = translation,
-            rotation = rotation,
-        )
+        val alignmentContainingSwitchSegments =
+            createAlignmentBySwitchAlignment(
+                switchAlignment_1_5_2,
+                translation = translation,
+                rotation = rotation,
+            )
 
-        val presentationJointLocation = alignmentContainingSwitchSegments.segments[1].alignmentPoints.first()
-        val switchTransformation = inferSwitchTransformation(
-            presentationJointLocation,
-            switchStructure,
-            switchAlignment_1_5_2.id as StringId,
-            alignmentContainingSwitchSegments,
-            ascending = true
-        )
+        val presentationJointLocation =
+            alignmentContainingSwitchSegments.segments[1].alignmentPoints.first()
+        val switchTransformation =
+            inferSwitchTransformation(
+                presentationJointLocation,
+                switchStructure,
+                switchAlignment_1_5_2.id as StringId,
+                alignmentContainingSwitchSegments,
+                ascending = true)
 
         if (switchTransformation != null) {
             val scaledRotation = (switchTransformation.rotation.rads + Math.PI * 2) % (Math.PI * 2)
@@ -93,22 +98,23 @@ class FittedSwitchTest {
         val rotation = degreesToRads(45.0)
         val translation = Point(2000.0, 3000.0)
 
-        val reversedAlignmentContainingSwitchSegments = reverseAlignment(
-            createAlignmentBySwitchAlignment(
-                switchAlignment_1_5_2,
-                translation = translation,
-                rotation = rotation,
-            )
-        )
+        val reversedAlignmentContainingSwitchSegments =
+            reverseAlignment(
+                createAlignmentBySwitchAlignment(
+                    switchAlignment_1_5_2,
+                    translation = translation,
+                    rotation = rotation,
+                ))
 
-        val presentationJointLocation = reversedAlignmentContainingSwitchSegments.segments[2].alignmentPoints.last()
-        val switchTransformation = inferSwitchTransformation(
-            presentationJointLocation,
-            switchStructure,
-            switchAlignment_1_5_2.id as StringId,
-            reversedAlignmentContainingSwitchSegments,
-            ascending = false
-        )
+        val presentationJointLocation =
+            reversedAlignmentContainingSwitchSegments.segments[2].alignmentPoints.last()
+        val switchTransformation =
+            inferSwitchTransformation(
+                presentationJointLocation,
+                switchStructure,
+                switchAlignment_1_5_2.id as StringId,
+                reversedAlignmentContainingSwitchSegments,
+                ascending = false)
         if (switchTransformation != null) {
             val scaledRotation = (switchTransformation.rotation.rads + Math.PI * 2) % (Math.PI * 2)
             assertEquals(rotation, scaledRotation, 0.01)
@@ -119,24 +125,32 @@ class FittedSwitchTest {
     }
 
     private fun reverseAlignment(alignment: LayoutAlignment): LayoutAlignment {
-        val reverseSegments = fixSegmentStarts(alignment.segments.reversed().map { segment ->
-            val reversedPoints = segment.segmentPoints.reversed()
-            var cumulativeM = 0.0
-            segment.copy(
-                geometry = segment.geometry.withPoints(
-                    reversedPoints.mapIndexed { index, point ->
-                        cumulativeM += if (index == 0) 0.0 else lineLength(reversedPoints[index - 1], point)
-                        point.copy(m = cumulativeM)
-                    },
-                ),
-                sourceId = null,
-                sourceStart = null,
-            )
-        })
+        val reverseSegments =
+            fixSegmentStarts(
+                alignment.segments.reversed().map { segment ->
+                    val reversedPoints = segment.segmentPoints.reversed()
+                    var cumulativeM = 0.0
+                    segment.copy(
+                        geometry =
+                            segment.geometry.withPoints(
+                                reversedPoints.mapIndexed { index, point ->
+                                    cumulativeM +=
+                                        if (index == 0) 0.0
+                                        else lineLength(reversedPoints[index - 1], point)
+                                    point.copy(m = cumulativeM)
+                                },
+                            ),
+                        sourceId = null,
+                        sourceStart = null,
+                    )
+                })
         return alignment.copy(segments = reverseSegments)
     }
 
-    private enum class SegmentEndPoint { START, END }
+    private enum class SegmentEndPoint {
+        START,
+        END
+    }
 
     private fun assertSuggestedSwitchContainsMatch(
         switchSuggestion: FittedSwitch,
@@ -145,12 +159,15 @@ class FittedSwitchTest {
         m: Double,
         endPoint: SegmentEndPoint,
     ) {
-        val joint = switchSuggestion.joints.find { joint -> joint.number == jointNumber }
-            ?: throw Exception("Switch structure does not contain joint ${jointNumber.intValue}")
+        val joint =
+            switchSuggestion.joints.find { joint -> joint.number == jointNumber }
+                ?: throw Exception(
+                    "Switch structure does not contain joint ${jointNumber.intValue}")
         if (!joint.matches.any { match ->
-                match.locationTrackId == alignmentId && (m - match.m).absoluteValue < 0.01
-            }) {
-            fail("Didn't found a match from joint ${jointNumber.intValue}: alignmentId $alignmentId, m $m, $endPoint")
+            match.locationTrackId == alignmentId && (m - match.m).absoluteValue < 0.01
+        }) {
+            fail(
+                "Didn't found a match from joint ${jointNumber.intValue}: alignmentId $alignmentId, m $m, $endPoint")
         }
     }
 
@@ -160,33 +177,40 @@ class FittedSwitchTest {
         val translation = Point(2000.0, 3000.0)
 
         val trackId: IntId<LocationTrack> = IntId(1)
-        val alignmentContainingSwitchSegments = createAlignmentBySwitchAlignment(
-            switchAlignment_1_5_2,
-            translation = translation,
-            rotation = rotation,
-        )
-        val locationTrack = locationTrack(IntId(0), alignment = alignmentContainingSwitchSegments, trackId, draft = false)
-        val presentationJointLocation = alignmentContainingSwitchSegments.segments[1].alignmentPoints.first()
+        val alignmentContainingSwitchSegments =
+            createAlignmentBySwitchAlignment(
+                switchAlignment_1_5_2,
+                translation = translation,
+                rotation = rotation,
+            )
+        val locationTrack =
+            locationTrack(
+                IntId(0), alignment = alignmentContainingSwitchSegments, trackId, draft = false)
+        val presentationJointLocation =
+            alignmentContainingSwitchSegments.segments[1].alignmentPoints.first()
 
-        val missingLocationTrackEndpoint = LocationTrackEndpoint(
-            trackId,
-            Point(presentationJointLocation),
-            LocationTrackPointUpdateType.START_POINT,
-        )
+        val missingLocationTrackEndpoint =
+            LocationTrackEndpoint(
+                trackId,
+                Point(presentationJointLocation),
+                LocationTrackPointUpdateType.START_POINT,
+            )
 
-        val suggestedSwitch = fitSwitch(
-            locationTrackEndpoint = missingLocationTrackEndpoint,
-            switchStructure,
-            alignmentMappings = listOf(
-                SuggestedSwitchCreateParamsAlignmentMapping(
-                    switchAlignmentId = switchAlignment_1_5_2.id as StringId,
-                    locationTrackId = IntId(1),
-                )
-            ),
-            nearbyAlignments = listOf(),
-            alignmentById = mapOf(trackId to (locationTrack to alignmentContainingSwitchSegments)),
-            getMeasurementMethod = { null },
-        )
+        val suggestedSwitch =
+            fitSwitch(
+                locationTrackEndpoint = missingLocationTrackEndpoint,
+                switchStructure,
+                alignmentMappings =
+                    listOf(
+                        SuggestedSwitchCreateParamsAlignmentMapping(
+                            switchAlignmentId = switchAlignment_1_5_2.id as StringId,
+                            locationTrackId = IntId(1),
+                        )),
+                nearbyAlignments = listOf(),
+                alignmentById =
+                    mapOf(trackId to (locationTrack to alignmentContainingSwitchSegments)),
+                getMeasurementMethod = { null },
+            )
 
         if (suggestedSwitch != null) {
             assertSuggestedSwitchContainsMatch(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDaoIT.kt
@@ -17,14 +17,17 @@ import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LinkingDaoIT @Autowired constructor(
+class LinkingDaoIT
+@Autowired
+constructor(
     private val linkingDao: LinkingDao,
 ) : DBTestBase() {
 
     @Test
     fun noSwitchBoundsAreFoundWhenNotLinkedToTracks() {
         val switchId = mainDraftContext.createSwitch().id
-        assertEquals(null, linkingDao.getSwitchBoundsFromTracks(MainLayoutContext.official, switchId))
+        assertEquals(
+            null, linkingDao.getSwitchBoundsFromTracks(MainLayoutContext.official, switchId))
         assertEquals(null, linkingDao.getSwitchBoundsFromTracks(MainLayoutContext.draft, switchId))
     }
 
@@ -59,12 +62,12 @@ class LinkingDaoIT @Autowired constructor(
             locationTrack(tnId),
             alignment(
                 segment(
-                    point3_1, point3_2,
+                    point3_1,
+                    point3_2,
                     switchId = switchId,
                     startJointNumber = JointNumber(1),
                     endJointNumber = JointNumber(2),
-                )
-            ),
+                )),
         )
         assertEquals(
             null,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -18,13 +18,14 @@ fun publicationRequest(
     switches: List<IntId<TrackLayoutSwitch>> = listOf(),
     referenceLines: List<IntId<ReferenceLine>> = listOf(),
     locationTracks: List<IntId<LocationTrack>> = listOf(),
-) = PublicationRequestIds(
-    trackNumbers = trackNumbers,
-    kmPosts = kmPosts,
-    switches = switches,
-    referenceLines = referenceLines,
-    locationTracks = locationTracks,
-)
+) =
+    PublicationRequestIds(
+        trackNumbers = trackNumbers,
+        kmPosts = kmPosts,
+        switches = switches,
+        referenceLines = referenceLines,
+        locationTracks = locationTracks,
+    )
 
 fun validationVersions(
     trackNumbers: List<LayoutDaoResponse<TrackLayoutTrackNumber>> = listOf(),
@@ -33,15 +34,16 @@ fun validationVersions(
     locationTracks: List<LayoutDaoResponse<LocationTrack>> = listOf(),
     switches: List<LayoutDaoResponse<TrackLayoutSwitch>> = listOf(),
     branch: LayoutBranch = LayoutBranch.main,
-) = ValidationVersions(
-    branch = branch,
-    trackNumbers = trackNumbers.map { (id, version) -> ValidationVersion(id, version) },
-    referenceLines = referenceLines.map { (id, version) -> ValidationVersion(id, version) },
-    kmPosts = kmPosts.map { (id, version) -> ValidationVersion(id, version) },
-    locationTracks = locationTracks.map { (id, version) -> ValidationVersion(id, version) },
-    switches = switches.map { (id, version) -> ValidationVersion(id, version) },
-    splits = listOf(),
-)
+) =
+    ValidationVersions(
+        branch = branch,
+        trackNumbers = trackNumbers.map { (id, version) -> ValidationVersion(id, version) },
+        referenceLines = referenceLines.map { (id, version) -> ValidationVersion(id, version) },
+        kmPosts = kmPosts.map { (id, version) -> ValidationVersion(id, version) },
+        locationTracks = locationTracks.map { (id, version) -> ValidationVersion(id, version) },
+        switches = switches.map { (id, version) -> ValidationVersion(id, version) },
+        splits = listOf(),
+    )
 
 fun publish(
     publicationService: PublicationService,
@@ -51,11 +53,11 @@ fun publish(
     switches: List<IntId<TrackLayoutSwitch>> = listOf(),
     referenceLines: List<IntId<ReferenceLine>> = listOf(),
     locationTracks: List<IntId<LocationTrack>> = listOf(),
-) = publish(
-    publicationService,
-    publicationRequest(trackNumbers, kmPosts, switches, referenceLines, locationTracks),
-    branch
-)
+) =
+    publish(
+        publicationService,
+        publicationRequest(trackNumbers, kmPosts, switches, referenceLines, locationTracks),
+        branch)
 
 fun publish(
     publicationService: PublicationService,
@@ -67,4 +69,5 @@ fun publish(
     return publicationService.publishChanges(branch, versions, calculatedChanges, "Test")
 }
 
-fun <T> daoResponseToValidationVersion(response: LayoutDaoResponse<T>) = ValidationVersion<T>(response.id, response.rowVersion)
+fun <T> daoResponseToValidationVersion(response: LayoutDaoResponse<T>) =
+    ValidationVersion<T>(response.id, response.rowVersion)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -13,16 +13,13 @@ import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.geometry.GeometryElement
 import fi.fta.geoviite.infra.geometry.GeometryElementLinkStatus
 import fi.fta.geoviite.infra.geometry.GeometryKmPostLinkStatus
-import fi.fta.geoviite.infra.geometry.GeometryLine
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.geometry.GeometryPlanLinkStatus
 import fi.fta.geoviite.infra.geometry.GeometryService
 import fi.fta.geoviite.infra.geometry.GeometrySwitchLinkStatus
 import fi.fta.geoviite.infra.geometry.PlanLayoutService
 import fi.fta.geoviite.infra.geometry.SwitchData
-import fi.fta.geoviite.infra.geometry.emptySwitchData
 import fi.fta.geoviite.infra.geometry.geometryAlignment
-import fi.fta.geoviite.infra.geometry.geometryElements
 import fi.fta.geoviite.infra.geometry.geometryLine
 import fi.fta.geoviite.infra.geometry.geometrySwitch
 import fi.fta.geoviite.infra.geometry.kmPosts
@@ -53,6 +50,8 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someKmNumber
 import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import java.math.BigDecimal
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -62,12 +61,12 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LinkingServiceIT @Autowired constructor(
+class LinkingServiceIT
+@Autowired
+constructor(
     private val geometryService: GeometryService,
     private val planLayoutService: PlanLayoutService,
     private val geometryDao: GeometryDao,
@@ -83,17 +82,20 @@ class LinkingServiceIT @Autowired constructor(
         // 6m of geometry to replace
         val geometrySegmentChange = geometryStart + Point(3.0, 3.5)
         val geometryEnd = geometrySegmentChange + Point(3.0, 2.5)
-        val plan = plan(
-            trackNumber = testDBService.getUnusedTrackNumber(),
-            srid = Srid(3067),
-            alignments = listOf(geometryAlignment(
-                line(geometryStart, geometrySegmentChange),
-                line(geometrySegmentChange, geometryEnd),
-            ))
-        )
+        val plan =
+            plan(
+                trackNumber = testDBService.getUnusedTrackNumber(),
+                srid = Srid(3067),
+                alignments =
+                    listOf(
+                        geometryAlignment(
+                            line(geometryStart, geometrySegmentChange),
+                            line(geometrySegmentChange, geometryEnd),
+                        )))
 
         val geometryPlanId = geometryDao.insertPlan(plan, testFile(), null)
-        val (geometryLayoutPlan, transformationError) = planLayoutService.getLayoutPlan(geometryPlanId.id)
+        val (geometryLayoutPlan, transformationError) =
+            planLayoutService.getLayoutPlan(geometryPlanId.id)
         assertNull(transformationError)
         assertNotNull(geometryLayoutPlan)
 
@@ -103,61 +105,88 @@ class LinkingServiceIT @Autowired constructor(
         assertNotEquals(geometryStartSegment, geometryEndSegment)
 
         // Geometry is about 6m and we need 1m for transition on both sides
-        // Build layout so that we keep first point, replacing the next 8: 4 from first, 4 from second segment
+        // Build layout so that we keep first point, replacing the next 8: 4 from first, 4 from
+        // second segment
         val start = geometryStart - Point(1.0, 1.5)
-        val segment1 = segment(
-            start, start + 1.0, start + 2.0, start + 3.0, start + 4.0,
-            startM = 0.0,
-        )
-        val segment2 = segment(
-            start + 4.0, start + 5.0, start + 6.0, start + 7.0, start + 8.0, start + 9.0,
-            startM = segment1.length,
-        )
-        val segment3 = segment(
-            start + 9.0, start + 10.0, start + 11.0,
-            startM = segment2.length,
-        )
+        val segment1 =
+            segment(
+                start,
+                start + 1.0,
+                start + 2.0,
+                start + 3.0,
+                start + 4.0,
+                startM = 0.0,
+            )
+        val segment2 =
+            segment(
+                start + 4.0,
+                start + 5.0,
+                start + 6.0,
+                start + 7.0,
+                start + 8.0,
+                start + 9.0,
+                startM = segment1.length,
+            )
+        val segment3 =
+            segment(
+                start + 9.0,
+                start + 10.0,
+                start + 11.0,
+                startM = segment2.length,
+            )
 
-        val (locationTrack, alignment) = locationTrackAndAlignment(
-            mainOfficialContext.createLayoutTrackNumber().id, segment1, segment2, segment3, draft = true
-        )
-        val (locationTrackId, locationTrackVersion) = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
-        locationTrackService.publish(LayoutBranch.main, ValidationVersion(locationTrackId, locationTrackVersion))
+        val (locationTrack, alignment) =
+            locationTrackAndAlignment(
+                mainOfficialContext.createLayoutTrackNumber().id,
+                segment1,
+                segment2,
+                segment3,
+                draft = true)
+        val (locationTrackId, locationTrackVersion) =
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
+        locationTrackService.publish(
+            LayoutBranch.main, ValidationVersion(locationTrackId, locationTrackVersion))
 
-        val (officialTrack, officialAlignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.official, locationTrackId)
+        val (officialTrack, officialAlignment) =
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.official, locationTrackId)
         assertMatches(
             officialTrack to officialAlignment,
             locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId),
         )
 
         // Pick the whole geometry as interval
-        val geometryInterval = GeometryInterval(
-            alignmentId = geometryLayoutAlignment.id as IntId,
-            mRange = Range(
-                geometryStartSegment.alignmentPoints.first().m,
-                geometryEndSegment.alignmentPoints.last().m,
-            ),
-        )
+        val geometryInterval =
+            GeometryInterval(
+                alignmentId = geometryLayoutAlignment.id as IntId,
+                mRange =
+                    Range(
+                        geometryStartSegment.alignmentPoints.first().m,
+                        geometryEndSegment.alignmentPoints.last().m,
+                    ),
+            )
 
         // Pick layout interval to cut after first 2 point, skipping to 5th point of second interval
-        val layoutInterval = LayoutInterval(
-            alignmentId = locationTrackId,
-            mRange = Range(
-                officialAlignment.segments[0].alignmentPoints.first().m,
-                officialAlignment.segments[1].alignmentPoints[4].m,
-            ),
-        )
+        val layoutInterval =
+            LayoutInterval(
+                alignmentId = locationTrackId,
+                mRange =
+                    Range(
+                        officialAlignment.segments[0].alignmentPoints.first().m,
+                        officialAlignment.segments[1].alignmentPoints[4].m,
+                    ),
+            )
 
         linkingService.saveLocationTrackLinking(
             LayoutBranch.main,
-            LinkingParameters(geometryPlanId.id, geometryInterval, layoutInterval)
-        )
+            LinkingParameters(geometryPlanId.id, geometryInterval, layoutInterval))
         assertEquals(
             officialTrack to officialAlignment,
             locationTrackService.getWithAlignment(MainLayoutContext.official, locationTrackId),
         )
 
-        val (_, draftAlignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
+        val (_, draftAlignment) =
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
         assertNotEquals(officialAlignment, draftAlignment)
         // Should be split so that we have;
         // all geometry segments
@@ -172,8 +201,12 @@ class LinkingServiceIT @Autowired constructor(
                 draftAlignment.segments[i].alignmentPoints.size,
             )
         }
-        assertEquals(2, draftAlignment.segments[1 + geometryLayoutAlignment.segments.size].alignmentPoints.size)
-        assertEquals(3, draftAlignment.segments[2 + geometryLayoutAlignment.segments.size].alignmentPoints.size)
+        assertEquals(
+            2,
+            draftAlignment.segments[1 + geometryLayoutAlignment.segments.size].alignmentPoints.size)
+        assertEquals(
+            3,
+            draftAlignment.segments[2 + geometryLayoutAlignment.segments.size].alignmentPoints.size)
     }
 
     @Test
@@ -182,7 +215,10 @@ class LinkingServiceIT @Autowired constructor(
         val kmPostId = mainOfficialContext.insert(kmPost(trackNumberId, someKmNumber())).id
         val officialKmPost = kmPostService.get(MainLayoutContext.official, kmPostId)
 
-        assertMatches(officialKmPost!!, kmPostService.getOrThrow(MainLayoutContext.draft, kmPostId), contextMatch = false)
+        assertMatches(
+            officialKmPost!!,
+            kmPostService.getOrThrow(MainLayoutContext.draft, kmPostId),
+            contextMatch = false)
 
         val trackNumber = testDBService.getUnusedTrackNumber()
 
@@ -194,7 +230,8 @@ class LinkingServiceIT @Autowired constructor(
         val geometryKmPostId = fetchedPlan.kmPosts[1].id as IntId
         val geometryKmPost = geometryDao.fetchKmPosts(kmPostId = geometryKmPostId)[0]
 
-        val kmPostLinkingParameters = KmPostLinkingParameters(geometryPlanId, geometryKmPostId, kmPostId)
+        val kmPostLinkingParameters =
+            KmPostLinkingParameters(geometryPlanId, geometryKmPostId, kmPostId)
 
         linkingService.saveKmPostLinking(LayoutBranch.main, kmPostLinkingParameters)
 
@@ -217,34 +254,39 @@ class LinkingServiceIT @Autowired constructor(
 
         val geometryPlanId = geometryDao.insertPlan(plan, testFile(), null)
 
-        val (locationTrack, alignment) = locationTrackAndAlignment(
-            trackNumberId = mainOfficialContext.createLayoutTrackNumber().id,
-            state = LocationTrackState.DELETED,
-            draft = true,
-        )
-        val (locationTrackId, locationTrackVersion) = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
-        locationTrackService.publish(LayoutBranch.main, ValidationVersion(locationTrackId, locationTrackVersion))
-
-        val geometryInterval = GeometryInterval(
-            alignmentId = IntId(0),
-            mRange = Range(0.0, 0.0),
-        )
-
-        val layoutInterval = LayoutInterval(
-            alignmentId = locationTrackId,
-            mRange = Range(0.0, 0.0),
-        )
-
-        val ex = assertThrows<LinkingFailureException> {
-            linkingService.saveLocationTrackLinking(
-                LayoutBranch.main,
-                LinkingParameters(
-                    geometryPlanId.id,
-                    geometryInterval,
-                    layoutInterval,
-                )
+        val (locationTrack, alignment) =
+            locationTrackAndAlignment(
+                trackNumberId = mainOfficialContext.createLayoutTrackNumber().id,
+                state = LocationTrackState.DELETED,
+                draft = true,
             )
-        }
+        val (locationTrackId, locationTrackVersion) =
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
+        locationTrackService.publish(
+            LayoutBranch.main, ValidationVersion(locationTrackId, locationTrackVersion))
+
+        val geometryInterval =
+            GeometryInterval(
+                alignmentId = IntId(0),
+                mRange = Range(0.0, 0.0),
+            )
+
+        val layoutInterval =
+            LayoutInterval(
+                alignmentId = locationTrackId,
+                mRange = Range(0.0, 0.0),
+            )
+
+        val ex =
+            assertThrows<LinkingFailureException> {
+                linkingService.saveLocationTrackLinking(
+                    LayoutBranch.main,
+                    LinkingParameters(
+                        geometryPlanId.id,
+                        geometryInterval,
+                        layoutInterval,
+                    ))
+            }
         assertEquals("Linking failed: Cannot link a location track that is deleted", ex.message)
     }
 
@@ -255,19 +297,26 @@ class LinkingServiceIT @Autowired constructor(
 
         val geometryPlanId = geometryDao.insertPlan(plan, testFile(), null)
 
-        val (locationTrack, alignment) = locationTrackAndAlignment(mainOfficialContext.createLayoutTrackNumber().id, draft = true)
-        val locationTrackResponse = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
-            .let { (id, rowVersion) -> locationTrackService.publish(LayoutBranch.main, ValidationVersion(id, rowVersion)) }
+        val (locationTrack, alignment) =
+            locationTrackAndAlignment(
+                mainOfficialContext.createLayoutTrackNumber().id, draft = true)
+        val locationTrackResponse =
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment).let {
+                (id, rowVersion) ->
+                locationTrackService.publish(LayoutBranch.main, ValidationVersion(id, rowVersion))
+            }
 
-        val geometryInterval = GeometryInterval(
-            alignmentId = IntId(0),
-            mRange = Range(0.0, 0.0),
-        )
+        val geometryInterval =
+            GeometryInterval(
+                alignmentId = IntId(0),
+                mRange = Range(0.0, 0.0),
+            )
 
-        val layoutInterval = LayoutInterval(
-            alignmentId = locationTrackResponse.id,
-            mRange = Range(0.0, 0.0),
-        )
+        val layoutInterval =
+            LayoutInterval(
+                alignmentId = locationTrackResponse.id,
+                mRange = Range(0.0, 0.0),
+            )
 
         splitDao.saveSplit(
             locationTrackResponse.rowVersion,
@@ -276,13 +325,14 @@ class LinkingServiceIT @Autowired constructor(
             updatedDuplicates = emptyList(),
         )
 
-        val ex = assertThrows<LinkingFailureException> {
-            linkingService.saveLocationTrackLinking(
-                LayoutBranch.main,
-                LinkingParameters(geometryPlanId.id, geometryInterval, layoutInterval)
-            )
-        }
-        assertEquals("Linking failed: Cannot link a location track that has unfinished splits", ex.message)
+        val ex =
+            assertThrows<LinkingFailureException> {
+                linkingService.saveLocationTrackLinking(
+                    LayoutBranch.main,
+                    LinkingParameters(geometryPlanId.id, geometryInterval, layoutInterval))
+            }
+        assertEquals(
+            "Linking failed: Cannot link a location track that has unfinished splits", ex.message)
     }
 
     @Test
@@ -293,12 +343,14 @@ class LinkingServiceIT @Autowired constructor(
         // 6m of geometry to replace
         val geometrySegmentChange = geometryStart + Point(3.0, 3.5)
         val geometryEnd = geometrySegmentChange + Point(3.0, 2.5)
-        val plan = plan(
-            trackNumber, LAYOUT_SRID, geometryAlignment(
-                line(geometryStart, geometrySegmentChange),
-                line(geometrySegmentChange, geometryEnd),
-            )
-        )
+        val plan =
+            plan(
+                trackNumber,
+                LAYOUT_SRID,
+                geometryAlignment(
+                    line(geometryStart, geometrySegmentChange),
+                    line(geometrySegmentChange, geometryEnd),
+                ))
 
         val geometryPlanId = geometryDao.insertPlan(plan, testFile(), null)
         val (geometryLayoutPlan, _) = planLayoutService.getLayoutPlan(geometryPlanId.id)
@@ -308,43 +360,60 @@ class LinkingServiceIT @Autowired constructor(
         val geometryEndSegment = geometryLayoutAlignment.segments.last()
 
         val start = geometryStart - Point(1.0, 1.5)
-        val segment1 = segment(
-            start, start + 1.0, start + 2.0, start + 3.0, start + 4.0,
-            startM = 0.0,
-        )
-
-        val (locationTrack, alignment) = locationTrackAndAlignment(
-            mainOfficialContext.createLayoutTrackNumber().id, segment1, draft = true,
-        )
-        val locationTrackResponse = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
-            .let { (id, rowVersion) -> locationTrackService.publish(LayoutBranch.main, ValidationVersion(id, rowVersion)) }
-
-        val (_, officialAlignment) = locationTrackService.getWithAlignment(locationTrackResponse.rowVersion)
-
-        val geometryInterval = GeometryInterval(
-            alignmentId = geometryLayoutAlignment.id as IntId,
-            mRange = Range(
-                geometryStartSegment.alignmentPoints.first().m,
-                geometryEndSegment.alignmentPoints.last().m,
-            ),
-        )
-
-        val layoutInterval = LayoutInterval(
-            alignmentId = locationTrackResponse.id,
-            mRange = Range(
-                officialAlignment.segments[0].alignmentPoints.first().m,
-                officialAlignment.segments[0].alignmentPoints[4].m,
-            ),
-        )
-
-        val split = splitDao.getOrThrow(
-            splitDao.saveSplit(
-                locationTrackResponse.rowVersion,
-                listOf(SplitTarget(locationTrackResponse.id, 0..1, SplitTargetOperation.CREATE)),
-                relinkedSwitches = emptyList(),
-                updatedDuplicates = emptyList(),
+        val segment1 =
+            segment(
+                start,
+                start + 1.0,
+                start + 2.0,
+                start + 3.0,
+                start + 4.0,
+                startM = 0.0,
             )
-        )
+
+        val (locationTrack, alignment) =
+            locationTrackAndAlignment(
+                mainOfficialContext.createLayoutTrackNumber().id,
+                segment1,
+                draft = true,
+            )
+        val locationTrackResponse =
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment).let {
+                (id, rowVersion) ->
+                locationTrackService.publish(LayoutBranch.main, ValidationVersion(id, rowVersion))
+            }
+
+        val (_, officialAlignment) =
+            locationTrackService.getWithAlignment(locationTrackResponse.rowVersion)
+
+        val geometryInterval =
+            GeometryInterval(
+                alignmentId = geometryLayoutAlignment.id as IntId,
+                mRange =
+                    Range(
+                        geometryStartSegment.alignmentPoints.first().m,
+                        geometryEndSegment.alignmentPoints.last().m,
+                    ),
+            )
+
+        val layoutInterval =
+            LayoutInterval(
+                alignmentId = locationTrackResponse.id,
+                mRange =
+                    Range(
+                        officialAlignment.segments[0].alignmentPoints.first().m,
+                        officialAlignment.segments[0].alignmentPoints[4].m,
+                    ),
+            )
+
+        val split =
+            splitDao.getOrThrow(
+                splitDao.saveSplit(
+                    locationTrackResponse.rowVersion,
+                    listOf(
+                        SplitTarget(locationTrackResponse.id, 0..1, SplitTargetOperation.CREATE)),
+                    relinkedSwitches = emptyList(),
+                    updatedDuplicates = emptyList(),
+                ))
         splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
 
         assertDoesNotThrow {
@@ -354,8 +423,7 @@ class LinkingServiceIT @Autowired constructor(
                     geometryPlanId.id,
                     geometryInterval,
                     layoutInterval,
-                )
-            )
+                ))
         }
     }
 
@@ -364,113 +432,117 @@ class LinkingServiceIT @Autowired constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         fun makeSomePlan(): GeometryPlan {
             val switch = geometrySwitch()
-            val line = geometryLine(
-                "S004",
-                "3",
-                Point(x = 385372.582, y = 6673712.000614),
-                Point(x = 385379.2240573294, y = 6673744.810696),
-                BigDecimal("543.333470"),
-                BigDecimal("33.475639"),
-                elementSwitchData = SwitchData(
-                    switchId = switch.id, null, null
-                )
-            )
+            val line =
+                geometryLine(
+                    "S004",
+                    "3",
+                    Point(x = 385372.582, y = 6673712.000614),
+                    Point(x = 385379.2240573294, y = 6673744.810696),
+                    BigDecimal("543.333470"),
+                    BigDecimal("33.475639"),
+                    elementSwitchData = SwitchData(switchId = switch.id, null, null))
             return plan(
                 trackNumber,
                 alignments = listOf(geometryAlignment(line)),
                 switches = listOf(switch),
-                kmPosts = kmPosts(Srid(3879)).take(1)
-            )
+                kmPosts = kmPosts(Srid(3879)).take(1))
         }
-        val linkingLocationTrack = geometryDao.fetchPlan(geometryDao.insertPlan(makeSomePlan(), testFile(), null))
-        val linkingReferenceLine = geometryDao.fetchPlan(geometryDao.insertPlan(makeSomePlan(), testFile(), null))
+        val linkingLocationTrack =
+            geometryDao.fetchPlan(geometryDao.insertPlan(makeSomePlan(), testFile(), null))
+        val linkingReferenceLine =
+            geometryDao.fetchPlan(geometryDao.insertPlan(makeSomePlan(), testFile(), null))
         val linkingSwitchAndLocationTrack =
             geometryDao.fetchPlan(geometryDao.insertPlan(makeSomePlan(), testFile(), null))
-        val linkingKmPost = geometryDao.fetchPlan(geometryDao.insertPlan(makeSomePlan(), testFile(), null))
+        val linkingKmPost =
+            geometryDao.fetchPlan(geometryDao.insertPlan(makeSomePlan(), testFile(), null))
         val trackNumberId = mainOfficialContext.insert(trackNumber(trackNumber)).id
-        val linkedLocationTrack = mainDraftContext.insert(
-            locationTrackAndAlignment(
-                trackNumberId,
-                segment(
-                    Point(0.0, 0.0),
-                    Point(10.0, 0.0)
-                ).copy(sourceId = linkingLocationTrack.alignments[0].elements[0].id)
-            )
-        ).id
-        val linkedReferenceLine = mainDraftContext.insert(
-            referenceLineAndAlignment(
-                trackNumberId,
-                segment(
-                    Point(0.0, 0.0),
-                    Point(10.0, 0.0)
-                ).copy(sourceId = linkingReferenceLine.alignments[0].elements[0].id)
-            )
-        ).id
+        val linkedLocationTrack =
+            mainDraftContext
+                .insert(
+                    locationTrackAndAlignment(
+                        trackNumberId,
+                        segment(Point(0.0, 0.0), Point(10.0, 0.0))
+                            .copy(sourceId = linkingLocationTrack.alignments[0].elements[0].id)))
+                .id
+        val linkedReferenceLine =
+            mainDraftContext
+                .insert(
+                    referenceLineAndAlignment(
+                        trackNumberId,
+                        segment(Point(0.0, 0.0), Point(10.0, 0.0))
+                            .copy(sourceId = linkingReferenceLine.alignments[0].elements[0].id)))
+                .id
         val linkedSwitch = mainDraftContext.insert(switch()).id
-        val linkedLocationTrackAlongSwitch = mainDraftContext.insert(
-            locationTrackAndAlignment(
-                trackNumberId, segment(Point(0.0, 0.0), Point(10.0, 0.0)).copy(
-                    sourceId = linkingSwitchAndLocationTrack.alignments[0].elements[0].id,
-                    switchId = linkedSwitch
-                )
-            )
-        ).id
-        val linkedKmPost = mainDraftContext.insert(
-            kmPost(
-                trackNumberId,
-                KmNumber("123"),
-                sourceId = linkingKmPost.kmPosts[0].id as IntId
-            )
-        ).id
-        val allPlanIds = listOf(
-            linkingLocationTrack,
-            linkingReferenceLine,
-            linkingSwitchAndLocationTrack,
-            linkingKmPost
-        ).map { it.id as IntId }
+        val linkedLocationTrackAlongSwitch =
+            mainDraftContext
+                .insert(
+                    locationTrackAndAlignment(
+                        trackNumberId,
+                        segment(Point(0.0, 0.0), Point(10.0, 0.0))
+                            .copy(
+                                sourceId =
+                                    linkingSwitchAndLocationTrack.alignments[0].elements[0].id,
+                                switchId = linkedSwitch)))
+                .id
+        val linkedKmPost =
+            mainDraftContext
+                .insert(
+                    kmPost(
+                        trackNumberId,
+                        KmNumber("123"),
+                        sourceId = linkingKmPost.kmPosts[0].id as IntId))
+                .id
+        val allPlanIds =
+            listOf(
+                    linkingLocationTrack,
+                    linkingReferenceLine,
+                    linkingSwitchAndLocationTrack,
+                    linkingKmPost)
+                .map { it.id as IntId }
 
         assertEquals(
             listOf(
                 expectPlanLinkedObjects(linkingLocationTrack),
                 expectPlanLinkedObjects(linkingReferenceLine),
                 expectPlanLinkedObjects(linkingSwitchAndLocationTrack),
-                expectPlanLinkedObjects(linkingKmPost)
-            ), linkingService.getGeometryPlanLinkStatuses(mainOfficialContext.context, allPlanIds)
-        )
+                expectPlanLinkedObjects(linkingKmPost)),
+            linkingService.getGeometryPlanLinkStatuses(mainOfficialContext.context, allPlanIds))
         assertEquals(
             listOf(
                 expectPlanLinkedObjects(linkingLocationTrack, linkedLocationTrack to null),
                 expectPlanLinkedObjects(linkingReferenceLine, null to linkedReferenceLine),
                 expectPlanLinkedObjects(
-                    linkingSwitchAndLocationTrack, linkedLocationTrackAlongSwitch to null, firstSwitchIsLinked = true
-                ),
-                expectPlanLinkedObjects(linkingKmPost, kmPostLinkedToFirst = linkedKmPost)
-            ), linkingService.getGeometryPlanLinkStatuses(mainDraftContext.context, allPlanIds)
-        )
+                    linkingSwitchAndLocationTrack,
+                    linkedLocationTrackAlongSwitch to null,
+                    firstSwitchIsLinked = true),
+                expectPlanLinkedObjects(linkingKmPost, kmPostLinkedToFirst = linkedKmPost)),
+            linkingService.getGeometryPlanLinkStatuses(mainDraftContext.context, allPlanIds))
     }
 
     fun expectPlanLinkedObjects(
         plan: GeometryPlan,
-        firstAlignmentFirstElementLink: Pair<IntId<LocationTrack>?, IntId<ReferenceLine>?> = null to null,
+        firstAlignmentFirstElementLink: Pair<IntId<LocationTrack>?, IntId<ReferenceLine>?> =
+            null to null,
         firstSwitchIsLinked: Boolean = false,
         kmPostLinkedToFirst: IntId<TrackLayoutKmPost>? = null,
-    ) = GeometryPlanLinkStatus(
-        plan.id as IntId,
-        listOf(
-            GeometryAlignmentLinkStatus(
-                plan.alignments[0].id as IntId, listOf(
-                    GeometryElementLinkStatus(
-                        plan.alignments[0].elements[0].id as IndexedId<GeometryElement>,
-                        firstAlignmentFirstElementLink.first != null || firstAlignmentFirstElementLink.second != null,
-                        listOfNotNull(firstAlignmentFirstElementLink.first),
-                        listOfNotNull(firstAlignmentFirstElementLink.second),
-                    )
-                )
-            )
-        ),
-        listOf(GeometrySwitchLinkStatus(plan.switches[0].id as IntId, firstSwitchIsLinked)),
-        listOf(GeometryKmPostLinkStatus(plan.kmPosts[0].id as IntId, listOfNotNull(kmPostLinkedToFirst)))
-    )
+    ) =
+        GeometryPlanLinkStatus(
+            plan.id as IntId,
+            listOf(
+                GeometryAlignmentLinkStatus(
+                    plan.alignments[0].id as IntId,
+                    listOf(
+                        GeometryElementLinkStatus(
+                            plan.alignments[0].elements[0].id as IndexedId<GeometryElement>,
+                            firstAlignmentFirstElementLink.first != null ||
+                                firstAlignmentFirstElementLink.second != null,
+                            listOfNotNull(firstAlignmentFirstElementLink.first),
+                            listOfNotNull(firstAlignmentFirstElementLink.second),
+                        )))),
+            listOf(GeometrySwitchLinkStatus(plan.switches[0].id as IntId, firstSwitchIsLinked)),
+            listOf(
+                GeometryKmPostLinkStatus(
+                    plan.kmPosts[0].id as IntId, listOfNotNull(kmPostLinkedToFirst))))
 
     fun assertMatches(
         trackAndAlignment1: Pair<LocationTrack, LayoutAlignment>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingTest.kt
@@ -17,30 +17,32 @@ class LinkingTest {
 
     @Test
     fun `Layout alignment can be replace with geometry alignment`() {
-        val layoutAlignment = alignment(
-            fixSegmentStarts(
-                segment(Point(1.0, 1.0), Point(2.0, 2.0)),
-                segment(Point(2.0, 2.0), Point(3.0, 3.0)),
+        val layoutAlignment =
+            alignment(
+                fixSegmentStarts(
+                    segment(Point(1.0, 1.0), Point(2.0, 2.0)),
+                    segment(Point(2.0, 2.0), Point(3.0, 3.0)),
+                ))
+        val geometryAlignment =
+            mapAlignment(
+                mapSegment(
+                    Point3DM(10.0, 10.0, 0.0),
+                    Point3DM(13.0, 10.0, 3.0),
+                    Point3DM(16.0, 10.0, 6.0),
+                    startM = 0.0,
+                ),
+                mapSegment(
+                    Point3DM(16.0, 10.0, 0.0),
+                    Point3DM(19.0, 10.0, 3.0),
+                    Point3DM(22.0, 10.0, 6.0),
+                    startM = 6.0,
+                ),
             )
-        )
-        val geometryAlignment = mapAlignment(
-            mapSegment(
-                Point3DM(10.0, 10.0, 0.0),
-                Point3DM(13.0, 10.0, 3.0),
-                Point3DM(16.0, 10.0, 6.0),
-                startM = 0.0,
-            ),
-            mapSegment(
-                Point3DM(16.0, 10.0, 0.0),
-                Point3DM(19.0, 10.0, 3.0),
-                Point3DM(22.0, 10.0, 6.0),
-                startM = 6.0,
-            ),
-        )
         // Take the full range of geometry -> all points match
         assertGeometryChange(
             layoutAlignment,
-            replaceLayoutGeometry(layoutAlignment, geometryAlignment, Range(0.0, geometryAlignment.length)),
+            replaceLayoutGeometry(
+                layoutAlignment, geometryAlignment, Range(0.0, geometryAlignment.length)),
             geometryAlignment.segments.map { s -> s.segmentPoints },
         )
         // Split so that we skip the first and last points
@@ -51,30 +53,35 @@ class LinkingTest {
                 listOf(
                     geometryAlignment.segments[0].segmentPoints.takeLast(2),
                     geometryAlignment.segments[1].segmentPoints.take(2),
-                )
-            ),
+                )),
         )
         // Split both segments between points
         assertGeometryChange(
             layoutAlignment,
             replaceLayoutGeometry(layoutAlignment, geometryAlignment, Range(2.5, 11.0)),
             listOf(
-                toSegmentPoints(Point3DM(12.5, 10.0, 0.0), Point3DM(13.0, 10.0, 0.5), Point3DM(16.0, 10.0, 3.5)),
-                toSegmentPoints(Point3DM(16.0, 10.0, 0.0), Point3DM(19.0, 10.0, 3.0), Point3DM(21.0, 10.0, 5.0)),
+                toSegmentPoints(
+                    Point3DM(12.5, 10.0, 0.0),
+                    Point3DM(13.0, 10.0, 0.5),
+                    Point3DM(16.0, 10.0, 3.5)),
+                toSegmentPoints(
+                    Point3DM(16.0, 10.0, 0.0),
+                    Point3DM(19.0, 10.0, 3.0),
+                    Point3DM(21.0, 10.0, 5.0)),
             ),
         )
     }
 
     @Test
     fun `Layout alignment can be shortened`() {
-        val layoutAlignment = alignment(
-            fixSegmentStarts(
-                // First segment m values: 0, 1, 2
-                segment(Point(1.0, 0.0), Point(2.0, 0.0), Point(3.0, 0.0)),
-                // Second segment m values: 2, 3, 4
-                segment(Point(3.0, 0.0), Point(4.0, 0.0), Point(5.0, 0.0)),
-            )
-        )
+        val layoutAlignment =
+            alignment(
+                fixSegmentStarts(
+                    // First segment m values: 0, 1, 2
+                    segment(Point(1.0, 0.0), Point(2.0, 0.0), Point(3.0, 0.0)),
+                    // Second segment m values: 2, 3, 4
+                    segment(Point(3.0, 0.0), Point(4.0, 0.0), Point(5.0, 0.0)),
+                ))
         // Cut nothing -> geometry remains the same
         assertGeometryChange(
             layoutAlignment,
@@ -85,25 +92,28 @@ class LinkingTest {
         assertGeometryChange(
             layoutAlignment,
             cutLayoutGeometry(layoutAlignment, Range(1.0, 4.0)),
-            withPointsStartingFrom0(listOf(
-                layoutAlignment.segments[0].segmentPoints.takeLast(2),
-                layoutAlignment.segments[1].segmentPoints,
-            )),
+            withPointsStartingFrom0(
+                listOf(
+                    layoutAlignment.segments[0].segmentPoints.takeLast(2),
+                    layoutAlignment.segments[1].segmentPoints,
+                )),
         )
         // Cut 1m from end
         assertGeometryChange(
             layoutAlignment,
             cutLayoutGeometry(layoutAlignment, Range(0.0, 3.0)),
-            withPointsStartingFrom0(listOf(
-                layoutAlignment.segments[0].segmentPoints,
-                layoutAlignment.segments[1].segmentPoints.take(2),
-            )),
+            withPointsStartingFrom0(
+                listOf(
+                    layoutAlignment.segments[0].segmentPoints,
+                    layoutAlignment.segments[1].segmentPoints.take(2),
+                )),
         )
         // Cut to just 1m in the middle, splitting only a piece of the first segment
         assertGeometryChange(
             layoutAlignment,
             cutLayoutGeometry(layoutAlignment, Range(1.0, 2.0)),
-            withPointsStartingFrom0(listOf(layoutAlignment.segments.first().segmentPoints.takeLast(2))),
+            withPointsStartingFrom0(
+                listOf(layoutAlignment.segments.first().segmentPoints.takeLast(2))),
         )
         // Cut to just 1m in the middle, splitting only a piece of the second segment
         assertGeometryChange(
@@ -115,124 +125,141 @@ class LinkingTest {
         assertGeometryChange(
             layoutAlignment,
             cutLayoutGeometry(layoutAlignment, Range(1.0, 3.0)),
-            withPointsStartingFrom0(listOf(
-                layoutAlignment.segments.first().segmentPoints.takeLast(2),
-                layoutAlignment.segments.last().segmentPoints.take(2),
-            )),
+            withPointsStartingFrom0(
+                listOf(
+                    layoutAlignment.segments.first().segmentPoints.takeLast(2),
+                    layoutAlignment.segments.last().segmentPoints.take(2),
+                )),
         )
         // Cut to just 2m in the middle, splitting each segment between-points
         assertGeometryChange(
             layoutAlignment,
             cutLayoutGeometry(layoutAlignment, Range(0.5, 3.5)),
             listOf(
-                toSegmentPoints(Point3DM(1.5, 0.0, 0.0), Point3DM(2.0, 0.0, 0.5), Point3DM(3.0, 0.0, 1.5)),
-                toSegmentPoints(Point3DM(3.0, 0.0, 0.0), Point3DM(4.0, 0.0, 1.0), Point3DM(4.5, 0.0, 1.5)),
+                toSegmentPoints(
+                    Point3DM(1.5, 0.0, 0.0), Point3DM(2.0, 0.0, 0.5), Point3DM(3.0, 0.0, 1.5)),
+                toSegmentPoints(
+                    Point3DM(3.0, 0.0, 0.0), Point3DM(4.0, 0.0, 1.0), Point3DM(4.5, 0.0, 1.5)),
             ),
         )
     }
 
     @Test
     fun `Portion of layout alignment can be linked from geometry`() {
-        val layoutAlignment = alignment(
-            // First segment m values, matching y: 0, 1, 2, 3
-            segment(
-                Point(0.0, 0.0),
-                Point(0.0, 1.0),
-                Point(0.0, 2.0),
-                Point(0.0, 3.0),
-                startM = 0.0,
-            ),
-            // Second segment m values, matching y: 3, 4, 5, 6
-            segment(
-                Point(0.0, 3.0),
-                Point(0.0, 4.0),
-                Point(0.0, 5.0),
-                Point(0.0, 6.0),
-                startM = 3.0,
-            ),
-        )
+        val layoutAlignment =
+            alignment(
+                // First segment m values, matching y: 0, 1, 2, 3
+                segment(
+                    Point(0.0, 0.0),
+                    Point(0.0, 1.0),
+                    Point(0.0, 2.0),
+                    Point(0.0, 3.0),
+                    startM = 0.0,
+                ),
+                // Second segment m values, matching y: 3, 4, 5, 6
+                segment(
+                    Point(0.0, 3.0),
+                    Point(0.0, 4.0),
+                    Point(0.0, 5.0),
+                    Point(0.0, 6.0),
+                    startM = 3.0,
+                ),
+            )
         // Geometry alignment, offset 0.1m in x axis
-        val geometryAlignment = mapAlignment(
-            mapSegment(
-                Point3DM(0.1, 0.0, 0.0),
-                Point3DM(0.1, 1.0, 1.0),
-                Point3DM(0.1, 2.0, 2.0),
-                Point3DM(0.1, 3.0, 3.0),
-                startM = 0.0,
-            ),
-            mapSegment(
-                Point3DM(0.1, 3.0, 0.0),
-                Point3DM(0.1, 4.0, 1.0),
-                Point3DM(0.1, 5.0, 2.0),
-                Point3DM(0.1, 6.0, 3.0),
-                startM = 3.0,
-            ),
-        )
+        val geometryAlignment =
+            mapAlignment(
+                mapSegment(
+                    Point3DM(0.1, 0.0, 0.0),
+                    Point3DM(0.1, 1.0, 1.0),
+                    Point3DM(0.1, 2.0, 2.0),
+                    Point3DM(0.1, 3.0, 3.0),
+                    startM = 0.0,
+                ),
+                mapSegment(
+                    Point3DM(0.1, 3.0, 0.0),
+                    Point3DM(0.1, 4.0, 1.0),
+                    Point3DM(0.1, 5.0, 2.0),
+                    Point3DM(0.1, 6.0, 3.0),
+                    startM = 3.0,
+                ),
+            )
         // Replace entire geometry
         assertGeometryChange(
             layoutAlignment,
-            linkLayoutGeometrySection(layoutAlignment, Range(0.0, 6.0), geometryAlignment, Range(0.0, 6.0)),
+            linkLayoutGeometrySection(
+                layoutAlignment, Range(0.0, 6.0), geometryAlignment, Range(0.0, 6.0)),
             geometryAlignment.segments.map { s -> s.segmentPoints },
         )
         // Keep start and take the rest from geometry
         assertGeometryChange(
             layoutAlignment,
-            linkLayoutGeometrySection(layoutAlignment, Range(2.0, 6.0), geometryAlignment, Range(3.0, 6.0)),
+            linkLayoutGeometrySection(
+                layoutAlignment, Range(2.0, 6.0), geometryAlignment, Range(3.0, 6.0)),
             withPointsStartingFrom0(
                 listOf(
                     layoutAlignment.segments[0].segmentPoints.take(3),
                     // Connection segment
                     toSegmentPoints(
                         Point3DM(0.0, 2.0, 0.0),
-                        Point3DM(0.1, 3.0, calculateDistance(LAYOUT_SRID, Point(0.0, 2.0), Point(0.1, 3.0))),
+                        Point3DM(
+                            0.1,
+                            3.0,
+                            calculateDistance(LAYOUT_SRID, Point(0.0, 2.0), Point(0.1, 3.0))),
                     ),
                     geometryAlignment.segments[1].segmentPoints,
-                )
-            ),
+                )),
         )
         // Keep end and take the start from geometry
         assertGeometryChange(
             layoutAlignment,
-            linkLayoutGeometrySection(layoutAlignment, Range(0.0, 3.0), geometryAlignment, Range(0.0, 2.0)),
+            linkLayoutGeometrySection(
+                layoutAlignment, Range(0.0, 3.0), geometryAlignment, Range(0.0, 2.0)),
             withPointsStartingFrom0(
                 listOf(
                     geometryAlignment.segments[0].segmentPoints.take(3),
                     // Connection segment
                     toSegmentPoints(
                         Point3DM(0.1, 2.0, 0.0),
-                        Point3DM(0.0, 3.0, calculateDistance(LAYOUT_SRID, Point(0.1, 2.0), Point(0.0, 3.0))),
+                        Point3DM(
+                            0.0,
+                            3.0,
+                            calculateDistance(LAYOUT_SRID, Point(0.1, 2.0), Point(0.0, 3.0))),
                     ),
                     layoutAlignment.segments[1].segmentPoints,
-                )
-            )
-        )
+                )))
         // Keep start and end, taking the middle from geometry
         assertGeometryChange(
             layoutAlignment,
-            linkLayoutGeometrySection(layoutAlignment, Range(1.0, 5.0), geometryAlignment, Range(2.0, 4.0)),
+            linkLayoutGeometrySection(
+                layoutAlignment, Range(1.0, 5.0), geometryAlignment, Range(2.0, 4.0)),
             withPointsStartingFrom0(
                 listOf(
                     layoutAlignment.segments[0].segmentPoints.take(2),
                     // Connection segment
                     toSegmentPoints(
                         Point3DM(0.0, 1.0, 0.0),
-                        Point3DM(0.1, 2.0, calculateDistance(LAYOUT_SRID, Point(0.0, 1.0), Point(0.1, 2.0))),
+                        Point3DM(
+                            0.1,
+                            2.0,
+                            calculateDistance(LAYOUT_SRID, Point(0.0, 1.0), Point(0.1, 2.0))),
                     ),
                     geometryAlignment.segments[0].segmentPoints.takeLast(2),
                     geometryAlignment.segments[1].segmentPoints.take(2),
                     // Connection segment
                     toSegmentPoints(
                         Point3DM(0.1, 4.0, 0.0),
-                        Point3DM(0.0, 5.0, calculateDistance(LAYOUT_SRID, Point(0.1, 4.0), Point(0.0, 5.0))),
+                        Point3DM(
+                            0.0,
+                            5.0,
+                            calculateDistance(LAYOUT_SRID, Point(0.1, 4.0), Point(0.0, 5.0))),
                     ),
                     layoutAlignment.segments[1].segmentPoints.takeLast(2),
-                )
-            )
-        )
+                )))
         // Keep start and end, taking the middle from geometry but splitting between points
         assertGeometryChange(
             layoutAlignment,
-            linkLayoutGeometrySection(layoutAlignment, Range(1.5, 4.5), geometryAlignment, Range(2.5, 3.5)),
+            linkLayoutGeometrySection(
+                layoutAlignment, Range(1.5, 4.5), geometryAlignment, Range(2.5, 3.5)),
             withPointsStartingFrom0(
                 listOf(
                     // First part from layout, last point is interpolated
@@ -240,7 +267,10 @@ class LinkingTest {
                     // Connection segment
                     toSegmentPoints(
                         Point3DM(0.0, 1.5, 0.0),
-                        Point3DM(0.1, 2.5, calculateDistance(LAYOUT_SRID, Point(0.0, 1.5), Point(0.1, 2.5))),
+                        Point3DM(
+                            0.1,
+                            2.5,
+                            calculateDistance(LAYOUT_SRID, Point(0.0, 1.5), Point(0.1, 2.5))),
                     ),
                     // Middle 2 segments from geometry, ends both interpolated
                     toSegmentPoints(Point(0.1, 2.5), Point(0.1, 3.0)),
@@ -248,62 +278,66 @@ class LinkingTest {
                     // Connection segment
                     toSegmentPoints(
                         Point3DM(0.1, 3.5, 0.0),
-                        Point3DM(0.0, 4.5, calculateDistance(LAYOUT_SRID, Point(0.1, 3.5), Point(0.0, 4.5))),
+                        Point3DM(
+                            0.0,
+                            4.5,
+                            calculateDistance(LAYOUT_SRID, Point(0.1, 3.5), Point(0.0, 4.5))),
                     ),
                     // Last part from layout, first point is interpolated
                     toSegmentPoints(Point(0.0, 4.5), Point(0.0, 5.0), Point(0.0, 6.0)),
-                )
-            )
-        )
+                )))
     }
 
     @Test
     fun `Alignment can be extended with portion of geometry`() {
-        val layoutAlignment = alignment(
-            // First segment m values, matching y: 0, 1, 2
-            segment(
-                Point(0.0, 0.0),
-                Point(0.0, 1.0),
-                Point(0.0, 2.0),
-                startM = 2.0,
-            ),
-            // Second segment m values, matching y: 2, 3, 4
-            segment(
-                Point(0.0, 2.0),
-                Point(0.0, 3.0),
-                Point(0.0, 4.0),
-                startM = 2.0,
-            ),
-        )
+        val layoutAlignment =
+            alignment(
+                // First segment m values, matching y: 0, 1, 2
+                segment(
+                    Point(0.0, 0.0),
+                    Point(0.0, 1.0),
+                    Point(0.0, 2.0),
+                    startM = 2.0,
+                ),
+                // Second segment m values, matching y: 2, 3, 4
+                segment(
+                    Point(0.0, 2.0),
+                    Point(0.0, 3.0),
+                    Point(0.0, 4.0),
+                    startM = 2.0,
+                ),
+            )
         // Geometry alignment, offset 0.1m in x-axis and long enough to be linked in both ends
-        val geometryAlignment = mapAlignment(
-            // First segment before layout alignment: m 0-3
-            mapSegment(
-                Point3DM(0.1, -3.0, 0.0),
-                Point3DM(0.1, -2.0, 1.0),
-                Point3DM(0.1, -1.0, 2.0),
-                Point3DM(0.1, 0.0, 3.0),
-                startM = 0.0,
-            ),
-            // Mid-segment next to the layout segments: m 3-7
-            mapSegment(
-                Point3DM(0.1, 0.0, 3.0),
-                Point3DM(0.1, 4.0, 7.0),
-                startM = 3.0,
-            ),
-            // Last segment after layout alignment: m 7-10
-            mapSegment(
-                Point3DM(0.1, 4.0, 7.0),
-                Point3DM(0.1, 5.0, 8.0),
-                Point3DM(0.1, 6.0, 9.0),
-                Point3DM(0.1, 7.0, 10.0),
-                startM = 7.0,
-            ),
-        )
+        val geometryAlignment =
+            mapAlignment(
+                // First segment before layout alignment: m 0-3
+                mapSegment(
+                    Point3DM(0.1, -3.0, 0.0),
+                    Point3DM(0.1, -2.0, 1.0),
+                    Point3DM(0.1, -1.0, 2.0),
+                    Point3DM(0.1, 0.0, 3.0),
+                    startM = 0.0,
+                ),
+                // Mid-segment next to the layout segments: m 3-7
+                mapSegment(
+                    Point3DM(0.1, 0.0, 3.0),
+                    Point3DM(0.1, 4.0, 7.0),
+                    startM = 3.0,
+                ),
+                // Last segment after layout alignment: m 7-10
+                mapSegment(
+                    Point3DM(0.1, 4.0, 7.0),
+                    Point3DM(0.1, 5.0, 8.0),
+                    Point3DM(0.1, 6.0, 9.0),
+                    Point3DM(0.1, 7.0, 10.0),
+                    startM = 7.0,
+                ),
+            )
         // Extend start
         assertGeometryChange(
             layoutAlignment,
-            linkLayoutGeometrySection(layoutAlignment, Range(0.0, 0.0), geometryAlignment, Range(0.0, 2.0)),
+            linkLayoutGeometrySection(
+                layoutAlignment, Range(0.0, 0.0), geometryAlignment, Range(0.0, 2.0)),
             withPointsStartingFrom0(
                 listOf(
                     // Extension from geometry
@@ -311,7 +345,10 @@ class LinkingTest {
                     // Connection segment
                     toSegmentPoints(
                         Point3DM(0.1, -1.0, 0.0),
-                        Point3DM(0.0, 0.0, calculateDistance(LAYOUT_SRID, Point(0.1, -1.0), Point(0.0, 0.0))),
+                        Point3DM(
+                            0.0,
+                            0.0,
+                            calculateDistance(LAYOUT_SRID, Point(0.1, -1.0), Point(0.0, 0.0))),
                     ),
                     // Rest from the layout alignment as-is
                 ) + layoutAlignment.segments.map { s -> s.segmentPoints },
@@ -320,17 +357,22 @@ class LinkingTest {
         // Extend end
         assertGeometryChange(
             layoutAlignment,
-            linkLayoutGeometrySection(layoutAlignment, Range(4.0, 4.0), geometryAlignment, Range(8.0, 10.0)),
+            linkLayoutGeometrySection(
+                layoutAlignment, Range(4.0, 4.0), geometryAlignment, Range(8.0, 10.0)),
             withPointsStartingFrom0(
-                layoutAlignment.segments.map { s -> s.segmentPoints } + listOf(
-                    // Connection segment
-                    toSegmentPoints(
-                        Point3DM(0.0, 4.0, 0.0),
-                        Point3DM(0.1, 5.0, calculateDistance(LAYOUT_SRID, Point(0.0, 4.0), Point(0.1, 5.0))),
+                layoutAlignment.segments.map { s -> s.segmentPoints } +
+                    listOf(
+                        // Connection segment
+                        toSegmentPoints(
+                            Point3DM(0.0, 4.0, 0.0),
+                            Point3DM(
+                                0.1,
+                                5.0,
+                                calculateDistance(LAYOUT_SRID, Point(0.0, 4.0), Point(0.1, 5.0))),
+                        ),
+                        // Extension from geometry
+                        geometryAlignment.segments[2].segmentPoints.takeLast(3),
                     ),
-                    // Extension from geometry
-                    geometryAlignment.segments[2].segmentPoints.takeLast(3),
-                ),
             ),
         )
     }
@@ -339,37 +381,44 @@ class LinkingTest {
     fun `Selected switches can be removed from alignment`() {
         val switchId1 = IntId<TrackLayoutSwitch>(1)
         val switchId2 = IntId<TrackLayoutSwitch>(2)
-        val segments = fixSegmentStarts(
-            segment(
-                Point(0.0, 0.0), Point(0.0, 1.0),
-                switchId = switchId1,
-                startJointNumber = JointNumber(1),
-                endJointNumber = JointNumber(2),
-            ),
-            segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            segment(
-                Point(0.0, 2.0), Point(0.0, 3.0),
-                switchId = switchId2,
-                startJointNumber = JointNumber(1),
-                endJointNumber = null,
-            ),
-            segment(
-                Point(0.0, 3.0), Point(0.0, 4.0),
-                switchId = switchId2,
-                startJointNumber = null,
-                endJointNumber = JointNumber(1),
-            ),
-            segment(Point(0.0, 4.0), Point(0.0, 5.0)),
-            segment(
-                Point(0.0, 5.0), Point(0.0, 6.0),
-                switchId = switchId1,
-                startJointNumber = JointNumber(1),
-                endJointNumber = JointNumber(2),
-            ),
-        )
+        val segments =
+            fixSegmentStarts(
+                segment(
+                    Point(0.0, 0.0),
+                    Point(0.0, 1.0),
+                    switchId = switchId1,
+                    startJointNumber = JointNumber(1),
+                    endJointNumber = JointNumber(2),
+                ),
+                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                segment(
+                    Point(0.0, 2.0),
+                    Point(0.0, 3.0),
+                    switchId = switchId2,
+                    startJointNumber = JointNumber(1),
+                    endJointNumber = null,
+                ),
+                segment(
+                    Point(0.0, 3.0),
+                    Point(0.0, 4.0),
+                    switchId = switchId2,
+                    startJointNumber = null,
+                    endJointNumber = JointNumber(1),
+                ),
+                segment(Point(0.0, 4.0), Point(0.0, 5.0)),
+                segment(
+                    Point(0.0, 5.0),
+                    Point(0.0, 6.0),
+                    switchId = switchId1,
+                    startJointNumber = JointNumber(1),
+                    endJointNumber = JointNumber(2),
+                ),
+            )
         assertEquals(segments, removeSwitches(segments, setOf()))
         assertEquals(
-            segments.map { s -> s.copy(switchId = null, startJointNumber = null, endJointNumber = null) },
+            segments.map { s ->
+                s.copy(switchId = null, startJointNumber = null, endJointNumber = null)
+            },
             removeSwitches(segments, setOf(switchId1, switchId2)),
         )
         assertEquals(
@@ -393,39 +442,48 @@ class LinkingTest {
         val switchId1 = IntId<TrackLayoutSwitch>(1)
         val switchId2 = IntId<TrackLayoutSwitch>(2)
         val switchId3 = IntId<TrackLayoutSwitch>(3)
-        val segments = fixSegmentStarts(
-            segment(Point(0.0, 0.0), Point(0.0, 1.0), switchId = switchId1),
-            segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            segment(Point(0.0, 2.0), Point(0.0, 3.0), switchId = switchId2),
-            segment(Point(0.0, 3.0), Point(0.0, 4.0), switchId = switchId2),
-            segment(Point(0.0, 4.0), Point(0.0, 5.0)),
-            segment(Point(0.0, 5.0), Point(0.0, 6.0), switchId = switchId3),
-        )
+        val segments =
+            fixSegmentStarts(
+                segment(Point(0.0, 0.0), Point(0.0, 1.0), switchId = switchId1),
+                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                segment(Point(0.0, 2.0), Point(0.0, 3.0), switchId = switchId2),
+                segment(Point(0.0, 3.0), Point(0.0, 4.0), switchId = switchId2),
+                segment(Point(0.0, 4.0), Point(0.0, 5.0)),
+                segment(Point(0.0, 5.0), Point(0.0, 6.0), switchId = switchId3),
+            )
 
-        assertEquals(setOf<DomainId<TrackLayoutSwitch>>(), getSwitchIdsInside(segments, Range(0.0, 0.0)))
-        assertEquals(setOf<DomainId<TrackLayoutSwitch>>(), getSwitchIdsInside(segments, Range(4.0, 5.0)))
-        assertEquals(setOf(switchId1, switchId2, switchId3), getSwitchIdsInside(segments, Range(0.0, 6.0)))
+        assertEquals(
+            setOf<DomainId<TrackLayoutSwitch>>(), getSwitchIdsInside(segments, Range(0.0, 0.0)))
+        assertEquals(
+            setOf<DomainId<TrackLayoutSwitch>>(), getSwitchIdsInside(segments, Range(4.0, 5.0)))
+        assertEquals(
+            setOf(switchId1, switchId2, switchId3), getSwitchIdsInside(segments, Range(0.0, 6.0)))
         assertEquals(setOf(switchId2, switchId3), getSwitchIdsInside(segments, Range(3.1, 5.1)))
         assertEquals(setOf(switchId2), getSwitchIdsInside(segments, Range(3.5, 4.5)))
         assertEquals(setOf(switchId2), getSwitchIdsInside(segments, Range(1.5, 4.5)))
-        assertEquals(setOf<DomainId<TrackLayoutSwitch>>(), getSwitchIdsInside(segments, Range(4.5, 4.7)))
+        assertEquals(
+            setOf<DomainId<TrackLayoutSwitch>>(), getSwitchIdsInside(segments, Range(4.5, 4.7)))
         assertEquals(setOf(switchId3), getSwitchIdsInside(segments, Range(5.5, 5.7)))
 
-        assertEquals(setOf(switchId1, switchId2, switchId3), getSwitchIdsOutside(segments, Range(0.0, 0.0)))
-        assertEquals(setOf(switchId1, switchId2, switchId3), getSwitchIdsOutside(segments, Range(4.0, 5.0)))
+        assertEquals(
+            setOf(switchId1, switchId2, switchId3), getSwitchIdsOutside(segments, Range(0.0, 0.0)))
+        assertEquals(
+            setOf(switchId1, switchId2, switchId3), getSwitchIdsOutside(segments, Range(4.0, 5.0)))
         assertEquals(setOf(switchId1, switchId3), getSwitchIdsOutside(segments, Range(1.0, 5.0)))
         assertEquals(setOf(switchId1, switchId3), getSwitchIdsOutside(segments, Range(0.5, 4.5)))
-        assertEquals(setOf<DomainId<TrackLayoutSwitch>>(), getSwitchIdsOutside(segments, Range(0.0, 6.0)))
+        assertEquals(
+            setOf<DomainId<TrackLayoutSwitch>>(), getSwitchIdsOutside(segments, Range(0.0, 6.0)))
     }
 
     @Test
     fun `Source length values are correct after splitting`() {
         val sourceId = IndexedId<GeometryElement>(1, 2)
-        val segments = fixSegmentStarts(
-            segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-            segment(Point(0.0, 1.0), Point(0.0, 2.0), sourceId = sourceId, sourceStart = 10.0),
-            segment(Point(0.0, 2.0), Point(0.0, 3.0)),
-        )
+        val segments =
+            fixSegmentStarts(
+                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                segment(Point(0.0, 1.0), Point(0.0, 2.0), sourceId = sourceId, sourceStart = 10.0),
+                segment(Point(0.0, 2.0), Point(0.0, 3.0)),
+            )
         // Cutting other segments doesn't affect source start
         assertEquals(10.0, sliceSegments(segments, Range(0.5, 2.5))[1].sourceStart)
         // Cutting the sourced segment from beginning adds to the source start
@@ -435,7 +493,9 @@ class LinkingTest {
     }
 }
 
-private fun withPointsStartingFrom0(pointLists: List<List<SegmentPoint>>): List<List<SegmentPoint>> {
+private fun withPointsStartingFrom0(
+    pointLists: List<List<SegmentPoint>>
+): List<List<SegmentPoint>> {
     return pointLists.map { pointList ->
         var totalM = 0.0
         var lastM = pointList.first().m

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LocationTrackEndpointTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LocationTrackEndpointTest.kt
@@ -7,8 +7,8 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.getLocationTrackEndpoints
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
 import fi.fta.geoviite.infra.tracklayout.segment
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class LocationTrackEndpointTest {
     private val bbox = BoundingBox(-10.0..10.0, -10.0..10.0)
@@ -20,12 +20,13 @@ class LocationTrackEndpointTest {
 
     @Test
     fun shouldFindLocationTrackStartPoint() {
-        val trackWithStartPointInsideBbox = locationTrackAndAlignment(
-            trackNumberId = IntId(0),
-            segments = listOf(segment(pointInsideBbox, pointOutsideBbox)),
-            id = IntId(0),
-            draft = false,
-        )
+        val trackWithStartPointInsideBbox =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(0),
+                segments = listOf(segment(pointInsideBbox, pointOutsideBbox)),
+                id = IntId(0),
+                draft = false,
+            )
         val alignments = listOf(trackWithStartPointInsideBbox)
 
         val endpoints = getLocationTrackEndpoints(alignments, bbox)
@@ -35,20 +36,20 @@ class LocationTrackEndpointTest {
             LocationTrackEndpoint(
                 locationTrackId = trackWithStartPointInsideBbox.first.id as IntId<LocationTrack>,
                 location = pointInsideBbox,
-                updateType = LocationTrackPointUpdateType.START_POINT
-            ),
+                updateType = LocationTrackPointUpdateType.START_POINT),
             endpoints.first(),
         )
     }
 
     @Test
     fun shouldFindLocationTrackEndPoint() {
-        val trackWithEndPointInsideBbox = locationTrackAndAlignment(
-            trackNumberId = IntId(0),
-            segments = listOf(segment(pointOutsideBbox, otherPointInsideBbox)),
-            id = IntId(0),
-            draft = false,
-        )
+        val trackWithEndPointInsideBbox =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(0),
+                segments = listOf(segment(pointOutsideBbox, otherPointInsideBbox)),
+                id = IntId(0),
+                draft = false,
+            )
         val alignments = listOf(trackWithEndPointInsideBbox)
 
         val endpoints = getLocationTrackEndpoints(alignments, bbox)
@@ -58,23 +59,24 @@ class LocationTrackEndpointTest {
             LocationTrackEndpoint(
                 locationTrackId = trackWithEndPointInsideBbox.first.id as IntId<LocationTrack>,
                 location = otherPointInsideBbox,
-                updateType = LocationTrackPointUpdateType.END_POINT
-            ),
+                updateType = LocationTrackPointUpdateType.END_POINT),
             endpoints.first(),
         )
     }
 
     @Test
     fun shouldFindBothLocationTrackEndpoints() {
-        val alignmentWithMissingBothEndpointsInsideBbox = locationTrackAndAlignment(
-            trackNumberId = IntId(0),
-            segments = listOf(
-                segment(pointInsideBbox, otherPointInsideBbox),
-                segment(otherPointInsideBbox, thirdPointInsideBbox),
-            ),
-            id = IntId(1),
-            draft = false,
-        )
+        val alignmentWithMissingBothEndpointsInsideBbox =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(0),
+                segments =
+                    listOf(
+                        segment(pointInsideBbox, otherPointInsideBbox),
+                        segment(otherPointInsideBbox, thirdPointInsideBbox),
+                    ),
+                id = IntId(1),
+                draft = false,
+            )
         val alignments = listOf(alignmentWithMissingBothEndpointsInsideBbox)
 
         val endpoints = getLocationTrackEndpoints(alignments, bbox)
@@ -82,33 +84,32 @@ class LocationTrackEndpointTest {
         assert(
             endpoints.contains(
                 LocationTrackEndpoint(
-                    locationTrackId = alignmentWithMissingBothEndpointsInsideBbox.first.id as IntId<LocationTrack>,
+                    locationTrackId =
+                        alignmentWithMissingBothEndpointsInsideBbox.first.id
+                            as IntId<LocationTrack>,
                     location = pointInsideBbox,
-                    updateType = LocationTrackPointUpdateType.START_POINT
-                )
-            )
-        )
+                    updateType = LocationTrackPointUpdateType.START_POINT)))
         assert(
             endpoints.contains(
                 LocationTrackEndpoint(
-                    locationTrackId = alignmentWithMissingBothEndpointsInsideBbox.first.id as IntId<LocationTrack>,
+                    locationTrackId =
+                        alignmentWithMissingBothEndpointsInsideBbox.first.id
+                            as IntId<LocationTrack>,
                     location = thirdPointInsideBbox,
-                    updateType = LocationTrackPointUpdateType.END_POINT
-                )
-            )
-        )
+                    updateType = LocationTrackPointUpdateType.END_POINT)))
     }
 
     @Test
     fun shouldIgnoreLocationTrackEndpointsOutsideBbox() {
-        val alignmentsWithEndpointsOutsideBbox = listOf(
-            locationTrackAndAlignment(
-                trackNumberId = IntId(0),
-                id = IntId(0),
-                segments = listOf(segment(pointOutsideBbox, otherPointOutsideBbox)),
-                draft = false,
-            ),
-        )
+        val alignmentsWithEndpointsOutsideBbox =
+            listOf(
+                locationTrackAndAlignment(
+                    trackNumberId = IntId(0),
+                    id = IntId(0),
+                    segments = listOf(segment(pointOutsideBbox, otherPointOutsideBbox)),
+                    draft = false,
+                ),
+            )
 
         val endpoints = getLocationTrackEndpoints(alignmentsWithEndpointsOutsideBbox, bbox)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -57,18 +57,20 @@ import fi.fta.geoviite.infra.ui.testdata.createSwitchAndAlignments
 import fi.fta.geoviite.infra.ui.testdata.locationTrackAndAlignmentForGeometryAlignment
 import fi.fta.geoviite.infra.ui.testdata.switchJoint
 import fi.fta.geoviite.infra.util.LocalizationKey
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class SwitchLinkingServiceIT @Autowired constructor(
+class SwitchLinkingServiceIT
+@Autowired
+constructor(
     private val switchLinkingService: SwitchLinkingService,
     private val switchDao: LayoutSwitchDao,
     private val locationTrackService: LocationTrackService,
@@ -84,10 +86,14 @@ class SwitchLinkingServiceIT @Autowired constructor(
 
     @BeforeEach
     fun setup() {
-        switchStructure = switchStructureDao.fetchSwitchStructures().find { s -> s.type.typeName == "YV60-300-1:9-O" }!!
+        switchStructure =
+            switchStructureDao.fetchSwitchStructures().find { s ->
+                s.type.typeName == "YV60-300-1:9-O"
+            }!!
         switchAlignment_1_5_2 =
-            switchStructure.alignments.find { alignment -> alignment.jointNumbers.contains(JointNumber(5)) }
-                ?: throw IllegalStateException("Invalid switch structure")
+            switchStructure.alignments.find { alignment ->
+                alignment.jointNumbers.contains(JointNumber(5))
+            } ?: throw IllegalStateException("Invalid switch structure")
     }
 
     @BeforeEach
@@ -102,29 +108,29 @@ class SwitchLinkingServiceIT @Autowired constructor(
             BoundingBox(
                 x = Range(500000.0, 600000.0),
                 y = Range(6900000.0, 7000000.0),
-            )
-        )
+            ))
     }
 
     @Test
     fun updatingSwitchLinkingChangesSourceToGenerated() {
-        val insertedSwitch = switchDao.fetch(
-            switchDao.insert(switch(665, draft = false)).rowVersion
-        )
-        val suggestedSwitch = switchLinkingService.matchFittedSwitch(
-            LayoutBranch.main,
-            FittedSwitch(
-                joints = emptyList(),
-                geometrySwitchId = null,
-                switchStructureId = insertedSwitch.switchStructureId,
-                name = SwitchName("Foo V123"),
-                alignmentEndPoint = null,
-            ),
-            insertedSwitch.id as IntId,
-        )
-        val rowVersion = switchLinkingService
-            .saveSwitchLinking(LayoutBranch.main, suggestedSwitch, insertedSwitch.id as IntId)
-            .rowVersion
+        val insertedSwitch =
+            switchDao.fetch(switchDao.insert(switch(665, draft = false)).rowVersion)
+        val suggestedSwitch =
+            switchLinkingService.matchFittedSwitch(
+                LayoutBranch.main,
+                FittedSwitch(
+                    joints = emptyList(),
+                    geometrySwitchId = null,
+                    switchStructureId = insertedSwitch.switchStructureId,
+                    name = SwitchName("Foo V123"),
+                    alignmentEndPoint = null,
+                ),
+                insertedSwitch.id as IntId,
+            )
+        val rowVersion =
+            switchLinkingService
+                .saveSwitchLinking(LayoutBranch.main, suggestedSwitch, insertedSwitch.id as IntId)
+                .rowVersion
         val switch = switchDao.fetch(rowVersion)
         assertEquals(switch.source, GeometrySource.GENERATED)
     }
@@ -132,81 +138,94 @@ class SwitchLinkingServiceIT @Autowired constructor(
     @Test
     fun linkingExistingGeometrySwitchGetsSwitchAccuracyForJoints() {
         setupJointLocationAccuracyTest()
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitches(
-            LayoutBranch.main,
-            BoundingBox(
-                x = Range(0.0, 100.0),
-                y = Range(0.0, 100.0),
-            )
-        )[0]
+        val suggestedSwitch =
+            switchLinkingService
+                .getSuggestedSwitches(
+                    LayoutBranch.main,
+                    BoundingBox(
+                        x = Range(0.0, 100.0),
+                        y = Range(0.0, 100.0),
+                    ))[0]
         for (joint in suggestedSwitch.joints.map { j -> j.number }) {
-            assertJointPointLocationAccuracy(suggestedSwitch, joint, LocationAccuracy.DIGITIZED_AERIAL_IMAGE)
+            assertJointPointLocationAccuracy(
+                suggestedSwitch, joint, LocationAccuracy.DIGITIZED_AERIAL_IMAGE)
         }
     }
 
     @Test
     fun linkingManualSwitchGetsGeometryCalculatedAccuracy() {
         val suggestedSwitchCreateParams = setupJointLocationAccuracyTest()
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, suggestedSwitchCreateParams)!!
+        val suggestedSwitch =
+            switchLinkingService.getSuggestedSwitch(
+                LayoutBranch.main, suggestedSwitchCreateParams)!!
 
         for (joint in suggestedSwitch.joints.map { j -> j.number }) {
-            assertJointPointLocationAccuracy(suggestedSwitch, joint, LocationAccuracy.GEOMETRY_CALCULATED)
+            assertJointPointLocationAccuracy(
+                suggestedSwitch, joint, LocationAccuracy.GEOMETRY_CALCULATED)
         }
     }
 
     @Test
     fun `should match with first switch alignment match only`() {
         var startLength = 0.0
-        val segments = (1..5).map { num ->
-            val start = (num - 1).toDouble() * 10.0
-            val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-        }
+        val segments =
+            (1..5).map { num ->
+                val start = (num - 1).toDouble() * 10.0
+                val end = start + 10.0
+                segment(Point(start, start), Point(end, end), startM = startLength).also { s ->
+                    startLength += s.length
+                }
+            }
 
-        val locationTrackId = mainDraftContext.insert(
-            locationTrackAndAlignment(trackNumberId = mainDraftContext.createLayoutTrackNumber().id, segments = segments)
-        ).id
+        val locationTrackId =
+            mainDraftContext
+                .insert(
+                    locationTrackAndAlignment(
+                        trackNumberId = mainDraftContext.createLayoutTrackNumber().id,
+                        segments = segments))
+                .id
 
         val insertedSwitch = mainOfficialContext.insertAndFetch(switch(665))
 
-        val linkingJoints = listOf(
-            FittedSwitchJoint(
-                JointNumber(1),
-                Point(x = 9.5, y = 9.5),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    suggestedSwitchJointMatch(
-                        locationTrackId = locationTrackId,
-                        segmentIndex = 1,
-                        m = segments[1].startM,
-                    )
+        val linkingJoints =
+            listOf(
+                FittedSwitchJoint(
+                    JointNumber(1),
+                    Point(x = 9.5, y = 9.5),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            suggestedSwitchJointMatch(
+                                locationTrackId = locationTrackId,
+                                segmentIndex = 1,
+                                m = segments[1].startM,
+                            )),
                 ),
-            ),
-            FittedSwitchJoint(
-                JointNumber(2),
-                Point(x = 20.0, y = 20.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    suggestedSwitchJointMatch(
-                        locationTrackId = locationTrackId,
-                        segmentIndex = 1,
-                        m = segments[1].endM,
-                    )
+                FittedSwitchJoint(
+                    JointNumber(2),
+                    Point(x = 20.0, y = 20.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            suggestedSwitchJointMatch(
+                                locationTrackId = locationTrackId,
+                                segmentIndex = 1,
+                                m = segments[1].endM,
+                            )),
                 ),
-            ),
-            FittedSwitchJoint(
-                JointNumber(3),
-                Point(x = 20.0, y = 20.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    suggestedSwitchJointMatch(
-                        locationTrackId = locationTrackId,
-                        segmentIndex = 1,
-                        m = segments[1].endM,
-                    )
+                FittedSwitchJoint(
+                    JointNumber(3),
+                    Point(x = 20.0, y = 20.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            suggestedSwitchJointMatch(
+                                locationTrackId = locationTrackId,
+                                segmentIndex = 1,
+                                m = segments[1].endM,
+                            )),
                 ),
-            ),
-        )
+            )
 
         switchLinkingService.saveSwitchLinking(
             LayoutBranch.main,
@@ -215,77 +234,87 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 suggestedSwitchFitting(
                     joints = linkingJoints,
                     geometrySwitchId = null,
-                    switchStructureId = insertedSwitch.switchStructureId
-                ),
+                    switchStructureId = insertedSwitch.switchStructureId),
                 insertedSwitch.id as IntId,
             ),
             insertedSwitch.id as IntId,
         )
 
-        val (_, alignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
+        val (_, alignment) =
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
         val joint12Segment = alignment.segments[1]
 
         assertEquals(JointNumber(1), joint12Segment.startJointNumber)
         assertEquals(JointNumber(2), joint12Segment.endJointNumber)
 
-        assertTrue(alignment.segments.none {
-            it.endJointNumber == JointNumber(3) || it.startJointNumber == JointNumber(3)
-        })
+        assertTrue(
+            alignment.segments.none {
+                it.endJointNumber == JointNumber(3) || it.startJointNumber == JointNumber(3)
+            })
     }
 
     @Test
     fun `should filter out switch matches that do not match with switch structure alignment`() {
         var startLength = 0.0
-        val segments = (1..5).map { num ->
-            val start = (num - 1).toDouble() * 10.0
-            val end = start + 10.0
-            segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-        }
+        val segments =
+            (1..5).map { num ->
+                val start = (num - 1).toDouble() * 10.0
+                val end = start + 10.0
+                segment(Point(start, start), Point(end, end), startM = startLength).also { s ->
+                    startLength += s.length
+                }
+            }
 
-        val locationTrackId = mainDraftContext.insert(
-            locationTrackAndAlignment(trackNumberId = mainDraftContext.createLayoutTrackNumber().id, segments = segments)
-        ).id
+        val locationTrackId =
+            mainDraftContext
+                .insert(
+                    locationTrackAndAlignment(
+                        trackNumberId = mainDraftContext.createLayoutTrackNumber().id,
+                        segments = segments))
+                .id
 
-        val insertedSwitch = switchDao.fetch(switchDao.insert(switch(665, draft = false)).rowVersion)
+        val insertedSwitch =
+            switchDao.fetch(switchDao.insert(switch(665, draft = false)).rowVersion)
 
-        val linkingJoints = listOf(
-            FittedSwitchJoint(
-                JointNumber(1),
-                Point(x = 9.5, y = 9.5),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    suggestedSwitchJointMatch(
-                        locationTrackId = locationTrackId,
-                        segmentIndex = 1,
-                        m = segments[1].startM,
-                    )
+        val linkingJoints =
+            listOf(
+                FittedSwitchJoint(
+                    JointNumber(1),
+                    Point(x = 9.5, y = 9.5),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            suggestedSwitchJointMatch(
+                                locationTrackId = locationTrackId,
+                                segmentIndex = 1,
+                                m = segments[1].startM,
+                            )),
                 ),
-            ),
-            FittedSwitchJoint(
-                JointNumber(5),
-                Point(x = 20.0, y = 20.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    suggestedSwitchJointMatch(
-                        locationTrackId = locationTrackId,
-                        segmentIndex = 1,
-                        m = segments[1].endM,
-                    )
+                FittedSwitchJoint(
+                    JointNumber(5),
+                    Point(x = 20.0, y = 20.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            suggestedSwitchJointMatch(
+                                locationTrackId = locationTrackId,
+                                segmentIndex = 1,
+                                m = segments[1].endM,
+                            )),
                 ),
-            ),
-            FittedSwitchJoint(
-                JointNumber(3),
-                Point(x = 20.0, y = 20.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    suggestedSwitchJointMatch(
-                        locationTrackId = locationTrackId,
-                        segmentIndex = 1,
-                        m = segments[1].endM,
-                    )
+                FittedSwitchJoint(
+                    JointNumber(3),
+                    Point(x = 20.0, y = 20.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            suggestedSwitchJointMatch(
+                                locationTrackId = locationTrackId,
+                                segmentIndex = 1,
+                                m = segments[1].endM,
+                            )),
                 ),
-            ),
-        )
+            )
 
         switchLinkingService.saveSwitchLinking(
             LayoutBranch.main,
@@ -294,20 +323,23 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 suggestedSwitchFitting(
                     joints = linkingJoints,
                     geometrySwitchId = null,
-                    switchStructureId = insertedSwitch.switchStructureId
-                ), insertedSwitch.id as IntId,
-            ), insertedSwitch.id as IntId,
+                    switchStructureId = insertedSwitch.switchStructureId),
+                insertedSwitch.id as IntId,
+            ),
+            insertedSwitch.id as IntId,
         )
 
-        val (_, alignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
+        val (_, alignment) =
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
         val joint12Segment = alignment.segments[1]
 
         assertEquals(JointNumber(1), joint12Segment.startJointNumber)
         assertEquals(JointNumber(3), joint12Segment.endJointNumber)
 
-        assertTrue(alignment.segments.none {
-            it.endJointNumber == JointNumber(5) || it.startJointNumber == JointNumber(5)
-        })
+        assertTrue(
+            alignment.segments.none {
+                it.endJointNumber == JointNumber(5) || it.startJointNumber == JointNumber(5)
+            })
     }
 
     private fun createAndLinkSwitch(
@@ -315,10 +347,10 @@ class SwitchLinkingServiceIT @Autowired constructor(
         linkedJoints: List<FittedSwitchJoint>,
     ): TrackLayoutSwitch {
         return switch(
-            seed = seed,
-            joints = listOf(),
-            stateCategory = LayoutStateCategory.EXISTING,
-        )
+                seed = seed,
+                joints = listOf(),
+                stateCategory = LayoutStateCategory.EXISTING,
+            )
             .let(mainOfficialContext::insertAndFetch)
             .let { storedSwitch ->
                 switchLinkingService.saveSwitchLinking(
@@ -337,86 +369,102 @@ class SwitchLinkingServiceIT @Autowired constructor(
             .let { switchDaoResponse -> switchDao.fetch(switchDaoResponse.rowVersion) }
     }
 
-    private data class LocationTracksWithLinkedSwitch (
+    private data class LocationTracksWithLinkedSwitch(
         val straightTrack: LocationTrack,
         val straightTrackAlignment: LayoutAlignment,
-
         val divertingTrack: LocationTrack,
         val divertingTrackAlignment: LayoutAlignment,
-
         val linkedSwitch: TrackLayoutSwitch,
     )
 
     private fun createLocationTracksWithLinkedSwitch(
         seed: Int = 12345,
     ): LocationTracksWithLinkedSwitch {
-        val (straightTrack, straightAlignment) = createDraftLocationTrackFromLayoutSegments(
+        val (straightTrack, straightAlignment) =
+            createDraftLocationTrackFromLayoutSegments(
+                listOf(
+                    segment(Point(0.0, 0.0), Point(20.0, 0.0)), // Example: Beginning of the track
+                    segment(
+                        Point(20.0, 0.0),
+                        Point(40.0, 0.0)), // Example: first switch start joint (1) -> joint (5)
+                    segment(
+                        Point(40.0, 0.0),
+                        Point(
+                            60.0,
+                            0.0)), // Example: first switch joint (5) -> end joint (2), will be
+                                   // split when linking the overlapping switch
+                    segment(
+                        Point(60.0, 0.0),
+                        Point(
+                            80.0,
+                            0.0)), // Example: second switch joint (1) WITHOUT OVERLAP -> joint (5)
+                    segment(
+                        Point(80.0, 0.0), Point(100.0, 0.0)), // Example: joint (5) -> end joint (2)
+                    segment(Point(100.0, 0.0), Point(120.0, 0.0)), // Example:  Rest of the track
+                ))
+
+        val (divertingTrack, divertingAlignment) =
+            createDraftLocationTrackFromLayoutSegments(
+                listOf(segment(Point(20.0, 0.0), Point(60.0, 60.0))))
+
+        val switchJoints =
             listOf(
-                segment(Point(0.0, 0.0), Point(20.0, 0.0)),  // Example: Beginning of the track
-                segment(Point(20.0, 0.0), Point(40.0, 0.0)), // Example: first switch start joint (1) -> joint (5)
-                segment(Point(40.0, 0.0), Point(60.0, 0.0)), // Example: first switch joint (5) -> end joint (2), will be split when linking the overlapping switch
-                segment(Point(60.0, 0.0), Point(80.0, 0.0)), // Example: second switch joint (1) WITHOUT OVERLAP -> joint (5)
-                segment(Point(80.0, 0.0), Point(100.0, 0.0)), // Example: joint (5) -> end joint (2)
-                segment(Point(100.0, 0.0), Point(120.0, 0.0)), // Example:  Rest of the track
+
+                // Continuing track
+                FittedSwitchJoint(
+                    JointNumber(1),
+                    Point(20.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            switchLinkingAtStart(straightTrack.id, straightAlignment, 1),
+                            switchLinkingAtStart(divertingTrack.id, divertingAlignment, 0),
+                        ),
+                ),
+                FittedSwitchJoint(
+                    JointNumber(5),
+                    Point(40.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            switchLinkingAtStart(straightTrack.id, straightAlignment, 2),
+                        ),
+                ),
+                FittedSwitchJoint(
+                    JointNumber(2),
+                    Point(60.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            switchLinkingAtEnd(straightTrack.id, straightAlignment, 2),
+                        ),
+                ),
+
+                // Diverting track
+                FittedSwitchJoint(
+                    JointNumber(3),
+                    Point(100.0, 60.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            switchLinkingAtEnd(divertingTrack.id, divertingAlignment, 0),
+                        ),
+                ),
             )
-        )
 
-        val (divertingTrack, divertingAlignment) = createDraftLocationTrackFromLayoutSegments(
-            listOf(segment(Point(20.0, 0.0), Point(60.0, 60.0)))
-        )
-
-        val switchJoints = listOf(
-
-            // Continuing track
-            FittedSwitchJoint(
-                JointNumber(1),
-                Point(20.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    switchLinkingAtStart(straightTrack.id, straightAlignment, 1),
-                    switchLinkingAtStart(divertingTrack.id, divertingAlignment, 0),
-                ),
-            ),
-
-            FittedSwitchJoint(
-                JointNumber(5),
-                Point(40.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    switchLinkingAtStart(straightTrack.id, straightAlignment, 2),
-                ),
-            ),
-
-            FittedSwitchJoint(
-                JointNumber(2),
-                Point(60.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    switchLinkingAtEnd(straightTrack.id, straightAlignment, 2),
-                ),
-            ),
-
-            // Diverting track
-            FittedSwitchJoint(
-                JointNumber(3),
-                Point(100.0, 60.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    switchLinkingAtEnd(divertingTrack.id, divertingAlignment, 0),
-                ),
-            ),
-        )
-
-        val linkedSwitch = createAndLinkSwitch(
-            seed = seed,
-            linkedJoints = switchJoints,
-        )
+        val linkedSwitch =
+            createAndLinkSwitch(
+                seed = seed,
+                linkedJoints = switchJoints,
+            )
 
         val (linkedStraightTrack, linkedStraightTrackAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, straightTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.draft, straightTrack.id as IntId)
 
         val (linkedDivertingTrack, linkedDivertingTrackAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, divertingTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.draft, divertingTrack.id as IntId)
 
         // No segment splits are excepted to have happened.
         assertEquals(straightAlignment.segments.size, linkedStraightTrackAlignment.segments.size)
@@ -426,12 +474,16 @@ class SwitchLinkingServiceIT @Autowired constructor(
         assertEquals(null, linkedStraightTrackAlignment.segments[0].endJointNumber)
 
         assertEquals(linkedSwitch.id, linkedStraightTrackAlignment.segments[1].switchId)
-        assertEquals(switchJoints[0].number, linkedStraightTrackAlignment.segments[1].startJointNumber)
-        assertEquals(switchJoints[1].number, linkedStraightTrackAlignment.segments[1].endJointNumber)
+        assertEquals(
+            switchJoints[0].number, linkedStraightTrackAlignment.segments[1].startJointNumber)
+        assertEquals(
+            switchJoints[1].number, linkedStraightTrackAlignment.segments[1].endJointNumber)
 
         assertEquals(linkedSwitch.id, linkedStraightTrackAlignment.segments[2].switchId)
-        assertEquals(switchJoints[1].number, linkedStraightTrackAlignment.segments[2].startJointNumber)
-        assertEquals(switchJoints[2].number, linkedStraightTrackAlignment.segments[2].endJointNumber)
+        assertEquals(
+            switchJoints[1].number, linkedStraightTrackAlignment.segments[2].startJointNumber)
+        assertEquals(
+            switchJoints[2].number, linkedStraightTrackAlignment.segments[2].endJointNumber)
 
         assertEquals(null, linkedStraightTrackAlignment.segments[3].switchId)
         assertEquals(null, linkedStraightTrackAlignment.segments[3].startJointNumber)
@@ -440,16 +492,16 @@ class SwitchLinkingServiceIT @Autowired constructor(
         // The diverting track segments should not have been split either.
         assertEquals(1, linkedDivertingTrackAlignment.segments.size)
         assertEquals(linkedSwitch.id, linkedDivertingTrackAlignment.segments[0].switchId)
-        assertEquals(switchJoints[0].number, linkedDivertingTrackAlignment.segments[0].startJointNumber)
-        assertEquals(switchJoints[3].number, linkedDivertingTrackAlignment.segments[0].endJointNumber)
+        assertEquals(
+            switchJoints[0].number, linkedDivertingTrackAlignment.segments[0].startJointNumber)
+        assertEquals(
+            switchJoints[3].number, linkedDivertingTrackAlignment.segments[0].endJointNumber)
 
         return LocationTracksWithLinkedSwitch(
             straightTrack = linkedStraightTrack,
             straightTrackAlignment = linkedStraightTrackAlignment,
-
             divertingTrack = linkedDivertingTrack,
             divertingTrackAlignment = linkedDivertingTrackAlignment,
-
             linkedSwitch = linkedSwitch,
         )
     }
@@ -459,74 +511,94 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val switchOverlapAmount = 4.99
         val testLocation = createLocationTracksWithLinkedSwitch()
 
-        val (secondDiversionTrack, secondDiversionAlignment) = createDraftLocationTrackFromLayoutSegments(
-            // The second diversion track's starting point and the related switch is purposefully built to overlap the first switch.
-            listOf(segment(Point(60.0 - switchOverlapAmount, 0.0), Point(100.0, 100.0)))
-        )
+        val (secondDiversionTrack, secondDiversionAlignment) =
+            createDraftLocationTrackFromLayoutSegments(
+                // The second diversion track's starting point and the related switch is
+                // purposefully built to overlap the first switch.
+                listOf(segment(Point(60.0 - switchOverlapAmount, 0.0), Point(100.0, 100.0))))
 
-        val overlappingSwitchJoints = listOf(
-            // Continuing track
-            FittedSwitchJoint(
-                JointNumber(1),
-                Point(60.0 - switchOverlapAmount, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    suggestedSwitchJointMatch(
-                        locationTrackId = testLocation.straightTrack.id as IntId,
-                        segmentIndex = 2,
-                        m = testLocation.straightTrackAlignment.segments[2].endM - switchOverlapAmount,
-                    ),
-
-                    switchLinkingAtStart(secondDiversionTrack.id, secondDiversionAlignment, 0),
+        val overlappingSwitchJoints =
+            listOf(
+                // Continuing track
+                FittedSwitchJoint(
+                    JointNumber(1),
+                    Point(60.0 - switchOverlapAmount, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            suggestedSwitchJointMatch(
+                                locationTrackId = testLocation.straightTrack.id as IntId,
+                                segmentIndex = 2,
+                                m =
+                                    testLocation.straightTrackAlignment.segments[2].endM -
+                                        switchOverlapAmount,
+                            ),
+                            switchLinkingAtStart(
+                                secondDiversionTrack.id, secondDiversionAlignment, 0),
+                        ),
                 ),
-            ),
-
-            FittedSwitchJoint(
-                JointNumber(5),
-                Point(80.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    switchLinkingAtStart(testLocation.straightTrack.id, testLocation.straightTrackAlignment, 4),
+                FittedSwitchJoint(
+                    JointNumber(5),
+                    Point(80.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            switchLinkingAtStart(
+                                testLocation.straightTrack.id,
+                                testLocation.straightTrackAlignment,
+                                4),
+                        ),
                 ),
-            ),
-
-            FittedSwitchJoint(
-                JointNumber(2),
-                Point(100.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    switchLinkingAtEnd(testLocation.straightTrack.id, testLocation.straightTrackAlignment, 4),
+                FittedSwitchJoint(
+                    JointNumber(2),
+                    Point(100.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            switchLinkingAtEnd(
+                                testLocation.straightTrack.id,
+                                testLocation.straightTrackAlignment,
+                                4),
+                        ),
                 ),
-            ),
 
-            // Diverting track
-            FittedSwitchJoint(
-                JointNumber(3),
-                Point(100.0, 100.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    switchLinkingAtEnd(testLocation.divertingTrack.id, testLocation.divertingTrackAlignment, 0),
+                // Diverting track
+                FittedSwitchJoint(
+                    JointNumber(3),
+                    Point(100.0, 100.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches =
+                        listOf(
+                            switchLinkingAtEnd(
+                                testLocation.divertingTrack.id,
+                                testLocation.divertingTrackAlignment,
+                                0),
+                        ),
                 ),
-            ),
-        )
+            )
 
-        val newSwitch = createAndLinkSwitch(
-            seed = 98765,
-            linkedJoints = overlappingSwitchJoints,
-        )
+        val newSwitch =
+            createAndLinkSwitch(
+                seed = 98765,
+                linkedJoints = overlappingSwitchJoints,
+            )
 
         val (_, overlapLinkedStraightAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocation.straightTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.draft, testLocation.straightTrack.id as IntId)
 
         // The overlapping segment has not been split, the next segment is used.
-        assertEquals(testLocation.straightTrackAlignment.segments.size, overlapLinkedStraightAlignment.segments.size)
+        assertEquals(
+            testLocation.straightTrackAlignment.segments.size,
+            overlapLinkedStraightAlignment.segments.size)
 
         assertEquals(null, overlapLinkedStraightAlignment.segments[0].switchId)
         assertEquals(null, overlapLinkedStraightAlignment.segments[0].startJointNumber)
         assertEquals(null, overlapLinkedStraightAlignment.segments[0].endJointNumber)
 
         // Previously existing switch segments should stay the same.
-        assertEquals(testLocation.linkedSwitch.id, overlapLinkedStraightAlignment.segments[1].switchId)
+        assertEquals(
+            testLocation.linkedSwitch.id, overlapLinkedStraightAlignment.segments[1].switchId)
         assertEquals(
             testLocation.straightTrackAlignment.segments[1].startJointNumber,
             overlapLinkedStraightAlignment.segments[1].startJointNumber,
@@ -536,7 +608,8 @@ class SwitchLinkingServiceIT @Autowired constructor(
             overlapLinkedStraightAlignment.segments[1].endJointNumber,
         )
 
-        assertEquals(testLocation.linkedSwitch.id, overlapLinkedStraightAlignment.segments[2].switchId)
+        assertEquals(
+            testLocation.linkedSwitch.id, overlapLinkedStraightAlignment.segments[2].switchId)
         assertEquals(
             testLocation.straightTrackAlignment.segments[2].startJointNumber,
             overlapLinkedStraightAlignment.segments[2].startJointNumber,
@@ -548,12 +621,20 @@ class SwitchLinkingServiceIT @Autowired constructor(
 
         // New switch
         assertEquals(newSwitch.id, overlapLinkedStraightAlignment.segments[3].switchId)
-        assertEquals(overlappingSwitchJoints[0].number, overlapLinkedStraightAlignment.segments[3].startJointNumber)
-        assertEquals(overlappingSwitchJoints[1].number, overlapLinkedStraightAlignment.segments[3].endJointNumber)
+        assertEquals(
+            overlappingSwitchJoints[0].number,
+            overlapLinkedStraightAlignment.segments[3].startJointNumber)
+        assertEquals(
+            overlappingSwitchJoints[1].number,
+            overlapLinkedStraightAlignment.segments[3].endJointNumber)
 
         assertEquals(newSwitch.id, overlapLinkedStraightAlignment.segments[4].switchId)
-        assertEquals(overlappingSwitchJoints[1].number, overlapLinkedStraightAlignment.segments[4].startJointNumber)
-        assertEquals(overlappingSwitchJoints[2].number, overlapLinkedStraightAlignment.segments[4].endJointNumber)
+        assertEquals(
+            overlappingSwitchJoints[1].number,
+            overlapLinkedStraightAlignment.segments[4].startJointNumber)
+        assertEquals(
+            overlappingSwitchJoints[2].number,
+            overlapLinkedStraightAlignment.segments[4].endJointNumber)
 
         assertEquals(null, overlapLinkedStraightAlignment.segments[5].switchId)
         assertEquals(null, overlapLinkedStraightAlignment.segments[5].startJointNumber)
@@ -562,94 +643,92 @@ class SwitchLinkingServiceIT @Autowired constructor(
 
     @Test
     fun `Switch linking slight overlap correction should work with multiple overlapping segments`() {
-        val (testLocationTrack, testAlignment) = createDraftLocationTrackFromLayoutSegments(
+        val (testLocationTrack, testAlignment) =
+            createDraftLocationTrackFromLayoutSegments(
+                listOf(
+                    segment(Point(0.0, 0.0), Point(10.0, 0.0)),
+                    segment(Point(10.0, 0.0), Point(20.0, 0.0)),
+                    segment(Point(20.0, 0.0), Point(21.0, 0.0)),
+                    segment(Point(21.0, 0.0), Point(22.0, 0.0)),
+                    segment(Point(22.0, 0.0), Point(23.0, 0.0)),
+                    segment(Point(23.0, 0.0), Point(24.0, 0.0)),
+                    segment(Point(24.0, 0.0), Point(25.0, 0.0)),
+                    segment(Point(25.0, 0.0), Point(40.0, 0.0)),
+                    segment(Point(40.0, 0.0), Point(60.0, 0.0)),
+                    segment(Point(60.0, 0.0), Point(80.0, 0.0)),
+                    segment(Point(80.0, 0.0), Point(90.0, 0.0)),
+                ))
+
+        val existingSwitchJoints =
             listOf(
-                segment(Point(0.0, 0.0), Point(10.0, 0.0)),
-                segment(Point(10.0, 0.0), Point(20.0, 0.0)),
-                segment(Point(20.0, 0.0), Point(21.0, 0.0)),
-                segment(Point(21.0, 0.0), Point(22.0, 0.0)),
-                segment(Point(22.0, 0.0), Point(23.0, 0.0)),
-                segment(Point(23.0, 0.0), Point(24.0, 0.0)),
-                segment(Point(24.0, 0.0), Point(25.0, 0.0)),
-                segment(Point(25.0, 0.0), Point(40.0, 0.0)),
-                segment(Point(40.0, 0.0), Point(60.0, 0.0)),
-                segment(Point(60.0, 0.0), Point(80.0, 0.0)),
-                segment(Point(80.0, 0.0), Point(90.0, 0.0)),
+                FittedSwitchJoint(
+                    JointNumber(1),
+                    Point(21.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 3))),
+                FittedSwitchJoint(
+                    JointNumber(5),
+                    Point(40.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 8))),
+                FittedSwitchJoint(
+                    JointNumber(2),
+                    Point(60.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 9))),
             )
-        )
 
-        val existingSwitchJoints = listOf(
-            FittedSwitchJoint(
-                JointNumber(1),
-                Point(21.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 3))
-            ),
+        val existingSwitch =
+            createAndLinkSwitch(
+                seed = 98765_1,
+                linkedJoints = existingSwitchJoints,
+            )
 
-            FittedSwitchJoint(
-                JointNumber(5),
-                Point(40.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 8))
-            ),
+        val overlappingSwitchJoints =
+            listOf(
+                FittedSwitchJoint(
+                    JointNumber(1),
+                    Point(0.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 0))),
+                FittedSwitchJoint(
+                    JointNumber(5),
+                    Point(10.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 1))),
+                FittedSwitchJoint(
+                    JointNumber(2),
+                    Point(25.0, 0.0),
+                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 7))),
+            )
 
-            FittedSwitchJoint(
-                JointNumber(2),
-                Point(60.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 9))
-            ),
-        )
-
-        val existingSwitch = createAndLinkSwitch(
-            seed = 98765_1,
-            linkedJoints = existingSwitchJoints,
-        )
-
-        val overlappingSwitchJoints = listOf(
-            FittedSwitchJoint(
-                JointNumber(1),
-                Point(0.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 0))
-            ),
-
-            FittedSwitchJoint(
-                JointNumber(5),
-                Point(10.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 1))
-            ),
-
-            FittedSwitchJoint(
-                JointNumber(2),
-                Point(25.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 7))
-            ),
-        )
-
-        val linkedSwitchWithOverlap = createAndLinkSwitch(
-            seed = 98765_2,
-            linkedJoints = overlappingSwitchJoints,
-        )
+        val linkedSwitchWithOverlap =
+            createAndLinkSwitch(
+                seed = 98765_2,
+                linkedJoints = overlappingSwitchJoints,
+            )
 
         val (_, linkedTestAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocationTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.draft, testLocationTrack.id as IntId)
 
         assertEquals(testAlignment.segments.size, linkedTestAlignment.segments.size)
 
-        assertEquals(existingSwitchJoints[0].number, linkedTestAlignment.segments[0].startJointNumber)
+        assertEquals(
+            existingSwitchJoints[0].number, linkedTestAlignment.segments[0].startJointNumber)
         assertEquals(existingSwitchJoints[1].number, linkedTestAlignment.segments[0].endJointNumber)
 
-        assertEquals(existingSwitchJoints[1].number, linkedTestAlignment.segments[1].startJointNumber)
+        assertEquals(
+            existingSwitchJoints[1].number, linkedTestAlignment.segments[1].startJointNumber)
         assertEquals(null, linkedTestAlignment.segments[1].endJointNumber)
 
         assertEquals(null, linkedTestAlignment.segments[2].startJointNumber)
         assertEquals(existingSwitchJoints[2].number, linkedTestAlignment.segments[2].endJointNumber)
 
         (0..2).forEach { segmentIndex ->
-            assertEquals(linkedSwitchWithOverlap.id, linkedTestAlignment.segments[segmentIndex].switchId)
+            assertEquals(
+                linkedSwitchWithOverlap.id, linkedTestAlignment.segments[segmentIndex].switchId)
         }
 
         (3..9).forEach { segmentIndex ->
@@ -661,13 +740,17 @@ class SwitchLinkingServiceIT @Autowired constructor(
             assertEquals(null, linkedTestAlignment.segments[segmentIndex].endJointNumber)
         }
 
-        assertEquals(overlappingSwitchJoints[0].number, linkedTestAlignment.segments[3].startJointNumber)
+        assertEquals(
+            overlappingSwitchJoints[0].number, linkedTestAlignment.segments[3].startJointNumber)
         assertEquals(null, linkedTestAlignment.segments[3].endJointNumber)
 
-        assertEquals(overlappingSwitchJoints[1].number, linkedTestAlignment.segments[8].startJointNumber)
-        assertEquals(overlappingSwitchJoints[2].number, linkedTestAlignment.segments[8].endJointNumber)
+        assertEquals(
+            overlappingSwitchJoints[1].number, linkedTestAlignment.segments[8].startJointNumber)
+        assertEquals(
+            overlappingSwitchJoints[2].number, linkedTestAlignment.segments[8].endJointNumber)
 
-        assertEquals(overlappingSwitchJoints[2].number, linkedTestAlignment.segments[9].startJointNumber)
+        assertEquals(
+            overlappingSwitchJoints[2].number, linkedTestAlignment.segments[9].startJointNumber)
         assertEquals(null, linkedTestAlignment.segments[9].endJointNumber)
 
         assertEquals(null, linkedTestAlignment.segments[10].switchId)
@@ -680,11 +763,136 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val overlapAmount = 4.99
 
         listOf(
-            Triple(JointNumber(1), JointNumber(5), JointNumber(2)),
-            Triple(JointNumber(2), JointNumber(5), JointNumber(1)),
-        ).forEachIndexed { index, (firstJointNumber, secondJointNumber, thirdJointNumber) ->
+                Triple(JointNumber(1), JointNumber(5), JointNumber(2)),
+                Triple(JointNumber(2), JointNumber(5), JointNumber(1)),
+            )
+            .forEachIndexed { index, (firstJointNumber, secondJointNumber, thirdJointNumber) ->
+                val (testLocationTrack, testAlignment) =
+                    createDraftLocationTrackFromLayoutSegments(
+                        listOf(
+                            segment(Point(0.0, 0.0), Point(20.0, 0.0)),
+                            segment(Point(20.0, 0.0), Point(40.0, 0.0)),
+                            segment(Point(40.0, 0.0), Point(60.0, 0.0)),
+                            segment(Point(60.0, 0.0), Point(80.0, 0.0)),
+                            segment(Point(80.0, 0.0), Point(100.0, 0.0)),
+                            segment(Point(100.0, 0.0), Point(120.0, 0.0)),
+                        ))
 
-            val (testLocationTrack, testAlignment) = createDraftLocationTrackFromLayoutSegments(
+                val existingSwitchJoints =
+                    listOf(
+                        FittedSwitchJoint(
+                            JointNumber(1),
+                            Point(20.0, 0.0),
+                            LocationAccuracy.DESIGNED_GEOLOCATION,
+                            matches =
+                                listOf(
+                                    switchLinkingAtStart(testLocationTrack.id, testAlignment, 1))),
+                        FittedSwitchJoint(
+                            JointNumber(5),
+                            Point(40.0, 0.0),
+                            LocationAccuracy.DESIGNED_GEOLOCATION,
+                            matches =
+                                listOf(
+                                    switchLinkingAtStart(testLocationTrack.id, testAlignment, 2))),
+                        FittedSwitchJoint(
+                            JointNumber(2),
+                            Point(60.0, 0.0),
+                            LocationAccuracy.DESIGNED_GEOLOCATION,
+                            matches =
+                                listOf(switchLinkingAtEnd(testLocationTrack.id, testAlignment, 2))))
+
+                val existingLayoutSwitch =
+                    createAndLinkSwitch(
+                        seed = index,
+                        linkedJoints = existingSwitchJoints,
+                    )
+
+                val linkedSwitchWithOverlap =
+                    createAndLinkSwitch(
+                        seed = 1000 + index,
+                        linkedJoints =
+                            listOf(
+                                FittedSwitchJoint(
+                                    firstJointNumber,
+                                    Point(60.0 - overlapAmount, 0.0),
+                                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                                    matches =
+                                        listOf(
+                                            suggestedSwitchJointMatch(
+                                                locationTrackId = testLocationTrack.id as IntId,
+                                                segmentIndex = 2,
+                                                m = testAlignment.segments[2].endM - overlapAmount,
+                                            ),
+                                        ),
+                                ),
+                                FittedSwitchJoint(
+                                    secondJointNumber,
+                                    Point(80.0, 0.0),
+                                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                                    matches =
+                                        listOf(
+                                            switchLinkingAtStart(
+                                                testLocationTrack.id, testAlignment, 4))),
+                                FittedSwitchJoint(
+                                    thirdJointNumber,
+                                    Point(100.0, 0.0),
+                                    LocationAccuracy.DESIGNED_GEOLOCATION,
+                                    matches =
+                                        listOf(
+                                            switchLinkingAtStart(
+                                                testLocationTrack.id, testAlignment, 5))),
+                            ),
+                    )
+
+                val (_, linkedTestAlignment) =
+                    locationTrackService.getWithAlignmentOrThrow(
+                        MainLayoutContext.draft, testLocationTrack.id as IntId)
+
+                assertEquals(null, linkedTestAlignment.segments[0].switchId)
+                assertEquals(null, linkedTestAlignment.segments[0].startJointNumber)
+                assertEquals(null, linkedTestAlignment.segments[0].endJointNumber)
+
+                (1..2).forEach { segmentIndex ->
+                    assertEquals(
+                        existingLayoutSwitch.id,
+                        linkedTestAlignment.segments[segmentIndex].switchId)
+                }
+
+                assertEquals(
+                    existingSwitchJoints[0].number,
+                    linkedTestAlignment.segments[1].startJointNumber)
+                assertEquals(
+                    existingSwitchJoints[1].number, linkedTestAlignment.segments[1].endJointNumber)
+
+                assertEquals(
+                    existingSwitchJoints[1].number,
+                    linkedTestAlignment.segments[2].startJointNumber)
+                assertEquals(
+                    existingSwitchJoints[2].number, linkedTestAlignment.segments[2].endJointNumber)
+
+                (3..5).forEach { segmentIndex ->
+                    assertEquals(
+                        linkedSwitchWithOverlap.id,
+                        linkedTestAlignment.segments[segmentIndex].switchId)
+                }
+
+                assertEquals(firstJointNumber, linkedTestAlignment.segments[3].startJointNumber)
+                assertEquals(secondJointNumber, linkedTestAlignment.segments[3].endJointNumber)
+
+                assertEquals(secondJointNumber, linkedTestAlignment.segments[4].startJointNumber)
+                assertEquals(thirdJointNumber, linkedTestAlignment.segments[4].endJointNumber)
+
+                assertEquals(thirdJointNumber, linkedTestAlignment.segments[5].startJointNumber)
+                assertEquals(null, linkedTestAlignment.segments[5].endJointNumber)
+            }
+    }
+
+    @Test
+    fun `Switch linking slight overlap correction should override the original switch when the overlap correction limit is exceeded`() {
+        val moreThanAllowedOverlap = 5.01
+
+        val (testLocationTrack, testAlignment) =
+            createDraftLocationTrackFromLayoutSegments(
                 listOf(
                     segment(Point(0.0, 0.0), Point(20.0, 0.0)),
                     segment(Point(20.0, 0.0), Point(40.0, 0.0)),
@@ -692,187 +900,85 @@ class SwitchLinkingServiceIT @Autowired constructor(
                     segment(Point(60.0, 0.0), Point(80.0, 0.0)),
                     segment(Point(80.0, 0.0), Point(100.0, 0.0)),
                     segment(Point(100.0, 0.0), Point(120.0, 0.0)),
-                )
+                ))
+
+        val linkedSwitch =
+            createAndLinkSwitch(
+                seed = 98765_1,
+                linkedJoints =
+                    listOf(
+                        FittedSwitchJoint(
+                            JointNumber(1),
+                            Point(20.0, 0.0),
+                            LocationAccuracy.DESIGNED_GEOLOCATION,
+                            matches =
+                                listOf(
+                                    switchLinkingAtStart(testLocationTrack.id, testAlignment, 1))),
+                        FittedSwitchJoint(
+                            JointNumber(5),
+                            Point(40.0, 0.0),
+                            LocationAccuracy.DESIGNED_GEOLOCATION,
+                            matches =
+                                listOf(
+                                    switchLinkingAtStart(testLocationTrack.id, testAlignment, 2))),
+                        FittedSwitchJoint(
+                            JointNumber(2),
+                            Point(60.0, 0.0),
+                            LocationAccuracy.DESIGNED_GEOLOCATION,
+                            matches =
+                                listOf(switchLinkingAtEnd(testLocationTrack.id, testAlignment, 2))),
+                    ),
             )
 
-            val existingSwitchJoints = listOf(
+        val (_, linkedTestAlignmentBeforeTryingOverlap) =
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.draft, testLocationTrack.id as IntId)
+
+        (1..2).forEach { segmentIndex ->
+            assertEquals(
+                linkedSwitch.id,
+                linkedTestAlignmentBeforeTryingOverlap.segments[segmentIndex].switchId)
+        }
+
+        val jointsForSwitchWithTooMuchOverlap =
+            listOf(
                 FittedSwitchJoint(
                     JointNumber(1),
-                    Point(20.0, 0.0),
+                    Point(60.0 - moreThanAllowedOverlap, 0.0),
                     LocationAccuracy.DESIGNED_GEOLOCATION,
-                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 1))
-                ),
-
-                FittedSwitchJoint(
-                    JointNumber(5),
-                    Point(40.0, 0.0),
-                    LocationAccuracy.DESIGNED_GEOLOCATION,
-                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 2))
-                ),
-
-                FittedSwitchJoint(
-                    JointNumber(2),
-                    Point(60.0, 0.0),
-                    LocationAccuracy.DESIGNED_GEOLOCATION,
-                    matches = listOf(switchLinkingAtEnd(testLocationTrack.id, testAlignment, 2))
-                )
-            )
-
-            val existingLayoutSwitch = createAndLinkSwitch(
-                seed = index,
-                linkedJoints = existingSwitchJoints,
-            )
-
-            val linkedSwitchWithOverlap = createAndLinkSwitch(
-                seed = 1000 + index,
-                linkedJoints = listOf(
-                    FittedSwitchJoint(
-                        firstJointNumber,
-                        Point(60.0 - overlapAmount, 0.0),
-                        LocationAccuracy.DESIGNED_GEOLOCATION,
-                        matches = listOf(
+                    matches =
+                        listOf(
                             suggestedSwitchJointMatch(
                                 locationTrackId = testLocationTrack.id as IntId,
                                 segmentIndex = 2,
-                                m = testAlignment.segments[2].endM - overlapAmount,
+                                m = testAlignment.segments[2].endM - moreThanAllowedOverlap,
                             ),
                         ),
-                    ),
-
-                    FittedSwitchJoint(
-                        secondJointNumber,
-                        Point(80.0, 0.0),
-                        LocationAccuracy.DESIGNED_GEOLOCATION,
-                        matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 4))
-                    ),
-
-                    FittedSwitchJoint(
-                        thirdJointNumber,
-                        Point(100.0, 0.0),
-                        LocationAccuracy.DESIGNED_GEOLOCATION,
-                        matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 5))
-                    ),
                 ),
-            )
-
-            val (_, linkedTestAlignment) =
-                locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocationTrack.id as IntId)
-
-            assertEquals(null, linkedTestAlignment.segments[0].switchId)
-            assertEquals(null, linkedTestAlignment.segments[0].startJointNumber)
-            assertEquals(null, linkedTestAlignment.segments[0].endJointNumber)
-
-            (1..2).forEach { segmentIndex ->
-                assertEquals(existingLayoutSwitch.id, linkedTestAlignment.segments[segmentIndex].switchId)
-            }
-
-            assertEquals(existingSwitchJoints[0].number, linkedTestAlignment.segments[1].startJointNumber)
-            assertEquals(existingSwitchJoints[1].number, linkedTestAlignment.segments[1].endJointNumber)
-
-            assertEquals(existingSwitchJoints[1].number, linkedTestAlignment.segments[2].startJointNumber)
-            assertEquals(existingSwitchJoints[2].number, linkedTestAlignment.segments[2].endJointNumber)
-
-            (3..5).forEach { segmentIndex ->
-                assertEquals(linkedSwitchWithOverlap.id, linkedTestAlignment.segments[segmentIndex].switchId)
-            }
-
-            assertEquals(firstJointNumber, linkedTestAlignment.segments[3].startJointNumber)
-            assertEquals(secondJointNumber, linkedTestAlignment.segments[3].endJointNumber)
-
-            assertEquals(secondJointNumber, linkedTestAlignment.segments[4].startJointNumber)
-            assertEquals(thirdJointNumber, linkedTestAlignment.segments[4].endJointNumber)
-
-            assertEquals(thirdJointNumber, linkedTestAlignment.segments[5].startJointNumber)
-            assertEquals(null, linkedTestAlignment.segments[5].endJointNumber)
-        }
-    }
-
-    @Test
-    fun `Switch linking slight overlap correction should override the original switch when the overlap correction limit is exceeded`() {
-        val moreThanAllowedOverlap = 5.01
-
-        val (testLocationTrack, testAlignment) = createDraftLocationTrackFromLayoutSegments(
-            listOf(
-                segment(Point(0.0, 0.0), Point(20.0, 0.0)),
-                segment(Point(20.0, 0.0), Point(40.0, 0.0)),
-                segment(Point(40.0, 0.0), Point(60.0, 0.0)),
-                segment(Point(60.0, 0.0), Point(80.0, 0.0)),
-                segment(Point(80.0, 0.0), Point(100.0, 0.0)),
-                segment(Point(100.0, 0.0), Point(120.0, 0.0)),
-            )
-        )
-
-        val linkedSwitch = createAndLinkSwitch(
-            seed = 98765_1,
-            linkedJoints = listOf(
-                FittedSwitchJoint(
-                    JointNumber(1),
-                    Point(20.0, 0.0),
-                    LocationAccuracy.DESIGNED_GEOLOCATION,
-                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 1))
-                ),
-
                 FittedSwitchJoint(
                     JointNumber(5),
-                    Point(40.0, 0.0),
+                    Point(80.0, 0.0),
                     LocationAccuracy.DESIGNED_GEOLOCATION,
-                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 2))
-                ),
-
+                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 4))),
                 FittedSwitchJoint(
                     JointNumber(2),
-                    Point(60.0, 0.0),
+                    Point(100.0, 0.0),
                     LocationAccuracy.DESIGNED_GEOLOCATION,
-                    matches = listOf(switchLinkingAtEnd(testLocationTrack.id, testAlignment, 2))
-                ),
-            ),
-        )
+                    matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 5))),
+            )
 
-        val (_, linkedTestAlignmentBeforeTryingOverlap) =
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocationTrack.id as IntId)
-
-        (1..2).forEach { segmentIndex ->
-            assertEquals(linkedSwitch.id, linkedTestAlignmentBeforeTryingOverlap.segments[segmentIndex].switchId)
-        }
-
-        val jointsForSwitchWithTooMuchOverlap = listOf(
-            FittedSwitchJoint(
-                JointNumber(1),
-                Point(60.0 - moreThanAllowedOverlap, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(
-                    suggestedSwitchJointMatch(
-                        locationTrackId = testLocationTrack.id as IntId,
-                        segmentIndex = 2,
-                        m = testAlignment.segments[2].endM - moreThanAllowedOverlap,
-                    ),
-                ),
-            ),
-
-            FittedSwitchJoint(
-                JointNumber(5),
-                Point(80.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 4))
-            ),
-
-            FittedSwitchJoint(
-                JointNumber(2),
-                Point(100.0, 0.0),
-                LocationAccuracy.DESIGNED_GEOLOCATION,
-                matches = listOf(switchLinkingAtStart(testLocationTrack.id, testAlignment, 5))
-            ),
-        )
-
-        val linkedSwitchWithTooMuchOverlap = createAndLinkSwitch(
-            seed = 98765_2,
-            linkedJoints = jointsForSwitchWithTooMuchOverlap,
-        )
+        val linkedSwitchWithTooMuchOverlap =
+            createAndLinkSwitch(
+                seed = 98765_2,
+                linkedJoints = jointsForSwitchWithTooMuchOverlap,
+            )
 
         val (_, linkedTestAlignment) =
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, testLocationTrack.id as IntId)
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.draft, testLocationTrack.id as IntId)
 
-        // The original alignment is expected to have been split at the desired starting point of the new switch,
+        // The original alignment is expected to have been split at the desired starting point of
+        // the new switch,
         // as it was not possible to snap it to a nearby segment without overlap.
         assertEquals(testAlignment.segments.size + 1, linkedTestAlignment.segments.size)
 
@@ -881,19 +987,29 @@ class SwitchLinkingServiceIT @Autowired constructor(
         }
 
         (3..6).forEach { segmentIndex ->
-            assertEquals(linkedSwitchWithTooMuchOverlap.id, linkedTestAlignment.segments[segmentIndex].switchId)
+            assertEquals(
+                linkedSwitchWithTooMuchOverlap.id,
+                linkedTestAlignment.segments[segmentIndex].switchId)
         }
 
-        assertEquals(jointsForSwitchWithTooMuchOverlap[0].number, linkedTestAlignment.segments[3].startJointNumber)
+        assertEquals(
+            jointsForSwitchWithTooMuchOverlap[0].number,
+            linkedTestAlignment.segments[3].startJointNumber)
         assertEquals(null, linkedTestAlignment.segments[4].endJointNumber)
 
         assertEquals(null, linkedTestAlignment.segments[4].startJointNumber)
         assertEquals(null, linkedTestAlignment.segments[4].endJointNumber)
 
-        assertEquals(jointsForSwitchWithTooMuchOverlap[1].number, linkedTestAlignment.segments[5].startJointNumber)
-        assertEquals(jointsForSwitchWithTooMuchOverlap[2].number, linkedTestAlignment.segments[5].endJointNumber)
+        assertEquals(
+            jointsForSwitchWithTooMuchOverlap[1].number,
+            linkedTestAlignment.segments[5].startJointNumber)
+        assertEquals(
+            jointsForSwitchWithTooMuchOverlap[2].number,
+            linkedTestAlignment.segments[5].endJointNumber)
 
-        assertEquals(jointsForSwitchWithTooMuchOverlap[2].number, linkedTestAlignment.segments[6].startJointNumber)
+        assertEquals(
+            jointsForSwitchWithTooMuchOverlap[2].number,
+            linkedTestAlignment.segments[6].startJointNumber)
         assertEquals(null, linkedTestAlignment.segments[6].endJointNumber)
     }
 
@@ -901,108 +1017,141 @@ class SwitchLinkingServiceIT @Autowired constructor(
         source: LayoutSegment,
         switchId: DomainId<TrackLayoutSwitch>?,
         shiftVector: Point,
-    ): LayoutSegment = source.copy(
-        geometry = SegmentGeometry(
-            source.geometry.resolution,
-            source.geometry.segmentPoints.map { sp -> sp.copy(x = sp.x + shiftVector.x, y = sp.y + shiftVector.y) },
-        ),
-        switchId = switchId,
-        startJointNumber = if (switchId == null) null else JointNumber(1),
-        endJointNumber = null,
-    )
+    ): LayoutSegment =
+        source.copy(
+            geometry =
+                SegmentGeometry(
+                    source.geometry.resolution,
+                    source.geometry.segmentPoints.map { sp ->
+                        sp.copy(x = sp.x + shiftVector.x, y = sp.y + shiftVector.y)
+                    },
+                ),
+            switchId = switchId,
+            startJointNumber = if (switchId == null) null else JointNumber(1),
+            endJointNumber = null,
+        )
 
-    private fun shiftSwitch(source: TrackLayoutSwitch, name: String, shiftVector: Point) = source.copy(
-        contextData = LayoutContextData.newOfficial(LayoutBranch.main),
-        joints = source.joints.map { joint -> joint.copy(location = joint.location + shiftVector) },
-        name = SwitchName(name)
-    )
+    private fun shiftSwitch(source: TrackLayoutSwitch, name: String, shiftVector: Point) =
+        source.copy(
+            contextData = LayoutContextData.newOfficial(LayoutBranch.main),
+            joints =
+                source.joints.map { joint -> joint.copy(location = joint.location + shiftVector) },
+            name = SwitchName(name))
 
-    private fun shiftTrack(template: List<LayoutSegment>, switchId: DomainId<TrackLayoutSwitch>?, shiftVector: Point) =
-        template.map { segment -> shiftSegmentGeometry(segment, switchId, shiftVector)}
+    private fun shiftTrack(
+        template: List<LayoutSegment>,
+        switchId: DomainId<TrackLayoutSwitch>?,
+        shiftVector: Point
+    ) = template.map { segment -> shiftSegmentGeometry(segment, switchId, shiftVector) }
 
     @Test
     fun `validateRelinkingTrack relinks okay cases and gives validation errors about bad ones`() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
-        ).id
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
+                )
+                .id
 
-        // slightly silly way to make a through track with several switches on a track: Start with a template and
+        // slightly silly way to make a through track with several switches on a track: Start with a
+        // template and
         // paste it over several times
-        val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
-        val (templateSwitch, templateTrackSections) = switchAndMatchingAlignments(
-            trackNumberId = trackNumberId,
-            structure = switchStructure,
-            draft = false,
-        )
+        val switchStructure =
+            switchLibraryService.getSwitchStructures().find {
+                it.type.typeName == "YV60-300-1:9-O"
+            }!!
+        val (templateSwitch, templateTrackSections) =
+            switchAndMatchingAlignments(
+                trackNumberId = trackNumberId,
+                structure = switchStructure,
+                draft = false,
+            )
         val templateThroughTrackSegments = templateTrackSections[0].second.segments
         val templateBranchingTrackSegments = templateTrackSections[1].second.segments
         val shift0 = Point(0.0, 0.0)
-        val shift1 = templateThroughTrackSegments.last().segmentPoints.last().let { p -> Point(p.x, p.y) } + Point(10.0, 0.0)
+        val shift1 =
+            templateThroughTrackSegments.last().segmentPoints.last().let { p -> Point(p.x, p.y) } +
+                Point(10.0, 0.0)
         val shift2 = shift1 + shift1
 
-        // through track has three switches; first one is linked OK, second one is linkable but will cause a validation
-        // error as the only branching track is a duplicate, third one can't be linked as there is no branching track
+        // through track has three switches; first one is linked OK, second one is linkable but will
+        // cause a validation
+        // error as the only branching track is a duplicate, third one can't be linked as there is
+        // no branching track
         val okSwitch = switchDao.insert(shiftSwitch(templateSwitch, "ok", shift0))
-        val okButValidationErrorSwitch = switchDao.insert(shiftSwitch(templateSwitch, "ok but val", shift1))
+        val okButValidationErrorSwitch =
+            switchDao.insert(shiftSwitch(templateSwitch, "ok but val", shift1))
         val unsaveableSwitch = switchDao.insert(shiftSwitch(templateSwitch, "unsaveable", shift2))
 
-        val throughTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "through track", draft = true),
-            alignment(
-                pasteTrackSegmentsWithSpacers(
-                    listOf(
-                        listOf(segment(Point(0.0, 0.0), Point(1.0, 0.0))),
-                        setSwitchId(templateThroughTrackSegments, okSwitch.id),
-                        setSwitchId(templateThroughTrackSegments, okButValidationErrorSwitch.id),
-                        setSwitchId(templateThroughTrackSegments, unsaveableSwitch.id)
-                    ),
-                    Point(10.0, 0.0),
-                    Point(-11.0, 0.0),
-                ).flatten()
-            )
-        )
+        val throughTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, name = "through track", draft = true),
+                alignment(
+                    pasteTrackSegmentsWithSpacers(
+                            listOf(
+                                listOf(segment(Point(0.0, 0.0), Point(1.0, 0.0))),
+                                setSwitchId(templateThroughTrackSegments, okSwitch.id),
+                                setSwitchId(
+                                    templateThroughTrackSegments, okButValidationErrorSwitch.id),
+                                setSwitchId(templateThroughTrackSegments, unsaveableSwitch.id)),
+                            Point(10.0, 0.0),
+                            Point(-11.0, 0.0),
+                        )
+                        .flatten()))
 
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId, name = "ok branching track", draft = true),
-            alignment(shiftTrack(templateBranchingTrackSegments, null, shift0))
-        )
+            alignment(shiftTrack(templateBranchingTrackSegments, null, shift0)))
         // linkable, but will cause a validation error due to being wrongly marked as a duplicate
         locationTrackService.saveDraft(
             LayoutBranch.main,
-            locationTrack(trackNumberId, name = "bad branching track", duplicateOf = throughTrack.id, draft = true),
-            alignment(shiftTrack(templateBranchingTrackSegments, null, shift1))
-        )
-        val validationResult = switchLinkingService.validateRelinkingTrack(LayoutBranch.main, throughTrack.id)
+            locationTrack(
+                trackNumberId,
+                name = "bad branching track",
+                duplicateOf = throughTrack.id,
+                draft = true),
+            alignment(shiftTrack(templateBranchingTrackSegments, null, shift1)))
+        val validationResult =
+            switchLinkingService.validateRelinkingTrack(LayoutBranch.main, throughTrack.id)
         assertEqualsRounded(
             listOf(
                 SwitchRelinkingValidationResult(
                     id = okSwitch.id,
-                    successfulSuggestion = SwitchRelinkingSuggestion(Point(0.0, 0.0), TrackMeter("0000+0000.000")),
+                    successfulSuggestion =
+                        SwitchRelinkingSuggestion(Point(0.0, 0.0), TrackMeter("0000+0000.000")),
                     validationIssues = listOf(),
                 ),
                 SwitchRelinkingValidationResult(
                     id = okButValidationErrorSwitch.id,
-                    successfulSuggestion = SwitchRelinkingSuggestion(shift1, TrackMeter("0000+0044.430")),
-                    validationIssues = listOf(
-                        LayoutValidationIssue(
-                            type = LayoutValidationIssueType.WARNING,
-                            localizationKey = LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-only-connected-to-duplicate"),
-                            params = LocalizationParams(mapOf("locationTracks" to "1-3", "switch" to "ok but val")),
-                        )
-                    ),
+                    successfulSuggestion =
+                        SwitchRelinkingSuggestion(shift1, TrackMeter("0000+0044.430")),
+                    validationIssues =
+                        listOf(
+                            LayoutValidationIssue(
+                                type = LayoutValidationIssueType.WARNING,
+                                localizationKey =
+                                    LocalizationKey(
+                                        "validation.layout.switch.track-linkage.switch-alignment-only-connected-to-duplicate"),
+                                params =
+                                    LocalizationParams(
+                                        mapOf("locationTracks" to "1-3", "switch" to "ok but val")),
+                            )),
                 ),
                 SwitchRelinkingValidationResult(
                     id = unsaveableSwitch.id,
                     successfulSuggestion = null,
-                    validationIssues = listOf(
-                        LayoutValidationIssue(
-                            type = LayoutValidationIssueType.ERROR,
-                            localizationKey = LocalizationKey("validation.layout.switch.track-linkage.relinking-failed"),
-                            params = LocalizationParams(mapOf("switch" to "unsaveable")),
+                    validationIssues =
+                        listOf(
+                            LayoutValidationIssue(
+                                type = LayoutValidationIssueType.ERROR,
+                                localizationKey =
+                                    LocalizationKey(
+                                        "validation.layout.switch.track-linkage.relinking-failed"),
+                                params = LocalizationParams(mapOf("switch" to "unsaveable")),
+                            ),
                         ),
-                    ),
                 ),
             ),
             validationResult,
@@ -1011,131 +1160,154 @@ class SwitchLinkingServiceIT @Autowired constructor(
 
     @Test
     fun `relinkTrack and validateRelinkingTrack find nearby switches`() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
-        ).id
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
+                )
+                .id
 
-        val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
-        val (templateSwitch, templateTrackSections) = switchAndMatchingAlignments(trackNumberId, switchStructure, draft = false)
+        val switchStructure =
+            switchLibraryService.getSwitchStructures().find {
+                it.type.typeName == "YV60-300-1:9-O"
+            }!!
+        val (templateSwitch, templateTrackSections) =
+            switchAndMatchingAlignments(trackNumberId, switchStructure, draft = false)
         val templateThroughTrackSegments = templateTrackSections[0].second.segments
         val templateBranchingTrackSegments = templateTrackSections[1].second.segments
-        val track152 = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "track152", draft = true), alignment(
-                listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))) + shiftTrack(
-                    templateThroughTrackSegments,
-                    null,
-                    Point(10.0, 0.0)
-                )
-            )
-        ).id
+        val track152 =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumberId, name = "track152", draft = true),
+                    alignment(
+                        listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))) +
+                            shiftTrack(templateThroughTrackSegments, null, Point(10.0, 0.0))))
+                .id
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId, name = "track13", draft = true),
-            alignment(shiftTrack(templateBranchingTrackSegments, null, Point(10.0, 0.0)))
-        )
+            alignment(shiftTrack(templateBranchingTrackSegments, null, Point(10.0, 0.0))))
         val okSwitch = switchDao.insert(shiftSwitch(templateSwitch, "ok", Point(10.0, 0.0)))
 
-        val validationResult = switchLinkingService.validateRelinkingTrack(LayoutBranch.main, track152)
+        val validationResult =
+            switchLinkingService.validateRelinkingTrack(LayoutBranch.main, track152)
         val relinkingResult = switchLinkingService.relinkTrack(LayoutBranch.main, track152)
         assertEquals(
             listOf(
                 SwitchRelinkingValidationResult(
-                    okSwitch.id, SwitchRelinkingSuggestion(Point(10.0, 0.0), TrackMeter("0000+0010.000")), listOf()
-                )
-            ),
+                    okSwitch.id,
+                    SwitchRelinkingSuggestion(Point(10.0, 0.0), TrackMeter("0000+0010.000")),
+                    listOf())),
             validationResult,
         )
         assertEquals(
-            listOf(TrackSwitchRelinkingResult(okSwitch.id, TrackSwitchRelinkingResultType.RELINKED)),
+            listOf(
+                TrackSwitchRelinkingResult(okSwitch.id, TrackSwitchRelinkingResultType.RELINKED)),
             relinkingResult,
         )
     }
 
     @Test
     fun `validateRelinkingTrack relinks switches that don't end up linked to the original track as well`() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
-        ).id
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
+                )
+                .id
 
-        val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
-        val (templateSwitch, templateTrackSections) = switchAndMatchingAlignments(
-            trackNumberId = trackNumberId,
-            structure = switchStructure,
-            draft = true,
-        )
+        val switchStructure =
+            switchLibraryService.getSwitchStructures().find {
+                it.type.typeName == "YV60-300-1:9-O"
+            }!!
+        val (templateSwitch, templateTrackSections) =
+            switchAndMatchingAlignments(
+                trackNumberId = trackNumberId,
+                structure = switchStructure,
+                draft = true,
+            )
         val templateThroughTrackSegments = templateTrackSections[0].second.segments
         val templateBranchingTrackSegments = templateTrackSections[1].second.segments
         val basePoint = Point(10.0, 0.0)
         val somewhereElse = Point(100.0, 100.0)
 
-        // we'll be linking topoTrack, which currently has a link to a switch that's actually somewhere completely
-        // different, so once it gets relinked, it'll have no match on topoTrack (it's immaterial that the link happens
+        // we'll be linking topoTrack, which currently has a link to a switch that's actually
+        // somewhere completely
+        // different, so once it gets relinked, it'll have no match on topoTrack (it's immaterial
+        // that the link happens
         // to be topological; the important thing is the misplaced switch)
         val okSwitch = switchDao.insert(shiftSwitch(templateSwitch, "ok", basePoint))
-        val switchSomewhereElse = switchDao.insert(shiftSwitch(templateSwitch, "somewhere else", somewhereElse))
+        val switchSomewhereElse =
+            switchDao.insert(shiftSwitch(templateSwitch, "somewhere else", somewhereElse))
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId, name = "track152", draft = true),
-            alignment(shiftTrack(templateThroughTrackSegments, okSwitch.id, basePoint))
-        )
+            alignment(shiftTrack(templateThroughTrackSegments, okSwitch.id, basePoint)))
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId, name = "track13", draft = true),
-            alignment(shiftTrack(templateBranchingTrackSegments, okSwitch.id, basePoint))
-        )
+            alignment(shiftTrack(templateBranchingTrackSegments, okSwitch.id, basePoint)))
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId, name = "some other track152", draft = true),
-            alignment(shiftTrack(templateThroughTrackSegments, null, somewhereElse))
-        )
+            alignment(shiftTrack(templateThroughTrackSegments, null, somewhereElse)))
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId, name = "some other track13", draft = true),
-            alignment(shiftTrack(templateBranchingTrackSegments, okSwitch.id, somewhereElse))
-        )
+            alignment(shiftTrack(templateBranchingTrackSegments, okSwitch.id, somewhereElse)))
 
-        val topoTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "topoTrack",
-                topologyEndSwitch = TopologyLocationTrackSwitch(okSwitch.id, JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(5.0, 0.0),
-                    switchId = switchSomewhereElse.id,
+        val topoTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "topoTrack",
+                    topologyEndSwitch = TopologyLocationTrackSwitch(okSwitch.id, JointNumber(1)),
+                    draft = true,
                 ),
-                segment(Point(5.0, 0.0), basePoint),
-            ),
-        )
-        val validationResult = switchLinkingService.validateRelinkingTrack(LayoutBranch.main, topoTrack.id)
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(5.0, 0.0),
+                        switchId = switchSomewhereElse.id,
+                    ),
+                    segment(Point(5.0, 0.0), basePoint),
+                ),
+            )
+        val validationResult =
+            switchLinkingService.validateRelinkingTrack(LayoutBranch.main, topoTrack.id)
         assertEqualsRounded(
             listOf(
                 SwitchRelinkingValidationResult(
                     id = okSwitch.id,
-                    successfulSuggestion = SwitchRelinkingSuggestion(basePoint, TrackMeter("0000+0010.000")),
-                    validationIssues = listOf(
-                        LayoutValidationIssue(
-                        LayoutValidationIssueType.ERROR,
-                        localizationKey = LocalizationKey("validation.layout.split.track-links-missing-after-relinking"),
-                        params = LocalizationParams(mapOf("switchName" to "ok", "sourceName" to "topoTrack")),
-                    )
-                    ),
+                    successfulSuggestion =
+                        SwitchRelinkingSuggestion(basePoint, TrackMeter("0000+0010.000")),
+                    validationIssues =
+                        listOf(
+                            LayoutValidationIssue(
+                                LayoutValidationIssueType.ERROR,
+                                localizationKey =
+                                    LocalizationKey(
+                                        "validation.layout.split.track-links-missing-after-relinking"),
+                                params =
+                                    LocalizationParams(
+                                        mapOf("switchName" to "ok", "sourceName" to "topoTrack")),
+                            )),
                 ),
                 SwitchRelinkingValidationResult(
                     id = switchSomewhereElse.id,
-                    successfulSuggestion = SwitchRelinkingSuggestion(somewhereElse, TrackMeter("0000+0100.000")),
-                    validationIssues = listOf(
-                        LayoutValidationIssue(
-                            LayoutValidationIssueType.WARNING,
-                            localizationKey = LocalizationKey("validation.layout.switch.track-linkage.front-joint-not-connected"),
-                            params = LocalizationParams(mapOf("switch" to "somewhere else")),
-                        )
-                    ),
+                    successfulSuggestion =
+                        SwitchRelinkingSuggestion(somewhereElse, TrackMeter("0000+0100.000")),
+                    validationIssues =
+                        listOf(
+                            LayoutValidationIssue(
+                                LayoutValidationIssueType.WARNING,
+                                localizationKey =
+                                    LocalizationKey(
+                                        "validation.layout.switch.track-linkage.front-joint-not-connected"),
+                                params = LocalizationParams(mapOf("switch" to "somewhere else")),
+                            )),
                 ),
             ),
             validationResult,
@@ -1144,43 +1316,57 @@ class SwitchLinkingServiceIT @Autowired constructor(
 
     @Test
     fun `re-linking switch cleans up previous references consistently`() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
-        ).id
-        val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
-        val (templateSwitch, templateTrackSections) = switchAndMatchingAlignments(
-            trackNumberId = trackNumberId,
-            structure = switchStructure,
-            draft = false,
-        )
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
+                )
+                .id
+        val switchStructure =
+            switchLibraryService.getSwitchStructures().find {
+                it.type.typeName == "YV60-300-1:9-O"
+            }!!
+        val (templateSwitch, templateTrackSections) =
+            switchAndMatchingAlignments(
+                trackNumberId = trackNumberId,
+                structure = switchStructure,
+                draft = false,
+            )
         val templateThroughTrackSegments = templateTrackSections[0].second.segments
         val branchingTrackSegments = templateTrackSections[1].second.segments
-        val switch = switchDao.insert(templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
-        val throughTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "through track", draft = true),
-            alignment(
-                pasteTrackSegmentsWithSpacers(
-                    listOf(
-                        setSwitchId(templateThroughTrackSegments, switch.id),
-                        setSwitchId(templateThroughTrackSegments, null),
-                    ), Point(100.0, 0.0)
-                ).flatten()
-            ),
-        )
-        val originallyLinkedBranchingTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "originally linked branching track", draft = true),
-            alignment(setSwitchId(branchingTrackSegments, switch.id))
-        )
-        val newBranchingTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "new branching track", draft = true),
-            alignment(shiftTrack(branchingTrackSegments, switch.id, Point(134.321, 0.0)))
-        )
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(134.321, 0.0), switch.id)!!
+        val switch =
+            switchDao.insert(
+                templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
+        val throughTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, name = "through track", draft = true),
+                alignment(
+                    pasteTrackSegmentsWithSpacers(
+                            listOf(
+                                setSwitchId(templateThroughTrackSegments, switch.id),
+                                setSwitchId(templateThroughTrackSegments, null),
+                            ),
+                            Point(100.0, 0.0))
+                        .flatten()),
+            )
+        val originallyLinkedBranchingTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId, name = "originally linked branching track", draft = true),
+                alignment(setSwitchId(branchingTrackSegments, switch.id)))
+        val newBranchingTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, name = "new branching track", draft = true),
+                alignment(shiftTrack(branchingTrackSegments, switch.id, Point(134.321, 0.0))))
+        val suggestedSwitch =
+            switchLinkingService.getSuggestedSwitch(
+                LayoutBranch.main, Point(134.321, 0.0), switch.id)!!
         switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
-        assertTrackDraftVersionSwitchLinks(originallyLinkedBranchingTrack.id, null, null, listOf(0.0..34.3 to null))
+        assertTrackDraftVersionSwitchLinks(
+            originallyLinkedBranchingTrack.id, null, null, listOf(0.0..34.3 to null))
         assertTrackDraftVersionSwitchLinks(
             newBranchingTrack.id,
             null,
@@ -1202,180 +1388,218 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 LayoutBranch.main,
                 Point(123.0, 456.0),
                 switchDao.insert(switch(draft = false)).id,
-            )
-        )
+            ))
     }
 
     @Test
     fun `re-linking switch cleans up topological connections`() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
-        ).id
-        val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "RR54-4x1:9" }!!
-        val (templateSwitch, templateTrackSections) = switchAndMatchingAlignments(
-            trackNumberId = trackNumberId,
-            structure = switchStructure,
-            draft = false,
-        )
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
+                )
+                .id
+        val switchStructure =
+            switchLibraryService.getSwitchStructures().find { it.type.typeName == "RR54-4x1:9" }!!
+        val (templateSwitch, templateTrackSections) =
+            switchAndMatchingAlignments(
+                trackNumberId = trackNumberId,
+                structure = switchStructure,
+                draft = false,
+            )
         val templateOneTwoTrackSegments = templateTrackSections[0].second.segments
         val templateFourThreeTrackSegments = templateTrackSections[1].second.segments
         val oneFive = templateOneTwoTrackSegments[0]
         val fiveTwo = templateOneTwoTrackSegments[1]
-        val switch = switchDao.insert(templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
+        val switch =
+            switchDao.insert(
+                templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
 
-        val oneFiveTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "one-five with topo link",
-                topologyEndSwitch = TopologyLocationTrackSwitch(switch.id, JointNumber(5)),
-                draft = true,
-            ),
-            alignment(setSwitchId(listOf(oneFive), null)),
-        )
+        val oneFiveTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "one-five with topo link",
+                    topologyEndSwitch = TopologyLocationTrackSwitch(switch.id, JointNumber(5)),
+                    draft = true,
+                ),
+                alignment(setSwitchId(listOf(oneFive), null)),
+            )
 
-        val fiveTwoTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "five-two with topo link",
-                topologyStartSwitch = TopologyLocationTrackSwitch(switch.id, JointNumber(5)),
-                draft = true,
-            ),
-            alignment(setSwitchId(listOf(fiveTwo), null)),
-        )
-        val threeFourTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "three-four", draft = true),
-            alignment(setSwitchId(templateFourThreeTrackSegments, switch.id))
-        )
+        val fiveTwoTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "five-two with topo link",
+                    topologyStartSwitch = TopologyLocationTrackSwitch(switch.id, JointNumber(5)),
+                    draft = true,
+                ),
+                alignment(setSwitchId(listOf(fiveTwo), null)),
+            )
+        val threeFourTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, name = "three-four", draft = true),
+                alignment(setSwitchId(templateFourThreeTrackSegments, switch.id)))
 
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(0.0, 0.0), switch.id)!!
+        val suggestedSwitch =
+            switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(0.0, 0.0), switch.id)!!
         switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
 
-        assertTrackDraftVersionSwitchLinks(oneFiveTrack.id, null, null, listOf(0.0..5.2 to switch.id))
-        assertTrackDraftVersionSwitchLinks(fiveTwoTrack.id, null, null, listOf(0.0..5.2 to switch.id))
-        assertTrackDraftVersionSwitchLinks(threeFourTrack.id, null, null, listOf(0.0..10.4 to switch.id))
+        assertTrackDraftVersionSwitchLinks(
+            oneFiveTrack.id, null, null, listOf(0.0..5.2 to switch.id))
+        assertTrackDraftVersionSwitchLinks(
+            fiveTwoTrack.id, null, null, listOf(0.0..5.2 to switch.id))
+        assertTrackDraftVersionSwitchLinks(
+            threeFourTrack.id, null, null, listOf(0.0..10.4 to switch.id))
     }
 
     @Test
     fun `mislinked track with wrong alignment link gets replaced with topology link`() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
-        ).id
-        val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
-        val (templateSwitch, templateTrackSections) = switchAndMatchingAlignments(
-            trackNumberId = trackNumberId,
-            structure = switchStructure,
-            draft = false,
-        )
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
+                )
+                .id
+        val switchStructure =
+            switchLibraryService.getSwitchStructures().find {
+                it.type.typeName == "YV60-300-1:9-O"
+            }!!
+        val (templateSwitch, templateTrackSections) =
+            switchAndMatchingAlignments(
+                trackNumberId = trackNumberId,
+                structure = switchStructure,
+                draft = false,
+            )
         val templateThroughTrackSegments = templateTrackSections[0].second.segments
         val templateBranchingTrackSegments = templateTrackSections[1].second.segments
-        val switch = switchDao.insert(templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
+        val switch =
+            switchDao.insert(
+                templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
         val shift =
-            templateThroughTrackSegments.last().segmentEnd.toPoint() - templateThroughTrackSegments.first().segmentStart.toPoint()
+            templateThroughTrackSegments.last().segmentEnd.toPoint() -
+                templateThroughTrackSegments.first().segmentStart.toPoint()
         val fullShift = shift + Point(100.0, 0.0)
 
-        val throughTrackStart = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "through track start", draft = true), alignment(
-                setSwitchId(templateThroughTrackSegments + listOf(segment(shift, fullShift)), switch.id),
-            )
-        )
-        val throughTrackSwitchAndEnd = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "through track switch and end", draft = true), alignment(
-                shiftTrack(templateThroughTrackSegments, switch.id, fullShift)
-            )
-        )
-        val originallyLinkedBranchingTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "originally linked branching track", draft = true),
-            alignment(setSwitchId(templateBranchingTrackSegments, switch.id))
-        )
-        val newBranchingTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "new branching track", draft = true),
-            alignment(shiftTrack(templateBranchingTrackSegments, switch.id, fullShift))
-        )
+        val throughTrackStart =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, name = "through track start", draft = true),
+                alignment(
+                    setSwitchId(
+                        templateThroughTrackSegments + listOf(segment(shift, fullShift)),
+                        switch.id),
+                ))
+        val throughTrackSwitchAndEnd =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, name = "through track switch and end", draft = true),
+                alignment(shiftTrack(templateThroughTrackSegments, switch.id, fullShift)))
+        val originallyLinkedBranchingTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId, name = "originally linked branching track", draft = true),
+                alignment(setSwitchId(templateBranchingTrackSegments, switch.id)))
+        val newBranchingTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, name = "new branching track", draft = true),
+                alignment(shiftTrack(templateBranchingTrackSegments, switch.id, fullShift)))
 
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, fullShift, switch.id)!!
+        val suggestedSwitch =
+            switchLinkingService.getSuggestedSwitch(LayoutBranch.main, fullShift, switch.id)!!
         switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
 
         assertTrackDraftVersionSwitchLinks(
-            throughTrackStart.id, null, switch.id, listOf(0.0..134.4 to null)
-        )
+            throughTrackStart.id, null, switch.id, listOf(0.0..134.4 to null))
 
         assertTrackDraftVersionSwitchLinks(
-            throughTrackSwitchAndEnd.id, null, null, listOf(0.0..34.4 to switch.id)
-        )
+            throughTrackSwitchAndEnd.id, null, null, listOf(0.0..34.4 to switch.id))
 
         assertTrackDraftVersionSwitchLinks(
-            originallyLinkedBranchingTrack.id, null, null, listOf(0.0..34.3 to null)
-        )
+            originallyLinkedBranchingTrack.id, null, null, listOf(0.0..34.3 to null))
 
         assertTrackDraftVersionSwitchLinks(
-            newBranchingTrack.id, null, null, listOf(0.0..34.3 to switch.id)
-        )
+            newBranchingTrack.id, null, null, listOf(0.0..34.3 to switch.id))
     }
 
     @Test
     fun `relinking moves mislinked topo link to correct switch despite confuser branching track, and does not pointlessly update alignments or tracks`() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
-        ).id
-        val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
-        val (templateSwitch, templateTrackSections) = switchAndMatchingAlignments(
-            trackNumberId = trackNumberId,
-            structure = switchStructure,
-            draft = false,
-        )
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
+                )
+                .id
+        val switchStructure =
+            switchLibraryService.getSwitchStructures().find {
+                it.type.typeName == "YV60-300-1:9-O"
+            }!!
+        val (templateSwitch, templateTrackSections) =
+            switchAndMatchingAlignments(
+                trackNumberId = trackNumberId,
+                structure = switchStructure,
+                draft = false,
+            )
         val templateThroughTrackSegments = templateTrackSections[0].second.segments
         val templateBranchingTrackSegments = templateTrackSections[1].second.segments
-        val switch = switchDao.insert(templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
+        val switch =
+            switchDao.insert(
+                templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
         val someOtherSwitch = switchDao.insert(switch(123, draft = false))
 
         val shift =
-            templateThroughTrackSegments.last().segmentEnd.toPoint() - templateThroughTrackSegments.first().segmentStart.toPoint()
+            templateThroughTrackSegments.last().segmentEnd.toPoint() -
+                templateThroughTrackSegments.first().segmentStart.toPoint()
         val fullShift = shift + Point(100.0, 0.0)
 
-        val throughTrackStart = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "through track start",
-                topologyEndSwitch = TopologyLocationTrackSwitch(someOtherSwitch.id, JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                setSwitchId(templateThroughTrackSegments + listOf(segment(shift, fullShift)), null),
-            )
-        )
+        val throughTrackStart =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "through track start",
+                    topologyEndSwitch =
+                        TopologyLocationTrackSwitch(someOtherSwitch.id, JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(
+                    setSwitchId(
+                        templateThroughTrackSegments + listOf(segment(shift, fullShift)), null),
+                ))
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId, name = "through track switch and end", draft = true),
             alignment(shiftTrack(templateThroughTrackSegments, switch.id, fullShift)),
         )
-        // confuser branching track is misleadingly placed starting at the origin, while the switch is at x=134.43
+        // confuser branching track is misleadingly placed starting at the origin, while the switch
+        // is at x=134.43
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId, name = "branching track", draft = true),
-            alignment(setSwitchId(templateBranchingTrackSegments, switch.id))
-        )
-        val uninvolvedTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "uninvolved track", draft = true),
-            alignment(shiftTrack(templateThroughTrackSegments, null, fullShift - Point(1.0, 1.0))),
-        )
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, fullShift, switch.id)!!
+            alignment(setSwitchId(templateBranchingTrackSegments, switch.id)))
+        val uninvolvedTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, name = "uninvolved track", draft = true),
+                alignment(
+                    shiftTrack(templateThroughTrackSegments, null, fullShift - Point(1.0, 1.0))),
+            )
+        val suggestedSwitch =
+            switchLinkingService.getSuggestedSwitch(LayoutBranch.main, fullShift, switch.id)!!
         switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
 
         assertTrackDraftVersionSwitchLinks(
-            throughTrackStart.id, null, switch.id, listOf(0.0..134.4 to null)
-        )
+            throughTrackStart.id, null, switch.id, listOf(0.0..134.4 to null))
         assertEquals(
             locationTrackDao.fetch(throughTrackStart.rowVersion).alignmentVersion!!,
-            locationTrackDao.getOrThrow(MainLayoutContext.draft, throughTrackStart.id).alignmentVersion!!,
+            locationTrackDao
+                .getOrThrow(MainLayoutContext.draft, throughTrackStart.id)
+                .alignmentVersion!!,
         )
         assertEquals(
             uninvolvedTrack.rowVersion,
@@ -1385,16 +1609,22 @@ class SwitchLinkingServiceIT @Autowired constructor(
 
     @Test
     fun `relinking removes misplaced topological switch link`() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-        ).id
-        val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "RR54-4x1:9" }!!
-        val (templateSwitch, templateTrackSections) = switchAndMatchingAlignments(
-            trackNumberId = trackNumberId,
-            structure = switchStructure,
-            draft = false,
-        )
-        val switch = switchDao.insert(templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
+                .id
+        val switchStructure =
+            switchLibraryService.getSwitchStructures().find { it.type.typeName == "RR54-4x1:9" }!!
+        val (templateSwitch, templateTrackSections) =
+            switchAndMatchingAlignments(
+                trackNumberId = trackNumberId,
+                structure = switchStructure,
+                draft = false,
+            )
+        val switch =
+            switchDao.insert(
+                templateSwitch.copy(contextData = LayoutContextData.newOfficial(LayoutBranch.main)))
         templateTrackSections.forEach { (_, a) ->
             locationTrackService.saveDraft(
                 LayoutBranch.main,
@@ -1402,90 +1632,112 @@ class SwitchLinkingServiceIT @Autowired constructor(
                 alignment(setSwitchId(a.segments, null)),
             )
         }
-        val otherLocationTrackWithTopoSwitchLink = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "unrelated mislinked track",
-                topologyEndSwitch = TopologyLocationTrackSwitch(switch.id, JointNumber(1)),
-                draft = true,
-            ),
-            alignment(segment(Point(456.7, 345.5), Point(457.8, 346.9))),
-        )
-        val suggestedSwitch = switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(0.0, 0.0), switch.id)!!
+        val otherLocationTrackWithTopoSwitchLink =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "unrelated mislinked track",
+                    topologyEndSwitch = TopologyLocationTrackSwitch(switch.id, JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(segment(Point(456.7, 345.5), Point(457.8, 346.9))),
+            )
+        val suggestedSwitch =
+            switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(0.0, 0.0), switch.id)!!
         switchLinkingService.saveSwitchLinking(LayoutBranch.main, suggestedSwitch, switch.id)
         assertTrackDraftVersionSwitchLinks(
-            otherLocationTrackWithTopoSwitchLink.id, null, null, listOf(0.0..1.7 to null)
-        )
+            otherLocationTrackWithTopoSwitchLink.id, null, null, listOf(0.0..1.7 to null))
     }
 
     @Test
     fun `nearby track end not within bounding box of switch joints still gets topologically connected when linking single switch`() {
-        val (_, branchingTrackContinuation, switchId) = setupForLinkingTopoLinkToTrackOutsideSwitchJointBoundingBox()
+        val (_, branchingTrackContinuation, switchId) =
+            setupForLinkingTopoLinkToTrackOutsideSwitchJointBoundingBox()
         switchLinkingService.saveSwitchLinking(
             LayoutBranch.main,
             switchLinkingService.getSuggestedSwitch(LayoutBranch.main, Point(0.0, 0.0), switchId)!!,
             switchId,
         )
         val expected = TopologyLocationTrackSwitch(switchId, JointNumber(3))
-        val actual = locationTrackDao.fetch(
-            locationTrackDao.fetchVersion(MainLayoutContext.draft, branchingTrackContinuation)!!
-        ).topologyStartSwitch
+        val actual =
+            locationTrackDao
+                .fetch(
+                    locationTrackDao.fetchVersion(
+                        MainLayoutContext.draft, branchingTrackContinuation)!!)
+                .topologyStartSwitch
         assertEquals(expected, actual)
     }
 
     @Test
     fun `nearby track end not within bounding box of switch joints still gets topologically connected when linking track`() {
-        val (throughTrack, branchingTrackContinuation, switchId) = setupForLinkingTopoLinkToTrackOutsideSwitchJointBoundingBox()
+        val (throughTrack, branchingTrackContinuation, switchId) =
+            setupForLinkingTopoLinkToTrackOutsideSwitchJointBoundingBox()
         switchLinkingService.relinkTrack(LayoutBranch.main, throughTrack)
         val expected = TopologyLocationTrackSwitch(switchId, JointNumber(3))
-        val actual = locationTrackDao.fetch(
-            locationTrackDao.fetchVersion(MainLayoutContext.draft, branchingTrackContinuation)!!
-        ).topologyStartSwitch
+        val actual =
+            locationTrackDao
+                .fetch(
+                    locationTrackDao.fetchVersion(
+                        MainLayoutContext.draft, branchingTrackContinuation)!!)
+                .topologyStartSwitch
         assertEquals(expected, actual)
     }
 
-    private fun setupForLinkingTopoLinkToTrackOutsideSwitchJointBoundingBox(): Triple<IntId<LocationTrack>, IntId<LocationTrack>, IntId<TrackLayoutSwitch>> {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
-        ).id
+    private fun setupForLinkingTopoLinkToTrackOutsideSwitchJointBoundingBox():
+        Triple<IntId<LocationTrack>, IntId<LocationTrack>, IntId<TrackLayoutSwitch>> {
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    alignment(segment(Point(0.0, 0.0), Point(200.0, 0.0))),
+                )
+                .id
         // switch structure YV60_300_1_9_O's rightmost joints are at x-coords:
         // - 34.430 (through track)
         // - 34.321 (branching track)
-        // so with the branching track's continuation starting at 35, it doesn't fall within the switch's bounding box
-        val switchStructureId = switchLibraryService
-            .getSwitchStructures()
-            .find { it.type.typeName == "YV60-300-1:9-O" }!!.id as IntId
-        val switchId = switchDao.insert(
-            switch(
-                seed = 123,
-                structureId = switchStructureId,
-                joints = listOf(switchJoint(Point(0.0, 0.0))),
-                draft = false,
-            )
-        ).id
-        val throughTrackId = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "through track", draft = true),
-            alignment(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(40.0, 0.0),
-                    switchId = switchId,
-                    startJointNumber = JointNumber(1),
+        // so with the branching track's continuation starting at 35, it doesn't fall within the
+        // switch's bounding box
+        val switchStructureId =
+            switchLibraryService
+                .getSwitchStructures()
+                .find { it.type.typeName == "YV60-300-1:9-O" }!!
+                .id as IntId
+        val switchId =
+            switchDao
+                .insert(
+                    switch(
+                        seed = 123,
+                        structureId = switchStructureId,
+                        joints = listOf(switchJoint(Point(0.0, 0.0))),
+                        draft = false,
+                    ))
+                .id
+        val throughTrackId =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumberId, name = "through track", draft = true),
+                    alignment(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(40.0, 0.0),
+                            switchId = switchId,
+                            startJointNumber = JointNumber(1),
+                        )),
                 )
-            ),
-        ).id
+                .id
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId, name = "branching track start", draft = true),
-            alignment(segment(Point(0.0, 0.0), Point(34.9, -2.0)))
-        )
-        val branchingTrackContinuationId = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, name = "branching track continuation", draft = true),
-            alignment(segment(Point(35.0, -2.0), Point(50.0, -3.0)))
-        ).id
+            alignment(segment(Point(0.0, 0.0), Point(34.9, -2.0))))
+        val branchingTrackContinuationId =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(
+                        trackNumberId, name = "branching track continuation", draft = true),
+                    alignment(segment(Point(35.0, -2.0), Point(50.0, -3.0))))
+                .id
         return Triple(throughTrackId, branchingTrackContinuationId, switchId)
     }
 
@@ -1503,16 +1755,23 @@ class SwitchLinkingServiceIT @Autowired constructor(
         segmentSwitchesByMRange.forEach { (range, switchId) ->
             val rangeStartSegmentIndex = alignment.getSegmentIndexAtM(range.start)
             val rangeEndSegmentIndex = alignment.getSegmentIndexAtM(range.endInclusive)
-            assertEquals(range.start, alignment.segments[rangeStartSegmentIndex].startM, 0.1, "segment range starts at given m-value")
-            assertEquals(range.endInclusive, alignment.segments[rangeEndSegmentIndex].endM, 0.1, "segment range ends at given m-value")
+            assertEquals(
+                range.start,
+                alignment.segments[rangeStartSegmentIndex].startM,
+                0.1,
+                "segment range starts at given m-value")
+            assertEquals(
+                range.endInclusive,
+                alignment.segments[rangeEndSegmentIndex].endM,
+                0.1,
+                "segment range ends at given m-value")
             (rangeStartSegmentIndex..rangeEndSegmentIndex).forEach { i ->
                 assertEquals(
                     switchId,
                     alignment.segments[i].switchId,
                     "switch at segment index $i (asserted m-range ${range.start}..${
                         range.endInclusive
-                    }, segment m-range ${alignment.segments[i].startM}..${alignment.segments[i].endM}"
-                )
+                    }, segment m-range ${alignment.segments[i].startM}..${alignment.segments[i].endM}")
             }
         }
     }
@@ -1525,26 +1784,30 @@ class SwitchLinkingServiceIT @Autowired constructor(
         val acc = mutableListOf<List<LayoutSegment>>()
         var shift = alignmentShift
         segmentss.forEach { segments ->
-            acc += segments.map { segment ->
-                val segmentStart = Point(0.0, 0.0) - segment.segmentStart.toPoint()
-                val s = segment.copy(
-                    geometry = segment.geometry.copy(
-                        segmentPoints = segment.geometry.segmentPoints.map { point ->
-                            point.copy(
-                                x = point.x + shift.x + segmentStart.x,
-                                y = point.y + shift.y + segmentStart.y,
-                            )
-                        }
-                    )
-                )
-                shift += s.segmentEnd.toPoint() - s.segmentStart.toPoint()
-                s
-            }
+            acc +=
+                segments.map { segment ->
+                    val segmentStart = Point(0.0, 0.0) - segment.segmentStart.toPoint()
+                    val s =
+                        segment.copy(
+                            geometry =
+                                segment.geometry.copy(
+                                    segmentPoints =
+                                        segment.geometry.segmentPoints.map { point ->
+                                            point.copy(
+                                                x = point.x + shift.x + segmentStart.x,
+                                                y = point.y + shift.y + segmentStart.y,
+                                            )
+                                        }))
+                    shift += s.segmentEnd.toPoint() - s.segmentStart.toPoint()
+                    s
+                }
 
             acc += listOf(segment(shift, shift + spacerVector))
             shift += spacerVector
         }
-        return acc.map { ss -> ss.map { s -> s.copy(id = StringId(), geometry = s.geometry.copy(id = StringId())) } }
+        return acc.map { ss ->
+            ss.map { s -> s.copy(id = StringId(), geometry = s.geometry.copy(id = StringId())) }
+        }
     }
 
     private fun setSwitchId(segments: List<LayoutSegment>, switchId: IntId<TrackLayoutSwitch>?) =
@@ -1559,55 +1822,65 @@ class SwitchLinkingServiceIT @Autowired constructor(
     private fun createDraftLocationTrackFromLayoutSegments(
         layoutSegments: List<LayoutSegment>,
     ): Pair<LocationTrack, LayoutAlignment> {
-        val (locationTrack, alignment) = locationTrackAndAlignment(
-            trackNumberId = mainDraftContext.createLayoutTrackNumber().id,
-            segments = layoutSegments,
-            draft = true,
-        )
-        val locationTrackId = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment).id
-        return locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
+        val (locationTrack, alignment) =
+            locationTrackAndAlignment(
+                trackNumberId = mainDraftContext.createLayoutTrackNumber().id,
+                segments = layoutSegments,
+                draft = true,
+            )
+        val locationTrackId =
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment).id
+        return locationTrackService.getWithAlignmentOrThrow(
+            MainLayoutContext.draft, locationTrackId)
     }
 
     private fun setupJointLocationAccuracyTest(): SuggestedSwitchCreateParams {
         val trackNumber = mainOfficialContext.createAndFetchLayoutTrackNumber()
-        val (switch, switchAlignments) = createSwitchAndAlignments(
-            "fooSwitch",
-            switchStructure,
-            0.01, // avoid plan1's bounding box becoming degenerate by slightly rotating the main track
-            Point(50.0, 50.0),
-        )
-
-        val plan1 = makeAndSavePlan(
-            trackNumber.number,
-            MeasurementMethod.DIGITIZED_AERIAL_IMAGE,
-            switches = listOf(switch),
-            alignments = listOf(switchAlignments[0]),
-        )
-
-        val plan2 = makeAndSavePlan(
-            trackNumber.number,
-            measurementMethod = null,
-            alignments = listOf(switchAlignments[1]),
-        )
-
-        val trackNumberIds = (plan1.alignments + plan2.alignments).map { a ->
-            val (locationTrack, alignment) = locationTrackAndAlignmentForGeometryAlignment(
-                trackNumber.id as IntId,
-                a,
-                kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.KKJ_TO_TM35FIN),
-                kkjTm35FinTriangulationDao.fetchTriangulationNetwork(TriangulationDirection.TM35FIN_TO_KKJ),
-                draft = true,
+        val (switch, switchAlignments) =
+            createSwitchAndAlignments(
+                "fooSwitch",
+                switchStructure,
+                0.01, // avoid plan1's bounding box becoming degenerate by slightly rotating the
+                      // main track
+                Point(50.0, 50.0),
             )
-            locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
-        }
+
+        val plan1 =
+            makeAndSavePlan(
+                trackNumber.number,
+                MeasurementMethod.DIGITIZED_AERIAL_IMAGE,
+                switches = listOf(switch),
+                alignments = listOf(switchAlignments[0]),
+            )
+
+        val plan2 =
+            makeAndSavePlan(
+                trackNumber.number,
+                measurementMethod = null,
+                alignments = listOf(switchAlignments[1]),
+            )
+
+        val trackNumberIds =
+            (plan1.alignments + plan2.alignments).map { a ->
+                val (locationTrack, alignment) =
+                    locationTrackAndAlignmentForGeometryAlignment(
+                        trackNumber.id as IntId,
+                        a,
+                        kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                            TriangulationDirection.KKJ_TO_TM35FIN),
+                        kkjTm35FinTriangulationDao.fetchTriangulationNetwork(
+                            TriangulationDirection.TM35FIN_TO_KKJ),
+                        draft = true,
+                    )
+                locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
+            }
         val mainLocationTrackId = trackNumberIds[0].id
 
         return SuggestedSwitchCreateParams(
             LocationTrackEndpoint(
                 locationTrackId = mainLocationTrackId,
                 location = Point(50.0, 50.0),
-                updateType = LocationTrackPointUpdateType.START_POINT
-            ),
+                updateType = LocationTrackPointUpdateType.START_POINT),
             switchStructure.id as IntId,
             listOf(
                 SuggestedSwitchCreateParamsAlignmentMapping(
@@ -1624,37 +1897,42 @@ class SwitchLinkingServiceIT @Autowired constructor(
         measurementMethod: MeasurementMethod?,
         alignments: List<GeometryAlignment> = listOf(),
         switches: List<GeometrySwitch> = listOf(),
-    ): GeometryPlan = geometryDao.fetchPlan(
-        geometryDao.insertPlan(
-            plan(
-                trackNumber = trackNumber,
-                alignments = alignments,
-                switches = switches,
-                measurementMethod = measurementMethod,
-                srid = LAYOUT_SRID
-            ),
-            testFile(),
-            null,
-        )
-    )
+    ): GeometryPlan =
+        geometryDao.fetchPlan(
+            geometryDao.insertPlan(
+                plan(
+                    trackNumber = trackNumber,
+                    alignments = alignments,
+                    switches = switches,
+                    measurementMethod = measurementMethod,
+                    srid = LAYOUT_SRID),
+                testFile(),
+                null,
+            ))
 
     private fun assertJointPointLocationAccuracy(
         switch: SuggestedSwitch,
         jointNumber: JointNumber,
         locationAccuracy: LocationAccuracy?,
-    ) = assertEquals(locationAccuracy, switch.joints.find { j -> j.number == jointNumber }!!.locationAccuracy)
+    ) =
+        assertEquals(
+            locationAccuracy,
+            switch.joints.find { j -> j.number == jointNumber }!!.locationAccuracy)
 
     private fun assertEqualsRounded(
         expected: List<SwitchRelinkingValidationResult>,
         actual: List<SwitchRelinkingValidationResult>,
     ) = assertEquals(roundRelinkingResult(expected), roundRelinkingResult(actual))
 
-    private fun roundRelinkingResult(r: List<SwitchRelinkingValidationResult>): List<SwitchRelinkingValidationResult> =
+    private fun roundRelinkingResult(
+        r: List<SwitchRelinkingValidationResult>
+    ): List<SwitchRelinkingValidationResult> =
         r.map { one ->
             one.copy(
-                successfulSuggestion = one.successfulSuggestion?.copy(
-                    location = one.successfulSuggestion!!.location.round(1).toPoint(),
-                ),
+                successfulSuggestion =
+                    one.successfulSuggestion?.copy(
+                        location = one.successfulSuggestion!!.location.round(1).toPoint(),
+                    ),
             )
         }
 }
@@ -1663,16 +1941,16 @@ fun suggestedSwitchJointMatch(
     locationTrackId: IntId<LocationTrack>,
     segmentIndex: Int,
     m: Double,
-): FittedSwitchJointMatch = FittedSwitchJointMatch(
-    locationTrackId,
-    segmentIndex,
-    m,
-    SwitchJoint(JointNumber(1), Point(1.0, 2.0)),
-    SuggestedSwitchJointMatchType.START,
-    0.1,
-    0.1,
-    null
-)
+): FittedSwitchJointMatch =
+    FittedSwitchJointMatch(
+        locationTrackId,
+        segmentIndex,
+        m,
+        SwitchJoint(JointNumber(1), Point(1.0, 2.0)),
+        SuggestedSwitchJointMatchType.START,
+        0.1,
+        0.1,
+        null)
 
 fun suggestedSwitchFitting(
     switchStructureId: IntId<SwitchStructure>,
@@ -1680,10 +1958,10 @@ fun suggestedSwitchFitting(
     name: SwitchName? = null,
     alignmentEndPoint: LocationTrackEndpoint? = null,
     geometrySwitchId: IntId<GeometrySwitch>? = null,
-): FittedSwitch = FittedSwitch(
-    name = name ?: SwitchName("Foo V123"),
-    switchStructureId = switchStructureId,
-    joints = joints,
-    alignmentEndPoint = alignmentEndPoint,
-    geometrySwitchId = geometrySwitchId
-)
+): FittedSwitch =
+    FittedSwitch(
+        name = name ?: SwitchName("Foo V123"),
+        switchStructureId = switchStructureId,
+        joints = joints,
+        alignmentEndPoint = alignmentEndPoint,
+        geometrySwitchId = geometrySwitchId)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
@@ -12,10 +12,10 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.data.YV60_300_1_10_V
 import fi.fta.geoviite.infra.switchLibrary.data.YV60_300_1_9_O
 import fi.fta.geoviite.infra.tracklayout.*
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class SwitchLinkingTest {
     private var testLayoutSwitchId = IntId<TrackLayoutSwitch>(0)
@@ -30,34 +30,54 @@ class SwitchLinkingTest {
     ) {
         val fullSegmentName = "Segment" + if (segmentName.isNotEmpty()) " ($segmentName)" else ""
         assertEquals(layoutSwitchId, segment.switchId, "$fullSegmentName switchId")
-        assertEquals(startJointNumber, segment.startJointNumber, "$fullSegmentName startJointNumber")
+        assertEquals(
+            startJointNumber, segment.startJointNumber, "$fullSegmentName startJointNumber")
         assertEquals(endJointNumber, segment.endJointNumber, "$fullSegmentName endJointNumber")
     }
 
     private fun toSwitchLinkingJoint(ss: FittedSwitchJointMatch) =
         SwitchLinkingJoint(ss.switchJoint.number, ss.segmentIndex, ss.m, Point(0.0, 0.0))
 
-    private fun switchLinkingJointAtStart(alignment: LayoutAlignment, segmentIndex: Int, jointNumber: Int): SwitchLinkingJoint =
+    private fun switchLinkingJointAtStart(
+        alignment: LayoutAlignment,
+        segmentIndex: Int,
+        jointNumber: Int
+    ): SwitchLinkingJoint =
         toSwitchLinkingJoint(switchLinkingAtStart(IntId(-1), alignment, segmentIndex, jointNumber))
-    private fun switchLinkingJointAtHalf(alignment: LayoutAlignment, segmentIndex: Int, jointNumber: Int): SwitchLinkingJoint =
+
+    private fun switchLinkingJointAtHalf(
+        alignment: LayoutAlignment,
+        segmentIndex: Int,
+        jointNumber: Int
+    ): SwitchLinkingJoint =
         toSwitchLinkingJoint(switchLinkingAtHalf(IntId(-1), alignment, segmentIndex, jointNumber))
-    private fun switchLinkingJointAtEnd(alignment: LayoutAlignment, segmentIndex: Int, jointNumber: Int): SwitchLinkingJoint =
+
+    private fun switchLinkingJointAtEnd(
+        alignment: LayoutAlignment,
+        segmentIndex: Int,
+        jointNumber: Int
+    ): SwitchLinkingJoint =
         toSwitchLinkingJoint(switchLinkingAtEnd(IntId(-1), alignment, segmentIndex, jointNumber))
 
     @Test
     fun adjacentSegmentsShouldHaveSameJointNumber() {
         var startLength = 0.0
         val locationTrackId = IntId<LocationTrack>(0)
-        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(
-            trackNumberId = IntId(0),
-            segments = (1..5).map { num ->
-                val start = (num - 1).toDouble() * 10.0
-                val end = start + 10.0
-                segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-            },
-            id = locationTrackId,
-            draft = false,
-        )
+        val (_, origAlignmentNoSwitchInfo) =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(0),
+                segments =
+                    (1..5).map { num ->
+                        val start = (num - 1).toDouble() * 10.0
+                        val end = start + 10.0
+                        segment(Point(start, start), Point(end, end), startM = startLength).also { s
+                            ->
+                            startLength += s.length
+                        }
+                    },
+                id = locationTrackId,
+                draft = false,
+            )
 
         val joint1 = switchLinkingJointAtStart(origAlignmentNoSwitchInfo, 0, 1)
         val joint2 = switchLinkingJointAtStart(origAlignmentNoSwitchInfo, 1, 5)
@@ -65,13 +85,14 @@ class SwitchLinkingTest {
 
         val linkingJoints = listOf(joint1, joint2, joint3)
 
-        val updatedAlignment = updateAlignmentSegmentsWithSwitchLinking(
-            origAlignmentNoSwitchInfo,
-            testLayoutSwitchId,
-            linkingJoints,
-        )
+        val updatedAlignment =
+            updateAlignmentSegmentsWithSwitchLinking(
+                origAlignmentNoSwitchInfo,
+                testLayoutSwitchId,
+                linkingJoints,
+            )
 
-        assertEquals(origAlignmentNoSwitchInfo.segments.size+1, updatedAlignment.segments.size)
+        assertEquals(origAlignmentNoSwitchInfo.segments.size + 1, updatedAlignment.segments.size)
         assertEquals(joint1.m, updatedAlignment.segments[0].startM)
         assertEquals(joint2.m, updatedAlignment.segments[0].endM)
         assertEquals(joint2.m, updatedAlignment.segments[1].startM)
@@ -98,37 +119,44 @@ class SwitchLinkingTest {
     fun shouldSnapToSegmentsFirstAndLastPoint() {
         var startLength = 0.0
         val locationTrackId = IntId<LocationTrack>(0)
-        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(
-            trackNumberId = IntId(0),
-            segments = (1..5).map { num ->
-                val start = (num - 1).toDouble() * 10.0
-                val end = start + 10.0
-                segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-            },
-            id = locationTrackId,
-            draft = false,
-        )
+        val (_, origAlignmentNoSwitchInfo) =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(0),
+                segments =
+                    (1..5).map { num ->
+                        val start = (num - 1).toDouble() * 10.0
+                        val end = start + 10.0
+                        segment(Point(start, start), Point(end, end), startM = startLength).also { s
+                            ->
+                            startLength += s.length
+                        }
+                    },
+                id = locationTrackId,
+                draft = false,
+            )
 
-        val linkingJoints = listOf(
-            SwitchLinkingJoint(
-                JointNumber(1),
-                1,
-                origAlignmentNoSwitchInfo.segments[1].startM - 0.0001,
-                Point(0.0, 0.0),
-            ),
-            SwitchLinkingJoint(
-                JointNumber(2),
-                1,
-                origAlignmentNoSwitchInfo.segments[1].endM + 0.0001,
-                Point(0.0, 0.0),
-            ),
-        )
+        val linkingJoints =
+            listOf(
+                SwitchLinkingJoint(
+                    JointNumber(1),
+                    1,
+                    origAlignmentNoSwitchInfo.segments[1].startM - 0.0001,
+                    Point(0.0, 0.0),
+                ),
+                SwitchLinkingJoint(
+                    JointNumber(2),
+                    1,
+                    origAlignmentNoSwitchInfo.segments[1].endM + 0.0001,
+                    Point(0.0, 0.0),
+                ),
+            )
 
-        val updatedAlignment = updateAlignmentSegmentsWithSwitchLinking(
-            origAlignmentNoSwitchInfo,
-            testLayoutSwitchId,
-            linkingJoints,
-        )
+        val updatedAlignment =
+            updateAlignmentSegmentsWithSwitchLinking(
+                origAlignmentNoSwitchInfo,
+                testLayoutSwitchId,
+                linkingJoints,
+            )
         assertEquals(origAlignmentNoSwitchInfo.segments.size, updatedAlignment.segments.size)
         assertSwitchLinkingInfoEquals(
             updatedAlignment.segments[1],
@@ -143,32 +171,41 @@ class SwitchLinkingTest {
     fun shouldSplitSegmentsToSwitchGeometry() {
         var startLength = 0.0
         val locationTrackId = IntId<LocationTrack>(0)
-        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(
-            trackNumberId = IntId(0),
-            segments = (1..5).map { num ->
-                val start = (num - 1).toDouble() * 10.0
-                val end = start + 10.0
-                segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-            },
-            id = locationTrackId,
-            draft = false,
-        )
+        val (_, origAlignmentNoSwitchInfo) =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(0),
+                segments =
+                    (1..5).map { num ->
+                        val start = (num - 1).toDouble() * 10.0
+                        val end = start + 10.0
+                        segment(Point(start, start), Point(end, end), startM = startLength).also { s
+                            ->
+                            startLength += s.length
+                        }
+                    },
+                id = locationTrackId,
+                draft = false,
+            )
 
         val splitSegmentIndex = 1
-        val splitPointM = origAlignmentNoSwitchInfo.segments[splitSegmentIndex]
-            .let { s -> interpolate(s.startM, s.endM, 0.5) }
-        val linkingJoints = listOf(
-            switchLinkingJointAtStart(origAlignmentNoSwitchInfo, 0, 1),
-            SwitchLinkingJoint(JointNumber(2), splitSegmentIndex, splitPointM, Point(0.0, 0.0)),
-        )
+        val splitPointM =
+            origAlignmentNoSwitchInfo.segments[splitSegmentIndex].let { s ->
+                interpolate(s.startM, s.endM, 0.5)
+            }
+        val linkingJoints =
+            listOf(
+                switchLinkingJointAtStart(origAlignmentNoSwitchInfo, 0, 1),
+                SwitchLinkingJoint(JointNumber(2), splitSegmentIndex, splitPointM, Point(0.0, 0.0)),
+            )
 
-        val updatedAlignment = updateAlignmentSegmentsWithSwitchLinking(
-            origAlignmentNoSwitchInfo,
-            testLayoutSwitchId,
-            linkingJoints,
-        )
+        val updatedAlignment =
+            updateAlignmentSegmentsWithSwitchLinking(
+                origAlignmentNoSwitchInfo,
+                testLayoutSwitchId,
+                linkingJoints,
+            )
 
-        assertEquals(origAlignmentNoSwitchInfo.segments.size+1, updatedAlignment.segments.size)
+        assertEquals(origAlignmentNoSwitchInfo.segments.size + 1, updatedAlignment.segments.size)
 
         assertSwitchLinkingInfoEquals(
             updatedAlignment.segments[0],
@@ -191,27 +228,34 @@ class SwitchLinkingTest {
     fun shouldUpdateSwitchLinkingIntoAlignment() {
         var startLength = 0.0
         val locationTrackId = IntId<LocationTrack>(0)
-        val (_, origAlignmentNoSwitchInfo) = locationTrackAndAlignment(
-            trackNumberId = IntId(0),
-            segments = (1..3).map { num ->
-                val start = (num - 1).toDouble() * 10.0
-                val end = start + 10.0
-                segment(Point(start, start), Point(end, end), startM = startLength).also { s -> startLength += s.length }
-            },
-            id = locationTrackId,
-            draft = false,
-        )
+        val (_, origAlignmentNoSwitchInfo) =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(0),
+                segments =
+                    (1..3).map { num ->
+                        val start = (num - 1).toDouble() * 10.0
+                        val end = start + 10.0
+                        segment(Point(start, start), Point(end, end), startM = startLength).also { s
+                            ->
+                            startLength += s.length
+                        }
+                    },
+                id = locationTrackId,
+                draft = false,
+            )
 
-        val linkingJoints = listOf(
-            switchLinkingJointAtStart(origAlignmentNoSwitchInfo, 0, 1),
-            switchLinkingJointAtEnd(origAlignmentNoSwitchInfo, 2, 2),
-        )
+        val linkingJoints =
+            listOf(
+                switchLinkingJointAtStart(origAlignmentNoSwitchInfo, 0, 1),
+                switchLinkingJointAtEnd(origAlignmentNoSwitchInfo, 2, 2),
+            )
 
-        val updatedAlignment = updateAlignmentSegmentsWithSwitchLinking(
-            origAlignmentNoSwitchInfo,
-            testLayoutSwitchId,
-            linkingJoints,
-        )
+        val updatedAlignment =
+            updateAlignmentSegmentsWithSwitchLinking(
+                origAlignmentNoSwitchInfo,
+                testLayoutSwitchId,
+                linkingJoints,
+            )
 
         assertSwitchLinkingInfoEquals(
             updatedAlignment.segments[0],
@@ -238,53 +282,66 @@ class SwitchLinkingTest {
 
     @Test
     fun shouldClearSwitchTopologyLinkingFromLocationTrackStart() {
-        val locationTrackWithStartLink = locationTrack(
-            trackNumberId = IntId(1),
-            topologyStartSwitch = TopologyLocationTrackSwitch(testLayoutSwitchId, JointNumber(2)),
-            topologyEndSwitch = TopologyLocationTrackSwitch(otherLayoutSwitchId, JointNumber(1)),
-            draft = false,
-        )
-        val (locationTrackWithStartLinkCleared, _) = clearLinksToSwitch(
-            locationTrackWithStartLink,
-            alignment(someSegment()),
-            testLayoutSwitchId,
-        )
+        val locationTrackWithStartLink =
+            locationTrack(
+                trackNumberId = IntId(1),
+                topologyStartSwitch =
+                    TopologyLocationTrackSwitch(testLayoutSwitchId, JointNumber(2)),
+                topologyEndSwitch =
+                    TopologyLocationTrackSwitch(otherLayoutSwitchId, JointNumber(1)),
+                draft = false,
+            )
+        val (locationTrackWithStartLinkCleared, _) =
+            clearLinksToSwitch(
+                locationTrackWithStartLink,
+                alignment(someSegment()),
+                testLayoutSwitchId,
+            )
         assertEquals(null, locationTrackWithStartLinkCleared.topologyStartSwitch)
-        assertEquals(locationTrackWithStartLink.topologyEndSwitch, locationTrackWithStartLinkCleared.topologyEndSwitch)
+        assertEquals(
+            locationTrackWithStartLink.topologyEndSwitch,
+            locationTrackWithStartLinkCleared.topologyEndSwitch)
     }
 
     @Test
     fun shouldClearSwitchTopologyLinkingFromLocationTrackEnd() {
-        val locationTrackWithEndLink = locationTrack(
-            trackNumberId = IntId(1),
-            topologyStartSwitch = TopologyLocationTrackSwitch(otherLayoutSwitchId, JointNumber(2)),
-            topologyEndSwitch = TopologyLocationTrackSwitch(testLayoutSwitchId, JointNumber(1)),
-            draft = false,
-        )
-        val (locationTrackWithEndLinkCleared, _) = clearLinksToSwitch(
-            locationTrackWithEndLink,
-            alignment(someSegment()),
-            testLayoutSwitchId,
-        )
+        val locationTrackWithEndLink =
+            locationTrack(
+                trackNumberId = IntId(1),
+                topologyStartSwitch =
+                    TopologyLocationTrackSwitch(otherLayoutSwitchId, JointNumber(2)),
+                topologyEndSwitch = TopologyLocationTrackSwitch(testLayoutSwitchId, JointNumber(1)),
+                draft = false,
+            )
+        val (locationTrackWithEndLinkCleared, _) =
+            clearLinksToSwitch(
+                locationTrackWithEndLink,
+                alignment(someSegment()),
+                testLayoutSwitchId,
+            )
         assertEquals(null, locationTrackWithEndLinkCleared.topologyEndSwitch)
-        assertEquals(locationTrackWithEndLink.topologyStartSwitch, locationTrackWithEndLinkCleared.topologyStartSwitch)
+        assertEquals(
+            locationTrackWithEndLink.topologyStartSwitch,
+            locationTrackWithEndLinkCleared.topologyStartSwitch)
     }
 
     @Test
     fun shouldClearSwitchLinkingInfoFromAlignment() {
-        val (origLocationTrack, origAlignment) = locationTrackWithTwoSwitches(
-            trackNumberId = IntId(0),
-            layoutSwitchId = testLayoutSwitchId,
-            otherLayoutSwitchId = otherLayoutSwitchId,
-            locationTrackId = IntId(0),
-            draft = false,
-        )
+        val (origLocationTrack, origAlignment) =
+            locationTrackWithTwoSwitches(
+                trackNumberId = IntId(0),
+                layoutSwitchId = testLayoutSwitchId,
+                otherLayoutSwitchId = otherLayoutSwitchId,
+                locationTrackId = IntId(0),
+                draft = false,
+            )
 
-        val (_, clearedAlignment) = clearLinksToSwitch(
-            origLocationTrack,
-            origAlignment,
-            testLayoutSwitchId,
-        )
+        val (_, clearedAlignment) =
+            clearLinksToSwitch(
+                origLocationTrack,
+                origAlignment,
+                testLayoutSwitchId,
+            )
 
         (1..3).forEach { i ->
             assertSwitchLinkingInfoEquals(
@@ -300,8 +357,7 @@ class SwitchLinkingTest {
             assertEquals(
                 origAlignment.segments[i],
                 clearedAlignment.segments[i],
-                "Segments related to another switch should be untouched"
-            )
+                "Segments related to another switch should be untouched")
         }
     }
 
@@ -309,54 +365,60 @@ class SwitchLinkingTest {
     fun `should find joint matches for suggested switch`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(0.0, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(5),
-                Point(5.0, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(10.0, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(3),
-                Point(5.0, 5.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(0.0, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(5),
+                    Point(5.0, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(10.0, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(3),
+                    Point(5.0, 5.0),
+                ),
+            )
 
         val locationTrack1 = locationTrack(IntId(1), id = IntId(1), draft = false)
-        val alignment1 = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(5.0, 0.0),
-                    Point(10.0, 0.0),
-                )
-            ),
-        )
+        val alignment1 =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(5.0, 0.0),
+                            Point(10.0, 0.0),
+                        )),
+            )
 
         val locationTrack2 = locationTrack(IntId(1), id = IntId(2), draft = false)
-        val alignment2 = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(5.0, 5.0),
-                )
-            ),
-        )
+        val alignment2 =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(5.0, 5.0),
+                        )),
+            )
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            listOf(locationTrack1 to alignment1, locationTrack2 to alignment2),
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                listOf(locationTrack1 to alignment1, locationTrack2 to alignment2),
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
         listOf(1, 5, 2, 3).forEach { jointNumber ->
             assertTrue(suggestedSwitch.joints.any { it.number.intValue == jointNumber })
@@ -367,12 +429,12 @@ class SwitchLinkingTest {
         val joint2 = getJoint(suggestedSwitch, 2)
         val joint3 = getJoint(suggestedSwitch, 3)
 
-        //Line 1-5-2
+        // Line 1-5-2
         assertTrue(joint1.matches.any { it.locationTrackId == locationTrack1.id })
         assertTrue(joint5.matches.any { it.locationTrackId == locationTrack1.id })
         assertTrue(joint2.matches.any { it.locationTrackId == locationTrack1.id })
 
-        //Line 1-3
+        // Line 1-3
         assertTrue(joint1.matches.any { it.locationTrackId == locationTrack2.id })
         assertTrue(joint3.matches.any { it.locationTrackId == locationTrack2.id })
     }
@@ -381,497 +443,567 @@ class SwitchLinkingTest {
     fun `should match suggested switch with inner segment`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(5.25, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(14.75, 0.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(5.25, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(14.75, 0.0),
+                ),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
-        val alignment = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(2.5, 0.0),
-                    Point(5.0, 0.0),
-                ),
-                segment(
-                    Point(5.0, 0.0),
-                    Point(7.5, 0.0),
-                    Point(10.0, 0.0),
-                    startM = 5.0,
-                ),
-                segment(
-                    Point(10.0, 0.0),
-                    Point(12.5, 0.0),
-                    Point(15.0, 0.0),
-                    startM = 10.0,
-                ),
-                segment(
-                    Point(15.0, 0.0),
-                    Point(17.5, 0.0),
-                    Point(20.0, 0.0),
-                    startM = 15.0,
-                ),
-            ),
-        )
+        val alignment =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(2.5, 0.0),
+                            Point(5.0, 0.0),
+                        ),
+                        segment(
+                            Point(5.0, 0.0),
+                            Point(7.5, 0.0),
+                            Point(10.0, 0.0),
+                            startM = 5.0,
+                        ),
+                        segment(
+                            Point(10.0, 0.0),
+                            Point(12.5, 0.0),
+                            Point(15.0, 0.0),
+                            startM = 10.0,
+                        ),
+                        segment(
+                            Point(15.0, 0.0),
+                            Point(17.5, 0.0),
+                            Point(20.0, 0.0),
+                            startM = 15.0,
+                        ),
+                    ),
+            )
 
         val tracks = listOf(locationTrack to alignment)
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            listOf(locationTrack to alignment),
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                listOf(locationTrack to alignment),
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
-        assertOnlyJointMatch(suggestedSwitch, tracks, 1, locationTrack.id, 1, SuggestedSwitchJointMatchType.START)
-        assertOnlyJointMatch(suggestedSwitch, tracks, 2, locationTrack.id, 2, SuggestedSwitchJointMatchType.END)
+        assertOnlyJointMatch(
+            suggestedSwitch, tracks, 1, locationTrack.id, 1, SuggestedSwitchJointMatchType.START)
+        assertOnlyJointMatch(
+            suggestedSwitch, tracks, 2, locationTrack.id, 2, SuggestedSwitchJointMatchType.END)
     }
 
     @Test
     fun `should match suggested switch with inner segment even if its further away`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(4.75, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(15.25, 0.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(4.75, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(15.25, 0.0),
+                ),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
-        val alignment = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(2.5, 0.0),
-                    Point(5.0, 0.0),
-                ),
-                segment(
-                    Point(5.0, 0.0),
-                    Point(7.5, 0.0),
-                    Point(10.0, 0.0),
-                    startM = 5.0,
-                ),
-                segment(
-                    Point(10.0, 0.0),
-                    Point(12.5, 0.0),
-                    Point(15.0, 0.0),
-                    startM = 10.0,
-                ),
-                segment(
-                    Point(15.0, 0.0),
-                    Point(17.5, 0.0),
-                    Point(20.0, 0.0),
-                    startM = 15.0,
-                ),
-            ),
-        )
+        val alignment =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(2.5, 0.0),
+                            Point(5.0, 0.0),
+                        ),
+                        segment(
+                            Point(5.0, 0.0),
+                            Point(7.5, 0.0),
+                            Point(10.0, 0.0),
+                            startM = 5.0,
+                        ),
+                        segment(
+                            Point(10.0, 0.0),
+                            Point(12.5, 0.0),
+                            Point(15.0, 0.0),
+                            startM = 10.0,
+                        ),
+                        segment(
+                            Point(15.0, 0.0),
+                            Point(17.5, 0.0),
+                            Point(20.0, 0.0),
+                            startM = 15.0,
+                        ),
+                    ),
+            )
 
         val tracks = listOf(locationTrack to alignment)
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            tracks,
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                tracks,
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
-        assertOnlyJointMatch(suggestedSwitch, tracks, 1, locationTrack.id, 1, SuggestedSwitchJointMatchType.START)
-        assertOnlyJointMatch(suggestedSwitch, tracks, 2, locationTrack.id, 2, SuggestedSwitchJointMatchType.END)
+        assertOnlyJointMatch(
+            suggestedSwitch, tracks, 1, locationTrack.id, 1, SuggestedSwitchJointMatchType.START)
+        assertOnlyJointMatch(
+            suggestedSwitch, tracks, 2, locationTrack.id, 2, SuggestedSwitchJointMatchType.END)
     }
 
     @Test
     fun `should match with closest segment end point when there are multiple matches`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(0.6, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(10.6, 0.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(0.6, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(10.6, 0.0),
+                ),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
-        val alignment = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(0.1, 0.0),
-                    Point(0.5, 0.0),
-                ),
-                segment(
-                    Point(0.5, 0.0),
-                    Point(0.6, 0.0),
-                    Point(10.0, 0.0),
-                    startM = 0.5,
-                ),
-                segment(
-                    Point(10.0, 0.0),
-                    Point(10.6, 0.0),
-                    Point(11.0, 0.0),
-                    startM = 10.0,
-                ),
-                segment(
-                    Point(11.0, 0.0),
-                    Point(20.0, 0.0),
-                    startM = 11.0,
-                ),
-            ),
-        )
+        val alignment =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(0.1, 0.0),
+                            Point(0.5, 0.0),
+                        ),
+                        segment(
+                            Point(0.5, 0.0),
+                            Point(0.6, 0.0),
+                            Point(10.0, 0.0),
+                            startM = 0.5,
+                        ),
+                        segment(
+                            Point(10.0, 0.0),
+                            Point(10.6, 0.0),
+                            Point(11.0, 0.0),
+                            startM = 10.0,
+                        ),
+                        segment(
+                            Point(11.0, 0.0),
+                            Point(20.0, 0.0),
+                            startM = 11.0,
+                        ),
+                    ),
+            )
 
         val tracks = listOf(locationTrack to alignment)
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            tracks,
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                tracks,
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
-        assertOnlyJointMatch(suggestedSwitch, tracks, 1, locationTrack.id, 1, SuggestedSwitchJointMatchType.START)
-        assertOnlyJointMatch(suggestedSwitch, tracks, 2, locationTrack.id, 2, SuggestedSwitchJointMatchType.END)
+        assertOnlyJointMatch(
+            suggestedSwitch, tracks, 1, locationTrack.id, 1, SuggestedSwitchJointMatchType.START)
+        assertOnlyJointMatch(
+            suggestedSwitch, tracks, 2, locationTrack.id, 2, SuggestedSwitchJointMatchType.END)
     }
 
     @Test
     fun `should prefer segment end points over normal ones`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(0.25, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(9.75, 0.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(0.25, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(9.75, 0.0),
+                ),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
-        val alignment = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(0.5, 0.0),
-                    Point(1.0, 0.0),
-                ),
-                segment(
-                    Point(1.0, 0.0),
-                    Point(9.5, 0.0),
-                    Point(10.0, 0.0),
-                    startM = 1.0,
-                ),
-            ),
-        )
+        val alignment =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(0.5, 0.0),
+                            Point(1.0, 0.0),
+                        ),
+                        segment(
+                            Point(1.0, 0.0),
+                            Point(9.5, 0.0),
+                            Point(10.0, 0.0),
+                            startM = 1.0,
+                        ),
+                    ),
+            )
 
         val tracks = listOf(locationTrack to alignment)
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            tracks,
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                tracks,
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
-        assertOnlyJointMatch(suggestedSwitch, tracks, 1, locationTrack.id, 0, SuggestedSwitchJointMatchType.START)
-        assertOnlyJointMatch(suggestedSwitch, tracks, 2, locationTrack.id, 1, SuggestedSwitchJointMatchType.END)
+        assertOnlyJointMatch(
+            suggestedSwitch, tracks, 1, locationTrack.id, 0, SuggestedSwitchJointMatchType.START)
+        assertOnlyJointMatch(
+            suggestedSwitch, tracks, 2, locationTrack.id, 1, SuggestedSwitchJointMatchType.END)
     }
 
     @Test
     fun `should never match with segment end point for the first joint`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(3.9995, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(10.0, 0.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(3.9995, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(10.0, 0.0),
+                ),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
-        val alignment = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(1.0, 0.0),
-                    Point(4.9991, 0.0),
-                ),
-                segment(
-                    Point(5.0, 0.0),
-                    Point(10.0, 0.0),
-                    startM = 4.999,
-                ),
-            ),
-        )
+        val alignment =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(1.0, 0.0),
+                            Point(4.9991, 0.0),
+                        ),
+                        segment(
+                            Point(5.0, 0.0),
+                            Point(10.0, 0.0),
+                            startM = 4.999,
+                        ),
+                    ),
+            )
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            listOf(locationTrack to alignment),
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                listOf(locationTrack to alignment),
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
         val joint1 = getJoint(suggestedSwitch, 1)
         assertEquals(1, joint1.matches.size)
-        assertTrue(joint1.matches.none { it.locationTrackId == locationTrack.id && it.matchType == SuggestedSwitchJointMatchType.END })
+        assertTrue(
+            joint1.matches.none {
+                it.locationTrackId == locationTrack.id &&
+                    it.matchType == SuggestedSwitchJointMatchType.END
+            })
     }
 
     @Test
     fun `should never match with the first point for last joint`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(0.0, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(11.0005, 0.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(0.0, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(11.0005, 0.0),
+                ),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
-        val alignment = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(5.0, 0.0),
-                ),
-                segment(
-                    Point(5.0, 0.0),
-                    Point(10.0, 0.0),
-                    startM = 5.0,
-                ),
-                segment(
-                    Point(10.0009, 0.0),
-                    Point(15.0, 0.0),
-                    Point(20.0, 0.0),
-                    startM = 10.0,
-                ),
-            ),
-        )
+        val alignment =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(5.0, 0.0),
+                        ),
+                        segment(
+                            Point(5.0, 0.0),
+                            Point(10.0, 0.0),
+                            startM = 5.0,
+                        ),
+                        segment(
+                            Point(10.0009, 0.0),
+                            Point(15.0, 0.0),
+                            Point(20.0, 0.0),
+                            startM = 10.0,
+                        ),
+                    ),
+            )
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            listOf(locationTrack to alignment),
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                listOf(locationTrack to alignment),
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
         val joint2 = getJoint(suggestedSwitch, 2)
         assertEquals(1, joint2.matches.size)
-        assertTrue(joint2.matches.none { it.locationTrackId == locationTrack.id && it.matchType == SuggestedSwitchJointMatchType.START })
+        assertTrue(
+            joint2.matches.none {
+                it.locationTrackId == locationTrack.id &&
+                    it.matchType == SuggestedSwitchJointMatchType.START
+            })
     }
 
     @Test
     fun `should match with alignment regardless of direction`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(10.0, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(15.0, 0.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(10.0, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(15.0, 0.0),
+                ),
+            )
 
         val locationTrack1 = locationTrack(IntId(1), id = IntId(1), draft = false)
-        val alignment1 = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(4.0, 0.0),
-                ),
-                segment(
-                    Point(4.0, 0.0),
-                    Point(8.0, 0.0),
-                    startM = 4.0,
-                ),
-                segment(
-                    Point(8.0, 0.0),
-                    Point(10.0, 0.0),
-                    startM = 8.0,
-                ),
-                segment(
-                    Point(10.0, 0.0),
-                    Point(12.0, 0.0),
-                    startM = 10.0,
-                ),
-                segment(
-                    Point(12.0, 0.0),
-                    Point(15.0, 0.0),
-                    startM = 12.0,
-                ),
-                segment(
-                    Point(15.0, 0.0),
-                    Point(16.0, 0.0),
-                    startM = 15.0,
-                ),
-                segment(
-                    Point(16.0, 0.0),
-                    Point(20.0, 0.0),
-                    startM = 16.0,
-                ),
-            ),
-        )
+        val alignment1 =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(4.0, 0.0),
+                        ),
+                        segment(
+                            Point(4.0, 0.0),
+                            Point(8.0, 0.0),
+                            startM = 4.0,
+                        ),
+                        segment(
+                            Point(8.0, 0.0),
+                            Point(10.0, 0.0),
+                            startM = 8.0,
+                        ),
+                        segment(
+                            Point(10.0, 0.0),
+                            Point(12.0, 0.0),
+                            startM = 10.0,
+                        ),
+                        segment(
+                            Point(12.0, 0.0),
+                            Point(15.0, 0.0),
+                            startM = 12.0,
+                        ),
+                        segment(
+                            Point(15.0, 0.0),
+                            Point(16.0, 0.0),
+                            startM = 15.0,
+                        ),
+                        segment(
+                            Point(16.0, 0.0),
+                            Point(20.0, 0.0),
+                            startM = 16.0,
+                        ),
+                    ),
+            )
 
         val locationTrack2 = locationTrack(IntId(1), id = IntId(2), draft = false)
-        val alignment2 = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(20.0, 0.0),
-                    Point(19.0, 0.0),
-                    Point(18.0, 0.0),
-                    Point(17.0, 0.0),
-                    Point(16.0, 0.0),
-                    Point(15.0, 0.0),
-                ),
-                segment(
-                    Point(15.0, 0.0),
-                    Point(14.0, 0.0),
-                    Point(13.0, 0.0),
-                    startM = 5.0,
-                ),
-                segment(
-                    Point(13.0, 0.0),
-                    Point(12.0, 0.0),
-                    Point(11.0, 0.0),
-                    Point(10.0, 0.0),
-                    startM = 7.0,
-                ),
-                segment(
-                    Point(10.0, 0.0),
-                    Point(9.0, 0.0),
-                    Point(8.0, 0.0),
-                    Point(7.0, 0.0),
-                    Point(6.0, 0.0),
-                    Point(5.0, 0.0),
-                    startM = 10.0,
-                ),
-                segment(
-                    Point(5.0, 0.0),
-                    Point(4.0, 0.0),
-                    Point(3.0, 0.0),
-                    Point(2.0, 0.0),
-                    Point(1.0, 0.0),
-                    Point(0.0, 0.0),
-                    startM = 15.0,
-                ),
-            ),
-        )
+        val alignment2 =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(20.0, 0.0),
+                            Point(19.0, 0.0),
+                            Point(18.0, 0.0),
+                            Point(17.0, 0.0),
+                            Point(16.0, 0.0),
+                            Point(15.0, 0.0),
+                        ),
+                        segment(
+                            Point(15.0, 0.0),
+                            Point(14.0, 0.0),
+                            Point(13.0, 0.0),
+                            startM = 5.0,
+                        ),
+                        segment(
+                            Point(13.0, 0.0),
+                            Point(12.0, 0.0),
+                            Point(11.0, 0.0),
+                            Point(10.0, 0.0),
+                            startM = 7.0,
+                        ),
+                        segment(
+                            Point(10.0, 0.0),
+                            Point(9.0, 0.0),
+                            Point(8.0, 0.0),
+                            Point(7.0, 0.0),
+                            Point(6.0, 0.0),
+                            Point(5.0, 0.0),
+                            startM = 10.0,
+                        ),
+                        segment(
+                            Point(5.0, 0.0),
+                            Point(4.0, 0.0),
+                            Point(3.0, 0.0),
+                            Point(2.0, 0.0),
+                            Point(1.0, 0.0),
+                            Point(0.0, 0.0),
+                            startM = 15.0,
+                        ),
+                    ),
+            )
 
         val tracks = listOf(locationTrack1 to alignment1, locationTrack2 to alignment2)
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            tracks,
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                tracks,
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
         val joint1 = getJoint(suggestedSwitch, 1)
         assertEquals(2, joint1.matches.size)
-        assertJointMatchExists(suggestedSwitch, tracks, 1, locationTrack1.id, 3, SuggestedSwitchJointMatchType.START)
-        assertJointMatchExists(suggestedSwitch, tracks, 1, locationTrack2.id, 2, SuggestedSwitchJointMatchType.END)
+        assertJointMatchExists(
+            suggestedSwitch, tracks, 1, locationTrack1.id, 3, SuggestedSwitchJointMatchType.START)
+        assertJointMatchExists(
+            suggestedSwitch, tracks, 1, locationTrack2.id, 2, SuggestedSwitchJointMatchType.END)
 
         val joint2 = getJoint(suggestedSwitch, 2)
         assertEquals(2, joint2.matches.size)
-        assertJointMatchExists(suggestedSwitch, tracks, 2, locationTrack1.id, 4, SuggestedSwitchJointMatchType.END)
-        assertJointMatchExists(suggestedSwitch, tracks, 2, locationTrack2.id, 1, SuggestedSwitchJointMatchType.START)
+        assertJointMatchExists(
+            suggestedSwitch, tracks, 2, locationTrack1.id, 4, SuggestedSwitchJointMatchType.END)
+        assertJointMatchExists(
+            suggestedSwitch, tracks, 2, locationTrack2.id, 1, SuggestedSwitchJointMatchType.START)
     }
 
     @Test
     fun `should match with alignment if joint is on the line`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(0.0, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(11.0, 0.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(0.0, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(11.0, 0.0),
+                ),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
-        val alignment = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(5.0, 0.0),
-                ),
-                segment(
-                    Point(5.0, 0.0),
-                    Point(7.5, 0.0),
-                    Point(10.0, 0.0),
-                    Point(12.5, 0.0),
-                    Point(15.0, 0.0),
-                    startM = 5.0,
-                ),
-                segment(
-                    Point(15.0, 0.0),
-                    Point(20.0, 0.0),
-                    startM = 15.0,
-                ),
-            ),
-        )
+        val alignment =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(5.0, 0.0),
+                        ),
+                        segment(
+                            Point(5.0, 0.0),
+                            Point(7.5, 0.0),
+                            Point(10.0, 0.0),
+                            Point(12.5, 0.0),
+                            Point(15.0, 0.0),
+                            startM = 5.0,
+                        ),
+                        segment(
+                            Point(15.0, 0.0),
+                            Point(20.0, 0.0),
+                            startM = 15.0,
+                        ),
+                    ),
+            )
 
         val tracks = listOf(locationTrack to alignment)
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            tracks,
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                tracks,
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
         assertOnlyJointMatch(suggestedSwitch, tracks, 2, locationTrack.id, 1)
     }
@@ -880,111 +1012,122 @@ class SwitchLinkingTest {
     fun `should match with alignment even if there's no point close by`() {
         val switch = YV60_300_1_10_V()
 
-        val joints = listOf(
-            SwitchJoint(
-                JointNumber(1),
-                Point(0.0, 0.0),
-            ),
-            SwitchJoint(
-                JointNumber(2),
-                Point(11.5, 0.0),
-            ),
-        )
+        val joints =
+            listOf(
+                SwitchJoint(
+                    JointNumber(1),
+                    Point(0.0, 0.0),
+                ),
+                SwitchJoint(
+                    JointNumber(2),
+                    Point(11.5, 0.0),
+                ),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
-        val alignment = LayoutAlignment(
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(5.0, 0.0),
-                ),
-                segment(
-                    Point(5.0, 0.0),
-                    Point(10.0, 0.0),
-                    Point(15.0, 0.0),
-                    startM = 5.0,
-                ),
-                segment(
-                    Point(15.0, 0.0),
-                    Point(20.0, 0.0),
-                    startM = 15.0,
-                ),
-            ),
-        )
+        val alignment =
+            LayoutAlignment(
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(5.0, 0.0),
+                        ),
+                        segment(
+                            Point(5.0, 0.0),
+                            Point(10.0, 0.0),
+                            Point(15.0, 0.0),
+                            startM = 5.0,
+                        ),
+                        segment(
+                            Point(15.0, 0.0),
+                            Point(20.0, 0.0),
+                            startM = 15.0,
+                        ),
+                    ),
+            )
 
         val tracks = listOf(locationTrack to alignment)
 
-        val suggestedSwitch = fitSwitch(
-            joints,
-            switch,
-            tracks,
-            null,
-            null,
-            null,
-        ) { null }
+        val suggestedSwitch =
+            fitSwitch(
+                joints,
+                switch,
+                tracks,
+                null,
+                null,
+                null,
+            ) {
+                null
+            }
 
-        assertOnlyJointMatch(suggestedSwitch, tracks, 2, locationTrack.id, 1, SuggestedSwitchJointMatchType.LINE)
+        assertOnlyJointMatch(
+            suggestedSwitch, tracks, 2, locationTrack.id, 1, SuggestedSwitchJointMatchType.LINE)
     }
 
     @Test
     fun `should remove layout switches from all segments that are overridden by switch linking`() {
-        val (_, origAlignment) = locationTrackWithTwoSwitches(
-            trackNumberId = IntId(0),
-            layoutSwitchId = testLayoutSwitchId,
-            otherLayoutSwitchId = otherLayoutSwitchId,
-            locationTrackId = IntId(0),
-            draft = false,
-        )
+        val (_, origAlignment) =
+            locationTrackWithTwoSwitches(
+                trackNumberId = IntId(0),
+                layoutSwitchId = testLayoutSwitchId,
+                otherLayoutSwitchId = otherLayoutSwitchId,
+                locationTrackId = IntId(0),
+                draft = false,
+            )
 
-        val linkingJoints = listOf(
-            switchLinkingJointAtStart(origAlignment, 0, 1),
-            switchLinkingJointAtEnd(origAlignment, 1, 2),
-        )
+        val linkingJoints =
+            listOf(
+                switchLinkingJointAtStart(origAlignment, 0, 1),
+                switchLinkingJointAtEnd(origAlignment, 1, 2),
+            )
 
-        val updatedAlignment = updateAlignmentSegmentsWithSwitchLinking(
-            origAlignment,
-            IntId(100),
-            linkingJoints,
-        )
+        val updatedAlignment =
+            updateAlignmentSegmentsWithSwitchLinking(
+                origAlignment,
+                IntId(100),
+                linkingJoints,
+            )
 
         assertTrue { updatedAlignment.segments.none { it.switchId == testLayoutSwitchId } }
     }
 
     @Test
     fun cropAlignmentPointsShouldFindPointsInArea() {
-        val bbox = BoundingBox(
-            -2.0..3.0,
-            -10.0..10.0,
-        )
-        val locationTrackInArea = locationTrackAndAlignment(
-            segment(
-                Point(-4.0, 0.0),
-                Point(-3.0, 0.0),
-                Point(-2.0, 0.0),
-            ),
-            segment(
-                Point(-2.0, 0.0),
-                Point(-1.0, 0.0),
-                Point(0.0, 0.0),
-                Point(1.0, 0.0),
-                Point(2.0, 0.0),
-            ),
-            segment(
-                Point(2.0, 0.0),
-                Point(3.0, 0.0),
-                Point(4.0, 0.0),
-                Point(5.0, 0.0),
-            ),
-            draft = false,
-        )
+        val bbox =
+            BoundingBox(
+                -2.0..3.0,
+                -10.0..10.0,
+            )
+        val locationTrackInArea =
+            locationTrackAndAlignment(
+                segment(
+                    Point(-4.0, 0.0),
+                    Point(-3.0, 0.0),
+                    Point(-2.0, 0.0),
+                ),
+                segment(
+                    Point(-2.0, 0.0),
+                    Point(-1.0, 0.0),
+                    Point(0.0, 0.0),
+                    Point(1.0, 0.0),
+                    Point(2.0, 0.0),
+                ),
+                segment(
+                    Point(2.0, 0.0),
+                    Point(3.0, 0.0),
+                    Point(4.0, 0.0),
+                    Point(5.0, 0.0),
+                ),
+                draft = false,
+            )
         val croppedAlignment = cropPoints(locationTrackInArea.second, bbox)
 
         assertEquals(2, croppedAlignment.segments.size)
         assertEquals(Point(-2.0, 0.0), croppedAlignment.firstSegmentStart?.toPoint())
         assertEquals(Point(3.0, 0.0), croppedAlignment.lastSegmentEnd?.toPoint())
     }
-
 
     @Test
     fun cropAlignmentPointsShouldIgnoreSegmentsThatDoesNotHavePointsInArea() {
@@ -1000,19 +1143,21 @@ class SwitchLinkingTest {
         //  □ = bounding box
         //  \ = alignment
 
-        val bbox = BoundingBox(
-            -5.0..-4.0,
-            4.0..5.0,
-        )
-        val locationTrack = locationTrackAndAlignment(
-            segment(
-                points = arrayOf(
-                    Point(-5.0, 0.0),
-                    Point(5.0, 5.0),
-                )
-            ),
-            draft = false,
-        )
+        val bbox =
+            BoundingBox(
+                -5.0..-4.0,
+                4.0..5.0,
+            )
+        val locationTrack =
+            locationTrackAndAlignment(
+                segment(
+                    points =
+                        arrayOf(
+                            Point(-5.0, 0.0),
+                            Point(5.0, 5.0),
+                        )),
+                draft = false,
+            )
         val croppedAlignment = cropPoints(locationTrack.second, bbox)
 
         assertTrue(bbox.intersects(locationTrack.second.segments.first().boundingBox))
@@ -1023,75 +1168,77 @@ class SwitchLinkingTest {
     fun shouldFindMatchForYVSwitch() {
         val yvTurnRatio = 1.967 / 34.321 // ~ 0.06
         val switchStructure = YV60_300_1_9_O().copy(id = IntId(1))
-        val locationTrack152 = locationTrackAndAlignment(
-            segment(from = segmentPoint(-200.0, 0.0), to = Point(-100.0, 0.0)),
-            segment(from = Point(-100.0, 0.0), to = Point(100.0, 0.0)),
-            id = IntId(1),
-            draft = false,
-        )
-        val locationTrack13 = locationTrackAndAlignment(
-            segment(from = Point(0.0, 0.0), to = Point(100.0, -100.0 * yvTurnRatio)),
-            id = IntId(2),
-            draft = false,
-        )
+        val locationTrack152 =
+            locationTrackAndAlignment(
+                segment(from = segmentPoint(-200.0, 0.0), to = Point(-100.0, 0.0)),
+                segment(from = Point(-100.0, 0.0), to = Point(100.0, 0.0)),
+                id = IntId(1),
+                draft = false,
+            )
+        val locationTrack13 =
+            locationTrackAndAlignment(
+                segment(from = Point(0.0, 0.0), to = Point(100.0, -100.0 * yvTurnRatio)),
+                id = IntId(2),
+                draft = false,
+            )
         val nearbyPoint = Point(10.0, -1.0)
 
-        val suggestedSwitch = createSuggestedSwitchByPoint(
-            nearbyPoint,
-            switchStructure,
-            listOf(locationTrack152, locationTrack13),
-        )
+        val suggestedSwitch =
+            createSuggestedSwitchByPoint(
+                nearbyPoint,
+                switchStructure,
+                listOf(locationTrack152, locationTrack13),
+            )
 
         assertNotNull(suggestedSwitch)
     }
 
     @Test
     fun `getSwitchBoundsFromTracks handles topology and segment points`() {
-        val topoLinkedTrack = locationTrack(
-            trackNumberId = IntId(1),
-            topologyEndSwitch = TopologyLocationTrackSwitch(IntId(1), JointNumber(1)),
-            draft = false,
-        )
-        // let's say the switch's main joint is at (5.0, 5.0), this geometry incidentally doesn't *quite* come to the
+        val topoLinkedTrack =
+            locationTrack(
+                trackNumberId = IntId(1),
+                topologyEndSwitch = TopologyLocationTrackSwitch(IntId(1), JointNumber(1)),
+                draft = false,
+            )
+        // let's say the switch's main joint is at (5.0, 5.0), this geometry incidentally doesn't
+        // *quite* come to the
         // front joint, but close enough to link anyway
         val topoAlignment = alignment(segment(Point(4.0, 5.0), Point(4.9, 5.0)))
 
-        val alignmentOn152 = alignment(
-            segment(
-                Point(5.0, 5.0),
-                Point(6.0, 5.0),
-                switchId = IntId(1),
-                startJointNumber = JointNumber(1),
-                endJointNumber = JointNumber(5)
-            ),
-            segment(
-                Point(6.0, 5.0),
-                Point(7.0, 5.0),
-                switchId = IntId(1),
-                startJointNumber = JointNumber(5),
-                endJointNumber = JointNumber(2)
-            ),
-            segment(Point(7.0, 5.0), Point(8.0, 5.0)),
-        )
-        val alignmentOn13 = alignment(
-            segment(
-                Point(5.0, 5.0),
-                Point(6.0, 6.0),
-                switchId = IntId(1),
-                startJointNumber = JointNumber(1),
-                endJointNumber = JointNumber(3)
+        val alignmentOn152 =
+            alignment(
+                segment(
+                    Point(5.0, 5.0),
+                    Point(6.0, 5.0),
+                    switchId = IntId(1),
+                    startJointNumber = JointNumber(1),
+                    endJointNumber = JointNumber(5)),
+                segment(
+                    Point(6.0, 5.0),
+                    Point(7.0, 5.0),
+                    switchId = IntId(1),
+                    startJointNumber = JointNumber(5),
+                    endJointNumber = JointNumber(2)),
+                segment(Point(7.0, 5.0), Point(8.0, 5.0)),
             )
-        )
-        val tracks = listOf(
-            topoLinkedTrack to topoAlignment,
-            locationTrack(IntId(1), draft = false) to alignmentOn152,
-            locationTrack(IntId(1), draft = false) to alignmentOn13,
-        )
+        val alignmentOn13 =
+            alignment(
+                segment(
+                    Point(5.0, 5.0),
+                    Point(6.0, 6.0),
+                    switchId = IntId(1),
+                    startJointNumber = JointNumber(1),
+                    endJointNumber = JointNumber(3)))
+        val tracks =
+            listOf(
+                topoLinkedTrack to topoAlignment,
+                locationTrack(IntId(1), draft = false) to alignmentOn152,
+                locationTrack(IntId(1), draft = false) to alignmentOn13,
+            )
         assertEquals(
-            boundingBoxAroundPoints(listOf(Point(4.9, 5.0), Point(7.0, 6.0))), getSwitchBoundsFromTracks(
-                tracks, IntId(1)
-            )
-        )
+            boundingBoxAroundPoints(listOf(Point(4.9, 5.0), Point(7.0, 6.0))),
+            getSwitchBoundsFromTracks(tracks, IntId(1)))
         assertEquals(null, getSwitchBoundsFromTracks(tracks, IntId(2)))
     }
 }
@@ -1108,7 +1255,8 @@ private fun assertOnlyJointMatch(
     matchType: SuggestedSwitchJointMatchType? = null,
 ) {
     assertEquals(1, getJoint(switchSuggestion, jointNumber).matches.size)
-    assertJointMatchExists(switchSuggestion, tracks, jointNumber, locationTrackId, segmentIndex, matchType)
+    assertJointMatchExists(
+        switchSuggestion, tracks, jointNumber, locationTrackId, segmentIndex, matchType)
 }
 
 private fun assertJointMatchExists(
@@ -1123,10 +1271,14 @@ private fun assertJointMatchExists(
 
     val joint = getJoint(switchSuggestion, jointNumber)
     val match = joint.matches.find { it.locationTrackId == locationTrackId }!!
-    if (matchType != null) assertEquals(
-        matchType,
-        match.matchType,
-        "match type for joint $jointNumber on track $locationTrackId",
-    )
-    assertEquals(segmentIndex, match.segmentIndex, "segment index for joint $jointNumber on track $locationTrackId")
+    if (matchType != null)
+        assertEquals(
+            matchType,
+            match.matchType,
+            "match type for joint $jointNumber on track $locationTrackId",
+        )
+    assertEquals(
+        segmentIndex,
+        match.segmentIndex,
+        "segment index for joint $jointNumber on track $locationTrackId")
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/AngleTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/AngleTest.kt
@@ -1,10 +1,10 @@
 package fi.fta.geoviite.infra.math
 
+import kotlin.math.PI
+import kotlin.test.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.math.PI
-import kotlin.test.assertFalse
 
 const val DOUBLE_CALC_DELTA = 0.00000000000001
 
@@ -67,14 +67,14 @@ class AngleTest {
         assertEquals(0.0, rotateAngle(PI, -PI), DOUBLE_CALC_DELTA)
         assertEquals(-PI, rotateAngle(0.0, -PI), DOUBLE_CALC_DELTA)
         assertEquals(-PI, rotateAngle(0.0, PI), DOUBLE_CALC_DELTA)
-        assertEquals(-PI, rotateAngle(0.0, 3*PI), DOUBLE_CALC_DELTA)
-        assertEquals(-PI, rotateAngle(0.0, -3*PI), DOUBLE_CALC_DELTA)
-        assertEquals(0.1, rotateAngle(0.0, -4*PI+0.1), DOUBLE_CALC_DELTA)
-        assertEquals(0.1, rotateAngle(0.0, 4*PI+0.1), DOUBLE_CALC_DELTA)
-        assertEquals(0.8*PI, rotateAngle(-0.6*PI, -0.6*PI), DOUBLE_CALC_DELTA)
-        assertEquals(-0.8*PI, rotateAngle(0.6*PI, 0.6*PI), DOUBLE_CALC_DELTA)
-        assertEquals(0.0, rotateAngle(0.6*PI, -0.6*PI), DOUBLE_CALC_DELTA)
-        assertEquals(0.0, rotateAngle(-0.6*PI, 0.6*PI), DOUBLE_CALC_DELTA)
+        assertEquals(-PI, rotateAngle(0.0, 3 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(-PI, rotateAngle(0.0, -3 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(0.1, rotateAngle(0.0, -4 * PI + 0.1), DOUBLE_CALC_DELTA)
+        assertEquals(0.1, rotateAngle(0.0, 4 * PI + 0.1), DOUBLE_CALC_DELTA)
+        assertEquals(0.8 * PI, rotateAngle(-0.6 * PI, -0.6 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(-0.8 * PI, rotateAngle(0.6 * PI, 0.6 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(0.0, rotateAngle(0.6 * PI, -0.6 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(0.0, rotateAngle(-0.6 * PI, 0.6 * PI), DOUBLE_CALC_DELTA)
     }
 
     @Test
@@ -96,13 +96,13 @@ class AngleTest {
         assertEquals(0.0, angleAvgRads(0.1, -0.1), DOUBLE_CALC_DELTA)
         assertEquals(0.1, angleAvgRads(0.0, 0.2), DOUBLE_CALC_DELTA)
         assertEquals(-0.2, angleAvgRads(-0.1, -0.3), DOUBLE_CALC_DELTA)
-        assertEquals(0.0, angleAvgRads(0.4*PI, -0.4*PI), DOUBLE_CALC_DELTA)
-        assertEquals(PI, angleAvgRads(0.6*PI, -0.6*PI), DOUBLE_CALC_DELTA)
-        assertEquals(PI, angleAvgRads(0.9*PI, -0.9*PI), DOUBLE_CALC_DELTA)
+        assertEquals(0.0, angleAvgRads(0.4 * PI, -0.4 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(PI, angleAvgRads(0.6 * PI, -0.6 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(PI, angleAvgRads(0.9 * PI, -0.9 * PI), DOUBLE_CALC_DELTA)
         assertEquals(PI, angleAvgRads(PI, -PI), DOUBLE_CALC_DELTA)
-        assertEquals(0.8*PI, angleAvgRads(0.9*PI, 0.7*PI), DOUBLE_CALC_DELTA)
-        assertEquals(0.9*PI, angleAvgRads(0.7*PI, -0.9*PI), DOUBLE_CALC_DELTA)
-        assertEquals(-0.9*PI, angleAvgRads(0.9*PI, -0.7*PI), DOUBLE_CALC_DELTA)
+        assertEquals(0.8 * PI, angleAvgRads(0.9 * PI, 0.7 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(0.9 * PI, angleAvgRads(0.7 * PI, -0.9 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(-0.9 * PI, angleAvgRads(0.9 * PI, -0.7 * PI), DOUBLE_CALC_DELTA)
     }
 
     @Test
@@ -135,21 +135,21 @@ class AngleTest {
 
     @Test
     fun relativeAngleWorks() {
-        assertEquals(-0.2, relativeAngle(-5*PI+0.1, 5*PI-0.1), DOUBLE_CALC_DELTA)
-        assertEquals(0.2, relativeAngle(5*PI-0.1, -5*PI+0.1), DOUBLE_CALC_DELTA)
+        assertEquals(-0.2, relativeAngle(-5 * PI + 0.1, 5 * PI - 0.1), DOUBLE_CALC_DELTA)
+        assertEquals(0.2, relativeAngle(5 * PI - 0.1, -5 * PI + 0.1), DOUBLE_CALC_DELTA)
         assertEquals(0.0, relativeAngle(0.0, 0.0), DOUBLE_CALC_DELTA)
         assertEquals(0.0, relativeAngle(0.7, 0.7), DOUBLE_CALC_DELTA)
         assertEquals(0.1, relativeAngle(0.7, 0.8), DOUBLE_CALC_DELTA)
         assertEquals(0.1, relativeAngle(3.08, 3.18), DOUBLE_CALC_DELTA)
         assertEquals(-0.1, relativeAngle(0.7, 0.6), DOUBLE_CALC_DELTA)
         assertEquals(-0.1, relativeAngle(3.18, 3.08), DOUBLE_CALC_DELTA)
-        assertEquals(3.0, relativeAngle(0.0, 3.0), DOUBLE_CALC_DELTA);
-        assertEquals(5.0-PI*2.0, relativeAngle(0.0, 5.0), DOUBLE_CALC_DELTA)
-        assertEquals(PI*2.0-5.0, relativeAngle(5.0, 0.0), DOUBLE_CALC_DELTA)
+        assertEquals(3.0, relativeAngle(0.0, 3.0), DOUBLE_CALC_DELTA)
+        assertEquals(5.0 - PI * 2.0, relativeAngle(0.0, 5.0), DOUBLE_CALC_DELTA)
+        assertEquals(PI * 2.0 - 5.0, relativeAngle(5.0, 0.0), DOUBLE_CALC_DELTA)
 
         // sign flip exactly around pi
-        assertEquals(-PI+0.01, relativeAngle(0.0, PI+0.01), DOUBLE_CALC_DELTA)
-        assertEquals(PI-0.01, relativeAngle(0.0, PI-0.01), DOUBLE_CALC_DELTA)
+        assertEquals(-PI + 0.01, relativeAngle(0.0, PI + 0.01), DOUBLE_CALC_DELTA)
+        assertEquals(PI - 0.01, relativeAngle(0.0, PI - 0.01), DOUBLE_CALC_DELTA)
         // results in half-closed [-PI..PI) range
         assertEquals(-PI, relativeAngle(0.0, PI), DOUBLE_CALC_DELTA)
         assertEquals(-PI, relativeAngle(PI, 0.0), DOUBLE_CALC_DELTA)
@@ -158,28 +158,42 @@ class AngleTest {
             for (y in (0..7)) {
                 val a = x.toDouble()
                 val b = y.toDouble()
-                assertEquals(relativeAngle(a, b), -relativeAngle(b, a), DOUBLE_CALC_DELTA, "relativeAngle antisymmetry with (a, b) = ($a, $b")
+                assertEquals(
+                    relativeAngle(a, b),
+                    -relativeAngle(b, a),
+                    DOUBLE_CALC_DELTA,
+                    "relativeAngle antisymmetry with (a, b) = ($a, $b")
             }
         }
     }
 
     @Test
     fun geoMathAngleConversionWorks() {
-        verifyMathGeoConversion(0.0, 0.5*PI)
-        verifyMathGeoConversion(0.1*PI, 0.4*PI)
-        verifyMathGeoConversion(0.6*PI, 1.9*PI)
-        verifyMathGeoConversion(0.9*PI, 1.6*PI)
-        verifyMathGeoConversion(-0.1*PI, 0.6*PI)
-        verifyMathGeoConversion(-0.4*PI, 0.9*PI)
-        verifyMathGeoConversion(-0.6*PI, 1.1*PI)
-        verifyMathGeoConversion(-0.9*PI, 1.4*PI)
+        verifyMathGeoConversion(0.0, 0.5 * PI)
+        verifyMathGeoConversion(0.1 * PI, 0.4 * PI)
+        verifyMathGeoConversion(0.6 * PI, 1.9 * PI)
+        verifyMathGeoConversion(0.9 * PI, 1.6 * PI)
+        verifyMathGeoConversion(-0.1 * PI, 0.6 * PI)
+        verifyMathGeoConversion(-0.4 * PI, 0.9 * PI)
+        verifyMathGeoConversion(-0.6 * PI, 1.1 * PI)
+        verifyMathGeoConversion(-0.9 * PI, 1.4 * PI)
     }
 
     private fun verifyMathGeoConversion(mathRads: Double, geoRads: Double) {
         val delta = 0.00000001
-        assertEquals(geoRads, radsMathToGeo(mathRads), delta, "math=PI*${mathRads/PI} geo=PI*${geoRads/PI}")
-        assertEquals(mathRads, radsGeoToMath(geoRads), delta, "math=PI*${mathRads/PI} geo=PI*${geoRads/PI}")
-        assertEquals(geoRads, radsMathToGeo(radsGeoToMath(geoRads)), delta, "math=PI*${mathRads/PI} geo=PI*${geoRads/PI}")
-        assertEquals(mathRads, radsGeoToMath(radsMathToGeo(mathRads)), delta, "math=PI*${mathRads/PI} geo=PI*${geoRads/PI}")
+        assertEquals(
+            geoRads, radsMathToGeo(mathRads), delta, "math=PI*${mathRads/PI} geo=PI*${geoRads/PI}")
+        assertEquals(
+            mathRads, radsGeoToMath(geoRads), delta, "math=PI*${mathRads/PI} geo=PI*${geoRads/PI}")
+        assertEquals(
+            geoRads,
+            radsMathToGeo(radsGeoToMath(geoRads)),
+            delta,
+            "math=PI*${mathRads/PI} geo=PI*${geoRads/PI}")
+        assertEquals(
+            mathRads,
+            radsGeoToMath(radsMathToGeo(mathRads)),
+            delta,
+            "math=PI*${mathRads/PI} geo=PI*${geoRads/PI}")
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/BiquadraticParabolaTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/BiquadraticParabolaTest.kt
@@ -17,7 +17,6 @@ class BiquadraticParabolaTest {
         assertApproximatelyEquals(Point(250.0, 9.115), biquadraticParabola(250.0), accuracy)
     }
 
-
     @Test
     fun pointAtDistanceWorksForNegativeR1000L250() {
         val accuracy = 0.001
@@ -38,18 +37,22 @@ class BiquadraticParabolaTest {
         var previousD = -1.0
         for (x in 0..180) {
             val currentD = biquadraticSTransition(x.toDouble(), totalD, length)
-            val linearTransitionValue = (x.toDouble()/length)*totalD
+            val linearTransitionValue = (x.toDouble() / length) * totalD
             assertTrue(currentD > previousD, "D value should grow: $currentD > $previousD")
-            if (x <= length/2) {
-                assertTrue(currentD in 0.0..linearTransitionValue,
+            if (x <= length / 2) {
+                assertTrue(
+                    currentD in 0.0..linearTransitionValue,
                     "D on 1st half should be lower than linear: 0.0 < $currentD < $linearTransitionValue")
             } else {
-                assertTrue(currentD in linearTransitionValue..totalD,
+                assertTrue(
+                    currentD in linearTransitionValue..totalD,
                     "D on 2nd half should be greater than linear: $linearTransitionValue < $currentD < $totalD")
             }
             previousD = currentD
         }
     }
 
-    private fun biquadraticParabolaFunction(R: Double, L: Double) = { d: Double -> biquadraticParabolaPointAtOffset(d, R, L) }
+    private fun biquadraticParabolaFunction(R: Double, L: Double) = { d: Double ->
+        biquadraticParabolaPointAtOffset(d, R, L)
+    }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/BoundingBoxTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/BoundingBoxTest.kt
@@ -9,8 +9,7 @@ class BoundingBoxTest {
     fun boxCornersAreCorrect() {
         assertEquals(
             listOf(Point(1.0, 3.0), Point(2.0, 3.0), Point(2.0, 4.0), Point(1.0, 4.0)),
-            BoundingBox(1.0..2.0, 3.0..4.0).corners
-        )
+            BoundingBox(1.0..2.0, 3.0..4.0).corners)
     }
 
     @Test
@@ -74,39 +73,32 @@ class BoundingBoxTest {
 
     @Test
     fun createFromPointListOfOne() {
-        val bbox = boundingBoxAroundPoints(listOf(
-            Point(10.0, 10.0),
-        ))
+        val bbox =
+            boundingBoxAroundPoints(
+                listOf(
+                    Point(10.0, 10.0),
+                ))
         assertApproximatelyEquals(Point(10.0, 10.0), bbox.min)
         assertApproximatelyEquals(Point(10.0, 10.0), bbox.max)
     }
 
     @Test
     fun createFromPointList() {
-        val bbox = boundingBoxAroundPoints(listOf(
-            Point(10.0, -10.0),
-            Point(-20.0, 20.0)
-        ))
+        val bbox = boundingBoxAroundPoints(listOf(Point(10.0, -10.0), Point(-20.0, 20.0)))
         assertApproximatelyEquals(Point(-20.0, -10.0), bbox.min)
         assertApproximatelyEquals(Point(10.0, 20.0), bbox.max)
     }
 
     @Test
     fun expandBoundingBox() {
-        val bbox = boundingBoxAroundPoints(listOf(
-            Point(10.0, 10.0),
-            Point(20.0, 30.0)
-        )) + 5.0;
+        val bbox = boundingBoxAroundPoints(listOf(Point(10.0, 10.0), Point(20.0, 30.0))) + 5.0
         assertApproximatelyEquals(Point(5.0, 5.0), bbox.min)
         assertApproximatelyEquals(Point(25.0, 35.0), bbox.max)
     }
 
     @Test
     fun expandBoundingBoxByRatio() {
-        val bbox = boundingBoxAroundPoints(listOf(
-            Point(10.0, 10.0),
-            Point(20.0, 30.0)
-        )) * 1.5;
+        val bbox = boundingBoxAroundPoints(listOf(Point(10.0, 10.0), Point(20.0, 30.0))) * 1.5
         assertApproximatelyEquals(Point(10 - 2.5, 10 - 5.0), bbox.min)
         assertApproximatelyEquals(Point(20 + 2.5, 30 + 5.0), bbox.max)
     }
@@ -114,16 +106,15 @@ class BoundingBoxTest {
     @Test
     fun readCenter() {
         val bbox = BoundingBox(Point(0.0, 0.0), Point(10.0, 30.0))
-        assertEquals(Point(5.0, 15.0), bbox.center);
+        assertEquals(Point(5.0, 15.0), bbox.center)
     }
 
     @Test
     fun centerAt() {
-        val bbox = BoundingBox(Point(0.0, 0.0), Point(10.0, 10.0))
-            .centerAt(Point(20.0, 30.0))
+        val bbox = BoundingBox(Point(0.0, 0.0), Point(10.0, 10.0)).centerAt(Point(20.0, 30.0))
 
-        assertEquals(Point(15.0, 25.0), bbox.min);
-        assertEquals(Point(25.0, 35.0), bbox.max);
-        assertEquals(Point(20.0, 30.0), bbox.center);
+        assertEquals(Point(15.0, 25.0), bbox.min)
+        assertEquals(Point(25.0, 35.0), bbox.max)
+        assertEquals(Point(20.0, 30.0), bbox.center)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/CircleTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/CircleTest.kt
@@ -1,9 +1,9 @@
 package fi.fta.geoviite.infra.math
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import kotlin.math.PI
 import kotlin.math.sqrt
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class CircleTest {
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/ClothoidTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/ClothoidTest.kt
@@ -46,7 +46,11 @@ class ClothoidTest {
         assertCoordinateAtOffset(472.679000, 75.0, Pair(74.99888294202714, 0.3148311978089424))
     }
 
-    private fun assertCoordinateAtOffset(constantA: Double, distance: Double, expected: Pair<Double, Double>) {
+    private fun assertCoordinateAtOffset(
+        constantA: Double,
+        distance: Double,
+        expected: Pair<Double, Double>
+    ) {
         val delta = 0.001
         val actual = clothoidPointAtOffset(constantA, distance)
         assertEquals(expected.first, actual.x, delta)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/GeographyTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/GeographyTest.kt
@@ -6,35 +6,37 @@ import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.geography.crs
 import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.geography.transformToGKCoordinate
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import kotlin.test.assertEquals
 
 class GeographyTest {
 
     @Test
     fun boundingPolygonEpsg3067To3067Works() {
-        val points3067 = listOf(
-            Point(410380.415197, 6695143.038955),
-            Point(413592.399002, 6696145.121685),
-            Point(418533.823337, 6697740.232228),
-            Point(425552.596286, 6696334.091957),
-            Point(424930.649942, 6696750.252024),
-            Point(424912.100006, 6696759.418478),
-            Point(416258.105283, 6697012.526639),
-        )
+        val points3067 =
+            listOf(
+                Point(410380.415197, 6695143.038955),
+                Point(413592.399002, 6696145.121685),
+                Point(418533.823337, 6697740.232228),
+                Point(425552.596286, 6696334.091957),
+                Point(424930.649942, 6696750.252024),
+                Point(424912.100006, 6696759.418478),
+                Point(416258.105283, 6697012.526639),
+            )
 
         val bounds = boundingPolygonPointsByConvexHull(points3067, crs(Srid(3067)))
 
-        val expectedBounds = listOf(
-            Point(410380.415197, 6695143.038955),
-            Point(418533.823337, 6697740.232228),
-            Point(424912.100006, 6696759.418478),
-            Point(424930.649942, 6696750.252024),
-            Point(425552.596286, 6696334.091957),
-            Point(410380.415197, 6695143.038955),
-        )
+        val expectedBounds =
+            listOf(
+                Point(410380.415197, 6695143.038955),
+                Point(418533.823337, 6697740.232228),
+                Point(424912.100006, 6696759.418478),
+                Point(424930.649942, 6696750.252024),
+                Point(425552.596286, 6696334.091957),
+                Point(410380.415197, 6695143.038955),
+            )
 
         assertEquals(expectedBounds, bounds)
     }
@@ -139,7 +141,8 @@ class GeographyTest {
                 listOf(
                     Point(24.92842, 60.29733),
                     Point(25.47091, 65.00844),
-                ), Srid(4326)),
+                ),
+                Srid(4326)),
             0.001,
         )
     }
@@ -148,11 +151,13 @@ class GeographyTest {
     fun shouldReturnDistanceBetweenMultiplePoints() {
         Assertions.assertEquals(
             558.088,
-            calculateDistance(listOf(
-                Point(25.41464, 65.01486),
-                Point(25.42244, 65.01473),
-                Point(25.42499, 65.01605),
-            ), Srid(4326)),
+            calculateDistance(
+                listOf(
+                    Point(25.41464, 65.01486),
+                    Point(25.42244, 65.01473),
+                    Point(25.42499, 65.01605),
+                ),
+                Srid(4326)),
             0.001,
         )
     }
@@ -162,8 +167,7 @@ class GeographyTest {
         val p3067 = Point(509099.11577, 6711823.23316)
         val p4326 = transformNonKKJCoordinate(Srid(3067), Srid(4326), p3067)
         val p3067v2 = transformNonKKJCoordinate(Srid(4326), Srid(3067), p4326)
-        assertApproximatelyEquals(Point(x=27.165853988, y=60.542330292), p4326, 0.000000001)
+        assertApproximatelyEquals(Point(x = 27.165853988, y = 60.542330292), p4326, 0.000000001)
         assertApproximatelyEquals(p3067, p3067v2, 0.01)
     }
-
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/LineTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/LineTest.kt
@@ -1,10 +1,10 @@
 package fi.fta.geoviite.infra.math
 
 import fi.fta.geoviite.infra.math.IntersectType.*
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import kotlin.math.hypot
 import kotlin.math.sqrt
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 const val DOUBLE_CALC_ACCURACY = 0.00000000000001
 
@@ -23,16 +23,24 @@ class LineTest {
 
     @Test
     fun pointAlongLineWorks() {
-        assertEquals(Point(3.0, 3.0), linePointAtDistance(Point(2.0, 2.0), Point(4.0, 4.0), sqrt(2.0)))
-        assertEquals(Point(3.0, 3.0), linePointAtDistance(Point(4.0, 4.0), Point(2.0, 2.0), sqrt(2.0)))
+        assertEquals(
+            Point(3.0, 3.0), linePointAtDistance(Point(2.0, 2.0), Point(4.0, 4.0), sqrt(2.0)))
+        assertEquals(
+            Point(3.0, 3.0), linePointAtDistance(Point(4.0, 4.0), Point(2.0, 2.0), sqrt(2.0)))
 
-        assertEquals(Point(-3.0, -3.0), linePointAtDistance(Point(-2.0, -2.0), Point(-4.0, -4.0), sqrt(2.0)))
-        assertEquals(Point(-3.0, -3.0), linePointAtDistance(Point(-4.0, -4.0), Point(-2.0, -2.0), sqrt(2.0)))
+        assertEquals(
+            Point(-3.0, -3.0), linePointAtDistance(Point(-2.0, -2.0), Point(-4.0, -4.0), sqrt(2.0)))
+        assertEquals(
+            Point(-3.0, -3.0), linePointAtDistance(Point(-4.0, -4.0), Point(-2.0, -2.0), sqrt(2.0)))
 
-        assertEquals(Point(1.0, 1.0), linePointAtDistance(Point(0.0, 0.0), Point(2.0, 2.0), sqrt(2.0)))
-        assertEquals(Point(1.0, -1.0), linePointAtDistance(Point(0.0, 0.0), Point(2.0, -2.0), sqrt(2.0)))
-        assertEquals(Point(-1.0, -1.0), linePointAtDistance(Point(0.0, 0.0), Point(-2.0, -2.0), sqrt(2.0)))
-        assertEquals(Point(-1.0, 1.0), linePointAtDistance(Point(0.0, 0.0), Point(-2.0, 2.0), sqrt(2.0)))
+        assertEquals(
+            Point(1.0, 1.0), linePointAtDistance(Point(0.0, 0.0), Point(2.0, 2.0), sqrt(2.0)))
+        assertEquals(
+            Point(1.0, -1.0), linePointAtDistance(Point(0.0, 0.0), Point(2.0, -2.0), sqrt(2.0)))
+        assertEquals(
+            Point(-1.0, -1.0), linePointAtDistance(Point(0.0, 0.0), Point(-2.0, -2.0), sqrt(2.0)))
+        assertEquals(
+            Point(-1.0, 1.0), linePointAtDistance(Point(0.0, 0.0), Point(-2.0, 2.0), sqrt(2.0)))
     }
 
     @Test
@@ -111,14 +119,20 @@ class LineTest {
         assertEquals(0.0, pointDistanceToLine(start, end, Point(2.0, 2.0)))
         assertEquals(0.0, pointDistanceToLine(start, end, Point(1.5, 1.5)))
 
-        assertEquals(hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(1.0, 2.0)), DOUBLE_CALC_ACCURACY)
-        assertEquals(hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(2.0, 1.0)), DOUBLE_CALC_ACCURACY)
+        assertEquals(
+            hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(1.0, 2.0)), DOUBLE_CALC_ACCURACY)
+        assertEquals(
+            hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(2.0, 1.0)), DOUBLE_CALC_ACCURACY)
 
-        assertEquals(hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(2.5, 2.5)), DOUBLE_CALC_ACCURACY)
-        assertEquals(hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(0.5, 0.5)), DOUBLE_CALC_ACCURACY)
+        assertEquals(
+            hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(2.5, 2.5)), DOUBLE_CALC_ACCURACY)
+        assertEquals(
+            hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(0.5, 0.5)), DOUBLE_CALC_ACCURACY)
 
-        assertEquals(hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(1.5, 2.5)), DOUBLE_CALC_ACCURACY)
-        assertEquals(hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(2.5, 1.5)), DOUBLE_CALC_ACCURACY)
+        assertEquals(
+            hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(1.5, 2.5)), DOUBLE_CALC_ACCURACY)
+        assertEquals(
+            hypot(0.5, 0.5), pointDistanceToLine(start, end, Point(2.5, 1.5)), DOUBLE_CALC_ACCURACY)
     }
 
     @Test
@@ -128,46 +142,64 @@ class LineTest {
                 val xi = xIntersection.toDouble()
                 val yi = yIntersection.toDouble()
                 assertIntersection(
-                    Point(xi, yi), inSegment1 = WITHIN, inSegment2 = WITHIN,
+                    Point(xi, yi),
+                    inSegment1 = WITHIN,
+                    inSegment2 = WITHIN,
                     lineIntersection(
-                        Point(xi - 10.0, yi), Point(xi + 10.0, yi),
-                        Point(xi, yi - 10.0), Point(xi, yi + 10.0)
-                    )!!,
+                        Point(xi - 10.0, yi),
+                        Point(xi + 10.0, yi),
+                        Point(xi, yi - 10.0),
+                        Point(xi, yi + 10.0))!!,
                 )
                 assertIntersection(
-                    Point(xi, yi), inSegment1 = WITHIN, inSegment2 = WITHIN,
+                    Point(xi, yi),
+                    inSegment1 = WITHIN,
+                    inSegment2 = WITHIN,
                     lineIntersection(
-                        Point(xi - 4.0, yi - 3.0), Point(xi + 4.0, yi + 3.0),
-                        Point(xi + 2.0, yi - 4.0), Point(xi - 2.0, yi + 4.0)
-                    )!!,
+                        Point(xi - 4.0, yi - 3.0),
+                        Point(xi + 4.0, yi + 3.0),
+                        Point(xi + 2.0, yi - 4.0),
+                        Point(xi - 2.0, yi + 4.0))!!,
                 )
                 assertIntersection(
-                    Point(xi, yi), inSegment1 = AFTER, inSegment2 = WITHIN,
+                    Point(xi, yi),
+                    inSegment1 = AFTER,
+                    inSegment2 = WITHIN,
                     lineIntersection(
-                        Point(xi - 10.0, yi), Point(xi - 1.0, yi),
-                        Point(xi, yi - 10.0), Point(xi, yi + 10.0)
-                    )!!,
+                        Point(xi - 10.0, yi),
+                        Point(xi - 1.0, yi),
+                        Point(xi, yi - 10.0),
+                        Point(xi, yi + 10.0))!!,
                 )
                 assertIntersection(
-                    Point(xi, yi), inSegment1 = BEFORE, inSegment2 = WITHIN,
+                    Point(xi, yi),
+                    inSegment1 = BEFORE,
+                    inSegment2 = WITHIN,
                     lineIntersection(
-                        Point(xi - 1.0, yi), Point(xi - 10.0, yi),
-                        Point(xi, yi - 10.0), Point(xi, yi + 10.0)
-                    )!!,
+                        Point(xi - 1.0, yi),
+                        Point(xi - 10.0, yi),
+                        Point(xi, yi - 10.0),
+                        Point(xi, yi + 10.0))!!,
                 )
                 assertIntersection(
-                    Point(xi, yi), inSegment1 = WITHIN, inSegment2 = AFTER,
+                    Point(xi, yi),
+                    inSegment1 = WITHIN,
+                    inSegment2 = AFTER,
                     lineIntersection(
-                        Point(xi - 10.0, yi), Point(xi + 10.0, yi),
-                        Point(xi, yi + 10.0), Point(xi, yi + 1.0)
-                    )!!,
+                        Point(xi - 10.0, yi),
+                        Point(xi + 10.0, yi),
+                        Point(xi, yi + 10.0),
+                        Point(xi, yi + 1.0))!!,
                 )
                 assertIntersection(
-                    Point(xi, yi), inSegment1 = WITHIN, inSegment2 = BEFORE,
+                    Point(xi, yi),
+                    inSegment1 = WITHIN,
+                    inSegment2 = BEFORE,
                     lineIntersection(
-                        Point(xi - 10.0, yi), Point(xi + 10.0, yi),
-                        Point(xi, yi + 1.0), Point(xi, yi + 10.0)
-                    )!!,
+                        Point(xi - 10.0, yi),
+                        Point(xi + 10.0, yi),
+                        Point(xi, yi + 1.0),
+                        Point(xi, yi + 10.0))!!,
                 )
             }
         }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/PointTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/PointTest.kt
@@ -1,9 +1,9 @@
 package fi.fta.geoviite.infra.math
 
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
 import kotlin.math.PI
 import kotlin.math.sqrt
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 class PointTest {
 
@@ -27,23 +27,31 @@ class PointTest {
     @Test
     fun pointInDirectionFromOtherPointWorks() {
         val startPoint = Point(4.0, 3.0)
-        assertApproximatelyEquals(startPoint + Point(1.0, 0.0), pointInDirection(startPoint, 1.0, 0.0))
-        assertApproximatelyEquals(startPoint + Point(0.0, 1.0), pointInDirection(startPoint, 1.0, 0.5 * PI))
-        assertApproximatelyEquals(startPoint + Point(-1.0, 0.0), pointInDirection(startPoint, 1.0, PI))
-        assertApproximatelyEquals(startPoint + Point(0.0, -1.0), pointInDirection(startPoint, 1.0, 1.5 * PI))
-        assertApproximatelyEquals(startPoint + Point(1.0, 0.0), pointInDirection(startPoint, 1.0, 2 * PI))
+        assertApproximatelyEquals(
+            startPoint + Point(1.0, 0.0), pointInDirection(startPoint, 1.0, 0.0))
+        assertApproximatelyEquals(
+            startPoint + Point(0.0, 1.0), pointInDirection(startPoint, 1.0, 0.5 * PI))
+        assertApproximatelyEquals(
+            startPoint + Point(-1.0, 0.0), pointInDirection(startPoint, 1.0, PI))
+        assertApproximatelyEquals(
+            startPoint + Point(0.0, -1.0), pointInDirection(startPoint, 1.0, 1.5 * PI))
+        assertApproximatelyEquals(
+            startPoint + Point(1.0, 0.0), pointInDirection(startPoint, 1.0, 2 * PI))
 
-        assertApproximatelyEquals(startPoint + Point(sqrt(0.5), sqrt(0.5)),
-            pointInDirection(startPoint, 1.0, 0.25 * PI))
-        assertApproximatelyEquals(startPoint + Point(-sqrt(0.5), sqrt(0.5)),
-            pointInDirection(startPoint, 1.0, 0.75 * PI))
-        assertApproximatelyEquals(startPoint + Point(-sqrt(0.5), -sqrt(0.5)),
+        assertApproximatelyEquals(
+            startPoint + Point(sqrt(0.5), sqrt(0.5)), pointInDirection(startPoint, 1.0, 0.25 * PI))
+        assertApproximatelyEquals(
+            startPoint + Point(-sqrt(0.5), sqrt(0.5)), pointInDirection(startPoint, 1.0, 0.75 * PI))
+        assertApproximatelyEquals(
+            startPoint + Point(-sqrt(0.5), -sqrt(0.5)),
             pointInDirection(startPoint, 1.0, 1.25 * PI))
-        assertApproximatelyEquals(startPoint + Point(sqrt(0.5), -sqrt(0.5)),
-            pointInDirection(startPoint, 1.0, 1.75 * PI))
+        assertApproximatelyEquals(
+            startPoint + Point(sqrt(0.5), -sqrt(0.5)), pointInDirection(startPoint, 1.0, 1.75 * PI))
 
-        assertApproximatelyEquals(startPoint + Point(2.5, 0.0), pointInDirection(startPoint, 2.5, 0.0))
-        assertApproximatelyEquals(startPoint + Point(0.0, 10.1), pointInDirection(startPoint, 10.1, 0.5 * PI))
+        assertApproximatelyEquals(
+            startPoint + Point(2.5, 0.0), pointInDirection(startPoint, 2.5, 0.0))
+        assertApproximatelyEquals(
+            startPoint + Point(0.0, 10.1), pointInDirection(startPoint, 10.1, 0.5 * PI))
     }
 
     @Test
@@ -66,12 +74,17 @@ class PointTest {
 
     @Test
     fun rotateAroundOrigin() {
-        assertApproximatelyEquals(Point(12.34, 45.67), rotateAroundOrigin(2 * PI, Point(12.34, 45.67)))
+        assertApproximatelyEquals(
+            Point(12.34, 45.67), rotateAroundOrigin(2 * PI, Point(12.34, 45.67)))
         assertApproximatelyEquals(Point(12.34, 45.67), rotateAroundOrigin(0.0, Point(12.34, 45.67)))
-        assertApproximatelyEquals(Point(-12.34, -45.67), rotateAroundOrigin(PI, Point(12.34, 45.67)))
-        assertApproximatelyEquals(Point(-45.67, 12.34), rotateAroundOrigin(PI / 2, Point(12.34, 45.67)))
-        assertApproximatelyEquals(Point(45.67, -12.34), rotateAroundOrigin(3 * PI / 2, Point(12.34, 45.67)))
-        assertApproximatelyEquals(Point(45.67, -12.34), rotateAroundOrigin(-PI / 2, Point(12.34, 45.67)))
+        assertApproximatelyEquals(
+            Point(-12.34, -45.67), rotateAroundOrigin(PI, Point(12.34, 45.67)))
+        assertApproximatelyEquals(
+            Point(-45.67, 12.34), rotateAroundOrigin(PI / 2, Point(12.34, 45.67)))
+        assertApproximatelyEquals(
+            Point(45.67, -12.34), rotateAroundOrigin(3 * PI / 2, Point(12.34, 45.67)))
+        assertApproximatelyEquals(
+            Point(45.67, -12.34), rotateAroundOrigin(-PI / 2, Point(12.34, 45.67)))
     }
 
     @Test
@@ -85,12 +98,22 @@ class PointTest {
 }
 
 fun assertApproximatelyEquals(p1: IPoint, p2: IPoint, accuracy: Double = 0.0001) {
-    assertEquals(p1.x, p2.x, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
-    assertEquals(p1.y, p2.y, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
+    assertEquals(
+        p1.x, p2.x, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
+    assertEquals(
+        p1.y, p2.y, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
     if (p1 is IPoint3DM && p2 is IPoint3DM) {
-        assertEquals(p1.m, p2.m, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
+        assertEquals(
+            p1.m,
+            p2.m,
+            accuracy,
+            "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
     }
     if (p1 is IPoint3DZ && p2 is IPoint3DZ) {
-        assertEquals(p1.z, p2.z, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
+        assertEquals(
+            p1.z,
+            p2.z,
+            accuracy,
+            "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVApiSerializationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVApiSerializationTest.kt
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.HttpsUrl
+import java.time.Instant
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "nodb")
 @SpringBootTest
@@ -23,7 +23,8 @@ class PVApiSerializationTest @Autowired constructor(val mapper: ObjectMapper) {
         val searchId = PVId("asdf123")
         val startTime = Instant.now()
         val validFor = 123456L
-        val json = """{"tila":"$state","hakutunniste":"$searchId","alkuaika":"$startTime","hakutunniste-voimassa":$validFor}"""
+        val json =
+            """{"tila":"$state","hakutunniste":"$searchId","alkuaika":"$startTime","hakutunniste-voimassa":$validFor}"""
         val data = PVApiSearchStatus(state, searchId, startTime, validFor)
 
         assertEquals(json, toJson(data))
@@ -40,16 +41,17 @@ class PVApiSerializationTest @Autowired constructor(val mapper: ObjectMapper) {
         val technicalFields = listOf<PVDictionaryCode>()
         val containsPersonalInfo = null
 
-        val json = """{"tila":"$materialState","kuvaus":"$description","laji":"$materialCategory","dokumenttityyppi":"$documentType","ryhma":"$materialGroup","tekniikka-alat":[],"sisaltaa-henkilotietoja":null}"""
-        val data = PVApiDocumentMetadata(
-            materialState,
-            description,
-            materialCategory,
-            documentType,
-            materialGroup,
-            technicalFields,
-            containsPersonalInfo
-        )
+        val json =
+            """{"tila":"$materialState","kuvaus":"$description","laji":"$materialCategory","dokumenttityyppi":"$documentType","ryhma":"$materialGroup","tekniikka-alat":[],"sisaltaa-henkilotietoja":null}"""
+        val data =
+            PVApiDocumentMetadata(
+                materialState,
+                description,
+                materialCategory,
+                documentType,
+                materialGroup,
+                technicalFields,
+                containsPersonalInfo)
 
         assertEquals(json, toJson(data))
         assertEquals(data, toObject<PVApiDocumentMetadata>(json))
@@ -60,7 +62,8 @@ class PVApiSerializationTest @Autowired constructor(val mapper: ObjectMapper) {
         val masterSystem = PVMasterSystem("someservice")
         val targetCategory = PVTargetCategory("somenamespace/somecategory")
         val targetUrl = HttpsUrl("https://some.url.org:1234/some-path?query=test&other=other")
-        val json = """{"master-jarjestelma":"$masterSystem","kohdeluokka":"$targetCategory","kohde-url":"$targetUrl"}"""
+        val json =
+            """{"master-jarjestelma":"$masterSystem","kohdeluokka":"$targetCategory","kohde-url":"$targetUrl"}"""
         val data = PVApiRedirect(masterSystem, targetCategory, targetUrl)
 
         assertEquals(json, toJson(data))
@@ -68,5 +71,6 @@ class PVApiSerializationTest @Autowired constructor(val mapper: ObjectMapper) {
     }
 
     private fun toJson(value: Any): String = mapper.writeValueAsString(value)
+
     private inline fun <reified T> toObject(value: String): T = mapper.readValue<T>(value)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocumentServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVDocumentServiceIT.kt
@@ -2,16 +2,18 @@ package fi.fta.geoviite.infra.projektivelho
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.Oid
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class PVDocumentServiceIT @Autowired constructor(
+class PVDocumentServiceIT
+@Autowired
+constructor(
     private val pvDocumentService: PVDocumentService,
     private val pvDao: PVDao,
 ) : DBTestBase() {
@@ -24,7 +26,8 @@ class PVDocumentServiceIT @Autowired constructor(
     @Test
     fun `Changing document status works`() {
         insertTestDictionary(pvDao)
-        val document = insertDocumentMetaWithStatus(pvDao, Oid("1.2.3.4.5"), PVDocumentStatus.SUGGESTED)
+        val document =
+            insertDocumentMetaWithStatus(pvDao, Oid("1.2.3.4.5"), PVDocumentStatus.SUGGESTED)
         val id = pvDocumentService.updateDocumentStatus(document.id, PVDocumentStatus.ACCEPTED)
         val header = pvDocumentService.getDocumentHeader(id)
         assertEquals(document.id, id)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
@@ -13,19 +13,21 @@ import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.PROJECT_STATE
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.TECHNICS_FIELD
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.LocalizationKey
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest(properties = ["geoviite.projektivelho=true"])
-class PVIntegrationServiceIT @Autowired constructor(
+class PVIntegrationServiceIT
+@Autowired
+constructor(
     @Value("\${geoviite.projektivelho.test-port:12346}") private val projektiVelhoPort: Int,
     private val pvIntegrationService: PVIntegrationService,
     private val pvDao: PVDao,
@@ -41,120 +43,136 @@ class PVIntegrationServiceIT @Autowired constructor(
     }
 
     @Test
-    fun `Spinning up search works`(): Unit = fakeProjektiVelho().use { fakeProjektiVelho ->
-        fakeProjektiVelho.login()
-        fakeProjektiVelho.search()
-        val search = pvIntegrationService.search()
-        assertNotNull(search)
-        assertEquals(search.searchId, pvDao.fetchLatestActiveSearch()?.token)
-    }
+    fun `Spinning up search works`(): Unit =
+        fakeProjektiVelho().use { fakeProjektiVelho ->
+            fakeProjektiVelho.login()
+            fakeProjektiVelho.search()
+            val search = pvIntegrationService.search()
+            assertNotNull(search)
+            assertEquals(search.searchId, pvDao.fetchLatestActiveSearch()?.token)
+        }
 
     @Test
-    fun `Dictionary update works`(): Unit = fakeProjektiVelho().use { fakeProjektiVelho ->
-        fakeProjektiVelho.login()
-        PVDictionaryType.values().forEach { type ->
-            assertEquals(mapOf(), pvDao.fetchDictionary(type))
-        }
+    fun `Dictionary update works`(): Unit =
+        fakeProjektiVelho().use { fakeProjektiVelho ->
+            fakeProjektiVelho.login()
+            PVDictionaryType.values().forEach { type ->
+                assertEquals(mapOf(), pvDao.fetchDictionary(type))
+            }
 
-        fakeProjektiVelho.fetchDictionaries(MATERIAL, materialDictionaries)
-        fakeProjektiVelho.fetchDictionaries(PROJECT, projectDictionaries)
-        pvIntegrationService.updateDictionaries()
-        PVDictionaryType.values().forEach { type ->
-            assertEquals(
-                (materialDictionaries + projectDictionaries)[type]!!.map { e -> e.code to e.name }.associate { it },
-                pvDao.fetchDictionary(type),
-            )
-        }
+            fakeProjektiVelho.fetchDictionaries(MATERIAL, materialDictionaries)
+            fakeProjektiVelho.fetchDictionaries(PROJECT, projectDictionaries)
+            pvIntegrationService.updateDictionaries()
+            PVDictionaryType.values().forEach { type ->
+                assertEquals(
+                    (materialDictionaries + projectDictionaries)[type]!!
+                        .map { e -> e.code to e.name }
+                        .associate { it },
+                    pvDao.fetchDictionary(type),
+                )
+            }
 
-        val materialDictionaries2: Map<PVDictionaryType, List<PVDictionaryEntry>> = mapOf(
-            DOCUMENT_TYPE to listOf(
-                PVDictionaryEntry("dokumenttityyppi/dt01", "test doc type 1"),
-                PVDictionaryEntry("dokumenttityyppi/dt02", "test doc type 2 altered"),
-                PVDictionaryEntry("dokumenttityyppi/dt03", "test doc type 3 added"),
-            ),
-            MATERIAL_STATE to listOf(
-                PVDictionaryEntry("aineistotila/tila01", "test mat state 1"),
-                PVDictionaryEntry("aineistotila/tila02", "test mat state 2 altered"),
-                PVDictionaryEntry("aineistotila/tila03", "test mat state 3 added"),
-            ),
-            MATERIAL_CATEGORY to listOf(
-                PVDictionaryEntry("aineistolaji/al00", "test mat category 0 altered"),
-                PVDictionaryEntry("aineistolaji/al01", "test mat category 1"),
-                PVDictionaryEntry("aineistolaji/al02", "test mat category 2 added"),
-            ),
-            MATERIAL_GROUP to listOf(
-                PVDictionaryEntry("aineistoryhma/ar00", "test mat group 0 altered"),
-                PVDictionaryEntry("aineistoryhma/ar01", "test mat group 1"),
-                PVDictionaryEntry("aineistoryhma/ar02", "test mat group 2 added"),
-            ),
-            TECHNICS_FIELD to listOf(
-                PVDictionaryEntry("tekniikka-ala/ta00", "test tech field 0"),
-                PVDictionaryEntry("tekniikka-ala/ta01", "test tech field 1 altered"),
-                PVDictionaryEntry("tekniikka-ala/ta02", "test tech field 2 added"),
-            ),
-        )
-        val projectDictionaries2: Map<PVDictionaryType, List<PVDictionaryEntry>> = mapOf(
-            PROJECT_STATE to listOf(
-                PVDictionaryEntry("tila/tila14", "test state 14 altered"),
-                PVDictionaryEntry("tila/tila15", "test state 15"),
-                PVDictionaryEntry("tila/tila15", "test state 16 added"),
-            ),
-        )
-        fakeProjektiVelho.fetchDictionaries(MATERIAL, materialDictionaries2)
-        fakeProjektiVelho.fetchDictionaries(PROJECT, projectDictionaries2)
-        pvIntegrationService.updateDictionaries()
-        PVDictionaryType.values().forEach { type ->
-            assertEquals(
-                (materialDictionaries2 + projectDictionaries2)[type]!!.map { e -> e.code to e.name }.associate { it },
-                pvDao.fetchDictionary(type),
-            )
+            val materialDictionaries2: Map<PVDictionaryType, List<PVDictionaryEntry>> =
+                mapOf(
+                    DOCUMENT_TYPE to
+                        listOf(
+                            PVDictionaryEntry("dokumenttityyppi/dt01", "test doc type 1"),
+                            PVDictionaryEntry("dokumenttityyppi/dt02", "test doc type 2 altered"),
+                            PVDictionaryEntry("dokumenttityyppi/dt03", "test doc type 3 added"),
+                        ),
+                    MATERIAL_STATE to
+                        listOf(
+                            PVDictionaryEntry("aineistotila/tila01", "test mat state 1"),
+                            PVDictionaryEntry("aineistotila/tila02", "test mat state 2 altered"),
+                            PVDictionaryEntry("aineistotila/tila03", "test mat state 3 added"),
+                        ),
+                    MATERIAL_CATEGORY to
+                        listOf(
+                            PVDictionaryEntry("aineistolaji/al00", "test mat category 0 altered"),
+                            PVDictionaryEntry("aineistolaji/al01", "test mat category 1"),
+                            PVDictionaryEntry("aineistolaji/al02", "test mat category 2 added"),
+                        ),
+                    MATERIAL_GROUP to
+                        listOf(
+                            PVDictionaryEntry("aineistoryhma/ar00", "test mat group 0 altered"),
+                            PVDictionaryEntry("aineistoryhma/ar01", "test mat group 1"),
+                            PVDictionaryEntry("aineistoryhma/ar02", "test mat group 2 added"),
+                        ),
+                    TECHNICS_FIELD to
+                        listOf(
+                            PVDictionaryEntry("tekniikka-ala/ta00", "test tech field 0"),
+                            PVDictionaryEntry("tekniikka-ala/ta01", "test tech field 1 altered"),
+                            PVDictionaryEntry("tekniikka-ala/ta02", "test tech field 2 added"),
+                        ),
+                )
+            val projectDictionaries2: Map<PVDictionaryType, List<PVDictionaryEntry>> =
+                mapOf(
+                    PROJECT_STATE to
+                        listOf(
+                            PVDictionaryEntry("tila/tila14", "test state 14 altered"),
+                            PVDictionaryEntry("tila/tila15", "test state 15"),
+                            PVDictionaryEntry("tila/tila15", "test state 16 added"),
+                        ),
+                )
+            fakeProjektiVelho.fetchDictionaries(MATERIAL, materialDictionaries2)
+            fakeProjektiVelho.fetchDictionaries(PROJECT, projectDictionaries2)
+            pvIntegrationService.updateDictionaries()
+            PVDictionaryType.values().forEach { type ->
+                assertEquals(
+                    (materialDictionaries2 + projectDictionaries2)[type]!!
+                        .map { e -> e.code to e.name }
+                        .associate { it },
+                    pvDao.fetchDictionary(type),
+                )
+            }
         }
-    }
 
     @Test
-    fun `Importing through search happy case works`(): Unit = fakeProjektiVelho().use { fakeProjektiVelho ->
-        val searchId = PVId("123")
-        val documentOid = Oid<PVDocument>("1.2.3.4.5")
-        val assignmentOid = Oid<PVAssignment>("1.2.4.5.6")
-        val version = PVId("1")
-        val description = "description 1"
-        val documentType = materialDictionaries[DOCUMENT_TYPE]!!.first().code
-        val materialState = materialDictionaries[MATERIAL_STATE]!!.first().code
-        val materialGroup = materialDictionaries[MATERIAL_GROUP]!!.first().code
-        val materialCategory = materialDictionaries[MATERIAL_CATEGORY]!!.first().code
+    fun `Importing through search happy case works`(): Unit =
+        fakeProjektiVelho().use { fakeProjektiVelho ->
+            val searchId = PVId("123")
+            val documentOid = Oid<PVDocument>("1.2.3.4.5")
+            val assignmentOid = Oid<PVAssignment>("1.2.4.5.6")
+            val version = PVId("1")
+            val description = "description 1"
+            val documentType = materialDictionaries[DOCUMENT_TYPE]!!.first().code
+            val materialState = materialDictionaries[MATERIAL_STATE]!!.first().code
+            val materialGroup = materialDictionaries[MATERIAL_GROUP]!!.first().code
+            val materialCategory = materialDictionaries[MATERIAL_CATEGORY]!!.first().code
 
-        fakeProjektiVelho.login()
-        fakeProjektiVelho.fetchDictionaries(MATERIAL, materialDictionaries)
-        fakeProjektiVelho.fetchDictionaries(PROJECT, projectDictionaries)
-        fakeProjektiVelho.searchStatus(searchId)
-        fakeProjektiVelho.searchResults(searchId, listOf(PVApiMatch(documentOid, assignmentOid)))
-        fakeProjektiVelho.fileMetadata(
-            documentOid,
-            version,
-            description = description,
-            documentType = documentType,
-            materialState = materialState,
-            materialGroup = materialGroup,
-            materialCategory = materialCategory,
-        )
-        fakeProjektiVelho.fileContent(documentOid)
+            fakeProjektiVelho.login()
+            fakeProjektiVelho.fetchDictionaries(MATERIAL, materialDictionaries)
+            fakeProjektiVelho.fetchDictionaries(PROJECT, projectDictionaries)
+            fakeProjektiVelho.searchStatus(searchId)
+            fakeProjektiVelho.searchResults(
+                searchId, listOf(PVApiMatch(documentOid, assignmentOid)))
+            fakeProjektiVelho.fileMetadata(
+                documentOid,
+                version,
+                description = description,
+                documentType = documentType,
+                materialState = materialState,
+                materialGroup = materialGroup,
+                materialCategory = materialCategory,
+            )
+            fakeProjektiVelho.fileContent(documentOid)
 
-        pvIntegrationService.updateDictionaries()
-        pvDao.insertFetchInfo(searchId, Instant.now().plusSeconds(3600))
-        val search = pvDao.fetchLatestActiveSearch()!!
-        val status = pvIntegrationService.getSearchStatusIfReady(search)!!
+            pvIntegrationService.updateDictionaries()
+            pvDao.insertFetchInfo(searchId, Instant.now().plusSeconds(3600))
+            val search = pvDao.fetchLatestActiveSearch()!!
+            val status = pvIntegrationService.getSearchStatusIfReady(search)!!
 
-        pvIntegrationService.importFilesFromProjektiVelho(search, status)
-        assertDocumentExists(
-            documentOid,
-            PVDocumentStatus.SUGGESTED,
-            description = description,
-            documentType = documentType,
-            materialState = materialState,
-            materialGroup = materialGroup,
-            materialCategory = materialCategory,
-        )
-    }
+            pvIntegrationService.importFilesFromProjektiVelho(search, status)
+            assertDocumentExists(
+                documentOid,
+                PVDocumentStatus.SUGGESTED,
+                description = description,
+                documentType = documentType,
+                materialState = materialState,
+                materialGroup = materialGroup,
+                materialCategory = materialCategory,
+            )
+        }
 
     @Test
     fun `Document count fetching works`() {
@@ -170,7 +188,8 @@ class PVIntegrationServiceIT @Autowired constructor(
     @Test
     fun `Document rejection works`() {
         insertTestDictionary(pvDao)
-        val version = insertDocumentMetaWithStatus(pvDao, Oid("1.2.3.4.7"), PVDocumentStatus.REJECTED)
+        val version =
+            insertDocumentMetaWithStatus(pvDao, Oid("1.2.3.4.7"), PVDocumentStatus.REJECTED)
         pvDao.insertRejection(version, "test")
         val rejection = pvDao.getRejection(version)
 
@@ -192,9 +211,13 @@ class PVIntegrationServiceIT @Autowired constructor(
         assertEquals(description, header.document.description?.toString())
         assertEquals(status, header.document.status)
         assertEquals(getTestDataDictionaryName(DOCUMENT_TYPE, documentType)!!, header.document.type)
-        assertEquals(getTestDataDictionaryName(MATERIAL_STATE, materialState)!!, header.document.state)
-        assertEquals(getTestDataDictionaryName(MATERIAL_GROUP, materialGroup)!!, header.document.group)
-        assertEquals(getTestDataDictionaryName(MATERIAL_CATEGORY, materialCategory)!!, header.document.category)
+        assertEquals(
+            getTestDataDictionaryName(MATERIAL_STATE, materialState)!!, header.document.state)
+        assertEquals(
+            getTestDataDictionaryName(MATERIAL_GROUP, materialGroup)!!, header.document.group)
+        assertEquals(
+            getTestDataDictionaryName(MATERIAL_CATEGORY, materialCategory)!!,
+            header.document.category)
     }
 }
 
@@ -207,18 +230,23 @@ fun insertTestDictionary(pvDao: PVDao) {
 
 fun insertDocumentMetaWithStatus(pvDao: PVDao, oid: Oid<PVDocument>, status: PVDocumentStatus) =
     pvDao.insertDocumentMetadata(
-        oid = oid, assignmentOid = null, latestVersion = PVApiLatestVersion(
-            version = PVId("test"), name = FileName("test"), changeTime = Instant.now()
-        ), metadata = PVApiDocumentMetadata(
-            materialCategory = PVDictionaryCode("test"),
-            description = null,
-            materialGroup = PVDictionaryCode("test"),
-            materialState = PVDictionaryCode("test"),
-            documentType = PVDictionaryCode("test"),
-            technicalFields = emptyList(),
-            containsPersonalInfo = false
-        ), projectGroupOid = null, projectOid = null, status = status
-    )
+        oid = oid,
+        assignmentOid = null,
+        latestVersion =
+            PVApiLatestVersion(
+                version = PVId("test"), name = FileName("test"), changeTime = Instant.now()),
+        metadata =
+            PVApiDocumentMetadata(
+                materialCategory = PVDictionaryCode("test"),
+                description = null,
+                materialGroup = PVDictionaryCode("test"),
+                materialState = PVDictionaryCode("test"),
+                documentType = PVDictionaryCode("test"),
+                technicalFields = emptyList(),
+                containsPersonalInfo = false),
+        projectGroupOid = null,
+        projectOid = null,
+        status = status)
 
 private fun getTestDataDictionaryName(type: PVDictionaryType, code: PVDictionaryCode) =
     (materialDictionaries + projectDictionaries)[type]?.find { e -> e.code == code }?.name

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVTestData.kt
@@ -1,31 +1,39 @@
 package fi.fta.geoviite.infra.projektivelho
 
-val materialDictionaries: Map<PVDictionaryType, List<PVDictionaryEntry>> = mapOf(
-    PVDictionaryType.DOCUMENT_TYPE to listOf(
-        PVDictionaryEntry("dokumenttityyppi/dt01", "test doc type 1"),
-        PVDictionaryEntry("dokumenttityyppi/dt02", "test doc type 2"),
-    ),
-    PVDictionaryType.MATERIAL_STATE to listOf(
-        PVDictionaryEntry("aineistotila/tila01", "test mat state 1"),
-        PVDictionaryEntry("aineistotila/tila02", "test mat state 2"),
-    ),
-    PVDictionaryType.MATERIAL_CATEGORY to listOf(
-        PVDictionaryEntry("aineistolaji/al00", "test mat category 0"),
-        PVDictionaryEntry("aineistolaji/al01", "test mat category 1"),
-    ),
-    PVDictionaryType.MATERIAL_GROUP to listOf(
-        PVDictionaryEntry("aineistoryhma/ar00", "test mat group 0"),
-        PVDictionaryEntry("aineistoryhma/ar01", "test mat group 1"),
-    ),
-    PVDictionaryType.TECHNICS_FIELD to listOf(
-        PVDictionaryEntry("tekniikka-ala/ta00", "test tech field 0"),
-        PVDictionaryEntry("tekniikka-ala/ta01", "test tech field 1"),
-    ),
-)
+val materialDictionaries: Map<PVDictionaryType, List<PVDictionaryEntry>> =
+    mapOf(
+        PVDictionaryType.DOCUMENT_TYPE to
+            listOf(
+                PVDictionaryEntry("dokumenttityyppi/dt01", "test doc type 1"),
+                PVDictionaryEntry("dokumenttityyppi/dt02", "test doc type 2"),
+            ),
+        PVDictionaryType.MATERIAL_STATE to
+            listOf(
+                PVDictionaryEntry("aineistotila/tila01", "test mat state 1"),
+                PVDictionaryEntry("aineistotila/tila02", "test mat state 2"),
+            ),
+        PVDictionaryType.MATERIAL_CATEGORY to
+            listOf(
+                PVDictionaryEntry("aineistolaji/al00", "test mat category 0"),
+                PVDictionaryEntry("aineistolaji/al01", "test mat category 1"),
+            ),
+        PVDictionaryType.MATERIAL_GROUP to
+            listOf(
+                PVDictionaryEntry("aineistoryhma/ar00", "test mat group 0"),
+                PVDictionaryEntry("aineistoryhma/ar01", "test mat group 1"),
+            ),
+        PVDictionaryType.TECHNICS_FIELD to
+            listOf(
+                PVDictionaryEntry("tekniikka-ala/ta00", "test tech field 0"),
+                PVDictionaryEntry("tekniikka-ala/ta01", "test tech field 1"),
+            ),
+    )
 
-val projectDictionaries: Map<PVDictionaryType, List<PVDictionaryEntry>> = mapOf(
-    PVDictionaryType.PROJECT_STATE to listOf(
-        PVDictionaryEntry("tila/tila14", "test state 14"),
-        PVDictionaryEntry("tila/tila15", "test state 15"),
-    ),
-)
+val projectDictionaries: Map<PVDictionaryType, List<PVDictionaryEntry>> =
+    mapOf(
+        PVDictionaryType.PROJECT_STATE to
+            listOf(
+                PVDictionaryEntry("tila/tila14", "test state 14"),
+                PVDictionaryEntry("tila/tila15", "test state 15"),
+            ),
+    )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -48,17 +48,19 @@ import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class PublicationDaoIT @Autowired constructor(
+class PublicationDaoIT
+@Autowired
+constructor(
     val publicationDao: PublicationDao,
     val switchDao: LayoutSwitchDao,
     val trackNumberDao: LayoutTrackNumberDao,
@@ -77,20 +79,25 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun noPublicationCandidatesFoundWithoutDrafts() {
-        assertTrue(publicationDao.fetchTrackNumberPublicationCandidates(PublicationInMain).isEmpty())
-        assertTrue(publicationDao.fetchReferenceLinePublicationCandidates(PublicationInMain).isEmpty())
-        assertTrue(publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain).isEmpty())
+        assertTrue(
+            publicationDao.fetchTrackNumberPublicationCandidates(PublicationInMain).isEmpty())
+        assertTrue(
+            publicationDao.fetchReferenceLinePublicationCandidates(PublicationInMain).isEmpty())
+        assertTrue(
+            publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain).isEmpty())
         assertTrue(publicationDao.fetchSwitchPublicationCandidates(PublicationInMain).isEmpty())
         assertTrue(publicationDao.fetchKmPostPublicationCandidates(PublicationInMain).isEmpty())
     }
 
     @Test
     fun referenceLinePublicationCandidatesAreFound() {
-        val trackNumberId = insertAndCheck(trackNumber(testDBService.getUnusedTrackNumber(), draft = false)).first.id
+        val trackNumberId =
+            insertAndCheck(trackNumber(testDBService.getUnusedTrackNumber(), draft = false))
+                .first
+                .id
         val (_, line) = insertAndCheck(referenceLine(trackNumberId, draft = false))
-        val (_, draft) = insertAndCheck(
-            asMainDraft(line).copy(startAddress = TrackMeter("0123", 658.321, 3))
-        )
+        val (_, draft) =
+            insertAndCheck(asMainDraft(line).copy(startAddress = TrackMeter("0123", 658.321, 3)))
         val candidates = publicationDao.fetchReferenceLinePublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(line.id, candidates.first().id)
@@ -101,10 +108,11 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun locationTrackPublicationCandidatesAreFound() {
-        val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
-        val (_, draft) = insertAndCheck(
-            asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT"))
-        )
+        val (_, track) =
+            insertAndCheck(
+                locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
+        val (_, draft) =
+            insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
         val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -117,7 +125,8 @@ class PublicationDaoIT @Autowired constructor(
     @Test
     fun switchPublicationCandidatesAreFound() {
         val (_, switch) = insertAndCheck(switch(987, draft = false))
-        val (_, draft) = insertAndCheck(asMainDraft(switch).copy(name = SwitchName("${switch.name} DRAFT")))
+        val (_, draft) =
+            insertAndCheck(asMainDraft(switch).copy(name = SwitchName("${switch.name} DRAFT")))
         val candidates = publicationDao.fetchSwitchPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(switch.id, candidates.first().id)
@@ -128,7 +137,9 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun createOperationIsInferredCorrectly() {
-        val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = true))
+        val (_, track) =
+            insertAndCheck(
+                locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = true))
         val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -137,12 +148,16 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun modifyOperationIsInferredCorrectly() {
-        val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
-        val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
+        val (_, track) =
+            insertAndCheck(
+                locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
+        val (version, draft) =
+            insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
         publishAndCheck(version.rowVersion)
         locationTrackService.saveDraft(
             LayoutBranch.main,
-            locationTrackService.getOrThrow(MainLayoutContext.official, draft.id as IntId).let { lt ->
+            locationTrackService.getOrThrow(MainLayoutContext.official, draft.id as IntId).let { lt
+                ->
                 lt.copy(name = AlignmentName("${lt.name} TEST"))
             },
         )
@@ -154,12 +169,16 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun deleteOperationIsInferredCorrectly() {
-        val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
-        val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
+        val (_, track) =
+            insertAndCheck(
+                locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
+        val (version, draft) =
+            insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
         publishAndCheck(version.rowVersion)
         locationTrackService.saveDraft(
             LayoutBranch.main,
-            locationTrackService.getOrThrow(MainLayoutContext.official, draft.id as IntId)
+            locationTrackService
+                .getOrThrow(MainLayoutContext.official, draft.id as IntId)
                 .copy(state = LocationTrackState.DELETED),
         )
         val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
@@ -170,17 +189,21 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun restoreOperationIsInferredCorrectly() {
-        val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
-        val (version, draft) = insertAndCheck(
-            asMainDraft(track).copy(
-                name = AlignmentName("${track.name} DRAFT"),
-                state = LocationTrackState.DELETED,
-            )
-        )
+        val (_, track) =
+            insertAndCheck(
+                locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
+        val (version, draft) =
+            insertAndCheck(
+                asMainDraft(track)
+                    .copy(
+                        name = AlignmentName("${track.name} DRAFT"),
+                        state = LocationTrackState.DELETED,
+                    ))
         publishAndCheck(version.rowVersion)
         locationTrackService.saveDraft(
             LayoutBranch.main,
-            locationTrackService.getOrThrow(MainLayoutContext.official, draft.id as IntId)
+            locationTrackService
+                .getOrThrow(MainLayoutContext.official, draft.id as IntId)
                 .copy(state = LocationTrackState.IN_USE),
         )
         val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
@@ -195,43 +218,47 @@ class PublicationDaoIT @Autowired constructor(
         val locationTrackId = insertAndCheck(locationTrack(trackNumberId, draft = false)).first.id
         val switchId = insertAndCheck(switch(234, draft = false)).first.id
 
-        val switchJointChange = SwitchJointChange(
-            JointNumber(1),
-            false,
-            TrackMeter(1234, "AA", 12.34, 3),
-            Point(100.0, 200.0),
-            locationTrackId,
-            Oid("123.456.789"),
-            trackNumberId,
-            Oid("1.234.567")
-        )
+        val switchJointChange =
+            SwitchJointChange(
+                JointNumber(1),
+                false,
+                TrackMeter(1234, "AA", 12.34, 3),
+                Point(100.0, 200.0),
+                locationTrackId,
+                Oid("123.456.789"),
+                trackNumberId,
+                Oid("1.234.567"))
 
-        val changes = CalculatedChanges(
-            directChanges = DirectChanges(
-                trackNumberChanges = listOf(
-                    TrackNumberChange(
-                        trackNumberId,
-                        setOf(KmNumber(1234), KmNumber(45, "AB")),
-                        isStartChanged = true,
-                        isEndChanged = false
+        val changes =
+            CalculatedChanges(
+                directChanges =
+                    DirectChanges(
+                        trackNumberChanges =
+                            listOf(
+                                TrackNumberChange(
+                                    trackNumberId,
+                                    setOf(KmNumber(1234), KmNumber(45, "AB")),
+                                    isStartChanged = true,
+                                    isEndChanged = false),
+                            ),
+                        kmPostChanges = emptyList(),
+                        referenceLineChanges = emptyList(),
+                        locationTrackChanges =
+                            listOf(
+                                LocationTrackChange(
+                                    locationTrackId,
+                                    setOf(KmNumber(456)),
+                                    isStartChanged = false,
+                                    isEndChanged = true,
+                                ),
+                            ),
+                        switchChanges =
+                            listOf(
+                                SwitchChange(switchId, listOf(switchJointChange)),
+                            ),
                     ),
-                ),
-                kmPostChanges = emptyList(),
-                referenceLineChanges = emptyList(),
-                locationTrackChanges = listOf(
-                    LocationTrackChange(
-                        locationTrackId,
-                        setOf(KmNumber(456)),
-                        isStartChanged = false,
-                        isEndChanged = true,
-                    ),
-                ),
-                switchChanges = listOf(
-                    SwitchChange(switchId, listOf(switchJointChange)),
-                ),
-            ),
-            indirectChanges = IndirectChanges(emptyList(), emptyList(), emptyList()),
-        )
+                indirectChanges = IndirectChanges(emptyList(), emptyList(), emptyList()),
+            )
         val publicationId = publicationDao.createPublication(LayoutBranch.main, "")
         publicationDao.insertCalculatedChanges(publicationId, changes)
 
@@ -251,7 +278,8 @@ class PublicationDaoIT @Autowired constructor(
         )
 
         assertTrue(publishedSwitches.directChanges.all { it.id == switchId })
-        assertEquals(listOf(switchJointChange), publishedSwitches.directChanges.flatMap { it.changedJoints })
+        assertEquals(
+            listOf(switchJointChange), publishedSwitches.directChanges.flatMap { it.changedJoints })
     }
 
     @Test
@@ -267,13 +295,12 @@ class PublicationDaoIT @Autowired constructor(
         val (_, switch) = insertAndCheck(switch(234, name = "Foo", draft = false))
         val switchId = switch.id as IntId
         insertAndCheck(
-            locationTrack(trackNumberId, draft = false).copy(
-                topologyEndSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(1))
-            )
-        )
+            locationTrack(trackNumberId, draft = false)
+                .copy(topologyEndSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(1))))
         insertAndCheck(asMainDraft(switch.copy(name = SwitchName("FooEdited"))))
 
-        val publicationCandidates = publicationDao.fetchSwitchPublicationCandidates(PublicationInMain)
+        val publicationCandidates =
+            publicationDao.fetchSwitchPublicationCandidates(PublicationInMain)
         val editedCandidate = publicationCandidates.first { s -> s.name == SwitchName("FooEdited") }
         assertEquals(editedCandidate.trackNumberIds, listOf(trackNumberId))
     }
@@ -284,14 +311,15 @@ class PublicationDaoIT @Autowired constructor(
         val (_, switch) = insertAndCheck(switch(345, name = "Foo", draft = true))
         val switchId = switch.id as IntId
         insertAndCheck(
-            locationTrack(trackNumberId, draft = true).copy(
-                topologyEndSwitch = TopologyLocationTrackSwitch(
-                    switchId,
-                    JointNumber(1),
-                )
-            )
-        )
-        val publicationCandidates = publicationDao.fetchSwitchPublicationCandidates(PublicationInMain)
+            locationTrack(trackNumberId, draft = true)
+                .copy(
+                    topologyEndSwitch =
+                        TopologyLocationTrackSwitch(
+                            switchId,
+                            JointNumber(1),
+                        )))
+        val publicationCandidates =
+            publicationDao.fetchSwitchPublicationCandidates(PublicationInMain)
         val editedCandidate = publicationCandidates.first { s -> s.name == SwitchName("Foo") }
         assertEquals(editedCandidate.trackNumberIds, listOf(trackNumberId))
     }
@@ -302,90 +330,86 @@ class PublicationDaoIT @Autowired constructor(
         val switchByAlignment = switchDao.insert(switch(1, draft = false)).id
         val switchByTopo = switchDao.insert(switch(2, draft = false)).id
         val dummyAlignment = alignmentDao.insert(alignment())
-        val officialLinkedTopo = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(1)),
-                alignmentVersion = dummyAlignment,
-                draft = false,
-            )
-        )
-        val draftLinkedTopo = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(3)),
-                alignmentVersion = dummyAlignment,
-                draft = true,
-            )
-        )
-        val officialLinkedAlignment = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                alignmentVersion = alignmentDao.insert(
-                    alignment(
-                        segment(
-                            Point(0.0, 0.0),
-                            Point(1.0, 1.0),
-                            switchId = switchByAlignment,
-                            startJointNumber = JointNumber(1)
-                        )
-                    )
-                ),
-                draft = false,
-            )
-        )
-        val draftLinkedAlignment = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                alignmentVersion = alignmentDao.insert(
-                    alignment(
-                        segment(
-                            Point(2.0, 2.0),
-                            Point(3.0, 3.0),
-                            switchId = switchByAlignment,
-                            startJointNumber = JointNumber(3)
-                        )
-                    )
-                ),
-                draft = true,
-            )
-        )
+        val officialLinkedTopo =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(1)),
+                    alignmentVersion = dummyAlignment,
+                    draft = false,
+                ))
+        val draftLinkedTopo =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(switchByTopo, JointNumber(3)),
+                    alignmentVersion = dummyAlignment,
+                    draft = true,
+                ))
+        val officialLinkedAlignment =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    alignmentVersion =
+                        alignmentDao.insert(
+                            alignment(
+                                segment(
+                                    Point(0.0, 0.0),
+                                    Point(1.0, 1.0),
+                                    switchId = switchByAlignment,
+                                    startJointNumber = JointNumber(1)))),
+                    draft = false,
+                ))
+        val draftLinkedAlignment =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    alignmentVersion =
+                        alignmentDao.insert(
+                            alignment(
+                                segment(
+                                    Point(2.0, 2.0),
+                                    Point(3.0, 3.0),
+                                    switchId = switchByAlignment,
+                                    startJointNumber = JointNumber(3)))),
+                    draft = true,
+                ))
         assertEquals(
             setOf(officialLinkedAlignment, draftLinkedAlignment),
-            publicationDao.fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByAlignment))[switchByAlignment],
+            publicationDao
+                .fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByAlignment))[
+                    switchByAlignment],
         )
         assertEquals(
             setOf(officialLinkedAlignment),
-            publicationDao.fetchLinkedLocationTracks(
-                LayoutBranch.main,
-                listOf(switchByAlignment),
-                listOf()
-            )[switchByAlignment]
-        )
+            publicationDao
+                .fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByAlignment), listOf())[
+                    switchByAlignment])
         assertEquals(
             setOf(officialLinkedAlignment, draftLinkedAlignment),
-            publicationDao.fetchLinkedLocationTracks(
-                LayoutBranch.main,
-                listOf(switchByAlignment),
-                listOf(draftLinkedAlignment.id),
-            )[switchByAlignment],
+            publicationDao
+                .fetchLinkedLocationTracks(
+                    LayoutBranch.main,
+                    listOf(switchByAlignment),
+                    listOf(draftLinkedAlignment.id),
+                )[switchByAlignment],
         )
         assertEquals(
             setOf(officialLinkedTopo, draftLinkedTopo),
-            publicationDao.fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByTopo))[switchByTopo],
+            publicationDao
+                .fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByTopo))[switchByTopo],
         )
         assertEquals(
             setOf(officialLinkedTopo),
-            publicationDao.fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByTopo), listOf())[switchByTopo]
-        )
+            publicationDao
+                .fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByTopo), listOf())[
+                    switchByTopo])
         assertEquals(
             setOf(officialLinkedTopo, draftLinkedTopo),
-            publicationDao.fetchLinkedLocationTracks(
-                LayoutBranch.main,
-                listOf(switchByTopo),
-                listOf(draftLinkedTopo.id)
-            )[switchByTopo]
-        )
+            publicationDao
+                .fetchLinkedLocationTracks(
+                    LayoutBranch.main, listOf(switchByTopo), listOf(draftLinkedTopo.id))[
+                    switchByTopo])
     }
 
     @Test
@@ -398,12 +422,10 @@ class PublicationDaoIT @Autowired constructor(
         publicationDao.createPublication(LayoutBranch.main, "again in main")
         assertEquals(
             listOf("in anotherDesign", "in someDesign"),
-            publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 2).map { it.message }
-        )
+            publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 2).map { it.message })
         assertEquals(
             listOf("again in main", "in main"),
-            publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, 2).map { it.message }
-        )
+            publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, 2).map { it.message })
     }
 
     private fun insertAndCheck(
@@ -419,7 +441,9 @@ class PublicationDaoIT @Autowired constructor(
         return official to fromDb
     }
 
-    private fun insertAndCheck(switch: TrackLayoutSwitch): Pair<LayoutDaoResponse<TrackLayoutSwitch>, TrackLayoutSwitch> {
+    private fun insertAndCheck(
+        switch: TrackLayoutSwitch
+    ): Pair<LayoutDaoResponse<TrackLayoutSwitch>, TrackLayoutSwitch> {
         val official = switchDao.insert(switch)
         val fromDb = switchDao.fetch(official.rowVersion)
         assertEquals(official.id, fromDb.id)
@@ -430,7 +454,9 @@ class PublicationDaoIT @Autowired constructor(
         return official to fromDb
     }
 
-    private fun insertAndCheck(referenceLine: ReferenceLine): Pair<LayoutDaoResponse<ReferenceLine>, ReferenceLine> {
+    private fun insertAndCheck(
+        referenceLine: ReferenceLine
+    ): Pair<LayoutDaoResponse<ReferenceLine>, ReferenceLine> {
         val dbAlignmentVersion = alignmentDao.insert(alignment())
         val lineWithAlignment = referenceLine.copy(alignmentVersion = dbAlignmentVersion)
         val official = referenceLineDao.insert(lineWithAlignment)
@@ -443,7 +469,9 @@ class PublicationDaoIT @Autowired constructor(
         return official to fromDb
     }
 
-    private fun insertAndCheck(locationTrack: LocationTrack): Pair<LayoutDaoResponse<LocationTrack>, LocationTrack> {
+    private fun insertAndCheck(
+        locationTrack: LocationTrack
+    ): Pair<LayoutDaoResponse<LocationTrack>, LocationTrack> {
         val dbAlignmentVersion = alignmentDao.insert(alignment())
         val trackWithAlignment = locationTrack.copy(alignmentVersion = dbAlignmentVersion)
         val official = locationTrackDao.insert(trackWithAlignment)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -94,15 +94,6 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.LocalizationKey
 import fi.fta.geoviite.infra.util.SortOrder
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import publicationRequest
-import publish
 import java.math.BigDecimal
 import kotlin.math.absoluteValue
 import kotlin.test.assertContains
@@ -112,10 +103,21 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import publicationRequest
+import publish
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class PublicationServiceIT @Autowired constructor(
+class PublicationServiceIT
+@Autowired
+constructor(
     val publicationService: PublicationService,
     val publicationDao: PublicationDao,
     val alignmentDao: LayoutAlignmentDao,
@@ -141,15 +143,16 @@ class PublicationServiceIT @Autowired constructor(
     fun cleanup() {
         testDBService.clearPublicationTables()
         testDBService.clearLayoutTables()
-        val request = publicationService.collectPublicationCandidates(PublicationInMain).let {
-            PublicationRequestIds(
-                it.trackNumbers.map(TrackNumberPublicationCandidate::id),
-                it.locationTracks.map(LocationTrackPublicationCandidate::id),
-                it.referenceLines.map(ReferenceLinePublicationCandidate::id),
-                it.switches.map(SwitchPublicationCandidate::id),
-                it.kmPosts.map(KmPostPublicationCandidate::id),
-            )
-        }
+        val request =
+            publicationService.collectPublicationCandidates(PublicationInMain).let {
+                PublicationRequestIds(
+                    it.trackNumbers.map(TrackNumberPublicationCandidate::id),
+                    it.locationTracks.map(LocationTrackPublicationCandidate::id),
+                    it.referenceLines.map(ReferenceLinePublicationCandidate::id),
+                    it.switches.map(SwitchPublicationCandidate::id),
+                    it.kmPosts.map(KmPostPublicationCandidate::id),
+                )
+            }
         publicationService.revertPublicationCandidates(LayoutBranch.main, request)
     }
 
@@ -160,34 +163,42 @@ class PublicationServiceIT @Autowired constructor(
 
         val switches = mainDraftContext.insertMany(switch(111), switch(112))
 
-        val referenceLines = mainDraftContext.insertMany(
-            referenceLineAndAlignment(officialTrackNumberId),
-            referenceLineAndAlignment(trackNumbers[0].id, segment(Point(1.0, 1.0), Point(2.0, 2.0))),
-            referenceLineAndAlignment(trackNumbers[1].id, segment(Point(5.0, 5.0), Point(6.0, 6.0))),
-        )
+        val referenceLines =
+            mainDraftContext.insertMany(
+                referenceLineAndAlignment(officialTrackNumberId),
+                referenceLineAndAlignment(
+                    trackNumbers[0].id, segment(Point(1.0, 1.0), Point(2.0, 2.0))),
+                referenceLineAndAlignment(
+                    trackNumbers[1].id, segment(Point(5.0, 5.0), Point(6.0, 6.0))),
+            )
 
-        val locationTracks = mainDraftContext.insertMany(
-            locationTrackAndAlignment(trackNumbers[0].id),
-            locationTrackAndAlignment(trackNumbers[0].id),
-        )
+        val locationTracks =
+            mainDraftContext.insertMany(
+                locationTrackAndAlignment(trackNumbers[0].id),
+                locationTrackAndAlignment(trackNumbers[0].id),
+            )
 
-        val kmPosts = mainDraftContext.insertMany(
-            kmPost(trackNumbers[0].id, KmNumber(1)),
-            kmPost(trackNumbers[0].id, KmNumber(2)),
-        )
+        val kmPosts =
+            mainDraftContext.insertMany(
+                kmPost(trackNumbers[0].id, KmNumber(1)),
+                kmPost(trackNumbers[0].id, KmNumber(2)),
+            )
 
-        val publicationRequestIds = PublicationRequestIds(
-            trackNumbers.map { it.id },
-            locationTracks.map { it.id },
-            referenceLines.map { it.id },
-            switches.map { it.id },
-            kmPosts.map { it.id },
-        )
+        val publicationRequestIds =
+            PublicationRequestIds(
+                trackNumbers.map { it.id },
+                locationTracks.map { it.id },
+                referenceLines.map { it.id },
+                switches.map { it.id },
+                kmPosts.map { it.id },
+            )
 
-        val publicationVersions = publicationService.getValidationVersions(LayoutBranch.main, publicationRequestIds)
+        val publicationVersions =
+            publicationService.getValidationVersions(LayoutBranch.main, publicationRequestIds)
         val draftCalculatedChanges = getCalculatedChangesInRequest(publicationVersions)
         val beforeInsert = testDBService.getDbTime()
-        val publicationResult = testPublish(LayoutBranch.main, publicationVersions, draftCalculatedChanges)
+        val publicationResult =
+            testPublish(LayoutBranch.main, publicationVersions, draftCalculatedChanges)
         val afterInsert = testDBService.getDbTime()
         assertNotNull(publicationResult.publicationId)
         val publish = publicationService.getPublicationDetails(publicationResult.publicationId!!)
@@ -203,7 +214,8 @@ class PublicationServiceIT @Autowired constructor(
 
         val segment = segment(Point(0.0, 0.0), Point(1.0, 1.0), switchId = switch.id)
         val track1 = mainDraftContext.insert(locationTrackAndAlignment(trackNumber.id, segment))
-        val track2 = mainDraftContext.insert(locationTrackAndAlignment(trackNumber.id, name = "TEST-1"))
+        val track2 =
+            mainDraftContext.insert(locationTrackAndAlignment(trackNumber.id, name = "TEST-1"))
 
         val referenceLine = mainDraftContext.insert(referenceLineAndAlignment(trackNumber.id))
 
@@ -232,20 +244,23 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Publication contains correct TrackNumber links for switches`() {
         val switch = mainDraftContext.insert(switch(123))
-        val trackNumberIds = listOf(
-            mainOfficialContext.createLayoutTrackNumber().id,
-            mainOfficialContext.createLayoutTrackNumber().id,
-        )
-        val locationTracks = trackNumberIds.map { trackNumberId ->
-            val segment = segment(Point(0.0, 0.0), Point(1.0, 1.0), switchId = switch.id)
-            mainDraftContext.insert(locationTrackAndAlignment(trackNumberId, segment))
-        }
+        val trackNumberIds =
+            listOf(
+                mainOfficialContext.createLayoutTrackNumber().id,
+                mainOfficialContext.createLayoutTrackNumber().id,
+            )
+        val locationTracks =
+            trackNumberIds.map { trackNumberId ->
+                val segment = segment(Point(0.0, 0.0), Point(1.0, 1.0), switchId = switch.id)
+                mainDraftContext.insert(locationTrackAndAlignment(trackNumberId, segment))
+            }
 
-        val publicationResult = publish(
-            publicationService,
-            locationTracks = locationTracks.map { it.id },
-            switches = listOf(switch.id),
-        )
+        val publicationResult =
+            publish(
+                publicationService,
+                locationTracks = locationTracks.map { it.id },
+                switches = listOf(switch.id),
+            )
         val publish = publicationService.getPublicationDetails(publicationResult.publicationId!!)
         assertEquals(
             trackNumberIds.sortedBy { it.intValue },
@@ -261,10 +276,12 @@ class PublicationServiceIT @Autowired constructor(
         assertNotNull(mainDraftContext.fetch(draftLine.id))
 
         val publicationRequest = publicationRequest(referenceLines = listOf(draftLine.id))
-        val versions = publicationService.getValidationVersions(LayoutBranch.main, publicationRequest)
+        val versions =
+            publicationService.getValidationVersions(LayoutBranch.main, publicationRequest)
         val draftCalculatedChanges = getCalculatedChangesInRequest(versions)
         val publicationResult = testPublish(LayoutBranch.main, versions, draftCalculatedChanges)
-        val publication = publicationService.getPublicationDetails(publicationResult.publicationId!!)
+        val publication =
+            publicationService.getPublicationDetails(publicationResult.publicationId!!)
 
         assertNotNull(publicationResult.publicationId)
         assertEquals(0, publicationResult.trackNumbers)
@@ -288,33 +305,39 @@ class PublicationServiceIT @Autowired constructor(
         assertNull(mainOfficialContext.fetch(referenceLineId))
         assertNotNull(mainDraftContext.fetch(referenceLineId))
         // The first publication must be together with the track number
-        val publicationRequest = publicationRequest(
-            trackNumbers = listOf(trackNumberId),
-            referenceLines = listOf(referenceLineId),
-        )
-        val versions = publicationService.getValidationVersions(LayoutBranch.main, publicationRequest)
+        val publicationRequest =
+            publicationRequest(
+                trackNumbers = listOf(trackNumberId),
+                referenceLines = listOf(referenceLineId),
+            )
+        val versions =
+            publicationService.getValidationVersions(LayoutBranch.main, publicationRequest)
         val draftCalculatedChanges = getCalculatedChangesInRequest(versions)
         val publication = testPublish(LayoutBranch.main, versions, draftCalculatedChanges)
-        val publicationDetails = publicationService.getPublicationDetails(publication.publicationId!!)
+        val publicationDetails =
+            publicationService.getPublicationDetails(publication.publicationId!!)
         assertEquals(1, publicationDetails.trackNumbers.size)
         assertEquals(1, publicationDetails.referenceLines.size)
         assertEquals(Operation.CREATE, publicationDetails.trackNumbers[0].operation)
         assertEquals(Operation.CREATE, publicationDetails.referenceLines[0].operation)
-        val publishedReferenceLine = referenceLineService.get(MainLayoutContext.official, referenceLineId)!!
+        val publishedReferenceLine =
+            referenceLineService.get(MainLayoutContext.official, referenceLineId)!!
 
         // Update can happen independently
-        val updateResponse = referenceLineService.updateTrackNumberReferenceLine(
-            LayoutBranch.main,
-            publishedReferenceLine.trackNumberId,
-            publishedReferenceLine.startAddress.copy(
-                meters = publishedReferenceLine.startAddress.meters.add(BigDecimal.ONE),
-            ),
-        )
+        val updateResponse =
+            referenceLineService.updateTrackNumberReferenceLine(
+                LayoutBranch.main,
+                publishedReferenceLine.trackNumberId,
+                publishedReferenceLine.startAddress.copy(
+                    meters = publishedReferenceLine.startAddress.meters.add(BigDecimal.ONE),
+                ),
+            )
         val pubReq2 = publicationRequest(referenceLines = listOf(updateResponse!!.id))
         val versions2 = publicationService.getValidationVersions(LayoutBranch.main, pubReq2)
         val draftCalculatedChanges2 = getCalculatedChangesInRequest(versions2)
         val publication2 = testPublish(LayoutBranch.main, versions2, draftCalculatedChanges2)
-        val publicationDetails2 = publicationService.getPublicationDetails(publication2.publicationId!!)
+        val publicationDetails2 =
+            publicationService.getPublicationDetails(publication2.publicationId!!)
         assertEquals(1, publicationDetails2.referenceLines.size)
         assertEquals(Operation.MODIFY, publicationDetails2.referenceLines[0].operation)
     }
@@ -343,25 +366,27 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun publishingReferenceLineChangesWorks() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val officialId = mainOfficialContext.insert(
-            referenceLineAndAlignment(
-                trackNumberId,
-                segment(Point(1.0, 1.0), Point(2.0, 2.0)),
-                startAddress = TrackMeter("0001", 10)
-            )
-        ).id
+        val officialId =
+            mainOfficialContext
+                .insert(
+                    referenceLineAndAlignment(
+                        trackNumberId,
+                        segment(Point(1.0, 1.0), Point(2.0, 2.0)),
+                        startAddress = TrackMeter("0001", 10)))
+                .id
 
-        val (tmpLine, tmpAlignment) = referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.draft, officialId)
+        val (tmpLine, tmpAlignment) =
+            referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.draft, officialId)
         referenceLineService.saveDraft(
             LayoutBranch.main,
             tmpLine.copy(startAddress = TrackMeter("0002", 20)),
             tmpAlignment.copy(
-                segments = fixSegmentStarts(
-                    listOf(
-                        segment(Point(1.0, 1.0), Point(2.0, 2.0)),
-                        segment(Point(2.0, 2.0), Point(3.0, 3.0)),
-                    )
-                ),
+                segments =
+                    fixSegmentStarts(
+                        listOf(
+                            segment(Point(1.0, 1.0), Point(2.0, 2.0)),
+                            segment(Point(2.0, 2.0), Point(3.0, 3.0)),
+                        )),
             ),
         )
         assertNotEquals(
@@ -371,11 +396,19 @@ class PublicationServiceIT @Autowired constructor(
 
         assertEquals(
             1,
-            referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.official, officialId).second.segments.size,
+            referenceLineService
+                .getWithAlignmentOrThrow(MainLayoutContext.official, officialId)
+                .second
+                .segments
+                .size,
         )
         assertEquals(
             2,
-            referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.draft, officialId).second.segments.size,
+            referenceLineService
+                .getWithAlignmentOrThrow(MainLayoutContext.draft, officialId)
+                .second
+                .segments
+                .size,
         )
 
         publishAndVerify(LayoutBranch.main, publicationRequest(referenceLines = listOf(officialId)))
@@ -386,36 +419,53 @@ class PublicationServiceIT @Autowired constructor(
         )
         assertEquals(
             2,
-            referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.official, officialId).second.segments.size,
+            referenceLineService
+                .getWithAlignmentOrThrow(MainLayoutContext.official, officialId)
+                .second
+                .segments
+                .size,
         )
         assertEquals(
-            referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.official, officialId).second.segments,
-            referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.draft, officialId).second.segments,
+            referenceLineService
+                .getWithAlignmentOrThrow(MainLayoutContext.official, officialId)
+                .second
+                .segments,
+            referenceLineService
+                .getWithAlignmentOrThrow(MainLayoutContext.draft, officialId)
+                .second
+                .segments,
         )
     }
 
     @Test
     fun publishingLocationTrackChangesWorks() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
-            lineAlignment = alignment(segment(Point(0.0, 0.0), Point(4.0, 4.0))),
-        ).id
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    lineAlignment = alignment(segment(Point(0.0, 0.0), Point(4.0, 4.0))),
+                )
+                .id
 
-        val officialId = mainOfficialContext.insert(
-            locationTrack(trackNumberId = trackNumberId, name = "test 01"),
-            alignment(segment(Point(1.0, 1.0), Point(2.0, 2.0))),
-        ).id
+        val officialId =
+            mainOfficialContext
+                .insert(
+                    locationTrack(trackNumberId = trackNumberId, name = "test 01"),
+                    alignment(segment(Point(1.0, 1.0), Point(2.0, 2.0))),
+                )
+                .id
 
-        val (tmpTrack, tmpAlignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, officialId)
+        val (tmpTrack, tmpAlignment) =
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, officialId)
         locationTrackService.saveDraft(
             LayoutBranch.main,
             tmpTrack.copy(name = AlignmentName("DRAFT test 01")),
             tmpAlignment.copy(
-                segments = fixSegmentStarts(
-                    listOf(
-                        segment(Point(1.0, 1.0), Point(2.0, 2.0)),
-                        segment(Point(2.0, 2.0), Point(3.0, 3.0)),
-                    )
-                ),
+                segments =
+                    fixSegmentStarts(
+                        listOf(
+                            segment(Point(1.0, 1.0), Point(2.0, 2.0)),
+                            segment(Point(2.0, 2.0), Point(3.0, 3.0)),
+                        )),
             ),
         )
         assertNotEquals(
@@ -424,11 +474,19 @@ class PublicationServiceIT @Autowired constructor(
         )
         assertEquals(
             1,
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.official, officialId).second.segments.size,
+            locationTrackService
+                .getWithAlignmentOrThrow(MainLayoutContext.official, officialId)
+                .second
+                .segments
+                .size,
         )
         assertEquals(
             2,
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, officialId).second.segments.size,
+            locationTrackService
+                .getWithAlignmentOrThrow(MainLayoutContext.draft, officialId)
+                .second
+                .segments
+                .size,
         )
 
         publishAndVerify(LayoutBranch.main, publicationRequest(locationTracks = listOf(officialId)))
@@ -439,11 +497,21 @@ class PublicationServiceIT @Autowired constructor(
         )
         assertEquals(
             2,
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.official, officialId).second.segments.size,
+            locationTrackService
+                .getWithAlignmentOrThrow(MainLayoutContext.official, officialId)
+                .second
+                .segments
+                .size,
         )
         assertEquals(
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.official, officialId).second.segments,
-            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, officialId).second.segments,
+            locationTrackService
+                .getWithAlignmentOrThrow(MainLayoutContext.official, officialId)
+                .second
+                .segments,
+            locationTrackService
+                .getWithAlignmentOrThrow(MainLayoutContext.draft, officialId)
+                .second
+                .segments,
         )
     }
 
@@ -469,25 +537,30 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun publishingSwitchChangesWorks() {
-        val officialId = switchDao.insert(
-            switch(55, draft = false).copy(
-                name = SwitchName("TST 001"),
-                joints = listOf(switchJoint(1), switchJoint(3)),
-            )
-        ).id
+        val officialId =
+            switchDao
+                .insert(
+                    switch(55, draft = false)
+                        .copy(
+                            name = SwitchName("TST 001"),
+                            joints = listOf(switchJoint(1), switchJoint(3)),
+                        ))
+                .id
 
         switchService.saveDraft(
             LayoutBranch.main,
-            switchService.getOrThrow(MainLayoutContext.draft, officialId).copy(
-                name = SwitchName("DRAFT TST 001"),
-                joints = listOf(switchJoint(2), switchJoint(3), switchJoint(4)),
-            )
-        )
+            switchService
+                .getOrThrow(MainLayoutContext.draft, officialId)
+                .copy(
+                    name = SwitchName("DRAFT TST 001"),
+                    joints = listOf(switchJoint(2), switchJoint(3), switchJoint(4)),
+                ))
         assertNotEquals(
             switchService.getOrThrow(MainLayoutContext.official, officialId).name,
             switchService.getOrThrow(MainLayoutContext.draft, officialId).name,
         )
-        assertEquals(2, switchService.getOrThrow(MainLayoutContext.official, officialId).joints.size)
+        assertEquals(
+            2, switchService.getOrThrow(MainLayoutContext.official, officialId).joints.size)
         assertEquals(3, switchService.getOrThrow(MainLayoutContext.draft, officialId).joints.size)
 
         publishAndVerify(LayoutBranch.main, publicationRequest(switches = listOf(officialId)))
@@ -496,7 +569,8 @@ class PublicationServiceIT @Autowired constructor(
             switchService.getOrThrow(MainLayoutContext.official, officialId).name,
             switchService.getOrThrow(MainLayoutContext.draft, officialId).name,
         )
-        assertEquals(3, switchService.getOrThrow(MainLayoutContext.official, officialId).joints.size)
+        assertEquals(
+            3, switchService.getOrThrow(MainLayoutContext.official, officialId).joints.size)
         assertEquals(
             switchService.getOrThrow(MainLayoutContext.official, officialId).joints,
             switchService.getOrThrow(MainLayoutContext.draft, officialId).joints,
@@ -527,20 +601,24 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun publishingTrackNumberChangesWorks() {
-        val officialId = trackNumberDao.insert(
-            trackNumber(draft = false).copy(
-                number = testDBService.getUnusedTrackNumber(),
-                description = FreeText("Test 1"),
-            )
-        ).id
+        val officialId =
+            trackNumberDao
+                .insert(
+                    trackNumber(draft = false)
+                        .copy(
+                            number = testDBService.getUnusedTrackNumber(),
+                            description = FreeText("Test 1"),
+                        ))
+                .id
 
         trackNumberService.saveDraft(
             LayoutBranch.main,
-            trackNumberService.get(MainLayoutContext.draft, officialId)!!.copy(
-                number = testDBService.getUnusedTrackNumber(),
-                description = FreeText("Test 2"),
-            )
-        )
+            trackNumberService
+                .get(MainLayoutContext.draft, officialId)!!
+                .copy(
+                    number = testDBService.getUnusedTrackNumber(),
+                    description = FreeText("Test 2"),
+                ))
 
         assertNotEquals(
             trackNumberService.getOrThrow(MainLayoutContext.official, officialId).number,
@@ -591,15 +669,18 @@ class PublicationServiceIT @Autowired constructor(
         }
         assertEquals(draftId, locationTrackService.getOrThrow(MainLayoutContext.draft, draftId).id)
 
-        val publicationCountBeforePublishing = publicationService.fetchPublications(LayoutBranch.main).size
+        val publicationCountBeforePublishing =
+            publicationService.fetchPublications(LayoutBranch.main).size
 
-        val publicationResult = publish(
-            publicationService,
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(draftId),
-        )
+        val publicationResult =
+            publish(
+                publicationService,
+                trackNumbers = listOf(trackNumberId),
+                locationTracks = listOf(draftId),
+            )
 
-        val publicationCountAfterPublishing = publicationService.fetchPublications(LayoutBranch.main)
+        val publicationCountAfterPublishing =
+            publicationService.fetchPublications(LayoutBranch.main)
 
         assertEquals(publicationCountBeforePublishing + 1, publicationCountAfterPublishing.size)
         assertEquals(publicationResult.publicationId, publicationCountAfterPublishing.last().id)
@@ -644,7 +725,9 @@ class PublicationServiceIT @Autowired constructor(
             locationTrackDao,
             locationTrackService,
             { locationTrack(tnId, draft = true) },
-            { orig -> asMainDraft(orig.copy(descriptionBase = FreeText("${orig.descriptionBase}_edit"))) },
+            { orig ->
+                asMainDraft(orig.copy(descriptionBase = FreeText("${orig.descriptionBase}_edit")))
+            },
         )
     }
 
@@ -663,10 +746,10 @@ class PublicationServiceIT @Autowired constructor(
         val switch1 = switchService.saveDraft(LayoutBranch.main, switch(123, draft = true)).id
         val switch2 = switchService.saveDraft(LayoutBranch.main, switch(234, draft = true)).id
 
-        val revertResult = publicationService.revertPublicationCandidates(
-            LayoutBranch.main,
-            PublicationRequestIds(listOf(), listOf(), listOf(), listOf(switch1), listOf())
-        )
+        val revertResult =
+            publicationService.revertPublicationCandidates(
+                LayoutBranch.main,
+                PublicationRequestIds(listOf(), listOf(), listOf(), listOf(switch1), listOf()))
 
         assertEquals(revertResult.switches, 1)
         assertNull(switchService.get(MainLayoutContext.draft, switch1))
@@ -679,8 +762,9 @@ class PublicationServiceIT @Autowired constructor(
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
 
         assertTrue {
-            splitDao.fetchUnfinishedSplits(LayoutBranch.main)
-                .any { split -> split.sourceLocationTrackId == splitSetup.sourceTrack.id }
+            splitDao.fetchUnfinishedSplits(LayoutBranch.main).any { split ->
+                split.sourceLocationTrackId == splitSetup.sourceTrack.id
+            }
         }
 
         publicationService.revertPublicationCandidates(
@@ -689,8 +773,9 @@ class PublicationServiceIT @Autowired constructor(
         )
 
         assertTrue {
-            splitDao.fetchUnfinishedSplits(LayoutBranch.main)
-                .none { split -> split.sourceLocationTrackId == splitSetup.sourceTrack.id }
+            splitDao.fetchUnfinishedSplits(LayoutBranch.main).none { split ->
+                split.sourceLocationTrackId == splitSetup.sourceTrack.id
+            }
         }
     }
 
@@ -703,8 +788,9 @@ class PublicationServiceIT @Autowired constructor(
         val endTargetTrack = splitSetup.targetTracks.last().first
 
         assertTrue {
-            splitDao.fetchUnfinishedSplits(LayoutBranch.main)
-                .any { split -> split.containsLocationTrack(endTargetTrack.id) }
+            splitDao.fetchUnfinishedSplits(LayoutBranch.main).any { split ->
+                split.containsLocationTrack(endTargetTrack.id)
+            }
         }
 
         publicationService.revertPublicationCandidates(
@@ -713,8 +799,9 @@ class PublicationServiceIT @Autowired constructor(
         )
 
         assertTrue {
-            splitDao.fetchUnfinishedSplits(LayoutBranch.main)
-                .none { split -> split.containsLocationTrack(endTargetTrack.id) }
+            splitDao.fetchUnfinishedSplits(LayoutBranch.main).none { split ->
+                split.containsLocationTrack(endTargetTrack.id)
+            }
         }
     }
 
@@ -723,20 +810,26 @@ class PublicationServiceIT @Autowired constructor(
         val splitSetup = simpleSplitSetup()
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
 
-        val splitBeforePublish = splitDao.fetchUnfinishedSplits(LayoutBranch.main).first { split ->
-            split.sourceLocationTrackId == splitSetup.sourceTrack.id
-        }
+        val splitBeforePublish =
+            splitDao.fetchUnfinishedSplits(LayoutBranch.main).first { split ->
+                split.sourceLocationTrackId == splitSetup.sourceTrack.id
+            }
 
         assertNull(splitBeforePublish.publicationId)
 
-        val publicationId = publicationService.getValidationVersions(
-            LayoutBranch.main,
-            publicationRequest(locationTracks = splitSetup.trackIds)
-        ).let { versions ->
+        val publicationId =
             publicationService
-                .publishChanges(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions), "")
-                .publicationId
-        }
+                .getValidationVersions(
+                    LayoutBranch.main, publicationRequest(locationTracks = splitSetup.trackIds))
+                .let { versions ->
+                    publicationService
+                        .publishChanges(
+                            LayoutBranch.main,
+                            versions,
+                            getCalculatedChangesInRequest(versions),
+                            "")
+                        .publicationId
+                }
 
         assertEquals(publicationId, splitDao.getOrThrow(splitBeforePublish.id).publicationId)
     }
@@ -747,10 +840,9 @@ class PublicationServiceIT @Autowired constructor(
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
 
         for (id in splitSetup.trackIds) {
-            val dependencies = publicationService.getRevertRequestDependencies(
-                LayoutBranch.main,
-                publicationRequest(locationTracks = listOf(id))
-            )
+            val dependencies =
+                publicationService.getRevertRequestDependencies(
+                    LayoutBranch.main, publicationRequest(locationTracks = listOf(id)))
 
             for (otherId in splitSetup.trackIds) {
                 assertContains(dependencies.locationTracks, otherId)
@@ -761,48 +853,60 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun trackNumberAndReferenceLineChangesDependOnEachOther() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
-        val referenceLine = referenceLineService.saveDraft(
-            LayoutBranch.main,
-            referenceLine(trackNumber, draft = true),
-        ).id
-        val publishBoth = publicationRequest(trackNumbers = listOf(trackNumber), referenceLines = listOf(referenceLine))
+        val referenceLine =
+            referenceLineService
+                .saveDraft(
+                    LayoutBranch.main,
+                    referenceLine(trackNumber, draft = true),
+                )
+                .id
+        val publishBoth =
+            publicationRequest(
+                trackNumbers = listOf(trackNumber), referenceLines = listOf(referenceLine))
         assertEquals(
             publishBoth,
             publicationService.getRevertRequestDependencies(
                 LayoutBranch.main,
                 publicationRequest(trackNumbers = listOf(trackNumber)),
-            )
-        )
+            ))
         assertEquals(
             publishBoth,
             publicationService.getRevertRequestDependencies(
                 LayoutBranch.main,
                 publicationRequest(referenceLines = listOf(referenceLine)),
-            )
-        )
+            ))
     }
 
     @Test
     fun `Assets on draft only track number depend on its reference line`() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
-        val referenceLine = referenceLineService.saveDraft(
-            LayoutBranch.main,
-            referenceLine(trackNumber, draft = true),
-        ).id
-        val kmPost = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumber, KmNumber(0), draft = true),
-        ).id
-        val locationTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumber, draft = true),
-        ).id
-        val publishAll = publicationRequest(
-            trackNumbers = listOf(trackNumber),
-            referenceLines = listOf(referenceLine),
-            kmPosts = listOf(kmPost),
-            locationTracks = listOf(locationTrack)
-        )
+        val referenceLine =
+            referenceLineService
+                .saveDraft(
+                    LayoutBranch.main,
+                    referenceLine(trackNumber, draft = true),
+                )
+                .id
+        val kmPost =
+            kmPostService
+                .saveDraft(
+                    LayoutBranch.main,
+                    kmPost(trackNumber, KmNumber(0), draft = true),
+                )
+                .id
+        val locationTrack =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumber, draft = true),
+                )
+                .id
+        val publishAll =
+            publicationRequest(
+                trackNumbers = listOf(trackNumber),
+                referenceLines = listOf(referenceLine),
+                kmPosts = listOf(kmPost),
+                locationTracks = listOf(locationTrack))
         assertEquals(
             publishAll,
             publicationService.getRevertRequestDependencies(
@@ -815,19 +919,26 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun kmPostsAndLocationTracksDependOnTheirTrackNumber() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
-        val locationTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumber, draft = true),
-        ).id
-        val kmPost = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumber, KmNumber(0), draft = true),
-        ).id
-        val all = publicationRequest(
-            trackNumbers = listOf(trackNumber),
-            locationTracks = listOf(locationTrack),
-            kmPosts = listOf(kmPost),
-        )
+        val locationTrack =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumber, draft = true),
+                )
+                .id
+        val kmPost =
+            kmPostService
+                .saveDraft(
+                    LayoutBranch.main,
+                    kmPost(trackNumber, KmNumber(0), draft = true),
+                )
+                .id
+        val all =
+            publicationRequest(
+                trackNumbers = listOf(trackNumber),
+                locationTracks = listOf(locationTrack),
+                kmPosts = listOf(kmPost),
+            )
         assertEquals(
             all,
             publicationService.getRevertRequestDependencies(
@@ -841,10 +952,11 @@ class PublicationServiceIT @Autowired constructor(
     fun `should sort publications by publication time in descending order`() {
         val trackNumber1Id = mainDraftContext.createLayoutTrackNumber().id
         val trackNumber2Id = mainDraftContext.createLayoutTrackNumber().id
-        val publish1Result = publicationRequest(trackNumbers = listOf(trackNumber1Id, trackNumber2Id)).let { r ->
-            val versions = publicationService.getValidationVersions(LayoutBranch.main, r)
-            testPublish(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions))
-        }
+        val publish1Result =
+            publicationRequest(trackNumbers = listOf(trackNumber1Id, trackNumber2Id)).let { r ->
+                val versions = publicationService.getValidationVersions(LayoutBranch.main, r)
+                testPublish(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions))
+            }
 
         assertEquals(2, publish1Result.trackNumbers)
 
@@ -859,10 +971,11 @@ class PublicationServiceIT @Autowired constructor(
             LayoutBranch.main,
             trackNumber1.copy(number = TrackNumber(newTrackNumber1TrackNumber)),
         )
-        val publish2Result = publicationRequest(trackNumbers = listOf(trackNumber1Id)).let { r ->
-            val versions = publicationService.getValidationVersions(LayoutBranch.main, r)
-            testPublish(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions))
-        }
+        val publish2Result =
+            publicationRequest(trackNumbers = listOf(trackNumber1Id)).let { r ->
+                val versions = publicationService.getValidationVersions(LayoutBranch.main, r)
+                testPublish(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions))
+            }
 
         assertEquals(1, publish2Result.trackNumbers)
     }
@@ -870,20 +983,20 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Validating official location track should work`() {
         val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
-        val (locationTrack, alignment) = locationTrackAndAlignment(
-            trackNumber,
-            segment(Point(4.0, 4.0), Point(5.0, 5.0)),
-            draft = false,
-        )
-        val locationTrackId = locationTrackDao.insert(
-            locationTrack.copy(
-                alignmentVersion = alignmentDao.insert(alignment)
+        val (locationTrack, alignment) =
+            locationTrackAndAlignment(
+                trackNumber,
+                segment(Point(4.0, 4.0), Point(5.0, 5.0)),
+                draft = false,
             )
-        )
+        val locationTrackId =
+            locationTrackDao.insert(
+                locationTrack.copy(alignmentVersion = alignmentDao.insert(alignment)))
 
-        val validation = publicationService
-            .validateLocationTracks(MainLayoutContext.official, listOf(locationTrackId.id))
-            .first()
+        val validation =
+            publicationService
+                .validateLocationTracks(MainLayoutContext.official, listOf(locationTrackId.id))
+                .first()
         assertEquals(validation.errors.size, 1)
     }
 
@@ -891,9 +1004,11 @@ class PublicationServiceIT @Autowired constructor(
     fun `Validating official track number should work`() {
         val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
 
-        val validation = publicationService
-            .validateTrackNumbersAndReferenceLines(MainLayoutContext.official, listOf(trackNumber))
-            .first()
+        val validation =
+            publicationService
+                .validateTrackNumbersAndReferenceLines(
+                    MainLayoutContext.official, listOf(trackNumber))
+                .first()
         assertEquals(validation.errors.size, 1)
     }
 
@@ -901,7 +1016,8 @@ class PublicationServiceIT @Autowired constructor(
     fun `Validating official switch should work`() {
         val switchId = switchDao.insert(switch(123, draft = false)).id
 
-        val validation = publicationService.validateSwitches(MainLayoutContext.official, listOf(switchId))
+        val validation =
+            publicationService.validateSwitches(MainLayoutContext.official, listOf(switchId))
         assertEquals(1, validation.size)
         assertEquals(3, validation[0].errors.size)
     }
@@ -912,9 +1028,11 @@ class PublicationServiceIT @Autowired constructor(
         val switchId2 = switchDao.insert(switch(234, draft = false)).id
         val switchId3 = switchDao.insert(switch(456, draft = false)).id
 
-        val validationIds = publicationService
-            .validateSwitches(MainLayoutContext.official, listOf(switchId, switchId2, switchId3))
-            .map { it.id }
+        val validationIds =
+            publicationService
+                .validateSwitches(
+                    MainLayoutContext.official, listOf(switchId, switchId2, switchId3))
+                .map { it.id }
         assertEquals(3, validationIds.size)
         assertContains(validationIds, switchId)
         assertContains(validationIds, switchId2)
@@ -923,71 +1041,102 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `Validating official km post should work`() {
-        val kmPostId = kmPostDao.insert(kmPost(mainOfficialContext.createLayoutTrackNumber().id, km = KmNumber.ZERO, draft = false)).id
+        val kmPostId =
+            kmPostDao
+                .insert(
+                    kmPost(
+                        mainOfficialContext.createLayoutTrackNumber().id,
+                        km = KmNumber.ZERO,
+                        draft = false))
+                .id
 
-        val validation = publicationService.validateKmPosts(MainLayoutContext.official, listOf(kmPostId)).first()
+        val validation =
+            publicationService.validateKmPosts(MainLayoutContext.official, listOf(kmPostId)).first()
         assertEquals(validation.errors.size, 1)
     }
 
     @Test
     fun `Publication validation identifies duplicate names`() {
         trackNumberDao.insert(trackNumber(number = TrackNumber("TN"), draft = false))
-        val draftTrackNumberId = trackNumberDao.insert(trackNumber(number = TrackNumber("TN"), draft = true)).id
+        val draftTrackNumberId =
+            trackNumberDao.insert(trackNumber(number = TrackNumber("TN"), draft = true)).id
 
-        val someAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        val referenceLineId = referenceLineDao.insert(
-            referenceLine(draftTrackNumberId, alignmentVersion = someAlignment, draft = true)
-        ).id
+        val someAlignment =
+            alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        val referenceLineId =
+            referenceLineDao
+                .insert(
+                    referenceLine(
+                        draftTrackNumberId, alignmentVersion = someAlignment, draft = true))
+                .id
         locationTrackDao.insert(
-            locationTrack(draftTrackNumberId, name = "LT", alignmentVersion = someAlignment, draft = false)
-        )
+            locationTrack(
+                draftTrackNumberId, name = "LT", alignmentVersion = someAlignment, draft = false))
         // one new draft location track trying to use an official one's name
-        val draftLocationTrackId = locationTrackDao.insert(
-            locationTrack(draftTrackNumberId, name = "LT", alignmentVersion = someAlignment, draft = true)
-        ).id
+        val draftLocationTrackId =
+            locationTrackDao
+                .insert(
+                    locationTrack(
+                        draftTrackNumberId,
+                        name = "LT",
+                        alignmentVersion = someAlignment,
+                        draft = true))
+                .id
 
         // two new location tracks stepping over each other's names
-        val newLt = locationTrack(
-            draftTrackNumberId,
-            name = "NLT",
-            alignmentVersion = someAlignment,
-            externalId = null,
-            draft = true,
-        )
+        val newLt =
+            locationTrack(
+                draftTrackNumberId,
+                name = "NLT",
+                alignmentVersion = someAlignment,
+                externalId = null,
+                draft = true,
+            )
         val newLocationTrack1 = locationTrackDao.insert(newLt).id
         val newLocationTrack2 = locationTrackDao.insert(newLt).id
 
-        switchDao.insert(switch(123, name = "SW", stateCategory = LayoutStateCategory.EXISTING, draft = false))
+        switchDao.insert(
+            switch(123, name = "SW", stateCategory = LayoutStateCategory.EXISTING, draft = false))
         // one new switch trying to use an official one's name
-        val draftSwitchId = switchDao.insert(
-            switch(123, name = "SW", stateCategory = LayoutStateCategory.EXISTING, draft = true)
-        ).id
+        val draftSwitchId =
+            switchDao
+                .insert(
+                    switch(
+                        123,
+                        name = "SW",
+                        stateCategory = LayoutStateCategory.EXISTING,
+                        draft = true))
+                .id
 
         // two new switches both trying to use the same name
-        val newSwitch = switch(124, name = "NSW", stateCategory = LayoutStateCategory.EXISTING, draft = true)
+        val newSwitch =
+            switch(124, name = "NSW", stateCategory = LayoutStateCategory.EXISTING, draft = true)
         val newSwitch1 = switchDao.insert(newSwitch).id
         val newSwitch2 = switchDao.insert(newSwitch).id
 
-        val validation = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(PublicationInMain),
-            PublicationRequestIds(
-                trackNumbers = listOf(draftTrackNumberId),
-                locationTracks = listOf(draftLocationTrackId, newLocationTrack1, newLocationTrack2),
-                kmPosts = listOf(),
-                referenceLines = listOf(referenceLineId),
-                switches = listOf(draftSwitchId, newSwitch1, newSwitch2)
-            ),
-        )
+        val validation =
+            publicationService.validatePublicationCandidates(
+                publicationService.collectPublicationCandidates(PublicationInMain),
+                PublicationRequestIds(
+                    trackNumbers = listOf(draftTrackNumberId),
+                    locationTracks =
+                        listOf(draftLocationTrackId, newLocationTrack1, newLocationTrack2),
+                    kmPosts = listOf(),
+                    referenceLines = listOf(referenceLineId),
+                    switches = listOf(draftSwitchId, newSwitch1, newSwitch2)),
+            )
 
         assertEquals(
             listOf(
                 LayoutValidationIssue(
                     LayoutValidationIssueType.ERROR,
                     "validation.layout.location-track.duplicate-name-official",
-                    mapOf("locationTrack" to AlignmentName("LT"), "trackNumber" to TrackNumber("TN"))
-                )
-            ),
-            validation.validatedAsPublicationUnit.locationTracks.find { lt -> lt.id == draftLocationTrackId }?.issues,
+                    mapOf(
+                        "locationTrack" to AlignmentName("LT"),
+                        "trackNumber" to TrackNumber("TN")))),
+            validation.validatedAsPublicationUnit.locationTracks
+                .find { lt -> lt.id == draftLocationTrackId }
+                ?.issues,
         )
 
         assertEquals(
@@ -995,8 +1144,9 @@ class PublicationServiceIT @Autowired constructor(
                 LayoutValidationIssue(
                     LayoutValidationIssueType.ERROR,
                     "validation.layout.location-track.duplicate-name-draft",
-                    mapOf("locationTrack" to AlignmentName("NLT"), "trackNumber" to TrackNumber("TN"))
-                )
+                    mapOf(
+                        "locationTrack" to AlignmentName("NLT"),
+                        "trackNumber" to TrackNumber("TN")))
             },
             validation.validatedAsPublicationUnit.locationTracks
                 .filter { lt -> lt.name == AlignmentName("NLT") }
@@ -1008,13 +1158,14 @@ class PublicationServiceIT @Autowired constructor(
                 LayoutValidationIssue(
                     LayoutValidationIssueType.ERROR,
                     "validation.layout.switch.duplicate-name-official",
-                    mapOf("switch" to SwitchName("SW"))
-                )
-            ),
+                    mapOf("switch" to SwitchName("SW")))),
             validation.validatedAsPublicationUnit.switches
                 .find { it.name == SwitchName("SW") }
                 ?.issues
-                ?.filter { it.localizationKey.toString() == "validation.layout.switch.duplicate-name-official" },
+                ?.filter {
+                    it.localizationKey.toString() ==
+                        "validation.layout.switch.duplicate-name-official"
+                },
         )
 
         assertEquals(
@@ -1022,13 +1173,14 @@ class PublicationServiceIT @Autowired constructor(
                 LayoutValidationIssue(
                     LayoutValidationIssueType.ERROR,
                     "validation.layout.switch.duplicate-name-draft",
-                    mapOf("switch" to SwitchName("NSW"))
-                )
+                    mapOf("switch" to SwitchName("NSW")))
             },
             validation.validatedAsPublicationUnit.switches
                 .filter { it.name == SwitchName("NSW") }
                 .flatMap { it.issues }
-                .filter { it.localizationKey.toString() == "validation.layout.switch.duplicate-name-draft" },
+                .filter {
+                    it.localizationKey.toString() == "validation.layout.switch.duplicate-name-draft"
+                },
         )
 
         assertEquals(
@@ -1036,9 +1188,7 @@ class PublicationServiceIT @Autowired constructor(
                 LayoutValidationIssue(
                     LayoutValidationIssueType.ERROR,
                     "validation.layout.track-number.duplicate-name-official",
-                    mapOf("trackNumber" to TrackNumber("TN"))
-                )
-            ),
+                    mapOf("trackNumber" to TrackNumber("TN")))),
             validation.validatedAsPublicationUnit.trackNumbers[0].issues,
         )
     }
@@ -1046,32 +1196,49 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Publication rejects duplicate track number names`() {
         trackNumberDao.insert(trackNumber(number = TrackNumber("TN"), draft = false))
-        val draftTrackNumberId = trackNumberDao.insert(trackNumber(number = TrackNumber("TN"), draft = true)).id
+        val draftTrackNumberId =
+            trackNumberDao.insert(trackNumber(number = TrackNumber("TN"), draft = true)).id
 
-        val someAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        referenceLineDao.insert(referenceLine(draftTrackNumberId, alignmentVersion = someAlignment, draft = true)).id
-        val exception = assertThrows<DuplicateNameInPublicationException> {
-            publish(publicationService, trackNumbers = listOf(draftTrackNumberId))
-        }
-        assertEquals("error.publication.duplicate-name-on.track-number", exception.localizationKey.toString())
+        val someAlignment =
+            alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        referenceLineDao
+            .insert(
+                referenceLine(draftTrackNumberId, alignmentVersion = someAlignment, draft = true))
+            .id
+        val exception =
+            assertThrows<DuplicateNameInPublicationException> {
+                publish(publicationService, trackNumbers = listOf(draftTrackNumberId))
+            }
+        assertEquals(
+            "error.publication.duplicate-name-on.track-number",
+            exception.localizationKey.toString())
         assertEquals(mapOf("name" to "TN"), exception.localizationParams.params)
     }
 
     @Test
     fun `Publication rejects duplicate location track names`() {
-        val trackNumberId = trackNumberDao.insert(trackNumber(number = TrackNumber("TN"), draft = false)).id
-        val someAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = someAlignment, draft = true)).id
+        val trackNumberId =
+            trackNumberDao.insert(trackNumber(number = TrackNumber("TN"), draft = false)).id
+        val someAlignment =
+            alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        referenceLineDao
+            .insert(referenceLine(trackNumberId, alignmentVersion = someAlignment, draft = true))
+            .id
 
         locationTrackDao.insert(
-            locationTrack(trackNumberId, name = "LT", alignmentVersion = someAlignment, draft = false)
-        )
-        val draftLt = locationTrack(trackNumberId, name = "LT", alignmentVersion = someAlignment, draft = true)
+            locationTrack(
+                trackNumberId, name = "LT", alignmentVersion = someAlignment, draft = false))
+        val draftLt =
+            locationTrack(
+                trackNumberId, name = "LT", alignmentVersion = someAlignment, draft = true)
         val draftLocationTrackId = locationTrackDao.insert(draftLt).id
-        val exception = assertThrows<DuplicateLocationTrackNameInPublicationException> {
-            publish(publicationService, locationTracks = listOf(draftLocationTrackId))
-        }
-        assertEquals("error.publication.duplicate-name-on.location-track", exception.localizationKey.toString())
+        val exception =
+            assertThrows<DuplicateLocationTrackNameInPublicationException> {
+                publish(publicationService, locationTracks = listOf(draftLocationTrackId))
+            }
+        assertEquals(
+            "error.publication.duplicate-name-on.location-track",
+            exception.localizationKey.toString())
         assertEquals(
             mapOf("locationTrack" to "LT", "trackNumber" to "TN"),
             exception.localizationParams.params,
@@ -1081,32 +1248,39 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Location tracks can be renamed over each other`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val someAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = someAlignment, draft = true)).id
+        val someAlignment =
+            alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        referenceLineDao
+            .insert(referenceLine(trackNumberId, alignmentVersion = someAlignment, draft = true))
+            .id
 
-        val lt1 = locationTrack(
-            trackNumberId = trackNumberId,
-            name = "LT1",
-            alignmentVersion = someAlignment,
-            externalId = null,
-            draft = false,
-        )
+        val lt1 =
+            locationTrack(
+                trackNumberId = trackNumberId,
+                name = "LT1",
+                alignmentVersion = someAlignment,
+                externalId = null,
+                draft = false,
+            )
         val lt1OriginalVersion = locationTrackDao.insert(lt1).rowVersion
-        val lt1RenamedDraft = locationTrackDao.insert(
-            asMainDraft(locationTrackDao.fetch(lt1OriginalVersion).copy(name = AlignmentName("LT2")))
-        )
+        val lt1RenamedDraft =
+            locationTrackDao.insert(
+                asMainDraft(
+                    locationTrackDao.fetch(lt1OriginalVersion).copy(name = AlignmentName("LT2"))))
 
-        val lt2 = locationTrack(
-            trackNumberId = trackNumberId,
-            name = "LT2",
-            alignmentVersion = someAlignment,
-            externalId = null,
-            draft = false,
-        )
+        val lt2 =
+            locationTrack(
+                trackNumberId = trackNumberId,
+                name = "LT2",
+                alignmentVersion = someAlignment,
+                externalId = null,
+                draft = false,
+            )
         val lt2OriginalVersion = locationTrackDao.insert(lt2).rowVersion
-        val lt2RenamedDraft = locationTrackDao.insert(
-            asMainDraft(locationTrackDao.fetch(lt2OriginalVersion).copy(name = AlignmentName("LT1")))
-        )
+        val lt2RenamedDraft =
+            locationTrackDao.insert(
+                asMainDraft(
+                    locationTrackDao.fetch(lt2OriginalVersion).copy(name = AlignmentName("LT1"))))
 
         publish(publicationService, locationTracks = listOf(lt1RenamedDraft.id, lt2RenamedDraft.id))
     }
@@ -1115,38 +1289,46 @@ class PublicationServiceIT @Autowired constructor(
     fun `Publication rejects duplicate switch names`() {
         switchDao.insert(switch(123, name = "SW123", draft = false))
         val draftSwitchId = switchDao.insert(switch(123, name = "SW123", draft = true)).id
-        val exception = assertThrows<DuplicateNameInPublicationException> {
-            publish(publicationService, switches = listOf(draftSwitchId))
-        }
-        assertEquals("error.publication.duplicate-name-on.switch", exception.localizationKey.toString())
+        val exception =
+            assertThrows<DuplicateNameInPublicationException> {
+                publish(publicationService, switches = listOf(draftSwitchId))
+            }
+        assertEquals(
+            "error.publication.duplicate-name-on.switch", exception.localizationKey.toString())
         assertEquals(mapOf("name" to "SW123"), exception.localizationParams.params)
     }
 
     @Test
     fun `Publication validation rejects duplication by another referencing track`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val dummyAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(1.0, 1.0))))
-        // Initial state, all official: Small duplicates middle, middle and big don't duplicate anything
-        val middleTrack = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId,
-                name = "middle track",
-                alignmentVersion = dummyAlignment,
-                draft = false,
-            )
-        )
-        val smallTrack = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId,
-                name = "small track",
-                duplicateOf = middleTrack.id,
-                alignmentVersion = dummyAlignment,
-                draft = false,
-            )
-        )
-        val bigTrack = locationTrackDao.insert(
-            locationTrack(trackNumberId, name = "big track", alignmentVersion = dummyAlignment, draft = false)
-        )
+        val dummyAlignment =
+            alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(1.0, 1.0))))
+        // Initial state, all official: Small duplicates middle, middle and big don't duplicate
+        // anything
+        val middleTrack =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    name = "middle track",
+                    alignmentVersion = dummyAlignment,
+                    draft = false,
+                ))
+        val smallTrack =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    name = "small track",
+                    duplicateOf = middleTrack.id,
+                    alignmentVersion = dummyAlignment,
+                    draft = false,
+                ))
+        val bigTrack =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    name = "big track",
+                    alignmentVersion = dummyAlignment,
+                    draft = false))
 
         // In new draft, middle wants to duplicate big (leading to: small->middle->big)
         locationTrackService.saveDraft(
@@ -1157,31 +1339,35 @@ class PublicationServiceIT @Autowired constructor(
         fun getPublishingDuplicateWhileDuplicatedValidationError(
             vararg publishableTracks: IntId<LocationTrack>,
         ): LayoutValidationIssue? {
-            val validation = publicationService.validatePublicationCandidates(
-                publicationService.collectPublicationCandidates(PublicationInMain),
-                PublicationRequestIds(
-                    trackNumbers = listOf(),
-                    locationTracks = listOf(*publishableTracks),
-                    kmPosts = listOf(),
-                    referenceLines = listOf(),
-                    switches = listOf()
-                ),
-            )
+            val validation =
+                publicationService.validatePublicationCandidates(
+                    publicationService.collectPublicationCandidates(PublicationInMain),
+                    PublicationRequestIds(
+                        trackNumbers = listOf(),
+                        locationTracks = listOf(*publishableTracks),
+                        kmPosts = listOf(),
+                        referenceLines = listOf(),
+                        switches = listOf()),
+                )
             val trackErrors = validation.validatedAsPublicationUnit.locationTracks[0].issues
             return trackErrors.find { error ->
-                error.localizationKey == LocalizationKey(
-                    "validation.layout.location-track.duplicate-of.publishing-duplicate-while-duplicated"
-                )
+                error.localizationKey ==
+                    LocalizationKey(
+                        "validation.layout.location-track.duplicate-of.publishing-duplicate-while-duplicated")
             }
         }
 
-        // if we're only trying to publish the middle track, but the small is still duplicating it, we pop
+        // if we're only trying to publish the middle track, but the small is still duplicating it,
+        // we pop
         val duplicateError = getPublishingDuplicateWhileDuplicatedValidationError(middleTrack.id)
-        assertNotNull(duplicateError, "small track duplicates to-be-published middle track which duplicates big track")
+        assertNotNull(
+            duplicateError,
+            "small track duplicates to-be-published middle track which duplicates big track")
         assertEquals("small track", duplicateError.params.get("otherDuplicates"))
         assertEquals("big track", duplicateError.params.get("duplicateTrack"))
 
-        // if we have a draft of the small track that is not a duplicate of the middle track, but we're not publishing
+        // if we have a draft of the small track that is not a duplicate of the middle track, but
+        // we're not publishing
         // it in this unit, that doesn't fix the issue yet
         locationTrackService.saveDraft(
             LayoutBranch.main,
@@ -1192,57 +1378,64 @@ class PublicationServiceIT @Autowired constructor(
             "only saving a draft of small track",
         )
 
-        // but if we have the new non-duplicating small track in the same publication unit, it's fine
+        // but if we have the new non-duplicating small track in the same publication unit, it's
+        // fine
         assertNull(
             getPublishingDuplicateWhileDuplicatedValidationError(middleTrack.id, smallTrack.id),
             "publishing new small track",
         )
 
-        // finally, if we have a track whose official version doesn't duplicate the middle track, but the draft does,
+        // finally, if we have a track whose official version doesn't duplicate the middle track,
+        // but the draft does,
         // it's only bad if the draft is in the publication unit
-        val otherSmallTrack = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId,
-                name = "other small track",
-                alignmentVersion = dummyAlignment,
-                draft = false,
-            )
-        )
+        val otherSmallTrack =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    name = "other small track",
+                    alignmentVersion = dummyAlignment,
+                    draft = false,
+                ))
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrackDao.fetch(otherSmallTrack.rowVersion).copy(duplicateOf = middleTrack.id),
         )
         assertNull(
             getPublishingDuplicateWhileDuplicatedValidationError(middleTrack.id, smallTrack.id),
-            "publishing new small track with other small track added"
-        )
+            "publishing new small track with other small track added")
         assertNotNull(
-            getPublishingDuplicateWhileDuplicatedValidationError(middleTrack.id, smallTrack.id, otherSmallTrack.id),
-            "publishing new small track with other small track added and in publication unit"
-        )
+            getPublishingDuplicateWhileDuplicatedValidationError(
+                middleTrack.id, smallTrack.id, otherSmallTrack.id),
+            "publishing new small track with other small track added and in publication unit")
     }
 
     private fun getCalculatedChangesInRequest(versions: ValidationVersions): CalculatedChanges =
         calculatedChangesService.getCalculatedChanges(versions)
 
-    private fun publishAndVerify(layoutBranch: LayoutBranch, request: PublicationRequestIds): PublicationResult {
+    private fun publishAndVerify(
+        layoutBranch: LayoutBranch,
+        request: PublicationRequestIds
+    ): PublicationResult {
         val versions = publicationService.getValidationVersions(layoutBranch, request)
         verifyVersions(request, versions)
         verifyVersionsAreDrafts(layoutBranch, versions)
         val draftCalculatedChanges = getCalculatedChangesInRequest(versions)
         val publicationResult = testPublish(layoutBranch, versions, draftCalculatedChanges)
-        val publicationDetails = publicationService.getPublicationDetails(publicationResult.publicationId!!)
+        val publicationDetails =
+            publicationService.getPublicationDetails(publicationResult.publicationId!!)
         assertNotNull(publicationResult.publicationId)
         verifyPublished(layoutBranch, versions.trackNumbers, trackNumberDao) { draft, published ->
             assertMatches(draft, published, contextMatch = false)
         }
-        verifyPublished(layoutBranch, versions.referenceLines, referenceLineDao) { draft, published ->
+        verifyPublished(layoutBranch, versions.referenceLines, referenceLineDao) { draft, published
+            ->
             assertMatches(draft, published, contextMatch = false)
         }
         verifyPublished(layoutBranch, versions.kmPosts, kmPostDao) { draft, published ->
             assertMatches(draft, published, contextMatch = false)
         }
-        verifyPublished(layoutBranch, versions.locationTracks, locationTrackDao) { draft, published ->
+        verifyPublished(layoutBranch, versions.locationTracks, locationTrackDao) { draft, published
+            ->
             assertMatches(draft, published, contextMatch = false)
         }
         verifyPublished(layoutBranch, versions.switches, switchDao) { draft, published ->
@@ -1264,25 +1457,27 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Track number diff finds all changed fields`() {
         val address = TrackMeter(0, 0)
-        val trackNumber = trackNumberService.get(
-            MainLayoutContext.draft,
-            trackNumberService.insert(
-                LayoutBranch.main,
-                TrackNumberSaveRequest(
-                    testDBService.getUnusedTrackNumber(),
-                    FreeText("TEST"),
-                    LayoutState.IN_USE,
-                    address,
-                )
-            ),
-        )
-        val rl = referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumber!!.id as IntId)!!
+        val trackNumber =
+            trackNumberService.get(
+                MainLayoutContext.draft,
+                trackNumberService.insert(
+                    LayoutBranch.main,
+                    TrackNumberSaveRequest(
+                        testDBService.getUnusedTrackNumber(),
+                        FreeText("TEST"),
+                        LayoutState.IN_USE,
+                        address,
+                    )),
+            )
+        val rl =
+            referenceLineService.getByTrackNumber(
+                MainLayoutContext.draft, trackNumber!!.id as IntId)!!
         publishAndVerify(
-            LayoutBranch.main, publicationRequest(
+            LayoutBranch.main,
+            publicationRequest(
                 trackNumbers = listOf(trackNumber.id as IntId),
                 referenceLines = listOf(rl.id as IntId),
-            )
-        )
+            ))
         trackNumberService.update(
             LayoutBranch.main,
             trackNumber.id as IntId,
@@ -1293,20 +1488,26 @@ class PublicationServiceIT @Autowired constructor(
                 state = LayoutState.NOT_IN_USE,
             ),
         )
-        publishAndVerify(LayoutBranch.main, publicationRequest(trackNumbers = listOf(trackNumber.id as IntId)))
-        val thisAndPreviousPublication = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
-        val changes = publicationDao.fetchPublicationTrackNumberChanges(
-            LayoutBranch.main,
-            thisAndPreviousPublication.first().id,
-            thisAndPreviousPublication.last().publicationTime,
-        )
+        publishAndVerify(
+            LayoutBranch.main, publicationRequest(trackNumbers = listOf(trackNumber.id as IntId)))
+        val thisAndPreviousPublication =
+            publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val changes =
+            publicationDao.fetchPublicationTrackNumberChanges(
+                LayoutBranch.main,
+                thisAndPreviousPublication.first().id,
+                thisAndPreviousPublication.last().publicationTime,
+            )
 
-        val diff = publicationService.diffTrackNumber(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(trackNumber.id as IntId),
-            thisAndPreviousPublication.first().publicationTime,
-            thisAndPreviousPublication.last().publicationTime,
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffTrackNumber(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(trackNumber.id as IntId),
+                thisAndPreviousPublication.first().publicationTime,
+                thisAndPreviousPublication.last().publicationTime,
+            ) { _, _ ->
+                null
+            }
         assertEquals(3, diff.size)
         assertEquals("track-number", diff[0].propKey.key.toString())
         assertEquals("state", diff[1].propKey.key.toString())
@@ -1316,51 +1517,61 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Changing specific Track Number field returns only that field`() {
         val address = TrackMeter(0, 0)
-        val trackNumber = trackNumberService.getOrThrow(
-            MainLayoutContext.draft,
-            trackNumberService.insert(
-                LayoutBranch.main,
-                TrackNumberSaveRequest(
-                    testDBService.getUnusedTrackNumber(),
-                    FreeText("TEST"),
-                    LayoutState.IN_USE,
-                    address,
-                )
-            ),
-        )
-        val rl = referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumber.id as IntId)!!
+        val trackNumber =
+            trackNumberService.getOrThrow(
+                MainLayoutContext.draft,
+                trackNumberService.insert(
+                    LayoutBranch.main,
+                    TrackNumberSaveRequest(
+                        testDBService.getUnusedTrackNumber(),
+                        FreeText("TEST"),
+                        LayoutState.IN_USE,
+                        address,
+                    )),
+            )
+        val rl =
+            referenceLineService.getByTrackNumber(
+                MainLayoutContext.draft, trackNumber.id as IntId)!!
         publishAndVerify(
-            LayoutBranch.main, publicationRequest(
+            LayoutBranch.main,
+            publicationRequest(
                 trackNumbers = listOf(trackNumber.id as IntId),
                 referenceLines = listOf(rl.id as IntId),
+            ))
+
+        val idOfUpdated =
+            trackNumberService.update(
+                LayoutBranch.main,
+                trackNumber.id as IntId,
+                TrackNumberSaveRequest(
+                    number = trackNumber.number,
+                    description = FreeText("TEST2"),
+                    startAddress = address,
+                    state = trackNumber.state,
+                ),
             )
-        )
+        publishAndVerify(
+            LayoutBranch.main, publicationRequest(trackNumbers = listOf(trackNumber.id as IntId)))
+        val thisAndPreviousPublication =
+            publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val changes =
+            publicationDao.fetchPublicationTrackNumberChanges(
+                LayoutBranch.main,
+                thisAndPreviousPublication.first().id,
+                thisAndPreviousPublication.last().publicationTime,
+            )
+        val updatedTrackNumber =
+            trackNumberService.getOrThrow(MainLayoutContext.official, idOfUpdated)
 
-        val idOfUpdated = trackNumberService.update(
-            LayoutBranch.main,
-            trackNumber.id as IntId,
-            TrackNumberSaveRequest(
-                number = trackNumber.number,
-                description = FreeText("TEST2"),
-                startAddress = address,
-                state = trackNumber.state,
-            ),
-        )
-        publishAndVerify(LayoutBranch.main, publicationRequest(trackNumbers = listOf(trackNumber.id as IntId)))
-        val thisAndPreviousPublication = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
-        val changes = publicationDao.fetchPublicationTrackNumberChanges(
-            LayoutBranch.main,
-            thisAndPreviousPublication.first().id,
-            thisAndPreviousPublication.last().publicationTime,
-        )
-        val updatedTrackNumber = trackNumberService.getOrThrow(MainLayoutContext.official, idOfUpdated)
-
-        val diff = publicationService.diffTrackNumber(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(trackNumber.id as IntId),
-            thisAndPreviousPublication.first().publicationTime,
-            thisAndPreviousPublication.last().publicationTime,
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffTrackNumber(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(trackNumber.id as IntId),
+                thisAndPreviousPublication.first().publicationTime,
+                thisAndPreviousPublication.last().publicationTime,
+            ) { _, _ ->
+                null
+            }
         assertEquals(1, diff.size)
         assertEquals("description", diff[0].propKey.key.toString())
         assertEquals(trackNumber.description, diff[0].value.oldValue)
@@ -1369,100 +1580,109 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `Location track diff finds all changed fields`() {
-        val duplicate = locationTrackDao.fetch(
-            locationTrackService.insert(
-                LayoutBranch.main,
-                LocationTrackSaveRequest(
-                    AlignmentName("TEST duplicate"),
-                    FreeText("Test"),
-                    DescriptionSuffixType.NONE,
-                    LocationTrackType.MAIN,
-                    LocationTrackState.IN_USE,
-                    mainDraftContext.createLayoutTrackNumber().id,
-                    null,
-                    TopologicalConnectivityType.NONE,
-                    IntId(1),
-                )
-            ).rowVersion
-        )
+        val duplicate =
+            locationTrackDao.fetch(
+                locationTrackService
+                    .insert(
+                        LayoutBranch.main,
+                        LocationTrackSaveRequest(
+                            AlignmentName("TEST duplicate"),
+                            FreeText("Test"),
+                            DescriptionSuffixType.NONE,
+                            LocationTrackType.MAIN,
+                            LocationTrackState.IN_USE,
+                            mainDraftContext.createLayoutTrackNumber().id,
+                            null,
+                            TopologicalConnectivityType.NONE,
+                            IntId(1),
+                        ))
+                    .rowVersion)
 
-        val duplicate2 = locationTrackDao.fetch(
-            locationTrackService.insert(
-                LayoutBranch.main,
-                LocationTrackSaveRequest(
-                    AlignmentName("TEST duplicate 2"),
-                    FreeText("Test"),
-                    DescriptionSuffixType.NONE,
-                    LocationTrackType.MAIN,
-                    LocationTrackState.IN_USE,
-                    mainDraftContext.createLayoutTrackNumber().id,
-                    null,
-                    TopologicalConnectivityType.NONE,
-                    IntId(1),
-                )
-            ).rowVersion
-        )
+        val duplicate2 =
+            locationTrackDao.fetch(
+                locationTrackService
+                    .insert(
+                        LayoutBranch.main,
+                        LocationTrackSaveRequest(
+                            AlignmentName("TEST duplicate 2"),
+                            FreeText("Test"),
+                            DescriptionSuffixType.NONE,
+                            LocationTrackType.MAIN,
+                            LocationTrackState.IN_USE,
+                            mainDraftContext.createLayoutTrackNumber().id,
+                            null,
+                            TopologicalConnectivityType.NONE,
+                            IntId(1),
+                        ))
+                    .rowVersion)
 
-        val locationTrack = locationTrackDao.fetch(
-            locationTrackService.insert(
-                LayoutBranch.main,
-                LocationTrackSaveRequest(
-                    AlignmentName("TEST"),
-                    FreeText("Test"),
-                    DescriptionSuffixType.NONE,
-                    LocationTrackType.MAIN,
-                    LocationTrackState.IN_USE,
-                    mainDraftContext.createLayoutTrackNumber().id,
-                    duplicate.id as IntId<LocationTrack>,
-                    TopologicalConnectivityType.NONE,
-                    IntId(1),
-                )
-            ).rowVersion
-        )
+        val locationTrack =
+            locationTrackDao.fetch(
+                locationTrackService
+                    .insert(
+                        LayoutBranch.main,
+                        LocationTrackSaveRequest(
+                            AlignmentName("TEST"),
+                            FreeText("Test"),
+                            DescriptionSuffixType.NONE,
+                            LocationTrackType.MAIN,
+                            LocationTrackState.IN_USE,
+                            mainDraftContext.createLayoutTrackNumber().id,
+                            duplicate.id as IntId<LocationTrack>,
+                            TopologicalConnectivityType.NONE,
+                            IntId(1),
+                        ))
+                    .rowVersion)
         publishAndVerify(
             LayoutBranch.main,
             publicationRequest(
-                locationTracks = listOf(
-                    locationTrack.id as IntId<LocationTrack>,
-                    duplicate.id as IntId<LocationTrack>,
-                    duplicate2.id as IntId<LocationTrack>,
-                )
-            )
-        )
+                locationTracks =
+                    listOf(
+                        locationTrack.id as IntId<LocationTrack>,
+                        duplicate.id as IntId<LocationTrack>,
+                        duplicate2.id as IntId<LocationTrack>,
+                    )))
 
-        val updatedLocationTrack = locationTrackDao.fetch(
-            locationTrackService.update(
-                LayoutBranch.main,
-                locationTrack.id as IntId,
-                LocationTrackSaveRequest(
-                    name = AlignmentName("TEST2"),
-                    descriptionBase = FreeText("Test2"),
-                    descriptionSuffix = DescriptionSuffixType.SWITCH_TO_BUFFER,
-                    type = LocationTrackType.SIDE,
-                    state = LocationTrackState.NOT_IN_USE,
-                    trackNumberId = locationTrack.trackNumberId,
-                    duplicate2.id as IntId<LocationTrack>,
-                    topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
-                    IntId(1),
-                ),
-            ).rowVersion
-        )
-        publish(publicationService, locationTracks = listOf(updatedLocationTrack.id as IntId<LocationTrack>))
+        val updatedLocationTrack =
+            locationTrackDao.fetch(
+                locationTrackService
+                    .update(
+                        LayoutBranch.main,
+                        locationTrack.id as IntId,
+                        LocationTrackSaveRequest(
+                            name = AlignmentName("TEST2"),
+                            descriptionBase = FreeText("Test2"),
+                            descriptionSuffix = DescriptionSuffixType.SWITCH_TO_BUFFER,
+                            type = LocationTrackType.SIDE,
+                            state = LocationTrackState.NOT_IN_USE,
+                            trackNumberId = locationTrack.trackNumberId,
+                            duplicate2.id as IntId<LocationTrack>,
+                            topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
+                            IntId(1),
+                        ),
+                    )
+                    .rowVersion)
+        publish(
+            publicationService,
+            locationTracks = listOf(updatedLocationTrack.id as IntId<LocationTrack>))
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
 
-        val diff = publicationService.diffLocationTrack(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(locationTrack.id as IntId<LocationTrack>),
-            null,
-            LayoutBranch.main,
-            latestPub.publicationTime,
-            previousPub.publicationTime,
-            trackNumberDao.fetchTrackNumberNames(),
-            emptySet(),
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffLocationTrack(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(locationTrack.id as IntId<LocationTrack>),
+                null,
+                LayoutBranch.main,
+                latestPub.publicationTime,
+                previousPub.publicationTime,
+                trackNumberDao.fetchTrackNumberNames(),
+                emptySet(),
+            ) { _, _ ->
+                null
+            }
         assertEquals(6, diff.size)
         assertEquals("location-track", diff[0].propKey.key.toString())
         assertEquals("state", diff[1].propKey.key.toString())
@@ -1475,40 +1695,39 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Don't allow publishing a track that is a duplicate of an unpublished draft-only one`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val (draftOnlyTrack, draftOnlyAlignment) = locationTrackAndAlignment(
-            trackNumberId = trackNumberId,
-            segments = listOf(someSegment()),
-            duplicateOf = null,
-            draft = true,
-        )
-        val draftOnlyId = locationTrackService.saveDraft(LayoutBranch.main, draftOnlyTrack, draftOnlyAlignment).id
+        val (draftOnlyTrack, draftOnlyAlignment) =
+            locationTrackAndAlignment(
+                trackNumberId = trackNumberId,
+                segments = listOf(someSegment()),
+                duplicateOf = null,
+                draft = true,
+            )
+        val draftOnlyId =
+            locationTrackService.saveDraft(LayoutBranch.main, draftOnlyTrack, draftOnlyAlignment).id
 
-        val (duplicateTrack, duplicateAlignment) = locationTrackAndAlignment(
-            trackNumberId = trackNumberId,
-            segments = listOf(someSegment()),
-            duplicateOf = draftOnlyId,
-            draft = true,
-        )
-        val duplicateId = locationTrackService.saveDraft(LayoutBranch.main, duplicateTrack, duplicateAlignment).id
+        val (duplicateTrack, duplicateAlignment) =
+            locationTrackAndAlignment(
+                trackNumberId = trackNumberId,
+                segments = listOf(someSegment()),
+                duplicateOf = draftOnlyId,
+                draft = true,
+            )
+        val duplicateId =
+            locationTrackService.saveDraft(LayoutBranch.main, duplicateTrack, duplicateAlignment).id
 
         // Both tracks in validation set: this is fine
         assertFalse(
             containsDuplicateOfNotPublishedError(
-                validateLocationTrack(toValidate = duplicateId, duplicateId, draftOnlyId)
-            )
-        )
+                validateLocationTrack(toValidate = duplicateId, duplicateId, draftOnlyId)))
         // Only the target (main) track in set: this is also fine
         assertFalse(
             containsDuplicateOfNotPublishedError(
-                validateLocationTrack(toValidate = draftOnlyId, draftOnlyId)
-            )
-        )
-        // Only the duplicate track in set: this would result in official referring to draft through duplicateOf
+                validateLocationTrack(toValidate = draftOnlyId, draftOnlyId)))
+        // Only the duplicate track in set: this would result in official referring to draft through
+        // duplicateOf
         assertTrue(
             containsDuplicateOfNotPublishedError(
-                validateLocationTrack(toValidate = duplicateId, duplicateId)
-            )
-        )
+                validateLocationTrack(toValidate = duplicateId, duplicateId)))
     }
 
     private fun containsDuplicateOfNotPublishedError(errors: List<LayoutValidationIssue>) =
@@ -1521,56 +1740,65 @@ class PublicationServiceIT @Autowired constructor(
         toValidate: IntId<LocationTrack>,
         vararg publicationSet: IntId<LocationTrack>,
     ): List<LayoutValidationIssue> {
-        val candidates = publicationService
-            .collectPublicationCandidates(PublicationInMain)
-            .filter(publicationRequest(locationTracks = publicationSet.toList()))
+        val candidates =
+            publicationService
+                .collectPublicationCandidates(PublicationInMain)
+                .filter(publicationRequest(locationTracks = publicationSet.toList()))
         return publicationService
             .validateAsPublicationUnit(candidates, false)
-            .locationTracks.find { c -> c.id == toValidate }!!
+            .locationTracks
+            .find { c -> c.id == toValidate }!!
             .issues
     }
 
     @Test
     fun `Changing specific Location Track field returns only that field`() {
-        val saveReq = LocationTrackSaveRequest(
-            AlignmentName("TEST"),
-            FreeText("Test"),
-            DescriptionSuffixType.NONE,
-            LocationTrackType.MAIN,
-            LocationTrackState.IN_USE,
-            mainOfficialContext.createLayoutTrackNumber().id,
-            null,
-            TopologicalConnectivityType.NONE,
-            IntId(1)
-        )
+        val saveReq =
+            LocationTrackSaveRequest(
+                AlignmentName("TEST"),
+                FreeText("Test"),
+                DescriptionSuffixType.NONE,
+                LocationTrackType.MAIN,
+                LocationTrackState.IN_USE,
+                mainOfficialContext.createLayoutTrackNumber().id,
+                null,
+                TopologicalConnectivityType.NONE,
+                IntId(1))
 
-        val locationTrack = locationTrackDao.fetch(
-            locationTrackService.insert(LayoutBranch.main, saveReq).rowVersion
-        )
-        publish(publicationService, locationTracks = listOf(locationTrack.id as IntId<LocationTrack>))
+        val locationTrack =
+            locationTrackDao.fetch(
+                locationTrackService.insert(LayoutBranch.main, saveReq).rowVersion)
+        publish(
+            publicationService, locationTracks = listOf(locationTrack.id as IntId<LocationTrack>))
 
-        val updatedLocationTrack = locationTrackDao.fetch(
-            locationTrackService.update(
-                LayoutBranch.main,
-                locationTrack.id as IntId, saveReq.copy(descriptionBase = FreeText("TEST2"))
-            ).rowVersion
-        )
-        publish(publicationService, locationTracks = listOf(updatedLocationTrack.id as IntId<LocationTrack>))
+        val updatedLocationTrack =
+            locationTrackDao.fetch(
+                locationTrackService
+                    .update(
+                        LayoutBranch.main,
+                        locationTrack.id as IntId,
+                        saveReq.copy(descriptionBase = FreeText("TEST2")))
+                    .rowVersion)
+        publish(
+            publicationService,
+            locationTracks = listOf(updatedLocationTrack.id as IntId<LocationTrack>))
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
 
-        val diff = publicationService.diffLocationTrack(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(locationTrack.id as IntId<LocationTrack>),
-            null,
-            LayoutBranch.main,
-            latestPub.publicationTime,
-            previousPub.publicationTime,
-            trackNumberDao.fetchTrackNumberNames(),
-            emptySet()
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffLocationTrack(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(locationTrack.id as IntId<LocationTrack>),
+                null,
+                LayoutBranch.main,
+                latestPub.publicationTime,
+                previousPub.publicationTime,
+                trackNumberDao.fetchTrackNumberNames(),
+                emptySet()) { _, _ ->
+                    null
+                }
         assertEquals(1, diff.size)
         assertEquals("description-base", diff[0].propKey.key.toString())
         assertEquals(locationTrack.descriptionBase, diff[0].value.oldValue)
@@ -1579,73 +1807,81 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `KM Post diff finds all changed fields`() {
-        val trackNumberSaveReq = TrackNumberSaveRequest(
-            testDBService.getUnusedTrackNumber(),
-            FreeText("TEST"),
-            LayoutState.IN_USE,
-            TrackMeter(0, 0),
-        )
-        val trackNumber = trackNumberService.getOrThrow(
-            MainLayoutContext.draft,
-            trackNumberService.insert(LayoutBranch.main, trackNumberSaveReq),
-        )
-        val trackNumber2 = trackNumberService.getOrThrow(
-            MainLayoutContext.draft,
-            trackNumberService.insert(
-                LayoutBranch.main,
-                trackNumberSaveReq.copy(testDBService.getUnusedTrackNumber(), FreeText("TEST 2")),
-            ),
-        )
+        val trackNumberSaveReq =
+            TrackNumberSaveRequest(
+                testDBService.getUnusedTrackNumber(),
+                FreeText("TEST"),
+                LayoutState.IN_USE,
+                TrackMeter(0, 0),
+            )
+        val trackNumber =
+            trackNumberService.getOrThrow(
+                MainLayoutContext.draft,
+                trackNumberService.insert(LayoutBranch.main, trackNumberSaveReq),
+            )
+        val trackNumber2 =
+            trackNumberService.getOrThrow(
+                MainLayoutContext.draft,
+                trackNumberService.insert(
+                    LayoutBranch.main,
+                    trackNumberSaveReq.copy(
+                        testDBService.getUnusedTrackNumber(), FreeText("TEST 2")),
+                ),
+            )
 
-        val kmPost = kmPostService.getOrThrow(
-            MainLayoutContext.draft,
-            kmPostService.insertKmPost(
-                LayoutBranch.main,
-                TrackLayoutKmPostSaveRequest(
-                    KmNumber(0),
-                    LayoutState.IN_USE,
-                    trackNumber.id as IntId,
-                    gkLocation = null,
-                    gkLocationSource = null,
-                    gkLocationConfirmed = false,
-                )
-            ),
-        )
+        val kmPost =
+            kmPostService.getOrThrow(
+                MainLayoutContext.draft,
+                kmPostService.insertKmPost(
+                    LayoutBranch.main,
+                    TrackLayoutKmPostSaveRequest(
+                        KmNumber(0),
+                        LayoutState.IN_USE,
+                        trackNumber.id as IntId,
+                        gkLocation = null,
+                        gkLocationSource = null,
+                        gkLocationConfirmed = false,
+                    )),
+            )
         publish(
             publicationService,
             kmPosts = listOf(kmPost.id as IntId),
-            trackNumbers = listOf(trackNumber.id as IntId, trackNumber2.id as IntId)
-        )
-        val updatedKmPost = kmPostService.getOrThrow(
-            MainLayoutContext.draft,
-            kmPostService.updateKmPost(
-                LayoutBranch.main,
-                kmPost.id as IntId,
-                TrackLayoutKmPostSaveRequest(
-                    KmNumber(1),
-                    LayoutState.NOT_IN_USE,
-                    trackNumber2.id as IntId,
-                    gkLocation = null,
-                    gkLocationSource = null,
-                    gkLocationConfirmed = false,
+            trackNumbers = listOf(trackNumber.id as IntId, trackNumber2.id as IntId))
+        val updatedKmPost =
+            kmPostService.getOrThrow(
+                MainLayoutContext.draft,
+                kmPostService.updateKmPost(
+                    LayoutBranch.main,
+                    kmPost.id as IntId,
+                    TrackLayoutKmPostSaveRequest(
+                        KmNumber(1),
+                        LayoutState.NOT_IN_USE,
+                        trackNumber2.id as IntId,
+                        gkLocation = null,
+                        gkLocationSource = null,
+                        gkLocationConfirmed = false,
+                    ),
                 ),
-            ),
-        )
+            )
         publish(publicationService, kmPosts = listOf(updatedKmPost.id as IntId))
 
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
         val latestPub = latestPubs.first()
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
 
-        val diff = publicationService.diffKmPost(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(kmPost.id as IntId),
-            latestPub.publicationTime,
-            latestPub.publicationTime.minusMillis(1),
-            trackNumberDao.fetchTrackNumberNames(),
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffKmPost(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(kmPost.id as IntId),
+                latestPub.publicationTime,
+                latestPub.publicationTime.minusMillis(1),
+                trackNumberDao.fetchTrackNumberNames(),
+            ) { _, _ ->
+                null
+            }
         assertEquals(2, diff.size)
-        // assertEquals("track-number", diff[0].propKey) TODO Enable when track number switching works
+        // assertEquals("track-number", diff[0].propKey) TODO Enable when track number switching
+        // works
         assertEquals("km-post", diff[0].propKey.key.toString())
         assertEquals("state", diff[1].propKey.key.toString())
     }
@@ -1655,7 +1891,8 @@ class PublicationServiceIT @Autowired constructor(
         val trackNumber = mainOfficialContext.insert(trackNumber()).id
         val kmPost = mainOfficialContext.insert(kmPost(trackNumber, KmNumber(1))).id
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
-        kmPostService.saveDraft(testBranch, mainOfficialContext.fetch(kmPost)!!.copy(kmNumber = KmNumber(2)))
+        kmPostService.saveDraft(
+            testBranch, mainOfficialContext.fetch(kmPost)!!.copy(kmNumber = KmNumber(2)))
         publish(publicationService, testBranch, kmPosts = listOf(kmPost))
         kmPostService.mergeToMainBranch(testBranch, kmPost)
         publish(publicationService, kmPosts = listOf(kmPost))
@@ -1666,7 +1903,9 @@ class PublicationServiceIT @Autowired constructor(
         assertEquals(KmNumber(2), diff[0].value.newValue)
     }
 
-    private fun getLatestPublicationDiffForKmPost(id: IntId<TrackLayoutKmPost>): List<PublicationChange<out Comparable<Nothing>?>> {
+    private fun getLatestPublicationDiffForKmPost(
+        id: IntId<TrackLayoutKmPost>
+    ): List<PublicationChange<out Comparable<Nothing>?>> {
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
         val latestPub = latestPubs.first()
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
@@ -1676,41 +1915,50 @@ class PublicationServiceIT @Autowired constructor(
             latestPub.publicationTime,
             latestPub.publicationTime.minusMillis(1),
             trackNumberDao.fetchTrackNumberNames(),
-        ) { _, _ -> null }
+        ) { _, _ ->
+            null
+        }
     }
 
     @Test
     fun `Changing specific KM Post field returns only that field`() {
-        val saveReq = TrackLayoutKmPostSaveRequest(
-            KmNumber(0),
-            LayoutState.IN_USE,
-            mainOfficialContext.createLayoutTrackNumber().id,
-            gkLocation = null,
-            gkLocationSource = null,
-            gkLocationConfirmed = false,
-        )
+        val saveReq =
+            TrackLayoutKmPostSaveRequest(
+                KmNumber(0),
+                LayoutState.IN_USE,
+                mainOfficialContext.createLayoutTrackNumber().id,
+                gkLocation = null,
+                gkLocationSource = null,
+                gkLocationConfirmed = false,
+            )
 
-        val kmPost = kmPostService.getOrThrow(
-            MainLayoutContext.draft,
-            kmPostService.insertKmPost(LayoutBranch.main, saveReq),
-        )
+        val kmPost =
+            kmPostService.getOrThrow(
+                MainLayoutContext.draft,
+                kmPostService.insertKmPost(LayoutBranch.main, saveReq),
+            )
         publish(publicationService, kmPosts = listOf(kmPost.id as IntId))
-        val updatedKmPost = kmPostService.getOrThrow(
-            MainLayoutContext.draft,
-            kmPostService.updateKmPost(LayoutBranch.main, kmPost.id as IntId, saveReq.copy(kmNumber = KmNumber(1))),
-        )
+        val updatedKmPost =
+            kmPostService.getOrThrow(
+                MainLayoutContext.draft,
+                kmPostService.updateKmPost(
+                    LayoutBranch.main, kmPost.id as IntId, saveReq.copy(kmNumber = KmNumber(1))),
+            )
         publish(publicationService, kmPosts = listOf(updatedKmPost.id as IntId))
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
         val latestPub = latestPubs.first()
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
 
-        val diff = publicationService.diffKmPost(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(kmPost.id as IntId),
-            latestPub.publicationTime,
-            latestPub.publicationTime.minusMillis(1),
-            trackNumberDao.fetchTrackNumberNames(),
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffKmPost(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(kmPost.id as IntId),
+                latestPub.publicationTime,
+                latestPub.publicationTime.minusMillis(1),
+                trackNumberDao.fetchTrackNumberNames(),
+            ) { _, _ ->
+                null
+            }
         assertEquals(1, diff.size)
         assertEquals("km-post", diff[0].propKey.key.toString())
         assertEquals(kmPost.kmNumber, diff[0].value.oldValue)
@@ -1719,46 +1967,51 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `Switch diff finds all changed fields`() {
-        val trackNumberSaveReq = TrackNumberSaveRequest(
-            testDBService.getUnusedTrackNumber(),
-            FreeText("TEST"),
-            LayoutState.IN_USE,
-            TrackMeter(0, 0),
-        )
+        val trackNumberSaveReq =
+            TrackNumberSaveRequest(
+                testDBService.getUnusedTrackNumber(),
+                FreeText("TEST"),
+                LayoutState.IN_USE,
+                TrackMeter(0, 0),
+            )
         val tn1 = trackNumberService.insert(LayoutBranch.main, trackNumberSaveReq)
-        val tn2 = trackNumberService.insert(
-            LayoutBranch.main,
-            trackNumberSaveReq.copy(testDBService.getUnusedTrackNumber(), FreeText("TEST 2"))
-        )
+        val tn2 =
+            trackNumberService.insert(
+                LayoutBranch.main,
+                trackNumberSaveReq.copy(testDBService.getUnusedTrackNumber(), FreeText("TEST 2")))
 
-        val switch = switchService.getOrThrow(
-            MainLayoutContext.draft,
-            switchService.insertSwitch(
-                LayoutBranch.main,
-                TrackLayoutSwitchSaveRequest(
-                    SwitchName("TEST"),
-                    IntId(1),
-                    LayoutStateCategory.EXISTING,
-                    IntId(1),
-                    false,
-                )
-            ),
-        )
-        publish(publicationService, switches = listOf(switch.id as IntId), trackNumbers = listOf(tn1, tn2))
-        val updatedSwitch = switchService.getOrThrow(
-            MainLayoutContext.draft,
-            switchService.updateSwitch(
-                LayoutBranch.main,
-                switch.id as IntId,
-                TrackLayoutSwitchSaveRequest(
-                    SwitchName("TEST 2"),
-                    IntId(2),
-                    LayoutStateCategory.FUTURE_EXISTING,
-                    IntId(2),
-                    true,
+        val switch =
+            switchService.getOrThrow(
+                MainLayoutContext.draft,
+                switchService.insertSwitch(
+                    LayoutBranch.main,
+                    TrackLayoutSwitchSaveRequest(
+                        SwitchName("TEST"),
+                        IntId(1),
+                        LayoutStateCategory.EXISTING,
+                        IntId(1),
+                        false,
+                    )),
+            )
+        publish(
+            publicationService,
+            switches = listOf(switch.id as IntId),
+            trackNumbers = listOf(tn1, tn2))
+        val updatedSwitch =
+            switchService.getOrThrow(
+                MainLayoutContext.draft,
+                switchService.updateSwitch(
+                    LayoutBranch.main,
+                    switch.id as IntId,
+                    TrackLayoutSwitchSaveRequest(
+                        SwitchName("TEST 2"),
+                        IntId(2),
+                        LayoutStateCategory.FUTURE_EXISTING,
+                        IntId(2),
+                        true,
+                    ),
                 ),
-            ),
-        )
+            )
         publish(publicationService, switches = listOf(updatedSwitch.id as IntId))
 
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
@@ -1766,14 +2019,16 @@ class PublicationServiceIT @Autowired constructor(
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
 
-        val diff = publicationService.diffSwitch(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(switch.id as IntId),
-            latestPub.publicationTime,
-            previousPub.publicationTime,
-            Operation.MODIFY,
-            trackNumberDao.fetchTrackNumberNames()
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffSwitch(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(switch.id as IntId),
+                latestPub.publicationTime,
+                previousPub.publicationTime,
+                Operation.MODIFY,
+                trackNumberDao.fetchTrackNumberNames()) { _, _ ->
+                    null
+                }
         assertEquals(5, diff.size)
         assertEquals("switch", diff[0].propKey.key.toString())
         assertEquals("state-category", diff[1].propKey.key.toString())
@@ -1784,27 +2039,30 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `Changing specific switch field returns only that field`() {
-        val saveReq = TrackLayoutSwitchSaveRequest(
-            SwitchName("TEST"),
-            IntId(1),
-            LayoutStateCategory.EXISTING,
-            IntId(1),
-            false,
-        )
+        val saveReq =
+            TrackLayoutSwitchSaveRequest(
+                SwitchName("TEST"),
+                IntId(1),
+                LayoutStateCategory.EXISTING,
+                IntId(1),
+                false,
+            )
 
-        val switch = switchService.getOrThrow(
-            MainLayoutContext.draft,
-            switchService.insertSwitch(LayoutBranch.main, saveReq),
-        )
+        val switch =
+            switchService.getOrThrow(
+                MainLayoutContext.draft,
+                switchService.insertSwitch(LayoutBranch.main, saveReq),
+            )
         publish(publicationService, switches = listOf(switch.id as IntId))
-        val updatedSwitch = switchService.getOrThrow(
-            MainLayoutContext.draft,
-            switchService.updateSwitch(
-                LayoutBranch.main,
-                switch.id as IntId,
-                saveReq.copy(name = SwitchName("TEST 2")),
-            ),
-        )
+        val updatedSwitch =
+            switchService.getOrThrow(
+                MainLayoutContext.draft,
+                switchService.updateSwitch(
+                    LayoutBranch.main,
+                    switch.id as IntId,
+                    saveReq.copy(name = SwitchName("TEST 2")),
+                ),
+            )
         publish(publicationService, switches = listOf(updatedSwitch.id as IntId))
 
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
@@ -1812,102 +2070,116 @@ class PublicationServiceIT @Autowired constructor(
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
 
-        val diff = publicationService.diffSwitch(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(switch.id as IntId),
-            latestPub.publicationTime,
-            previousPub.publicationTime,
-            Operation.MODIFY,
-            trackNumberDao.fetchTrackNumberNames()
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffSwitch(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(switch.id as IntId),
+                latestPub.publicationTime,
+                previousPub.publicationTime,
+                Operation.MODIFY,
+                trackNumberDao.fetchTrackNumberNames()) { _, _ ->
+                    null
+                }
         assertEquals(1, diff.size)
         assertEquals("switch", diff[0].propKey.key.toString())
         assertEquals(switch.name, diff[0].value.oldValue)
         assertEquals(updatedSwitch.name, diff[0].value.newValue)
     }
 
-    private fun alignmentWithSwitchLinks(vararg switchIds: IntId<TrackLayoutSwitch>?): LayoutAlignment =
-        alignment(switchIds.mapIndexed { index, switchId ->
-            segment(Point(0.0, index * 1.0), Point(0.0, index * 1.0 + 1.0)).let { segment ->
-                if (switchId == null) {
-                    segment
-                } else {
-                    segment.copy(switchId = switchId, startJointNumber = JointNumber(1))
+    private fun alignmentWithSwitchLinks(
+        vararg switchIds: IntId<TrackLayoutSwitch>?
+    ): LayoutAlignment =
+        alignment(
+            switchIds.mapIndexed { index, switchId ->
+                segment(Point(0.0, index * 1.0), Point(0.0, index * 1.0 + 1.0)).let { segment ->
+                    if (switchId == null) {
+                        segment
+                    } else {
+                        segment.copy(switchId = switchId, startJointNumber = JointNumber(1))
+                    }
                 }
-            }
-        })
+            })
 
     @Test
     fun `Location track switch link changes are reported`() {
-        val switchUnlinkedFromTopology = switchDao.insert(
-            switch(name = "sw-unlinked-from-topology", externalId = "1.1.1.1.1", draft = false)
-        )
-        val switchUnlinkedFromAlignment = switchDao.insert(
-            switch(name = "sw-unlinked-from-alignment", externalId = "1.1.1.1.2", draft = false)
-        )
-        val switchAddedToTopologyStart = switchDao.insert(
-            switch(name = "sw-added-to-topo-start", externalId = "1.1.1.1.3", draft = false)
-        )
-        val switchAddedToTopologyEnd = switchDao.insert(
-            switch(name = "sw-added-to-topo-end", externalId = "1.1.1.1.4", draft = false)
-        )
-        val switchAddedToAlignment = switchDao.insert(
-            switch(name = "sw-added-to-alignment", externalId = "1.1.1.1.5", draft = false)
-        )
-        val switchDeleted = switchDao.insert(
-            switch(name = "sw-deleted", externalId = "1.1.1.1.6", draft = false)
-        )
-        val switchMerelyRenamed = switchDao.insert(
-            switch(name = "sw-merely-renamed", externalId = "1.1.1.1.7", draft = false)
-        )
-        val originalSwitchReplacedWithNewSameName = switchDao.insert(
-            switch(name = "sw-replaced-with-new-same-name", externalId = "1.1.1.1.8", draft = false)
-        )
+        val switchUnlinkedFromTopology =
+            switchDao.insert(
+                switch(name = "sw-unlinked-from-topology", externalId = "1.1.1.1.1", draft = false))
+        val switchUnlinkedFromAlignment =
+            switchDao.insert(
+                switch(
+                    name = "sw-unlinked-from-alignment", externalId = "1.1.1.1.2", draft = false))
+        val switchAddedToTopologyStart =
+            switchDao.insert(
+                switch(name = "sw-added-to-topo-start", externalId = "1.1.1.1.3", draft = false))
+        val switchAddedToTopologyEnd =
+            switchDao.insert(
+                switch(name = "sw-added-to-topo-end", externalId = "1.1.1.1.4", draft = false))
+        val switchAddedToAlignment =
+            switchDao.insert(
+                switch(name = "sw-added-to-alignment", externalId = "1.1.1.1.5", draft = false))
+        val switchDeleted =
+            switchDao.insert(switch(name = "sw-deleted", externalId = "1.1.1.1.6", draft = false))
+        val switchMerelyRenamed =
+            switchDao.insert(
+                switch(name = "sw-merely-renamed", externalId = "1.1.1.1.7", draft = false))
+        val originalSwitchReplacedWithNewSameName =
+            switchDao.insert(
+                switch(
+                    name = "sw-replaced-with-new-same-name",
+                    externalId = "1.1.1.1.8",
+                    draft = false))
 
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
 
-        val originalLocationTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchUnlinkedFromTopology.id, JointNumber(1)),
-                draft = true,
-            ),
-            alignmentWithSwitchLinks(
-                switchUnlinkedFromAlignment.id,
-                switchDeleted.id,
-                switchMerelyRenamed.id,
-                originalSwitchReplacedWithNewSameName.id
-            ),
-        )
+        val originalLocationTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    topologyStartSwitch =
+                        TopologyLocationTrackSwitch(switchUnlinkedFromTopology.id, JointNumber(1)),
+                    draft = true,
+                ),
+                alignmentWithSwitchLinks(
+                    switchUnlinkedFromAlignment.id,
+                    switchDeleted.id,
+                    switchMerelyRenamed.id,
+                    originalSwitchReplacedWithNewSameName.id),
+            )
         publish(publicationService, locationTracks = listOf(originalLocationTrack.id))
         switchService.saveDraft(
             LayoutBranch.main,
-            switchDao.fetch(switchDeleted.rowVersion).copy(stateCategory = LayoutStateCategory.NOT_EXISTING)
-        )
+            switchDao
+                .fetch(switchDeleted.rowVersion)
+                .copy(stateCategory = LayoutStateCategory.NOT_EXISTING))
         switchService.saveDraft(
             LayoutBranch.main,
             switchDao
                 .fetch(originalSwitchReplacedWithNewSameName.rowVersion)
-                .copy(stateCategory = LayoutStateCategory.NOT_EXISTING)
-        )
+                .copy(stateCategory = LayoutStateCategory.NOT_EXISTING))
         switchService.saveDraft(
             LayoutBranch.main,
-            switchDao.fetch(switchMerelyRenamed.rowVersion).copy(name = SwitchName("sw-with-new-name"))
-        )
-        val newSwitchReplacingOldWithSameName = switchService.saveDraft(
-            LayoutBranch.main,
-            switch(name = "sw-replaced-with-new-same-name", externalId = "1.1.1.1.9", draft = true)
-        )
+            switchDao
+                .fetch(switchMerelyRenamed.rowVersion)
+                .copy(name = SwitchName("sw-with-new-name")))
+        val newSwitchReplacingOldWithSameName =
+            switchService.saveDraft(
+                LayoutBranch.main,
+                switch(
+                    name = "sw-replaced-with-new-same-name",
+                    externalId = "1.1.1.1.9",
+                    draft = true))
 
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrackDao
                 .getOrThrow(MainLayoutContext.official, originalLocationTrack.id)
                 .copy(
-                    topologyStartSwitch = TopologyLocationTrackSwitch(switchAddedToTopologyStart.id, JointNumber(1)),
-                    topologyEndSwitch = TopologyLocationTrackSwitch(switchAddedToTopologyEnd.id, JointNumber(1))
-                ),
+                    topologyStartSwitch =
+                        TopologyLocationTrackSwitch(switchAddedToTopologyStart.id, JointNumber(1)),
+                    topologyEndSwitch =
+                        TopologyLocationTrackSwitch(switchAddedToTopologyEnd.id, JointNumber(1))),
             alignmentWithSwitchLinks(
                 switchAddedToAlignment.id,
                 switchMerelyRenamed.id,
@@ -1918,28 +2190,34 @@ class PublicationServiceIT @Autowired constructor(
         publish(
             publicationService,
             locationTracks = listOf(originalLocationTrack.id),
-            switches = listOf(
-                switchDeleted.id,
-                switchMerelyRenamed.id,
-                originalSwitchReplacedWithNewSameName.id,
-                newSwitchReplacingOldWithSameName.id,
-            ),
+            switches =
+                listOf(
+                    switchDeleted.id,
+                    switchMerelyRenamed.id,
+                    originalSwitchReplacedWithNewSameName.id,
+                    newSwitchReplacingOldWithSameName.id,
+                ),
         )
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
         val latestPub = latestPubs[0]
         val previousPub = latestPubs[1]
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
 
-        val diff = publicationService.diffLocationTrack(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(originalLocationTrack.id),
-            publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(latestPub.id)[originalLocationTrack.id],
-            LayoutBranch.main,
-            latestPub.publicationTime,
-            previousPub.publicationTime,
-            trackNumberDao.fetchTrackNumberNames(),
-            setOf(),
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffLocationTrack(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(originalLocationTrack.id),
+                publicationDao
+                    .fetchPublicationLocationTrackSwitchLinkChanges(latestPub.id)[
+                        originalLocationTrack.id],
+                LayoutBranch.main,
+                latestPub.publicationTime,
+                previousPub.publicationTime,
+                trackNumberDao.fetchTrackNumberNames(),
+                setOf(),
+            ) { _, _ ->
+                null
+            }
         assertEquals(1, diff.size)
         assertEquals("linked-switches", diff[0].propKey.key.toString())
         assertEquals(
@@ -1947,87 +2225,97 @@ class PublicationServiceIT @Autowired constructor(
                 Vaihteiden sw-deleted, sw-replaced-with-new-same-name (1.1.1.1.8), sw-unlinked-from-alignment,
                 sw-unlinked-from-topology linkitys purettu. Vaihteet sw-added-to-alignment, sw-added-to-topo-end,
                 sw-added-to-topo-start, sw-replaced-with-new-same-name (1.1.1.1.9) linkitetty.
-            """.trimIndent().replace("\n", " "),
+            """
+                .trimIndent()
+                .replace("\n", " "),
             diff[0].remark,
         )
     }
 
     @Test
     fun `Location track switch link changes made in design are reported`() {
-        val switchUnlinkedFromTopology = switchDao.insert(
-            switch(name = "sw-unlinked-from-topology", externalId = "1.1.1.1.1", draft = false)
-        )
-        val switchUnlinkedFromAlignment = switchDao.insert(
-            switch(name = "sw-unlinked-from-alignment", externalId = "1.1.1.1.2", draft = false)
-        )
-        val switchAddedToTopologyStart = switchDao.insert(
-            switch(name = "sw-added-to-topo-start", externalId = "1.1.1.1.3", draft = false)
-        )
-        val switchAddedToTopologyEnd = switchDao.insert(
-            switch(name = "sw-added-to-topo-end", externalId = "1.1.1.1.4", draft = false)
-        )
-        val switchAddedToAlignment = switchDao.insert(
-            switch(name = "sw-added-to-alignment", externalId = "1.1.1.1.5", draft = false)
-        )
-        val switchDeleted = switchDao.insert(
-            switch(name = "sw-deleted", externalId = "1.1.1.1.6", draft = false)
-        )
-        val switchMerelyRenamed = switchDao.insert(
-            switch(name = "sw-merely-renamed", externalId = "1.1.1.1.7", draft = false)
-        )
-        val originalSwitchReplacedWithNewSameName = switchDao.insert(
-            switch(name = "sw-replaced-with-new-same-name", externalId = "1.1.1.1.8", draft = false)
-        )
+        val switchUnlinkedFromTopology =
+            switchDao.insert(
+                switch(name = "sw-unlinked-from-topology", externalId = "1.1.1.1.1", draft = false))
+        val switchUnlinkedFromAlignment =
+            switchDao.insert(
+                switch(
+                    name = "sw-unlinked-from-alignment", externalId = "1.1.1.1.2", draft = false))
+        val switchAddedToTopologyStart =
+            switchDao.insert(
+                switch(name = "sw-added-to-topo-start", externalId = "1.1.1.1.3", draft = false))
+        val switchAddedToTopologyEnd =
+            switchDao.insert(
+                switch(name = "sw-added-to-topo-end", externalId = "1.1.1.1.4", draft = false))
+        val switchAddedToAlignment =
+            switchDao.insert(
+                switch(name = "sw-added-to-alignment", externalId = "1.1.1.1.5", draft = false))
+        val switchDeleted =
+            switchDao.insert(switch(name = "sw-deleted", externalId = "1.1.1.1.6", draft = false))
+        val switchMerelyRenamed =
+            switchDao.insert(
+                switch(name = "sw-merely-renamed", externalId = "1.1.1.1.7", draft = false))
+        val originalSwitchReplacedWithNewSameName =
+            switchDao.insert(
+                switch(
+                    name = "sw-replaced-with-new-same-name",
+                    externalId = "1.1.1.1.8",
+                    draft = false))
 
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
 
-        val originalLocationTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchUnlinkedFromTopology.id, JointNumber(1)),
-                draft = true,
-            ),
-            alignmentWithSwitchLinks(
-                switchUnlinkedFromAlignment.id,
-                switchDeleted.id,
-                switchMerelyRenamed.id,
-                originalSwitchReplacedWithNewSameName.id
-            ),
-        )
-        publish(publicationService,  locationTracks = listOf(originalLocationTrack.id))
+        val originalLocationTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    topologyStartSwitch =
+                        TopologyLocationTrackSwitch(switchUnlinkedFromTopology.id, JointNumber(1)),
+                    draft = true,
+                ),
+                alignmentWithSwitchLinks(
+                    switchUnlinkedFromAlignment.id,
+                    switchDeleted.id,
+                    switchMerelyRenamed.id,
+                    originalSwitchReplacedWithNewSameName.id),
+            )
+        publish(publicationService, locationTracks = listOf(originalLocationTrack.id))
 
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
 
         switchService.saveDraft(
             testBranch,
-            switchDao.fetch(switchDeleted.rowVersion).copy(stateCategory = LayoutStateCategory.NOT_EXISTING)
-        )
+            switchDao
+                .fetch(switchDeleted.rowVersion)
+                .copy(stateCategory = LayoutStateCategory.NOT_EXISTING))
         switchService.saveDraft(
             testBranch,
             switchDao
                 .fetch(originalSwitchReplacedWithNewSameName.rowVersion)
-                .copy(stateCategory = LayoutStateCategory.NOT_EXISTING)
-        )
+                .copy(stateCategory = LayoutStateCategory.NOT_EXISTING))
         switchService.saveDraft(
             testBranch,
-            switchDao.fetch(switchMerelyRenamed.rowVersion).copy(name = SwitchName("sw-with-new-name"))
-        )
-        val newSwitchReplacingOldWithSameName = testDBService.testContext(testBranch, DRAFT).insert(
-            switch(
-                name = "sw-replaced-with-new-same-name",
-                externalId = "1.1.1.1.9",
-            )
-        )
+            switchDao
+                .fetch(switchMerelyRenamed.rowVersion)
+                .copy(name = SwitchName("sw-with-new-name")))
+        val newSwitchReplacingOldWithSameName =
+            testDBService
+                .testContext(testBranch, DRAFT)
+                .insert(
+                    switch(
+                        name = "sw-replaced-with-new-same-name",
+                        externalId = "1.1.1.1.9",
+                    ))
 
         locationTrackService.saveDraft(
             testBranch,
             locationTrackDao
                 .getOrThrow(MainLayoutContext.official, originalLocationTrack.id)
                 .copy(
-                    topologyStartSwitch = TopologyLocationTrackSwitch(switchAddedToTopologyStart.id, JointNumber(1)),
-                    topologyEndSwitch = TopologyLocationTrackSwitch(switchAddedToTopologyEnd.id, JointNumber(1))
-                ),
+                    topologyStartSwitch =
+                        TopologyLocationTrackSwitch(switchAddedToTopologyStart.id, JointNumber(1)),
+                    topologyEndSwitch =
+                        TopologyLocationTrackSwitch(switchAddedToTopologyEnd.id, JointNumber(1))),
             alignmentWithSwitchLinks(
                 switchAddedToAlignment.id,
                 switchMerelyRenamed.id,
@@ -2039,45 +2327,52 @@ class PublicationServiceIT @Autowired constructor(
             publicationService,
             testBranch,
             locationTracks = listOf(originalLocationTrack.id),
-            switches = listOf(
-                switchDeleted.id,
-                switchMerelyRenamed.id,
-                originalSwitchReplacedWithNewSameName.id,
-                newSwitchReplacingOldWithSameName.id,
-            ),
+            switches =
+                listOf(
+                    switchDeleted.id,
+                    switchMerelyRenamed.id,
+                    originalSwitchReplacedWithNewSameName.id,
+                    newSwitchReplacingOldWithSameName.id,
+                ),
         )
         locationTrackService.mergeToMainBranch(testBranch, originalLocationTrack.id)
         listOf(
-            switchDeleted.id,
-            switchMerelyRenamed.id,
-            originalSwitchReplacedWithNewSameName.id,
-            newSwitchReplacingOldWithSameName.id
-        ).forEach { id -> switchService.mergeToMainBranch(testBranch, id) }
-        publish(
-            publicationService,
-            locationTracks = listOf(originalLocationTrack.id),
-            switches = listOf(
                 switchDeleted.id,
                 switchMerelyRenamed.id,
                 originalSwitchReplacedWithNewSameName.id,
-                newSwitchReplacingOldWithSameName.id,
-            ),
+                newSwitchReplacingOldWithSameName.id)
+            .forEach { id -> switchService.mergeToMainBranch(testBranch, id) }
+        publish(
+            publicationService,
+            locationTracks = listOf(originalLocationTrack.id),
+            switches =
+                listOf(
+                    switchDeleted.id,
+                    switchMerelyRenamed.id,
+                    originalSwitchReplacedWithNewSameName.id,
+                    newSwitchReplacingOldWithSameName.id,
+                ),
         )
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
         val latestPub = latestPubs[0]
         val previousPub = latestPubs[1]
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
 
-        val diff = publicationService.diffLocationTrack(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(originalLocationTrack.id),
-            publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(latestPub.id)[originalLocationTrack.id],
-            LayoutBranch.main,
-            latestPub.publicationTime,
-            previousPub.publicationTime,
-            trackNumberDao.fetchTrackNumberNames(),
-            setOf(),
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffLocationTrack(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(originalLocationTrack.id),
+                publicationDao
+                    .fetchPublicationLocationTrackSwitchLinkChanges(latestPub.id)[
+                        originalLocationTrack.id],
+                LayoutBranch.main,
+                latestPub.publicationTime,
+                previousPub.publicationTime,
+                trackNumberDao.fetchTrackNumberNames(),
+                setOf(),
+            ) { _, _ ->
+                null
+            }
         assertEquals(1, diff.size)
         assertEquals("linked-switches", diff[0].propKey.key.toString())
         assertEquals(
@@ -2085,7 +2380,9 @@ class PublicationServiceIT @Autowired constructor(
                 Vaihteiden sw-deleted, sw-replaced-with-new-same-name (1.1.1.1.8), sw-unlinked-from-alignment,
                 sw-unlinked-from-topology linkitys purettu. Vaihteet sw-added-to-alignment, sw-added-to-topo-end,
                 sw-added-to-topo-start, sw-replaced-with-new-same-name (1.1.1.1.9) linkitetty.
-            """.trimIndent().replace("\n", " "),
+            """
+                .trimIndent()
+                .replace("\n", " "),
             diff[0].remark,
         )
     }
@@ -2093,47 +2390,60 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Location track geometry changes are reported`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        fun segmentWithCurveToMaxY(maxY: Double) = segment(
-            *(0..10)
-                .map { x -> Point(x.toDouble(), (5.0 - (x.toDouble() - 5.0).absoluteValue) / 10.0 * maxY) }
-                .toTypedArray(),
-        )
+        fun segmentWithCurveToMaxY(maxY: Double) =
+            segment(
+                *(0..10)
+                    .map { x ->
+                        Point(
+                            x.toDouble(), (5.0 - (x.toDouble() - 5.0).absoluteValue) / 10.0 * maxY)
+                    }
+                    .toTypedArray(),
+            )
 
         val referenceLineAlignment = alignmentDao.insert(alignment(segmentWithCurveToMaxY(0.0)))
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = referenceLineAlignment, draft = false))
+        referenceLineDao.insert(
+            referenceLine(trackNumberId, alignmentVersion = referenceLineAlignment, draft = false))
 
-        // track that had bump to y=-10 goes to having a bump to y=10, meaning the length and ends stay the same,
+        // track that had bump to y=-10 goes to having a bump to y=10, meaning the length and ends
+        // stay the same,
         // but the geometry changes
         val originalAlignment = alignment(segmentWithCurveToMaxY(-10.0))
         val newAlignment = alignment(segmentWithCurveToMaxY(10.0))
-        val originalLocationTrack = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId,
-                alignmentVersion = alignmentDao.insert(originalAlignment),
-                draft = false,
-            )
-        )
+        val originalLocationTrack =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    alignmentVersion = alignmentDao.insert(originalAlignment),
+                    draft = false,
+                ))
         locationTrackService.saveDraft(
             LayoutBranch.main,
             asMainDraft(locationTrackDao.fetch(originalLocationTrack.rowVersion)),
             newAlignment,
         )
         publish(publicationService, locationTracks = listOf(originalLocationTrack.id))
-        val latestPub = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)[0]
+        val latestPub =
+            publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)[0]
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
 
-        val diff = publicationService.diffLocationTrack(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(originalLocationTrack.id),
-            publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(latestPub.id)[originalLocationTrack.id],
-            LayoutBranch.main,
-            latestPub.publicationTime,
-            latestPub.publicationTime,
-            trackNumberDao.fetchTrackNumberNames(),
-            setOf(KmNumber(0)),
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffLocationTrack(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(originalLocationTrack.id),
+                publicationDao
+                    .fetchPublicationLocationTrackSwitchLinkChanges(latestPub.id)[
+                        originalLocationTrack.id],
+                LayoutBranch.main,
+                latestPub.publicationTime,
+                latestPub.publicationTime,
+                trackNumberDao.fetchTrackNumberNames(),
+                setOf(KmNumber(0)),
+            ) { _, _ ->
+                null
+            }
         assertEquals(1, diff.size)
-        assertEquals("Muutos välillä 0000+0001-0000+0009, sivusuuntainen muutos 10.0 m", diff[0].remark)
+        assertEquals(
+            "Muutos välillä 0000+0001-0000+0009, sivusuuntainen muutos 10.0 m", diff[0].remark)
     }
 
     @Test
@@ -2145,15 +2455,17 @@ class PublicationServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
         )
 
-        val locationTrack1 = locationTrackAndAlignment(trackNumberId1, draft = true).let { (lt, a) ->
-            locationTrackService.saveDraft(LayoutBranch.main, lt, a).id
-        }
+        val locationTrack1 =
+            locationTrackAndAlignment(trackNumberId1, draft = true).let { (lt, a) ->
+                locationTrackService.saveDraft(LayoutBranch.main, lt, a).id
+            }
 
-        val publish1 = publish(
-            publicationService,
-            trackNumbers = listOf(trackNumberId1),
-            locationTracks = listOf(locationTrack1),
-        )
+        val publish1 =
+            publish(
+                publicationService,
+                trackNumbers = listOf(trackNumberId1),
+                locationTracks = listOf(locationTrack1),
+            )
 
         val trackNumberId2 = mainDraftContext.createLayoutTrackNumber().id
         referenceLineService.saveDraft(
@@ -2162,39 +2474,44 @@ class PublicationServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
         )
 
-        val locationTrack2 = locationTrackAndAlignment(trackNumberId2, draft = true).let { (lt, a) ->
-            locationTrackService.saveDraft(LayoutBranch.main, lt, a).id
-        }
+        val locationTrack2 =
+            locationTrackAndAlignment(trackNumberId2, draft = true).let { (lt, a) ->
+                locationTrackService.saveDraft(LayoutBranch.main, lt, a).id
+            }
 
-        val publish2 = publish(
-            publicationService,
-            trackNumbers = listOf(trackNumberId2),
-            locationTracks = listOf(locationTrack2),
-        )
+        val publish2 =
+            publish(
+                publicationService,
+                trackNumbers = listOf(trackNumberId2),
+                locationTracks = listOf(locationTrack2),
+            )
 
         val publication1 = publicationDao.getPublication(publish1.publicationId!!)
         val publication2 = publicationDao.getPublication(publish2.publicationId!!)
 
         assertTrue {
             publicationService
-                .fetchPublicationDetailsBetweenInstants(LayoutBranch.main, to = publication1.publicationTime)
+                .fetchPublicationDetailsBetweenInstants(
+                    LayoutBranch.main, to = publication1.publicationTime)
                 .isEmpty()
         }
 
         assertTrue {
-            publicationService.fetchPublicationDetailsBetweenInstants(
-                LayoutBranch.main,
-                from = publication2.publicationTime.plusMillis(1)
-            ).isEmpty()
+            publicationService
+                .fetchPublicationDetailsBetweenInstants(
+                    LayoutBranch.main, from = publication2.publicationTime.plusMillis(1))
+                .isEmpty()
         }
 
         assertEquals(
             2,
-            publicationService.fetchPublicationDetailsBetweenInstants(
-                LayoutBranch.main,
-                from = publication1.publicationTime,
-                to = publication2.publicationTime.plusMillis(1),
-            ).size,
+            publicationService
+                .fetchPublicationDetailsBetweenInstants(
+                    LayoutBranch.main,
+                    from = publication1.publicationTime,
+                    to = publication2.publicationTime.plusMillis(1),
+                )
+                .size,
         )
     }
 
@@ -2207,15 +2524,17 @@ class PublicationServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
         )
 
-        val locationTrack1 = locationTrackAndAlignment(trackNumberId1, draft = true).let { (lt, a) ->
-            locationTrackService.saveDraft(LayoutBranch.main, lt, a).id
-        }
+        val locationTrack1 =
+            locationTrackAndAlignment(trackNumberId1, draft = true).let { (lt, a) ->
+                locationTrackService.saveDraft(LayoutBranch.main, lt, a).id
+            }
 
-        val publish1 = publish(
-            publicationService,
-            trackNumbers = listOf(trackNumberId1),
-            locationTracks = listOf(locationTrack1),
-        )
+        val publish1 =
+            publish(
+                publicationService,
+                trackNumbers = listOf(trackNumberId1),
+                locationTracks = listOf(locationTrack1),
+            )
 
         val trackNumberId2 = mainDraftContext.createLayoutTrackNumber().id
         referenceLineService.saveDraft(
@@ -2224,36 +2543,41 @@ class PublicationServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
         )
 
-        val locationTrack2 = locationTrackAndAlignment(trackNumberId2, draft = true).let { (lt, a) ->
-            locationTrackService.saveDraft(LayoutBranch.main, lt, a).id
-        }
+        val locationTrack2 =
+            locationTrackAndAlignment(trackNumberId2, draft = true).let { (lt, a) ->
+                locationTrackService.saveDraft(LayoutBranch.main, lt, a).id
+            }
 
-        val publish2 = publish(
-            publicationService,
-            trackNumbers = listOf(trackNumberId2),
-            locationTracks = listOf(locationTrack2),
-        )
+        val publish2 =
+            publish(
+                publicationService,
+                trackNumbers = listOf(trackNumberId2),
+                locationTracks = listOf(locationTrack2),
+            )
 
         assertEquals(2, publicationService.fetchPublications(LayoutBranch.main).size)
 
-        assertEquals(1, publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).size)
+        assertEquals(
+            1, publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).size)
         assertEquals(
             publish2.publicationId,
-            publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)[0].id
-        )
+            publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)[0].id)
 
-        assertEquals(2, publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).size)
+        assertEquals(
+            2, publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).size)
         assertEquals(
             publish1.publicationId,
-            publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 10)[1].id
-        )
+            publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 10)[1].id)
 
-        assertTrue { publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 0).isEmpty() }
+        assertTrue {
+            publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 0).isEmpty()
+        }
     }
 
     @Test
     fun `should sort publications by header column`() {
-        val trackNumberId1 = mainDraftContext.getOrCreateLayoutTrackNumber(TrackNumber("1234")).id as IntId
+        val trackNumberId1 =
+            mainDraftContext.getOrCreateLayoutTrackNumber(TrackNumber("1234")).id as IntId
         referenceLineService.saveDraft(
             LayoutBranch.main,
             referenceLine(trackNumberId1, draft = true),
@@ -2262,7 +2586,8 @@ class PublicationServiceIT @Autowired constructor(
 
         publish(publicationService, trackNumbers = listOf(trackNumberId1))
 
-        val trackNumberId2 = mainDraftContext.getOrCreateLayoutTrackNumber(TrackNumber("4321")).id as IntId
+        val trackNumberId2 =
+            mainDraftContext.getOrCreateLayoutTrackNumber(TrackNumber("4321")).id as IntId
         referenceLineService.saveDraft(
             LayoutBranch.main,
             referenceLine(trackNumberId2, draft = true),
@@ -2271,31 +2596,32 @@ class PublicationServiceIT @Autowired constructor(
 
         publish(publicationService, trackNumbers = listOf(trackNumberId2))
 
-        val rows1 = publicationService.fetchPublicationDetails(
-            LayoutBranch.main,
-            sortBy = PublicationTableColumn.NAME,
-            translation = localizationService.getLocalization(LocalizationLanguage.FI),
-        )
+        val rows1 =
+            publicationService.fetchPublicationDetails(
+                LayoutBranch.main,
+                sortBy = PublicationTableColumn.NAME,
+                translation = localizationService.getLocalization(LocalizationLanguage.FI),
+            )
 
         assertEquals(2, rows1.size)
         assertTrue { rows1[0].name.contains("1234") }
 
-        val rows2 = publicationService.fetchPublicationDetails(
-            LayoutBranch.main,
-            sortBy = PublicationTableColumn.NAME,
-            order = SortOrder.DESCENDING,
-            translation = localizationService.getLocalization(LocalizationLanguage.FI)
-        )
+        val rows2 =
+            publicationService.fetchPublicationDetails(
+                LayoutBranch.main,
+                sortBy = PublicationTableColumn.NAME,
+                order = SortOrder.DESCENDING,
+                translation = localizationService.getLocalization(LocalizationLanguage.FI))
 
         assertEquals(2, rows2.size)
         assertTrue { rows2[0].name.contains("4321") }
 
-        val rows3 = publicationService.fetchPublicationDetails(
-            LayoutBranch.main,
-            sortBy = PublicationTableColumn.PUBLICATION_TIME,
-            order = SortOrder.ASCENDING,
-            translation = localizationService.getLocalization(LocalizationLanguage.FI)
-        )
+        val rows3 =
+            publicationService.fetchPublicationDetails(
+                LayoutBranch.main,
+                sortBy = PublicationTableColumn.PUBLICATION_TIME,
+                order = SortOrder.ASCENDING,
+                translation = localizationService.getLocalization(LocalizationLanguage.FI))
 
         assertEquals(2, rows3.size)
         assertTrue { rows3[0].name.contains("1234") }
@@ -2303,65 +2629,77 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `switch diff consistently uses segment point for joint location`() {
-        val trackNumberId = mainOfficialContext.getOrCreateLayoutTrackNumber(TrackNumber("1234")).id as IntId
+        val trackNumberId =
+            mainOfficialContext.getOrCreateLayoutTrackNumber(TrackNumber("1234")).id as IntId
         referenceLineDao.insert(
             referenceLine(
                 trackNumberId,
-                alignmentVersion = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(11.0, 0.0)))),
+                alignmentVersion =
+                    alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(11.0, 0.0)))),
                 draft = false,
+            ))
+        val switch =
+            switchDao.insert(
+                switch(
+                    seed = 123,
+                    joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(4.2, 0.1), null)),
+                    draft = false,
+                ))
+        val originalAlignment =
+            alignment(
+                segment(Point(0.0, 0.0), Point(4.0, 0.0)),
+                segment(Point(4.0, 0.0), Point(10.0, 0.0))
+                    .copy(
+                        switchId = switch.id,
+                        startJointNumber = JointNumber(1),
+                    ),
             )
-        )
-        val switch = switchDao.insert(
-            switch(
-                seed = 123,
-                joints = listOf(
-                    TrackLayoutSwitchJoint(JointNumber(1), Point(4.2, 0.1), null)
-                ),
-                draft = false,
-            )
-        )
-        val originalAlignment = alignment(
-            segment(Point(0.0, 0.0), Point(4.0, 0.0)),
-            segment(Point(4.0, 0.0), Point(10.0, 0.0)).copy(
-                switchId = switch.id,
-                startJointNumber = JointNumber(1),
-            ),
-        )
-        val locationTrack = locationTrackDao.insert(
-            locationTrack(trackNumberId, alignmentVersion = alignmentDao.insert(originalAlignment), draft = false)
-        )
+        val locationTrack =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    alignmentVersion = alignmentDao.insert(originalAlignment),
+                    draft = false))
         switchService.saveDraft(
             LayoutBranch.main,
-            switchDao.fetch(switch.rowVersion).copy(
-                joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(4.1, 0.2), null)),
-            ),
+            switchDao
+                .fetch(switch.rowVersion)
+                .copy(
+                    joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(4.1, 0.2), null)),
+                ),
         )
-        val updatedAlignment = alignment(
-            segment(Point(0.1, 0.0), Point(4.1, 0.0)),
-            segment(Point(4.1, 0.0), Point(10.1, 0.0)).copy(switchId = switch.id, startJointNumber = JointNumber(1))
-        )
-        locationTrackService.saveDraft(LayoutBranch.main, locationTrackDao.fetch(locationTrack.rowVersion), updatedAlignment)
+        val updatedAlignment =
+            alignment(
+                segment(Point(0.1, 0.0), Point(4.1, 0.0)),
+                segment(Point(4.1, 0.0), Point(10.1, 0.0))
+                    .copy(switchId = switch.id, startJointNumber = JointNumber(1)))
+        locationTrackService.saveDraft(
+            LayoutBranch.main, locationTrackDao.fetch(locationTrack.rowVersion), updatedAlignment)
 
-        publish(publicationService, switches = listOf(switch.id), locationTracks = listOf(locationTrack.id))
+        publish(
+            publicationService,
+            switches = listOf(switch.id),
+            locationTracks = listOf(locationTrack.id))
 
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
 
-        val diff = publicationService.diffSwitch(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(switch.id),
-            latestPub.publicationTime,
-            previousPub.publicationTime,
-            Operation.MODIFY,
-            trackNumberDao.fetchTrackNumberNames()
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffSwitch(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(switch.id),
+                latestPub.publicationTime,
+                previousPub.publicationTime,
+                Operation.MODIFY,
+                trackNumberDao.fetchTrackNumberNames()) { _, _ ->
+                    null
+                }
         assertEquals(2, diff.size)
         assertEquals(
             listOf("switch-joint-location", "switch-track-address").sorted(),
-            diff.map { it.propKey.key.toString() }.sorted()
-        )
+            diff.map { it.propKey.key.toString() }.sorted())
         val jointLocationDiff = diff.find { it.propKey.key.toString() == "switch-joint-location" }!!
         assertEquals("4.000 E, 0.000 N", jointLocationDiff.value.oldValue)
         assertEquals("4.100 E, 0.000 N", jointLocationDiff.value.newValue)
@@ -2371,71 +2709,87 @@ class PublicationServiceIT @Autowired constructor(
 
     @Test
     fun `switch diff consistently uses segment point for joint location with edit made in design`() {
-        val trackNumberId = mainOfficialContext.getOrCreateLayoutTrackNumber(TrackNumber("1234")).id as IntId
+        val trackNumberId =
+            mainOfficialContext.getOrCreateLayoutTrackNumber(TrackNumber("1234")).id as IntId
         referenceLineDao.insert(
             referenceLine(
                 trackNumberId,
-                alignmentVersion = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(11.0, 0.0)))),
+                alignmentVersion =
+                    alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(11.0, 0.0)))),
                 draft = false,
+            ))
+        val switch =
+            switchDao.insert(
+                switch(
+                    seed = 123,
+                    joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(4.2, 0.1), null)),
+                    draft = false,
+                ))
+        val originalAlignment =
+            alignment(
+                segment(Point(0.0, 0.0), Point(4.0, 0.0)),
+                segment(Point(4.0, 0.0), Point(10.0, 0.0))
+                    .copy(
+                        switchId = switch.id,
+                        startJointNumber = JointNumber(1),
+                    ),
             )
-        )
-        val switch = switchDao.insert(
-            switch(
-                seed = 123,
-                joints = listOf(
-                    TrackLayoutSwitchJoint(JointNumber(1), Point(4.2, 0.1), null)
-                ),
-                draft = false,
-            )
-        )
-        val originalAlignment = alignment(
-            segment(Point(0.0, 0.0), Point(4.0, 0.0)),
-            segment(Point(4.0, 0.0), Point(10.0, 0.0)).copy(
-                switchId = switch.id,
-                startJointNumber = JointNumber(1),
-            ),
-        )
-        val locationTrack = locationTrackDao.insert(
-            locationTrack(trackNumberId, alignmentVersion = alignmentDao.insert(originalAlignment), draft = false)
-        )
+        val locationTrack =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    alignmentVersion = alignmentDao.insert(originalAlignment),
+                    draft = false))
 
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
 
         switchService.saveDraft(
             testBranch,
-            switchDao.fetch(switch.rowVersion).copy(
-                joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(4.1, 0.2), null)),
-            ),
+            switchDao
+                .fetch(switch.rowVersion)
+                .copy(
+                    joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(4.1, 0.2), null)),
+                ),
         )
-        val updatedAlignment = alignment(
-            segment(Point(0.1, 0.0), Point(4.1, 0.0)),
-            segment(Point(4.1, 0.0), Point(10.1, 0.0)).copy(switchId = switch.id, startJointNumber = JointNumber(1))
-        )
-        locationTrackService.saveDraft(testBranch, locationTrackDao.fetch(locationTrack.rowVersion), updatedAlignment)
+        val updatedAlignment =
+            alignment(
+                segment(Point(0.1, 0.0), Point(4.1, 0.0)),
+                segment(Point(4.1, 0.0), Point(10.1, 0.0))
+                    .copy(switchId = switch.id, startJointNumber = JointNumber(1)))
+        locationTrackService.saveDraft(
+            testBranch, locationTrackDao.fetch(locationTrack.rowVersion), updatedAlignment)
 
-        publish(publicationService, testBranch, switches = listOf(switch.id), locationTracks = listOf(locationTrack.id))
+        publish(
+            publicationService,
+            testBranch,
+            switches = listOf(switch.id),
+            locationTracks = listOf(locationTrack.id))
         locationTrackService.mergeToMainBranch(testBranch, locationTrack.id)
         switchService.mergeToMainBranch(testBranch, switch.id)
-        publish(publicationService, switches = listOf(switch.id), locationTracks = listOf(locationTrack.id))
+        publish(
+            publicationService,
+            switches = listOf(switch.id),
+            locationTracks = listOf(locationTrack.id))
 
         val latestPubs = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
 
-        val diff = publicationService.diffSwitch(
-            localizationService.getLocalization(LocalizationLanguage.FI),
-            changes.getValue(switch.id),
-            latestPub.publicationTime,
-            previousPub.publicationTime,
-            Operation.MODIFY,
-            trackNumberDao.fetchTrackNumberNames()
-        ) { _, _ -> null }
+        val diff =
+            publicationService.diffSwitch(
+                localizationService.getLocalization(LocalizationLanguage.FI),
+                changes.getValue(switch.id),
+                latestPub.publicationTime,
+                previousPub.publicationTime,
+                Operation.MODIFY,
+                trackNumberDao.fetchTrackNumberNames()) { _, _ ->
+                    null
+                }
         assertEquals(2, diff.size)
         assertEquals(
             listOf("switch-joint-location", "switch-track-address").sorted(),
-            diff.map { it.propKey.key.toString() }.sorted()
-        )
+            diff.map { it.propKey.key.toString() }.sorted())
         val jointLocationDiff = diff.find { it.propKey.key.toString() == "switch-joint-location" }!!
         assertEquals("4.000 E, 0.000 N", jointLocationDiff.value.oldValue)
         assertEquals("4.100 E, 0.000 N", jointLocationDiff.value.newValue)
@@ -2450,33 +2804,40 @@ class PublicationServiceIT @Autowired constructor(
     )
 
     private fun getTopologicalSwitchConnectionTestData(): TopologicalSwitchConnectionTestData {
-        val (topologyStartSwitchId, topologyStartSwitchInnerTrackIds) = mainDraftContext.createSwitchWithInnerTracks(
-            name = "Topological switch connection test start switch",
-            listOf(
-                JointNumber(1) to Point(0.0, 0.0),
-                JointNumber(3) to Point(1.0, 0.0),
-            ),
-        )
-        val (topologyEndSwitchId, topologyEndSwitchInnerTrackIds) = mainDraftContext.createSwitchWithInnerTracks(
-            name = "Topological switch connection test end switch",
-            listOf(
-                JointNumber(1) to Point(2.0, 0.0),
-                JointNumber(3) to Point(3.0, 0.0),
-            ),
-        )
+        val (topologyStartSwitchId, topologyStartSwitchInnerTrackIds) =
+            mainDraftContext.createSwitchWithInnerTracks(
+                name = "Topological switch connection test start switch",
+                listOf(
+                    JointNumber(1) to Point(0.0, 0.0),
+                    JointNumber(3) to Point(1.0, 0.0),
+                ),
+            )
+        val (topologyEndSwitchId, topologyEndSwitchInnerTrackIds) =
+            mainDraftContext.createSwitchWithInnerTracks(
+                name = "Topological switch connection test end switch",
+                listOf(
+                    JointNumber(1) to Point(2.0, 0.0),
+                    JointNumber(3) to Point(3.0, 0.0),
+                ),
+            )
 
         val locationTrackAlignment = alignment(segment(Point(1.0, 0.0), Point(2.0, 0.0)))
-        val locationTracksUnderTest = getTopologicalSwitchConnectionTestCases(
-            { mainOfficialContext.createLayoutTrackNumber().id },
-            TopologyLocationTrackSwitch(topologyStartSwitchId, JointNumber(1)),
-            TopologyLocationTrackSwitch(topologyEndSwitchId, JointNumber(3)),
-        )
+        val locationTracksUnderTest =
+            getTopologicalSwitchConnectionTestCases(
+                { mainOfficialContext.createLayoutTrackNumber().id },
+                TopologyLocationTrackSwitch(topologyStartSwitchId, JointNumber(1)),
+                TopologyLocationTrackSwitch(topologyEndSwitchId, JointNumber(3)),
+            )
 
-        val locationTrackIdsUnderTest = locationTracksUnderTest.map { locationTrack ->
-            locationTrack.copy(alignmentVersion = alignmentDao.insert(locationTrackAlignment))
-        }.map { locationTrack ->
-            locationTrackDao.insert(asMainDraft(locationTrack)).id to locationTrack
-        }
+        val locationTrackIdsUnderTest =
+            locationTracksUnderTest
+                .map { locationTrack ->
+                    locationTrack.copy(
+                        alignmentVersion = alignmentDao.insert(locationTrackAlignment))
+                }
+                .map { locationTrack ->
+                    locationTrackDao.insert(asMainDraft(locationTrack)).id to locationTrack
+                }
 
         return TopologicalSwitchConnectionTestData(
             locationTracksUnderTest = locationTrackIdsUnderTest,
@@ -2490,40 +2851,46 @@ class PublicationServiceIT @Autowired constructor(
         stagedSwitches: List<IntId<TrackLayoutSwitch>> = listOf(),
         stagedTracks: List<IntId<LocationTrack>> = listOf(locationTrackId),
     ): LocationTrackPublicationCandidate {
-        val publicationRequestIds = PublicationRequestIds(
-            trackNumbers = listOf(),
-            locationTracks = stagedTracks,
-            referenceLines = listOf(),
-            switches = stagedSwitches,
-            kmPosts = listOf(),
-        )
+        val publicationRequestIds =
+            PublicationRequestIds(
+                trackNumbers = listOf(),
+                locationTracks = stagedTracks,
+                referenceLines = listOf(),
+                switches = stagedSwitches,
+                kmPosts = listOf(),
+            )
 
-        val validationResult = publicationService.validateAsPublicationUnit(
-            publicationService.collectPublicationCandidates(PublicationInMain).filter(publicationRequestIds),
-            allowMultipleSplits = false,
-        )
+        val validationResult =
+            publicationService.validateAsPublicationUnit(
+                publicationService
+                    .collectPublicationCandidates(PublicationInMain)
+                    .filter(publicationRequestIds),
+                allowMultipleSplits = false,
+            )
 
         return validationResult.locationTracks.find { lt -> lt.id == locationTrackId }!!
     }
 
-    private fun switchAlignmentNotConnectedTrackValidationError(locationTrackNames: String, switchName: String) =
+    private fun switchAlignmentNotConnectedTrackValidationError(
+        locationTrackNames: String,
+        switchName: String
+    ) =
         LayoutValidationIssue(
             LayoutValidationIssueType.WARNING,
             "validation.layout.location-track.switch-linkage.switch-alignment-not-connected",
-            mapOf("locationTracks" to locationTrackNames, "switch" to switchName)
-        )
+            mapOf("locationTracks" to locationTrackNames, "switch" to switchName))
 
-    private fun switchNotPublishedError(switchName: String) = LayoutValidationIssue(
-        LayoutValidationIssueType.ERROR,
-        "validation.layout.location-track.switch.not-published",
-        mapOf("switch" to switchName)
-    )
+    private fun switchNotPublishedError(switchName: String) =
+        LayoutValidationIssue(
+            LayoutValidationIssueType.ERROR,
+            "validation.layout.location-track.switch.not-published",
+            mapOf("switch" to switchName))
 
-    private fun switchFrontJointNotConnectedError(switchName: String) = LayoutValidationIssue(
-        LayoutValidationIssueType.WARNING,
-        "validation.layout.location-track.switch-linkage.front-joint-not-connected",
-        mapOf("switch" to switchName)
-    )
+    private fun switchFrontJointNotConnectedError(switchName: String) =
+        LayoutValidationIssue(
+            LayoutValidationIssueType.WARNING,
+            "validation.layout.location-track.switch-linkage.front-joint-not-connected",
+            mapOf("switch" to switchName))
 
     private fun assertValidationErrorsForEach(
         expecteds: List<List<LayoutValidationIssue>>,
@@ -2540,14 +2907,16 @@ class PublicationServiceIT @Autowired constructor(
         actual: List<LayoutValidationIssue>,
         index: Int,
     ) {
-        val allKeys = expected.map { it.localizationKey.toString() } + actual.map { it.localizationKey.toString() }
-        val commonPrefix = allKeys.reduce { acc, next ->
-            acc.take(acc.zip(next) { a, b -> a == b }.takeWhile { it }.count())
-        }
+        val allKeys =
+            expected.map { it.localizationKey.toString() } +
+                actual.map { it.localizationKey.toString() }
+        val commonPrefix =
+            allKeys.reduce { acc, next ->
+                acc.take(acc.zip(next) { a, b -> a == b }.takeWhile { it }.count())
+            }
 
-        fun cleanupKey(key: LocalizationKey) = key.toString().let { k ->
-            if (commonPrefix.length > 3) "...$k" else k
-        }
+        fun cleanupKey(key: LocalizationKey) =
+            key.toString().let { k -> if (commonPrefix.length > 3) "...$k" else k }
 
         assertEquals(
             expected.map { cleanupKey(it.localizationKey) }.sorted(),
@@ -2571,68 +2940,81 @@ class PublicationServiceIT @Autowired constructor(
         }
     }
 
-    private val topoTestDataContextOnLocationTrackValidationError = listOf(
-        validationError("validation.layout.location-track.no-context"),
-    )
-    private val topoTestDataStartSwitchNotPublishedError = switchNotPublishedError(
-        "Topological switch connection test start switch"
-    )
-    private val topoTestDataStartSwitchJointsNotConnectedError = switchAlignmentNotConnectedTrackValidationError(
-        "1-5-2", // alignment 1-3 is generated in the data, 1-5-2 is not
-        "Topological switch connection test start switch",
-    )
+    private val topoTestDataContextOnLocationTrackValidationError =
+        listOf(
+            validationError("validation.layout.location-track.no-context"),
+        )
+    private val topoTestDataStartSwitchNotPublishedError =
+        switchNotPublishedError("Topological switch connection test start switch")
+    private val topoTestDataStartSwitchJointsNotConnectedError =
+        switchAlignmentNotConnectedTrackValidationError(
+            "1-5-2", // alignment 1-3 is generated in the data, 1-5-2 is not
+            "Topological switch connection test start switch",
+        )
     private val topoTestDataEndSwitchNotPublishedError =
         switchNotPublishedError("Topological switch connection test end switch")
-    private val topoTestDataEndSwitchJointsNotConnectedError = switchAlignmentNotConnectedTrackValidationError(
-        "1-5-2", // alignment 1-3 is generated in the data, 1-5-2 is not
-        "Topological switch connection test end switch",
-    )
-    private val topoTestDataEndSwitchFrontJointNotConnectedError = switchFrontJointNotConnectedError(
-        "Topological switch connection test end switch"
-    )
+    private val topoTestDataEndSwitchJointsNotConnectedError =
+        switchAlignmentNotConnectedTrackValidationError(
+            "1-5-2", // alignment 1-3 is generated in the data, 1-5-2 is not
+            "Topological switch connection test end switch",
+        )
+    private val topoTestDataEndSwitchFrontJointNotConnectedError =
+        switchFrontJointNotConnectedError("Topological switch connection test end switch")
 
     @Test
     fun `Location track validation should fail for unofficial and unstaged topologically linked switches`() {
         val topologyTestData = getTopologicalSwitchConnectionTestData()
-        val noStart = listOf(
-            topoTestDataStartSwitchNotPublishedError,
-            // no error about no track continuing from the front joint, because a track in fact does continue from it
-        )
-        val noEnd = listOf(
-            topoTestDataEndSwitchNotPublishedError,
-        )
-        val expected = listOf(
-            topoTestDataContextOnLocationTrackValidationError,
-            topoTestDataContextOnLocationTrackValidationError + noStart,
-            topoTestDataContextOnLocationTrackValidationError + noEnd,
-            topoTestDataContextOnLocationTrackValidationError + noStart + noEnd
-        )
-        val actual = topologyTestData.locationTracksUnderTest.map { (locationTrackId) ->
-            getLocationTrackValidationResult(locationTrackId).issues
-        }
+        val noStart =
+            listOf(
+                topoTestDataStartSwitchNotPublishedError,
+                // no error about no track continuing from the front joint, because a track in fact
+                // does continue from it
+            )
+        val noEnd =
+            listOf(
+                topoTestDataEndSwitchNotPublishedError,
+            )
+        val expected =
+            listOf(
+                topoTestDataContextOnLocationTrackValidationError,
+                topoTestDataContextOnLocationTrackValidationError + noStart,
+                topoTestDataContextOnLocationTrackValidationError + noEnd,
+                topoTestDataContextOnLocationTrackValidationError + noStart + noEnd)
+        val actual =
+            topologyTestData.locationTracksUnderTest.map { (locationTrackId) ->
+                getLocationTrackValidationResult(locationTrackId).issues
+            }
         assertValidationErrorsForEach(expected, actual)
     }
 
     @Test
     fun `Location track validation should succeed for unofficial, but staged topologically linked switches`() {
         val topologyTestData = getTopologicalSwitchConnectionTestData()
-        val noStart = listOf(
-            topoTestDataStartSwitchJointsNotConnectedError,
-            // no error about no track continuing from the front joint, because a track in fact does continue from it
-        )
-        val noEnd = listOf(
-            topoTestDataEndSwitchJointsNotConnectedError,
-            topoTestDataEndSwitchFrontJointNotConnectedError,
-        )
-        val expected = listOf(
-            topoTestDataContextOnLocationTrackValidationError,
-            topoTestDataContextOnLocationTrackValidationError + noStart,
-            topoTestDataContextOnLocationTrackValidationError + noEnd,
-            topoTestDataContextOnLocationTrackValidationError + noStart + noEnd
-        )
-        val actual = topologyTestData.locationTracksUnderTest.map { (locationTrackId) ->
-            getLocationTrackValidationResult(locationTrackId, topologyTestData.switchIdsUnderTest, topologyTestData.switchInnerTrackIds + locationTrackId).issues
-        }
+        val noStart =
+            listOf(
+                topoTestDataStartSwitchJointsNotConnectedError,
+                // no error about no track continuing from the front joint, because a track in fact
+                // does continue from it
+            )
+        val noEnd =
+            listOf(
+                topoTestDataEndSwitchJointsNotConnectedError,
+                topoTestDataEndSwitchFrontJointNotConnectedError,
+            )
+        val expected =
+            listOf(
+                topoTestDataContextOnLocationTrackValidationError,
+                topoTestDataContextOnLocationTrackValidationError + noStart,
+                topoTestDataContextOnLocationTrackValidationError + noEnd,
+                topoTestDataContextOnLocationTrackValidationError + noStart + noEnd)
+        val actual =
+            topologyTestData.locationTracksUnderTest.map { (locationTrackId) ->
+                getLocationTrackValidationResult(
+                        locationTrackId,
+                        topologyTestData.switchIdsUnderTest,
+                        topologyTestData.switchInnerTrackIds + locationTrackId)
+                    .issues
+            }
 
         assertValidationErrorsForEach(expected, actual)
     }
@@ -2641,88 +3023,109 @@ class PublicationServiceIT @Autowired constructor(
     fun `Location track validation should succeed for topologically linked official switches`() {
         val topologyTestData = getTopologicalSwitchConnectionTestData()
 
-        val noStart = listOf(
-            topoTestDataStartSwitchJointsNotConnectedError,
-            // no error about no track continuing from the front joint, because a track in fact does continue from it
-        )
-        val noEnd = listOf(
-            topoTestDataEndSwitchJointsNotConnectedError,
-            topoTestDataEndSwitchFrontJointNotConnectedError,
-        )
-        val expected = listOf(
-            topoTestDataContextOnLocationTrackValidationError,
-            topoTestDataContextOnLocationTrackValidationError + noStart,
-            topoTestDataContextOnLocationTrackValidationError + noEnd,
-            topoTestDataContextOnLocationTrackValidationError + noStart + noEnd
-        )
+        val noStart =
+            listOf(
+                topoTestDataStartSwitchJointsNotConnectedError,
+                // no error about no track continuing from the front joint, because a track in fact
+                // does continue from it
+            )
+        val noEnd =
+            listOf(
+                topoTestDataEndSwitchJointsNotConnectedError,
+                topoTestDataEndSwitchFrontJointNotConnectedError,
+            )
+        val expected =
+            listOf(
+                topoTestDataContextOnLocationTrackValidationError,
+                topoTestDataContextOnLocationTrackValidationError + noStart,
+                topoTestDataContextOnLocationTrackValidationError + noEnd,
+                topoTestDataContextOnLocationTrackValidationError + noStart + noEnd)
 
-        publish(publicationService, switches = topologyTestData.switchIdsUnderTest, locationTracks = topologyTestData.switchInnerTrackIds)
-        val actual = topologyTestData.locationTracksUnderTest.map { (locationTrackId) ->
-            getLocationTrackValidationResult(locationTrackId).issues
-        }
+        publish(
+            publicationService,
+            switches = topologyTestData.switchIdsUnderTest,
+            locationTracks = topologyTestData.switchInnerTrackIds)
+        val actual =
+            topologyTestData.locationTracksUnderTest.map { (locationTrackId) ->
+                getLocationTrackValidationResult(locationTrackId).issues
+            }
         assertValidationErrorsForEach(expected, actual)
     }
 
     @Test
     fun `Switch validation checks duplicate tracks through non-math joints`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val switchId = switchService.saveDraft(
-            LayoutBranch.main,
-            switch(
-                seed = 123,
-                structureId = switchStructureDao
-                    .fetchSwitchStructures()
-                    .find { ss -> ss.type.typeName == "KRV43-233-1:9" }!!.id as IntId,
-                stateCategory = LayoutStateCategory.EXISTING,
-                draft = true,
+        val switchId =
+            switchService
+                .saveDraft(
+                    LayoutBranch.main,
+                    switch(
+                        seed = 123,
+                        structureId =
+                            switchStructureDao
+                                .fetchSwitchStructures()
+                                .find { ss -> ss.type.typeName == "KRV43-233-1:9" }!!
+                                .id as IntId,
+                        stateCategory = LayoutStateCategory.EXISTING,
+                        draft = true,
+                    ))
+                .id
+        val locationTrack1 =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, draft = true),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(2.0, 2.0)),
+                    segment(Point(2.0, 2.0), Point(5.0, 5.0))
+                        .copy(
+                            switchId = switchId,
+                            startJointNumber = JointNumber(1),
+                            endJointNumber = JointNumber(5),
+                        ),
+                    segment(Point(5.0, 5.0), Point(8.0, 8.0))
+                        .copy(
+                            switchId = switchId,
+                            startJointNumber = JointNumber(5),
+                            endJointNumber = JointNumber(2),
+                        ),
+                    segment(Point(8.0, 8.0), Point(10.0, 10.0)),
+                ),
             )
-        ).id
-        val locationTrack1 = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(2.0, 2.0)),
-                segment(Point(2.0, 2.0), Point(5.0, 5.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(5),
-                ),
-                segment(Point(5.0, 5.0), Point(8.0, 8.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(5),
-                    endJointNumber = JointNumber(2),
-                ),
-                segment(Point(8.0, 8.0), Point(10.0, 10.0)),
-            ),
-        )
 
-        fun otherAlignment() = alignment(
-            segment(Point(10.0, 0.0), Point(8.0, 2.0)),
-            segment(Point(8.0, 2.0), Point(5.0, 5.0)).copy(
-                switchId = switchId,
-                startJointNumber = JointNumber(4),
-                endJointNumber = JointNumber(5),
-            ),
-            segment(Point(5.0, 5.0), Point(2.0, 8.0)).copy(
-                switchId = switchId,
-                startJointNumber = JointNumber(5),
-                endJointNumber = JointNumber(3),
-            ),
-            segment(Point(2.0, 8.0), Point(0.0, 10.0)),
-        )
+        fun otherAlignment() =
+            alignment(
+                segment(Point(10.0, 0.0), Point(8.0, 2.0)),
+                segment(Point(8.0, 2.0), Point(5.0, 5.0))
+                    .copy(
+                        switchId = switchId,
+                        startJointNumber = JointNumber(4),
+                        endJointNumber = JointNumber(5),
+                    ),
+                segment(Point(5.0, 5.0), Point(2.0, 8.0))
+                    .copy(
+                        switchId = switchId,
+                        startJointNumber = JointNumber(5),
+                        endJointNumber = JointNumber(3),
+                    ),
+                segment(Point(2.0, 8.0), Point(0.0, 10.0)),
+            )
 
         val locationTrack2 = locationTrack(trackNumberId, draft = true)
         val locationTrack3 = locationTrack(trackNumberId, draft = true)
-        val locationTrack2Id = locationTrackService.saveDraft(LayoutBranch.main, locationTrack2, otherAlignment())
-        val locationTrack3Id = locationTrackService.saveDraft(LayoutBranch.main, locationTrack3, otherAlignment())
+        val locationTrack2Id =
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack2, otherAlignment())
+        val locationTrack3Id =
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack3, otherAlignment())
 
-        val validated = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(PublicationInMain),
-            publicationRequestIds(
-                locationTracks = listOf(locationTrack1.id, locationTrack2Id.id, locationTrack3Id.id),
-                switches = listOf(switchId),
-            ),
-        )
+        val validated =
+            publicationService.validatePublicationCandidates(
+                publicationService.collectPublicationCandidates(PublicationInMain),
+                publicationRequestIds(
+                    locationTracks =
+                        listOf(locationTrack1.id, locationTrack2Id.id, locationTrack3Id.id),
+                    switches = listOf(switchId),
+                ),
+            )
         val switchValidation = validated.validatedAsPublicationUnit.switches[0].issues
         assertContains(
             switchValidation,
@@ -2730,7 +3133,8 @@ class PublicationServiceIT @Autowired constructor(
                 LayoutValidationIssueType.WARNING,
                 "validation.layout.switch.track-linkage.multiple-tracks-through-joint",
                 mapOf(
-                    "locationTracks" to "3 (${locationTrack2.name}, ${locationTrack3.name}), 4 (${locationTrack2.name}, ${locationTrack3.name})",
+                    "locationTracks" to
+                        "3 (${locationTrack2.name}, ${locationTrack3.name}), 4 (${locationTrack2.name}, ${locationTrack3.name})",
                     "switch" to "TV123",
                 ),
             ),
@@ -2740,51 +3144,66 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Switch validation requires a track to continue from the front joint`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val switchId = switchService.saveDraft(
-            LayoutBranch.main,
-            switch(
-                seed = 123,
-                structureId = switchStructureYV60_300_1_9().id as IntId,
-                stateCategory = LayoutStateCategory.EXISTING,
-                draft = true,
-            )
-        ).id
-        val trackOn152Alignment = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(5.0, 0.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(5),
-                ),
-                segment(Point(5.0, 0.0), Point(10.0, 0.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(5),
-                    endJointNumber = JointNumber(2),
-                ),
-            ),
-        ).id
-        val trackOn13Alignment = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(10.0, 2.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(5),
-                    endJointNumber = JointNumber(3),
-                ),
-            ),
-        ).id
+        val switchId =
+            switchService
+                .saveDraft(
+                    LayoutBranch.main,
+                    switch(
+                        seed = 123,
+                        structureId = switchStructureYV60_300_1_9().id as IntId,
+                        stateCategory = LayoutStateCategory.EXISTING,
+                        draft = true,
+                    ))
+                .id
+        val trackOn152Alignment =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumberId, draft = true),
+                    alignment(
+                        segment(Point(0.0, 0.0), Point(5.0, 0.0))
+                            .copy(
+                                switchId = switchId,
+                                startJointNumber = JointNumber(1),
+                                endJointNumber = JointNumber(5),
+                            ),
+                        segment(Point(5.0, 0.0), Point(10.0, 0.0))
+                            .copy(
+                                switchId = switchId,
+                                startJointNumber = JointNumber(5),
+                                endJointNumber = JointNumber(2),
+                            ),
+                    ),
+                )
+                .id
+        val trackOn13Alignment =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(trackNumberId, draft = true),
+                    alignment(
+                        segment(Point(0.0, 0.0), Point(10.0, 2.0))
+                            .copy(
+                                switchId = switchId,
+                                startJointNumber = JointNumber(5),
+                                endJointNumber = JointNumber(3),
+                            ),
+                    ),
+                )
+                .id
 
         fun errorsWhenValidatingSwitchWithTracks(vararg locationTracks: IntId<LocationTrack>) =
-            publicationService.validatePublicationCandidates(
-                publicationService.collectPublicationCandidates(PublicationInMain),
-                publicationRequestIds(
-                    locationTracks = locationTracks.toList(),
-                    switches = listOf(switchId),
-                ),
-            ).validatedAsPublicationUnit.switches[0].issues
+            publicationService
+                .validatePublicationCandidates(
+                    publicationService.collectPublicationCandidates(PublicationInMain),
+                    publicationRequestIds(
+                        locationTracks = locationTracks.toList(),
+                        switches = listOf(switchId),
+                    ),
+                )
+                .validatedAsPublicationUnit
+                .switches[0]
+                .issues
 
         assertContains(
             errorsWhenValidatingSwitchWithTracks(trackOn152Alignment, trackOn13Alignment),
@@ -2795,18 +3214,21 @@ class PublicationServiceIT @Autowired constructor(
             ),
         )
 
-        val topoTrackMarkedAsDuplicate = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId = trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(1)),
-                duplicateOf = trackOn13Alignment,
-                draft = true,
-            )
-        ).id
+        val topoTrackMarkedAsDuplicate =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(
+                        trackNumberId = trackNumberId,
+                        topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(1)),
+                        duplicateOf = trackOn13Alignment,
+                        draft = true,
+                    ))
+                .id
 
         assertContains(
-            errorsWhenValidatingSwitchWithTracks(trackOn152Alignment, trackOn13Alignment, topoTrackMarkedAsDuplicate),
+            errorsWhenValidatingSwitchWithTracks(
+                trackOn152Alignment, trackOn13Alignment, topoTrackMarkedAsDuplicate),
             LayoutValidationIssue(
                 LayoutValidationIssueType.WARNING,
                 "validation.layout.switch.track-linkage.front-joint-only-duplicate-connected",
@@ -2814,28 +3236,30 @@ class PublicationServiceIT @Autowired constructor(
             ),
         )
 
-        val goodTopoTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(1)),
-                draft = true,
-            )
-        ).id
+        val goodTopoTrack =
+            locationTrackService
+                .saveDraft(
+                    LayoutBranch.main,
+                    locationTrack(
+                        trackNumberId,
+                        topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(1)),
+                        draft = true,
+                    ))
+                .id
 
-        val errors = errorsWhenValidatingSwitchWithTracks(
-            trackOn152Alignment,
-            trackOn13Alignment,
-            topoTrackMarkedAsDuplicate,
-            goodTopoTrack,
-        )
+        val errors =
+            errorsWhenValidatingSwitchWithTracks(
+                trackOn152Alignment,
+                trackOn13Alignment,
+                topoTrackMarkedAsDuplicate,
+                goodTopoTrack,
+            )
         assertFalse(
             errors.any { e ->
                 e.localizationKey.contains(
-                    "validation.layout.switch.track-linkage.front-joint-not-connected"
-                ) || e.localizationKey.contains(
-                    "validation.layout.switch.track-linkage.front-joint-only-duplicate-connected"
-                )
+                    "validation.layout.switch.track-linkage.front-joint-not-connected") ||
+                    e.localizationKey.contains(
+                        "validation.layout.switch.track-linkage.front-joint-only-duplicate-connected")
             },
         )
     }
@@ -2847,18 +3271,18 @@ class PublicationServiceIT @Autowired constructor(
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
         publish(publicationService, locationTracks = splitSetup.trackIds)
 
-        val draft = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrackDao.getOrThrow(MainLayoutContext.draft, splitSetup.targetTracks.first().first.id)
-        )
+        val draft =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrackDao.getOrThrow(
+                    MainLayoutContext.draft, splitSetup.targetTracks.first().first.id))
 
         val errors = validateLocationTracks(listOf(draft.id))
         assertContains(
             errors,
             validationError(
                 "validation.layout.split.track-split-in-progress",
-                "sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack.rowVersion).name
-            ),
+                "sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack.rowVersion).name),
         )
     }
 
@@ -2871,10 +3295,12 @@ class PublicationServiceIT @Autowired constructor(
 
         splitDao.updateSplit(splitId, bulkTransferState = BulkTransferState.DONE)
 
-        val draft = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrackDao.getOrThrow(MainLayoutContext.draft, splitSetup.targetTracks.first().first.id),
-        )
+        val draft =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrackDao.getOrThrow(
+                    MainLayoutContext.draft, splitSetup.targetTracks.first().first.id),
+            )
 
         val errors = validateLocationTracks(listOf(draft.id))
         assertTrue { errors.isEmpty() }
@@ -2887,18 +3313,18 @@ class PublicationServiceIT @Autowired constructor(
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
         publish(publicationService, locationTracks = splitSetup.trackIds)
 
-        val draft = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrackDao.getOrThrow(MainLayoutContext.draft, splitSetup.sourceTrack.id),
-        )
+        val draft =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrackDao.getOrThrow(MainLayoutContext.draft, splitSetup.sourceTrack.id),
+            )
 
         val errors = validateLocationTracks(listOf(draft.id))
         assertContains(
             errors,
             validationError(
                 "validation.layout.split.track-split-in-progress",
-                "sourceName" to locationTrackDao.fetch(draft.rowVersion).name
-            ),
+                "sourceName" to locationTrackDao.fetch(draft.rowVersion).name),
         )
     }
 
@@ -2911,10 +3337,11 @@ class PublicationServiceIT @Autowired constructor(
 
         splitDao.updateSplit(splitId, bulkTransferState = BulkTransferState.DONE)
 
-        val draft = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrackDao.getOrThrow(MainLayoutContext.draft, splitSetup.sourceTrack.id),
-        )
+        val draft =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrackDao.getOrThrow(MainLayoutContext.draft, splitSetup.sourceTrack.id),
+            )
 
         val errors = validateLocationTracks(listOf(draft.id))
         assertTrue { errors.isEmpty() }
@@ -2933,8 +3360,7 @@ class PublicationServiceIT @Autowired constructor(
                 LayoutValidationIssueType.ERROR,
                 LocalizationKey("validation.layout.split.source-not-deleted"),
                 localizationParams(
-                    "sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack.rowVersion).name
-                ),
+                    "sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack.rowVersion).name),
             ),
         )
     }
@@ -2944,8 +3370,7 @@ class PublicationServiceIT @Autowired constructor(
         val splitSetup = simpleSplitSetup()
         val startTarget = locationTrackDao.fetch(splitSetup.targetTracks.first().first.rowVersion)
         locationTrackDao.update(
-            startTarget.copy(trackNumberId = mainDraftContext.createLayoutTrackNumber().id)
-        )
+            startTarget.copy(trackNumberId = mainDraftContext.createLayoutTrackNumber().id))
 
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
 
@@ -2954,7 +3379,8 @@ class PublicationServiceIT @Autowired constructor(
             errors,
             LayoutValidationIssue(
                 LayoutValidationIssueType.ERROR,
-                LocalizationKey("validation.layout.split.source-and-target-track-numbers-are-different"),
+                LocalizationKey(
+                    "validation.layout.split.source-and-target-track-numbers-are-different"),
                 localizationParams(
                     "targetName" to startTarget.name,
                     "sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack.rowVersion).name,
@@ -2966,15 +3392,19 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `km post split validation should fail on unfinished split`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val kmPostId = mainDraftContext.insert(kmPost(trackNumberId = trackNumberId, km = KmNumber.ZERO)).id
-        val locationTrackResponse = mainDraftContext.insert(locationTrack(trackNumberId), alignment())
+        val kmPostId =
+            mainDraftContext.insert(kmPost(trackNumberId = trackNumberId, km = KmNumber.ZERO)).id
+        val locationTrackResponse =
+            mainDraftContext.insert(locationTrack(trackNumberId), alignment())
 
         saveSplit(locationTrackResponse.rowVersion)
 
-        val validation = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(PublicationInMain),
-            publicationRequestIds(locationTracks = listOf(locationTrackResponse.id), kmPosts = listOf(kmPostId)),
-        )
+        val validation =
+            publicationService.validatePublicationCandidates(
+                publicationService.collectPublicationCandidates(PublicationInMain),
+                publicationRequestIds(
+                    locationTracks = listOf(locationTrackResponse.id), kmPosts = listOf(kmPostId)),
+            )
 
         val errors = validation.validatedAsPublicationUnit.kmPosts.flatMap { it.issues }
 
@@ -2982,8 +3412,7 @@ class PublicationServiceIT @Autowired constructor(
             errors,
             validationError(
                 "validation.layout.split.affected-split-in-progress",
-                "sourceName" to locationTrackDao.fetch(locationTrackResponse.rowVersion).name
-            ),
+                "sourceName" to locationTrackDao.fetch(locationTrackResponse.rowVersion).name),
         )
     }
 
@@ -2991,20 +3420,23 @@ class PublicationServiceIT @Autowired constructor(
     fun `reference line split validation should fail on unfinished split`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        val referenceLineVersion = mainOfficialContext.insert(referenceLine(trackNumberId), alignment)
-            .let { v -> referenceLineService.saveDraft(LayoutBranch.main, referenceLineDao.fetch(v.rowVersion)) }
+        val referenceLineVersion =
+            mainOfficialContext.insert(referenceLine(trackNumberId), alignment).let { v ->
+                referenceLineService.saveDraft(
+                    LayoutBranch.main, referenceLineDao.fetch(v.rowVersion))
+            }
 
         val locationTrackResponse = mainDraftContext.insert(locationTrack(trackNumberId), alignment)
 
         saveSplit(locationTrackResponse.rowVersion)
 
-        val validation = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(PublicationInMain),
-            publicationRequestIds(
-                locationTracks = listOf(locationTrackResponse.id),
-                referenceLines = listOf(referenceLineVersion.id),
-            )
-        )
+        val validation =
+            publicationService.validatePublicationCandidates(
+                publicationService.collectPublicationCandidates(PublicationInMain),
+                publicationRequestIds(
+                    locationTracks = listOf(locationTrackResponse.id),
+                    referenceLines = listOf(referenceLineVersion.id),
+                ))
 
         val errors = validation.validatedAsPublicationUnit.referenceLines.flatMap { it.issues }
 
@@ -3012,8 +3444,7 @@ class PublicationServiceIT @Autowired constructor(
             errors,
             validationError(
                 "validation.layout.split.affected-split-in-progress",
-                "sourceName" to locationTrackDao.fetch(locationTrackResponse.rowVersion).name
-            ),
+                "sourceName" to locationTrackDao.fetch(locationTrackResponse.rowVersion).name),
         )
     }
 
@@ -3023,7 +3454,7 @@ class PublicationServiceIT @Autowired constructor(
         val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
 
         val referenceLine = mainOfficialContext.insert(referenceLine(trackNumberId), alignment)
-        val locationTrackResponse =  mainDraftContext.insert(locationTrack(trackNumberId), alignment)
+        val locationTrackResponse = mainDraftContext.insert(locationTrack(trackNumberId), alignment)
 
         referenceLineDao.fetch(referenceLine.rowVersion).also { d ->
             referenceLineService.saveDraft(LayoutBranch.main, d)
@@ -3034,10 +3465,10 @@ class PublicationServiceIT @Autowired constructor(
             splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
         }
 
-        val validation = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(PublicationInMain),
-            publicationRequestIds(referenceLines = listOf(referenceLine.id))
-        )
+        val validation =
+            publicationService.validatePublicationCandidates(
+                publicationService.collectPublicationCandidates(PublicationInMain),
+                publicationRequestIds(referenceLines = listOf(referenceLine.id)))
 
         val errors = validation.validatedAsPublicationUnit.referenceLines.flatMap { it.issues }
 
@@ -3053,47 +3484,60 @@ class PublicationServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val sourceTrackResponse = mainOfficialContext.insert(
-            locationTrack(trackNumberId),
-            alignment(
-                segment(Point(0.0, 0.0), Point(5.0, 0.0)),
-                segment(Point(5.0, 0.0), Point(10.0, 0.0)),
-            ),
-        )
+        val sourceTrackResponse =
+            mainOfficialContext.insert(
+                locationTrack(trackNumberId),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(5.0, 0.0)),
+                    segment(Point(5.0, 0.0), Point(10.0, 0.0)),
+                ),
+            )
 
-        val updatedSourceTrackResponse = alignmentDao
-            .insert(alignment(
-                segment(Point(0.0, 0.0), Point(5.0, 5.0)),
-                segment(Point(5.0, 5.0), Point(10.0, 0.0)),
-            ))
-            .let { newAlignment ->
-                val lt = locationTrackDao.fetch(sourceTrackResponse.rowVersion).copy(
-                    state = LocationTrackState.DELETED,
-                    alignmentVersion = newAlignment,
-                )
+        val updatedSourceTrackResponse =
+            alignmentDao
+                .insert(
+                    alignment(
+                        segment(Point(0.0, 0.0), Point(5.0, 5.0)),
+                        segment(Point(5.0, 5.0), Point(10.0, 0.0)),
+                    ))
+                .let { newAlignment ->
+                    val lt =
+                        locationTrackDao
+                            .fetch(sourceTrackResponse.rowVersion)
+                            .copy(
+                                state = LocationTrackState.DELETED,
+                                alignmentVersion = newAlignment,
+                            )
 
-                locationTrackService.saveDraft(LayoutBranch.main, lt)
-            }
+                    locationTrackService.saveDraft(LayoutBranch.main, lt)
+                }
 
         assertEquals(sourceTrackResponse.id, updatedSourceTrackResponse.id)
         assertNotEquals(sourceTrackResponse.rowVersion, updatedSourceTrackResponse.rowVersion)
 
-        val startTargetTrackId = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(0.0, 0.0), Point(5.0, 0.0))),
-        ).id
+        val startTargetTrackId =
+            mainDraftContext
+                .insert(
+                    locationTrack(trackNumberId),
+                    alignment(segment(Point(0.0, 0.0), Point(5.0, 0.0))),
+                )
+                .id
 
-        val endTargetTrackId = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
-        ).id
+        val endTargetTrackId =
+            mainDraftContext
+                .insert(
+                    locationTrack(trackNumberId),
+                    alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
+                )
+                .id
 
         saveSplit(
             updatedSourceTrackResponse.rowVersion,
             listOf(startTargetTrackId to 0..0, endTargetTrackId to 1..1),
         )
 
-        val errors = validateLocationTracks(sourceTrackResponse.id, startTargetTrackId, endTargetTrackId)
+        val errors =
+            validateLocationTracks(sourceTrackResponse.id, startTargetTrackId, endTargetTrackId)
 
         assertTrue {
             errors.any {
@@ -3111,35 +3555,46 @@ class PublicationServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val sourceTrackResponse = mainOfficialContext.insert(
-            locationTrack(trackNumberId),
-            alignment(
-                segment(Point(0.0, 0.0), Point(5.0, 0.0)),
-                segment(Point(5.0, 0.0), Point(10.0, 0.0)),
-            ),
-        ).let { response ->
-            val lt = locationTrackDao.fetch(response.rowVersion).copy(
-                state = LocationTrackState.DELETED
-            )
-            locationTrackService.saveDraft(LayoutBranch.main, lt)
-        }
+        val sourceTrackResponse =
+            mainOfficialContext
+                .insert(
+                    locationTrack(trackNumberId),
+                    alignment(
+                        segment(Point(0.0, 0.0), Point(5.0, 0.0)),
+                        segment(Point(5.0, 0.0), Point(10.0, 0.0)),
+                    ),
+                )
+                .let { response ->
+                    val lt =
+                        locationTrackDao
+                            .fetch(response.rowVersion)
+                            .copy(state = LocationTrackState.DELETED)
+                    locationTrackService.saveDraft(LayoutBranch.main, lt)
+                }
 
-        val startTargetTrackId = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(0.0, 0.0), Point(5.0, 10.0))),
-        ).id
+        val startTargetTrackId =
+            mainDraftContext
+                .insert(
+                    locationTrack(trackNumberId),
+                    alignment(segment(Point(0.0, 0.0), Point(5.0, 10.0))),
+                )
+                .id
 
-        val endTargetTrackId = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
-        ).id
+        val endTargetTrackId =
+            mainDraftContext
+                .insert(
+                    locationTrack(trackNumberId),
+                    alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
+                )
+                .id
 
         saveSplit(
             sourceTrackResponse.rowVersion,
             listOf(startTargetTrackId to 0..0, endTargetTrackId to 1..1),
         )
 
-        val errors = validateLocationTracks(sourceTrackResponse.id, startTargetTrackId, endTargetTrackId)
+        val errors =
+            validateLocationTracks(sourceTrackResponse.id, startTargetTrackId, endTargetTrackId)
         assertTrue {
             errors.any {
                 it.localizationKey == LocalizationKey("validation.layout.split.geometry-changed")
@@ -3153,7 +3608,8 @@ class PublicationServiceIT @Autowired constructor(
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
 
         val errors = validateLocationTracks(splitSetup.targetTracks.map { it.first.id })
-        assertContains(errors, validationError("validation.layout.split.split-missing-location-tracks"))
+        assertContains(
+            errors, validationError("validation.layout.split.split-missing-location-tracks"))
     }
 
     @Test
@@ -3162,24 +3618,30 @@ class PublicationServiceIT @Autowired constructor(
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
 
         val errors = validateLocationTracks(listOf(splitSetup.sourceTrack.id))
-        assertContains(errors, validationError("validation.layout.split.split-missing-location-tracks"))
+        assertContains(
+            errors, validationError("validation.layout.split.split-missing-location-tracks"))
     }
 
     @Test
     fun `Split validation should respect allowMultipleSplits`() {
         val splitSetup = simpleSplitSetup()
-        val split = saveSplit(
-            sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
-            targetTracks = splitSetup.targetParams,
-        ).let(splitDao::getOrThrow)
+        val split =
+            saveSplit(
+                    sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
+                    targetTracks = splitSetup.targetParams,
+                )
+                .let(splitDao::getOrThrow)
 
         val splitSetup2 = simpleSplitSetup()
-        val split2 = saveSplit(
-            sourceTrackVersion = splitSetup2.sourceTrack.rowVersion,
-            targetTracks = splitSetup2.targetParams,
-        ).let(splitDao::getOrThrow)
+        val split2 =
+            saveSplit(
+                    sourceTrackVersion = splitSetup2.sourceTrack.rowVersion,
+                    targetTracks = splitSetup2.targetParams,
+                )
+                .let(splitDao::getOrThrow)
 
-        val trackValidationVersions = splitSetup.trackValidationVersions + splitSetup2.trackValidationVersions
+        val trackValidationVersions =
+            splitSetup.trackValidationVersions + splitSetup2.trackValidationVersions
 
         assertContains(
             validateSplitContent(trackValidationVersions, emptyList(), listOf(split, split2), false)
@@ -3189,7 +3651,9 @@ class PublicationServiceIT @Autowired constructor(
         assertTrue(
             validateSplitContent(trackValidationVersions, emptyList(), listOf(split, split2), true)
                 .map { it.second }
-                .none { error -> error == validationError("validation.layout.split.multiple-splits-not-allowed") },
+                .none { error ->
+                    error == validationError("validation.layout.split.multiple-splits-not-allowed")
+                },
         )
     }
 
@@ -3197,19 +3661,22 @@ class PublicationServiceIT @Autowired constructor(
     fun `Split validation should fail if switches are missing`() {
         val splitSetup = simpleSplitSetup()
         val switch = mainOfficialContext.createSwitch()
-        val split = saveSplit(
-            sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
-            targetTracks = splitSetup.targetParams,
-            switches = listOf(switch.id),
-        ).let(splitDao::getOrThrow)
+        val split =
+            saveSplit(
+                    sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
+                    targetTracks = splitSetup.targetParams,
+                    switches = listOf(switch.id),
+                )
+                .let(splitDao::getOrThrow)
 
         assertContains(
             validateSplitContent(
-                splitSetup.trackValidationVersions,
-                emptyList(),
-                listOf(split),
-                false,
-            ).map { it.second },
+                    splitSetup.trackValidationVersions,
+                    emptyList(),
+                    listOf(split),
+                    false,
+                )
+                .map { it.second },
             validationError("validation.layout.split.split-missing-switches"),
         )
     }
@@ -3218,19 +3685,22 @@ class PublicationServiceIT @Autowired constructor(
     fun `Split validation should fail if only switches are staged`() {
         val splitSetup = simpleSplitSetup()
         val switch = mainOfficialContext.createSwitch()
-        val split = saveSplit(
-            sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
-            targetTracks = splitSetup.targetParams,
-            switches = listOf(switch.id),
-        ).let(splitDao::getOrThrow)
+        val split =
+            saveSplit(
+                    sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
+                    targetTracks = splitSetup.targetParams,
+                    switches = listOf(switch.id),
+                )
+                .let(splitDao::getOrThrow)
 
         assertContains(
             validateSplitContent(
-                emptyList(),
-                listOf(ValidationVersion(switch.id, switch.rowVersion)),
-                listOf(split),
-                false,
-            ).map { it.second },
+                    emptyList(),
+                    listOf(ValidationVersion(switch.id, switch.rowVersion)),
+                    listOf(split),
+                    false,
+                )
+                .map { it.second },
             validationError("validation.layout.split.split-missing-location-tracks"),
         )
     }
@@ -3239,20 +3709,23 @@ class PublicationServiceIT @Autowired constructor(
     fun `Split validation should not fail if switches and location tracks are staged`() {
         val splitSetup = simpleSplitSetup()
         val switch = mainOfficialContext.createSwitch()
-        val split = saveSplit(
-            sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
-            targetTracks = splitSetup.targetParams,
-            switches = listOf(switch.id),
-        ).let(splitDao::getOrThrow)
+        val split =
+            saveSplit(
+                    sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
+                    targetTracks = splitSetup.targetParams,
+                    switches = listOf(switch.id),
+                )
+                .let(splitDao::getOrThrow)
 
         assertEquals(
             0,
             validateSplitContent(
-                splitSetup.trackValidationVersions,
-                listOf(ValidationVersion(switch.id, switch.rowVersion)),
-                listOf(split),
-                false,
-            ).size,
+                    splitSetup.trackValidationVersions,
+                    listOf(ValidationVersion(switch.id, switch.rowVersion)),
+                    listOf(split),
+                    false,
+                )
+                .size,
         )
     }
 
@@ -3262,8 +3735,10 @@ class PublicationServiceIT @Autowired constructor(
         val designDraftContext = testDBService.testContext(testBranch, DRAFT)
         val trackNumber = designDraftContext.insert(trackNumber()).id
         val alignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        val referenceLine = designDraftContext.insert(referenceLine(trackNumber, alignmentVersion = alignment)).id
-        val locationTrack = designDraftContext.insert(locationTrack(trackNumber, alignmentVersion = alignment)).id
+        val referenceLine =
+            designDraftContext.insert(referenceLine(trackNumber, alignmentVersion = alignment)).id
+        val locationTrack =
+            designDraftContext.insert(locationTrack(trackNumber, alignmentVersion = alignment)).id
         val kmPost = designDraftContext.insert(kmPost(trackNumber, KmNumber(1), Point(1.0, 1.0))).id
         val switch = designDraftContext.insert(switch(123)).id
 
@@ -3295,14 +3770,17 @@ class PublicationServiceIT @Autowired constructor(
             ),
         )
     }
+
     @Test
     fun `create in design and update once in design before publishing in main`() {
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
         val testDraftContext = testDBService.testContext(testBranch, DRAFT)
         val trackNumber = testDraftContext.insert(trackNumber()).id
         val alignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        val referenceLine = testDraftContext.insert(referenceLine(trackNumber, alignmentVersion = alignment)).id
-        val locationTrack = testDraftContext.insert(locationTrack(trackNumber, alignmentVersion = alignment)).id
+        val referenceLine =
+            testDraftContext.insert(referenceLine(trackNumber, alignmentVersion = alignment)).id
+        val locationTrack =
+            testDraftContext.insert(locationTrack(trackNumber, alignmentVersion = alignment)).id
         val kmPost = testDraftContext.insert(kmPost(trackNumber, KmNumber(1), Point(1.0, 1.0))).id
         val switch = testDraftContext.insert(switch(123)).id
 
@@ -3318,11 +3796,16 @@ class PublicationServiceIT @Autowired constructor(
         )
 
         val testOfficialContext = testDBService.testContext(testBranch, OFFICIAL)
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(trackNumber)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(referenceLine)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(locationTrack)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(kmPost)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(switch)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(trackNumber)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(referenceLine)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(locationTrack)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(kmPost)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(switch)!!, testBranch.designId))
         publishAndVerify(
             testBranch,
             publicationRequest(
@@ -3356,9 +3839,12 @@ class PublicationServiceIT @Autowired constructor(
     fun `create in main and alter in design once before updating main`() {
         val trackNumber = mainOfficialContext.insert(trackNumber()).id
         val alignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        val referenceLine = mainOfficialContext.insert(referenceLine(trackNumber, alignmentVersion = alignment)).id
-        val locationTrack = mainOfficialContext.insert(locationTrack(trackNumber, alignmentVersion = alignment)).id
-        val kmPost = mainOfficialContext.insert(kmPost(trackNumber, KmNumber(1), Point(1.0, 1.0))).id
+        val referenceLine =
+            mainOfficialContext.insert(referenceLine(trackNumber, alignmentVersion = alignment)).id
+        val locationTrack =
+            mainOfficialContext.insert(locationTrack(trackNumber, alignmentVersion = alignment)).id
+        val kmPost =
+            mainOfficialContext.insert(kmPost(trackNumber, KmNumber(1), Point(1.0, 1.0))).id
         val switch = mainOfficialContext.insert(switch(123)).id
 
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
@@ -3367,40 +3853,31 @@ class PublicationServiceIT @Autowired constructor(
 
         testDraftContext.insert(
             asDesignDraft(
-                mainOfficialContext
-                    .fetch(trackNumber)!!
-                    .copy(number = TrackNumber("edited")),
+                mainOfficialContext.fetch(trackNumber)!!.copy(number = TrackNumber("edited")),
                 testBranch.designId,
-            )
-        )
+            ))
         testDraftContext.insert(
             asDesignDraft(
                 mainOfficialContext
                     .fetch(referenceLine)!!
                     .copy(startAddress = TrackMeter("0001+0123")),
                 testBranch.designId,
-            )
-        )
+            ))
         testDraftContext.insert(
             asDesignDraft(
-                mainOfficialContext
-                    .fetch(locationTrack)!!
-                    .copy(name = AlignmentName("edited")),
+                mainOfficialContext.fetch(locationTrack)!!.copy(name = AlignmentName("edited")),
                 testBranch.designId,
-            )
-        )
+            ))
         testDraftContext.insert(
             asDesignDraft(
                 mainOfficialContext.fetch(kmPost)!!.copy(kmNumber = KmNumber(123)),
                 testBranch.designId,
-            )
-        )
+            ))
         testDraftContext.insert(
             asDesignDraft(
                 mainOfficialContext.fetch(switch)!!.copy(name = SwitchName("edited")),
                 testBranch.designId,
-            )
-        )
+            ))
 
         publishAndVerify(
             testBranch,
@@ -3430,7 +3907,8 @@ class PublicationServiceIT @Autowired constructor(
         )
 
         assertEquals("edited", mainOfficialContext.fetch(trackNumber)!!.number.toString())
-        assertEquals("0001+0123", mainOfficialContext.fetch(referenceLine)!!.startAddress.toString())
+        assertEquals(
+            "0001+0123", mainOfficialContext.fetch(referenceLine)!!.startAddress.toString())
         assertEquals("edited", mainOfficialContext.fetch(locationTrack)!!.name.toString())
         assertEquals("0123", mainOfficialContext.fetch(kmPost)!!.kmNumber.toString())
         assertEquals("edited", mainOfficialContext.fetch(switch)!!.name.toString())
@@ -3440,46 +3918,59 @@ class PublicationServiceIT @Autowired constructor(
     fun `create in main and alter in design twice before updating main`() {
         val trackNumber = mainOfficialContext.insert(trackNumber()).id
         val alignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        val referenceLine = mainOfficialContext.insert(referenceLine(trackNumber, alignmentVersion = alignment)).id
-        val locationTrack = mainOfficialContext.insert(locationTrack(trackNumber, alignmentVersion = alignment)).id
-        val kmPost = mainOfficialContext.insert(kmPost(trackNumber, KmNumber(1), Point(1.0, 1.0))).id
+        val referenceLine =
+            mainOfficialContext.insert(referenceLine(trackNumber, alignmentVersion = alignment)).id
+        val locationTrack =
+            mainOfficialContext.insert(locationTrack(trackNumber, alignmentVersion = alignment)).id
+        val kmPost =
+            mainOfficialContext.insert(kmPost(trackNumber, KmNumber(1), Point(1.0, 1.0))).id
         val switch = mainOfficialContext.insert(switch(123)).id
 
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
         val testDraftContext = testDBService.testContext(testBranch, DRAFT)
         val testOfficialContext = testDBService.testContext(testBranch, OFFICIAL)
 
-        testDraftContext.insert(asDesignDraft(mainOfficialContext.fetch(trackNumber)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(mainOfficialContext.fetch(referenceLine)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(mainOfficialContext.fetch(locationTrack)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(mainOfficialContext.fetch(kmPost)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(mainOfficialContext.fetch(switch)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(mainOfficialContext.fetch(trackNumber)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(mainOfficialContext.fetch(referenceLine)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(mainOfficialContext.fetch(locationTrack)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(mainOfficialContext.fetch(kmPost)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(mainOfficialContext.fetch(switch)!!, testBranch.designId))
 
         publishAndVerify(
-            testBranch, publicationRequest(
+            testBranch,
+            publicationRequest(
                 trackNumbers = listOf(trackNumber),
                 referenceLines = listOf(referenceLine),
                 kmPosts = listOf(kmPost),
                 locationTracks = listOf(locationTrack),
                 switches = listOf(switch),
-            )
-        )
+            ))
 
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(trackNumber)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(referenceLine)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(locationTrack)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(kmPost)!!, testBranch.designId))
-        testDraftContext.insert(asDesignDraft(testOfficialContext.fetch(switch)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(trackNumber)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(referenceLine)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(locationTrack)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(kmPost)!!, testBranch.designId))
+        testDraftContext.insert(
+            asDesignDraft(testOfficialContext.fetch(switch)!!, testBranch.designId))
 
         publishAndVerify(
-            testBranch, publicationRequest(
+            testBranch,
+            publicationRequest(
                 trackNumbers = listOf(trackNumber),
                 referenceLines = listOf(referenceLine),
                 kmPosts = listOf(kmPost),
                 locationTracks = listOf(locationTrack),
                 switches = listOf(switch),
-            )
-        )
+            ))
 
         trackNumberService.mergeToMainBranch(testBranch, trackNumber)
         referenceLineService.mergeToMainBranch(testBranch, referenceLine)
@@ -3488,14 +3979,14 @@ class PublicationServiceIT @Autowired constructor(
         switchService.mergeToMainBranch(testBranch, switch)
 
         publishAndVerify(
-            LayoutBranch.main, publicationRequest(
+            LayoutBranch.main,
+            publicationRequest(
                 trackNumbers = listOf(trackNumber),
                 referenceLines = listOf(referenceLine),
                 kmPosts = listOf(kmPost),
                 locationTracks = listOf(locationTrack),
                 switches = listOf(switch),
-            )
-        )
+            ))
     }
 
     @Test
@@ -3504,37 +3995,38 @@ class PublicationServiceIT @Autowired constructor(
         mainOfficialContext.insert(
             referenceLine(
                 trackNumber,
-                alignmentVersion = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-            )
-        )
+                alignmentVersion =
+                    alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))))
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
         val testDraftContext = testDBService.testContext(testBranch, DRAFT)
 
         val switch = testDraftContext.insert(switch()).id
 
-        val locationTrack = testDraftContext.insert(
-            locationTrackAndAlignment(
-                trackNumber,
-                segment(Point(0.0, 0.0), Point(10.0, 10.0)).copy(startJointNumber = JointNumber(1), switchId = switch)
-            )
-        ).id
+        val locationTrack =
+            testDraftContext
+                .insert(
+                    locationTrackAndAlignment(
+                        trackNumber,
+                        segment(Point(0.0, 0.0), Point(10.0, 10.0))
+                            .copy(startJointNumber = JointNumber(1), switchId = switch)))
+                .id
 
         publishAndVerify(
-            testBranch, publicationRequest(
+            testBranch,
+            publicationRequest(
                 locationTracks = listOf(locationTrack),
                 switches = listOf(switch),
-            )
-        )
+            ))
 
         locationTrackService.mergeToMainBranch(testBranch, locationTrack)
         switchService.mergeToMainBranch(testBranch, switch)
 
         publishAndVerify(
-            MainBranch.instance, publicationRequest(
+            MainBranch.instance,
+            publicationRequest(
                 locationTracks = listOf(locationTrack),
                 switches = listOf(switch),
-            )
-        )
+            ))
     }
 
     @Test
@@ -3543,49 +4035,53 @@ class PublicationServiceIT @Autowired constructor(
         mainOfficialContext.insert(
             referenceLine(
                 trackNumber,
-                alignmentVersion = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-            )
-        )
+                alignmentVersion =
+                    alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))))
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
         val testDraftContext = testDBService.testContext(testBranch, DRAFT)
 
         val switch = mainOfficialContext.insert(switch()).id
 
-        val locationTrack = mainOfficialContext.insert(
-            locationTrackAndAlignment(
-                trackNumber,
-                segment(Point(0.0, 0.0), Point(10.0, 10.0)).copy(startJointNumber = JointNumber(1), switchId = switch)
-            )
-        ).id
+        val locationTrack =
+            mainOfficialContext
+                .insert(
+                    locationTrackAndAlignment(
+                        trackNumber,
+                        segment(Point(0.0, 0.0), Point(10.0, 10.0))
+                            .copy(startJointNumber = JointNumber(1), switchId = switch)))
+                .id
 
-        val editedAlignmentVersion = alignmentDao.insert(
-            alignment(
-                segment(Point(0.0, 0.0), Point(10.0, 10.0)).copy(
-                    endJointNumber = JointNumber(1),
-                    switchId = switch
-                )
-            )
-        )
+        val editedAlignmentVersion =
+            alignmentDao.insert(
+                alignment(
+                    segment(Point(0.0, 0.0), Point(10.0, 10.0))
+                        .copy(endJointNumber = JointNumber(1), switchId = switch)))
         testDraftContext.insert(
-            asDesignDraft(mainOfficialContext
-                .fetch(locationTrack)!!
-                .copy(alignmentVersion = editedAlignmentVersion), testBranch.designId)
-        )
+            asDesignDraft(
+                mainOfficialContext
+                    .fetch(locationTrack)!!
+                    .copy(alignmentVersion = editedAlignmentVersion),
+                testBranch.designId))
 
         publishAndVerify(testBranch, publicationRequest(locationTracks = listOf(locationTrack)))
         locationTrackService.mergeToMainBranch(testBranch, locationTrack)
-        publishAndVerify(MainBranch.instance, publicationRequest(locationTracks = listOf(locationTrack)))
+        publishAndVerify(
+            MainBranch.instance, publicationRequest(locationTracks = listOf(locationTrack)))
     }
 
-    private fun validateLocationTracks(vararg locationTracks: IntId<LocationTrack>): List<LayoutValidationIssue> =
-        validateLocationTracks(locationTracks.toList())
+    private fun validateLocationTracks(
+        vararg locationTracks: IntId<LocationTrack>
+    ): List<LayoutValidationIssue> = validateLocationTracks(locationTracks.toList())
 
-    private fun validateLocationTracks(locationTracks: List<IntId<LocationTrack>>): List<LayoutValidationIssue> {
+    private fun validateLocationTracks(
+        locationTracks: List<IntId<LocationTrack>>
+    ): List<LayoutValidationIssue> {
         val publicationRequest = publicationRequestIds(locationTracks = locationTracks)
-        val validation = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(PublicationInMain),
-            publicationRequest,
-        )
+        val validation =
+            publicationService.validatePublicationCandidates(
+                publicationService.collectPublicationCandidates(PublicationInMain),
+                publicationRequest,
+            )
 
         return validation.validatedAsPublicationUnit.locationTracks.flatMap { it.issues }
     }
@@ -3597,7 +4093,10 @@ class PublicationServiceIT @Autowired constructor(
     ): IntId<Split> {
         return splitDao.saveSplit(
             sourceTrackVersion,
-            splitTargets = targetTracks.map { (id, indices) -> SplitTarget(id, indices, SplitTargetOperation.CREATE) },
+            splitTargets =
+                targetTracks.map { (id, indices) ->
+                    SplitTarget(id, indices, SplitTargetOperation.CREATE)
+                },
             relinkedSwitches = switches,
             updatedDuplicates = emptyList(),
         )
@@ -3628,25 +4127,29 @@ class PublicationServiceIT @Autowired constructor(
 
         val startSegment = segment(Point(0.0, 0.0), Point(5.0, 0.0))
         val endSegment = segment(Point(5.0, 0.0), Point(10.0, 0.0))
-        val sourceTrack = mainOfficialContext.insert(
-            locationTrack(trackNumberId),
-            alignment(startSegment, endSegment),
-        )
+        val sourceTrack =
+            mainOfficialContext.insert(
+                locationTrack(trackNumberId),
+                alignment(startSegment, endSegment),
+            )
 
-        val draftSource = locationTrackDao
-            .fetch(sourceTrack.rowVersion)
-            .copy(state = sourceLocationTrackState)
-            .let { d -> locationTrackService.saveDraft(LayoutBranch.main, d) }
+        val draftSource =
+            locationTrackDao
+                .fetch(sourceTrack.rowVersion)
+                .copy(state = sourceLocationTrackState)
+                .let { d -> locationTrackService.saveDraft(LayoutBranch.main, d) }
 
-        val startTrack = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(startSegment),
-        )
+        val startTrack =
+            mainDraftContext.insert(
+                locationTrack(trackNumberId),
+                alignment(startSegment),
+            )
 
-        val endTrack = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(endSegment),
-        )
+        val endTrack =
+            mainDraftContext.insert(
+                locationTrack(trackNumberId),
+                alignment(endSegment),
+            )
 
         return SplitSetup(draftSource, listOf(startTrack to 0..0, endTrack to 1..1))
     }
@@ -3654,163 +4157,217 @@ class PublicationServiceIT @Autowired constructor(
     @Test
     fun `Location track validation catches only switch topology errors related to its own changes`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val switchId = switchDao.insert(
-            switch(
-                seed = 123,
-                structureId = switchStructureYV60_300_1_9().id as IntId,
-                draft = false,
-            ).copy(stateCategory = LayoutStateCategory.EXISTING)
-        ).id
-        val officialTrackOn152 = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                alignmentVersion = alignmentDao.insert(
-                    alignment(
-                        segment(Point(0.0, 5.0), Point(0.0, 0.0)),
-                        segment(Point(0.0, 0.0), Point(5.0, 0.0)).copy(
-                            switchId = switchId,
-                            startJointNumber = JointNumber(1),
-                            endJointNumber = JointNumber(5),
-                        ),
-                        segment(Point(5.0, 0.0), Point(10.0, 0.0)).copy(
-                            switchId = switchId,
-                            startJointNumber = JointNumber(5),
-                            endJointNumber = JointNumber(2),
-                        ),
-                    )
-                ),
-                draft = false,
-            )
-        )
-        val officialTrackOn13 = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                alignmentVersion = alignmentDao.insert(
-                    alignment(
-                        segment(Point(0.0, 0.0), Point(10.0, 2.0)).copy(
-                            switchId = switchId,
-                            startJointNumber = JointNumber(1),
-                            endJointNumber = JointNumber(3),
-                        ),
-                    )
-                ),
-                draft = false,
-            )
-        )
+        val switchId =
+            switchDao
+                .insert(
+                    switch(
+                            seed = 123,
+                            structureId = switchStructureYV60_300_1_9().id as IntId,
+                            draft = false,
+                        )
+                        .copy(stateCategory = LayoutStateCategory.EXISTING))
+                .id
+        val officialTrackOn152 =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    alignmentVersion =
+                        alignmentDao.insert(
+                            alignment(
+                                segment(Point(0.0, 5.0), Point(0.0, 0.0)),
+                                segment(Point(0.0, 0.0), Point(5.0, 0.0))
+                                    .copy(
+                                        switchId = switchId,
+                                        startJointNumber = JointNumber(1),
+                                        endJointNumber = JointNumber(5),
+                                    ),
+                                segment(Point(5.0, 0.0), Point(10.0, 0.0))
+                                    .copy(
+                                        switchId = switchId,
+                                        startJointNumber = JointNumber(5),
+                                        endJointNumber = JointNumber(2),
+                                    ),
+                            )),
+                    draft = false,
+                ))
+        val officialTrackOn13 =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    alignmentVersion =
+                        alignmentDao.insert(
+                            alignment(
+                                segment(Point(0.0, 0.0), Point(10.0, 2.0))
+                                    .copy(
+                                        switchId = switchId,
+                                        startJointNumber = JointNumber(1),
+                                        endJointNumber = JointNumber(3),
+                                    ),
+                            )),
+                    draft = false,
+                ))
         locationTrackService.saveDraft(
             LayoutBranch.main,
-            locationTrackDao.fetch(officialTrackOn152.rowVersion).copy(state = LocationTrackState.DELETED)
-        )
+            locationTrackDao
+                .fetch(officialTrackOn152.rowVersion)
+                .copy(state = LocationTrackState.DELETED))
         locationTrackService.saveDraft(
             LayoutBranch.main,
-            locationTrackDao.fetch(officialTrackOn13.rowVersion).copy(state = LocationTrackState.DELETED)
-        )
+            locationTrackDao
+                .fetch(officialTrackOn13.rowVersion)
+                .copy(state = LocationTrackState.DELETED))
 
-        val errorsWhenDeletingStraightTrack = getLocationTrackValidationResult(officialTrackOn152.id).issues
-        assertTrue(errorsWhenDeletingStraightTrack.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
-                    error.params.get("locationTracks") == "1-5-2" && error.params.get("switch") == "TV123"
-        })
-        assertTrue(errorsWhenDeletingStraightTrack.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.front-joint-not-connected") &&
+        val errorsWhenDeletingStraightTrack =
+            getLocationTrackValidationResult(officialTrackOn152.id).issues
+        assertTrue(
+            errorsWhenDeletingStraightTrack.any { error ->
+                error.localizationKey ==
+                    LocalizationKey(
+                        "validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
+                    error.params.get("locationTracks") == "1-5-2" &&
                     error.params.get("switch") == "TV123"
-        })
+            })
+        assertTrue(
+            errorsWhenDeletingStraightTrack.any { error ->
+                error.localizationKey ==
+                    LocalizationKey(
+                        "validation.layout.location-track.switch-linkage.front-joint-not-connected") &&
+                    error.params.get("switch") == "TV123"
+            })
 
-        val errorsWhenDeletingBranchingTrack = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(PublicationInMain),
-            publicationRequestIds(locationTracks = listOf(officialTrackOn13.id)),
-        ).validatedAsPublicationUnit.locationTracks[0].issues
-        assertTrue(errorsWhenDeletingBranchingTrack.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
-                    error.params.get("locationTracks") == "1-3" && error.params.get("switch") == "TV123"
-        })
-        assertFalse(errorsWhenDeletingBranchingTrack.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.front-joint-not-connected") })
+        val errorsWhenDeletingBranchingTrack =
+            publicationService
+                .validatePublicationCandidates(
+                    publicationService.collectPublicationCandidates(PublicationInMain),
+                    publicationRequestIds(locationTracks = listOf(officialTrackOn13.id)),
+                )
+                .validatedAsPublicationUnit
+                .locationTracks[0]
+                .issues
+        assertTrue(
+            errorsWhenDeletingBranchingTrack.any { error ->
+                error.localizationKey ==
+                    LocalizationKey(
+                        "validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
+                    error.params.get("locationTracks") == "1-3" &&
+                    error.params.get("switch") == "TV123"
+            })
+        assertFalse(
+            errorsWhenDeletingBranchingTrack.any { error ->
+                error.localizationKey ==
+                    LocalizationKey(
+                        "validation.layout.location-track.switch-linkage.front-joint-not-connected")
+            })
     }
 
     @Test
     fun `Location track validation catches track removal causing switches to go unlinked`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val switchId = switchDao.insert(
-            switch(
-                seed = 123,
-                structureId = switchStructureYV60_300_1_9().id as IntId,
-                stateCategory = LayoutStateCategory.EXISTING,
-                draft = false
-            )
-        ).id
-        val officialTrackOn152 = locationTrackDao.insert(
+        val switchId =
+            switchDao
+                .insert(
+                    switch(
+                        seed = 123,
+                        structureId = switchStructureYV60_300_1_9().id as IntId,
+                        stateCategory = LayoutStateCategory.EXISTING,
+                        draft = false))
+                .id
+        val officialTrackOn152 =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    alignmentVersion =
+                        alignmentDao.insert(
+                            alignment(
+                                segment(Point(0.0, 0.0), Point(5.0, 0.0))
+                                    .copy(
+                                        switchId = switchId,
+                                        startJointNumber = JointNumber(1),
+                                        endJointNumber = JointNumber(5),
+                                    ),
+                                segment(Point(5.0, 0.0), Point(10.0, 0.0))
+                                    .copy(
+                                        switchId = switchId,
+                                        startJointNumber = JointNumber(5),
+                                        endJointNumber = JointNumber(2),
+                                    ),
+                            )),
+                    draft = false,
+                ))
+        locationTrackService.saveDraft(
+            LayoutBranch.main,
+            locationTrackDao
+                .fetch(officialTrackOn152.rowVersion)
+                .copy(state = LocationTrackState.DELETED))
+        locationTrackDao.insert(
             locationTrack(
-                trackNumberId = trackNumberId,
-                alignmentVersion = alignmentDao.insert(
-                    alignment(
-                        segment(Point(0.0, 0.0), Point(5.0, 0.0)).copy(
+                trackNumberId,
+                alignmentVersion =
+                    alignmentDao.insert(
+                        alignment(
+                            segment(Point(0.0, 0.0), Point(10.0, 2.0))
+                                .copy(
+                                    switchId = switchId,
+                                    startJointNumber = JointNumber(1),
+                                    endJointNumber = JointNumber(3),
+                                ),
+                        )),
+                draft = false,
+            ))
+
+        val locationTrackDeletionErrors =
+            publicationService
+                .validatePublicationCandidates(
+                    publicationService.collectPublicationCandidates(PublicationInMain),
+                    publicationRequestIds(locationTracks = listOf(officialTrackOn152.id)),
+                )
+                .validatedAsPublicationUnit
+                .locationTracks[0]
+                .issues
+        assertTrue(
+            locationTrackDeletionErrors.any { error ->
+                error.localizationKey ==
+                    LocalizationKey(
+                        "validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
+                    error.params.get("locationTracks") == "1-5-2" &&
+                    error.params.get("switch") == "TV123"
+            })
+        // but it's OK if we link a replacement track
+        val replacementTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, draft = true),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(5.0, 0.0))
+                        .copy(
                             switchId = switchId,
                             startJointNumber = JointNumber(1),
                             endJointNumber = JointNumber(5),
                         ),
-                        segment(Point(5.0, 0.0), Point(10.0, 0.0)).copy(
+                    segment(Point(5.0, 0.0), Point(10.0, 0.0))
+                        .copy(
                             switchId = switchId,
                             startJointNumber = JointNumber(5),
                             endJointNumber = JointNumber(2),
                         ),
-                    )
                 ),
-                draft = false,
             )
-        )
-        locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrackDao.fetch(officialTrackOn152.rowVersion).copy(state = LocationTrackState.DELETED)
-        )
-        locationTrackDao.insert(
-            locationTrack(
-                trackNumberId,
-                alignmentVersion = alignmentDao.insert(
-                    alignment(
-                        segment(Point(0.0, 0.0), Point(10.0, 2.0)).copy(
-                            switchId = switchId,
-                            startJointNumber = JointNumber(1),
-                            endJointNumber = JointNumber(3),
-                        ),
-                    )
-                ),
-                draft = false,
-            )
-        )
-
-        val locationTrackDeletionErrors = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(PublicationInMain),
-            publicationRequestIds(locationTracks = listOf(officialTrackOn152.id)),
-        ).validatedAsPublicationUnit.locationTracks[0].issues
-        assertTrue(locationTrackDeletionErrors.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
-                    error.params.get("locationTracks") == "1-5-2" && error.params.get("switch") == "TV123"
-        })
-        // but it's OK if we link a replacement track
-        val replacementTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(5.0, 0.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(5),
-                ),
-                segment(Point(5.0, 0.0), Point(10.0, 0.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(5),
-                    endJointNumber = JointNumber(2),
-                ),
-            ),
-        )
-        val errorsWithReplacementTrackLinked = publicationService.validatePublicationCandidates(
-            publicationService.collectPublicationCandidates(PublicationInMain),
-            publicationRequestIds(locationTracks = listOf(officialTrackOn152.id, replacementTrack.id)),
-        ).validatedAsPublicationUnit.locationTracks[0].issues
-        assertFalse(errorsWithReplacementTrackLinked.any { error ->
-            error.localizationKey == LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected")
-        })
+        val errorsWithReplacementTrackLinked =
+            publicationService
+                .validatePublicationCandidates(
+                    publicationService.collectPublicationCandidates(PublicationInMain),
+                    publicationRequestIds(
+                        locationTracks = listOf(officialTrackOn152.id, replacementTrack.id)),
+                )
+                .validatedAsPublicationUnit
+                .locationTracks[0]
+                .issues
+        assertFalse(
+            errorsWithReplacementTrackLinked.any { error ->
+                error.localizationKey ==
+                    LocalizationKey(
+                        "validation.layout.location-track.switch-linkage.switch-alignment-not-connected")
+            })
     }
 
     @Test
@@ -3818,12 +4375,15 @@ class PublicationServiceIT @Autowired constructor(
         val splitSetup = simpleSplitSetup()
         saveSplit(splitSetup.sourceTrack.rowVersion, splitSetup.targetParams)
 
-        val publicationId = publicationService.getValidationVersions(
-            LayoutBranch.main,
-            publicationRequest(locationTracks = splitSetup.trackIds)
-        ).let { versions ->
-            testPublish(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions)).publicationId
-        }
+        val publicationId =
+            publicationService
+                .getValidationVersions(
+                    LayoutBranch.main, publicationRequest(locationTracks = splitSetup.trackIds))
+                .let { versions ->
+                    testPublish(
+                            LayoutBranch.main, versions, getCalculatedChangesInRequest(versions))
+                        .publicationId
+                }
 
         val splitInPublication = publicationService.getSplitInPublication(publicationId!!)
         assertNotNull(splitInPublication)
@@ -3848,24 +4408,28 @@ class PublicationServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val someTrack = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
+        val someTrack =
+            mainDraftContext.insert(
+                locationTrack(trackNumberId),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
 
-        val someDuplicateTrack = mainDraftContext.insert(
-            locationTrack(trackNumberId = trackNumberId, duplicateOf = someTrack.id),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
+        val someDuplicateTrack =
+            mainDraftContext.insert(
+                locationTrack(trackNumberId = trackNumberId, duplicateOf = someTrack.id),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
 
-        val someTrackIds = listOf(
-            someTrack.id,
-            someDuplicateTrack.id,
-        )
+        val someTrackIds =
+            listOf(
+                someTrack.id,
+                someDuplicateTrack.id,
+            )
 
         val someSwitchId = mainDraftContext.createSwitch().id
 
-        val publicationCandidates = publicationService.collectPublicationCandidates(PublicationInMain)
+        val publicationCandidates =
+            publicationService.collectPublicationCandidates(PublicationInMain)
 
         publicationCandidates.locationTracks
             .filter { candidate -> candidate.id in someTrackIds }
@@ -3882,22 +4446,24 @@ class PublicationServiceIT @Autowired constructor(
     fun `Publication group should be set for assets related to a split`() {
         (1..4).forEach { testIndex ->
             val testData = insertPublicationGroupTestData()
-            val splits = splitService.findUnfinishedSplits(
-                LayoutBranch.main,
-                locationTrackIds = listOf(testData.sourceLocationTrackId)
-            )
+            val splits =
+                splitService.findUnfinishedSplits(
+                    LayoutBranch.main, locationTrackIds = listOf(testData.sourceLocationTrackId))
 
             assertEquals(1, splits.size)
             val splitId = splits[0].id
 
-            val publicationCandidates = publicationService.collectPublicationCandidates(PublicationInMain)
+            val publicationCandidates =
+                publicationService.collectPublicationCandidates(PublicationInMain)
 
             val amountOfNonDuplicatesInCurrentTest = 3
             val amountOfDuplicatesInCurrentTest = 5
             val expectedTotalUnpublishedLocationTrackAmount =
                 testIndex * (amountOfNonDuplicatesInCurrentTest + amountOfDuplicatesInCurrentTest)
 
-            assertEquals(expectedTotalUnpublishedLocationTrackAmount, publicationCandidates.locationTracks.size)
+            assertEquals(
+                expectedTotalUnpublishedLocationTrackAmount,
+                publicationCandidates.locationTracks.size)
 
             publicationCandidates.locationTracks
                 .filter { candidate -> candidate.id in testData.allLocationTrackIds }
@@ -3933,22 +4499,26 @@ class PublicationServiceIT @Autowired constructor(
             assertEquals(null, split.publicationId)
         }
 
-        val publicationId = publicationService.getValidationVersions(
-            LayoutBranch.main,
-            publicationRequest(locationTracks = splitSetup.trackIds)
-        ).let { versions ->
-            testPublish(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions)).publicationId
-        }
+        val publicationId =
+            publicationService
+                .getValidationVersions(
+                    LayoutBranch.main, publicationRequest(locationTracks = splitSetup.trackIds))
+                .let { versions ->
+                    testPublish(
+                            LayoutBranch.main, versions, getCalculatedChangesInRequest(versions))
+                        .publicationId
+                }
 
         splitDao.get(splitId).let { split ->
             assertNotNull(split)
             assertEquals(publicationId, split.publicationId)
         }
 
-        val (targetTrackToModify, targetAlignment) = locationTrackService.getWithAlignmentOrThrow(
-            MainLayoutContext.draft,
-            splitSetup.targetTracks.first().first.id,
-        )
+        val (targetTrackToModify, targetAlignment) =
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.draft,
+                splitSetup.targetTracks.first().first.id,
+            )
         locationTrackService.saveDraft(
             LayoutBranch.main,
             draftAsset = targetTrackToModify.copy(name = AlignmentName("Some other draft name")),
@@ -3960,7 +4530,8 @@ class PublicationServiceIT @Autowired constructor(
             publicationRequestIds(locationTracks = listOf(targetTrackToModify.id as IntId)),
         )
 
-        // Split should be found and not be deleted even after reverting the draft change to the modified locationTrack.
+        // Split should be found and not be deleted even after reverting the draft change to the
+        // modified locationTrack.
         assertNotNull(splitDao.get(splitId))
     }
 
@@ -3970,21 +4541,24 @@ class PublicationServiceIT @Autowired constructor(
 
         val someSwitch = mainDraftContext.createSwitch()
 
-        val splitId = saveSplit(
-            sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
-            targetTracks = splitSetup.targetParams,
-            switches = listOf(someSwitch.id),
-        )
-
-        publicationService.getValidationVersions(
-            LayoutBranch.main,
-            publicationRequest(
-                locationTracks = splitSetup.trackIds,
+        val splitId =
+            saveSplit(
+                sourceTrackVersion = splitSetup.sourceTrack.rowVersion,
+                targetTracks = splitSetup.targetParams,
                 switches = listOf(someSwitch.id),
             )
-        ).let { versions ->
-            testPublish(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions)).publicationId
-        }
+
+        publicationService
+            .getValidationVersions(
+                LayoutBranch.main,
+                publicationRequest(
+                    locationTracks = splitSetup.trackIds,
+                    switches = listOf(someSwitch.id),
+                ))
+            .let { versions ->
+                testPublish(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions))
+                    .publicationId
+            }
 
         switchService.get(MainLayoutContext.draft, someSwitch.id).let { publishedSwitch ->
             assertNotNull(publishedSwitch)
@@ -3997,13 +4571,10 @@ class PublicationServiceIT @Autowired constructor(
         }
 
         publicationService.revertPublicationCandidates(
-            LayoutBranch.main,
-            publicationRequestIds(
-                switches = listOf(someSwitch.id)
-            )
-        )
+            LayoutBranch.main, publicationRequestIds(switches = listOf(someSwitch.id)))
 
-        // Split should be found and not be deleted even after reverting the draft change to the modified switch.
+        // Split should be found and not be deleted even after reverting the draft change to the
+        // modified switch.
         assertNotNull(splitDao.get(splitId))
     }
 
@@ -4022,7 +4593,11 @@ class PublicationServiceIT @Autowired constructor(
     fun `location track created in design is reported as created`() {
         val trackNumber = mainOfficialContext.insert(trackNumber()).id
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
-        val locationTrack = testDBService.testContext(testBranch, DRAFT).insert(locationTrack(trackNumber), alignment()).id
+        val locationTrack =
+            testDBService
+                .testContext(testBranch, DRAFT)
+                .insert(locationTrack(trackNumber), alignment())
+                .id
         publish(publicationService, testBranch, locationTracks = listOf(locationTrack))
         locationTrackService.mergeToMainBranch(testBranch, locationTrack)
         publish(publicationService, locationTracks = listOf(locationTrack))
@@ -4045,7 +4620,8 @@ class PublicationServiceIT @Autowired constructor(
     fun `km post created in design is reported as created`() {
         val trackNumber = mainOfficialContext.insert(trackNumber()).id
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
-        val kmPost = testDBService.testContext(testBranch, DRAFT).insert(kmPost(trackNumber, KmNumber(2))).id
+        val kmPost =
+            testDBService.testContext(testBranch, DRAFT).insert(kmPost(trackNumber, KmNumber(2))).id
         publish(publicationService, testBranch, kmPosts = listOf(kmPost))
         kmPostService.mergeToMainBranch(testBranch, kmPost)
         publish(publicationService, kmPosts = listOf(kmPost))
@@ -4069,31 +4645,35 @@ class PublicationServiceIT @Autowired constructor(
 
         // Due to using splitDao.saveSplit and not actually running a split,
         // the sourceTrack is created as a draft as well.
-        val sourceTrack = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
-
-        val middleTrack = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(2.0, 0.0), Point(3.0, 0.0))),
-        )
-
-        val endTrack = mainDraftContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
-        )
-
-        val someSwitches = (0..5).map {
-            mainDraftContext.createSwitch().id
-        }
-
-        val someDuplicates = (0..4).map { i ->
+        val sourceTrack =
             mainDraftContext.insert(
-                locationTrack(trackNumberId = trackNumberId, duplicateOf = sourceTrack.id),
-                alignment(segment(Point(i.toDouble(), 0.0), Point(i + 0.75, 0.0))),
-            ).id
-        }
+                locationTrack(trackNumberId),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
+
+        val middleTrack =
+            mainDraftContext.insert(
+                locationTrack(trackNumberId),
+                alignment(segment(Point(2.0, 0.0), Point(3.0, 0.0))),
+            )
+
+        val endTrack =
+            mainDraftContext.insert(
+                locationTrack(trackNumberId),
+                alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
+            )
+
+        val someSwitches = (0..5).map { mainDraftContext.createSwitch().id }
+
+        val someDuplicates =
+            (0..4).map { i ->
+                mainDraftContext
+                    .insert(
+                        locationTrack(trackNumberId = trackNumberId, duplicateOf = sourceTrack.id),
+                        alignment(segment(Point(i.toDouble(), 0.0), Point(i + 0.75, 0.0))),
+                    )
+                    .id
+            }
 
         splitDao.saveSplit(
             sourceTrack.rowVersion,
@@ -4107,14 +4687,16 @@ class PublicationServiceIT @Autowired constructor(
 
         return PublicationGroupTestData(
             sourceLocationTrackId = sourceTrack.id,
-            allLocationTrackIds = listOf(
+            allLocationTrackIds =
                 listOf(
-                    sourceTrack.id,
-                    middleTrack.id,
-                    endTrack.id,
-                ),
-                someDuplicates,
-            ).flatten(),
+                        listOf(
+                            sourceTrack.id,
+                            middleTrack.id,
+                            endTrack.id,
+                        ),
+                        someDuplicates,
+                    )
+                    .flatten(),
             switchIds = someSwitches,
             duplicateLocationTrackIds = someDuplicates,
         )
@@ -4124,12 +4706,13 @@ class PublicationServiceIT @Autowired constructor(
         layoutBranch: LayoutBranch,
         versions: ValidationVersions,
         calculatedChanges: CalculatedChanges,
-    ): PublicationResult = publicationService.publishChanges(
-        layoutBranch,
-        versions,
-        calculatedChanges,
-        "${this::class.simpleName}",
-    )
+    ): PublicationResult =
+        publicationService.publishChanges(
+            layoutBranch,
+            versions,
+            calculatedChanges,
+            "${this::class.simpleName}",
+        )
 }
 
 fun publicationRequestIds(
@@ -4138,7 +4721,8 @@ fun publicationRequestIds(
     referenceLines: List<IntId<ReferenceLine>> = listOf(),
     switches: List<IntId<TrackLayoutSwitch>> = listOf(),
     kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
-): PublicationRequestIds = PublicationRequestIds(trackNumbers, locationTracks, referenceLines, switches, kmPosts)
+): PublicationRequestIds =
+    PublicationRequestIds(trackNumbers, locationTracks, referenceLines, switches, kmPosts)
 
 private fun assertEqualsCalculatedChanges(
     calculatedChanges: CalculatedChanges,
@@ -4149,7 +4733,8 @@ private fun assertEqualsCalculatedChanges(
         publishedLocationTracks: List<PublishedLocationTrack>,
     ) {
         calculatedLocationTracks.forEach { calculatedTrack ->
-            val locationTrack = publishedLocationTracks.find { it.id == calculatedTrack.locationTrackId }
+            val locationTrack =
+                publishedLocationTracks.find { it.id == calculatedTrack.locationTrackId }
             assertNotNull(locationTrack)
             assertEquals(locationTrack.changedKmNumbers, calculatedTrack.changedKmNumbers)
         }
@@ -4160,7 +4745,8 @@ private fun assertEqualsCalculatedChanges(
         publishedTrackNumbers: List<PublishedTrackNumber>,
     ) {
         calculatedTrackNumbers.forEach { calculatedTrackNumber ->
-            val trackNumber = publishedTrackNumbers.find { it.id == calculatedTrackNumber.trackNumberId }
+            val trackNumber =
+                publishedTrackNumbers.find { it.id == calculatedTrackNumber.trackNumberId }
             assertNotNull(trackNumber)
             assertEquals(trackNumber.changedKmNumbers, calculatedTrackNumber.changedKmNumbers)
         }
@@ -4174,8 +4760,10 @@ private fun assertEqualsCalculatedChanges(
         assertTrue(publicationDetails.referenceLines.any { it.id == calculatedReferenceLineId })
     }
 
-    trackNumberEquals(calculatedChanges.directChanges.trackNumberChanges, publicationDetails.trackNumbers)
-    locationTrackEquals(calculatedChanges.directChanges.locationTrackChanges, publicationDetails.locationTracks)
+    trackNumberEquals(
+        calculatedChanges.directChanges.trackNumberChanges, publicationDetails.trackNumbers)
+    locationTrackEquals(
+        calculatedChanges.directChanges.locationTrackChanges, publicationDetails.locationTracks)
 
     calculatedChanges.directChanges.switchChanges.forEach { calculatedSwitch ->
         val switch = publicationDetails.switches.find { it.id == calculatedSwitch.switchId }
@@ -4194,15 +4782,19 @@ private fun assertEqualsCalculatedChanges(
     )
 
     calculatedChanges.indirectChanges.switchChanges.forEach { calculatedSwitch ->
-        val switch = publicationDetails.indirectChanges.switches.find { s ->
-            s.id == calculatedSwitch.switchId
-        }
+        val switch =
+            publicationDetails.indirectChanges.switches.find { s ->
+                s.id == calculatedSwitch.switchId
+            }
         assertNotNull(switch)
         assertEquals(switch.changedJoints, calculatedSwitch.changedJoints)
     }
 }
 
-private fun verifyVersions(publicationRequestIds: PublicationRequestIds, validationVersions: ValidationVersions) {
+private fun verifyVersions(
+    publicationRequestIds: PublicationRequestIds,
+    validationVersions: ValidationVersions
+) {
     verifyVersions(publicationRequestIds.trackNumbers, validationVersions.trackNumbers)
     verifyVersions(publicationRequestIds.referenceLines, validationVersions.referenceLines)
     verifyVersions(publicationRequestIds.kmPosts, validationVersions.kmPosts)
@@ -4210,7 +4802,10 @@ private fun verifyVersions(publicationRequestIds: PublicationRequestIds, validat
     verifyVersions(publicationRequestIds.switches, validationVersions.switches)
 }
 
-private fun <T : LayoutAsset<T>> verifyVersions(ids: List<IntId<T>>, versions: List<ValidationVersion<T>>) {
+private fun <T : LayoutAsset<T>> verifyVersions(
+    ids: List<IntId<T>>,
+    versions: List<ValidationVersion<T>>
+) {
     assertEquals(ids.size, versions.size)
     ids.forEach { id -> assertTrue(versions.any { v -> v.officialId == id }) }
 }
@@ -4220,10 +4815,13 @@ private fun <T : LayoutAsset<T>, S : LayoutAssetDao<T>> verifyVersionsAreDrafts(
     dao: S,
     versions: List<ValidationVersion<T>>,
 ) {
-    versions.map { v -> v.validatedAssetVersion }.map(dao::fetch).forEach { asset ->
-        assertTrue(asset.isDraft)
-        assertEquals(branch, asset.branch)
-    }
+    versions
+        .map { v -> v.validatedAssetVersion }
+        .map(dao::fetch)
+        .forEach { asset ->
+            assertTrue(asset.isDraft)
+            assertEquals(branch, asset.branch)
+        }
 }
 
 private fun <T : LayoutAsset<T>, S : LayoutAssetDao<T>> verifyPublishingWorks(
@@ -4242,7 +4840,8 @@ private fun <T : LayoutAsset<T>, S : LayoutAssetDao<T>> verifyPublishingWorks(
     assertEquals(draftVersion1.rowId, officialVersion1.rowVersion.rowId)
     assertEquals(2, officialVersion1.rowVersion.version)
 
-    val draftVersion2 = service.saveDraft(LayoutBranch.main, mutate(dao.fetch(officialVersion1.rowVersion)))
+    val draftVersion2 =
+        service.saveDraft(LayoutBranch.main, mutate(dao.fetch(officialVersion1.rowVersion)))
     assertEquals(officialId, draftVersion2.id)
     // Second draft must be a separate row to not touch the official
     assertNotEquals(officialVersion1.rowVersion.rowId, draftVersion2.rowVersion.rowId)
@@ -4307,8 +4906,10 @@ fun <T : LayoutAsset<T>, S : LayoutAssetDao<T>> verifyPublished(
     dao: S,
     checkMatch: (draft: T, published: T) -> Unit,
 ) {
-    val currentOfficialVersion = dao.fetchVersionOrThrow(layoutBranch.official, validationVersion.officialId)
-    val currentDraftVersion = dao.fetchVersionOrThrow(layoutBranch.draft, validationVersion.officialId)
+    val currentOfficialVersion =
+        dao.fetchVersionOrThrow(layoutBranch.official, validationVersion.officialId)
+    val currentDraftVersion =
+        dao.fetchVersionOrThrow(layoutBranch.draft, validationVersion.officialId)
     assertEquals(currentOfficialVersion, currentDraftVersion)
     val draft = dao.fetch(validationVersion.validatedAssetVersion)
     assertTrue(draft.isDraft)
@@ -4327,27 +4928,23 @@ private fun getTopologicalSwitchConnectionTestCases(
             trackNumberId = trackNumberGenerator(),
             draft = true,
         ),
-
         locationTrack(
             trackNumberId = trackNumberGenerator(),
             topologicalConnectivity = TopologicalConnectivityType.START,
             topologyStartSwitch = topologyStartSwitch,
             draft = true,
         ),
-
         locationTrack(
             trackNumberId = trackNumberGenerator(),
             topologicalConnectivity = TopologicalConnectivityType.END,
             topologyEndSwitch = topologyEndSwitch,
             draft = true,
         ),
-
         locationTrack(
             trackNumberId = trackNumberGenerator(),
             topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
             topologyStartSwitch = topologyStartSwitch,
             topologyEndSwitch = topologyEndSwitch,
             draft = true,
-        )
-    )
+        ))
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationUtilsTest.kt
@@ -63,12 +63,22 @@ class PublicationUtilsTest {
 
     @Test
     fun `summarizeAlignmentChanges detects change to track geometry`() {
-        val oldAlignment = alignment(
-            segment(Point(0.0, 0.0), Point(1.0, 0.0), Point(2.0, 0.0), Point(3.0, 0.0), Point(4.0, 0.0))
-        )
-        val newAlignment = alignment(
-            segment(Point(0.0, 0.0), Point(1.0, 1.2), Point(2.0, 1.4), Point(3.0, 1.2), Point(4.0, 0.0))
-        )
+        val oldAlignment =
+            alignment(
+                segment(
+                    Point(0.0, 0.0),
+                    Point(1.0, 0.0),
+                    Point(2.0, 0.0),
+                    Point(3.0, 0.0),
+                    Point(4.0, 0.0)))
+        val newAlignment =
+            alignment(
+                segment(
+                    Point(0.0, 0.0),
+                    Point(1.0, 1.2),
+                    Point(2.0, 1.4),
+                    Point(3.0, 1.2),
+                    Point(4.0, 0.0)))
 
         val result = summarizeAlignmentChanges(xAxisGeocodingContext(), oldAlignment, newAlignment)
         assertEquals(1, result.size)
@@ -79,20 +89,27 @@ class PublicationUtilsTest {
 
     @Test
     fun `summarizeAlignmentChanges detects multiple changes based on segment identity match`() {
-        val oldAlignment = alignment(
-            ((0..4).map { segmentIx ->
-                segment(*(0..4).map { pointIx ->
-                    Point(segmentIx * 4.0 + pointIx * 1.0, 0.0)
-                }.toTypedArray())
-            })
-        )
-        val newAlignment = alignment(
-            oldAlignment.segments[0],
-            segment(Point(4.0, 0.0), Point(5.0, 1.2), Point(6.0, 1.5), Point(7.0, 1.2), Point(8.0, 0.0)),
-            oldAlignment.segments[2],
-            segment(Point(12.0, 0.0), Point(13.0, 1.2), Point(15.0, 2.0)),
-            segment(Point(15.0, 2.0), Point(16.0, 3.0), Point(17.0, 4.0), Point(18.0, 5.0)),
-        )
+        val oldAlignment =
+            alignment(
+                ((0..4).map { segmentIx ->
+                    segment(
+                        *(0..4)
+                            .map { pointIx -> Point(segmentIx * 4.0 + pointIx * 1.0, 0.0) }
+                            .toTypedArray())
+                }))
+        val newAlignment =
+            alignment(
+                oldAlignment.segments[0],
+                segment(
+                    Point(4.0, 0.0),
+                    Point(5.0, 1.2),
+                    Point(6.0, 1.5),
+                    Point(7.0, 1.2),
+                    Point(8.0, 0.0)),
+                oldAlignment.segments[2],
+                segment(Point(12.0, 0.0), Point(13.0, 1.2), Point(15.0, 2.0)),
+                segment(Point(15.0, 2.0), Point(16.0, 3.0), Point(17.0, 4.0), Point(18.0, 5.0)),
+            )
 
         val result = summarizeAlignmentChanges(xAxisGeocodingContext(), oldAlignment, newAlignment)
         assertEquals(2, result.size)
@@ -104,27 +121,27 @@ class PublicationUtilsTest {
 
     @Test
     fun `summarizeAlignmentChanges detects multiple changes in a single segment`() {
-        val oldAlignment = alignment(
-            segment(Point(0.0, 0.0), Point(60.0, 0.0))
-        )
-        val newAlignment = alignment(
-            singleSegmentWithInterpolatedPoints(
-                Point(0.0, 0.0),
-                Point(5.0, 0.0),
-                Point(10.0, 2.0),
-                Point(15.0, 0.0),
-                Point(30.0, 0.0),
-                Point(40.0, 3.0),
-                Point(50.0, 0.0),
-                Point(60.0, 0.0),
-            )
-        )
+        val oldAlignment = alignment(segment(Point(0.0, 0.0), Point(60.0, 0.0)))
+        val newAlignment =
+            alignment(
+                singleSegmentWithInterpolatedPoints(
+                    Point(0.0, 0.0),
+                    Point(5.0, 0.0),
+                    Point(10.0, 2.0),
+                    Point(15.0, 0.0),
+                    Point(30.0, 0.0),
+                    Point(40.0, 3.0),
+                    Point(50.0, 0.0),
+                    Point(60.0, 0.0),
+                ))
 
-        val result = summarizeAlignmentChanges(
-            xAxisGeocodingContext(),
-            oldAlignment,
-            alignment(segment(toSegmentPoints(to3DMPoints(newAlignment.allSegmentPoints.toList())))),
-        )
+        val result =
+            summarizeAlignmentChanges(
+                xAxisGeocodingContext(),
+                oldAlignment,
+                alignment(
+                    segment(toSegmentPoints(to3DMPoints(newAlignment.allSegmentPoints.toList())))),
+            )
         assertEquals(2, result.size)
         assertEquals(2.0, result[0].maxDistance, 0.1)
         assertEquals(4.0, result[0].changedLengthM)
@@ -132,7 +149,8 @@ class PublicationUtilsTest {
         assertEquals(12.0, result[1].changedLengthM)
     }
 
-    private fun xAxisGeocodingContext() = geocodingContext(
-        (0..60).map { x -> Point(x.toDouble(), 0.0)},
-    )
+    private fun xAxisGeocodingContext() =
+        geocodingContext(
+            (0..60).map { x -> Point(x.toDouble(), 0.0) },
+        )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -48,10 +48,10 @@ import fi.fta.geoviite.infra.tracklayout.to3DMPoints
 import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.LocalizationKey
-import org.junit.jupiter.api.Test
 import kotlin.math.PI
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class PublicationValidationTest {
 
@@ -74,7 +74,8 @@ class PublicationValidationTest {
     @Test
     fun trackNumberValidationCatchesLocationTrackReferencingDeletedTrackNumber() {
         val trackNumber = trackNumber(id = IntId(1), draft = true)
-        val referenceLine = referenceLine(trackNumberId = trackNumber.id as IntId, id = IntId(1), draft = true)
+        val referenceLine =
+            referenceLine(trackNumberId = trackNumber.id as IntId, id = IntId(1), draft = true)
         val alignment = locationTrack(trackNumberId = IntId(1), draft = true)
         assertTrackNumberReferenceError(
             true,
@@ -102,8 +103,10 @@ class PublicationValidationTest {
     @Test
     fun kmPostFieldValidationCatchesCatchesPublishingPlanned() {
         val someKmPost = kmPost(IntId(1), KmNumber(1), draft = true)
-        assertFieldError(true, someKmPost.copy(state = LayoutState.PLANNED), "$VALIDATION_KM_POST.state.PLANNED")
-        assertFieldError(false, someKmPost.copy(state = LayoutState.IN_USE), "$VALIDATION_KM_POST.state.PLANNED")
+        assertFieldError(
+            true, someKmPost.copy(state = LayoutState.PLANNED), "$VALIDATION_KM_POST.state.PLANNED")
+        assertFieldError(
+            false, someKmPost.copy(state = LayoutState.IN_USE), "$VALIDATION_KM_POST.state.PLANNED")
     }
 
     @Test
@@ -163,28 +166,26 @@ class PublicationValidationTest {
     @Test
     fun switchValidationCatchesNonContinuousAlignment() {
         val switch = switch(structureId = structure.id as IntId, id = IntId(1), draft = true)
-        val good = locationTrackAndAlignment(
-            trackNumberId = IntId(0),
-            segment(Point(0.0, 0.0), Point(10.0, 10.0)).copy(
-                switchId = switch.id, endJointNumber = switch.joints.last().number
-            ),
-            segment(Point(10.0, 10.0), Point(20.0, 20.0)).copy(
-                switchId = switch.id, startJointNumber = switch.joints.first().number
-            ),
-            segment(Point(20.0, 20.0), Point(30.0, 30.0)),
-            draft = true,
-        )
-        val broken = locationTrackAndAlignment(
-            trackNumberId = IntId(0),
-            segment(Point(0.0, 0.0), Point(10.0, 10.0)).copy(
-                switchId = switch.id, endJointNumber = switch.joints.last().number
-            ),
-            segment(Point(10.0, 10.0), Point(20.0, 20.0)),
-            segment(Point(20.0, 20.0), Point(30.0, 30.0)).copy(
-                switchId = switch.id, startJointNumber = switch.joints.first().number
-            ),
-            draft = true,
-        )
+        val good =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(0),
+                segment(Point(0.0, 0.0), Point(10.0, 10.0))
+                    .copy(switchId = switch.id, endJointNumber = switch.joints.last().number),
+                segment(Point(10.0, 10.0), Point(20.0, 20.0))
+                    .copy(switchId = switch.id, startJointNumber = switch.joints.first().number),
+                segment(Point(20.0, 20.0), Point(30.0, 30.0)),
+                draft = true,
+            )
+        val broken =
+            locationTrackAndAlignment(
+                trackNumberId = IntId(0),
+                segment(Point(0.0, 0.0), Point(10.0, 10.0))
+                    .copy(switchId = switch.id, endJointNumber = switch.joints.last().number),
+                segment(Point(10.0, 10.0), Point(20.0, 20.0)),
+                segment(Point(20.0, 20.0), Point(30.0, 30.0))
+                    .copy(switchId = switch.id, startJointNumber = switch.joints.first().number),
+                draft = true,
+            )
 
         assertSwitchSegmentStructureError(
             false,
@@ -203,10 +204,11 @@ class PublicationValidationTest {
     @Test
     fun switchValidationCatchesLocationMismatch() {
         val (switch, alignments) = switchAndMatchingAlignments(IntId(0), structure, draft = true)
-        val broken = alignments.mapIndexed { index, (track, alignment) ->
-            if (index == 0) track to offsetAlignment(alignment, Point(5.0, 0.0))
-            else track to alignment
-        }
+        val broken =
+            alignments.mapIndexed { index, (track, alignment) ->
+                if (index == 0) track to offsetAlignment(alignment, Point(5.0, 0.0))
+                else track to alignment
+            }
         assertSwitchSegmentStructureError(
             hasError = false,
             switch = switch,
@@ -334,13 +336,14 @@ class PublicationValidationTest {
             true,
             editSegment(segmentSwitch) { segment ->
                 segment.copy(
-                    geometry = segment.geometry.withPoints(
-                        segmentPoints = toSegmentPoints(
-                            segment.alignmentPoints.first(),
-                            segment.alignmentPoints.last() + Point(0.0, 1.0),
-                        ),
-                    )
-                )
+                    geometry =
+                        segment.geometry.withPoints(
+                            segmentPoints =
+                                toSegmentPoints(
+                                    segment.alignmentPoints.first(),
+                                    segment.alignmentPoints.last() + Point(0.0, 1.0),
+                                ),
+                        ))
             },
             "$VALIDATION_LOCATION_TRACK.switch.joint-location-mismatch",
         )
@@ -348,13 +351,14 @@ class PublicationValidationTest {
             true,
             editSegment(segmentSwitch) { segment ->
                 segment.copy(
-                    geometry = segment.geometry.withPoints(
-                        segmentPoints = toSegmentPoints(
-                            segment.alignmentPoints.first() + Point(0.0, 1.0),
-                            segment.alignmentPoints.last(),
-                        ),
-                    )
-                )
+                    geometry =
+                        segment.geometry.withPoints(
+                            segmentPoints =
+                                toSegmentPoints(
+                                    segment.alignmentPoints.first() + Point(0.0, 1.0),
+                                    segment.alignmentPoints.last(),
+                                ),
+                        ))
             },
             "$VALIDATION_LOCATION_TRACK.switch.joint-location-mismatch",
         )
@@ -378,34 +382,33 @@ class PublicationValidationTest {
             ) {
                 // Alignment at slight angle to reference line -> should be OK
                 context.getAddressPoints(
-                    alignment(segment(Point(10.0, 10.0), Point(20.0, 100.0))).copy(id = IntId(2))
-                )
+                    alignment(segment(Point(10.0, 10.0), Point(20.0, 100.0))).copy(id = IntId(2)))
             },
         )
     }
 
     @Test
     fun validationCatchesStretchedOutAddressPoints() {
-        val context = simpleGeocodingContext(
-            // Reference line goes straight up
-            toSegmentPoints(
-                Point(0.0, 0.0),
-                Point(0.0, 1000.0),
-            )
-        )
+        val context =
+            simpleGeocodingContext(
+                // Reference line goes straight up
+                toSegmentPoints(
+                    Point(0.0, 0.0),
+                    Point(0.0, 1000.0),
+                ))
         val geocode = {
             context.getAddressPoints(
                 alignment(
-                    segment(
-                        Point(0.0, 10.0),
-                        Point(0.0, 20.0),
-                        Point(10.0, 40.0),
-                        Point(30.0, 60.0),
-                        Point(50.0, 70.0), // Over 45 degree diff to reference line -> should fail
-                        Point(70.0, 90.0),
-                    )
-                ).copy(id = IntId(2))
-            )
+                        segment(
+                            Point(0.0, 10.0),
+                            Point(0.0, 20.0),
+                            Point(10.0, 40.0),
+                            Point(30.0, 60.0),
+                            Point(
+                                50.0, 70.0), // Over 45 degree diff to reference line -> should fail
+                            Point(70.0, 90.0),
+                        ))
+                    .copy(id = IntId(2)))
         }
         assertAddressPointError(true, geocode, "$VALIDATION_GEOCODING.stretched-meters")
         assertSingleAddressPointErrorRangeDescription(geocode, "0000+0060..0000+0070")
@@ -413,51 +416,48 @@ class PublicationValidationTest {
 
     @Test
     fun stretchedOutAddressPointsAtStartAndEndOfLineAreDescribedProperly() {
-        val context = simpleGeocodingContext(
-            // Reference line goes straight up
-            toSegmentPoints(
-                Point(0.0, 0.0),
-                Point(0.0, 1000.0),
-            )
-        )
+        val context =
+            simpleGeocodingContext(
+                // Reference line goes straight up
+                toSegmentPoints(
+                    Point(0.0, 0.0),
+                    Point(0.0, 1000.0),
+                ))
         val geocode = {
             context.getAddressPoints(
                 alignment(
-                    segment(
-                        Point(0.0, 0.0),
-                        Point(120.0, 50.0),
-                        Point(120.0, 60.0),
-                        Point(240.0, 110.0),
-                    )
-                ).copy(id = IntId(2))
-            )
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(120.0, 50.0),
+                            Point(120.0, 60.0),
+                            Point(240.0, 110.0),
+                        ))
+                    .copy(id = IntId(2)))
         }
         assertSingleAddressPointErrorRangeDescription(
-            geocode, "0000+0000..0000+0050, 0000+0060..0000+0110"
-        )
+            geocode, "0000+0000..0000+0050, 0000+0060..0000+0110")
     }
 
     @Test
     fun validationCatchesZigZagAddressPoints() {
-        val context = simpleGeocodingContext(
-            toSegmentPoints(
-                Point(0.0, 0.0),
-                Point(0.0, 10.0),
-                // Reference line makes a bend to right
-                Point(2.5, 15.0),
-                Point(2.5, 25.0),
-            )
-        )
+        val context =
+            simpleGeocodingContext(
+                toSegmentPoints(
+                    Point(0.0, 0.0),
+                    Point(0.0, 10.0),
+                    // Reference line makes a bend to right
+                    Point(2.5, 15.0),
+                    Point(2.5, 25.0),
+                ))
         val geocode = {
             //  alignment goes straight up at offset -> should get non-continuous points
             context.getAddressPoints(
                 alignment(
-                    segment(
-                        Point(5.0, 5.0),
-                        Point(5.0, 25.0),
-                    )
-                ).copy(id = IntId(2))
-            )
+                        segment(
+                            Point(5.0, 5.0),
+                            Point(5.0, 25.0),
+                        ))
+                    .copy(id = IntId(2)))
         }
         assertAddressPointError(true, geocode, "$VALIDATION_GEOCODING.sharp-angle")
     }
@@ -467,22 +467,22 @@ class PublicationValidationTest {
         val referenceLinePoints = simpleSphereArc(10.0, PI, 20)
         val context = simpleGeocodingContext(toSegmentPoints(to3DMPoints(referenceLinePoints)))
 
-        val sharpAngleTrack = to3DMPoints(
-            listOf(
-                Point(10.0, 0.0),
-                Point(10.0, 10.0),
-                Point(0.0, 0.0),
-            )
-        )
+        val sharpAngleTrack =
+            to3DMPoints(
+                listOf(
+                    Point(10.0, 0.0),
+                    Point(10.0, 10.0),
+                    Point(0.0, 0.0),
+                ))
 
         val geocode = {
             context.getAddressPoints(
-                alignment(segment(toSegmentPoints(sharpAngleTrack))).copy(id = IntId(2))
-            )
+                alignment(segment(toSegmentPoints(sharpAngleTrack))).copy(id = IntId(2)))
         }
 
         assertAddressPointError(true, geocode, "$VALIDATION_GEOCODING.sharp-angle")
-        // the correct error range is hard to calculate because it depends on how lines get projected; this at least
+        // the correct error range is hard to calculate because it depends on how lines get
+        // projected; this at least
         // seems OK though
         assertSingleAddressPointErrorRangeDescription(geocode, "0000+0006..0000+0008")
     }
@@ -567,62 +567,71 @@ class PublicationValidationTest {
         assertContainsError(
             true,
             validateDuplicateOfState(lt, lt, AlignmentName("duplicateof"), listOf()),
-            "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-of-duplicated"
-        )
+            "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-of-duplicated")
     }
 
     @Test
     fun validationCatchesMisplacedTopologyLink() {
-        val wrongPlaceSwitch = switch(
-            seed = 123,
-            joints = listOf(
-                TrackLayoutSwitchJoint(JointNumber(1), Point(100.0, 100.0), null),
-            ),
-            id = IntId(1),
-            draft = true,
-        )
-        val rightPlaceSwitch = switch(
-            seed = 124,
-            joints = listOf(
-                TrackLayoutSwitchJoint(JointNumber(1), Point(200.0, 200.0), null),
-            ),
-            id = IntId(2),
-            draft = true,
-        )
-        val unlinkedTrack = locationTrackAndAlignment(
-            IntId(0),
-            segment(Point(150.0, 150.0), Point(200.0, 200.0)),
-            draft = true,
-        )
-        val lt = unlinkedTrack.first.copy(
-            topologyStartSwitch = TopologyLocationTrackSwitch(wrongPlaceSwitch.id as IntId, JointNumber(1)),
-            topologyEndSwitch = TopologyLocationTrackSwitch(rightPlaceSwitch.id as IntId, JointNumber(1))
-        ) to unlinkedTrack.second
+        val wrongPlaceSwitch =
+            switch(
+                seed = 123,
+                joints =
+                    listOf(
+                        TrackLayoutSwitchJoint(JointNumber(1), Point(100.0, 100.0), null),
+                    ),
+                id = IntId(1),
+                draft = true,
+            )
+        val rightPlaceSwitch =
+            switch(
+                seed = 124,
+                joints =
+                    listOf(
+                        TrackLayoutSwitchJoint(JointNumber(1), Point(200.0, 200.0), null),
+                    ),
+                id = IntId(2),
+                draft = true,
+            )
+        val unlinkedTrack =
+            locationTrackAndAlignment(
+                IntId(0),
+                segment(Point(150.0, 150.0), Point(200.0, 200.0)),
+                draft = true,
+            )
+        val lt =
+            unlinkedTrack.first.copy(
+                topologyStartSwitch =
+                    TopologyLocationTrackSwitch(wrongPlaceSwitch.id as IntId, JointNumber(1)),
+                topologyEndSwitch =
+                    TopologyLocationTrackSwitch(rightPlaceSwitch.id as IntId, JointNumber(1))) to
+                unlinkedTrack.second
 
         assertContainsError(
             true,
-            validateSwitchLocationTrackLinkStructure(wrongPlaceSwitch, switchStructureYV60_300_1_9(), listOf(lt)),
-            "$VALIDATION_SWITCH.location-track.joint-location-mismatch"
-        )
+            validateSwitchLocationTrackLinkStructure(
+                wrongPlaceSwitch, switchStructureYV60_300_1_9(), listOf(lt)),
+            "$VALIDATION_SWITCH.location-track.joint-location-mismatch")
 
         assertContainsError(
             false,
-            validateSwitchLocationTrackLinkStructure(rightPlaceSwitch, switchStructureYV60_300_1_9(), listOf(lt)),
-            "$VALIDATION_SWITCH.location-track.joint-location-mismatch"
-        )
+            validateSwitchLocationTrackLinkStructure(
+                rightPlaceSwitch, switchStructureYV60_300_1_9(), listOf(lt)),
+            "$VALIDATION_SWITCH.location-track.joint-location-mismatch")
     }
 
     @Test
     fun `Combine versions overrides official version with validation version`() {
-        val officialVersions: List<LayoutDaoResponse<PublicationValidationTest>> = listOf(
-            LayoutDaoResponse(IntId(1), LayoutRowVersion(LayoutRowId(1), 2)),
-            LayoutDaoResponse(IntId(2), LayoutRowVersion(LayoutRowId(2), 3)),
-            LayoutDaoResponse(IntId(3), LayoutRowVersion(LayoutRowId(3), 4)),
-        )
-        val validationVersions: List<ValidationVersion<PublicationValidationTest>> = listOf(
-            ValidationVersion(IntId(2), LayoutRowVersion(LayoutRowId(16), 1)),
-            ValidationVersion(IntId(4), LayoutRowVersion(LayoutRowId(17), 1)),
-        )
+        val officialVersions: List<LayoutDaoResponse<PublicationValidationTest>> =
+            listOf(
+                LayoutDaoResponse(IntId(1), LayoutRowVersion(LayoutRowId(1), 2)),
+                LayoutDaoResponse(IntId(2), LayoutRowVersion(LayoutRowId(2), 3)),
+                LayoutDaoResponse(IntId(3), LayoutRowVersion(LayoutRowId(3), 4)),
+            )
+        val validationVersions: List<ValidationVersion<PublicationValidationTest>> =
+            listOf(
+                ValidationVersion(IntId(2), LayoutRowVersion(LayoutRowId(16), 1)),
+                ValidationVersion(IntId(4), LayoutRowVersion(LayoutRowId(17), 1)),
+            )
         assertEquals(
             listOf(
                 LayoutRowVersion(LayoutRowId(1), 2),
@@ -637,71 +646,89 @@ class PublicationValidationTest {
 
     @Test
     fun `should return validation warning if location track end is linked to switch a but connectivity type is set to NONE`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.NONE,
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0), switchId = IntId(100), endJointNumber = JointNumber(1))
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.NONE,
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(
+                        Point(0.0, 1.0),
+                        Point(0.0, 2.0),
+                        switchId = IntId(100),
+                        endJointNumber = JointNumber(1))),
+            )
 
         assertEquals(1, connectivityWarnings.size)
-        assertContainsConnectivityWarning(connectivityWarnings, "end-switch-is-topologically-connected")
+        assertContainsConnectivityWarning(
+            connectivityWarnings, "end-switch-is-topologically-connected")
     }
 
     @Test
     fun `should return validation warnings if location track start is not linked to a switch but connectivity type is set to START`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.START,
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0), switchId = IntId(100), endJointNumber = JointNumber(1))
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.START,
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(
+                        Point(0.0, 1.0),
+                        Point(0.0, 2.0),
+                        switchId = IntId(100),
+                        endJointNumber = JointNumber(1))),
+            )
 
         assertEquals(2, connectivityWarnings.size)
         assertContainsConnectivityWarning(connectivityWarnings, "start-switch-missing")
-        assertContainsConnectivityWarning(connectivityWarnings, "end-switch-is-topologically-connected")
+        assertContainsConnectivityWarning(
+            connectivityWarnings, "end-switch-is-topologically-connected")
     }
 
     @Test
     fun `should not return any validation warnings if location track end is linked to a switch and connectivity type is set to END`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.END,
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0), switchId = IntId(100), endJointNumber = JointNumber(1))
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.END,
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(
+                        Point(0.0, 1.0),
+                        Point(0.0, 2.0),
+                        switchId = IntId(100),
+                        endJointNumber = JointNumber(1))),
+            )
 
         assertEquals(0, connectivityWarnings.size)
     }
 
     @Test
     fun `should return validation warning if only location track end is linked to a switch but connectivity type is set to START AND END`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0), switchId = IntId(100), endJointNumber = JointNumber(1))
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(
+                        Point(0.0, 1.0),
+                        Point(0.0, 2.0),
+                        switchId = IntId(100),
+                        endJointNumber = JointNumber(1))),
+            )
 
         assertEquals(1, connectivityWarnings.size)
         assertContainsConnectivityWarning(connectivityWarnings, "start-switch-missing")
@@ -709,71 +736,89 @@ class PublicationValidationTest {
 
     @Test
     fun `should return validation warning if location track start is linked to a switch but connectivity type is set to NONE`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.NONE,
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0), switchId = IntId(100), startJointNumber = JointNumber(1)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0))
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.NONE,
+                    draft = true,
+                ),
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(0.0, 1.0),
+                        switchId = IntId(100),
+                        startJointNumber = JointNumber(1)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+            )
 
         assertEquals(1, connectivityWarnings.size)
-        assertContainsConnectivityWarning(connectivityWarnings, "start-switch-is-topologically-connected")
+        assertContainsConnectivityWarning(
+            connectivityWarnings, "start-switch-is-topologically-connected")
     }
 
     @Test
     fun `should not return validation warning if location track start is linked to a switch and connectivity type is set to START`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.START,
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0), switchId = IntId(100), startJointNumber = JointNumber(1)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0))
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.START,
+                    draft = true,
+                ),
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(0.0, 1.0),
+                        switchId = IntId(100),
+                        startJointNumber = JointNumber(1)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+            )
 
         assertEquals(0, connectivityWarnings.size)
     }
 
     @Test
     fun `should return validation warnings if location start is linked to a switch but connectivity type is set to END`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.END,
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0), switchId = IntId(100), startJointNumber = JointNumber(1)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0))
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.END,
+                    draft = true,
+                ),
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(0.0, 1.0),
+                        switchId = IntId(100),
+                        startJointNumber = JointNumber(1)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+            )
 
         assertEquals(2, connectivityWarnings.size)
-        assertContainsConnectivityWarning(connectivityWarnings, "start-switch-is-topologically-connected")
+        assertContainsConnectivityWarning(
+            connectivityWarnings, "start-switch-is-topologically-connected")
         assertContainsConnectivityWarning(connectivityWarnings, "end-switch-missing")
     }
 
     @Test
     fun `should return validation warning if location start is linked to a switch but connectivity type is set to START AND END`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0), switchId = IntId(100), startJointNumber = JointNumber(1)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0))
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
+                    draft = true,
+                ),
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(0.0, 1.0),
+                        switchId = IntId(100),
+                        startJointNumber = JointNumber(1)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+            )
 
         assertEquals(1, connectivityWarnings.size)
         assertContainsConnectivityWarning(connectivityWarnings, "end-switch-missing")
@@ -781,75 +826,81 @@ class PublicationValidationTest {
 
     @Test
     fun `should return validation warning if location track end is topologically connected but connectivity type is set to NONE`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.NONE,
-                topologyEndSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.NONE,
+                    topologyEndSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                ),
+            )
 
         assertEquals(1, connectivityWarnings.size)
-        assertContainsConnectivityWarning(connectivityWarnings, "end-switch-is-topologically-connected")
+        assertContainsConnectivityWarning(
+            connectivityWarnings, "end-switch-is-topologically-connected")
     }
 
     @Test
     fun `should return validation warnings if location track end is topologically connected but connectivity type is set to START`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                trackNumberId = IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.START,
-                topologyEndSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    trackNumberId = IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.START,
+                    topologyEndSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                ),
+            )
 
         assertEquals(2, connectivityWarnings.size)
         assertContainsConnectivityWarning(connectivityWarnings, "start-switch-missing")
-        assertContainsConnectivityWarning(connectivityWarnings, "end-switch-is-topologically-connected")
+        assertContainsConnectivityWarning(
+            connectivityWarnings, "end-switch-is-topologically-connected")
     }
 
     @Test
     fun `should not return any validation warnings if location track end is topologically connected and connectivity type is set to END`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.END,
-                topologyEndSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.END,
+                    topologyEndSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                ),
+            )
 
         assertEquals(0, connectivityWarnings.size)
     }
 
     @Test
     fun `should return validation warning if location track end is topologically connected but connectivity type is set to START AND END`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
-                topologyEndSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
+                    topologyEndSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                ),
+            )
 
         assertEquals(1, connectivityWarnings.size)
         assertContainsConnectivityWarning(connectivityWarnings, "start-switch-missing")
@@ -857,75 +908,81 @@ class PublicationValidationTest {
 
     @Test
     fun `should return validation warning if location track start is topologically connected but connectivity type is set to NONE`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.NONE,
-                topologyStartSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.NONE,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                ),
+            )
 
         assertEquals(1, connectivityWarnings.size)
-        assertContainsConnectivityWarning(connectivityWarnings, "start-switch-is-topologically-connected")
+        assertContainsConnectivityWarning(
+            connectivityWarnings, "start-switch-is-topologically-connected")
     }
 
     @Test
     fun `should not return any validation warnings if location track start is topologically connected and connectivity type is set to START`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.START,
-                topologyStartSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.START,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                ),
+            )
 
         assertEquals(0, connectivityWarnings.size)
     }
 
     @Test
     fun `should return validation warnings if location track start is topologically connected but connectivity type is set to END`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.END,
-                topologyStartSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.END,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                ),
+            )
 
         assertEquals(2, connectivityWarnings.size)
-        assertContainsConnectivityWarning(connectivityWarnings, "start-switch-is-topologically-connected")
+        assertContainsConnectivityWarning(
+            connectivityWarnings, "start-switch-is-topologically-connected")
         assertContainsConnectivityWarning(connectivityWarnings, "end-switch-missing")
     }
 
     @Test
     fun `should return validation warning if location start is topologically connceted but connectivity type is set to START AND END`() {
-        val connectivityWarnings = validateLocationTrackSwitchConnectivity(
-            locationTrack(
-                IntId(100),
-                topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
-                topologyStartSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
-                draft = true,
-            ),
-            alignment(
-                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
-                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
-            ),
-        )
+        val connectivityWarnings =
+            validateLocationTrackSwitchConnectivity(
+                locationTrack(
+                    IntId(100),
+                    topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(IntId(100), JointNumber(1)),
+                    draft = true,
+                ),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                    segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                ),
+            )
 
         assertEquals(1, connectivityWarnings.size)
         assertContainsConnectivityWarning(connectivityWarnings, "end-switch-missing")
@@ -944,7 +1001,10 @@ class PublicationValidationTest {
         )
     }
 
-    private fun editSegment(segmentSwitch: SegmentSwitch, edit: (segment: LayoutSegment) -> LayoutSegment) =
+    private fun editSegment(
+        segmentSwitch: SegmentSwitch,
+        edit: (segment: LayoutSegment) -> LayoutSegment
+    ) =
         segmentSwitch.copy(
             segments = segmentSwitch.segments.map(edit),
         )
@@ -954,20 +1014,23 @@ class PublicationValidationTest {
         switchDraft: Boolean = false,
         switchInPublication: Boolean = true,
     ): SegmentSwitch {
-        val switch = switch(
-            seed = 123,
-            id = if (switchDraft) IntId(2) else IntId(1),
-            stateCategory = switchStateCategory,
-            draft = switchDraft,
-            draftOfId = if (switchDraft) IntId(1) else null,
-        )
+        val switch =
+            switch(
+                seed = 123,
+                id = if (switchDraft) IntId(2) else IntId(1),
+                stateCategory = switchStateCategory,
+                draft = switchDraft,
+                draftOfId = if (switchDraft) IntId(1) else null,
+            )
         val joint1 = switch.joints.first()
         val joint2 = switch.joints.last()
-        val segment = segment(joint1.location, joint2.location).copy(
-            switchId = switch.id,
-            startJointNumber = joint1.number,
-            endJointNumber = joint2.number,
-        )
+        val segment =
+            segment(joint1.location, joint2.location)
+                .copy(
+                    switchId = switch.id,
+                    startJointNumber = joint1.number,
+                    endJointNumber = joint2.number,
+                )
         return SegmentSwitch(
             switchId = switch.id as IntId,
             switchName = switch.name,
@@ -977,8 +1040,11 @@ class PublicationValidationTest {
         )
     }
 
-    private fun assertFieldError(hasError: Boolean, trackNumber: TrackLayoutTrackNumber, error: String) =
-        assertContainsError(hasError, validateDraftTrackNumberFields(trackNumber), error)
+    private fun assertFieldError(
+        hasError: Boolean,
+        trackNumber: TrackLayoutTrackNumber,
+        error: String
+    ) = assertContainsError(hasError, validateDraftTrackNumberFields(trackNumber), error)
 
     private fun assertFieldError(hasError: Boolean, kmPost: TrackLayoutKmPost, error: String) =
         assertContainsError(hasError, validateDraftKmPostFields(kmPost), error)
@@ -989,8 +1055,11 @@ class PublicationValidationTest {
     private fun assertFieldError(hasError: Boolean, track: LocationTrack, error: String) =
         assertContainsError(hasError, validateDraftLocationTrackFields(track), error)
 
-    private fun assertLocationTrackFieldError(hasError: Boolean, alignment: LayoutAlignment, error: String) =
-        assertContainsError(hasError, validateLocationTrackAlignment(alignment), error)
+    private fun assertLocationTrackFieldError(
+        hasError: Boolean,
+        alignment: LayoutAlignment,
+        error: String
+    ) = assertContainsError(hasError, validateLocationTrackAlignment(alignment), error)
 
     private fun assertTrackNumberReferenceError(
         hasError: Boolean,
@@ -998,13 +1067,14 @@ class PublicationValidationTest {
         referenceLine: ReferenceLine?,
         locationTrack: LocationTrack,
         error: String,
-    ) = assertTrackNumberReferenceError(
-        hasError,
-        trackNumber,
-        referenceLine,
-        error,
-        locationTracks = listOf(locationTrack),
-    )
+    ) =
+        assertTrackNumberReferenceError(
+            hasError,
+            trackNumber,
+            referenceLine,
+            error,
+            locationTracks = listOf(locationTrack),
+        )
 
     private fun assertTrackNumberReferenceError(
         hasError: Boolean,
@@ -1013,11 +1083,12 @@ class PublicationValidationTest {
         error: String,
         kmPosts: List<TrackLayoutKmPost> = listOf(),
         locationTracks: List<LocationTrack> = listOf(),
-    ) = assertContainsError(
-        hasError,
-        validateTrackNumberReferences(trackNumber, referenceLine, kmPosts, locationTracks),
-        error,
-    )
+    ) =
+        assertContainsError(
+            hasError,
+            validateTrackNumberReferences(trackNumber, referenceLine, kmPosts, locationTracks),
+            error,
+        )
 
     private fun assertKmPostReferenceError(
         hasError: Boolean,
@@ -1026,22 +1097,24 @@ class PublicationValidationTest {
         referenceLine: ReferenceLine?,
         trackNumberNumber: TrackNumber,
         error: String,
-    ) = assertContainsError(
-        hasError,
-        validateKmPostReferences(kmPost, trackNumber, referenceLine, trackNumberNumber),
-        error,
-    )
+    ) =
+        assertContainsError(
+            hasError,
+            validateKmPostReferences(kmPost, trackNumber, referenceLine, trackNumberNumber),
+            error,
+        )
 
     private fun assertSegmentSwitchError(
         hasError: Boolean,
         segmentAndSwitch: SegmentSwitch,
         error: String,
         locationTrack: LocationTrack = locationTrack(IntId(1), draft = true),
-    ) = assertContainsError(
-        hasError,
-        validateSegmentSwitchReferences(locationTrack, listOf(segmentAndSwitch)),
-        error,
-    )
+    ) =
+        assertContainsError(
+            hasError,
+            validateSegmentSwitchReferences(locationTrack, listOf(segmentAndSwitch)),
+            error,
+        )
 
     private fun assertSwitchSegmentStructureError(
         hasError: Boolean,
@@ -1060,9 +1133,14 @@ class PublicationValidationTest {
     private fun getSwitchSegmentStructureErrors(
         switch: TrackLayoutSwitch,
         tracks: List<Pair<LocationTrack, LayoutAlignment>>,
-    ): List<LayoutValidationIssue> = validateSwitchLocationTrackLinkStructure(switch, structure, tracks)
+    ): List<LayoutValidationIssue> =
+        validateSwitchLocationTrackLinkStructure(switch, structure, tracks)
 
-    private fun assertAddressPointError(hasError: Boolean, geocode: () -> AlignmentAddresses?, error: String) {
+    private fun assertAddressPointError(
+        hasError: Boolean,
+        geocode: () -> AlignmentAddresses?,
+        error: String
+    ) {
         assertContainsError(
             hasError,
             validateAddressPoints(
@@ -1079,18 +1157,25 @@ class PublicationValidationTest {
         geocode: () -> AlignmentAddresses?,
         errorRangeDescription: String,
     ) {
-        val errors = validateAddressPoints(
-            trackNumber(draft = true),
-            locationTrack(IntId(1), draft = true),
-            "",
-            geocode,
-        )
+        val errors =
+            validateAddressPoints(
+                trackNumber(draft = true),
+                locationTrack(IntId(1), draft = true),
+                "",
+                geocode,
+            )
         assertEquals(errorRangeDescription, errors[0].params.get("kmNumbers"))
     }
 
-    private fun assertContainsError(contains: Boolean, errors: List<LayoutValidationIssue>, error: String) {
-        val message = "Expected to ${if (contains) "have" else "not have"} error: expected=$error actual=$errors"
-        assertEquals(contains, errors.any { e -> e.localizationKey == LocalizationKey(error) }, message)
+    private fun assertContainsError(
+        contains: Boolean,
+        errors: List<LayoutValidationIssue>,
+        error: String
+    ) {
+        val message =
+            "Expected to ${if (contains) "have" else "not have"} error: expected=$error actual=$errors"
+        assertEquals(
+            contains, errors.any { e -> e.localizationKey == LocalizationKey(error) }, message)
     }
 
     private fun simpleGeocodingContext(referenceLinePoints: List<SegmentPoint>): GeocodingContext =
@@ -1100,12 +1185,13 @@ class PublicationValidationTest {
         referenceLinePoints: List<SegmentPoint>,
         kmPosts: List<TrackLayoutKmPost>,
     ): GeocodingContextCreateResult {
-        val (referenceLine, alignment) = referenceLineAndAlignment(
-            trackNumberId = IntId(1),
-            segments = listOf(segment(referenceLinePoints)),
-            startAddress = TrackMeter.ZERO,
-            draft = true,
-        )
+        val (referenceLine, alignment) =
+            referenceLineAndAlignment(
+                trackNumberId = IntId(1),
+                segments = listOf(segment(referenceLinePoints)),
+                startAddress = TrackMeter.ZERO,
+                draft = true,
+            )
         return GeocodingContext.create(
             // Start the geocoding from 0+0m
             TrackNumber("0000"),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
@@ -30,7 +30,9 @@ import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class ValidationContextIT @Autowired constructor(
+class ValidationContextIT
+@Autowired
+constructor(
     val trackNumberDao: LayoutTrackNumberDao,
     val referenceLineDao: ReferenceLineDao,
     val kmPostDao: LayoutKmPostDao,
@@ -86,7 +88,8 @@ class ValidationContextIT @Autowired constructor(
         )
         assertEquals(
             listOf(trackNumberDao.fetch(tn1DraftVersion)),
-            validationContext(trackNumbers = listOf(tn1Id)).getTrackNumbersByNumber(trackNumber1.number),
+            validationContext(trackNumbers = listOf(tn1Id))
+                .getTrackNumbersByNumber(trackNumber1.number),
         )
 
         assertEquals(
@@ -95,16 +98,20 @@ class ValidationContextIT @Autowired constructor(
         )
         assertEquals(
             listOf(trackNumberDao.fetch(tn2DraftVersion)),
-            validationContext(trackNumbers = listOf(tn2Id)).getTrackNumbersByNumber(trackNumber2.number),
+            validationContext(trackNumbers = listOf(tn2Id))
+                .getTrackNumbersByNumber(trackNumber2.number),
         )
     }
 
     @Test
     fun `ValidationContext returns correct versions for LocationTrack`() {
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
-        val (lt1Id, lt1OfficialVersion) = mainOfficialContext.insert(locationTrackAndAlignment(trackNumberId))
-        val (_, lt1DraftVersion) = locationTrackDao.insert(asMainDraft(locationTrackDao.fetch(lt1OfficialVersion)))
-        val (lt2Id, lt2DraftVersion) = mainDraftContext.insert(locationTrackAndAlignment(trackNumberId))
+        val (lt1Id, lt1OfficialVersion) =
+            mainOfficialContext.insert(locationTrackAndAlignment(trackNumberId))
+        val (_, lt1DraftVersion) =
+            locationTrackDao.insert(asMainDraft(locationTrackDao.fetch(lt1OfficialVersion)))
+        val (lt2Id, lt2DraftVersion) =
+            mainDraftContext.insert(locationTrackAndAlignment(trackNumberId))
 
         assertEquals(
             locationTrackDao.fetch(lt1OfficialVersion),
@@ -124,7 +131,8 @@ class ValidationContextIT @Autowired constructor(
     @Test
     fun `ValidationContext returns correct versions for Switch`() {
         val switchName1 = testDBService.getUnusedSwitchName()
-        val (s1Id, s1OfficialVersion) = mainOfficialContext.insert(switch(name = switchName1.toString()))
+        val (s1Id, s1OfficialVersion) =
+            mainOfficialContext.insert(switch(name = switchName1.toString()))
         val (_, s1DraftVersion) = switchDao.insert(asMainDraft(switchDao.fetch(s1OfficialVersion)))
         val switchName2 = testDBService.getUnusedSwitchName()
         val (s2Id, s2DraftVersion) = mainDraftContext.insert(switch(name = switchName2.toString()))
@@ -151,7 +159,8 @@ class ValidationContextIT @Autowired constructor(
             listOf(switchDao.fetch(s1DraftVersion)),
             validationContext(switches = listOf(s1Id)).getSwitchesByName(switchName1),
         )
-        assertEquals(emptyList<TrackLayoutSwitch>(), validationContext().getSwitchesByName(switchName2))
+        assertEquals(
+            emptyList<TrackLayoutSwitch>(), validationContext().getSwitchesByName(switchName2))
         assertEquals(
             listOf(switchDao.fetch(s2DraftVersion)),
             validationContext(switches = listOf(s2Id)).getSwitchesByName(switchName2),
@@ -161,8 +170,10 @@ class ValidationContextIT @Autowired constructor(
     @Test
     fun `ValidationContext returns correct versions for KM-Post`() {
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
-        val (kmp1Id, kmp1OfficialVersion) = mainOfficialContext.insert(kmPost(trackNumberId, KmNumber(1)))
-        val (_, kmp1DraftVersion) = kmPostDao.insert(asMainDraft(kmPostDao.fetch(kmp1OfficialVersion)))
+        val (kmp1Id, kmp1OfficialVersion) =
+            mainOfficialContext.insert(kmPost(trackNumberId, KmNumber(1)))
+        val (_, kmp1DraftVersion) =
+            kmPostDao.insert(asMainDraft(kmPostDao.fetch(kmp1OfficialVersion)))
         val (kmp2Id, kmp2DraftVersion) = mainDraftContext.insert(kmPost(trackNumberId, KmNumber(2)))
         assertEquals(
             kmPostDao.fetch(kmp1OfficialVersion),
@@ -186,25 +197,29 @@ class ValidationContextIT @Autowired constructor(
         referenceLines: List<IntId<ReferenceLine>> = listOf(),
         switches: List<IntId<TrackLayoutSwitch>> = listOf(),
         kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
-    ): ValidationContext = ValidationContext(
-        trackNumberDao = trackNumberDao,
-        referenceLineDao = referenceLineDao,
-        kmPostDao = kmPostDao,
-        locationTrackDao = locationTrackDao,
-        switchDao = switchDao,
-        geocodingService = geocodingService,
-        alignmentDao = alignmentDao,
-        publicationDao = publicationDao,
-        switchLibraryService = switchLibraryService,
-        splitService = splitService,
-        publicationSet = ValidationVersions(
-            branch = branch,
-            trackNumbers = trackNumberDao.fetchPublicationVersions(branch, trackNumbers),
-            referenceLines = referenceLineDao.fetchPublicationVersions(branch, referenceLines),
-            kmPosts = kmPostDao.fetchPublicationVersions(branch, kmPosts),
-            locationTracks = locationTrackDao.fetchPublicationVersions(branch, locationTracks),
-            switches = switchDao.fetchPublicationVersions(branch, switches),
-            splits = splitService.fetchPublicationVersions(branch, locationTracks, switches),
-        )
-    )
+    ): ValidationContext =
+        ValidationContext(
+            trackNumberDao = trackNumberDao,
+            referenceLineDao = referenceLineDao,
+            kmPostDao = kmPostDao,
+            locationTrackDao = locationTrackDao,
+            switchDao = switchDao,
+            geocodingService = geocodingService,
+            alignmentDao = alignmentDao,
+            publicationDao = publicationDao,
+            switchLibraryService = switchLibraryService,
+            splitService = splitService,
+            publicationSet =
+                ValidationVersions(
+                    branch = branch,
+                    trackNumbers = trackNumberDao.fetchPublicationVersions(branch, trackNumbers),
+                    referenceLines =
+                        referenceLineDao.fetchPublicationVersions(branch, referenceLines),
+                    kmPosts = kmPostDao.fetchPublicationVersions(branch, kmPosts),
+                    locationTracks =
+                        locationTrackDao.fetchPublicationVersions(branch, locationTracks),
+                    switches = switchDao.fetchPublicationVersions(branch, switches),
+                    splits =
+                        splitService.fetchPublicationVersions(branch, locationTracks, switches),
+                ))
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -50,16 +50,21 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 
 @ConditionalOnProperty("geoviite.ratko.test-port")
 @GeoviiteService
-class FakeRatkoService @Autowired constructor(@Value("\${geoviite.ratko.test-port:}") private val testRatkoPort: Int) {
+class FakeRatkoService
+@Autowired
+constructor(@Value("\${geoviite.ratko.test-port:}") private val testRatkoPort: Int) {
     fun start(): FakeRatko = FakeRatko(testRatkoPort)
 }
 
 class FakeRatko(port: Int) {
     private val mockServer: ClientAndServer =
-        ClientAndServer.startClientAndServer(Configuration.configuration().logLevel(Level.ERROR), port)
+        ClientAndServer.startClientAndServer(
+            Configuration.configuration().logLevel(Level.ERROR), port)
 
     private val jsonMapper =
-        jsonMapper { addModule(kotlinModule { configure(KotlinFeature.NullIsSameAsDefault, true) }) }
+        jsonMapper {
+                addModule(kotlinModule { configure(KotlinFeature.NullIsSameAsDefault, true) })
+            }
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
     fun stop() {
@@ -71,7 +76,9 @@ class FakeRatko(port: Int) {
     }
 
     fun isOffline() {
-        get("/api/versions/v1.0/version").withId("version-check").respond(HttpResponse.response().withStatusCode(500))
+        get("/api/versions/v1.0/version")
+            .withId("version-check")
+            .respond(HttpResponse.response().withStatusCode(500))
     }
 
     fun acceptsNewRouteNumbersGivingThemOids(oids: List<String>) {
@@ -79,25 +86,34 @@ class FakeRatko(port: Int) {
 
         oids.forEach { oid ->
             post("/api/infra/v1.0/routenumber/points/$oid").respond(ok())
-            post("/api/infra/v1.0/routenumbers", mapOf("id" to oid)).respond(okJson(mapOf("id" to oid)))
-            post("/api/infra/v1.0/routenumbers", times = Times.once()).respond(okJson(mapOf("id" to oid)))
+            post("/api/infra/v1.0/routenumbers", mapOf("id" to oid))
+                .respond(okJson(mapOf("id" to oid)))
+            post("/api/infra/v1.0/routenumbers", times = Times.once())
+                .respond(okJson(mapOf("id" to oid)))
         }
     }
 
     fun acceptsNewLocationTrackGivingItOid(oid: String) {
-        post("/api/infra/v1.0/locationtracks", mapOf<String, String>(), MatchType.STRICT, Times.once())
+        post(
+                "/api/infra/v1.0/locationtracks",
+                mapOf<String, String>(),
+                MatchType.STRICT,
+                Times.once())
             .respond(okJson(mapOf("id" to oid)))
         put("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(ok())
-        get("/api/locations/v1.1/locationtracks/${oid}", Times.once()).respond(okJson(listOf<Unit>()))
+        get("/api/locations/v1.1/locationtracks/${oid}", Times.once())
+            .respond(okJson(listOf<Unit>()))
         post("/api/infra/v1.0/points/${oid}").respond(ok())
         patch("/api/infra/v1.0/points/${oid}").respond(ok())
-        post("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(okJson(mapOf("id" to oid)))
+        post("/api/infra/v1.0/locationtracks", mapOf("id" to oid))
+            .respond(okJson(mapOf("id" to oid)))
         post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
     fun acceptsNewSwitchGivingItOid(oid: String) {
-        post("/api/assets/v1.2", mapOf("type" to "turnout", "id" to oid)).respond(okJson(listOf(mapOf("id" to oid))))
+        post("/api/assets/v1.2", mapOf("type" to "turnout", "id" to oid))
+            .respond(okJson(listOf(mapOf("id" to oid))))
         put("/api/assets/v1.2/${oid}/locations").respond(ok())
         put("/api/assets/v1.2/${oid}/geoms").respond(ok())
         put("/api/assets/v1.2/${oid}/properties").respond(ok())
@@ -107,13 +123,15 @@ class FakeRatko(port: Int) {
 
     fun hasRouteNumber(routeNumberAsset: InterfaceRatkoRouteNumber) {
         put("/api/infra/v1.0/routenumbers", mapOf("id" to routeNumberAsset.id)).respond(ok())
-        get("/api/locations/v1.1/routenumber/${routeNumberAsset.id}").respond(okJson(routeNumberAsset))
+        get("/api/locations/v1.1/routenumber/${routeNumberAsset.id}")
+            .respond(okJson(routeNumberAsset))
         patch("/api/infra/v1.0/routenumber/points/${routeNumberAsset.id}").respond(ok())
     }
 
     fun hasLocationTrack(locationTrackAsset: InterfaceRatkoLocationTrack) {
         put("/api/infra/v1.0/locationtracks", mapOf("id" to locationTrackAsset.id)).respond(ok())
-        get("/api/locations/v1.1/locationtracks/${locationTrackAsset.id}").respond(okJson(listOf(locationTrackAsset)))
+        get("/api/locations/v1.1/locationtracks/${locationTrackAsset.id}")
+            .respond(okJson(listOf(locationTrackAsset)))
         patch("/api/infra/v1.0/points/${locationTrackAsset.id}").respond(ok())
     }
 
@@ -123,7 +141,9 @@ class FakeRatko(port: Int) {
     }
 
     fun getPushedRouteNumber(oid: Oid<TrackLayoutTrackNumber>): List<RatkoRouteNumber> =
-        mockServer.retrieveRecordedRequests(request("/api/infra/v1.0/routenumbers").withMethod("POST|PUT"))
+        mockServer
+            .retrieveRecordedRequests(
+                request("/api/infra/v1.0/routenumbers").withMethod("POST|PUT"))
             .map { request -> request.bodyAsString }
             .filter { body -> body.length > 3 }
             .mapNotNull { body ->
@@ -132,10 +152,13 @@ class FakeRatko(port: Int) {
             }
 
     fun acceptsNewBulkTransferGivingItId(bulkTransferId: IntId<BulkTransfer>) {
-        val responseStarted = BulkTransferResponse(id = bulkTransferId, state = BulkTransferState.IN_PROGRESS)
-        val responseFinished = BulkTransferResponse(id = bulkTransferId, state = BulkTransferState.DONE)
+        val responseStarted =
+            BulkTransferResponse(id = bulkTransferId, state = BulkTransferState.IN_PROGRESS)
+        val responseFinished =
+            BulkTransferResponse(id = bulkTransferId, state = BulkTransferState.DONE)
 
-        post("/api/split/bulk-transfer/start", times = Times.once()).respond(okJson(responseStarted))
+        post("/api/split/bulk-transfer/start", times = Times.once())
+            .respond(okJson(responseStarted))
         get("/api/split/bulk-transfer/$bulkTransferId/state").respond(okJson(responseFinished))
     }
 
@@ -147,70 +170,89 @@ class FakeRatko(port: Int) {
         get("/api/split/bulk-transfer/$bulkTransferId/state").respond(okJson(response))
     }
 
-    // return deleted route number kms, or an empty string if all of a route number points were deleted
+    // return deleted route number kms, or an empty string if all of a route number points were
+    // deleted
     fun getRouteNumberPointDeletions(oid: String): List<String> =
         getPointDeletions(oid, "infra/v1.0/routenumber/points")
 
-    fun getLocationTrackPointDeletions(oid: String): List<String> = getPointDeletions(oid, "infra/v1.0/points")
+    fun getLocationTrackPointDeletions(oid: String): List<String> =
+        getPointDeletions(oid, "infra/v1.0/points")
 
-    fun getCreatedRouteNumberPoints(oid: String) = getPointUpdates(oid, "infra/v1.0/routenumber/points", "POST")
+    fun getCreatedRouteNumberPoints(oid: String) =
+        getPointUpdates(oid, "infra/v1.0/routenumber/points", "POST")
 
-    fun getUpdatedRouteNumberPoints(oid: String) = getPointUpdates(oid, "infra/v1.0/routenumber/points", "PATCH")
+    fun getUpdatedRouteNumberPoints(oid: String) =
+        getPointUpdates(oid, "infra/v1.0/routenumber/points", "PATCH")
 
-    fun getCreatedLocationTrackPoints(oid: String) = getPointUpdates(oid, "infra/v1.0/points", "POST")
+    fun getCreatedLocationTrackPoints(oid: String) =
+        getPointUpdates(oid, "infra/v1.0/points", "POST")
 
-    fun getUpdatedLocationTrackPoints(oid: String) = getPointUpdates(oid, "infra/v1.0/points", "PATCH")
+    fun getUpdatedLocationTrackPoints(oid: String) =
+        getPointUpdates(oid, "infra/v1.0/points", "PATCH")
 
     private fun metadataFilterOn(pointField: String, oid: String) =
         mapOf(
-            "locations" to listOf(
-                mapOf(
-                    "nodecollection" to mapOf(
-                        "nodes" to listOf(
-                            mapOf("point" to mapOf(pointField to (mapOf("id" to oid)))),
-                            mapOf("point" to mapOf(pointField to (mapOf("id" to oid)))),
-                        )
-                    )
-                )
-            )
-        )
+            "locations" to
+                listOf(
+                    mapOf(
+                        "nodecollection" to
+                            mapOf(
+                                "nodes" to
+                                    listOf(
+                                        mapOf("point" to mapOf(pointField to (mapOf("id" to oid)))),
+                                        mapOf("point" to mapOf(pointField to (mapOf("id" to oid)))),
+                                    )))))
 
-    fun getPushedMetadata(locationTrackOid: String? = null, routeNumberOid: String? = null): List<RatkoMetadataAsset> =
-        mockServer.retrieveRecordedRequests(
-            request().withPath("/api/assets/v1.2")
-                .withMethod("POST")
-                .withBody(
-                    JsonBody.json(
-                        mapOf("type" to RatkoAssetType.METADATA.value) +
-                                (locationTrackOid?.let { oid -> metadataFilterOn("locationtrack", oid) } ?: mapOf()) +
-                                (routeNumberOid?.let { oid -> metadataFilterOn("routenumber", oid) } ?: mapOf())
-                    )
-                )
-        ).map { req ->
-            jsonMapper.readValue(req.bodyAsString)
+    fun getPushedMetadata(
+        locationTrackOid: String? = null,
+        routeNumberOid: String? = null
+    ): List<RatkoMetadataAsset> =
+        mockServer
+            .retrieveRecordedRequests(
+                request()
+                    .withPath("/api/assets/v1.2")
+                    .withMethod("POST")
+                    .withBody(
+                        JsonBody.json(
+                            mapOf("type" to RatkoAssetType.METADATA.value) +
+                                (locationTrackOid?.let { oid ->
+                                    metadataFilterOn("locationtrack", oid)
+                                } ?: mapOf()) +
+                                (routeNumberOid?.let { oid -> metadataFilterOn("routenumber", oid) }
+                                    ?: mapOf()))))
+            .map { req -> jsonMapper.readValue(req.bodyAsString) }
+
+    private fun putKmMs(nodeCollection: JsonNode) =
+        nodeCollection.get("nodes").forEach { node ->
+            val point = node.get("point") as ObjectNode
+            val kmM = point.get("kmM").textValue()
+            point.put("km", kmM.substring(0, 4))
+            point.put("m", kmM.substring(5))
         }
 
-    private fun putKmMs(nodeCollection: JsonNode) = nodeCollection.get("nodes").forEach { node ->
-        val point = node.get("point") as ObjectNode
-        val kmM = point.get("kmM").textValue()
-        point.put("km", kmM.substring(0, 4))
-        point.put("m", kmM.substring(5))
-    }
-
-    fun lastPushedSwitchBody(oid: String): String = mockServer.retrieveRecordedRequests(
-        request().withPath("/api/assets/v1.2")
-            .withMethod("POST")
-            .withBody(JsonBody.json(mapOf("type" to "turnout", "id" to oid)))
-    ).last().bodyAsString
+    fun lastPushedSwitchBody(oid: String): String =
+        mockServer
+            .retrieveRecordedRequests(
+                request()
+                    .withPath("/api/assets/v1.2")
+                    .withMethod("POST")
+                    .withBody(JsonBody.json(mapOf("type" to "turnout", "id" to oid))))
+            .last()
+            .bodyAsString
 
     fun hostPushedSwitch(oid: String) = hasSwitch(getLastPushedSwitch(oid))
 
-    fun getLastPushedSwitch(oid: String): InterfaceRatkoSwitch = jsonMapper.readValue(lastPushedSwitchBody(oid))
+    fun getLastPushedSwitch(oid: String): InterfaceRatkoSwitch =
+        jsonMapper.readValue(lastPushedSwitchBody(oid))
 
-    private fun lastPushedLocationTrackBody(oid: String): String = mockServer.retrieveRecordedRequests(
-        request("/api/infra/v1.0/locationtracks").withMethod("POST|PUT")
-            .withBody(JsonBody.json(mapOf("id" to oid), MatchType.ONLY_MATCHING_FIELDS))
-    ).last().bodyAsString!!
+    private fun lastPushedLocationTrackBody(oid: String): String =
+        mockServer
+            .retrieveRecordedRequests(
+                request("/api/infra/v1.0/locationtracks")
+                    .withMethod("POST|PUT")
+                    .withBody(JsonBody.json(mapOf("id" to oid), MatchType.ONLY_MATCHING_FIELDS)))
+            .last()
+            .bodyAsString!!
 
     fun hostPushedLocationTrack(oid: String) {
         val tree = jsonMapper.readTree(lastPushedLocationTrackBody(oid))
@@ -222,39 +264,45 @@ class FakeRatko(port: Int) {
         jsonMapper.readValue(lastPushedLocationTrackBody(oid))
 
     fun getPushedSwitchLocations(oid: String): List<List<RatkoAssetLocation>> =
-        mockServer.retrieveRecordedRequests(
-            request().withPath("/api/assets/v1.2/${oid}/locations").withMethod("PUT")
-        ).map { request ->
-            jsonMapper.readValue(request.bodyAsString)
-        }
+        mockServer
+            .retrieveRecordedRequests(
+                request().withPath("/api/assets/v1.2/${oid}/locations").withMethod("PUT"))
+            .map { request -> jsonMapper.readValue(request.bodyAsString) }
 
     fun getPushedSwitchGeometries(oid: String): List<List<RatkoAssetGeometry>> =
-        mockServer.retrieveRecordedRequests(
-            request().withPath("/api/assets/v1.2/${oid}/geoms").withMethod("PUT")
-        ).map { request -> jsonMapper.readValue(request.bodyAsString) }
+        mockServer
+            .retrieveRecordedRequests(
+                request().withPath("/api/assets/v1.2/${oid}/geoms").withMethod("PUT"))
+            .map { request -> jsonMapper.readValue(request.bodyAsString) }
 
-    fun hasOperatingPoints(points: List<RatkoOperatingPointParse>) = post(
-        "/api/assets/v1.2/search",
-        mapOf("assetType" to "railway_traffic_operating_point"),
-        times = Times.once(),
-    ).respond(okJson(RatkoOperatingPointAssetsResponse(points.map(::marshallOperatingPoint))))
+    fun hasOperatingPoints(points: List<RatkoOperatingPointParse>) =
+        post(
+                "/api/assets/v1.2/search",
+                mapOf("assetType" to "railway_traffic_operating_point"),
+                times = Times.once(),
+            )
+            .respond(
+                okJson(RatkoOperatingPointAssetsResponse(points.map(::marshallOperatingPoint))))
 
-    private fun getPointUpdates(oid: String, urlInfix: String, method: String): List<List<RatkoPoint>> =
-        mockServer.retrieveRecordedRequests(
-            request("/api/$urlInfix/$oid").withMethod(method)
-        )
+    private fun getPointUpdates(
+        oid: String,
+        urlInfix: String,
+        method: String
+    ): List<List<RatkoPoint>> =
+        mockServer
+            .retrieveRecordedRequests(request("/api/$urlInfix/$oid").withMethod(method))
             .map { request -> request.bodyAsString }
             .filter { body -> body.length > 3 }
             .map(jsonMapper::readValue)
 
     private fun getPointDeletions(oid: String, urlInfix: String): List<String> =
-        mockServer.retrieveRecordedRequests(
-            request().withPath("/api/$urlInfix/$oid.*").withMethod("DELETE")
-        )
+        mockServer
+            .retrieveRecordedRequests(
+                request().withPath("/api/$urlInfix/$oid.*").withMethod("DELETE"))
             .map { request ->
-                request.path.toString()
-                    .substring("/api/$urlInfix/$oid".length)
-                    .dropWhile { it == '/' }
+                request.path.toString().substring("/api/$urlInfix/$oid".length).dropWhile {
+                    it == '/'
+                }
             }
 
     private fun get(url: String, times: Times? = null): ForwardChainExpectation =
@@ -265,24 +313,21 @@ class FakeRatko(port: Int) {
         body: Any? = null,
         bodyMatchType: MatchType? = null,
         times: Times? = null,
-    ): ForwardChainExpectation =
-        expectation(url, "PUT", body, bodyMatchType, times)
+    ): ForwardChainExpectation = expectation(url, "PUT", body, bodyMatchType, times)
 
     private fun post(
         url: String,
         body: Any? = null,
         bodyMatchType: MatchType? = null,
         times: Times? = null,
-    ): ForwardChainExpectation =
-        expectation(url, "POST", body, bodyMatchType, times)
+    ): ForwardChainExpectation = expectation(url, "POST", body, bodyMatchType, times)
 
     private fun patch(
         url: String,
         body: Any? = null,
         bodyMatchType: MatchType? = null,
         times: Times? = null,
-    ): ForwardChainExpectation =
-        expectation(url, "PATCH", body, bodyMatchType, times)
+    ): ForwardChainExpectation = expectation(url, "PATCH", body, bodyMatchType, times)
 
     private fun expectation(
         url: String,
@@ -291,14 +336,16 @@ class FakeRatko(port: Int) {
         bodyMatchType: MatchType?,
         times: Times?,
     ): ForwardChainExpectation =
-        mockServer.`when`(request(url).withMethod(method).apply {
-            if (body != null) {
-                this.withBody(JsonBody.json(body, bodyMatchType ?: MatchType.ONLY_MATCHING_FIELDS))
-            }
-        }, times ?: Times.unlimited())
+        mockServer.`when`(
+            request(url).withMethod(method).apply {
+                if (body != null) {
+                    this.withBody(
+                        JsonBody.json(body, bodyMatchType ?: MatchType.ONLY_MATCHING_FIELDS))
+                }
+            },
+            times ?: Times.unlimited())
 
-    private fun ok() =
-        HttpResponse.response().withStatusCode(200)
+    private fun ok() = HttpResponse.response().withStatusCode(200)
 
     private fun okJson(body: Any) =
         HttpResponse.response(jsonMapper.writeValueAsString(body))
@@ -306,34 +353,36 @@ class FakeRatko(port: Int) {
             .withContentType(MediaType.APPLICATION_JSON)
 }
 
-private fun marshallOperatingPoint(point: RatkoOperatingPointParse): RatkoOperatingPointAsset = RatkoOperatingPointAsset(
-    id = point.externalId.toString(),
-    properties = listOf(
-        RatkoAssetProperty("operational_point_type", enumValue = point.type.name),
-        RatkoAssetProperty("name", stringValue = point.name),
-        RatkoAssetProperty("operational_point_abbreviation", stringValue = point.abbreviation),
-        RatkoAssetProperty("operational_point_code", stringValue = point.uicCode),
-    ),
-    locations = listOf(
-        IncomingRatkoAssetLocation(
-            nodecollection = IncomingRatkoNodes(
-                nodes = listOf(
-                    IncomingRatkoNode(
-                        nodeType = RatkoNodeType.SOLO_POINT,
-                        point = IncomingRatkoPoint(
-                            geometry = IncomingRatkoGeometry(
-                                RatkoGeometryType.POINT,
-                                point.location.let { listOf(it.x, it.y) },
-                                RatkoCrs()
-                            ),
-                            routenumber = RatkoOid(point.trackNumberExternalId),
-                        )
-                    )
-                )
-            )
-        )
-    ),
-)
+private fun marshallOperatingPoint(point: RatkoOperatingPointParse): RatkoOperatingPointAsset =
+    RatkoOperatingPointAsset(
+        id = point.externalId.toString(),
+        properties =
+            listOf(
+                RatkoAssetProperty("operational_point_type", enumValue = point.type.name),
+                RatkoAssetProperty("name", stringValue = point.name),
+                RatkoAssetProperty(
+                    "operational_point_abbreviation", stringValue = point.abbreviation),
+                RatkoAssetProperty("operational_point_code", stringValue = point.uicCode),
+            ),
+        locations =
+            listOf(
+                IncomingRatkoAssetLocation(
+                    nodecollection =
+                        IncomingRatkoNodes(
+                            nodes =
+                                listOf(
+                                    IncomingRatkoNode(
+                                        nodeType = RatkoNodeType.SOLO_POINT,
+                                        point =
+                                            IncomingRatkoPoint(
+                                                geometry =
+                                                    IncomingRatkoGeometry(
+                                                        RatkoGeometryType.POINT,
+                                                        point.location.let { listOf(it.x, it.y) },
+                                                        RatkoCrs()),
+                                                routenumber = RatkoOid(point.trackNumberExternalId),
+                                            )))))),
+    )
 
 data class BulkTransferResponse(
     val id: IntId<BulkTransfer>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
@@ -22,7 +22,9 @@ import org.springframework.test.context.ActiveProfiles
 @ActiveProfiles("dev", "test")
 @SpringBootTest
 @ConditionalOnBean(RatkoClient::class)
-class RatkoClientIT @Autowired constructor(
+class RatkoClientIT
+@Autowired
+constructor(
     private val ratkoClient: RatkoClient,
     private val switchLibraryService: SwitchLibraryService,
     private val fakeRatkoService: FakeRatkoService,
@@ -69,11 +71,15 @@ class RatkoClientIT @Autowired constructor(
     }
 
     private fun createRatkoBasicUpdateSwitch(layoutSwitch: TrackLayoutSwitch): RatkoSwitchAsset {
-        val switchStructure = switchLibraryService.getSwitchStructure(layoutSwitch.switchStructureId)
-        val oid = (layoutSwitch.externalId ?: throw IllegalArgumentException("No switch external ID")).toString()
+        val switchStructure =
+            switchLibraryService.getSwitchStructure(layoutSwitch.switchStructureId)
+        val oid =
+            (layoutSwitch.externalId ?: throw IllegalArgumentException("No switch external ID"))
+                .toString()
         fakeRatko.hasSwitch(ratkoSwitch(oid))
         val ratkoSwitch = ratkoClient.getSwitchAsset(RatkoOid(oid))
-        return convertToRatkoSwitch(layoutSwitch, switchStructure, switchOwners.firstOrNull(), ratkoSwitch)
+        return convertToRatkoSwitch(
+            layoutSwitch, switchStructure, switchOwners.firstOrNull(), ratkoSwitch)
     }
 
     @Test
@@ -90,14 +96,13 @@ class RatkoClientIT @Autowired constructor(
 
     @Test
     fun `New bulk transfer can be started`() {
-        val split = splitTestDataService
-            .insertSplit()
-            .let(splitDao::getOrThrow)
+        val split = splitTestDataService.insertSplit().let(splitDao::getOrThrow)
 
         val expectedBulkTransferId = testDBService.getUnusedBulkTransferId()
 
         fakeRatko.acceptsNewBulkTransferGivingItId(expectedBulkTransferId)
-        val (receivedBulkTransferId, receivedBulkTransferState) = ratkoClient.startNewBulkTransfer(split)
+        val (receivedBulkTransferId, receivedBulkTransferState) =
+            ratkoClient.startNewBulkTransfer(split)
 
         assertEquals(expectedBulkTransferId, receivedBulkTransferId)
         assertEquals(BulkTransferState.IN_PROGRESS, receivedBulkTransferState)
@@ -105,15 +110,14 @@ class RatkoClientIT @Autowired constructor(
 
     @Test
     fun `Bulk transfer state can be polled`() {
-        val split = splitTestDataService
-            .insertSplit()
-            .let(splitDao::getOrThrow)
+        val split = splitTestDataService.insertSplit().let(splitDao::getOrThrow)
 
         val expectedBulkTransferId = testDBService.getUnusedBulkTransferId()
 
         fakeRatko.acceptsNewBulkTransferGivingItId(expectedBulkTransferId)
         val (receivedBulkTransferId, _) = ratkoClient.startNewBulkTransfer(split)
 
-        assertEquals(BulkTransferState.DONE, ratkoClient.pollBulkTransferState(receivedBulkTransferId))
+        assertEquals(
+            BulkTransferState.DONE, ratkoClient.pollBulkTransferState(receivedBulkTransferId))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoConversionTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoConversionTest.kt
@@ -12,9 +12,9 @@ import fi.fta.geoviite.infra.ratko.model.mapToRatkoLocationTrackType
 import fi.fta.geoviite.infra.switchLibrary.SwitchBaseType
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
 
 class RatkoConversionTest {
 
@@ -46,48 +46,45 @@ class RatkoConversionTest {
 
     @Test
     fun `should not return locations with empty nodes`() {
-        val jointChanges = listOf(
-            SwitchJointChange(
-                number = JointNumber(1),
-                isRemoved = false,
-                address = TrackMeter("0000+0000"),
-                locationTrackExternalId = Oid("11.11111.1111"),
-                locationTrackId = IntId(1),
-                point = Point(0.0, 2.0),
-                trackNumberExternalId = Oid("00.00000.0000"),
-                trackNumberId = IntId(0)
-            ),
-            SwitchJointChange(
-                number = JointNumber(5),
-                isRemoved = false,
-                address = TrackMeter("0000+0000"),
-                locationTrackExternalId = Oid("11.11111.1111"),
-                locationTrackId = IntId(1),
-                point = Point(0.0, 1.0),
-                trackNumberExternalId = Oid("00.00000.0000"),
-                trackNumberId = IntId(0)
-            ),
-            SwitchJointChange(
-                number = JointNumber(2),
-                isRemoved = false,
-                address = TrackMeter("0000+0000"),
-                locationTrackExternalId = Oid("11.11111.1111"),
-                locationTrackId = IntId(1),
-                point = Point(0.0, 0.0),
-                trackNumberExternalId = Oid("00.00000.0000"),
-                trackNumberId = IntId(0)
-            ),
-            SwitchJointChange(
-                number = JointNumber(5),
-                isRemoved = false,
-                address = TrackMeter("0000+0000"),
-                locationTrackExternalId = Oid("22.22222.2222"),
-                locationTrackId = IntId(2),
-                point = Point(0.0, 1.0),
-                trackNumberExternalId = Oid("00.00000.0000"),
-                trackNumberId = IntId(0)
-            ),
-        )
+        val jointChanges =
+            listOf(
+                SwitchJointChange(
+                    number = JointNumber(1),
+                    isRemoved = false,
+                    address = TrackMeter("0000+0000"),
+                    locationTrackExternalId = Oid("11.11111.1111"),
+                    locationTrackId = IntId(1),
+                    point = Point(0.0, 2.0),
+                    trackNumberExternalId = Oid("00.00000.0000"),
+                    trackNumberId = IntId(0)),
+                SwitchJointChange(
+                    number = JointNumber(5),
+                    isRemoved = false,
+                    address = TrackMeter("0000+0000"),
+                    locationTrackExternalId = Oid("11.11111.1111"),
+                    locationTrackId = IntId(1),
+                    point = Point(0.0, 1.0),
+                    trackNumberExternalId = Oid("00.00000.0000"),
+                    trackNumberId = IntId(0)),
+                SwitchJointChange(
+                    number = JointNumber(2),
+                    isRemoved = false,
+                    address = TrackMeter("0000+0000"),
+                    locationTrackExternalId = Oid("11.11111.1111"),
+                    locationTrackId = IntId(1),
+                    point = Point(0.0, 0.0),
+                    trackNumberExternalId = Oid("00.00000.0000"),
+                    trackNumberId = IntId(0)),
+                SwitchJointChange(
+                    number = JointNumber(5),
+                    isRemoved = false,
+                    address = TrackMeter("0000+0000"),
+                    locationTrackExternalId = Oid("22.22222.2222"),
+                    locationTrackId = IntId(2),
+                    point = Point(0.0, 1.0),
+                    trackNumberExternalId = Oid("00.00000.0000"),
+                    trackNumberId = IntId(0)),
+            )
 
         val locations = convertToRatkoAssetLocations(jointChanges, SwitchBaseType.KRV)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalServiceIT.kt
@@ -10,145 +10,156 @@ import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumber
 import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FreeText
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class RatkoLocalServiceIT @Autowired constructor(
+class RatkoLocalServiceIT
+@Autowired
+constructor(
     private val ratkoLocalService: RatkoLocalService,
     private val operatingPointDao: RatkoOperatingPointDao,
 ) : DBTestBase() {
 
     @BeforeEach
     fun clearOperatingPoints() {
-        val sql = """
+        val sql =
+            """
             truncate layout.operating_point cascade;
             truncate layout.operating_point_version cascade;
-        """.trimIndent()
+        """
+                .trimIndent()
         jdbc.execute(sql) { it.execute() }
     }
 
     @Test
     fun `Operating points can be found by exact name`() {
-        val operatingPointNames = listOf(
-            "Some operating point",
-            "Foo",
-            "Bar",
-        )
-
-        operatingPointNames.map { name ->
-            createTestOperatingPoint(
-                name = name,
-                abbreviation = "Unused",
+        val operatingPointNames =
+            listOf(
+                "Some operating point",
+                "Foo",
+                "Bar",
             )
-        }.let(operatingPointDao::updateOperatingPoints)
 
         operatingPointNames
-            .forEach { operatingPointName ->
-                val result = ratkoLocalService.searchOperatingPoints(
-                    FreeText(operatingPointName)
+            .map { name ->
+                createTestOperatingPoint(
+                    name = name,
+                    abbreviation = "Unused",
                 )
-
-                assertEquals(1, result.size)
-                assertEquals(operatingPointName, result[0].name)
             }
+            .let(operatingPointDao::updateOperatingPoints)
+
+        operatingPointNames.forEach { operatingPointName ->
+            val result = ratkoLocalService.searchOperatingPoints(FreeText(operatingPointName))
+
+            assertEquals(1, result.size)
+            assertEquals(operatingPointName, result[0].name)
+        }
     }
 
     @Test
     fun `Operating points can be found by partial name`() {
-        val operatingPointNames = listOf(
-            "Some operating point",
-            "Foo",
-            "Bar",
-        )
-
-        operatingPointNames.map { name ->
-            createTestOperatingPoint(
-                name = name,
-                abbreviation = "Unused",
+        val operatingPointNames =
+            listOf(
+                "Some operating point",
+                "Foo",
+                "Bar",
             )
-        }.let(operatingPointDao::updateOperatingPoints)
 
         operatingPointNames
-            .forEach { operatingPointName ->
-                val result = ratkoLocalService.searchOperatingPoints(
-                    FreeText(operatingPointName.takeLast(2))
+            .map { name ->
+                createTestOperatingPoint(
+                    name = name,
+                    abbreviation = "Unused",
                 )
-
-                assertEquals(1, result.size)
-                assertEquals(operatingPointName, result[0].name)
             }
+            .let(operatingPointDao::updateOperatingPoints)
+
+        operatingPointNames.forEach { operatingPointName ->
+            val result =
+                ratkoLocalService.searchOperatingPoints(FreeText(operatingPointName.takeLast(2)))
+
+            assertEquals(1, result.size)
+            assertEquals(operatingPointName, result[0].name)
+        }
     }
 
     @Test
     fun `Multiple operating points can be found in same search`() {
-        val operatingPointNames = listOf(
-            "FOO AAA BBB",
-            "AAA FOO BBB",
-            "BBB AAA",
-        )
-
-        operatingPointNames.map { name ->
-            createTestOperatingPoint(
-                name = name,
-                abbreviation = "Unused",
+        val operatingPointNames =
+            listOf(
+                "FOO AAA BBB",
+                "AAA FOO BBB",
+                "BBB AAA",
             )
-        }.let(operatingPointDao::updateOperatingPoints)
 
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("FOO"))
-            .let { result -> assertEquals(2, result.size) }
+        operatingPointNames
+            .map { name ->
+                createTestOperatingPoint(
+                    name = name,
+                    abbreviation = "Unused",
+                )
+            }
+            .let(operatingPointDao::updateOperatingPoints)
 
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("AAA"))
-            .let { result -> assertEquals(3, result.size) }
+        ratkoLocalService.searchOperatingPoints(FreeText("FOO")).let { result ->
+            assertEquals(2, result.size)
+        }
 
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("BBB"))
-            .let { result -> assertEquals(3, result.size) }
+        ratkoLocalService.searchOperatingPoints(FreeText("AAA")).let { result ->
+            assertEquals(3, result.size)
+        }
+
+        ratkoLocalService.searchOperatingPoints(FreeText("BBB")).let { result ->
+            assertEquals(3, result.size)
+        }
     }
 
     @Test
     fun `Operating points can be found by abbreviation`() {
-        val operatingPointAbbreviations = listOf(
-            "BBB",
-            "AAA",
-        )
-
-        operatingPointAbbreviations.map { abbreviation ->
-            createTestOperatingPoint(
-                name = "unused",
-                abbreviation = abbreviation,
+        val operatingPointAbbreviations =
+            listOf(
+                "BBB",
+                "AAA",
             )
-        }.let(operatingPointDao::updateOperatingPoints)
 
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("BBB"))
-            .let { result -> assertEquals(1, result.size) }
+        operatingPointAbbreviations
+            .map { abbreviation ->
+                createTestOperatingPoint(
+                    name = "unused",
+                    abbreviation = abbreviation,
+                )
+            }
+            .let(operatingPointDao::updateOperatingPoints)
 
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("AAA"))
-            .let { result -> assertEquals(1, result.size) }
+        ratkoLocalService.searchOperatingPoints(FreeText("BBB")).let { result ->
+            assertEquals(1, result.size)
+        }
+
+        ratkoLocalService.searchOperatingPoints(FreeText("AAA")).let { result ->
+            assertEquals(1, result.size)
+        }
     }
-
 
     @Test
     fun `Operating points search limit restricts the amount of results`() {
         val stringThatMatchesAll = "Operating point"
 
-        (1..20).map { index ->
-            "$stringThatMatchesAll $index"
-        }.map { name ->
-            createTestOperatingPoint(
-                name = name,
-                abbreviation = "unused",
-            )
-        }.let(operatingPointDao::updateOperatingPoints)
+        (1..20)
+            .map { index -> "$stringThatMatchesAll $index" }
+            .map { name ->
+                createTestOperatingPoint(
+                    name = name,
+                    abbreviation = "unused",
+                )
+            }
+            .let(operatingPointDao::updateOperatingPoints)
 
         ratkoLocalService
             .searchOperatingPoints(FreeText(stringThatMatchesAll)) // Limit should be 10 by default.
@@ -165,120 +176,110 @@ class RatkoLocalServiceIT @Autowired constructor(
 
     @Test
     fun `Operating points search results are sorted by name`() {
-        val operatingPointNames = listOf(
-            "BBB 1",
-            "CCC 1",
-            "AAA 1",
-        )
-
-        operatingPointNames.map { name ->
-            createTestOperatingPoint(
-                name = name,
-                abbreviation = "unused",
+        val operatingPointNames =
+            listOf(
+                "BBB 1",
+                "CCC 1",
+                "AAA 1",
             )
-        }.let(operatingPointDao::updateOperatingPoints)
 
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("1"))
-            .let { result ->
-                assertEquals(3, result.size)
-
-                assertEquals(operatingPointNames[2], result[0].name)
-                assertEquals(operatingPointNames[0], result[1].name)
-                assertEquals(operatingPointNames[1], result[2].name)
+        operatingPointNames
+            .map { name ->
+                createTestOperatingPoint(
+                    name = name,
+                    abbreviation = "unused",
+                )
             }
+            .let(operatingPointDao::updateOperatingPoints)
+
+        ratkoLocalService.searchOperatingPoints(FreeText("1")).let { result ->
+            assertEquals(3, result.size)
+
+            assertEquals(operatingPointNames[2], result[0].name)
+            assertEquals(operatingPointNames[0], result[1].name)
+            assertEquals(operatingPointNames[1], result[2].name)
+        }
     }
 
     @Test
     fun `Operating points search matching both name and abbreviation returns the result only once`() {
         listOf(
-            createTestOperatingPoint(
-                name = "AAA",
-                abbreviation = "AAA",
-            )
-        ).let(operatingPointDao::updateOperatingPoints)
+                createTestOperatingPoint(
+                    name = "AAA",
+                    abbreviation = "AAA",
+                ))
+            .let(operatingPointDao::updateOperatingPoints)
 
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("A"))
-            .let { result ->
-                assertEquals(1, result.size)
+        ratkoLocalService.searchOperatingPoints(FreeText("A")).let { result ->
+            assertEquals(1, result.size)
 
-                assertEquals("AAA", result[0].name)
-                assertEquals("AAA", result[0].abbreviation)
-            }
+            assertEquals("AAA", result[0].name)
+            assertEquals("AAA", result[0].abbreviation)
+        }
     }
 
     @Test
     fun `Operating points search finds mixed results (match by name or abbreviation)`() {
         listOf(
-            createTestOperatingPoint(
-                name = "AAA",
-                abbreviation = "BBB",
-            ),
+                createTestOperatingPoint(
+                    name = "AAA",
+                    abbreviation = "BBB",
+                ),
+                createTestOperatingPoint(
+                    name = "BBB",
+                    abbreviation = "AAA",
+                ),
+            )
+            .let(operatingPointDao::updateOperatingPoints)
 
-            createTestOperatingPoint(
-                name = "BBB",
-                abbreviation = "AAA",
-            ),
-        ).let(operatingPointDao::updateOperatingPoints)
+        ratkoLocalService.searchOperatingPoints(FreeText("A")).let { result ->
+            assertEquals(2, result.size)
+        }
 
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("A"))
-            .let { result ->
-                assertEquals(2, result.size)
-            }
-
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("B"))
-            .let { result ->
-                assertEquals(2, result.size)
-            }
+        ratkoLocalService.searchOperatingPoints(FreeText("B")).let { result ->
+            assertEquals(2, result.size)
+        }
     }
 
     @Test
     fun `Operating points search finds matches case-insensitively`() {
         listOf(
-            createTestOperatingPoint(
-                name = "AAA",
-                abbreviation = "unused",
-            ),
+                createTestOperatingPoint(
+                    name = "AAA",
+                    abbreviation = "unused",
+                ),
+                createTestOperatingPoint(
+                    name = "unused",
+                    abbreviation = "bbb",
+                ),
+            )
+            .let(operatingPointDao::updateOperatingPoints)
 
-            createTestOperatingPoint(
-                name = "unused",
-                abbreviation = "bbb",
-            ),
-        ).let(operatingPointDao::updateOperatingPoints)
+        ratkoLocalService.searchOperatingPoints(FreeText("a")).let { result ->
+            assertEquals(1, result.size)
+            assertEquals("AAA", result[0].name)
+        }
 
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("a"))
-            .let { result ->
-                assertEquals(1, result.size)
-                assertEquals("AAA", result[0].name)
-            }
-
-        ratkoLocalService
-            .searchOperatingPoints(FreeText("B"))
-            .let { result ->
-                assertEquals(1, result.size)
-                assertEquals("bbb", result[0].abbreviation)
-            }
+        ratkoLocalService.searchOperatingPoints(FreeText("B")).let { result ->
+            assertEquals(1, result.size)
+            assertEquals("bbb", result[0].abbreviation)
+        }
     }
 
     @Test
     fun `Operating points can be found by their exact oid`() {
         listOf(
-            createTestOperatingPoint(
-                name = "AAA",
-                abbreviation = "unused",
-                externalId = someOid(),
-            ),
-
-            createTestOperatingPoint(
-                name = "BBB",
-                abbreviation = "unused",
-                externalId = someOid(),
-            ),
-        )
+                createTestOperatingPoint(
+                    name = "AAA",
+                    abbreviation = "unused",
+                    externalId = someOid(),
+                ),
+                createTestOperatingPoint(
+                    name = "BBB",
+                    abbreviation = "unused",
+                    externalId = someOid(),
+                ),
+            )
             .also(operatingPointDao::updateOperatingPoints)
             .forEach { testOperatingPoint ->
                 ratkoLocalService
@@ -293,19 +294,18 @@ class RatkoLocalServiceIT @Autowired constructor(
     @Test
     fun `Operating points cannot be found by partial oid`() {
         listOf(
-            createTestOperatingPoint(
-                name = "AAA",
-                abbreviation = "unused",
-                externalId = someOid(),
-            ),
-        )
+                createTestOperatingPoint(
+                    name = "AAA",
+                    abbreviation = "unused",
+                    externalId = someOid(),
+                ),
+            )
             .also(operatingPointDao::updateOperatingPoints)
             .forEach { testOperatingPoint ->
                 ratkoLocalService
-                    .searchOperatingPoints(FreeText(testOperatingPoint.externalId.toString().substring(0, 4)))
-                    .let { result ->
-                        assertEquals(0, result.size)
-                    }
+                    .searchOperatingPoints(
+                        FreeText(testOperatingPoint.externalId.toString().substring(0, 4)))
+                    .let { result -> assertEquals(0, result.size) }
             }
     }
 
@@ -315,17 +315,18 @@ class RatkoLocalServiceIT @Autowired constructor(
         externalId: Oid<RatkoOperatingPoint> = someOid(),
         ratkoRouteNumberOid: Oid<RatkoRouteNumber>? = null,
     ): RatkoOperatingPointParse {
-        val trackNumberExternalId: Oid<RatkoRouteNumber> = when {
-            ratkoRouteNumberOid != null -> ratkoRouteNumberOid
-            else -> someOid<RatkoRouteNumber>().also { oid ->
-                mainDraftContext.insert(
-                    trackNumber(
-                        testDBService.getUnusedTrackNumber(),
-                        externalId = Oid(oid.toString())
-                    ),
-                )
+        val trackNumberExternalId: Oid<RatkoRouteNumber> =
+            when {
+                ratkoRouteNumberOid != null -> ratkoRouteNumberOid
+                else ->
+                    someOid<RatkoRouteNumber>().also { oid ->
+                        mainDraftContext.insert(
+                            trackNumber(
+                                testDBService.getUnusedTrackNumber(),
+                                externalId = Oid(oid.toString())),
+                        )
+                    }
             }
-        }
 
         return RatkoOperatingPointParse(
             externalId = externalId,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -74,6 +74,8 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.queryOne
+import java.time.Instant
+import kotlin.test.assertNotEquals
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -82,12 +84,12 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import kotlin.test.assertNotEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class RatkoServiceIT @Autowired constructor(
+class RatkoServiceIT
+@Autowired
+constructor(
     val trackNumberService: LayoutTrackNumberService,
     val locationTrackService: LocationTrackService,
     val locationTrackDao: LocationTrackDao,
@@ -110,14 +112,16 @@ class RatkoServiceIT @Autowired constructor(
 ) : DBTestBase() {
     @BeforeEach
     fun cleanup() {
-        val sql = """
+        val sql =
+            """
             truncate publication.publication cascade;
             truncate integrations.lock cascade;
             truncate layout.track_number cascade;
             truncate layout.switch cascade;
             truncate layout.operating_point cascade;
             truncate layout.operating_point_version cascade;
-        """.trimIndent()
+        """
+                .trimIndent()
         jdbc.execute(sql) { it.execute() }
     }
 
@@ -141,8 +145,10 @@ class RatkoServiceIT @Autowired constructor(
 
     @Test
     fun testChangeSet() {
-        val referenceLineAlignmentVersion = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
-        val locationTrackAlignmentVersion = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        val referenceLineAlignmentVersion =
+            alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
+        val locationTrackAlignmentVersion =
+            alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
         val trackNumber = trackNumber(testDBService.getUnusedTrackNumber(), draft = false)
         val trackNumberId = layoutTrackNumberDao.insert(trackNumber).id
         referenceLineDao.insert(
@@ -150,18 +156,18 @@ class RatkoServiceIT @Autowired constructor(
                 trackNumberId = trackNumberId,
                 alignmentVersion = referenceLineAlignmentVersion,
                 draft = false,
-            )
-        )
-        val official = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                alignmentVersion = locationTrackAlignmentVersion,
-                draft = false,
-            )
-        )
-        val draft = locationTrackService.getOrThrow(MainLayoutContext.draft, official.id).let { orig ->
-            orig.copy(name = AlignmentName("${orig.name}-draft"))
-        }
+            ))
+        val official =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    alignmentVersion = locationTrackAlignmentVersion,
+                    draft = false,
+                ))
+        val draft =
+            locationTrackService.getOrThrow(MainLayoutContext.draft, official.id).let { orig ->
+                orig.copy(name = AlignmentName("${orig.name}-draft"))
+            }
         locationTrackService
             .saveDraft(LayoutBranch.main, draft, alignmentDao.fetch(locationTrackAlignmentVersion))
             .rowVersion
@@ -172,9 +178,9 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun pushNewTrackNumber() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val originalTrackNumber = layoutTrackNumberDao.insert(
-            trackNumber(trackNumber, description = "augh", externalId = null, draft = false)
-        )
+        val originalTrackNumber =
+            layoutTrackNumberDao.insert(
+                trackNumber(trackNumber, description = "augh", externalId = null, draft = false))
         insertSomeOfficialReferenceLineFor(originalTrackNumber.id)
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
@@ -228,31 +234,39 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun pushAndDeleteLocationTrack() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = layoutTrackNumberDao.insert(
-            trackNumber(trackNumber, description = "augh", externalId = Oid("1.2.3.4.5"), draft = false)
-        ).id
+        val trackNumberId =
+            layoutTrackNumberDao
+                .insert(
+                    trackNumber(
+                        trackNumber,
+                        description = "augh",
+                        externalId = Oid("1.2.3.4.5"),
+                        draft = false))
+                .id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
-        val locationTrackOriginal = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "abcde",
-                description = "cdefg",
-                type = LocationTrackType.CHORD,
-                state = LocationTrackState.BUILT,
-                externalId = null,
-                draft = true,
-            ),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
+        val locationTrackOriginal =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "abcde",
+                    description = "cdefg",
+                    type = LocationTrackType.CHORD,
+                    state = LocationTrackState.BUILT,
+                    externalId = null,
+                    draft = true,
+                ),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         fakeRatko.hostPushedLocationTrack("2.3.4.5.6")
-        val officialVersion = locationTrackDao.fetchVersionOrThrow(
-            MainLayoutContext.official,
-            locationTrackOriginal.id,
-        )
+        val officialVersion =
+            locationTrackDao.fetchVersionOrThrow(
+                MainLayoutContext.official,
+                locationTrackOriginal.id,
+            )
         val createdPush = fakeRatko.getLastPushedLocationTrack("2.3.4.5.6")
         assertEquals("abcde", createdPush.name)
         assertEquals("cdefg", createdPush.description)
@@ -273,45 +287,49 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun modifyLocationTrackProperties() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = layoutTrackNumberDao.insert(
-            trackNumber(
-                trackNumber,
-                description = "augh",
-                externalId = Oid("1.2.3.4.5"),
-                draft = false,
-            )
-        ).id
+        val trackNumberId =
+            layoutTrackNumberDao
+                .insert(
+                    trackNumber(
+                        trackNumber,
+                        description = "augh",
+                        externalId = Oid("1.2.3.4.5"),
+                        draft = false,
+                    ))
+                .id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
-        val locationTrackOriginal = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "abcde",
-                description = "cdefg",
-                type = LocationTrackType.CHORD,
-                externalId = null,
-                draft = true,
-            ),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
+        val locationTrackOriginal =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "abcde",
+                    description = "cdefg",
+                    type = LocationTrackType.CHORD,
+                    externalId = null,
+                    draft = true,
+                ),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         fakeRatko.hostPushedLocationTrack("2.3.4.5.6")
-        val officialVersion = locationTrackDao.fetchVersionOrThrow(
-            MainLayoutContext.official,
-            locationTrackOriginal.id,
-        )
+        val officialVersion =
+            locationTrackDao.fetchVersionOrThrow(
+                MainLayoutContext.official,
+                locationTrackOriginal.id,
+            )
         locationTrackService.saveDraft(
             LayoutBranch.main,
             asMainDraft(
-                locationTrackDao.fetch(officialVersion).copy(
-                    descriptionBase = FreeText("aoeu"),
-                    name = AlignmentName("uuba aaba"),
-                    type = LocationTrackType.MAIN,
-                )
-            )
-        )
+                locationTrackDao
+                    .fetch(officialVersion)
+                    .copy(
+                        descriptionBase = FreeText("aoeu"),
+                        name = AlignmentName("uuba aaba"),
+                        type = LocationTrackType.MAIN,
+                    )))
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         val pushed = fakeRatko.getLastPushedLocationTrack("2.3.4.5.6")
         val createdPoints = fakeRatko.getCreatedLocationTrackPoints("2.3.4.5.6")
@@ -329,35 +347,39 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun lengthenLocationTrack() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = layoutTrackNumberDao.insert(
-            trackNumber(
-                trackNumber,
-                description = "augh",
-                externalId = Oid("1.2.3.4.5"),
-                draft = false,
-            )
-        ).id
+        val trackNumberId =
+            layoutTrackNumberDao
+                .insert(
+                    trackNumber(
+                        trackNumber,
+                        description = "augh",
+                        externalId = Oid("1.2.3.4.5"),
+                        draft = false,
+                    ))
+                .id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
-        val locationTrackOriginal = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "abcde",
-                description = "cdefg",
-                type = LocationTrackType.CHORD,
-                externalId = null,
-                draft = true,
-            ),
-            alignment(segment(Point(4.0, 0.0), Point(6.0, 0.0))),
-        )
+        val locationTrackOriginal =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "abcde",
+                    description = "cdefg",
+                    type = LocationTrackType.CHORD,
+                    externalId = null,
+                    draft = true,
+                ),
+                alignment(segment(Point(4.0, 0.0), Point(6.0, 0.0))),
+            )
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         fakeRatko.hostPushedLocationTrack("2.3.4.5.6")
-        val officialVersion = locationTrackDao.fetchVersionOrThrow(
-            MainLayoutContext.official,
-            locationTrackOriginal.id,
-        )
+        val officialVersion =
+            locationTrackDao.fetchVersionOrThrow(
+                MainLayoutContext.official,
+                locationTrackOriginal.id,
+            )
         locationTrackService.saveDraft(
             LayoutBranch.main,
             asMainDraft(locationTrackDao.fetch(officialVersion)),
@@ -377,34 +399,38 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun shortenLocationTrack() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = layoutTrackNumberDao.insert(
-            trackNumber(
-                trackNumber,
-                description = "augh",
-                externalId = Oid("1.2.3.4.5"),
-                draft = false,
-            )
-        ).id
+        val trackNumberId =
+            layoutTrackNumberDao
+                .insert(
+                    trackNumber(
+                        trackNumber,
+                        description = "augh",
+                        externalId = Oid("1.2.3.4.5"),
+                        draft = false,
+                    ))
+                .id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
-        val locationTrackOriginal = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "abcde",
-                description = "cdefg",
-                type = LocationTrackType.CHORD,
-                externalId = null,
-                draft = true,
-            ), alignment(segment(Point(2.0, 0.0), Point(8.0, 0.0)))
-        )
+        val locationTrackOriginal =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "abcde",
+                    description = "cdefg",
+                    type = LocationTrackType.CHORD,
+                    externalId = null,
+                    draft = true,
+                ),
+                alignment(segment(Point(2.0, 0.0), Point(8.0, 0.0))))
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         fakeRatko.hostPushedLocationTrack("2.3.4.5.6")
-        val officialVersion = locationTrackDao.fetchVersionOrThrow(
-            MainLayoutContext.official,
-            locationTrackOriginal.id,
-        )
+        val officialVersion =
+            locationTrackDao.fetchVersionOrThrow(
+                MainLayoutContext.official,
+                locationTrackOriginal.id,
+            )
         locationTrackService.saveDraft(
             LayoutBranch.main,
             asMainDraft(locationTrackDao.fetch(officialVersion)),
@@ -424,47 +450,50 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun alterLocationTrackGeometry() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = layoutTrackNumberDao.insert(
-            trackNumber(
-                trackNumber,
-                description = "augh",
-                externalId = Oid("1.2.3.4.5"),
-                draft = false,
-            )
-        ).id
+        val trackNumberId =
+            layoutTrackNumberDao
+                .insert(
+                    trackNumber(
+                        trackNumber,
+                        description = "augh",
+                        externalId = Oid("1.2.3.4.5"),
+                        draft = false,
+                    ))
+                .id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
-        val locationTrackOriginal = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "abcde",
-                description = "cdefg",
-                type = LocationTrackType.CHORD,
-                externalId = null,
-                draft = true,
-            ),
-            alignment(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(1.0, 0.0),
-                    Point(5.0, 3.0),
-                    Point(9.0, 0.0),
-                    Point(10.0, 0.0),
-                )
-            ),
-        )
+        val locationTrackOriginal =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "abcde",
+                    description = "cdefg",
+                    type = LocationTrackType.CHORD,
+                    externalId = null,
+                    draft = true,
+                ),
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(1.0, 0.0),
+                        Point(5.0, 3.0),
+                        Point(9.0, 0.0),
+                        Point(10.0, 0.0),
+                    )),
+            )
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         fakeRatko.hostPushedLocationTrack("2.3.4.5.6")
-        val officialVersion = locationTrackDao.fetchVersionOrThrow(
-            MainLayoutContext.official,
-            locationTrackOriginal.id,
-        )
+        val officialVersion =
+            locationTrackDao.fetchVersionOrThrow(
+                MainLayoutContext.official,
+                locationTrackOriginal.id,
+            )
         locationTrackService.saveDraft(
             LayoutBranch.main,
-            asMainDraft(locationTrackDao.fetch(officialVersion)), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        )
+            asMainDraft(locationTrackDao.fetch(officialVersion)),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         val createdPoints = fakeRatko.getCreatedLocationTrackPoints("2.3.4.5.6")
         val updatedPoints = fakeRatko.getUpdatedLocationTrackPoints("2.3.4.5.6")
@@ -487,48 +516,55 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun pushLocationTrackMetadata() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = layoutTrackNumberDao.insert(
-            trackNumber(
-                trackNumber,
-                description = "augh",
-                externalId = Oid("1.2.3.4.5"),
-                draft = false,
-            )
-        ).id
+        val trackNumberId =
+            layoutTrackNumberDao
+                .insert(
+                    trackNumber(
+                        trackNumber,
+                        description = "augh",
+                        externalId = Oid("1.2.3.4.5"),
+                        draft = false,
+                    ))
+                .id
         insertSomeOfficialReferenceLineFor(trackNumberId)
 
-        val planVersion = geometryDao.insertPlan(
-            plan(
-                trackNumber,
-                srid = Srid(3879),
-                measurementMethod = MeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY,
-                planTime = Instant.parse("2018-11-30T18:35:24.00Z"),
-                alignments = listOf(
-                    geometryAlignment(
-                        name = "geo name",
-                        elements = listOf(lineFromOrigin(1.0)),
-                    )
+        val planVersion =
+            geometryDao.insertPlan(
+                plan(
+                    trackNumber,
+                    srid = Srid(3879),
+                    measurementMethod = MeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY,
+                    planTime = Instant.parse("2018-11-30T18:35:24.00Z"),
+                    alignments =
+                        listOf(
+                            geometryAlignment(
+                                name = "geo name",
+                                elements = listOf(lineFromOrigin(1.0)),
+                            )),
                 ),
-            ),
-            InfraModelFile(FileName("foobar"), "<a></a>"),
-            null,
-        )
+                InfraModelFile(FileName("foobar"), "<a></a>"),
+                null,
+            )
         val plan = geometryDao.fetchPlan(planVersion)
 
-        val locationTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(
-                trackNumberId,
-                name = "abcde",
-                description = "cdefg",
-                type = LocationTrackType.CHORD,
-                externalId = null,
-                draft = true,
-            ),
-            alignment(
-                segment(Point(2.0, 0.0), Point(8.0, 0.0), sourceId = plan.alignments[0].elements[0].id),
-            ),
-        )
+        val locationTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(
+                    trackNumberId,
+                    name = "abcde",
+                    description = "cdefg",
+                    type = LocationTrackType.CHORD,
+                    externalId = null,
+                    draft = true,
+                ),
+                alignment(
+                    segment(
+                        Point(2.0, 0.0),
+                        Point(8.0, 0.0),
+                        sourceId = plan.alignments[0].elements[0].id),
+                ),
+            )
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(locationTracks = listOf(locationTrack.id))
         val metadata = fakeRatko.getPushedMetadata(locationTrackOid = "2.3.4.5.6")
@@ -548,16 +584,14 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun pushTwoTrackNumbers() {
         val trackNumber1 = testDBService.getUnusedTrackNumber()
-        val trackNumber1Version = trackNumberService.saveDraft(
-            LayoutBranch.main,
-            trackNumber(trackNumber1, externalId = null, draft = true)
-        )
+        val trackNumber1Version =
+            trackNumberService.saveDraft(
+                LayoutBranch.main, trackNumber(trackNumber1, externalId = null, draft = true))
         insertSomeOfficialReferenceLineFor(trackNumber1Version.id)
         val trackNumber2 = testDBService.getUnusedTrackNumber()
-        val trackNumber2Version = trackNumberService.saveDraft(
-            LayoutBranch.main,
-            trackNumber(trackNumber2, externalId = null, draft = true)
-        )
+        val trackNumber2Version =
+            trackNumberService.saveDraft(
+                LayoutBranch.main, trackNumber(trackNumber2, externalId = null, draft = true))
         insertSomeOfficialReferenceLineFor(trackNumber2Version.id)
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("2.3.4.5.6", "3.4.5.6.7"))
@@ -571,11 +605,13 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun lengthenReferenceLine() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val originalTrackNumber = layoutTrackNumberDao.insert(
-            trackNumber(trackNumber, description = "augh", externalId = null, draft = false)
-        )
-        val originalReferenceLineDaoResponse = insertSomeOfficialReferenceLineFor(originalTrackNumber.id)
-        val originalReferenceLine = referenceLineDao.fetch(originalReferenceLineDaoResponse.rowVersion)
+        val originalTrackNumber =
+            layoutTrackNumberDao.insert(
+                trackNumber(trackNumber, description = "augh", externalId = null, draft = false))
+        val originalReferenceLineDaoResponse =
+            insertSomeOfficialReferenceLineFor(originalTrackNumber.id)
+        val originalReferenceLine =
+            referenceLineDao.fetch(originalReferenceLineDaoResponse.rowVersion)
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
         publishAndPush(trackNumbers = listOf(originalTrackNumber.id))
@@ -598,21 +634,21 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun shortenReferenceLine() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val originalTrackNumber = trackNumberService.saveDraft(
-            LayoutBranch.main,
-            trackNumber(trackNumber, description = "augh", externalId = null, draft = true)
-        )
-        val originalReferenceLineDaoResponse = referenceLineService.saveDraft(
-            LayoutBranch.main,
-            referenceLine(originalTrackNumber.id, draft = true),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
+        val originalTrackNumber =
+            trackNumberService.saveDraft(
+                LayoutBranch.main,
+                trackNumber(trackNumber, description = "augh", externalId = null, draft = true))
+        val originalReferenceLineDaoResponse =
+            referenceLineService.saveDraft(
+                LayoutBranch.main,
+                referenceLine(originalTrackNumber.id, draft = true),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
         publishAndPush(
             trackNumbers = listOf(originalTrackNumber.id),
-            referenceLines = listOf(originalReferenceLineDaoResponse.id)
-        )
+            referenceLines = listOf(originalReferenceLineDaoResponse.id))
         fakeRatko.hasRouteNumber(ratkoRouteNumber("1.2.3.4.5"))
         referenceLineService.saveDraft(
             LayoutBranch.main,
@@ -621,9 +657,7 @@ class RatkoServiceIT @Autowired constructor(
                     referenceLineDao.fetchVersionByTrackNumberId(
                         MainLayoutContext.official,
                         originalTrackNumber.id,
-                    )!!
-                )
-            ),
+                    )!!)),
             alignment(segment(Point(0.0, 0.0), Point(5.0, 0.0))),
         )
         publishAndPush(referenceLines = listOf(originalReferenceLineDaoResponse.id))
@@ -636,44 +670,45 @@ class RatkoServiceIT @Autowired constructor(
             pushedPoints[0].take(4).map { p -> p.geometry?.coordinates },
             updatedPoints[0].map { p -> p.geometry?.coordinates },
         )
-        assertEquals(RatkoPointStates.VALID, pushedPoints[0].map { p -> p.state?.name }.distinct().single())
-        assertEquals(RatkoPointStates.VALID, updatedPoints[0].map { p -> p.state?.name }.distinct().single())
+        assertEquals(
+            RatkoPointStates.VALID, pushedPoints[0].map { p -> p.state?.name }.distinct().single())
+        assertEquals(
+            RatkoPointStates.VALID, updatedPoints[0].map { p -> p.state?.name }.distinct().single())
         assertEquals(listOf("0000"), deletions)
     }
 
     @Test
     fun changeReferenceLineGeometry() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val originalTrackNumber = trackNumberService.saveDraft(
-            LayoutBranch.main,
-            trackNumber(trackNumber, description = "augh", externalId = null, draft = true)
-        )
-        val originalReferenceLineDaoResponse = referenceLineService.saveDraft(
-            LayoutBranch.main,
-            referenceLine(originalTrackNumber.id, draft = true),
-            alignment(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(10.0, 0.0),
-                    Point(20.0, 1.0), // reference line has bump
-                    Point(30.0, 0.0),
-                    Point(40.0, 0.0),
-                )
-            ),
-        )
-        val locationTrackDaoResponse = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(originalTrackNumber.id, externalId = null, draft = true),
-            alignment(segment(Point(0.0, 0.0), Point(40.0, 0.0)))
-        )
+        val originalTrackNumber =
+            trackNumberService.saveDraft(
+                LayoutBranch.main,
+                trackNumber(trackNumber, description = "augh", externalId = null, draft = true))
+        val originalReferenceLineDaoResponse =
+            referenceLineService.saveDraft(
+                LayoutBranch.main,
+                referenceLine(originalTrackNumber.id, draft = true),
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(10.0, 0.0),
+                        Point(20.0, 1.0), // reference line has bump
+                        Point(30.0, 0.0),
+                        Point(40.0, 0.0),
+                    )),
+            )
+        val locationTrackDaoResponse =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(originalTrackNumber.id, externalId = null, draft = true),
+                alignment(segment(Point(0.0, 0.0), Point(40.0, 0.0))))
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.3.4.5.6")
         publishAndPush(
             trackNumbers = listOf(originalTrackNumber.id),
             referenceLines = listOf(originalReferenceLineDaoResponse.id),
-            locationTracks = listOf(locationTrackDaoResponse.id)
-        )
+            locationTracks = listOf(locationTrackDaoResponse.id))
         fakeRatko.hasRouteNumber(ratkoRouteNumber("1.2.3.4.5"))
         fakeRatko.hostPushedLocationTrack("2.3.4.5.6")
         referenceLineService.saveDraft(
@@ -683,20 +718,20 @@ class RatkoServiceIT @Autowired constructor(
                     referenceLineDao.fetchVersionByTrackNumberId(
                         MainLayoutContext.official,
                         originalTrackNumber.id,
-                    )!!
-                )
-            ),
+                    )!!)),
             alignment(segment(Point(0.0, 0.0), Point(40.0, 0.0))),
         )
         publishAndPush(
-            // not publishing a change to location track, but we want to update its points anyway due to reference line
+            // not publishing a change to location track, but we want to update its points anyway
+            // due to reference line
             // geometry change
             referenceLines = listOf(originalReferenceLineDaoResponse.id),
         )
         val deletedOnTrack = fakeRatko.getLocationTrackPointDeletions("2.3.4.5.6")
         val updatedOnTrack = fakeRatko.getUpdatedLocationTrackPoints("2.3.4.5.6")
         val createdOnTrack = fakeRatko.getCreatedLocationTrackPoints("2.3.4.5.6")
-        // bump in reference line was after 10 m, so the addresses of the first 9 points (separate of start point) on
+        // bump in reference line was after 10 m, so the addresses of the first 9 points (separate
+        // of start point) on
         // the track don't move, but the rest do
         assertEquals(40, createdOnTrack[0].size)
         assertEquals(39, updatedOnTrack[0].size)
@@ -716,20 +751,27 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun removeKmPostBeforeSwitch() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = layoutTrackNumberDao.insert(
-            trackNumber(trackNumber, description = "augh", externalId = Oid("1.1.1.1.1"), draft = false)
-        ).id
+        val trackNumberId =
+            layoutTrackNumberDao
+                .insert(
+                    trackNumber(
+                        trackNumber,
+                        description = "augh",
+                        externalId = Oid("1.1.1.1.1"),
+                        draft = false))
+                .id
         insertSomeOfficialReferenceLineFor(trackNumberId)
-        val kmPost1 = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumberId, KmNumber(1), Point(2.0, 0.0), draft = true)
-        )
-        val kmPost2 = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumberId, KmNumber(2), Point(4.0, 0.0), draft = true)
-        )
+        val kmPost1 =
+            kmPostService.saveDraft(
+                LayoutBranch.main,
+                kmPost(trackNumberId, KmNumber(1), Point(2.0, 0.0), draft = true))
+        val kmPost2 =
+            kmPostService.saveDraft(
+                LayoutBranch.main,
+                kmPost(trackNumberId, KmNumber(2), Point(4.0, 0.0), draft = true))
 
-        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumberId)
+        val (switch, throughTrack, branchingTrack) =
+            setupDraftSwitchAndLocationTracks(trackNumberId)
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
         fakeRatko.acceptsNewSwitchGivingItOid("3.4.5.6.7")
         fakeRatko.hasRouteNumber(ratkoRouteNumber("1.1.1.1.1"))
@@ -743,8 +785,7 @@ class RatkoServiceIT @Autowired constructor(
         kmPostService.saveDraft(
             LayoutBranch.main,
             asMainDraft(kmPostDao.getOrThrow(MainLayoutContext.official, kmPost2.id))
-                .copy(state = LayoutState.DELETED)
-        )
+                .copy(state = LayoutState.DELETED))
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::hostPushedLocationTrack)
         fakeRatko.hostPushedSwitch("3.4.5.6.7")
 
@@ -752,25 +793,30 @@ class RatkoServiceIT @Autowired constructor(
 
         val switchLocations = fakeRatko.getPushedSwitchLocations("3.4.5.6.7")
         // switch was originally after kmPost2, but it got removed and then we pushed again
-        assertEquals("0002+0001", switchLocations[0][0].nodecollection.nodes.first().point.kmM.toString())
-        assertEquals("0002+0003.5", switchLocations[0][1].nodecollection.nodes.first().point.kmM.toString())
-        assertEquals("0001+0003", switchLocations[1][0].nodecollection.nodes.first().point.kmM.toString())
-        assertEquals("0001+0005.5", switchLocations[1][1].nodecollection.nodes.first().point.kmM.toString())
+        assertEquals(
+            "0002+0001", switchLocations[0][0].nodecollection.nodes.first().point.kmM.toString())
+        assertEquals(
+            "0002+0003.5", switchLocations[0][1].nodecollection.nodes.first().point.kmM.toString())
+        assertEquals(
+            "0001+0003", switchLocations[1][0].nodecollection.nodes.first().point.kmM.toString())
+        assertEquals(
+            "0001+0005.5", switchLocations[1][1].nodecollection.nodes.first().point.kmM.toString())
     }
 
     @Test
     fun removeLocationTrackWithSwitch() {
         val trackNumber = establishedTrackNumber()
-        val kmPost1 = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true)
-        )
-        val kmPost2 = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true)
-        )
+        val kmPost1 =
+            kmPostService.saveDraft(
+                LayoutBranch.main,
+                kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true))
+        val kmPost2 =
+            kmPostService.saveDraft(
+                LayoutBranch.main,
+                kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true))
 
-        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+        val (switch, throughTrack, branchingTrack) =
+            setupDraftSwitchAndLocationTracks(trackNumber.id)
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
         fakeRatko.acceptsNewSwitchGivingItOid("3.4.5.6.7")
 
@@ -780,14 +826,16 @@ class RatkoServiceIT @Autowired constructor(
             kmPosts = listOf(kmPost1.id, kmPost2.id),
         )
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::hostPushedLocationTrack)
-        val officialThroughTrackVersion = locationTrackDao.fetchVersionOrThrow(
-            MainLayoutContext.official,
-            throughTrack.id,
-        )
+        val officialThroughTrackVersion =
+            locationTrackDao.fetchVersionOrThrow(
+                MainLayoutContext.official,
+                throughTrack.id,
+            )
         locationTrackService.saveDraft(
             LayoutBranch.main,
-            locationTrackDao.fetch(officialThroughTrackVersion).copy(state = LocationTrackState.DELETED)
-        )
+            locationTrackDao
+                .fetch(officialThroughTrackVersion)
+                .copy(state = LocationTrackState.DELETED))
         publishAndPush(locationTracks = listOf(throughTrack.id))
         val pushedSwitchLocations = fakeRatko.getPushedSwitchLocations("3.4.5.6.7")
         assertEquals(2, pushedSwitchLocations.size)
@@ -805,16 +853,17 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun modifySwitchJointPositionAccuracy() {
         val trackNumber = establishedTrackNumber()
-        val kmPost1 = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true)
-        )
-        val kmPost2 = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true)
-        )
+        val kmPost1 =
+            kmPostService.saveDraft(
+                LayoutBranch.main,
+                kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true))
+        val kmPost2 =
+            kmPostService.saveDraft(
+                LayoutBranch.main,
+                kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true))
 
-        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+        val (switch, throughTrack, branchingTrack) =
+            setupDraftSwitchAndLocationTracks(trackNumber.id)
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
         fakeRatko.acceptsNewSwitchGivingItOid("3.4.5.6.7")
 
@@ -826,16 +875,17 @@ class RatkoServiceIT @Autowired constructor(
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::hostPushedLocationTrack)
         fakeRatko.hostPushedSwitch("3.4.5.6.7")
 
-        val officialSwitchVersion = switchDao.fetchVersionOrThrow(MainLayoutContext.official, switch.id)
+        val officialSwitchVersion =
+            switchDao.fetchVersionOrThrow(MainLayoutContext.official, switch.id)
         val officialSwitch = switchDao.fetch(officialSwitchVersion)
         switchService.saveDraft(
             LayoutBranch.main,
             officialSwitch.copy(
-                joints = officialSwitch.joints.map { j ->
-                    j.copy(locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED)
-                },
-            )
-        )
+                joints =
+                    officialSwitch.joints.map { j ->
+                        j.copy(locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED)
+                    },
+            ))
         publishAndPush(switches = listOf(switch.id))
         val pushedSwitchGeoms = fakeRatko.getPushedSwitchGeometries("3.4.5.6.7")
         assertEquals(
@@ -852,31 +902,37 @@ class RatkoServiceIT @Autowired constructor(
     fun pushSwitch() {
         val trackNumber = establishedTrackNumber()
 
-        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+        val (switch, throughTrack, branchingTrack) =
+            setupDraftSwitchAndLocationTracks(trackNumber.id)
 
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
         fakeRatko.acceptsNewSwitchGivingItOid("3.4.5.6.7")
 
         publishAndPush(
             locationTracks = listOf(throughTrack.id, branchingTrack.id),
-            switches = listOf(switch.id)
-        )
+            switches = listOf(switch.id))
         val switchLocations = fakeRatko.getPushedSwitchLocations("3.4.5.6.7")[0]
         assertEquals(
             listOf(listOf(5f, 5f), listOf(7.5f)),
-            switchLocations.map { l -> l.nodecollection.nodes.map { p -> p.point.kmM.meters.toFloat() } },
+            switchLocations.map { l ->
+                l.nodecollection.nodes.map { p -> p.point.kmM.meters.toFloat() }
+            },
         )
         assertEquals(
-            listOf(listOf(RatkoNodeType.JOINT_A, RatkoNodeType.JOINT_C), listOf(RatkoNodeType.JOINT_C)),
+            listOf(
+                listOf(RatkoNodeType.JOINT_A, RatkoNodeType.JOINT_C),
+                listOf(RatkoNodeType.JOINT_C)),
             switchLocations.map { l -> l.nodecollection.nodes.map { n -> n.nodeType } },
         )
         assertEquals(
             listOf(listOf("1.2.3.4.5", "1.2.3.4.5"), listOf("2.3.4.5.6")),
-            switchLocations.map { push -> push.nodecollection.nodes.map { n -> n.point.locationtrack!!.toString() } }
-        )
+            switchLocations.map { push ->
+                push.nodecollection.nodes.map { n -> n.point.locationtrack!!.toString() }
+            })
         assertEquals(
             trackNumber.externalId.toString(),
-            switchLocations.map { s -> s.nodecollection.nodes.first().point.routenumber!!.toString() }
+            switchLocations
+                .map { s -> s.nodecollection.nodes.first().point.routenumber!!.toString() }
                 .distinct()
                 .single(),
         )
@@ -891,45 +947,64 @@ class RatkoServiceIT @Autowired constructor(
     fun moveSwitch() {
         val trackNumber = establishedTrackNumber()
 
-        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+        val (switch, throughTrack, branchingTrack) =
+            setupDraftSwitchAndLocationTracks(trackNumber.id)
 
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
         fakeRatko.acceptsNewSwitchGivingItOid("3.4.5.6.7")
 
         publishAndPush(
             locationTracks = listOf(throughTrack.id, branchingTrack.id),
-            switches = listOf(switch.id)
-        )
+            switches = listOf(switch.id))
         fakeRatko.hasSwitch(fakeRatko.getLastPushedSwitch("3.4.5.6.7"))
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::hostPushedLocationTrack)
 
         detachSwitchesFromTrack(throughTrack.id)
         detachSwitchesFromTrack(branchingTrack.id)
 
-        val differentThroughTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumber.id, externalId = null, draft = true),
-            alignment(
-                segment(Point(0.0, 10.0), Point(5.0, 10.0), switchId = switch.id, endJointNumber = JointNumber(1)),
-                segment(Point(5.0, 10.0), Point(10.0, 10.0), switchId = switch.id, startJointNumber = JointNumber(3)),
-            ),
-        )
-        val differentBranchingTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumber.id, externalId = null, draft = true),
-            alignment(
-                segment(Point(5.0, 10.0), Point(7.5, 10.5), switchId = switch.id, endJointNumber = JointNumber(3)),
-                segment(Point(7.5, 10.5), Point(10.0, 11.0), switchId = switch.id, startJointNumber = JointNumber(3))
-            ),
-        )
+        val differentThroughTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumber.id, externalId = null, draft = true),
+                alignment(
+                    segment(
+                        Point(0.0, 10.0),
+                        Point(5.0, 10.0),
+                        switchId = switch.id,
+                        endJointNumber = JointNumber(1)),
+                    segment(
+                        Point(5.0, 10.0),
+                        Point(10.0, 10.0),
+                        switchId = switch.id,
+                        startJointNumber = JointNumber(3)),
+                ),
+            )
+        val differentBranchingTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumber.id, externalId = null, draft = true),
+                alignment(
+                    segment(
+                        Point(5.0, 10.0),
+                        Point(7.5, 10.5),
+                        switchId = switch.id,
+                        endJointNumber = JointNumber(3)),
+                    segment(
+                        Point(7.5, 10.5),
+                        Point(10.0, 11.0),
+                        switchId = switch.id,
+                        startJointNumber = JointNumber(3))),
+            )
         listOf("4.4.4.4.4", "5.5.5.5.5").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
-        publishAndPush(locationTracks = listOf(differentThroughTrack.id, differentBranchingTrack.id))
+        publishAndPush(
+            locationTracks = listOf(differentThroughTrack.id, differentBranchingTrack.id))
         val switchLocations = fakeRatko.getPushedSwitchLocations("3.4.5.6.7")
 
-        val expectedNodeTypes = listOf(
-            listOf(RatkoNodeType.JOINT_A, RatkoNodeType.JOINT_C),
-            listOf(RatkoNodeType.JOINT_C),
-        )
+        val expectedNodeTypes =
+            listOf(
+                listOf(RatkoNodeType.JOINT_A, RatkoNodeType.JOINT_C),
+                listOf(RatkoNodeType.JOINT_C),
+            )
         assertEquals(
             listOf(expectedNodeTypes, expectedNodeTypes),
             switchLocations.map { push ->
@@ -954,16 +1029,17 @@ class RatkoServiceIT @Autowired constructor(
     @Test
     fun changeSwitchStateCategory() {
         val trackNumber = establishedTrackNumber()
-        val kmPost1 = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true)
-        )
-        val kmPost2 = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true)
-        )
+        val kmPost1 =
+            kmPostService.saveDraft(
+                LayoutBranch.main,
+                kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true))
+        val kmPost2 =
+            kmPostService.saveDraft(
+                LayoutBranch.main,
+                kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true))
 
-        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+        val (switch, throughTrack, branchingTrack) =
+            setupDraftSwitchAndLocationTracks(trackNumber.id)
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
         fakeRatko.acceptsNewSwitchGivingItOid("3.4.5.6.7")
 
@@ -973,87 +1049,127 @@ class RatkoServiceIT @Autowired constructor(
             kmPosts = listOf(kmPost1.id, kmPost2.id),
         )
         fakeRatko.hostPushedSwitch("3.4.5.6.7")
-        val officialSwitchVersion = switchDao.fetchVersionOrThrow(MainLayoutContext.official, switch.id)
+        val officialSwitchVersion =
+            switchDao.fetchVersionOrThrow(MainLayoutContext.official, switch.id)
         switchService.saveDraft(
             LayoutBranch.main,
-            switchDao.fetch(officialSwitchVersion).copy(stateCategory = LayoutStateCategory.FUTURE_EXISTING)
-        )
+            switchDao
+                .fetch(officialSwitchVersion)
+                .copy(stateCategory = LayoutStateCategory.FUTURE_EXISTING))
         publishAndPush(switches = listOf(switch.id))
         assertEquals(listOf<String>(), fakeRatko.getLocationTrackPointDeletions("1.2.3.4.5"))
         assertEquals(listOf<String>(), fakeRatko.getLocationTrackPointDeletions("2.3.4.5.6"))
-        assertEquals(listOf<List<RatkoPoint>>(), fakeRatko.getUpdatedLocationTrackPoints("1.2.3.4.5"))
-        assertEquals(listOf<List<RatkoPoint>>(), fakeRatko.getUpdatedLocationTrackPoints("2.3.4.5.6"))
+        assertEquals(
+            listOf<List<RatkoPoint>>(), fakeRatko.getUpdatedLocationTrackPoints("1.2.3.4.5"))
+        assertEquals(
+            listOf<List<RatkoPoint>>(), fakeRatko.getUpdatedLocationTrackPoints("2.3.4.5.6"))
         val pushedSwitch = fakeRatko.getLastPushedSwitch("3.4.5.6.7")
         assertEquals("FUTURE_EXISTING", pushedSwitch.state!!.category!!.name)
     }
 
     private fun setupDraftSwitchAndLocationTracks(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
-    ): Triple<LayoutDaoResponse<TrackLayoutSwitch>, LayoutDaoResponse<LocationTrack>, LayoutDaoResponse<LocationTrack>> {
-        val switch = switchService.saveDraft(
-            LayoutBranch.main,
-            switch(
-                seed = 123,
-                joints = listOf(
-                    switchJoint(124).copy(
-                        number = JointNumber(1),
-                        locationAccuracy = LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY,
-                    ),
-                    switchJoint(125).copy(
-                        number = JointNumber(3),
-                        locationAccuracy = LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY,
-                    ),
+    ): Triple<
+        LayoutDaoResponse<TrackLayoutSwitch>,
+        LayoutDaoResponse<LocationTrack>,
+        LayoutDaoResponse<LocationTrack>> {
+        val switch =
+            switchService.saveDraft(
+                LayoutBranch.main,
+                switch(
+                    seed = 123,
+                    joints =
+                        listOf(
+                            switchJoint(124)
+                                .copy(
+                                    number = JointNumber(1),
+                                    locationAccuracy =
+                                        LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY,
+                                ),
+                            switchJoint(125)
+                                .copy(
+                                    number = JointNumber(3),
+                                    locationAccuracy =
+                                        LocationAccuracy.OFFICIALLY_MEASURED_GEODETICALLY,
+                                ),
+                        ),
+                    draft = true,
+                ))
+        val throughTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, externalId = null, draft = true),
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(5.0, 0.0),
+                        switchId = switch.id,
+                        endJointNumber = JointNumber(1)),
+                    segment(
+                        Point(5.0, 0.0),
+                        Point(10.0, 0.0),
+                        switchId = switch.id,
+                        startJointNumber = JointNumber(3)),
                 ),
-                draft = true,
             )
-        )
-        val throughTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, externalId = null, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(5.0, 0.0), switchId = switch.id, endJointNumber = JointNumber(1)),
-                segment(Point(5.0, 0.0), Point(10.0, 0.0), switchId = switch.id, startJointNumber = JointNumber(3)),
-            ),
-        )
-        val branchingTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumberId, externalId = null, draft = true),
-            alignment(
-                segment(Point(5.0, 0.0), Point(7.5, 0.5), switchId = switch.id, endJointNumber = JointNumber(3)),
-                segment(Point(7.5, 0.5), Point(10.0, 1.0), switchId = switch.id, startJointNumber = JointNumber(3)),
-            ),
-        )
+        val branchingTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumberId, externalId = null, draft = true),
+                alignment(
+                    segment(
+                        Point(5.0, 0.0),
+                        Point(7.5, 0.5),
+                        switchId = switch.id,
+                        endJointNumber = JointNumber(3)),
+                    segment(
+                        Point(7.5, 0.5),
+                        Point(10.0, 1.0),
+                        switchId = switch.id,
+                        startJointNumber = JointNumber(3)),
+                ),
+            )
 
         return Triple(switch, throughTrack, branchingTrack)
     }
 
     @Test
     fun linkKmPost() {
-        val trackNumber = layoutTrackNumberDao.insert(
-            trackNumber(testDBService.getUnusedTrackNumber(), externalId = null, draft = false)
-        )
+        val trackNumber =
+            layoutTrackNumberDao.insert(
+                trackNumber(testDBService.getUnusedTrackNumber(), externalId = null, draft = false))
         insertSomeOfficialReferenceLineFor(trackNumber.id)
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
         publishAndPush(trackNumbers = listOf(trackNumber.id))
         fakeRatko.hasRouteNumber(ratkoRouteNumber(id = "1.2.3.4.5"))
         val pushedPoints = fakeRatko.getCreatedRouteNumberPoints("1.2.3.4.5")
 
-        val kmPost = kmPostService.saveDraft(
-            LayoutBranch.main,
-            kmPost(trackNumber.id, KmNumber(1), roughLayoutLocation = Point(5.0, 0.0), draft = true),
-        )
+        val kmPost =
+            kmPostService.saveDraft(
+                LayoutBranch.main,
+                kmPost(
+                    trackNumber.id,
+                    KmNumber(1),
+                    roughLayoutLocation = Point(5.0, 0.0),
+                    draft = true),
+            )
         publishAndPush(kmPosts = listOf(kmPost.id))
         val deletions = fakeRatko.getRouteNumberPointDeletions("1.2.3.4.5")
         val updatedPoints = fakeRatko.getUpdatedRouteNumberPoints("1.2.3.4.5")
         assertEquals(listOf("0000", "0001"), deletions)
-        // km post was placed roughly at meter point, causing updated points' positions to move slightly due to
+        // km post was placed roughly at meter point, causing updated points' positions to move
+        // slightly due to
         // conversion from GK to layout coordinates
         pushedPoints.flatten().zip(updatedPoints.flatten()) { expected, actual ->
-            assertEquals(expected.geometry!!.coordinates[0], actual.geometry!!.coordinates[0], 0.000001)
-            assertEquals(expected.geometry!!.coordinates[1], actual.geometry!!.coordinates[1], 0.000001)
+            assertEquals(
+                expected.geometry!!.coordinates[0], actual.geometry!!.coordinates[0], 0.000001)
+            assertEquals(
+                expected.geometry!!.coordinates[1], actual.geometry!!.coordinates[1], 0.000001)
         }
-        assertEquals("0000", updatedPoints[0].map { p -> p.kmM.kmNumber.toString() }.distinct().single())
-        assertEquals("0001", updatedPoints[1].map { p -> p.kmM.kmNumber.toString() }.distinct().single())
+        assertEquals(
+            "0000", updatedPoints[0].map { p -> p.kmM.kmNumber.toString() }.distinct().single())
+        assertEquals(
+            "0001", updatedPoints[1].map { p -> p.kmM.kmNumber.toString() }.distinct().single())
     }
 
     @Test
@@ -1064,11 +1180,12 @@ class RatkoServiceIT @Autowired constructor(
             trackNumber.trackNumberObject.copy(state = LayoutState.DELETED),
         )
 
-        val originalLocationTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumber.id, draft = true),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
+        val originalLocationTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumber.id, draft = true),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
         val locationTrack = locationTrackDao.fetch(originalLocationTrack.rowVersion)
         locationTrackService.saveDraft(
             LayoutBranch.main,
@@ -1081,32 +1198,45 @@ class RatkoServiceIT @Autowired constructor(
             trackNumbers = listOf(trackNumber.id),
             locationTracks = listOf(originalLocationTrack.id),
         )
-        assertEquals(listOf(""), fakeRatko.getRouteNumberPointDeletions(trackNumber.externalId.toString()))
-        assertEquals(listOf(""), fakeRatko.getLocationTrackPointDeletions(locationTrack.externalId!!.toString()))
+        assertEquals(
+            listOf(""), fakeRatko.getRouteNumberPointDeletions(trackNumber.externalId.toString()))
+        assertEquals(
+            listOf(""),
+            fakeRatko.getLocationTrackPointDeletions(locationTrack.externalId!!.toString()))
     }
 
     @Test
     fun avoidPushingShortMetadata() {
         val trackNumber = establishedTrackNumber()
-        val plan = plan(
-            trackNumber.number,
-            LAYOUT_SRID,
-            // elements don't matter, only the names being different matters since that makes the metadatas distinct
-            geometryAlignment(elements = listOf(lineFromOrigin(1.0)), name = "foo"),
-            geometryAlignment(elements = listOf(lineFromOrigin(1.0)), name = "bar"),
-        )
+        val plan =
+            plan(
+                trackNumber.number,
+                LAYOUT_SRID,
+                // elements don't matter, only the names being different matters since that makes
+                // the metadatas distinct
+                geometryAlignment(elements = listOf(lineFromOrigin(1.0)), name = "foo"),
+                geometryAlignment(elements = listOf(lineFromOrigin(1.0)), name = "bar"),
+            )
         val fileContent = "<a></a>"
-        val planVersion = geometryDao.insertPlan(plan, InfraModelFile(plan.fileName, fileContent), null)
+        val planVersion =
+            geometryDao.insertPlan(plan, InfraModelFile(plan.fileName, fileContent), null)
         val planAlignments = geometryDao.fetchPlan(planVersion).alignments
 
-        val locationTrack = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack(trackNumber.id, externalId = null, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(5.0, 0.0), sourceId = planAlignments[0].elements[0].id),
-                segment(Point(5.0, 0.0), Point(5.6, 0.0), sourceId = planAlignments[1].elements[0].id),
-            ),
-        )
+        val locationTrack =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack(trackNumber.id, externalId = null, draft = true),
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(5.0, 0.0),
+                        sourceId = planAlignments[0].elements[0].id),
+                    segment(
+                        Point(5.0, 0.0),
+                        Point(5.6, 0.0),
+                        sourceId = planAlignments[1].elements[0].id),
+                ),
+            )
 
         fakeRatko.acceptsNewLocationTrackGivingItOid("1.2.3.4.5")
         publishAndPush(locationTracks = listOf(locationTrack.id))
@@ -1122,27 +1252,32 @@ class RatkoServiceIT @Autowired constructor(
         name: String,
         trackNumberOid: Oid<RatkoRouteNumber>,
         location: Point = Point(10.0, 10.0),
-    ) = RatkoOperatingPointParse(Oid(oid), name, name, name, OperationalPointType.LP, location, trackNumberOid)
+    ) =
+        RatkoOperatingPointParse(
+            Oid(oid), name, name, name, OperationalPointType.LP, location, trackNumberOid)
 
     @Test
     fun fetchAndFindOperatingPoints() {
-        val trackNumberId = trackNumberService.saveDraft(
-            LayoutBranch.main,
-            trackNumber(
-                testDBService.getUnusedTrackNumber(),
-                externalId = Oid("5.5.5.5.5"),
-                draft = true,
+        val trackNumberId =
+            trackNumberService
+                .saveDraft(
+                    LayoutBranch.main,
+                    trackNumber(
+                        testDBService.getUnusedTrackNumber(),
+                        externalId = Oid("5.5.5.5.5"),
+                        draft = true,
+                    ))
+                .id
+        val kannustamoOperatingPoint =
+            RatkoOperatingPointParse(
+                Oid("1.2.3.4.5"),
+                "Kannustamo",
+                "KST",
+                "KST-123",
+                OperationalPointType.LPO,
+                Point(100.0, 100.0),
+                Oid("5.5.5.5.5"),
             )
-        ).id
-        val kannustamoOperatingPoint = RatkoOperatingPointParse(
-            Oid("1.2.3.4.5"),
-            "Kannustamo",
-            "KST",
-            "KST-123",
-            OperationalPointType.LPO,
-            Point(100.0, 100.0),
-            Oid("5.5.5.5.5"),
-        )
         fakeRatko.hasOperatingPoints(
             listOf(
                 operatingPoint(
@@ -1152,10 +1287,10 @@ class RatkoServiceIT @Autowired constructor(
                     location = Point(10.0, 10.0),
                 ),
                 kannustamoOperatingPoint,
-            )
-        )
+            ))
         ratkoService.updateOperatingPointsFromRatko()
-        val pointsFromDatabase = ratkoLocalService.getOperatingPoints(boundingBoxAroundPoint(Point(95.0, 95.0), 10.0))
+        val pointsFromDatabase =
+            ratkoLocalService.getOperatingPoints(boundingBoxAroundPoint(Point(95.0, 95.0), 10.0))
         assertEquals(1, pointsFromDatabase.size)
         val point = pointsFromDatabase[0]
         assertEquals("1.2.3.4.5", point.externalId.toString())
@@ -1169,34 +1304,39 @@ class RatkoServiceIT @Autowired constructor(
 
     @Test
     fun updateOperatingPointsVersioning() {
-        trackNumberService.saveDraft(
-            LayoutBranch.main,
-            trackNumber(
-                testDBService.getUnusedTrackNumber(),
-                externalId = Oid("5.5.5.5.5"),
-                draft = true
-            )
-        ).id
+        trackNumberService
+            .saveDraft(
+                LayoutBranch.main,
+                trackNumber(
+                    testDBService.getUnusedTrackNumber(),
+                    externalId = Oid("5.5.5.5.5"),
+                    draft = true))
+            .id
         val turpeela = operatingPoint("1.2.3.4.6", "Turpeela", Oid("5.5.5.5.5"))
         val kannustamo = operatingPoint("1.2.3.4.5", "Kannustamo", Oid("5.5.5.5.5"))
         val liukuainen = operatingPoint("1.2.3.4.7", "Liukuainen", Oid("5.5.5.5.5"))
 
-        fakeRatko.hasOperatingPoints(
-            listOf(
-                turpeela, kannustamo, liukuainen
-            )
-        )
+        fakeRatko.hasOperatingPoints(listOf(turpeela, kannustamo, liukuainen))
         ratkoService.updateOperatingPointsFromRatko()
         fakeRatko.hasOperatingPoints(listOf(turpeela.copy(name = "Turpasauna"), liukuainen))
         ratkoService.updateOperatingPointsFromRatko()
-        assertTrue(jdbc.queryOne("""select deleted from layout.operating_point_version where name = 'Kannustamo' and version = 2""") { rs, _ ->
-            rs.getBoolean("deleted")
-        })
-        val pointsFromDatabase = ratkoLocalService.getOperatingPoints(boundingBoxAroundPoint(Point(10.0, 10.0), 10.0))
+        assertTrue(
+            jdbc.queryOne(
+                """select deleted from layout.operating_point_version where name = 'Kannustamo' and version = 2""") {
+                    rs,
+                    _ ->
+                    rs.getBoolean("deleted")
+                })
+        val pointsFromDatabase =
+            ratkoLocalService.getOperatingPoints(boundingBoxAroundPoint(Point(10.0, 10.0), 10.0))
         assertEquals(2, pointsFromDatabase.size)
-        assertEquals(listOf("Liukuainen", "Turpasauna"), pointsFromDatabase.map { it.name }.sorted())
-        assertEquals(5,
-            jdbc.queryOne("""select count(*) as c from layout.operating_point_version""") { rs, _ -> rs.getInt("c") })
+        assertEquals(
+            listOf("Liukuainen", "Turpasauna"), pointsFromDatabase.map { it.name }.sorted())
+        assertEquals(
+            5,
+            jdbc.queryOne("""select count(*) as c from layout.operating_point_version""") { rs, _ ->
+                rs.getInt("c")
+            })
     }
 
     @Test
@@ -1217,7 +1357,9 @@ class RatkoServiceIT @Autowired constructor(
         splitTestDataService.forcefullyFinishAllCurrentlyUnfinishedSplits(LayoutBranch.main)
 
         val splitId = splitTestDataService.insertSplit()
-        val publicationId = publicationDao.createPublication(LayoutBranch.main, "test: bulk transfer to in progress")
+        val publicationId =
+            publicationDao.createPublication(
+                LayoutBranch.main, "test: bulk transfer to in progress")
         splitDao.updateSplit(splitId = splitId, publicationId = publicationId)
 
         val someBulkTransferId = testDBService.getUnusedBulkTransferId()
@@ -1241,39 +1383,55 @@ class RatkoServiceIT @Autowired constructor(
         val someBulkTransferId = testDBService.getUnusedBulkTransferId()
 
         splitTestDataService.insertSplit().let { splitId ->
-            splitDao.updateSplit(
-                splitId = splitId,
-                publicationId = publicationDao.createPublication(LayoutBranch.main, "some in progress bulk transfer"),
-                bulkTransferState = BulkTransferState.IN_PROGRESS,
-                bulkTransferId = someBulkTransferId,
-            ).id
+            splitDao
+                .updateSplit(
+                    splitId = splitId,
+                    publicationId =
+                        publicationDao.createPublication(
+                            LayoutBranch.main, "some in progress bulk transfer"),
+                    bulkTransferState = BulkTransferState.IN_PROGRESS,
+                    bulkTransferId = someBulkTransferId,
+                )
+                .id
         }
 
-        val pendingSplitId = splitTestDataService.insertSplit().let { splitId ->
-            splitDao.updateSplit(
-                splitId = splitId,
-                publicationId = publicationDao.createPublication(LayoutBranch.main, "pending bulk transfer"),
-            ).id
-        }
+        val pendingSplitId =
+            splitTestDataService.insertSplit().let { splitId ->
+                splitDao
+                    .updateSplit(
+                        splitId = splitId,
+                        publicationId =
+                            publicationDao.createPublication(
+                                LayoutBranch.main, "pending bulk transfer"),
+                    )
+                    .id
+            }
 
-        fakeRatko.allowsBulkTransferStatePollingAndAnswersWithState(someBulkTransferId, BulkTransferState.IN_PROGRESS)
+        fakeRatko.allowsBulkTransferStatePollingAndAnswersWithState(
+            someBulkTransferId, BulkTransferState.IN_PROGRESS)
         ratkoService.manageRatkoBulkTransfers(LayoutBranch.main)
 
         val pendingSplitAfterBulkTransferProcessing = splitDao.getOrThrow(pendingSplitId)
         assertEquals(null, pendingSplitAfterBulkTransferProcessing.bulkTransferId)
-        assertEquals(BulkTransferState.PENDING, pendingSplitAfterBulkTransferProcessing.bulkTransferState)
+        assertEquals(
+            BulkTransferState.PENDING, pendingSplitAfterBulkTransferProcessing.bulkTransferState)
     }
 
     @Test
     fun `Temporary failed bulk transfer should be retried`() {
         splitTestDataService.forcefullyFinishAllCurrentlyUnfinishedSplits(LayoutBranch.main)
 
-        val splitId = splitTestDataService.insertSplit().let { splitId ->
-            splitDao.updateSplit(
-                splitId = splitId,
-                publicationId = publicationDao.createPublication(LayoutBranch.main, "pending bulk transfer"),
-            ).id
-        }
+        val splitId =
+            splitTestDataService.insertSplit().let { splitId ->
+                splitDao
+                    .updateSplit(
+                        splitId = splitId,
+                        publicationId =
+                            publicationDao.createPublication(
+                                LayoutBranch.main, "pending bulk transfer"),
+                    )
+                    .id
+            }
 
         val bulkTransferIdThatWillFail = testDBService.getUnusedBulkTransferId()
         fakeRatko.acceptsNewBulkTransferGivingItId(bulkTransferIdThatWillFail)
@@ -1281,7 +1439,8 @@ class RatkoServiceIT @Autowired constructor(
 
         val splitAfterFirstBulkTransferStart = splitDao.getOrThrow(splitId)
         assertEquals(bulkTransferIdThatWillFail, splitAfterFirstBulkTransferStart.bulkTransferId)
-        assertEquals(BulkTransferState.IN_PROGRESS, splitAfterFirstBulkTransferStart.bulkTransferState)
+        assertEquals(
+            BulkTransferState.IN_PROGRESS, splitAfterFirstBulkTransferStart.bulkTransferState)
 
         splitDao.updateSplit(
             splitId = splitId,
@@ -1293,22 +1452,30 @@ class RatkoServiceIT @Autowired constructor(
         ratkoService.manageRatkoBulkTransfers(LayoutBranch.main)
 
         val splitAfterSecondExpectedBulkTransferStart = splitDao.getOrThrow(splitId)
-        assertEquals(retriedBulkTransferId, splitAfterSecondExpectedBulkTransferStart.bulkTransferId)
-        assertEquals(BulkTransferState.IN_PROGRESS, splitAfterSecondExpectedBulkTransferStart.bulkTransferState)
+        assertEquals(
+            retriedBulkTransferId, splitAfterSecondExpectedBulkTransferStart.bulkTransferId)
+        assertEquals(
+            BulkTransferState.IN_PROGRESS,
+            splitAfterSecondExpectedBulkTransferStart.bulkTransferState)
     }
 
     @Test
     fun `Bulk transfer should be started on the earliest unfinished split`() {
         splitTestDataService.forcefullyFinishAllCurrentlyUnfinishedSplits(LayoutBranch.main)
 
-        val splitIds = (0..2).map { index ->
-            splitTestDataService.insertSplit().let { splitId ->
-                splitDao.updateSplit(
-                    splitId = splitId,
-                    publicationId = publicationDao.createPublication(LayoutBranch.main, "pending bulk transfer $index"),
-                ).id
+        val splitIds =
+            (0..2).map { index ->
+                splitTestDataService.insertSplit().let { splitId ->
+                    splitDao
+                        .updateSplit(
+                            splitId = splitId,
+                            publicationId =
+                                publicationDao.createPublication(
+                                    LayoutBranch.main, "pending bulk transfer $index"),
+                        )
+                        .id
+                }
             }
-        }
 
         val someBulkTransferId = testDBService.getUnusedBulkTransferId()
         fakeRatko.acceptsNewBulkTransferGivingItId(someBulkTransferId)
@@ -1316,34 +1483,37 @@ class RatkoServiceIT @Autowired constructor(
 
         val splitAfterSecondExpectedBulkTransferStart = splitDao.getOrThrow(splitIds[0])
         assertEquals(someBulkTransferId, splitAfterSecondExpectedBulkTransferStart.bulkTransferId)
-        assertEquals(BulkTransferState.IN_PROGRESS, splitAfterSecondExpectedBulkTransferStart.bulkTransferState)
+        assertEquals(
+            BulkTransferState.IN_PROGRESS,
+            splitAfterSecondExpectedBulkTransferStart.bulkTransferState)
     }
 
     @Test
     fun `Polling bulk transfer state updates should not change the state of any splits that are not in progress`() {
-        val splitsAndExpectedBulkTransferStates = BulkTransferState.entries
-            .filter { state -> state != BulkTransferState.IN_PROGRESS }
-            .map { bulkTransferState ->
-                val splitId = splitTestDataService.insertSplit()
+        val splitsAndExpectedBulkTransferStates =
+            BulkTransferState.entries
+                .filter { state -> state != BulkTransferState.IN_PROGRESS }
+                .map { bulkTransferState ->
+                    val splitId = splitTestDataService.insertSplit()
 
-                when (bulkTransferState) {
-                    BulkTransferState.PENDING ->
-                        splitDao.updateSplit(
-                            splitId = splitId,
-                            bulkTransferState = bulkTransferState
-                        )
+                    when (bulkTransferState) {
+                        BulkTransferState.PENDING ->
+                            splitDao.updateSplit(
+                                splitId = splitId, bulkTransferState = bulkTransferState)
 
-                    else ->
-                        splitDao.updateSplit(
-                            splitId = splitId,
-                            publicationId = publicationDao.createPublication(LayoutBranch.main, "testing $bulkTransferState"),
-                            bulkTransferId = testDBService.getUnusedBulkTransferId(),
-                            bulkTransferState = bulkTransferState,
-                        )
+                        else ->
+                            splitDao.updateSplit(
+                                splitId = splitId,
+                                publicationId =
+                                    publicationDao.createPublication(
+                                        LayoutBranch.main, "testing $bulkTransferState"),
+                                bulkTransferId = testDBService.getUnusedBulkTransferId(),
+                                bulkTransferState = bulkTransferState,
+                            )
+                    }
+
+                    splitId to bulkTransferState
                 }
-
-                splitId to bulkTransferState
-            }
 
         splitsAndExpectedBulkTransferStates.forEach { (splitId, _) ->
             val split = splitDao.getOrThrow(splitId)
@@ -1365,8 +1535,7 @@ class RatkoServiceIT @Autowired constructor(
                 trackNumberId,
                 segment(Point(0.0, 0.0), Point(10.0, 0.0)),
                 draft = false,
-            )
-        )
+            ))
     }
 
     private fun insertOfficialReferenceLineFromPair(
@@ -1379,9 +1548,10 @@ class RatkoServiceIT @Autowired constructor(
     private fun detachSwitchesFromTrack(locationTrackId: IntId<LocationTrack>) {
         val locationTrack = locationTrackDao.getOrThrow(MainLayoutContext.draft, locationTrackId)
         val alignment = alignmentDao.fetch(locationTrack.alignmentVersion!!)
-        val deSwitchedAlignment = alignment.copy(
-            segments = alignment.segments.map(LayoutSegment::withoutSwitch),
-        )
+        val deSwitchedAlignment =
+            alignment.copy(
+                segments = alignment.segments.map(LayoutSegment::withoutSwitch),
+            )
         locationTrackService.saveDraft(LayoutBranch.main, locationTrack, deSwitchedAlignment)
     }
 
@@ -1392,13 +1562,14 @@ class RatkoServiceIT @Autowired constructor(
         switches: List<IntId<TrackLayoutSwitch>> = listOf(),
         kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
     ) {
-        val ids = PublicationRequestIds(
-            trackNumbers = trackNumbers,
-            referenceLines = referenceLines,
-            locationTracks = locationTracks,
-            switches = switches,
-            kmPosts = kmPosts,
-        )
+        val ids =
+            PublicationRequestIds(
+                trackNumbers = trackNumbers,
+                referenceLines = referenceLines,
+                locationTracks = locationTracks,
+                switches = switches,
+                kmPosts = kmPosts,
+            )
         publicationService.updateExternalId(LayoutBranch.main, ids)
         val versions = publicationService.getValidationVersions(LayoutBranch.main, ids)
         val calculatedChanges = publicationService.getCalculatedChanges(versions)
@@ -1419,15 +1590,13 @@ class RatkoServiceIT @Autowired constructor(
     private fun establishedTrackNumber(oidString: String = "1.1.1.1.1"): EstablishedTrackNumber {
         val oid = Oid<TrackLayoutTrackNumber>(oidString)
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberDaoResponse = layoutTrackNumberDao.insert(
-            trackNumber(trackNumber, externalId = oid, draft = false)
-        )
+        val trackNumberDaoResponse =
+            layoutTrackNumberDao.insert(trackNumber(trackNumber, externalId = oid, draft = false))
         insertSomeOfficialReferenceLineFor(trackNumberDaoResponse.id)
         fakeRatko.hasRouteNumber(ratkoRouteNumber(oidString))
         return EstablishedTrackNumber(
             daoResponse = trackNumberDaoResponse,
             externalId = oid,
-            trackNumberObject = layoutTrackNumberDao.fetch(trackNumberDaoResponse.rowVersion)
-        )
+            trackNumberObject = layoutTrackNumberDao.fetch(trackNumberDaoResponse.rowVersion))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtilsTest.kt
@@ -2,8 +2,8 @@ package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.dataImport.switchStructures
 import fi.fta.geoviite.infra.switchLibrary.SwitchHand
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class RatkoUtilsTest {
 
@@ -16,18 +16,19 @@ class RatkoUtilsTest {
             } else {
                 assertEquals(ratkoFormat, switchStructure.type.toString().dropLast(2))
             }
-
         }
     }
 
     @Test
     fun `should format unique Ratko switch types from Geoviite types`() {
-        val ratkoTypes = switchStructures.mapNotNull { switchStructure ->
-            // Include non-left-handed switches only to pick only one of each YV/KV etc. switch type
-            if (switchStructure.type.parts.hand != SwitchHand.LEFT)
-                asSwitchTypeString(switchStructure.type)
-            else null
-        }
+        val ratkoTypes =
+            switchStructures.mapNotNull { switchStructure ->
+                // Include non-left-handed switches only to pick only one of each YV/KV etc. switch
+                // type
+                if (switchStructure.type.parts.hand != SwitchHand.LEFT)
+                    asSwitchTypeString(switchStructure.type)
+                else null
+            }
         assertEquals(ratkoTypes, ratkoTypes.distinct())
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/TestRatkoAsset.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/TestRatkoAsset.kt
@@ -3,10 +3,15 @@ package fi.fta.geoviite.infra.ratko
 import fi.fta.geoviite.infra.ratko.model.*
 
 /*
- Shadow clones of the parts of Ratko's API that we actually use, in the specific form that Ratko sends them, which can
- be fairly unlike our own Ratko-prefixed classes.
- */
-data class InterfaceRatkoGeometry(val type: RatkoGeometryType, val coordinates: List<Double>, val crs: RatkoCrs)
+Shadow clones of the parts of Ratko's API that we actually use, in the specific form that Ratko sends them, which can
+be fairly unlike our own Ratko-prefixed classes.
+*/
+data class InterfaceRatkoGeometry(
+    val type: RatkoGeometryType,
+    val coordinates: List<Double>,
+    val crs: RatkoCrs
+)
+
 data class InterfaceRatkoAssetGeometry(
     val geometryOriginal: InterfaceRatkoGeometry,
     val geomType: RatkoAssetGeometryType,
@@ -82,7 +87,8 @@ fun ratkoLocationTrack(
     state: RatkoLocationTrackState = RatkoLocationTrackState.IN_USE,
     rowMetadata: RatkoMetadata = RatkoMetadata(),
     duplicateOf: String? = null,
-    topologicalConnectivityType: RatkoTopologicalConnectivityType = RatkoTopologicalConnectivityType.NONE,
+    topologicalConnectivityType: RatkoTopologicalConnectivityType =
+        RatkoTopologicalConnectivityType.NONE,
 ) =
     InterfaceRatkoLocationTrack(
         id,
@@ -94,8 +100,7 @@ fun ratkoLocationTrack(
         state,
         rowMetadata,
         duplicateOf,
-        topologicalConnectivityType
-    )
+        topologicalConnectivityType)
 
 fun ratkoSwitch(
     oid: String,
@@ -109,5 +114,4 @@ fun ratkoSwitch(
         state = state,
         properties = properties,
         locations = locations,
-        assetGeoms = assetGeoms
-    )
+        assetGeoms = assetGeoms)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -9,19 +9,21 @@ import fi.fta.geoviite.infra.publication.PublicationDao
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.segment
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class SplitDaoIT @Autowired constructor(
+class SplitDaoIT
+@Autowired
+constructor(
     val splitDao: SplitDao,
     val publicationDao: PublicationDao,
 ) : DBTestBase() {
@@ -36,12 +38,15 @@ class SplitDaoIT @Autowired constructor(
 
         val relinkedSwitchId = mainOfficialContext.createSwitch().id
 
-        val split = splitDao.saveSplit(
-            sourceTrack.rowVersion,
-            listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
-            listOf(relinkedSwitchId),
-            updatedDuplicates = emptyList(),
-        ).let(splitDao::getOrThrow)
+        val split =
+            splitDao
+                .saveSplit(
+                    sourceTrack.rowVersion,
+                    listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
+                    listOf(relinkedSwitchId),
+                    updatedDuplicates = emptyList(),
+                )
+                .let(splitDao::getOrThrow)
 
         assertTrue { split.bulkTransferState == BulkTransferState.PENDING }
         assertNull(split.publicationId)
@@ -64,19 +69,26 @@ class SplitDaoIT @Autowired constructor(
 
         val relinkedSwitchId = mainOfficialContext.createSwitch().id
 
-        val split = splitDao.saveSplit(
-            sourceTrack.rowVersion,
-            listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
-            listOf(relinkedSwitchId),
-            updatedDuplicates = emptyList(),
-        ).let(splitDao::getOrThrow)
+        val split =
+            splitDao
+                .saveSplit(
+                    sourceTrack.rowVersion,
+                    listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
+                    listOf(relinkedSwitchId),
+                    updatedDuplicates = emptyList(),
+                )
+                .let(splitDao::getOrThrow)
 
         val publicationId = publicationDao.createPublication(LayoutBranch.main, "SPLIT PUBLICATION")
-        val updatedSplit = splitDao.updateSplit(
-            splitId = split.id,
-            bulkTransferState = BulkTransferState.FAILED,
-            publicationId = publicationId,
-        ).id.let(splitDao::getOrThrow)
+        val updatedSplit =
+            splitDao
+                .updateSplit(
+                    splitId = split.id,
+                    bulkTransferState = BulkTransferState.FAILED,
+                    publicationId = publicationId,
+                )
+                .id
+                .let(splitDao::getOrThrow)
 
         assertEquals(BulkTransferState.FAILED, updatedSplit.bulkTransferState)
         assertEquals(publicationId, updatedSplit.publicationId)
@@ -95,22 +107,26 @@ class SplitDaoIT @Autowired constructor(
         val relinkedSwitchId1 = mainOfficialContext.createSwitch().id
         val relinkedSwitchId2 = mainOfficialContext.createSwitch().id
 
-        val doneSplit = splitDao.saveSplit(
-            sourceTrack.rowVersion,
-            listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.CREATE)),
-            listOf(relinkedSwitchId1),
-            updatedDuplicates = emptyList(),
-        ).also { splitId ->
-            val split = splitDao.getOrThrow(splitId)
-            splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
-        }
+        val doneSplit =
+            splitDao
+                .saveSplit(
+                    sourceTrack.rowVersion,
+                    listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.CREATE)),
+                    listOf(relinkedSwitchId1),
+                    updatedDuplicates = emptyList(),
+                )
+                .also { splitId ->
+                    val split = splitDao.getOrThrow(splitId)
+                    splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)
+                }
 
-        val pendingSplitId = splitDao.saveSplit(
-            sourceTrack.rowVersion,
-            listOf(SplitTarget(targetTrack2.id, 0..0, SplitTargetOperation.CREATE)),
-            listOf(relinkedSwitchId2),
-            updatedDuplicates = emptyList(),
-        )
+        val pendingSplitId =
+            splitDao.saveSplit(
+                sourceTrack.rowVersion,
+                listOf(SplitTarget(targetTrack2.id, 0..0, SplitTargetOperation.CREATE)),
+                listOf(relinkedSwitchId2),
+                updatedDuplicates = emptyList(),
+            )
 
         val splits = splitDao.fetchUnfinishedSplits(LayoutBranch.main)
 
@@ -129,12 +145,12 @@ class SplitDaoIT @Autowired constructor(
 
         val relinkedSwitchId = mainOfficialContext.createSwitch().id
 
-        val splitId = splitDao.saveSplit(
-            sourceTrack.rowVersion,
-            listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.OVERWRITE)),
-            listOf(relinkedSwitchId),
-            updatedDuplicates = listOf(someDuplicateTrack.id)
-        )
+        val splitId =
+            splitDao.saveSplit(
+                sourceTrack.rowVersion,
+                listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.OVERWRITE)),
+                listOf(relinkedSwitchId),
+                updatedDuplicates = listOf(someDuplicateTrack.id))
 
         assertTrue { splitDao.fetchUnfinishedSplits(LayoutBranch.main).any { it.id == splitId } }
 
@@ -153,12 +169,13 @@ class SplitDaoIT @Autowired constructor(
 
         val relinkedSwitchId = mainOfficialContext.createSwitch().id
 
-        val splitId = splitDao.saveSplit(
-            sourceTrack.rowVersion,
-            listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.CREATE)),
-            listOf(relinkedSwitchId),
-            updatedDuplicates = emptyList(),
-        )
+        val splitId =
+            splitDao.saveSplit(
+                sourceTrack.rowVersion,
+                listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.CREATE)),
+                listOf(relinkedSwitchId),
+                updatedDuplicates = emptyList(),
+            )
 
         val splitHeader = splitDao.getSplitHeader(splitId)
         assertEquals(splitId, splitHeader.id)
@@ -187,21 +204,22 @@ class SplitDaoIT @Autowired constructor(
     @Test
     fun `Split bulk transfer state can be updated`() {
         val splitId = createSplit()
-        val publicationId = publicationDao.createPublication(LayoutBranch.main, "test: bulk transfer state update")
+        val publicationId =
+            publicationDao.createPublication(LayoutBranch.main, "test: bulk transfer state update")
 
         BulkTransferState.entries.forEach { newBulkTransferState ->
             when (newBulkTransferState) {
-                BulkTransferState.PENDING -> splitDao.updateSplit(
-                    splitId = splitId,
-                    bulkTransferState = newBulkTransferState
-                )
+                BulkTransferState.PENDING ->
+                    splitDao.updateSplit(
+                        splitId = splitId, bulkTransferState = newBulkTransferState)
 
-                else -> splitDao.updateSplit(
-                    splitId = splitId,
-                    publicationId = publicationId,
-                    bulkTransferState = newBulkTransferState,
-                    bulkTransferId = testDBService.getUnusedBulkTransferId(),
-                )
+                else ->
+                    splitDao.updateSplit(
+                        splitId = splitId,
+                        publicationId = publicationId,
+                        bulkTransferState = newBulkTransferState,
+                        bulkTransferId = testDBService.getUnusedBulkTransferId(),
+                    )
             }
             splitDao.updateSplit(splitId, bulkTransferState = newBulkTransferState)
             assertEquals(newBulkTransferState, splitDao.getOrThrow(splitId).bulkTransferState)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDomainTestData.kt
@@ -22,13 +22,14 @@ fun targetRequest(
     descriptionSuffix: DescriptionSuffixType = DescriptionSuffixType.SWITCH_TO_SWITCH,
     duplicateTrackId: IntId<LocationTrack>? = null,
     operation: SplitTargetDuplicateOperation = SplitTargetDuplicateOperation.OVERWRITE,
-): SplitRequestTarget = SplitRequestTarget(
-    duplicateTrack = duplicateTrackId?.let { id -> SplitRequestTargetDuplicate(id, operation) },
-    startAtSwitchId = startAtSwitchId,
-    name = AlignmentName(name),
-    descriptionBase = FreeText(descriptionBase),
-    descriptionSuffix = descriptionSuffix,
-)
+): SplitRequestTarget =
+    SplitRequestTarget(
+        duplicateTrack = duplicateTrackId?.let { id -> SplitRequestTargetDuplicate(id, operation) },
+        startAtSwitchId = startAtSwitchId,
+        name = AlignmentName(name),
+        descriptionBase = FreeText(descriptionBase),
+        descriptionSuffix = descriptionSuffix,
+    )
 
 fun targetParams(
     switchId: IntId<TrackLayoutSwitch>?,
@@ -39,22 +40,26 @@ fun targetParams(
     duplicate: Pair<LocationTrack, LayoutAlignment>? = null,
 ): SplitTargetParams {
     return SplitTargetParams(
-        startSwitch = if (switchId != null && switchJoint != null) {
-            SplitPointSwitch(switchId, switchJoint, SwitchName("S${switchId.intValue}"))
-        } else {
-            null
-        },
-        request = SplitRequestTarget(
-            duplicateTrack = (duplicate?.first?.id as? IntId)?.let { id ->
-                SplitRequestTargetDuplicate(id, SplitTargetDuplicateOperation.OVERWRITE)
+        startSwitch =
+            if (switchId != null && switchJoint != null) {
+                SplitPointSwitch(switchId, switchJoint, SwitchName("S${switchId.intValue}"))
+            } else {
+                null
             },
-            startAtSwitchId = switchId,
-            name = AlignmentName(name),
-            descriptionBase = FreeText(descriptionBase),
-            descriptionSuffix = descriptionSuffixType,
-        ),
-        duplicate = duplicate?.let { (track, alignment) ->
-            SplitTargetDuplicate(SplitTargetDuplicateOperation.OVERWRITE, track, alignment)
-        },
+        request =
+            SplitRequestTarget(
+                duplicateTrack =
+                    (duplicate?.first?.id as? IntId)?.let { id ->
+                        SplitRequestTargetDuplicate(id, SplitTargetDuplicateOperation.OVERWRITE)
+                    },
+                startAtSwitchId = switchId,
+                name = AlignmentName(name),
+                descriptionBase = FreeText(descriptionBase),
+                descriptionSuffix = descriptionSuffixType,
+            ),
+        duplicate =
+            duplicate?.let { (track, alignment) ->
+                SplitTargetDuplicate(SplitTargetDuplicateOperation.OVERWRITE, track, alignment)
+            },
     )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -23,6 +23,7 @@ import fi.fta.geoviite.infra.tracklayout.assertMatches
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -31,11 +32,12 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class SplitServiceIT @Autowired constructor(
+class SplitServiceIT
+@Autowired
+constructor(
     val splitService: SplitService,
     val splitDao: SplitDao,
     val switchDao: LayoutSwitchDao,
@@ -43,7 +45,8 @@ class SplitServiceIT @Autowired constructor(
     val locationTrackService: LocationTrackService,
     val splitTestDataService: SplitTestDataService,
 ) : DBTestBase() {
-    // The run order of the tests in this test suite matters if the database is not cleaned before each test.
+    // The run order of the tests in this test suite matters if the database is not cleaned before
+    // each test.
     // This gave false positive results for tests.
     //
     // This cleanup code can be removed after GVT-2484 has been implemented.
@@ -62,7 +65,8 @@ class SplitServiceIT @Autowired constructor(
 
         val preSegments = splitTestDataService.createSegments(Point(0.0, 0.0), 3)
 
-        // Segments that are a part of the first switch + the branching track for switch re-linking to work
+        // Segments that are a part of the first switch + the branching track for switch re-linking
+        // to work
         val (switch1, switchSegments1, turningSegments1) =
             splitTestDataService.createSwitchAndGeometry(lastPoint(preSegments))
 
@@ -70,7 +74,8 @@ class SplitServiceIT @Autowired constructor(
 
         val segments1To2 = splitTestDataService.createSegments(lastPoint(switchSegments1), 2)
 
-        // Segments that are a part of the second switch + the branching track for switch re-linking to work
+        // Segments that are a part of the second switch + the branching track for switch re-linking
+        // to work
         val (switch2, switchSegments2, turningSegments2) =
             splitTestDataService.createSwitchAndGeometry(lastPoint(segments1To2))
 
@@ -78,16 +83,17 @@ class SplitServiceIT @Autowired constructor(
 
         val postSegments = splitTestDataService.createSegments(lastPoint(switchSegments2), 4)
 
-        val track = splitTestDataService.createAsMainTrack(
-            preSegments + switchSegments1 + segments1To2 + switchSegments2 + postSegments
-        )
+        val track =
+            splitTestDataService.createAsMainTrack(
+                preSegments + switchSegments1 + segments1To2 + switchSegments2 + postSegments)
 
-        val request = splitRequest(
-            track.id,
-            targetRequest(null, "part1"),
-            targetRequest(switch1.id, "part2"),
-            targetRequest(switch2.id, "part3"),
-        )
+        val request =
+            splitRequest(
+                track.id,
+                targetRequest(null, "part1"),
+                targetRequest(switch1.id, "part2"),
+                targetRequest(switch2.id, "part3"),
+            )
         val result = splitDao.getOrThrow(splitService.split(LayoutBranch.main, request))
 
         assertSplitMatchesRequest(request, result)
@@ -96,7 +102,9 @@ class SplitServiceIT @Autowired constructor(
             assertTargetTrack(track, targetRequest, result.targetLocationTracks[index])
         }
 
-        assertEquals(LocationTrackState.DELETED, locationTrackService.get(MainLayoutContext.draft, track.id)?.state)
+        assertEquals(
+            LocationTrackState.DELETED,
+            locationTrackService.get(MainLayoutContext.draft, track.id)?.state)
     }
 
     @Test
@@ -109,37 +117,43 @@ class SplitServiceIT @Autowired constructor(
 
         val preSegments = splitTestDataService.createSegments(Point(0.0, 0.0), 3)
 
-        // Segments that are a part of the first switch + the branching track for switch re-linking to work
-        val (switch1, switchSegments1, turningSegments1) = splitTestDataService.createSwitchAndGeometry(lastPoint(preSegments))
+        // Segments that are a part of the first switch + the branching track for switch re-linking
+        // to work
+        val (switch1, switchSegments1, turningSegments1) =
+            splitTestDataService.createSwitchAndGeometry(lastPoint(preSegments))
         splitTestDataService.insertAsTrack(turningSegments1)
 
         val segments1To2 = splitTestDataService.createSegments(lastPoint(switchSegments1), 2)
 
-        // Segments that are a part of the second switch + the branching track for switch re-linking to work
-        val (switch2, switchSegments2, turningSegments2) = splitTestDataService.createSwitchAndGeometry(lastPoint(segments1To2))
+        // Segments that are a part of the second switch + the branching track for switch re-linking
+        // to work
+        val (switch2, switchSegments2, turningSegments2) =
+            splitTestDataService.createSwitchAndGeometry(lastPoint(segments1To2))
         splitTestDataService.insertAsTrack(turningSegments2)
 
         val postSegments = splitTestDataService.createSegments(lastPoint(switchSegments2), 4)
 
-        val track = splitTestDataService.createAsMainTrack(
-            preSegments + switchSegments1 + segments1To2 + switchSegments2 + postSegments
-        )
+        val track =
+            splitTestDataService.createAsMainTrack(
+                preSegments + switchSegments1 + segments1To2 + switchSegments2 + postSegments)
 
         // Create duplicates as completely separate of the original, as they're overwritten anyhow
-        val duplicate1 = splitTestDataService.insertAsTrack(
-            splitTestDataService.createSegments(Point(5.0, 5.0), 2), duplicateOf = track.id
-        )
+        val duplicate1 =
+            splitTestDataService.insertAsTrack(
+                splitTestDataService.createSegments(Point(5.0, 5.0), 2), duplicateOf = track.id)
 
-        val duplicate2 = splitTestDataService.insertAsTrack(
-            splitTestDataService.createSegments(Point(15.0, 15.0), 5), duplicateOf = track.id
-        )
+        val duplicate2 =
+            splitTestDataService.insertAsTrack(
+                splitTestDataService.createSegments(Point(15.0, 15.0), 5), duplicateOf = track.id)
 
-        val request = splitRequest(
-            track.id,
-            targetRequest(null, "part1", duplicateTrackId = duplicate1, operation = OVERWRITE),
-            targetRequest(switch1.id, "part2", duplicateTrackId = duplicate2, operation = OVERWRITE),
-            targetRequest(switch2.id, "part3"),
-        )
+        val request =
+            splitRequest(
+                track.id,
+                targetRequest(null, "part1", duplicateTrackId = duplicate1, operation = OVERWRITE),
+                targetRequest(
+                    switch1.id, "part2", duplicateTrackId = duplicate2, operation = OVERWRITE),
+                targetRequest(switch2.id, "part3"),
+            )
         val result = splitDao.getOrThrow(splitService.split(LayoutBranch.main, request))
 
         assertSplitMatchesRequest(request, result)
@@ -148,7 +162,9 @@ class SplitServiceIT @Autowired constructor(
             assertTargetTrack(track, targetRequest, result.targetLocationTracks[index])
         }
 
-        assertEquals(LocationTrackState.DELETED, locationTrackService.get(MainLayoutContext.draft, track.id)?.state)
+        assertEquals(
+            LocationTrackState.DELETED,
+            locationTrackService.get(MainLayoutContext.draft, track.id)?.state)
     }
 
     @Test
@@ -161,47 +177,55 @@ class SplitServiceIT @Autowired constructor(
 
         val preSegments = splitTestDataService.createSegments(Point(0.0, 0.0), 3)
 
-        // Segments that are a part of the first switch + the branching track for switch re-linking to work
-        val (switch1, switchSegments1, switchTurningSegments1) = splitTestDataService
-            .createSwitchAndGeometry(lastPoint(preSegments))
+        // Segments that are a part of the first switch + the branching track for switch re-linking
+        // to work
+        val (switch1, switchSegments1, switchTurningSegments1) =
+            splitTestDataService.createSwitchAndGeometry(lastPoint(preSegments))
         splitTestDataService.insertAsTrack(switchTurningSegments1)
 
         val segments1To2 = splitTestDataService.createSegments(lastPoint(switchSegments1), 2)
 
-        // Segments that are a part of the second switch + the branching track for switch re-linking to work
-        val (switch2, switchSegments2, switchTurningSegments2) = splitTestDataService
-            .createSwitchAndGeometry(lastPoint(segments1To2))
+        // Segments that are a part of the second switch + the branching track for switch re-linking
+        // to work
+        val (switch2, switchSegments2, switchTurningSegments2) =
+            splitTestDataService.createSwitchAndGeometry(lastPoint(segments1To2))
         splitTestDataService.insertAsTrack(switchTurningSegments2)
 
         val segments2To3 = splitTestDataService.createSegments(lastPoint(switchSegments2), 3)
 
-        // Segments that are a part of the second switch + the branching track for switch re-linking to work
-        val (_, switchSegments3, switchTurningSegments3) = splitTestDataService
-            .createSwitchAndGeometry(lastPoint(segments2To3))
+        // Segments that are a part of the second switch + the branching track for switch re-linking
+        // to work
+        val (_, switchSegments3, switchTurningSegments3) =
+            splitTestDataService.createSwitchAndGeometry(lastPoint(segments2To3))
         splitTestDataService.insertAsTrack(switchTurningSegments3)
 
         val postSegments = splitTestDataService.createSegments(lastPoint(switchSegments3), 4)
 
         // The main track goes from switch 1 to switch 3
-        val track = splitTestDataService.createAsMainTrack(
-            switchSegments1 + segments1To2 + switchSegments2 + segments2To3
-        )
+        val track =
+            splitTestDataService.createAsMainTrack(
+                switchSegments1 + segments1To2 + switchSegments2 + segments2To3)
         // Duplicate 1 starts before the main track and continues after the first switch
-        val duplicate1 = splitTestDataService.insertAsTrack(
-            segments = preSegments + switchSegments1 + segments1To2,
-            duplicateOf = track.id,
-        )
+        val duplicate1 =
+            splitTestDataService.insertAsTrack(
+                segments = preSegments + switchSegments1 + segments1To2,
+                duplicateOf = track.id,
+            )
         // Duplicate 2 starts from the second switch and continues beyond the main track
-        val duplicate2 = splitTestDataService.insertAsTrack(
-            segments = switchSegments2 + segments2To3 + switchSegments3 + postSegments,
-            duplicateOf = track.id,
-        )
+        val duplicate2 =
+            splitTestDataService.insertAsTrack(
+                segments = switchSegments2 + segments2To3 + switchSegments3 + postSegments,
+                duplicateOf = track.id,
+            )
 
-        val request = splitRequest(
-            track.id,
-            targetRequest(switch1.id, "part2", duplicateTrackId = duplicate1, operation = TRANSFER),
-            targetRequest(switch2.id, "part3", duplicateTrackId = duplicate2, operation = TRANSFER),
-        )
+        val request =
+            splitRequest(
+                track.id,
+                targetRequest(
+                    switch1.id, "part2", duplicateTrackId = duplicate1, operation = TRANSFER),
+                targetRequest(
+                    switch2.id, "part3", duplicateTrackId = duplicate2, operation = TRANSFER),
+            )
         val result = splitDao.getOrThrow(splitService.split(LayoutBranch.main, request))
 
         assertSplitMatchesRequest(request, result)
@@ -210,10 +234,13 @@ class SplitServiceIT @Autowired constructor(
             assertTransferTargetTrack(targetRequest, result.targetLocationTracks[index])
         }
 
-        assertEquals(LocationTrackState.DELETED, locationTrackService.get(MainLayoutContext.draft, track.id)?.state)
+        assertEquals(
+            LocationTrackState.DELETED,
+            locationTrackService.get(MainLayoutContext.draft, track.id)?.state)
     }
 
-    private fun lastPoint(segments: List<LayoutSegment>): IPoint = segments.last().segmentPoints.last()
+    private fun lastPoint(segments: List<LayoutSegment>): IPoint =
+        segments.last().segmentPoints.last()
 
     private fun assertSplitMatchesRequest(request: SplitRequest, split: Split) {
         assertEquals(request.sourceTrackId, split.sourceLocationTrackId)
@@ -236,21 +263,25 @@ class SplitServiceIT @Autowired constructor(
         // This assert is for TRANSFER only: use assertTargetTrack for other operations
         assertEquals(SplitTargetOperation.TRANSFER, request.getOperation())
 
-        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(
-            MainLayoutContext.draft,
-            response.locationTrackId,
-        )
-        val (originalTrack, originalAlignment) = locationTrackService.getWithAlignmentOrThrow(
-            MainLayoutContext.official,
-            response.locationTrackId,
-        )
+        val (track, alignment) =
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.draft,
+                response.locationTrackId,
+            )
+        val (originalTrack, originalAlignment) =
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.official,
+                response.locationTrackId,
+            )
 
         // TRANSFER operation should not change the duplicate track geometry or fields
         assertEquals(originalTrack.name, track.name)
         assertEquals(originalTrack.descriptionBase, track.descriptionBase)
         assertEquals(originalTrack.descriptionSuffix, track.descriptionSuffix)
         assertNull(track.duplicateOf)
-        request.startAtSwitchId?.let { startSwitchId -> assertEquals(startSwitchId, track.switchIds.first()) }
+        request.startAtSwitchId?.let { startSwitchId ->
+            assertEquals(startSwitchId, track.switchIds.first())
+        }
 
         assertMatches(originalAlignment, alignment)
     }
@@ -264,15 +295,20 @@ class SplitServiceIT @Autowired constructor(
         assertNotEquals(SplitTargetOperation.TRANSFER, request.getOperation())
 
         val (_, source) = locationTrackService.getWithAlignment(sourceResponse.rowVersion)
-        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, response.locationTrackId)
+        val (track, alignment) =
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.draft, response.locationTrackId)
 
         assertEquals(request.name, track.name)
         assertEquals(request.descriptionBase, track.descriptionBase)
         assertEquals(request.descriptionSuffix, track.descriptionSuffix)
         assertNull(track.duplicateOf)
-        request.startAtSwitchId?.let { startSwitchId -> assertEquals(startSwitchId, track.switchIds.first()) }
+        request.startAtSwitchId?.let { startSwitchId ->
+            assertEquals(startSwitchId, track.switchIds.first())
+        }
 
-        val sourceSegments = source.segments.subList(response.segmentIndices.first, response.segmentIndices.last + 1)
+        val sourceSegments =
+            source.segments.subList(response.segmentIndices.first, response.segmentIndices.last + 1)
 
         assertEquals(sourceSegments.size, alignment.segments.size)
         assertEquals(sourceSegments.sumOf { s -> s.length }, alignment.length, 0.001)
@@ -283,10 +319,11 @@ class SplitServiceIT @Autowired constructor(
         val splitId = insertSplitWithTwoTracks()
         val split = splitDao.getOrThrow(splitId)
 
-        val foundSplits = splitService.findUnfinishedSplits(
-            LayoutBranch.main,
-            locationTrackIds = listOf(split.sourceLocationTrackId),
-        )
+        val foundSplits =
+            splitService.findUnfinishedSplits(
+                LayoutBranch.main,
+                locationTrackIds = listOf(split.sourceLocationTrackId),
+            )
 
         assertEquals(splitId, foundSplits.first().id)
     }
@@ -296,10 +333,11 @@ class SplitServiceIT @Autowired constructor(
         val splitId = insertSplitWithTwoTracks()
         val split = splitDao.getOrThrow(splitId)
 
-        val foundSplits = splitService.findUnfinishedSplits(
-            LayoutBranch.main,
-            locationTrackIds = listOf(split.targetLocationTracks.first().locationTrackId),
-        )
+        val foundSplits =
+            splitService.findUnfinishedSplits(
+                LayoutBranch.main,
+                locationTrackIds = listOf(split.targetLocationTracks.first().locationTrackId),
+            )
 
         assertEquals(splitId, foundSplits.first().id)
     }
@@ -309,7 +347,8 @@ class SplitServiceIT @Autowired constructor(
         val splitId = insertSplitWithTwoTracks()
         val split = splitDao.getOrThrow(splitId)
 
-        val foundSplits = splitService.findUnfinishedSplits(LayoutBranch.main, switchIds = split.relinkedSwitches)
+        val foundSplits =
+            splitService.findUnfinishedSplits(LayoutBranch.main, switchIds = split.relinkedSwitches)
 
         assertEquals(splitId, foundSplits.first().id)
     }
@@ -322,98 +361,100 @@ class SplitServiceIT @Autowired constructor(
             alignment(segment(Point(-1000.0, 0.0), Point(1000.0, 0.0))),
         )
 
-        val switchStartPoints = listOf(
-            Point(100.0, 0.0),
-            Point(200.0, 0.0),
-            Point(300.0, 0.0),
-            Point(400.0, 0.0),
-            Point(500.0, 0.0),
-        )
+        val switchStartPoints =
+            listOf(
+                Point(100.0, 0.0),
+                Point(200.0, 0.0),
+                Point(300.0, 0.0),
+                Point(400.0, 0.0),
+                Point(500.0, 0.0),
+            )
 
-        val (
-            switchesAndSegments,
-            alignment
-        ) = alignmentWithMultipleSwitches(switchStartPoints)
+        val (switchesAndSegments, alignment) = alignmentWithMultipleSwitches(switchStartPoints)
 
         val sourceTrack = mainOfficialContext.insert(locationTrack(trackNumberId), alignment)
 
-        val duplicateIds = listOf(
-            mainOfficialContext.insert(
-                locationTrack(
-                    name = "Used duplicate between first and second switch",
-                    trackNumberId = trackNumberId,
-                    duplicateOf = sourceTrack.id,
-                ),
-                alignment(segment(Point(100.0, 0.0), Point(200.0, 0.0))),
-            ),
-
-            mainOfficialContext.insert(
-                locationTrack(
-                    name = "Unused dupe with full overlap",
-                    trackNumberId = trackNumberId,
-                    duplicateOf = sourceTrack.id,
-                ),
-                alignment(segment(Point(250.0, 0.0), Point(275.0, 0.0))),
-            ),
-
-            mainOfficialContext.insert(
-                locationTrack(
-                    name = "Unused dupe with partial overlap of two new tracks",
-                    trackNumberId = trackNumberId,
-                    duplicateOf = sourceTrack.id,
-                ),
-                alignment(segment(Point(275.0, 0.0), Point(350.0, 0.0))),
-            ),
-
-            mainOfficialContext.insert(
-                locationTrack(
-                    name = "Unused dupe with flipped partial overlap",
-                    trackNumberId = trackNumberId,
-                    duplicateOf = sourceTrack.id,
-                ),
-                alignment(segment(Point(370.0, 0.0), Point(410.0, 0.0))),
-            ),
-        ).map { daoResponse -> daoResponse.id }
-
-        val splitRequest = SplitRequest(
-            sourceTrack.id,
+        val duplicateIds =
             listOf(
-                targetRequest(
-                    null,
-                    "track start",
+                    mainOfficialContext.insert(
+                        locationTrack(
+                            name = "Used duplicate between first and second switch",
+                            trackNumberId = trackNumberId,
+                            duplicateOf = sourceTrack.id,
+                        ),
+                        alignment(segment(Point(100.0, 0.0), Point(200.0, 0.0))),
+                    ),
+                    mainOfficialContext.insert(
+                        locationTrack(
+                            name = "Unused dupe with full overlap",
+                            trackNumberId = trackNumberId,
+                            duplicateOf = sourceTrack.id,
+                        ),
+                        alignment(segment(Point(250.0, 0.0), Point(275.0, 0.0))),
+                    ),
+                    mainOfficialContext.insert(
+                        locationTrack(
+                            name = "Unused dupe with partial overlap of two new tracks",
+                            trackNumberId = trackNumberId,
+                            duplicateOf = sourceTrack.id,
+                        ),
+                        alignment(segment(Point(275.0, 0.0), Point(350.0, 0.0))),
+                    ),
+                    mainOfficialContext.insert(
+                        locationTrack(
+                            name = "Unused dupe with flipped partial overlap",
+                            trackNumberId = trackNumberId,
+                            duplicateOf = sourceTrack.id,
+                        ),
+                        alignment(segment(Point(370.0, 0.0), Point(410.0, 0.0))),
+                    ),
+                )
+                .map { daoResponse -> daoResponse.id }
+
+        val splitRequest =
+            SplitRequest(
+                sourceTrack.id,
+                listOf(
+                    targetRequest(
+                        null,
+                        "track start",
+                    ),
+                    targetRequest(
+                        switchesAndSegments.switchIds[0],
+                        "used dupe track between switch 0 and 1",
+                        duplicateTrackId = duplicateIds[0],
+                    ),
+                    targetRequest(
+                        switchesAndSegments.switchIds[1],
+                        "track with full dupe overlap after split",
+                    ),
+                    targetRequest(
+                        switchesAndSegments.switchIds[2],
+                        "track with partial dupe overlap after split",
+                    ),
+                    targetRequest(
+                        switchesAndSegments.switchIds[3],
+                        "track with flipped partial overlap",
+                    ),
+                    targetRequest(
+                        switchesAndSegments.switchIds[4],
+                        "track end",
+                    ),
                 ),
-                targetRequest(
-                    switchesAndSegments.switchIds[0],
-                    "used dupe track between switch 0 and 1",
-                    duplicateTrackId = duplicateIds[0],
-                ),
-                targetRequest(
-                    switchesAndSegments.switchIds[1],
-                    "track with full dupe overlap after split",
-                ),
-                targetRequest(
-                    switchesAndSegments.switchIds[2],
-                    "track with partial dupe overlap after split",
-                ),
-                targetRequest(
-                    switchesAndSegments.switchIds[3],
-                    "track with flipped partial overlap",
-                ),
-                targetRequest(
-                    switchesAndSegments.switchIds[4],
-                    "track end",
-                ),
-            ),
-        )
+            )
         val splitResult = splitDao.getOrThrow(splitService.split(LayoutBranch.main, splitRequest))
 
-        val usedDuplicateTrackAfterSplit = locationTrackService.getOrThrow(
-            MainLayoutContext.draft,
-            splitResult.targetLocationTracks[1].locationTrackId,
-        )
-        val unusedDuplicateFullyOverlappingNewTrack = locationTrackService.getOrThrow(MainLayoutContext.draft, duplicateIds[1])
-        val unusedDuplicatePartiallyOverlappingNewTrack = locationTrackService.getOrThrow(MainLayoutContext.draft, duplicateIds[2])
-        val unusedDuplicateWithFlippedPartialOverlap = locationTrackService.getOrThrow(MainLayoutContext.draft, duplicateIds[3])
+        val usedDuplicateTrackAfterSplit =
+            locationTrackService.getOrThrow(
+                MainLayoutContext.draft,
+                splitResult.targetLocationTracks[1].locationTrackId,
+            )
+        val unusedDuplicateFullyOverlappingNewTrack =
+            locationTrackService.getOrThrow(MainLayoutContext.draft, duplicateIds[1])
+        val unusedDuplicatePartiallyOverlappingNewTrack =
+            locationTrackService.getOrThrow(MainLayoutContext.draft, duplicateIds[2])
+        val unusedDuplicateWithFlippedPartialOverlap =
+            locationTrackService.getOrThrow(MainLayoutContext.draft, duplicateIds[3])
 
         assertEquals(null, usedDuplicateTrackAfterSplit.duplicateOf)
 
@@ -435,7 +476,10 @@ class SplitServiceIT @Autowired constructor(
     }
 
     private fun getYvStructure(): SwitchStructure =
-        requireNotNull(switchStructureDao.fetchSwitchStructures().find { s -> s.type.typeName == "YV60-300-1:9-O" })
+        requireNotNull(
+            switchStructureDao.fetchSwitchStructures().find { s ->
+                s.type.typeName == "YV60-300-1:9-O"
+            })
 
     private fun insertSplitWithTwoTracks(): IntId<Split> {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
@@ -444,15 +488,17 @@ class SplitServiceIT @Autowired constructor(
             alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
         )
 
-        val sourceTrack = mainOfficialContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
+        val sourceTrack =
+            mainOfficialContext.insert(
+                locationTrack(trackNumberId),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
 
-        val endTrack = mainOfficialContext.insert(
-            locationTrack(trackNumberId),
-            alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
-        )
+        val endTrack =
+            mainOfficialContext.insert(
+                locationTrack(trackNumberId),
+                alignment(segment(Point(5.0, 0.0), Point(10.0, 0.0))),
+            )
 
         val relinkedSwitchId = mainOfficialContext.createSwitch().id
 
@@ -474,51 +520,58 @@ class SplitServiceIT @Autowired constructor(
         startPoints: List<Point>,
         structure: SwitchStructure = getYvStructure(),
     ): Pair<SwitchesAndSegments, LayoutAlignment> {
-        val segmentsBeforeFirstSwitch = startPoints.first().toPoint().let { firstSwitchStart ->
-            listOf(
-                segment(
-                    Point(firstSwitchStart.x - 20.0, firstSwitchStart.y),
-                    Point(firstSwitchStart.x - 10.0, firstSwitchStart.y)
-                ),
-                segment(
-                    Point(firstSwitchStart.x - 10.0, firstSwitchStart.y),
-                    Point(firstSwitchStart.x, firstSwitchStart.y),
-                ),
-            )
-        }
-
-        val initialSwitchesAndSegments = SwitchesAndSegments(
-            segments = segmentsBeforeFirstSwitch,
-        )
-
-        return startPoints.zip(
-            startPoints.drop(1) + null
-        ).fold(initialSwitchesAndSegments) { switchesAndSegments, (startPoint, nextStartPoint) ->
-            val (switch, switchSegments, turningSegments) = splitTestDataService.createSwitchAndGeometry(startPoint, structure)
-            // For the switch relinking to have another track to find near the start of every switch.
-            splitTestDataService.insertAsTrack(turningSegments)
-
-            val switchEnd = switchSegments.last().segmentPoints.last()
-            val pointAfterSwitch = switchEnd + Point(10.0, startPoint.y)
-            val segmentAfterSwitch = segment(switchEnd, pointAfterSwitch)
-
-            val postSwitchSegments = nextStartPoint?.let { actualNextStartPoint ->
+        val segmentsBeforeFirstSwitch =
+            startPoints.first().toPoint().let { firstSwitchStart ->
                 listOf(
-                    segmentAfterSwitch,
-                    segment(pointAfterSwitch, actualNextStartPoint),
+                    segment(
+                        Point(firstSwitchStart.x - 20.0, firstSwitchStart.y),
+                        Point(firstSwitchStart.x - 10.0, firstSwitchStart.y)),
+                    segment(
+                        Point(firstSwitchStart.x - 10.0, firstSwitchStart.y),
+                        Point(firstSwitchStart.x, firstSwitchStart.y),
+                    ),
                 )
-            } ?: listOf(
-                segmentAfterSwitch,
-                segment(pointAfterSwitch, Point(pointAfterSwitch.x + 10.0, pointAfterSwitch.y)),
+            }
+
+        val initialSwitchesAndSegments =
+            SwitchesAndSegments(
+                segments = segmentsBeforeFirstSwitch,
             )
 
-            SwitchesAndSegments(
-                switchIds = switchesAndSegments.switchIds + switch.id,
-                switchStartPoints = switchesAndSegments.switchStartPoints + startPoint,
-                segments = switchesAndSegments.segments + switchSegments + postSwitchSegments
-            )
-        }.let { switchesAndSegments ->
-            switchesAndSegments to alignment(switchesAndSegments.segments)
-        }
+        return startPoints
+            .zip(startPoints.drop(1) + null)
+            .fold(initialSwitchesAndSegments) { switchesAndSegments, (startPoint, nextStartPoint) ->
+                val (switch, switchSegments, turningSegments) =
+                    splitTestDataService.createSwitchAndGeometry(startPoint, structure)
+                // For the switch relinking to have another track to find near the start of every
+                // switch.
+                splitTestDataService.insertAsTrack(turningSegments)
+
+                val switchEnd = switchSegments.last().segmentPoints.last()
+                val pointAfterSwitch = switchEnd + Point(10.0, startPoint.y)
+                val segmentAfterSwitch = segment(switchEnd, pointAfterSwitch)
+
+                val postSwitchSegments =
+                    nextStartPoint?.let { actualNextStartPoint ->
+                        listOf(
+                            segmentAfterSwitch,
+                            segment(pointAfterSwitch, actualNextStartPoint),
+                        )
+                    }
+                        ?: listOf(
+                            segmentAfterSwitch,
+                            segment(
+                                pointAfterSwitch,
+                                Point(pointAfterSwitch.x + 10.0, pointAfterSwitch.y)),
+                        )
+
+                SwitchesAndSegments(
+                    switchIds = switchesAndSegments.switchIds + switch.id,
+                    switchStartPoints = switchesAndSegments.switchStartPoints + startPoint,
+                    segments = switchesAndSegments.segments + switchSegments + postSwitchSegments)
+            }
+            .let { switchesAndSegments ->
+                switchesAndSegments to alignment(switchesAndSegments.segments)
+            }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
@@ -23,17 +23,21 @@ class SplitTest {
     @Test
     fun `minimal location track split works`() {
         val track = locationTrack(trackNumberId = IntId(123), draft = false)
-        val alignment = alignment(
-            linearSegment(0..1, switchId = null, startJoint = null, endJoint = null),
-            linearSegment(1..2, switchId = IntId(1), startJoint = 1, endJoint = 2),
-        )
-        val targets = listOf(
-            targetParams(null, null, "split1", "split desc 1"),
-            targetParams(IntId(1), JointNumber(1), "split2", "split desc 2"),
-        )
+        val alignment =
+            alignment(
+                linearSegment(0..1, switchId = null, startJoint = null, endJoint = null),
+                linearSegment(1..2, switchId = IntId(1), startJoint = 1, endJoint = 2),
+            )
+        val targets =
+            listOf(
+                targetParams(null, null, "split1", "split desc 1"),
+                targetParams(IntId(1), JointNumber(1), "split2", "split desc 2"),
+            )
         val resultTracks = splitLocationTrack(track, alignment, targets)
         assertEquals(targets.size, resultTracks.size)
-        resultTracks.forEachIndexed { index, result -> assertSplitResultFields(track, targets[index].request, result) }
+        resultTracks.forEachIndexed { index, result ->
+            assertSplitResultFields(track, targets[index].request, result)
+        }
         assertSegmentsMatch(alignment.segments.subList(0, 1), resultTracks[0].alignment)
         assertSegmentsMatch(alignment.segments.subList(1, 2), resultTracks[1].alignment)
     }
@@ -41,20 +45,25 @@ class SplitTest {
     @Test
     fun `location track split works when overriding existing duplicate`() {
         val track = locationTrack(trackNumberId = IntId(123), draft = false)
-        val alignment = alignment(
-            linearSegment(0..1, switchId = null, startJoint = null, endJoint = null),
-            linearSegment(1..2, switchId = IntId(1), startJoint = 1, endJoint = 2),
-        )
+        val alignment =
+            alignment(
+                linearSegment(0..1, switchId = null, startJoint = null, endJoint = null),
+                linearSegment(1..2, switchId = IntId(1), startJoint = 1, endJoint = 2),
+            )
         val dupTrack = locationTrack(trackNumberId = IntId(123), draft = false)
-        // over-large duplicate, but the geometry should be overridden anyhow, so just make it different
+        // over-large duplicate, but the geometry should be overridden anyhow, so just make it
+        // different
         val dupAlignment = alignment(linearSegment(-1..5))
-        val targets = listOf(
-            targetParams(null, null, name = "split1", duplicate = dupTrack to dupAlignment),
-            targetParams(IntId(1), JointNumber(1), "split2"),
-        )
+        val targets =
+            listOf(
+                targetParams(null, null, name = "split1", duplicate = dupTrack to dupAlignment),
+                targetParams(IntId(1), JointNumber(1), "split2"),
+            )
         val resultTracks = splitLocationTrack(track, alignment, targets)
         assertEquals(targets.size, resultTracks.size)
-        resultTracks.forEachIndexed { index, result -> assertSplitResultFields(track, targets[index].request, result) }
+        resultTracks.forEachIndexed { index, result ->
+            assertSplitResultFields(track, targets[index].request, result)
+        }
         assertEquals(dupTrack.id, resultTracks[0].locationTrack.id)
         assertEquals(dupTrack.externalId, resultTracks[0].locationTrack.externalId)
         assertSegmentsMatch(alignment.segments.subList(0, 1), resultTracks[0].alignment)
@@ -64,28 +73,38 @@ class SplitTest {
     @Test
     fun `complex location track split works`() {
         val track = locationTrack(trackNumberId = IntId(123), draft = false)
-        val alignment = alignment(
-            linearSegment(0..2, switchId = null, startJoint = null, endJoint = null),
-            linearSegment(2..5, switchId = IntId(1), startJoint = 5, endJoint = 4),
-            // Split point 1: id=1 & joint=4
-            linearSegment(5..6, switchId = IntId(1), startJoint = 4, endJoint = 3),
-            linearSegment(6..8, switchId = IntId(1), startJoint = 3, endJoint = 2),
-            linearSegment(8..9, switchId = IntId(1), startJoint = 2, endJoint = 1),
-            // Split point 2: id=2 & joint = 3
-            linearSegment(9..11, switchId = IntId(2), startJoint = 3, endJoint = 2),
-            linearSegment(11..12, switchId = IntId(3), startJoint = 5, endJoint = 2),
-            // Split point 3: id=3 & joint = 2 -- but it was mentioned only at the end of the previous
-            linearSegment(12..13, switchId = null, startJoint = null, endJoint = null),
-        )
-        val targets = listOf(
-            targetParams(null, null, "split1", "split desc 1", NONE),
-            targetParams(IntId(1), JointNumber(4), "split2", "split desc 2", SWITCH_TO_BUFFER),
-            targetParams(IntId(2), JointNumber(3), "split3", "split desc 3", SWITCH_TO_OWNERSHIP_BOUNDARY),
-            targetParams(IntId(3), JointNumber(2), "split4", "split desc 4", SWITCH_TO_SWITCH),
-        )
+        val alignment =
+            alignment(
+                linearSegment(0..2, switchId = null, startJoint = null, endJoint = null),
+                linearSegment(2..5, switchId = IntId(1), startJoint = 5, endJoint = 4),
+                // Split point 1: id=1 & joint=4
+                linearSegment(5..6, switchId = IntId(1), startJoint = 4, endJoint = 3),
+                linearSegment(6..8, switchId = IntId(1), startJoint = 3, endJoint = 2),
+                linearSegment(8..9, switchId = IntId(1), startJoint = 2, endJoint = 1),
+                // Split point 2: id=2 & joint = 3
+                linearSegment(9..11, switchId = IntId(2), startJoint = 3, endJoint = 2),
+                linearSegment(11..12, switchId = IntId(3), startJoint = 5, endJoint = 2),
+                // Split point 3: id=3 & joint = 2 -- but it was mentioned only at the end of the
+                // previous
+                linearSegment(12..13, switchId = null, startJoint = null, endJoint = null),
+            )
+        val targets =
+            listOf(
+                targetParams(null, null, "split1", "split desc 1", NONE),
+                targetParams(IntId(1), JointNumber(4), "split2", "split desc 2", SWITCH_TO_BUFFER),
+                targetParams(
+                    IntId(2),
+                    JointNumber(3),
+                    "split3",
+                    "split desc 3",
+                    SWITCH_TO_OWNERSHIP_BOUNDARY),
+                targetParams(IntId(3), JointNumber(2), "split4", "split desc 4", SWITCH_TO_SWITCH),
+            )
         val resultTracks = splitLocationTrack(track, alignment, targets)
         assertEquals(targets.size, resultTracks.size)
-        resultTracks.forEachIndexed { index, result -> assertSplitResultFields(track, targets[index].request, result) }
+        resultTracks.forEachIndexed { index, result ->
+            assertSplitResultFields(track, targets[index].request, result)
+        }
         assertSegmentsMatch(alignment.segments.subList(0, 2), resultTracks[0].alignment)
         assertSegmentsMatch(alignment.segments.subList(2, 5), resultTracks[1].alignment)
         assertSegmentsMatch(alignment.segments.subList(5, 7), resultTracks[2].alignment)
@@ -98,12 +117,13 @@ fun linearSegment(
     switchId: IntId<TrackLayoutSwitch>? = null,
     startJoint: Int? = null,
     endJoint: Int? = null,
-): LayoutSegment = segment(
-    points = points.map { value -> Point(value.toDouble(), 0.0) }.toTypedArray(),
-    switchId = switchId,
-    startJointNumber = startJoint?.let(::JointNumber),
-    endJointNumber = endJoint?.let(::JointNumber),
-)
+): LayoutSegment =
+    segment(
+        points = points.map { value -> Point(value.toDouble(), 0.0) }.toTypedArray(),
+        switchId = switchId,
+        startJointNumber = startJoint?.let(::JointNumber),
+        endJointNumber = endJoint?.let(::JointNumber),
+    )
 
 private fun assertSegmentsMatch(expectedSegments: List<LayoutSegment>, result: LayoutAlignment) {
     assertEquals(expectedSegments.size, result.segments.size)
@@ -116,7 +136,11 @@ private fun assertSegmentsMatch(expectedSegments: List<LayoutSegment>, result: L
     }
 }
 
-private fun assertSplitResultFields(track: LocationTrack, request: SplitRequestTarget, result: SplitTargetResult) {
+private fun assertSplitResultFields(
+    track: LocationTrack,
+    request: SplitRequestTarget,
+    result: SplitTargetResult
+) {
     assertEquals(track.trackNumberId, result.locationTrack.trackNumberId)
     assertEquals(track.type, result.locationTrack.type)
     assertEquals(track.state, result.locationTrack.state)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTestDataService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTestDataService.kt
@@ -22,9 +22,9 @@ import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.segmentsFromSwitchStructure
 import fi.fta.geoviite.infra.tracklayout.switchFromDbStructure
+import kotlin.test.assertEquals
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import kotlin.test.assertEquals
 
 data class SwitchAndSegments(
     val switch: LayoutDaoResponse<TrackLayoutSwitch>,
@@ -33,7 +33,9 @@ data class SwitchAndSegments(
 )
 
 @Service
-class SplitTestDataService @Autowired constructor(
+class SplitTestDataService
+@Autowired
+constructor(
     private val switchStructureDao: SwitchStructureDao,
     private val locationTrackService: LocationTrackService,
     private val splitDao: SplitDao,
@@ -41,7 +43,8 @@ class SplitTestDataService @Autowired constructor(
 ) : DBTestBase() {
 
     fun clearSplits() {
-        val sql = """
+        val sql =
+            """
         truncate publication.split cascade;
         truncate publication.split_version cascade;
         truncate publication.split_relinked_switch cascade;
@@ -50,22 +53,25 @@ class SplitTestDataService @Autowired constructor(
         truncate publication.split_target_location_track_version cascade;
         truncate publication.split_updated_duplicate cascade;
         truncate publication.split_updated_duplicate_version cascade;
-    """.trimIndent()
+    """
+                .trimIndent()
         jdbc.execute(sql) { it.execute() }
     }
 
     fun insertSplit(
-        trackNumberId: IntId<TrackLayoutTrackNumber> = mainOfficialContext.createLayoutTrackNumber().id,
+        trackNumberId: IntId<TrackLayoutTrackNumber> =
+            mainOfficialContext.createLayoutTrackNumber().id,
     ): IntId<Split> {
         val alignment = alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
 
-        val sourceTrack = mainDraftContext.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                state = LocationTrackState.DELETED,
-            ),
-            alignment,
-        )
+        val sourceTrack =
+            mainDraftContext.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    state = LocationTrackState.DELETED,
+                ),
+                alignment,
+            )
         val targetTrack = mainDraftContext.insert(locationTrack(trackNumberId), alignment)
 
         return splitDao.saveSplit(
@@ -81,22 +87,28 @@ class SplitTestDataService @Autowired constructor(
         structure: SwitchStructure = getYvStructure(),
         externalId: Oid<TrackLayoutSwitch>? = null,
     ): SwitchAndSegments {
-        val switchInsertResponse = mainOfficialContext.insert(
-            switchFromDbStructure(
-                testDBService.getUnusedSwitchName().toString(),
-                startPoint,
-                structure,
-                externalId = externalId?.toString(),
-            )
-        )
+        val switchInsertResponse =
+            mainOfficialContext.insert(
+                switchFromDbStructure(
+                    testDBService.getUnusedSwitchName().toString(),
+                    startPoint,
+                    structure,
+                    externalId = externalId?.toString(),
+                ))
         return SwitchAndSegments(
             switchInsertResponse,
-            segmentsFromSwitchStructure(startPoint, switchInsertResponse.id, structure, listOf(1, 5, 2)),
-            segmentsFromSwitchStructure(startPoint, switchInsertResponse.id, structure, listOf(1, 3)),
+            segmentsFromSwitchStructure(
+                startPoint, switchInsertResponse.id, structure, listOf(1, 5, 2)),
+            segmentsFromSwitchStructure(
+                startPoint, switchInsertResponse.id, structure, listOf(1, 3)),
         )
     }
 
-    fun createSegments(startPoint: IPoint, count: Int = 3, pointOffset: Double = 10.0): List<LayoutSegment> {
+    fun createSegments(
+        startPoint: IPoint,
+        count: Int = 3,
+        pointOffset: Double = 10.0
+    ): List<LayoutSegment> {
         return (0..<count).map { idx ->
             val start = startPoint + Point(idx * pointOffset, 0.0)
             val end = start + Point(pointOffset, 0.0)
@@ -107,18 +119,22 @@ class SplitTestDataService @Autowired constructor(
     fun insertAsTrack(
         segments: List<LayoutSegment>,
         duplicateOf: IntId<LocationTrack>? = null,
-        trackNumberId: IntId<TrackLayoutTrackNumber> = mainOfficialContext.createLayoutTrackNumber().id,
+        trackNumberId: IntId<TrackLayoutTrackNumber> =
+            mainOfficialContext.createLayoutTrackNumber().id,
     ): IntId<LocationTrack> {
         val alignment = alignment(segments)
-        return mainOfficialContext.insert(
-            locationTrack(trackNumberId = trackNumberId, duplicateOf = duplicateOf),
-            alignment,
-        ).id
+        return mainOfficialContext
+            .insert(
+                locationTrack(trackNumberId = trackNumberId, duplicateOf = duplicateOf),
+                alignment,
+            )
+            .id
     }
 
     fun createAsMainTrack(
         segments: List<LayoutSegment>,
-        trackNumberId: IntId<TrackLayoutTrackNumber> = mainOfficialContext.createLayoutTrackNumber().id,
+        trackNumberId: IntId<TrackLayoutTrackNumber> =
+            mainOfficialContext.createLayoutTrackNumber().id,
     ): LayoutDaoResponse<LocationTrack> {
         val alignment = alignment(segments)
         mainOfficialContext.insert(referenceLine(trackNumberId), alignment)
@@ -132,17 +148,19 @@ class SplitTestDataService @Autowired constructor(
     }
 
     fun getYvStructure(): SwitchStructure =
-        requireNotNull(switchStructureDao.fetchSwitchStructures().find { s -> s.type.typeName == "YV60-300-1:9-O" })
+        requireNotNull(
+            switchStructureDao.fetchSwitchStructures().find { s ->
+                s.type.typeName == "YV60-300-1:9-O"
+            })
 
     fun forcefullyFinishAllCurrentlyUnfinishedSplits(branch: LayoutBranch) {
         assertMainBranch(branch)
 
-        splitService.findUnfinishedSplits(branch)
-            .forEach { split ->
-                splitService.updateSplit(
-                    splitId = split.id,
-                    bulkTransferState = BulkTransferState.DONE,
-                )
-            }
+        splitService.findUnfinishedSplits(branch).forEach { split ->
+            splitService.updateSplit(
+                splitId = split.id,
+                bulkTransferState = BulkTransferState.DONE,
+            )
+        }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ElementListingFileDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ElementListingFileDaoIT.kt
@@ -2,21 +2,23 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.util.FileName
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class ElementListingFileDaoIT @Autowired constructor(
+class ElementListingFileDaoIT
+@Autowired
+constructor(
     private val elementListingFileDao: ElementListingFileDao,
-): DBTestBase() {
+) : DBTestBase() {
 
     @BeforeEach
     fun setUp() {
@@ -28,27 +30,31 @@ class ElementListingFileDaoIT @Autowired constructor(
         assertNull(elementListingFileDao.getElementListingFile())
         assertEquals(Instant.EPOCH, elementListingFileDao.getLastFileListingTime())
 
-        val originalFile = ElementListingFile(
-            name = FileName("test file name 1"),
-            content = """
+        val originalFile =
+            ElementListingFile(
+                name = FileName("test file name 1"),
+                content =
+                    """
                 col1, col2, col3
                 abc, def, ghi
                 123, 456, 789
-            """.trimIndent()
-        )
+            """
+                        .trimIndent())
         elementListingFileDao.upsertElementListingFile(originalFile)
         assertEquals(originalFile, elementListingFileDao.getElementListingFile())
         val originalChangeTime = elementListingFileDao.getLastFileListingTime()
         assertTrue(originalChangeTime > Instant.EPOCH)
 
-        val updatedFile = ElementListingFile(
-            name = FileName("new test file name 2"),
-            content = """
+        val updatedFile =
+            ElementListingFile(
+                name = FileName("new test file name 2"),
+                content =
+                    """
                 col1, col2, col3
                 abc2, def2, ghi2
                 something, else, here 
-            """.trimIndent()
-        )
+            """
+                        .trimIndent())
         elementListingFileDao.upsertElementListingFile(updatedFile)
         assertEquals(updatedFile, elementListingFileDao.getElementListingFile())
         val updatedChangeTime = elementListingFileDao.getLastFileListingTime()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
@@ -17,6 +17,7 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoints
 import fi.fta.geoviite.infra.util.getIntId
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -27,11 +28,12 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutAlignmentDaoIT @Autowired constructor(
+class LayoutAlignmentDaoIT
+@Autowired
+constructor(
     private val referenceLineDao: ReferenceLineDao,
     private val locationTrackDao: LocationTrackDao,
     private val alignmentDao: LayoutAlignmentDao,
@@ -46,12 +48,16 @@ class LayoutAlignmentDaoIT @Autowired constructor(
 
     @Test
     fun alignmentsAreStoredAndLoadedOk() {
-        (0..20).map { seed -> alignmentWithZAndCant(seed) }.forEach { alignment -> insertAndVerify(alignment) }
+        (0..20)
+            .map { seed -> alignmentWithZAndCant(seed) }
+            .forEach { alignment -> insertAndVerify(alignment) }
     }
 
     @Test
     fun alignmentsWithoutProfileOrCantIsStoredAndLoadedOk() {
-        (0..20).map { alignmentSeed -> alignmentWithoutZAndCant(alignmentSeed) }.forEach { a -> insertAndVerify(a) }
+        (0..20)
+            .map { alignmentSeed -> alignmentWithoutZAndCant(alignmentSeed) }
+            .forEach { a -> insertAndVerify(a) }
     }
 
     @Test
@@ -110,8 +116,7 @@ class LayoutAlignmentDaoIT @Autowired constructor(
                 alignment = alignmentLocationTrack,
                 alignmentVersion = locationTrackAlignmentVersion,
                 draft = false,
-            )
-        )
+            ))
         val referenceLineAlignmentVersion = alignmentDao.insert(alignmentReferenceLine)
         referenceLineDao.insert(
             referenceLine(
@@ -119,8 +124,7 @@ class LayoutAlignmentDaoIT @Autowired constructor(
                 alignment = alignmentReferenceLine,
                 alignmentVersion = referenceLineAlignmentVersion,
                 draft = false,
-            )
-        )
+            ))
 
         val orphanAlignmentBeforeDelete = alignmentDao.fetch(orphanAlignmentVersion)
         assertMatches(alignmentOrphan, orphanAlignmentBeforeDelete)
@@ -137,51 +141,53 @@ class LayoutAlignmentDaoIT @Autowired constructor(
 
     @Test
     fun mixedNullsInHeightAndCantWork() {
-        val points = listOf(
-            SegmentPoint(
-                x = 10.0,
-                y = 20.0,
-                z = 1.0,
-                cant = 0.1,
-                m = 0.0,
-            ),
-            SegmentPoint(
-                x = 10.0,
-                y = 21.0,
-                z = null,
-                cant = null,
-                m = 1.0,
-            ),
-            SegmentPoint(
-                x = 10.0,
-                y = 22.0,
-                z = 1.5,
-                cant = 0.2,
-                m = 2.0,
-            ),
-        )
+        val points =
+            listOf(
+                SegmentPoint(
+                    x = 10.0,
+                    y = 20.0,
+                    z = 1.0,
+                    cant = 0.1,
+                    m = 0.0,
+                ),
+                SegmentPoint(
+                    x = 10.0,
+                    y = 21.0,
+                    z = null,
+                    cant = null,
+                    m = 1.0,
+                ),
+                SegmentPoint(
+                    x = 10.0,
+                    y = 22.0,
+                    z = 1.5,
+                    cant = 0.2,
+                    m = 2.0,
+                ),
+            )
         val alignment = alignment(segment(points))
         val version = alignmentDao.insert(alignment)
         val fromDb = alignmentDao.fetch(version)
         assertEquals(1, fromDb.segments.size)
         assertEquals(points, fromDb.segments[0].segmentPoints)
 
-        val points2 = listOf(
-            SegmentPoint(
-                x = 11.0,
-                y = 22.0,
-                z = 1.0,
-                cant = null,
-                m = 0.0,
-            ),
-            SegmentPoint(
-                x = 11.0,
-                y = 23.0,
-                z = null,
-                cant = 0.3,
-                m = 1.0,
-            ),
-        )
+        val points2 =
+            listOf(
+                SegmentPoint(
+                    x = 11.0,
+                    y = 22.0,
+                    z = 1.0,
+                    cant = null,
+                    m = 0.0,
+                ),
+                SegmentPoint(
+                    x = 11.0,
+                    y = 23.0,
+                    z = null,
+                    cant = 0.3,
+                    m = 1.0,
+                ),
+            )
 
         val updatedVersion = alignmentDao.update(fromDb.copy(segments = listOf(segment(points2))))
         val updatedFromDb = alignmentDao.fetch(updatedVersion)
@@ -199,32 +205,39 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         val points5 = arrayOf(Point(10.0, 14.0), Point(10.0, 15.0))
 
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val planVersion = geometryDao.insertPlan(
-            plan = plan(
-                trackNumber = trackNumber,
-                alignments = listOf(
-                    geometryAlignment(
-                        name = "test-alignment-name",
-                        elements = listOf(line(Point(1.0, 1.0), Point(3.0, 3.0))),
-                    )
-                ),
-            ),
-            file = infraModelFile("testfile.xml"),
-            boundingBoxInLayoutCoordinates = null,
-        )
+        val planVersion =
+            geometryDao.insertPlan(
+                plan =
+                    plan(
+                        trackNumber = trackNumber,
+                        alignments =
+                            listOf(
+                                geometryAlignment(
+                                    name = "test-alignment-name",
+                                    elements = listOf(line(Point(1.0, 1.0), Point(3.0, 3.0))),
+                                )),
+                    ),
+                file = infraModelFile("testfile.xml"),
+                boundingBoxInLayoutCoordinates = null,
+            )
         val plan = geometryDao.fetchPlan(planVersion)
         val geometryAlignment = plan.alignments.first()
         val geometryElement = geometryAlignment.elements.first()
-        val alignment = alignment(
-            segment(points = points, source = GeometrySource.PLAN, sourceId = geometryElement.id),
-            segment(points = points2, source = GeometrySource.PLAN, sourceId = geometryElement.id),
-            segment(points = points3, source = GeometrySource.GENERATED),
-            segment(points = points4, source = GeometrySource.GENERATED),
-            segment(points = points5, source = GeometrySource.PLAN, sourceId = geometryElement.id),
-        )
+        val alignment =
+            alignment(
+                segment(
+                    points = points, source = GeometrySource.PLAN, sourceId = geometryElement.id),
+                segment(
+                    points = points2, source = GeometrySource.PLAN, sourceId = geometryElement.id),
+                segment(points = points3, source = GeometrySource.GENERATED),
+                segment(points = points4, source = GeometrySource.GENERATED),
+                segment(
+                    points = points5, source = GeometrySource.PLAN, sourceId = geometryElement.id),
+            )
         val version = alignmentDao.insert(alignment)
 
-        val segmentGeometriesAndPlanMetadatas = alignmentDao.fetchSegmentGeometriesAndPlanMetadata(version, null, null)
+        val segmentGeometriesAndPlanMetadatas =
+            alignmentDao.fetchSegmentGeometriesAndPlanMetadata(version, null, null)
         assertEquals(3, segmentGeometriesAndPlanMetadatas.size)
 
         assertApproximatelyEquals(points.first(), segmentGeometriesAndPlanMetadatas[0].startPoint!!)
@@ -234,14 +247,16 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         assertEquals(plan.fileName, segmentGeometriesAndPlanMetadatas[0].fileName)
         assertEquals(geometryAlignment.name, segmentGeometriesAndPlanMetadatas[0].alignmentName)
 
-        assertApproximatelyEquals(points3.first(), segmentGeometriesAndPlanMetadatas[1].startPoint!!)
+        assertApproximatelyEquals(
+            points3.first(), segmentGeometriesAndPlanMetadatas[1].startPoint!!)
         assertApproximatelyEquals(points4.last(), segmentGeometriesAndPlanMetadatas[1].endPoint!!)
         assertEquals(false, segmentGeometriesAndPlanMetadatas[1].isLinked)
         assertEquals(null, segmentGeometriesAndPlanMetadatas[1].planId)
         assertEquals(null, segmentGeometriesAndPlanMetadatas[1].fileName)
         assertEquals(null, segmentGeometriesAndPlanMetadatas[1].alignmentName)
 
-        assertApproximatelyEquals(points5.first(), segmentGeometriesAndPlanMetadatas[2].startPoint!!)
+        assertApproximatelyEquals(
+            points5.first(), segmentGeometriesAndPlanMetadatas[2].startPoint!!)
         assertApproximatelyEquals(points5.last(), segmentGeometriesAndPlanMetadatas[2].endPoint!!)
         assertEquals(true, segmentGeometriesAndPlanMetadatas[2].isLinked)
         assertEquals(planVersion.id, segmentGeometriesAndPlanMetadatas[2].planId)
@@ -258,58 +273,70 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         val points5 = arrayOf(Point(10.0, 14.0), Point(10.0, 15.0))
 
         val (trackNumber, trackNumberId) = mainOfficialContext.createTrackNumberAndId()
-        val planVersion = geometryDao.insertPlan(
-            plan = plan(
-                trackNumber = trackNumber,
-                alignments = listOf(
-                    geometryAlignment(
-                        name = "test-alignment-name",
-                        elements = listOf(line(Point(1.0, 1.0), Point(3.0, 3.0))),
-                    )
-                ),
-                coordinateSystemName = CoordinateSystemName("testcrs"),
-                verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
-            ),
-            file = infraModelFile("testfile.xml"),
-            boundingBoxInLayoutCoordinates = null,
-        )
+        val planVersion =
+            geometryDao.insertPlan(
+                plan =
+                    plan(
+                        trackNumber = trackNumber,
+                        alignments =
+                            listOf(
+                                geometryAlignment(
+                                    name = "test-alignment-name",
+                                    elements = listOf(line(Point(1.0, 1.0), Point(3.0, 3.0))),
+                                )),
+                        coordinateSystemName = CoordinateSystemName("testcrs"),
+                        verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
+                    ),
+                file = infraModelFile("testfile.xml"),
+                boundingBoxInLayoutCoordinates = null,
+            )
         val plan = geometryDao.fetchPlan(planVersion)
         val geometryAlignment = plan.alignments.first()
         val geometryElement = geometryAlignment.elements.first()
 
-        val planVersionWithoutCrs = geometryDao.insertPlan(
-            plan = plan(
-                trackNumber = trackNumber,
-                alignments = listOf(
-                    geometryAlignment(
-                        name = "test-alignment-name-2",
-                        elements = listOf(line(Point(1.0, 1.0), Point(3.0, 3.0))),
-                    )
-                ),
-                coordinateSystemName = null,
-                verticalCoordinateSystem = null,
-            ),
-            file = infraModelFile("testfile2.xml"),
-            boundingBoxInLayoutCoordinates = null,
-        )
+        val planVersionWithoutCrs =
+            geometryDao.insertPlan(
+                plan =
+                    plan(
+                        trackNumber = trackNumber,
+                        alignments =
+                            listOf(
+                                geometryAlignment(
+                                    name = "test-alignment-name-2",
+                                    elements = listOf(line(Point(1.0, 1.0), Point(3.0, 3.0))),
+                                )),
+                        coordinateSystemName = null,
+                        verticalCoordinateSystem = null,
+                    ),
+                file = infraModelFile("testfile2.xml"),
+                boundingBoxInLayoutCoordinates = null,
+            )
         val planWithoutCrs = geometryDao.fetchPlan(planVersionWithoutCrs)
         val geometryAlignmentWithoutCrs = planWithoutCrs.alignments.first()
         val geometryElementWithoutCrs = geometryAlignmentWithoutCrs.elements.first()
 
-        val alignment = alignment(
-            segment(points = points, source = GeometrySource.PLAN, sourceId = geometryElement.id),
-            segment(points = points2, source = GeometrySource.IMPORTED),
-            segment(points = points3, source = GeometrySource.GENERATED),
-            segment(points = points4, source = GeometrySource.PLAN, sourceId = geometryElementWithoutCrs.id),
-            segment(points = points5, source = GeometrySource.PLAN, sourceId = geometryElement.id),
-        )
+        val alignment =
+            alignment(
+                segment(
+                    points = points, source = GeometrySource.PLAN, sourceId = geometryElement.id),
+                segment(points = points2, source = GeometrySource.IMPORTED),
+                segment(points = points3, source = GeometrySource.GENERATED),
+                segment(
+                    points = points4,
+                    source = GeometrySource.PLAN,
+                    sourceId = geometryElementWithoutCrs.id),
+                segment(
+                    points = points5, source = GeometrySource.PLAN, sourceId = geometryElement.id),
+            )
         val version = alignmentDao.insert(alignment)
-        locationTrackDao.insert(locationTrack(trackNumberId, alignmentVersion = version, draft = false))
+        locationTrackDao.insert(
+            locationTrack(trackNumberId, alignmentVersion = version, draft = false))
 
-        val profileInfo = alignmentDao.fetchProfileInfoForSegmentsInBoundingBox<LocationTrack>(
-            MainLayoutContext.official,
-            boundingBoxAroundPoints((points + points2 + points3 + points4 + points5).toList()),
-        )
+        val profileInfo =
+            alignmentDao.fetchProfileInfoForSegmentsInBoundingBox<LocationTrack>(
+                MainLayoutContext.official,
+                boundingBoxAroundPoints((points + points2 + points3 + points4 + points5).toList()),
+            )
         assertEquals(5, profileInfo.size)
         assertTrue(profileInfo[0].hasProfile)
         assertFalse(profileInfo[1].hasProfile)
@@ -330,31 +357,34 @@ class LayoutAlignmentDaoIT @Autowired constructor(
     private fun segmentsWithoutZAndCant(alignmentSeed: Int, count: Int) =
         fixSegmentStarts((0..count).map { seed -> segmentWithoutZAndCant(alignmentSeed + seed) })
 
-    private fun segmentWithoutZAndCant(segmentSeed: Int) = createSegment(
-        segmentSeed,
-        points(
-            count = 10,
-            x = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
-            y = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
-        ),
-    )
+    private fun segmentWithoutZAndCant(segmentSeed: Int) =
+        createSegment(
+            segmentSeed,
+            points(
+                count = 10,
+                x = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
+                y = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
+            ),
+        )
 
-    private fun segmentWithZAndCant(segmentSeed: Int) = createSegment(
-        segmentSeed,
-        points(
-            count = 20,
-            x = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
-            y = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
-            z = segmentSeed.toDouble()..segmentSeed + 20.0,
-            cant = segmentSeed.toDouble()..segmentSeed + 20.0,
-        ),
-    )
+    private fun segmentWithZAndCant(segmentSeed: Int) =
+        createSegment(
+            segmentSeed,
+            points(
+                count = 20,
+                x = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
+                y = (segmentSeed * 10).toDouble()..(segmentSeed * 10 + 10.0),
+                z = segmentSeed.toDouble()..segmentSeed + 20.0,
+                cant = segmentSeed.toDouble()..segmentSeed + 20.0,
+            ),
+        )
 
-    private fun createSegment(segmentSeed: Int, points: List<SegmentPoint>) = segment(
-        points = points,
-        startM = segmentSeed * 0.1,
-        source = GeometrySource.PLAN,
-    )
+    private fun createSegment(segmentSeed: Int, points: List<SegmentPoint>) =
+        segment(
+            points = points,
+            startM = segmentSeed * 0.1,
+            source = GeometrySource.PLAN,
+        )
 
     fun insertAndVerify(alignment: LayoutAlignment): RowVersion<LayoutAlignment> {
         val rowVersion = alignmentDao.insert(alignment)
@@ -373,30 +403,36 @@ class LayoutAlignmentDaoIT @Autowired constructor(
         return rowVersion
     }
 
-    fun getDbSegmentCount(alignmentId: IntId<LayoutAlignment>): Int = jdbc.queryForObject(
-        """
+    fun getDbSegmentCount(alignmentId: IntId<LayoutAlignment>): Int =
+        jdbc.queryForObject(
+            """
                 select count(*) 
                 from layout.alignment inner join layout.segment_version 
                   on alignment.id = segment_version.alignment_id and alignment.version = segment_version.alignment_version
                 where alignment_id = :id
                 """,
-        mapOf("id" to alignmentId.intValue),
-    ) { rs, _ -> rs.getInt("count") } ?: 0
+            mapOf("id" to alignmentId.intValue),
+        ) { rs, _ ->
+            rs.getInt("count")
+        } ?: 0
 
     private fun assertDbGeometriesHaveCorrectMValues() {
-        val sql = """
+        val sql =
+            """
            select id, postgis.st_astext(geometry) as geom, postgis.st_length(geometry) as length
            from layout.segment_geometry
            where postgis.st_m(postgis.st_startpoint(geometry)) <> 0.0
              or abs(postgis.st_m(postgis.st_endpoint(geometry)) - postgis.st_length(geometry))/postgis.st_length(geometry) > 0.01;
-        """.trimIndent()
-        val geometriesWithInvalidMValues = jdbc.query(sql, mapOf<String, Any>()) { rs, _ ->
-            Triple(
-                rs.getIntId<SegmentGeometry>("id"),
-                rs.getDouble("length"),
-                rs.getString("geom"),
-            )
-        }
+        """
+                .trimIndent()
+        val geometriesWithInvalidMValues =
+            jdbc.query(sql, mapOf<String, Any>()) { rs, _ ->
+                Triple(
+                    rs.getIntId<SegmentGeometry>("id"),
+                    rs.getDouble("length"),
+                    rs.getString("geom"),
+                )
+            }
         assertTrue(
             geometriesWithInvalidMValues.isEmpty(),
             "All geometries should have m-values at 0.0-length: violations=$geometriesWithInvalidMValues",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
@@ -1,15 +1,19 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
-import org.junit.jupiter.api.Assertions.assertEquals
 import kotlin.test.assertNull
+import org.junit.jupiter.api.Assertions.assertEquals
 
 private const val COORDINATE_DELTA: Double = 0.000000001
 private const val LENGTH_DELTA: Double = 0.00001
 private const val HEIGHT_DELTA: Double = 0.000001
 private const val CANT_DELTA: Double = 0.000001
 
-fun assertMatches(expected: TrackLayoutTrackNumber, actual: TrackLayoutTrackNumber, contextMatch: Boolean = false) {
+fun assertMatches(
+    expected: TrackLayoutTrackNumber,
+    actual: TrackLayoutTrackNumber,
+    contextMatch: Boolean = false
+) {
     if (contextMatch) {
         assertEquals(expected, actual)
     } else {
@@ -19,10 +23,11 @@ fun assertMatches(expected: TrackLayoutTrackNumber, actual: TrackLayoutTrackNumb
 }
 
 fun assertMatches(expected: ReferenceLine, actual: ReferenceLine, contextMatch: Boolean = false) {
-    val expectedWithSameFloats = expected.copy(
-        boundingBox = actual.boundingBox,
-        length = actual.length,
-    )
+    val expectedWithSameFloats =
+        expected.copy(
+            boundingBox = actual.boundingBox,
+            length = actual.length,
+        )
     if (contextMatch) {
         assertEquals(expectedWithSameFloats, actual)
     } else {
@@ -33,10 +38,11 @@ fun assertMatches(expected: ReferenceLine, actual: ReferenceLine, contextMatch: 
 }
 
 fun assertMatches(expected: LocationTrack, actual: LocationTrack, contextMatch: Boolean = false) {
-    val expectedWithSameFloats = expected.copy(
-        boundingBox = actual.boundingBox,
-        length = actual.length,
-    )
+    val expectedWithSameFloats =
+        expected.copy(
+            boundingBox = actual.boundingBox,
+            length = actual.length,
+        )
     if (contextMatch) {
         assertEquals(expectedWithSameFloats, actual)
     } else {
@@ -47,16 +53,18 @@ fun assertMatches(expected: LocationTrack, actual: LocationTrack, contextMatch: 
 }
 
 fun assertMatches(expected: LayoutAlignment, actual: LayoutAlignment, idMatch: Boolean = false) {
-    val expectedWithSameFloats = expected.copy(
-        segments = actual.segments,
-    )
+    val expectedWithSameFloats =
+        expected.copy(
+            segments = actual.segments,
+        )
     if (idMatch) {
         assertEquals(expectedWithSameFloats, actual)
     } else {
-        val unified = actual.copy(
-            id = expected.id,
-            dataType = expected.dataType,
-        )
+        val unified =
+            actual.copy(
+                id = expected.id,
+                dataType = expected.dataType,
+            )
         assertEquals(expectedWithSameFloats, unified)
     }
     assertEquals(expected.length, actual.length, LENGTH_DELTA)
@@ -71,14 +79,17 @@ fun assertMatches(expected: LayoutSegment, actual: LayoutSegment, idMatch: Boole
     if (idMatch) {
         assertEquals(expectedWithSameFloats, actual)
     } else {
-        assertEquals(expectedWithSameFloats, actual.copy(id = expected.id, sourceId = expected.sourceId))
+        assertEquals(
+            expectedWithSameFloats, actual.copy(id = expected.id, sourceId = expected.sourceId))
         assertEquals(expected.sourceId != null, actual.sourceId != null)
     }
     assertEquals(expected.startM, actual.startM, LENGTH_DELTA)
     assertEquals(expected.length, actual.length, LENGTH_DELTA)
     assertEquals(expected.alignmentPoints.size, actual.alignmentPoints.size)
     assertEquals(expected.resolution, actual.resolution)
-    expected.alignmentPoints.forEachIndexed { index, point -> assertMatches(point, actual.alignmentPoints[index]) }
+    expected.alignmentPoints.forEachIndexed { index, point ->
+        assertMatches(point, actual.alignmentPoints[index])
+    }
 }
 
 fun assertMatches(expected: AlignmentPoint, actual: AlignmentPoint) {
@@ -91,21 +102,31 @@ fun assertMatches(expected: AlignmentPoint, actual: AlignmentPoint) {
     else assertEquals(expected.cant!!, actual.cant!!, CANT_DELTA)
 }
 
-fun assertMatches(expected: TrackLayoutKmPost, actual: TrackLayoutKmPost, contextMatch: Boolean = false) {
+fun assertMatches(
+    expected: TrackLayoutKmPost,
+    actual: TrackLayoutKmPost,
+    contextMatch: Boolean = false
+) {
     if (contextMatch) {
         assertEquals(expected, actual)
     } else {
-        val unified = actual.copy(
-            contextData = expected.contextData,
-            sourceId = expected.sourceId,
-        )
+        val unified =
+            actual.copy(
+                contextData = expected.contextData,
+                sourceId = expected.sourceId,
+            )
         assertEquals(expected, unified)
         assertEquals(expected.sourceId != null, actual.sourceId != null)
     }
 }
 
-fun assertMatches(expected: TrackLayoutSwitch, actual: TrackLayoutSwitch, contextMatch: Boolean = false) {
-    val expectedWithSameFloats = expected.copy(joints = actual.joints, switchStructureId = actual.switchStructureId)
+fun assertMatches(
+    expected: TrackLayoutSwitch,
+    actual: TrackLayoutSwitch,
+    contextMatch: Boolean = false
+) {
+    val expectedWithSameFloats =
+        expected.copy(joints = actual.joints, switchStructureId = actual.switchStructureId)
     if (contextMatch) {
         assertEquals(expectedWithSameFloats, actual)
     } else {
@@ -115,7 +136,9 @@ fun assertMatches(expected: TrackLayoutSwitch, actual: TrackLayoutSwitch, contex
     assertEquals(expected.switchStructureId, actual.switchStructureId)
     assertEquals(expected.joints.size, actual.joints.size)
     val expectedJoints = expected.joints.sortedBy(TrackLayoutSwitchJoint::number)
-    expectedJoints.forEachIndexed { index, expJoint -> assertMatches(expJoint, actual.joints[index]) }
+    expectedJoints.forEachIndexed { index, expJoint ->
+        assertMatches(expJoint, actual.joints[index])
+    }
 }
 
 fun assertMatches(expected: TrackLayoutSwitchJoint, actual: TrackLayoutSwitchJoint) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
@@ -8,20 +8,21 @@ import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
-import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.util.FreeText
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutAssetServiceIT @Autowired constructor(
+class LayoutAssetServiceIT
+@Autowired
+constructor(
     private val layoutTrackNumberService: LayoutTrackNumberService,
     private val layoutReferenceLineService: ReferenceLineService,
     private val layoutLocationTrackService: LocationTrackService,
@@ -37,11 +38,14 @@ class LayoutAssetServiceIT @Autowired constructor(
     @Test
     fun `objects with alignments can be merged to main-draft and then deleted from main-draft`() {
         val someDesignBranch = testDBService.createDesignBranch()
-        val designOfficialContext = testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
+        val designOfficialContext =
+            testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
 
         val trackNumberId = designOfficialContext.insert(trackNumber()).id
-        val referenceLineId = designOfficialContext.insert(referenceLineAndAlignment(trackNumberId)).id
-        val locationTrackId = designOfficialContext.insert(locationTrackAndAlignment(trackNumberId)).id
+        val referenceLineId =
+            designOfficialContext.insert(referenceLineAndAlignment(trackNumberId)).id
+        val locationTrackId =
+            designOfficialContext.insert(locationTrackAndAlignment(trackNumberId)).id
 
         layoutTrackNumberService.mergeToMainBranch(someDesignBranch, trackNumberId)
         layoutReferenceLineService.mergeToMainBranch(someDesignBranch, referenceLineId)
@@ -57,18 +61,16 @@ class LayoutAssetServiceIT @Autowired constructor(
     @Test
     fun `objects with a main-draft copy can still be edited in their design`() {
         val someDesignBranch = testDBService.createDesignBranch()
-        val designOfficialContext = testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
+        val designOfficialContext =
+            testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
         val designDraftContext = testDBService.testContext(someDesignBranch, PublicationState.DRAFT)
 
         val trackNumberId = designOfficialContext.insert(trackNumber(TrackNumber("original"))).id
         layoutTrackNumberService.mergeToMainBranch(someDesignBranch, trackNumberId)
         designDraftContext.insert(
             asDesignDraft(
-                designOfficialContext
-                    .fetch(trackNumberId)!!
-                    .copy(number = TrackNumber("edited")), someDesignBranch.designId
-            )
-        )
+                designOfficialContext.fetch(trackNumberId)!!.copy(number = TrackNumber("edited")),
+                someDesignBranch.designId))
         assertEquals("original", designOfficialContext.fetch(trackNumberId)!!.number.toString())
         assertEquals("edited", designDraftContext.fetch(trackNumberId)!!.number.toString())
     }
@@ -76,11 +78,14 @@ class LayoutAssetServiceIT @Autowired constructor(
     @Test
     fun `object in design-official can be merged to main-draft`() {
         val someDesignBranch = testDBService.createDesignBranch()
-        val designOfficialContext = testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
+        val designOfficialContext =
+            testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
 
         val trackNumberId = designOfficialContext.insert(trackNumber()).id
-        val referenceLineId = designOfficialContext.insert(referenceLineAndAlignment(trackNumberId)).id
-        val locationTrackId = designOfficialContext.insert(locationTrackAndAlignment(trackNumberId)).id
+        val referenceLineId =
+            designOfficialContext.insert(referenceLineAndAlignment(trackNumberId)).id
+        val locationTrackId =
+            designOfficialContext.insert(locationTrackAndAlignment(trackNumberId)).id
         val switchId = designOfficialContext.insert(switch()).id
         val kmPostId = designOfficialContext.insert(kmPost(trackNumberId, KmNumber(123))).id
 
@@ -90,83 +95,146 @@ class LayoutAssetServiceIT @Autowired constructor(
         layoutSwitchService.mergeToMainBranch(someDesignBranch, switchId)
         layoutKmPostService.mergeToMainBranch(someDesignBranch, kmPostId)
 
-        assertNotEquals(trackNumberId.intValue, mainDraftContext.fetch(trackNumberId)!!.contextData.rowId!!.intValue)
-        assertNotEquals(referenceLineId.intValue, mainDraftContext.fetch(referenceLineId)!!.contextData.rowId!!.intValue)
-        assertNotEquals(locationTrackId.intValue, mainDraftContext.fetch(locationTrackId)!!.contextData.rowId!!.intValue)
-        assertNotEquals(switchId.intValue, mainDraftContext.fetch(switchId)!!.contextData.rowId!!.intValue)
-        assertNotEquals(kmPostId.intValue, mainDraftContext.fetch(kmPostId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            trackNumberId.intValue,
+            mainDraftContext.fetch(trackNumberId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            referenceLineId.intValue,
+            mainDraftContext.fetch(referenceLineId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            locationTrackId.intValue,
+            mainDraftContext.fetch(locationTrackId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            switchId.intValue, mainDraftContext.fetch(switchId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            kmPostId.intValue, mainDraftContext.fetch(kmPostId)!!.contextData.rowId!!.intValue)
 
-        assertEquals(trackNumberId.intValue, mainDraftContext.fetch(trackNumberId)!!.contextData.designRowId!!.intValue)
-        assertEquals(referenceLineId.intValue, mainDraftContext.fetch(referenceLineId)!!.contextData.designRowId!!.intValue)
-        assertEquals(locationTrackId.intValue, mainDraftContext.fetch(locationTrackId)!!.contextData.designRowId!!.intValue)
-        assertEquals(switchId.intValue, mainDraftContext.fetch(switchId)!!.contextData.designRowId!!.intValue)
-        assertEquals(kmPostId.intValue, mainDraftContext.fetch(kmPostId)!!.contextData.designRowId!!.intValue)
+        assertEquals(
+            trackNumberId.intValue,
+            mainDraftContext.fetch(trackNumberId)!!.contextData.designRowId!!.intValue)
+        assertEquals(
+            referenceLineId.intValue,
+            mainDraftContext.fetch(referenceLineId)!!.contextData.designRowId!!.intValue)
+        assertEquals(
+            locationTrackId.intValue,
+            mainDraftContext.fetch(locationTrackId)!!.contextData.designRowId!!.intValue)
+        assertEquals(
+            switchId.intValue,
+            mainDraftContext.fetch(switchId)!!.contextData.designRowId!!.intValue)
+        assertEquals(
+            kmPostId.intValue,
+            mainDraftContext.fetch(kmPostId)!!.contextData.designRowId!!.intValue)
 
-        assertEquals(trackNumberId.intValue, designOfficialContext.fetch(trackNumberId)!!.contextData.rowId!!.intValue)
-        assertEquals(referenceLineId.intValue, designOfficialContext.fetch(referenceLineId)!!.contextData.rowId!!.intValue)
-        assertEquals(locationTrackId.intValue, designOfficialContext.fetch(locationTrackId)!!.contextData.rowId!!.intValue)
-        assertEquals(switchId.intValue, designOfficialContext.fetch(switchId)!!.contextData.rowId!!.intValue)
-        assertEquals(kmPostId.intValue, designOfficialContext.fetch(kmPostId)!!.contextData.rowId!!.intValue)
+        assertEquals(
+            trackNumberId.intValue,
+            designOfficialContext.fetch(trackNumberId)!!.contextData.rowId!!.intValue)
+        assertEquals(
+            referenceLineId.intValue,
+            designOfficialContext.fetch(referenceLineId)!!.contextData.rowId!!.intValue)
+        assertEquals(
+            locationTrackId.intValue,
+            designOfficialContext.fetch(locationTrackId)!!.contextData.rowId!!.intValue)
+        assertEquals(
+            switchId.intValue, designOfficialContext.fetch(switchId)!!.contextData.rowId!!.intValue)
+        assertEquals(
+            kmPostId.intValue, designOfficialContext.fetch(kmPostId)!!.contextData.rowId!!.intValue)
     }
 
     @Test
     fun `existing main-draft is overridden when merging object from design-official`() {
         val someDesignBranch = testDBService.createDesignBranch()
-        val designOfficialContext = testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
+        val designOfficialContext =
+            testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
         val designDraftContext = testDBService.testContext(someDesignBranch, PublicationState.DRAFT)
 
         val trackNumberId = mainOfficialContext.insert(trackNumber()).id
-        val referenceLineId = mainOfficialContext.insert(referenceLineAndAlignment(trackNumberId)).id
-        val locationTrackId = mainOfficialContext.insert(locationTrackAndAlignment(trackNumberId)).id
+        val referenceLineId =
+            mainOfficialContext.insert(referenceLineAndAlignment(trackNumberId)).id
+        val locationTrackId =
+            mainOfficialContext.insert(locationTrackAndAlignment(trackNumberId)).id
         val switchId = mainOfficialContext.insert(switch()).id
         val kmPostId = mainOfficialContext.insert(kmPost(trackNumberId, KmNumber(123))).id
 
-        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(trackNumberId)!!).copy(description = FreeText("edited in main")))
-        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(referenceLineId)!!).copy(startAddress = TrackMeter("0000+0123")))
-        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(locationTrackId)!!).copy(name = AlignmentName("edited in main")))
-        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(switchId)!!).copy(name = SwitchName("edited in main")))
-        mainDraftContext.insert(asMainDraft(mainOfficialContext.fetch(kmPostId)!!).copy(kmNumber = KmNumber(123)))
+        mainDraftContext.insert(
+            asMainDraft(mainOfficialContext.fetch(trackNumberId)!!)
+                .copy(description = FreeText("edited in main")))
+        mainDraftContext.insert(
+            asMainDraft(mainOfficialContext.fetch(referenceLineId)!!)
+                .copy(startAddress = TrackMeter("0000+0123")))
+        mainDraftContext.insert(
+            asMainDraft(mainOfficialContext.fetch(locationTrackId)!!)
+                .copy(name = AlignmentName("edited in main")))
+        mainDraftContext.insert(
+            asMainDraft(mainOfficialContext.fetch(switchId)!!)
+                .copy(name = SwitchName("edited in main")))
+        mainDraftContext.insert(
+            asMainDraft(mainOfficialContext.fetch(kmPostId)!!).copy(kmNumber = KmNumber(123)))
 
-        val designOfficialTrackNumberRowId = designOfficialContext.moveFrom(
-            designDraftContext.insert(
-                asDesignDraft(
-                    mainOfficialContext.fetch(trackNumberId)!!.copy(description = FreeText("edited in design")),
-                    someDesignBranch.designId
-                )
-            ).rowVersion
-        ).rowVersion.rowId
-        val designOfficialReferenceLineRowId = designOfficialContext.moveFrom(
-            designDraftContext.insert(
-                asDesignDraft(
-                    mainOfficialContext.fetch(referenceLineId)!!.copy(startAddress = TrackMeter("0123+0000")),
-                    someDesignBranch.designId
-                )
-            ).rowVersion
-        ).rowVersion.rowId
-        val designOfficialLocationTrackRowId = designOfficialContext.moveFrom(
-            designDraftContext.insert(
-                asDesignDraft(
-                    mainOfficialContext.fetch(locationTrackId)!!.copy(name = AlignmentName("edited in design")),
-                    someDesignBranch.designId
-                )
-            ).rowVersion
-        ).rowVersion.rowId
-        val designOfficialSwitchRowId = designOfficialContext.moveFrom(
-            designDraftContext.insert(
-                asDesignDraft(
-                    mainOfficialContext.fetch(switchId)!!.copy(name = SwitchName("edited in design")),
-                    someDesignBranch.designId
-                )
-            ).rowVersion
-        ).rowVersion.rowId
-        val designOfficialKmPostRowId = designOfficialContext.moveFrom(
-            designDraftContext.insert(
-                asDesignDraft(
-                    mainOfficialContext.fetch(kmPostId)!!.copy(kmNumber = KmNumber(321)),
-                    someDesignBranch.designId
-                )
-            ).rowVersion
-        ).rowVersion.rowId
+        val designOfficialTrackNumberRowId =
+            designOfficialContext
+                .moveFrom(
+                    designDraftContext
+                        .insert(
+                            asDesignDraft(
+                                mainOfficialContext
+                                    .fetch(trackNumberId)!!
+                                    .copy(description = FreeText("edited in design")),
+                                someDesignBranch.designId))
+                        .rowVersion)
+                .rowVersion
+                .rowId
+        val designOfficialReferenceLineRowId =
+            designOfficialContext
+                .moveFrom(
+                    designDraftContext
+                        .insert(
+                            asDesignDraft(
+                                mainOfficialContext
+                                    .fetch(referenceLineId)!!
+                                    .copy(startAddress = TrackMeter("0123+0000")),
+                                someDesignBranch.designId))
+                        .rowVersion)
+                .rowVersion
+                .rowId
+        val designOfficialLocationTrackRowId =
+            designOfficialContext
+                .moveFrom(
+                    designDraftContext
+                        .insert(
+                            asDesignDraft(
+                                mainOfficialContext
+                                    .fetch(locationTrackId)!!
+                                    .copy(name = AlignmentName("edited in design")),
+                                someDesignBranch.designId))
+                        .rowVersion)
+                .rowVersion
+                .rowId
+        val designOfficialSwitchRowId =
+            designOfficialContext
+                .moveFrom(
+                    designDraftContext
+                        .insert(
+                            asDesignDraft(
+                                mainOfficialContext
+                                    .fetch(switchId)!!
+                                    .copy(name = SwitchName("edited in design")),
+                                someDesignBranch.designId))
+                        .rowVersion)
+                .rowVersion
+                .rowId
+        val designOfficialKmPostRowId =
+            designOfficialContext
+                .moveFrom(
+                    designDraftContext
+                        .insert(
+                            asDesignDraft(
+                                mainOfficialContext
+                                    .fetch(kmPostId)!!
+                                    .copy(kmNumber = KmNumber(321)),
+                                someDesignBranch.designId))
+                        .rowVersion)
+                .rowVersion
+                .rowId
 
         layoutTrackNumberService.mergeToMainBranch(someDesignBranch, trackNumberId)
         layoutReferenceLineService.mergeToMainBranch(someDesignBranch, referenceLineId)
@@ -174,19 +242,36 @@ class LayoutAssetServiceIT @Autowired constructor(
         layoutSwitchService.mergeToMainBranch(someDesignBranch, switchId)
         layoutKmPostService.mergeToMainBranch(someDesignBranch, kmPostId)
 
-        assertNotEquals(trackNumberId.intValue, mainDraftContext.fetch(trackNumberId)!!.contextData.rowId!!.intValue)
-        assertNotEquals(referenceLineId.intValue, mainDraftContext.fetch(referenceLineId)!!.contextData.rowId!!.intValue)
-        assertNotEquals(locationTrackId.intValue, mainDraftContext.fetch(locationTrackId)!!.contextData.rowId!!.intValue)
-        assertNotEquals(switchId.intValue, mainDraftContext.fetch(switchId)!!.contextData.rowId!!.intValue)
-        assertNotEquals(kmPostId.intValue, mainDraftContext.fetch(kmPostId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            trackNumberId.intValue,
+            mainDraftContext.fetch(trackNumberId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            referenceLineId.intValue,
+            mainDraftContext.fetch(referenceLineId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            locationTrackId.intValue,
+            mainDraftContext.fetch(locationTrackId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            switchId.intValue, mainDraftContext.fetch(switchId)!!.contextData.rowId!!.intValue)
+        assertNotEquals(
+            kmPostId.intValue, mainDraftContext.fetch(kmPostId)!!.contextData.rowId!!.intValue)
 
-        assertEquals(designOfficialTrackNumberRowId, mainDraftContext.fetch(trackNumberId)!!.contextData.designRowId)
-        assertEquals(designOfficialReferenceLineRowId, mainDraftContext.fetch(referenceLineId)!!.contextData.designRowId)
-        assertEquals(designOfficialLocationTrackRowId, mainDraftContext.fetch(locationTrackId)!!.contextData.designRowId)
-        assertEquals(designOfficialSwitchRowId, mainDraftContext.fetch(switchId)!!.contextData.designRowId)
-        assertEquals(designOfficialKmPostRowId, mainDraftContext.fetch(kmPostId)!!.contextData.designRowId)
+        assertEquals(
+            designOfficialTrackNumberRowId,
+            mainDraftContext.fetch(trackNumberId)!!.contextData.designRowId)
+        assertEquals(
+            designOfficialReferenceLineRowId,
+            mainDraftContext.fetch(referenceLineId)!!.contextData.designRowId)
+        assertEquals(
+            designOfficialLocationTrackRowId,
+            mainDraftContext.fetch(locationTrackId)!!.contextData.designRowId)
+        assertEquals(
+            designOfficialSwitchRowId, mainDraftContext.fetch(switchId)!!.contextData.designRowId)
+        assertEquals(
+            designOfficialKmPostRowId, mainDraftContext.fetch(kmPostId)!!.contextData.designRowId)
 
-        assertEquals("edited in design", mainDraftContext.fetch(trackNumberId)!!.description.toString())
+        assertEquals(
+            "edited in design", mainDraftContext.fetch(trackNumberId)!!.description.toString())
         assertEquals(123, mainDraftContext.fetch(referenceLineId)!!.startAddress.kmNumber.number)
         assertEquals("edited in design", mainDraftContext.fetch(locationTrackId)!!.name.toString())
         assertEquals("edited in design", mainDraftContext.fetch(switchId)!!.name.toString())

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
@@ -22,7 +22,9 @@ import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutContextDataIT @Autowired constructor(
+class LayoutContextDataIT
+@Autowired
+constructor(
     private val switchDao: LayoutSwitchDao,
     private val switchService: LayoutSwitchService,
     private val kmPostService: LayoutKmPostService,
@@ -78,7 +80,12 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun draftAndOfficialKmPostsHaveSameOfficialId() {
-        val dbKmPost = insertAndVerify(kmPost(mainOfficialContext.createLayoutTrackNumber().id, someKmNumber(), draft = false))
+        val dbKmPost =
+            insertAndVerify(
+                kmPost(
+                    mainOfficialContext.createLayoutTrackNumber().id,
+                    someKmNumber(),
+                    draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbKmPost)))
 
         assertNotEquals(dbKmPost, dbDraft)
@@ -135,7 +142,12 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun draftKmPostsAreIncludedInDraftListingsOnly() {
-        val dbKmPost = insertAndVerify(kmPost(mainOfficialContext.createLayoutTrackNumber().id, someKmNumber(), draft = false))
+        val dbKmPost =
+            insertAndVerify(
+                kmPost(
+                    mainOfficialContext.createLayoutTrackNumber().id,
+                    someKmNumber(),
+                    draft = false))
         val dbDraft = insertAndVerify(alter(createAndVerifyDraft(dbKmPost)))
 
         val officials = kmPostService.list(MainLayoutContext.official)
@@ -183,7 +195,12 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun kmPostCanOnlyHaveOneDraft() {
-        val kmPost = insertAndVerify(kmPost(mainOfficialContext.createLayoutTrackNumber().id, someKmNumber(), draft = false))
+        val kmPost =
+            insertAndVerify(
+                kmPost(
+                    mainOfficialContext.createLayoutTrackNumber().id,
+                    someKmNumber(),
+                    draft = false))
 
         val draft1 = asMainDraft(kmPost)
         val draft2 = asMainDraft(kmPost)
@@ -194,7 +211,8 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun trackNumberCanOnlyHaveOneDraft() {
-        val trackNumber = insertAndVerify(trackNumber(testDBService.getUnusedTrackNumber(), draft = false))
+        val trackNumber =
+            insertAndVerify(trackNumber(testDBService.getUnusedTrackNumber(), draft = false))
 
         val draft1 = asMainDraft(trackNumber)
         val draft2 = asMainDraft(trackNumber)
@@ -213,7 +231,12 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun editStateOfOfficialIsReturnedCorrectly() {
-        val official = insertAndVerify(kmPost(mainOfficialContext.createLayoutTrackNumber().id, someKmNumber(), draft = false))
+        val official =
+            insertAndVerify(
+                kmPost(
+                    mainOfficialContext.createLayoutTrackNumber().id,
+                    someKmNumber(),
+                    draft = false))
         assertEquals(official.editState, EditState.UNEDITED)
         assertTrue(official.isOfficial)
         assertFalse(official.isDraft)
@@ -221,20 +244,30 @@ class LayoutContextDataIT @Autowired constructor(
 
     @Test
     fun editStateOfChangedDraftIsReturnedCorrectly() {
-        val edited = asMainDraft(insertAndVerify(kmPost(mainOfficialContext.createLayoutTrackNumber().id, someKmNumber(), draft = false)))
+        val edited =
+            asMainDraft(
+                insertAndVerify(
+                    kmPost(
+                        mainOfficialContext.createLayoutTrackNumber().id,
+                        someKmNumber(),
+                        draft = false)))
         assertEquals(edited.editState, EditState.EDITED)
         assertFalse(edited.isOfficial)
         assertTrue(edited.isDraft)
     }
 
-    private fun createReferenceLineAndAlignment(draft: Boolean): Pair<ReferenceLine, LayoutAlignment> =
+    private fun createReferenceLineAndAlignment(
+        draft: Boolean
+    ): Pair<ReferenceLine, LayoutAlignment> =
         referenceLineAndAlignment(
             mainOfficialContext.createLayoutTrackNumber().id,
             segment(Point(10.0, 10.0), Point(11.0, 11.0)),
             draft = draft,
         )
 
-    private fun createLocationTrackAndAlignment(draft: Boolean): Pair<LocationTrack, LayoutAlignment> =
+    private fun createLocationTrackAndAlignment(
+        draft: Boolean
+    ): Pair<LocationTrack, LayoutAlignment> =
         locationTrackAndAlignment(
             mainOfficialContext.createLayoutTrackNumber().id,
             segment(Point(10.0, 10.0), Point(11.0, 11.0)),
@@ -295,18 +328,20 @@ class LayoutContextDataIT @Autowired constructor(
         return draft
     }
 
-    private fun alterLine(lineAndAlignment: Pair<ReferenceLine, LayoutAlignment>) = lineAndAlignment.first.copy(
-        startAddress = lineAndAlignment.first.startAddress + 10.0
-    ) to lineAndAlignment.second
+    private fun alterLine(lineAndAlignment: Pair<ReferenceLine, LayoutAlignment>) =
+        lineAndAlignment.first.copy(startAddress = lineAndAlignment.first.startAddress + 10.0) to
+            lineAndAlignment.second
 
-    private fun alterTrack(trackAndAlignment: Pair<LocationTrack, LayoutAlignment>) = trackAndAlignment.first.copy(
-        name = AlignmentName("${trackAndAlignment.first.name}-D")
-    ) to trackAndAlignment.second
+    private fun alterTrack(trackAndAlignment: Pair<LocationTrack, LayoutAlignment>) =
+        trackAndAlignment.first.copy(name = AlignmentName("${trackAndAlignment.first.name}-D")) to
+            trackAndAlignment.second
 
-    private fun alter(switch: TrackLayoutSwitch): TrackLayoutSwitch = switch.copy(name = SwitchName("${switch.name}-D"))
+    private fun alter(switch: TrackLayoutSwitch): TrackLayoutSwitch =
+        switch.copy(name = SwitchName("${switch.name}-D"))
 
     private fun alter(kmPost: TrackLayoutKmPost): TrackLayoutKmPost =
-        kmPost.copy(kmNumber = KmNumber(kmPost.kmNumber.number, (kmPost.kmNumber.extension ?: "") + "B"))
+        kmPost.copy(
+            kmNumber = KmNumber(kmPost.kmNumber.number, (kmPost.kmNumber.extension ?: "") + "B"))
 
     private fun insertAndVerifyLine(
         lineAndAlignment: Pair<ReferenceLine, LayoutAlignment>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextTest.kt
@@ -4,14 +4,14 @@ import fi.fta.geoviite.infra.common.DataType.STORED
 import fi.fta.geoviite.infra.common.DataType.TEMP
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.StringId
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 class LayoutContextTest {
 
@@ -24,20 +24,40 @@ class LayoutContextTest {
         val tmpId = StringId<TrackLayoutTrackNumber>()
         val anotherVersion = LayoutRowVersion<TrackLayoutTrackNumber>(LayoutRowId(123), 123)
 
-        assertEquals(tmpId, MainOfficialContextData(UnstoredContextIdHolder(anotherVersion, tmpId)).id)
-        assertEquals(IntId(1), MainOfficialContextData(OverwritingContextIdHolder(rowId, anotherVersion)).id)
+        assertEquals(
+            tmpId, MainOfficialContextData(UnstoredContextIdHolder(anotherVersion, tmpId)).id)
+        assertEquals(
+            IntId(1), MainOfficialContextData(OverwritingContextIdHolder(rowId, anotherVersion)).id)
         assertEquals(IntId(1), MainOfficialContextData(StoredContextIdHolder(rowVersion)).id)
 
-        assertEquals(IntId(2), MainDraftContextData(StoredContextIdHolder(rowVersion), officialRowId, designRowId).id)
-        assertEquals(IntId(3), MainDraftContextData(StoredContextIdHolder(rowVersion), null, designRowId).id)
-        assertEquals(IntId(1), MainDraftContextData(StoredContextIdHolder(rowVersion), null, null).id)
+        assertEquals(
+            IntId(2),
+            MainDraftContextData(StoredContextIdHolder(rowVersion), officialRowId, designRowId).id)
+        assertEquals(
+            IntId(3), MainDraftContextData(StoredContextIdHolder(rowVersion), null, designRowId).id)
+        assertEquals(
+            IntId(1), MainDraftContextData(StoredContextIdHolder(rowVersion), null, null).id)
 
-        assertEquals(IntId(2), DesignOfficialContextData(StoredContextIdHolder(rowVersion), officialRowId, IntId(10)).id)
-        assertEquals(IntId(1), DesignOfficialContextData(StoredContextIdHolder(rowVersion), null, IntId(10)).id)
+        assertEquals(
+            IntId(2),
+            DesignOfficialContextData(StoredContextIdHolder(rowVersion), officialRowId, IntId(10))
+                .id)
+        assertEquals(
+            IntId(1),
+            DesignOfficialContextData(StoredContextIdHolder(rowVersion), null, IntId(10)).id)
 
-        assertEquals(IntId(2), DesignDraftContextData(StoredContextIdHolder(rowVersion), designRowId, officialRowId, IntId(10)).id)
-        assertEquals(IntId(3), DesignDraftContextData(StoredContextIdHolder(rowVersion), designRowId, null, IntId(10)).id)
-        assertEquals(IntId(1), DesignDraftContextData(StoredContextIdHolder(rowVersion), null, null, IntId(10)).id)
+        assertEquals(
+            IntId(2),
+            DesignDraftContextData(
+                    StoredContextIdHolder(rowVersion), designRowId, officialRowId, IntId(10))
+                .id)
+        assertEquals(
+            IntId(3),
+            DesignDraftContextData(StoredContextIdHolder(rowVersion), designRowId, null, IntId(10))
+                .id)
+        assertEquals(
+            IntId(1),
+            DesignDraftContextData(StoredContextIdHolder(rowVersion), null, null, IntId(10)).id)
     }
 
     @Test
@@ -290,11 +310,12 @@ class LayoutContextTest {
         val mainDraftId = LayoutRowId<TrackLayoutTrackNumber>(3)
         val designId = IntId<LayoutDesign>(123)
 
-        val designOfficial = DesignOfficialContextData(
-            contextIdHolder = StoredContextIdHolder(LayoutRowVersion(designOfficialId, 123)),
-            officialRowId = mainOfficialId,
-            designId = designId,
-        )
+        val designOfficial =
+            DesignOfficialContextData(
+                contextIdHolder = StoredContextIdHolder(LayoutRowVersion(designOfficialId, 123)),
+                officialRowId = mainOfficialId,
+                designId = designId,
+            )
         val designDraft = designOfficial.asMainDraft(mainDraftId)
 
         assertEquals(IntId(1), designDraft.id)
@@ -318,20 +339,45 @@ class LayoutContextTest {
         assertNotNull(MainDraftContextData(storedContext, null, null).asMainOfficial())
         assertNotNull(DesignOfficialContextData(storedContext, null, IntId(1)).asMainDraft(null))
         assertNotNull(DesignOfficialContextData(storedContext, null, IntId(1)).asDesignDraft())
-        assertNotNull(DesignDraftContextData(storedContext, null, null, IntId(1)).asDesignOfficial())
+        assertNotNull(
+            DesignDraftContextData(storedContext, null, null, IntId(1)).asDesignOfficial())
 
-        assertThrows<IllegalStateException> { MainOfficialContextData(unstoredContext).asMainDraft() }
-        assertThrows<IllegalStateException> { MainOfficialContextData(unstoredContext).asDesignDraft(IntId(1)) }
-        assertThrows<IllegalStateException> { MainDraftContextData(unstoredContext, null, null).asMainOfficial() }
-        assertThrows<IllegalStateException> { DesignOfficialContextData(unstoredContext, null, IntId(1)).asMainDraft(null) }
-        assertThrows<IllegalStateException> { DesignOfficialContextData(unstoredContext, null, IntId(1)).asDesignDraft() }
-        assertThrows<IllegalStateException> { DesignDraftContextData(unstoredContext, null, null, IntId(1)).asDesignOfficial() }
+        assertThrows<IllegalStateException> {
+            MainOfficialContextData(unstoredContext).asMainDraft()
+        }
+        assertThrows<IllegalStateException> {
+            MainOfficialContextData(unstoredContext).asDesignDraft(IntId(1))
+        }
+        assertThrows<IllegalStateException> {
+            MainDraftContextData(unstoredContext, null, null).asMainOfficial()
+        }
+        assertThrows<IllegalStateException> {
+            DesignOfficialContextData(unstoredContext, null, IntId(1)).asMainDraft(null)
+        }
+        assertThrows<IllegalStateException> {
+            DesignOfficialContextData(unstoredContext, null, IntId(1)).asDesignDraft()
+        }
+        assertThrows<IllegalStateException> {
+            DesignDraftContextData(unstoredContext, null, null, IntId(1)).asDesignOfficial()
+        }
 
-        assertThrows<IllegalStateException> { MainOfficialContextData(overwritingContext).asMainDraft() }
-        assertThrows<IllegalStateException> { MainOfficialContextData(overwritingContext).asDesignDraft(IntId(1)) }
-        assertThrows<IllegalStateException> { MainDraftContextData(overwritingContext, null, null).asMainOfficial() }
-        assertThrows<IllegalStateException> { DesignOfficialContextData(overwritingContext, null, IntId(1)).asMainDraft(null) }
-        assertThrows<IllegalStateException> { DesignOfficialContextData(overwritingContext, null, IntId(1)).asDesignDraft() }
-        assertThrows<IllegalStateException> { DesignDraftContextData(overwritingContext, null, null, IntId(1)).asDesignOfficial() }
+        assertThrows<IllegalStateException> {
+            MainOfficialContextData(overwritingContext).asMainDraft()
+        }
+        assertThrows<IllegalStateException> {
+            MainOfficialContextData(overwritingContext).asDesignDraft(IntId(1))
+        }
+        assertThrows<IllegalStateException> {
+            MainDraftContextData(overwritingContext, null, null).asMainOfficial()
+        }
+        assertThrows<IllegalStateException> {
+            DesignOfficialContextData(overwritingContext, null, IntId(1)).asMainDraft(null)
+        }
+        assertThrows<IllegalStateException> {
+            DesignOfficialContextData(overwritingContext, null, IntId(1)).asDesignDraft()
+        }
+        assertThrows<IllegalStateException> {
+            DesignDraftContextData(overwritingContext, null, null, IntId(1)).asDesignOfficial()
+        }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDaoIT.kt
@@ -2,6 +2,10 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.util.FreeText
+import java.time.LocalDate
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -10,15 +14,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.context.ActiveProfiles
-import java.time.LocalDate
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: LayoutDesignDao) : DBTestBase() {
+class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: LayoutDesignDao) :
+    DBTestBase() {
 
     @BeforeEach
     fun cleanup() {
@@ -27,19 +27,22 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
 
     @Test
     fun `insert, update, list and fetch work`() {
-        val insertAsIs = layoutDesignDao.insert(layoutDesignSaveRequest("foo bar")).let(layoutDesignDao::fetch)
-        val update = layoutDesignDao.insert(layoutDesignSaveRequest("aa bee see")).let(layoutDesignDao::fetch)
+        val insertAsIs =
+            layoutDesignDao.insert(layoutDesignSaveRequest("foo bar")).let(layoutDesignDao::fetch)
+        val update =
+            layoutDesignDao
+                .insert(layoutDesignSaveRequest("aa bee see"))
+                .let(layoutDesignDao::fetch)
         layoutDesignDao.update(
             update.id,
             LayoutDesignSaveRequest(
                 name = FreeText("abc"),
                 estimatedCompletion = LocalDate.parse("2024-01-02"),
-                designState = update.designState
-            )
-        )
+                designState = update.designState))
         assertEquals(
             listOf(
-                update.copy(name = FreeText("abc"), estimatedCompletion = LocalDate.parse("2024-01-02")),
+                update.copy(
+                    name = FreeText("abc"), estimatedCompletion = LocalDate.parse("2024-01-02")),
                 insertAsIs,
             ),
             layoutDesignDao.list().sortedBy(LayoutDesign::name),
@@ -49,21 +52,26 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
     @Test
     fun `insert() throws if name exists on non-deleted design ignoring case`() {
         layoutDesignDao.insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE))
-        layoutDesignDao.insert(layoutDesignSaveRequest("foo barbar", designState = DesignState.COMPLETED))
-        layoutDesignDao.insert(layoutDesignSaveRequest("boo too far", designState = DesignState.DELETED))
-        val exception = assertThrows<DataIntegrityViolationException> {
-            layoutDesignDao.insert(layoutDesignSaveRequest("foo bar"))
-        }
+        layoutDesignDao.insert(
+            layoutDesignSaveRequest("foo barbar", designState = DesignState.COMPLETED))
+        layoutDesignDao.insert(
+            layoutDesignSaveRequest("boo too far", designState = DesignState.DELETED))
+        val exception =
+            assertThrows<DataIntegrityViolationException> {
+                layoutDesignDao.insert(layoutDesignSaveRequest("foo bar"))
+            }
         assertNotNull(asDuplicateNameException(exception))
 
-        val exception2 = assertThrows<DataIntegrityViolationException> {
-            layoutDesignDao.insert(layoutDesignSaveRequest("FOO BAR"))
-        }
+        val exception2 =
+            assertThrows<DataIntegrityViolationException> {
+                layoutDesignDao.insert(layoutDesignSaveRequest("FOO BAR"))
+            }
         assertNotNull(asDuplicateNameException(exception2))
 
-        val exception3 = assertThrows<DataIntegrityViolationException> {
-            layoutDesignDao.insert(layoutDesignSaveRequest("foo barbar"))
-        }
+        val exception3 =
+            assertThrows<DataIntegrityViolationException> {
+                layoutDesignDao.insert(layoutDesignSaveRequest("foo barbar"))
+            }
         assertNotNull(asDuplicateNameException(exception3))
 
         assertDoesNotThrow { layoutDesignDao.insert(layoutDesignSaveRequest("boo too far")) }
@@ -71,32 +79,37 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
 
     @Test
     fun `update() throws if name exists on non-deleted design ignoring case`() {
-        val design = layoutDesignDao.insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE)).let(layoutDesignDao::fetch)
-        layoutDesignDao.insert(layoutDesignSaveRequest("boo too far", designState = DesignState.COMPLETED)).let(layoutDesignDao::fetch)
-        layoutDesignDao.insert(layoutDesignSaveRequest("way too far", designState = DesignState.DELETED)).let(layoutDesignDao::fetch)
+        val design =
+            layoutDesignDao
+                .insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE))
+                .let(layoutDesignDao::fetch)
+        layoutDesignDao
+            .insert(layoutDesignSaveRequest("boo too far", designState = DesignState.COMPLETED))
+            .let(layoutDesignDao::fetch)
+        layoutDesignDao
+            .insert(layoutDesignSaveRequest("way too far", designState = DesignState.DELETED))
+            .let(layoutDesignDao::fetch)
 
-        val exception = assertThrows<DataIntegrityViolationException> {
-            layoutDesignDao.update(
-                design.id,
-                LayoutDesignSaveRequest(
-                    name = FreeText("boo too far"),
-                    estimatedCompletion = design.estimatedCompletion,
-                    designState = design.designState
-                )
-            )
-        }
+        val exception =
+            assertThrows<DataIntegrityViolationException> {
+                layoutDesignDao.update(
+                    design.id,
+                    LayoutDesignSaveRequest(
+                        name = FreeText("boo too far"),
+                        estimatedCompletion = design.estimatedCompletion,
+                        designState = design.designState))
+            }
         assertNotNull(asDuplicateNameException(exception))
 
-        val exception2 = assertThrows<DataIntegrityViolationException> {
-            layoutDesignDao.update(
-                design.id,
-                LayoutDesignSaveRequest(
-                    name = FreeText("BOO TOO FAR"),
-                    estimatedCompletion = design.estimatedCompletion,
-                    designState = design.designState
-                )
-            )
-        }
+        val exception2 =
+            assertThrows<DataIntegrityViolationException> {
+                layoutDesignDao.update(
+                    design.id,
+                    LayoutDesignSaveRequest(
+                        name = FreeText("BOO TOO FAR"),
+                        estimatedCompletion = design.estimatedCompletion,
+                        designState = design.designState))
+            }
         assertNotNull(asDuplicateNameException(exception2))
 
         assertDoesNotThrow {
@@ -105,16 +118,20 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
                 LayoutDesignSaveRequest(
                     name = FreeText("way too far"),
                     estimatedCompletion = design.estimatedCompletion,
-                    designState = design.designState
-                )
-            )
+                    designState = design.designState))
         }
     }
 
     @Test
     fun `list() respects includeCompleted`() {
-        val design1 = layoutDesignDao.insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE)).let(layoutDesignDao::fetch)
-        val design2 = layoutDesignDao.insert(layoutDesignSaveRequest("aa bee dee", designState = DesignState.COMPLETED)).let(layoutDesignDao::fetch)
+        val design1 =
+            layoutDesignDao
+                .insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE))
+                .let(layoutDesignDao::fetch)
+        val design2 =
+            layoutDesignDao
+                .insert(layoutDesignSaveRequest("aa bee dee", designState = DesignState.COMPLETED))
+                .let(layoutDesignDao::fetch)
 
         val listWithCompleted = layoutDesignDao.list(includeCompleted = true)
         assertContains(listWithCompleted, design1)
@@ -124,8 +141,14 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
 
     @Test
     fun `list() respects includeDeleted`() {
-        val design1 = layoutDesignDao.insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE)).let(layoutDesignDao::fetch)
-        val design2 = layoutDesignDao.insert(layoutDesignSaveRequest("aa bee see", designState = DesignState.DELETED)).let(layoutDesignDao::fetch)
+        val design1 =
+            layoutDesignDao
+                .insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE))
+                .let(layoutDesignDao::fetch)
+        val design2 =
+            layoutDesignDao
+                .insert(layoutDesignSaveRequest("aa bee see", designState = DesignState.DELETED))
+                .let(layoutDesignDao::fetch)
 
         val listWithDeleted = layoutDesignDao.list(includeDeleted = true)
         assertContains(listWithDeleted, design1)
@@ -135,18 +158,27 @@ class LayoutDesignDaoIT @Autowired constructor(private val layoutDesignDao: Layo
 
     @Test
     fun `list() respects includeCompleted and includeDeleted`() {
-        val design1 = layoutDesignDao.insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE)).let(layoutDesignDao::fetch)
-        val design2 = layoutDesignDao.insert(layoutDesignSaveRequest("aa bee see", designState = DesignState.DELETED)).let(layoutDesignDao::fetch)
-        val design3 = layoutDesignDao.insert(layoutDesignSaveRequest("aa bee dee", designState = DesignState.COMPLETED)).let(layoutDesignDao::fetch)
+        val design1 =
+            layoutDesignDao
+                .insert(layoutDesignSaveRequest("foo bar", designState = DesignState.ACTIVE))
+                .let(layoutDesignDao::fetch)
+        val design2 =
+            layoutDesignDao
+                .insert(layoutDesignSaveRequest("aa bee see", designState = DesignState.DELETED))
+                .let(layoutDesignDao::fetch)
+        val design3 =
+            layoutDesignDao
+                .insert(layoutDesignSaveRequest("aa bee dee", designState = DesignState.COMPLETED))
+                .let(layoutDesignDao::fetch)
 
         assertEquals(
             listOf(
                 design1,
             ),
-            layoutDesignDao.list(includeCompleted = false, includeDeleted = false)
-        )
+            layoutDesignDao.list(includeCompleted = false, includeDeleted = false))
 
-        val listWithDeletedAndCompleted = layoutDesignDao.list(includeCompleted = true, includeDeleted = true)
+        val listWithDeletedAndCompleted =
+            layoutDesignDao.list(includeCompleted = true, includeDeleted = true)
         assertContains(listWithDeletedAndCompleted, design1)
         assertContains(listWithDeletedAndCompleted, design2)
         assertContains(listWithDeletedAndCompleted, design3)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometryTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometryTest.kt
@@ -4,11 +4,11 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
+import kotlin.math.hypot
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
-import kotlin.math.hypot
-import kotlin.test.assertEquals
 
 class LayoutGeometryTest {
 
@@ -16,11 +16,12 @@ class LayoutGeometryTest {
 
     @Test
     fun shouldReturnSegmentAsIsWhenDistanceIsOverSegmentsMValues() {
-        val segment = segment(
-            segmentPoint(0.0, 0.0, 1.0),
-            segmentPoint(10.0, 0.0, 11.0),
-            segmentPoint(20.0, 0.0, 21.0),
-        )
+        val segment =
+            segment(
+                segmentPoint(0.0, 0.0, 1.0),
+                segmentPoint(10.0, 0.0, 11.0),
+                segmentPoint(20.0, 0.0, 21.0),
+            )
 
         val (startSegment, endSegment) = segment.splitAtM(30.0, 0.0)
         assertEquals(segment, startSegment)
@@ -33,12 +34,13 @@ class LayoutGeometryTest {
 
     @Test
     fun shouldSplitFromSegmentPoint() {
-        val segment = segment(
-            segmentPoint(0.0, 0.0, 0.0),
-            segmentPoint(10.0, 0.0, 10.0),
-            segmentPoint(20.0, 0.0, 20.0),
-            start = 1.0,
-        )
+        val segment =
+            segment(
+                segmentPoint(0.0, 0.0, 0.0),
+                segmentPoint(10.0, 0.0, 10.0),
+                segmentPoint(20.0, 0.0, 20.0),
+                start = 1.0,
+            )
 
         val (startSegment, endSegment) = segment.splitAtM(11.0, 0.0001)
         assertEquals(2, startSegment.alignmentPoints.size)
@@ -55,22 +57,25 @@ class LayoutGeometryTest {
 
     @Test
     fun splitSegmentMetadataShouldBeCorrect() {
-        val segment = LayoutSegment(
-            geometry = SegmentGeometry(
-                segmentPoints = listOf(
-                    segmentPoint(10.0, 10.0, 0.0),
-                    segmentPoint(20.0, 20.0, 0.0 + hypot(10.0, 10.0)),
-                ),
-                resolution = 2,
-            ),
-            startM = 10.0,
-            sourceId = StringId(),
-            sourceStart = 15.0,
-            switchId = StringId(),
-            startJointNumber = JointNumber(2),
-            endJointNumber = JointNumber(2),
-            source = GeometrySource.IMPORTED,
-        )
+        val segment =
+            LayoutSegment(
+                geometry =
+                    SegmentGeometry(
+                        segmentPoints =
+                            listOf(
+                                segmentPoint(10.0, 10.0, 0.0),
+                                segmentPoint(20.0, 20.0, 0.0 + hypot(10.0, 10.0)),
+                            ),
+                        resolution = 2,
+                    ),
+                startM = 10.0,
+                sourceId = StringId(),
+                sourceStart = 15.0,
+                switchId = StringId(),
+                startJointNumber = JointNumber(2),
+                endJointNumber = JointNumber(2),
+                source = GeometrySource.IMPORTED,
+            )
 
         val (startSegment, endSegment) = segment.splitAtM(20.0, 0.5)
         assertNotNull(endSegment)
@@ -95,11 +100,12 @@ class LayoutGeometryTest {
 
     @Test
     fun shouldSplitFromPointWithinTolerance() {
-        val segment = segment(
-            segmentPoint(0.0, 0.0, 0.0),
-            segmentPoint(10.0, 0.0, 10.0),
-            segmentPoint(20.0, 0.0, 20.0),
-        )
+        val segment =
+            segment(
+                segmentPoint(0.0, 0.0, 0.0),
+                segmentPoint(10.0, 0.0, 10.0),
+                segmentPoint(20.0, 0.0, 20.0),
+            )
 
         val (startSegment, endSegment) = segment.splitAtM(9.9, 0.5)
         assertEquals(2, startSegment.alignmentPoints.size)
@@ -116,11 +122,12 @@ class LayoutGeometryTest {
 
     @Test
     fun shouldNotSplitWhenEndPointIsWithinTolerance() {
-        val segment = segment(
-            segmentPoint(0.0, 0.0, 0.0),
-            segmentPoint(10.0, 0.0, 10.0),
-            segmentPoint(20.0, 0.0, 20.0),
-        )
+        val segment =
+            segment(
+                segmentPoint(0.0, 0.0, 0.0),
+                segmentPoint(10.0, 0.0, 10.0),
+                segmentPoint(20.0, 0.0, 20.0),
+            )
 
         val (startSegment, endSegment) = segment.splitAtM(20.5, 1.0)
         assertNull(endSegment)
@@ -131,11 +138,12 @@ class LayoutGeometryTest {
 
     @Test
     fun shouldSplitFromANewPointWhenNonePointsWithinTolerance() {
-        val segment = segment(
-            segmentPoint(0.0, 0.0, 0.0),
-            segmentPoint(10.0, 0.0, 10.0),
-            segmentPoint(20.0, 0.0, 20.0),
-        )
+        val segment =
+            segment(
+                segmentPoint(0.0, 0.0, 0.0),
+                segmentPoint(10.0, 0.0, 10.0),
+                segmentPoint(20.0, 0.0, 20.0),
+            )
 
         val (startSegment1, endSegment1) = segment.splitAtM(5.0, 0.5)
         assertEquals(2, startSegment1.alignmentPoints.size)
@@ -168,11 +176,12 @@ class LayoutGeometryTest {
 
     @Test
     fun seekSegmentPointAtMWorks() {
-        val segment = segment(
-            segmentPoint(0.0, 0.0, 0.0),
-            segmentPoint(10.0, 0.0, 10.0),
-            segmentPoint(20.0, 0.0, 20.0),
-        )
+        val segment =
+            segment(
+                segmentPoint(0.0, 0.0, 0.0),
+                segmentPoint(10.0, 0.0, 10.0),
+                segmentPoint(20.0, 0.0, 20.0),
+            )
         assertEquals(
             PointSeekResult(alignmentPoint(0.0, 0.0, 0.0), 0, true),
             segment.seekPointAtM(0.0),
@@ -207,11 +216,12 @@ class LayoutGeometryTest {
 
     @Test
     fun segmentPointAtLengthSnapsCorrectly() {
-        val segment = segment(
-            segmentPoint(0.0, 0.0, 0.0),
-            segmentPoint(10.0, 0.0, 10.0),
-            segmentPoint(20.0, 0.0, 20.0),
-        )
+        val segment =
+            segment(
+                segmentPoint(0.0, 0.0, 0.0),
+                segmentPoint(10.0, 0.0, 10.0),
+                segmentPoint(20.0, 0.0, 20.0),
+            )
         assertEquals(
             PointSeekResult(alignmentPoint(0.05, 0.0, 0.05), 1, false),
             segment.seekPointAtM(0.05, 0.0),
@@ -267,17 +277,18 @@ class LayoutGeometryTest {
     @Test
     fun alignmentPointAtLengthWorks() {
         val diagonalLength = hypot(5.0, 5.0)
-        val alignment = alignment(
-            segment(
-                segmentPoint(0.0, 0.0, 0.0),
-                segmentPoint(10.0, 0.0, 10.0),
-            ),
-            segment(
-                segmentPoint(10.0, 0.0, 10.0),
-                segmentPoint(15.0, 5.0, 10.0 + diagonalLength),
-                segmentPoint(15.0, 15.0, 20.0 + diagonalLength),
-            ),
-        )
+        val alignment =
+            alignment(
+                segment(
+                    segmentPoint(0.0, 0.0, 0.0),
+                    segmentPoint(10.0, 0.0, 10.0),
+                ),
+                segment(
+                    segmentPoint(10.0, 0.0, 10.0),
+                    segmentPoint(15.0, 5.0, 10.0 + diagonalLength),
+                    segmentPoint(15.0, 15.0, 20.0 + diagonalLength),
+                ),
+            )
 
         assertApproximatelyEquals(
             segmentPoint(0.0, 0.0, 0.0),
@@ -301,11 +312,9 @@ class LayoutGeometryTest {
         )
 
         assertApproximatelyEquals(
-            segmentPoint(0.0, 0.0, 0.0),
-            alignment.getPointAtM(-5.0)!!,
-            accuracy)
+            segmentPoint(0.0, 0.0, 0.0), alignment.getPointAtM(-5.0)!!, accuracy)
         assertApproximatelyEquals(
-            segmentPoint(15.0, 15.0, 20.0+diagonalLength),
+            segmentPoint(15.0, 15.0, 20.0 + diagonalLength),
             alignment.getPointAtM(50.0)!!,
             accuracy,
         )
@@ -325,24 +334,27 @@ class LayoutGeometryTest {
     @Test
     fun sliceWorksWithNewStartM() {
         val pointInterval = hypot(10.0, 10.0)
-        val original = LayoutSegment(
-            geometry = SegmentGeometry(
-                segmentPoints = listOf(
-                    segmentPoint(10.0, 10.0, 0.0),
-                    segmentPoint(20.0, 20.0, 0.0 + pointInterval),
-                    segmentPoint(30.0, 30.0, 0.0 + 2 * pointInterval),
-                    segmentPoint(40.0, 40.0, 0.0 + 3 * pointInterval),
-                ),
-                resolution = 2,
-            ),
-            startM = 10.0,
-            sourceId = StringId(),
-            sourceStart = 15.0,
-            switchId = StringId(),
-            startJointNumber = JointNumber(2),
-            endJointNumber = JointNumber(2),
-            source = GeometrySource.IMPORTED,
-        )
+        val original =
+            LayoutSegment(
+                geometry =
+                    SegmentGeometry(
+                        segmentPoints =
+                            listOf(
+                                segmentPoint(10.0, 10.0, 0.0),
+                                segmentPoint(20.0, 20.0, 0.0 + pointInterval),
+                                segmentPoint(30.0, 30.0, 0.0 + 2 * pointInterval),
+                                segmentPoint(40.0, 40.0, 0.0 + 3 * pointInterval),
+                            ),
+                        resolution = 2,
+                    ),
+                startM = 10.0,
+                sourceId = StringId(),
+                sourceStart = 15.0,
+                switchId = StringId(),
+                startJointNumber = JointNumber(2),
+                endJointNumber = JointNumber(2),
+                source = GeometrySource.IMPORTED,
+            )
 
         val newStart = 11.0
         val slice = original.slice(1, 2, newStart)
@@ -369,24 +381,27 @@ class LayoutGeometryTest {
     @Test
     fun sliceWorksWithDefaultStartM() {
         val pointInterval = hypot(10.0, 10.0)
-        val original = LayoutSegment(
-            geometry = SegmentGeometry(
-                segmentPoints = listOf(
-                    segmentPoint(10.0, 10.0, 0.0),
-                    segmentPoint(20.0, 20.0, 0.0 + pointInterval),
-                    segmentPoint(30.0, 30.0, 0.0 + 2 * pointInterval),
-                    segmentPoint(40.0, 40.0, 0.0 + 3 * pointInterval),
-                ),
-                resolution = 2,
-            ),
-            startM = 10.0,
-            sourceId = StringId(),
-            sourceStart = 15.0,
-            switchId = StringId(),
-            startJointNumber = JointNumber(2),
-            endJointNumber = JointNumber(2),
-            source = GeometrySource.IMPORTED,
-        )
+        val original =
+            LayoutSegment(
+                geometry =
+                    SegmentGeometry(
+                        segmentPoints =
+                            listOf(
+                                segmentPoint(10.0, 10.0, 0.0),
+                                segmentPoint(20.0, 20.0, 0.0 + pointInterval),
+                                segmentPoint(30.0, 30.0, 0.0 + 2 * pointInterval),
+                                segmentPoint(40.0, 40.0, 0.0 + 3 * pointInterval),
+                            ),
+                        resolution = 2,
+                    ),
+                startM = 10.0,
+                sourceId = StringId(),
+                sourceStart = 15.0,
+                switchId = StringId(),
+                startJointNumber = JointNumber(2),
+                endJointNumber = JointNumber(2),
+                source = GeometrySource.IMPORTED,
+            )
 
         val slice = original.slice(1, 2)
         assertNotNull(slice)
@@ -411,28 +426,29 @@ class LayoutGeometryTest {
 
     @Test
     fun `getMaxDirectionDeltaRads with shared segment points`() {
-        val alignment = alignment(
-            segment(Point(0.0, 0.0), Point(1.0, 1.0)),
-            segment(Point(1.0, 1.0), Point(2.0, 2.0)),
-        )
+        val alignment =
+            alignment(
+                segment(Point(0.0, 0.0), Point(1.0, 1.0)),
+                segment(Point(1.0, 1.0), Point(2.0, 2.0)),
+            )
         assertEquals(0.0, alignment.getMaxDirectionDeltaRads())
     }
 
     @Test
     fun `takeLast(n) with smaller last segment than n points`() {
-        val alignment = alignment(
-            segment(Point(0.0, 0.0), Point(3.0, 0.0)),
-            segment(Point(3.0001, 0.0), Point(4.0001, 0.0), Point(5.0001, 0.0))
-        )
+        val alignment =
+            alignment(
+                segment(Point(0.0, 0.0), Point(3.0, 0.0)),
+                segment(Point(3.0001, 0.0), Point(4.0001, 0.0), Point(5.0001, 0.0)))
         assertEquals(listOf(1.0, 2.0, 3.0001, 4.0001, 5.0001), alignment.takeLast(5).map { it.x })
     }
 
     @Test
     fun `takeFirst(n) with smaller first segment than n points`() {
-        val alignment = alignment(
-            segment(Point(0.0, 0.0), Point(3.0, 0.0)),
-            segment(Point(3.0001, 0.0), Point(4.0001, 0.0), Point(5.0001, 0.0))
-        )
+        val alignment =
+            alignment(
+                segment(Point(0.0, 0.0), Point(3.0, 0.0)),
+                segment(Point(3.0001, 0.0), Point(4.0001, 0.0), Point(5.0001, 0.0)))
         assertEquals(listOf(0.0, 1.0, 2.0, 3.0001, 4.0001), alignment.takeFirst(5).map { it.x })
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDaoIT.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutState.DELETED
 import fi.fta.geoviite.infra.tracklayout.LayoutState.IN_USE
 import fi.fta.geoviite.infra.tracklayout.LayoutState.NOT_IN_USE
 import fi.fta.geoviite.infra.tracklayout.LayoutState.PLANNED
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -24,40 +25,44 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutKmPostDaoIT @Autowired constructor(
+class LayoutKmPostDaoIT
+@Autowired
+constructor(
     private val kmPostDao: LayoutKmPostDao,
 ) : DBTestBase() {
 
     @Test
     fun kmPostsAreStoredAndLoadedOk() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val post1 = kmPost(
-            trackNumberId = trackNumberId,
-            km = KmNumber(123),
-            gkLocation = GeometryPoint(25500000.0, 6675000.0, Srid(3879)),
-            state = IN_USE,
-            draft = false,
-            gkLocationConfirmed = true,
-            gkLocationSource = KmPostGkLocationSource.FROM_GEOMETRY,
-        )
-        val post2 = kmPost(
-            trackNumberId = trackNumberId,
-            km = KmNumber(125),
-            gkLocation = GeometryPoint(25500005.0, 6675005.0, Srid(3879)),
-            state = NOT_IN_USE,
-            draft = false,
-        )
-        val post3 = kmPost(
-            trackNumberId = trackNumberId,
-            km = KmNumber(124),
-            gkLocation = GeometryPoint(25500010.0, 6675000.0, Srid(3879)),
-            state = PLANNED,
-            draft = false,
-        )
+        val post1 =
+            kmPost(
+                trackNumberId = trackNumberId,
+                km = KmNumber(123),
+                gkLocation = GeometryPoint(25500000.0, 6675000.0, Srid(3879)),
+                state = IN_USE,
+                draft = false,
+                gkLocationConfirmed = true,
+                gkLocationSource = KmPostGkLocationSource.FROM_GEOMETRY,
+            )
+        val post2 =
+            kmPost(
+                trackNumberId = trackNumberId,
+                km = KmNumber(125),
+                gkLocation = GeometryPoint(25500005.0, 6675005.0, Srid(3879)),
+                state = NOT_IN_USE,
+                draft = false,
+            )
+        val post3 =
+            kmPost(
+                trackNumberId = trackNumberId,
+                km = KmNumber(124),
+                gkLocation = GeometryPoint(25500010.0, 6675000.0, Srid(3879)),
+                state = PLANNED,
+                draft = false,
+            )
         insertAndVerify(post1)
         insertAndVerify(post2)
         insertAndVerify(post3)
@@ -73,7 +78,8 @@ class LayoutKmPostDaoIT @Autowired constructor(
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val official = mainOfficialContext.insert(kmPost(trackNumberId, KmNumber(234)))
         assertEquals(official.id.intValue, official.rowVersion.rowId.intValue)
-        assertEquals(official.rowVersion, kmPostDao.fetchVersion(MainLayoutContext.official, official.id))
+        assertEquals(
+            official.rowVersion, kmPostDao.fetchVersion(MainLayoutContext.official, official.id))
 
         val draft = mainDraftContext.insert(kmPost(trackNumberId, KmNumber(432)))
         assertEquals(draft.id.intValue, draft.rowVersion.rowId.intValue)
@@ -83,8 +89,12 @@ class LayoutKmPostDaoIT @Autowired constructor(
         val alteredDraft = testDBService.createDraft(official.rowVersion)
         assertEquals(official.id, alteredDraft.id)
         assertNotEquals(official.id.intValue, alteredDraft.rowVersion.rowId.intValue)
-        assertEquals(official.rowVersion, kmPostDao.fetchVersion(MainLayoutContext.official, alteredDraft.id))
-        assertEquals(alteredDraft.rowVersion, kmPostDao.fetchVersion(MainLayoutContext.draft, alteredDraft.id))
+        assertEquals(
+            official.rowVersion,
+            kmPostDao.fetchVersion(MainLayoutContext.official, alteredDraft.id))
+        assertEquals(
+            alteredDraft.rowVersion,
+            kmPostDao.fetchVersion(MainLayoutContext.draft, alteredDraft.id))
     }
 
     @Test
@@ -125,30 +135,40 @@ class LayoutKmPostDaoIT @Autowired constructor(
     fun fetchVersionsForPublicationReturnsDraftsOnlyForPublishableSet() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val postOneOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(1), draft = false))
-        val postOneDraft = kmPostDao.insert(asMainDraft(kmPostDao.fetch(postOneOfficial.rowVersion)))
+        val postOneDraft =
+            kmPostDao.insert(asMainDraft(kmPostDao.fetch(postOneOfficial.rowVersion)))
         val postTwoOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(2), draft = false))
         kmPostDao.insert(asMainDraft(kmPostDao.fetch(postTwoOfficial.rowVersion)))
         val postThreeOnlyDraft = kmPostDao.insert(kmPost(trackNumberId, KmNumber(3), draft = true))
-        val postFourOnlyOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(4), draft = false))
+        val postFourOnlyOfficial =
+            kmPostDao.insert(kmPost(trackNumberId, KmNumber(4), draft = false))
 
-        val versionsEmpty = kmPostDao.fetchVersionsForPublication(
-            LayoutBranch.main,
-            listOf(trackNumberId),
-            listOf(),
-        )[trackNumberId]!!
-        val versionsOnlyOne = kmPostDao.fetchVersionsForPublication(
-            LayoutBranch.main,
-            listOf(trackNumberId),
-            listOf(postOneOfficial.id),
-        )[trackNumberId]!!
-        val versionsOneAndThree = kmPostDao.fetchVersionsForPublication(
-            LayoutBranch.main,
-            listOf(trackNumberId),
-            listOf(postOneOfficial.id, postThreeOnlyDraft.id),
-        )[trackNumberId]!!
+        val versionsEmpty =
+            kmPostDao
+                .fetchVersionsForPublication(
+                    LayoutBranch.main,
+                    listOf(trackNumberId),
+                    listOf(),
+                )[trackNumberId]!!
+        val versionsOnlyOne =
+            kmPostDao
+                .fetchVersionsForPublication(
+                    LayoutBranch.main,
+                    listOf(trackNumberId),
+                    listOf(postOneOfficial.id),
+                )[trackNumberId]!!
+        val versionsOneAndThree =
+            kmPostDao
+                .fetchVersionsForPublication(
+                    LayoutBranch.main,
+                    listOf(trackNumberId),
+                    listOf(postOneOfficial.id, postThreeOnlyDraft.id),
+                )[trackNumberId]!!
 
-        assertEquals(setOf(postOneOfficial, postTwoOfficial, postFourOnlyOfficial), versionsEmpty.toSet())
-        assertEquals(setOf(postOneDraft, postTwoOfficial, postFourOnlyOfficial), versionsOnlyOne.toSet())
+        assertEquals(
+            setOf(postOneOfficial, postTwoOfficial, postFourOnlyOfficial), versionsEmpty.toSet())
+        assertEquals(
+            setOf(postOneDraft, postTwoOfficial, postFourOnlyOfficial), versionsOnlyOne.toSet())
         assertEquals(
             setOf(postOneDraft, postTwoOfficial, postThreeOnlyDraft, postFourOnlyOfficial),
             versionsOneAndThree.toSet(),
@@ -160,7 +180,8 @@ class LayoutKmPostDaoIT @Autowired constructor(
         val tnId = mainOfficialContext.createLayoutTrackNumber().id
         val officialVersion = mainOfficialContext.insert(kmPost(tnId, KmNumber(1)))
         val undeletedDraftVersion = mainDraftContext.insert(kmPost(tnId, KmNumber(2)))
-        val deleteStateDraftVersion = mainDraftContext.insert(kmPost(tnId, KmNumber(3), state = DELETED))
+        val deleteStateDraftVersion =
+            mainDraftContext.insert(kmPost(tnId, KmNumber(3), state = DELETED))
         val deletedDraftVersion = mainDraftContext.insert(kmPost(tnId, KmNumber(4)))
         kmPostDao.deleteDraft(LayoutBranch.main, deletedDraftVersion.id)
 
@@ -197,7 +218,10 @@ class LayoutKmPostDaoIT @Autowired constructor(
         Thread.sleep(1) // Ensure that they get different timestamps
 
         val kmPost1MainV2 = testDBService.update(kmPost1MainV1).rowVersion
-        val kmPost1DesignV2 = designOfficialContext.copyFrom(kmPost1MainV1, officialRowId = kmPost1MainV1.rowId).rowVersion
+        val kmPost1DesignV2 =
+            designOfficialContext
+                .copyFrom(kmPost1MainV1, officialRowId = kmPost1MainV1.rowId)
+                .rowVersion
         val kmPost2DesignV2 = testDBService.update(kmPost2DesignV1).rowVersion
         kmPostDao.deleteRow(kmPost3DesignV1.rowId)
         val v2Time = kmPostDao.fetchChangeTime()
@@ -208,32 +232,59 @@ class LayoutKmPostDaoIT @Autowired constructor(
         val kmPost2MainV3 = mainOfficialContext.moveFrom(kmPost2DesignV2).rowVersion
         val v3Time = kmPostDao.fetchChangeTime()
 
-        assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost1Id, v0Time))
-        assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost2Id, v0Time))
-        assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost3Id, v0Time))
+        assertEquals(
+            null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost1Id, v0Time))
+        assertEquals(
+            null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost2Id, v0Time))
+        assertEquals(
+            null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost3Id, v0Time))
         assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost1Id, v0Time))
         assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost2Id, v0Time))
         assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost3Id, v0Time))
 
-        assertEquals(kmPost1MainV1, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost1Id, v1Time))
-        assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost2Id, v1Time))
-        assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost3Id, v1Time))
-        assertEquals(kmPost1MainV1, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost1Id, v1Time))
-        assertEquals(kmPost2DesignV1, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost2Id, v1Time))
-        assertEquals(kmPost3DesignV1, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost3Id, v1Time))
+        assertEquals(
+            kmPost1MainV1,
+            kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost1Id, v1Time))
+        assertEquals(
+            null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost2Id, v1Time))
+        assertEquals(
+            null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost3Id, v1Time))
+        assertEquals(
+            kmPost1MainV1, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost1Id, v1Time))
+        assertEquals(
+            kmPost2DesignV1,
+            kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost2Id, v1Time))
+        assertEquals(
+            kmPost3DesignV1,
+            kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost3Id, v1Time))
 
-        assertEquals(kmPost1MainV2, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost1Id, v2Time))
-        assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost2Id, v2Time))
-        assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost3Id, v2Time))
-        assertEquals(kmPost1DesignV2, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost1Id, v2Time))
-        assertEquals(kmPost2DesignV2, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost2Id, v2Time))
+        assertEquals(
+            kmPost1MainV2,
+            kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost1Id, v2Time))
+        assertEquals(
+            null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost2Id, v2Time))
+        assertEquals(
+            null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost3Id, v2Time))
+        assertEquals(
+            kmPost1DesignV2,
+            kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost1Id, v2Time))
+        assertEquals(
+            kmPost2DesignV2,
+            kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost2Id, v2Time))
         assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost3Id, v2Time))
 
-        assertEquals(kmPost1MainV2, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost1Id, v3Time))
-        assertEquals(kmPost2MainV3, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost2Id, v3Time))
-        assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost3Id, v3Time))
-        assertEquals(kmPost1MainV2, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost1Id, v3Time))
-        assertEquals(kmPost2MainV3, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost2Id, v3Time))
+        assertEquals(
+            kmPost1MainV2,
+            kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost1Id, v3Time))
+        assertEquals(
+            kmPost2MainV3,
+            kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost2Id, v3Time))
+        assertEquals(
+            null, kmPostDao.fetchOfficialVersionAtMoment(LayoutBranch.main, kmPost3Id, v3Time))
+        assertEquals(
+            kmPost1MainV2, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost1Id, v3Time))
+        assertEquals(
+            kmPost2MainV3, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost2Id, v3Time))
         assertEquals(null, kmPostDao.fetchOfficialVersionAtMoment(designBranch, kmPost3Id, v3Time))
     }
 
@@ -259,11 +310,13 @@ class LayoutKmPostDaoIT @Autowired constructor(
         val tnId = mainOfficialContext.createLayoutTrackNumber().id
         val tnId2 = mainOfficialContext.createLayoutTrackNumber().id
         val undeletedDraftVersion = mainDraftContext.insert(kmPost(tnId, KmNumber(1)))
-        val deleteStateDraftVersion = mainDraftContext.insert(kmPost(tnId, KmNumber(2), state = DELETED))
+        val deleteStateDraftVersion =
+            mainDraftContext.insert(kmPost(tnId, KmNumber(2), state = DELETED))
         val changeTrackNumberOriginal = mainOfficialContext.insert(kmPost(tnId, KmNumber(3)))
-        val changeTrackNumberChanged = testDBService.createDraft(changeTrackNumberOriginal.rowVersion) { kmp ->
-            kmp.copy(trackNumberId = tnId2)
-        }
+        val changeTrackNumberChanged =
+            testDBService.createDraft(changeTrackNumberOriginal.rowVersion) { kmp ->
+                kmp.copy(trackNumberId = tnId2)
+            }
         val deletedDraftId = mainDraftContext.insert(kmPost(tnId, KmNumber(4))).id
         kmPostDao.deleteDraft(LayoutBranch.main, deletedDraftId)
 
@@ -286,7 +339,10 @@ class LayoutKmPostDaoIT @Autowired constructor(
         )
     }
 
-    private fun insertOfficial(tnId: IntId<TrackLayoutTrackNumber>, kmNumber: Int): LayoutDaoResponse<TrackLayoutKmPost> {
+    private fun insertOfficial(
+        tnId: IntId<TrackLayoutTrackNumber>,
+        kmNumber: Int
+    ): LayoutDaoResponse<TrackLayoutKmPost> {
         return kmPostDao.insert(kmPost(tnId, KmNumber(kmNumber), draft = false))
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -7,17 +7,19 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.linking.TrackLayoutKmPostSaveRequest
 import fi.fta.geoviite.infra.math.Point
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutKmPostServiceIT @Autowired constructor(
+class LayoutKmPostServiceIT
+@Autowired
+constructor(
     private val kmPostService: LayoutKmPostService,
     private val kmPostDao: LayoutKmPostDao,
     private val trackNumberService: LayoutTrackNumberService,
@@ -27,36 +29,39 @@ class LayoutKmPostServiceIT @Autowired constructor(
     @Test
     fun nearbyKmPostsAreReturnedInOrder() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val kmPost1 = kmPostDao.fetch(
-            kmPostDao.insert(
-                kmPost(
-                    trackNumberId = trackNumberId,
-                    km = KmNumber(1),
-                    roughLayoutLocation = Point(1.0, 1.0),
-                    draft = false,
-                )
-            ).rowVersion
-        )
-        val kmPost2 = kmPostDao.fetch(
-            kmPostDao.insert(
-                kmPost(
-                    trackNumberId = trackNumberId,
-                    km = KmNumber(2),
-                    roughLayoutLocation = Point(2.0, 1.0),
-                    draft = false,
-                )
-            ).rowVersion
-        )
-        val kmPost3 = kmPostDao.fetch(
-            kmPostDao.insert(
-                kmPost(
-                    trackNumberId = trackNumberId,
-                    km = KmNumber(3),
-                    roughLayoutLocation = null,
-                    draft = false,
-                )
-            ).rowVersion
-        )
+        val kmPost1 =
+            kmPostDao.fetch(
+                kmPostDao
+                    .insert(
+                        kmPost(
+                            trackNumberId = trackNumberId,
+                            km = KmNumber(1),
+                            roughLayoutLocation = Point(1.0, 1.0),
+                            draft = false,
+                        ))
+                    .rowVersion)
+        val kmPost2 =
+            kmPostDao.fetch(
+                kmPostDao
+                    .insert(
+                        kmPost(
+                            trackNumberId = trackNumberId,
+                            km = KmNumber(2),
+                            roughLayoutLocation = Point(2.0, 1.0),
+                            draft = false,
+                        ))
+                    .rowVersion)
+        val kmPost3 =
+            kmPostDao.fetch(
+                kmPostDao
+                    .insert(
+                        kmPost(
+                            trackNumberId = trackNumberId,
+                            km = KmNumber(3),
+                            roughLayoutLocation = null,
+                            draft = false,
+                        ))
+                    .rowVersion)
 
         kmPostDao.insert(
             kmPost(
@@ -64,16 +69,16 @@ class LayoutKmPostServiceIT @Autowired constructor(
                 km = KmNumber(4),
                 roughLayoutLocation = null,
                 draft = false,
-            )
-        )
+            ))
 
-        val actual = kmPostService.listNearbyOnTrackPaged(
-            MainLayoutContext.official,
-            Point(0.0, 0.0),
-            trackNumberId,
-            0,
-            null,
-        )
+        val actual =
+            kmPostService.listNearbyOnTrackPaged(
+                MainLayoutContext.official,
+                Point(0.0, 0.0),
+                trackNumberId,
+                0,
+                null,
+            )
         val expected = listOf(kmPost3, kmPost1, kmPost2)
         assertEquals(expected, actual)
     }
@@ -81,23 +86,25 @@ class LayoutKmPostServiceIT @Autowired constructor(
     @Test
     fun findsKmPostAtKmNumber() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val kmPost = kmPostDao.fetch(
-            kmPostDao.insert(
-                kmPost(
-                    trackNumberId = trackNumberId,
-                    km = KmNumber(1),
-                    roughLayoutLocation = Point(1.0, 1.0),
-                    draft = false,
-                )
-            ).rowVersion
-        )
+        val kmPost =
+            kmPostDao.fetch(
+                kmPostDao
+                    .insert(
+                        kmPost(
+                            trackNumberId = trackNumberId,
+                            km = KmNumber(1),
+                            roughLayoutLocation = Point(1.0, 1.0),
+                            draft = false,
+                        ))
+                    .rowVersion)
 
-        val result = kmPostService.getByKmNumber(
-            MainLayoutContext.official,
-            trackNumberId,
-            kmPost.kmNumber,
-            true,
-        )
+        val result =
+            kmPostService.getByKmNumber(
+                MainLayoutContext.official,
+                trackNumberId,
+                kmPost.kmNumber,
+                true,
+            )
         assertNotNull(result)
         assertMatches(kmPost, result)
     }
@@ -111,28 +118,32 @@ class LayoutKmPostServiceIT @Autowired constructor(
                 km = KmNumber(1),
                 roughLayoutLocation = Point(1.0, 1.0),
                 draft = false,
-            )
-        )
+            ))
 
-        assertNull(kmPostService.getByKmNumber(MainLayoutContext.official, trackNumberId, KmNumber(2), true))
+        assertNull(
+            kmPostService.getByKmNumber(
+                MainLayoutContext.official, trackNumberId, KmNumber(2), true))
     }
 
     @Test
     fun doesntFindKmPostOnWrongTrack() {
         val trackNumber1Id = mainOfficialContext.createLayoutTrackNumber().id
         val trackNumber2Id = mainOfficialContext.createLayoutTrackNumber().id
-        val kmPost = kmPostDao.fetch(
-            kmPostDao.insert(
-                kmPost(
-                    trackNumberId = trackNumber1Id,
-                    km = KmNumber(1),
-                    roughLayoutLocation = Point(1.0, 1.0),
-                    draft = false,
-                )
-            ).rowVersion
-        )
+        val kmPost =
+            kmPostDao.fetch(
+                kmPostDao
+                    .insert(
+                        kmPost(
+                            trackNumberId = trackNumber1Id,
+                            km = KmNumber(1),
+                            roughLayoutLocation = Point(1.0, 1.0),
+                            draft = false,
+                        ))
+                    .rowVersion)
 
-        assertNull(kmPostService.getByKmNumber(MainLayoutContext.official, trackNumber2Id, kmPost.kmNumber, true))
+        assertNull(
+            kmPostService.getByKmNumber(
+                MainLayoutContext.official, trackNumber2Id, kmPost.kmNumber, true))
     }
 
     @Test
@@ -153,14 +164,15 @@ class LayoutKmPostServiceIT @Autowired constructor(
     @Test
     fun kmPostIdIsReturnedWhenAddingNewKmPost() {
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
-        val kmPost = TrackLayoutKmPostSaveRequest(
-            kmNumber = someKmNumber(),
-            state = LayoutState.IN_USE,
-            trackNumberId = trackNumberId,
-            gkLocation = null,
-            gkLocationSource = null,
-            gkLocationConfirmed = false,
-        )
+        val kmPost =
+            TrackLayoutKmPostSaveRequest(
+                kmNumber = someKmNumber(),
+                state = LayoutState.IN_USE,
+                trackNumberId = trackNumberId,
+                gkLocation = null,
+                gkLocationSource = null,
+                gkLocationConfirmed = false,
+            )
         val kmPostId = kmPostService.insertKmPost(LayoutBranch.main, kmPost)
 
         val fetchedKmPost = kmPostService.getOrThrow(MainLayoutContext.draft, kmPostId)
@@ -185,27 +197,40 @@ class LayoutKmPostServiceIT @Autowired constructor(
                     Point(1.0, 10.0),
                     Point(3.0, 15.0),
                     Point(4.0, 20.0),
-                )
-            ),
+                )),
         )
-        val kmPosts = listOf(
-            kmPost(trackNumberId, KmNumber(1), Point(0.0, 3.0), draft = true),
-            kmPost(trackNumberId, KmNumber(2), Point(0.0, 5.0), draft = true),
-            kmPost(trackNumberId, KmNumber(3), null, draft = true),
-            kmPost(trackNumberId, KmNumber(4), Point(0.0, 6.0), state = LayoutState.NOT_IN_USE, draft = true),
-            kmPost(trackNumberId, KmNumber(5), Point(0.0, 10.0), state = LayoutState.PLANNED, draft = true),
-            kmPost(trackNumberId, KmNumber(6, "A"), Point(3.0, 14.0), draft = true),
-            kmPost(trackNumberId, KmNumber(6, "AA"), Point(6.0, 18.0), draft = true),
-        )
-        val kmPostSaveResults = kmPosts
-            .map { d -> kmPostService.saveDraft(LayoutBranch.main, d) }
-            .map(LayoutDaoResponse<TrackLayoutKmPost>::id)
+        val kmPosts =
+            listOf(
+                kmPost(trackNumberId, KmNumber(1), Point(0.0, 3.0), draft = true),
+                kmPost(trackNumberId, KmNumber(2), Point(0.0, 5.0), draft = true),
+                kmPost(trackNumberId, KmNumber(3), null, draft = true),
+                kmPost(
+                    trackNumberId,
+                    KmNumber(4),
+                    Point(0.0, 6.0),
+                    state = LayoutState.NOT_IN_USE,
+                    draft = true),
+                kmPost(
+                    trackNumberId,
+                    KmNumber(5),
+                    Point(0.0, 10.0),
+                    state = LayoutState.PLANNED,
+                    draft = true),
+                kmPost(trackNumberId, KmNumber(6, "A"), Point(3.0, 14.0), draft = true),
+                kmPost(trackNumberId, KmNumber(6, "AA"), Point(6.0, 18.0), draft = true),
+            )
+        val kmPostSaveResults =
+            kmPosts
+                .map { d -> kmPostService.saveDraft(LayoutBranch.main, d) }
+                .map(LayoutDaoResponse<TrackLayoutKmPost>::id)
 
         // drop(1) because the track number km lengths include the section before the first km post
-        val expected = trackNumberService.getKmLengths(MainLayoutContext.draft, trackNumberId)!!.drop(1)
-        val actual = kmPostSaveResults.mapNotNull { kmPost ->
-            kmPostService.getKmPostInfoboxExtras(MainLayoutContext.draft, kmPost).kmLength
-        }
+        val expected =
+            trackNumberService.getKmLengths(MainLayoutContext.draft, trackNumberId)!!.drop(1)
+        val actual =
+            kmPostSaveResults.mapNotNull { kmPost ->
+                kmPostService.getKmPostInfoboxExtras(MainLayoutContext.draft, kmPost).kmLength
+            }
         assertEquals(expected.size, actual.size)
         expected.zip(actual) { e, a -> assertEquals(e.length.toDouble(), a, 0.001) }
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
@@ -11,17 +11,19 @@ import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.util.FreeText
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutSearchServiceIT @Autowired constructor(
+class LayoutSearchServiceIT
+@Autowired
+constructor(
     val searchService: LayoutSearchService,
     val trackNumberService: LayoutTrackNumberService,
     val locationTrackService: LocationTrackService,
@@ -35,12 +37,12 @@ class LayoutSearchServiceIT @Autowired constructor(
 
     @Test
     fun `free text search should find multiple matching track numbers, and not the ones that did not match`() {
-        val trackNumbers = listOf(
-            TrackNumber("track number 1"),
-            TrackNumber("track number 11"),
-            TrackNumber("number 111"),
-            TrackNumber("number111 111")
-        )
+        val trackNumbers =
+            listOf(
+                TrackNumber("track number 1"),
+                TrackNumber("track number 11"),
+                TrackNumber("number 111"),
+                TrackNumber("number111 111"))
 
         saveTrackNumbersWithSaveRequests(
             trackNumbers,
@@ -49,7 +51,9 @@ class LayoutSearchServiceIT @Autowired constructor(
 
         assertEquals(
             2,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100).size,
+            searchService
+                .searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100)
+                .size,
         )
         assertEquals(
             3,
@@ -63,9 +67,7 @@ class LayoutSearchServiceIT @Autowired constructor(
 
     @Test
     fun `free text search should limit the amount of returned track numbers as specified`() {
-        val trackNumbers = (0..15).map { number ->
-            TrackNumber("some track $number")
-        }
+        val trackNumbers = (0..15).map { number -> TrackNumber("some track $number") }
 
         saveTrackNumbersWithSaveRequests(
             trackNumbers,
@@ -74,114 +76,162 @@ class LayoutSearchServiceIT @Autowired constructor(
 
         assertEquals(
             5,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 5).size,
+            searchService
+                .searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 5)
+                .size,
         )
         assertEquals(
             10,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 10).size,
+            searchService
+                .searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 10)
+                .size,
         )
         assertEquals(
             15,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 15).size,
+            searchService
+                .searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 15)
+                .size,
         )
     }
 
     @Test
     fun `free text search should not return deleted track numbers when its domain id or external id does not match the search term`() {
-        val trackNumbers = listOf(
-            TrackNumber("track number 1"),
-            TrackNumber("track number 11"),
-        )
+        val trackNumbers =
+            listOf(
+                TrackNumber("track number 1"),
+                TrackNumber("track number 11"),
+            )
 
         saveTrackNumbersWithSaveRequests(trackNumbers, LayoutState.DELETED)
         assertEquals(
             0,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100).size,
+            searchService
+                .searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100)
+                .size,
         )
     }
 
     @Test
     fun `free text search should return deleted track number when its domain id or external id matches`() {
-        val trackNumbers = listOf(
-            TrackNumber("track number 1"),
-            TrackNumber("track number 11"),
-        )
+        val trackNumbers =
+            listOf(
+                TrackNumber("track number 1"),
+                TrackNumber("track number 11"),
+            )
 
         saveTrackNumbersWithSaveRequests(
-            trackNumbers,
-            LayoutState.DELETED,
-        ).forEachIndexed { index, trackNumberId ->
-            val oid = Oid<TrackLayoutTrackNumber>("1.2.3.4.5.6.$index")
-            trackNumberService.updateExternalId(LayoutBranch.main, trackNumberId, oid)
+                trackNumbers,
+                LayoutState.DELETED,
+            )
+            .forEachIndexed { index, trackNumberId ->
+                val oid = Oid<TrackLayoutTrackNumber>("1.2.3.4.5.6.$index")
+                trackNumberService.updateExternalId(LayoutBranch.main, trackNumberId, oid)
 
-            assertEquals(1, searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText(oid.toString()), 100).size)
-            assertEquals(1, searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText(trackNumberId.toString()), 100).size)
-        }
+                assertEquals(
+                    1,
+                    searchService
+                        .searchAllTrackNumbers(
+                            MainLayoutContext.draft, FreeText(oid.toString()), 100)
+                        .size)
+                assertEquals(
+                    1,
+                    searchService
+                        .searchAllTrackNumbers(
+                            MainLayoutContext.draft, FreeText(trackNumberId.toString()), 100)
+                        .size)
+            }
 
-        // LayoutState was set to DELETED, meaning that these track numbers should not be found by free text.
-        assertEquals(0, searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100).size)
+        // LayoutState was set to DELETED, meaning that these track numbers should not be found by
+        // free text.
+        assertEquals(
+            0,
+            searchService
+                .searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100)
+                .size)
     }
 
     @Test
     fun `free text search using locationt track as search scope should return only assets relating to search scope`() {
-        val trackNumberId = saveTrackNumbersWithSaveRequests(
-            listOf(TrackNumber("track number 1")),
-            LayoutState.IN_USE,
-        ).first()
+        val trackNumberId =
+            saveTrackNumbersWithSaveRequests(
+                    listOf(TrackNumber("track number 1")),
+                    LayoutState.IN_USE,
+                )
+                .first()
 
         // Search scope origin track's start switch, should be included
-        val topologyStartSwitchId = switchDao.fetch(
-            switchService.saveDraft(LayoutBranch.main, switch(name = "blaa V0001", draft = true)).rowVersion
-        ).id as IntId
+        val topologyStartSwitchId =
+            switchDao
+                .fetch(
+                    switchService
+                        .saveDraft(LayoutBranch.main, switch(name = "blaa V0001", draft = true))
+                        .rowVersion)
+                .id as IntId
         // Search scope origin track's end switch, should be included
-        val topologyEndSwitchId = switchDao.fetch(
-            switchService.saveDraft(LayoutBranch.main, switch(name = "blee V0002", draft = true)).rowVersion
-        ).id as IntId
+        val topologyEndSwitchId =
+            switchDao
+                .fetch(
+                    switchService
+                        .saveDraft(LayoutBranch.main, switch(name = "blee V0002", draft = true))
+                        .rowVersion)
+                .id as IntId
         // Related to duplicate but not in search scope, should be left out of search results
-        val duplicateStartSwitchId = switchDao.fetch(
-            switchService.saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true)).rowVersion
-        ).id as IntId
+        val duplicateStartSwitchId =
+            switchDao
+                .fetch(
+                    switchService
+                        .saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true))
+                        .rowVersion)
+                .id as IntId
         // Entirely unrelated, should be left out of search results
-        switchDao.fetch(
-            switchService.saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true)).rowVersion
-        ).id as IntId
+        switchDao
+            .fetch(
+                switchService
+                    .saveDraft(LayoutBranch.main, switch(name = "bluu V0003", draft = true))
+                    .rowVersion)
+            .id as IntId
 
-        val lt1 = mainDraftContext.insert( // Location track search scope origin, should be included
-            locationTrack(
-                trackNumberId = trackNumberId,
-                name = "blaa",
-                topologyStartSwitch = TopologyLocationTrackSwitch(topologyStartSwitchId, JointNumber(3)),
-                topologyEndSwitch = TopologyLocationTrackSwitch(topologyEndSwitchId, JointNumber(5)),
-            ),
-            someAlignment()
-        )
-        val lt2 = mainDraftContext.insert( // Duplicate based on duplicateOf, should be included
-            locationTrack(
-                trackNumberId = trackNumberId,
-                name = "blee",
-                topologyStartSwitch = TopologyLocationTrackSwitch(duplicateStartSwitchId, JointNumber(3)),
-                duplicateOf = lt1.id,
-            ),
-            someAlignment()
-        )
-        val lt3 = mainDraftContext.insert( // Duplicate based on switches, should be included
-            locationTrack(
-                trackNumberId = trackNumberId,
-                name = "bloo",
-                topologyStartSwitch = TopologyLocationTrackSwitch(topologyStartSwitchId, JointNumber(3)),
-                topologyEndSwitch = TopologyLocationTrackSwitch(topologyEndSwitchId, JointNumber(5)),
-            ),
-            someAlignment()
-        )
+        val lt1 =
+            mainDraftContext.insert( // Location track search scope origin, should be included
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    name = "blaa",
+                    topologyStartSwitch =
+                        TopologyLocationTrackSwitch(topologyStartSwitchId, JointNumber(3)),
+                    topologyEndSwitch =
+                        TopologyLocationTrackSwitch(topologyEndSwitchId, JointNumber(5)),
+                ),
+                someAlignment())
+        val lt2 =
+            mainDraftContext.insert( // Duplicate based on duplicateOf, should be included
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    name = "blee",
+                    topologyStartSwitch =
+                        TopologyLocationTrackSwitch(duplicateStartSwitchId, JointNumber(3)),
+                    duplicateOf = lt1.id,
+                ),
+                someAlignment())
+        val lt3 =
+            mainDraftContext.insert( // Duplicate based on switches, should be included
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    name = "bloo",
+                    topologyStartSwitch =
+                        TopologyLocationTrackSwitch(topologyStartSwitchId, JointNumber(3)),
+                    topologyEndSwitch =
+                        TopologyLocationTrackSwitch(topologyEndSwitchId, JointNumber(5)),
+                ),
+                someAlignment())
         mainDraftContext.insert( // Non-duplicate, shouldn't be included in search results
             locationTrack(
                 trackNumberId = trackNumberId,
                 name = "bluu",
             ),
-            someAlignment()
-        )
+            someAlignment())
 
-        val searchResults = searchService.searchAssets(MainLayoutContext.draft, FreeText("bl"), 100, lt1.id)
+        val searchResults =
+            searchService.searchAssets(MainLayoutContext.draft, FreeText("bl"), 100, lt1.id)
 
         assertEquals(3, searchResults.locationTracks.size)
         assertContains(searchResults.locationTracks.map { it.id }, lt1.id)
@@ -199,15 +249,15 @@ class LayoutSearchServiceIT @Autowired constructor(
         trackNumbers: List<TrackNumber>,
         layoutState: LayoutState,
     ): List<IntId<TrackLayoutTrackNumber>> {
-        return trackNumbers.map { trackNumber ->
-            TrackNumberSaveRequest(
-                trackNumber,
-                FreeText("some description"),
-                layoutState,
-                TrackMeter(KmNumber(5555), 5.5, 1),
-            )
-        }.map { saveRequest ->
-            trackNumberService.insert(LayoutBranch.main, saveRequest)
-        }
+        return trackNumbers
+            .map { trackNumber ->
+                TrackNumberSaveRequest(
+                    trackNumber,
+                    FreeText("some description"),
+                    layoutState,
+                    TrackMeter(KmNumber(5555), 5.5, 1),
+                )
+            }
+            .map { saveRequest -> trackNumberService.insert(LayoutBranch.main, saveRequest) }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
@@ -8,6 +8,8 @@ import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.error.DeletingFailureException
 import fi.fta.geoviite.infra.error.NoSuchEntityException
+import kotlin.test.assertContains
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
@@ -17,12 +19,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutSwitchDaoIT @Autowired constructor(
+class LayoutSwitchDaoIT
+@Autowired
+constructor(
     private val switchDao: LayoutSwitchDao,
 ) : DBTestBase() {
 
@@ -49,10 +51,12 @@ class LayoutSwitchDaoIT @Autowired constructor(
 
     @Test
     fun switchesAreStoredAndLoadedOk() {
-        (1..10).map { seed -> switch(seed, draft = false) }.forEach { switch ->
-            val rowVersion = switchDao.insert(switch).rowVersion
-            assertMatches(switch, switchDao.fetch(rowVersion))
-        }
+        (1..10)
+            .map { seed -> switch(seed, draft = false) }
+            .forEach { switch ->
+                val rowVersion = switchDao.insert(switch).rowVersion
+                assertMatches(switch, switchDao.fetch(rowVersion))
+            }
     }
 
     @Test
@@ -129,7 +133,7 @@ class LayoutSwitchDaoIT @Autowired constructor(
         val draftWithoutDeleted = switchDao.fetchVersions(MainLayoutContext.draft, false)
         assertContains(draftWithoutDeleted, undeletedDraft)
         assertFalse(draftWithoutDeleted.contains(deleteStateDraft))
-        assertFalse(draftWithoutDeleted.any { r -> r.id == deletedDraft.id})
+        assertFalse(draftWithoutDeleted.any { r -> r.id == deletedDraft.id })
 
         val draftWithDeleted = switchDao.fetchVersions(MainLayoutContext.draft, true)
         assertContains(draftWithDeleted, undeletedDraft)
@@ -152,7 +156,10 @@ class LayoutSwitchDaoIT @Autowired constructor(
         Thread.sleep(1) // Ensure that they get different timestamps
 
         val switch1MainV2 = testDBService.update(switch1MainV1).rowVersion
-        val switch1DesignV2 = designOfficialContext.copyFrom(switch1MainV1, officialRowId = switch1MainV1.rowId).rowVersion
+        val switch1DesignV2 =
+            designOfficialContext
+                .copyFrom(switch1MainV1, officialRowId = switch1MainV1.rowId)
+                .rowVersion
         val switch2DesignV2 = testDBService.update(switch2DesignV1).rowVersion
         switchDao.deleteRow(switch3DesignV1.rowId)
         val v2Time = switchDao.fetchChangeTime()
@@ -163,32 +170,59 @@ class LayoutSwitchDaoIT @Autowired constructor(
         val switch2MainV3 = mainOfficialContext.moveFrom(switch2DesignV2).rowVersion
         val v3Time = switchDao.fetchChangeTime()
 
-        assertEquals(null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch1Id, v0Time))
-        assertEquals(null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch2Id, v0Time))
-        assertEquals(null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch3Id, v0Time))
+        assertEquals(
+            null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch1Id, v0Time))
+        assertEquals(
+            null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch2Id, v0Time))
+        assertEquals(
+            null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch3Id, v0Time))
         assertEquals(null, switchDao.fetchOfficialVersionAtMoment(designBranch, switch1Id, v0Time))
         assertEquals(null, switchDao.fetchOfficialVersionAtMoment(designBranch, switch2Id, v0Time))
         assertEquals(null, switchDao.fetchOfficialVersionAtMoment(designBranch, switch3Id, v0Time))
 
-        assertEquals(switch1MainV1, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch1Id, v1Time))
-        assertEquals(null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch2Id, v1Time))
-        assertEquals(null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch3Id, v1Time))
-        assertEquals(switch1MainV1, switchDao.fetchOfficialVersionAtMoment(designBranch, switch1Id, v1Time))
-        assertEquals(switch2DesignV1, switchDao.fetchOfficialVersionAtMoment(designBranch, switch2Id, v1Time))
-        assertEquals(switch3DesignV1, switchDao.fetchOfficialVersionAtMoment(designBranch, switch3Id, v1Time))
+        assertEquals(
+            switch1MainV1,
+            switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch1Id, v1Time))
+        assertEquals(
+            null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch2Id, v1Time))
+        assertEquals(
+            null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch3Id, v1Time))
+        assertEquals(
+            switch1MainV1, switchDao.fetchOfficialVersionAtMoment(designBranch, switch1Id, v1Time))
+        assertEquals(
+            switch2DesignV1,
+            switchDao.fetchOfficialVersionAtMoment(designBranch, switch2Id, v1Time))
+        assertEquals(
+            switch3DesignV1,
+            switchDao.fetchOfficialVersionAtMoment(designBranch, switch3Id, v1Time))
 
-        assertEquals(switch1MainV2, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch1Id, v2Time))
-        assertEquals(null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch2Id, v2Time))
-        assertEquals(null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch3Id, v2Time))
-        assertEquals(switch1DesignV2, switchDao.fetchOfficialVersionAtMoment(designBranch, switch1Id, v2Time))
-        assertEquals(switch2DesignV2, switchDao.fetchOfficialVersionAtMoment(designBranch, switch2Id, v2Time))
+        assertEquals(
+            switch1MainV2,
+            switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch1Id, v2Time))
+        assertEquals(
+            null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch2Id, v2Time))
+        assertEquals(
+            null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch3Id, v2Time))
+        assertEquals(
+            switch1DesignV2,
+            switchDao.fetchOfficialVersionAtMoment(designBranch, switch1Id, v2Time))
+        assertEquals(
+            switch2DesignV2,
+            switchDao.fetchOfficialVersionAtMoment(designBranch, switch2Id, v2Time))
         assertEquals(null, switchDao.fetchOfficialVersionAtMoment(designBranch, switch3Id, v2Time))
 
-        assertEquals(switch1MainV2, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch1Id, v3Time))
-        assertEquals(switch2MainV3, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch2Id, v3Time))
-        assertEquals(null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch3Id, v3Time))
-        assertEquals(switch1MainV2, switchDao.fetchOfficialVersionAtMoment(designBranch, switch1Id, v3Time))
-        assertEquals(switch2MainV3, switchDao.fetchOfficialVersionAtMoment(designBranch, switch2Id, v3Time))
+        assertEquals(
+            switch1MainV2,
+            switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch1Id, v3Time))
+        assertEquals(
+            switch2MainV3,
+            switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch2Id, v3Time))
+        assertEquals(
+            null, switchDao.fetchOfficialVersionAtMoment(LayoutBranch.main, switch3Id, v3Time))
+        assertEquals(
+            switch1MainV2, switchDao.fetchOfficialVersionAtMoment(designBranch, switch1Id, v3Time))
+        assertEquals(
+            switch2MainV3, switchDao.fetchOfficialVersionAtMoment(designBranch, switch2Id, v3Time))
         assertEquals(null, switchDao.fetchOfficialVersionAtMoment(designBranch, switch3Id, v3Time))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -17,6 +17,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao.LocationTrackIdentifiers
+import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -27,11 +28,12 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutSwitchServiceIT @Autowired constructor(
+class LayoutSwitchServiceIT
+@Autowired
+constructor(
     private val switchService: LayoutSwitchService,
     private val switchLibraryService: SwitchLibraryService,
     private val locationTrackService: LocationTrackService,
@@ -70,13 +72,15 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun switchIsReturnedByBoundingBox() {
-        val switch = switch(
-            joints = listOf(
-                switchJoint(1, Point(428423.66891764296, 7210292.096537605)),
-                switchJoint(5, Point(428412.6499928745, 7210278.867815434)),
-            ),
-            draft = false,
-        )
+        val switch =
+            switch(
+                joints =
+                    listOf(
+                        switchJoint(1, Point(428423.66891764296, 7210292.096537605)),
+                        switchJoint(5, Point(428412.6499928745, 7210278.867815434)),
+                    ),
+                draft = false,
+            )
         val id = switchDao.insert(switch).id
 
         val bbox = BoundingBox(428125.0..428906.25, 7210156.25..7210937.5)
@@ -88,13 +92,15 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun switchOutsideBoundingBoxIsNotReturned() {
-        val switchOutsideBoundingBox = switch(
-            joints = listOf(
-                switchJoint(1, Point(428423.66891764296, 7210292.096537605)),
-                switchJoint(5, Point(428412.6499928745, 7210278.867815434)),
-            ),
-            draft = false,
-        )
+        val switchOutsideBoundingBox =
+            switch(
+                joints =
+                    listOf(
+                        switchJoint(1, Point(428423.66891764296, 7210292.096537605)),
+                        switchJoint(5, Point(428412.6499928745, 7210278.867815434)),
+                    ),
+                draft = false,
+            )
 
         val id = switchDao.insert(switchOutsideBoundingBox).id
 
@@ -123,16 +129,18 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun returnsOnlySwitchesThatAreNotDeleted() {
-        val inUseSwitch = switch(
-            name = testDBService.getUnusedSwitchName().toString(),
-            stateCategory = LayoutStateCategory.EXISTING,
-            draft = false,
-        )
-        val deletedSwitch = switch(
-            name = testDBService.getUnusedSwitchName().toString(),
-            stateCategory = LayoutStateCategory.NOT_EXISTING,
-            draft = false,
-        )
+        val inUseSwitch =
+            switch(
+                name = testDBService.getUnusedSwitchName().toString(),
+                stateCategory = LayoutStateCategory.EXISTING,
+                draft = false,
+            )
+        val deletedSwitch =
+            switch(
+                name = testDBService.getUnusedSwitchName().toString(),
+                stateCategory = LayoutStateCategory.NOT_EXISTING,
+                draft = false,
+            )
         val inUseSwitchId = switchDao.insert(inUseSwitch)
         val deletedSwitchId = switchDao.insert(deletedSwitch)
 
@@ -175,15 +183,19 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun switchWithNoJointsIsReturnedFirst() {
-        val idOfSwitchWithNoJoints = mainOfficialContext.insert(
-            switch(name = testDBService.getUnusedSwitchName().toString(), joints = listOf())
-        ).id
+        val idOfSwitchWithNoJoints =
+            mainOfficialContext
+                .insert(
+                    switch(
+                        name = testDBService.getUnusedSwitchName().toString(), joints = listOf()))
+                .id
         val idOfRandomSwitch = mainOfficialContext.createSwitch().id
 
         val switches = pageSwitches(getSwitches(), 0, null, Point(422222.2, 7222222.2)).items
 
         val indexOfRandomSwitch = switches.indexOfFirst { s -> s.id == idOfRandomSwitch }
-        val indexOfSwitchWithNoJoints = switches.indexOfFirst { s -> s.id == idOfSwitchWithNoJoints }
+        val indexOfSwitchWithNoJoints =
+            switches.indexOfFirst { s -> s.id == idOfSwitchWithNoJoints }
 
         assertTrue(indexOfSwitchWithNoJoints >= 0)
         assertTrue(indexOfRandomSwitch >= 0)
@@ -194,23 +206,23 @@ class LayoutSwitchServiceIT @Autowired constructor(
     fun switchesAreSortedByComparisonPoint() {
         val idOfRandomSwitch = mainOfficialContext.createSwitch().id
 
-        val idOfSwitchLocatedAtComparisonPoint = mainOfficialContext.insert(
-            switch(
-                name = testDBService.getUnusedSwitchName().toString(),
-                joints = listOf(
-                    TrackLayoutSwitchJoint(
-                        JointNumber(1),
-                        location = Point(422222.2, 7222222.2),
-                        locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED
-                    ),
-                    TrackLayoutSwitchJoint(
-                        JointNumber(5),
-                        location = Point(428305.33617941965, 7210146.458099049),
-                        locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED
-                    )
-                ),
-            )
-        ).id
+        val idOfSwitchLocatedAtComparisonPoint =
+            mainOfficialContext
+                .insert(
+                    switch(
+                        name = testDBService.getUnusedSwitchName().toString(),
+                        joints =
+                            listOf(
+                                TrackLayoutSwitchJoint(
+                                    JointNumber(1),
+                                    location = Point(422222.2, 7222222.2),
+                                    locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED),
+                                TrackLayoutSwitchJoint(
+                                    JointNumber(5),
+                                    location = Point(428305.33617941965, 7210146.458099049),
+                                    locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED)),
+                    ))
+                .id
 
         val switches = pageSwitches(getSwitches(), 0, null, Point(422222.2, 7222222.2)).items
 
@@ -254,43 +266,55 @@ class LayoutSwitchServiceIT @Autowired constructor(
     @Test
     fun throwsIfFetchingOfficialVersionOfDraftOnlySwitchUsingGetOrThrow() {
         val draftSwitch = switchService.saveDraft(LayoutBranch.main, switch(draft = true))
-        assertThrows<NoSuchEntityException> { switchService.getOrThrow(MainLayoutContext.official, draftSwitch.id) }
+        assertThrows<NoSuchEntityException> {
+            switchService.getOrThrow(MainLayoutContext.official, draftSwitch.id)
+        }
     }
 
     @Test
     fun switchConnectedLocationTracksFound() {
         val tnId = mainDraftContext.createLayoutTrackNumber().id
-        val switch = switchService.getOrThrow(
-            MainLayoutContext.draft,
-            switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id,
-        )
-        val (_, withStartLink) = insertDraft(
-            locationTrack(tnId, externalId = someOid(), draft = true).copy(
-                topologyStartSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(1)),
-            ),
-            alignment(someSegment()),
-        )
-        val (_, withEndLink) = insertDraft(
-            locationTrack(tnId, externalId = null, draft = true).copy(
-                topologyEndSwitch = TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
-            ),
-            alignment(someSegment()),
-        )
-        val (_, withSegmentLink) = insertDraft(
-            locationTrack(tnId, externalId = someOid(), draft = true),
-            alignment(
-                someSegment().copy(
-                    switchId = switch.id as IntId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(2),
-                )
-            ),
-        )
+        val switch =
+            switchService.getOrThrow(
+                MainLayoutContext.draft,
+                switchService.saveDraft(LayoutBranch.main, switch(1, draft = true)).id,
+            )
+        val (_, withStartLink) =
+            insertDraft(
+                locationTrack(tnId, externalId = someOid(), draft = true)
+                    .copy(
+                        topologyStartSwitch =
+                            TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(1)),
+                    ),
+                alignment(someSegment()),
+            )
+        val (_, withEndLink) =
+            insertDraft(
+                locationTrack(tnId, externalId = null, draft = true)
+                    .copy(
+                        topologyEndSwitch =
+                            TopologyLocationTrackSwitch(switch.id as IntId, JointNumber(2)),
+                    ),
+                alignment(someSegment()),
+            )
+        val (_, withSegmentLink) =
+            insertDraft(
+                locationTrack(tnId, externalId = someOid(), draft = true),
+                alignment(
+                    someSegment()
+                        .copy(
+                            switchId = switch.id as IntId,
+                            startJointNumber = JointNumber(1),
+                            endJointNumber = JointNumber(2),
+                        )),
+            )
         assertEquals(
             listOf<LocationTrackIdentifiers>(),
-            switchDao.findLocationTracksLinkedToSwitch(MainLayoutContext.official, switch.id as IntId),
+            switchDao.findLocationTracksLinkedToSwitch(
+                MainLayoutContext.official, switch.id as IntId),
         )
-        val result = switchDao.findLocationTracksLinkedToSwitch(MainLayoutContext.draft, switch.id as IntId)
+        val result =
+            switchDao.findLocationTracksLinkedToSwitch(MainLayoutContext.draft, switch.id as IntId)
         assertEquals(
             listOf(withStartLink, withEndLink, withSegmentLink),
             result.sortedBy { ids -> ids.rowVersion.rowId.intValue },
@@ -299,7 +323,10 @@ class LayoutSwitchServiceIT @Autowired constructor(
 
     @Test
     fun `Getting location tracks of switches returns empty list if argument is an empty list`() {
-        assertTrue(switchDao.findLocationTracksLinkedToSwitches(MainLayoutContext.official, emptyList()).isEmpty())
+        assertTrue(
+            switchDao
+                .findLocationTracksLinkedToSwitches(MainLayoutContext.official, emptyList())
+                .isEmpty())
     }
 
     @Test
@@ -308,48 +335,51 @@ class LayoutSwitchServiceIT @Autowired constructor(
         val switchId = mainOfficialContext.insert(switch(1)).id
 
         val locationTrack1Oid = someOid<LocationTrack>()
-        val locationTrack1 = mainOfficialContext.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                externalId = locationTrack1Oid,
-                name = "LT 1",
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(1)),
-            ),
-            alignment(someSegment()),
-        )
+        val locationTrack1 =
+            mainOfficialContext.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    externalId = locationTrack1Oid,
+                    name = "LT 1",
+                    topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(1)),
+                ),
+                alignment(someSegment()),
+            )
 
-        val locationTrack2 = mainOfficialContext.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                name = "LT 2",
-                topologyEndSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(2)),
-            ),
-            alignment(someSegment()),
-        )
+        val locationTrack2 =
+            mainOfficialContext.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    name = "LT 2",
+                    topologyEndSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(2)),
+                ),
+                alignment(someSegment()),
+            )
 
         val locationTrack3Oid = someOid<LocationTrack>()
-        val locationTrack3 = mainOfficialContext.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                externalId = locationTrack3Oid,
-                name = "LT 3",
-                topologyEndSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(2)),
-            ),
-            alignment(
-                someSegment().copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(2),
-                )
-            )
-        )
+        val locationTrack3 =
+            mainOfficialContext.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    externalId = locationTrack3Oid,
+                    name = "LT 3",
+                    topologyEndSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(2)),
+                ),
+                alignment(
+                    someSegment()
+                        .copy(
+                            switchId = switchId,
+                            startJointNumber = JointNumber(1),
+                            endJointNumber = JointNumber(2),
+                        )))
 
-        val linkedLocationTracks = switchDao.findLocationTracksLinkedToSwitchAtMoment(
-            LayoutBranch.main,
-            switchId,
-            JointNumber(1),
-            Instant.now(),
-        )
+        val linkedLocationTracks =
+            switchDao.findLocationTracksLinkedToSwitchAtMoment(
+                LayoutBranch.main,
+                switchId,
+                JointNumber(1),
+                Instant.now(),
+            )
         assertEquals(2, linkedLocationTracks.size)
 
         assertTrue(
@@ -357,18 +387,14 @@ class LayoutSwitchServiceIT @Autowired constructor(
                 LocationTrackIdentifiers(
                     rowVersion = locationTrack1.rowVersion,
                     externalId = locationTrack1Oid,
-                )
-            )
-        )
+                )))
 
         assertTrue(
             linkedLocationTracks.contains(
                 LocationTrackIdentifiers(
                     rowVersion = locationTrack3.rowVersion,
                     externalId = locationTrack3Oid,
-                )
-            )
-        )
+                )))
 
         assertTrue(linkedLocationTracks.none { lt -> lt.rowVersion == locationTrack2.rowVersion })
     }
@@ -378,33 +404,38 @@ class LayoutSwitchServiceIT @Autowired constructor(
         val switch = switch(123, IntId(1), draft = false)
         val switchVersion = switchDao.insert(switch)
         val joint1Point = switch.getJoint(JointNumber(1))!!.location
-        val (locationTrack, alignment) = locationTrackAndAlignment(
-            mainDraftContext.createLayoutTrackNumber().id,
-            segment(joint1Point - 1.0, joint1Point),
-            draft = true,
-        )
-        val locationTrackVersion = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrack.copy(topologyEndSwitch = TopologyLocationTrackSwitch(switchVersion.id, JointNumber(1))),
-            alignment,
-        )
-        val connections = switchService.getSwitchJointConnections(MainLayoutContext.draft, switchVersion.id)
+        val (locationTrack, alignment) =
+            locationTrackAndAlignment(
+                mainDraftContext.createLayoutTrackNumber().id,
+                segment(joint1Point - 1.0, joint1Point),
+                draft = true,
+            )
+        val locationTrackVersion =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                locationTrack.copy(
+                    topologyEndSwitch =
+                        TopologyLocationTrackSwitch(switchVersion.id, JointNumber(1))),
+                alignment,
+            )
+        val connections =
+            switchService.getSwitchJointConnections(MainLayoutContext.draft, switchVersion.id)
 
         assertEquals(
             listOf(TrackLayoutSwitchJointMatch(locationTrackVersion.id, joint1Point)),
-            connections.first { connection -> connection.number == JointNumber(1) }.accurateMatches
-        )
+            connections.first { connection -> connection.number == JointNumber(1) }.accurateMatches)
     }
 
     @Test
     fun switchIdIsReturnedWhenAddingNewSwitch() {
-        val switch = TrackLayoutSwitchSaveRequest(
-            SwitchName("XYZ-987"),
-            IntId(5),
-            LayoutStateCategory.EXISTING,
-            ownerId = IntId(3),
-            trapPoint = null,
-        )
+        val switch =
+            TrackLayoutSwitchSaveRequest(
+                SwitchName("XYZ-987"),
+                IntId(5),
+                LayoutStateCategory.EXISTING,
+                ownerId = IntId(3),
+                trapPoint = null,
+            )
         val switchId = switchService.insertSwitch(LayoutBranch.main, switch)
         val fetchedSwitch = switchService.get(MainLayoutContext.draft, switchId)!!
         assertNull(switchService.get(MainLayoutContext.official, switchId))
@@ -419,14 +450,19 @@ class LayoutSwitchServiceIT @Autowired constructor(
         locationTrack: LocationTrack,
         alignment: LayoutAlignment,
     ): Pair<LocationTrack, LocationTrackIdentifiers> {
-        val (id, version) = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
+        val (id, version) =
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment)
         val track = locationTrackService.getOrThrow(MainLayoutContext.draft, id)
         val identifiers = LocationTrackIdentifiers(version, locationTrack.externalId)
         return track to identifiers
     }
 
-    private fun getSwitches(filter: (Pair<TrackLayoutSwitch, SwitchStructure>) -> Boolean): List<TrackLayoutSwitch> =
-        switchService.listWithStructure(MainLayoutContext.official).filter(filter).map { (s, _) -> s }
+    private fun getSwitches(
+        filter: (Pair<TrackLayoutSwitch, SwitchStructure>) -> Boolean
+    ): List<TrackLayoutSwitch> =
+        switchService.listWithStructure(MainLayoutContext.official).filter(filter).map { (s, _) ->
+            s
+        }
 
     private fun getSwitches() = switchService.listWithStructure(MainLayoutContext.official)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -13,6 +13,11 @@ import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
 import fi.fta.geoviite.infra.util.FreeText
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -20,15 +25,12 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LayoutTrackNumberServiceIT @Autowired constructor(
+class LayoutTrackNumberServiceIT
+@Autowired
+constructor(
     private val trackNumberService: LayoutTrackNumberService,
     private val referenceLineService: ReferenceLineService,
     private val trackNumberDao: LayoutTrackNumberDao,
@@ -44,17 +46,19 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
 
     @Test
     fun updatingExternalIdWorks() {
-        val saveRequest = TrackNumberSaveRequest(
-            testDBService.getUnusedTrackNumber(), FreeText("description"), LayoutState.IN_USE, TrackMeter(
-                KmNumber(5555), 5.5, 1
-            )
-        )
+        val saveRequest =
+            TrackNumberSaveRequest(
+                testDBService.getUnusedTrackNumber(),
+                FreeText("description"),
+                LayoutState.IN_USE,
+                TrackMeter(KmNumber(5555), 5.5, 1))
         val id = trackNumberService.insert(LayoutBranch.main, saveRequest)
         val trackNumber = trackNumberService.get(MainLayoutContext.draft, id)!!
 
         assertNull(trackNumber.externalId)
 
-        trackNumberService.updateExternalId(LayoutBranch.main, trackNumber.id as IntId, externalIdForTrackNumber())
+        trackNumberService.updateExternalId(
+            LayoutBranch.main, trackNumber.id as IntId, externalIdForTrackNumber())
 
         val updatedTrackNumber = trackNumberService.get(MainLayoutContext.draft, id)!!
         assertNotNull(updatedTrackNumber.externalId)
@@ -62,11 +66,14 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
 
     @Test
     fun deletingDraftOnlyTrackNumberDeletesItAndReferenceLineAndAlignment() {
-        val (trackNumber, referenceLine, alignment) = createTrackNumberAndReferenceLineAndAlignment()
+        val (trackNumber, referenceLine, alignment) =
+            createTrackNumberAndReferenceLineAndAlignment()
         assertEquals(referenceLine.alignmentVersion?.id, alignment.id as IntId)
         val trackNumberId = trackNumber.id as IntId
 
-        assertDoesNotThrow { trackNumberService.deleteDraftAndReferenceLine(LayoutBranch.main, trackNumberId) }
+        assertDoesNotThrow {
+            trackNumberService.deleteDraftAndReferenceLine(LayoutBranch.main, trackNumberId)
+        }
         assertThrows<NoSuchEntityException> {
             referenceLineService.getOrThrow(MainLayoutContext.draft, referenceLine.id as IntId)
         }
@@ -89,43 +96,52 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
 
     @Test
     fun `should return correct lengths for km posts`() {
-        val trackNumber = trackNumberDao.fetch(
-            trackNumberDao.insert(trackNumber(testDBService.getUnusedTrackNumber(), draft = false)).rowVersion
-        )
+        val trackNumber =
+            trackNumberDao.fetch(
+                trackNumberDao
+                    .insert(trackNumber(testDBService.getUnusedTrackNumber(), draft = false))
+                    .rowVersion)
         referenceLineAndAlignment(
-            trackNumberId = trackNumber.id as IntId, segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(1.0, 0.0),
-                    Point(2.0, 0.0),
-                    Point(3.0, 0.0),
-                    Point(4.0, 0.0),
+                trackNumberId = trackNumber.id as IntId,
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(1.0, 0.0),
+                            Point(2.0, 0.0),
+                            Point(3.0, 0.0),
+                            Point(4.0, 0.0),
+                        )),
+                startAddress = TrackMeter(KmNumber(1), BigDecimal(0.5)),
+                draft = false,
+            )
+            .let { (referenceLine, alignment) ->
+                val referenceLineVersion =
+                    referenceLineDao.insert(
+                        referenceLine.copy(alignmentVersion = alignmentDao.insert(alignment)))
+                referenceLineDao.fetch(referenceLineVersion.rowVersion)
+            }
+
+        val kmPostVersions =
+            listOf(
+                    kmPost(
+                        trackNumberId = trackNumber.id as IntId,
+                        km = KmNumber(2),
+                        roughLayoutLocation = Point(1.0, 0.0),
+                        draft = false,
+                    ),
+                    kmPost(
+                        trackNumberId = trackNumber.id as IntId,
+                        km = KmNumber(3),
+                        roughLayoutLocation = Point(3.0, 0.0),
+                        draft = false,
+                    ),
                 )
-            ),
-            startAddress = TrackMeter(KmNumber(1), BigDecimal(0.5)),
-            draft = false,
-        ).let { (referenceLine, alignment) ->
-            val referenceLineVersion =
-                referenceLineDao.insert(referenceLine.copy(alignmentVersion = alignmentDao.insert(alignment)))
-            referenceLineDao.fetch(referenceLineVersion.rowVersion)
-        }
+                .map(kmPostDao::insert)
+                .map(LayoutDaoResponse<TrackLayoutKmPost>::rowVersion)
 
-        val kmPostVersions = listOf(
-            kmPost(
-                trackNumberId = trackNumber.id as IntId,
-                km = KmNumber(2),
-                roughLayoutLocation = Point(1.0, 0.0),
-                draft = false,
-            ),
-            kmPost(
-                trackNumberId = trackNumber.id as IntId,
-                km = KmNumber(3),
-                roughLayoutLocation = Point(3.0, 0.0),
-                draft = false,
-            ),
-        ).map(kmPostDao::insert).map(LayoutDaoResponse<TrackLayoutKmPost>::rowVersion)
-
-        val kmLengths = trackNumberService.getKmLengths(MainLayoutContext.official, trackNumber.id as IntId)
+        val kmLengths =
+            trackNumberService.getKmLengths(MainLayoutContext.official, trackNumber.id as IntId)
         assertNotNull(kmLengths)
         assertEquals(3, kmLengths.size)
 
@@ -141,8 +157,8 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
                 gkLocationConfirmed = false,
                 gkLocationSource = null,
                 gkLocationLinkedFromGeometry = false,
-            ), kmLengths.first()
-        )
+            ),
+            kmLengths.first())
 
         val kmPostLocation1 = kmPostDao.fetch(kmPostVersions[0]).layoutLocation
         assertEquals(
@@ -157,9 +173,12 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
                 gkLocationConfirmed = false,
                 gkLocationSource = null,
                 gkLocationLinkedFromGeometry = false,
-            ), kmLengths[1].copy(gkLocation = null)
-        )
-        assertApproximatelyEquals(transformToGKCoordinate(LAYOUT_SRID, kmPostLocation1!!), kmLengths[1].gkLocation!!, 0.01)
+            ),
+            kmLengths[1].copy(gkLocation = null))
+        assertApproximatelyEquals(
+            transformToGKCoordinate(LAYOUT_SRID, kmPostLocation1!!),
+            kmLengths[1].gkLocation!!,
+            0.01)
 
         val kmPostLocation2 = kmPostDao.fetch(kmPostVersions[1]).layoutLocation
         assertEquals(
@@ -174,53 +193,64 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
                 gkLocationConfirmed = false,
                 gkLocationSource = null,
                 gkLocationLinkedFromGeometry = false,
-            ), kmLengths[2].copy(gkLocation = null)
-        )
-        assertApproximatelyEquals(transformToGKCoordinate(LAYOUT_SRID, kmPostLocation2!!), kmLengths[2].gkLocation!!, 0.01)
+            ),
+            kmLengths[2].copy(gkLocation = null))
+        assertApproximatelyEquals(
+            transformToGKCoordinate(LAYOUT_SRID, kmPostLocation2!!),
+            kmLengths[2].gkLocation!!,
+            0.01)
     }
 
     @Test
     fun `should ignore km posts without location when calculating lengths between km posts`() {
-        val trackNumber = trackNumberDao.fetch(
-            trackNumberDao.insert(trackNumber(testDBService.getUnusedTrackNumber(), draft = false)).rowVersion
-        )
+        val trackNumber =
+            trackNumberDao.fetch(
+                trackNumberDao
+                    .insert(trackNumber(testDBService.getUnusedTrackNumber(), draft = false))
+                    .rowVersion)
 
         referenceLineAndAlignment(
-            trackNumberId = trackNumber.id as IntId,
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(1.0, 0.0),
-                    Point(2.0, 0.0),
-                    Point(3.0, 0.0),
-                    Point(4.0, 0.0),
+                trackNumberId = trackNumber.id as IntId,
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(1.0, 0.0),
+                            Point(2.0, 0.0),
+                            Point(3.0, 0.0),
+                            Point(4.0, 0.0),
+                        )),
+                startAddress = TrackMeter(KmNumber(1), BigDecimal(0.5)),
+                draft = false,
+            )
+            .let { (referenceLine, alignment) ->
+                val referenceLineVersion =
+                    referenceLineDao.insert(
+                        referenceLine.copy(alignmentVersion = alignmentDao.insert(alignment)))
+
+                referenceLineDao.fetch(referenceLineVersion.rowVersion)
+            }
+
+        val kmPostVersions =
+            listOf(
+                    kmPost(
+                        trackNumberId = trackNumber.id as IntId,
+                        km = KmNumber(2),
+                        roughLayoutLocation = Point(1.0, 0.0),
+                        draft = false,
+                    ),
+                    kmPost(
+                        trackNumberId = trackNumber.id as IntId,
+                        km = KmNumber(3),
+                        roughLayoutLocation = null,
+                        draft = false,
+                    ),
                 )
-            ),
-            startAddress = TrackMeter(KmNumber(1), BigDecimal(0.5)),
-            draft = false,
-        ).let { (referenceLine, alignment) ->
-            val referenceLineVersion = referenceLineDao
-                .insert(referenceLine.copy(alignmentVersion = alignmentDao.insert(alignment)))
+                .map(kmPostDao::insert)
+                .map(LayoutDaoResponse<TrackLayoutKmPost>::rowVersion)
 
-            referenceLineDao.fetch(referenceLineVersion.rowVersion)
-        }
-
-        val kmPostVersions = listOf(
-            kmPost(
-                trackNumberId = trackNumber.id as IntId,
-                km = KmNumber(2),
-                roughLayoutLocation = Point(1.0, 0.0),
-                draft = false,
-            ),
-            kmPost(
-                trackNumberId = trackNumber.id as IntId,
-                km = KmNumber(3),
-                roughLayoutLocation = null,
-                draft = false,
-            ),
-        ).map(kmPostDao::insert).map(LayoutDaoResponse<TrackLayoutKmPost>::rowVersion)
-
-        val kmLengths = trackNumberService.getKmLengths(MainLayoutContext.official, trackNumber.id as IntId)
+        val kmLengths =
+            trackNumberService.getKmLengths(MainLayoutContext.official, trackNumber.id as IntId)
         assertNotNull(kmLengths)
         assertEquals(2, kmLengths.size)
 
@@ -256,32 +286,41 @@ class LayoutTrackNumberServiceIT @Autowired constructor(
             ),
             kmLengths.last().copy(gkLocation = null),
         )
-        assertApproximatelyEquals(transformToGKCoordinate(LAYOUT_SRID, kmPostLocation!!), kmLengths.last().gkLocation!!, 0.01)
+        assertApproximatelyEquals(
+            transformToGKCoordinate(LAYOUT_SRID, kmPostLocation!!),
+            kmLengths.last().gkLocation!!,
+            0.01)
     }
 
-    fun createTrackNumberAndReferenceLineAndAlignment(): Triple<TrackLayoutTrackNumber, ReferenceLine, LayoutAlignment> {
-        val saveRequest = TrackNumberSaveRequest(
-            testDBService.getUnusedTrackNumber(), FreeText(trackNumberDescription), LayoutState.IN_USE, TrackMeter(
-                KmNumber(5555), 5.5, 1
-            )
-        )
+    fun createTrackNumberAndReferenceLineAndAlignment():
+        Triple<TrackLayoutTrackNumber, ReferenceLine, LayoutAlignment> {
+        val saveRequest =
+            TrackNumberSaveRequest(
+                testDBService.getUnusedTrackNumber(),
+                FreeText(trackNumberDescription),
+                LayoutState.IN_USE,
+                TrackMeter(KmNumber(5555), 5.5, 1))
         val id = trackNumberService.insert(LayoutBranch.main, saveRequest)
         val trackNumber = trackNumberService.get(MainLayoutContext.draft, id)!!
 
-        val (referenceLine, alignment) = referenceLineService.getByTrackNumberWithAlignment(
-            MainLayoutContext.draft, trackNumber.id as IntId<TrackLayoutTrackNumber>
-        )!! // Always exists, since we just created it
+        val (referenceLine, alignment) =
+            referenceLineService.getByTrackNumberWithAlignment(
+                MainLayoutContext.draft,
+                trackNumber.id
+                    as IntId<TrackLayoutTrackNumber>)!! // Always exists, since we just created it
 
         return Triple(trackNumber, referenceLine, alignment)
     }
 
     private fun publishTrackNumber(id: IntId<TrackLayoutTrackNumber>) =
-        trackNumberDao.fetchPublicationVersions(LayoutBranch.main, listOf(id))
-            .first()
-            .let { version -> trackNumberService.publish(LayoutBranch.main, version) }
+        trackNumberDao.fetchPublicationVersions(LayoutBranch.main, listOf(id)).first().let { version
+            ->
+            trackNumberService.publish(LayoutBranch.main, version)
+        }
 
-    private fun publishReferenceLine(id: IntId<ReferenceLine>): LayoutDaoResponse<ReferenceLine> = referenceLineDao
-        .fetchPublicationVersions(LayoutBranch.main, listOf(id))
-        .first()
-        .let { version -> referenceLineService.publish(LayoutBranch.main, version) }
+    private fun publishReferenceLine(id: IntId<ReferenceLine>): LayoutDaoResponse<ReferenceLine> =
+        referenceLineDao.fetchPublicationVersions(LayoutBranch.main, listOf(id)).first().let {
+            version ->
+            referenceLineService.publish(LayoutBranch.main, version)
+        }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
@@ -19,6 +19,8 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackType.SIDE
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.queryOne
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -27,12 +29,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
-import kotlin.test.assertFalse
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LocationTrackDaoIT @Autowired constructor(
+class LocationTrackDaoIT
+@Autowired
+constructor(
     private val alignmentService: LayoutAlignmentService,
     private val alignmentDao: LayoutAlignmentDao,
     private val locationTrackDao: LocationTrackDao,
@@ -47,33 +49,42 @@ class LocationTrackDaoIT @Autowired constructor(
     fun locationTrackSaveAndLoadWorks() {
         val alignment = alignment()
         val alignmentVersion = alignmentDao.insert(alignment)
-        val locationTrack = locationTrack(mainOfficialContext.createLayoutTrackNumber().id, alignment, draft = false).copy(
-            name = AlignmentName("ORIG"),
-            descriptionBase = FreeText("Oridinal location track"),
-            type = MAIN,
-            state = LocationTrackState.IN_USE,
-            alignmentVersion = alignmentVersion,
-        )
+        val locationTrack =
+            locationTrack(
+                    mainOfficialContext.createLayoutTrackNumber().id, alignment, draft = false)
+                .copy(
+                    name = AlignmentName("ORIG"),
+                    descriptionBase = FreeText("Oridinal location track"),
+                    type = MAIN,
+                    state = LocationTrackState.IN_USE,
+                    alignmentVersion = alignmentVersion,
+                )
 
         val inserted = locationTrackDao.insert(locationTrack)
-        assertEquals(inserted.rowVersion, locationTrackDao.fetchVersion(MainLayoutContext.official, inserted.id))
-        assertEquals(inserted.rowVersion, locationTrackDao.fetchVersion(MainLayoutContext.draft, inserted.id))
+        assertEquals(
+            inserted.rowVersion,
+            locationTrackDao.fetchVersion(MainLayoutContext.official, inserted.id))
+        assertEquals(
+            inserted.rowVersion,
+            locationTrackDao.fetchVersion(MainLayoutContext.draft, inserted.id))
         val fromDb = locationTrackDao.fetch(inserted.rowVersion)
         assertMatches(locationTrack, fromDb, contextMatch = false)
         assertEquals(inserted.id, fromDb.id)
 
-        val updatedTrack = fromDb.copy(
-            name = AlignmentName("UPD"),
-            descriptionBase = FreeText("Updated location track"),
-            type = SIDE,
-            state = LocationTrackState.NOT_IN_USE,
-            topologicalConnectivity = TopologicalConnectivityType.END
-        )
+        val updatedTrack =
+            fromDb.copy(
+                name = AlignmentName("UPD"),
+                descriptionBase = FreeText("Updated location track"),
+                type = SIDE,
+                state = LocationTrackState.NOT_IN_USE,
+                topologicalConnectivity = TopologicalConnectivityType.END)
         val (updatedId, updatedVersion) = locationTrackDao.update(updatedTrack)
         assertEquals(inserted.id, updatedId)
         assertEquals(inserted.rowVersion.rowId, updatedVersion.rowId)
-        assertEquals(updatedVersion, locationTrackDao.fetchVersion(MainLayoutContext.official, inserted.id))
-        assertEquals(updatedVersion, locationTrackDao.fetchVersion(MainLayoutContext.draft, inserted.id))
+        assertEquals(
+            updatedVersion, locationTrackDao.fetchVersion(MainLayoutContext.official, inserted.id))
+        assertEquals(
+            updatedVersion, locationTrackDao.fetchVersion(MainLayoutContext.draft, inserted.id))
         val updatedFromDb = locationTrackDao.fetch(updatedVersion)
         assertMatches(updatedTrack, updatedFromDb, contextMatch = false)
         assertEquals(inserted.id, updatedFromDb.id)
@@ -91,19 +102,21 @@ class LocationTrackDaoIT @Autowired constructor(
 
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val alignmentVersion1 = alignmentDao.insert(alignment())
-        val locationTrack1 = locationTrack(
-            trackNumberId = trackNumberId,
-            externalId = oid,
-            alignmentVersion = alignmentVersion1,
-            draft = false,
-        )
+        val locationTrack1 =
+            locationTrack(
+                trackNumberId = trackNumberId,
+                externalId = oid,
+                alignmentVersion = alignmentVersion1,
+                draft = false,
+            )
         val alignmentVersion2 = alignmentDao.insert(alignment())
-        val locationTrack2 = locationTrack(
-            trackNumberId = trackNumberId,
-            externalId = oid,
-            alignmentVersion = alignmentVersion2,
-            draft = false,
-        )
+        val locationTrack2 =
+            locationTrack(
+                trackNumberId = trackNumberId,
+                externalId = oid,
+                alignmentVersion = alignmentVersion2,
+                draft = false,
+            )
 
         locationTrackDao.insert(locationTrack1)
         assertThrows<DuplicateKeyException> { locationTrackDao.insert(locationTrack2) }
@@ -114,13 +127,14 @@ class LocationTrackDaoIT @Autowired constructor(
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val tempAlignment = alignment(segment(Point(1.0, 1.0), Point(2.0, 2.0)))
         val alignmentVersion = alignmentDao.insert(tempAlignment)
-        val tempTrack = locationTrack(
-            trackNumberId = trackNumberId,
-            name = "test1",
-            alignment = tempAlignment,
-            alignmentVersion = alignmentVersion,
-            draft = false,
-        )
+        val tempTrack =
+            locationTrack(
+                trackNumberId = trackNumberId,
+                name = "test1",
+                alignment = tempAlignment,
+                alignmentVersion = alignmentVersion,
+                draft = false,
+            )
         val (id, insertVersion) = locationTrackDao.insert(tempTrack)
         val inserted = locationTrackDao.fetch(insertVersion)
         assertMatches(tempTrack, inserted)
@@ -138,7 +152,8 @@ class LocationTrackDaoIT @Autowired constructor(
 
         val newTempAlignment = alignment(segment(Point(2.0, 2.0), Point(4.0, 4.0)))
         val newAlignmentVersion = alignmentDao.insert(newTempAlignment)
-        val tempDraft2 = draft1.copy(alignmentVersion = newAlignmentVersion, length = newTempAlignment.length)
+        val tempDraft2 =
+            draft1.copy(alignmentVersion = newAlignmentVersion, length = newTempAlignment.length)
         val (draftId2, draftVersion2) = locationTrackDao.update(tempDraft2)
         val draft2 = locationTrackDao.fetch(draftVersion2)
         assertEquals(id, draftId2)
@@ -193,13 +208,18 @@ class LocationTrackDaoIT @Autowired constructor(
         Thread.sleep(1) // Ensure that they get different timestamps
 
         val (track1Id, track1MainV1) = mainOfficialContext.insert(locationTrackAndAlignment(tnId))
-        val (track2Id, track2DesignV1) = designOfficialContext.insert(locationTrackAndAlignment(tnId))
-        val (track3Id, track3DesignV1) = designOfficialContext.insert(locationTrackAndAlignment(tnId))
+        val (track2Id, track2DesignV1) =
+            designOfficialContext.insert(locationTrackAndAlignment(tnId))
+        val (track3Id, track3DesignV1) =
+            designOfficialContext.insert(locationTrackAndAlignment(tnId))
         val v1Time = locationTrackDao.fetchChangeTime()
         Thread.sleep(1) // Ensure that they get different timestamps
 
         val track1MainV2 = testDBService.update(track1MainV1).rowVersion
-        val track1DesignV2 = designOfficialContext.copyFrom(track1MainV1, officialRowId = track1MainV1.rowId).rowVersion
+        val track1DesignV2 =
+            designOfficialContext
+                .copyFrom(track1MainV1, officialRowId = track1MainV1.rowId)
+                .rowVersion
         val track2DesignV2 = testDBService.update(track2DesignV1).rowVersion
         locationTrackDao.deleteRow(track3DesignV1.rowId)
         val v2Time = locationTrackDao.fetchChangeTime()
@@ -210,33 +230,76 @@ class LocationTrackDaoIT @Autowired constructor(
         val track2MainV3 = mainOfficialContext.moveFrom(track2DesignV2).rowVersion
         val v3Time = locationTrackDao.fetchChangeTime()
 
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track1Id, v0Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track2Id, v0Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track3Id, v0Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track1Id, v0Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track2Id, v0Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track3Id, v0Time))
+        assertEquals(
+            null,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track1Id, v0Time))
+        assertEquals(
+            null,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track2Id, v0Time))
+        assertEquals(
+            null,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track3Id, v0Time))
+        assertEquals(
+            null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track1Id, v0Time))
+        assertEquals(
+            null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track2Id, v0Time))
+        assertEquals(
+            null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track3Id, v0Time))
 
-        assertEquals(track1MainV1, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track1Id, v1Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track2Id, v1Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track3Id, v1Time))
-        assertEquals(track1MainV1, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track1Id, v1Time))
-        assertEquals(track2DesignV1, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track2Id, v1Time))
-        assertEquals(track3DesignV1, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track3Id, v1Time))
+        assertEquals(
+            track1MainV1,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track1Id, v1Time))
+        assertEquals(
+            null,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track2Id, v1Time))
+        assertEquals(
+            null,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track3Id, v1Time))
+        assertEquals(
+            track1MainV1,
+            locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track1Id, v1Time))
+        assertEquals(
+            track2DesignV1,
+            locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track2Id, v1Time))
+        assertEquals(
+            track3DesignV1,
+            locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track3Id, v1Time))
 
-        assertEquals(track1MainV2, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track1Id, v2Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track2Id, v2Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track3Id, v2Time))
-        assertEquals(track1DesignV2, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track1Id, v2Time))
-        assertEquals(track2DesignV2, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track2Id, v2Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track3Id, v2Time))
+        assertEquals(
+            track1MainV2,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track1Id, v2Time))
+        assertEquals(
+            null,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track2Id, v2Time))
+        assertEquals(
+            null,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track3Id, v2Time))
+        assertEquals(
+            track1DesignV2,
+            locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track1Id, v2Time))
+        assertEquals(
+            track2DesignV2,
+            locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track2Id, v2Time))
+        assertEquals(
+            null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track3Id, v2Time))
 
-        assertEquals(track1MainV2, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track1Id, v3Time))
-        assertEquals(track2MainV3, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track2Id, v3Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track3Id, v3Time))
-        assertEquals(track1MainV2, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track1Id, v3Time))
-        assertEquals(track2MainV3, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track2Id, v3Time))
-        assertEquals(null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track3Id, v3Time))
+        assertEquals(
+            track1MainV2,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track1Id, v3Time))
+        assertEquals(
+            track2MainV3,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track2Id, v3Time))
+        assertEquals(
+            null,
+            locationTrackDao.fetchOfficialVersionAtMoment(LayoutBranch.main, track3Id, v3Time))
+        assertEquals(
+            track1MainV2,
+            locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track1Id, v3Time))
+        assertEquals(
+            track2MainV3,
+            locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track2Id, v3Time))
+        assertEquals(
+            null, locationTrackDao.fetchOfficialVersionAtMoment(designBranch, track3Id, v3Time))
     }
 
     @Test
@@ -263,7 +326,8 @@ class LocationTrackDaoIT @Autowired constructor(
         val undeletedDraftVersion = insertDraftLocationTrack(tnId)
         val deleteStateDraftVersion = insertDraftLocationTrack(tnId, LocationTrackState.DELETED)
         val changeTrackNumberOriginal = insertOfficialLocationTrack(tnId)
-        val changeTrackNumberChanged = createDraftWithNewTrackNumber(changeTrackNumberOriginal.rowVersion, tnId2)
+        val changeTrackNumberChanged =
+            createDraftWithNewTrackNumber(changeTrackNumberOriginal.rowVersion, tnId2)
         val deletedDraftId = insertDraftLocationTrack(tnId).id
         locationTrackDao.deleteDraft(LayoutBranch.main, deletedDraftId)
 
@@ -298,10 +362,11 @@ class LocationTrackDaoIT @Autowired constructor(
         val locationTrack1 = insertOfficialLocationTrack(tnId)
         val locationTrack2 = insertOfficialLocationTrack(tnId)
 
-        val expected = locationTrackDao.fetchVersions(
-            MainLayoutContext.official,
-            listOf(locationTrack1.id, locationTrack2.id),
-        )
+        val expected =
+            locationTrackDao.fetchVersions(
+                MainLayoutContext.official,
+                listOf(locationTrack1.id, locationTrack2.id),
+            )
         assertEquals(expected.size, 2)
         assertContains(expected, locationTrack1)
         assertContains(expected, locationTrack2)
@@ -319,10 +384,11 @@ class LocationTrackDaoIT @Autowired constructor(
         val locationTrack1 = insertDraftLocationTrack(tnId)
         val locationTrack2 = insertDraftLocationTrack(tnId)
 
-        val expected = locationTrackDao.fetchVersions(
-            MainLayoutContext.draft,
-            listOf(locationTrack1.id, locationTrack2.id),
-        )
+        val expected =
+            locationTrackDao.fetchVersions(
+                MainLayoutContext.draft,
+                listOf(locationTrack1.id, locationTrack2.id),
+            )
         assertEquals(expected.size, 2)
         assertContains(expected, locationTrack1)
         assertContains(expected, locationTrack2)
@@ -336,9 +402,10 @@ class LocationTrackDaoIT @Autowired constructor(
         val draftOnly = insertDraftLocationTrack(tnId)
         val entirelyMissing = IntId<LocationTrack>(0)
 
-        val res = locationTrackDao.fetchVersions(
-            MainLayoutContext.official, listOf(locationTrack1.id, locationTrack2.id, draftOnly.id, entirelyMissing)
-        )
+        val res =
+            locationTrackDao.fetchVersions(
+                MainLayoutContext.official,
+                listOf(locationTrack1.id, locationTrack2.id, draftOnly.id, entirelyMissing))
         assertEquals(res.size, 2)
         assertContains(res, locationTrack1)
         assertContains(res, locationTrack2)
@@ -348,42 +415,41 @@ class LocationTrackDaoIT @Autowired constructor(
     fun `different layout contexts work for objects initialized in official context`() {
         val tnId = mainOfficialContext.createLayoutTrackNumber().id
         val alignmentVersion = alignmentDao.insert(alignment())
-        val officialVersion = locationTrackDao.insert(
-            locationTrack(
-                tnId,
-                name = "official",
-                draft = false,
-                alignmentVersion = alignmentVersion
-            )
-        )
+        val officialVersion =
+            locationTrackDao.insert(
+                locationTrack(
+                    tnId, name = "official", draft = false, alignmentVersion = alignmentVersion))
         val official = locationTrackDao.fetch(officialVersion.rowVersion)
         locationTrackDao.insert(asMainDraft(official.copy(name = AlignmentName("draft"))))
         val bothDesign = layoutDesignDao.insert(layoutDesign("both"))
-        val bothDesignInitialDesignDraftFromOfficial = locationTrackDao.insert(
-            asDesignDraft(
-                official.copy(name = AlignmentName("design-official both")),
-                bothDesign
-            )
-        ).rowVersion
-        val updatedToDesignOfficial = locationTrackDao.update(
-            asDesignOfficial(
-                locationTrackDao.fetch(bothDesignInitialDesignDraftFromOfficial), bothDesign
-            )
-        ).rowVersion
-        val bothDesignDesignDraftVersion = locationTrackDao.insert(
-            asDesignDraft(
-                locationTrackDao.fetch(updatedToDesignOfficial)
-                    .copy(name = AlignmentName("design-draft both")),
-                bothDesign
-            )
-        ).rowVersion
+        val bothDesignInitialDesignDraftFromOfficial =
+            locationTrackDao
+                .insert(
+                    asDesignDraft(
+                        official.copy(name = AlignmentName("design-official both")), bothDesign))
+                .rowVersion
+        val updatedToDesignOfficial =
+            locationTrackDao
+                .update(
+                    asDesignOfficial(
+                        locationTrackDao.fetch(bothDesignInitialDesignDraftFromOfficial),
+                        bothDesign))
+                .rowVersion
+        val bothDesignDesignDraftVersion =
+            locationTrackDao
+                .insert(
+                    asDesignDraft(
+                        locationTrackDao
+                            .fetch(updatedToDesignOfficial)
+                            .copy(name = AlignmentName("design-draft both")),
+                        bothDesign))
+                .rowVersion
         val onlyDraftDesign = layoutDesignDao.insert(layoutDesign("onlyDraft"))
-        locationTrackDao.insert(
-            asDesignDraft(
-                official.copy(name = AlignmentName("design-draft onlyDraft")),
-                onlyDraftDesign
-            )
-        ).rowVersion
+        locationTrackDao
+            .insert(
+                asDesignDraft(
+                    official.copy(name = AlignmentName("design-draft onlyDraft")), onlyDraftDesign))
+            .rowVersion
 
         fun contextTracks(layoutContext: LayoutContext) =
             getTrackNameSetByLayoutContextAndTrackNumber(layoutContext, tnId)
@@ -392,26 +458,20 @@ class LocationTrackDaoIT @Autowired constructor(
         assertEquals(setOf("draft"), contextTracks(MainLayoutContext.draft))
         assertEquals(
             setOf("design-official both"),
-            contextTracks(DesignLayoutContext.of(bothDesign, OFFICIAL))
-        )
+            contextTracks(DesignLayoutContext.of(bothDesign, OFFICIAL)))
         assertEquals(
             setOf("design-draft both"),
-            contextTracks(DesignLayoutContext.of(bothDesign, PublicationState.DRAFT))
-        )
+            contextTracks(DesignLayoutContext.of(bothDesign, PublicationState.DRAFT)))
 
         assertEquals(
             setOf("design-draft onlyDraft"),
-            contextTracks(DesignLayoutContext.of(onlyDraftDesign, PublicationState.DRAFT))
-        )
+            contextTracks(DesignLayoutContext.of(onlyDraftDesign, PublicationState.DRAFT)))
 
         assertChangeInfo(
             officialVersion.rowVersion,
             bothDesignDesignDraftVersion,
             locationTrackDao.fetchLayoutAssetChangeInfo(
-                DesignLayoutContext.of(bothDesign, PublicationState.DRAFT),
-                officialVersion.id
-            )!!
-        )
+                DesignLayoutContext.of(bothDesign, PublicationState.DRAFT), officialVersion.id)!!)
     }
 
     @Test
@@ -425,49 +485,43 @@ class LocationTrackDaoIT @Autowired constructor(
                     tnId,
                     name = "design-official",
                     contextData = LayoutContextData.newDraft(DesignBranch.of(bothDesign)),
-                    alignmentVersion = alignmentVersion
-                )
-            )
-        val bothDesignNowOfficial = locationTrackDao.update(
-            asDesignOfficial(
-                locationTrackDao.fetch(initialVersion.rowVersion),
-                bothDesign,
-            )
-        ).rowVersion
-        val lastDesignDraftVersion = locationTrackDao.insert(
-            asDesignDraft(
-                locationTrackDao.fetch(bothDesignNowOfficial).copy(name = AlignmentName("design-draft")),
-                bothDesign,
-            )
-        ).rowVersion
+                    alignmentVersion = alignmentVersion))
+        val bothDesignNowOfficial =
+            locationTrackDao
+                .update(
+                    asDesignOfficial(
+                        locationTrackDao.fetch(initialVersion.rowVersion),
+                        bothDesign,
+                    ))
+                .rowVersion
+        val lastDesignDraftVersion =
+            locationTrackDao
+                .insert(
+                    asDesignDraft(
+                        locationTrackDao
+                            .fetch(bothDesignNowOfficial)
+                            .copy(name = AlignmentName("design-draft")),
+                        bothDesign,
+                    ))
+                .rowVersion
 
         fun contextTracks(layoutContext: LayoutContext) =
             getTrackNameSetByLayoutContextAndTrackNumber(layoutContext, tnId)
 
         assertEquals(
-            setOf("design-official"),
-            contextTracks(DesignLayoutContext.of(bothDesign, OFFICIAL))
-        )
+            setOf("design-official"), contextTracks(DesignLayoutContext.of(bothDesign, OFFICIAL)))
         assertEquals(
             setOf("design-draft"),
-            contextTracks(DesignLayoutContext.of(bothDesign, PublicationState.DRAFT))
-        )
-        assertEquals(
-            setOf<String>(),
-            contextTracks(MainLayoutContext.of(PublicationState.DRAFT))
-        )
-        assertEquals(
-            setOf<String>(),
-            contextTracks(MainLayoutContext.of(OFFICIAL))
-        )
+            contextTracks(DesignLayoutContext.of(bothDesign, PublicationState.DRAFT)))
+        assertEquals(setOf<String>(), contextTracks(MainLayoutContext.of(PublicationState.DRAFT)))
+        assertEquals(setOf<String>(), contextTracks(MainLayoutContext.of(OFFICIAL)))
         assertChangeInfo(
             initialVersion.rowVersion,
             lastDesignDraftVersion,
             locationTrackDao.fetchLayoutAssetChangeInfo(
                 DesignLayoutContext.of(bothDesign, PublicationState.DRAFT),
                 initialVersion.id,
-            )!!
-        )
+            )!!)
     }
 
     @Test
@@ -475,20 +529,19 @@ class LocationTrackDaoIT @Autowired constructor(
         val tnId = mainOfficialContext.createLayoutTrackNumber().id
         val alignmentVersion = alignmentDao.insert(alignment())
         val someDesign = layoutDesignDao.insert(layoutDesign("some design"))
-        locationTrackDao.insert(
-            locationTrack(
-                tnId,
-                name = "official",
-                draft = false,
-                alignmentVersion = alignmentVersion
-            )
-        ).rowVersion
+        locationTrackDao
+            .insert(
+                locationTrack(
+                    tnId, name = "official", draft = false, alignmentVersion = alignmentVersion))
+            .rowVersion
 
         fun contextTracks(layoutContext: LayoutContext) =
             getTrackNameSetByLayoutContextAndTrackNumber(layoutContext, tnId)
 
         assertEquals(setOf("official"), contextTracks(DesignLayoutContext.of(someDesign, OFFICIAL)))
-        assertEquals(setOf("official"), contextTracks(DesignLayoutContext.of(someDesign, PublicationState.DRAFT)))
+        assertEquals(
+            setOf("official"),
+            contextTracks(DesignLayoutContext.of(someDesign, PublicationState.DRAFT)))
         assertEquals(setOf("official"), contextTracks(MainLayoutContext.of(OFFICIAL)))
         assertEquals(setOf("official"), contextTracks(MainLayoutContext.of(PublicationState.DRAFT)))
     }
@@ -498,20 +551,19 @@ class LocationTrackDaoIT @Autowired constructor(
         val tnId = mainOfficialContext.createLayoutTrackNumber().id
         val alignmentVersion = alignmentDao.insert(alignment())
         val someDesign = layoutDesignDao.insert(layoutDesign("some design"))
-        locationTrackDao.insert(
-            locationTrack(
-                tnId,
-                name = "draft",
-                draft = true,
-                alignmentVersion = alignmentVersion
-            )
-        ).rowVersion
+        locationTrackDao
+            .insert(
+                locationTrack(
+                    tnId, name = "draft", draft = true, alignmentVersion = alignmentVersion))
+            .rowVersion
 
         fun contextTracks(layoutContext: LayoutContext) =
             getTrackNameSetByLayoutContextAndTrackNumber(layoutContext, tnId)
 
         assertEquals(setOf<String>(), contextTracks(DesignLayoutContext.of(someDesign, OFFICIAL)))
-        assertEquals(setOf<String>(), contextTracks(DesignLayoutContext.of(someDesign, PublicationState.DRAFT)))
+        assertEquals(
+            setOf<String>(),
+            contextTracks(DesignLayoutContext.of(someDesign, PublicationState.DRAFT)))
         assertEquals(setOf<String>(), contextTracks(MainLayoutContext.of(OFFICIAL)))
         assertEquals(setOf("draft"), contextTracks(MainLayoutContext.of(PublicationState.DRAFT)))
     }
@@ -521,20 +573,22 @@ class LocationTrackDaoIT @Autowired constructor(
         val tnId = mainOfficialContext.createLayoutTrackNumber().id
         val alignmentVersion = alignmentDao.insert(alignment())
         val someDesign = layoutDesignDao.insert(layoutDesign("some design"))
-        locationTrackDao.insert(
-            locationTrack(
-                tnId,
-                name = "design-draft",
-                contextData = LayoutContextData.newDraft(DesignBranch.of(someDesign)),
-                alignmentVersion = alignmentVersion
-            )
-        ).rowVersion
+        locationTrackDao
+            .insert(
+                locationTrack(
+                    tnId,
+                    name = "design-draft",
+                    contextData = LayoutContextData.newDraft(DesignBranch.of(someDesign)),
+                    alignmentVersion = alignmentVersion))
+            .rowVersion
 
         fun contextTracks(layoutContext: LayoutContext) =
             getTrackNameSetByLayoutContextAndTrackNumber(layoutContext, tnId)
 
         assertEquals(setOf<String>(), contextTracks(DesignLayoutContext.of(someDesign, OFFICIAL)))
-        assertEquals(setOf("design-draft"), contextTracks(DesignLayoutContext.of(someDesign, PublicationState.DRAFT)))
+        assertEquals(
+            setOf("design-draft"),
+            contextTracks(DesignLayoutContext.of(someDesign, PublicationState.DRAFT)))
         assertEquals(setOf<String>(), contextTracks(MainLayoutContext.of(OFFICIAL)))
         assertEquals(setOf<String>(), contextTracks(MainLayoutContext.of(PublicationState.DRAFT)))
     }
@@ -544,98 +598,98 @@ class LocationTrackDaoIT @Autowired constructor(
         val tnId = mainOfficialContext.createLayoutTrackNumber().id
         val alignmentVersion = alignmentDao.insert(alignment())
         val someDesignId = layoutDesignDao.insert(layoutDesign("some design"))
-        val official = locationTrackDao.insert(
-            locationTrack(
-                tnId,
-                name = "official",
-                draft = false,
-                alignmentVersion = alignmentVersion
-            )
-        )
-        val designDraftVersion = locationTrackDao.insert(
-            asDesignDraft(
-                locationTrackDao
-                    .fetch(official.rowVersion)
-                    .copy(name = AlignmentName("design-official")),
-                someDesignId,
-            )
-        ).rowVersion
-        locationTrackDao.update(asDesignOfficial(locationTrackDao.fetch(designDraftVersion), someDesignId))
+        val official =
+            locationTrackDao.insert(
+                locationTrack(
+                    tnId, name = "official", draft = false, alignmentVersion = alignmentVersion))
+        val designDraftVersion =
+            locationTrackDao
+                .insert(
+                    asDesignDraft(
+                        locationTrackDao
+                            .fetch(official.rowVersion)
+                            .copy(name = AlignmentName("design-official")),
+                        someDesignId,
+                    ))
+                .rowVersion
+        locationTrackDao.update(
+            asDesignOfficial(locationTrackDao.fetch(designDraftVersion), someDesignId))
 
         fun contextTracks(layoutContext: LayoutContext) =
             getTrackNameSetByLayoutContextAndTrackNumber(layoutContext, tnId)
 
         assertEquals(
-            setOf("design-official"),
-            contextTracks(DesignLayoutContext.of(someDesignId, OFFICIAL))
-        )
+            setOf("design-official"), contextTracks(DesignLayoutContext.of(someDesignId, OFFICIAL)))
         assertEquals(
             setOf("design-official"),
-            contextTracks(DesignLayoutContext.of(someDesignId, PublicationState.DRAFT))
-        )
+            contextTracks(DesignLayoutContext.of(someDesignId, PublicationState.DRAFT)))
         assertEquals(setOf("official"), contextTracks(MainLayoutContext.of(OFFICIAL)))
         assertEquals(setOf("official"), contextTracks(MainLayoutContext.of(PublicationState.DRAFT)))
         assertChangeInfo(
             official.rowVersion,
             designDraftVersion,
             locationTrackDao.fetchLayoutAssetChangeInfo(
-                DesignLayoutContext.of(someDesignId, PublicationState.DRAFT),
-                official.id
-            )!!
-        )
+                DesignLayoutContext.of(someDesignId, PublicationState.DRAFT), official.id)!!)
     }
 
     @Test
     fun `fetchVersionsNear() returns only the correct context's version when multiple are visible`() {
         testDBService.clearLayoutTables()
         val trackNumber = mainOfficialContext.insert(trackNumber()).id
-        val officialTrackVersion = mainOfficialContext.insert(
-            locationTrack(trackNumber), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        ).rowVersion
-        val draftTrackVersion = mainDraftContext.insert(
-            asMainDraft(locationTrackDao.fetch(officialTrackVersion)),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        ).rowVersion
+        val officialTrackVersion =
+            mainOfficialContext
+                .insert(
+                    locationTrack(trackNumber),
+                    alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+                .rowVersion
+        val draftTrackVersion =
+            mainDraftContext
+                .insert(
+                    asMainDraft(locationTrackDao.fetch(officialTrackVersion)),
+                    alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+                .rowVersion
         assertEquals(
             listOf(draftTrackVersion),
-            locationTrackDao.fetchVersionsNear(MainLayoutContext.draft, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0))
-        )
+            locationTrackDao.fetchVersionsNear(
+                MainLayoutContext.draft, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0)))
         assertEquals(
             listOf(officialTrackVersion),
-            locationTrackDao.fetchVersionsNear(MainLayoutContext.official, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0))
-        )
+            locationTrackDao.fetchVersionsNear(
+                MainLayoutContext.official, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0)))
     }
 
     @Test
     fun `fetchVersionsNear() returns only the correct context's version when track is moved`() {
         testDBService.clearLayoutTables()
         val trackNumber = mainOfficialContext.insert(trackNumber()).id
-        val officialTrackVersion = mainOfficialContext.insert(
-            locationTrack(trackNumber), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
-        ).rowVersion
-        val draftTrackVersion = mainDraftContext.insert(
-            asMainDraft(locationTrackDao.fetch(officialTrackVersion)),
-            alignment(segment(Point(0.0, 10.0), Point(10.0, 10.0)))
-        ).rowVersion
+        val officialTrackVersion =
+            mainOfficialContext
+                .insert(
+                    locationTrack(trackNumber),
+                    alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+                .rowVersion
+        val draftTrackVersion =
+            mainDraftContext
+                .insert(
+                    asMainDraft(locationTrackDao.fetch(officialTrackVersion)),
+                    alignment(segment(Point(0.0, 10.0), Point(10.0, 10.0))))
+                .rowVersion
         assertEquals(
             listOf<LayoutRowVersion<LocationTrack>>(),
-            locationTrackDao
-                .fetchVersionsNear(MainLayoutContext.official, boundingBoxAroundPoint(Point(0.0, 10.0), 1.0))
-        )
+            locationTrackDao.fetchVersionsNear(
+                MainLayoutContext.official, boundingBoxAroundPoint(Point(0.0, 10.0), 1.0)))
         assertEquals(
             listOf(draftTrackVersion),
-            locationTrackDao
-                .fetchVersionsNear(MainLayoutContext.draft, boundingBoxAroundPoint(Point(0.0, 10.0), 1.0))
-        )
+            locationTrackDao.fetchVersionsNear(
+                MainLayoutContext.draft, boundingBoxAroundPoint(Point(0.0, 10.0), 1.0)))
         assertEquals(
             listOf(officialTrackVersion),
-            locationTrackDao
-                .fetchVersionsNear(MainLayoutContext.official, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0))
-        )
+            locationTrackDao.fetchVersionsNear(
+                MainLayoutContext.official, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0)))
         assertEquals(
             listOf<LayoutRowVersion<LocationTrack>>(),
-            locationTrackDao.fetchVersionsNear(MainLayoutContext.draft, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0))
-        )
+            locationTrackDao.fetchVersionsNear(
+                MainLayoutContext.draft, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0)))
     }
 
     private fun assertChangeInfo(
@@ -649,24 +703,29 @@ class LocationTrackDaoIT @Autowired constructor(
         assertEquals(contextVersionChangeTime, changeInfo.changed, "changed time")
     }
 
-    private fun getChangeTime(version: LayoutRowVersion<LocationTrack>) = jdbc.queryOne(
-        "select change_time from layout.location_track_version where id = :id and version = :version",
-        mapOf("id" to version.rowId.intValue, "version" to version.version)
-    ) { rs, _ -> rs.getInstant("change_time") }
+    private fun getChangeTime(version: LayoutRowVersion<LocationTrack>) =
+        jdbc.queryOne(
+            "select change_time from layout.location_track_version where id = :id and version = :version",
+            mapOf("id" to version.rowId.intValue, "version" to version.version)) { rs, _ ->
+                rs.getInstant("change_time")
+            }
 
     private fun getTrackNameSetByLayoutContextAndTrackNumber(
         layoutContext: LayoutContext,
         trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): Set<String> {
-        val names = locationTrackDao
-            .list(layoutContext, includeDeleted = false, trackNumberId = trackNumberId)
-            .map { it.name.toString() }
+        val names =
+            locationTrackDao
+                .list(layoutContext, includeDeleted = false, trackNumberId = trackNumberId)
+                .map { it.name.toString() }
         val nameSet = names.toSet()
         assertEquals(names.size, nameSet.size)
         return nameSet
     }
 
-    private fun insertOfficialLocationTrack(tnId: IntId<TrackLayoutTrackNumber>): LayoutDaoResponse<LocationTrack> {
+    private fun insertOfficialLocationTrack(
+        tnId: IntId<TrackLayoutTrackNumber>
+    ): LayoutDaoResponse<LocationTrack> {
         val (track, alignment) = locationTrackAndAlignment(tnId, draft = false)
         val alignmentVersion = alignmentDao.insert(alignment)
         return locationTrackDao.insert(track.copy(alignmentVersion = alignmentVersion))
@@ -676,11 +735,12 @@ class LocationTrackDaoIT @Autowired constructor(
         tnId: IntId<TrackLayoutTrackNumber>,
         state: LocationTrackState = LocationTrackState.IN_USE,
     ): LayoutDaoResponse<LocationTrack> {
-        val (track, alignment) = locationTrackAndAlignment(
-            trackNumberId = tnId,
-            state = state,
-            draft = true,
-        )
+        val (track, alignment) =
+            locationTrackAndAlignment(
+                trackNumberId = tnId,
+                state = state,
+                draft = true,
+            )
         val alignmentVersion = alignmentDao.insert(alignment)
         return locationTrackDao.insert(track.copy(alignmentVersion = alignmentVersion))
     }
@@ -693,10 +753,10 @@ class LocationTrackDaoIT @Autowired constructor(
         assertFalse(track.isDraft)
         val alignmentVersion = alignmentService.duplicate(track.alignmentVersion!!)
         return locationTrackDao.insert(
-            asMainDraft(track).copy(
-                alignmentVersion = alignmentVersion,
-                trackNumberId = newTrackNumber,
-            )
-        )
+            asMainDraft(track)
+                .copy(
+                    alignmentVersion = alignmentVersion,
+                    trackNumberId = newTrackNumber,
+                ))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -17,6 +17,7 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.SplitTestDataService
 import fi.fta.geoviite.infra.util.FreeText
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -29,11 +30,12 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class LocationTrackServiceIT @Autowired constructor(
+class LocationTrackServiceIT
+@Autowired
+constructor(
     private val locationTrackService: LocationTrackService,
     private val locationTrackDao: LocationTrackDao,
     private val alignmentDao: LayoutAlignmentDao,
@@ -56,7 +58,9 @@ class LocationTrackServiceIT @Autowired constructor(
 
     @Test
     fun creatingAndDeletingUnpublishedTrackWithAlignmentWorks() {
-        val (track, alignment) = locationTrackAndAlignment(mainDraftContext.createLayoutTrackNumber().id, someSegment(), draft = true)
+        val (track, alignment) =
+            locationTrackAndAlignment(
+                mainDraftContext.createLayoutTrackNumber().id, someSegment(), draft = true)
         val (id, version) = locationTrackService.saveDraft(LayoutBranch.main, track, alignment)
         val (savedTrack, savedAlignment) = locationTrackService.getWithAlignment(version)
         assertTrue(alignmentExists(savedTrack.alignmentVersion!!.id))
@@ -68,42 +72,49 @@ class LocationTrackServiceIT @Autowired constructor(
 
     @Test
     fun deletingOfficialLocationTrackThrowsException() {
-        val (track, alignment) = locationTrackAndAlignment(mainOfficialContext.createLayoutTrackNumber().id, someSegment(), draft = true)
+        val (track, alignment) =
+            locationTrackAndAlignment(
+                mainOfficialContext.createLayoutTrackNumber().id, someSegment(), draft = true)
         val version = locationTrackService.saveDraft(LayoutBranch.main, track, alignment)
         publish(version.id)
-        assertThrows<DeletingFailureException> { locationTrackService.deleteDraft(LayoutBranch.main, version.id) }
+        assertThrows<DeletingFailureException> {
+            locationTrackService.deleteDraft(LayoutBranch.main, version.id)
+        }
     }
 
     @Test
     fun nearbyLocationTracksAreFoundWithBbox() {
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
-        val (trackInside, alignmentInside) = locationTrackAndAlignment(
-            trackNumberId,
-            segment(
-                Point(x = 0.0, y = 0.0),
-                Point(x = 5.0, y = 0.0),
-                startM = 5.0,
-            ),
-            draft = true,
-        )
-        val (trackOutside, alignmentOutside) = locationTrackAndAlignment(
-            trackNumberId,
-            segment(
-                Point(x = 20.0, y = 20.0),
-                Point(x = 30.0, y = 20.0),
-                startM = 10.0,
-            ),
-            draft = true,
-        )
+        val (trackInside, alignmentInside) =
+            locationTrackAndAlignment(
+                trackNumberId,
+                segment(
+                    Point(x = 0.0, y = 0.0),
+                    Point(x = 5.0, y = 0.0),
+                    startM = 5.0,
+                ),
+                draft = true,
+            )
+        val (trackOutside, alignmentOutside) =
+            locationTrackAndAlignment(
+                trackNumberId,
+                segment(
+                    Point(x = 20.0, y = 20.0),
+                    Point(x = 30.0, y = 20.0),
+                    startM = 10.0,
+                ),
+                draft = true,
+            )
 
-        val alignmentIdInBbox = locationTrackService
-            .saveDraft(LayoutBranch.main, trackInside, alignmentInside).id
-        val alignmentIdOutsideBbox = locationTrackService
-            .saveDraft(LayoutBranch.main, trackOutside, alignmentOutside).id
+        val alignmentIdInBbox =
+            locationTrackService.saveDraft(LayoutBranch.main, trackInside, alignmentInside).id
+        val alignmentIdOutsideBbox =
+            locationTrackService.saveDraft(LayoutBranch.main, trackOutside, alignmentOutside).id
 
         val boundingBox = BoundingBox(Point(0.0, 0.0), Point(10.0, 10.0))
 
-        val tracksAndAlignments = locationTrackService.listNearWithAlignments(MainLayoutContext.draft, boundingBox)
+        val tracksAndAlignments =
+            locationTrackService.listNearWithAlignments(MainLayoutContext.draft, boundingBox)
 
         assertTrue(tracksAndAlignments.any { (t, _) -> t.id == alignmentIdInBbox })
         assertTrue(tracksAndAlignments.none { (t, _) -> t.id == alignmentIdOutsideBbox })
@@ -117,8 +128,9 @@ class LocationTrackServiceIT @Autowired constructor(
         val (id, insertedTrackVersion) = response
         val changeTimeAfterInsert = locationTrackService.getChangeTime()
 
-        val updateRequest = saveRequest(trackNumberId, 2)
-            .copy(topologicalConnectivity = TopologicalConnectivityType.NONE)
+        val updateRequest =
+            saveRequest(trackNumberId, 2)
+                .copy(topologicalConnectivity = TopologicalConnectivityType.NONE)
         val updatedTrackVersion = locationTrackService.update(LayoutBranch.main, id, updateRequest)
         assertEquals(id, updatedTrackVersion.id)
         assertEquals(insertedTrackVersion.rowId, updatedTrackVersion.rowVersion.rowId)
@@ -137,10 +149,11 @@ class LocationTrackServiceIT @Autowired constructor(
     fun savingCreatesDraft() {
         val (publicationResponse, published) = createPublishedLocationTrack(1)
 
-        val editedVersion = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            published.copy(name = AlignmentName("EDITED1")),
-        )
+        val editedVersion =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                published.copy(name = AlignmentName("EDITED1")),
+            )
         assertEquals(publicationResponse.id, editedVersion.id)
         assertNotEquals(publicationResponse.rowVersion.rowId, editedVersion.rowVersion.rowId)
 
@@ -149,10 +162,11 @@ class LocationTrackServiceIT @Autowired constructor(
         // Creating a draft should duplicate the alignment
         assertNotEquals(published.alignmentVersion!!.id, editedDraft.alignmentVersion!!.id)
 
-        val editedVersion2 = locationTrackService.saveDraft(
-            LayoutBranch.main,
-            editedDraft.copy(name = AlignmentName("EDITED2")),
-        )
+        val editedVersion2 =
+            locationTrackService.saveDraft(
+                LayoutBranch.main,
+                editedDraft.copy(name = AlignmentName("EDITED2")),
+            )
         assertEquals(publicationResponse.id, editedVersion2.id)
         assertNotEquals(publicationResponse.rowVersion.rowId, editedVersion2.rowVersion.rowId)
 
@@ -168,7 +182,8 @@ class LocationTrackServiceIT @Autowired constructor(
         val (publicationResponse, published) = createPublishedLocationTrack(2)
 
         val alignmentTmp = alignment(segment(2, 10.0, 20.0, 10.0, 20.0))
-        val editedVersion = locationTrackService.saveDraft(LayoutBranch.main, published, alignmentTmp)
+        val editedVersion =
+            locationTrackService.saveDraft(LayoutBranch.main, published, alignmentTmp)
         assertEquals(publicationResponse.id, editedVersion.id)
         assertNotEquals(publicationResponse.rowVersion.rowId, editedVersion.rowVersion.rowId)
 
@@ -182,11 +197,13 @@ class LocationTrackServiceIT @Autowired constructor(
         assertNotEquals(published.alignmentVersion!!.id, editedDraft.alignmentVersion!!.id)
 
         val alignmentTmp2 = alignment(segment(4, 10.0, 20.0, 10.0, 20.0))
-        val editedVersion2 = locationTrackService.saveDraft(LayoutBranch.main, editedDraft, alignmentTmp2)
+        val editedVersion2 =
+            locationTrackService.saveDraft(LayoutBranch.main, editedDraft, alignmentTmp2)
         assertEquals(publicationResponse.id, editedVersion2.id)
         assertNotEquals(publicationResponse.rowVersion.rowId, editedVersion2.rowVersion.rowId)
 
-        val (editedDraft2, editedAlignment2) = getAndVerifyDraftWithAlignment(publicationResponse.id)
+        val (editedDraft2, editedAlignment2) =
+            getAndVerifyDraftWithAlignment(publicationResponse.id)
         assertEquals(
             alignmentTmp2.segments.flatMap(LayoutSegment::alignmentPoints),
             editedAlignment2.segments.flatMap(LayoutSegment::alignmentPoints),
@@ -194,7 +211,8 @@ class LocationTrackServiceIT @Autowired constructor(
         assertNotEquals(published.alignmentVersion!!.id, editedDraft2.alignmentVersion!!.id)
         // Second edit to same draft should not duplicate alignment again
         assertEquals(editedDraft.alignmentVersion!!.id, editedDraft2.alignmentVersion!!.id)
-        assertNotEquals(editedDraft.alignmentVersion!!.version, editedDraft2.alignmentVersion!!.version)
+        assertNotEquals(
+            editedDraft.alignmentVersion!!.version, editedDraft2.alignmentVersion!!.version)
     }
 
     @Test
@@ -240,28 +258,33 @@ class LocationTrackServiceIT @Autowired constructor(
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
         val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(10.0, 0.0)),
-                segment(Point(10.0, 0.0), Point(20.0, 0.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(2),
+        val (_, _) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(10.0, 0.0)),
+                    segment(Point(10.0, 0.0), Point(20.0, 0.0))
+                        .copy(
+                            switchId = switchId,
+                            startJointNumber = JointNumber(1),
+                            endJointNumber = JointNumber(2),
+                        ),
+                    segment(Point(20.0, 0.0), Point(30.0, 0.0)),
                 ),
-                segment(Point(20.0, 0.0), Point(30.0, 0.0)),
-            ),
-        )
+            )
 
-        val (track, alignment) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(Point(10.2, 0.0), Point(10.2, 20.2))),
-        )
+        val (track, alignment) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(segment(Point(10.2, 0.0), Point(10.2, 20.2))),
+            )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
-        assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(1)), updatedTrack.topologyStartSwitch)
+        val updatedTrack =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track, alignment)
+        assertEquals(
+            TopologyLocationTrackSwitch(switchId, JointNumber(1)), updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
 
@@ -270,29 +293,34 @@ class LocationTrackServiceIT @Autowired constructor(
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
         val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(10.0, 0.0)),
-                segment(Point(10.0, 0.0), Point(20.0, 0.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(2),
+        val (_, _) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(10.0, 0.0)),
+                    segment(Point(10.0, 0.0), Point(20.0, 0.0))
+                        .copy(
+                            switchId = switchId,
+                            startJointNumber = JointNumber(1),
+                            endJointNumber = JointNumber(2),
+                        ),
+                    segment(Point(20.0, 0.0), Point(30.0, 0.0)),
                 ),
-                segment(Point(20.0, 0.0), Point(30.0, 0.0)),
-            ),
-        )
+            )
 
-        val (track, alignment) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(Point(20.2, -20.0), Point(20.2, 0.2))),
-        )
+        val (track, alignment) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(segment(Point(20.2, -20.0), Point(20.2, 0.2))),
+            )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
+        val updatedTrack =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
-        assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(2)), updatedTrack.topologyEndSwitch)
+        assertEquals(
+            TopologyLocationTrackSwitch(switchId, JointNumber(2)), updatedTrack.topologyEndSwitch)
     }
 
     @Test
@@ -300,27 +328,31 @@ class LocationTrackServiceIT @Autowired constructor(
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
         val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(Point(1000.0, 1000.0), Point(1010.0, 1000.0)),
-                segment(Point(1010.0, 1000.0), Point(1020.0, 1000.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(2),
+        val (_, _) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(
+                    segment(Point(1000.0, 1000.0), Point(1010.0, 1000.0)),
+                    segment(Point(1010.0, 1000.0), Point(1020.0, 1000.0))
+                        .copy(
+                            switchId = switchId,
+                            startJointNumber = JointNumber(1),
+                            endJointNumber = JointNumber(2),
+                        ),
+                    segment(Point(1020.0, 1000.0), Point(1030.0, 1000.0)),
                 ),
-                segment(Point(1020.0, 1000.0), Point(1030.0, 1000.0)),
-            ),
-        )
+            )
 
-        val (track, alignment) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(Point(1010.0, 990.0), Point(1010.0, 1000.0), Point(1010.0, 1010.0)))
-        )
+        val (track, alignment) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(
+                    segment(Point(1010.0, 990.0), Point(1010.0, 1000.0), Point(1010.0, 1010.0))))
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
+        val updatedTrack =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -330,27 +362,31 @@ class LocationTrackServiceIT @Autowired constructor(
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
         val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(
-                segment(Point(0.0, 0.0), Point(10.0, 0.0)),
-                segment(Point(10.0, 0.0), Point(20.0, 0.0)).copy(
-                    switchId = switchId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(2),
+        val (_, _) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(
+                    segment(Point(0.0, 0.0), Point(10.0, 0.0)),
+                    segment(Point(10.0, 0.0), Point(20.0, 0.0))
+                        .copy(
+                            switchId = switchId,
+                            startJointNumber = JointNumber(1),
+                            endJointNumber = JointNumber(2),
+                        ),
+                    segment(Point(20.0, 0.0), Point(30.0, 0.0)),
                 ),
-                segment(Point(20.0, 0.0), Point(30.0, 0.0)),
-            ),
-        )
+            )
 
-        val (track, alignment) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(Point(12.0, 0.0), Point(22.0, 0.0))),
-        )
+        val (track, alignment) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(segment(Point(12.0, 0.0), Point(22.0, 0.0))),
+            )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
+        val updatedTrack =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track, alignment)
         assertEquals(null, updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
@@ -361,63 +397,78 @@ class LocationTrackServiceIT @Autowired constructor(
         val switchId1 = insertAndFetchDraft(switch(draft = true)).id as IntId
         val switchId2 = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetchDraft(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchId1, JointNumber(3)),
-                topologyEndSwitch = TopologyLocationTrackSwitch(switchId2, JointNumber(5)),
-                draft = true,
-            ),
-            alignment(segment(Point(2000.0, 2000.0), Point(2010.0, 2010.0))),
-        )
+        val (_, _) =
+            insertAndFetchDraft(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(switchId1, JointNumber(3)),
+                    topologyEndSwitch = TopologyLocationTrackSwitch(switchId2, JointNumber(5)),
+                    draft = true,
+                ),
+                alignment(segment(Point(2000.0, 2000.0), Point(2010.0, 2010.0))),
+            )
 
-        val (track1, alignment1) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(Point(2000.0, 2000.0), Point(2022.0, 2000.0))),
-        )
+        val (track1, alignment1) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(segment(Point(2000.0, 2000.0), Point(2022.0, 2000.0))),
+            )
         assertEquals(null, track1.topologyStartSwitch)
         assertEquals(null, track1.topologyEndSwitch)
 
-        val updatedTrack1 = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track1, alignment1)
-        assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack1.topologyStartSwitch)
+        val updatedTrack1 =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track1, alignment1)
+        assertEquals(
+            TopologyLocationTrackSwitch(switchId1, JointNumber(3)),
+            updatedTrack1.topologyStartSwitch)
         assertEquals(null, updatedTrack1.topologyEndSwitch)
 
-        val (track2, alignment2) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(Point(2009.9, 2010.0), Point(1990.0, 1990.0))),
-        )
+        val (track2, alignment2) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(segment(Point(2009.9, 2010.0), Point(1990.0, 1990.0))),
+            )
         assertEquals(null, track2.topologyStartSwitch)
         assertEquals(null, track2.topologyEndSwitch)
 
-        val updatedTrack2 = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track2, alignment2)
-        assertEquals(TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack2.topologyStartSwitch)
+        val updatedTrack2 =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track2, alignment2)
+        assertEquals(
+            TopologyLocationTrackSwitch(switchId2, JointNumber(5)),
+            updatedTrack2.topologyStartSwitch)
         assertEquals(null, updatedTrack2.topologyEndSwitch)
 
-        val (track3, alignment3) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(Point(1990.0, 1990.0), Point(1999.9, 2000.0))),
-        )
+        val (track3, alignment3) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(segment(Point(1990.0, 1990.0), Point(1999.9, 2000.0))),
+            )
         assertEquals(null, track3.topologyStartSwitch)
         assertEquals(null, track3.topologyEndSwitch)
 
-        val updatedTrack3 = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track3, alignment3)
+        val updatedTrack3 =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track3, alignment3)
         assertEquals(null, updatedTrack3.topologyStartSwitch)
-        assertEquals(TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack3.topologyEndSwitch)
+        assertEquals(
+            TopologyLocationTrackSwitch(switchId1, JointNumber(3)), updatedTrack3.topologyEndSwitch)
 
-        val (track4, alignment4) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(Point(2020.0, 2020.0), Point(2010.1, 2009.9))),
-        )
+        val (track4, alignment4) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(segment(Point(2020.0, 2020.0), Point(2010.1, 2009.9))),
+            )
         assertEquals(null, track4.topologyStartSwitch)
         assertEquals(null, track4.topologyEndSwitch)
 
-        val updatedTrack4 = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track4, alignment4)
+        val updatedTrack4 =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track4, alignment4)
         assertEquals(null, updatedTrack4.topologyStartSwitch)
-        assertEquals(TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack4.topologyEndSwitch)
+        assertEquals(
+            TopologyLocationTrackSwitch(switchId2, JointNumber(5)), updatedTrack4.topologyEndSwitch)
     }
 
     @Test
@@ -426,17 +477,19 @@ class LocationTrackServiceIT @Autowired constructor(
         val switchId1 = insertAndFetchDraft(switch(draft = true)).id as IntId
         val switchId2 = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (track, alignment) = insertAndFetchDraft(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchId1, JointNumber(3)),
-                topologyEndSwitch = TopologyLocationTrackSwitch(switchId2, JointNumber(5)),
-                draft = true,
-            ),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
-        val updated = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
+        val (track, alignment) =
+            insertAndFetchDraft(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(switchId1, JointNumber(3)),
+                    topologyEndSwitch = TopologyLocationTrackSwitch(switchId2, JointNumber(5)),
+                    draft = true,
+                ),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
+        val updated =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track, alignment)
         assertEquals(track.topologyStartSwitch, updated.topologyStartSwitch)
         assertEquals(track.topologyEndSwitch, updated.topologyEndSwitch)
     }
@@ -446,24 +499,28 @@ class LocationTrackServiceIT @Autowired constructor(
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
         val switchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (_, _) = insertAndFetchDraft(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(3)),
-                draft = true,
-            ),
-            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-        )
+        val (_, _) =
+            insertAndFetchDraft(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    topologyStartSwitch = TopologyLocationTrackSwitch(switchId, JointNumber(3)),
+                    draft = true,
+                ),
+                alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+            )
 
-        val (track, alignment) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment(segment(Point(0.0, 0.0), Point(22.0, 0.0))),
-        )
+        val (track, alignment) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, draft = true),
+                alignment(segment(Point(0.0, 0.0), Point(22.0, 0.0))),
+            )
         assertEquals(null, track.topologyStartSwitch)
         assertEquals(null, track.topologyEndSwitch)
-        val updatedTrack = locationTrackService
-            .fetchNearbyTracksAndCalculateLocationTrackTopology(MainLayoutContext.draft, track, alignment)
-        assertEquals(TopologyLocationTrackSwitch(switchId, JointNumber(3)), updatedTrack.topologyStartSwitch)
+        val updatedTrack =
+            locationTrackService.fetchNearbyTracksAndCalculateLocationTrackTopology(
+                MainLayoutContext.draft, track, alignment)
+        assertEquals(
+            TopologyLocationTrackSwitch(switchId, JointNumber(3)), updatedTrack.topologyStartSwitch)
         assertEquals(null, updatedTrack.topologyEndSwitch)
     }
 
@@ -474,25 +531,29 @@ class LocationTrackServiceIT @Autowired constructor(
         val topologyEndSwitchId = insertAndFetchDraft(switch(draft = true)).id as IntId
         val segmentSwitchId = insertAndFetchDraft(switch(draft = true)).id as IntId
 
-        val (track, _) = insertAndFetchDraft(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                topologyStartSwitch = TopologyLocationTrackSwitch(topologyStartSwitchId, JointNumber(3)),
-                topologyEndSwitch = TopologyLocationTrackSwitch(topologyEndSwitchId, JointNumber(5)),
-                draft = true,
-            ),
-            alignment(
-                segment(
-                    Point(0.0, 0.0),
-                    Point(10.0, 0.0),
-                    switchId = segmentSwitchId,
-                    startJointNumber = JointNumber(1),
-                    endJointNumber = JointNumber(2),
-                )
-            ),
-        )
+        val (track, _) =
+            insertAndFetchDraft(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    topologyStartSwitch =
+                        TopologyLocationTrackSwitch(topologyStartSwitchId, JointNumber(3)),
+                    topologyEndSwitch =
+                        TopologyLocationTrackSwitch(topologyEndSwitchId, JointNumber(5)),
+                    draft = true,
+                ),
+                alignment(
+                    segment(
+                        Point(0.0, 0.0),
+                        Point(10.0, 0.0),
+                        switchId = segmentSwitchId,
+                        startJointNumber = JointNumber(1),
+                        endJointNumber = JointNumber(2),
+                    )),
+            )
 
-        val switches = locationTrackService.getSwitchesForLocationTrack(MainLayoutContext.draft, track.id as IntId)
+        val switches =
+            locationTrackService.getSwitchesForLocationTrack(
+                MainLayoutContext.draft, track.id as IntId)
         assertContains(switches, topologyEndSwitchId)
         assertContains(switches, topologyStartSwitchId)
         assertContains(switches, segmentSwitchId)
@@ -501,107 +562,115 @@ class LocationTrackServiceIT @Autowired constructor(
     @Test
     fun fetchDuplicatesIsVersioned() {
         val alignment = someAlignment()
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(alignment).id
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(alignment).id
 
-        val (originalLocationTrack, _) = insertAndFetchDraft(
-            locationTrack(trackNumberId, draft = true),
-            alignment
-        )
+        val (originalLocationTrack, _) =
+            insertAndFetchDraft(locationTrack(trackNumberId, draft = true), alignment)
         publish(originalLocationTrack.id as IntId)
-        val originalLocationTrackId = originalLocationTrack.id as IntId;
+        val originalLocationTrackId = originalLocationTrack.id as IntId
 
-        val (duplicateInOfficial, _) = insertAndFetchDraft(
-            locationTrack(trackNumberId, duplicateOf = originalLocationTrackId, draft = true),
-            alignment,
-        )
+        val (duplicateInOfficial, _) =
+            insertAndFetchDraft(
+                locationTrack(trackNumberId, duplicateOf = originalLocationTrackId, draft = true),
+                alignment,
+            )
         publish(duplicateInOfficial.id as IntId<LocationTrack>)
 
-        val newTrackName = AlignmentName(duplicateInOfficial.name.toString()+" NEW NAME FOR DRAFT");
-        val duplicateInDraftVersion = locationTrackService.update(
-            LayoutBranch.main,
-            duplicateInOfficial.id as IntId,
-            saveRequest(trackNumberId, 1).copy(
-                name = newTrackName,
-                duplicateOf = originalLocationTrackId
-            ),
-        )
-        val duplicateInDraft = locationTrackService.get(MainLayoutContext.draft, duplicateInDraftVersion.id)!!
+        val newTrackName =
+            AlignmentName(duplicateInOfficial.name.toString() + " NEW NAME FOR DRAFT")
+        val duplicateInDraftVersion =
+            locationTrackService.update(
+                LayoutBranch.main,
+                duplicateInOfficial.id as IntId,
+                saveRequest(trackNumberId, 1)
+                    .copy(name = newTrackName, duplicateOf = originalLocationTrackId),
+            )
+        val duplicateInDraft =
+            locationTrackService.get(MainLayoutContext.draft, duplicateInDraftVersion.id)!!
 
         assertEquals(
             duplicateInOfficial.name,
-            locationTrackService.getInfoboxExtras(MainLayoutContext.official, originalLocationTrackId)
+            locationTrackService
+                .getInfoboxExtras(MainLayoutContext.official, originalLocationTrackId)
                 ?.duplicates
                 ?.firstOrNull()
-                ?.name
-        )
+                ?.name)
         assertEquals(
             duplicateInDraft.name,
-            locationTrackService.getInfoboxExtras(MainLayoutContext.draft, originalLocationTrackId)
+            locationTrackService
+                .getInfoboxExtras(MainLayoutContext.draft, originalLocationTrackId)
                 ?.duplicates
                 ?.firstOrNull()
-                ?.name
-        )
+                ?.name)
     }
 
     @Test
     fun `Splitting initialization parameters are fetched properly`() {
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
-        val rlAlignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(100.0, 0.0))))
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = rlAlignment, draft = false))
+        val rlAlignment =
+            alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(100.0, 0.0))))
+        referenceLineDao.insert(
+            referenceLine(trackNumberId, alignmentVersion = rlAlignment, draft = false))
 
-        val switch = insertAndFetchDraft(
-            switch(
-                joints = listOf(
-                    TrackLayoutSwitchJoint(
-                        JointNumber(1),
-                        Point(100.0, 0.0),
-                        LocationAccuracy.DIGITIZED_AERIAL_IMAGE,
-                    )
-                ),
-                draft = true,
-            )
-        ).id as IntId
-        val locationTrack = locationTrackDao.insert(
-            locationTrack(
-                trackNumberId = trackNumberId,
-                alignmentVersion = alignmentDao.insert(
-                    alignment(
-                        segment(
-                            Point(50.0, 0.0),
-                            Point(100.0, 0.0),
-                            switchId = switch,
-                            startJointNumber = JointNumber(1),
-                        )
-                    )
-                ),
-                draft = false,
-            )
-        )
-        val duplicateLocationTrack = locationTrackDao.insert(
-            locationTrack(trackNumberId, alignmentVersion = rlAlignment, duplicateOf = locationTrack.id, draft = false)
-        )
+        val switch =
+            insertAndFetchDraft(
+                    switch(
+                        joints =
+                            listOf(
+                                TrackLayoutSwitchJoint(
+                                    JointNumber(1),
+                                    Point(100.0, 0.0),
+                                    LocationAccuracy.DIGITIZED_AERIAL_IMAGE,
+                                )),
+                        draft = true,
+                    ))
+                .id as IntId
+        val locationTrack =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId = trackNumberId,
+                    alignmentVersion =
+                        alignmentDao.insert(
+                            alignment(
+                                segment(
+                                    Point(50.0, 0.0),
+                                    Point(100.0, 0.0),
+                                    switchId = switch,
+                                    startJointNumber = JointNumber(1),
+                                ))),
+                    draft = false,
+                ))
+        val duplicateLocationTrack =
+            locationTrackDao.insert(
+                locationTrack(
+                    trackNumberId,
+                    alignmentVersion = rlAlignment,
+                    duplicateOf = locationTrack.id,
+                    draft = false))
 
-        val splittingParams = locationTrackService
-            .getSplittingInitializationParameters(MainLayoutContext.draft, locationTrack.id)
+        val splittingParams =
+            locationTrackService.getSplittingInitializationParameters(
+                MainLayoutContext.draft, locationTrack.id)
         assertNotNull(splittingParams)
         assertEquals(locationTrack.id, splittingParams?.id)
         assertEquals(1, splittingParams?.switches?.size)
         assertEquals(1, splittingParams?.duplicates?.size)
         assertContains(splittingParams?.switches?.map { it.switchId } ?: emptyList(), switch)
-        assertContains(splittingParams?.duplicates?.map { it.id } ?: emptyList(), duplicateLocationTrack.id)
+        assertContains(
+            splittingParams?.duplicates?.map { it.id } ?: emptyList(), duplicateLocationTrack.id)
         assertEquals(50.0, splittingParams?.switches?.first()?.distance ?: 0.0, 0.01)
     }
 
     @Test
     fun `Trying to update a split source location track should throw`() {
-        val split = splitTestDataService
-            .insertSplit()
-            .let(splitService::getOrThrow)
+        val split = splitTestDataService.insertSplit().let(splitService::getOrThrow)
 
-        val sourceLocationTrack = locationTrackService.getOrThrow(
-            MainLayoutContext.draft,
-            split.sourceLocationTrackId,
-        )
+        val sourceLocationTrack =
+            locationTrackService.getOrThrow(
+                MainLayoutContext.draft,
+                split.sourceLocationTrackId,
+            )
 
         assertThrows<SplitSourceLocationTrackUpdateException> {
             locationTrackService.update(
@@ -617,18 +686,18 @@ class LocationTrackServiceIT @Autowired constructor(
                     duplicateOf = sourceLocationTrack.duplicateOf,
                     topologicalConnectivity = sourceLocationTrack.topologicalConnectivity,
                     ownerId = sourceLocationTrack.ownerId,
-                )
-            )
+                ))
         }
     }
 
-    private fun asLocationTrackDuplicate(locationTrack: LocationTrack): LocationTrackDuplicate = LocationTrackDuplicate(
-        locationTrack.id as IntId,
-        locationTrack.trackNumberId,
-        locationTrack.name,
-        locationTrack.externalId,
-        DuplicateStatus(DuplicateMatch.NONE, locationTrack.duplicateOf, null, null),
-    )
+    private fun asLocationTrackDuplicate(locationTrack: LocationTrack): LocationTrackDuplicate =
+        LocationTrackDuplicate(
+            locationTrack.id as IntId,
+            locationTrack.trackNumberId,
+            locationTrack.name,
+            locationTrack.externalId,
+            DuplicateStatus(DuplicateMatch.NONE, locationTrack.duplicateOf, null, null),
+        )
 
     private fun insertAndFetchDraft(switch: TrackLayoutSwitch): TrackLayoutSwitch =
         switchDao.fetch(switchService.saveDraft(LayoutBranch.main, switch).rowVersion)
@@ -636,10 +705,13 @@ class LocationTrackServiceIT @Autowired constructor(
     private fun insertAndFetchDraft(
         locationTrack: LocationTrack,
         alignment: LayoutAlignment,
-    ): Pair<LocationTrack, LayoutAlignment> = locationTrackService
-        .getWithAlignment(locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment).rowVersion)
+    ): Pair<LocationTrack, LayoutAlignment> =
+        locationTrackService.getWithAlignment(
+            locationTrackService.saveDraft(LayoutBranch.main, locationTrack, alignment).rowVersion)
 
-    private fun createPublishedLocationTrack(seed: Int): Pair<LayoutDaoResponse<LocationTrack>, LocationTrack> {
+    private fun createPublishedLocationTrack(
+        seed: Int
+    ): Pair<LayoutDaoResponse<LocationTrack>, LocationTrack> {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val (trackInsertResponse, _) = createAndVerifyTrack(trackNumberId, seed)
         return publishAndVerify(trackInsertResponse.id)
@@ -659,15 +731,16 @@ class LocationTrackServiceIT @Autowired constructor(
     private fun publishAndVerify(
         locationTrackId: IntId<LocationTrack>,
     ): Pair<LayoutDaoResponse<LocationTrack>, LocationTrack> {
-        val (draft, draftAlignment) = locationTrackService
-            .getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
+        val (draft, draftAlignment) =
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, locationTrackId)
         assertTrue(draft.isDraft)
 
         val publicationResponse = publish(draft.id as IntId)
-        val (published, publishedAlignment) = locationTrackService.getWithAlignmentOrThrow(
-            MainLayoutContext.official,
-            publicationResponse.id,
-        )
+        val (published, publishedAlignment) =
+            locationTrackService.getWithAlignmentOrThrow(
+                MainLayoutContext.official,
+                publicationResponse.id,
+            )
         assertFalse(published.isDraft)
         assertEquals(draft.id, published.id)
         assertEquals(published.id, publicationResponse.id)
@@ -684,8 +757,11 @@ class LocationTrackServiceIT @Autowired constructor(
         return draft
     }
 
-    private fun getAndVerifyDraftWithAlignment(id: IntId<LocationTrack>): Pair<LocationTrack, LayoutAlignment> {
-        val (draft, alignment) = locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, id)
+    private fun getAndVerifyDraftWithAlignment(
+        id: IntId<LocationTrack>
+    ): Pair<LocationTrack, LayoutAlignment> {
+        val (draft, alignment) =
+            locationTrackService.getWithAlignmentOrThrow(MainLayoutContext.draft, id)
         assertEquals(id, draft.id)
         assertTrue(draft.isDraft)
         assertEquals(draft.alignmentVersion!!.id, alignment.id)
@@ -711,20 +787,21 @@ class LocationTrackServiceIT @Autowired constructor(
     private fun saveRequest(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         seed: Int,
-    ) = LocationTrackSaveRequest(
-        name = AlignmentName("TST-TRACK$seed"),
-        descriptionBase = FreeText("Description - $seed"),
-        descriptionSuffix = DescriptionSuffixType.NONE,
-        type = getSomeValue(seed),
-        state = getSomeValue(seed),
-        trackNumberId = trackNumberId,
-        duplicateOf = null,
-        topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
-        ownerId = IntId(1)
-    )
+    ) =
+        LocationTrackSaveRequest(
+            name = AlignmentName("TST-TRACK$seed"),
+            descriptionBase = FreeText("Description - $seed"),
+            descriptionSuffix = DescriptionSuffixType.NONE,
+            type = getSomeValue(seed),
+            state = getSomeValue(seed),
+            trackNumberId = trackNumberId,
+            duplicateOf = null,
+            topologicalConnectivity = TopologicalConnectivityType.START_AND_END,
+            ownerId = IntId(1))
 
-    private fun publish(id: IntId<LocationTrack>): LayoutDaoResponse<LocationTrack> = locationTrackDao
-        .fetchPublicationVersions(LayoutBranch.main, listOf(id))
-        .first()
-        .let { version -> locationTrackService.publish(LayoutBranch.main, version) }
+    private fun publish(id: IntId<LocationTrack>): LayoutDaoResponse<LocationTrack> =
+        locationTrackDao.fetchPublicationVersions(LayoutBranch.main, listOf(id)).first().let {
+            version ->
+            locationTrackService.publish(LayoutBranch.main, version)
+        }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDaoIT.kt
@@ -17,7 +17,9 @@ import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class ReferenceLineDaoIT @Autowired constructor(
+class ReferenceLineDaoIT
+@Autowired
+constructor(
     private val alignmentDao: LayoutAlignmentDao,
     private val referenceLineDao: ReferenceLineDao,
 ) : DBTestBase() {
@@ -27,10 +29,12 @@ class ReferenceLineDaoIT @Autowired constructor(
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val alignment = alignment()
         val alignmentVersion = alignmentDao.insert(alignment)
-        val referenceLine = referenceLine(trackNumberId, alignment, draft = false).copy(
-            startAddress = TrackMeter(KmNumber(10), 125.5, 3),
-            alignmentVersion = alignmentVersion,
-        )
+        val referenceLine =
+            referenceLine(trackNumberId, alignment, draft = false)
+                .copy(
+                    startAddress = TrackMeter(KmNumber(10), 125.5, 3),
+                    alignmentVersion = alignmentVersion,
+                )
 
         assertEquals(DataType.TEMP, referenceLine.dataType)
         val (id, version) = referenceLineDao.insert(referenceLine)
@@ -40,9 +44,10 @@ class ReferenceLineDaoIT @Autowired constructor(
         assertEquals(DataType.STORED, fromDb.dataType)
         assertMatches(referenceLine, fromDb, contextMatch = false)
 
-        val updatedLine = fromDb.copy(
-            startAddress = TrackMeter(KmNumber(12), 321),
-        )
+        val updatedLine =
+            fromDb.copy(
+                startAddress = TrackMeter(KmNumber(12), 321),
+            )
         val (updatedId, updatedVersion) = referenceLineDao.update(updatedLine)
         assertEquals(id, updatedId)
         assertEquals(updatedVersion.rowId, version.rowId)
@@ -58,13 +63,14 @@ class ReferenceLineDaoIT @Autowired constructor(
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val tempAlignment = alignment(segment(Point(1.0, 1.0), Point(2.0, 2.0)))
         val alignmentVersion = alignmentDao.insert(tempAlignment)
-        val tempTrack = referenceLine(
-            trackNumberId = trackNumberId,
-            startAddress = TrackMeter(12, 13),
-            alignment = tempAlignment,
-            alignmentVersion = alignmentVersion,
-            draft = false,
-        )
+        val tempTrack =
+            referenceLine(
+                trackNumberId = trackNumberId,
+                startAddress = TrackMeter(12, 13),
+                alignment = tempAlignment,
+                alignmentVersion = alignmentVersion,
+                draft = false,
+            )
         val (id, insertVersion) = referenceLineDao.insert(tempTrack)
         val inserted = referenceLineDao.fetch(insertVersion)
         assertMatches(tempTrack, inserted, contextMatch = false)
@@ -80,7 +86,8 @@ class ReferenceLineDaoIT @Autowired constructor(
 
         val newTempAlignment = alignment(segment(Point(2.0, 2.0), Point(4.0, 4.0)))
         val newAlignmentVersion = alignmentDao.insert(newTempAlignment)
-        val tempDraft2 = draft1.copy(alignmentVersion = newAlignmentVersion, length = newTempAlignment.length)
+        val tempDraft2 =
+            draft1.copy(alignmentVersion = newAlignmentVersion, length = newTempAlignment.length)
         val draftVersion2 = referenceLineDao.update(tempDraft2).rowVersion
         val draft2 = referenceLineDao.fetch(draftVersion2)
         assertMatches(tempDraft2, draft2, contextMatch = false)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
@@ -28,7 +28,9 @@ import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
-class ReferenceLineServiceIT @Autowired constructor(
+class ReferenceLineServiceIT
+@Autowired
+constructor(
     private val trackNumberService: LayoutTrackNumberService,
     private val referenceLineService: ReferenceLineService,
     private val trackNumberDao: LayoutTrackNumberDao,
@@ -37,10 +39,14 @@ class ReferenceLineServiceIT @Autowired constructor(
 
     @Test
     fun creatingAndDeletingUnpublishedReferenceLineWithAlignmentWorks() {
-        val trackNumberId = createTrackNumber() // automatically creates first version of reference line
-        val (savedLine, savedAlignment) = requireNotNull(
-            referenceLineService.getByTrackNumberWithAlignment(MainLayoutContext.draft, trackNumberId)
-        ) { "Reference line was not automatically created" }
+        val trackNumberId =
+            createTrackNumber() // automatically creates first version of reference line
+        val (savedLine, savedAlignment) =
+            requireNotNull(
+                referenceLineService.getByTrackNumberWithAlignment(
+                    MainLayoutContext.draft, trackNumberId)) {
+                    "Reference line was not automatically created"
+                }
         assertTrue(alignmentExists(savedLine.alignmentVersion!!.id))
         assertEquals(savedLine.alignmentVersion?.id, savedAlignment.id as IntId)
         assertThrows<DataIntegrityViolationException> {
@@ -54,18 +60,24 @@ class ReferenceLineServiceIT @Autowired constructor(
     @Test
     fun deletingOfficialAlignmentThrowsException() {
         val trackNumber = createAndPublishTrackNumber()
-        val referenceLineId = referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumber)?.id as IntId
+        val referenceLineId =
+            referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumber)?.id as IntId
         publish(referenceLineId)
-        val (line, _) = referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.official, referenceLineId)
+        val (line, _) =
+            referenceLineService.getWithAlignmentOrThrow(
+                MainLayoutContext.official, referenceLineId)
         assertFalse(line.isDraft)
-        assertThrows<DeletingFailureException> { referenceLineService.deleteDraft(LayoutBranch.main, referenceLineId) }
+        assertThrows<DeletingFailureException> {
+            referenceLineService.deleteDraft(LayoutBranch.main, referenceLineId)
+        }
     }
 
     @Test
     fun referenceLineAddAndUpdateWorks() {
         val trackNumberId = createTrackNumber() // First version is created automatically
 
-        val referenceLine = referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId)
+        val referenceLine =
+            referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId)
         assertNotNull(referenceLine)
         assertTrue(referenceLine?.isDraft ?: false)
         assertEquals(0.0, referenceLine?.length)
@@ -74,8 +86,9 @@ class ReferenceLineServiceIT @Autowired constructor(
         val referenceLineId = referenceLine?.id as IntId
 
         val address = address(2)
-        val updateResponse = referenceLineService
-            .updateTrackNumberReferenceLine(LayoutBranch.main, trackNumberId, address)
+        val updateResponse =
+            referenceLineService.updateTrackNumberReferenceLine(
+                LayoutBranch.main, trackNumberId, address)
         assertEquals(referenceLineId, updateResponse?.id)
         val updatedLine = referenceLineService.get(MainLayoutContext.draft, referenceLineId)!!
         assertEquals(address, updatedLine.startAddress)
@@ -83,7 +96,8 @@ class ReferenceLineServiceIT @Autowired constructor(
         assertEquals(referenceLine.alignmentVersion, updatedLine.alignmentVersion)
         val changeTimeAfterUpdate = referenceLineService.getChangeTime()
 
-        val changeInfo = referenceLineService.getLayoutAssetChangeInfo(MainLayoutContext.draft, referenceLineId)
+        val changeInfo =
+            referenceLineService.getLayoutAssetChangeInfo(MainLayoutContext.draft, referenceLineId)
         assertEquals(changeTimeAfterInsert, changeInfo?.created)
         assertEquals(changeTimeAfterUpdate, changeInfo?.changed)
     }
@@ -92,11 +106,14 @@ class ReferenceLineServiceIT @Autowired constructor(
     fun updatingThroughTrackNumberCreatesDraft() {
         val trackNumberId = createAndPublishTrackNumber() // First version is created automatically
 
-        val referenceLineId = referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId)!!.id as IntId
+        val referenceLineId =
+            referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId)!!.id
+                as IntId
         val (publishResponse, published) = publishAndVerify(trackNumberId, referenceLineId)
 
-        val editResponse = referenceLineService
-            .updateTrackNumberReferenceLine(LayoutBranch.main, trackNumberId, TrackMeter(3, 5))
+        val editResponse =
+            referenceLineService.updateTrackNumberReferenceLine(
+                LayoutBranch.main, trackNumberId, TrackMeter(3, 5))
         assertEquals(publishResponse.id, editResponse?.id)
         assertNotEquals(publishResponse.rowVersion.rowId, editResponse?.rowVersion?.rowId)
 
@@ -105,8 +122,9 @@ class ReferenceLineServiceIT @Autowired constructor(
         // Creating a draft should duplicate the alignment
         assertNotEquals(published.alignmentVersion!!.id, editedDraft.alignmentVersion!!.id)
 
-        val editResponse2 = referenceLineService
-            .updateTrackNumberReferenceLine(LayoutBranch.main, trackNumberId, TrackMeter(8, 9))
+        val editResponse2 =
+            referenceLineService.updateTrackNumberReferenceLine(
+                LayoutBranch.main, trackNumberId, TrackMeter(8, 9))
         assertEquals(publishResponse.id, editResponse2?.id)
         assertNotEquals(publishResponse.rowVersion.rowId, editResponse2?.rowVersion?.rowId)
 
@@ -121,12 +139,16 @@ class ReferenceLineServiceIT @Autowired constructor(
     fun savingCreatesDraft() {
         val trackNumberId = createAndPublishTrackNumber() // First version is created automatically
 
-        val referenceLineId = referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId)!!.id as IntId
+        val referenceLineId =
+            referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId)!!.id
+                as IntId
         val (publishResponse, published) = publishAndVerify(trackNumberId, referenceLineId)
 
-        val editedVersion = referenceLineService.saveDraft(
-            LayoutBranch.main, published.copy(startAddress = TrackMeter(1, 1)),
-        )
+        val editedVersion =
+            referenceLineService.saveDraft(
+                LayoutBranch.main,
+                published.copy(startAddress = TrackMeter(1, 1)),
+            )
         assertEquals(publishResponse.id, editedVersion.id)
         assertNotEquals(publishResponse.rowVersion.rowId, editedVersion.rowVersion.rowId)
 
@@ -135,10 +157,11 @@ class ReferenceLineServiceIT @Autowired constructor(
         // Creating a draft should duplicate the alignment
         assertNotEquals(published.alignmentVersion!!.id, editedDraft.alignmentVersion!!.id)
 
-        val editedVersion2 = referenceLineService.saveDraft(
-            LayoutBranch.main,
-            editedDraft.copy(startAddress = TrackMeter(2, 2)),
-        )
+        val editedVersion2 =
+            referenceLineService.saveDraft(
+                LayoutBranch.main,
+                editedDraft.copy(startAddress = TrackMeter(2, 2)),
+            )
         assertEquals(publishResponse.id, editedVersion2.id)
         assertNotEquals(publishResponse.rowVersion.rowId, editedVersion2.rowVersion.rowId)
 
@@ -153,11 +176,14 @@ class ReferenceLineServiceIT @Autowired constructor(
     fun savingWithAlignmentCreatesDraft() {
         val trackNumberId = createAndPublishTrackNumber() // First version is created automatically
 
-        val referenceLineId = referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId)!!.id as IntId
+        val referenceLineId =
+            referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId)!!.id
+                as IntId
         val (publishResponse, published) = publishAndVerify(trackNumberId, referenceLineId)
 
         val alignmentTmp = alignment(segment(2, 10.0, 20.0, 10.0, 20.0))
-        val editedVersion = referenceLineService.saveDraft(LayoutBranch.main, published, alignmentTmp)
+        val editedVersion =
+            referenceLineService.saveDraft(LayoutBranch.main, published, alignmentTmp)
         assertEquals(publishResponse.id, editedVersion.id)
         assertNotEquals(publishResponse.rowVersion.rowId, editedVersion.rowVersion.rowId)
 
@@ -171,7 +197,8 @@ class ReferenceLineServiceIT @Autowired constructor(
         assertNotEquals(published.alignmentVersion!!.id, editedDraft.alignmentVersion!!.id)
 
         val alignmentTmp2 = alignment(segment(4, 10.0, 20.0, 10.0, 20.0))
-        val editedVersion2 = referenceLineService.saveDraft(LayoutBranch.main, editedDraft, alignmentTmp2)
+        val editedVersion2 =
+            referenceLineService.saveDraft(LayoutBranch.main, editedDraft, alignmentTmp2)
         assertEquals(publishResponse.id, editedVersion2.id)
         assertNotEquals(publishResponse.rowVersion.rowId, editedVersion2.rowVersion.rowId)
 
@@ -183,22 +210,27 @@ class ReferenceLineServiceIT @Autowired constructor(
         assertNotEquals(published.alignmentVersion!!.id, editedDraft2.alignmentVersion!!.id)
         // Second edit to same draft should not duplicate alignment again
         assertEquals(editedDraft.alignmentVersion!!.id, editedDraft2.alignmentVersion!!.id)
-        assertNotEquals(editedDraft.alignmentVersion!!.version, editedDraft2.alignmentVersion!!.version)
+        assertNotEquals(
+            editedDraft.alignmentVersion!!.version, editedDraft2.alignmentVersion!!.version)
     }
 
     @Test
     fun `should throw exception when there are switches linked to reference line`() {
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
 
-        val (referenceLine, alignment) = referenceLineAndAlignment(
-            trackNumberId = trackNumberId,
-            segments = listOf(
-                segment(
-                    Point(0.0, 0.0), Point(1.0, 1.0), switchId = IntId(100), startJointNumber = JointNumber(1)
-                ),
-            ),
-            draft = false,
-        )
+        val (referenceLine, alignment) =
+            referenceLineAndAlignment(
+                trackNumberId = trackNumberId,
+                segments =
+                    listOf(
+                        segment(
+                            Point(0.0, 0.0),
+                            Point(1.0, 1.0),
+                            switchId = IntId(100),
+                            startJointNumber = JointNumber(1)),
+                    ),
+                draft = false,
+            )
 
         assertThrows<IllegalArgumentException> {
             referenceLineService.saveDraft(LayoutBranch.main, referenceLine, alignment)
@@ -212,8 +244,11 @@ class ReferenceLineServiceIT @Autowired constructor(
         return draft
     }
 
-    private fun getAndVerifyDraftWithAlignment(id: IntId<ReferenceLine>): Pair<ReferenceLine, LayoutAlignment> {
-        val (draft, alignment) = referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.draft, id)
+    private fun getAndVerifyDraftWithAlignment(
+        id: IntId<ReferenceLine>
+    ): Pair<ReferenceLine, LayoutAlignment> {
+        val (draft, alignment) =
+            referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.draft, id)
         assertEquals(id, draft.id)
         assertTrue(draft.isDraft)
         assertEquals(draft.alignmentVersion!!.id, alignment.id)
@@ -224,17 +259,19 @@ class ReferenceLineServiceIT @Autowired constructor(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         referenceLineId: IntId<ReferenceLine>,
     ): Pair<LayoutDaoResponse<ReferenceLine>, ReferenceLine> {
-        val (draft, draftAlignment) = referenceLineService
-            .getWithAlignmentOrThrow(MainLayoutContext.draft, referenceLineId)
+        val (draft, draftAlignment) =
+            referenceLineService.getWithAlignmentOrThrow(MainLayoutContext.draft, referenceLineId)
         assertTrue(draft.isDraft)
-        assertEquals(draft, referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId))
+        assertEquals(
+            draft, referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId))
         assertNull(referenceLineService.getByTrackNumber(MainLayoutContext.official, trackNumberId))
 
         val publishedVersion = publish(draft.id as IntId)
-        val (published, publishedAlignment) = referenceLineService.getWithAlignmentOrThrow(
-            MainLayoutContext.official, publishedVersion.id
-        )
-        val publishedByTrackNumber = referenceLineService.getByTrackNumber(MainLayoutContext.official, trackNumberId)
+        val (published, publishedAlignment) =
+            referenceLineService.getWithAlignmentOrThrow(
+                MainLayoutContext.official, publishedVersion.id)
+        val publishedByTrackNumber =
+            referenceLineService.getByTrackNumber(MainLayoutContext.official, trackNumberId)
         assertEquals(published, publishedByTrackNumber)
         assertFalse(published.isDraft)
         assertEquals(draft.id, published.id)
@@ -252,25 +289,27 @@ class ReferenceLineServiceIT @Autowired constructor(
             ?: throw IllegalStateException("Exists-check failed")
     }
 
-    private fun createAndPublishTrackNumber() = createTrackNumber().let { id ->
-        val version = trackNumberDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
-        trackNumberService.publish(LayoutBranch.main, ValidationVersion(id, version)).id
-    }
+    private fun createAndPublishTrackNumber() =
+        createTrackNumber().let { id ->
+            val version = trackNumberDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
+            trackNumberService.publish(LayoutBranch.main, ValidationVersion(id, version)).id
+        }
 
-    private fun createTrackNumber() = trackNumberService.insert(
-        LayoutBranch.main,
-        TrackNumberSaveRequest(
-            number = testDBService.getUnusedTrackNumber(),
-            description = FreeText(trackNumberDescription),
-            state = LayoutState.IN_USE,
-            startAddress = TrackMeter.ZERO,
-        )
-    )
+    private fun createTrackNumber() =
+        trackNumberService.insert(
+            LayoutBranch.main,
+            TrackNumberSaveRequest(
+                number = testDBService.getUnusedTrackNumber(),
+                description = FreeText(trackNumberDescription),
+                state = LayoutState.IN_USE,
+                startAddress = TrackMeter.ZERO,
+            ))
 
     private fun address(seed: Int = 0) = TrackMeter(KmNumber(seed), seed * 100)
 
-    private fun publish(id: IntId<ReferenceLine>) = referenceLineDao
-        .fetchPublicationVersions(LayoutBranch.main, listOf(id))
-        .first()
-        .let { version -> referenceLineService.publish(LayoutBranch.main, version) }
+    private fun publish(id: IntId<ReferenceLine>) =
+        referenceLineDao.fetchPublicationVersions(LayoutBranch.main, listOf(id)).first().let {
+            version ->
+            referenceLineService.publish(LayoutBranch.main, version)
+        }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLinkTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLinkTest.kt
@@ -5,8 +5,8 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class SwitchLocationTrackLinkTest {
 
@@ -18,12 +18,14 @@ class SwitchLocationTrackLinkTest {
         //                 2-1..2-2..3-1
         assertEquals(
             expected = listOf(fullMatch(2 to 1, 3 to 1)),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(2 to 1, 2 to 2, 3 to 1),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(2 to 1, 2 to 2, 3 to 1),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -35,12 +37,14 @@ class SwitchLocationTrackLinkTest {
         //       1-1..1-2
         assertEquals(
             expected = listOf(fullMatch(1 to 1, 1 to 2)),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -52,12 +56,14 @@ class SwitchLocationTrackLinkTest {
         //                           3-1..3-2
         assertEquals(
             expected = listOf(fullMatch(3 to 1, 3 to 2)),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(3 to 1, 3 to 2),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(3 to 1, 3 to 2),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -69,12 +75,14 @@ class SwitchLocationTrackLinkTest {
         //       1-1..1-2..5-1..5-2
         assertEquals(
             expected = listOf(partialMatch(1 to 1, 1 to 2)),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 5 to 1, 5 to 2),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 5 to 1, 5 to 2),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -86,12 +94,14 @@ class SwitchLocationTrackLinkTest {
         //       5-1..1-2..2-1..6-2
         assertEquals(
             expected = listOf(partialMatch(1 to 2, 2 to 1, from = 1)),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(5 to 1, 1 to 2, 2 to 1, 6 to 2),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(5 to 1, 1 to 2, 2 to 1, 6 to 2),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -103,12 +113,14 @@ class SwitchLocationTrackLinkTest {
         //                 5-1..2-2..3-1..3-2
         assertEquals(
             expected = listOf(partialMatch(2 to 2, 3 to 2, from = 1)),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(5 to 1, 2 to 2, 3 to 1, 3 to 2),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(5 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -119,16 +131,19 @@ class SwitchLocationTrackLinkTest {
         // Dupl:  0    1         2    3
         //       1-1..1-2..5-5..2-2..3-1
         assertEquals(
-            expected = listOf(
-                partialMatch(1 to 1, 1 to 2),
-                partialMatch(2 to 2, 3 to 1, from = 2),
-            ),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 2, 3 to 1),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            expected =
+                listOf(
+                    partialMatch(1 to 1, 1 to 2),
+                    partialMatch(2 to 2, 3 to 1, from = 2),
+                ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 2, 3 to 1),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -139,16 +154,18 @@ class SwitchLocationTrackLinkTest {
         // Dupl:  0    1    2    3    4
         //       1-1..1-2..2-1..2-2..3-1
         assertEquals(
-            expected = listOf(
-                partialMatch(1 to 1, 1 to 2),
-                partialMatch(2 to 2, 3 to 1, from = 3),
-            ),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            expected =
+                listOf(
+                    partialMatch(1 to 1, 1 to 2),
+                    partialMatch(2 to 2, 3 to 1, from = 3),
+                ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -159,16 +176,19 @@ class SwitchLocationTrackLinkTest {
         // Dupl:  0    1         2    3
         //       1-1..1-2.......2-2..3-1
         assertEquals(
-            expected = listOf(
-                partialMatch(1 to 1, 1 to 2),
-                partialMatch(2 to 2, 3 to 1, from = 2),
-            ),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 2, 3 to 1),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            expected =
+                listOf(
+                    partialMatch(1 to 1, 1 to 2),
+                    partialMatch(2 to 2, 3 to 1, from = 2),
+                ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 2, 3 to 1),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -180,12 +200,14 @@ class SwitchLocationTrackLinkTest {
         //       1-1..1-2............3-1
         assertEquals(
             expected = listOf(partialMatch(1 to 1, 1 to 2)),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 3 to 1),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 3 to 1),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
 
@@ -198,30 +220,31 @@ class SwitchLocationTrackLinkTest {
         val start = Point(0.0, 0.0)
         val end = Point(10.0, 0.0)
         assertEquals(
-            expected = listOf(
-                0 to DuplicateStatus(
-                    DuplicateMatch.FULL,
-                    duplicateOfId = null,
-                    startSplitPoint = startPoint(start),
-                    endSplitPoint = endPoint(end)
-                )
-            ),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = listOf(
-                    startPoint(start),
-                    switchSplitPoint(1, 2),
-                    switchSplitPoint(2, 1),
-                    endPoint(end)
+            expected =
+                listOf(
+                    0 to
+                        DuplicateStatus(
+                            DuplicateMatch.FULL,
+                            duplicateOfId = null,
+                            startSplitPoint = startPoint(start),
+                            endSplitPoint = endPoint(end))),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        listOf(
+                            startPoint(start),
+                            switchSplitPoint(1, 2),
+                            switchSplitPoint(2, 1),
+                            endPoint(end)),
+                    duplicateTrackSplitPoints =
+                        listOf(
+                            startPoint(start),
+                            switchSplitPoint(1, 2),
+                            switchSplitPoint(2, 1),
+                            endPoint(end)),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
                 ),
-                duplicateTrackSplitPoints = listOf(
-                    startPoint(start),
-                    switchSplitPoint(1, 2),
-                    switchSplitPoint(2, 1),
-                    endPoint(end)
-                ),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
         )
     }
 
@@ -236,30 +259,31 @@ class SwitchLocationTrackLinkTest {
         val otherStart = Point(2.5, 0.0)
         val otherEnd = Point(12.5, 0.0)
         assertEquals(
-            expected = listOf(
-                1 to DuplicateStatus(
-                    DuplicateMatch.PARTIAL,
-                    duplicateOfId = null,
-                    startSplitPoint = switchSplitPoint(1, 2),
-                    endSplitPoint = switchSplitPoint(2, 1)
-                )
-            ),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = listOf(
-                    startPoint(start),
-                    switchSplitPoint(1, 2),
-                    switchSplitPoint(2, 1),
-                    endPoint(end)
+            expected =
+                listOf(
+                    1 to
+                        DuplicateStatus(
+                            DuplicateMatch.PARTIAL,
+                            duplicateOfId = null,
+                            startSplitPoint = switchSplitPoint(1, 2),
+                            endSplitPoint = switchSplitPoint(2, 1))),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        listOf(
+                            startPoint(start),
+                            switchSplitPoint(1, 2),
+                            switchSplitPoint(2, 1),
+                            endPoint(end)),
+                    duplicateTrackSplitPoints =
+                        listOf(
+                            startPoint(otherStart),
+                            switchSplitPoint(1, 2),
+                            switchSplitPoint(2, 1),
+                            endPoint(otherEnd)),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
                 ),
-                duplicateTrackSplitPoints = listOf(
-                    startPoint(otherStart),
-                    switchSplitPoint(1, 2),
-                    switchSplitPoint(2, 1),
-                    endPoint(otherEnd)
-                ),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
         )
     }
 
@@ -271,15 +295,16 @@ class SwitchLocationTrackLinkTest {
         //       start..1-2............3-1
         assertEquals(
             expected = listOf(partialMatch(1 to 1, 1 to 2)),
-            actual = getDuplicateMatches(
-                mainTrackSplitPoints = matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
-                duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 3 to 1),
-                mainTrackId = StringId(),
-                duplicateOf = null,
-            ),
+            actual =
+                getDuplicateMatches(
+                    mainTrackSplitPoints =
+                        matchRange(1 to 1, 1 to 2, 2 to 1, 2 to 2, 3 to 1, 3 to 2),
+                    duplicateTrackSplitPoints = matchRange(1 to 1, 1 to 2, 3 to 1),
+                    mainTrackId = StringId(),
+                    duplicateOf = null,
+                ),
         )
     }
-
 }
 
 fun emptyPoint() = AlignmentPoint(0.0, 0.0, 0.0, 0.0, 0.0)
@@ -290,12 +315,17 @@ fun partialMatch(
     from: Int = 0,
     startPoint: AlignmentPoint = emptyPoint(),
     endPoint: AlignmentPoint = emptyPoint(),
-) = from to DuplicateStatus(
-    DuplicateMatch.PARTIAL,
-    null,
-    startSplitPoint = SwitchSplitPoint(startPoint, null, IntId(startSwitch.first), JointNumber(startSwitch.second)),
-    endSplitPoint = SwitchSplitPoint(endPoint, null, IntId(endSwitch.first), JointNumber(endSwitch.second))
-)
+) =
+    from to
+        DuplicateStatus(
+            DuplicateMatch.PARTIAL,
+            null,
+            startSplitPoint =
+                SwitchSplitPoint(
+                    startPoint, null, IntId(startSwitch.first), JointNumber(startSwitch.second)),
+            endSplitPoint =
+                SwitchSplitPoint(
+                    endPoint, null, IntId(endSwitch.first), JointNumber(endSwitch.second)))
 
 fun fullMatch(
     startSwitch: Pair<Int, Int>,
@@ -303,30 +333,33 @@ fun fullMatch(
     from: Int = 0,
     startPoint: AlignmentPoint = emptyPoint(),
     endPoint: AlignmentPoint = emptyPoint(),
-) = from to DuplicateStatus(
-    DuplicateMatch.FULL,
-    null,
-    startSplitPoint = SwitchSplitPoint(startPoint, null, IntId(startSwitch.first), JointNumber(startSwitch.second)),
-    endSplitPoint = SwitchSplitPoint(endPoint, null, IntId(endSwitch.first), JointNumber(endSwitch.second))
-)
+) =
+    from to
+        DuplicateStatus(
+            DuplicateMatch.FULL,
+            null,
+            startSplitPoint =
+                SwitchSplitPoint(
+                    startPoint, null, IntId(startSwitch.first), JointNumber(startSwitch.second)),
+            endSplitPoint =
+                SwitchSplitPoint(
+                    endPoint, null, IntId(endSwitch.first), JointNumber(endSwitch.second)))
 
-fun startPoint(point: IPoint):EndpointSplitPoint {
+fun startPoint(point: IPoint): EndpointSplitPoint {
     return EndpointSplitPoint(
         location = AlignmentPoint(point.x, point.y, null, 0.0, null),
         address = null,
-        DuplicateEndPointType.START
-    )
+        DuplicateEndPointType.START)
 }
 
-fun endPoint(point: IPoint):EndpointSplitPoint {
+fun endPoint(point: IPoint): EndpointSplitPoint {
     return EndpointSplitPoint(
         location = AlignmentPoint(point.x, point.y, null, 0.0, null),
         address = null,
-        DuplicateEndPointType.END
-    )
+        DuplicateEndPointType.END)
 }
 
-fun switchSplitPoint(switchId:Int, joint:Int):SwitchSplitPoint {
+fun switchSplitPoint(switchId: Int, joint: Int): SwitchSplitPoint {
     return SwitchSplitPoint(
         emptyPoint(),
         null,
@@ -334,11 +367,13 @@ fun switchSplitPoint(switchId:Int, joint:Int):SwitchSplitPoint {
         JointNumber(joint),
     )
 }
-fun matchRange(vararg switchToJoint: Pair<Int, Int>): List<SplitPoint> = switchToJoint.map { (id, joint) ->
-    SwitchSplitPoint(
-        emptyPoint(),
-        null,
-        IntId(id),
-        JointNumber(joint),
-    )
-}
+
+fun matchRange(vararg switchToJoint: Pair<Int, Int>): List<SplitPoint> =
+    switchToJoint.map { (id, joint) ->
+        SwitchSplitPoint(
+            emptyPoint(),
+            null,
+            IntId(id),
+            JointNumber(joint),
+        )
+    }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
@@ -15,9 +15,7 @@ fun moveKmPostLocation(
     kmPostService: LayoutKmPostService,
 ) {
     val gkPoint = transformToGKCoordinate(LAYOUT_SRID, layoutLocation)
-    kmPostService.saveDraft(
-        LayoutBranch.main, kmPost.copy(gkLocation = gkPoint)
-    )
+    kmPostService.saveDraft(LayoutBranch.main, kmPost.copy(gkLocation = gkPoint))
 }
 
 fun moveLocationTrackGeometryPointsAndUpdate(
@@ -25,11 +23,12 @@ fun moveLocationTrackGeometryPointsAndUpdate(
     alignment: LayoutAlignment,
     moveFunc: (point: IPoint3DM) -> IPoint,
     locationTrackService: LocationTrackService,
-) = locationTrackService.saveDraft(
-    LayoutBranch.main,
-    locationTrack,
-    moveAlignmentPoints(alignment, moveFunc),
-)
+) =
+    locationTrackService.saveDraft(
+        LayoutBranch.main,
+        locationTrack,
+        moveAlignmentPoints(alignment, moveFunc),
+    )
 
 fun addTopologyEndSwitchIntoLocationTrackAndUpdate(
     locationTrack: LocationTrack,
@@ -37,29 +36,32 @@ fun addTopologyEndSwitchIntoLocationTrackAndUpdate(
     switchId: IntId<TrackLayoutSwitch>,
     jointNumber: JointNumber,
     locationTrackService: LocationTrackService,
-) = locationTrackService.saveDraft(
-    LayoutBranch.main,
-    locationTrack.copy(
-        topologyEndSwitch = TopologyLocationTrackSwitch(
-            switchId = switchId,
-            jointNumber = jointNumber,
+) =
+    locationTrackService.saveDraft(
+        LayoutBranch.main,
+        locationTrack.copy(
+            topologyEndSwitch =
+                TopologyLocationTrackSwitch(
+                    switchId = switchId,
+                    jointNumber = jointNumber,
+                ),
         ),
-    ),
-    alignment,
-)
+        alignment,
+    )
 
 fun removeTopologySwitchesFromLocationTrackAndUpdate(
     locationTrack: LocationTrack,
     alignment: LayoutAlignment,
     locationTrackService: LocationTrackService,
-) = locationTrackService.saveDraft(
-    LayoutBranch.main,
-    locationTrack.copy(
-        topologyStartSwitch = null,
-        topologyEndSwitch = null,
-    ),
-    alignment,
-)
+) =
+    locationTrackService.saveDraft(
+        LayoutBranch.main,
+        locationTrack.copy(
+            topologyStartSwitch = null,
+            topologyEndSwitch = null,
+        ),
+        alignment,
+    )
 
 fun addTopologyStartSwitchIntoLocationTrackAndUpdate(
     locationTrack: LocationTrack,
@@ -67,27 +69,30 @@ fun addTopologyStartSwitchIntoLocationTrackAndUpdate(
     switchId: IntId<TrackLayoutSwitch>,
     jointNumber: JointNumber,
     locationTrackService: LocationTrackService,
-): LayoutDaoResponse<LocationTrack> = locationTrackService.saveDraft(
-    LayoutBranch.main,
-    locationTrack.copy(
-        topologyStartSwitch = TopologyLocationTrackSwitch(
-            switchId = switchId,
-            jointNumber = jointNumber,
+): LayoutDaoResponse<LocationTrack> =
+    locationTrackService.saveDraft(
+        LayoutBranch.main,
+        locationTrack.copy(
+            topologyStartSwitch =
+                TopologyLocationTrackSwitch(
+                    switchId = switchId,
+                    jointNumber = jointNumber,
+                ),
         ),
-    ),
-    alignment,
-)
+        alignment,
+    )
 
 fun moveReferenceLineGeometryPointsAndUpdate(
     referenceLine: ReferenceLine,
     alignment: LayoutAlignment,
     moveFunc: (point: IPoint3DM) -> IPoint,
     referenceLineService: ReferenceLineService,
-): LayoutDaoResponse<ReferenceLine> = referenceLineService.saveDraft(
-    LayoutBranch.main,
-    referenceLine,
-    moveAlignmentPoints(alignment, moveFunc),
-)
+): LayoutDaoResponse<ReferenceLine> =
+    referenceLineService.saveDraft(
+        LayoutBranch.main,
+        referenceLine,
+        moveAlignmentPoints(alignment, moveFunc),
+    )
 
 fun moveAlignmentPoints(
     alignment: LayoutAlignment,
@@ -95,17 +100,21 @@ fun moveAlignmentPoints(
 ): LayoutAlignment {
     var segmentM = 0.0
     return alignment.copy(
-        segments = alignment.segments.map { segment ->
-            var prevPoint: IPoint3DM? = null
-            val newPoints = segment.segmentPoints.map { point ->
-                val newPoint = moveFunc(point.toAlignmentPoint(segment.startM))
-                val m = prevPoint?.let { p -> p.m + lineLength(p, newPoint) } ?: 0.0
-                point.copy(x = newPoint.x, y = newPoint.y, m = m).also { p -> prevPoint = p }
-            }
-            segment
-                .withPoints(points = newPoints, newStart = segmentM, newSourceStart = null)
-                .also { newSegment -> segmentM = newSegment.endM }
-        },
+        segments =
+            alignment.segments.map { segment ->
+                var prevPoint: IPoint3DM? = null
+                val newPoints =
+                    segment.segmentPoints.map { point ->
+                        val newPoint = moveFunc(point.toAlignmentPoint(segment.startM))
+                        val m = prevPoint?.let { p -> p.m + lineLength(p, newPoint) } ?: 0.0
+                        point.copy(x = newPoint.x, y = newPoint.y, m = m).also { p ->
+                            prevPoint = p
+                        }
+                    }
+                segment
+                    .withPoints(points = newPoints, newStart = segmentM, newSourceStart = null)
+                    .also { newSegment -> segmentM = newSegment.endM }
+            },
     )
 }
 
@@ -118,10 +127,8 @@ fun moveSwitchPoints(
 fun moveSwitchPoints(
     switch: TrackLayoutSwitch,
     moveFunc: (point: IPoint) -> IPoint,
-) = switch.copy(
-    joints = switch.joints.map { joint ->
-        joint.copy(
-            location = Point(moveFunc(joint.location))
-        )
-    },
-)
+) =
+    switch.copy(
+        joints =
+            switch.joints.map { joint -> joint.copy(location = Point(moveFunc(joint.location))) },
+    )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -9,16 +9,13 @@ import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LocationAccuracy
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.RowVersion
-import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
-import fi.fta.geoviite.infra.geography.ETRS89_SRID
 import fi.fta.geoviite.infra.geography.GeometryPoint
-import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.geography.transformToGKCoordinate
 import fi.fta.geoviite.infra.geometry.GeometryElement
 import fi.fta.geoviite.infra.geometry.GeometryKmPost
@@ -52,7 +49,6 @@ import fi.fta.geoviite.infra.tracklayout.GeometrySource.PLAN
 import fi.fta.geoviite.infra.util.FreeText
 import java.time.LocalDate
 import kotlin.math.ceil
-import kotlin.math.round
 import kotlin.random.Random
 import kotlin.random.Random.Default.nextInt
 
@@ -62,31 +58,36 @@ private val rand = Random(SEED)
 
 fun switchStructureYV60_300_1_9(): SwitchStructure {
     return SwitchStructure(
-        id = IntId(55), type = SwitchType("YV60-300-1:9-O"), presentationJointNumber = JointNumber(1), joints = listOf(
-            SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-            SwitchJoint(JointNumber(5), Point(16.615, 0.0)),
-            SwitchJoint(JointNumber(2), Point(34.430, 0.0)),
-            SwitchJoint(JointNumber(3), Point(34.321, -1.967)),
-        ), alignments = listOf(
-            SwitchAlignment(
-                jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)), elements = listOf(
-                    SwitchElementLine(
-                        IndexedId(1, 1), Point(0.0, 0.0), Point(16.615, 0.0)
-                    ), SwitchElementLine(
-                        IndexedId(1, 2), Point(16.615, 0.0), Point(34.430, 0.0)
-                    )
-                )
-            ), SwitchAlignment(
-                jointNumbers = listOf(JointNumber(1), JointNumber(3)), elements = listOf(
-                    SwitchElementCurve(
-                        IndexedId(2, 1), Point(0.0, 0.0), Point(33.128, -1.835), radius = 300.0
-                    ), SwitchElementLine(
-                        IndexedId(2, 2), Point(33.128, -1.835), Point(34.321, -1.967)
-                    )
-                )
-            )
-        )
-    )
+        id = IntId(55),
+        type = SwitchType("YV60-300-1:9-O"),
+        presentationJointNumber = JointNumber(1),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(5), Point(16.615, 0.0)),
+                SwitchJoint(JointNumber(2), Point(34.430, 0.0)),
+                SwitchJoint(JointNumber(3), Point(34.321, -1.967)),
+            ),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(IndexedId(1, 1), Point(0.0, 0.0), Point(16.615, 0.0)),
+                            SwitchElementLine(
+                                IndexedId(1, 2), Point(16.615, 0.0), Point(34.430, 0.0)))),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementCurve(
+                                IndexedId(2, 1),
+                                Point(0.0, 0.0),
+                                Point(33.128, -1.835),
+                                radius = 300.0),
+                            SwitchElementLine(
+                                IndexedId(2, 2), Point(33.128, -1.835), Point(34.321, -1.967))))))
 }
 
 fun switchAndMatchingAlignments(
@@ -96,37 +97,47 @@ fun switchAndMatchingAlignments(
 ): Pair<TrackLayoutSwitch, List<Pair<LocationTrack, LayoutAlignment>>> {
     val switchId = IntId<TrackLayoutSwitch>(1)
     val jointLocations = mutableMapOf<JointNumber, Point>()
-    val alignments = structure.alignments.map { alignment ->
-        val alignmentPoints = alignment.jointNumbers.map { jointNumber ->
-            val point = jointLocations.computeIfAbsent(jointNumber) { number ->
-                val joint = structure.joints.find { structureJoint -> structureJoint.number == number }
-                joint?.location ?: throw IllegalStateException("No such joint in structure")
-            }
-            jointNumber to point
+    val alignments =
+        structure.alignments.map { alignment ->
+            val alignmentPoints =
+                alignment.jointNumbers.map { jointNumber ->
+                    val point =
+                        jointLocations.computeIfAbsent(jointNumber) { number ->
+                            val joint =
+                                structure.joints.find { structureJoint ->
+                                    structureJoint.number == number
+                                }
+                            joint?.location
+                                ?: throw IllegalStateException("No such joint in structure")
+                        }
+                    jointNumber to point
+                }
+            locationTrackAndAlignment(
+                trackNumberId,
+                alignmentPoints.zipWithNext { start, end ->
+                    val (startJoint, startPoint) = start
+                    val (endJoint, endPoint) = end
+                    val length = lineLength(startPoint, endPoint)
+                    segment(
+                        points(length.toInt(), startPoint.x..endPoint.x, startPoint.y..endPoint.y),
+                        switchId = switchId,
+                        startJointNumber = startJoint,
+                        endJointNumber = endJoint,
+                    )
+                },
+                draft = draft,
+            )
         }
-        locationTrackAndAlignment(
-            trackNumberId, alignmentPoints.zipWithNext { start, end ->
-                val (startJoint, startPoint) = start
-                val (endJoint, endPoint) = end
-                val length = lineLength(startPoint, endPoint)
-                segment(
-                    points(length.toInt(), startPoint.x..endPoint.x, startPoint.y..endPoint.y),
-                    switchId = switchId,
-                    startJointNumber = startJoint,
-                    endJointNumber = endJoint,
-                )
-            },
+    val switch =
+        switch(
+            id = switchId,
+            structureId = structure.id as IntId,
+            joints =
+                jointLocations.map { (number, point) ->
+                    TrackLayoutSwitchJoint(number, point, null)
+                },
             draft = draft,
         )
-    }
-    val switch = switch(
-        id = switchId,
-        structureId = structure.id as IntId,
-        joints = jointLocations.map { (number, point) ->
-            TrackLayoutSwitchJoint(number, point, null)
-        },
-        draft = draft,
-    )
     return switch to alignments
 }
 
@@ -137,7 +148,8 @@ fun segmentsFromSwitchStructure(
     line: List<Int>,
 ): List<LayoutSegment> {
     val expectedJoints = line.map(::JointNumber)
-    val switchAlignment = requireNotNull(structure.alignments.find { a -> a.jointNumbers == expectedJoints })
+    val switchAlignment =
+        requireNotNull(structure.alignments.find { a -> a.jointNumbers == expectedJoints })
     return segmentsFromSwitchAlignment(start, switchId, switchAlignment)
 }
 
@@ -157,47 +169,47 @@ fun segmentsFromSwitchAlignment(
     // 3 joints to two elements;
     // 4 joints to three elements.
     return when (alignment.jointNumbers.size to alignment.elements.size) {
-        2 to 2 -> listOf(
-            segment(
-                points = toSegmentPoints(start + elements[0].start, start + elements[0].end),
-                switchId = switchId,
-                startJointNumber = jointNumbers[0],
-            ),
-
-            segment(
-                points = toSegmentPoints(start + elements[1].start, start + elements[1].end),
-                switchId = switchId,
-                endJointNumber = jointNumbers[1],
-            ),
-        )
-
-        2 to 3 -> listOf(
-            segment(
-                points = toSegmentPoints(start + elements[0].start, start + elements[0].end),
-                switchId = switchId,
-                startJointNumber = jointNumbers[0],
-            ),
-
-            segment(
-                points = toSegmentPoints(start + elements[1].start, start + elements[1].end),
-                switchId = switchId,
-            ),
-
-            segment(
-                points = toSegmentPoints(start + elements[2].start, start + elements[2].end),
-                switchId = switchId,
-                endJointNumber = jointNumbers[1],
-            ),
-        )
-
-        else -> alignment.elements.mapIndexed { i, e ->
-            segment(
-                points = toSegmentPoints(start + e.start, start + e.end),
-                switchId = switchId,
-                startJointNumber = alignment.jointNumbers[i],
-                endJointNumber = alignment.jointNumbers[i + 1],
+        2 to 2 ->
+            listOf(
+                segment(
+                    points = toSegmentPoints(start + elements[0].start, start + elements[0].end),
+                    switchId = switchId,
+                    startJointNumber = jointNumbers[0],
+                ),
+                segment(
+                    points = toSegmentPoints(start + elements[1].start, start + elements[1].end),
+                    switchId = switchId,
+                    endJointNumber = jointNumbers[1],
+                ),
             )
-        }
+
+        2 to 3 ->
+            listOf(
+                segment(
+                    points = toSegmentPoints(start + elements[0].start, start + elements[0].end),
+                    switchId = switchId,
+                    startJointNumber = jointNumbers[0],
+                ),
+                segment(
+                    points = toSegmentPoints(start + elements[1].start, start + elements[1].end),
+                    switchId = switchId,
+                ),
+                segment(
+                    points = toSegmentPoints(start + elements[2].start, start + elements[2].end),
+                    switchId = switchId,
+                    endJointNumber = jointNumbers[1],
+                ),
+            )
+
+        else ->
+            alignment.elements.mapIndexed { i, e ->
+                segment(
+                    points = toSegmentPoints(start + e.start, start + e.end),
+                    switchId = switchId,
+                    startJointNumber = alignment.jointNumbers[i],
+                    endJointNumber = alignment.jointNumbers[i + 1],
+                )
+            }
     }
 }
 
@@ -215,15 +227,16 @@ fun points(
     z: ClosedRange<Double>? = null,
     cant: ClosedRange<Double>? = null,
 ): List<SegmentPoint> {
-    val points = (0 until count).map { i ->
-        SegmentPoint(
-            x = valueOnRange(x, i, count),
-            y = valueOnRange(y, i, count),
-            z = z?.let { zRange -> valueOnRange(zRange, i, count) },
-            m = 0.0,
-            cant = cant?.let { cantRange -> valueOnRange(cantRange, i, count) },
-        )
-    }
+    val points =
+        (0 until count).map { i ->
+            SegmentPoint(
+                x = valueOnRange(x, i, count),
+                y = valueOnRange(y, i, count),
+                z = z?.let { zRange -> valueOnRange(zRange, i, count) },
+                m = 0.0,
+                cant = cant?.let { cantRange -> valueOnRange(cantRange, i, count) },
+            )
+        }
     var cumulativeM = 0.0
     return points.mapIndexed { index, point ->
         if (index > 0) cumulativeM += lineLength(points[index - 1], point)
@@ -242,26 +255,29 @@ fun trackNumber(
     state: LayoutState = LayoutState.IN_USE,
     id: IntId<TrackLayoutTrackNumber>? = null,
     draftOfId: IntId<TrackLayoutTrackNumber>? = null,
-    contextData: LayoutContextData<TrackLayoutTrackNumber> = createMainContext(id, draftOfId, draft),
-) = TrackLayoutTrackNumber(
-    number = number,
-    description = FreeText(description),
-    state = state,
-    externalId = externalId,
-    contextData = contextData,
-)
+    contextData: LayoutContextData<TrackLayoutTrackNumber> =
+        createMainContext(id, draftOfId, draft),
+) =
+    TrackLayoutTrackNumber(
+        number = number,
+        description = FreeText(description),
+        state = state,
+        externalId = externalId,
+        contextData = contextData,
+    )
 
 fun referenceLineAndAlignment(
     trackNumberId: IntId<TrackLayoutTrackNumber>,
     vararg segments: LayoutSegment,
     startAddress: TrackMeter = TrackMeter.ZERO,
     draft: Boolean = false,
-): Pair<ReferenceLine, LayoutAlignment> = referenceLineAndAlignment(
-    trackNumberId,
-    segments.toList(),
-    startAddress = startAddress,
-    draft = draft,
-)
+): Pair<ReferenceLine, LayoutAlignment> =
+    referenceLineAndAlignment(
+        trackNumberId,
+        segments.toList(),
+        startAddress = startAddress,
+        draft = draft,
+    )
 
 fun referenceLineAndAlignment(
     trackNumberId: IntId<TrackLayoutTrackNumber>,
@@ -270,12 +286,13 @@ fun referenceLineAndAlignment(
     draft: Boolean = false,
 ): Pair<ReferenceLine, LayoutAlignment> {
     val alignment = alignment(segments)
-    val referenceLine = referenceLine(
-        trackNumberId = trackNumberId,
-        alignment = alignment,
-        startAddress = startAddress,
-        draft = draft,
-    )
+    val referenceLine =
+        referenceLine(
+            trackNumberId = trackNumberId,
+            alignment = alignment,
+            startAddress = startAddress,
+            draft = draft,
+        )
     return referenceLine to alignment
 }
 
@@ -287,16 +304,17 @@ fun referenceLine(
     alignmentVersion: RowVersion<LayoutAlignment>? = if (id != null) someRowVersion() else null,
     draft: Boolean = false,
     contextData: LayoutContextData<ReferenceLine> = createMainContext(id, null, draft)
-) = ReferenceLine(
-    trackNumberId = trackNumberId,
-    startAddress = startAddress,
-    sourceId = null,
-    boundingBox = alignment?.boundingBox,
-    segmentCount = alignment?.segments?.size ?: 0,
-    length = alignment?.length ?: 0.0,
-    alignmentVersion = alignmentVersion,
-    contextData = contextData,
-)
+) =
+    ReferenceLine(
+        trackNumberId = trackNumberId,
+        startAddress = startAddress,
+        sourceId = null,
+        boundingBox = alignment?.boundingBox,
+        segmentCount = alignment?.segments?.size ?: 0,
+        length = alignment?.length ?: 0.0,
+        alignmentVersion = alignmentVersion,
+        contextData = contextData,
+    )
 
 private var locationTrackNameCounter = 0
 
@@ -328,19 +346,20 @@ fun locationTrackAndAlignment(
     externalId: Oid<LocationTrack>? = someOid(),
     topologyStartSwitch: TopologyLocationTrackSwitch? = null,
     topologyEndSwitch: TopologyLocationTrackSwitch? = null,
-): Pair<LocationTrack, LayoutAlignment> = locationTrackAndAlignment(
-    trackNumberId,
-    segments.toList(),
-    name = name,
-    description = description,
-    duplicateOf = duplicateOf,
-    state = state,
-    id = id,
-    draft = draft,
-    externalId = externalId,
-    topologyStartSwitch = topologyStartSwitch,
-    topologyEndSwitch = topologyEndSwitch,
-)
+): Pair<LocationTrack, LayoutAlignment> =
+    locationTrackAndAlignment(
+        trackNumberId,
+        segments.toList(),
+        name = name,
+        description = description,
+        duplicateOf = duplicateOf,
+        state = state,
+        id = id,
+        draft = draft,
+        externalId = externalId,
+        topologyStartSwitch = topologyStartSwitch,
+        topologyEndSwitch = topologyEndSwitch,
+    )
 
 fun locationTrackAndAlignment(
     trackNumberId: IntId<TrackLayoutTrackNumber>,
@@ -357,20 +376,21 @@ fun locationTrackAndAlignment(
     topologyEndSwitch: TopologyLocationTrackSwitch? = null,
 ): Pair<LocationTrack, LayoutAlignment> {
     val alignment = alignment(segments)
-    val locationTrack = locationTrack(
-        trackNumberId = trackNumberId,
-        alignment = alignment,
-        id = id,
-        draft = draft,
-        name = name,
-        type = type,
-        description = description,
-        duplicateOf = duplicateOf,
-        state = state,
-        externalId = externalId,
-        topologyStartSwitch = topologyStartSwitch,
-        topologyEndSwitch = topologyEndSwitch,
-    )
+    val locationTrack =
+        locationTrack(
+            trackNumberId = trackNumberId,
+            alignment = alignment,
+            id = id,
+            draft = draft,
+            name = name,
+            type = type,
+            description = description,
+            duplicateOf = duplicateOf,
+            state = state,
+            externalId = externalId,
+            topologyStartSwitch = topologyStartSwitch,
+            topologyEndSwitch = topologyEndSwitch,
+        )
     return locationTrack to alignment
 }
 
@@ -391,22 +411,23 @@ fun locationTrack(
     duplicateOf: IntId<LocationTrack>? = null,
     ownerId: IntId<LocationTrackOwner> = IntId(1),
     contextData: LayoutContextData<LocationTrack> = createMainContext(id, null, draft),
-) = locationTrack(
-    trackNumberId = trackNumberId,
-    alignment = alignment,
-    contextData = contextData,
-    name = name,
-    description = description,
-    type = type,
-    state = state,
-    externalId = externalId,
-    alignmentVersion = alignmentVersion,
-    topologicalConnectivity = topologicalConnectivity,
-    topologyStartSwitch = topologyStartSwitch,
-    topologyEndSwitch = topologyEndSwitch,
-    duplicateOf = duplicateOf,
-    ownerId = ownerId,
-)
+) =
+    locationTrack(
+        trackNumberId = trackNumberId,
+        alignment = alignment,
+        contextData = contextData,
+        name = name,
+        description = description,
+        type = type,
+        state = state,
+        externalId = externalId,
+        alignmentVersion = alignmentVersion,
+        topologicalConnectivity = topologicalConnectivity,
+        topologyStartSwitch = topologyStartSwitch,
+        topologyEndSwitch = topologyEndSwitch,
+        duplicateOf = duplicateOf,
+        ownerId = ownerId,
+    )
 
 fun locationTrack(
     trackNumberId: IntId<TrackLayoutTrackNumber>,
@@ -423,30 +444,29 @@ fun locationTrack(
     topologyEndSwitch: TopologyLocationTrackSwitch? = null,
     duplicateOf: IntId<LocationTrack>? = null,
     ownerId: IntId<LocationTrackOwner> = IntId(1),
-) = LocationTrack(
-    name = AlignmentName(name),
-    descriptionBase = FreeText(description),
-    descriptionSuffix = DescriptionSuffixType.NONE,
-    type = type,
-    state = state,
-    externalId = externalId,
-    trackNumberId = trackNumberId,
-    sourceId = null,
-    boundingBox = alignment?.boundingBox,
-    segmentCount = alignment?.segments?.size ?: 0,
-    length = alignment?.length ?: 0.0,
-    duplicateOf = duplicateOf,
-    topologicalConnectivity = topologicalConnectivity,
-    topologyStartSwitch = topologyStartSwitch,
-    topologyEndSwitch = topologyEndSwitch,
-    alignmentVersion = alignmentVersion,
-    ownerId = ownerId,
-    contextData = contextData,
-)
+) =
+    LocationTrack(
+        name = AlignmentName(name),
+        descriptionBase = FreeText(description),
+        descriptionSuffix = DescriptionSuffixType.NONE,
+        type = type,
+        state = state,
+        externalId = externalId,
+        trackNumberId = trackNumberId,
+        sourceId = null,
+        boundingBox = alignment?.boundingBox,
+        segmentCount = alignment?.segments?.size ?: 0,
+        length = alignment?.length ?: 0.0,
+        duplicateOf = duplicateOf,
+        topologicalConnectivity = topologicalConnectivity,
+        topologyStartSwitch = topologyStartSwitch,
+        topologyEndSwitch = topologyEndSwitch,
+        alignmentVersion = alignmentVersion,
+        ownerId = ownerId,
+        contextData = contextData,
+    )
 
-fun <T> someOid() = Oid<T>(
-    "${nextInt(10, 1000)}.${nextInt(10, 1000)}.${nextInt(10, 1000)}"
-)
+fun <T> someOid() = Oid<T>("${nextInt(10, 1000)}.${nextInt(10, 1000)}.${nextInt(10, 1000)}")
 
 fun someAlignment() = alignment(someSegment())
 
@@ -454,29 +474,33 @@ fun alignmentFromPoints(vararg points: Point) = alignment(segment(*points))
 
 fun alignment(vararg segments: LayoutSegment) = alignment(segments.toList())
 
-fun alignment(segments: List<LayoutSegment>) = LayoutAlignment(
-    segments = fixSegmentStarts(segments),
-)
+fun alignment(segments: List<LayoutSegment>) =
+    LayoutAlignment(
+        segments = fixSegmentStarts(segments),
+    )
 
 fun mapAlignment(vararg segments: PlanLayoutSegment) = mapAlignment(segments.toList())
 
-fun mapAlignment(segments: List<PlanLayoutSegment>) = PlanLayoutAlignment(
-    header = AlignmentHeader(
-        id = StringId(),
-        name = AlignmentName("test-alignment"),
-        alignmentSource = MapAlignmentSource.GEOMETRY,
-        alignmentType = MapAlignmentType.LOCATION_TRACK,
-        trackType = LocationTrackType.MAIN,
-        state = LayoutState.IN_USE,
-        segmentCount = segments.size,
-        trackNumberId = IntId(1),
-        version = null,
-        duplicateOf = null,
-        length = segments.map(PlanLayoutSegment::length).sum(),
-        boundingBox = boundingBoxCombining(segments.mapNotNull(PlanLayoutSegment::boundingBox)),
-    ),
-    segments = segments,
-)
+fun mapAlignment(segments: List<PlanLayoutSegment>) =
+    PlanLayoutAlignment(
+        header =
+            AlignmentHeader(
+                id = StringId(),
+                name = AlignmentName("test-alignment"),
+                alignmentSource = MapAlignmentSource.GEOMETRY,
+                alignmentType = MapAlignmentType.LOCATION_TRACK,
+                trackType = LocationTrackType.MAIN,
+                state = LayoutState.IN_USE,
+                segmentCount = segments.size,
+                trackNumberId = IntId(1),
+                version = null,
+                duplicateOf = null,
+                length = segments.map(PlanLayoutSegment::length).sum(),
+                boundingBox =
+                    boundingBoxCombining(segments.mapNotNull(PlanLayoutSegment::boundingBox)),
+            ),
+        segments = segments,
+    )
 
 fun locationTrackWithTwoSwitches(
     trackNumberId: IntId<TrackLayoutTrackNumber>,
@@ -486,60 +510,60 @@ fun locationTrackWithTwoSwitches(
     draft: Boolean,
 ): Pair<LocationTrack, LayoutAlignment> {
     val segmentLength = 10.0
-    val segments = (1..20).map { i ->
-        segment(
-            Point(i * segmentLength, 0.0), Point((i + 1) * segmentLength, 0.0), startM = i * segmentLength
+    val segments =
+        (1..20).map { i ->
+            segment(
+                Point(i * segmentLength, 0.0),
+                Point((i + 1) * segmentLength, 0.0),
+                startM = i * segmentLength)
+        }
+    val (locationTrack, alignment) =
+        locationTrackAndAlignment(
+            trackNumberId = trackNumberId,
+            segments = segments,
+            id = locationTrackId,
+            draft = draft,
         )
-    }
-    val (locationTrack, alignment) = locationTrackAndAlignment(
-        trackNumberId = trackNumberId,
-        segments = segments,
-        id = locationTrackId,
-        draft = draft,
-    )
     return attachSwitches(
-        locationTrack to alignment, layoutSwitchId to TargetSegmentStart(), otherLayoutSwitchId to TargetSegmentEnd()
-    )
+        locationTrack to alignment,
+        layoutSwitchId to TargetSegmentStart(),
+        otherLayoutSwitchId to TargetSegmentEnd())
 }
 
 fun attachSwitchToStart(
     locationTrackAndAlignment: Pair<LocationTrack, LayoutAlignment>,
     switchId: IntId<TrackLayoutSwitch>,
-): Pair<LocationTrack, LayoutAlignment> = attachSwitchToStart(
-    locationTrackAndAlignment.first, locationTrackAndAlignment.second, switchId
-)
+): Pair<LocationTrack, LayoutAlignment> =
+    attachSwitchToStart(locationTrackAndAlignment.first, locationTrackAndAlignment.second, switchId)
 
 fun attachSwitchToStart(
     locationTrack: LocationTrack,
     alignment: LayoutAlignment,
     switchId: IntId<TrackLayoutSwitch>,
 ): Pair<LocationTrack, LayoutAlignment> {
-    if (alignment.segments.count() < 3) throw IllegalArgumentException("Alignment must contain at least 3 segments")
-    return locationTrack to alignment.copy(segments = alignment.segments.mapIndexed { index, segment ->
-        when (index) {
-            0 -> segment.copy(
-                switchId = switchId, startJointNumber = JointNumber(1)
-            )
+    if (alignment.segments.count() < 3)
+        throw IllegalArgumentException("Alignment must contain at least 3 segments")
+    return locationTrack to
+        alignment.copy(
+            segments =
+                alignment.segments.mapIndexed { index, segment ->
+                    when (index) {
+                        0 -> segment.copy(switchId = switchId, startJointNumber = JointNumber(1))
 
-            1 -> segment.copy(
-                switchId = switchId
-            )
+                        1 -> segment.copy(switchId = switchId)
 
-            2 -> segment.copy(
-                switchId = switchId, endJointNumber = JointNumber(2)
-            )
+                        2 -> segment.copy(switchId = switchId, endJointNumber = JointNumber(2))
 
-            else -> segment
-        }
-    })
+                        else -> segment
+                    }
+                })
 }
 
 fun attachSwitchToEnd(
     locationTrackAndAlignment: Pair<LocationTrack, LayoutAlignment>,
     switchId: IntId<TrackLayoutSwitch>,
-): Pair<LocationTrack, LayoutAlignment> = attachSwitchToEnd(
-    locationTrackAndAlignment.first, locationTrackAndAlignment.second, switchId
-)
+): Pair<LocationTrack, LayoutAlignment> =
+    attachSwitchToEnd(locationTrackAndAlignment.first, locationTrackAndAlignment.second, switchId)
 
 fun attachSwitchToEnd(
     locationTrack: LocationTrack,
@@ -547,57 +571,57 @@ fun attachSwitchToEnd(
     switchId: IntId<TrackLayoutSwitch>,
 ): Pair<LocationTrack, LayoutAlignment> {
     val segmentCount = alignment.segments.count()
-    if (segmentCount < 3) throw IllegalArgumentException("Alignment must contain at least 3 segments")
-    return locationTrack to alignment.copy(segments = alignment.segments.mapIndexed { index, segment ->
-        when (index) {
-            segmentCount - 3 -> segment.copy(
-                switchId = switchId, startJointNumber = JointNumber(2)
-            )
+    if (segmentCount < 3)
+        throw IllegalArgumentException("Alignment must contain at least 3 segments")
+    return locationTrack to
+        alignment.copy(
+            segments =
+                alignment.segments.mapIndexed { index, segment ->
+                    when (index) {
+                        segmentCount - 3 ->
+                            segment.copy(switchId = switchId, startJointNumber = JointNumber(2))
 
-            segmentCount - 2 -> segment.copy(
-                switchId = switchId
-            )
+                        segmentCount - 2 -> segment.copy(switchId = switchId)
 
-            segmentCount - 1 -> segment.copy(
-                switchId = switchId, endJointNumber = JointNumber(1)
-            )
+                        segmentCount - 1 ->
+                            segment.copy(switchId = switchId, endJointNumber = JointNumber(1))
 
-            else -> segment
-        }
-    })
+                        else -> segment
+                    }
+                })
 }
 
 fun attachSwitchToIndex(
     locationTrackAndAlignment: Pair<LocationTrack, LayoutAlignment>,
     switchId: IntId<TrackLayoutSwitch>,
     segmentIndex: Int,
-): Pair<LocationTrack, LayoutAlignment> = locationTrackAndAlignment.first to attachSwitchToIndex(
-    locationTrackAndAlignment.second, switchId, segmentIndex
-)
+): Pair<LocationTrack, LayoutAlignment> =
+    locationTrackAndAlignment.first to
+        attachSwitchToIndex(locationTrackAndAlignment.second, switchId, segmentIndex)
 
 fun attachSwitchToIndex(
     alignment: LayoutAlignment,
     switchId: IntId<TrackLayoutSwitch>,
     segmentIndex: Int,
 ): LayoutAlignment {
-    if (alignment.segments.count() < segmentIndex + 3) throw IllegalArgumentException("Alignment must contain at least ${segmentIndex + 3} segments")
-    return alignment.copy(segments = alignment.segments.mapIndexed { index, segment ->
-        when (index) {
-            segmentIndex -> segment.copy(
-                switchId = switchId, startJointNumber = JointNumber(1)
-            )
+    if (alignment.segments.count() < segmentIndex + 3)
+        throw IllegalArgumentException(
+            "Alignment must contain at least ${segmentIndex + 3} segments")
+    return alignment.copy(
+        segments =
+            alignment.segments.mapIndexed { index, segment ->
+                when (index) {
+                    segmentIndex ->
+                        segment.copy(switchId = switchId, startJointNumber = JointNumber(1))
 
-            segmentIndex + 1 -> segment.copy(
-                switchId = switchId
-            )
+                    segmentIndex + 1 -> segment.copy(switchId = switchId)
 
-            segmentIndex + 2 -> segment.copy(
-                switchId = switchId, endJointNumber = JointNumber(2)
-            )
+                    segmentIndex + 2 ->
+                        segment.copy(switchId = switchId, endJointNumber = JointNumber(2))
 
-            else -> segment
-        }
-    })
+                    else -> segment
+                }
+            })
 }
 
 fun attachSwitchToIndex(
@@ -606,28 +630,34 @@ fun attachSwitchToIndex(
     segmentIndex: Int,
 ): LayoutAlignment {
     if (alignment.segments.count() < segmentIndex + 3) {
-        throw IllegalArgumentException("Alignment must contain at least ${segmentIndex + 3} segments")
+        throw IllegalArgumentException(
+            "Alignment must contain at least ${segmentIndex + 3} segments")
     }
 
-    return alignment.copy(segments = alignment.segments.mapIndexed { index, segment ->
-        when (index) {
-            segmentIndex -> segment.copy(
-                switchId = switch.id,
-                startJointNumber = JointNumber(1),
-            )
+    return alignment.copy(
+        segments =
+            alignment.segments.mapIndexed { index, segment ->
+                when (index) {
+                    segmentIndex ->
+                        segment.copy(
+                            switchId = switch.id,
+                            startJointNumber = JointNumber(1),
+                        )
 
-            segmentIndex + 1 -> segment.copy(
-                switchId = switch.id,
-            )
+                    segmentIndex + 1 ->
+                        segment.copy(
+                            switchId = switch.id,
+                        )
 
-            segmentIndex + 2 -> segment.copy(
-                switchId = switch.id,
-                endJointNumber = JointNumber(2),
-            )
+                    segmentIndex + 2 ->
+                        segment.copy(
+                            switchId = switch.id,
+                            endJointNumber = JointNumber(2),
+                        )
 
-            else -> segment
-        }
-    })
+                    else -> segment
+                }
+            })
 }
 
 fun geocodingContext(
@@ -635,29 +665,37 @@ fun geocodingContext(
     trackNumber: TrackNumber = TrackNumber("001"),
     startAddress: TrackMeter = TrackMeter.ZERO,
     kmPosts: List<TrackLayoutKmPost> = listOf(),
-) = alignment(segment(*referenceLinePoints.toTypedArray())).let { alignment ->
-    GeocodingContext.create(
-        trackNumber = trackNumber,
-        startAddress = startAddress,
-        referenceLineGeometry = alignment,
-        kmPosts = kmPosts,
-    ).geocodingContext
-}
+) =
+    alignment(segment(*referenceLinePoints.toTypedArray())).let { alignment ->
+        GeocodingContext.create(
+                trackNumber = trackNumber,
+                startAddress = startAddress,
+                referenceLineGeometry = alignment,
+                kmPosts = kmPosts,
+            )
+            .geocodingContext
+    }
 
 abstract class TargetSegment
+
 class TargetSegmentStart : TargetSegment()
+
 data class TargetSegmentMiddle(val index: Int) : TargetSegment()
+
 class TargetSegmentEnd : TargetSegment()
 
 fun attachSwitches(
     locationTrackAndAlignment: Pair<LocationTrack, LayoutAlignment>,
     vararg switchInfos: Pair<IntId<TrackLayoutSwitch>, TargetSegment>,
 ): Pair<LocationTrack, LayoutAlignment> {
-    return switchInfos.fold(locationTrackAndAlignment) { accLocationTrackAndAlignment, (switchId, targetSegment) ->
+    return switchInfos.fold(locationTrackAndAlignment) {
+        accLocationTrackAndAlignment,
+        (switchId, targetSegment) ->
         when (targetSegment) {
             is TargetSegmentStart -> attachSwitchToStart(accLocationTrackAndAlignment, switchId)
             is TargetSegmentEnd -> attachSwitchToEnd(accLocationTrackAndAlignment, switchId)
-            is TargetSegmentMiddle -> attachSwitchToIndex(accLocationTrackAndAlignment, switchId, targetSegment.index)
+            is TargetSegmentMiddle ->
+                attachSwitchToIndex(accLocationTrackAndAlignment, switchId, targetSegment.index)
             else -> throw NotImplementedError()
         }
     }
@@ -672,16 +710,17 @@ fun segment(
     startJointNumber: JointNumber? = null,
     endJointNumber: JointNumber? = null,
     sourceStart: Double? = null,
-) = segment(
-    toSegmentPoints(to3DMPoints(points.asList())),
-    startM = startM,
-    source = source,
-    sourceStart = sourceStart,
-    sourceId = sourceId,
-    switchId = switchId,
-    startJointNumber = startJointNumber,
-    endJointNumber = endJointNumber,
-)
+) =
+    segment(
+        toSegmentPoints(to3DMPoints(points.asList())),
+        startM = startM,
+        source = source,
+        sourceStart = sourceStart,
+        sourceId = sourceId,
+        switchId = switchId,
+        startJointNumber = startJointNumber,
+        endJointNumber = endJointNumber,
+    )
 
 fun segment(
     vararg points: Point3DZ,
@@ -707,19 +746,21 @@ fun segment(
     switchId: IntId<TrackLayoutSwitch>? = null,
     startJointNumber: JointNumber? = null,
     endJointNumber: JointNumber? = null,
-) = LayoutSegment(
-    geometry = SegmentGeometry(
-        segmentPoints = points,
-        resolution = resolution,
-    ),
-    startM = startM,
-    sourceId = sourceId,
-    sourceStart = sourceStart,
-    switchId = switchId,
-    startJointNumber = startJointNumber,
-    endJointNumber = endJointNumber,
-    source = source,
-)
+) =
+    LayoutSegment(
+        geometry =
+            SegmentGeometry(
+                segmentPoints = points,
+                resolution = resolution,
+            ),
+        startM = startM,
+        sourceId = sourceId,
+        sourceStart = sourceStart,
+        switchId = switchId,
+        startJointNumber = startJointNumber,
+        endJointNumber = endJointNumber,
+        source = source,
+    )
 
 fun mapSegment(
     vararg points: Point3DM,
@@ -727,13 +768,14 @@ fun mapSegment(
     sourceId: DomainId<GeometryElement>? = null,
     sourceStart: Double? = null,
     source: GeometrySource = PLAN,
-) = mapSegment(
-    points = toSegmentPoints(points.asList()),
-    start = startM,
-    sourceId = sourceId,
-    sourceStart = sourceStart,
-    source = source,
-)
+) =
+    mapSegment(
+        points = toSegmentPoints(points.asList()),
+        start = startM,
+        sourceId = sourceId,
+        sourceStart = sourceStart,
+        source = source,
+    )
 
 fun mapSegment(
     points: List<SegmentPoint>,
@@ -743,74 +785,90 @@ fun mapSegment(
     sourceStart: Double? = null,
     source: GeometrySource = PLAN,
     id: DomainId<LayoutSegment> = StringId(),
-) = PlanLayoutSegment(
-    geometry = SegmentGeometry(
-        segmentPoints = points,
-        resolution = resolution,
-    ),
-    startM = start,
-    pointCount = points.size,
-    sourceId = sourceId,
-    sourceStart = sourceStart,
-    source = source,
-    id = id,
-)
+) =
+    PlanLayoutSegment(
+        geometry =
+            SegmentGeometry(
+                segmentPoints = points,
+                resolution = resolution,
+            ),
+        startM = start,
+        pointCount = points.size,
+        sourceId = sourceId,
+        sourceStart = sourceStart,
+        source = source,
+        id = id,
+    )
 
 fun splitSegment(segment: LayoutSegment, numberOfParts: Int): List<LayoutSegment> {
     val allPoints = segment.alignmentPoints
     val indexRange = 0..allPoints.lastIndex
     val pointsPerSegment = allPoints.count() / numberOfParts.toDouble()
-    return indexRange.groupBy { index -> (index / pointsPerSegment).toInt() }.map { (_, groupIndexRange) ->
-            val points = allPoints.subList(
-                0.coerceAtLeast(groupIndexRange.first() - 1), groupIndexRange.last() + 1
-            )
-            segment(
-                points = points.map { Point(it) }.toTypedArray(), startM = points.first().m
-            )
+    return indexRange
+        .groupBy { index -> (index / pointsPerSegment).toInt() }
+        .map { (_, groupIndexRange) ->
+            val points =
+                allPoints.subList(
+                    0.coerceAtLeast(groupIndexRange.first() - 1), groupIndexRange.last() + 1)
+            segment(points = points.map { Point(it) }.toTypedArray(), startM = points.first().m)
         }
 }
 
 fun toSegmentPoints(vararg points: IPoint) = toSegmentPoints(to3DMPoints(points.asList()))
+
 fun toSegmentPoints(vararg points: Point3DZ) = toSegmentPoints(to3DMPoints(points.asList()))
+
 fun toSegmentPoints(vararg points: IPoint3DM) = toSegmentPoints(points.asList())
-fun toSegmentPoints(points: List<IPoint3DM>) = points.map { point ->
-    SegmentPoint(
-        x = point.x,
-        y = point.y,
-        z = when (point) {
-            is AlignmentPoint -> point.z
-            is IPoint3DZ -> point.z
-            else -> null
-        },
-        m = point.m - points.first().m,
-        cant = (point as? AlignmentPoint)?.cant,
-    )
-}
+
+fun toSegmentPoints(points: List<IPoint3DM>) =
+    points.map { point ->
+        SegmentPoint(
+            x = point.x,
+            y = point.y,
+            z =
+                when (point) {
+                    is AlignmentPoint -> point.z
+                    is IPoint3DZ -> point.z
+                    else -> null
+                },
+            m = point.m - points.first().m,
+            cant = (point as? AlignmentPoint)?.cant,
+        )
+    }
 
 fun toAlignmentPoints(vararg points: IPoint) = toAlignmentPoints(to3DMPoints(points.asList()))
+
 fun toAlignmentPoints(vararg points: Point3DZ) = toAlignmentPoints(to3DMPoints(points.asList()))
+
 fun toAlignmentPoints(vararg points: IPoint3DM) = toAlignmentPoints(points.asList())
-fun toAlignmentPoints(points: List<IPoint3DM>) = points.map { point ->
-    AlignmentPoint(
-        point.x,
-        point.y,
-        when (point) {
-            is AlignmentPoint -> point.z
-            is IPoint3DZ -> point.z
-            else -> null
-        },
-        point.m,
-        if (point is AlignmentPoint) point.cant else null,
-    )
-}
+
+fun toAlignmentPoints(points: List<IPoint3DM>) =
+    points.map { point ->
+        AlignmentPoint(
+            point.x,
+            point.y,
+            when (point) {
+                is AlignmentPoint -> point.z
+                is IPoint3DZ -> point.z
+                else -> null
+            },
+            point.m,
+            if (point is AlignmentPoint) point.cant else null,
+        )
+    }
 
 fun to3DMPoints(points: List<IPoint>, start: Double = 0.0): List<IPoint3DM> {
-    val pointsWithDistance = points.mapIndexed { index, point ->
-        val distance = points.getOrNull(index - 1)?.let { prev -> lineLength(prev, point) } ?: 0.0
-        point to distance
-    }
+    val pointsWithDistance =
+        points.mapIndexed { index, point ->
+            val distance =
+                points.getOrNull(index - 1)?.let { prev -> lineLength(prev, point) } ?: 0.0
+            point to distance
+        }
     return pointsWithDistance.mapIndexed { index, (point, _) ->
-        val m = pointsWithDistance.subList(0, index + 1).foldRight(start) { (_, distance), acc -> acc + distance }
+        val m =
+            pointsWithDistance.subList(0, index + 1).foldRight(start) { (_, distance), acc ->
+                acc + distance
+            }
         when (point) {
             is AlignmentPoint -> AlignmentPoint(point.x, point.y, point.z, m, point.cant)
             is Point3DZ -> Point4DZM(point.x, point.y, point.z, m)
@@ -833,31 +891,37 @@ fun someSegment() = segment(3, 10.0, 20.0, 10.0, 20.0)
 fun segment(points: Int, minX: Double, maxX: Double, minY: Double, maxY: Double) =
     segment(points = rawPoints(points, minX, maxX, minY, maxY))
 
-fun segment(points: Int, start: Point, end: Point) =
-    segment(points, start.x, end.x, start.y, end.y)
+fun segment(points: Int, start: Point, end: Point) = segment(points, start.x, end.x, start.y, end.y)
 
 fun segment(from: IPoint, to: IPoint): LayoutSegment {
-    return segment(toSegmentPoints(to3DMPoints((listOf(from) + middlePoints(from, to) + listOf(to)).distinct())))
+    return segment(
+        toSegmentPoints(
+            to3DMPoints((listOf(from) + middlePoints(from, to) + listOf(to)).distinct())))
 }
 
 private fun middlePoints(from: IPoint, to: IPoint) =
-    (1 until lineLength(from, to).toInt()).map { i -> (from + (to - from).normalized() * i.toDouble()) }
+    (1 until lineLength(from, to).toInt()).map { i ->
+        (from + (to - from).normalized() * i.toDouble())
+    }
 
 fun segments(from: IPoint, to: IPoint, segmentCount: Int): List<LayoutSegment> {
     return segments(from, to, lineLength(from, to) / segmentCount)
 }
 
 fun singleSegmentWithInterpolatedPoints(vararg points: IPoint): LayoutSegment =
-    segment(toSegmentPoints(to3DMPoints(points.toList().zipWithNext { a, b ->
-        listOf(a) + middlePoints(a, b)
-    }.flatten() + points.last())))
+    segment(
+        toSegmentPoints(
+            to3DMPoints(
+                points.toList().zipWithNext { a, b -> listOf(a) + middlePoints(a, b) }.flatten() +
+                    points.last())))
 
 fun segments(from: IPoint, to: IPoint, segmentLength: Double): List<LayoutSegment> {
     val dir = (to - from).normalized()
     val segmentCount = ceil(lineLength(from, to) / segmentLength).toInt()
-    val endPoints = listOf(from) + (1 until segmentCount).map { i ->
-        from + dir * segmentLength * i.toDouble()
-    } + listOf(to)
+    val endPoints =
+        listOf(from) +
+            (1 until segmentCount).map { i -> from + dir * segmentLength * i.toDouble() } +
+            listOf(to)
     return segments(endPoints = endPoints.toTypedArray())
 }
 
@@ -878,19 +942,21 @@ fun switchFromDbStructure(
     structure: SwitchStructure,
     draft: Boolean = false,
     externalId: String? = null,
-): TrackLayoutSwitch = switch(
-    name = name,
-    externalId = externalId,
-    structureId = structure.id as IntId,
-    draft = draft,
-    joints = structure.joints.map { j ->
-        TrackLayoutSwitchJoint(
-            number = j.number,
-            location = switchStart + j.location,
-            locationAccuracy = null,
-        )
-    },
-)
+): TrackLayoutSwitch =
+    switch(
+        name = name,
+        externalId = externalId,
+        structureId = structure.id as IntId,
+        draft = draft,
+        joints =
+            structure.joints.map { j ->
+                TrackLayoutSwitchJoint(
+                    number = j.number,
+                    location = switchStart + j.location,
+                    locationAccuracy = null,
+                )
+            },
+    )
 
 fun switch(
     seed: Int = 1,
@@ -904,44 +970,57 @@ fun switch(
     draftOfId: IntId<TrackLayoutSwitch>? = null,
     ownerId: IntId<SwitchOwner>? = switchOwnerVayla().id,
     contextData: LayoutContextData<TrackLayoutSwitch> = createMainContext(id, draftOfId, draft),
-) = TrackLayoutSwitch(
-    externalId = if (externalId != null) Oid(externalId) else null,
-    sourceId = null,
-    name = SwitchName(name),
-    stateCategory = stateCategory,
-    joints = joints,
-    switchStructureId = structureId,
-    trapPoint = false,
-    ownerId = ownerId,
-    source = GENERATED,
-    contextData = contextData,
-)
-
-fun <T> createMainContext(id: IntId<T>?, draftOfId: IntId<T>?, draft: Boolean): LayoutContextData<T> = if (draft) {
-    MainDraftContextData(
-        if (id != null) StoredContextIdHolder(LayoutRowVersion(id.intValue.let(::LayoutRowId), 1)) else UnstoredContextIdHolder(null),
-        officialRowId = draftOfId?.intValue?.let(::LayoutRowId),
-        designRowId = null,
+) =
+    TrackLayoutSwitch(
+        externalId = if (externalId != null) Oid(externalId) else null,
+        sourceId = null,
+        name = SwitchName(name),
+        stateCategory = stateCategory,
+        joints = joints,
+        switchStructureId = structureId,
+        trapPoint = false,
+        ownerId = ownerId,
+        source = GENERATED,
+        contextData = contextData,
     )
-} else {
-    MainOfficialContextData(
-        if (id != null) StoredContextIdHolder(LayoutRowVersion(id.intValue.let(::LayoutRowId), 1)) else UnstoredContextIdHolder(null),
+
+fun <T> createMainContext(
+    id: IntId<T>?,
+    draftOfId: IntId<T>?,
+    draft: Boolean
+): LayoutContextData<T> =
+    if (draft) {
+        MainDraftContextData(
+            if (id != null)
+                StoredContextIdHolder(LayoutRowVersion(id.intValue.let(::LayoutRowId), 1))
+            else UnstoredContextIdHolder(null),
+            officialRowId = draftOfId?.intValue?.let(::LayoutRowId),
+            designRowId = null,
+        )
+    } else {
+        MainOfficialContextData(
+            if (id != null)
+                StoredContextIdHolder(LayoutRowVersion(id.intValue.let(::LayoutRowId), 1))
+            else UnstoredContextIdHolder(null),
+        )
+    }
+
+fun joints(seed: Int = 1, count: Int = 5) =
+    (1..count).map { jointSeed -> switchJoint(seed * 100 + jointSeed) }
+
+fun switchJoint(seed: Int) =
+    TrackLayoutSwitchJoint(
+        number = JointNumber(1 + seed % 5),
+        location = Point(seed * 0.01, 1000.0 + seed * 0.01),
+        locationAccuracy = getSomeNullableValue<LocationAccuracy>(seed),
     )
-}
 
-fun joints(seed: Int = 1, count: Int = 5) = (1..count).map { jointSeed -> switchJoint(seed * 100 + jointSeed) }
-
-fun switchJoint(seed: Int) = TrackLayoutSwitchJoint(
-    number = JointNumber(1 + seed % 5),
-    location = Point(seed * 0.01, 1000.0 + seed * 0.01),
-    locationAccuracy = getSomeNullableValue<LocationAccuracy>(seed),
-)
-
-fun switchJoint(number: Int, location: Point) = TrackLayoutSwitchJoint(
-    number = JointNumber(number),
-    location = location,
-    locationAccuracy = null,
-)
+fun switchJoint(number: Int, location: Point) =
+    TrackLayoutSwitchJoint(
+        number = JointNumber(number),
+        location = location,
+        locationAccuracy = null,
+    )
 
 fun kmPost(
     trackNumberId: IntId<TrackLayoutTrackNumber>?,
@@ -962,34 +1041,54 @@ fun kmPost(
         state = state,
         sourceId = sourceId,
         contextData = contextData,
-        gkLocation = if (gkLocation == null && roughLayoutLocation != null) {
-            transformToGKCoordinate(LAYOUT_SRID, roughLayoutLocation)
-        } else gkLocation,
+        gkLocation =
+            if (gkLocation == null && roughLayoutLocation != null) {
+                transformToGKCoordinate(LAYOUT_SRID, roughLayoutLocation)
+            } else gkLocation,
         gkLocationConfirmed = gkLocationConfirmed,
         gkLocationSource = gkLocationSource,
     )
 }
 
 fun segmentPoint(x: Double, y: Double, m: Double = 1.0) = SegmentPoint(x, y, null, m, null)
+
 fun alignmentPoint(x: Double, y: Double, m: Double = 1.0) = AlignmentPoint(x, y, null, m, null)
 
 fun rawPoints(count: Int, minX: Double, maxX: Double, minY: Double, maxY: Double) =
-    toSegmentPoints(to3DMPoints((1..count).map { pointNumber ->
-        point2d(minX, maxX, minY, maxY, (pointNumber - 1).toDouble() / (count - 1))
-    }))
+    toSegmentPoints(
+        to3DMPoints(
+            (1..count).map { pointNumber ->
+                point2d(minX, maxX, minY, maxY, (pointNumber - 1).toDouble() / (count - 1))
+            }))
 
 fun points(count: Int, minX: Double, maxX: Double, minY: Double, maxY: Double) =
-    toAlignmentPoints(to3DMPoints((1..count).map { pointNumber ->
-        point2d(minX, maxX, minY, maxY, (pointNumber - 1).toDouble() / (count - 1))
-    }))
+    toAlignmentPoints(
+        to3DMPoints(
+            (1..count).map { pointNumber ->
+                point2d(minX, maxX, minY, maxY, (pointNumber - 1).toDouble() / (count - 1))
+            }))
 
-fun segmentPoint(minX: Double, maxX: Double, minY: Double, maxY: Double, m: Double, fraction: Double = rand.nextDouble()) =
-    AlignmentPoint(valueBetween(minX, maxX, fraction), valueBetween(minY, maxY, fraction), null, m, null)
+fun segmentPoint(
+    minX: Double,
+    maxX: Double,
+    minY: Double,
+    maxY: Double,
+    m: Double,
+    fraction: Double = rand.nextDouble()
+) =
+    AlignmentPoint(
+        valueBetween(minX, maxX, fraction), valueBetween(minY, maxY, fraction), null, m, null)
 
-fun point2d(minX: Double, maxX: Double, minY: Double, maxY: Double, fraction: Double = rand.nextDouble()) =
-    Point(valueBetween(minX, maxX, fraction), valueBetween(minY, maxY, fraction))
+fun point2d(
+    minX: Double,
+    maxX: Double,
+    minY: Double,
+    maxY: Double,
+    fraction: Double = rand.nextDouble()
+) = Point(valueBetween(minX, maxX, fraction), valueBetween(minY, maxY, fraction))
 
-fun valueBetween(min: Double, max: Double, fraction: Double = rand.nextDouble()) = min + (max - min) * fraction
+fun valueBetween(min: Double, max: Double, fraction: Double = rand.nextDouble()) =
+    min + (max - min) * fraction
 
 fun someKmNumber(): KmNumber {
     val allowedChars = ('A'..'Z').map(Char::toString)
@@ -997,10 +1096,12 @@ fun someKmNumber(): KmNumber {
 }
 
 fun offsetAlignment(alignment: LayoutAlignment, amount: Point) =
-    alignment.copy(segments = alignment.segments.map { origSegment -> offsetSegment(origSegment, amount) })
+    alignment.copy(
+        segments = alignment.segments.map { origSegment -> offsetSegment(origSegment, amount) })
 
 fun offsetSegment(segment: LayoutSegment, amount: Point): LayoutSegment {
-    val newPoints = toSegmentPoints(*(segment.alignmentPoints.map { p -> p + amount }.toTypedArray()))
+    val newPoints =
+        toSegmentPoints(*(segment.alignmentPoints.map { p -> p + amount }.toTypedArray()))
     return segment.copy(geometry = segment.geometry.withPoints(newPoints))
 }
 
@@ -1022,25 +1123,66 @@ fun externalIdForTrackNumber(): Oid<TrackLayoutTrackNumber> {
     return Oid("$first.$second.$third.$fourth")
 }
 
-fun switchLinkingAtStart(locationTrackId: DomainId<LocationTrack>, alignment: LayoutAlignment, segmentIndex: Int, jointNumber: Int = 1) =
-    switchLinkingAtStart(locationTrackId, alignment.segments, segmentIndex, jointNumber)
+fun switchLinkingAtStart(
+    locationTrackId: DomainId<LocationTrack>,
+    alignment: LayoutAlignment,
+    segmentIndex: Int,
+    jointNumber: Int = 1
+) = switchLinkingAtStart(locationTrackId, alignment.segments, segmentIndex, jointNumber)
 
-fun switchLinkingAtStart(locationTrackId: DomainId<LocationTrack>, segments: List<LayoutSegment>, segmentIndex: Int, jointNumber: Int = 1) =
-    switchLinkingAt(locationTrackId, segmentIndex, segments[segmentIndex].alignmentPoints.first().m, jointNumber)
+fun switchLinkingAtStart(
+    locationTrackId: DomainId<LocationTrack>,
+    segments: List<LayoutSegment>,
+    segmentIndex: Int,
+    jointNumber: Int = 1
+) =
+    switchLinkingAt(
+        locationTrackId,
+        segmentIndex,
+        segments[segmentIndex].alignmentPoints.first().m,
+        jointNumber)
 
-fun switchLinkingAtEnd(locationTrackId: DomainId<LocationTrack>, alignment: LayoutAlignment, segmentIndex: Int, jointNumber: Int = 1) =
-    switchLinkingAtEnd(locationTrackId, alignment.segments, segmentIndex, jointNumber)
+fun switchLinkingAtEnd(
+    locationTrackId: DomainId<LocationTrack>,
+    alignment: LayoutAlignment,
+    segmentIndex: Int,
+    jointNumber: Int = 1
+) = switchLinkingAtEnd(locationTrackId, alignment.segments, segmentIndex, jointNumber)
 
-fun switchLinkingAtEnd(locationTrackId: DomainId<LocationTrack>, segments: List<LayoutSegment>, segmentIndex: Int, jointNumber: Int = 1) =
-    switchLinkingAt(locationTrackId, segmentIndex, segments[segmentIndex].alignmentPoints.last().m, jointNumber)
+fun switchLinkingAtEnd(
+    locationTrackId: DomainId<LocationTrack>,
+    segments: List<LayoutSegment>,
+    segmentIndex: Int,
+    jointNumber: Int = 1
+) =
+    switchLinkingAt(
+        locationTrackId, segmentIndex, segments[segmentIndex].alignmentPoints.last().m, jointNumber)
 
-fun switchLinkingAtHalf(locationTrackId: DomainId<LocationTrack>, alignment: LayoutAlignment, segmentIndex: Int, jointNumber: Int = 1) =
-    switchLinkingAtHalf(locationTrackId, alignment.segments, segmentIndex, jointNumber)
+fun switchLinkingAtHalf(
+    locationTrackId: DomainId<LocationTrack>,
+    alignment: LayoutAlignment,
+    segmentIndex: Int,
+    jointNumber: Int = 1
+) = switchLinkingAtHalf(locationTrackId, alignment.segments, segmentIndex, jointNumber)
 
-fun switchLinkingAtHalf(locationTrackId: DomainId<LocationTrack>, segments: List<LayoutSegment>, segmentIndex: Int, jointNumber: Int = 1) =
-    switchLinkingAt(locationTrackId, segmentIndex, segments[segmentIndex].let { s -> (s.endM + s.startM) / 2 }, jointNumber)
+fun switchLinkingAtHalf(
+    locationTrackId: DomainId<LocationTrack>,
+    segments: List<LayoutSegment>,
+    segmentIndex: Int,
+    jointNumber: Int = 1
+) =
+    switchLinkingAt(
+        locationTrackId,
+        segmentIndex,
+        segments[segmentIndex].let { s -> (s.endM + s.startM) / 2 },
+        jointNumber)
 
-fun switchLinkingAt(locationTrackId: DomainId<LocationTrack>, segmentIndex: Int, m: Double, jointNumber: Int = 1) =
+fun switchLinkingAt(
+    locationTrackId: DomainId<LocationTrack>,
+    segmentIndex: Int,
+    m: Double,
+    jointNumber: Int = 1
+) =
     FittedSwitchJointMatch(
         locationTrackId = locationTrackId as IntId<LocationTrack>,
         segmentIndex = segmentIndex,
@@ -1056,9 +1198,7 @@ fun layoutDesign(
     name: String = "foo",
     estimatedCompletion: LocalDate = LocalDate.parse("2022-02-02"),
     designState: DesignState = DesignState.ACTIVE,
-) = LayoutDesignSaveRequest(
-    FreeText(name), estimatedCompletion, designState
-)
+) = LayoutDesignSaveRequest(FreeText(name), estimatedCompletion, designState)
 
 fun <T> someRowVersion() = RowVersion(IntId<T>(1), 1)
 
@@ -1067,9 +1207,10 @@ fun geocodingContextCacheKey(
     trackNumberVersion: LayoutRowVersion<TrackLayoutTrackNumber>,
     referenceLineVersion: LayoutRowVersion<ReferenceLine>,
     vararg kmPostVersions: LayoutRowVersion<TrackLayoutKmPost>,
-) = LayoutGeocodingContextCacheKey(
-    trackNumberId = trackNumberId,
-    trackNumberVersion = trackNumberVersion,
-    referenceLineVersion = referenceLineVersion,
-    kmPostVersions = kmPostVersions.toList().sortedBy { rv -> rv.rowId.intValue },
-)
+) =
+    LayoutGeocodingContextCacheKey(
+        trackNumberId = trackNumberId,
+        trackNumberVersion = trackNumberVersion,
+        referenceLineVersion = referenceLineVersion,
+        kmPostVersions = kmPostVersions.toList().sortedBy { rv -> rv.rowId.intValue },
+    )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutTest.kt
@@ -2,11 +2,11 @@ package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
+import java.util.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.util.*
 
 private const val SEED = 123321L
 
@@ -27,32 +27,40 @@ class TrackLayoutTest {
         val startSliceStart = 123.111
         val startSlice = original.slice(0, 2, startSliceStart)!!
         assertEquals(3, startSlice.alignmentPoints.size)
-        assertApproximatelyEquals(original.alignmentPoints[0].copy(m = startSliceStart), startSlice.alignmentPoints[0])
-        assertApproximatelyEquals(original.alignmentPoints[2].copy(m = original.alignmentPoints[2].m + startSliceStart), startSlice.alignmentPoints[startSlice.alignmentPoints.lastIndex])
+        assertApproximatelyEquals(
+            original.alignmentPoints[0].copy(m = startSliceStart), startSlice.alignmentPoints[0])
+        assertApproximatelyEquals(
+            original.alignmentPoints[2].copy(m = original.alignmentPoints[2].m + startSliceStart),
+            startSlice.alignmentPoints[startSlice.alignmentPoints.lastIndex])
         assertEquals(startSliceStart, startSlice.startM, 0.0001)
         assertEquals(original.alignmentPoints[2].m, startSlice.length, 0.0001)
 
         val endSliceStart = 123.222
         val endSlice = original.slice(8, 9, endSliceStart)!!
         assertEquals(2, endSlice.alignmentPoints.size)
-        assertApproximatelyEquals(original.alignmentPoints[8].copy(m = endSliceStart), endSlice.alignmentPoints[0])
         assertApproximatelyEquals(
-            original.alignmentPoints[9].copy(m = endSliceStart + original.length - original.alignmentPoints[8].m),
+            original.alignmentPoints[8].copy(m = endSliceStart), endSlice.alignmentPoints[0])
+        assertApproximatelyEquals(
+            original.alignmentPoints[9].copy(
+                m = endSliceStart + original.length - original.alignmentPoints[8].m),
             endSlice.alignmentPoints[endSlice.alignmentPoints.lastIndex],
         )
         assertEquals(endSliceStart, endSlice.startM, 0.0001)
-        assertEquals(original.alignmentPoints[9].m - original.alignmentPoints[8].m, endSlice.length, 0.0001)
+        assertEquals(
+            original.alignmentPoints[9].m - original.alignmentPoints[8].m, endSlice.length, 0.0001)
 
         val midSliceStart = 123.333
         val midSlice = original.slice(1, 8, midSliceStart)!!
         assertEquals(8, midSlice.alignmentPoints.size)
-        assertApproximatelyEquals(original.alignmentPoints[1].copy(m = midSliceStart), midSlice.alignmentPoints[0])
         assertApproximatelyEquals(
-            original.alignmentPoints[8].copy(m = midSliceStart + original.alignmentPoints[8].m - original.alignmentPoints[1].m),
-            midSlice.alignmentPoints[midSlice.alignmentPoints.lastIndex]
-        )
+            original.alignmentPoints[1].copy(m = midSliceStart), midSlice.alignmentPoints[0])
+        assertApproximatelyEquals(
+            original.alignmentPoints[8].copy(
+                m = midSliceStart + original.alignmentPoints[8].m - original.alignmentPoints[1].m),
+            midSlice.alignmentPoints[midSlice.alignmentPoints.lastIndex])
         assertEquals(midSliceStart, midSlice.startM, 0.0001)
-        assertEquals(original.alignmentPoints[8].m - original.alignmentPoints[1].m, midSlice.length, 0.0001)
+        assertEquals(
+            original.alignmentPoints[8].m - original.alignmentPoints[1].m, midSlice.length, 0.0001)
     }
 
     @Test
@@ -63,14 +71,12 @@ class TrackLayoutTest {
                     toSegmentPoints(
                         Point(0.0, 0.0),
                         Point(0.0, 100.0),
-                    )
-                ),
+                    )),
                 segment(
                     toSegmentPoints(
                         Point(1.0, 100.0),
                         Point(1.0, 200.0),
-                    )
-                ),
+                    )),
             )
         }
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/E2ETestWatcher.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/E2ETestWatcher.kt
@@ -2,13 +2,13 @@ package fi.fta.geoviite.infra.ui
 
 import DEV_DEBUG
 import closeBrowser
+import java.lang.reflect.Method
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.TestWatcher
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import printBrowserLogs
 import takeScreenShot
-import java.lang.reflect.Method
 
 class E2ETestWatcher : TestWatcher {
 
@@ -27,14 +27,15 @@ class E2ETestWatcher : TestWatcher {
         takeScreenShot("${context.getClassName()}.${context.getMethodName().replace(" ", "_")}")
         printBrowserLogs()
         // There's a lot of stuff in network logs: enable when needed
-//        printNetworkLogsAll()
+        //        printNetworkLogsAll()
     }
 
-    private fun finalize(op: () -> Unit = {}) = try {
-        op()
-    } finally {
-        if (!DEV_DEBUG) closeBrowser()
-    }
+    private fun finalize(op: () -> Unit = {}) =
+        try {
+            op()
+        } finally {
+            if (!DEV_DEBUG) closeBrowser()
+        }
 }
 
 fun ExtensionContext.getClassName(): String = requiredTestClass.let(Class<*>::getSimpleName)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/LocalWebClientConfiguration.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/LocalWebClientConfiguration.kt
@@ -8,7 +8,6 @@ class LocalHostWebClient(
     val client: WebClient,
 ) : WebClient by client
 
-
 @Configuration
 class LocalWebClientConfiguration {
     @Bean

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/SeleniumTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/SeleniumTest.kt
@@ -5,13 +5,13 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EAppBar
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2ERole
 import fi.fta.geoviite.infra.ui.pagemodel.frontpage.E2EFrontPage
+import java.util.*
 import openBrowser
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import java.util.*
 
 const val UI_TEST_USER = "UI_TEST_USER"
 
@@ -19,8 +19,7 @@ const val UI_TEST_USER = "UI_TEST_USER"
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class SeleniumTest : DBTestBase(UI_TEST_USER) {
 
-    @Value("\${geoviite.e2e.url}")
-    val startUrlProp: String? = null
+    @Value("\${geoviite.e2e.url}") val startUrlProp: String? = null
     val startUrl: String by lazy { requireNotNull(startUrlProp) }
 
     protected val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -35,7 +34,8 @@ open class SeleniumTest : DBTestBase(UI_TEST_USER) {
             return E2EFrontPage()
         }
 
-    val navigationBar: E2EAppBar get() = E2EAppBar()
+    val navigationBar: E2EAppBar
+        get() = E2EAppBar()
 
     fun startGeoviite() {
         logger.info("Navigate to Geoviite $startUrl")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EAccordion.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EAccordion.kt
@@ -3,9 +3,13 @@ package fi.fta.geoviite.infra.ui.pagemodel.common
 import org.openqa.selenium.By
 
 open class E2EAccordion(accordionBy: By) : E2EViewFragment(accordionBy) {
-    enum class Toggle { OPEN, CLOSE }
+    enum class Toggle {
+        OPEN,
+        CLOSE
+    }
 
-    val header: String get() = childText(By.className("accordion__header-title"))
+    val header: String
+        get() = childText(By.className("accordion__header-title"))
 
     fun toggleVisibility(): E2EAccordion = apply {
         logger.info("Toggle visibility")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EDialog.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EDialog.kt
@@ -8,7 +8,8 @@ val DIALOG_BY: By = By.className("dialog")
 
 open class E2EDialog(val dialogBy: By = DIALOG_BY) : E2EViewFragment(dialogBy) {
 
-    val title: String get() = childText(By.className("dialog__title"))
+    val title: String
+        get() = childText(By.className("dialog__title"))
 
     fun clickPrimaryButton() {
         logger.info("Click primary button")
@@ -34,11 +35,12 @@ open class E2EDialog(val dialogBy: By = DIALOG_BY) : E2EViewFragment(dialogBy) {
         clickButton(By.cssSelector("button.button--warning"))
     }
 
-    fun <T> waitUntilClosed(fn: () -> T): Unit = fn().run {
-        logger.info("Waiting for dialog to disappear")
+    fun <T> waitUntilClosed(fn: () -> T): Unit =
+        fn().run {
+            logger.info("Waiting for dialog to disappear")
 
-        waitUntilNotExist(dialogBy)
-    }
+            waitUntilNotExist(dialogBy)
+        }
 }
 
 class E2EDialogWithTextField(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy) {
@@ -46,22 +48,17 @@ class E2EDialogWithTextField(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy) {
         logger.info("Input field $textFieldIdx with value $value")
 
         childTextInput(
-            ByChained(
-                By.className("dialog__content"),
-                By.xpath("(//*[@class='text-field__input-element'])[${textFieldIdx + 1}]")
-            )
-        ).replaceValue(value)
+                ByChained(
+                    By.className("dialog__content"),
+                    By.xpath("(//*[@class='text-field__input-element'])[${textFieldIdx + 1}]")))
+            .replaceValue(value)
     }
 
     fun inputValues(values: List<String>): E2EDialogWithTextField = apply {
         logger.info("Input values $values")
 
-        values.forEachIndexed { index, value ->
-            inputValue(value, index)
-        }
+        values.forEachIndexed { index, value -> inputValue(value, index) }
     }
 
-    fun selectInput(by: By): E2EDialogWithTextField = apply {
-        clickChild(by)
-    }
+    fun selectInput(by: By): E2EDialogWithTextField = apply { clickChild(by) }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EDropdown.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EDropdown.kt
@@ -8,7 +8,6 @@ import org.openqa.selenium.support.pagefactory.ByChained
 import org.openqa.selenium.support.ui.ExpectedConditions
 import tryWait
 import waitUntilInvisible
-import waitUntilTextExists
 import waitUntilVisible
 
 private val CONTAINER_BY: By = By.className("dropdown__list-container")
@@ -19,19 +18,16 @@ class E2EDropdownList :
     E2EList<E2EDropdownListItem>(
         CONTAINER_BY,
         By.className("dropdown__list-item"),
-        selectedItemBy = null, // Add selectedItemBy if ever needed, as dropdowns can have selected items too
-        ) {
+        selectedItemBy =
+            null, // Add selectedItemBy if ever needed, as dropdowns can have selected items too
+    ) {
     override fun getItemContent(item: WebElement): E2EDropdownListItem {
         return E2EDropdownListItem(item.text, item.getAttribute("qa-id"))
     }
 
-    fun selectByQaId(qaId: String) = apply {
-        select { i -> i.qaId == qaId }
-    }
+    fun selectByQaId(qaId: String) = apply { select { i -> i.qaId == qaId } }
 
-    fun selectByName(name: String) = apply {
-        select { i -> i.name.contains(name) }
-    }
+    fun selectByName(name: String) = apply { select { i -> i.name.contains(name) } }
 }
 
 class E2EDropdown(dropdownBy: By) : E2EViewFragment(dropdownBy) {
@@ -40,13 +36,13 @@ class E2EDropdown(dropdownBy: By) : E2EViewFragment(dropdownBy) {
 
     private val input: E2ETextInput = childTextInput(inputBy)
 
-    private val optionsList: E2EDropdownList by lazy {
-        E2EDropdownList()
-    }
+    private val optionsList: E2EDropdownList by lazy { E2EDropdownList() }
 
-    val options: List<E2EDropdownListItem> get() = optionsList.items
+    val options: List<E2EDropdownListItem>
+        get() = optionsList.items
 
-    val value: String get() = input.value
+    val value: String
+        get() = input.value
 
     fun open(): E2EDropdown = apply {
         logger.info("Open dropdown")
@@ -81,10 +77,13 @@ class E2EDropdown(dropdownBy: By) : E2EViewFragment(dropdownBy) {
         // This can be removed once the dropdown component itself has been fixed
         tryWait(
             ExpectedConditions.textToBePresentInElementLocated(
-                ByChained(CONTAINER_BY, By.className("dropdown__list-item"), By.className("dropdown__list-item-text")),
-                name
-            )
-        ) { "Option list does not contain item $name" }
+                ByChained(
+                    CONTAINER_BY,
+                    By.className("dropdown__list-item"),
+                    By.className("dropdown__list-item-text")),
+                name)) {
+                "Option list does not contain item $name"
+            }
 
         optionsList.selectByName(name)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EInfoBox.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EInfoBox.kt
@@ -8,14 +8,17 @@ import waitUntilTextIs
 
 abstract class E2EInfoBox(infoboxBy: By) : E2EViewFragment(infoboxBy) {
 
-    protected val title: String get() = childText(By.className("infobox__title"))
+    protected val title: String
+        get() = childText(By.className("infobox__title"))
 
-    private fun getValueBy(fieldQaId: String) = ByChained(byQaId(fieldQaId), By.className("infobox__field-value"))
+    private fun getValueBy(fieldQaId: String) =
+        ByChained(byQaId(fieldQaId), By.className("infobox__field-value"))
 
     protected fun getEnumValueForField(fieldQaId: String): String {
         logger.info("Get enum value for field $fieldQaId")
 
-        return childElement(ByChained(getValueBy(fieldQaId), By.tagName("span"))).getAttribute("qa-id")
+        return childElement(ByChained(getValueBy(fieldQaId), By.tagName("span")))
+            .getAttribute("qa-id")
     }
 
     protected fun getValueForField(fieldQaId: String): String {
@@ -39,7 +42,10 @@ abstract class E2EInfoBox(infoboxBy: By) : E2EViewFragment(infoboxBy) {
         clickChild(By.className("infobox__edit-icon"))
     }
 
-    protected fun waitUntilValueChangesForField(fieldQaId: String, targetValue: String): E2EInfoBox = apply {
+    protected fun waitUntilValueChangesForField(
+        fieldQaId: String,
+        targetValue: String
+    ): E2EInfoBox = apply {
         logger.info("Wait for field $fieldQaId to change value to $targetValue")
 
         waitUntilTextIs(childBy(getValueBy(fieldQaId)), targetValue)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EList.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EList.kt
@@ -13,8 +13,8 @@ data class E2ETextListItem(val text: String) {
     constructor(element: WebElement) : this(element.text)
 }
 
-class E2ETextList(listBy: By, itemsBy: By = byLiTag, selectedItemBy: By)
-    : E2EList<E2ETextListItem>(listBy, itemsBy, selectedItemBy) {
+class E2ETextList(listBy: By, itemsBy: By = byLiTag, selectedItemBy: By) :
+    E2EList<E2ETextListItem>(listBy, itemsBy, selectedItemBy) {
 
     fun selectByText(text: String): E2EList<E2ETextListItem> {
         logger.info("Select item that contains $text")
@@ -31,11 +31,14 @@ class E2ETextList(listBy: By, itemsBy: By = byLiTag, selectedItemBy: By)
     override fun getItemContent(item: WebElement) = E2ETextListItem(item)
 }
 
-abstract class E2EList<T>(listBy: By, val itemsBy: By, val selectedItemBy: By? = null) : E2EViewFragment(listBy) {
+abstract class E2EList<T>(listBy: By, val itemsBy: By, val selectedItemBy: By? = null) :
+    E2EViewFragment(listBy) {
 
-    private val itemElements: List<Pair<WebElement, T>> get() = childElements(itemsBy).map { it to getItemContent(it) }
+    private val itemElements: List<Pair<WebElement, T>>
+        get() = childElements(itemsBy).map { it to getItemContent(it) }
 
-    val items: List<T> get() = itemElements.map { it.second }
+    val items: List<T>
+        get() = itemElements.map { it.second }
 
     protected abstract fun getItemContent(item: WebElement): T
 
@@ -79,21 +82,28 @@ abstract class E2EList<T>(listBy: By, val itemsBy: By, val selectedItemBy: By? =
     open fun select(item: T): E2EList<T> = apply {
         logger.info("Select item $item")
 
-         getElementWhenMatches { it == item }.first.let { match ->
-             val selectedItem = selectedItemBy?.let { getElementIfExists(selectedItemBy) }
-             if (selectedItem == null || selectedItem.let { selected -> !itemTextContains(match, selected.text) })
-                 match.click()
-         }
+        getElementWhenMatches { it == item }
+            .first
+            .let { match ->
+                val selectedItem = selectedItemBy?.let { getElementIfExists(selectedItemBy) }
+                if (selectedItem == null ||
+                    selectedItem.let { selected -> !itemTextContains(match, selected.text) })
+                    match.click()
+            }
     }
 
     open fun unselect(item: T): E2EList<T> = apply {
         logger.info("Unselect item $item")
 
-        getElementWhenMatches { it == item }.first.let { match ->
-            val selectedItem = selectedItemBy?.let { getElementIfExists(selectedItemBy) }
-            if (selectedItemBy != null && selectedItem?.let { selected -> itemTextContains(match, selected.text) } ?: false)
-                match.click()
-        }
+        getElementWhenMatches { it == item }
+            .first
+            .let { match ->
+                val selectedItem = selectedItemBy?.let { getElementIfExists(selectedItemBy) }
+                if (selectedItemBy != null &&
+                    selectedItem?.let { selected -> itemTextContains(match, selected.text) }
+                        ?: false)
+                    match.click()
+            }
     }
 
     open fun selectBy(item: T, by: By): E2EList<T> = apply {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EMenu.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EMenu.kt
@@ -8,14 +8,15 @@ open class E2EMenu(
     itemsBy: By = By.tagName("li"),
 ) : E2EList<E2EMenuItem>(menuBy, itemsBy) {
     override fun getItemContent(item: WebElement) = E2EMenuItem(item)
-
 }
 
 data class E2EMenuItem(
     val name: String,
     val element: WebElement?,
 ) {
-    constructor(item: WebElement) : this(
+    constructor(
+        item: WebElement
+    ) : this(
         name = item.text,
         element = item,
     )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2ETable.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2ETable.kt
@@ -13,20 +13,19 @@ abstract class E2ETable<T>(
         waitUntilReady()
     }
 
-    val rows: List<T> get() = items
+    val rows: List<T>
+        get() = items
 
-    protected val headerElements: List<WebElement> get() = childElements(headersBy)
+    protected val headerElements: List<WebElement>
+        get() = childElements(headersBy)
 
     abstract fun getRowContent(row: WebElement): T
 
     override fun getItemContent(item: WebElement) = getRowContent(item)
 
-
-    //Firefox doesn't handle tr clicks correctly, temporary fixed by clicking on the first td
-    //https://bugzilla.mozilla.org/show_bug.cgi?id=1448825
-    override fun select(item: T): E2ETable<T> = apply {
-        selectBy(item, By.tagName("td"))
-    }
+    // Firefox doesn't handle tr clicks correctly, temporary fixed by clicking on the first td
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1448825
+    override fun select(item: T): E2ETable<T> = apply { selectBy(item, By.tagName("td")) }
 
     fun waitUntilReady(): E2ETable<T> = apply {
         logger.info("Wait until table has finished loading")
@@ -38,12 +37,14 @@ abstract class E2ETable<T>(
 fun getColumnIndex(
     qaId: String,
     headers: List<WebElement>,
-) = headers.indexOfFirst { it.getAttribute("qa-id") == qaId }
-    .also { idx ->
-        check(idx != -1) {
-            "No header found with qa-id $qaId. Header: ${headers.map { it.getAttribute("qa-id") }}"
+) =
+    headers
+        .indexOfFirst { it.getAttribute("qa-id") == qaId }
+        .also { idx ->
+            check(idx != -1) {
+                "No header found with qa-id $qaId. Header: ${headers.map { it.getAttribute("qa-id") }}"
+            }
         }
-    }
 
 fun getColumnContent(
     qaId: String,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2ETextInput.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2ETextInput.kt
@@ -12,9 +12,11 @@ class E2ETextInput(private val inputBy: By) {
 
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    private val webElement: WebElement get() = getElementWhenVisible(inputBy)
+    private val webElement: WebElement
+        get() = getElementWhenVisible(inputBy)
 
-    val value: String get() = webElement.getAttribute("value")
+    val value: String
+        get() = webElement.getAttribute("value")
 
     fun replaceValue(text: String): E2ETextInput = apply {
         clear()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EToast.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EToast.kt
@@ -21,21 +21,23 @@ data class E2EToast(
     val content: String?,
     val type: ToastType,
 ) {
-    constructor(element: WebElement) : this(
+    constructor(
+        element: WebElement
+    ) : this(
         header = element.findElement(headerBy).text,
         content = if (element.childExists(contentBy)) element.findElement(contentBy).text else null,
-        type = getToastType(element)
-    )
+        type = getToastType(element))
 }
 
-private fun getToastType(toast: WebElement) = with(toast.getAttribute("class")) {
-    when {
-        contains("Toastify__toast--success") -> ToastType.SUCCESS
-        contains("Toastify__toast--error") -> ToastType.ERROR
-        contains("Toastify__toast--warning") -> ToastType.INFO
-        else -> error("Could not determine toast type")
+private fun getToastType(toast: WebElement) =
+    with(toast.getAttribute("class")) {
+        when {
+            contains("Toastify__toast--success") -> ToastType.SUCCESS
+            contains("Toastify__toast--error") -> ToastType.ERROR
+            contains("Toastify__toast--warning") -> ToastType.INFO
+            else -> error("Could not determine toast type")
+        }
     }
-}
 
 private fun clearToast(toastBy: By) {
     clickWhenClickable(toastBy)
@@ -45,7 +47,5 @@ private fun clearToast(toastBy: By) {
 fun waitAndClearToast(id: String): E2EToast {
     val toastBy = By.xpath("//div[starts-with(@id, 'toast') and contains(@id, '$id')]")
 
-    return getElementWhenVisible(toastBy)
-        .let(::E2EToast)
-        .also { clearToast(toastBy) }
+    return getElementWhenVisible(toastBy).let(::E2EToast).also { clearToast(toastBy) }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EViewFragment.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EViewFragment.kt
@@ -1,27 +1,21 @@
 package fi.fta.geoviite.infra.ui.pagemodel.common
 
-import browser
 import clickWhenClickable
 import defaultWait
 import exists
-import fi.fta.geoviite.infra.authorization.DESIRED_ROLE_COOKIE_NAME
-import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementWhenExists
 import getElementWhenVisible
 import getElementsWhenExists
 import getElementsWhenVisible
+import java.time.Duration
 import org.openqa.selenium.By
-import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 import org.openqa.selenium.support.pagefactory.ByChained
-import org.openqa.selenium.support.ui.WebDriverWait
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import waitUntilExists
 import waitUntilInvisible
 import waitUntilVisible
-import java.time.Duration
-
 
 abstract class E2EViewFragment(protected val viewBy: By) {
     constructor(parent: E2EViewFragment, by: By) : this(ByChained(parent.viewBy, by))
@@ -50,19 +44,22 @@ abstract class E2EViewFragment(protected val viewBy: By) {
     protected fun childElements(by: By, timeout: Duration = defaultWait): List<WebElement> =
         getElementsWhenVisible(childBy(by), timeout)
 
-    protected fun clickChild(by: By, timeout: Duration = defaultWait): Unit = clickWhenClickable(childBy(by), timeout)
+    protected fun clickChild(by: By, timeout: Duration = defaultWait): Unit =
+        clickWhenClickable(childBy(by), timeout)
 
     protected fun clickButton(by: By) = childButton(by).click()
 
-    protected fun childText(by: By, timeout: Duration = defaultWait): String = childElement(by, timeout).text
+    protected fun childText(by: By, timeout: Duration = defaultWait): String =
+        childElement(by, timeout).text
 
     protected fun childTexts(by: By, timeout: Duration = defaultWait): List<String> =
         childElements(by, timeout).map(WebElement::getText)
 
-    //This will not check for element's visibility
-    protected fun findElement(by: By, timeout: Duration = defaultWait): WebElement = getElementWhenExists(by, timeout)
+    // This will not check for element's visibility
+    protected fun findElement(by: By, timeout: Duration = defaultWait): WebElement =
+        getElementWhenExists(by, timeout)
 
-    //This will not check for elements' visibility
+    // This will not check for elements' visibility
     protected fun findElements(by: By, timeout: Duration = defaultWait): List<WebElement> =
         getElementsWhenExists(by, timeout)
 
@@ -72,7 +69,7 @@ abstract class E2EViewFragment(protected val viewBy: By) {
     protected fun waitUntilChildInvisible(by: By, timeout: Duration = defaultWait): Unit =
         waitUntilInvisible(childBy(by), timeout)
 
-    //This will not check for child's visibility
+    // This will not check for child's visibility
     protected fun waitUntilChildExists(by: By, timeout: Duration = defaultWait): Unit =
         waitUntilExists(childBy(by), timeout)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/dataproducts/GeometryElementListPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/dataproducts/GeometryElementListPage.kt
@@ -3,10 +3,10 @@ package fi.fta.geoviite.infra.ui.pagemodel.dataproducts
 import fi.fta.geoviite.infra.ui.pagemodel.common.*
 import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementIfExists
-import org.openqa.selenium.By
-import org.openqa.selenium.WebElement
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+import org.openqa.selenium.By
+import org.openqa.selenium.WebElement
 
 abstract class E2EElementListPage : E2EViewFragment(By.className("data-product-view")) {
     fun layoutListPage(): E2EDataProductLayoutElementListPage {
@@ -73,9 +73,12 @@ class E2EDataProductLayoutElementListPage : E2EElementListPage() {
     val resultList: E2EDataProductLayoutElementList = E2EDataProductLayoutElementList()
 
     val downloadUrl: String
-        get() = childElement(byQaId("location-track-element-list-csv-download")).getAttribute("href")
+        get() =
+            childElement(byQaId("location-track-element-list-csv-download")).getAttribute("href")
 
-    val locationTrackLayoutGeometryRadioButton by lazy { getElementIfExists(byQaId("select-layout-geometry")) }
+    val locationTrackLayoutGeometryRadioButton by lazy {
+        getElementIfExists(byQaId("select-layout-geometry"))
+    }
     val layoutPlanGeometryRadioButton by lazy { getElementIfExists(byQaId("select-plan-geometry")) }
     val entireRailNetworkGeometryRadioButton by lazy {
         getElementIfExists(byQaId("select-entire-rail-network"))
@@ -90,23 +93,24 @@ class E2EDataProductLayoutElementListPage : E2EElementListPage() {
     }
 }
 
-
 class E2EDataProductEntireNetworkElementListPage : E2EElementListPage() {
-    val downloadUrl: String get() = childElement(byQaId("element-list-csv-download")).getAttribute("href")
+    val downloadUrl: String
+        get() = childElement(byQaId("element-list-csv-download")).getAttribute("href")
 }
 
+abstract class E2EDataProductElementList<Item : E2EDataProductElementListItem> :
+    E2ETable<Item>(
+        tableBy = By.className("data-product-table__table-container"),
+        rowsBy = By.cssSelector("tbody tr"))
 
-abstract class E2EDataProductElementList<Item : E2EDataProductElementListItem> : E2ETable<Item>(
-    tableBy = By.className("data-product-table__table-container"),
-    rowsBy = By.cssSelector("tbody tr")
-)
-
-class E2EDataProductLayoutElementList : E2EDataProductElementList<E2EDataProductLayoutElementListItem>() {
+class E2EDataProductLayoutElementList :
+    E2EDataProductElementList<E2EDataProductLayoutElementListItem>() {
     override fun getRowContent(row: WebElement) =
         E2EDataProductLayoutElementListItem(row.findElements(By.tagName("td")), headerElements)
 }
 
-class E2EDataProductPlanElementList : E2EDataProductElementList<E2EDataProductPlanElementListItem>() {
+class E2EDataProductPlanElementList :
+    E2EDataProductElementList<E2EDataProductPlanElementListItem>() {
     override fun getRowContent(row: WebElement) =
         E2EDataProductPlanElementListItem(row.findElements(By.tagName("td")), headerElements)
 }
@@ -120,18 +124,34 @@ abstract class E2EDataProductElementListItem(
     val plan: String,
     val source: String,
 ) {
-    constructor(columns: List<WebElement>, headers: List<WebElement>) : this(
-        trackNumber = getColumnContent("data-products.element-list.element-list-table.track-number", columns, headers),
-        alignment = getColumnContent("data-products.element-list.element-list-table.alignment", columns, headers),
-        elementType = getColumnContent("data-products.element-list.element-list-table.element-type", columns, headers),
-        locationStartE = getColumnContent(
-            "data-products.element-list.element-list-table.location-start-e",
-            columns,
-            headers,
-        ),
-        length = getColumnContent("data-products.element-list.element-list-table.length", columns, headers),
-        plan = getColumnContent("data-products.element-list.element-list-table.plan", columns, headers),
-        source = getColumnContent("data-products.element-list.element-list-table.source", columns, headers),
+    constructor(
+        columns: List<WebElement>,
+        headers: List<WebElement>
+    ) : this(
+        trackNumber =
+            getColumnContent(
+                "data-products.element-list.element-list-table.track-number", columns, headers),
+        alignment =
+            getColumnContent(
+                "data-products.element-list.element-list-table.alignment", columns, headers),
+        elementType =
+            getColumnContent(
+                "data-products.element-list.element-list-table.element-type", columns, headers),
+        locationStartE =
+            getColumnContent(
+                "data-products.element-list.element-list-table.location-start-e",
+                columns,
+                headers,
+            ),
+        length =
+            getColumnContent(
+                "data-products.element-list.element-list-table.length", columns, headers),
+        plan =
+            getColumnContent(
+                "data-products.element-list.element-list-table.plan", columns, headers),
+        source =
+            getColumnContent(
+                "data-products.element-list.element-list-table.source", columns, headers),
     )
 }
 
@@ -144,9 +164,10 @@ data class E2EDataProductLayoutElementListItem(
     private val columns: List<WebElement>,
     private val headers: List<WebElement>,
 ) : E2EDataProductElementListItem(columns, headers) {
-    val locationTrack = getColumnContent(
-        "data-products.element-list.element-list-table.location-track",
-        columns,
-        headers,
-    )
+    val locationTrack =
+        getColumnContent(
+            "data-products.element-list.element-list-table.location-track",
+            columns,
+            headers,
+        )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/dataproducts/KilometerLengthsListPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/dataproducts/KilometerLengthsListPage.kt
@@ -5,7 +5,6 @@ import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementIfExists
 import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
-import getElements
 
 abstract class KilometerLengthsListPage : E2EViewFragment(By.className("data-product-view")) {
     fun openLocationTrackTab(): LocationTrackKilometerLengthsListPage {
@@ -38,25 +37,31 @@ class LocationTrackKilometerLengthsListPage : KilometerLengthsListPage() {
         locationTrack.selectFromDynamicByName(searchString)
     }
 
-    val downloadUrl: String get() = childElement(byQaId("km-lengths-csv-download")).getAttribute("href")
+    val downloadUrl: String
+        get() = childElement(byQaId("km-lengths-csv-download")).getAttribute("href")
 
-    val entireRailNetworkKmLengthsRadioButton = getElementIfExists(byQaId("select-entire-rail-network"))
+    val entireRailNetworkKmLengthsRadioButton =
+        getElementIfExists(byQaId("select-entire-rail-network"))
 }
 
-class LocationTrackKilometerLengthsList: E2ETable<LocationTrackKilometerLengthsListItem>(
-    tableBy = By.className("data-product-table__table-container"),
-    rowsBy = By.cssSelector("tbody tr")
-) {
+class LocationTrackKilometerLengthsList :
+    E2ETable<LocationTrackKilometerLengthsListItem>(
+        tableBy = By.className("data-product-table__table-container"),
+        rowsBy = By.cssSelector("tbody tr")) {
     override fun getRowContent(row: WebElement) =
         LocationTrackKilometerLengthsListItem(row.findElements(By.tagName("td")), headerElements)
 }
 
 class LocationTrackKilometerLengthsListItem(val stationStart: String) {
-    constructor(columns: List<WebElement>, headers: List<WebElement>) : this(
+    constructor(
+        columns: List<WebElement>,
+        headers: List<WebElement>
+    ) : this(
         stationStart = getColumnContent("km-length-header-station-start", columns, headers),
     )
 }
 
 class EntireNetworkKilometerLengthsListPage : KilometerLengthsListPage() {
-    val downloadUrl: String get() = childElement(byQaId("km-lengths-csv-download")).getAttribute("href")
+    val downloadUrl: String
+        get() = childElement(byQaId("km-lengths-csv-download")).getAttribute("href")
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/dataproducts/VerticalGeometryListPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/dataproducts/VerticalGeometryListPage.kt
@@ -6,12 +6,13 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
 import fi.fta.geoviite.infra.ui.pagemodel.common.getColumnContent
 import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementIfExists
-import org.openqa.selenium.By
-import org.openqa.selenium.WebElement
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+import org.openqa.selenium.By
+import org.openqa.selenium.WebElement
 
-abstract class E2EDataProductVerticalGeometryListPage : E2EViewFragment(By.className("data-product-view")) {
+abstract class E2EDataProductVerticalGeometryListPage :
+    E2EViewFragment(By.className("data-product-view")) {
     fun layoutListPage(): E2EDataProductLayoutVerticalGeometryListPage {
         logger.info("Open layout geometry tab")
 
@@ -33,12 +34,14 @@ abstract class E2EDataProductVerticalGeometryListPage : E2EViewFragment(By.class
         return E2EDataProductEntireNetworkVerticalGeometryListPage()
     }
 
-    val entireRailNetworkVerticalGeometryRadioButton = getElementIfExists(byQaId("select-entire-rail-network"))
+    val entireRailNetworkVerticalGeometryRadioButton =
+        getElementIfExists(byQaId("select-entire-rail-network"))
 }
 
 class E2EDataProductPlanVerticalGeometryListPage : E2EDataProductVerticalGeometryListPage() {
 
-    val resultList: E2EDataProductPlanVerticalGeometryList = E2EDataProductPlanVerticalGeometryList()
+    val resultList: E2EDataProductPlanVerticalGeometryList =
+        E2EDataProductPlanVerticalGeometryList()
 
     val plan: E2EDropdown = childDropdown(byQaId("data-products-search-plan"))
 
@@ -58,9 +61,11 @@ class E2EDataProductPlanVerticalGeometryListPage : E2EDataProductVerticalGeometr
 class E2EDataProductLayoutVerticalGeometryListPage : E2EDataProductVerticalGeometryListPage() {
     val locationTrack: E2EDropdown = childDropdown(byQaId("data-products-search-location-track"))
 
-    val resultList: E2EDataProductLayoutVerticalGeometryList = E2EDataProductLayoutVerticalGeometryList()
+    val resultList: E2EDataProductLayoutVerticalGeometryList =
+        E2EDataProductLayoutVerticalGeometryList()
 
-    val downloadUrl: String get() = childElement(byQaId("vertical-geometry-csv-download")).getAttribute("href")
+    val downloadUrl: String
+        get() = childElement(byQaId("vertical-geometry-csv-download")).getAttribute("href")
 
     fun selectLocationTrack(searchString: String) = apply {
         logger.info("Select location track $searchString")
@@ -69,27 +74,32 @@ class E2EDataProductLayoutVerticalGeometryListPage : E2EDataProductVerticalGeome
     }
 }
 
-class E2EDataProductEntireNetworkVerticalGeometryListPage : E2EDataProductVerticalGeometryListPage() {
-    val downloadUrl: String get() = childElement(byQaId("vertical-geometry-csv-download")).getAttribute("href")
+class E2EDataProductEntireNetworkVerticalGeometryListPage :
+    E2EDataProductVerticalGeometryListPage() {
+    val downloadUrl: String
+        get() = childElement(byQaId("vertical-geometry-csv-download")).getAttribute("href")
 }
 
-abstract class E2EDataProductVerticalGeometryList<Item : E2EDataProductVerticalGeometryListItem> : E2ETable<Item>(
-    tableBy = By.className("data-product-table__table-container"),
-    rowsBy = By.cssSelector("tbody tr"),
-) {
+abstract class E2EDataProductVerticalGeometryList<Item : E2EDataProductVerticalGeometryListItem> :
+    E2ETable<Item>(
+        tableBy = By.className("data-product-table__table-container"),
+        rowsBy = By.cssSelector("tbody tr"),
+    ) {
     override val headersBy: By = By.cssSelector("thead tr:nth-child(2) th")
 }
 
 class E2EDataProductLayoutVerticalGeometryList :
     E2EDataProductVerticalGeometryList<E2EDataProductLayoutVerticalGeometryListItem>() {
     override fun getRowContent(row: WebElement) =
-        E2EDataProductLayoutVerticalGeometryListItem(row.findElements(By.tagName("td")), headerElements)
+        E2EDataProductLayoutVerticalGeometryListItem(
+            row.findElements(By.tagName("td")), headerElements)
 }
 
 class E2EDataProductPlanVerticalGeometryList :
     E2EDataProductVerticalGeometryList<E2EDataProductPlanVerticalGeometryListItem>() {
     override fun getRowContent(row: WebElement) =
-        E2EDataProductPlanVerticalGeometryListItem(row.findElements(By.tagName("td")), headerElements)
+        E2EDataProductPlanVerticalGeometryListItem(
+            row.findElements(By.tagName("td")), headerElements)
 }
 
 abstract class E2EDataProductVerticalGeometryListItem(
@@ -97,14 +107,20 @@ abstract class E2EDataProductVerticalGeometryListItem(
     val pviPointHeight: String,
     val pviPointLocationE: String,
 ) {
-    constructor(columns: List<WebElement>, headers: List<WebElement>) : this(
+    constructor(
+        columns: List<WebElement>,
+        headers: List<WebElement>
+    ) : this(
         plan = getColumnContent("data-products.vertical-geometry.table.plan", columns, headers),
-        pviPointHeight = getColumnContent("data-products.vertical-geometry.table.pvi-point-height", columns, headers),
-        pviPointLocationE = getColumnContent(
-            "data-products.vertical-geometry.table.pvi-point-location-e",
-            columns,
-            headers,
-        ),
+        pviPointHeight =
+            getColumnContent(
+                "data-products.vertical-geometry.table.pvi-point-height", columns, headers),
+        pviPointLocationE =
+            getColumnContent(
+                "data-products.vertical-geometry.table.pvi-point-location-e",
+                columns,
+                headers,
+            ),
     )
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/frontpage/FrontPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/frontpage/FrontPage.kt
@@ -6,13 +6,13 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
 import fi.fta.geoviite.infra.ui.pagemodel.common.waitAndClearToast
 import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementWhenExists
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import org.openqa.selenium.By
 import org.openqa.selenium.support.pagefactory.ByChained
 import waitUntilExists
 import waitUntilNotExist
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 
 class E2EFrontPage : E2EViewFragment(By.className("frontpage")) {
 
@@ -20,11 +20,7 @@ class E2EFrontPage : E2EViewFragment(By.className("frontpage")) {
         logger.info("Open publication nth=$nth")
 
         clickChild(
-            ByChained(
-                By.xpath("(//div[@class='publication-list-item'])[$nth]"),
-                By.tagName("a")
-            )
-        )
+            ByChained(By.xpath("(//div[@class='publication-list-item'])[$nth]"), By.tagName("a")))
 
         return E2EPublicationDetailsPage()
     }
@@ -50,9 +46,7 @@ class E2EFrontPage : E2EViewFragment(By.className("frontpage")) {
         clickChild(
             ByChained(
                 By.xpath("(//div[@class='publication-list-item__split'])[$nth]"),
-                byQaId("publication-actions-menu-toggle")
-            )
-        )
+                byQaId("publication-actions-menu-toggle")))
     }
 
     fun openLatestPublication(): E2EPublicationDetailsPage {
@@ -76,7 +70,8 @@ class E2EFrontPage : E2EViewFragment(By.className("frontpage")) {
     }
 }
 
-class E2EPublicationDetailsPage(pageBy: By = By.className("publication-details")) : E2EViewFragment(pageBy) {
+class E2EPublicationDetailsPage(pageBy: By = By.className("publication-details")) :
+    E2EViewFragment(pageBy) {
     fun returnToFrontPage(): E2EFrontPage {
         logger.info("Go to front page")
 
@@ -115,16 +110,16 @@ class E2EPublicationLog(pageBy: By = By.className("publication-log")) : E2EViewF
     }
 
     fun setSearchStartDate(instant: Instant) = apply {
-        childTextInput(byQaId("publication-log-start-date-input")).replaceValue(formatInstant(instant))
+        childTextInput(byQaId("publication-log-start-date-input"))
+            .replaceValue(formatInstant(instant))
     }
 
     fun setSearchEndDate(instant: Instant) = apply {
-        childTextInput(byQaId("publication-log-end-date-input")).replaceValue(formatInstant(instant))
+        childTextInput(byQaId("publication-log-end-date-input"))
+            .replaceValue(formatInstant(instant))
     }
 
-    fun waitUntilLoaded() = apply {
-        waitUntilNotExist(By.className("table__container--loading"))
-    }
+    fun waitUntilLoaded() = apply { waitUntilNotExist(By.className("table__container--loading")) }
 
     val rows: List<E2EPublicationDetailRow>
         get() {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/frontpage/FrontPageElement.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/frontpage/FrontPageElement.kt
@@ -10,10 +10,12 @@ data class E2EPublicationDetailRow(
     val pushedToRatko: String,
 ) {
 
-    constructor(columns: List<WebElement>, headers: List<WebElement>) : this(
+    constructor(
+        columns: List<WebElement>,
+        headers: List<WebElement>
+    ) : this(
         name = getColumnContent("publication-table.name", columns, headers),
         message = getColumnContent("publication-table.message", columns, headers),
         trackNumbers = getColumnContent("publication-table.track-number", columns, headers),
-        pushedToRatko = getColumnContent("publication-table.pushed-to-ratko", columns, headers)
-    )
+        pushedToRatko = getColumnContent("publication-table.pushed-to-ratko", columns, headers))
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelElement.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelElement.kt
@@ -4,17 +4,17 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.*
 import fi.fta.geoviite.infra.ui.util.byQaId
 import fi.fta.geoviite.infra.ui.util.localDateFromString
 import fi.fta.geoviite.infra.ui.util.localDateTimeFromString
+import java.time.LocalDateTime
 import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
 import waitUntilTextIs
-import java.time.LocalDateTime
 
-
-class E2EInfraModelTable(tableBy: By) : E2ETable<E2EInfraModelTableRow>(
-    tableBy = tableBy,
-    headersBy = By.cssSelector("thead th"),
-    rowsBy = By.cssSelector("tbody tr"),
-) {
+class E2EInfraModelTable(tableBy: By) :
+    E2ETable<E2EInfraModelTableRow>(
+        tableBy = tableBy,
+        headersBy = By.cssSelector("thead th"),
+        rowsBy = By.cssSelector("tbody tr"),
+    ) {
     override fun getRowContent(row: WebElement): E2EInfraModelTableRow {
         return E2EInfraModelTableRow(row.findElements(By.tagName("td")), headerElements)
     }
@@ -44,7 +44,10 @@ data class E2EInfraModelTableRow(
     val linked: LocalDateTime?,
 ) {
 
-    constructor(columns: List<WebElement>, headers: List<WebElement>) : this(
+    constructor(
+        columns: List<WebElement>,
+        headers: List<WebElement>
+    ) : this(
         projectName = getColumnContent("im-form.name-header", columns, headers),
         fileName = getColumnContent("im-form.file-name-header", columns, headers),
         trackNumber = getColumnContent("im-form.track-number-header", columns, headers),
@@ -52,11 +55,15 @@ data class E2EInfraModelTableRow(
         endKmNumber = getColumnContent("im-form.km-end-header", columns, headers),
         planPhase = getColumnContent("im-form.plan-phase-header", columns, headers),
         decisionPhase = getColumnContent("im-form.decision-phase-header", columns, headers),
-        planTime = localDateFromString(getColumnContent("im-form.created-at-header", columns, headers)),
-        created = localDateTimeFromString(getColumnContent("im-form.uploaded-at-header", columns, headers)),
-        linked = getColumnContent("im-form.linked-at-header", columns, headers)
-            .takeIf(String::isNotBlank)
-            ?.let(::localDateFromString),
+        planTime =
+            localDateFromString(getColumnContent("im-form.created-at-header", columns, headers)),
+        created =
+            localDateTimeFromString(
+                getColumnContent("im-form.uploaded-at-header", columns, headers)),
+        linked =
+            getColumnContent("im-form.linked-at-header", columns, headers)
+                .takeIf(String::isNotBlank)
+                ?.let(::localDateFromString),
     )
 }
 
@@ -64,16 +71,14 @@ class E2EConfirmDialog : E2EDialog() {
     fun confirm() {
         logger.info("Confirm")
 
-        waitUntilClosed {
-            clickPrimaryButton()
-        }
+        waitUntilClosed { clickPrimaryButton() }
     }
 }
 
-
 abstract class E2EFormGroup(formBy: By) : E2EViewFragment(formBy) {
 
-    val title: String get() = childText(By.className("formgroup__title"))
+    val title: String
+        get() = childText(By.className("formgroup__title"))
 
     internal fun formGroupField(qaId: String) = childComponent(byQaId(qaId), ::E2EFormGroupField)
 }
@@ -84,8 +89,9 @@ internal class E2EFormGroupField(by: By) : E2EViewFragment(by) {
         get() {
             val dropdownValueBy = By.className("field-layout__value")
 
-            val valueClass = if (childExists(dropdownValueBy)) dropdownValueBy
-            else By.className("formgroup__field-value")
+            val valueClass =
+                if (childExists(dropdownValueBy)) dropdownValueBy
+                else By.className("formgroup__field-value")
 
             return childText(valueClass)
         }
@@ -96,8 +102,7 @@ internal class E2EFormGroupField(by: By) : E2EViewFragment(by) {
         toggleEdit()
 
         values.forEachIndexed { index, value ->
-            childDropdown(By.cssSelector(".dropdown:nth-child(${index + 1})"))
-                .selectByName(value)
+            childDropdown(By.cssSelector(".dropdown:nth-child(${index + 1})")).selectByName(value)
         }
 
         toggleEdit()
@@ -108,14 +113,11 @@ internal class E2EFormGroupField(by: By) : E2EViewFragment(by) {
 
         toggleEdit()
 
-        childDropdown(By.className("dropdown"))
-            .open()
-            .new()
+        childDropdown(By.className("dropdown")).open().new()
 
-        E2EDialogWithTextField()
-            .inputValues(newValues)
-            .clickPrimaryButton()
-            .also { waitAndClearToast(toastId) }
+        E2EDialogWithTextField().inputValues(newValues).clickPrimaryButton().also {
+            waitAndClearToast(toastId)
+        }
 
         toggleEdit()
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelForm.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelForm.kt
@@ -37,10 +37,9 @@ class E2EInfraModelForm : E2EViewFragment(By.className("infra-model-upload__form
     }
 
     private fun confirmSaving() {
-        //Confirm saving if confirmation dialog appears
+        // Confirm saving if confirmation dialog appears
         E2EConfirmDialog().confirm()
     }
-
 }
 
 class E2EMetaFormGroup(formBy: By) : E2EFormGroup(formBy) {
@@ -48,8 +47,11 @@ class E2EMetaFormGroup(formBy: By) : E2EFormGroup(formBy) {
     private val projectField: E2EFormGroupField = formGroupField("project-im-field")
     private val authorField: E2EFormGroupField = formGroupField("author-im-field")
 
-    val project: String get() = projectField.value
-    val author: String get() = authorField.value
+    val project: String
+        get() = projectField.value
+
+    val author: String
+        get() = authorField.value
 
     fun selectNewProject(newProject: String): E2EMetaFormGroup = apply {
         logger.info("Select new project $newProject")
@@ -72,13 +74,22 @@ class E2ELocationFormGroup(formBy: By) : E2EFormGroup(formBy) {
 
     private val trackNumberField: E2EFormGroupField = formGroupField("track-number-im-field")
     private val kmNumberField: E2EFormGroupField = formGroupField("km-interval-im-field")
-    private val coordinateSystemField: E2EFormGroupField = formGroupField("coordinate-system-im-field")
-    private val verticalCoordinateSystemField: E2EFormGroupField = formGroupField("vertical-coordinate-system-im-field")
+    private val coordinateSystemField: E2EFormGroupField =
+        formGroupField("coordinate-system-im-field")
+    private val verticalCoordinateSystemField: E2EFormGroupField =
+        formGroupField("vertical-coordinate-system-im-field")
 
-    val trackNumber: String get() = trackNumberField.value
-    val kmNumberRange: String get() = kmNumberField.value
-    val coordinateSystem: String get() = coordinateSystemField.value
-    val verticalCoordinateSystem: String get() = verticalCoordinateSystemField.value
+    val trackNumber: String
+        get() = trackNumberField.value
+
+    val kmNumberRange: String
+        get() = kmNumberField.value
+
+    val coordinateSystem: String
+        get() = coordinateSystemField.value
+
+    val verticalCoordinateSystem: String
+        get() = verticalCoordinateSystemField.value
 
     fun selectExistingTrackNumber(trackNumber: String): E2ELocationFormGroup = apply {
         logger.info("Select track number $trackNumber")
@@ -111,14 +122,22 @@ class E2EQualityFormGroup(formBy: By) : E2EFormGroup(formBy) {
 
     private val planPhaseField: E2EFormGroupField = formGroupField("plan-phase-im-field")
     private val decisionPhaseField: E2EFormGroupField = formGroupField("decision-phase-im-field")
-    private val measurementMethodField: E2EFormGroupField = formGroupField("measurement-method-im-field")
+    private val measurementMethodField: E2EFormGroupField =
+        formGroupField("measurement-method-im-field")
     private val elevationMeasurementMethodField: E2EFormGroupField =
         formGroupField("elevation-measurement-method-im-field")
 
-    val planPhase: String get() = planPhaseField.value
-    val decisionPhase: String get() = decisionPhaseField.value
-    val measurementMethod: String get() = measurementMethodField.value
-    val elevationMeasurementMethod: String get() = elevationMeasurementMethodField.value
+    val planPhase: String
+        get() = planPhaseField.value
+
+    val decisionPhase: String
+        get() = decisionPhaseField.value
+
+    val measurementMethod: String
+        get() = measurementMethodField.value
+
+    val elevationMeasurementMethod: String
+        get() = elevationMeasurementMethodField.value
 
     fun selectPlanPhase(phase: String): E2EQualityFormGroup = apply {
         logger.info("Select plan phase $phase")
@@ -149,7 +168,8 @@ class E2ELogFormGroup(formBy: By) : E2EFormGroup(formBy) {
 
     private val planTimeField: E2EFormGroupField = formGroupField("plan-time-im-field")
 
-    val planTime: String get() = planTimeField.value
+    val planTime: String
+        get() = planTimeField.value
 
     fun setPlanTime(month: String, year: String): E2ELogFormGroup = apply {
         logger.info("Select plan time $month $year")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelPage.kt
@@ -3,15 +3,12 @@ package fi.fta.geoviite.infra.ui.pagemodel.inframodel
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
 import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementIfExists
-import getElements
 import org.openqa.selenium.By
 
 class E2EInfraModelPage : E2EViewFragment(By.className("infra-model-main")) {
 
     val infraModelsList: E2EInfraModelTable by lazy {
-        childComponent(
-            By.className("infra-model-list-search-result__table"), ::E2EInfraModelTable
-        )
+        childComponent(By.className("infra-model-list-search-result__table"), ::E2EInfraModelTable)
     }
 
     fun upload(file: String): E2EInfraModelForm {
@@ -33,7 +30,8 @@ class E2EInfraModelPage : E2EViewFragment(By.className("infra-model-main")) {
         logger.info("Search infra models $query")
 
         waitUntilChildVisible(By.className("infra-model-list-search-result__table"))
-        childTextInput(By.cssSelector(".infra-model-search-form__auto-complete input")).replaceValue(query)
+        childTextInput(By.cssSelector(".infra-model-search-form__auto-complete input"))
+            .replaceValue(query)
 
         infraModelsList.waitUntilReady()
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/ProjektiVelhoPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/ProjektiVelhoPage.kt
@@ -7,10 +7,11 @@ import fi.fta.geoviite.infra.ui.util.byQaId
 import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
 
-class E2EProjektiVelhoPage : E2ETable<E2EProjektiVelhoListItem>(
-    tableBy = byQaId("main-content-container"),
-    rowsBy = By.cssSelector(".projektivelho-file-list table tbody tr"),
-) {
+class E2EProjektiVelhoPage :
+    E2ETable<E2EProjektiVelhoListItem>(
+        tableBy = byQaId("main-content-container"),
+        rowsBy = By.cssSelector(".projektivelho-file-list table tbody tr"),
+    ) {
     fun goToInfraModelList(): E2EInfraModelPage {
         clickChild(byQaId("infra-model-nav-tab-plan"))
         return E2EInfraModelPage()
@@ -50,10 +51,14 @@ data class E2EProjektiVelhoListItem(
     val documentDescription: String,
     val documentModified: String,
 ) {
-    constructor(columns: List<WebElement>, headers: List<WebElement>) : this(
+    constructor(
+        columns: List<WebElement>,
+        headers: List<WebElement>
+    ) : this(
         projectName = getColumnContent("projektivelho.project-name", columns, headers),
         documentName = getColumnContent("projektivelho.document-name", columns, headers),
-        documentDescription = getColumnContent("projektivelho.document-description", columns, headers),
+        documentDescription =
+            getColumnContent("projektivelho.document-description", columns, headers),
         documentModified = getColumnContent("projektivelho.document-modified", columns, headers),
     )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/PreviewChangesElement.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/PreviewChangesElement.kt
@@ -3,11 +3,9 @@ package fi.fta.geoviite.infra.ui.pagemodel.map
 import childExists
 import fi.fta.geoviite.infra.publication.PublicationGroup
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EMenu
-import fi.fta.geoviite.infra.ui.pagemodel.common.E2EMenuItem
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2ETable
 import fi.fta.geoviite.infra.ui.pagemodel.common.getColumnContent
 import fi.fta.geoviite.infra.ui.util.byQaId
-import getElement
 import getElementWhenExists
 import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
@@ -15,9 +13,11 @@ import org.openqa.selenium.WebElement
 class E2EChangePreviewTable(
     tableBy: By,
 ) : E2ETable<E2EChangePreviewRow>(tableBy, By.cssSelector("tbody tr")) {
-    val errorRows: List<E2EChangePreviewRow> get() = rows.filter { it.state == E2EChangePreviewRow.State.ERROR }
+    val errorRows: List<E2EChangePreviewRow>
+        get() = rows.filter { it.state == E2EChangePreviewRow.State.ERROR }
 
-    val warningRows: List<E2EChangePreviewRow> get() = rows.filter { it.state == E2EChangePreviewRow.State.WARNING }
+    val warningRows: List<E2EChangePreviewRow>
+        get() = rows.filter { it.state == E2EChangePreviewRow.State.WARNING }
 
     fun hasErrors(): Boolean = errorRows.isNotEmpty()
 
@@ -55,18 +55,20 @@ class E2EChangePreviewTable(
         rows.find { row ->
             val rowMenu = openMenu(row)
 
-            val movePublicationGroupMenuItem = rowMenu.items.firstOrNull { menuItem ->
-                val menuItemQaId = menuItem.element?.getAttribute("qa-id")
-                menuItemQaId == "preview-move-publication-group-${publicationGroup.id}"
-            }
+            val movePublicationGroupMenuItem =
+                rowMenu.items.firstOrNull { menuItem ->
+                    val menuItemQaId = menuItem.element?.getAttribute("qa-id")
+                    menuItemQaId == "preview-move-publication-group-${publicationGroup.id}"
+                }
 
             movePublicationGroupMenuItem?.let { item ->
                 item.element?.click()
                 true
-            } ?: run {
-                closeMenu(row)
-                false
             }
+                ?: run {
+                    closeMenu(row)
+                    false
+                }
         }
     }
 
@@ -80,14 +82,22 @@ data class E2EChangePreviewRow(
     val trackNumber: String,
     val state: State,
 ) {
-    enum class State { OK, WARNING, ERROR }
+    enum class State {
+        OK,
+        WARNING,
+        ERROR
+    }
 
-    constructor(row: WebElement, columns: List<WebElement>, headers: List<WebElement>) : this(
+    constructor(
+        row: WebElement,
+        columns: List<WebElement>,
+        headers: List<WebElement>
+    ) : this(
         name = getColumnContent("preview-table.change-target", columns, headers),
         trackNumber = getColumnContent("preview-table.track-number-short", columns, headers),
-        state = if (row.childExists(By.className("preview-table-item__error-status"))) State.ERROR
-        else if (row.childExists(By.className("preview-table-item__warning-status"))) State.WARNING
-        else State.OK
-    )
-
+        state =
+            if (row.childExists(By.className("preview-table-item__error-status"))) State.ERROR
+            else if (row.childExists(By.className("preview-table-item__warning-status")))
+                State.WARNING
+            else State.OK)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/PreviewChangesPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/PreviewChangesPage.kt
@@ -1,22 +1,23 @@
 package fi.fta.geoviite.infra.ui.pagemodel.map
 
-import fi.fta.geoviite.infra.publication.PublicationGroup
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EDialog
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
 import fi.fta.geoviite.infra.ui.pagemodel.common.waitAndClearToast
 import fi.fta.geoviite.infra.ui.util.byQaId
-import org.openqa.selenium.By
 import java.time.Duration
+import org.openqa.selenium.By
 
 class E2EPreviewChangesPage : E2EViewFragment(byQaId("preview-content")) {
 
     val changesTable: E2EChangePreviewTable by lazy {
-        waitUntilChildInvisible(By.className("preview-section__spinner-container"), Duration.ofSeconds(10L))
+        waitUntilChildInvisible(
+            By.className("preview-section__spinner-container"), Duration.ofSeconds(10L))
         E2EChangePreviewTable(childBy(By.cssSelector("[qa-id='unstaged-changes'] table")))
     }
 
     val stagedChangesTable: E2EChangePreviewTable by lazy {
-        waitUntilChildInvisible(By.className("preview-section__spinner-container"), Duration.ofSeconds(10L))
+        waitUntilChildInvisible(
+            By.className("preview-section__spinner-container"), Duration.ofSeconds(10L))
         E2EChangePreviewTable(childBy(By.cssSelector("[qa-id='staged-changes'] table")))
     }
 
@@ -59,7 +60,8 @@ class E2EPreviewChangesPage : E2EViewFragment(byQaId("preview-content")) {
     fun goToTrackLayout(): E2ETrackLayoutPage {
         logger.info("Return to draft view")
         clickChild(byQaId("go-to-track-layout-view"))
-        // utter hack: Somehow the map doesn't update the visible items when clicking that in tests; so let's force
+        // utter hack: Somehow the map doesn't update the visible items when clicking that in tests;
+        // so let's force
         // it to notice something changed by forcefully wiggling it
         return E2ETrackLayoutPage()
             .also { map -> map.scrollMap(1, 1) }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/SelectionPanel.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/SelectionPanel.kt
@@ -11,9 +11,7 @@ class E2ESelectionPanel(
         E2ETrackNumberSelectionList(viewBy)
     }
 
-    val kmPostsList: E2EKmPostSelectionList by lazy {
-        E2EKmPostSelectionList(viewBy)
-    }
+    val kmPostsList: E2EKmPostSelectionList by lazy { E2EKmPostSelectionList(viewBy) }
 
     val referenceLinesList: E2EReferenceLineSelectionList by lazy {
         E2EReferenceLineSelectionList(viewBy)
@@ -23,14 +21,17 @@ class E2ESelectionPanel(
         E2ELocationTrackSelectionList(viewBy)
     }
 
-    val switchesList: E2ESwitchesSelectionList by lazy {
-        E2ESwitchesSelectionList(viewBy)
-    }
+    val switchesList: E2ESwitchesSelectionList by lazy { E2ESwitchesSelectionList(viewBy) }
 
     val geometryPlans: List<E2EGeometryPlanAccordion> by lazy {
         childElements(By.cssSelector(".geometry-plan-panel .accordion__header-title"))
             .map { it.text }
-            .map { E2EGeometryPlanAccordion(By.xpath("//div[@class='accordion' and parent::div[@class='geometry-plan-panel'] and h4/span[text() = '${it}']]"), null) }
+            .map {
+                E2EGeometryPlanAccordion(
+                    By.xpath(
+                        "//div[@class='accordion' and parent::div[@class='geometry-plan-panel'] and h4/span[text() = '${it}']]"),
+                    null)
+            }
     }
 
     fun selectTrackNumber(name: String): E2ESelectionPanel = apply {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/SelectionPanelElement.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/SelectionPanelElement.kt
@@ -13,11 +13,20 @@ const val ALIGNMENT_ACCORDION_QA_ID = "geometry-plan-panel-alignments"
 const val KM_POST_ACCORDION_QA_ID = "geometry-plan-panel-km-posts"
 const val SWITCHES_ACCORDION_QA_ID = "geometry-plan-panel-switches"
 
-class E2EGeometryPlanAccordion(accordionBy: By, val selectedItemBy: By?) : E2EAccordion(accordionBy) {
+class E2EGeometryPlanAccordion(accordionBy: By, val selectedItemBy: By?) :
+    E2EAccordion(accordionBy) {
 
-    private val alignmentsAccordion by lazy { subAccordion(ALIGNMENT_ACCORDION_QA_ID, By.className("geometry-plan-panel__alignment--selected")) }
-    private val kmPostsAccordion by lazy { subAccordion(KM_POST_ACCORDION_QA_ID, By.className("geometry-plan-panel__kmpost--selected")) }
-    private val switchesAccordion by lazy { subAccordion(SWITCHES_ACCORDION_QA_ID, By.className("geometry-plan-panel__switch--selected")) }
+    private val alignmentsAccordion by lazy {
+        subAccordion(
+            ALIGNMENT_ACCORDION_QA_ID, By.className("geometry-plan-panel__alignment--selected"))
+    }
+    private val kmPostsAccordion by lazy {
+        subAccordion(KM_POST_ACCORDION_QA_ID, By.className("geometry-plan-panel__kmpost--selected"))
+    }
+    private val switchesAccordion by lazy {
+        subAccordion(
+            SWITCHES_ACCORDION_QA_ID, By.className("geometry-plan-panel__switch--selected"))
+    }
 
     val kmPostsList: E2ETextList = open().let { kmPostsAccordion.items }
     val alignmentsList: E2ETextList = open().let { alignmentsAccordion.items }
@@ -54,11 +63,10 @@ private class E2EGeometryPlanItemAccordion(
     selectedItemBy: By,
 ) : E2EAccordion(ByChained(parentBy, byQaId(qaId))) {
 
-    private val _items: E2ETextList by lazy {
-        E2ETextList(viewBy, selectedItemBy = selectedItemBy)
-    }
+    private val _items: E2ETextList by lazy { E2ETextList(viewBy, selectedItemBy = selectedItemBy) }
 
-    val items: E2ETextList get() = open().let { _items }
+    val items: E2ETextList
+        get() = open().let { _items }
 
     fun selectItem(name: String) {
         items.selectByText(name)
@@ -88,8 +96,11 @@ data class E2EKmPostSelectionListItem(override val name: String) : E2ESelectionL
     constructor(element: WebElement) : this(element.findElement(By.xpath("./div/span")).text)
 }
 
-data class E2ELocationTrackSelectionListItem(override val name: String, val type: String) : E2ESelectionListItem {
-    constructor(element: WebElement) : this(
+data class E2ELocationTrackSelectionListItem(override val name: String, val type: String) :
+    E2ESelectionListItem {
+    constructor(
+        element: WebElement
+    ) : this(
         name = element.findElement(By.xpath("./div/span")).text,
         type = element.findElement(By.tagName("span")).text,
     )
@@ -107,33 +118,38 @@ data class E2ESwitchSelectionListItem(override val name: String) : E2ESelectionL
     constructor(element: WebElement) : this(element.findElement(By.xpath("./span/span")).text)
 }
 
-class E2EKmPostSelectionList(parentBy: By) : E2ESelectionList<E2EKmPostSelectionListItem>(
-    listBy = ByChained(parentBy, By.className("km-posts-panel__km-posts")),
-    getContent = { e -> E2EKmPostSelectionListItem(e) },
-    selectedItemBy = ByChained(parentBy, By.className("km-post-badge--selected")),
-)
+class E2EKmPostSelectionList(parentBy: By) :
+    E2ESelectionList<E2EKmPostSelectionListItem>(
+        listBy = ByChained(parentBy, By.className("km-posts-panel__km-posts")),
+        getContent = { e -> E2EKmPostSelectionListItem(e) },
+        selectedItemBy = ByChained(parentBy, By.className("km-post-badge--selected")),
+    )
 
-class E2ELocationTrackSelectionList(parentBy: By) : E2ESelectionList<E2ELocationTrackSelectionListItem>(
-    listBy = ByChained(parentBy, byQaId("location-tracks-list")),
-    getContent = { e -> E2ELocationTrackSelectionListItem(e) },
-    selectedItemBy = ByChained(parentBy, By.className("alignment-badge--selected")),
-)
+class E2ELocationTrackSelectionList(parentBy: By) :
+    E2ESelectionList<E2ELocationTrackSelectionListItem>(
+        listBy = ByChained(parentBy, byQaId("location-tracks-list")),
+        getContent = { e -> E2ELocationTrackSelectionListItem(e) },
+        selectedItemBy = ByChained(parentBy, By.className("alignment-badge--selected")),
+    )
 
-class E2ETrackNumberSelectionList(parentBy: By) : E2ESelectionList<E2ETrackNumberSelectionListItem>(
-    listBy = ByChained(parentBy, By.className("track-number-panel__track-numbers")),
-    getContent = { e -> E2ETrackNumberSelectionListItem(e) },
-    selectedItemBy = ByChained(parentBy, By.className("alignment-badge--selected")),
-)
+class E2ETrackNumberSelectionList(parentBy: By) :
+    E2ESelectionList<E2ETrackNumberSelectionListItem>(
+        listBy = ByChained(parentBy, By.className("track-number-panel__track-numbers")),
+        getContent = { e -> E2ETrackNumberSelectionListItem(e) },
+        selectedItemBy = ByChained(parentBy, By.className("alignment-badge--selected")),
+    )
 
-class E2EReferenceLineSelectionList(parentBy: By) : E2ESelectionList<E2EReferenceLineSelectionListItem>(
-    listBy = ByChained(parentBy, byQaId("reference-lines-list")),
-    itemsBy = By.className("reference-lines-panel__reference-line"),
-    getContent = { e -> E2EReferenceLineSelectionListItem(e) },
-    selectedItemBy = ByChained(parentBy, By.className("alignment-badge--selected")),
-)
+class E2EReferenceLineSelectionList(parentBy: By) :
+    E2ESelectionList<E2EReferenceLineSelectionListItem>(
+        listBy = ByChained(parentBy, byQaId("reference-lines-list")),
+        itemsBy = By.className("reference-lines-panel__reference-line"),
+        getContent = { e -> E2EReferenceLineSelectionListItem(e) },
+        selectedItemBy = ByChained(parentBy, By.className("alignment-badge--selected")),
+    )
 
-class E2ESwitchesSelectionList(parentBy: By) : E2ESelectionList<E2ESwitchSelectionListItem>(
-    listBy = ByChained(parentBy, By.className("switch-panel__switches")),
-    getContent = { e -> E2ESwitchSelectionListItem(e) },
-    selectedItemBy = ByChained(parentBy, By.className("switch-badge--selected")),
-)
+class E2ESwitchesSelectionList(parentBy: By) :
+    E2ESelectionList<E2ESwitchSelectionListItem>(
+        listBy = ByChained(parentBy, By.className("switch-panel__switches")),
+        getContent = { e -> E2ESwitchSelectionListItem(e) },
+        selectedItemBy = ByChained(parentBy, By.className("switch-badge--selected")),
+    )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolBar.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolBar.kt
@@ -6,13 +6,14 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EDropdown
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EDropdownListItem
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
 import fi.fta.geoviite.infra.ui.util.byQaId
+import java.time.LocalDate
 import org.openqa.selenium.By
 import org.openqa.selenium.support.pagefactory.ByChained
 import waitUntilInvisible
 import waitUntilVisible
-import java.time.LocalDate
 
-class E2EToolBar(parentView: E2EViewFragment) : E2EViewFragment(parentView, By.className("tool-bar")) {
+class E2EToolBar(parentView: E2EViewFragment) :
+    E2EViewFragment(parentView, By.className("tool-bar")) {
     private val searchDropdown: E2EDropdown by lazy {
         childDropdown(By.cssSelector(".tool-bar__right-section .dropdown"))
     }
@@ -35,7 +36,8 @@ class E2EToolBar(parentView: E2EViewFragment) : E2EViewFragment(parentView, By.c
         waitUntilInvisible(By.className("dropdown__loading-indicator"))
     }
 
-    val searchResults: List<E2EDropdownListItem> get() = searchDropdown.options
+    val searchResults: List<E2EDropdownListItem>
+        get() = searchDropdown.options
 
     fun selectSearchResult(resultContains: String) = apply {
         logger.info("Select result '$resultContains'")
@@ -82,7 +84,8 @@ class E2EToolBar(parentView: E2EViewFragment) : E2EViewFragment(parentView, By.c
         E2EDropdown(byQaId("workspace-dropdown")).new()
         val newDialog = E2EWorkspaceEditDialog()
 
-        // Slight hack: Set date before name to make sure datepicker closes and doesn't block the save button
+        // Slight hack: Set date before name to make sure datepicker closes and doesn't block the
+        // save button
         newDialog.setDate(date)
         newDialog.setName(name)
         newDialog.save()
@@ -100,7 +103,6 @@ class E2EMapLayerPanel(panelBy: By) : E2EViewFragment(panelBy) {
         SWITCHES("switch-layer"),
         KM_POSTS("km-post-layer"),
         TRACK_NUMBER_DIAGRAM("track-number-diagram-layer"),
-
         GEOMETRY_ALIGNMENTS("geometry-alignment-layer"),
         GEOMETRY_SWITCHES("geometry-switch-layer"),
         GEOMETRY_KM_POSTS("geometry-km-post-layer"),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanel.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanel.kt
@@ -5,7 +5,8 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
 import fi.fta.geoviite.infra.ui.util.byQaId
 import org.openqa.selenium.By
 
-class E2EToolPanel(parentView: E2EViewFragment) : E2EViewFragment(parentView, By.className("tool-panel")) {
+class E2EToolPanel(parentView: E2EViewFragment) :
+    E2EViewFragment(parentView, By.className("tool-panel")) {
 
     fun selectToolPanelTab(tabName: String) {
         logger.info("Select tab $tabName")
@@ -38,14 +39,15 @@ class E2EToolPanel(parentView: E2EViewFragment) : E2EViewFragment(parentView, By
     }
 
     val locationTrackVerticalGeometry: E2ELocationTrackVerticalGeometryInfoBox by lazy {
-        infoBox("location-track-vertical-geometry-infobox", ::E2ELocationTrackVerticalGeometryInfoBox)
+        infoBox(
+            "location-track-vertical-geometry-infobox", ::E2ELocationTrackVerticalGeometryInfoBox)
     }
 
     val locationTrackLog: E2ELocationTrackLogInfoBox by lazy {
         infoBox("location-track-log-infobox", ::E2ELocationTrackLogInfoBox)
     }
 
-    //re-used old qa-id so don't worry
+    // re-used old qa-id so don't worry
     val trackNumberLog: E2ETrackNumberLogInfoBox by lazy {
         infoBox("track-number-log-infobox", ::E2ETrackNumberLogInfoBox)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanelDialog.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanelDialog.kt
@@ -6,8 +6,8 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EDropdown
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2ETextInput
 import fi.fta.geoviite.infra.ui.util.byQaId
 import fi.fta.geoviite.infra.ui.util.dateFormat
-import org.openqa.selenium.By
 import java.time.LocalDate
+import org.openqa.selenium.By
 
 class E2ELocationTrackEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy) {
     enum class State {
@@ -38,7 +38,9 @@ class E2ELocationTrackEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy)
 
     private val nameInput: E2ETextInput by lazy { childTextInput(byQaId("location-track-name")) }
 
-    private val trackNumberDropdown: E2EDropdown by lazy { childDropdown(byQaId("location-track-track-number")) }
+    private val trackNumberDropdown: E2EDropdown by lazy {
+        childDropdown(byQaId("location-track-track-number"))
+    }
 
     val ownerDropdown: E2EDropdown by lazy { childDropdown(byQaId("location-track-dialog.owner")) }
 
@@ -46,11 +48,17 @@ class E2ELocationTrackEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy)
 
     private val typeDropdown: E2EDropdown by lazy { childDropdown(byQaId("location-track-type")) }
 
-    private val descriptionBaseInput: E2ETextInput by lazy { childTextInput(byQaId("location-track-description-base")) }
+    private val descriptionBaseInput: E2ETextInput by lazy {
+        childTextInput(byQaId("location-track-description-base"))
+    }
 
-    private val descriptionSuffixDropdown: E2EDropdown by lazy { childDropdown(byQaId("location-track-description-suffix")) }
+    private val descriptionSuffixDropdown: E2EDropdown by lazy {
+        childDropdown(byQaId("location-track-description-suffix"))
+    }
 
-    private val topologicalConnectivityDropdown: E2EDropdown by lazy { childDropdown(byQaId("location-track-topological-connectivity")) }
+    private val topologicalConnectivityDropdown: E2EDropdown by lazy {
+        childDropdown(byQaId("location-track-topological-connectivity"))
+    }
 
     fun setName(name: String): E2ELocationTrackEditDialog = apply {
         logger.info("Set name $name")
@@ -82,18 +90,20 @@ class E2ELocationTrackEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy)
         descriptionBaseInput.replaceValue(description)
     }
 
-    fun setDescriptionSuffix(descriptionSuffix: DescriptionSuffix): E2ELocationTrackEditDialog = apply {
-        logger.info("Set description suffix $descriptionSuffix")
-
-        descriptionSuffixDropdown.selectByQaId(descriptionSuffix.name)
-    }
-
-    fun selectTopologicalConnectivity(topologicalConnectivity: TopologicalConnectivity): E2ELocationTrackEditDialog =
+    fun setDescriptionSuffix(descriptionSuffix: DescriptionSuffix): E2ELocationTrackEditDialog =
         apply {
-            logger.info("Select topological connectivity $topologicalConnectivity")
+            logger.info("Set description suffix $descriptionSuffix")
 
-            topologicalConnectivityDropdown.selectByQaId(topologicalConnectivity.name)
+            descriptionSuffixDropdown.selectByQaId(descriptionSuffix.name)
         }
+
+    fun selectTopologicalConnectivity(
+        topologicalConnectivity: TopologicalConnectivity
+    ): E2ELocationTrackEditDialog = apply {
+        logger.info("Select topological connectivity $topologicalConnectivity")
+
+        topologicalConnectivityDropdown.selectByQaId(topologicalConnectivity.name)
+    }
 
     fun save() = waitUntilClosed {
         logger.info("Save location track changes")
@@ -105,9 +115,7 @@ class E2ELocationTrackEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy)
             clickChild(
                 By.xpath(
                     "following-sibling::div[contains(@class, 'dialog')]" +
-                            "//button[contains(@class, 'button--primary')]"
-                )
-            )
+                        "//button[contains(@class, 'button--primary')]"))
         }
     }
 
@@ -127,8 +135,9 @@ class E2ETrackNumberEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy) {
 
     private val nameInput: E2ETextInput by lazy { childTextInput(byQaId("track-number-name")) }
     private val stateDropdown: E2EDropdown by lazy { childDropdown(byQaId("track-number-state")) }
-    private val descriptionInput: E2ETextInput by lazy { childTextInput(byQaId("track-number-description")) }
-
+    private val descriptionInput: E2ETextInput by lazy {
+        childTextInput(byQaId("track-number-description"))
+    }
 
     fun setName(name: String): E2ETrackNumberEditDialog = apply {
         logger.info("Set name $name")
@@ -158,9 +167,7 @@ class E2ETrackNumberEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy) {
             clickChild(
                 By.xpath(
                     "following-sibling::div[contains(@class, 'dialog')]/" +
-                            "/button[contains(@class, 'button--primary')]"
-                )
-            )
+                        "/button[contains(@class, 'button--primary')]"))
         }
     }
 }
@@ -231,8 +238,8 @@ class E2ELayoutSwitchEditDialog(dialogBy: By = DIALOG_BY) : E2EDialog(dialogBy) 
 
         if (isNotExisting) {
             clickChild(
-                By.xpath("following-sibling::div[contains(@class, 'dialog')]//button[contains(@class, 'button--primary')]")
-            )
+                By.xpath(
+                    "following-sibling::div[contains(@class, 'dialog')]//button[contains(@class, 'button--primary')]"))
         }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanelInfobox.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanelInfobox.kt
@@ -1,42 +1,74 @@
 package fi.fta.geoviite.infra.ui.pagemodel.map
 
 import clickWhenClickable
+import fi.fta.geoviite.infra.ui.pagemodel.common.E2EDialog
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EInfoBox
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2ERadio
 import fi.fta.geoviite.infra.ui.pagemodel.common.waitAndClearToast
-import fi.fta.geoviite.infra.ui.pagemodel.common.E2EDialog
 import fi.fta.geoviite.infra.ui.util.byQaId
 import org.openqa.selenium.By
 import org.openqa.selenium.support.pagefactory.ByChained
 import waitUntilExists
 
 class E2EGeometryPlanGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val remarks: String get() = getValueForField("geometry-plan-remarks")
-    val author: String get() = getValueForField("geometry-plan-author")
-    val projectName: String get() = getValueForField("geometry-plan-project")
-    val fileName: String get() = getValueForField("geometry-plan-file")
-    val planPhase: String get() = getValueForField("geometry-plan-phase")
-    val decisionPhase: String get() = getValueForField("geometry-plan-decision")
-    val trackNumber: String get() = getValueWhenFieldHasValue("geometry-plan-track-number")
-    val startKmNumber: String get() = getValueForField("geometry-plan-start-km")
-    val endKmNumber: String get() = getValueForField("geometry-plan-end-km")
+    val remarks: String
+        get() = getValueForField("geometry-plan-remarks")
+
+    val author: String
+        get() = getValueForField("geometry-plan-author")
+
+    val projectName: String
+        get() = getValueForField("geometry-plan-project")
+
+    val fileName: String
+        get() = getValueForField("geometry-plan-file")
+
+    val planPhase: String
+        get() = getValueForField("geometry-plan-phase")
+
+    val decisionPhase: String
+        get() = getValueForField("geometry-plan-decision")
+
+    val trackNumber: String
+        get() = getValueWhenFieldHasValue("geometry-plan-track-number")
+
+    val startKmNumber: String
+        get() = getValueForField("geometry-plan-start-km")
+
+    val endKmNumber: String
+        get() = getValueForField("geometry-plan-end-km")
 }
 
 class E2EGeometryPlanQualityInfobox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
 
-    val source: String get() = getValueForField("geometry-plan-source")
-    val planTime: String get() = getValueForField("geometry-plan-plan-time")
-    val measurementMethod: String get() = getValueForField("geometry-plan-measurement-method")
-    val coordinateSystem: String get() = getValueForField("geometry-plan-coordinate-system")
-    val verticalGeometry: String get() = getValueForField("geometry-plan-vertical-geometry")
-    val cant: String get() = getValueForField("geometry-plan-cant")
-    val verticalCoordinateSystem: String get() = getValueForField("geometry-plan-vertical-coordinate-system")
+    val source: String
+        get() = getValueForField("geometry-plan-source")
+
+    val planTime: String
+        get() = getValueForField("geometry-plan-plan-time")
+
+    val measurementMethod: String
+        get() = getValueForField("geometry-plan-measurement-method")
+
+    val coordinateSystem: String
+        get() = getValueForField("geometry-plan-coordinate-system")
+
+    val verticalGeometry: String
+        get() = getValueForField("geometry-plan-vertical-geometry")
+
+    val cant: String
+        get() = getValueForField("geometry-plan-cant")
+
+    val verticalCoordinateSystem: String
+        get() = getValueForField("geometry-plan-vertical-coordinate-system")
 }
 
 class E2ELayoutKmPostGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val name: String get() = getValueForField("km-post-km-number")
+    val name: String
+        get() = getValueForField("km-post-km-number")
 
-    val trackNumber: String get() = getValueWhenFieldHasValue("km-post-track-number")
+    val trackNumber: String
+        get() = getValueWhenFieldHasValue("km-post-track-number")
 
     fun zoomTo(): E2ELayoutKmPostGeneralInfoBox = apply {
         logger.info("Zoom to km post")
@@ -46,18 +78,32 @@ class E2ELayoutKmPostGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
 }
 
 class E2ELayoutKmPostLocationInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val coordinates: String get() = getValueForField("km-post-coordinates")
+    val coordinates: String
+        get() = getValueForField("km-post-coordinates")
 }
 
 class E2ELocationTrackLocationInfobox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val trackNumber: String get() = getValueForField("location-track-track-number")
-    val startLocation: String get() = getValueForField("location-track-start-track-meter")
-    val endLocation: String get() = getValueForField("location-track-end-track-meter")
+    val trackNumber: String
+        get() = getValueForField("location-track-track-number")
 
-    val trueLength: String get() = getValueForField("location-track-true-length")
-    val trueLengthDouble: Double? get() = Regex("[0-9.]*").find(trueLength)?.value?.toDouble()
-    val startCoordinates: String get() = getValueForField("location-track-start-coordinates")
-    val endCoordinates: String get() = getValueForField("location-track-end-coordinates")
+    val startLocation: String
+        get() = getValueForField("location-track-start-track-meter")
+
+    val endLocation: String
+        get() = getValueForField("location-track-end-track-meter")
+
+    val trueLength: String
+        get() = getValueForField("location-track-true-length")
+
+    val trueLengthDouble: Double?
+        get() = Regex("[0-9.]*").find(trueLength)?.value?.toDouble()
+
+    val startCoordinates: String
+        get() = getValueForField("location-track-start-coordinates")
+
+    val endCoordinates: String
+        get() = getValueForField("location-track-end-coordinates")
+
     fun waitForStartCoordinatesChange(value: String) =
         waitUntilValueChangesForField("location-track-start-coordinates", value)
 
@@ -70,10 +116,10 @@ class E2ELocationTrackLocationInfobox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
         childButton(byQaId("modify-start-or-end")).clickAndWaitToDisappear()
     }
 
-    fun startSplitting(): E2ELocationTrackSplittingInfobox { 
+    fun startSplitting(): E2ELocationTrackSplittingInfobox {
         logger.info("Start splitting")
         childButton(byQaId("start-splitting")).clickAndWaitToDisappear()
-        
+
         return E2ELocationTrackSplittingInfobox()
     }
 
@@ -85,19 +131,18 @@ class E2ELocationTrackLocationInfobox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
     }
 }
 
-class E2ELocationTrackSplittingInfobox(infoboxBy: By = byQaId("location-track-splitting-infobox")) : E2EInfoBox(infoboxBy) {
+class E2ELocationTrackSplittingInfobox(infoboxBy: By = byQaId("location-track-splitting-infobox")) :
+    E2EInfoBox(infoboxBy) {
     fun setTargetTrackName(index: Int, trackName: String) = apply {
-        val targetTrackNameInput = childTextInput(
-            By.xpath("(//*[@qa-id='split-target-track-name'])[${index + 1}]")
-        )
+        val targetTrackNameInput =
+            childTextInput(By.xpath("(//*[@qa-id='split-target-track-name'])[${index + 1}]"))
 
         targetTrackNameInput.replaceValue(trackName)
     }
 
     fun setTargetTrackDescription(index: Int, description: String) = apply {
-        val targetTrackNameInput = childTextInput(
-            By.xpath("(//*[@qa-id='split-target-track-description'])[${index + 1}]")
-        )
+        val targetTrackNameInput =
+            childTextInput(By.xpath("(//*[@qa-id='split-target-track-description'])[${index + 1}]"))
 
         targetTrackNameInput.replaceValue(description)
     }
@@ -117,22 +162,31 @@ class E2ELocationTrackSplittingInfobox(infoboxBy: By = byQaId("location-track-sp
     }
 
     fun waitUntilTargetTrackInputExists(index: Int) {
-        waitUntilExists(
-            By.xpath("(//*[@qa-id='split-target-track-name'])[${index + 1}]")
-        )
+        waitUntilExists(By.xpath("(//*[@qa-id='split-target-track-name'])[${index + 1}]"))
     }
 }
 
 class E2ELocationTrackGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val oid: String get() = getValueForField("location-track-oid")
-    val name: String get() = getValueForField("location-track-name")
-    val state: String get() = getEnumValueForField("location-track-state")
-    val type: String get() = getEnumValueForField("location-track-type")
+    val oid: String
+        get() = getValueForField("location-track-oid")
 
-    val description: String get() = getValueWhenFieldHasValue("location-track-description")
-    val trackNumber: String get() = getValueWhenFieldHasValue("location-track-track-number")
+    val name: String
+        get() = getValueForField("location-track-name")
 
-    fun waitUntilDescriptionChanges(value: String) = waitUntilValueChangesForField("location-track-description", value)
+    val state: String
+        get() = getEnumValueForField("location-track-state")
+
+    val type: String
+        get() = getEnumValueForField("location-track-type")
+
+    val description: String
+        get() = getValueWhenFieldHasValue("location-track-description")
+
+    val trackNumber: String
+        get() = getValueWhenFieldHasValue("location-track-track-number")
+
+    fun waitUntilDescriptionChanges(value: String) =
+        waitUntilValueChangesForField("location-track-description", value)
 
     fun edit(): E2ELocationTrackEditDialog {
         logger.info("Enable location track editing")
@@ -154,15 +208,25 @@ class E2ELocationTrackVerticalGeometryInfoBox(infoboxBy: By) : E2EInfoBox(infobo
 }
 
 class E2ELocationTrackLogInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val created: String get() = getValueForField("location-track-created-date")
-    val changed: String get() = getValueForField("location-track-changed-date")
+    val created: String
+        get() = getValueForField("location-track-created-date")
+
+    val changed: String
+        get() = getValueForField("location-track-changed-date")
 }
 
 class E2ETrackNumberGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val oid: String get() = getValueForField("track-number-oid")
-    val name: String get() = getValueForField("track-number-name")
-    val state: String get() = getValueForField("track-number-state")
-    val description: String get() = getValueForField("track-number-description")
+    val oid: String
+        get() = getValueForField("track-number-oid")
+
+    val name: String
+        get() = getValueForField("track-number-name")
+
+    val state: String
+        get() = getValueForField("track-number-state")
+
+    val description: String
+        get() = getValueForField("track-number-description")
 
     fun edit(): E2ETrackNumberEditDialog {
         logger.info("Enable track number editing")
@@ -173,11 +237,21 @@ class E2ETrackNumberGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
 }
 
 class E2ETrackNumberLocationInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val startLocation: String get() = getValueForField("track-number-start-track-meter")
-    val endLocation: String get() = getValueForField("track-number-end-track-meter")
-    val trueLength: String get() = getValueForField("track-number-true-length")
-    val startCoordinates: String get() = getValueForField("track-number-start-coordinates")
-    val endCoordinates: String get() = getValueForField("track-number-end-coordinates")
+    val startLocation: String
+        get() = getValueForField("track-number-start-track-meter")
+
+    val endLocation: String
+        get() = getValueForField("track-number-end-track-meter")
+
+    val trueLength: String
+        get() = getValueForField("track-number-true-length")
+
+    val startCoordinates: String
+        get() = getValueForField("track-number-start-coordinates")
+
+    val endCoordinates: String
+        get() = getValueForField("track-number-end-coordinates")
+
     fun zoomTo(): E2ETrackNumberLocationInfoBox = apply {
         logger.info("Zoom to track number")
 
@@ -186,14 +260,22 @@ class E2ETrackNumberLocationInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
 }
 
 class E2ETrackNumberLogInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val created: String get() = getValueForField("track-number-created-date")
-    val changed: String get() = getValueForField("track-number-changed-date")
+    val created: String
+        get() = getValueForField("track-number-created-date")
+
+    val changed: String
+        get() = getValueForField("track-number-changed-date")
 }
 
 class E2ELayoutSwitchGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val name: String get() = getValueForField("switch-name")
-    val oid: String get() = getValueForField("switch-oid")
-    val category: String get() = getValueForField("switch-state-category")
+    val name: String
+        get() = getValueForField("switch-name")
+
+    val oid: String
+        get() = getValueForField("switch-oid")
+
+    val category: String
+        get() = getValueForField("switch-state-category")
 
     fun edit(): E2ELayoutSwitchEditDialog {
         logger.info("Enable switch editing")
@@ -210,13 +292,19 @@ class E2ELayoutSwitchGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
 }
 
 class E2ELayoutSwitchAdditionalInfoInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val owner: String get() = getValueForField("switch-owner")
+    val owner: String
+        get() = getValueForField("switch-owner")
 }
 
 class E2ESwitchStructureGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val type: String get() = childText(By.cssSelector("p"))
-    val hand: String get() = getValueForField("switch-hand")
-    val trap: String get() = getValueForField("switch-trap-point")
+    val type: String
+        get() = childText(By.cssSelector("p"))
+
+    val hand: String
+        get() = getValueForField("switch-hand")
+
+    val trap: String
+        get() = getValueForField("switch-trap-point")
 }
 
 class E2ESwitchCoordinatesInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
@@ -225,26 +313,36 @@ class E2ESwitchCoordinatesInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
         val switchTrack: String,
     )
 
-    val coordinates: String get() = getValueForField("switch-coordinates")
+    val coordinates: String
+        get() = getValueForField("switch-coordinates")
 
     val jointAlignments: List<SwitchLineAndTrack>
         get() {
-            val switchLines = childTexts(By.cssSelector("dt.switch-joint-infobox__joint-alignments-title"))
-            val switchTracks = childTexts(By.cssSelector("dd.switch-joint-infobox__location-tracks div span"))
-            return switchLines.mapIndexed { index, line -> SwitchLineAndTrack(line, switchTracks[index]) }
+            val switchLines =
+                childTexts(By.cssSelector("dt.switch-joint-infobox__joint-alignments-title"))
+            val switchTracks =
+                childTexts(By.cssSelector("dd.switch-joint-infobox__location-tracks div span"))
+            return switchLines.mapIndexed { index, line ->
+                SwitchLineAndTrack(line, switchTracks[index])
+            }
         }
 
     fun jointAlignment(line: String) = jointAlignments.first { it.switchLine == line }
-
 }
 
 class E2EGeometryAlignmentGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val name: String get() = getValueForField("geometry-alignment-name")
-    val trackNumber: String get() = getValueForField("geometry-alignment-track-number")
+    val name: String
+        get() = getValueForField("geometry-alignment-name")
+
+    val trackNumber: String
+        get() = getValueForField("geometry-alignment-track-number")
+
     fun zoomTo() = apply {
         logger.info("Zoom to geometry alignment")
 
-        clickButton(byQaId("zoom-to-geometry-alignment")).also { E2ETrackLayoutPage.finishLoading() }
+        clickButton(byQaId("zoom-to-geometry-alignment")).also {
+            E2ETrackLayoutPage.finishLoading()
+        }
     }
 }
 
@@ -256,22 +354,19 @@ abstract class E2ELinkingInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
     abstract fun link(): E2ELinkingInfoBox
 
     abstract fun linkTo(name: String): E2ELinkingInfoBox
-
 }
 
 class E2EGeometryKmPostLinkingInfoBox(infoboxBy: By) : E2ELinkingInfoBox(infoboxBy) {
     override val linked: String
-        get() = childText(
-            ByChained(byQaId("geometry-km-post-linked"), By.className("infobox__field-value"))
-        )
+        get() =
+            childText(
+                ByChained(byQaId("geometry-km-post-linked"), By.className("infobox__field-value")))
 
     override fun linkTo(name: String): E2EGeometryKmPostLinkingInfoBox = apply {
         logger.info("Link km post to $name")
         clickChild(
             By.xpath(
-                "//li[@class='geometry-km-post-linking-infobox__layout-km-post' and //span[text() = '$name']]"
-            )
-        )
+                "//li[@class='geometry-km-post-linking-infobox__layout-km-post' and //span[text() = '$name']]"))
     }
 
     fun createNewTrackLayoutKmPost(): E2EKmPostEditDialog {
@@ -282,9 +377,8 @@ class E2EGeometryKmPostLinkingInfoBox(infoboxBy: By) : E2ELinkingInfoBox(infobox
     }
 
     val trackLayoutKmPosts: List<String>
-        get() = childTexts(
-            By.xpath(".//li[@class='geometry-km-post-linking-infobox__layout-km-post']")
-        )
+        get() =
+            childTexts(By.xpath(".//li[@class='geometry-km-post-linking-infobox__layout-km-post']"))
 
     override fun initiateLinking(): E2ELinkingInfoBox = apply {
         logger.info("Initiate linking")
@@ -301,7 +395,9 @@ class E2EGeometryKmPostLinkingInfoBox(infoboxBy: By) : E2ELinkingInfoBox(infobox
 
 class E2EGeometryAlignmentLinkingInfoBox(infoboxBy: By) : E2ELinkingInfoBox(infoboxBy) {
 
-    private val alignmentTypeRadio: E2ERadio by lazy { childRadio(By.className("geometry-alignment-infobox__radio-buttons")) }
+    private val alignmentTypeRadio: E2ERadio by lazy {
+        childRadio(By.className("geometry-alignment-infobox__radio-buttons"))
+    }
 
     fun selectLocationTrackLinking() {
         logger.info("Select location track linking")
@@ -316,20 +412,23 @@ class E2EGeometryAlignmentLinkingInfoBox(infoboxBy: By) : E2ELinkingInfoBox(info
     }
 
     override val linked: String
-        get() = childText(
-            ByChained(byQaId("geometry-alignment-linked"), By.className("infobox__field-value"))
-        )
+        get() =
+            childText(
+                ByChained(
+                    byQaId("geometry-alignment-linked"), By.className("infobox__field-value")))
 
     val linkedReferenceLines: List<String>
-        get() = childTexts(
-            ByChained(byQaId("geometry-alignment-linked-reference-lines"), By.className("alignment-badge"))
-        )
+        get() =
+            childTexts(
+                ByChained(
+                    byQaId("geometry-alignment-linked-reference-lines"),
+                    By.className("alignment-badge")))
 
     override fun linkTo(name: String): E2EGeometryAlignmentLinkingInfoBox = apply {
         logger.info("Link alignment to $name")
         clickChild(
-            By.xpath("//li[@class='geometry-alignment-infobox__alignment' and div/span[text() = '$name']]")
-        )
+            By.xpath(
+                "//li[@class='geometry-alignment-infobox__alignment' and div/span[text() = '$name']]"))
     }
 
     override fun initiateLinking(): E2ELinkingInfoBox = apply {
@@ -358,23 +457,25 @@ class E2EGeometryAlignmentLinkingInfoBox(infoboxBy: By) : E2ELinkingInfoBox(info
 }
 
 class E2EGeometrySwitchGeneralInfoBox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
-    val name: String get() = getValueForField("geometry-switch-name")
-    val hand: String get() = getValueForField("geometry-switch-hand")
+    val name: String
+        get() = getValueForField("geometry-switch-name")
+
+    val hand: String
+        get() = getValueForField("geometry-switch-hand")
 
     fun zoomTo(): E2EGeometrySwitchGeneralInfoBox = apply {
         logger.info("Zoom to geometry switch")
 
         clickButton(byQaId("zoom-to-geometry-switch")).also { E2ETrackLayoutPage.finishLoading() }
     }
-
 }
 
 class E2EGeometrySwitchLinkingInfoBox(infoboxBy: By) : E2ELinkingInfoBox(infoboxBy) {
 
     override val linked: String
-        get() = childText(
-            ByChained(byQaId("geometry-switch-linked"), By.className("infobox__field-value"))
-        )
+        get() =
+            childText(
+                ByChained(byQaId("geometry-switch-linked"), By.className("infobox__field-value")))
 
     fun createNewTrackLayoutSwitch(): E2ELayoutSwitchEditDialog {
         logger.info("Create new layout switch")
@@ -387,8 +488,7 @@ class E2EGeometrySwitchLinkingInfoBox(infoboxBy: By) : E2ELinkingInfoBox(infobox
         logger.info("Link switch to $name")
 
         clickChild(
-            By.xpath("//li[@class='geometry-switch-infobox__switch' and //span[text() = '$name']]")
-        )
+            By.xpath("//li[@class='geometry-switch-infobox__switch' and //span[text() = '$name']]"))
     }
 
     override fun initiateLinking(): E2ELinkingInfoBox = apply {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/TrackLayoutPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/TrackLayoutPage.kt
@@ -9,20 +9,17 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EDialog
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EDialogWithTextField
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EDropdown
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
-import fi.fta.geoviite.infra.ui.pagemodel.common.waitAndClearToast
 import fi.fta.geoviite.infra.ui.util.byQaId
-import getElement
 import getElementIfExists
 import getElementWhenExists
+import java.time.Instant
 import javaScriptExecutor
+import kotlin.math.roundToInt
 import org.openqa.selenium.By
 import org.openqa.selenium.interactions.Actions
-import org.xmlunit.diff.ElementSelectors.byXPath
 import tryWait
 import waitUntilExists
 import waitUntilNotExist
-import java.time.Instant
-import kotlin.math.roundToInt
 
 class E2ETrackLayoutPage : E2EViewFragment(byQaId("track-layout-content")) {
 
@@ -61,7 +58,9 @@ class E2ETrackLayoutPage : E2EViewFragment(byQaId("track-layout-content")) {
     val toolPanel: E2EToolPanel by lazy { E2EToolPanel(this) }
     val selectionPanel: E2ESelectionPanel by lazy { E2ESelectionPanel(this) }
     val toolBar: E2EToolBar by lazy { E2EToolBar(this) }
-    val verticalGeometryDiagram: E2EVerticalGeometryDiagram by lazy { E2EVerticalGeometryDiagram(this) }
+    val verticalGeometryDiagram: E2EVerticalGeometryDiagram by lazy {
+        E2EVerticalGeometryDiagram(this)
+    }
 
     private val resolution: Double
         get() = childElement(By.className("map__ol-map")).getAttribute("qa-resolution").toDouble()
@@ -70,11 +69,13 @@ class E2ETrackLayoutPage : E2EViewFragment(byQaId("track-layout-content")) {
     val switchToDesignModeButton = getElementIfExists(byQaId("design-mode-tab"))
 
     val mapScale: MapScale
-        get() = tryWait({
-            val scale = childText(By.className("ol-scale-line-inner"))
-            MapScale.entries.firstOrNull { it.value == scale }
-        }) { "Invalid map scale" }
-
+        get() =
+            tryWait({
+                val scale = childText(By.className("ol-scale-line-inner"))
+                MapScale.entries.firstOrNull { it.value == scale }
+            }) {
+                "Invalid map scale"
+            }
 
     companion object {
         fun finishLoading() {
@@ -95,22 +96,37 @@ class E2ETrackLayoutPage : E2EViewFragment(byQaId("track-layout-content")) {
         clickAtCoordinates(point.x, point.y, doubleClick)
     }
 
-    fun clickAtCoordinates(point: AlignmentPoint, doubleClick: Boolean = false): E2ETrackLayoutPage = apply {
+    fun clickAtCoordinates(
+        point: AlignmentPoint,
+        doubleClick: Boolean = false
+    ): E2ETrackLayoutPage = apply {
         finishLoading()
         clickAtCoordinates(point.x, point.y, doubleClick)
     }
 
-    fun clickAtCoordinates(xPoint: Double, yPoint: Double, doubleClick: Boolean = false): E2ETrackLayoutPage = apply {
+    fun clickAtCoordinates(
+        xPoint: Double,
+        yPoint: Double,
+        doubleClick: Boolean = false
+    ): E2ETrackLayoutPage = apply {
         finishLoading()
         val pxlCoordinates =
-            javaScriptExecutor().executeScript("return map.getPixelFromCoordinate([$xPoint,$yPoint])").toString()
-                .replace("[^0-9.,]".toRegex(), "").split(",").map { doubleStr -> doubleStr.toDouble().roundToInt() }
+            javaScriptExecutor()
+                .executeScript("return map.getPixelFromCoordinate([$xPoint,$yPoint])")
+                .toString()
+                .replace("[^0-9.,]".toRegex(), "")
+                .split(",")
+                .map { doubleStr -> doubleStr.toDouble().roundToInt() }
 
         logger.info("Map coordinates ($xPoint,$yPoint) are at $pxlCoordinates")
         clickAtCoordinates(pixelX = pxlCoordinates[0], pixelY = pxlCoordinates[1], doubleClick)
     }
 
-    fun clickAtCoordinates(pixelX: Int, pixelY: Int, doubleClick: Boolean = false): E2ETrackLayoutPage = apply {
+    fun clickAtCoordinates(
+        pixelX: Int,
+        pixelY: Int,
+        doubleClick: Boolean = false
+    ): E2ETrackLayoutPage = apply {
         finishLoading()
         logger.info("Click map at ($pixelX,$pixelY)")
         val canvas = childElement(By.cssSelector("div.map"))
@@ -162,8 +178,8 @@ class E2ETrackLayoutPage : E2EViewFragment(byQaId("track-layout-content")) {
             .selectInput(byQaId("workspace-dialog-date"))
             .also {
                 getElementWhenExists(
-                    By.xpath("//*[contains(@class, 'react-datepicker__day--001')]")
-                ).click()
+                        By.xpath("//*[contains(@class, 'react-datepicker__day--001')]"))
+                    .click()
             }
             .clickPrimaryButton()
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/VerticalGeometryDiagram.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/VerticalGeometryDiagram.kt
@@ -9,6 +9,7 @@ class E2EVerticalGeometryDiagram(parentView: E2EViewFragment) :
     E2EViewFragment(parentView, By.className("vertical-geometry-diagram-holder")) {
 
     fun waitForContent() { // will throw if no content
-        waitUntilChildExists(ByChained(byQaId("vertical-geometry-diagram-proper"), By.tagName("line")))
+        waitUntilChildExists(
+            ByChained(byQaId("vertical-geometry-diagram-proper"), By.tagName("line")))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -69,15 +69,16 @@ fun createGeometryKmPost(
     location: Point?,
     kmNumber: String,
     staInternal: BigDecimal = BigDecimal("-148.729000"),
-) = GeometryKmPost(
-    staBack = null,
-    staAhead = BigDecimal("-148.729000"),
-    staInternal = staInternal,
-    kmNumber = KmNumber(kmNumber),
-    description = PlanElementName("0"),
-    state = PlanState.PROPOSED,
-    location = location,
-)
+) =
+    GeometryKmPost(
+        staBack = null,
+        staAhead = BigDecimal("-148.729000"),
+        staInternal = staInternal,
+        kmNumber = KmNumber(kmNumber),
+        description = PlanElementName("0"),
+        state = PlanState.PROPOSED,
+        location = location,
+    )
 
 fun createGeometryAlignment(
     alignmentName: String,
@@ -88,8 +89,7 @@ fun createGeometryAlignment(
     val points = pointsFromIncrementList(basePoint, incrementPoints)
 
     return createGeometryAlignment(
-        alignmentName = alignmentName, locationPoints = points, switchData = switchData
-    )
+        alignmentName = alignmentName, locationPoints = points, switchData = switchData)
 }
 
 fun createGeometryAlignment(
@@ -99,12 +99,20 @@ fun createGeometryAlignment(
     switchData: List<SwitchData?> = emptyList(),
 ): GeometryAlignment {
     val staStart = BigDecimal("543.333470")
-    val elements = locationPoints.dropLast(1).mapIndexed { index, pointA ->
-        val elementSwitchData: SwitchData? = switchData.getOrNull(index)
-        val pointB = locationPoints[index + 1]
-        val length = calculateDistance(listOf(pointA, pointB), LAYOUT_SRID).toBigDecimal()
-        geometryLine("$elementNamePrefix-$index", "$index", pointA, pointB, staStart, length, elementSwitchData)
-    }
+    val elements =
+        locationPoints.dropLast(1).mapIndexed { index, pointA ->
+            val elementSwitchData: SwitchData? = switchData.getOrNull(index)
+            val pointB = locationPoints[index + 1]
+            val length = calculateDistance(listOf(pointA, pointB), LAYOUT_SRID).toBigDecimal()
+            geometryLine(
+                "$elementNamePrefix-$index",
+                "$index",
+                pointA,
+                pointB,
+                staStart,
+                length,
+                elementSwitchData)
+        }
 
     return GeometryAlignment(
         name = AlignmentName(alignmentName),
@@ -128,15 +136,16 @@ fun locationTrack(
     draft: Boolean = false,
 ): Pair<LocationTrack, LayoutAlignment> {
     val alignment = alignmentFromPointIncrementList(basePoint, incrementPoints)
-    val track = locationTrack(
-        trackNumberId = trackNumber,
-        alignment = alignment,
-        name = "lt-$name",
-        description = description,
-        type = layoutAlignmentType,
-        state = LocationTrackState.IN_USE,
-        draft = draft,
-    )
+    val track =
+        locationTrack(
+            trackNumberId = trackNumber,
+            alignment = alignment,
+            name = "lt-$name",
+            description = description,
+            type = layoutAlignmentType,
+            state = LocationTrackState.IN_USE,
+            draft = draft,
+        )
     return track to alignment
 }
 
@@ -147,54 +156,66 @@ fun referenceLine(
     draft: Boolean,
 ): Pair<ReferenceLine, LayoutAlignment> {
     val alignment = alignmentFromPointIncrementList(basePoint, incrementPoints)
-    val line = referenceLine(
-        trackNumberId = trackNumber,
-        alignment = alignment,
-        draft = draft,
-    )
+    val line =
+        referenceLine(
+            trackNumberId = trackNumber,
+            alignment = alignment,
+            draft = draft,
+        )
     return line to alignment
 }
 
-private fun alignmentFromPointIncrementList(basePoint: Point, incrementPoints: List<Point>): LayoutAlignment {
+private fun alignmentFromPointIncrementList(
+    basePoint: Point,
+    incrementPoints: List<Point>
+): LayoutAlignment {
     val points = pointsFromIncrementList(basePoint, incrementPoints)
 
     var startM = 0.0
-    val segments = points.dropLast(1).mapIndexed { index, pointA ->
-        val pointB = points[index + 1]
-        segment(points = toSegmentPoints(pointA, pointB), startM = startM).also { s -> startM += s.length }
-    }
+    val segments =
+        points.dropLast(1).mapIndexed { index, pointA ->
+            val pointB = points[index + 1]
+            segment(points = toSegmentPoints(pointA, pointB), startM = startM).also { s ->
+                startM += s.length
+            }
+        }
     return alignment(segments)
 }
 
-fun trackLayoutSwitch(name: String, jointPoints: List<Point>, switchStructure: SwitchStructure) = TrackLayoutSwitch(
-    externalId = null,
-    sourceId = null,
-    name = SwitchName(name),
-    stateCategory = LayoutStateCategory.EXISTING,
-    switchStructureId = switchStructure.id as IntId,
-    joints = jointPoints.map { point -> switchJoint(point) },
-    trapPoint = false,
-    ownerId = switchOwnerVayla().id,
-    source = GeometrySource.GENERATED,
-    contextData = LayoutContextData.newOfficial(LayoutBranch.main),
-)
+fun trackLayoutSwitch(name: String, jointPoints: List<Point>, switchStructure: SwitchStructure) =
+    TrackLayoutSwitch(
+        externalId = null,
+        sourceId = null,
+        name = SwitchName(name),
+        stateCategory = LayoutStateCategory.EXISTING,
+        switchStructureId = switchStructure.id as IntId,
+        joints = jointPoints.map { point -> switchJoint(point) },
+        trapPoint = false,
+        ownerId = switchOwnerVayla().id,
+        source = GeometrySource.GENERATED,
+        contextData = LayoutContextData.newOfficial(LayoutBranch.main),
+    )
 
-fun switchJoint(location: Point) = TrackLayoutSwitchJoint(
-    number = JointNumber(1), location = location, locationAccuracy = getSomeNullableValue<LocationAccuracy>(1)
-)
+fun switchJoint(location: Point) =
+    TrackLayoutSwitchJoint(
+        number = JointNumber(1),
+        location = location,
+        locationAccuracy = getSomeNullableValue<LocationAccuracy>(1))
 
-fun tmi35GeometryUnit() = GeometryUnits(
-    coordinateSystemSrid = LAYOUT_SRID,
-    coordinateSystemName = null,
-    verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
-    directionUnit = AngularUnit.GRADS,
-    linearUnit = LinearUnit.METER,
-)
+fun tmi35GeometryUnit() =
+    GeometryUnits(
+        coordinateSystemSrid = LAYOUT_SRID,
+        coordinateSystemName = null,
+        verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
+        directionUnit = AngularUnit.GRADS,
+        linearUnit = LinearUnit.METER,
+    )
 
-fun createProject(name: String) = Project(
-    name = ProjectName(name),
-    description = FreeText("E2E test project"),
-)
+fun createProject(name: String) =
+    Project(
+        name = ProjectName(name),
+        description = FreeText("E2E test project"),
+    )
 
 fun pointsFromIncrementList(basePoint: Point, incrementPoints: List<Point>) =
     incrementPoints.scan(basePoint) { prevPoint, pointIncr -> prevPoint + pointIncr }
@@ -207,33 +228,37 @@ fun locationTrackAndAlignmentForGeometryAlignment(
     planSrid: Srid = LAYOUT_SRID,
     draft: Boolean,
 ): Pair<LocationTrack, LayoutAlignment> {
-    val transformation = Transformation.possiblyTriangulableTransform(
-        planSrid,
-        LAYOUT_SRID,
-        ykjToEtrsTriangulationNetwork,
-        etrsToYkjTriangulationNetwork,
-    )
+    val transformation =
+        Transformation.possiblyTriangulableTransform(
+            planSrid,
+            LAYOUT_SRID,
+            ykjToEtrsTriangulationNetwork,
+            etrsToYkjTriangulationNetwork,
+        )
     var startM = 0.0
-    val segments = geometryAlignment.elements.map { element ->
-        val start = transformation.transform(element.start)
-        val end = transformation.transform(element.end)
-        LayoutSegment(
-            geometry = SegmentGeometry(
-                segmentPoints = listOf(
-                    SegmentPoint(start.x, start.y, 0.0, 0.0, 0.0),
-                    SegmentPoint(end.x, end.y, 0.0, element.calculatedLength, 0.0)
-                ),
-                resolution = 100,
-            ),
-            startM = startM,
-            startJointNumber = null,
-            endJointNumber = null,
-            source = GeometrySource.PLAN,
-            sourceId = element.id,
-            sourceStart = null,
-            switchId = null,
-        ).also { startM += it.length }
-    }
+    val segments =
+        geometryAlignment.elements.map { element ->
+            val start = transformation.transform(element.start)
+            val end = transformation.transform(element.end)
+            LayoutSegment(
+                    geometry =
+                        SegmentGeometry(
+                            segmentPoints =
+                                listOf(
+                                    SegmentPoint(start.x, start.y, 0.0, 0.0, 0.0),
+                                    SegmentPoint(end.x, end.y, 0.0, element.calculatedLength, 0.0)),
+                            resolution = 100,
+                        ),
+                    startM = startM,
+                    startJointNumber = null,
+                    endJointNumber = null,
+                    source = GeometrySource.PLAN,
+                    sourceId = element.id,
+                    sourceStart = null,
+                    switchId = null,
+                )
+                .also { startM += it.length }
+        }
     return locationTrackAndAlignment(trackNumberId, segments, draft = draft)
 }
 
@@ -245,24 +270,28 @@ fun createSwitchAndAlignments(
 ): Pair<GeometrySwitch, List<GeometryAlignment>> {
     val jointNumbers = switchStructure.joints.map { switchJoint -> switchJoint.number }
     logger.info("Switch structure id ${switchStructure.id}")
-    val geometrySwitch = GeometrySwitch(name = SwitchName(switchName),
-        switchStructureId = switchStructure.id as IntId,
-        typeName = GeometrySwitchTypeName(switchStructure.type.typeName),
-        state = PlanState.EXISTING,
-        joints = jointNumbers.map { jointNumber ->
-            GeometrySwitchJoint(
-                jointNumber,
-                getTransformedPoint(switchStructure, switchOrig, switchAngle, jointNumber),
-            )
-        })
+    val geometrySwitch =
+        GeometrySwitch(
+            name = SwitchName(switchName),
+            switchStructureId = switchStructure.id as IntId,
+            typeName = GeometrySwitchTypeName(switchStructure.type.typeName),
+            state = PlanState.EXISTING,
+            joints =
+                jointNumbers.map { jointNumber ->
+                    GeometrySwitchJoint(
+                        jointNumber,
+                        getTransformedPoint(switchStructure, switchOrig, switchAngle, jointNumber),
+                    )
+                })
 
-    val geometryAlignments = switchStructureToGeometryAlignment(
-        switchName,
-        switchStructure,
-        switchAngle,
-        switchOrig,
-        geometrySwitch,
-    )
+    val geometryAlignments =
+        switchStructureToGeometryAlignment(
+            switchName,
+            switchStructure,
+            switchAngle,
+            switchOrig,
+            geometrySwitch,
+        )
     return Pair(geometrySwitch, geometryAlignments)
 }
 
@@ -281,13 +310,14 @@ fun switchStructureToGeometryAlignment(
             state = PlanState.PROPOSED,
             featureTypeCode = FeatureTypeCode("111"),
             staStart = BigDecimal("0.000000"),
-            elements = alignmentElementsFromSwitchAlignment(
-                switchAlignment,
-                switchAngle,
-                switchOrig,
-                geometrySwitch.id,
-                switchStructure.joints,
-            ),
+            elements =
+                alignmentElementsFromSwitchAlignment(
+                    switchAlignment,
+                    switchAngle,
+                    switchOrig,
+                    geometrySwitch.id,
+                    switchStructure.joints,
+                ),
             profile = null,
         )
     }
@@ -301,12 +331,13 @@ private fun alignmentElementsFromSwitchAlignment(
     switchJoints: List<SwitchJoint>,
 ): List<GeometryElement> {
     val switchJointsByNumber = switchJoints.associateBy { it.number }
-    val switchJointData = switchAlignment.jointNumbers.dropLast(1).mapIndexed { index, startJointNumber ->
-        val endJointNumber = switchAlignment.jointNumbers[index + 1]
-        val startSwitchJoint = switchJointsByNumber[startJointNumber]!!
-        val endSwitchJoint = switchJointsByNumber[endJointNumber]!!
-        SwitchJointData(switchId, startSwitchJoint, endSwitchJoint)
-    }
+    val switchJointData =
+        switchAlignment.jointNumbers.dropLast(1).mapIndexed { index, startJointNumber ->
+            val endJointNumber = switchAlignment.jointNumbers[index + 1]
+            val startSwitchJoint = switchJointsByNumber[startJointNumber]!!
+            val endSwitchJoint = switchJointsByNumber[endJointNumber]!!
+            SwitchJointData(switchId, startSwitchJoint, endSwitchJoint)
+        }
 
     return switchAlignment.elements.mapIndexed { index, switchElement ->
         geometryLine(
@@ -314,10 +345,11 @@ private fun alignmentElementsFromSwitchAlignment(
             oidPart = "$index",
             start = rotateAroundOrigin(switchAngle, switchElement.start) + switchOrig,
             end = rotateAroundOrigin(switchAngle, switchElement.end) + switchOrig,
-            length = calculateDistance(listOf(switchElement.start, switchElement.end), LAYOUT_SRID).toBigDecimal(),
+            length =
+                calculateDistance(listOf(switchElement.start, switchElement.end), LAYOUT_SRID)
+                    .toBigDecimal(),
             staStart = BigDecimal("543.333470"),
-            elementSwitchData = matchSwitchDataToElement(switchElement, switchJointData, switchId)
-        )
+            elementSwitchData = matchSwitchDataToElement(switchElement, switchJointData, switchId))
     }
 }
 
@@ -331,7 +363,8 @@ private fun matchSwitchDataToElement(
             .first { data -> data.isInsideSwitchJoint(switchElement) }
             .let { SwitchData(switchId, it.startSwitchJoint.number, it.endSwitchJoint.number) }
     } catch (ex: java.util.NoSuchElementException) {
-        throw RuntimeException("Could not match switch element (${switchElement.start}, ${switchElement.end})")
+        throw RuntimeException(
+            "Could not match switch element (${switchElement.start}, ${switchElement.end})")
     }
 }
 
@@ -352,9 +385,14 @@ data class SwitchJointData(
     val endSwitchJoint: SwitchJoint,
 ) {
     fun isInsideSwitchJoint(switchElement: SwitchElement): Boolean {
-        logger.info("Matching switch element (${switchElement.start},${switchElement.end}) to ${startSwitchJoint.number}-${endSwitchJoint.number}")
-        val startDistance = pointDistanceToLine(startSwitchJoint.location, endSwitchJoint.location, switchElement.start)
-        val endDistance = pointDistanceToLine(startSwitchJoint.location, endSwitchJoint.location, switchElement.end)
+        logger.info(
+            "Matching switch element (${switchElement.start},${switchElement.end}) to ${startSwitchJoint.number}-${endSwitchJoint.number}")
+        val startDistance =
+            pointDistanceToLine(
+                startSwitchJoint.location, endSwitchJoint.location, switchElement.start)
+        val endDistance =
+            pointDistanceToLine(
+                startSwitchJoint.location, endSwitchJoint.location, switchElement.end)
         logger.info("start distance $startDistance, end distance $endDistance")
         return startDistance <= 0.5 && endDistance <= 2
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
@@ -55,9 +55,11 @@ class HelsinkiTestData private constructor() {
         }
 
         fun westGeometryAlignment(): GeometryAlignment {
-            val point1 = Point(x = HKI_BASE_POINT_X + 680.00, y = HKI_BASE_POINT_Y + 410.00) //etelä
+            val point1 =
+                Point(x = HKI_BASE_POINT_X + 680.00, y = HKI_BASE_POINT_Y + 410.00) // etelä
             val point2 = Point(x = HKI_BASE_POINT_X + 695.00, y = HKI_BASE_POINT_Y + 500.00)
-            val point3 = Point(x = HKI_BASE_POINT_X + 700.00, y = HKI_BASE_POINT_Y + 560.00) //pohjoinen
+            val point3 =
+                Point(x = HKI_BASE_POINT_X + 700.00, y = HKI_BASE_POINT_Y + 560.00) // pohjoinen
 
             val staStart = BigDecimal("543.333470")
             val length1 = calculateDistance(listOf(point1, point2), LAYOUT_SRID).toBigDecimal()
@@ -70,10 +72,10 @@ class HelsinkiTestData private constructor() {
                 state = PlanState.PROPOSED,
                 featureTypeCode = FeatureTypeCode("111"),
                 staStart = BigDecimal("0.000000"),
-                elements = listOf(
-                    geometryLine("south", "1", point1, point2, staStart, length1),
-                    geometryLine("north", "2", point2, point3, staStart, length2)
-                ),
+                elements =
+                    listOf(
+                        geometryLine("south", "1", point1, point2, staStart, length1),
+                        geometryLine("north", "2", point2, point3, staStart, length2)),
                 profile = null,
             )
         }
@@ -91,12 +93,17 @@ class HelsinkiTestData private constructor() {
             )
         }
 
-        fun westReferenceLine(trackNumber: IntId<TrackLayoutTrackNumber>, draft: Boolean = false): Pair<ReferenceLine, LayoutAlignment> {
-            val points = toSegmentPoints(
-                Point(x = HKI_BASE_POINT_X + 670.00, y = HKI_BASE_POINT_Y + 410.00), //etelä
-                Point(x = HKI_BASE_POINT_X + 685.00, y = HKI_BASE_POINT_Y + 500.00),
-                Point(x = HKI_BASE_POINT_X + 690.00, y = HKI_BASE_POINT_Y + 560.00), //pohjoinen
-            )
+        fun westReferenceLine(
+            trackNumber: IntId<TrackLayoutTrackNumber>,
+            draft: Boolean = false
+        ): Pair<ReferenceLine, LayoutAlignment> {
+            val points =
+                toSegmentPoints(
+                    Point(x = HKI_BASE_POINT_X + 670.00, y = HKI_BASE_POINT_Y + 410.00), // etelä
+                    Point(x = HKI_BASE_POINT_X + 685.00, y = HKI_BASE_POINT_Y + 500.00),
+                    Point(
+                        x = HKI_BASE_POINT_X + 690.00, y = HKI_BASE_POINT_Y + 560.00), // pohjoinen
+                )
             val alignment = alignment(segment(points))
             return referenceLine(
                 alignment = alignment,
@@ -106,12 +113,16 @@ class HelsinkiTestData private constructor() {
             ) to alignment
         }
 
-        fun eastReferenceLine(trackNumber: IntId<TrackLayoutTrackNumber>): Pair<ReferenceLine, LayoutAlignment> {
-            val points = toSegmentPoints(
-                Point(x = HKI_BASE_POINT_X + 675.00, y = HKI_BASE_POINT_Y + 410.00), //etelä
-                Point(x = HKI_BASE_POINT_X + 690.00, y = HKI_BASE_POINT_Y + 500.00),
-                Point(x = HKI_BASE_POINT_X + 695.00, y = HKI_BASE_POINT_Y + 560.00), //pohjoinen
-            )
+        fun eastReferenceLine(
+            trackNumber: IntId<TrackLayoutTrackNumber>
+        ): Pair<ReferenceLine, LayoutAlignment> {
+            val points =
+                toSegmentPoints(
+                    Point(x = HKI_BASE_POINT_X + 675.00, y = HKI_BASE_POINT_Y + 410.00), // etelä
+                    Point(x = HKI_BASE_POINT_X + 690.00, y = HKI_BASE_POINT_Y + 500.00),
+                    Point(
+                        x = HKI_BASE_POINT_X + 695.00, y = HKI_BASE_POINT_Y + 560.00), // pohjoinen
+                )
             val alignment = alignment(segment(points))
             return referenceLine(
                 alignment = alignment,
@@ -121,7 +132,9 @@ class HelsinkiTestData private constructor() {
             ) to alignment
         }
 
-        fun eastLocationTrack(trackNumberId: IntId<TrackLayoutTrackNumber>): Pair<LocationTrack, LayoutAlignment> {
+        fun eastLocationTrack(
+            trackNumberId: IntId<TrackLayoutTrackNumber>
+        ): Pair<LocationTrack, LayoutAlignment> {
             return locationTrack(
                 name = "east",
                 trackNumber = trackNumberId,
@@ -131,27 +144,55 @@ class HelsinkiTestData private constructor() {
             )
         }
 
-        fun westTrackLayoutKmPosts(trackNumberId: IntId<TrackLayoutTrackNumber>): List<TrackLayoutKmPost> {
+        fun westTrackLayoutKmPosts(
+            trackNumberId: IntId<TrackLayoutTrackNumber>
+        ): List<TrackLayoutKmPost> {
             val point1 = HKI_BASE_POINT + Point(x = 690.00, y = 410.00)
             val point2 = HKI_BASE_POINT + Point(x = 690.00, y = 485.00)
             val point3 = HKI_BASE_POINT + Point(x = 690.00, y = 560.00)
 
             return arrayListOf(
-                kmPost(trackNumberId = trackNumberId, km = KmNumber("0001we"), roughLayoutLocation = point1, draft = false),
-                kmPost(trackNumberId = trackNumberId, km = KmNumber("0002we"), roughLayoutLocation = point2, draft = false),
-                kmPost(trackNumberId = trackNumberId, km = KmNumber("0003we"), roughLayoutLocation = point3, draft = false),
+                kmPost(
+                    trackNumberId = trackNumberId,
+                    km = KmNumber("0001we"),
+                    roughLayoutLocation = point1,
+                    draft = false),
+                kmPost(
+                    trackNumberId = trackNumberId,
+                    km = KmNumber("0002we"),
+                    roughLayoutLocation = point2,
+                    draft = false),
+                kmPost(
+                    trackNumberId = trackNumberId,
+                    km = KmNumber("0003we"),
+                    roughLayoutLocation = point3,
+                    draft = false),
             )
         }
 
-        fun eastTrackLayoutKmPosts(trackNumberId: IntId<TrackLayoutTrackNumber>): List<TrackLayoutKmPost> {
+        fun eastTrackLayoutKmPosts(
+            trackNumberId: IntId<TrackLayoutTrackNumber>
+        ): List<TrackLayoutKmPost> {
             val point1 = HKI_BASE_POINT + Point(x = 752.00, y = 410.00)
             val point2 = HKI_BASE_POINT + Point(x = 752.00, y = 485.00)
             val point3 = HKI_BASE_POINT + Point(x = 752.00, y = 560.00)
 
             return arrayListOf(
-                kmPost(trackNumberId = trackNumberId, km = KmNumber("0001es"), roughLayoutLocation = point1, draft = false),
-                kmPost(trackNumberId = trackNumberId, km = KmNumber("0002es"), roughLayoutLocation = point2, draft = false),
-                kmPost(trackNumberId = trackNumberId, km = KmNumber("0003es"), roughLayoutLocation = point3, draft = false),
+                kmPost(
+                    trackNumberId = trackNumberId,
+                    km = KmNumber("0001es"),
+                    roughLayoutLocation = point1,
+                    draft = false),
+                kmPost(
+                    trackNumberId = trackNumberId,
+                    km = KmNumber("0002es"),
+                    roughLayoutLocation = point2,
+                    draft = false),
+                kmPost(
+                    trackNumberId = trackNumberId,
+                    km = KmNumber("0003es"),
+                    roughLayoutLocation = point3,
+                    draft = false),
             )
         }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
@@ -41,7 +41,9 @@ import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
-class BasicMapTestUI @Autowired constructor(
+class BasicMapTestUI
+@Autowired
+constructor(
     private val switchDao: LayoutSwitchDao,
     private val geometryDao: GeometryDao,
     private val trackNumberDao: LayoutTrackNumberDao,
@@ -59,7 +61,8 @@ class BasicMapTestUI @Autowired constructor(
     fun createTestData() {
         testDBService.clearAllTables()
 
-        // TODO: GVT-1945  Don't use shared test data - init the data in the test as is needed, so it's clear what is expected
+        // TODO: GVT-1945  Don't use shared test data - init the data in the test as is needed, so
+        // it's clear what is expected
         TRACK_NUMBER_WEST = trackNumber(HKI_TRACK_NUMBER_1, draft = false)
         val trackNumberEast = trackNumber(HKI_TRACK_NUMBER_2, draft = false)
         val trackNumberWestId = trackNumberDao.insert(TRACK_NUMBER_WEST)
@@ -83,9 +86,9 @@ class BasicMapTestUI @Autowired constructor(
         switchDao.insert(westTrackLayoutSwitch())
         switchDao.insert(EAST_LAYOUT_SWITCH)
 
-        GEOMETRY_PLAN = geometryDao.fetchPlan(
-            (geometryDao.insertPlan(geometryPlan(TRACK_NUMBER_WEST.number), testFile(), null))
-        )
+        GEOMETRY_PLAN =
+            geometryDao.fetchPlan(
+                (geometryDao.insertPlan(geometryPlan(TRACK_NUMBER_WEST.number), testFile(), null)))
 
         startGeoviite()
     }
@@ -142,7 +145,8 @@ class BasicMapTestUI @Autowired constructor(
         assertNotEquals("R36240 kuvaus", locationTrackInfobox.description)
 
         assertNotEquals(E2ELocationTrackEditDialog.Type.SIDE.name, locationTrackInfobox.type)
-        assertNotEquals(E2ELocationTrackEditDialog.State.NOT_IN_USE.name, locationTrackInfobox.state)
+        assertNotEquals(
+            E2ELocationTrackEditDialog.State.NOT_IN_USE.name, locationTrackInfobox.state)
     }
 
     @Test
@@ -159,10 +163,7 @@ class BasicMapTestUI @Autowired constructor(
         selectionPanel.selectLocationTrack(locationTrackToBeEdited)
         val editDialog = locationTrackInfobox.edit()
 
-        editDialog
-            .setName("R36240")
-            .setDescription("R36240 kuvaus")
-            .save()
+        editDialog.setName("R36240").setDescription("R36240 kuvaus").save()
 
         waitAndClearToast("location-track-dialog.modified-successfully")
 
@@ -181,7 +182,7 @@ class BasicMapTestUI @Autowired constructor(
         assertEquals("Sijaintiraide R36240", changedAlignment.name)
 
         previewChangesPage.stageChange("Sijaintiraide R36240").publish()
-        //selectionPanel.selectLocationTrack("R36240")
+        // selectionPanel.selectLocationTrack("R36240")
 
         assertEquals("R36240", locationTrackInfobox.name)
         locationTrackInfobox.waitUntilDescriptionChanges("R36240 kuvaus")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -25,17 +25,19 @@ import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.frontpage.E2EFrontPage
+import java.time.Instant
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
-class FrontPageTestUI @Autowired constructor(
+class FrontPageTestUI
+@Autowired
+constructor(
     private val trackNumberDao: LayoutTrackNumberDao,
     private val referenceLineDao: ReferenceLineDao,
     private val alignmentDao: LayoutAlignmentDao,
@@ -51,32 +53,39 @@ class FrontPageTestUI @Autowired constructor(
 
     @Test
     fun `Retry failed publication`() {
-        val originalTrackNumber = trackNumberDao.insert(
-            trackNumber(TrackNumber("original name"), externalId = Oid("1.2.3.4.5"), draft = false)
-        )
+        val originalTrackNumber =
+            trackNumberDao.insert(
+                trackNumber(
+                    TrackNumber("original name"), externalId = Oid("1.2.3.4.5"), draft = false))
         val trackNumberId = originalTrackNumber.id
-        val alignmentVersion = alignmentDao.insert(
-            alignment(segment(toSegmentPoints(Point(0.0, 0.0), Point(10.0, 0.0))))
-        )
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = alignmentVersion, draft = false))
+        val alignmentVersion =
+            alignmentDao.insert(
+                alignment(segment(toSegmentPoints(Point(0.0, 0.0), Point(10.0, 0.0)))))
+        referenceLineDao.insert(
+            referenceLine(trackNumberId, alignmentVersion = alignmentVersion, draft = false))
 
-        val successfulPublicationId = publicationDao.createPublication(LayoutBranch.main, "successful")
-        publicationDao.insertCalculatedChanges(successfulPublicationId, changesTouchingTrackNumber(trackNumberId))
+        val successfulPublicationId =
+            publicationDao.createPublication(LayoutBranch.main, "successful")
+        publicationDao.insertCalculatedChanges(
+            successfulPublicationId, changesTouchingTrackNumber(trackNumberId))
 
         trackNumberDao
             .fetch(originalTrackNumber.rowVersion)
             .copy(number = TrackNumber("updated name"))
             .let(trackNumberDao::update)
 
-        val failingPublicationId = publicationDao.createPublication(LayoutBranch.main, "failing test publication")
-        publicationDao.insertCalculatedChanges(failingPublicationId, changesTouchingTrackNumber(trackNumberId))
+        val failingPublicationId =
+            publicationDao.createPublication(LayoutBranch.main, "failing test publication")
+        publicationDao.insertCalculatedChanges(
+            failingPublicationId, changesTouchingTrackNumber(trackNumberId))
 
         val failedRatkoPushId = ratkoPushDao.startPushing(listOf(failingPublicationId))
         ratkoPushDao.updatePushStatus(failedRatkoPushId, RatkoPushStatus.FAILED)
 
         startGeoviite()
 
-        // two publications; an original one that succeeded (with the original name), then a new one above it that
+        // two publications; an original one that succeeded (with the original name), then a new one
+        // above it that
         // failed
         E2EFrontPage()
             .openNthPublication(2)
@@ -97,10 +106,13 @@ class FrontPageTestUI @Autowired constructor(
 
         E2EFrontPage().pushToRatko()
 
-        // the publication list will only update with the changeTimes mechanism, which can take up to 15 seconds,
-        // so we're not going to bother checking that; we'll just poll Ratko to see that the change went through instead
+        // the publication list will only update with the changeTimes mechanism, which can take up
+        // to 15 seconds,
+        // so we're not going to bother checking that; we'll just poll Ratko to see that the change
+        // went through instead
         val maxWaitUntil = Instant.now().plusSeconds(2)
-        while (Instant.now().isBefore(maxWaitUntil) && fakeRatko.getPushedRouteNumber(Oid("1.2.3.4.5")).isEmpty()) {
+        while (Instant.now().isBefore(maxWaitUntil) &&
+            fakeRatko.getPushedRouteNumber(Oid("1.2.3.4.5")).isEmpty()) {
             Thread.sleep(100)
         }
         assertEquals("updated name", fakeRatko.getPushedRouteNumber(Oid("1.2.3.4.5"))[0].name)
@@ -108,17 +120,19 @@ class FrontPageTestUI @Autowired constructor(
         fakeRatko.stop()
     }
 
-    private fun changesTouchingTrackNumber(trackNumberId: IntId<TrackLayoutTrackNumber>): CalculatedChanges =
+    private fun changesTouchingTrackNumber(
+        trackNumberId: IntId<TrackLayoutTrackNumber>
+    ): CalculatedChanges =
         CalculatedChanges(
             DirectChanges(
-                trackNumberChanges = listOf(
-                    TrackNumberChange(
-                        trackNumberId,
-                        changedKmNumbers = setOf(),
-                        isStartChanged = false,
-                        isEndChanged = false,
-                    )
-                ),
+                trackNumberChanges =
+                    listOf(
+                        TrackNumberChange(
+                            trackNumberId,
+                            changedKmNumbers = setOf(),
+                            isStartChanged = false,
+                            isEndChanged = false,
+                        )),
                 kmPostChanges = listOf(),
                 switchChanges = listOf(),
                 locationTrackChanges = listOf(),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/InfraModelTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/InfraModelTestUI.kt
@@ -4,6 +4,10 @@ import fi.fta.geoviite.infra.ui.E2EProperties
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.common.waitAndClearToast
 import fi.fta.geoviite.infra.ui.pagemodel.inframodel.E2EInfraModelPage
+import java.io.File
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -12,20 +16,19 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.io.File
-import java.time.LocalDateTime
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test", "e2e")
 @EnableAutoConfiguration
 @EnableConfigurationProperties(E2EProperties::class)
 @SpringBootTest
-class InfraModelTestUI @Autowired constructor(
+class InfraModelTestUI
+@Autowired
+constructor(
     val properties: E2EProperties,
 ) : SeleniumTest() {
     val TESTFILE_SIMPLE_PATH: String = "src/test/resources/inframodel/testfile_simple.xml"
-    val TESTFILE_CLOTHOID_AND_PARABOLA_PATH: String = "src/test/resources/inframodel/testfile_clothoid_and_parabola.xml"
+    val TESTFILE_CLOTHOID_AND_PARABOLA_PATH: String =
+        "src/test/resources/inframodel/testfile_clothoid_and_parabola.xml"
     val TESTFILE_CLOTHOID_AND_PARABOLA_2_PATH: String =
         "src/test/resources/inframodel/testfile_clothoid_and_parabola_2.xml"
 
@@ -79,21 +82,23 @@ class InfraModelTestUI @Autowired constructor(
         assertEquals("Ei tiedossa", tilanneJaLaatutiedot.decisionPhase)
         assertEquals("Ei tiedossa", tilanneJaLaatutiedot.measurementMethod)
 
-        //FIXME: disabled until we can se timezone to Helsinki/Finland in AWS
-        //val lokiJaLinkitystiedot = uploadForm.lokiJaLinkitystiedot()
-        //assertEquals("11.02.2021", lokiJaLinkitystiedot.laadittu())
+        // FIXME: disabled until we can se timezone to Helsinki/Finland in AWS
+        // val lokiJaLinkitystiedot = uploadForm.lokiJaLinkitystiedot()
+        // assertEquals("11.02.2021", lokiJaLinkitystiedot.laadittu())
 
         uploadForm.saveAsNew()
         val infraModelPageAfterUpload = E2EInfraModelPage()
         val infraModelRowsAfterUpload = infraModelPageAfterUpload.infraModelsList
 
-        val uploadedPlanRow = infraModelRowsAfterUpload.getItemWhenMatches { r ->
-            r.projectName == "TEST_Clothoid_and_parabola"
-        }
+        val uploadedPlanRow =
+            infraModelRowsAfterUpload.getItemWhenMatches { r ->
+                r.projectName == "TEST_Clothoid_and_parabola"
+            }
         assertNotNull(uploadedPlanRow)
         assertEquals("testfile_clothoid_and_parabola.xml", uploadedPlanRow.fileName)
 
-        logger.info("Local date time: ${LocalDateTime.now()} and upload time is ${uploadedPlanRow.created}")
+        logger.info(
+            "Local date time: ${LocalDateTime.now()} and upload time is ${uploadedPlanRow.created}")
 
         assertThat(uploadedPlanRow.created).isBefore(LocalDateTime.now())
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/LocationTrackDialogTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/LocationTrackDialogTestUI.kt
@@ -1,11 +1,11 @@
 package fi.fta.geoviite.infra.ui.testgroup1
 
 import fi.fta.geoviite.infra.ui.SeleniumTest
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
@@ -16,16 +16,10 @@ class LocationTrackDialogTestUI @Autowired constructor() : SeleniumTest() {
         startGeoviite()
         val page = goToMap().switchToDraftMode()
         val firstLoad = page.toolBar.createNewLocationTrack()
-        assertEquals(
-            "Väylävirasto",
-            firstLoad.ownerDropdown.value
-        )
+        assertEquals("Väylävirasto", firstLoad.ownerDropdown.value)
 
         firstLoad.cancel()
 
-        assertEquals(
-            "Väylävirasto",
-            page.toolBar.createNewLocationTrack().ownerDropdown.value
-        )
+        assertEquals("Väylävirasto", page.toolBar.createNewLocationTrack().ownerDropdown.value)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/ProjektiVelhoTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/ProjektiVelhoTestUI.kt
@@ -26,21 +26,24 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.waitAndClearToast
 import fi.fta.geoviite.infra.ui.pagemodel.inframodel.E2EProjektiVelhoListItem
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
+import java.io.File
+import java.time.Instant
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.io.File
-import java.time.Instant
-import kotlin.test.assertEquals
 
-const val TESTFILE_SIMPLE_ANONYMIZED_PATH: String = "src/test/resources/inframodel/testfile_simple_anonymized.xml"
+const val TESTFILE_SIMPLE_ANONYMIZED_PATH: String =
+    "src/test/resources/inframodel/testfile_simple_anonymized.xml"
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
-class ProjektiVelhoTestUI @Autowired constructor(
+class ProjektiVelhoTestUI
+@Autowired
+constructor(
     @Value("\${geoviite.projektivelho.test-port:12346}") private val projektiVelhoPort: Int,
     private val pvDao: PVDao,
     private val jsonMapper: ObjectMapper,
@@ -61,11 +64,11 @@ class ProjektiVelhoTestUI @Autowired constructor(
         insertFullExampleVelhoDocumentMetadata()
         startGeoviite()
         val velhoPage = goToInfraModelPage().openVelhoWaitingForApprovalList()
-        fun identifyTestProject(item: E2EProjektiVelhoListItem) = item.projectName == "testi_projekti"
+        fun identifyTestProject(item: E2EProjektiVelhoListItem) =
+            item.projectName == "testi_projekti"
         fun assertTestProjectIsVisible() {
             assertEquals(
-                "foo bar.xml", velhoPage.getItemWhenMatches(::identifyTestProject).documentName
-            )
+                "foo bar.xml", velhoPage.getItemWhenMatches(::identifyTestProject).documentName)
         }
 
         assertTestProjectIsVisible()
@@ -89,13 +92,13 @@ class ProjektiVelhoTestUI @Autowired constructor(
             val assignmentOid = Oid<PVAssignment>("7.8.9.10.11")
 
             pvDao.insertDocumentContent(
-                File(TESTFILE_SIMPLE_ANONYMIZED_PATH).readText(Charsets.UTF_8), insertFullExampleVelhoDocumentMetadata(
-                    documentOid = documentOid,
-                    projectOid = projectOid,
-                    projectGroupOid = projectGroupOid,
-                    assignmentOid = assignmentOid
-                ).id
-            )
+                File(TESTFILE_SIMPLE_ANONYMIZED_PATH).readText(Charsets.UTF_8),
+                insertFullExampleVelhoDocumentMetadata(
+                        documentOid = documentOid,
+                        projectOid = projectOid,
+                        projectGroupOid = projectGroupOid,
+                        assignmentOid = assignmentOid)
+                    .id)
 
             fakeProjektiVelho.login()
             fakeProjektiVelho.redirect(documentOid)
@@ -106,16 +109,18 @@ class ProjektiVelhoTestUI @Autowired constructor(
             val velhoPage = goToInfraModelPage().openVelhoWaitingForApprovalList()
             velhoPage
                 // project name comes from PV metadata here
-                .acceptFirstMatching { item -> item.projectName == "testi_projekti" }.save(true)
+                .acceptFirstMatching { item -> item.projectName == "testi_projekti" }
+                .save(true)
 
             waitAndClearToast("infra-model.import.success")
 
             val infraModelPage = velhoPage.goToInfraModelList()
             assertEquals(
-                "foo bar.xml", infraModelPage.infraModelsList
+                "foo bar.xml",
+                infraModelPage.infraModelsList
                     // project name comes from test file here
-                    .getItemWhenMatches { item -> item.projectName == "Geoviite test" }.fileName
-            )
+                    .getItemWhenMatches { item -> item.projectName == "Geoviite test" }
+                    .fileName)
         }
     }
 
@@ -125,10 +130,11 @@ class ProjektiVelhoTestUI @Autowired constructor(
         projectGroupOid: Oid<PVProjectGroup> = Oid("4.5.6.7.8"),
         assignmentOid: Oid<PVAssignment> = Oid("3.4.5.6.7"),
     ): RowVersion<PVDocument> {
-        val someProperties = PVApiProperties(
-            name = PVProjectName("testi_projekti"),
-            state = PVDictionaryCode("tila/tila14"),
-        )
+        val someProperties =
+            PVApiProperties(
+                name = PVProjectName("testi_projekti"),
+                state = PVDictionaryCode("tila/tila14"),
+            )
 
         pvDao.upsertAssignment(
             PVApiAssignment(
@@ -136,9 +142,7 @@ class ProjektiVelhoTestUI @Autowired constructor(
                 projectOid = projectOid,
                 createdAt = Instant.parse("2023-01-02T03:04:05.006Z"),
                 modified = Instant.parse("2023-02-02T03:04:05.006Z"),
-                properties = someProperties
-            )
-        )
+                properties = someProperties))
 
         pvDao.upsertProjectGroup(
             PVApiProjectGroup(
@@ -146,8 +150,7 @@ class ProjektiVelhoTestUI @Autowired constructor(
                 oid = projectGroupOid,
                 createdAt = Instant.parse("2023-01-02T03:04:05.006Z"),
                 modified = Instant.parse("2023-02-02T03:04:05.006Z"),
-            )
-        )
+            ))
 
         pvDao.upsertProject(
             PVApiProject(
@@ -156,29 +159,28 @@ class ProjektiVelhoTestUI @Autowired constructor(
                 createdAt = Instant.parse("2023-01-02T03:04:05.006Z"),
                 modified = Instant.parse("2023-02-02T03:04:05.006Z"),
                 projectGroupOid = projectGroupOid,
-            )
-        )
+            ))
 
         return pvDao.insertDocumentMetadata(
             oid = documentOid,
-            metadata = PVApiDocumentMetadata(
-                materialState = PVDictionaryCode("aineistotila/tila01"),
-                documentType = PVDictionaryCode("dokumenttityyppi/dt01"),
-                materialGroup = PVDictionaryCode("aineistoryhma/ar00"),
-                technicalFields = listOf(PVDictionaryCode("tekniikka-ala/ta00")),
-                materialCategory = PVDictionaryCode("aineistolaji/al00"),
-                containsPersonalInfo = false,
-                description = FreeText("goo goo ga ga")
-            ),
-            latestVersion = PVApiLatestVersion(
-                version = PVId("123456"),
-                name = FileName("foo bar.xml"),
-                changeTime = Instant.parse("2023-03-04T05:06:07.089Z"),
-            ),
+            metadata =
+                PVApiDocumentMetadata(
+                    materialState = PVDictionaryCode("aineistotila/tila01"),
+                    documentType = PVDictionaryCode("dokumenttityyppi/dt01"),
+                    materialGroup = PVDictionaryCode("aineistoryhma/ar00"),
+                    technicalFields = listOf(PVDictionaryCode("tekniikka-ala/ta00")),
+                    materialCategory = PVDictionaryCode("aineistolaji/al00"),
+                    containsPersonalInfo = false,
+                    description = FreeText("goo goo ga ga")),
+            latestVersion =
+                PVApiLatestVersion(
+                    version = PVId("123456"),
+                    name = FileName("foo bar.xml"),
+                    changeTime = Instant.parse("2023-03-04T05:06:07.089Z"),
+                ),
             status = PVDocumentStatus.SUGGESTED,
             assignmentOid = assignmentOid,
             projectGroupOid = projectGroupOid,
-            projectOid = projectOid
-        )
+            projectOid = projectOid)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SearchTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SearchTestUI.kt
@@ -2,12 +2,12 @@ package fi.fta.geoviite.infra.ui.testgroup1
 
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
 import fi.fta.geoviite.infra.ui.SeleniumTest
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
@@ -21,19 +21,19 @@ class SearchTestUI @Autowired constructor() : SeleniumTest() {
     @Test
     fun `Narrow search results`() {
         val tnId = mainDraftContext.createLayoutTrackNumber().id
-        val ltNames = listOf(
-            "test-lt A1" to "test-desc-1",
-            "test-lt B2" to "test-desc-2",
-            "test-lt B3" to "test-desc-3",
-        )
+        val ltNames =
+            listOf(
+                "test-lt A1" to "test-desc-1",
+                "test-lt B2" to "test-desc-2",
+                "test-lt B3" to "test-desc-3",
+            )
         ltNames.forEach { (name, desc) ->
             mainOfficialContext.insert(
                 locationTrackAndAlignment(
                     trackNumberId = tnId,
                     name = name,
                     description = desc,
-                )
-            )
+                ))
         }
 
         startGeoviite()
@@ -52,13 +52,13 @@ class SearchTestUI @Autowired constructor() : SeleniumTest() {
     @Test
     fun `Search opens specific location track`() {
         val (trackNumber, trackNumberId) = mainOfficialContext.createTrackNumberAndId()
-        val (track, _) = mainOfficialContext.insertAndFetch(
-            locationTrackAndAlignment(
-                trackNumberId = trackNumberId,
-                name = "test-lt specific 001",
-                description = "specific track selection test track 001",
-            )
-        )
+        val (track, _) =
+            mainOfficialContext.insertAndFetch(
+                locationTrackAndAlignment(
+                    trackNumberId = trackNumberId,
+                    name = "test-lt specific 001",
+                    description = "specific track selection test track 001",
+                ))
 
         startGeoviite()
         val mapPage = goToMap()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
@@ -19,17 +19,19 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EAppBar
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData
 import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementWhenExists
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
-class SplitTestUI @Autowired constructor(
+class SplitTestUI
+@Autowired
+constructor(
     private val locationTrackService: LocationTrackService,
     private val splitService: SplitService,
     private val splitTestDataService: SplitTestDataService,
@@ -41,7 +43,8 @@ class SplitTestUI @Autowired constructor(
         testDBService.clearAllTables()
 
         val trackNumber = TrackNumber("876")
-        val trackNumberId = mainOfficialContext.getOrCreateLayoutTrackNumber(trackNumber).id as IntId
+        val trackNumberId =
+            mainOfficialContext.getOrCreateLayoutTrackNumber(trackNumber).id as IntId
 
         val trackStartPoint = HelsinkiTestData.HKI_BASE_POINT + Point(x = 675.0, y = 410.0)
         val preSegments = splitTestDataService.createSegments(trackStartPoint, 3)
@@ -58,23 +61,31 @@ class SplitTestUI @Autowired constructor(
 
         val postSegments = splitTestDataService.createSegments(lastPoint(switchSegments2), 4)
 
-        val sourceTrackId = splitTestDataService.createAsMainTrack(
-            trackNumberId = trackNumberId,
-            segments = preSegments + switchSegments1 + segments1To2 + switchSegments2 + postSegments
-        ).id
+        val sourceTrackId =
+            splitTestDataService
+                .createAsMainTrack(
+                    trackNumberId = trackNumberId,
+                    segments =
+                        preSegments +
+                            switchSegments1 +
+                            segments1To2 +
+                            switchSegments2 +
+                            postSegments)
+                .id
 
-        val sourceTrackName = locationTrackService.get(MainLayoutContext.official, sourceTrackId)!!.name.toString()
-        splitTestDataService.insertAsTrack(trackNumberId = trackNumberId, segments = turningSegments1)
-        splitTestDataService.insertAsTrack(trackNumberId = trackNumberId, segments = turningSegments2)
+        val sourceTrackName =
+            locationTrackService.get(MainLayoutContext.official, sourceTrackId)!!.name.toString()
+        splitTestDataService.insertAsTrack(
+            trackNumberId = trackNumberId, segments = turningSegments1)
+        splitTestDataService.insertAsTrack(
+            trackNumberId = trackNumberId, segments = turningSegments2)
 
         val fakeRatko = fakeRatkoService.start()
         fakeRatko.isOnline()
 
         startGeoviite()
 
-        val trackLayoutPage = E2EAppBar()
-            .goToMap()
-            .switchToDraftMode()
+        val trackLayoutPage = E2EAppBar().goToMap().switchToDraftMode()
 
         trackLayoutPage.selectionPanel.selectReferenceLine(trackNumber.toString())
         trackLayoutPage.toolPanel.referenceLineLocation.zoomTo()
@@ -89,23 +100,27 @@ class SplitTestUI @Autowired constructor(
         trackLayoutPage.clickAtCoordinates(switchStartPoint2.toPoint())
         splittingInfobox.waitUntilTargetTrackInputExists(2)
 
-        val targetTrackNames = (0..2).map { index ->
-            val targetTrackName = "target track $index"
-            val targetTrackDescription = "target track description $index"
+        val targetTrackNames =
+            (0..2).map { index ->
+                val targetTrackName = "target track $index"
+                val targetTrackDescription = "target track description $index"
 
-            splittingInfobox
-                .setTargetTrackName(index, targetTrackName)
-                .setTargetTrackDescription(index, targetTrackDescription)
+                splittingInfobox
+                    .setTargetTrackName(index, targetTrackName)
+                    .setTargetTrackDescription(index, targetTrackDescription)
 
-            targetTrackName
-        }
+                targetTrackName
+            }
 
         splittingInfobox.confirmSplit()
 
-        val unpublishedSplit = splitService.findUnpublishedSplits(
-            branch = LayoutBranch.main,
-            locationTrackIds = listOf(sourceTrackId),
-        ).first()
+        val unpublishedSplit =
+            splitService
+                .findUnpublishedSplits(
+                    branch = LayoutBranch.main,
+                    locationTrackIds = listOf(sourceTrackId),
+                )
+                .first()
         assertEquals(3, unpublishedSplit.targetLocationTracks.size)
 
         // External IDs are fetched from (fake) Ratko service during publication,
@@ -116,37 +131,29 @@ class SplitTestUI @Autowired constructor(
             fakeRatko.acceptsNewLocationTrackGivingItOid(someOid<LocationTrack>().toString())
         }
 
-        val previewView = trackLayoutPage
-            .goToPreview()
-            .waitForAllTableValidationsToComplete()
+        val previewView = trackLayoutPage.goToPreview().waitForAllTableValidationsToComplete()
 
         val splitPublicationGroup = PublicationGroup(id = unpublishedSplit.id)
         previewView.changesTable.movePublicationGroup(splitPublicationGroup)
 
-        val trackLayoutPageAfterPublishing = previewView
-            .waitForAllTableValidationsToComplete()
-            .publish()
+        val trackLayoutPageAfterPublishing =
+            previewView.waitForAllTableValidationsToComplete().publish()
 
         trackLayoutPageAfterPublishing.selectionPanel.selectLocationTrack(targetTrackNames[0])
         assertFalse(
             getElementWhenExists(byQaId("start-splitting")).isEnabled,
-            "splitting a target track again should not be possible before bulk transfer has completed"
-        )
+            "splitting a target track again should not be possible before bulk transfer has completed")
 
         val frontpage = goToFrontPage()
-        val splitDetailsDialog = frontpage
-            .openNthSplitPublicationDetails(1)
+        val splitDetailsDialog = frontpage.openNthSplitPublicationDetails(1)
 
         assertEquals(sourceTrackName, splitDetailsDialog.sourceTrackName())
-        splitDetailsDialog
-            .close()
-            .setNthSplitBulkTransferCompleted(1)
+        splitDetailsDialog.close().setNthSplitBulkTransferCompleted(1)
 
         goToMap().selectionPanel.selectLocationTrack(targetTrackNames[1])
         assertTrue(
             getElementWhenExists(byQaId("start-splitting")).isEnabled,
-            "splitting a target track again should be possible after setting the bulk transfer to be completed"
-        )
+            "splitting a target track again should be possible after setting the bulk transfer to be completed")
 
         fakeRatko.stop()
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/UserRoleTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/UserRoleTestUI.kt
@@ -21,6 +21,11 @@ import fi.fta.geoviite.infra.ui.util.assertZeroBrowserConsoleErrors
 import fi.fta.geoviite.infra.ui.util.assertZeroErrorToasts
 import fi.fta.geoviite.infra.ui.util.byQaId
 import fi.fta.geoviite.infra.util.FreeText
+import java.time.LocalDate
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.openqa.selenium.By
@@ -29,15 +34,12 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import waitUntilExists
 import waitUntilNotExist
-import java.time.LocalDate
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
-class UserRoleTestUI @Autowired constructor(
+class UserRoleTestUI
+@Autowired
+constructor(
     private val trackNumberDao: LayoutTrackNumberDao,
     private val alignmentDao: LayoutAlignmentDao,
     private val referenceLineDao: ReferenceLineDao,
@@ -54,10 +56,12 @@ class UserRoleTestUI @Autowired constructor(
         val trackNumberId = trackNumberDao.insert(trackNumber)
         val referenceLineAndAlignment = westReferenceLine(trackNumberId.id)
         val alignmentVersion = alignmentDao.insert(referenceLineAndAlignment.second)
-        referenceLineDao.insert(referenceLineAndAlignment.first.copy(alignmentVersion = alignmentVersion))
+        referenceLineDao.insert(
+            referenceLineAndAlignment.first.copy(alignmentVersion = alignmentVersion))
 
         val designName = "test design"
-        layoutDesignDao.insert(LayoutDesignSaveRequest(FreeText(designName), LocalDate.now(), DesignState.ACTIVE))
+        layoutDesignDao.insert(
+            LayoutDesignSaveRequest(FreeText(designName), LocalDate.now(), DesignState.ACTIVE))
 
         startGeoviite()
 
@@ -99,26 +103,21 @@ fun assertFrontPage() {
 }
 
 fun assertPublicationLog(frontpage: E2EFrontPage) {
-    frontpage
-        .openPublicationLog()
-        .returnToFrontPage()
+    frontpage.openPublicationLog().returnToFrontPage()
 }
 
 fun assertMapPage(role: E2ERole, trackNumber: TrackNumber, designName: String) {
     val mapPage = E2EAppBar().goToMap()
 
     when (role) {
-        E2ERole.Operator,
-        -> {
+        E2ERole.Operator, -> {
             mapPage
                 .also { assertDraftAndDesignModeTabsVisible() }
-
                 .switchToDraftMode()
                 .also { page -> assertTrackLayoutPageEditButtonsVisible(page, trackNumber) }
                 .goToPreview()
                 .waitForAllTableValidationsToComplete()
                 .goToTrackLayout()
-
                 .switchToDesignMode()
                 .also { page ->
                     page.addDesign()
@@ -126,7 +125,6 @@ fun assertMapPage(role: E2ERole, trackNumber: TrackNumber, designName: String) {
                     assertTrackLayoutPageEditButtonsVisible(page, trackNumber)
                     page.removeActiveDesign()
                 }
-
                 .switchToOfficialMode()
         }
 
@@ -143,8 +141,7 @@ fun assertMapPage(role: E2ERole, trackNumber: TrackNumber, designName: String) {
 
         E2ERole.Authority,
         E2ERole.Browser,
-        E2ERole.Consultant,
-        -> {
+        E2ERole.Consultant, -> {
             mapPage
                 .also { assertDraftAndDesignModeTabsInvisible() }
                 .also { assertTrackLayoutPageEditButtonsInvisible(it, trackNumber) }
@@ -173,7 +170,10 @@ fun assertEditDesignButtonsInvisible() {
     waitUntilNotExist(byQaId("workspace-delete-button"))
 }
 
-fun assertTrackLayoutPageEditButtonsInvisible(trackLayoutPage: E2ETrackLayoutPage, trackNumber: TrackNumber) {
+fun assertTrackLayoutPageEditButtonsInvisible(
+    trackLayoutPage: E2ETrackLayoutPage,
+    trackNumber: TrackNumber
+) {
     trackLayoutPage.selectionPanel.selectReferenceLine(trackNumber.toString())
 
     waitUntilNotExist(byQaId("open-preview-view"))
@@ -181,7 +181,10 @@ fun assertTrackLayoutPageEditButtonsInvisible(trackLayoutPage: E2ETrackLayoutPag
     waitUntilNotExist(By.cssSelector(".infobox__edit-icon"))
 }
 
-fun assertTrackLayoutPageEditButtonsVisible(trackLayoutPage: E2ETrackLayoutPage, trackNumber: TrackNumber) {
+fun assertTrackLayoutPageEditButtonsVisible(
+    trackLayoutPage: E2ETrackLayoutPage,
+    trackNumber: TrackNumber
+) {
     trackLayoutPage.selectionPanel.selectReferenceLine(trackNumber.toString())
 
     waitUntilExists(byQaId("draft-mode-tab"))
@@ -196,8 +199,7 @@ fun assertInfraModelPage(role: E2ERole) {
         E2ERole.Operator,
         E2ERole.Team,
         E2ERole.Authority,
-        E2ERole.Browser,
-        -> {
+        E2ERole.Browser, -> {
             val infraModelPage = E2EAppBar().goToInfraModel()
             assertInfraModelPageTabs(role, infraModelPage)
         }
@@ -211,18 +213,13 @@ fun assertInfraModelPage(role: E2ERole) {
 fun assertInfraModelPageTabs(role: E2ERole, infraModelPage: E2EInfraModelPage) {
     when (role) {
         E2ERole.Operator,
-        E2ERole.Team,
-        -> {
-            infraModelPage
-                .openVelhoWaitingForApprovalList()
-                .openRejectedList()
-                .goToInfraModelList()
+        E2ERole.Team, -> {
+            infraModelPage.openVelhoWaitingForApprovalList().openRejectedList().goToInfraModelList()
         }
 
         E2ERole.Authority,
         E2ERole.Browser,
-        E2ERole.Consultant
-        -> {
+        E2ERole.Consultant -> {
             assertNotNull(infraModelPage.infraModelNavTabPlan)
             assertNull(infraModelPage.infraModelNavTabWaiting)
             assertNull(infraModelPage.infraModelNavTabRejected)
@@ -235,11 +232,9 @@ fun assertInfraModelLink(role: E2ERole) {
         E2ERole.Operator,
         E2ERole.Team,
         E2ERole.Authority,
-        E2ERole.Browser,
-        -> waitUntilExists(byQaId(E2EAppBar.NavLink.INFRA_MODEL.qaId))
+        E2ERole.Browser, -> waitUntilExists(byQaId(E2EAppBar.NavLink.INFRA_MODEL.qaId))
 
-        E2ERole.Consultant,
-        -> assertFalse(exists(byQaId(E2EAppBar.NavLink.INFRA_MODEL.qaId)))
+        E2ERole.Consultant, -> assertFalse(exists(byQaId(E2EAppBar.NavLink.INFRA_MODEL.qaId)))
     }
 }
 
@@ -250,8 +245,7 @@ fun assertDataProductNavigationLinks(role: E2ERole) {
         E2ERole.Operator,
         E2ERole.Team,
         E2ERole.Authority,
-        E2ERole.Browser,
-        -> {
+        E2ERole.Browser, -> {
             waitUntilExists(byQaId(E2EAppBar.NavLink.DATA_PRODUCT.qaId))
             assertTrue(exists(byQaId(E2EAppBar.NavLink.DATA_PRODUCT.qaId)))
 
@@ -263,8 +257,7 @@ fun assertDataProductNavigationLinks(role: E2ERole) {
 
             navigationBar.closeDataProductsMenu()
         }
-        E2ERole.Consultant ->
-            assertFalse(exists(byQaId(E2EAppBar.NavLink.DATA_PRODUCT.qaId)))
+        E2ERole.Consultant -> assertFalse(exists(byQaId(E2EAppBar.NavLink.DATA_PRODUCT.qaId)))
     }
 }
 
@@ -276,11 +269,9 @@ fun assertElementListLink(role: E2ERole, navigationBar: E2EAppBar) {
         E2ERole.Operator,
         E2ERole.Team,
         E2ERole.Authority,
-        E2ERole.Browser,
-        -> assertTrue(elementListLinkExists)
+        E2ERole.Browser, -> assertTrue(elementListLinkExists)
 
-        E2ERole.Consultant,
-        -> assertFalse(elementListLinkExists)
+        E2ERole.Consultant, -> assertFalse(elementListLinkExists)
     }
 }
 
@@ -292,11 +283,9 @@ fun assertVerticalGeometryListLink(role: E2ERole, navigationBar: E2EAppBar) {
         E2ERole.Operator,
         E2ERole.Team,
         E2ERole.Authority,
-        E2ERole.Browser,
-        -> assertTrue(verticalGeometryListLinkExists)
+        E2ERole.Browser, -> assertTrue(verticalGeometryListLinkExists)
 
-        E2ERole.Consultant,
-        -> assertFalse(verticalGeometryListLinkExists)
+        E2ERole.Consultant, -> assertFalse(verticalGeometryListLinkExists)
     }
 }
 
@@ -312,29 +301,23 @@ fun assertElementListingPage(role: E2ERole) {
         E2ERole.Operator,
         E2ERole.Team,
         E2ERole.Authority,
-        E2ERole.Browser,
-        -> {
+        E2ERole.Browser, -> {
             val elementListPage = E2EAppBar().goToElementListPage()
 
             when (role) {
                 E2ERole.Operator,
-                E2ERole.Team,
-                -> {
+                E2ERole.Team, -> {
                     val entireNetworkPage = elementListPage.entireNetworkPage()
                     assertNotNull(entireNetworkPage.downloadUrl)
                 }
 
-                else
-                -> assertNull(elementListPage.entireRailNetworkGeometryRadioButton)
+                else -> assertNull(elementListPage.entireRailNetworkGeometryRadioButton)
             }
 
-            elementListPage
-                .planListPage()
-                .layoutListPage()
+            elementListPage.planListPage().layoutListPage()
         }
 
-        E2ERole.Consultant,
-        -> {} // Consultant should not have access to this page.
+        E2ERole.Consultant, -> {} // Consultant should not have access to this page.
     }
 }
 
@@ -343,26 +326,23 @@ fun assertVerticalGeometryListPage(role: E2ERole) {
         E2ERole.Operator,
         E2ERole.Team,
         E2ERole.Authority,
-        E2ERole.Browser,
-        -> {
+        E2ERole.Browser, -> {
             val verticalGeometryListPage = E2EAppBar().goToVerticalGeometryListPage()
 
             when (role) {
                 E2ERole.Operator,
-                E2ERole.Team,
-                -> assertNotNull(verticalGeometryListPage.entireNetworkPage().downloadUrl)
+                E2ERole.Team, ->
+                    assertNotNull(verticalGeometryListPage.entireNetworkPage().downloadUrl)
 
-                else
-                -> assertNull(verticalGeometryListPage.entireRailNetworkVerticalGeometryRadioButton)
+                else ->
+                    assertNull(
+                        verticalGeometryListPage.entireRailNetworkVerticalGeometryRadioButton)
             }
 
-            verticalGeometryListPage
-                .planListPage()
-                .layoutListPage()
+            verticalGeometryListPage.planListPage().layoutListPage()
         }
 
-        E2ERole.Consultant,
-        -> {} // Consultant should not have access to this page.
+        E2ERole.Consultant, -> {} // Consultant should not have access to this page.
     }
 }
 
@@ -371,14 +351,12 @@ fun assertKmLengthsPage(role: E2ERole) {
         E2ERole.Operator,
         E2ERole.Team,
         E2ERole.Authority,
-        E2ERole.Browser
-        -> {
+        E2ERole.Browser -> {
             val kmLengthsPage = E2EAppBar().goToKilometerLengthsPage()
 
             when (role) {
                 E2ERole.Operator,
-                E2ERole.Team,
-                -> assertNotNull(kmLengthsPage.openEntireNetworkTab().downloadUrl)
+                E2ERole.Team, -> assertNotNull(kmLengthsPage.openEntireNetworkTab().downloadUrl)
 
                 else -> assertNull(kmLengthsPage.entireRailNetworkKmLengthsRadioButton)
             }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/GeometryElementListTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/GeometryElementListTestUI.kt
@@ -23,6 +23,7 @@ import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.ui.LocalHostWebClient
 import fi.fta.geoviite.infra.ui.SeleniumTest
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -30,11 +31,12 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
-class GeometryElementListTestUI @Autowired constructor(
+class GeometryElementListTestUI
+@Autowired
+constructor(
     private val geometryDao: GeometryDao,
     private val locationTrackDao: LocationTrackDao,
     private val alignmentDao: LayoutAlignmentDao,
@@ -50,7 +52,8 @@ class GeometryElementListTestUI @Autowired constructor(
     @Test
     fun `List layout geometry`() {
         val trackNumber = TrackNumber("foo")
-        val trackNumberId = mainOfficialContext.getOrCreateLayoutTrackNumber(trackNumber).id as IntId
+        val trackNumberId =
+            mainOfficialContext.getOrCreateLayoutTrackNumber(trackNumber).id as IntId
         val planVersion = insertSomePlan(trackNumber)
         linkPlanToSomeLocationTrack(planVersion, trackNumberId)
 
@@ -118,22 +121,23 @@ class GeometryElementListTestUI @Autowired constructor(
 
     private fun insertSomePlan(trackNumber: TrackNumber): RowVersion<GeometryPlan> =
         geometryDao.insertPlan(
-            plan = plan(
-                trackNumber = trackNumber,
-                alignments = listOf(
-                    geometryAlignment(
-                        name = "test-alignment-name",
-                        elements = listOf(
-                            line(Point(1.0, 1.0), Point(3.0, 3.0)),
-                            minimalClothoid(Point(3.0, 3.0), Point(5.0, 6.0)),
-                            line(Point(5.0, 6.0), Point(9.0, 10.0)),
-                            minimalCurve(Point(9.0, 10.0), Point(12.0, 13.0))
-                        ),
-                    )
+            plan =
+                plan(
+                    trackNumber = trackNumber,
+                    alignments =
+                        listOf(
+                            geometryAlignment(
+                                name = "test-alignment-name",
+                                elements =
+                                    listOf(
+                                        line(Point(1.0, 1.0), Point(3.0, 3.0)),
+                                        minimalClothoid(Point(3.0, 3.0), Point(5.0, 6.0)),
+                                        line(Point(5.0, 6.0), Point(9.0, 10.0)),
+                                        minimalCurve(Point(9.0, 10.0), Point(12.0, 13.0))),
+                            )),
+                    coordinateSystemName = CoordinateSystemName("testcrs"),
+                    verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
                 ),
-                coordinateSystemName = CoordinateSystemName("testcrs"),
-                verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
-            ),
             file = infraModelFile("testfile.xml"),
             boundingBoxInLayoutCoordinates = null,
         )
@@ -144,22 +148,25 @@ class GeometryElementListTestUI @Autowired constructor(
     ) {
         val geometryPlan = geometryDao.fetchPlan(planVersion)
         val geoAlignmentA = geometryPlan.alignments[0]
-        val locationTrackAlignment = alignmentDao.insert(
-            alignment(
-                segment(Point(1.0, 1.0), Point(2.0, 2.0)).copy(sourceId = geoAlignmentA.elements[0].id),
-                segment(Point(2.0, 2.0), Point(3.0, 3.0)).copy(sourceId = geoAlignmentA.elements[1].id),
-                segment(Point(3.0, 3.0), Point(4.0, 4.0)),
-                segment(Point(4.0, 4.0), Point(5.0, 5.0)).copy(sourceId = geoAlignmentA.elements[2].id),
-                segment(Point(5.0, 5.0), Point(6.0, 6.0)).copy(sourceId = geoAlignmentA.elements[3].id),
-            )
-        )
+        val locationTrackAlignment =
+            alignmentDao.insert(
+                alignment(
+                    segment(Point(1.0, 1.0), Point(2.0, 2.0))
+                        .copy(sourceId = geoAlignmentA.elements[0].id),
+                    segment(Point(2.0, 2.0), Point(3.0, 3.0))
+                        .copy(sourceId = geoAlignmentA.elements[1].id),
+                    segment(Point(3.0, 3.0), Point(4.0, 4.0)),
+                    segment(Point(4.0, 4.0), Point(5.0, 5.0))
+                        .copy(sourceId = geoAlignmentA.elements[2].id),
+                    segment(Point(5.0, 5.0), Point(6.0, 6.0))
+                        .copy(sourceId = geoAlignmentA.elements[3].id),
+                ))
         locationTrackDao.insert(
             locationTrack(
                 trackNumberId = trackNumberId,
                 name = "foo test track",
                 alignmentVersion = locationTrackAlignment,
                 draft = false,
-            )
-        )
+            ))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/KilometerLengthsTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/KilometerLengthsTestUI.kt
@@ -16,18 +16,20 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.ui.LocalHostWebClient
 import fi.fta.geoviite.infra.ui.SeleniumTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
-class KilometerLengthsTestUI @Autowired constructor(
+class KilometerLengthsTestUI
+@Autowired
+constructor(
     private val trackNumberDao: LayoutTrackNumberDao,
     private val locationTrackDao: LocationTrackDao,
     private val referenceLineDao: ReferenceLineDao,
@@ -43,15 +45,15 @@ class KilometerLengthsTestUI @Autowired constructor(
         val trackNumberId = trackNumberDao.insert(trackNumber(TrackNumber("foo"), draft = false)).id
 
         val alignment = alignmentDao.insert(alignment(segment(Point(0.0, 0.0), Point(4000.0, 0.0))))
-        referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = alignment, draft = false))
+        referenceLineDao.insert(
+            referenceLine(trackNumberId, alignmentVersion = alignment, draft = false))
         locationTrackDao.insert(
             locationTrack(
                 trackNumberId = trackNumberId,
                 name = "foo bar",
                 alignmentVersion = alignment,
                 draft = false,
-            )
-        )
+            ))
         kmPostDao.insert(kmPost(trackNumberId, KmNumber(1), Point(900.0, 1.0), draft = false))
         kmPostDao.insert(kmPost(trackNumberId, KmNumber(2), Point(2000.0, -1.0), draft = false))
         kmPostDao.insert(kmPost(trackNumberId, KmNumber(3), Point(3000.0, 0.0), draft = false))
@@ -65,7 +67,8 @@ class KilometerLengthsTestUI @Autowired constructor(
         val results = kmLengthsPage.resultList
         results.waitUntilItemCount(4)
         val items = results.items
-        assertEquals(listOf("0.000", "900.000", "2000.000", "3000.000"), items.map { it.stationStart })
+        assertEquals(
+            listOf("0.000", "900.000", "2000.000", "3000.000"), items.map { it.stationStart })
 
         val downloadUrl = kmLengthsPage.downloadUrl
         val csv = webClient.get().uri(downloadUrl).retrieve().bodyToMono(String::class.java).block()
@@ -84,5 +87,4 @@ class KilometerLengthsTestUI @Autowired constructor(
         assertNotNull(csv)
         Assertions.assertTrue(csv.isNotEmpty())
     }
-
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
@@ -27,16 +27,18 @@ import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.map.E2ETrackLayoutPage
+import java.math.BigDecimal
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
-class VerticalGeometryDiagramTestUI @Autowired constructor(
+class VerticalGeometryDiagramTestUI
+@Autowired
+constructor(
     private val referenceLineService: ReferenceLineService,
     private val kmPostDao: LayoutKmPostDao,
     private val locationTrackService: LocationTrackService,
@@ -54,62 +56,69 @@ class VerticalGeometryDiagramTestUI @Autowired constructor(
         referenceLineService.saveDraft(
             LayoutBranch.main,
             referenceLine(trackNumberId, draft = true),
-            alignment(segment(DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0)))
-        )
+            alignment(
+                segment(
+                    DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0))))
         kmPostDao.insert(
             kmPost(
                 trackNumberId = trackNumberId,
-                km = KmNumber(0), roughLayoutLocation = DEFAULT_BASE_POINT + Point(0.0, 0.0),
+                km = KmNumber(0),
+                roughLayoutLocation = DEFAULT_BASE_POINT + Point(0.0, 0.0),
                 draft = false,
-            )
-        )
-        val plan = geometryDao.fetchPlan(
-            geometryDao.insertPlan(
-                plan(
-                    trackNumber = trackNumber,
-                    units = GeometryUnits(
-                        coordinateSystemSrid = LAYOUT_SRID,
-                        coordinateSystemName = null,
-                        verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
-                        directionUnit = AngularUnit.GRADS,
-                        linearUnit = LinearUnit.METER,
-                    ),
-                    alignments = listOf(
-                        geometryAlignment(
-                            elements = listOf(
-                                line(
-                                    DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0)
-                                )
+            ))
+        val plan =
+            geometryDao.fetchPlan(
+                geometryDao.insertPlan(
+                    plan(
+                        trackNumber = trackNumber,
+                        units =
+                            GeometryUnits(
+                                coordinateSystemSrid = LAYOUT_SRID,
+                                coordinateSystemName = null,
+                                verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
+                                directionUnit = AngularUnit.GRADS,
+                                linearUnit = LinearUnit.METER,
                             ),
-                            profile = GeometryProfile(
-                                PlanElementName("aoeu"),
-                                listOf(
-                                    VIPoint(PlanElementName("startpoint"), Point(0.0, 50.0)),
-                                    VICircularCurve(
-                                        PlanElementName("rounding"),
-                                        Point(500.0, 50.0),
-                                        BigDecimal(20000),
-                                        BigDecimal(155),
-                                    ),
-                                    VIPoint(PlanElementName("endpoint"), Point(600.0, 51.0)),
-                                )
-                            )
-                        ),
-                    )
-                ),
-                testFile(),
-                null,
-            )
-        )
+                        alignments =
+                            listOf(
+                                geometryAlignment(
+                                    elements =
+                                        listOf(
+                                            line(
+                                                DEFAULT_BASE_POINT + Point(0.0, 0.0),
+                                                DEFAULT_BASE_POINT + Point(1000.0, 0.0))),
+                                    profile =
+                                        GeometryProfile(
+                                            PlanElementName("aoeu"),
+                                            listOf(
+                                                VIPoint(
+                                                    PlanElementName("startpoint"),
+                                                    Point(0.0, 50.0)),
+                                                VICircularCurve(
+                                                    PlanElementName("rounding"),
+                                                    Point(500.0, 50.0),
+                                                    BigDecimal(20000),
+                                                    BigDecimal(155),
+                                                ),
+                                                VIPoint(
+                                                    PlanElementName("endpoint"),
+                                                    Point(600.0, 51.0)),
+                                            ))),
+                            )),
+                    testFile(),
+                    null,
+                ))
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrack(trackNumberId = trackNumberId, name = "foo bar", draft = true),
             alignment(
-                segment(DEFAULT_BASE_POINT + Point(0.0, 0.0), DEFAULT_BASE_POINT + Point(1000.0, 0.0)).copy(
-                    sourceId = plan.alignments[0].elements[0].id,
-                    sourceStart = 0.0,
-                )
-            ),
+                segment(
+                        DEFAULT_BASE_POINT + Point(0.0, 0.0),
+                        DEFAULT_BASE_POINT + Point(1000.0, 0.0))
+                    .copy(
+                        sourceId = plan.alignments[0].elements[0].id,
+                        sourceStart = 0.0,
+                    )),
         )
         startGeoviite()
         val page = goToMap().switchToDraftMode().zoomToScale(E2ETrackLayoutPage.MapScale.M_500)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
@@ -27,20 +27,21 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.ui.LocalHostWebClient
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.testdata.createGeometryKmPost
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
 class VerticalGeometryElementListTestUI
-@Autowired constructor(
+@Autowired
+constructor(
     private val geometryDao: GeometryDao,
     private val geometryService: GeometryService,
     private val locationTrackDao: LocationTrackDao,
@@ -67,7 +68,8 @@ class VerticalGeometryElementListTestUI
         assertEquals(listOf("5.280", "5.240"), resultItems.map { it.pviPointHeight })
         assertEquals(listOf("385808.877", "385943.755"), resultItems.map { it.pviPointLocationE })
 
-        val csv = webClient.get().uri(page.downloadUrl).retrieve().bodyToMono(String::class.java).block()
+        val csv =
+            webClient.get().uri(page.downloadUrl).retrieve().bodyToMono(String::class.java).block()
 
         assertNotNull(csv)
         Assertions.assertTrue(csv.isNotEmpty())
@@ -89,7 +91,8 @@ class VerticalGeometryElementListTestUI
         assertEquals(listOf("5.280", "5.240"), resultItems.map { it.pviPointHeight })
         assertEquals(listOf("385808.877", "385943.755"), resultItems.map { it.pviPointLocationE })
 
-        val csv = webClient.get().uri(page.downloadUrl).retrieve().bodyToMono(String::class.java).block()
+        val csv =
+            webClient.get().uri(page.downloadUrl).retrieve().bodyToMono(String::class.java).block()
 
         assertNotNull(csv)
         Assertions.assertTrue(csv.isNotEmpty())
@@ -106,71 +109,80 @@ class VerticalGeometryElementListTestUI
         startGeoviite()
         val page = navigationBar.goToVerticalGeometryListPage().entireNetworkPage()
 
-        val csv = webClient.get().uri(page.downloadUrl).retrieve().bodyToMono(String::class.java).block()
+        val csv =
+            webClient.get().uri(page.downloadUrl).retrieve().bodyToMono(String::class.java).block()
 
         assertNotNull(csv)
         Assertions.assertTrue(csv.isNotEmpty())
     }
 
-    private fun someGeometryProfile() = GeometryProfile(
-        name = PlanElementName("test-profile"),
-        elements = listOf(
-            VIPoint(PlanElementName("startpoint"), Point(0.0, 5.3)),
-            VICircularCurve(
-                PlanElementName("one curve"), Point(30.0, 5.28), BigDecimal(2000), BigDecimal(4),
-            ),
-            VICircularCurve(
-                PlanElementName("another curve"),
-                Point(197.0, 5.24),
-                BigDecimal(-3000),
-                BigDecimal(22.5),
-            ),
-            VIPoint(PlanElementName("endpoint"), Point(216.386446, 5.094602)),
-        ),
-    )
+    private fun someGeometryProfile() =
+        GeometryProfile(
+            name = PlanElementName("test-profile"),
+            elements =
+                listOf(
+                    VIPoint(PlanElementName("startpoint"), Point(0.0, 5.3)),
+                    VICircularCurve(
+                        PlanElementName("one curve"),
+                        Point(30.0, 5.28),
+                        BigDecimal(2000),
+                        BigDecimal(4),
+                    ),
+                    VICircularCurve(
+                        PlanElementName("another curve"),
+                        Point(197.0, 5.24),
+                        BigDecimal(-3000),
+                        BigDecimal(22.5),
+                    ),
+                    VIPoint(PlanElementName("endpoint"), Point(216.386446, 5.094602)),
+                ),
+        )
 
     // no km posts, no elements, profile only, final destination
     private fun insertMinimalPlan(trackNumber: TrackNumber): RowVersion<GeometryPlan> =
         geometryDao.insertPlan(
-            plan = plan(
-                trackNumber = trackNumber,
-                srid = LAYOUT_SRID,
-                alignments = listOf(
-                    geometryAlignment(
-                        name = "test-alignment-name",
-                        profile = someGeometryProfile(),
-                    )
+            plan =
+                plan(
+                    trackNumber = trackNumber,
+                    srid = LAYOUT_SRID,
+                    alignments =
+                        listOf(
+                            geometryAlignment(
+                                name = "test-alignment-name",
+                                profile = someGeometryProfile(),
+                            )),
+                    coordinateSystemName = CoordinateSystemName("testcrs"),
+                    verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
                 ),
-                coordinateSystemName = CoordinateSystemName("testcrs"),
-                verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
-            ),
             file = infraModelFile("minimalplan.xml"),
             boundingBoxInLayoutCoordinates = null,
         )
 
     private fun insertGoodPlan(trackNumber: TrackNumber): RowVersion<GeometryPlan> =
         geometryDao.insertPlan(
-            plan = plan(
-                trackNumber = trackNumber,
-                srid = LAYOUT_SRID,
-                kmPosts = listOf(
-                    createGeometryKmPost(
-                        staInternal = BigDecimal(-10), location = DEFAULT_BASE_POINT, kmNumber = "0045"
-                    )
+            plan =
+                plan(
+                    trackNumber = trackNumber,
+                    srid = LAYOUT_SRID,
+                    kmPosts =
+                        listOf(
+                            createGeometryKmPost(
+                                staInternal = BigDecimal(-10),
+                                location = DEFAULT_BASE_POINT,
+                                kmNumber = "0045")),
+                    alignments =
+                        listOf(
+                            geometryAlignment(
+                                name = "test-alignment-name",
+                                elements =
+                                    listOf(
+                                        lineAtBasePoint(Point(1.0, 1.0), Point(150.0, 100.0)),
+                                        lineAtBasePoint(Point(150.0, 100.0), Point(300.0, 300.0))),
+                                profile = someGeometryProfile(),
+                            )),
+                    coordinateSystemName = CoordinateSystemName("testcrs"),
+                    verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
                 ),
-                alignments = listOf(
-                    geometryAlignment(
-                        name = "test-alignment-name",
-                        elements = listOf(
-                            lineAtBasePoint(Point(1.0, 1.0), Point(150.0, 100.0)),
-                            lineAtBasePoint(Point(150.0, 100.0), Point(300.0, 300.0))
-                        ),
-                        profile = someGeometryProfile(),
-                    )
-                ),
-                coordinateSystemName = CoordinateSystemName("testcrs"),
-                verticalCoordinateSystem = VerticalCoordinateSystem.N2000,
-            ),
             file = infraModelFile("goodplan.xml"),
             boundingBoxInLayoutCoordinates = null,
         )
@@ -181,23 +193,26 @@ class VerticalGeometryElementListTestUI
     ) {
         val geometryPlan = geometryDao.fetchPlan(planVersion)
         val geoAlignmentA = geometryPlan.alignments[0]
-        val locationTrackAlignment = alignmentDao.insert(
-            alignment(
-                segment(Point(1.0, 1.0), Point(200.0, 200.0)).copy(sourceId = geoAlignmentA.elements[0].id),
-                segment(Point(200.0, 200.0), Point(300.0, 300.0)).copy(sourceId = geoAlignmentA.elements[0].id),
-                segment(Point(300.0, 300.0), Point(400.0, 400.0)),
-                segment(Point(400.0, 400.0), Point(500.0, 500.0)).copy(sourceId = geoAlignmentA.elements[1].id),
-                segment(Point(500.0, 500.0), Point(600.0, 600.0)).copy(sourceId = geoAlignmentA.elements[1].id),
-            )
-        )
+        val locationTrackAlignment =
+            alignmentDao.insert(
+                alignment(
+                    segment(Point(1.0, 1.0), Point(200.0, 200.0))
+                        .copy(sourceId = geoAlignmentA.elements[0].id),
+                    segment(Point(200.0, 200.0), Point(300.0, 300.0))
+                        .copy(sourceId = geoAlignmentA.elements[0].id),
+                    segment(Point(300.0, 300.0), Point(400.0, 400.0)),
+                    segment(Point(400.0, 400.0), Point(500.0, 500.0))
+                        .copy(sourceId = geoAlignmentA.elements[1].id),
+                    segment(Point(500.0, 500.0), Point(600.0, 600.0))
+                        .copy(sourceId = geoAlignmentA.elements[1].id),
+                ))
         locationTrackDao.insert(
             locationTrack(
                 trackNumberId = trackNumberId,
                 name = "foo test track",
                 alignmentVersion = locationTrackAlignment,
                 draft = false,
-            )
-        )
+            ))
     }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/AssertionUtil.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/AssertionUtil.kt
@@ -3,12 +3,12 @@ package fi.fta.geoviite.infra.ui.util
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EToast
 import fi.fta.geoviite.infra.ui.pagemodel.common.ToastType
 import getElements
+import java.util.logging.Level
+import kotlin.test.assertEquals
 import org.openqa.selenium.By
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import synchronizeAndConsumeCurrentBrowserLog
-import java.util.logging.Level
-import kotlin.test.assertEquals
 
 private val logger: Logger = LoggerFactory.getLogger("BROWSER")
 
@@ -16,9 +16,8 @@ fun assertStringContains(expectedList: List<String>, actual: String) =
     expectedList.forEach { expected -> kotlin.test.assertContains(actual, expected) }
 
 fun assertZeroErrorToasts() {
-    val toasts = getElements(By.xpath("//div[starts-with(@id, 'toast')]"))
-        .map(::E2EToast)
-        .filter { toast ->
+    val toasts =
+        getElements(By.xpath("//div[starts-with(@id, 'toast')]")).map(::E2EToast).filter { toast ->
             toast.type == ToastType.ERROR
         }
 
@@ -26,30 +25,30 @@ fun assertZeroErrorToasts() {
 }
 
 fun assertZeroBrowserConsoleErrors() {
-    val skippedSevereErrors = listOf(
-        // The map tiles are not configured to work in the AWS environment during E2E tests.
-        // Consider that to be non-severe error for now.
-        //
-        // Example match:
-        // [SEVERE] http://127.0.0.1:9001/location-map/wmts/maasto?service=WMTS&request=GetCapabilities&version=1.0.0
-        // - Failed to load resource: the server responded with a status of 404 (Not Found)
-        "wmts/maasto?service=WMTS&request=GetCapabilities&version=1.0.0",
-    )
+    val skippedSevereErrors =
+        listOf(
+            // The map tiles are not configured to work in the AWS environment during E2E tests.
+            // Consider that to be non-severe error for now.
+            //
+            // Example match:
+            // [SEVERE]
+            // http://127.0.0.1:9001/location-map/wmts/maasto?service=WMTS&request=GetCapabilities&version=1.0.0
+            // - Failed to load resource: the server responded with a status of 404 (Not Found)
+            "wmts/maasto?service=WMTS&request=GetCapabilities&version=1.0.0",
+        )
 
     val logEntries = synchronizeAndConsumeCurrentBrowserLog()
 
-    val severeLogEntries = logEntries
-        .filter { logEntry -> logEntry.level == Level.SEVERE }
-        .filter { logEntry ->
-            !skippedSevereErrors.any { skippedError ->
-                skippedError in logEntry.toString()
+    val severeLogEntries =
+        logEntries
+            .filter { logEntry -> logEntry.level == Level.SEVERE }
+            .filter { logEntry ->
+                !skippedSevereErrors.any { skippedError -> skippedError in logEntry.toString() }
             }
-        }
 
-    severeLogEntries.forEach { logEntry ->
-        logger.error(logEntry.toString())
-    }
+    severeLogEntries.forEach { logEntry -> logger.error(logEntry.toString()) }
 
     val severeLogEntryAmount = severeLogEntries.toList().size
-    assertEquals(0, severeLogEntryAmount, "Expected zero console errors, but found $severeLogEntryAmount")
+    assertEquals(
+        0, severeLogEntryAmount, "Expected zero console errors, but found $severeLogEntryAmount")
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/CommonUiTestUtil.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/CommonUiTestUtil.kt
@@ -10,18 +10,23 @@ val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
 val dateTimeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH.mm")
 
 fun currentLocalDateFormatted(): String = LocalDate.now().format(dateFormat)
+
 fun currentLocalDateTimeFormatted(): String = LocalDateTime.now().format(dateTimeFormat)
 
-fun localDateFromString(date: String): LocalDateTime = LocalDate.parse(date, dateFormat).atStartOfDay()
-fun localDateTimeFromString(dateTime: String): LocalDateTime = LocalDateTime.parse(dateTime, dateTimeFormat)
+fun localDateFromString(date: String): LocalDateTime =
+    LocalDate.parse(date, dateFormat).atStartOfDay()
+
+fun localDateTimeFromString(dateTime: String): LocalDateTime =
+    LocalDateTime.parse(dateTime, dateTimeFormat)
 
 fun pointToCoordinateString(point: AlignmentPoint) = pointToCoordinateString(point.x, point.y)
 
 fun pointToCoordinateString(point: Point) = pointToCoordinateString(point.x, point.y)
 
-fun pointToCoordinateString(x: Double, y: Double) = "${asThreeDecimalPlaces(x)} E, ${asThreeDecimalPlaces(y)} N"
+fun pointToCoordinateString(x: Double, y: Double) =
+    "${asThreeDecimalPlaces(x)} E, ${asThreeDecimalPlaces(y)} N"
 
 fun metersToDouble(meters: String) = meters.substringBefore(' ').toDouble()
 
-//UI uses '.' instead of ','
+// UI uses '.' instead of ','
 private fun asThreeDecimalPlaces(v: Double) = String.format("%.3f", v).replace(",", ".")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/ElementBy.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/ElementBy.kt
@@ -2,5 +2,4 @@ package fi.fta.geoviite.infra.ui.util
 
 import org.openqa.selenium.By
 
-
 fun byQaId(qaId: String): By = By.cssSelector("[qa-id='$qaId']")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Elements.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Elements.kt
@@ -1,5 +1,6 @@
-
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
+import java.time.Duration
+import java.util.regex.Pattern
 import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
 import org.openqa.selenium.interactions.Actions
@@ -8,8 +9,6 @@ import org.openqa.selenium.support.ui.ExpectedConditions.*
 import org.openqa.selenium.support.ui.WebDriverWait
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.Duration
-import java.util.regex.Pattern
 
 private val logger: Logger = LoggerFactory.getLogger(E2EViewFragment::class.java)
 
@@ -18,18 +17,18 @@ val defaultPoll: Duration = Duration.ofMillis(100)
 
 fun clickElementAtPoint(element: WebElement, x: Int, y: Int, doubleClick: Boolean = false) {
 
-    //Invert results since negative means up/left
+    // Invert results since negative means up/left
     val offSetX = -((element.rect.width / 2) - x)
     val offSetY = -((element.rect.height / 2) - y)
 
-    logger.info("Click double=$doubleClick canvas [${element.rect.width}x${element.rect.height}], center offset ($offSetX,$offSetY)")
+    logger.info(
+        "Click double=$doubleClick canvas [${element.rect.width}x${element.rect.height}], center offset ($offSetX,$offSetY)")
 
     val actions = Actions(browser()).moveToElement(element, offSetX, offSetY).click()
     if (doubleClick) actions.click()
     actions.build().perform()
-    Thread.sleep(400) //Prevents double-clicking and zooming with map canvas
+    Thread.sleep(400) // Prevents double-clicking and zooming with map canvas
 }
-
 
 fun getElementWhenVisible(by: By, timeout: Duration = defaultWait): WebElement {
     return tryWait(timeout, visibilityOfElementLocated(by)) {
@@ -56,9 +55,7 @@ fun getElementsWhenExists(by: By, timeout: Duration = defaultWait): List<WebElem
 }
 
 fun getElementWhenClickable(by: By, timeout: Duration = defaultWait): WebElement {
-    return tryWait(timeout, elementToBeClickable(by)) {
-        "Wait for element to be clickable, by=$by"
-    }
+    return tryWait(timeout, elementToBeClickable(by)) { "Wait for element to be clickable, by=$by" }
 }
 
 fun waitUntilExists(by: By, timeout: Duration = defaultWait) {
@@ -133,12 +130,13 @@ fun <T> tryWait(
     pollInterval: Duration = defaultPoll,
     condition: ExpectedCondition<T?>,
     lazyErrorMessage: () -> String,
-): T = try {
-    WebDriverWait(browser(), timeout, pollInterval).until<T>(condition)
-} catch (e: Exception) {
-    logger.warn("${lazyErrorMessage()} cause=${e.message}")
-    throw e
-}
+): T =
+    try {
+        WebDriverWait(browser(), timeout, pollInterval).until<T>(condition)
+    } catch (e: Exception) {
+        logger.warn("${lazyErrorMessage()} cause=${e.message}")
+        throw e
+    }
 
 fun getElementIfExists(by: By): WebElement? {
     return getElements(by).firstOrNull()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/ListTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/ListTest.kt
@@ -1,8 +1,7 @@
 package fi.fta.geoviite.infra.util
 
-import fi.fta.geoviite.infra.util.rangesOfConsecutiveIndicesOf
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class ListTest {
 
@@ -10,14 +9,22 @@ class ListTest {
     fun `rangesOfConsecutiveIndicesOf returns proper ranges`() {
         assertEquals(listOf<IntRange>(), rangesOfConsecutiveIndicesOf(false, listOf()))
         assertEquals(listOf<IntRange>(), rangesOfConsecutiveIndicesOf(false, listOf(true)))
-        assertEquals(listOf<IntRange>(), rangesOfConsecutiveIndicesOf(false, listOf(true, true, true)))
-        assertEquals(listOf<IntRange>(), rangesOfConsecutiveIndicesOf(false, listOf(true, true, true), 1))
+        assertEquals(
+            listOf<IntRange>(), rangesOfConsecutiveIndicesOf(false, listOf(true, true, true)))
+        assertEquals(
+            listOf<IntRange>(), rangesOfConsecutiveIndicesOf(false, listOf(true, true, true), 1))
         assertEquals(listOf(0..0), rangesOfConsecutiveIndicesOf(false, listOf(false)))
         assertEquals(listOf(1..1), rangesOfConsecutiveIndicesOf(false, listOf(true, false)))
         assertEquals(listOf(0..0), rangesOfConsecutiveIndicesOf(false, listOf(false, true)))
         assertEquals(listOf(1..1), rangesOfConsecutiveIndicesOf(false, listOf(true, false, true)))
-        assertEquals(listOf(0..1, 3..3), rangesOfConsecutiveIndicesOf(false, listOf(false, false, true, false)))
-        assertEquals(listOf(0..2, 3..4), rangesOfConsecutiveIndicesOf(false, listOf(false, false, true, false), 1))
-        assertEquals(listOf(0..3, 3..5), rangesOfConsecutiveIndicesOf(false, listOf(false, false, true, false), 2))
+        assertEquals(
+            listOf(0..1, 3..3),
+            rangesOfConsecutiveIndicesOf(false, listOf(false, false, true, false)))
+        assertEquals(
+            listOf(0..2, 3..4),
+            rangesOfConsecutiveIndicesOf(false, listOf(false, false, true, false), 1))
+        assertEquals(
+            listOf(0..3, 3..5),
+            rangesOfConsecutiveIndicesOf(false, listOf(false, false, true, false), 2))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/PagingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/PagingTest.kt
@@ -1,7 +1,7 @@
 package fi.fta.geoviite.infra.util
 
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class PagingTest {
     @Test
@@ -19,15 +19,12 @@ class PagingTest {
         val order: Comparator<Int> = Comparator.naturalOrder()
         assertEquals(
             PageAndRest(Page(11, (0..3).toList(), 0), (4..10).toList()),
-            pageAndRest(items, 0, 4, order)
-        )
+            pageAndRest(items, 0, 4, order))
         assertEquals(
             PageAndRest(Page(11, (4..7).toList(), 4), (0..3).toList() + (8..10).toList()),
-            pageAndRest(items, 4, 4, order)
-        )
+            pageAndRest(items, 4, 4, order))
         assertEquals(
             PageAndRest(Page(11, (8..10).toList(), 8), (0..7).toList()),
-            pageAndRest(items, 8, 4, order)
-        )
+            pageAndRest(items, 8, 4, order))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
@@ -5,26 +5,28 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 
+val allowedFreeTextCases =
+    listOf(
+        "",
+        "Legal Free text: * -> 'asdf' (Äö/å) _-–\\ +123465790?!",
+    )
 
-val allowedFreeTextCases = listOf(
-    "",
-    "Legal Free text: * -> 'asdf' (Äö/å) _-–\\ +123465790?!",
-)
+val illegalFreeTextCases =
+    listOf(
+        "Illegal`",
+        "Illegal´",
+        "Illegal=",
+        "Illegal\"",
+        "Illegal\tName",
+    )
 
-val illegalFreeTextCases = listOf(
-    "Illegal`",
-    "Illegal´",
-    "Illegal=",
-    "Illegal\"",
-    "Illegal\tName",
-)
-
-val freeTextWithNewLineCases = listOf(
-    "\nStarting line break is allowed",
-    "Ending line break is allowed\n",
-    "Legal Free text with newline in the middle: * -> 'asdf' \n (Äö/å) _-–\\ +123465790?!",
-    "Legal Free text with multiple newlines \n in the middle: * -> 'asdf' \n (Äö/å) _-–\\ +123465790?!",
-)
+val freeTextWithNewLineCases =
+    listOf(
+        "\nStarting line break is allowed",
+        "Ending line break is allowed\n",
+        "Legal Free text with newline in the middle: * -> 'asdf' \n (Äö/å) _-–\\ +123465790?!",
+        "Legal Free text with multiple newlines \n in the middle: * -> 'asdf' \n (Äö/å) _-–\\ +123465790?!",
+    )
 
 class SanitizedStringTest {
 
@@ -62,9 +64,7 @@ class SanitizedStringTest {
         }
 
         (illegalFreeTextCases + freeTextWithNewLineCases).forEach { illegalFreeText ->
-            assertThrows<InputValidationException> {
-                FreeText(illegalFreeText)
-            }
+            assertThrows<InputValidationException> { FreeText(illegalFreeText) }
         }
     }
 
@@ -78,11 +78,7 @@ class SanitizedStringTest {
     @Test
     fun freeTextWithNewLinesCantContainIllegalChars() {
         illegalFreeTextCases.forEach { illegalFreeText ->
-            assertThrows<InputValidationException> {
-                FreeText(illegalFreeText)
-            }
+            assertThrows<InputValidationException> { FreeText(illegalFreeText) }
         }
     }
-
-
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/StringUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/StringUtilsTest.kt
@@ -3,15 +3,19 @@ package fi.fta.geoviite.infra.util
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 
-
-val linebreakNormalizationTestCases = listOf(
-    "string without linebreak is not modified" to "string without linebreak is not modified",
-    "ending unix linebreak is not modified\n" to "ending unix linebreak is not modified\n",
-    "ending Windows linebreak is modified to unix style\r\n" to "ending Windows linebreak is modified to unix style\n",
-    "ending Legacy linebreak is modified to unix style\r" to "ending Legacy linebreak is modified to unix style\n",
-    "Legacy linebreak modification doesn't result \r in additional linebreaks\r\r\n" to "Legacy linebreak modification doesn't result \n in additional linebreaks\n\n",
-    "\r\nMultiple \nlinebreaks are \r\n\r\ncorrectly modified to unix style\r" to "\nMultiple \nlinebreaks are \n\ncorrectly modified to unix style\n",
-)
+val linebreakNormalizationTestCases =
+    listOf(
+        "string without linebreak is not modified" to "string without linebreak is not modified",
+        "ending unix linebreak is not modified\n" to "ending unix linebreak is not modified\n",
+        "ending Windows linebreak is modified to unix style\r\n" to
+            "ending Windows linebreak is modified to unix style\n",
+        "ending Legacy linebreak is modified to unix style\r" to
+            "ending Legacy linebreak is modified to unix style\n",
+        "Legacy linebreak modification doesn't result \r in additional linebreaks\r\r\n" to
+            "Legacy linebreak modification doesn't result \n in additional linebreaks\n\n",
+        "\r\nMultiple \nlinebreaks are \r\n\r\ncorrectly modified to unix style\r" to
+            "\nMultiple \nlinebreaks are \n\ncorrectly modified to unix style\n",
+    )
 
 class StringUtilsTest {
 
@@ -20,8 +24,10 @@ class StringUtilsTest {
         linebreakNormalizationTestCases.forEach { (testCase, expectedResult) ->
             val modifiedString = normalizeLinebreaksToUnixFormat(testCase)
 
-            assertEquals(expectedResult, modifiedString,"Test failed with expected: $expectedResult, modified: $modifiedString")
+            assertEquals(
+                expectedResult,
+                modifiedString,
+                "Test failed with expected: $expectedResult, modified: $modifiedString")
         }
     }
-
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/XMLUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/XMLUtilsTest.kt
@@ -8,26 +8,31 @@ class XMLUtilsTest {
     @Test
     fun importingBOMFileWithISOXmlEncodingWorks() {
         val isoTestFileWithBom =
-            (ByteOrderMark.UTF_BOM + "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>").toByteArray()
+            (ByteOrderMark.UTF_BOM + "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>")
+                .toByteArray()
         assertDoesNotThrow { xmlBytesToString(isoTestFileWithBom) }
     }
 
     @Test
     fun importingUTF16FileWithBOMWorks() {
-        val utf16file = ByteOrderMark.UTF_16BE.bytes +
-                "<?xml version=\"1.0\" encoding=\"UTF-16\"?>".toByteArray(charset = Charsets.UTF_16BE)
+        val utf16file =
+            ByteOrderMark.UTF_16BE.bytes +
+                "<?xml version=\"1.0\" encoding=\"UTF-16\"?>"
+                    .toByteArray(charset = Charsets.UTF_16BE)
         assertDoesNotThrow { xmlBytesToString(utf16file) }
     }
 
     @Test
     fun importingUSASCIIFileWorks() {
-        val asciiTestFile = "<?xml version=\"1.0\" encoding=\"ASCII\"?>".toByteArray(charset = Charsets.US_ASCII)
+        val asciiTestFile =
+            "<?xml version=\"1.0\" encoding=\"ASCII\"?>".toByteArray(charset = Charsets.US_ASCII)
         assertDoesNotThrow { xmlBytesToString(asciiTestFile) }
     }
 
     @Test
     fun importingUTF8FileWorks() {
-        val testFileWithBom = (ByteOrderMark.UTF_BOM + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>").toByteArray()
+        val testFileWithBom =
+            (ByteOrderMark.UTF_BOM + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>").toByteArray()
         assertDoesNotThrow { xmlBytesToString(testFileWithBom) }
     }
 


### PR DESCRIPTION
`ktfmt`:lle annettu tyyli oli `kotlinlangstyle`, sillä se säilyttää ainoana 4 merkin sisennykset. Muuten ajo hoidettu defaulttiasetuksilla.