### PR TITLE
GVT-2741: Add support for trailing slashes in frame converter api

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
@@ -36,6 +36,12 @@ class FrameConverterApiObjectMapperV1 {
         "/rata-vkm/dev",
         "/rata-vkm/v1",
         "/rata-vkm/dev/v1",
+
+        // Trailing slashes are also supported in the frame converter.
+        "/rata-vkm/",
+        "/rata-vkm/dev/",
+        "/rata-vkm/v1/",
+        "/rata-vkm/dev/v1/",
     ],
 )
 class FrameConverterControllerV1 @Autowired constructor(

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterAddressIT.kt
@@ -1,0 +1,62 @@
+package fi.fta.geoviite.api.frameconverter.v1
+
+import TestGeoJsonFeatureCollection
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.InfraApplication
+import fi.fta.geoviite.infra.TestApi
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import kotlin.test.assertNotNull
+
+@ActiveProfiles("dev", "test", "integration-api")
+@SpringBootTest(
+    classes = [InfraApplication::class],
+)
+@AutoConfigureMockMvc
+class FrameConverterAddressIT @Autowired constructor(
+    mockMvc: MockMvc,
+) : DBTestBase() {
+
+    private val mapper = ObjectMapper().apply {
+        setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    }
+
+    val testApi = TestApi(mapper, mockMvc)
+
+    @Test
+    fun `All supported URL paths should work`() {
+        listOf(
+            "/rata-vkm",
+            "/rata-vkm/v1",
+            "/rata-vkm/dev",
+            "/rata-vkm/dev/v1",
+
+            // Trailing slashes should also work.
+            "/rata-vkm/",
+            "/rata-vkm/v1/",
+            "/rata-vkm/dev/",
+            "/rata-vkm/dev/v1/",
+        ).forEach { uri ->
+            mapOf(
+                "GET" to testApi.doGetWithParams(uri, mapOf(), HttpStatus.OK),
+                "POST" to testApi.doPostWithParams(uri, mapOf(), HttpStatus.OK),
+            ).forEach { (method, request) ->
+                val featureCollection =
+                    request.let { body -> mapper.readValue(body, TestGeoJsonFeatureCollection::class.java) }
+
+                assertNotNull(
+                    featureCollection.features[0].properties?.get("virheet"),
+                    "method=$method, uri=$uri",
+                )
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Laitettu eksplisiittisesti (ns. jokainen urli bindattu erikseen), kun kerta normaalissa backendissä näitä ei tueta niin päätyy devaajan silmille herkemmin näkyviin tällä tavoin. (Voisi sinänsä yhtä hyvin toteuttaa myös esim. filtterillä [=middleware], joka ottaisi ne vaan veks, joka olisi ns. implisiittistä)