### PR TITLE
GVT-2724 Fix display issues for invalid coordinate values in km-post edit dialog & infobox

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1775,7 +1775,8 @@
             "source-from-geometry": "Linkitetty geometriasta",
             "source-from-layout": "Konvertoitu paikannuspohjasta",
             "source-manual": "Asetettu suoraan",
-            "location-in-layout": "Sijainti paikannuspohjassa (TM35FIN)"
+            "location-in-layout": "Sijainti paikannuspohjassa (TM35FIN)",
+            "location-not-defined": "Sijaintia ei ole määritelty"
         }
     },
     "km-post-delete-dialog": {

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
@@ -17,9 +17,10 @@ import { GkLocationSource, LAYOUT_SRID } from 'track-layout/track-layout-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import proj4 from 'proj4';
 import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
-import { GeometryPoint } from 'model/geometry';
+import { GeometryPoint, Point } from 'model/geometry';
 import styles from 'tool-panel/km-post/dialog/km-post-edit-dialog.scss';
 import { Srid } from 'common/common-model';
+import { parseFloatOrUndefined } from 'utils/string-utils';
 
 // GK-FIN coordinate systems currently only used for the live display of layout coordinates when editing km post
 // positions manually
@@ -59,6 +60,22 @@ function gkLocationSourceI18nKey(source: GkLocationSource) {
     return `km-post-dialog.gk-location.source-${end}`;
 }
 
+function gkToLayout(gkSrid: Srid | undefined, xStr: string, yStr: string): Point | undefined {
+    const x = parseFloatOrUndefined(xStr);
+    const y = parseFloatOrUndefined(yStr);
+    const projection = GK_FIN_COORDINATE_SYSTEMS.find(([srid]) => srid === gkSrid)?.[1];
+    if (projection === undefined || x === undefined || y === undefined) {
+        return undefined;
+    } else {
+        try {
+            const res = proj4(projection, LAYOUT_SRID).forward({ x, y });
+            return Number.isFinite(res.x) && Number.isFinite(res.y) ? res : undefined;
+        } catch (e) {
+            return undefined;
+        }
+    }
+}
+
 export const KmPostEditDialogGkLocationSection: React.FC<
     KmPostEditDialogGkLocationSectionProps
 > = ({
@@ -79,24 +96,29 @@ export const KmPostEditDialogGkLocationSection: React.FC<
         (state.kmPost.gkLocationY !== '' && state.kmPost.gkLocationX !== '');
 
     const gkCoordinateSystem = useCoordinateSystem(state.kmPost.gkSrid);
-    const layoutLocation =
-        gkCoordinateSystem === undefined || !gkLocationEntered
-            ? undefined
-            : (() => {
-                  try {
-                      const projection = GK_FIN_COORDINATE_SYSTEMS.find(
-                          ([srid]) => srid === gkCoordinateSystem.srid,
-                      )?.[1];
-                      return projection === undefined
-                          ? undefined
-                          : proj4(projection, LAYOUT_SRID).forward({
-                                x: parseFloat(state.kmPost.gkLocationX),
-                                y: parseFloat(state.kmPost.gkLocationY),
-                            });
-                  } catch (e) {
-                      return undefined;
-                  }
-              })();
+    const layoutLocation = gkToLayout(
+        gkCoordinateSystem?.srid,
+        state.kmPost.gkLocationX,
+        state.kmPost.gkLocationY,
+    );
+    // const layoutLocation =
+    //     gkCoordinateSystem === undefined || !gkLocationEntered
+    //         ? undefined
+    //         : (() => {
+    //               try {
+    //                   const projection = GK_FIN_COORDINATE_SYSTEMS.find(
+    //                       ([srid]) => srid === gkCoordinateSystem.srid,
+    //                   )?.[1];
+    //                   return projection === undefined
+    //                       ? undefined
+    //                       : proj4(projection, LAYOUT_SRID).forward({
+    //                             x: parseFloat(state.kmPost.gkLocationX),
+    //                             y: parseFloat(state.kmPost.gkLocationY),
+    //                         });
+    //               } catch (e) {
+    //                   return undefined;
+    //               }
+    //           })();
 
     const coordinateSystems = useCoordinateSystems(GK_FIN_COORDINATE_SYSTEMS.map(([srid]) => srid));
 
@@ -185,7 +207,9 @@ export const KmPostEditDialogGkLocationSection: React.FC<
                 {t('km-post-dialog.gk-location.location-in-layout')}
             </Heading>
             <div className="field-layout__value">
-                {layoutLocation === undefined ? '' : formatToTM35FINString(layoutLocation)}
+                {layoutLocation === undefined
+                    ? t('km-post-dialog.gk-location.location-not-defined')
+                    : formatToTM35FINString(layoutLocation)}
             </div>
         </>
     );

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
@@ -101,24 +101,6 @@ export const KmPostEditDialogGkLocationSection: React.FC<
         state.kmPost.gkLocationX,
         state.kmPost.gkLocationY,
     );
-    // const layoutLocation =
-    //     gkCoordinateSystem === undefined || !gkLocationEntered
-    //         ? undefined
-    //         : (() => {
-    //               try {
-    //                   const projection = GK_FIN_COORDINATE_SYSTEMS.find(
-    //                       ([srid]) => srid === gkCoordinateSystem.srid,
-    //                   )?.[1];
-    //                   return projection === undefined
-    //                       ? undefined
-    //                       : proj4(projection, LAYOUT_SRID).forward({
-    //                             x: parseFloat(state.kmPost.gkLocationX),
-    //                             y: parseFloat(state.kmPost.gkLocationY),
-    //                         });
-    //               } catch (e) {
-    //                   return undefined;
-    //               }
-    //           })();
 
     const coordinateSystems = useCoordinateSystems(GK_FIN_COORDINATE_SYSTEMS.map(([srid]) => srid));
 

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -191,7 +191,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                     <InfoboxFieldWithEditLink
                         qaId="km-post-gk-coordinate-system"
                         label={t('tool-panel.km-post.layout.gk-coordinates.coordinate-system')}
-                        value={`${gkCoordinateSystem?.name} ${gkCoordinateSystem?.srid}`}
+                        value={`${gkCoordinateSystem?.name ?? '-'} ${gkCoordinateSystem?.srid ?? ''}`}
                     />
                     <InfoboxFieldWithEditLink
                         qaId="km-post-gk-coordinates"
@@ -199,7 +199,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                             gkCoordinateSystem === undefined
                                 ? ''
                                 : t('tool-panel.km-post.layout.gk-coordinates.location', {
-                                      coordinateSystemName: gkCoordinateSystem?.name,
+                                      coordinateSystemName: gkCoordinateSystem?.name ?? '',
                                   })
                         }
                         value={
@@ -246,7 +246,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                             ) : updatedKmPost?.gkLocationSource === 'MANUAL' ? (
                                 t('tool-panel.km-post.layout.gk-coordinates.source-manual')
                             ) : (
-                                ''
+                                '-'
                             )
                         }
                     />

