### PR TITLE
GVT-2763 Optimize fetchProfileInfoForSegmentsInBoundingBox

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
@@ -92,8 +92,7 @@ class MapAlignmentService(
         bbox: BoundingBox,
     ): List<MapAlignmentHighlight<LocationTrack>> {
         return alignmentDao
-            .fetchProfileInfoForSegmentsInBoundingBox<LocationTrack>(layoutContext, bbox)
-            .filter { !it.hasProfile }
+            .fetchProfileInfoForSegmentsInBoundingBox<LocationTrack>(layoutContext, bbox, false)
             .groupBy { it.id }
             .map { (id, profileInfos) ->
                 MapAlignmentHighlight(


### PR DESCRIPTION
Optimointivaraa ei aivan mielettömiä määriä ollut ilman isompia remontteja, suodatuksia vaan on viety mahdollisimman lähelle suodatettavaa tietoa. Ikkunointimagialla saisi pystygeometriattomien jaksojen laskemisen kokonaan tietokantaan, mutta sillä olisi iso kompleksisuusvaikutus, iso riski tehdä joistakin hauista todella hitaita, ja vain pieni hyöty yleisen tapauksen perffissä.