### PR TITLE
General: Enable gradle caches by default

### DIFF
--- a/infra/gradle.properties
+++ b/infra/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.jvmargs=-Xmx1g -Dkotlin.daemon.jvm.options=-Xmx1g
 org.gradle.parallel=true
+org.gradle.configuration-cache=true
+org.gradle.caching=true
 selenium.version=4.18.0


### PR DESCRIPTION
Huomasin että gradlessa ei ollut build cachet käytössä. Jos havaitsette näistä jotain ongelmia niin sanokaa, mutta tuon pitäisi nopeuttaa rebuildeja.