### PR TITLE
GVT-2532 (part 3): Uncomment initial PV-schedule to fix test startup error

### DIFF
--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -108,7 +108,7 @@ geoviite:
       enabled: true
 
       search-poll:
-        #      initial-delay: PT1H
+        initial-delay: PT1H
         interval: PT4H
 
       result-poll:


### PR DESCRIPTION
Due to ProjektiVelho being enabled in the application-test.yml (Spring test) profile, the new scheduler structure expected to find a default value for initial-delay of the search-poll -configuration variable when starting the application with the "test" profile. As the value couldn't be found when ProjektiVelho was enabled (in the test profile), it caused a failure to start the Spring application with the "test" profile, used by E2E (ui) tests. This meant that E2E tests could not be run at all.

Enabling the 1 hour initial delay of ProjektiVelho shouldn't cause issues even when running the application normally (as it's going to be run in 4h intervals anyway when enabled). This also standardizes the default application profile to have standard form (no commented out configuration and "sane default" values). 