### PR TITLE
GVT-2387 Fix length sanitizing & include it in tests

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
@@ -31,7 +31,7 @@ inline fun <reified T> parsePrefixed(prefix: String, value: String): String =
 fun formatForException(input: String, maxLength: Int = DEFAULT_EXCEPTION_MAX_LENGTH) = formatForLog(input, maxLength)
 
 fun sanitize(input: String, regex: Regex, maxLength: Int?): String =
-    (if (maxLength != null) limitLength(input, maxLength) else input).replace(regex, "")
+    input.replace(regex, "").let { s -> if (maxLength != null) s.take(maxLength) else s }
 
 fun formatForLog(input: String, maxLength: Int = DEFAULT_LOG_MAX_LENGTH): String =
     "\"${limitLength(input, maxLength).let(::removeLogUnsafe).let(::removeLinebreaks)}\""

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
@@ -70,12 +70,21 @@ class SanitizedStringTest {
         val legalCharacters = "ABCFÖ1-3_"
         val legalLength = 1..10
         val sanitizer = StringSanitizer(SanitizedStringTest::class, legalCharacters, legalLength)
+        // Legal characters pass
         assertSanitized(sanitizer, "ABCFÖ123_")
         assertSanitized(sanitizer, "C_2")
+        // Wrong characters filtered out
         assertNotSanitized(sanitizer, "AGB", "AB")
         assertNotSanitized(sanitizer, "abc2Af", "2A")
         assertNotSanitized(sanitizer, "4", "")
         assertNotSanitized(sanitizer, "A-B", "AB")
+        // OK length
+        assertSanitized(sanitizer, "A")
+        assertSanitized(sanitizer, "AAAAAAAAAA")
+        // Too long
+        assertNotSanitized(sanitizer, "AAAAAAAAAAA", "AAAAAAAAAA")
+        // Too short - cannot be fixed by filtering
+        assertNotSanitized(sanitizer, "", "")
     }
 
     private fun assertSanitized(sanitizer: StringSanitizer, value: String) {


### PR DESCRIPTION
Aiempi loggerin limit length teki tähän tarkoitukseen väärää asiaa -> korjattu sanitize yksinkertaisempaan malliin jotta hoitaa myös pituuden oikein.