### PR TITLE
GVT-2732: Pitkien suunnitelmanimien näyttäminen etusivun julkaisulistassa

### DIFF
--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -143,10 +143,14 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                         })()}
                     </span>
                 </span>
-                {design && (
-                    <span className={styles['publication-list-item__design-name']}>{design}: </span>
-                )}
-                <span>{publication.message}</span>
+                <span>
+                    {design && (
+                        <span className={styles['publication-list-item__design-name']}>
+                            {`${design}:`}
+                        </span>
+                    )}
+                    {publication.message}
+                </span>
             </div>
             {publication.split && (
                 <div className={styles['publication-list-item__split']}>

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -624,12 +624,11 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                     onSave={(_, request) => {
                         if (currentDesign) {
                             setSavingWorkspace(true);
-                            updateLayoutDesign(currentDesign.id, request)
-                                .finally(() => {
-                                    updateLayoutDesignChangeTime();
-                                    setShowEditWorkspaceDialog(false);
-                                })
-                                .finally(() => setSavingWorkspace(false));
+                            updateLayoutDesign(currentDesign.id, request).finally(() => {
+                                updateLayoutDesignChangeTime();
+                                setShowEditWorkspaceDialog(false);
+                                setSavingWorkspace(false);
+                            });
                         }
                     }}
                     saving={savingWorkspace}

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
@@ -56,7 +56,7 @@ export const LocationTrackInfoboxDuplicateOf: React.FC<LocationTrackInfoboxDupli
             />
             &nbsp;
             {currentTrackNumberId !== existingDuplicate.trackNumberId && (
-                <LocationTrackDuplicateInfoIcon type={'ERROR'} />
+                <LocationTrackDuplicateInfoIcon level={'ERROR'} />
             )}
         </span>
     ) : duplicatesOfLocationTrack ? (

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-track-entry.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-track-entry.tsx
@@ -28,15 +28,15 @@ type LocationTrackDuplicateNotice = {
 };
 
 export const LocationTrackDuplicateInfoIcon: React.FC<{
-    type: NoticeLevel;
-}> = ({ type }) => {
+    level: NoticeLevel;
+}> = ({ level }) => {
     return (
         <span
             className={createClassName(
                 styles['location-track-infobox-duplicate-of__icon'],
-                type === 'ERROR' && styles['location-track-infobox-duplicate-of__icon--error'],
+                level === 'ERROR' && styles['location-track-infobox-duplicate-of__icon--error'],
             )}>
-            {type === 'ERROR' ? (
+            {level === 'ERROR' ? (
                 <Icons.StatusError color={IconColor.INHERIT} size={IconSize.SMALL} />
             ) : (
                 <Icons.Info color={IconColor.INHERIT} size={IconSize.SMALL} />
@@ -192,7 +192,7 @@ export const LocationTrackInfoboxDuplicateTrackEntry: React.FC<
                 <span className={styles['location-track-infobox-duplicate-of__info-icons']}>
                     {notices.length > 0 && (
                         <LocationTrackDuplicateInfoIcon
-                            type={notices.some((n) => n.level === 'ERROR') ? 'ERROR' : 'INFO'}
+                            level={notices.some((n) => n.level === 'ERROR') ? 'ERROR' : 'INFO'}
                         />
                     )}
                 </span>


### PR DESCRIPTION
Suunnitelman nimi ja julkaisun selite rivittyvät nyt yhtenä kokonaisuutena. Rivit tasataan suunnitelman nimen alun tasolle. Päädyin lopulta olemaan miettimättä miten pelkkää whitespacea sisältävien suunnitelman nimien esittäminen kannattaisi hoitaa, sillä mielestäni sellaisia suunnitelmia ei saisi päästää bäkkärillä läpi suunnitelman nimen validaatiosta.

Lisäksi täällä korjattu pari pikkuista review-huomiota muilta tiketeiltä.