### PR TITLE
GVT-2387 Ease projektivelho & inframodel input sanitizing to get all fields into DB

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/UserData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/UserData.kt
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.util.assertLength
-import fi.fta.geoviite.infra.util.assertSanitized
-import fi.fta.geoviite.infra.util.isSanitized
-import fi.fta.geoviite.infra.util.removeLogUnsafe
+import fi.fta.geoviite.infra.util.StringSanitizer
 import org.springframework.security.core.GrantedAuthority
 
 data class User(val details: UserDetails, val role: Role, val availableRoles: List<Role>)
@@ -26,32 +23,36 @@ data class Privilege(val code: AuthCode) : GrantedAuthority {
     override fun getAuthority(): String = code.toString()
 }
 
-val userNameLength = 3..300
-
 data class UserName private constructor(private val value: String)
     : Comparable<UserName>, CharSequence by value {
     companion object {
+        val allowedLength = 3..300
+        const val ALLOWED_CHARACTERS = "A-Za-z0-9_\\-"
+        val sanitizer = StringSanitizer(UserName::class, ALLOWED_CHARACTERS, allowedLength)
+
         @JvmStatic
         @JsonCreator
-        fun of(name: String) = UserName(removeLogUnsafe(name))
+        fun of(name: String) = UserName(sanitizer.sanitize(name))
     }
-    init { assertLength<UserName>(value, userNameLength) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value
     override fun compareTo(other: UserName): Int = value.compareTo(other.value)
 }
 
-val authNameLength = 1..300
-
 data class AuthName private constructor(private val value: String)
     : Comparable<AuthName>, CharSequence by value {
     companion object {
+        val allowedLength = 1..300
+        const val ALLOWED_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 _\\-+:.,'/"
+        val sanitizer = StringSanitizer(UserName::class, ALLOWED_CHARACTERS, allowedLength)
+
         @JvmStatic
         @JsonCreator
-        fun of(name: String) = AuthName(removeLogUnsafe(name))
+        fun of(name: String) = AuthName(sanitizer.sanitize(name))
     }
-    init { assertLength<AuthName>(value, authNameLength) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value
@@ -62,14 +63,16 @@ data class AuthCode @JsonCreator(mode = DELEGATING) constructor(private val valu
     Comparable<AuthCode>, CharSequence by value {
 
     companion object {
-        val sanitizer = Regex("^[A-Za-z0-9_\\-.]+\$")
+        const val ALLOWED_CHARACTERS = "A-Za-z0-9_\\-."
+        val allowedLength = 1..20
+        val sanitizer = StringSanitizer(AuthCode::class, ALLOWED_CHARACTERS, allowedLength)
     }
 
-    init { assertSanitized<AuthCode>(value, sanitizer) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value
     override fun compareTo(other: AuthCode): Int = value.compareTo(other.value)
 }
 
-fun isValidCode(source: String): Boolean = isSanitized(source, AuthCode.sanitizer, allowBlank = false)
+fun isValidCode(source: String): Boolean = AuthCode.sanitizer.isSanitized(source)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/AlignmentName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/AlignmentName.kt
@@ -3,17 +3,20 @@ package fi.fta.geoviite.infra.common
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.util.assertSanitized
+import fi.fta.geoviite.infra.util.StringSanitizer
 
 data class AlignmentName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
     Comparable<AlignmentName>, CharSequence by value {
 
     companion object {
-        val sanitizer = Regex("^[A-Za-zÄÖÅäöå0-9 \\-_!?§]+\$")
+        const val ALLOWED_CHARACTERS = "A-Za-zÄÖÅäöå0-9 \\-_!?"
         val allowedLength = 1..50
+        val sanitizer = StringSanitizer(AlignmentName::class, ALLOWED_CHARACTERS, allowedLength)
+
+        fun ofUnsafe(value: String) = AlignmentName(sanitizer.sanitize(value))
     }
 
-    init { assertSanitized<AlignmentName>(value, sanitizer, allowedLength, allowBlank = false) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DISABLED
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.math.round
-import fi.fta.geoviite.infra.util.assertSanitized
+import fi.fta.geoviite.infra.util.StringSanitizer
 import fi.fta.geoviite.infra.util.formatForException
 import java.math.BigDecimal
 import java.math.RoundingMode.DOWN
@@ -29,7 +29,8 @@ data class KmNumber @JsonCreator(mode = DISABLED) constructor(
 
     companion object {
         private val extensionLength = 1..2
-        private val extensionSanitizer = Regex("^[A-Z]*\$")
+        private const val EXTENSION_CHARACTERS = "A-Z"
+        private val extensionSanitizer = StringSanitizer(KmNumber::class, EXTENSION_CHARACTERS, extensionLength)
         val ZERO = KmNumber(0)
     }
 
@@ -41,9 +42,7 @@ data class KmNumber @JsonCreator(mode = DISABLED) constructor(
     override fun toString(): String = stringValue
 
     init {
-        extension?.let {
-            assertSanitized<KmNumber>(it, extensionSanitizer, extensionLength, allowBlank = false)
-        }
+        extension?.let(extensionSanitizer::assertSanitized)
     }
 
     override fun compareTo(other: KmNumber): Int = stringValue.compareTo(other.stringValue)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Oid.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Oid.kt
@@ -12,7 +12,7 @@ data class Oid<T> @JsonCreator(mode = DELEGATING) constructor(private val value:
         private val sanitizer = Regex("^\\d+(\\.\\d+){2,9}\$")
     }
 
-    init { assertSanitized<Oid<T>>(value, sanitizer, allowedLength, allowBlank = false) }
+    init { assertSanitized<Oid<T>>(value, sanitizer, allowedLength) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ProjectName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ProjectName.kt
@@ -3,16 +3,18 @@ package fi.fta.geoviite.infra.common
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.util.assertSanitized
+import fi.fta.geoviite.infra.util.StringSanitizer
 
 data class ProjectName @JsonCreator(mode = DELEGATING) constructor(private val value: String) : CharSequence by value {
 
     companion object {
         val allowedLength = 1..100
-        val sanitizer = Regex("^[A-ZÄÖÅa-zäöå0-9 _\\-/+&.,]+\$")
+        const val ALLOWED_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 _\\-/+&.,"
+        val sanitizer = StringSanitizer(ProjectName::class, ALLOWED_CHARACTERS, allowedLength)
+        fun ofUnsafe(value: String) = ProjectName(sanitizer.sanitize(value))
     }
 
-    init { assertSanitized<ProjectName>(value, sanitizer, allowedLength, allowBlank = false) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Srid.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Srid.kt
@@ -18,7 +18,7 @@ data class Srid @JsonCreator(mode = DISABLED) constructor(val code: Int) {
     }
 
     init {
-        assertInput<Srid>(code in sridRange, code.toString()) {
+        assertInput(Srid::class, code in sridRange, code.toString()) {
             "SRID (EPSG code) $code outside allowed range $sridRange"
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/SwitchName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/SwitchName.kt
@@ -3,17 +3,19 @@ package fi.fta.geoviite.infra.common
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.util.assertSanitized
+import fi.fta.geoviite.infra.util.StringSanitizer
 
 data class SwitchName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
     Comparable<SwitchName>, CharSequence by value {
 
     companion object {
-        val sanitizer = Regex("^[A-ZÄÖÅa-zäöå0-9 \\-_/,.]+\$")
         val allowedLength = 1..50
+        const val ALLOWED_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 \\-_/,."
+        val sanitizer = StringSanitizer(SwitchName::class, ALLOWED_CHARACTERS, allowedLength)
+        fun ofUnsafe(value: String) = SwitchName(sanitizer.sanitize(value))
     }
 
-    init { assertSanitized<SwitchName>(value, sanitizer, allowedLength, allowBlank = false) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/TrackNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/TrackNumber.kt
@@ -3,17 +3,18 @@ package fi.fta.geoviite.infra.common
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.util.assertSanitized
+import fi.fta.geoviite.infra.util.StringSanitizer
 
 data class TrackNumber @JsonCreator(mode = DELEGATING) constructor(val value: String) :
     Comparable<TrackNumber>, CharSequence by value {
 
     companion object {
         val allowedLength = 2..30
-        val sanitizer = Regex("^[äÄöÖåÅA-Za-z0-9 ]+\$")
+        const val ALLOWED_CHARACTERS = "äÄöÖåÅA-Za-z0-9 "
+        val sanitizer = StringSanitizer(TrackNumber::class, ALLOWED_CHARACTERS, allowedLength)
     }
 
-    init { assertSanitized<TrackNumber>(value, sanitizer, allowedLength, allowBlank = false) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
@@ -36,14 +36,13 @@ import fi.fta.geoviite.infra.localization.LocalizationLanguage
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryCode
-import fi.fta.geoviite.infra.projektivelho.PVDictionaryName
 import fi.fta.geoviite.infra.projektivelho.PVId
-import fi.fta.geoviite.infra.projektivelho.PVTargetCategory
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import fi.fta.geoviite.infra.util.HttpsUrl
+import fi.fta.geoviite.infra.util.UnsafeString
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
@@ -77,6 +76,8 @@ class WebConfig(
 
         registry.addStringConstructorConverter(::CoordinateSystemName)
         registry.addStringConstructorConverter(::FeatureTypeCode)
+
+        registry.addStringConstructorConverter(::UnsafeString)
 
         logger.info("Registering geometry name converters")
         registry.addStringConstructorConverter(::FileName)
@@ -128,8 +129,6 @@ class WebConfig(
         logger.info("Registering ProjektiVelho sanitized string converters")
         registry.addStringConstructorConverter(::PVId)
         registry.addStringConstructorConverter(::PVDictionaryCode)
-        registry.addStringConstructorConverter(::PVDictionaryName)
-        registry.addStringConstructorConverter(::PVTargetCategory)
 
         logger.info("Registering localization language converters")
         registry.addStringConstructorConverter { enumCaseInsensitive<LocalizationLanguage>(it) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateSystem.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateSystem.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.common.Srid
-import fi.fta.geoviite.infra.util.assertSanitized
+import fi.fta.geoviite.infra.util.StringSanitizer
 
 data class CoordinateSystem(
     val srid: Srid,
@@ -12,12 +12,16 @@ data class CoordinateSystem(
     val aliases: List<CoordinateSystemName>,
 )
 
-val csNameLength = 1..100
-val csNameRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 _\\-/(),]+\$")
+data class CoordinateSystemName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    CharSequence by value {
 
-data class CoordinateSystemName @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : CharSequence by value {
-    init { assertSanitized<CoordinateSystemName>(value, csNameRegex, csNameLength, allowBlank = false) }
+    companion object {
+        private val allowedLength = 1..100
+        private const val ALLOWED_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 _\\-/(),"
+        val sanitizer = StringSanitizer(CoordinateSystemName::class, ALLOWED_CHARACTERS, allowedLength)
+    }
+
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometrySwitch.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometrySwitch.kt
@@ -3,11 +3,16 @@ package fi.fta.geoviite.infra.geometry
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.DomainId
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.StringId
+import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.ISwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.util.StringSanitizer
 import fi.fta.geoviite.infra.util.assertSanitized
 
 data class GeometrySwitch(
@@ -29,19 +34,16 @@ data class GeometrySwitch(
 
 data class GeometrySwitchJoint(override val number: JointNumber, override val location: Point) : ISwitchJoint
 
-private val geometrySwitchTypeNameLength = 0..30
-private val geometrySwitchTypeNameRegex = Regex("^[A-Za-z0-9:\\-/(),.]*\$")
+data class GeometrySwitchTypeName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<GeometrySwitchTypeName>, CharSequence by value {
 
-data class GeometrySwitchTypeName @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<GeometrySwitchTypeName>, CharSequence by value {
-    init {
-        assertSanitized<GeometrySwitchTypeName>(
-            value,
-            geometrySwitchTypeNameRegex,
-            geometrySwitchTypeNameLength,
-            allowBlank = true,
-        )
+    companion object {
+        private val allowedLength = 0..30
+        private const val ALLOWED_CHARACTERS = "A-Za-z0-9:\\-/(),."
+        private val sanitizer = StringSanitizer(GeometrySwitchTypeName::class, ALLOWED_CHARACTERS, allowedLength)
     }
+
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanMetaData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanMetaData.kt
@@ -7,7 +7,7 @@ import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.ProjectName
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.util.FreeText
-import fi.fta.geoviite.infra.util.assertSanitized
+import fi.fta.geoviite.infra.util.StringSanitizer
 
 enum class PlanState { ABANDONED, DESTROYED, EXISTING, PROPOSED }
 
@@ -34,18 +34,28 @@ data class Application(
 
 data class Author(val companyName: CompanyName, val id: DomainId<Author> = StringId())
 
-val metaDataNameLength = 1..100
-val metaDataNameRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 _\\-/+&,.:()]+\$")
-
 data class CompanyName @JsonCreator(mode = DELEGATING) constructor(private val value: String) : CharSequence by value {
-    init { assertSanitized<CompanyName>(value, metaDataNameRegex, metaDataNameLength) }
+    companion object {
+        val sanitizer = MetaDataName.sanitizer
+        fun ofUnsafe(value: String) = CompanyName(sanitizer.sanitize(value))
+    }
+
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value
 }
 
 data class MetaDataName @JsonCreator(mode = DELEGATING) constructor(private val value: String) : CharSequence by value {
-    init { assertSanitized<MetaDataName>(value, metaDataNameRegex, metaDataNameLength) }
+
+    companion object {
+        val allowedLength = 1..100
+        const val ALLOWED_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 _\\-/+&,.:()"
+        val sanitizer = StringSanitizer(MetaDataName::class, ALLOWED_CHARACTERS, allowedLength)
+        fun ofUnsafe(value: String) = MetaDataName(sanitizer.sanitize(value))
+    }
+
+    init { CompanyName.sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanMetaData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanMetaData.kt
@@ -55,7 +55,7 @@ data class MetaDataName @JsonCreator(mode = DELEGATING) constructor(private val 
         fun ofUnsafe(value: String) = MetaDataName(sanitizer.sanitize(value))
     }
 
-    init { CompanyName.sanitizer.assertSanitized(value) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/PlanElementName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/PlanElementName.kt
@@ -1,14 +1,17 @@
 package fi.fta.geoviite.infra.inframodel
 
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.util.assertSanitized
-
-
-val elementNameLength = 0..100
-val elementNameRegex = Regex("^[A-Za-zÄÖÅäöå0-9 \\-+_/!?§]*\$")
+import fi.fta.geoviite.infra.util.StringSanitizer
 
 data class PlanElementName(val value: String) : CharSequence by value {
-    init { assertSanitized<PlanElementName>(value, elementNameRegex, elementNameLength, allowBlank = true) }
+    companion object {
+        val allowedLength = 0..100
+        const val ALLOWED_CHARACTERS = "A-Za-zÄÖÅäöå0-9 \\-+_/!?§"
+        val sanitizer = StringSanitizer(PlanElementName::class, ALLOWED_CHARACTERS, allowedLength)
+        fun ofUnsafe(value: String) = PlanElementName(sanitizer.sanitize(value))
+    }
+
+    init { sanitizer.sanitize(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationKey.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationKey.kt
@@ -3,19 +3,40 @@ package fi.fta.geoviite.infra.localization
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.util.assertSanitized
+import fi.fta.geoviite.infra.util.StringSanitizer
 
 data class LocalizationKey @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
     Comparable<LocalizationKey>, CharSequence by value {
 
     companion object {
-        val sanitizer = Regex("^[A-Za-z0-9_\\-.]+\$")
         val allowedLength = 1..100
+        const val ALLOWED_CHARACTERS = "A-Za-z0-9_\\-."
+        val sanitizer = StringSanitizer(LocalizationKey::class, ALLOWED_CHARACTERS, allowedLength)
     }
 
-    init { assertSanitized<LocalizationKey>(value, sanitizer, allowedLength) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value
     override fun compareTo(other: LocalizationKey): Int = value.compareTo(other.value)
 }
+
+data class LocalizationParams @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+constructor(@JsonValue val params: Map<String, String>) {
+
+    companion object {
+        val allowedLength = 1..100
+        const val KEY_ALLOWED_CHARACTERS = "a-zA-Z0-9_\\s\\-"
+        val keySanitizer = StringSanitizer(LocalizationParams::class, KEY_ALLOWED_CHARACTERS, allowedLength)
+        val empty = LocalizationParams(emptyMap())
+    }
+
+    init { params.forEach { (key, _) -> keySanitizer.sanitize(key) } }
+
+    fun get(key: String) = params[key] ?: ""
+}
+
+fun localizationParams(params: Map<String, Any?>): LocalizationParams =
+    LocalizationParams(params.mapValues { it.value?.toString() ?: "" })
+
+fun localizationParams(vararg params: Pair<String, Any?>): LocalizationParams = localizationParams(mapOf(*params))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
@@ -1,38 +1,12 @@
 package fi.fta.geoviite.infra.localization
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.databind.json.JsonMapper
 import fi.fta.geoviite.infra.aspects.GeoviiteService
 import org.springframework.beans.factory.annotation.Value
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
-private val LOCALIZATION_PARAMS_KEY_REGEX = Regex("[a-zA-Z0-9_\\s\\-]*")
 private val LOCALIZATION_PARAMS_PLACEHOLDER_REGEX = Regex("\\{\\{[a-zA-Z0-9_\\s\\-]*\\}\\}")
-
-data class LocalizationParams @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    constructor(@JsonValue val params: Map<String, String>) {
-
-    init {
-        require(params.none { LOCALIZATION_PARAMS_KEY_REGEX.matchEntire(it.key) == null }) {
-            "There are localization keys that do not match with the localization pattern regex. Keys in question are ${
-                params.map { it.key }.filter { LOCALIZATION_PARAMS_KEY_REGEX.matchEntire(it) == null }
-            }"
-        }
-    }
-
-    fun get(key: String) = params[key] ?: ""
-
-    companion object {
-        val empty = LocalizationParams(emptyMap())
-    }
-}
-
-fun localizationParams(params: Map<String, Any?>): LocalizationParams =
-    LocalizationParams(params.mapValues { it.value?.toString() ?: "" })
-
-fun localizationParams(vararg params: Pair<String, Any?>): LocalizationParams = localizationParams(mapOf(*params))
 
 data class Translation(val lang: LocalizationLanguage, val localization: String) {
     private val jsonRoot = JsonMapper().readTree(localization)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVApi.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVApi.kt
@@ -8,42 +8,25 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.Oid
-import fi.fta.geoviite.infra.util.*
+import fi.fta.geoviite.infra.util.StringSanitizer
+import fi.fta.geoviite.infra.util.UnsafeString
+import fi.fta.geoviite.infra.util.assertLength
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
-import java.util.*
-
 
 private val logger = LoggerFactory.getLogger(PVClient::class.java)
 
-val pvTargetCategoryLength = 1..100
-val pvTargetCategoryRegex = Regex("^[A-ZÄÖÅa-zäöå0-9\\-/]+\$")
-data class PVTargetCategory @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<PVTargetCategory>, CharSequence by value {
-    init { assertSanitized<PVTargetCategory>(value, pvTargetCategoryRegex, pvTargetCategoryLength) }
+data class PVId @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<PVId>, CharSequence by value {
 
-    @JsonValue
-    override fun toString(): String = value
-    override fun compareTo(other: PVTargetCategory): Int = value.compareTo(other.value)
-}
+    companion object {
+        val allowedLength = 1..50
+        const val ALLOWED_CHARACTERS = "A-Za-z0-9_\\-./"
+        val sanitizer = StringSanitizer(PVId::class, ALLOWED_CHARACTERS, allowedLength)
+    }
 
-val pvMasterSystemLength = 1..30
-val pvMasterSystemRegex = Regex("^[A-ZÄÖÅa-zäöå0-9\\-/]+\$")
-data class PVMasterSystem @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<PVMasterSystem>, CharSequence by value {
-    init { assertSanitized<PVMasterSystem>(value, pvMasterSystemRegex, pvMasterSystemLength) }
-
-    @JsonValue
-    override fun toString(): String = value
-    override fun compareTo(other: PVMasterSystem): Int = value.compareTo(other.value)
-}
-
-val pvIdLength = 1..50
-val pvIdRegex = Regex("^[A-Za-z0-9_\\-./]+\$")
-data class PVId @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<PVId>, CharSequence by value {
-    init { assertSanitized<PVId>(value, pvIdRegex, pvIdLength) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value
@@ -58,6 +41,13 @@ data class PVApiSearchStatus(
     @JsonProperty("hakutunniste-voimassa") val validFor: Long
 )
 
+data class PVApiDictionaryEntry(
+    val code: PVDictionaryCode,
+    val name: UnsafeString,
+) {
+    constructor(code: String, name: String) : this(PVDictionaryCode(code), UnsafeString(name))
+}
+
 data class PVApiSearchResult(@JsonProperty("osumat") val matches: List<PVApiMatch>)
 
 data class PVApiMatch(
@@ -66,13 +56,13 @@ data class PVApiMatch(
 )
 data class PVApiLatestVersion(
     @JsonProperty("versio") val version: PVId,
-    @JsonProperty("nimi") val name: FileName,
+    @JsonProperty("nimi") val name: UnsafeString,
     @JsonProperty("muokattu") val changeTime: Instant
 )
 
 data class PVApiDocumentMetadata(
     @JsonProperty("tila") val materialState: PVDictionaryCode,
-    @JsonProperty("kuvaus") val description: FreeText?,
+    @JsonProperty("kuvaus") val description: UnsafeString?,
     @JsonProperty("laji") val materialCategory: PVDictionaryCode?,
     @JsonProperty("dokumenttityyppi") val documentType: PVDictionaryCode,
     @JsonProperty("ryhma") val materialGroup: PVDictionaryCode,
@@ -85,14 +75,8 @@ data class PVApiDocument(
     @JsonProperty("metatiedot") val metadata: PVApiDocumentMetadata
 )
 
-data class PVApiRedirect(
-    @JsonProperty("master-jarjestelma") val masterSystem: PVMasterSystem,
-    @JsonProperty("kohdeluokka") val targetCategory: PVTargetCategory,
-    @JsonProperty("kohde-url") val targetUrl: HttpsUrl,
-)
-
 data class PVApiProperties(
-    @JsonProperty("nimi") val name: PVProjectName,
+    @JsonProperty("nimi") val name: UnsafeString,
     @JsonProperty("tila") val state: PVDictionaryCode,
 )
 
@@ -133,18 +117,14 @@ enum class PVFetchStatus {
     ERROR,
 }
 
-
 val pvBearerTokenLength = 1..5000
-data class PVBearerToken @JsonCreator(mode = DELEGATING) constructor(private val value: String)
-    : Comparable<PVBearerToken>, CharSequence by value {
+data class PVBearerToken @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<PVBearerToken>, CharSequence by value {
 
     @get:JsonIgnore
     val decoded by lazy { JWT.decode(value) }
 
-    init {
-        assertLength<PVBearerToken>(value, pvBearerTokenLength)
-    }
-
+    init { assertLength(PVBearerToken::class, value, pvBearerTokenLength) }
 
     @JsonValue
     override fun toString(): String = value
@@ -156,14 +136,16 @@ data class PVAccessToken(
     @JsonProperty("access_token") val accessToken: PVBearerToken,
     @JsonProperty("expires_in") val expiresIn: Long,
     @JsonProperty("token_type") val tokenType: BearerTokenType,
-){
+) {
     private val issueTime: Instant = accessToken.decoded.issuedAtAsInstant ?: Instant.now()
+
     @get:JsonIgnore
     val expireTime: Instant get() = accessToken.decoded.expiresAtAsInstant ?: issueTime.plusSeconds(expiresIn)
 
     init {
         accessToken.decoded.let { t ->
-            logger.info("ProjektiVelho API Bearer token: " +
+            logger.info(
+                "ProjektiVelho API Bearer token: " +
                     "audience=${t.audience} " +
                     "issuer=${t.issuer} " +
                     "subject=${t.subject} " +

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDictionary.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDictionary.kt
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryGroup.MATERIAL
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryGroup.PROJECT
-import fi.fta.geoviite.infra.util.assertSanitized
+import fi.fta.geoviite.infra.util.StringSanitizer
+import fi.fta.geoviite.infra.util.UnsafeString
 
 enum class PVDictionaryGroup {
     MATERIAL,
@@ -20,28 +21,36 @@ enum class PVDictionaryType(val group: PVDictionaryGroup) {
     PROJECT_STATE (PROJECT), // projektin tila
 }
 
-val pvDictionaryCodeLength = 1..50
-val pvDictionaryCodeRegex = Regex("^[A-ZÄÖÅa-zäöå0-9\\-/]+\$")
-data class PVDictionaryCode @JsonCreator(mode = JsonCreator.Mode.DELEGATING) constructor(private val value: String)
-    : Comparable<PVDictionaryCode>, CharSequence by value {
-    init { assertSanitized<PVDictionaryCode>(value, pvDictionaryCodeRegex, pvDictionaryCodeLength) }
+data class PVDictionaryCode @JsonCreator(mode = JsonCreator.Mode.DELEGATING) constructor(private val value: String) :
+    Comparable<PVDictionaryCode>, CharSequence by value {
+
+    companion object {
+        val allowedLength = 1..50
+        const val ALLOWED_CHARACTERS = "A-ZÄÖÅa-zäöå0-9\\-/"
+        val sanitizer = StringSanitizer(PVDictionaryCode::class, ALLOWED_CHARACTERS, allowedLength)
+    }
+
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value
     override fun compareTo(other: PVDictionaryCode): Int = value.compareTo(other.value)
 }
 
-val pvDictionaryNameLength = 1..100
-val pvDictionaryNameRegex = Regex("^[A-ZÄÖÅa-zäöå0-9 _\\-–+().,'/*]*\$")
 data class PVDictionaryName @JsonCreator(mode = JsonCreator.Mode.DELEGATING) constructor(private val value: String)
     : Comparable<PVDictionaryName>, CharSequence by value {
-    init { assertSanitized<PVDictionaryName>(value, pvDictionaryNameRegex, pvDictionaryNameLength) }
+
+    companion object {
+        val allowedLength = 1..100
+        const val ALLOWED_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 _\\-–+().,'/*"
+        val sanitizer = StringSanitizer(PVDictionaryName::class, ALLOWED_CHARACTERS, allowedLength)
+    }
+
+    init { sanitizer.assertSanitized(value) }
+
+    constructor(unsafeString: UnsafeString): this(sanitizer.sanitize(unsafeString.unsafeValue))
 
     @JsonValue
     override fun toString(): String = value
     override fun compareTo(other: PVDictionaryName): Int = value.compareTo(other.value)
-}
-
-data class PVDictionaryEntry(val code: PVDictionaryCode, val name: PVDictionaryName) {
-    constructor(code: String, name: String): this(PVDictionaryCode(code), PVDictionaryName(name))
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationService.kt
@@ -6,11 +6,20 @@ import fi.fta.geoviite.infra.common.FeatureTypeCode
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.error.InframodelParsingException
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
-import fi.fta.geoviite.infra.inframodel.*
+import fi.fta.geoviite.infra.inframodel.INFRAMODEL_PARSING_KEY_GENERIC
+import fi.fta.geoviite.infra.inframodel.INFRAMODEL_PARSING_KEY_PARENT
+import fi.fta.geoviite.infra.inframodel.InfraModelService
+import fi.fta.geoviite.infra.inframodel.censorAuthorIdentifyingInfo
+import fi.fta.geoviite.infra.inframodel.toInfraModelFile
 import fi.fta.geoviite.infra.integration.DatabaseLock
 import fi.fta.geoviite.infra.integration.LockDao
-import fi.fta.geoviite.infra.projektivelho.PVDocumentStatus.*
-import fi.fta.geoviite.infra.projektivelho.PVFetchStatus.*
+import fi.fta.geoviite.infra.projektivelho.PVDocumentStatus.NOT_IM
+import fi.fta.geoviite.infra.projektivelho.PVDocumentStatus.REJECTED
+import fi.fta.geoviite.infra.projektivelho.PVDocumentStatus.SUGGESTED
+import fi.fta.geoviite.infra.projektivelho.PVFetchStatus.ERROR
+import fi.fta.geoviite.infra.projektivelho.PVFetchStatus.FETCHING
+import fi.fta.geoviite.infra.projektivelho.PVFetchStatus.FINISHED
+import fi.fta.geoviite.infra.projektivelho.PVFetchStatus.WAITING
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.formatForLog
 import org.slf4j.Logger
@@ -151,7 +160,8 @@ class PVIntegrationService @Autowired constructor(
     }
 
     private fun insertFileToDatabase(file: PVFileHolder, assignment: PVAssignmentHolder) {
-        val result = file.content?.let { content -> checkInfraModel(content, file.latestVersion.name) }
+        val result = file.content
+            ?.let { content -> checkInfraModel(content, FileName(file.latestVersion.name)) }
             ?: InfraModelCheckResult(NOT_IM, "error.infra-model.missing-file")
         val xmlContent = if (result.state == NOT_IM) null else file.content?.let(::censorAuthorIdentifyingInfo)
         val pvDocumentRowVersion = pvDao.insertDocumentMetadata(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -12,10 +12,25 @@ import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.Translation
 import fi.fta.geoviite.infra.localization.localizationParams
-import fi.fta.geoviite.infra.math.*
+import fi.fta.geoviite.infra.math.IPoint
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.math.Range
+import fi.fta.geoviite.infra.math.roundTo1Decimal
+import fi.fta.geoviite.infra.math.roundTo3Decimals
 import fi.fta.geoviite.infra.switchLibrary.SwitchBaseType
-import fi.fta.geoviite.infra.tracklayout.*
-import fi.fta.geoviite.infra.util.*
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutSegment
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.SegmentPoint
+import fi.fta.geoviite.infra.tracklayout.TopologyLocationTrackSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.util.CsvEntry
+import fi.fta.geoviite.infra.util.FileName
+import fi.fta.geoviite.infra.util.SortOrder
+import fi.fta.geoviite.infra.util.nullsLastComparator
+import fi.fta.geoviite.infra.util.printCsv
+import fi.fta.geoviite.infra.util.rangesOfConsecutiveIndicesOf
 import org.springframework.http.ContentDisposition
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -372,12 +387,10 @@ fun getKmNumbersChangedRemarkOrNull(
     )
 } else summaries.joinToString(". ") { summary ->
     translation.t(
-        "publication-details-table.remark.geometry-changed", LocalizationParams(
-            mapOf(
-                "changedLengthM" to roundTo1Decimal(summary.changedLengthM).toString(),
-                "maxDistance" to roundTo1Decimal(summary.maxDistance).toString(),
-                "addressRange" to "${summary.startAddress.round(0)}-${summary.endAddress.round(0)}"
-            )
+        "publication-details-table.remark.geometry-changed", localizationParams(
+            "changedLengthM" to roundTo1Decimal(summary.changedLengthM).toString(),
+            "maxDistance" to roundTo1Decimal(summary.maxDistance).toString(),
+            "addressRange" to "${summary.startAddress.round(0)}-${summary.endAddress.round(0)}"
         )
     )
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/FreeText.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/FreeText.kt
@@ -8,11 +8,13 @@ data class FreeText @JsonCreator(mode = DELEGATING) constructor(private val valu
     Comparable<FreeText>, CharSequence by value {
 
     companion object {
-        const val ALLOWED_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 _\\\\\\-–+().,'/*<>:;!?&\""
-        val sanitizer = Regex("^[$ALLOWED_CHARACTERS]*\$")
+        const val ALLOWED_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 \t_\\\\\\-–—+(){}.,´`'\"/*#<>\\[\\]:;!?&=€$£@%~$UNSAFE_REPLACEMENT"
+        val sanitizer = StringSanitizer(FreeText::class, ALLOWED_CHARACTERS)
     }
 
-    init { assertSanitized<FreeText>(value, sanitizer) }
+    init { sanitizer.assertSanitized(value) }
+
+    constructor(unsafeString: UnsafeString) : this(sanitizer.sanitize(unsafeString.unsafeValue))
 
     @JsonValue
     override fun toString(): String = value
@@ -25,14 +27,14 @@ data class FreeTextWithNewLines private constructor(private val value: String) :
 
     companion object {
         const val ALLOWED_CHARACTERS = FreeText.ALLOWED_CHARACTERS + "\n"
-        val sanitizer = Regex("^[$ALLOWED_CHARACTERS]*\$")
+        val sanitizer = StringSanitizer(FreeTextWithNewLines::class, ALLOWED_CHARACTERS)
 
         @JvmStatic
         @JsonCreator
         fun of(value: String) = FreeTextWithNewLines(normalizeLinebreaksToUnixFormat(value))
     }
 
-    init { assertSanitized<FreeTextWithNewLines>(value, sanitizer) }
+    init { sanitizer.assertSanitized(value) }
 
     @JsonValue
     override fun toString(): String = value

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/HttpsUrl.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/HttpsUrl.kt
@@ -17,7 +17,7 @@ data class HttpsUrl @JsonCreator(mode = DELEGATING) constructor(private val valu
     }
 
     init {
-        assertLength<HttpsUrl>(value.toString(), urlLength)
+        assertLength(HttpsUrl::class, value.toString(), urlLength)
         require(httpsValidator.isValid(value.toString())) {
             "Not a valid https url: \"${formatForException(value.toString())}\""
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -261,13 +261,17 @@ fun ResultSet.getPolygonPointList(name: String): List<Point> = verifyNotNull(nam
 
 fun ResultSet.getPolygonPointListOrNull(name: String): List<Point>? = getString(name)?.let(::parse2DPolygon)
 
-fun ResultSet.getPVProjectName(name: String): PVProjectName = verifyNotNull(name, ::getPVProjectNameOrNull)
+fun ResultSet.getUnsafeString(name: String): UnsafeString = verifyNotNull(name, ::getUnsafeStringOrNull)
 
-fun ResultSet.getPVProjectNameOrNull(name: String): PVProjectName? = getString(name)?.let(::PVProjectName)
+fun ResultSet.getUnsafeStringOrNull(name: String): UnsafeString? = getString(name)?.let(::UnsafeString)
 
 fun ResultSet.getPVDictionaryName(name: String): PVDictionaryName = verifyNotNull(name, ::getPVDictionaryNameOrNull)
 
-fun ResultSet.getPVDictionaryNameOrNull(name: String): PVDictionaryName? = getString(name)?.let(::PVDictionaryName)
+fun ResultSet.getPVDictionaryNameOrNull(name: String): PVDictionaryName? = getUnsafeStringOrNull(name)?.let(::PVDictionaryName)
+
+fun ResultSet.getPVProjectName(name: String): PVProjectName = verifyNotNull(name, ::getPVProjectNameOrNull)
+
+fun ResultSet.getPVProjectNameOrNull(name: String): PVProjectName? = getUnsafeStringOrNull(name)?.let(::PVProjectName)
 
 fun ResultSet.getPVDictionaryCode(name: String): PVDictionaryCode = verifyNotNull(name, ::getPVDictionaryCodeOrNull)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringSanitizer.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringSanitizer.kt
@@ -1,0 +1,14 @@
+package fi.fta.geoviite.infra.util
+
+import kotlin.reflect.KClass
+
+data class StringSanitizer(val type: KClass<*>, val allowedCharacters: String, val allowedLength: IntRange? = null) {
+    val safeStringRegex by lazy { Regex("^[$allowedCharacters]*\$") }
+    val unsafeCharactersRegex by lazy { Regex("[^$allowedCharacters]") }
+
+    fun assertSanitized(value: String) = assertSanitized(type, value, safeStringRegex, allowedLength)
+
+    fun sanitize(value: String) = sanitize(value, unsafeCharactersRegex, allowedLength?.last)
+
+    fun isSanitized(value: String) = isSanitized(value, safeStringRegex, allowedLength)
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
@@ -1,35 +1,37 @@
 package fi.fta.geoviite.infra.util
 
 import fi.fta.geoviite.infra.error.InputValidationException
-
-val lineBreakRegex = Regex("[\n\r\t]")
-const val UNSAFE_LOG_CHARACTERS = "[^A-Za-zäöÄÖåÅ0-9_-+!?.:;', �/]"
+import kotlin.reflect.KClass
 
 const val UNIX_LINEBREAK = "\n"
 const val LEGACY_LINEBREAK = "\r" // Possibly used in older files were text may be copied and pasted from.
 const val WINDOWS_LINEBREAK = "\r\n"
 
-// Order matters due to both Windows style & legacy linebreaks containing the same special character.
-val linebreakNormalizationRegex = Regex("$WINDOWS_LINEBREAK|$LEGACY_LINEBREAK")
-
 const val UNSAFE_REPLACEMENT = "�"
-const val LINE_BREAK_REPLACEMENT = "^"
+const val LINE_BREAK_REPLACEMENT = "\\n"
+
+const val SAFE_LOG_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 _\\\\\\-–—+(){}.,´`'\"/*#<>\\[\\]:;!?&=€$£@%~$UNSAFE_REPLACEMENT"
 
 const val DEFAULT_LOG_MAX_LENGTH = 100
 const val DEFAULT_EXCEPTION_MAX_LENGTH = 100
 
+val lineBreakRegex = Regex("[\n\r\t]")
+val logUnsafeRegex = Regex("[^$SAFE_LOG_CHARACTERS]")
+// Order matters due to both Windows style & legacy linebreaks containing the same special character.
+val linebreakNormalizationRegex = Regex("$WINDOWS_LINEBREAK|$LEGACY_LINEBREAK")
+
 inline fun <reified T> parsePrefixedInt(prefix: String, value: String): Int =
     parsePrefixed<T>(prefix, value).toIntOrNull()
-        ?: failInput<T>(value) { "Invalid string value: prefix=$prefix value=${formatForException(value)}" }
+        ?: failInput(T::class, value) { "Invalid string value: prefix=$prefix value=${formatForException(value)}" }
 
 inline fun <reified T> parsePrefixed(prefix: String, value: String): String =
     if (value.startsWith(prefix)) value.substring(prefix.length)
-    else failInput<T>(value) { "Invalid string prefix: prefix=$prefix value=${formatForException(value)}" }
-
-fun equalsIgnoreCaseAndWhitespace(s1: String, s2: String) =
-    s1.filterNot(Char::isWhitespace).equals(s2.filterNot(Char::isWhitespace), ignoreCase = false)
+    else failInput(T::class, value) { "Invalid string prefix: prefix=$prefix value=${formatForException(value)}" }
 
 fun formatForException(input: String, maxLength: Int = DEFAULT_EXCEPTION_MAX_LENGTH) = formatForLog(input, maxLength)
+
+fun sanitize(input: String, regex: Regex, maxLength: Int?): String =
+    (if (maxLength != null) limitLength(input, maxLength) else input).replace(regex, "")
 
 fun formatForLog(input: String, maxLength: Int = DEFAULT_LOG_MAX_LENGTH): String =
     "\"${limitLength(input, maxLength).let(::removeLogUnsafe).let(::removeLinebreaks)}\""
@@ -37,47 +39,45 @@ fun formatForLog(input: String, maxLength: Int = DEFAULT_LOG_MAX_LENGTH): String
 fun limitLength(input: String, maxLength: Int) =
     if (input.length <= maxLength) input else "${input.take(maxLength - 2)}.."
 
-fun removeLogUnsafe(input: String) = input.replace(UNSAFE_LOG_CHARACTERS, UNSAFE_REPLACEMENT)
+fun removeLogUnsafe(input: String) = input.replace(logUnsafeRegex, UNSAFE_REPLACEMENT)
 
 fun removeLinebreaks(input: String) = input.replace(lineBreakRegex, LINE_BREAK_REPLACEMENT)
 
 fun normalizeLinebreaksToUnixFormat(input: String) = input.replace(linebreakNormalizationRegex, UNIX_LINEBREAK)
 
-fun isSanitized(
-    stringValue: String,
-    regex: Regex,
-    length: ClosedRange<Int>? = null,
-    allowBlank: Boolean = true,
-) = (length == null || stringValue.length in length)
-        && (allowBlank || stringValue.isNotBlank())
-        && stringValue.matches(regex)
+fun isSanitized(stringValue: String, regex: Regex, length: ClosedRange<Int>? = null) =
+    (length == null || stringValue.length in length) && stringValue.matches(regex)
 
 inline fun <reified T> assertSanitized(
     stringValue: String,
     regex: Regex,
     length: IntRange? = null,
-    allowBlank: Boolean = true,
+) = assertSanitized(T::class, stringValue, regex, length)
+
+fun assertSanitized(
+    type: KClass<*>,
+    stringValue: String,
+    regex: Regex,
+    length: IntRange? = null,
 ) {
-    length?.let { l -> assertLength<T>(stringValue, l) }
-    assertInput<T>(allowBlank || stringValue.isNotBlank(), stringValue) {
-        "Invalid (blank) value for ${T::class.simpleName}: ${formatForException(stringValue)}"
-    }
-    assertInput<T>(stringValue.matches(regex), stringValue) {
-        "Invalid characters in ${T::class.simpleName}: ${formatForException(stringValue)}"
+    length?.let { l -> assertLength(type, stringValue, l) }
+    assertInput(type, stringValue.matches(regex), stringValue) {
+        "Invalid characters in ${type.simpleName}: ${formatForException(stringValue)}"
     }
 }
 
-inline fun <reified T> assertLength(
+fun assertLength(
+    type: KClass<*>,
     value: String,
     length: IntRange,
     getError: () -> String = {
-        "Invalid length for ${T::class.simpleName} ${value.length} not in [${length.first}..${length.last}]"
+        "Invalid length for ${type.simpleName} ${value.length} not in [${length.first}..${length.last}]"
     },
-): Unit = assertInput<T>(value.length in length, value, getError)
+): Unit = assertInput(type, value.length in length, value, getError)
 
-inline fun <reified T> assertInput(condition: Boolean, value: String, lazyMessage: () -> String) {
-    if (!condition) failInput<T>(value, lazyMessage)
+fun assertInput(type: KClass<*>, condition: Boolean, value: String, lazyMessage: () -> String) {
+    if (!condition) failInput(type, value, lazyMessage)
 }
 
-inline fun <reified T> failInput(value: String, lazyMessage: () -> String): Nothing =
-    throw InputValidationException(lazyMessage(), T::class, value)
+fun failInput(type: KClass<*>, value: String, lazyMessage: () -> String): Nothing =
+    throw InputValidationException(lazyMessage(), type, value)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
@@ -7,8 +7,8 @@ const val UNIX_LINEBREAK = "\n"
 const val LEGACY_LINEBREAK = "\r" // Possibly used in older files were text may be copied and pasted from.
 const val WINDOWS_LINEBREAK = "\r\n"
 
-const val UNSAFE_REPLACEMENT = "�"
-const val LINE_BREAK_REPLACEMENT = "\\n"
+const val UNSAFE_REPLACEMENT = "�" // Replace unsafe characters with a clear placeholder
+const val LINE_BREAK_REPLACEMENT = "\\n" // Escape line breaks to prevent log forging
 
 const val SAFE_LOG_CHARACTERS = "A-ZÄÖÅa-zäöå0-9 _\\\\\\-–—+(){}.,´`'\"/*#<>\\[\\]:;!?&=€$£@%~$UNSAFE_REPLACEMENT"
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/UnsafeString.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/UnsafeString.kt
@@ -1,0 +1,22 @@
+package fi.fta.geoviite.infra.util
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * Unlike most of the sanitized string classes, this one does not actually enforce any safe content.
+ * Instead, it takes in anything given, providing methods to get both the sanitized and unsafe values.
+ *
+ * This is useful when we cannot enforce the validity of the content but want to store it as-is, for
+ * example, integrations.
+ */
+data class UnsafeString @JsonCreator constructor(val unsafeValue: String) :
+    Comparable<UnsafeString>, CharSequence by unsafeValue {
+
+    override fun toString(): String = unsafeValue
+
+    override fun compareTo(other: UnsafeString): Int = unsafeValue.compareTo(other.unsafeValue)
+
+    @JsonValue
+    fun toJson(): String = error("${this::class.simpleName} should not be serialized")
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVApiSerializationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVApiSerializationTest.kt
@@ -2,8 +2,7 @@ package fi.fta.geoviite.infra.projektivelho
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import fi.fta.geoviite.infra.util.FreeText
-import fi.fta.geoviite.infra.util.HttpsUrl
+import fi.fta.geoviite.infra.util.UnsafeString
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -31,9 +30,9 @@ class PVApiSerializationTest @Autowired constructor(val mapper: ObjectMapper) {
     }
 
     @Test
-    fun `Metadata is serialized and deserialized correctly`() {
+    fun `Metadata is deserialized correctly`() {
         val materialState = PVDictionaryCode("matstate/some01")
-        val description = FreeText("some description")
+        val description = UnsafeString("some description")
         val materialCategory = PVDictionaryCode("matcat/some01")
         val documentType = PVDictionaryCode("doctype/some01")
         val materialGroup = PVDictionaryCode("matgrp/some01")
@@ -51,20 +50,8 @@ class PVApiSerializationTest @Autowired constructor(val mapper: ObjectMapper) {
             containsPersonalInfo
         )
 
-        assertEquals(json, toJson(data))
+        // Test only deserialization, as we never serialize these anyhow and unsafe string is not serializable
         assertEquals(data, toObject<PVApiDocumentMetadata>(json))
-    }
-
-    @Test
-    fun `Redirect is serialized and deserialized correctly`() {
-        val masterSystem = PVMasterSystem("someservice")
-        val targetCategory = PVTargetCategory("somenamespace/somecategory")
-        val targetUrl = HttpsUrl("https://some.url.org:1234/some-path?query=test&other=other")
-        val json = """{"master-jarjestelma":"$masterSystem","kohdeluokka":"$targetCategory","kohde-url":"$targetUrl"}"""
-        val data = PVApiRedirect(masterSystem, targetCategory, targetUrl)
-
-        assertEquals(json, toJson(data))
-        assertEquals(data, toObject<PVApiRedirect>(json))
     }
 
     private fun toJson(value: Any): String = mapper.writeValueAsString(value)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.projektivelho
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryGroup.MATERIAL
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryGroup.PROJECT
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.DOCUMENT_TYPE
@@ -11,8 +12,7 @@ import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.MATERIAL_GROUP
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.MATERIAL_STATE
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.PROJECT_STATE
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.TECHNICS_FIELD
-import fi.fta.geoviite.infra.util.FileName
-import fi.fta.geoviite.infra.localization.LocalizationKey
+import fi.fta.geoviite.infra.util.UnsafeString
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -61,43 +61,43 @@ class PVIntegrationServiceIT @Autowired constructor(
         pvIntegrationService.updateDictionaries()
         PVDictionaryType.values().forEach { type ->
             assertEquals(
-                (materialDictionaries + projectDictionaries)[type]!!.map { e -> e.code to e.name }.associate { it },
+                (materialDictionaries + projectDictionaries)[type]!!.map { e -> e.code to PVDictionaryName(e.name) }.associate { it },
                 pvDao.fetchDictionary(type),
             )
         }
 
-        val materialDictionaries2: Map<PVDictionaryType, List<PVDictionaryEntry>> = mapOf(
+        val materialDictionaries2: Map<PVDictionaryType, List<PVApiDictionaryEntry>> = mapOf(
             DOCUMENT_TYPE to listOf(
-                PVDictionaryEntry("dokumenttityyppi/dt01", "test doc type 1"),
-                PVDictionaryEntry("dokumenttityyppi/dt02", "test doc type 2 altered"),
-                PVDictionaryEntry("dokumenttityyppi/dt03", "test doc type 3 added"),
+                PVApiDictionaryEntry("dokumenttityyppi/dt01", "test doc type 1"),
+                PVApiDictionaryEntry("dokumenttityyppi/dt02", "test doc type 2 altered"),
+                PVApiDictionaryEntry("dokumenttityyppi/dt03", "test doc type 3 added"),
             ),
             MATERIAL_STATE to listOf(
-                PVDictionaryEntry("aineistotila/tila01", "test mat state 1"),
-                PVDictionaryEntry("aineistotila/tila02", "test mat state 2 altered"),
-                PVDictionaryEntry("aineistotila/tila03", "test mat state 3 added"),
+                PVApiDictionaryEntry("aineistotila/tila01", "test mat state 1"),
+                PVApiDictionaryEntry("aineistotila/tila02", "test mat state 2 altered"),
+                PVApiDictionaryEntry("aineistotila/tila03", "test mat state 3 added"),
             ),
             MATERIAL_CATEGORY to listOf(
-                PVDictionaryEntry("aineistolaji/al00", "test mat category 0 altered"),
-                PVDictionaryEntry("aineistolaji/al01", "test mat category 1"),
-                PVDictionaryEntry("aineistolaji/al02", "test mat category 2 added"),
+                PVApiDictionaryEntry("aineistolaji/al00", "test mat category 0 altered"),
+                PVApiDictionaryEntry("aineistolaji/al01", "test mat category 1"),
+                PVApiDictionaryEntry("aineistolaji/al02", "test mat category 2 added"),
             ),
             MATERIAL_GROUP to listOf(
-                PVDictionaryEntry("aineistoryhma/ar00", "test mat group 0 altered"),
-                PVDictionaryEntry("aineistoryhma/ar01", "test mat group 1"),
-                PVDictionaryEntry("aineistoryhma/ar02", "test mat group 2 added"),
+                PVApiDictionaryEntry("aineistoryhma/ar00", "test mat group 0 altered"),
+                PVApiDictionaryEntry("aineistoryhma/ar01", "test mat group 1"),
+                PVApiDictionaryEntry("aineistoryhma/ar02", "test mat group 2 added"),
             ),
             TECHNICS_FIELD to listOf(
-                PVDictionaryEntry("tekniikka-ala/ta00", "test tech field 0"),
-                PVDictionaryEntry("tekniikka-ala/ta01", "test tech field 1 altered"),
-                PVDictionaryEntry("tekniikka-ala/ta02", "test tech field 2 added"),
+                PVApiDictionaryEntry("tekniikka-ala/ta00", "test tech field 0"),
+                PVApiDictionaryEntry("tekniikka-ala/ta01", "test tech field 1 altered"),
+                PVApiDictionaryEntry("tekniikka-ala/ta02", "test tech field 2 added"),
             ),
         )
-        val projectDictionaries2: Map<PVDictionaryType, List<PVDictionaryEntry>> = mapOf(
+        val projectDictionaries2: Map<PVDictionaryType, List<PVApiDictionaryEntry>> = mapOf(
             PROJECT_STATE to listOf(
-                PVDictionaryEntry("tila/tila14", "test state 14 altered"),
-                PVDictionaryEntry("tila/tila15", "test state 15"),
-                PVDictionaryEntry("tila/tila15", "test state 16 added"),
+                PVApiDictionaryEntry("tila/tila14", "test state 14 altered"),
+                PVApiDictionaryEntry("tila/tila15", "test state 15"),
+                PVApiDictionaryEntry("tila/tila15", "test state 16 added"),
             ),
         )
         fakeProjektiVelho.fetchDictionaries(MATERIAL, materialDictionaries2)
@@ -105,7 +105,7 @@ class PVIntegrationServiceIT @Autowired constructor(
         pvIntegrationService.updateDictionaries()
         PVDictionaryType.values().forEach { type ->
             assertEquals(
-                (materialDictionaries2 + projectDictionaries2)[type]!!.map { e -> e.code to e.name }.associate { it },
+                (materialDictionaries2 + projectDictionaries2)[type]!!.map { e -> e.code to PVDictionaryName(e.name) }.associate { it },
                 pvDao.fetchDictionary(type),
             )
         }
@@ -199,17 +199,22 @@ class PVIntegrationServiceIT @Autowired constructor(
 }
 
 fun insertTestDictionary(pvDao: PVDao) {
-    pvDao.upsertDictionary(DOCUMENT_TYPE, listOf(PVDictionaryEntry("test", "test")))
-    pvDao.upsertDictionary(MATERIAL_CATEGORY, listOf(PVDictionaryEntry("test", "test")))
-    pvDao.upsertDictionary(MATERIAL_GROUP, listOf(PVDictionaryEntry("test", "test")))
-    pvDao.upsertDictionary(MATERIAL_STATE, listOf(PVDictionaryEntry("test", "test")))
+    pvDao.upsertDictionary(DOCUMENT_TYPE, listOf(PVApiDictionaryEntry("test", "test")))
+    pvDao.upsertDictionary(MATERIAL_CATEGORY, listOf(PVApiDictionaryEntry("test", "test")))
+    pvDao.upsertDictionary(MATERIAL_GROUP, listOf(PVApiDictionaryEntry("test", "test")))
+    pvDao.upsertDictionary(MATERIAL_STATE, listOf(PVApiDictionaryEntry("test", "test")))
 }
 
 fun insertDocumentMetaWithStatus(pvDao: PVDao, oid: Oid<PVDocument>, status: PVDocumentStatus) =
     pvDao.insertDocumentMetadata(
-        oid = oid, assignmentOid = null, latestVersion = PVApiLatestVersion(
-            version = PVId("test"), name = FileName("test"), changeTime = Instant.now()
-        ), metadata = PVApiDocumentMetadata(
+        oid = oid,
+        assignmentOid = null,
+        latestVersion = PVApiLatestVersion(
+            version = PVId("test"),
+            name = UnsafeString("test"),
+            changeTime = Instant.now()
+        ),
+        metadata = PVApiDocumentMetadata(
             materialCategory = PVDictionaryCode("test"),
             description = null,
             materialGroup = PVDictionaryCode("test"),
@@ -217,8 +222,9 @@ fun insertDocumentMetaWithStatus(pvDao: PVDao, oid: Oid<PVDocument>, status: PVD
             documentType = PVDictionaryCode("test"),
             technicalFields = emptyList(),
             containsPersonalInfo = false
-        ), projectGroupOid = null, projectOid = null, status = status
+        ),
+        projectGroupOid = null, projectOid = null, status = status
     )
 
-private fun getTestDataDictionaryName(type: PVDictionaryType, code: PVDictionaryCode) =
-    (materialDictionaries + projectDictionaries)[type]?.find { e -> e.code == code }?.name
+private fun getTestDataDictionaryName(type: PVDictionaryType, code: PVDictionaryCode): PVDictionaryName? =
+    (materialDictionaries + projectDictionaries)[type]?.find { e -> e.code == code }?.name?.let(::PVDictionaryName)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVTestData.kt
@@ -1,31 +1,31 @@
 package fi.fta.geoviite.infra.projektivelho
 
-val materialDictionaries: Map<PVDictionaryType, List<PVDictionaryEntry>> = mapOf(
+val materialDictionaries: Map<PVDictionaryType, List<PVApiDictionaryEntry>> = mapOf(
     PVDictionaryType.DOCUMENT_TYPE to listOf(
-        PVDictionaryEntry("dokumenttityyppi/dt01", "test doc type 1"),
-        PVDictionaryEntry("dokumenttityyppi/dt02", "test doc type 2"),
+        PVApiDictionaryEntry("dokumenttityyppi/dt01", "test doc type 1"),
+        PVApiDictionaryEntry("dokumenttityyppi/dt02", "test doc type 2"),
     ),
     PVDictionaryType.MATERIAL_STATE to listOf(
-        PVDictionaryEntry("aineistotila/tila01", "test mat state 1"),
-        PVDictionaryEntry("aineistotila/tila02", "test mat state 2"),
+        PVApiDictionaryEntry("aineistotila/tila01", "test mat state 1"),
+        PVApiDictionaryEntry("aineistotila/tila02", "test mat state 2"),
     ),
     PVDictionaryType.MATERIAL_CATEGORY to listOf(
-        PVDictionaryEntry("aineistolaji/al00", "test mat category 0"),
-        PVDictionaryEntry("aineistolaji/al01", "test mat category 1"),
+        PVApiDictionaryEntry("aineistolaji/al00", "test mat category 0"),
+        PVApiDictionaryEntry("aineistolaji/al01", "test mat category 1"),
     ),
     PVDictionaryType.MATERIAL_GROUP to listOf(
-        PVDictionaryEntry("aineistoryhma/ar00", "test mat group 0"),
-        PVDictionaryEntry("aineistoryhma/ar01", "test mat group 1"),
+        PVApiDictionaryEntry("aineistoryhma/ar00", "test mat group 0"),
+        PVApiDictionaryEntry("aineistoryhma/ar01", "test mat group 1"),
     ),
     PVDictionaryType.TECHNICS_FIELD to listOf(
-        PVDictionaryEntry("tekniikka-ala/ta00", "test tech field 0"),
-        PVDictionaryEntry("tekniikka-ala/ta01", "test tech field 1"),
+        PVApiDictionaryEntry("tekniikka-ala/ta00", "test tech field 0"),
+        PVApiDictionaryEntry("tekniikka-ala/ta01", "test tech field 1"),
     ),
 )
 
-val projectDictionaries: Map<PVDictionaryType, List<PVDictionaryEntry>> = mapOf(
+val projectDictionaries: Map<PVDictionaryType, List<PVApiDictionaryEntry>> = mapOf(
     PVDictionaryType.PROJECT_STATE to listOf(
-        PVDictionaryEntry("tila/tila14", "test state 14"),
-        PVDictionaryEntry("tila/tila15", "test state 15"),
+        PVApiDictionaryEntry("tila/tila14", "test state 14"),
+        PVApiDictionaryEntry("tila/tila15", "test state 15"),
     ),
 )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/ProjektiVelhoTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/ProjektiVelhoTestUI.kt
@@ -18,14 +18,12 @@ import fi.fta.geoviite.infra.projektivelho.PVDocumentStatus
 import fi.fta.geoviite.infra.projektivelho.PVId
 import fi.fta.geoviite.infra.projektivelho.PVProject
 import fi.fta.geoviite.infra.projektivelho.PVProjectGroup
-import fi.fta.geoviite.infra.projektivelho.PVProjectName
 import fi.fta.geoviite.infra.projektivelho.materialDictionaries
 import fi.fta.geoviite.infra.projektivelho.projectDictionaries
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.common.waitAndClearToast
 import fi.fta.geoviite.infra.ui.pagemodel.inframodel.E2EProjektiVelhoListItem
-import fi.fta.geoviite.infra.util.FileName
-import fi.fta.geoviite.infra.util.FreeText
+import fi.fta.geoviite.infra.util.UnsafeString
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -98,10 +96,6 @@ class ProjektiVelhoTestUI @Autowired constructor(
             )
 
             fakeProjektiVelho.login()
-            fakeProjektiVelho.redirect(documentOid)
-            fakeProjektiVelho.redirect(projectOid)
-            fakeProjektiVelho.redirect(projectGroupOid)
-            fakeProjektiVelho.redirect(assignmentOid)
             startGeoviite()
             val velhoPage = goToInfraModelPage().openVelhoWaitingForApprovalList()
             velhoPage
@@ -126,7 +120,7 @@ class ProjektiVelhoTestUI @Autowired constructor(
         assignmentOid: Oid<PVAssignment> = Oid("3.4.5.6.7"),
     ): RowVersion<PVDocument> {
         val someProperties = PVApiProperties(
-            name = PVProjectName("testi_projekti"),
+            name = UnsafeString("testi_projekti"),
             state = PVDictionaryCode("tila/tila14"),
         )
 
@@ -168,11 +162,11 @@ class ProjektiVelhoTestUI @Autowired constructor(
                 technicalFields = listOf(PVDictionaryCode("tekniikka-ala/ta00")),
                 materialCategory = PVDictionaryCode("aineistolaji/al00"),
                 containsPersonalInfo = false,
-                description = FreeText("goo goo ga ga")
+                description = UnsafeString("goo goo ga ga")
             ),
             latestVersion = PVApiLatestVersion(
                 version = PVId("123456"),
-                name = FileName("foo bar.xml"),
+                name = UnsafeString("foo bar.xml"),
                 changeTime = Instant.parse("2023-03-04T05:06:07.089Z"),
             ),
             status = PVDocumentStatus.SUGGESTED,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
@@ -11,13 +11,13 @@ val allowedFreeTextCases = listOf(
     "",
     "Legal Free text: * -> 'asdf' (Äö/å) _-–\\ +123465790?!",
     "legal with quote\"",
+    "legal ´`@%=",
+    "legal \tName",
 )
 
 val illegalFreeTextCases = listOf(
-    "Illegal`",
-    "Illegal´",
-    "Illegal=",
-    "Illegal\tName",
+    "Illegal^",
+    "Illegal|",
 )
 
 val freeTextWithNewLineCases = listOf(
@@ -28,33 +28,6 @@ val freeTextWithNewLineCases = listOf(
 )
 
 class SanitizedStringTest {
-
-    @Test
-    fun `Code can't contain illegal chars`() {
-        assertDoesNotThrow { AuthCode("LEGAL-M123.3_0") }
-        assertThrows<InputValidationException> { AuthCode("") }
-        assertThrows<InputValidationException> { AuthCode("Ä1") }
-        assertThrows<InputValidationException> { AuthCode("A A") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL'") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL`") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL´") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL*") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL+") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL(") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL)") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL<") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL>") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL!") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL=") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL?") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL/") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL:") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL;") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL\\") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL\"") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL\n") }
-        assertThrows<InputValidationException> { AuthCode("ILLEGAL\tCode") }
-    }
 
     @Test
     fun `FreeText can't contain illegal chars`() {


### PR DESCRIPTION
Täällä oikeat sanitoinnin muutokset:
- Tein erillisen sanitizer-tyypin ja yhtenäistin parilla eri tavalla tehdyt sanitoinnit sen alle
- Projektivelhon string-muotoiset kentät otetaan sisään sellaisenaan ja UnsafeString-tyypillä ja tallennetaan. Lukuvaiheessa niistä sanitoidaan ei-sallitut merkit pois ja ne luetaan nirsompiin tyyppeihin
- Vastaavaa muutosta tehty myös inframallien parsintaan