### PR TITLE
GVT-2702: Yksittäisen InfraModelin detaljinäkymän parannuksia + edit-ikonien napittaminen

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EInfoBox.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EInfoBox.kt
@@ -37,7 +37,7 @@ abstract class E2EInfoBox(infoboxBy: By) : E2EViewFragment(infoboxBy) {
     protected fun editFields(): E2EInfoBox = apply {
         logger.info("Enable editing")
 
-        clickChild(By.className("infobox__edit-icon"))
+        clickChild(byQaId("infobox-edit-button"))
     }
 
     protected fun waitUntilValueChangesForField(fieldQaId: String, targetValue: String): E2EInfoBox = apply {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelElement.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/inframodel/InfraModelElement.kt
@@ -126,5 +126,5 @@ internal class E2EFormGroupField(by: By) : E2EViewFragment(by) {
         waitUntilFieldIs(value)
     }
 
-    private fun toggleEdit() = clickChild(By.xpath("div[@class='formgroup__edit-icon']/div"))
+    private fun toggleEdit() = clickChild(By.xpath("div[@class='formgroup__edit-icon']/button"))
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/UserRoleTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/UserRoleTestUI.kt
@@ -28,7 +28,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.openqa.selenium.By
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -173,7 +172,7 @@ fun assertTrackLayoutPageEditButtonsInvisible(trackLayoutPage: E2ETrackLayoutPag
 
     waitUntilNotExist(byQaId("open-preview-view"))
     waitUntilNotExist(byQaId("tool-bar.new"))
-    waitUntilNotExist(By.cssSelector(".infobox__edit-icon"))
+    waitUntilNotExist(byQaId("infobox-edit-button"))
 }
 
 fun assertTrackLayoutPageEditButtonsVisible(trackLayoutPage: E2ETrackLayoutPage, trackNumber: TrackNumber) {
@@ -183,7 +182,7 @@ fun assertTrackLayoutPageEditButtonsVisible(trackLayoutPage: E2ETrackLayoutPage,
     waitUntilExists(byQaId("design-mode-tab"))
     waitUntilExists(byQaId("open-preview-view"))
     waitUntilExists(byQaId("tool-bar.new"))
-    waitUntilExists(By.cssSelector(".infobox__edit-icon"))
+    waitUntilExists(byQaId("infobox-edit-button"))
 }
 
 fun assertInfraModelPage(role: E2ERole) {

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -158,6 +158,11 @@ const infraModelSlice = createSlice({
             { payload: response }: PayloadAction<ValidationResponse>,
         ) => {
             state.validationResponse = response;
+            state.validationIssues = validateParams(
+                response.geometryPlan,
+                state.extraInfraModelParameters,
+                state.overrideInfraModelParameters,
+            );
 
             if (response.planLayout) {
                 const bBox = response.planLayout.boundingBox;

--- a/ui/src/infra-model/view/formgroup/formgroup-field.tsx
+++ b/ui/src/infra-model/view/formgroup/formgroup-field.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import styles from './formgroup.module.scss';
-import { Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { Icons } from 'vayla-design-lib/icon/Icon';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_GEOMETRY_FILE } from 'user/user-model';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 
 type InfoboxFieldProps = {
     label: string;
@@ -12,6 +13,7 @@ type InfoboxFieldProps = {
     inEditMode?: boolean;
     onEdit?: () => void;
     onClose?: () => void;
+    disabled?: boolean;
 };
 
 const FormgroupField: React.FC<InfoboxFieldProps> = ({
@@ -20,6 +22,7 @@ const FormgroupField: React.FC<InfoboxFieldProps> = ({
     children,
     inEditMode = false,
     qaId,
+    disabled = false,
     ...props
 }: InfoboxFieldProps) => {
     return (
@@ -29,15 +32,22 @@ const FormgroupField: React.FC<InfoboxFieldProps> = ({
             <div className={styles['formgroup__edit-icon']}>
                 {!inEditMode && props.onEdit && (
                     <PrivilegeRequired privilege={EDIT_GEOMETRY_FILE}>
-                        <div onClick={() => props.onEdit && props.onEdit()}>
-                            <Icons.Edit size={IconSize.SMALL} />
-                        </div>
+                        <Button
+                            variant={ButtonVariant.GHOST}
+                            icon={Icons.Edit}
+                            disabled={disabled}
+                            size={ButtonSize.SMALL}
+                            onClick={() => props.onEdit && props.onEdit()}
+                        />
                     </PrivilegeRequired>
                 )}
                 {inEditMode && props.onClose && (
-                    <div onClick={() => props.onClose && props.onClose()}>
-                        <Icons.Tick size={IconSize.SMALL} />
-                    </div>
+                    <Button
+                        variant={ButtonVariant.GHOST}
+                        icon={Icons.Tick}
+                        size={ButtonSize.SMALL}
+                        onClick={() => props.onClose && props.onClose()}
+                    />
                 )}
             </div>
         </div>

--- a/ui/src/infra-model/view/formgroup/formgroup-textarea.tsx
+++ b/ui/src/infra-model/view/formgroup/formgroup-textarea.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import styles from './formgroup.module.scss';
-import { Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { Icons } from 'vayla-design-lib/icon/Icon';
 import { TextAreaAutoResizing } from 'vayla-design-lib/text-area/text-area-autoresizing';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_GEOMETRY_FILE } from 'user/user-model';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 
 type TextareaProps = {
     label: string;
@@ -45,15 +46,21 @@ const FormgroupTextarea: React.FC<TextareaProps> = ({
             <div className={styles['formgroup__edit-icon']}>
                 {!inEditMode && props.onEdit && (
                     <PrivilegeRequired privilege={EDIT_GEOMETRY_FILE}>
-                        <div onClick={() => props.onEdit && props.onEdit()}>
-                            <Icons.Edit size={IconSize.SMALL} />
-                        </div>
+                        <Button
+                            variant={ButtonVariant.GHOST}
+                            size={ButtonSize.SMALL}
+                            icon={Icons.Edit}
+                            onClick={() => props.onEdit && props.onEdit()}
+                        />
                     </PrivilegeRequired>
                 )}
                 {inEditMode && props.onClose && (
-                    <div onClick={() => props.onClose && props.onClose()}>
-                        <Icons.Tick size={IconSize.SMALL} />
-                    </div>
+                    <Button
+                        variant={ButtonVariant.GHOST}
+                        size={ButtonSize.SMALL}
+                        icon={Icons.Tick}
+                        onClick={() => props.onClose && props.onClose()}
+                    />
                 )}
             </div>
         </div>

--- a/ui/src/infra-model/view/infra-model-import-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-import-loader.tsx
@@ -9,7 +9,6 @@ import { GeometryPlan } from 'geometry/geometry-model';
 export type InfraModelImportLoaderProps = InfraModelBaseProps & {
     setExistingInfraModel: (plan: GeometryPlan | undefined) => void;
     onValidation: (validationResponse: ValidationResponse) => void;
-    setLoading: (loading: boolean) => void;
 };
 
 export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ ...props }) => {
@@ -20,21 +19,23 @@ export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ 
 
     const onInit: () => void = async () => {
         if (pvDocumentId) {
+            props.clearInfraModelState();
             props.setLoading(true);
-            const validation = await getValidationIssuesForPVDocument(pvDocumentId);
-            props.setExistingInfraModel(validation.geometryPlan);
-            props.onValidation(validation);
-            setInitPVDocumentId(pvDocumentId);
-            props.setLoading(false);
+            await getValidationIssuesForPVDocument(pvDocumentId)
+                .then((validation) => {
+                    props.setExistingInfraModel(validation.geometryPlan);
+                    props.onValidation(validation);
+                    setInitPVDocumentId(pvDocumentId);
+                })
+                .finally(() => props.setLoading(false));
         }
     };
     const onValidate: () => void = async () => {
         if (pvDocumentId && pvDocumentId == initPVDocumentId) {
             props.setLoading(true);
-            props.onValidation(
-                await getValidationIssuesForPVDocument(pvDocumentId, overrideParams),
-            );
-            props.setLoading(false);
+            await getValidationIssuesForPVDocument(pvDocumentId, overrideParams)
+                .then(props.onValidation)
+                .finally(() => props.setLoading(false));
         }
         return undefined;
     };
@@ -49,10 +50,10 @@ export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ 
 
     const onSave: () => Promise<boolean> = async () => {
         if (!pvDocumentId) return false;
-        props.setLoading(true);
-        const response = await importPVDocument(pvDocumentId, extraParams, overrideParams);
-        props.setLoading(false);
-        return !!response;
+        props.setSaving(true);
+        return await importPVDocument(pvDocumentId, extraParams, overrideParams)
+            .then((response) => response !== undefined)
+            .finally(() => props.setSaving(false));
     };
-    return <InfraModelView {...props} onSave={onSave} />;
+    return <InfraModelView {...props} fileSource={'IMPORT'} onSave={onSave} />;
 };

--- a/ui/src/infra-model/view/infra-model-upload-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-upload-loader.tsx
@@ -13,7 +13,6 @@ import { ValidationResponse } from 'infra-model/infra-model-slice';
 export type InfraModelUploadLoaderProps = InfraModelBaseProps & {
     file?: SerializableFile;
     onValidation: (validationResponse: ValidationResponse) => void;
-    setLoading: (loading: boolean) => void;
 };
 
 export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ ...props }) => {
@@ -25,6 +24,8 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
     const overrideParams = props.overrideInfraModelParameters;
 
     React.useEffect(() => {
+        props.clearInfraModelState();
+
         // Convert serializable file to native file
         if (props.file) {
             const file = convertToNativeFile(props.file);
@@ -35,10 +36,9 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
     const onValidate: () => void = async () => {
         if (file) {
             props.setLoading(true);
-            props.onValidation(
-                await getGeometryValidationIssuesForInfraModelFile(file, overrideParams),
-            );
-            props.setLoading(false);
+            await getGeometryValidationIssuesForInfraModelFile(file, overrideParams)
+                .then(props.onValidation)
+                .finally(() => props.setLoading(false));
         }
     };
     // Automatically re-validate whenever the file or manually input data changes
@@ -48,13 +48,12 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
 
     const onSave: () => Promise<boolean> = async () => {
         if (file) {
-            props.setLoading(true);
-            const response = await saveInfraModelFile(file, extraParams, overrideParams).finally(
-                () => {
-                    props.setLoading(false);
-                },
-            );
-            return response != undefined;
+            props.setSaving(true);
+            return await saveInfraModelFile(file, extraParams, overrideParams)
+                .then((response) => response != undefined)
+                .finally(() => {
+                    props.setSaving(false);
+                });
         } else {
             return false;
         }
@@ -68,7 +67,7 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
 
     return (
         <>
-            <InfraModelView {...props} onSave={onSave} />
+            <InfraModelView {...props} fileSource={'UPLOAD'} onSave={onSave} />
 
             {showFileHandlingFailed && (
                 <CharsetSelectDialog

--- a/ui/src/infra-model/view/infra-model-view-container.tsx
+++ b/ui/src/infra-model/view/infra-model-view-container.tsx
@@ -22,6 +22,7 @@ export const InfraModelViewContainer: React.FC<InfraModelViewContainerProps> = (
     const delegates = React.useMemo(() => createDelegates(infraModelActionCreators), []);
 
     const [isLoading, setLoading] = React.useState(false);
+    const [isSaving, setSaving] = React.useState(false);
 
     const generalProps = {
         ...infraModelState,
@@ -30,12 +31,15 @@ export const InfraModelViewContainer: React.FC<InfraModelViewContainerProps> = (
         onSelect: delegates.onSelect,
         changeTimes: changeTimes,
         isLoading: isLoading,
+        isSaving: isSaving,
+        clearInfraModelState: delegates.clearInfraModelState,
         onClose: () => navigate('inframodel-list'),
     };
 
     const loaderProps = {
         ...generalProps,
         setLoading: setLoading,
+        setSaving: setSaving,
         onValidation: delegates.onPlanValidated,
     };
 

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -24,6 +24,8 @@ import { MapViewContainer } from 'map/map-view-container';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_GEOMETRY_FILE } from 'user/user-model';
 
+type InfraModelFileSource = 'STORED' | 'IMPORT' | 'UPLOAD';
+
 export type InfraModelBaseProps = InfraModelState & {
     onExtraParametersChange: <TKey extends keyof ExtraInfraModelParameters>(
         parameters: Prop<ExtraInfraModelParameters, TKey>,
@@ -32,10 +34,15 @@ export type InfraModelBaseProps = InfraModelState & {
     onSelect: OnSelectFunction;
     changeTimes: ChangeTimes;
     isLoading: boolean;
+    isSaving: boolean;
     onClose: () => void;
+    setLoading: (loading: boolean) => void;
+    setSaving: (saving: boolean) => void;
+    clearInfraModelState: () => void;
 };
 export type InfraModelViewProps = InfraModelBaseProps & {
     onSave: () => Promise<boolean>;
+    fileSource: InfraModelFileSource;
 };
 
 export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelViewProps) => {
@@ -46,7 +53,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
 
     const geometryPlan = props.validationResponse?.geometryPlan;
     const planLayout = props.validationResponse?.planLayout;
-    const isNewPlan = geometryPlan?.dataType !== 'STORED';
+    const isNewPlan = props.fileSource === 'UPLOAD';
 
     const fileMenuItems: Item<FileMenuOption>[] = isNewPlan
         ? [
@@ -96,7 +103,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
     };
 
     const fileName = geometryPlan?.fileName || '';
-    const toolbarName = `${isNewPlan ? `${t('im-form.toolbar.upload')}: ` : ''}${fileName}`;
+    const toolbarName = `${isNewPlan && fileName.length > 0 ? `${t('im-form.toolbar.upload')}: ` : ''}${fileName}`;
     const showMap = props.validationResponse?.planLayout != undefined;
 
     return (
@@ -112,7 +119,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                         <InfraModelForm
                             changeTimes={props.changeTimes}
                             validationIssues={props.validationIssues}
-                            upLoading={props.isLoading}
+                            upLoading={props.isSaving}
                             geometryPlan={geometryPlan}
                             onInfraModelOverrideParametersChange={props.onOverrideParametersChange}
                             onInfraModelExtraParametersChange={props.onExtraParametersChange}
@@ -179,15 +186,15 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                         <div className={dialogStyles['dialog__footer-content--centered']}>
                             <Button
                                 variant={ButtonVariant.SECONDARY}
-                                disabled={props.isLoading}
+                                disabled={props.isSaving}
                                 onClick={() => setShowCriticalWarning(false)}>
                                 {t('button.cancel')}
                             </Button>
                             <Button
                                 id="infra-model-upload-dialog-save-button"
                                 onClick={() => onSaveClick()}
-                                disabled={props.isLoading}
-                                isProcessing={props.isLoading}>
+                                disabled={props.isSaving}
+                                isProcessing={props.isSaving}>
                                 {t('button.save')}
                             </Button>
                         </div>

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -73,7 +73,9 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
     };
 
     const onProgressClick = () => {
-        getFieldValidationWarnings().length || !planLayout
+        getFieldValidationWarnings().length > 0 ||
+        getFieldValidationIssues().length > 0 ||
+        !planLayout
             ? setShowCriticalWarning(true)
             : onSaveClick();
     };

--- a/ui/src/tool-panel/infobox/infobox-field.tsx
+++ b/ui/src/tool-panel/infobox/infobox-field.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import styles from './infobox.module.scss';
-import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { Icons } from 'vayla-design-lib/icon/Icon';
 import { createClassName } from 'vayla-design-lib/utils';
 import { useTranslation } from 'react-i18next';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 
 type InfoboxFieldProps = {
     label: React.ReactNode;
@@ -34,7 +35,6 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
     const iconTitle = iconDisabled
         ? t('tool-panel.disabled.activity-disabled-in-official-mode')
         : '';
-    const iconColor = iconDisabled ? IconColor.DISABLED : IconColor.ORIGINAL;
 
     return (
         <div className={classes} qa-id={qaId}>
@@ -54,14 +54,15 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
             </div>
             {props.onEdit && !iconHidden && (
                 <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                    <div
-                        className={styles['infobox__edit-icon']}
+                    <Button
+                        title={iconTitle}
+                        disabled={iconDisabled || !props.onEdit}
+                        icon={Icons.Edit}
+                        variant={ButtonVariant.GHOST}
+                        size={ButtonSize.SMALL}
                         onClick={() => !iconDisabled && props.onEdit && props.onEdit()}
-                        qa-id={`${qaId}-edit`}>
-                        <span title={iconTitle}>
-                            <Icons.Edit size={IconSize.SMALL} color={iconColor} />
-                        </span>
-                    </div>
+                        qa-id={`${qaId}-edit`}
+                    />
                 </PrivilegeRequired>
             )}
         </div>

--- a/ui/src/tool-panel/infobox/infobox-field.tsx
+++ b/ui/src/tool-panel/infobox/infobox-field.tsx
@@ -54,15 +54,17 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
             </div>
             {props.onEdit && !iconHidden && (
                 <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                    <Button
-                        title={iconTitle}
-                        disabled={iconDisabled || !props.onEdit}
-                        icon={Icons.Edit}
-                        variant={ButtonVariant.GHOST}
-                        size={ButtonSize.SMALL}
-                        onClick={() => !iconDisabled && props.onEdit && props.onEdit()}
-                        qa-id={`${qaId}-edit`}
-                    />
+                    <span qa-id={`${qaId}-edit`}>
+                        <Button
+                            title={iconTitle}
+                            disabled={iconDisabled || !props.onEdit}
+                            icon={Icons.Edit}
+                            variant={ButtonVariant.GHOST}
+                            size={ButtonSize.SMALL}
+                            onClick={() => !iconDisabled && props.onEdit && props.onEdit()}
+                            qa-id={`infobox-edit-button`}
+                        />
+                    </span>
                 </PrivilegeRequired>
             )}
         </div>

--- a/ui/src/tool-panel/infobox/infobox.module.scss
+++ b/ui/src/tool-panel/infobox/infobox.module.scss
@@ -72,11 +72,6 @@
         }
     }
 
-    &__edit-icon {
-        padding: 0 5px;
-        cursor: pointer;
-    }
-
     &__text {
         @include vayla-design.typography-caption;
 


### PR DESCRIPTION
Tiketillä mainittu alkuperäinen bugi oli siis, että jos ensin ProjektiVelhon InfraModel-importissa on käyty katsomassa inframallia A, navigoidaan takaisin inframallilistaukseen ja mennään ProjektiVelhon listauksesta InfraModel-tiedoston B importtiin, niin inframallin A tiedot näkyvät hetken inframallinäkymässä ennen B:n tietojen latautumista. Tämä on korjattu (yksittäisen inframallin näkymän tila clearataan nyt aina näkymään mentäessä.)

Tällä sivuvaikutuksena oli se, että kun aiemmin inframallin uploadissa (ja vain inframallin uploadissa) on pystynyt navigoimaan toisiin näkymiin ja tulemaan takaisin selaimen backilla siten että näkymässä tehdyt tallentamattomat muutokset pysyvät olemassa, niin nyt ne muutokset katoavat. Tästä tilanteesta on kysytty Karilta, jonka mukaan tämä muutos on ihan ok, ja tämä tuo nyt upload-tapauksen samaan linjaan muokkaus- ja projektivelhotuontikeissien kanssa. Toiminnallisena huomiona uuden inframallin lopullinen tallennus Geoviitteeseen tuollaisen selain-back-navigoinnin jälkeen ei ole muutenkaan toiminut, joten ainoa oikeasti tässä tilanteessa katoava asia on toiminnallisuuden illuusio (nyt koko näkymä clearataan upload-tilanteessa tuon toimimattomuuden takia - Geoviite on toiminut näin jo aiemmin jos on käynyt InfraModel-listassa ja sen jälkeen back-navigoinut takaisin uploadiin, joten kyseessä on taas toiminnallisuuksien yhtenäistämisestä)

Tiketillä tuli tehtyä tuon lisäksi muutakin ylimääräistä:
- Inframallin tallennuksen ja validoinnin virhehallinnan parannus: Aiemmin näissä oltiin käytetty `Adt`-funktioita joka on tarkoittanut sitä, että virheet on vaan syöty. Täällä siirrytty non-Adt-versioihin, ja virhetilanteissa näytetään nyt sentään toasti
- Muutettu inframallinäkymän ja samaan rahaan karttanäkymän toolpanelin kynäikonit oikeiksi `<Button>`:eiksi
- Muita pienempiä parannuksia