### PR TITLE
GVT-2723: Hide validation spinner only after the last validation call has finished

### DIFF
--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -125,6 +125,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
 
     const [showPreview, setShowPreview] = React.useState<boolean>(true);
 
+    const latestValidationIdRef = React.useRef<number>(0);
     const [showValidationStatusSpinner, setShowValidationStatusSpinner] =
         React.useState<boolean>(true);
 
@@ -200,12 +201,18 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                 });
             }
 
+            const validationId = latestValidationIdRef.current + 1;
+            latestValidationIdRef.current = validationId;
             setShowValidationStatusSpinner(true);
 
             return validateDebounced(
                 props.layoutContext.branch,
                 props.stagedPublicationCandidateReferences,
-            ).finally(() => setShowValidationStatusSpinner(false));
+            ).finally(() => {
+                if (latestValidationIdRef.current === validationId) {
+                    setShowValidationStatusSpinner(false);
+                }
+            });
         }, [props.stagedPublicationCandidateReferences, publicationCandidates]) ??
         emptyValidatedPublicationCandidates();
 
@@ -529,8 +536,8 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                     ? officialLayoutContext(props.layoutContext)
                                     : draftMainLayoutContext()
                                 : mapDisplayTransitionSide === 'WITH_CHANGES'
-                                  ? draftLayoutContext(props.layoutContext)
-                                  : officialLayoutContext(props.layoutContext)
+                                ? draftLayoutContext(props.layoutContext)
+                                : officialLayoutContext(props.layoutContext)
                         }
                     />
                 </MapContext.Provider>


### PR DESCRIPTION
Previously if there were multiple in-flight validation requests where at least one took more than a second, the previous validation call may have returned and cleared the validation loading status before the further call finished, which would allow a user to publish items that were not yet validated.