### PR TITLE
GVT-2357 Optimize calculateSwitchLocationDelta

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
@@ -789,7 +789,7 @@ fun validateSwitch(
 
 fun validateSwitchGeometry(switch: GeometrySwitch, switchStructure: SwitchStructure): List<SwitchDefinitionError> {
     val joints: List<GeometrySwitchJoint> = switch.joints
-    val positionTransformation = if (joints.size > 1) getSwitchPositionTransformation(switchStructure, joints) else null
+    val positionTransformation = if (joints.size > 1) calculateSwitchLocationDelta(joints, switchStructure) else null
     return if (positionTransformation == null) {
         listOfNotNull(
             validate(joints.size <= 1) { SwitchDefinitionError("location-difference", OBSERVATION_MAJOR, switch.name) }
@@ -871,13 +871,6 @@ fun validateSwitchAlignments(
         )
     }
 }
-
-fun getSwitchPositionTransformation(switchStructure: SwitchStructure, joints: List<GeometrySwitchJoint>) =
-    try {
-        calculateSwitchLocationDelta(joints, switchStructure)
-    } catch (e: Exception) {
-        null
-    }
 
 fun collectAlignmentSwitchJoints(switchId: DomainId<GeometrySwitch>, alignment: GeometryAlignment): AlignmentSwitch? {
     return alignment.elements

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
@@ -38,7 +38,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.switchLibrary.SwitchPositionTransformation
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
-import fi.fta.geoviite.infra.switchLibrary.calculateSwitchLocationDeltaOrNull
+import fi.fta.geoviite.infra.switchLibrary.calculateSwitchLocationDelta
 import fi.fta.geoviite.infra.switchLibrary.transformSwitchPoint
 import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.IAlignment
@@ -171,7 +171,7 @@ fun calculateLayoutSwitchJoints(
         geomSwitch.joints.map { geomJoint ->
             SwitchJoint(number = geomJoint.number, location = toLayoutCoordinate.transform(geomJoint.location))
         }
-    val switchLocationDelta = calculateSwitchLocationDeltaOrNull(layoutJointPoints, switchStructure)
+    val switchLocationDelta = calculateSwitchLocationDelta(layoutJointPoints, switchStructure)
     return if (switchLocationDelta != null) {
         switchStructure.alignmentJoints.map { joint ->
             SwitchJoint(number = joint.number, location = transformSwitchPoint(switchLocationDelta, joint.location))
@@ -549,7 +549,7 @@ fun findTransformations(
         )
         .mapNotNull { (from, to) ->
             val testJoints = listOf(joint.copy(location = from.toPoint()), farthestJoint.copy(location = to.toPoint()))
-            calculateSwitchLocationDeltaOrNull(testJoints, switchStructure)
+            calculateSwitchLocationDelta(testJoints, switchStructure)
         }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -281,21 +281,10 @@ data class SwitchStructure(
 /** Contains information how the geometry of a switch is transformed from an ideal switch (from the switch library). */
 data class SwitchPositionTransformation(val translation: Point, val rotation: Angle, val rotationReferencePoint: Point)
 
-fun calculateSwitchLocationDeltaOrNull(
-    joints: List<ISwitchJoint>,
-    switchStructure: SwitchStructure,
-): SwitchPositionTransformation? {
-    return try {
-        calculateSwitchLocationDelta(joints, switchStructure)
-    } catch (e: InvalidJointsException) {
-        null
-    }
-}
-
 fun calculateSwitchLocationDelta(
     joints: List<ISwitchJoint>,
     switchStructure: SwitchStructure,
-): SwitchPositionTransformation {
+): SwitchPositionTransformation? {
     val jointPairs =
         joints.mapNotNull { joint ->
             val matchingStructureJoint =
@@ -303,17 +292,14 @@ fun calculateSwitchLocationDelta(
             if (matchingStructureJoint != null) Pair(joint, matchingStructureJoint) else null
         }
 
-    if (jointPairs.size < 2) {
-        throw InvalidJointsException("Switch angle cannot be calculated by ${jointPairs.size} common joints!")
-    }
-
     if (
-        abs(
-            lineLength(jointPairs[0].first.location, jointPairs[1].first.location) -
-                lineLength(jointPairs[0].second.location, jointPairs[1].second.location)
-        ) > 0.1
+        jointPairs.size < 2 ||
+            abs(
+                lineLength(jointPairs[0].first.location, jointPairs[1].first.location) -
+                    lineLength(jointPairs[0].second.location, jointPairs[1].second.location)
+            ) > 0.1
     ) {
-        throw InvalidJointsException("Given joints do not match to the given switch structure!")
+        return null
     }
 
     val angleDelta =


### PR DESCRIPTION
Vaihteiden live-linkityksen muut optimoinnit (jotka tulevat myöhemmissä, isommissa pullareissa) saivat aikaan sen, että poikkeusten heitto tästä funktiosta alkoi näkyä profiileissa aika isona. Poikkeustiedolla ei missään tehdä oikeasti mitään, ja kaikki kutsujat korvasivat poikkeuksen nullilla, eli sama palauttaa näissä ihan vaan suoraan nullia näissä tilanteissa, jotka eivät sitten kai olekaan niin poikkeuksellisia.