### PR TITLE
GVT-2670 Validate when merging to main

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
@@ -192,23 +192,23 @@ class GeocodingDao(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
         versions: ValidationVersions,
     ): GeocodingContextCacheKey? {
-        val official = getLayoutGeocodingContextCacheKey(versions.branch.official, trackNumberId)
+        val base = getLayoutGeocodingContextCacheKey(versions.target.baseContext, trackNumberId)
         val trackNumberVersion =
-            versions.findTrackNumber(trackNumberId)?.validatedAssetVersion ?: official?.trackNumberVersion
+            versions.findTrackNumber(trackNumberId)?.validatedAssetVersion ?: base?.trackNumberVersion
         // We have to fetch the actual objects (reference line & km-post) here to check references
         // However, when this is done, the objects are needed elsewhere as well -> they should
         // always be in cache
         val referenceLineVersion =
             versions.referenceLines
                 .find { v -> referenceLineDao.fetch(v.validatedAssetVersion).trackNumberId == trackNumberId }
-                ?.validatedAssetVersion ?: official?.referenceLineVersion
+                ?.validatedAssetVersion ?: base?.referenceLineVersion
         return if (trackNumberVersion != null && referenceLineVersion != null) {
             val mainOrDesignOfficialRowIdsWithDraftKmPosts =
                 versions.kmPosts
                     .map { v -> kmPostDao.fetch(v.validatedAssetVersion) }
                     .flatMap { draft -> listOfNotNull(draft.contextData.designRowId, draft.contextData.officialRowId) }
             val officialKmPosts =
-                official?.kmPostVersions?.filter { v -> !mainOrDesignOfficialRowIdsWithDraftKmPosts.contains(v.rowId) }
+                base?.kmPostVersions?.filter { v -> !mainOrDesignOfficialRowIdsWithDraftKmPosts.contains(v.rowId) }
                     ?: listOf()
             val draftKmPosts =
                 versions.kmPosts

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -471,21 +471,21 @@ class CalculatedChangesService(
     private fun createChangeContext(versions: ValidationVersions) =
         ChangeContext(
             geocodingService = geocodingService,
-            trackNumbers = createTypedContext(versions.branch, trackNumberDao, versions.trackNumbers),
-            referenceLines = createTypedContext(versions.branch, referenceLineDao, versions.referenceLines),
-            kmPosts = createTypedContext(versions.branch, kmPostDao, versions.kmPosts),
-            locationTracks = createTypedContext(versions.branch, locationTrackDao, versions.locationTracks),
-            switches = createTypedContext(versions.branch, switchDao, versions.switches),
+            trackNumbers = createTypedContext(versions.target.baseContext, trackNumberDao, versions.trackNumbers),
+            referenceLines = createTypedContext(versions.target.baseContext, referenceLineDao, versions.referenceLines),
+            kmPosts = createTypedContext(versions.target.baseContext, kmPostDao, versions.kmPosts),
+            locationTracks = createTypedContext(versions.target.baseContext, locationTrackDao, versions.locationTracks),
+            switches = createTypedContext(versions.target.baseContext, switchDao, versions.switches),
             geocodingKeysBefore =
                 LazyMap { id: IntId<TrackLayoutTrackNumber> ->
-                    geocodingService.getGeocodingContextCacheKey(versions.branch.official, id)
+                    geocodingService.getGeocodingContextCacheKey(versions.target.baseContext, id)
                 },
             geocodingKeysAfter =
                 LazyMap { id: IntId<TrackLayoutTrackNumber> ->
                     geocodingService.getGeocodingContextCacheKey(id, versions)
                 },
             getTrackNumberTracksBefore = { trackNumberId: IntId<TrackLayoutTrackNumber> ->
-                locationTrackDao.fetchVersions(versions.branch.official, false, trackNumberId)
+                locationTrackDao.fetchVersions(versions.target.baseContext, false, trackNumberId)
             },
         )
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/ChangeContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/ChangeContext.kt
@@ -1,5 +1,6 @@
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingService
@@ -43,16 +44,14 @@ class ChangeContext(
 }
 
 inline fun <reified T : LayoutAsset<T>> createTypedContext(
-    branch: LayoutBranch,
+    baseContext: LayoutContext,
     dao: LayoutAssetDao<T>,
     versions: List<ValidationVersion<T>>,
 ): TypedChangeContext<T> =
     createTypedContext(
         dao,
-        { id -> dao.fetchVersion(branch.official, id) },
-        { id ->
-            versions.find { v -> v.officialId == id }?.validatedAssetVersion ?: dao.fetchVersion(branch.official, id)
-        },
+        { id -> dao.fetchVersion(baseContext, id) },
+        { id -> versions.find { v -> v.officialId == id }?.validatedAssetVersion ?: dao.fetchVersion(baseContext, id) },
     )
 
 inline fun <reified T : LayoutAsset<T>> createTypedContext(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -54,7 +54,7 @@ constructor(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable("from_state") fromState: PublicationState,
     ): PublicationCandidates {
-        return publicationService.collectPublicationCandidates(LayoutContextTransition.of(branch, fromState))
+        return publicationService.collectPublicationCandidates(publicationInOrMergeFromBranch(branch, fromState))
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
@@ -65,6 +65,18 @@ constructor(
     ): ValidatedPublicationCandidates {
         return publicationService.validatePublicationCandidates(
             publicationService.collectPublicationCandidates(LayoutContextTransition.publicationIn(branch)),
+            request,
+        )
+    }
+
+    @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
+    @PostMapping("/{$LAYOUT_BRANCH}/validate-merge-to-main")
+    fun validateMergeToMain(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody request: PublicationRequestIds,
+    ): ValidatedPublicationCandidates {
+        return publicationService.validatePublicationCandidates(
+            publicationService.collectPublicationCandidates(LayoutContextTransition.mergeToMainFrom(branch)),
             request,
         )
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -285,7 +285,7 @@ class SplitService(
             splits.mapNotNull { (_, sourceTrack) ->
                 produceIf(trackId == sourceTrack.id) {
                     val draftAddresses = context.getAddressPoints(sourceTrack)
-                    val officialAddresses = geocodingService.getAddressPoints(context.branch.official, trackId)
+                    val officialAddresses = geocodingService.getAddressPoints(context.target.baseContext, trackId)
                     validateSourceGeometry(draftAddresses, officialAddresses)
                 }
             }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -59,9 +59,9 @@ interface LayoutAssetReader<T : LayoutAsset<T>> {
 
     fun fetchVersions(layoutContext: LayoutContext, includeDeleted: Boolean): List<LayoutDaoResponse<T>>
 
-    fun fetchPublicationVersions(branch: LayoutBranch): List<ValidationVersion<T>>
+    fun fetchCandidateVersions(candidateContext: LayoutContext): List<ValidationVersion<T>>
 
-    fun fetchPublicationVersions(branch: LayoutBranch, ids: List<IntId<T>>): List<ValidationVersion<T>>
+    fun fetchCandidateVersions(candidateContext: LayoutContext, ids: List<IntId<T>>): List<ValidationVersion<T>>
 
     fun fetchVersion(layoutContext: LayoutContext, id: IntId<T>): LayoutRowVersion<T>?
 
@@ -112,19 +112,19 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
 
     abstract fun preloadCache()
 
-    private val allPublicationVersionsSql =
+    private val allCandidateVersionsSql =
         """
         select
           official_id,
           id as row_id,
           version as row_version
         from ${table.fullName}
-        where draft
+        where draft = (:publication_state::layout.publication_state = 'DRAFT')
           and design_id is not distinct from :design_id
     """
             .trimIndent()
 
-    private val publicationVersionsSql =
+    private val candidateVersionsSql =
         """
         select
           official_id,
@@ -132,21 +132,27 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
           version as row_version
         from ${table.fullName}
         where official_id in (:ids)
-          and draft
+          and draft = (:publication_state::layout.publication_state = 'DRAFT')
           and design_id is not distinct from :design_id
     """
             .trimIndent()
 
-    override fun fetchPublicationVersions(branch: LayoutBranch): List<ValidationVersion<T>> {
+    override fun fetchCandidateVersions(candidateContext: LayoutContext): List<ValidationVersion<T>> {
         return jdbcTemplate.query<ValidationVersion<T>>(
-            allPublicationVersionsSql,
-            mapOf("design_id" to branch.designId?.intValue),
+            allCandidateVersionsSql,
+            mapOf(
+                "publication_state" to candidateContext.state.name,
+                "design_id" to candidateContext.branch.designId?.intValue,
+            ),
         ) { rs, _ ->
             ValidationVersion(rs.getIntId("official_id"), rs.getLayoutRowVersion("row_id", "row_version"))
         }
     }
 
-    override fun fetchPublicationVersions(branch: LayoutBranch, ids: List<IntId<T>>): List<ValidationVersion<T>> {
+    override fun fetchCandidateVersions(
+        candidateContext: LayoutContext,
+        ids: List<IntId<T>>,
+    ): List<ValidationVersion<T>> {
         // Empty lists don't play nice in the SQL, but the result would be empty anyhow
         if (ids.isEmpty()) return listOf()
         val distinctIds = ids.distinct()
@@ -155,9 +161,14 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
                 "Requested publication versions with duplicate ids: duplicated=${ids.size - distinctIds.size} requested=$ids"
             )
         }
-        val params = mapOf("ids" to distinctIds.map { id -> id.intValue }, "design_id" to branch.designId?.intValue)
+        val params =
+            mapOf(
+                "ids" to distinctIds.map { id -> id.intValue },
+                "publication_state" to candidateContext.state.name,
+                "design_id" to candidateContext.branch.designId?.intValue,
+            )
         return jdbcTemplate
-            .query<ValidationVersion<T>>(publicationVersionsSql, params) { rs, _ ->
+            .query<ValidationVersion<T>>(candidateVersionsSql, params) { rs, _ ->
                 ValidationVersion(rs.getIntId("official_id"), rs.getLayoutRowVersion("row_id", "row_version"))
             }
             .also { found ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostController.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.publication.ValidatedAsset
+import fi.fta.geoviite.infra.publication.draftTransitionOrOfficialState
 import fi.fta.geoviite.infra.util.toResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -117,8 +118,10 @@ class LayoutKmPostController(
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutKmPost>,
     ): ResponseEntity<ValidatedAsset<TrackLayoutKmPost>> {
-        val context = LayoutContext.of(branch, publicationState)
-        return publicationService.validateKmPosts(context, listOf(id)).firstOrNull().let(::toResponse)
+        return publicationService
+            .validateKmPosts(draftTransitionOrOfficialState(publicationState, branch), listOf(id))
+            .firstOrNull()
+            .let(::toResponse)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.publication.ValidatedAsset
+import fi.fta.geoviite.infra.publication.draftTransitionOrOfficialState
 import fi.fta.geoviite.infra.util.toResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -103,7 +104,7 @@ class LayoutSwitchController(
             }
         val switchIds =
             switches.filter { switch -> switchMatchesBbox(switch, bbox, false) }.map { sw -> sw.id as IntId }
-        return publicationService.validateSwitches(layoutContext, switchIds)
+        return publicationService.validateSwitches(draftTransitionOrOfficialState(publicationState, branch), switchIds)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -18,6 +18,7 @@ import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.publication.ValidatedAsset
+import fi.fta.geoviite.infra.publication.draftTransitionOrOfficialState
 import fi.fta.geoviite.infra.publication.getCsvResponseEntity
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.toResponse
@@ -70,9 +71,8 @@ class LayoutTrackNumberController(
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<TrackLayoutTrackNumber>,
     ): ResponseEntity<ValidatedAsset<TrackLayoutTrackNumber>> {
-        val context = LayoutContext.of(branch, publicationState)
         return publicationService
-            .validateTrackNumbersAndReferenceLines(context, listOf(id))
+            .validateTrackNumbersAndReferenceLines(draftTransitionOrOfficialState(publicationState, branch), listOf(id))
             .firstOrNull()
             .let(::toResponse)
     }

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1396,7 +1396,8 @@
                     "reference-deleted": "Poistettavaan ratanumeroon viittaa edelleen poistamattomia tasakilometripisteitä: {{kmPosts}}"
                 },
                 "duplicate-name-official": "Ratanumeron numero {{trackNumber}} on jo käytössä",
-                "duplicate-name-draft": "Muutosjoukossa on monta ratanumeroa nimellä {{trackNumber}}"
+                "duplicate-name-draft": "Muutosjoukossa on monta ratanumeroa nimellä {{trackNumber}}",
+                "duplicate-name-draft-in-main": "Ratanumeron numero {{trackNumber}} on jo käytössä luonnostilassa"
             },
             "km-post": {
                 "no-context": "Ratanumerolta ei voida laskea tasametripisteitä koska siltä puuttuu tietoja",
@@ -1412,7 +1413,8 @@
                 },
                 "reference-line": {
                     "null": "Tasakilometripisteen pituusmittauslinja ei ole mukana julkaisussa"
-                }
+                },
+                "duplicate-km-number": "Ratanumerolla ei voi olla kahta tasakilometripistettä samalla tunnuksella. Tunnus on jo käytössä tällä ratanumerolla."
             },
             "reference-line": {
                 "no-context": "Pituusmittauslinjalle ei voida laskea tasametripisteitä koska siltä puuttuu tietoja",
@@ -1472,6 +1474,7 @@
                 },
                 "duplicate-name-official": "Sijaintiraiteen nimi {{locationTrack}} on jo käytössä toisella ratanumeron {{trackNumber}} sijaintiraiteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta sijaintiraidetta nimellä {{locationTrack}} ratanumerolla {{trackNumber}}",
+                "duplicate-name-draft-in-main": "Sijaintiraiteen nimi {{locationTrack}} on jo käytössä toisella ratanumeron {{trackNumber}} sijaintiraiteella luonnostilassa",
                 "topological-connectivity": {
                     "start-switch-is-topologically-connected": "Raiteen alku on kytkeytynyt rataverkkoon vaikka ominaisuustietojen mukaan raiteen ei pitäisi olla kytketty",
                     "end-switch-is-topologically-connected": "Raiteen loppu on kytkeytynyt rataverkkoon vaikka ominaisuustietojen mukaan raiteen ei pitäisi olla kytketty",
@@ -1491,6 +1494,7 @@
                 },
                 "duplicate-name-official": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{switch}}",
+                "duplicate-name-draft-in-main": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella luonnostilassa",
                 "track-linkage": {
                     "front-joint-not-connected": "Vaihteen etujatkokselta ei jatku raidetta",
                     "front-joint-only-duplicate-connected": "Vaihteen etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -7,6 +7,7 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
+import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
@@ -19,6 +20,7 @@ import fi.fta.geoviite.infra.math.Line
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.publication.ValidationVersions
+import fi.fta.geoviite.infra.publication.draftTransitionOrOfficialState
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
@@ -1342,14 +1344,15 @@ constructor(
         switchIds: List<IntId<TrackLayoutSwitch>> = emptyList(),
         trackNumberIds: List<IntId<TrackLayoutTrackNumber>> = emptyList(),
     ): CalculatedChanges {
+        val target = draftTransitionOrOfficialState(PublicationState.DRAFT, LayoutBranch.main)
         val publicationVersions =
             ValidationVersions(
-                branch = LayoutBranch.main,
-                locationTracks = locationTrackDao.fetchPublicationVersions(LayoutBranch.main, locationTrackIds),
-                kmPosts = layoutKmPostDao.fetchPublicationVersions(LayoutBranch.main, kmPostIds),
-                referenceLines = referenceLineDao.fetchPublicationVersions(LayoutBranch.main, referenceLineIds),
-                switches = switchDao.fetchPublicationVersions(LayoutBranch.main, switchIds),
-                trackNumbers = layoutTrackNumberDao.fetchPublicationVersions(LayoutBranch.main, trackNumberIds),
+                target = target,
+                locationTracks = locationTrackDao.fetchCandidateVersions(target.candidateContext, locationTrackIds),
+                kmPosts = layoutKmPostDao.fetchCandidateVersions(target.candidateContext, kmPostIds),
+                referenceLines = referenceLineDao.fetchCandidateVersions(target.candidateContext, referenceLineIds),
+                switches = switchDao.fetchCandidateVersions(target.candidateContext, switchIds),
+                trackNumbers = layoutTrackNumberDao.fetchCandidateVersions(target.candidateContext, trackNumberIds),
                 splits = listOf(),
             )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -1,10 +1,13 @@
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.publication.PublicationRequestIds
 import fi.fta.geoviite.infra.publication.PublicationResult
 import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.publication.ValidationTarget
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.publication.ValidationVersions
+import fi.fta.geoviite.infra.publication.draftTransitionOrOfficialState
 import fi.fta.geoviite.infra.tracklayout.LayoutDaoResponse
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
@@ -34,10 +37,10 @@ fun validationVersions(
     kmPosts: List<LayoutDaoResponse<TrackLayoutKmPost>> = listOf(),
     locationTracks: List<LayoutDaoResponse<LocationTrack>> = listOf(),
     switches: List<LayoutDaoResponse<TrackLayoutSwitch>> = listOf(),
-    branch: LayoutBranch = LayoutBranch.main,
+    target: ValidationTarget = draftTransitionOrOfficialState(PublicationState.DRAFT, LayoutBranch.main),
 ) =
     ValidationVersions(
-        branch = branch,
+        target = target,
         trackNumbers = trackNumbers.map { (id, version) -> ValidationVersion(id, version) },
         referenceLines = referenceLines.map { (id, version) -> ValidationVersion(id, version) },
         kmPosts = kmPosts.map { (id, version) -> ValidationVersion(id, version) },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.integration.CalculatedChanges
@@ -353,37 +354,33 @@ constructor(
                     draft = true,
                 )
             )
+        val target = draftTransitionOrOfficialState(PublicationState.DRAFT, LayoutBranch.main)
         assertEquals(
             setOf(officialLinkedAlignment, draftLinkedAlignment),
-            publicationDao.fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByAlignment))[switchByAlignment],
+            publicationDao.fetchLinkedLocationTracks(target, listOf(switchByAlignment))[switchByAlignment],
         )
         assertEquals(
             setOf(officialLinkedAlignment),
-            publicationDao
-                .fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByAlignment), listOf())[switchByAlignment],
+            publicationDao.fetchLinkedLocationTracks(target, listOf(switchByAlignment), listOf())[switchByAlignment],
         )
         assertEquals(
             setOf(officialLinkedAlignment, draftLinkedAlignment),
             publicationDao
-                .fetchLinkedLocationTracks(
-                    LayoutBranch.main,
-                    listOf(switchByAlignment),
-                    listOf(draftLinkedAlignment.id),
-                )[switchByAlignment],
+                .fetchLinkedLocationTracks(target, listOf(switchByAlignment), listOf(draftLinkedAlignment.id))[
+                    switchByAlignment],
         )
         assertEquals(
             setOf(officialLinkedTopo, draftLinkedTopo),
-            publicationDao.fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByTopo))[switchByTopo],
+            publicationDao.fetchLinkedLocationTracks(target, listOf(switchByTopo))[switchByTopo],
         )
         assertEquals(
             setOf(officialLinkedTopo),
-            publicationDao.fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByTopo), listOf())[switchByTopo],
+            publicationDao.fetchLinkedLocationTracks(target, listOf(switchByTopo), listOf())[switchByTopo],
         )
         assertEquals(
             setOf(officialLinkedTopo, draftLinkedTopo),
             publicationDao
-                .fetchLinkedLocationTracks(LayoutBranch.main, listOf(switchByTopo), listOf(draftLinkedTopo.id))[
-                    switchByTopo],
+                .fetchLinkedLocationTracks(target, listOf(switchByTopo), listOf(draftLinkedTopo.id))[switchByTopo],
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -82,7 +82,6 @@ import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.asDesignDraft
 import fi.fta.geoviite.infra.tracklayout.asMainDraft
 import fi.fta.geoviite.infra.tracklayout.assertMatches
-import fi.fta.geoviite.infra.tracklayout.joints
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.layoutDesign
 import fi.fta.geoviite.infra.tracklayout.locationTrack
@@ -887,7 +886,12 @@ constructor(
             locationTrackDao.insert(locationTrack.copy(alignmentVersion = alignmentDao.insert(alignment)))
 
         val validation =
-            publicationService.validateLocationTracks(MainLayoutContext.official, listOf(locationTrackId.id)).first()
+            publicationService
+                .validateLocationTracks(
+                    draftTransitionOrOfficialState(OFFICIAL, LayoutBranch.main),
+                    listOf(locationTrackId.id),
+                )
+                .first()
         assertEquals(validation.errors.size, 1)
     }
 
@@ -897,7 +901,10 @@ constructor(
 
         val validation =
             publicationService
-                .validateTrackNumbersAndReferenceLines(MainLayoutContext.official, listOf(trackNumber))
+                .validateTrackNumbersAndReferenceLines(
+                    draftTransitionOrOfficialState(OFFICIAL, LayoutBranch.main),
+                    listOf(trackNumber),
+                )
                 .first()
         assertEquals(validation.errors.size, 1)
     }
@@ -906,7 +913,11 @@ constructor(
     fun `Validating official switch should work`() {
         val switchId = switchDao.insert(switch(draft = false, stateCategory = EXISTING)).id
 
-        val validation = publicationService.validateSwitches(MainLayoutContext.official, listOf(switchId))
+        val validation =
+            publicationService.validateSwitches(
+                draftTransitionOrOfficialState(OFFICIAL, LayoutBranch.main),
+                listOf(switchId),
+            )
         assertEquals(1, validation.size)
         assertEquals(1, validation[0].errors.size)
     }
@@ -919,7 +930,10 @@ constructor(
 
         val validationIds =
             publicationService
-                .validateSwitches(MainLayoutContext.official, listOf(switchId, switchId2, switchId3))
+                .validateSwitches(
+                    draftTransitionOrOfficialState(OFFICIAL, LayoutBranch.main),
+                    listOf(switchId, switchId2, switchId3),
+                )
                 .map { it.id }
         assertEquals(3, validationIds.size)
         assertContains(validationIds, switchId)
@@ -934,7 +948,10 @@ constructor(
                 .insert(kmPost(mainOfficialContext.createLayoutTrackNumber().id, km = KmNumber.ZERO, draft = false))
                 .id
 
-        val validation = publicationService.validateKmPosts(MainLayoutContext.official, listOf(kmPostId)).first()
+        val validation =
+            publicationService
+                .validateKmPosts(draftTransitionOrOfficialState(OFFICIAL, LayoutBranch.main), listOf(kmPostId))
+                .first()
         assertEquals(validation.errors.size, 1)
     }
 
@@ -994,7 +1011,7 @@ constructor(
         assertEquals(
             listOf(
                 LayoutValidationIssue(
-                    LayoutValidationIssueType.ERROR,
+                    LayoutValidationIssueType.FATAL,
                     "validation.layout.location-track.duplicate-name-official",
                     mapOf("locationTrack" to AlignmentName("LT"), "trackNumber" to TrackNumber("TN")),
                 )
@@ -1005,7 +1022,7 @@ constructor(
         assertEquals(
             List(2) {
                 LayoutValidationIssue(
-                    LayoutValidationIssueType.ERROR,
+                    LayoutValidationIssueType.FATAL,
                     "validation.layout.location-track.duplicate-name-draft",
                     mapOf("locationTrack" to AlignmentName("NLT"), "trackNumber" to TrackNumber("TN")),
                 )
@@ -1018,7 +1035,7 @@ constructor(
         assertEquals(
             listOf(
                 LayoutValidationIssue(
-                    LayoutValidationIssueType.ERROR,
+                    LayoutValidationIssueType.FATAL,
                     "validation.layout.switch.duplicate-name-official",
                     mapOf("switch" to SwitchName("SW")),
                 )
@@ -1032,7 +1049,7 @@ constructor(
         assertEquals(
             List(2) {
                 LayoutValidationIssue(
-                    LayoutValidationIssueType.ERROR,
+                    LayoutValidationIssueType.FATAL,
                     "validation.layout.switch.duplicate-name-draft",
                     mapOf("switch" to SwitchName("NSW")),
                 )
@@ -1046,7 +1063,7 @@ constructor(
         assertEquals(
             listOf(
                 LayoutValidationIssue(
-                    LayoutValidationIssueType.ERROR,
+                    LayoutValidationIssueType.FATAL,
                     "validation.layout.track-number.duplicate-name-official",
                     mapOf("trackNumber" to TrackNumber("TN")),
                 )
@@ -3682,6 +3699,7 @@ constructor(
         val sourceTrack: LayoutDaoResponse<LocationTrack>,
         val targetTracks: List<Pair<LayoutDaoResponse<LocationTrack>, IntRange>>,
     ) {
+
         val targetParams: List<Pair<IntId<LocationTrack>, IntRange>> =
             targetTracks.map { (track, range) -> track.id to range }
 
@@ -4164,6 +4182,118 @@ constructor(
         publish(publicationService, kmPosts = listOf(kmPost))
         val latestPub = publicationService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)
         assertEquals(Operation.CREATE, latestPub[0].kmPosts[0].operation)
+    }
+
+    @Test
+    fun `duplicate km posts are fatal in validation`() {
+        val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
+        mainOfficialContext.insert(kmPost(trackNumber, KmNumber(1)))
+        mainOfficialContext.insert(referenceLineAndAlignment(trackNumber, segment(Point(0.0, 0.0), Point(2.0, 2.0))))
+        val design = testDBService.createDesignBranch()
+        val designKmPost = testDBService.testContext(design, OFFICIAL).insert(kmPost(trackNumber, KmNumber(1)))
+        val transition = ValidateTransition(LayoutContextTransition.mergeToMainFrom(design))
+        val validation = publicationService.validateKmPosts(transition, listOf(designKmPost.id)).first()
+
+        assertTrue(
+            validation.errors.any {
+                it.type == LayoutValidationIssueType.FATAL &&
+                    it.localizationKey == LocalizationKey("$VALIDATION_GEOCODING.duplicate-km-posts")
+            }
+        )
+    }
+
+    @Test
+    fun `duplicate switch names are found in merge to main`() {
+        mainDraftContext.insert(switch(name = "ABC V123"))
+        val design = testDBService.createDesignBranch()
+        val designSwitch = testDBService.testContext(design, OFFICIAL).insert(switch(name = "ABC V123"))
+        val transition = ValidateTransition(LayoutContextTransition.mergeToMainFrom(design))
+        val validation = publicationService.validateSwitches(transition, listOf(designSwitch.id)).first()
+        assertTrue(
+            validation.errors.any {
+                it.type == LayoutValidationIssueType.FATAL &&
+                    it.localizationKey == LocalizationKey("validation.layout.switch.duplicate-name-draft-in-main")
+            }
+        )
+    }
+
+    @Test
+    fun `duplicate track numbers are found in merge to main`() {
+        mainDraftContext.insert(trackNumber(number = TrackNumber("123")))
+        val design = testDBService.createDesignBranch()
+        val designTrackNumber =
+            testDBService.testContext(design, OFFICIAL).insert(trackNumber(number = TrackNumber("123")))
+        val transition = ValidateTransition(LayoutContextTransition.mergeToMainFrom(design))
+        val validation =
+            publicationService.validateTrackNumbersAndReferenceLines(transition, listOf(designTrackNumber.id)).first()
+        assertTrue(
+            validation.errors.any {
+                it.type == LayoutValidationIssueType.FATAL &&
+                    it.localizationKey == LocalizationKey("validation.layout.track-number.duplicate-name-draft-in-main")
+            }
+        )
+    }
+
+    @Test
+    fun `duplicate location track from draft mode are found`() {
+        val trackNumber = mainOfficialContext.insert(trackNumber()).id
+        mainDraftContext.insert(
+            locationTrackAndAlignment(
+                trackNumber,
+                name = "ABC 123",
+                segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
+            )
+        )
+        val design = testDBService.createDesignBranch()
+        val designLocationTrack =
+            testDBService
+                .testContext(design, OFFICIAL)
+                .insert(
+                    locationTrackAndAlignment(
+                        trackNumber,
+                        name = "ABC 123",
+                        segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
+                    )
+                )
+        val transition = ValidateTransition(LayoutContextTransition.mergeToMainFrom(design))
+        val validation = publicationService.validateLocationTracks(transition, listOf(designLocationTrack.id)).first()
+        assertTrue(
+            validation.errors.any {
+                it.type == LayoutValidationIssueType.FATAL &&
+                    it.localizationKey == LocalizationKey("$VALIDATION_LOCATION_TRACK.duplicate-name-draft-in-main")
+            }
+        )
+    }
+
+    @Test
+    fun `reference lines are validated on merge to main`() {
+        val design = testDBService.createDesignBranch()
+        val designOfficialContext = testDBService.testContext(design, OFFICIAL)
+        val trackNumberId = designOfficialContext.insert(trackNumber()).id
+        val referenceLineId =
+            designOfficialContext
+                .insert(
+                    // segment with bendy alignment
+                    referenceLineAndAlignment(trackNumberId, segment(Point(0.0, 0.0), Point(1.0, 0.0), Point(0.0, 1.0)))
+                )
+                .id
+        val validated =
+            publicationService.validatePublicationCandidates(
+                publicationService.collectPublicationCandidates(MergeFromDesign(design)),
+                PublicationRequestIds(
+                    trackNumbers = listOf(trackNumberId),
+                    locationTracks = listOf(),
+                    kmPosts = listOf(),
+                    referenceLines = listOf(referenceLineId),
+                    switches = listOf(),
+                ),
+            )
+        val referenceLineIssues = validated.validatedAsPublicationUnit.referenceLines[0].issues
+        assertEquals(1, referenceLineIssues.size)
+        assertEquals(
+            LocalizationKey("validation.layout.reference-line.points.not-continuous"),
+            referenceLineIssues[0].localizationKey,
+        )
     }
 
     data class PublicationGroupTestData(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
@@ -164,8 +165,10 @@ constructor(
         referenceLines: List<IntId<ReferenceLine>> = listOf(),
         switches: List<IntId<TrackLayoutSwitch>> = listOf(),
         kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
-    ): ValidationContext =
-        ValidationContext(
+    ): ValidationContext {
+        val target = draftTransitionOrOfficialState(PublicationState.DRAFT, branch)
+        val candidateContext = target.candidateContext
+        return ValidationContext(
             trackNumberDao = trackNumberDao,
             referenceLineDao = referenceLineDao,
             kmPostDao = kmPostDao,
@@ -178,13 +181,14 @@ constructor(
             splitService = splitService,
             publicationSet =
                 ValidationVersions(
-                    branch = branch,
-                    trackNumbers = trackNumberDao.fetchPublicationVersions(branch, trackNumbers),
-                    referenceLines = referenceLineDao.fetchPublicationVersions(branch, referenceLines),
-                    kmPosts = kmPostDao.fetchPublicationVersions(branch, kmPosts),
-                    locationTracks = locationTrackDao.fetchPublicationVersions(branch, locationTracks),
-                    switches = switchDao.fetchPublicationVersions(branch, switches),
+                    target = target,
+                    trackNumbers = trackNumberDao.fetchCandidateVersions(candidateContext, trackNumbers),
+                    referenceLines = referenceLineDao.fetchCandidateVersions(candidateContext, referenceLines),
+                    kmPosts = kmPostDao.fetchCandidateVersions(candidateContext, kmPosts),
+                    locationTracks = locationTrackDao.fetchCandidateVersions(candidateContext, locationTracks),
+                    switches = switchDao.fetchCandidateVersions(candidateContext, switches),
                     splits = splitService.fetchPublicationVersions(branch, locationTracks, switches),
                 ),
         )
+    }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDaoIT.kt
@@ -11,6 +11,7 @@ import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geography.GeometryPoint
+import fi.fta.geoviite.infra.publication.draftTransitionOrOfficialState
 import fi.fta.geoviite.infra.tracklayout.LayoutState.DELETED
 import fi.fta.geoviite.infra.tracklayout.LayoutState.IN_USE
 import fi.fta.geoviite.infra.tracklayout.LayoutState.NOT_IN_USE
@@ -121,16 +122,16 @@ class LayoutKmPostDaoIT @Autowired constructor(private val kmPostDao: LayoutKmPo
         val postThreeOnlyDraft = kmPostDao.insert(kmPost(trackNumberId, KmNumber(3), draft = true))
         val postFourOnlyOfficial = kmPostDao.insert(kmPost(trackNumberId, KmNumber(4), draft = false))
 
+        val target = draftTransitionOrOfficialState(PublicationState.DRAFT, LayoutBranch.main)
         val versionsEmpty =
-            kmPostDao.fetchVersionsForPublication(LayoutBranch.main, listOf(trackNumberId), listOf())[trackNumberId]!!
+            kmPostDao.fetchVersionsForPublication(target, listOf(trackNumberId), listOf())[trackNumberId]!!
         val versionsOnlyOne =
             kmPostDao
-                .fetchVersionsForPublication(LayoutBranch.main, listOf(trackNumberId), listOf(postOneOfficial.id))[
-                    trackNumberId]!!
+                .fetchVersionsForPublication(target, listOf(trackNumberId), listOf(postOneOfficial.id))[trackNumberId]!!
         val versionsOneAndThree =
             kmPostDao
                 .fetchVersionsForPublication(
-                    LayoutBranch.main,
+                    target,
                     listOf(trackNumberId),
                     listOf(postOneOfficial.id, postThreeOnlyDraft.id),
                 )[trackNumberId]!!

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -291,12 +291,12 @@ constructor(
     }
 
     private fun publishTrackNumber(id: IntId<TrackLayoutTrackNumber>) =
-        trackNumberDao.fetchPublicationVersions(LayoutBranch.main, listOf(id)).first().let { version ->
+        trackNumberDao.fetchCandidateVersions(MainLayoutContext.draft, listOf(id)).first().let { version ->
             trackNumberService.publish(LayoutBranch.main, version)
         }
 
     private fun publishReferenceLine(id: IntId<ReferenceLine>): LayoutDaoResponse<ReferenceLine> =
-        referenceLineDao.fetchPublicationVersions(LayoutBranch.main, listOf(id)).first().let { version ->
+        referenceLineDao.fetchCandidateVersions(MainLayoutContext.draft, listOf(id)).first().let { version ->
             referenceLineService.publish(LayoutBranch.main, version)
         }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -768,7 +768,7 @@ constructor(
         )
 
     private fun publish(id: IntId<LocationTrack>): LayoutDaoResponse<LocationTrack> =
-        locationTrackDao.fetchPublicationVersions(LayoutBranch.main, listOf(id)).first().let { version ->
+        locationTrackDao.fetchCandidateVersions(MainLayoutContext.draft, listOf(id)).first().let { version ->
             locationTrackService.publish(LayoutBranch.main, version)
         }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
@@ -279,7 +279,7 @@ constructor(
     private fun address(seed: Int = 0) = TrackMeter(KmNumber(seed), seed * 100)
 
     private fun publish(id: IntId<ReferenceLine>) =
-        referenceLineDao.fetchPublicationVersions(LayoutBranch.main, listOf(id)).first().let { version ->
+        referenceLineDao.fetchCandidateVersions(MainLayoutContext.draft, listOf(id)).first().let { version ->
             referenceLineService.publish(LayoutBranch.main, version)
         }
 }

--- a/ui/src/preview/change-table-sorting.ts
+++ b/ui/src/preview/change-table-sorting.ts
@@ -1,4 +1,8 @@
-import { Operation, LayoutValidationIssue } from 'publication/publication-model';
+import {
+    Operation,
+    LayoutValidationIssue,
+    validationIssueIsError,
+} from 'publication/publication-model';
 import { fieldComparator } from 'utils/array-utils';
 import { nextSortDirection, SortDirection } from 'utils/table-utils';
 
@@ -18,9 +22,9 @@ export type SortInformation = {
 };
 
 const includesErrors = (issues: LayoutValidationIssue[]) =>
-    issues.some((err) => err.type == 'ERROR');
+    issues.some((err) => validationIssueIsError(err.type));
 const includesWarnings = (issues: LayoutValidationIssue[]) =>
-    issues.some((err) => err.type == 'WARNING');
+    issues.some((err) => !validationIssueIsError(err.type));
 const issueSeverityPriority = (issues: LayoutValidationIssue[]) => {
     let priority = 0;
     if (includesErrors(issues)) priority += 2;

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -3,8 +3,9 @@ import { Icons } from 'vayla-design-lib/icon/Icon';
 import { formatDateFull } from 'utils/date-utils';
 import { useTranslation } from 'react-i18next';
 import {
-    PublicationStage,
     LayoutValidationIssue,
+    LayoutValidationIssueType,
+    PublicationStage,
     PublicationValidationState,
 } from 'publication/publication-model';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
@@ -57,15 +58,16 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     const [isErrorRowExpanded, setIsErrorRowExpanded] = React.useState(false);
     const [actionMenuVisible, setActionMenuVisible] = React.useState(false);
 
-    const issuesToStrings = (list: LayoutValidationIssue[], type: 'ERROR' | 'WARNING') => {
+    const issuesToStrings = (list: LayoutValidationIssue[], type: LayoutValidationIssueType) => {
         const filtered = list.filter((e) => e.type === type);
         return filtered.map((error) => t(error.localizationKey, error.params));
     };
 
-    const hasErrors = tableEntry.issues.length > 0;
-
+    const fatalTexts = issuesToStrings(tableEntry.issues, 'FATAL');
     const errorTexts = issuesToStrings(tableEntry.issues, 'ERROR');
     const warningTexts = issuesToStrings(tableEntry.issues, 'WARNING');
+
+    const hasErrors = tableEntry.issues.length > 0;
 
     const actionMenuRef = React.useRef(null);
 
@@ -193,10 +195,11 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                 <ValidationStateCell
                     validationState={validationState}
                     hasErrors={hasErrors}
-                    errorTexts={errorTexts}
+                    errorTexts={errorTexts.concat(fatalTexts)}
                     warningTexts={warningTexts}
                     toggleRowExpansion={() => setIsErrorRowExpanded(!isErrorRowExpanded)}
                 />
+
                 <td className={'preview-table-item preview-table-item__actions--cell'}>
                     <Button
                         qa-id={'stage-change-button'}
@@ -227,7 +230,10 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                 </td>
             </tr>
             {isErrorRowExpanded && hasErrors && (
-                <ValidationStateRow errorTexts={errorTexts} warningTexts={warningTexts} />
+                <ValidationStateRow
+                    errorTexts={errorTexts.concat(fatalTexts)}
+                    warningTexts={warningTexts}
+                />
             )}
             {actionMenuVisible && (
                 <Menu

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -171,12 +171,32 @@ export const getPublicationCandidates = (
         `${publicationUri(layoutBranch)}/${fromState}/candidates`,
     ).then(toPublicationCandidates);
 
-export const validatePublicationCandidates = (
+export const validateMergeToMainCandidates = (
     layoutBranch: LayoutBranch,
     candidates: PublicationCandidateReference[],
 ) =>
     postNonNull<PublicationRequestIds, ValidatedPublicationCandidatesResponse>(
-        `${publicationUri(layoutBranch)}/validate`,
+        `${publicationUri(layoutBranch)}/validate-merge-to-main`,
+        toPublicationRequestIds(candidates),
+    ).then(toValidatedPublicationCandidates);
+
+export const validatePublicationCandidates = (
+    layoutBranch: LayoutBranch,
+    candidates: PublicationCandidateReference[],
+) => validatePublicationCandidatesWith('validate', layoutBranch, candidates);
+
+export const validateMergeToMain = (
+    layoutBranch: LayoutBranch,
+    candidates: PublicationCandidateReference[],
+) => validatePublicationCandidatesWith('validate-merge-to-main', layoutBranch, candidates);
+
+const validatePublicationCandidatesWith = (
+    validationPath: string,
+    layoutBranch: LayoutBranch,
+    candidates: PublicationCandidateReference[],
+) =>
+    postNonNull<PublicationRequestIds, ValidatedPublicationCandidatesResponse>(
+        `${publicationUri(layoutBranch)}/${validationPath}`,
         toPublicationRequestIds(candidates),
     ).then(toValidatedPublicationCandidates);
 

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -22,12 +22,28 @@ import { RatkoPushStatus } from 'ratko/ratko-model';
 import { BoundingBox, Point } from 'model/geometry';
 import { LocalizationParams } from 'i18n/config';
 import { SplitTargetOperation } from 'tool-panel/location-track/split-store';
+import { exhaustiveMatchingGuard } from 'utils/type-utils';
 
 export type LayoutValidationIssue = {
-    type: 'ERROR' | 'WARNING';
+    type: LayoutValidationIssueType;
     localizationKey: string;
     params: LocalizationParams;
 };
+
+export type LayoutValidationIssueType = 'FATAL' | 'ERROR' | 'WARNING';
+
+export const validationIssueIsAtLeastAsBadAs =
+    (base: LayoutValidationIssueType) =>
+    (issue: LayoutValidationIssueType): boolean =>
+        issue === 'FATAL'
+            ? true
+            : issue === 'ERROR'
+              ? base !== 'FATAL'
+              : issue === 'WARNING'
+                ? base === 'WARNING'
+                : exhaustiveMatchingGuard(issue);
+
+export const validationIssueIsError = validationIssueIsAtLeastAsBadAs('ERROR');
 
 export enum DraftChangeType {
     TRACK_NUMBER = 'TRACK_NUMBER',

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -1,13 +1,13 @@
 import { subMonths } from 'date-fns';
 import {
+    CalculatedChanges,
+    DraftChangeType,
+    PublicationCandidate,
+    PublicationCandidateId,
+    PublicationCandidateReference,
     PublicationGroupId,
     PublicationSearch,
     PublicationStage,
-    PublicationCandidate,
-    PublicationCandidateReference,
-    DraftChangeType,
-    PublicationCandidateId,
-    CalculatedChanges,
 } from 'publication/publication-model';
 import { currentDay } from 'utils/date-utils';
 import { candidateIdAndTypeMatches } from 'preview/preview-view-filters';
@@ -116,13 +116,6 @@ export const addValidationState = (
             : candidate;
     });
 };
-
-// TODO GVT-2421: Only needed while we don't do real validation
-export const pretendValidated = (candidate: PublicationCandidate): PublicationCandidate => ({
-    ...candidate,
-    validationState: 'API_CALL_OK',
-    issues: [],
-});
 
 export const setValidationStateToApiError = (
     candidate: PublicationCandidate,

--- a/ui/src/tool-panel/asset-validation-infobox-container.tsx
+++ b/ui/src/tool-panel/asset-validation-infobox-container.tsx
@@ -5,7 +5,7 @@ import { AssetId, LayoutContext, TimeStamp } from 'common/common-model';
 import { getKmPostValidation } from 'track-layout/layout-km-post-api';
 import { getSwitchValidation } from 'track-layout/layout-switch-api';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
-import { ValidatedAsset } from 'publication/publication-model';
+import { ValidatedAsset, validationIssueIsError } from 'publication/publication-model';
 import {
     LayoutKmPostId,
     LayoutSwitchId,
@@ -57,8 +57,8 @@ export const AssetValidationInfoboxContainer: React.FC<AssetValidationInfoboxPro
         layoutContext.branch,
         changeTime,
     ]);
-    const errors = validation?.errors.filter((err) => err.type === 'ERROR') || [];
-    const warnings = validation?.errors.filter((err) => err.type === 'WARNING') || [];
+    const errors = validation?.errors.filter((err) => validationIssueIsError(err.type)) || [];
+    const warnings = validation?.errors.filter((err) => !validationIssueIsError(err.type)) || [];
 
     return (
         <AssetValidationInfobox

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -27,6 +27,7 @@ import { useTrackLayoutAppSelector } from 'store/hooks';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
+import { validationIssueIsError } from 'publication/publication-model';
 
 type SwitchRelinkingValidationTaskListProps = {
     layoutContext: LayoutContext;
@@ -165,8 +166,8 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
                                 );
 
                                 const errors =
-                                    switchRelinkingResult?.validationIssues?.filter(
-                                        (e) => e.type === 'ERROR',
+                                    switchRelinkingResult?.validationIssues?.filter((e) =>
+                                        validationIssueIsError(e.type),
                                     ) ?? [];
 
                                 const title = errors

--- a/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-validation-infobox-container.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useCommonDataAppSelector } from 'store/hooks';
 import { EDIT_LAYOUT } from 'user/user-model';
 import { PrivilegeRequired } from 'user/privilege-required';
+import { validationIssueIsError } from 'publication/publication-model';
 
 type LocationTrackValidationInfoboxProps = {
     id: LocationTrackId;
@@ -37,8 +38,8 @@ export const LocationTrackValidationInfoboxContainer: React.FC<
         [id, layoutContext.publicationState, layoutContext.branch, changeTimes.layoutLocationTrack],
     );
 
-    const errors = validation?.errors.filter((err) => err.type === 'ERROR') || [];
-    const warnings = validation?.errors.filter((err) => err.type === 'WARNING') || [];
+    const errors = validation?.errors.filter((err) => validationIssueIsError(err.type)) || [];
+    const warnings = validation?.errors.filter((err) => !validationIssueIsError(err.type)) || [];
 
     return (
         <AssetValidationInfobox


### PR DESCRIPTION
Validaatio tapahtui aiemmin jossain haarassa, ja sen kohde oli joko virallinen tila tai jonkin luonnosjoukon tuominen viralliseen tilaan. Nyt validaatiota luonnehtii kaksi luokkaa:

- LayoutContextTransition: Jo vähän aiemmin tehty luokka. Kertoo kontekstien välisistä siirroista, millaisesta siirrosta on kyse, vaihtoehdoilla julkaisu haarassa tai merge mainiin.
- ValidationTarget: Tässä kommitissa tullut luokka. Kertoo, mitä asiaa validoidaan: Joko validoidaan jotain siirtoa tilojen välillä, missä jonkun pohjatilan päälle tuodaan jokin joukko olioita toisesta tilasta; tai validoidaan vain jotain tilaa.

Periaatteessa ValidationTargetissa on ehkä vielä jonkin verran miettimisen varaa, koska esim. main-draftin validointi tilana `ValidateContext(MainLayoutContext.draft)` tarkoittaa lopulta samaa asiaa kuin draftitilan kaikkien olioiden julkaisun validointi `ValidateTransition(PublicationInMain())`. Ts. siis ValidationTarget on itsessään koherentti ajatus, ja geoviitteen olioiden perintä tilojen välillä on toinen koherentti ajatus, mutta kun ne lyödään yhteen, niissä on päällekkäisyyttä.

Se, mitä tällä saadaan nyt aikaan on, että voidaan erottaa toisistaan jonkin design-haaran `ValidateContext(designBranch.official)` ja `ValidateTransition(MergeFromDesign(designBranch))` toisistaan.

Mergen validaation avuksi piti lisätä myös FATAL-taso validaatio-ongelmille, ja asetettu se sellaisten validaatio-ongelmien tasoksi, jotka veisivät paikannuspohjan sellaiseen tilaan, missä sen ei haluta olevan ikinä edes luonnostilassa. Merge-näkymä sitten katsoo, että löytyikö validaatio-ongelmista fataaleja virheitä, eikä salli tällöin mergeä.

Tällä hetkellä fatal- ja error-tasoisten ongelmien välillä ei ole vielä minkäänlaista visuaalista eroa, se pitää miettiä erikseen.