### PR TITLE
GVT-2775 Fix missing ordering in fetchProfileInfoForSegmentsInBoundingBox

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -566,7 +566,8 @@ class LayoutAlignmentDao(
                   ) location_track using (alignment_id, alignment_version)
                   where ((:has_profile_info::boolean is null) or :has_profile_info = has_profile_info)
                   group by official_id, alignment_id, alignment_version
-              ) grouped;
+              ) grouped
+              order by official_id, segment_index;
         """
                 .trimIndent()
 


### PR DESCRIPTION
Testit sattui menemään näemmä tuurilla läpi viime pullarissa ilmankin tätä, mutta segment_indexin perusteella sorttaus on ihan oikeasti tässä tarpeen, ja sen puute aiheuttaa ainakin testifleikkejä ja saattaa ehkä rikkoa ominaisuuden itsensäkin.