### PR TITLE
GVT-2727 & GVT-2731: Parannuksia työtilojen luonnin/muokkauksen virhekäsittelyyn

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -129,6 +129,9 @@
                 "plan-transformation-failed": "Suunnitelman muuntaminen kartalla esitettävään muotoon epäonnistui"
             }
         },
+        "design": {
+            "duplicate-name": "Nimi {{name}} on jo käytössä toisella suunnitelmalla"
+        },
         "entity-not-found": "Tietoa ei löydy",
         "entity-not-found-on-path": "Tietoa ei löytynyt: {{path}}",
         "request-failed": "Pyyntö epäonnistui: {{path}}",

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -216,6 +216,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     const [showEditWorkspaceDialog, setShowEditWorkspaceDialog] = React.useState(false);
     const [showDeleteWorkspaceDialog, setShowDeleteWorkspaceDialog] = React.useState(false);
     const [designIdSelectorOpened, setDesignIdSelectorOpened] = React.useState(false);
+    const [savingWorkspace, setSavingWorkspace] = React.useState(false);
     const menuRef = React.useRef(null);
     const designIdSelectorRef = React.useRef(null);
 
@@ -622,12 +623,16 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                     onCancel={() => setShowEditWorkspaceDialog(false)}
                     onSave={(_, request) => {
                         if (currentDesign) {
-                            updateLayoutDesign(currentDesign.id, request).finally(() => {
-                                updateLayoutDesignChangeTime();
-                                setShowEditWorkspaceDialog(false);
-                            });
+                            setSavingWorkspace(true);
+                            updateLayoutDesign(currentDesign.id, request)
+                                .finally(() => {
+                                    updateLayoutDesignChangeTime();
+                                    setShowEditWorkspaceDialog(false);
+                                })
+                                .finally(() => setSavingWorkspace(false));
                         }
                     }}
+                    saving={savingWorkspace}
                 />
             )}
 

--- a/ui/src/tool-bar/workspace-dialog.tsx
+++ b/ui/src/tool-bar/workspace-dialog.tsx
@@ -24,6 +24,7 @@ type WorkspaceDialogProps = {
     existingDesign?: LayoutDesign;
     onCancel: () => void;
     onSave: (id: LayoutDesignId | undefined, saveRequest: LayoutDesignSaveRequest) => void;
+    saving: boolean;
 };
 
 const saveRequest = (name: string, estimatedCompletion: Date): LayoutDesignSaveRequest => ({
@@ -36,6 +37,7 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
     existingDesign,
     onCancel,
     onSave,
+    saving,
 }) => {
     const { t } = useTranslation();
 
@@ -67,12 +69,14 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
                         <Button
                             variant={ButtonVariant.SECONDARY}
                             onClick={onCancel}
+                            disabled={saving}
                             qa-id={'workspace-dialog-cancel'}>
                             {t('button.cancel')}
                         </Button>
                         <Button
-                            disabled={!name || !selectedDate || designNameNotUnique}
+                            disabled={!name || !selectedDate || designNameNotUnique || saving}
                             qa-id={'workspace-dialog-save'}
+                            isProcessing={saving}
                             onClick={() => {
                                 if (name && selectedDate) {
                                     onSave(existingDesign?.id, saveRequest(name, selectedDate));

--- a/ui/src/tool-bar/workspace-selection.tsx
+++ b/ui/src/tool-bar/workspace-selection.tsx
@@ -47,6 +47,7 @@ type DesignSelectionProps = {
 export const DesignSelection: React.FC<DesignSelectionProps> = ({ designId, onDesignSelected }) => {
     const { t } = useTranslation();
     const [showCreateWorkspaceDialog, setShowCreateWorkspaceDialog] = React.useState(false);
+    const [savingWorkspace, setSavingWorkspace] = React.useState(false);
     const selectWorkspaceDropdownRef = React.useRef<HTMLInputElement>(null);
 
     React.useEffect(() => {
@@ -93,7 +94,11 @@ export const DesignSelection: React.FC<DesignSelectionProps> = ({ designId, onDe
             {showCreateWorkspaceDialog && (
                 <WorkspaceDialog
                     onCancel={() => setShowCreateWorkspaceDialog(false)}
-                    onSave={(_, request) => handleInsertLayoutDesign(request)}
+                    onSave={(_, request) => {
+                        setSavingWorkspace(true);
+                        handleInsertLayoutDesign(request).finally(() => setSavingWorkspace(false));
+                    }}
+                    saving={savingWorkspace}
                 />
             )}
         </React.Fragment>


### PR DESCRIPTION
Täällä lisätty puuttuva käännös bäkkärivirheelle jos työtila on jo olemassa (GVT-2727) sekä varmistuttu että työtilan muokkausdialogin nappeja ei voi painella kun tallennuspyyntö on matkalla (GVT-2731)