### PR TITLE
GVT-2387 Canonize linebreaks in FreeTextWithNewLines

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/UserData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/UserData.kt
@@ -1,10 +1,11 @@
 package fi.fta.geoviite.infra.authorization
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.util.*
+import fi.fta.geoviite.infra.util.Code
+import fi.fta.geoviite.infra.util.assertLength
+import fi.fta.geoviite.infra.util.removeLogUnsafe
 import org.springframework.security.core.GrantedAuthority
 
 data class User(val details: UserDetails, val role: Role, val availableRoles: List<Role>)
@@ -25,9 +26,11 @@ data class Privilege(val code: Code) : GrantedAuthority {
 
 val userNameLength = 3..300
 
-data class UserName @JsonCreator(mode = DELEGATING) private constructor(private val value: String)
+data class UserName private constructor(private val value: String)
     : Comparable<UserName>, CharSequence by value {
     companion object {
+        @JvmStatic
+        @JsonCreator
         fun of(name: String) = UserName(removeLogUnsafe(name))
     }
     init { assertLength<UserName>(value, userNameLength) }
@@ -39,9 +42,11 @@ data class UserName @JsonCreator(mode = DELEGATING) private constructor(private 
 
 val authNameLength = 1..300
 
-data class AuthName @JsonCreator(mode = DELEGATING) private constructor(private val value: String)
+data class AuthName private constructor(private val value: String)
     : Comparable<AuthName>, CharSequence by value {
     companion object {
+        @JvmStatic
+        @JsonCreator
         fun of(name: String) = AuthName(removeLogUnsafe(name))
     }
     init { assertLength<AuthName>(value, authNameLength) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
@@ -41,6 +41,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.util.Code
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
+import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import fi.fta.geoviite.infra.util.HttpsUrl
 import fi.fta.geoviite.infra.util.LocalizationKey
 import org.slf4j.Logger
@@ -68,6 +69,7 @@ class WebConfig(
         logger.info("Registering sanitized string converters")
         registry.addStringConstructorConverter(::Code)
         registry.addStringConstructorConverter(::FreeText)
+        registry.addStringConstructorConverter(FreeTextWithNewLines::of)
         registry.addStringConstructorConverter(::LocalizationKey)
 
         registry.addStringConstructorConverter(UserName::of)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -13,11 +13,11 @@ import fi.fta.geoviite.infra.geometry.Author
 import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.geometry.GeometryService
+import fi.fta.geoviite.infra.geometry.GeometryValidationIssue
 import fi.fta.geoviite.infra.geometry.PlanLayoutCache
 import fi.fta.geoviite.infra.geometry.PlanSource
 import fi.fta.geoviite.infra.geometry.Project
 import fi.fta.geoviite.infra.geometry.TransformationError
-import fi.fta.geoviite.infra.geometry.GeometryValidationIssue
 import fi.fta.geoviite.infra.geometry.getBoundingPolygonPointsFromAlignments
 import fi.fta.geoviite.infra.geometry.validate
 import fi.fta.geoviite.infra.localization.localizationParams
@@ -26,7 +26,6 @@ import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import fi.fta.geoviite.infra.util.LocalizationKey
-import fi.fta.geoviite.infra.util.normalizeLinebreaksToUnixFormat
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -176,9 +175,6 @@ class InfraModelService @Autowired constructor(
 
         val overrideCs = overrideParameters?.coordinateSystemSrid?.let(geographyService::getCoordinateSystem)
 
-        val messageWithNormalizedLinebreaks = extraInfoParameters
-            ?.message?.let { normalizeLinebreaksToUnixFormat(extraInfoParameters.message) }
-
         // Nullable fields that do not contain a default parameter via the elvis-operator are considered to be assignable
         // to null even if they have non-null values stored in the database.
         return plan.copy(
@@ -196,7 +192,7 @@ class InfraModelService @Autowired constructor(
             decisionPhase = extraInfoParameters?.decisionPhase,
             measurementMethod = extraInfoParameters?.measurementMethod,
             elevationMeasurementMethod = extraInfoParameters?.elevationMeasurementMethod,
-            message = messageWithNormalizedLinebreaks ?: plan.message,
+            message = extraInfoParameters?.message ?: plan.message,
             planTime = overrideParameters?.createdDate ?: plan.planTime,
             uploadTime = plan.uploadTime,
             source = overrideParameters?.source ?: plan.source,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -245,7 +245,7 @@ fun ResultSet.getFreeTextOrNull(name: String): FreeText? = getString(name)?.let(
 
 fun ResultSet.getFreeTextWithNewLines(name: String): FreeTextWithNewLines = verifyNotNull(name, ::getFreeTextWithNewLinesOrNull)
 
-fun ResultSet.getFreeTextWithNewLinesOrNull(name: String): FreeTextWithNewLines? = getString(name)?.let(::FreeTextWithNewLines)
+fun ResultSet.getFreeTextWithNewLinesOrNull(name: String): FreeTextWithNewLines? = getString(name)?.let(FreeTextWithNewLines::of)
 
 fun ResultSet.getFileName(name: String): FileName = verifyNotNull(name, ::getFileNameOrNull)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/SanitizedString.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/SanitizedString.kt
@@ -36,12 +36,16 @@ data class FreeText @JsonCreator(mode = DELEGATING) constructor(private val valu
     operator fun plus(addition: String) = FreeText("$value$addition")
 }
 
-data class FreeTextWithNewLines @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+data class FreeTextWithNewLines private constructor(private val value: String) :
     Comparable<FreeTextWithNewLines>, CharSequence by value {
 
     companion object {
         const val ALLOWED_CHARACTERS = FreeText.ALLOWED_CHARACTERS + "\n"
         val sanitizer = Regex("^[$ALLOWED_CHARACTERS]*\$")
+
+        @JvmStatic
+        @JsonCreator
+        fun of(value: String) = FreeTextWithNewLines(normalizeLinebreaksToUnixFormat(value))
     }
 
     init { assertSanitized<FreeTextWithNewLines>(value, sanitizer) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
@@ -42,8 +42,6 @@ fun removeLogUnsafe(input: String) = input.replace(UNSAFE_LOG_CHARACTERS, UNSAFE
 fun removeLinebreaks(input: String) = input.replace(lineBreakRegex, LINE_BREAK_REPLACEMENT)
 
 fun normalizeLinebreaksToUnixFormat(input: String) = input.replace(linebreakNormalizationRegex, UNIX_LINEBREAK)
-fun normalizeLinebreaksToUnixFormat(input: FreeTextWithNewLines) =
-    FreeTextWithNewLines(normalizeLinebreaksToUnixFormat(input.toString()))
 
 fun isSanitized(
     stringValue: String,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
@@ -436,7 +436,7 @@ fun plan(
         decisionPhase = PlanDecisionPhase.APPROVED_PLAN,
         measurementMethod = measurementMethod,
         elevationMeasurementMethod = elevationMeasurementMethod,
-        message = FreeTextWithNewLines("test text \n description"),
+        message = FreeTextWithNewLines.of("test text \n description"),
         uploadTime = Instant.now(),
     )
 }
@@ -465,7 +465,7 @@ fun planHeader(
     planTime = Instant.EPOCH,
     trackNumber = trackNumber,
     linkedAsPlanId = null,
-    message = FreeTextWithNewLines("test text \n description"),
+    message = FreeTextWithNewLines.of("test text \n description"),
     uploadTime = Instant.now(),
     source = source,
     hasCant = false,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
@@ -98,7 +98,7 @@ class InfraModelServiceIT @Autowired constructor(
             decisionPhase = PlanDecisionPhase.APPROVED_PLAN,
             measurementMethod = MeasurementMethod.OFFICIALLY_MEASURED_GEODETICALLY,
             elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_RAIL,
-            message = FreeTextWithNewLines("test message 1"),
+            message = FreeTextWithNewLines.of("test message 1"),
         )
 
         val overrides2 = OverrideParameters(
@@ -116,7 +116,7 @@ class InfraModelServiceIT @Autowired constructor(
             decisionPhase = PlanDecisionPhase.UNDER_CONSTRUCTION,
             measurementMethod = MeasurementMethod.DIGITIZED_AERIAL_IMAGE,
             elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_SLEEPER,
-            message = FreeTextWithNewLines("test message 2"),
+            message = FreeTextWithNewLines.of("test message 2"),
         )
 
         val planId = infraModelService.saveInfraModel(file, overrides1, extraInfo1).id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -250,7 +250,7 @@ internal class RatkoPushDaoIT @Autowired constructor(
         message: String = "",
     ): IntId<Publication> =
         publicationDao
-            .createPublication(layoutBranch = layoutBranch, message = FreeTextWithNewLines(message))
+            .createPublication(layoutBranch = layoutBranch, message = FreeTextWithNewLines.of(message))
             .also { publicationId ->
                 val calculatedChanges = CalculatedChanges(
                     directChanges = DirectChanges(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -65,5 +65,5 @@ fun publish(
 ): PublicationResult {
     val versions = publicationService.getValidationVersions(branch, request)
     val calculatedChanges = publicationService.getCalculatedChanges(versions)
-    return publicationService.publishChanges(branch, versions, calculatedChanges, FreeTextWithNewLines("Test"))
+    return publicationService.publishChanges(branch, versions, calculatedChanges, FreeTextWithNewLines.of("Test"))
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -233,7 +233,7 @@ class PublicationDaoIT @Autowired constructor(
             ),
             indirectChanges = IndirectChanges(emptyList(), emptyList(), emptyList()),
         )
-        val publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines(""))
+        val publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of(""))
         publicationDao.insertCalculatedChanges(publicationId, changes)
 
         val publishedTrackNumbers = publicationDao.fetchPublishedTrackNumbers(publicationId)
@@ -257,7 +257,7 @@ class PublicationDaoIT @Autowired constructor(
 
     @Test
     fun `Publication message is stored and fetched correctly`() {
-        val message = FreeTextWithNewLines("Test")
+        val message = FreeTextWithNewLines.of("Test")
         val publicationId = publicationDao.createPublication(LayoutBranch.main, message)
         assertEquals(message, publicationDao.getPublication(publicationId).message)
     }
@@ -393,10 +393,10 @@ class PublicationDaoIT @Autowired constructor(
     fun `fetchLatestPublicationDetails lists design publications in design mode`() {
         val someDesign = DesignBranch.of(layoutDesignDao.insert(layoutDesign("one")))
         val anotherDesign = DesignBranch.of(layoutDesignDao.insert(layoutDesign("two")))
-        publicationDao.createPublication(someDesign, FreeTextWithNewLines("in someDesign"))
-        publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("in main"))
-        publicationDao.createPublication(anotherDesign, FreeTextWithNewLines("in anotherDesign"))
-        publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("again in main"))
+        publicationDao.createPublication(someDesign, FreeTextWithNewLines.of("in someDesign"))
+        publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("in main"))
+        publicationDao.createPublication(anotherDesign, FreeTextWithNewLines.of("in anotherDesign"))
+        publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("again in main"))
         assertEquals(
             listOf("in anotherDesign", "in someDesign"),
             publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 2).map { it.message.toString() }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -737,7 +737,7 @@ class PublicationServiceIT @Autowired constructor(
             publicationRequest(locationTracks = splitSetup.trackIds)
         ).let { versions ->
             publicationService
-                .publishChanges(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions), FreeTextWithNewLines(""))
+                .publishChanges(LayoutBranch.main, versions, getCalculatedChangesInRequest(versions), FreeTextWithNewLines.of(""))
                 .publicationId
         }
 
@@ -4136,7 +4136,7 @@ class PublicationServiceIT @Autowired constructor(
         layoutBranch,
         versions,
         calculatedChanges,
-        FreeTextWithNewLines("${this::class.simpleName}"),
+        FreeTextWithNewLines.of("${this::class.simpleName}"),
     )
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -1218,7 +1218,7 @@ class RatkoServiceIT @Autowired constructor(
         splitTestDataService.forcefullyFinishAllCurrentlyUnfinishedSplits(LayoutBranch.main)
 
         val splitId = splitTestDataService.insertSplit()
-        val publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("test: bulk transfer to in progress"))
+        val publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("test: bulk transfer to in progress"))
         splitDao.updateSplit(splitId = splitId, publicationId = publicationId)
 
         val someBulkTransferId = testDBService.getUnusedBulkTransferId()
@@ -1244,7 +1244,7 @@ class RatkoServiceIT @Autowired constructor(
         splitTestDataService.insertSplit().let { splitId ->
             splitDao.updateSplit(
                 splitId = splitId,
-                publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("some in progress bulk transfer")),
+                publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("some in progress bulk transfer")),
                 bulkTransferState = BulkTransferState.IN_PROGRESS,
                 bulkTransferId = someBulkTransferId,
             ).id
@@ -1253,7 +1253,7 @@ class RatkoServiceIT @Autowired constructor(
         val pendingSplitId = splitTestDataService.insertSplit().let { splitId ->
             splitDao.updateSplit(
                 splitId = splitId,
-                publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("pending bulk transfer")),
+                publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("pending bulk transfer")),
             ).id
         }
 
@@ -1272,7 +1272,7 @@ class RatkoServiceIT @Autowired constructor(
         val splitId = splitTestDataService.insertSplit().let { splitId ->
             splitDao.updateSplit(
                 splitId = splitId,
-                publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("pending bulk transfer")),
+                publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("pending bulk transfer")),
             ).id
         }
 
@@ -1306,7 +1306,7 @@ class RatkoServiceIT @Autowired constructor(
             splitTestDataService.insertSplit().let { splitId ->
                 splitDao.updateSplit(
                     splitId = splitId,
-                    publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("pending bulk transfer $index")),
+                    publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("pending bulk transfer $index")),
                 ).id
             }
         }
@@ -1337,7 +1337,7 @@ class RatkoServiceIT @Autowired constructor(
                     else ->
                         splitDao.updateSplit(
                             splitId = splitId,
-                            publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("testing $bulkTransferState")),
+                            publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("testing $bulkTransferState")),
                             bulkTransferId = testDBService.getUnusedBulkTransferId(),
                             bulkTransferState = bulkTransferState,
                         )
@@ -1403,7 +1403,7 @@ class RatkoServiceIT @Autowired constructor(
         publicationService.updateExternalId(LayoutBranch.main, ids)
         val versions = publicationService.getValidationVersions(LayoutBranch.main, ids)
         val calculatedChanges = publicationService.getCalculatedChanges(versions)
-        publicationService.publishChanges(LayoutBranch.main, versions, calculatedChanges, FreeTextWithNewLines(""))
+        publicationService.publishChanges(LayoutBranch.main, versions, calculatedChanges, FreeTextWithNewLines.of(""))
         ratkoService.pushChangesToRatko(LayoutBranch.main)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -72,7 +72,7 @@ class SplitDaoIT @Autowired constructor(
             updatedDuplicates = emptyList(),
         ).let(splitDao::getOrThrow)
 
-        val publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("SPLIT PUBLICATION"))
+        val publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("SPLIT PUBLICATION"))
         val updatedSplit = splitDao.updateSplit(
             splitId = split.id,
             bulkTransferState = BulkTransferState.FAILED,
@@ -188,7 +188,7 @@ class SplitDaoIT @Autowired constructor(
     @Test
     fun `Split bulk transfer state can be updated`() {
         val splitId = createSplit()
-        val publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("test: bulk transfer state update"))
+        val publicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("test: bulk transfer state update"))
 
         BulkTransferState.entries.forEach { newBulkTransferState ->
             when (newBulkTransferState) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -61,7 +61,7 @@ class FrontPageTestUI @Autowired constructor(
         )
         referenceLineDao.insert(referenceLine(trackNumberId, alignmentVersion = alignmentVersion, draft = false))
 
-        val successfulPublicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("successful"))
+        val successfulPublicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("successful"))
         publicationDao.insertCalculatedChanges(successfulPublicationId, changesTouchingTrackNumber(trackNumberId))
 
         trackNumberDao
@@ -69,7 +69,7 @@ class FrontPageTestUI @Autowired constructor(
             .copy(number = TrackNumber("updated name"))
             .let(trackNumberDao::update)
 
-        val failingPublicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines("failing test publication"))
+        val failingPublicationId = publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("failing test publication"))
         publicationDao.insertCalculatedChanges(failingPublicationId, changesTouchingTrackNumber(trackNumberId))
 
         val failedRatkoPushId = ratkoPushDao.startPushing(listOf(failingPublicationId))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
@@ -46,21 +46,21 @@ class PublicationLogSearchTestUI @Autowired constructor(
                 content = publicationRequestIds(
                     trackNumbers = listOf(someTrackNumberId)
                 ),
-                message = FreeTextWithNewLines("some test publication 1"),
+                message = FreeTextWithNewLines.of("some test publication 1"),
             ),
 
             PublicationRequest(
                 content = publicationRequestIds(
                     referenceLines = listOf(mainDraftContext.insert(someReferenceLine.first, someReferenceLine.second).id)
                 ),
-                message = FreeTextWithNewLines("some test publication 2"),
+                message = FreeTextWithNewLines.of("some test publication 2"),
             ),
 
             PublicationRequest(
                 content = publicationRequestIds(
                     locationTracks = listOf(mainDraftContext.insert(someTrack).id)
                 ),
-                message = FreeTextWithNewLines("some test publication 3"),
+                message = FreeTextWithNewLines.of("some test publication 3"),
             )
         )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.error.InputValidationException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
 
 val allowedFreeTextCases = listOf(
     "",
@@ -28,7 +29,7 @@ val freeTextWithNewLineCases = listOf(
 class SanitizedStringTest {
 
     @Test
-    fun codeCantContainIllegalChars() {
+    fun `Code can't contain illegal chars`() {
         assertDoesNotThrow { Code("LEGAL-M123.3_0") }
         assertThrows<InputValidationException> { Code("") }
         assertThrows<InputValidationException> { Code("Ä1") }
@@ -55,7 +56,7 @@ class SanitizedStringTest {
     }
 
     @Test
-    fun freeTextCantContainIllegalChars() {
+    fun `FreeText can't contain illegal chars`() {
         allowedFreeTextCases.forEach { allowedFreeText ->
             assertDoesNotThrow { FreeText(allowedFreeText) }
         }
@@ -68,18 +69,24 @@ class SanitizedStringTest {
     }
 
     @Test
-    fun freeTextWithNewLinesCanContainNewLines() {
+    fun `FreeTextWithNewLines can contain line breaks`() {
         (allowedFreeTextCases + freeTextWithNewLineCases).forEach { allowedFreeTextWithNewlines ->
-            assertDoesNotThrow { FreeTextWithNewLines(allowedFreeTextWithNewlines) }
+            assertDoesNotThrow { FreeTextWithNewLines.of(allowedFreeTextWithNewlines) }
         }
     }
 
     @Test
-    fun freeTextWithNewLinesCantContainIllegalChars() {
+    fun `FreeTextWithNewLines can't contain illegal chars`() {
         illegalFreeTextCases.forEach { illegalFreeText ->
             assertThrows<InputValidationException> {
                 FreeText(illegalFreeText)
             }
         }
+    }
+
+    @Test
+    fun `FreeTextWithNewLines canonizes line breaks`() {
+        val text = FreeTextWithNewLines.of("Windows\r\nline break")
+        assertEquals("Windows\nline break", text.toString())
     }
 }


### PR DESCRIPTION
Muutos itsessään on pieni. Tiedostomäärä johtuu siitä että noita luodaan aika monessa paikassa ja rakentaja piti vaihtaa factory-metodiin.