--- a/ui/src/utils/string-utils.ts
+++ b/ui/src/utils/string-utils.ts
@@ -16,3 +16,12 @@ export function isEmpty(str: string) {
 
 export const isEqualIgnoreCase = (str1: string, str2: string): boolean =>
     str1.localeCompare(str2, i18next.language, { sensitivity: 'accent' }) === 0;
+
+export function parseFloatOrUndefined(str: string): number | undefined {
+    if (!str) {
+        return undefined;
+    } else {
+        const parsed = parseFloat(str);
+        return isNaN(parsed) ? undefined : parsed;
+    }
+}


### PR DESCRIPTION
Korjattu pienet huomiot:
- KM-pylvään infoboxissa ei enää näytetä undefined-koordinaatteja. Muutkin puuttuvat arvot on yleisemmin korjattu muotoon '-' kuten joissain kentissä jo oli
- Kun koordinaattia ei ole, edit-dialogilla tyhjäksi jäänyt layout-koordinaatin näyttökohta näyttää nyt viestin "Sijaintia ei ole määritelty"
- Jos layout-muunnos tuottaa infinity-arvoja, niitäkään ei näytetä, vaan edelleen näytetään tuo sama virhe

Yleisemmin nuo kentät kannattaisi validoida inputtien osalta vähän fiksumminkin jotta käyttäjää ohjattaisi paremmin. En kuitenkaan tehnyt sitä tässä yhteydessä vaan tein sille erillisen tiketin: https://extranet.vayla.fi/jira/browse/GVT-2747