### PR TITLE
GVT-2716 fix some official ids ignoring design_row_id

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
@@ -93,7 +93,7 @@ class GeocodingDao(
             with 
               tn_versions as (
                 select distinct on (id) 
-                  id, version, deleted, design_id is not null as is_design, coalesce(official_row_id, id) as official_id
+                  id, version, deleted, design_id is not null as is_design, official_id
                 from layout.track_number_version
                 where (id = :tn_id or official_row_id = :tn_id)
                   and draft = false
@@ -127,7 +127,7 @@ class GeocodingDao(
               ),
               kmp_versions as (
                 select distinct on (id)
-                  id, version, state, deleted, design_id is not null as is_design, coalesce(official_row_id, id) as official_id
+                  id, version, state, deleted, design_id is not null as is_design, official_id
                 from layout.km_post_version
                 where track_number_id = :tn_id
                   and draft = false

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -226,20 +226,20 @@ class GeometryDao @Autowired constructor(
             with
               location_tracks as (
                 select
-                  distinct ga.plan_id, coalesce(track.official_row_id, track.id) as id
+                  distinct ga.plan_id, track.official_id as id
                   from layout.location_track track
                     left join layout.segment_version sv on sv.alignment_id = track.alignment_id and sv.alignment_version = track.alignment_version
                     left join geometry.alignment ga on ga.id = sv.geometry_alignment_id
               ),
               switches as (
                 select
-                  distinct gs.plan_id, coalesce(switch.official_row_id, switch.id) as id
+                  distinct gs.plan_id, switch.official_id as id
                   from layout.switch
                     left join geometry.switch gs on gs.id = switch.geometry_switch_id
               ),
               km_posts as (
                 select
-                  distinct gp.plan_id, coalesce(km_post.official_row_id, km_post.id) as id
+                  distinct gp.plan_id, km_post.official_id as id
                   from layout.km_post
                     left join geometry.km_post gp on gp.id = km_post.geometry_km_post_id
               )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
@@ -145,7 +145,7 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
            select
               plan_id,
               geometry_km_post.id,
-              array_agg(coalesce(km_post.official_row_id, km_post.design_row_id, km_post.id)) as km_post_id_list
+              array_agg(km_post.official_id) as km_post_id_list
               from geometry.km_post geometry_km_post
               left join (select * from layout.km_post,
                 layout.km_post_is_in_layout_context(:publication_state::layout.publication_state, :design_id, km_post))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -123,7 +123,7 @@ class PublicationDao(
             with splits as (
                 select
                     split.id as split_id,
-                    coalesce(source.official_row_id, source.id) as source_track_id,
+                    source.official_id as source_track_id,
                     array_agg(stlt.location_track_id) as target_track_ids,
                     array_agg(split_updated_duplicates.duplicate_location_track_id) as split_updated_duplicate_ids
                 from publication.split
@@ -134,7 +134,7 @@ class PublicationDao(
                     left join publication.split_updated_duplicate split_updated_duplicates 
                         on split_updated_duplicates.split_id = split.id
                 where split.publication_id is null
-                group by split.id, source.official_row_id, source.id
+                group by split.id, source.official_id
             )
             select 
               candidate_location_track.row_id,
@@ -528,7 +528,7 @@ class PublicationDao(
         assertMainBranch(layoutBranch)
         val sql = """
             select
-              coalesce(tn.official_row_id, tn.design_row_id, tn.id) as tn_official_id,
+              tn.official_id as tn_official_id,
               tn.number as track_number,
               old_tn.number as old_track_number,
               tn.description as description,
@@ -957,7 +957,7 @@ class PublicationDao(
     fun fetchPublicationReferenceLineChanges(publicationId: IntId<Publication>): Map<IntId<ReferenceLine>, ReferenceLineChanges> {
         val sql = """
             select
-              coalesce(rlv.official_row_id, rlv.design_row_id, rlv.id) as rl_official_id,
+              rlv.official_id as rl_official_id,
               rlv.track_number_id as track_number_id,
               old_rlv.track_number_id as old_track_number_id,
               av.length,
@@ -1434,7 +1434,7 @@ class PublicationDao(
     fun fetchPublishedLocationTracks(publicationId: IntId<Publication>): PublishedItemListing<PublishedLocationTrack> {
         val sql = """
             select
-              coalesce(ltv.official_row_id, ltv.design_row_id, ltv.id) as official_id,
+              official_id,
               ltv.id as row_id,
               ltv.version as row_version,
               ltv.name,
@@ -1477,7 +1477,7 @@ class PublicationDao(
                 and design_id is not distinct from (select design_id from publication.publication where id = :publication_id)
             )
             select
-              coalesce(rl.official_row_id, rl.design_row_id, rl.id) as official_id,
+              rl.official_id,
               rl.id as row_id,
               rl.version as row_version,
               rl.track_number_id,
@@ -1519,7 +1519,7 @@ class PublicationDao(
     fun fetchPublishedKmPosts(publicationId: IntId<Publication>): List<PublishedKmPost> {
         val sql = """
             select
-              coalesce(kmp.official_row_id, kmp.design_row_id, kmp.id) as official_id,
+              official_id,
               kmp.id as row_id,
               kmp.version as row_version,
               layout.infer_operation_from_state_transition(kpc.old_state, kpc.state) as operation,
@@ -1549,7 +1549,7 @@ class PublicationDao(
     fun fetchPublishedSwitches(publicationId: IntId<Publication>): PublishedItemListing<PublishedSwitch> {
         val sql = """
             select
-              coalesce(sv.official_row_id, sv.design_row_id, sv.id) as official_id,
+              sv.official_id,
               sv.id as row_id,
               sv.version as row_version,
               sv.name,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -177,7 +177,7 @@ class SplitDao(
               split.bulk_transfer_id,
               split.publication_id,
               publication.publication_time,
-              coalesce(source_track.official_row_id, source_track.id) as source_location_track_official_id,
+              source_track.official_id as source_location_track_official_id,
               split.source_location_track_row_id,
               split.source_location_track_row_version,
               array_agg(split_relinked_switch.switch_id) as switch_ids,
@@ -190,7 +190,7 @@ class SplitDao(
               left join publication.split_relinked_switch on split.id = split_relinked_switch.split_id
               left join publication.split_updated_duplicate on split.id = split_updated_duplicate.split_id
           where split.id = :id
-          group by split.id, source_track.official_row_id, source_track.id, publication.publication_time
+          group by split.id, source_track.official_id, publication.publication_time
         """.trimIndent()
 
         return getOptional(
@@ -205,7 +205,7 @@ class SplitDao(
               split.id,
               split.bulk_transfer_state,
               split.publication_id,
-              coalesce(ltv.official_row_id, ltv.id) as source_location_track_official_id
+              ltv.official_id as source_location_track_official_id
           from publication.split 
               inner join layout.location_track_version ltv 
                   on split.source_location_track_row_id = ltv.id
@@ -291,7 +291,7 @@ class SplitDao(
               publication.publication_time,
               array_agg(split_relinked_switch.switch_id) as switch_ids,
               array_agg(split_updated_duplicate.duplicate_location_track_id) as updated_duplicate_ids,
-              coalesce(ltv.official_row_id, ltv.design_row_id, ltv.id) as source_location_track_official_id,
+              ltv.official_id as source_location_track_official_id,
               split.source_location_track_row_id,
               split.source_location_track_row_version
           from publication.split 
@@ -303,7 +303,7 @@ class SplitDao(
                    and split.source_location_track_row_version = ltv.version
           where split.bulk_transfer_state != 'DONE'
             and (ltv.design_id is null or ltv.design_id = :design_id)
-          group by split.id, ltv.official_row_id, ltv.design_row_id, ltv.id, publication.publication_time
+          group by split.id, ltv.official_id, publication.publication_time
         """.trimIndent()
 
         return jdbcTemplate.query(sql, mapOf("design_id" to branch.designId?.intValue)) { rs, _ ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -108,21 +108,23 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
 
     private val allPublicationVersionsSql = """
         select
-          coalesce(official_row_id, design_row_id, id) as official_id,
+          official_id,
           id as row_id,
           version as row_version
         from ${table.fullName}
-        where draft and design_id is not distinct from :design_id
+        where draft
+          and design_id is not distinct from :design_id
     """.trimIndent()
 
     private val publicationVersionsSql = """
         select
-          coalesce(official_row_id, design_row_id, id) as official_id,
+          official_id,
           id as row_id,
           version as row_version
         from ${table.fullName}
-        where coalesce(official_row_id, design_row_id, id) in (:ids)
-          and draft and design_id is not distinct from :design_id
+        where official_id in (:ids)
+          and draft
+          and design_id is not distinct from :design_id
     """.trimIndent()
 
     override fun fetchPublicationVersions(branch: LayoutBranch): List<ValidationVersion<T>> {
@@ -307,7 +309,7 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
             where id = :row_id
               and (draft = true or design_id is not null) -- Don't allow deleting main-official rows
             returning 
-              coalesce(official_row_id, design_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()
@@ -346,7 +348,7 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
               and (:id::int is null or :id = id or :id = design_row_id or :id = official_row_id)
               and design_id is not distinct from :design_id
             returning 
-              coalesce(official_row_id, design_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -18,7 +18,6 @@ import fi.fta.geoviite.infra.util.getIntIdOrNull
 import fi.fta.geoviite.infra.util.getKmNumber
 import fi.fta.geoviite.infra.util.getLayoutContextData
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
-import fi.fta.geoviite.infra.util.getPointOrNull
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
 import fi.fta.geoviite.infra.util.toDbId
@@ -256,7 +255,7 @@ class LayoutKmPostDao(
               :design_id
             )
             returning 
-              coalesce(official_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()
@@ -311,7 +310,7 @@ class LayoutKmPostDao(
               design_id = :design_id
             where id = :km_post_id
             returning 
-              coalesce(official_row_id, design_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -167,7 +167,7 @@ class LayoutSwitchDao(
               :source::layout.geometry_source
             )
             returning 
-              coalesce(official_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()
@@ -215,7 +215,7 @@ class LayoutSwitchDao(
               owner_id = :owner_id
             where id = :id
             returning 
-              coalesce(official_row_id, design_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -79,11 +79,10 @@ class LayoutTrackNumberDao(
               tn.number,
               tn.description,
               tn.state,
-              coalesce(rl.official_row_id, rl.design_row_id, rl.id) reference_line_id
+              rl.official_id reference_line_id
             from layout.track_number_version tn
               -- TrackNumber reference line identity should never change, so we can join version 1
-              left join layout.reference_line_version rl on 
-                rl.track_number_id = coalesce(tn.official_row_id, tn.design_row_id, tn.id) and rl.version = 1
+              left join layout.reference_line_version rl on rl.track_number_id = tn.official_id and rl.version = 1
             where tn.id = :id
               and tn.version = :version
               and tn.deleted = false
@@ -112,9 +111,9 @@ class LayoutTrackNumberDao(
               tn.number, 
               tn.description,
               tn.state,
-              coalesce(rl.official_row_id, rl.id) as reference_line_id
+              rl.official_id as reference_line_id
             from layout.track_number tn
-              left join layout.reference_line rl on rl.track_number_id = coalesce(tn.official_row_id, tn.id)
+              left join layout.reference_line rl on rl.track_number_id = tn.official_id
             order by tn.id, rl.id
         """.trimIndent()
         val trackNumbers = jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ -> getLayoutTrackNumber(rs) }
@@ -164,7 +163,7 @@ class LayoutTrackNumberDao(
               :design_id
             ) 
             returning 
-              coalesce(official_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()
@@ -204,7 +203,7 @@ class LayoutTrackNumberDao(
               design_id = :design_id
             where id = :id
             returning 
-              coalesce(official_row_id, design_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -278,7 +278,7 @@ class LocationTrackDao(
               :owner_id
             ) 
             returning 
-              coalesce(official_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()
@@ -343,7 +343,7 @@ class LocationTrackDao(
               owner_id = :owner_id
             where id = :id
             returning 
-              coalesce(official_row_id, design_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()
@@ -423,7 +423,7 @@ class LocationTrackDao(
         val sql = """
             select row_id, row_version
               from (
-                select coalesce(official_row_id, design_row_id, id) as official_id, id as row_id, version as row_version
+                select official_id, id as row_id, version as row_version
                   from layout.location_track
                     join (
                     select distinct alignment_id, alignment_version

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -130,7 +130,7 @@ class ReferenceLineDao(
               :design_id
             ) 
             returning 
-              coalesce(official_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()
@@ -172,7 +172,7 @@ class ReferenceLineDao(
               design_id = :design_id
             where id = :id
             returning 
-              coalesce(official_row_id, design_row_id, id) as official_id,
+              official_id,
               id as row_id,
               version as row_version
         """.trimIndent()

--- a/infra/src/main/resources/db/migration/prod/V89__add_official_id_as_generated_column.sql
+++ b/infra/src/main/resources/db/migration/prod/V89__add_official_id_as_generated_column.sql
@@ -1,0 +1,69 @@
+alter table layout.track_number disable trigger version_update_trigger;
+alter table layout.track_number disable trigger version_row_trigger;
+
+alter table layout.reference_line disable trigger version_update_trigger;
+alter table layout.reference_line disable trigger version_row_trigger;
+
+alter table layout.location_track disable trigger version_update_trigger;
+alter table layout.location_track disable trigger version_row_trigger;
+
+alter table layout.switch disable trigger version_update_trigger;
+alter table layout.switch disable trigger version_row_trigger;
+
+alter table layout.km_post disable trigger version_update_trigger;
+alter table layout.km_post disable trigger version_row_trigger;
+
+alter table layout.track_number
+  add column official_id integer not null references layout.track_number(id)
+    generated always as (coalesce(official_row_id, design_row_id, id)) stored;
+
+alter table layout.track_number_version add column official_id integer null;
+update layout.track_number_version set official_id = (coalesce(official_row_id, design_row_id, id)) where true;
+alter table layout.track_number_version alter column official_id set not null;
+
+alter table layout.reference_line
+  add column official_id integer not null references layout.reference_line(id)
+    generated always as (coalesce(official_row_id, design_row_id, id)) stored;
+
+alter table layout.reference_line_version add column official_id integer null;
+update layout.reference_line_version set official_id = (coalesce(official_row_id, design_row_id, id)) where true;
+alter table layout.reference_line_version alter column official_id set not null;
+
+alter table layout.location_track
+  add column official_id integer not null references layout.location_track(id)
+    generated always as (coalesce(official_row_id, design_row_id, id)) stored;
+
+alter table layout.location_track_version add column official_id integer null;
+update layout.location_track_version set official_id = (coalesce(official_row_id, design_row_id, id)) where true;
+alter table layout.location_track_version alter column official_id set not null;
+
+alter table layout.switch
+  add column official_id integer not null references layout.switch(id)
+    generated always as (coalesce(official_row_id, design_row_id, id)) stored;
+
+alter table layout.switch_version add column official_id integer null;
+update layout.switch_version set official_id = (coalesce(official_row_id, design_row_id, id)) where true;
+alter table layout.switch_version alter column official_id set not null;
+
+alter table layout.km_post
+  add column official_id integer not null references layout.km_post(id)
+    generated always as (coalesce(official_row_id, design_row_id, id)) stored;
+
+alter table layout.km_post_version add column official_id integer null;
+update layout.km_post_version set official_id = (coalesce(official_row_id, design_row_id, id)) where true;
+alter table layout.km_post_version alter column official_id set not null;
+
+alter table layout.track_number enable trigger version_update_trigger;
+alter table layout.track_number enable trigger version_row_trigger;
+
+alter table layout.reference_line enable trigger version_update_trigger;
+alter table layout.reference_line enable trigger version_row_trigger;
+
+alter table layout.location_track enable trigger version_update_trigger;
+alter table layout.location_track enable trigger version_row_trigger;
+
+alter table layout.switch enable trigger version_update_trigger;
+alter table layout.switch enable trigger version_row_trigger;
+
+alter table layout.km_post enable trigger version_update_trigger;
+alter table layout.km_post enable trigger version_row_trigger;

--- a/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
@@ -62,7 +62,7 @@ as
 $$
 select
   row.id as row_id,
-  coalesce(row.official_row_id, row.design_row_id, row.id) as official_id,
+  row.official_id,
   design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,

--- a/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
@@ -66,7 +66,7 @@ as
 $$
 select
   row.id as row_id,
-  coalesce(official_row_id, design_row_id, row.id) as official_id,
+  official_id,
   design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,

--- a/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
@@ -76,7 +76,7 @@ as
 $$
 select
   row.id as row_id,
-  coalesce(official_row_id, design_row_id, row.id) as official_id,
+  official_id,
   design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,

--- a/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
@@ -64,7 +64,7 @@ as
 $$
 select
   row.id as row_id,
-  coalesce(official_row_id, design_row_id, row.id) as official_id,
+  official_id,
   design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,

--- a/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
@@ -64,7 +64,7 @@ as
 $$
 select
   row.id as row_id,
-  coalesce(official_row_id, design_row_id, row.id) as official_id,
+  official_id,
   design_id,
   case when row.draft then row.id end as draft_id,
   row.version as row_version,


### PR DESCRIPTION
Lisätty official id laskettuna columnina ja otettu se käyttöön coalescejen tilalle. Tämä mahdollistanee myös optimointia/yksinkertaistusta joihinkin nykyisiin hakuihin, mutta niitä ei ole tässä yhteydessä muokattu.

Tämä siis korjaa tuon 500-virheen samalla koska se johtui inserttien puutteellisesta official_id päättelystä, joka ei ottanut huomioon että myös design_row_id voi olla se official.