### PR TITLE
General: Bump TypeScript version

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -67,7 +67,7 @@
                 "ts-loader": "~9.5.1",
                 "ts-node": "~10.9.1",
                 "typed-scss-modules": "^8.0.1",
-                "typescript": "~5.3.3",
+                "typescript": "^5.5.4",
                 "webpack": "~5.90.3",
                 "webpack-cli": "~5.1.4",
                 "webpack-dev-server": "~5.0.2",
@@ -12033,10 +12033,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,7 +44,7 @@
         "ts-loader": "~9.5.1",
         "ts-node": "~10.9.1",
         "typed-scss-modules": "^8.0.1",
-        "typescript": "~5.3.3",
+        "typescript": "~5.5.4",
         "webpack": "~5.90.3",
         "webpack-cli": "~5.1.4",
         "webpack-dev-server": "~5.0.2",

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -56,7 +56,7 @@ export const countPublicationGroupAmounts = (
         const publicationGroupId = candidate.publicationGroup?.id;
 
         if (publicationGroupId) {
-            publicationGroupId in groupSizes
+            groupSizes[publicationGroupId] !== undefined
                 ? (groupSizes[publicationGroupId] += 1)
                 : (groupSizes[publicationGroupId] = 1);
         }


### PR DESCRIPTION
Ei itse asiassa kummempaa syytä päivittää juuri tällä hetkellä, satuin vaan katsomaan että onpas taas näppäriä ominaisuuksia saatu. En lähtenyt https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#inferred-type-predicates myötä vielä poistamaan filterNotEmptyjä pois, eikä kai kannatkaan.