### PR TITLE
GVT-2665 & GVT-2722 (part 2): Review fixes

### DIFF
--- a/doc/ajoitetut_tehtavat.md
+++ b/doc/ajoitetut_tehtavat.md
@@ -8,17 +8,16 @@ tiedostohierarkiassa. Scheduler-luokat esimerkiksi tietylle Spring-palvelulle (S
 ajoitetun tehtävän hallinnan ja vastaavasti *Task-luokat ovat yksittäisiä tehtäviä varten, mutta nämäkin tyypillisesti
 kutsuvat jonkin Spring-palvelun funktiota.
 
-Valinta Scheduler-luokan tai useamman Task-luokan välillä riippuu
-kontekstista. Järkevät kokonaisuudet tai samoja ajoituksia käyttävät ajoitetut tehtävät on yleensä järkevämpää koostaa
-yhteen Scheduler-luokkaan. Vastaavasti esimerkiksi tietotuotteiden luonnit ovat usein yksiselitteisempiä ymmärtää omina
-tehtävinään, jolloin käytettäisiin Task-luokkia niitä varten.
+Valinta Scheduler-luokan tai useamman Task-luokan välillä riippuu kontekstista. Järkevät kokonaisuudet tai samoja
+ajoituksia käyttävät ajoitetut tehtävät on yleensä järkevämpää koostaa yhteen Scheduler-luokkaan. Vastaavasti
+esimerkiksi tietotuotteiden luonnit ovat usein yksiselitteisempiä ymmärtää omina tehtävinään, jolloin käytettäisiin
+Task-luokkia niitä varten.
 
 ## Asetustiedostot
 
-Tavoitteena olisi, että ajoitetut tehtävät olisi
-mahdollista kytkeä päälle sekä pois riippuen sovelluksen suorituksessa käytettävistä Spring-profiileista, sillä eri
-suoritustilanteissa ei haluta kaikkien ajoitettujen tehtävien suorittamista. Esimerkiksi testien suorituksen aikana ei
-tyypillisesti kaivata tietotuotteen automaattista luontia.
+Tavoitteena voisi pitää, että ajoitetut tehtävät olisi mahdollista kytkeä päälle sekä pois riippuen sovelluksen
+suorituksessa käytettävistä Spring-profiileista, sillä eri suoritustilanteissa ei haluta kaikkien ajoitettujen tehtävien
+suorittamista. Esimerkiksi testien suorituksen aikana ei tyypillisesti kaivata tietotuotteen automaattista luontia.
 
 Spring-profiilien asetukset näiden ajoitettujen tehtävien
 suoritukselle löytyvät tiedostohierarkiasta kahdesta paikasta (huomaa polussa siis main/test-ero):

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceScheduler.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceScheduler.kt
@@ -15,7 +15,7 @@ class PVIntegrationServiceScheduler @Autowired constructor(private val pvIntegra
         initialDelayString = "\${geoviite.projektivelho.tasks.search-poll.initial-delay}",
         fixedRateString = "\${geoviite.projektivelho.tasks.search-poll.interval}",
     )
-    fun scheduledSearch() {
+    private fun scheduledSearch() {
         pvIntegrationService.search()
     }
 
@@ -23,7 +23,7 @@ class PVIntegrationServiceScheduler @Autowired constructor(private val pvIntegra
         initialDelayString = "\${geoviite.projektivelho.tasks.result-poll.initial-delay}",
         fixedRateString = "\${geoviite.projektivelho.tasks.result-poll.interval}",
     )
-    fun scheduledPollAndFetchIfWaiting() {
+    private fun scheduledPollAndFetchIfWaiting() {
         pvIntegrationService.pollAndFetchIfWaiting()
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateTask.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateTask.kt
@@ -19,7 +19,7 @@ constructor(private val publicationGeometryChangeRemarksUpdateService: Publicati
         initialDelayString = "\${geoviite.data-products.tasks.publication-geometry-remarks-update.initial-delay}",
         fixedDelayString = "\${geoviite.data-products.tasks.publication-geometry-remarks-update.interval}",
     )
-    fun scheduledUpdateUnprocessedGeometryChangeRemarks() {
+    private fun scheduledUpdateUnprocessedGeometryChangeRemarks() {
         publicationGeometryChangeRemarksUpdateService.updateUnprocessedGeometryChangeRemarks()
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointsFetchTask.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperatingPointsFetchTask.kt
@@ -20,7 +20,7 @@ class RatkoOperatingPointsFetchTask @Autowired constructor(private val ratkoServ
     }
 
     @Scheduled(cron = "\${geoviite.ratko.tasks.operating-points-fetch.cron}")
-    fun scheduledRatkoOperatingPointsFetch() {
+    private fun scheduledRatkoOperatingPointsFetch() {
         withUser(ratkoOperatingPointTaskUserName, ratkoService::updateOperatingPointsFromRatko)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushTask.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushTask.kt
@@ -20,7 +20,7 @@ class RatkoPushTask @Autowired constructor(private val ratkoService: RatkoServic
     }
 
     @Scheduled(cron = "\${geoviite.ratko.tasks.push.cron}")
-    fun scheduledRatkoPush() {
+    private fun scheduledRatkoPush() {
         withUser(ratkoPushTaskUserName) {
             // Don't retry failed on auto-push
             ratkoService.pushChangesToRatko(LayoutBranch.main, retryFailed = false)


### PR DESCRIPTION
* Scheduled functions are now private (this causes detekt warnings, but is more correct)

* Fixed md-file wrapping