### PR TITLE
General: Fix, clarify, and add tests for fetchVersionsNear()s

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -222,7 +222,7 @@ constructor(
     ): Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>> {
         fun indexTracksInBounds(boundingBox: BoundingBox?) =
             boundingBox
-                ?.let { bounds -> locationTrackDao.fetchVersionsNear(branch.draft, false, null, bounds) }
+                ?.let { bounds -> locationTrackDao.fetchVersionsNear(branch.draft, bounds) }
                 ?.map(locationTrackService::getWithAlignment)
                 ?.associate { trackAndAlignment -> trackAndAlignment.first.id as IntId to trackAndAlignment } ?: mapOf()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -433,13 +433,13 @@ class LocationTrackDao(
     }
 
     fun listNear(context: LayoutContext, bbox: BoundingBox): List<LocationTrack> =
-        fetchVersionsNear(context, false, null, bbox).map(::fetch)
+        fetchVersionsNear(context, bbox).map(::fetch)
 
     fun fetchVersionsNear(
         context: LayoutContext,
-        includeDeleted: Boolean,
-        trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
         bbox: BoundingBox,
+        includeDeleted: Boolean = false,
+        trackNumberId: IntId<TrackLayoutTrackNumber>? = null,
     ): List<LayoutRowVersion<LocationTrack>> {
         val sql =
             """
@@ -478,7 +478,7 @@ class LocationTrackDao(
                 select *
                   from layout.location_track_in_layout_context(:publication_state::layout.publication_state,
                                                                :design_id, location_track.official_id)
-                  where state != 'DELETED') in_layout_context using (row_id, row_version);
+                                                               ) in_layout_context using (row_id, row_version);
         """
                 .trimIndent()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -270,7 +270,7 @@ class LocationTrackService(
         return if (boundingBox == null) {
                 dao.list(layoutContext, includeDeleted, trackNumberId)
             } else {
-                dao.fetchVersionsNear(layoutContext, includeDeleted, trackNumberId, boundingBox).map(dao::fetch)
+                dao.fetchVersionsNear(layoutContext, boundingBox, includeDeleted, trackNumberId).map(dao::fetch)
             }
             .let { list -> filterByBoundingBox(list, boundingBox) }
             .let(::associateWithAlignments)
@@ -609,7 +609,7 @@ class LocationTrackService(
         layoutContext: LayoutContext,
         targetPoint: LayoutPoint,
     ): List<Pair<LocationTrack, LayoutAlignment>> {
-        return dao.fetchVersionsNear(layoutContext, false, null, boundingBoxAroundPoint(targetPoint, 1.0))
+        return dao.fetchVersionsNear(layoutContext, boundingBoxAroundPoint(targetPoint, 1.0))
             .map { version -> getWithAlignmentInternal(version) }
             .filter { (track, alignment) -> alignment.segments.isNotEmpty() && track.exists }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -265,11 +265,10 @@ class ReferenceLineDao(
         return jdbcTemplate.query(sql, params) { rs, _ -> rs.getDaoResponse("official_id", "row_id", "row_version") }
     }
 
-    // TODO: No IT test runs this
     fun fetchVersionsNear(
         layoutContext: LayoutContext,
         bbox: BoundingBox,
-        includeDeleted: Boolean,
+        includeDeleted: Boolean = false,
     ): List<LayoutRowVersion<ReferenceLine>> {
         val sql =
             """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -220,7 +220,7 @@ class ReferenceLineService(
     }
 
     fun listNear(layoutContext: LayoutContext, bbox: BoundingBox): List<ReferenceLine> {
-        return dao.fetchVersionsNear(layoutContext, bbox, false).map(dao::fetch)
+        return dao.fetchVersionsNear(layoutContext, bbox, includeDeleted = false).map(dao::fetch)
     }
 
     override fun mergeToMainBranch(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -238,6 +238,8 @@ class TestDBService(
         return SwitchName(getUniqueName(DbTable.LAYOUT_SWITCH, SwitchName.allowedLength.last))
     }
 
+    fun getUnusedDesignName() = getUniqueName(DbTable.LAYOUT_DESIGN, 50) // arbitrary length limit, fix in GVT-2719
+
     fun getUnusedProjectName(): ProjectName = ProjectName(getUniqueName(DbTable.GEOMETRY_PLAN_PROJECT, 100))
 
     fun getUnusedAuthorCompanyName(): CompanyName = CompanyName(getUniqueName(DbTable.GEOMETRY_PLAN_AUTHOR, 100))
@@ -314,7 +316,7 @@ class TestDBService(
         return dao.update(mutate(dao.fetch(rowVersion)))
     }
 
-    fun createLayoutDesign(): IntId<LayoutDesign> = layoutDesignDao.insert(layoutDesign())
+    fun createLayoutDesign(): IntId<LayoutDesign> = layoutDesignDao.insert(layoutDesign(getUnusedDesignName()))
 
     fun createDesignBranch(): DesignBranch = LayoutBranch.design(createLayoutDesign())
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
@@ -17,7 +17,6 @@ import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.geocodingContextCacheKey
 import fi.fta.geoviite.infra.tracklayout.kmPost
-import fi.fta.geoviite.infra.tracklayout.layoutDesign
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndAlignment
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -142,7 +141,7 @@ constructor(
 
     @Test
     fun `Cache keys are correctly fetched by moment`() {
-        val designBranch = LayoutBranch.design(designDao.insert(layoutDesign()))
+        val designBranch = testDBService.createDesignBranch()
         val officialDesignContext = testDBService.testContext(designBranch, OFFICIAL)
         val designDraftContext = testDBService.testContext(designBranch, DRAFT)
 


### PR DESCRIPTION
Katselmointikommentteja fiksaillessa päätin kirjoittaa pari testiä, ja hyötyä oli, kun ne löysivät ihan juuri tekemäni buginkin: LocationTrackDao#fetchVersionsNear()issa oli ylimääräinen deleted-tilan tarkistus, minkä takia sen includeDeleted-parametri ei toiminut.