### PR TITLE
GVT-2695 Fix internal server error on invalid gk-coordinates

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -44,7 +44,14 @@ class LinkingFailureException(
     message: String,
     cause: Throwable? = null,
     localizedMessageKey: String = "generic",
-) : ClientException(BAD_REQUEST, "Linking failed: $message", cause, "$LOCALIZATION_KEY_BASE.$localizedMessageKey") {
+    localizedMessageParams: LocalizationParams = LocalizationParams.empty,
+) : ClientException(
+    status = BAD_REQUEST,
+    message = "Linking failed: $message",
+    cause = cause,
+    localizedMessageKey = "$LOCALIZATION_KEY_BASE.$localizedMessageKey",
+    localizedMessageParams = localizedMessageParams,
+) {
     companion object {
         const val LOCALIZATION_KEY_BASE = "error.linking"
     }

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -31,7 +31,7 @@
             "plan-hidden": "Linkitystä ei voida tehdä, koska suunnitelma on poistettu",
             "unfinished-splits": "Linkitystä ei voida tehdä, koska raiteen jakaminen ei ole valmis",
             "location-track-deleted": "Linkitystä ei voida tehdä, koska sijaintiraide on Poistettu-tilassa",
-            "invalid-gk-srid": "Annettu koordinaattijärjestelmä (EPSG:{{srid}}) ei ole GK-koordinaattijärjestelmä",
+            "invalid-gk-srid": "Asetettu koordinaattijärjestelmä (EPSG:{{srid}}) ei ole GK-koordinaattijärjestelmä",
             "invalid-gk-location": "Sijainnin määritys on virheellinen: {{y}} N {{x}} E (EPSG:{{srid}})"
         },
         "split": {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -30,7 +30,9 @@
             "segments-sharp-angle": "Uudessa geometriassa on yli 90 asteen kulma",
             "plan-hidden": "Linkitystä ei voida tehdä, koska suunnitelma on poistettu",
             "unfinished-splits": "Linkitystä ei voida tehdä, koska raiteen jakaminen ei ole valmis",
-            "location-track-deleted": "Linkitystä ei voida tehdä, koska sijaintiraide on Poistettu-tilassa"
+            "location-track-deleted": "Linkitystä ei voida tehdä, koska sijaintiraide on Poistettu-tilassa",
+            "invalid-gk-srid": "Annettu koordinaattijärjestelmä (EPSG:{{srid}}) ei ole GK-koordinaattijärjestelmä",
+            "invalid-gk-location": "Sijainnin määritys on virheellinen: {{y}} N {{x}} E (EPSG:{{srid}})"
         },
         "split": {
             "source-track-state-not-in-use": "Jakamista ei voitu suorittaa, koska jaettava raide ei ole \"Käytössä\"-tilassa",


### PR DESCRIPTION
Ei poista virhettä, mutta tekee siistä siistin virhe-toastin internal server errorin sijaan.