### PR TITLE
GVT-2768 Fix design publishing potentially leading to 2 rows in one context

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -12,6 +12,7 @@ import fi.fta.geoviite.infra.error.DeletingFailureException
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.AccessType.DELETE
+import fi.fta.geoviite.infra.logging.AccessType.UPDATE
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.publication.ValidationVersion
 import fi.fta.geoviite.infra.util.DaoBase
@@ -29,11 +30,11 @@ import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.requireOne
 import fi.fta.geoviite.infra.util.setUser
-import java.sql.Timestamp
-import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
+import java.time.Instant
 
 data class LayoutDaoResponse<T>(val id: IntId<T>, val rowVersion: LayoutRowVersion<T>)
 
@@ -47,6 +48,11 @@ interface LayoutAssetWriter<T : LayoutAsset<T>> {
     fun deleteDraft(branch: LayoutBranch, id: IntId<T>): LayoutDaoResponse<T>
 
     fun deleteDrafts(branch: LayoutBranch): List<LayoutDaoResponse<T>>
+
+    fun updateImplementedDesignDraftReferences(
+        designRowId: LayoutRowId<T>,
+        officialRowId: LayoutRowId<T>,
+    ): LayoutDaoResponse<T>?
 }
 
 @Transactional(readOnly = true)
@@ -339,6 +345,34 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
                 logger.daoAccess(DELETE, table.fullName, deleted)
                 deleted
             }
+    }
+
+    override fun updateImplementedDesignDraftReferences(
+        designRowId: LayoutRowId<T>,
+        officialRowId: LayoutRowId<T>,
+    ): LayoutDaoResponse<T>? {
+        val sql =
+            """
+            update ${table.fullName} set
+              design_row_id = null,
+              official_row_id = :official_row_id
+            where draft = true
+              and design_id is not null
+              and design_row_id = :design_row_id
+            returning 
+              official_id,
+              id as row_id,
+              version as row_version
+        """
+                .trimIndent()
+        jdbcTemplate.setUser()
+        val params = mapOf("official_row_id" to officialRowId.intValue, "design_row_id" to officialRowId.intValue)
+        return jdbcTemplate
+            .query<LayoutDaoResponse<T>>(sql, params) { rs, _ ->
+                rs.getDaoResponse("official_id", "row_id", "row_version")
+            }
+            .singleOrNull()
+            ?.also { updated -> logger.daoAccess(UPDATE, table.fullName, updated) }
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
@@ -90,13 +90,15 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
 
     protected fun publishInternal(
         branch: LayoutBranch,
-        version: LayoutRowVersion<ObjectType>,
+        draftVersion: LayoutRowVersion<ObjectType>,
     ): LayoutDaoResponse<ObjectType> {
-        val draft = dao.fetch(version)
+        val draft = dao.fetch(draftVersion)
         require(branch == draft.branch) {
             "Draft branch does not match the publishing operation: branch=$branch draft=$draft"
         }
-        require(draft.isDraft) { "Object to publish is not a draft: version=$version context=${draft.contextData}" }
+        require(draft.isDraft) {
+            "Object to publish is not a draft: draftVersion=$draftVersion context=${draft.contextData}"
+        }
         val published = asOfficial(branch, draft)
         require(!published.isDraft) { "Published object is still a draft: context=${published.contextData}" }
         verifyObjectIsExisting(published)
@@ -105,18 +107,23 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
             dao.update(published).also { r ->
                 require(r.id == draft.id) { "Publication response ID doesn't match object: id=${draft.id} updated=$r" }
             }
+        val publishedRowId = publicationResponse.rowVersion.rowId
         // If draft row-id changed, the data was updated to the official row -> delete the
         // now-redundant draft row
-        if (version.rowId != publicationResponse.rowVersion.rowId) {
-            dao.deleteRow(version.rowId)
+        if (draftVersion.rowId != publishedRowId) {
+            dao.deleteRow(draftVersion.rowId)
         }
-        // If main-draft was published and it came from a design row that wasn't updated, then that
-        // row is redundant too
-        if (
-            draft.branch == LayoutBranch.main && draft.contextData.designRowId != publicationResponse.rowVersion.rowId
-        ) {
-            draft.contextData.designRowId?.let(dao::deleteRow)
-        }
+
+        // When a design row is implemented into main-official, it ceases to be a part of the design
+        draft.contextData.designRowId
+            ?.takeIf { draft.branch == LayoutBranch.main }
+            ?.let { designRowId ->
+                // If the design row didn't become the main-row, it's redundant
+                if (designRowId != publishedRowId) dao.deleteRow(designRowId)
+                // Update potential draft-design references to point to the new main row
+                dao.updateImplementedDesignDraftReferences(designRowId, publishedRowId)
+            }
+
         return publicationResponse
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -83,7 +83,7 @@ class LayoutTrackNumberController(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @RequestBody saveRequest: TrackNumberSaveRequest,
     ): IntId<TrackLayoutTrackNumber> {
-        return trackNumberService.insert(branch, saveRequest)
+        return trackNumberService.insert(branch, saveRequest).id
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
@@ -93,7 +93,7 @@ class LayoutTrackNumberController(
         @PathVariable id: IntId<TrackLayoutTrackNumber>,
         @RequestBody saveRequest: TrackNumberSaveRequest,
     ): IntId<TrackLayoutTrackNumber> {
-        return trackNumberService.update(branch, id, saveRequest)
+        return trackNumberService.update(branch, id, saveRequest).id
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -24,8 +24,8 @@ import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.roundTo3Decimals
 import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.printCsv
-import java.util.stream.Collectors
 import org.springframework.transaction.annotation.Transactional
+import java.util.stream.Collectors
 
 const val KM_LENGTHS_CSV_TRANSLATION_PREFIX = "data-products.km-lengths.csv"
 
@@ -45,7 +45,7 @@ class LayoutTrackNumberService(
 ) : LayoutAssetService<TrackLayoutTrackNumber, LayoutTrackNumberDao>(dao) {
 
     @Transactional
-    fun insert(branch: LayoutBranch, saveRequest: TrackNumberSaveRequest): IntId<TrackLayoutTrackNumber> {
+    fun insert(branch: LayoutBranch, saveRequest: TrackNumberSaveRequest): LayoutDaoResponse<TrackLayoutTrackNumber> {
         val draftSaveResponse =
             saveDraftInternal(
                 branch,
@@ -58,7 +58,7 @@ class LayoutTrackNumberService(
                 ),
             )
         referenceLineService.addTrackNumberReferenceLine(branch, draftSaveResponse.id, saveRequest.startAddress)
-        return draftSaveResponse.id
+        return draftSaveResponse
     }
 
     @Transactional
@@ -66,7 +66,7 @@ class LayoutTrackNumberService(
         branch: LayoutBranch,
         id: IntId<TrackLayoutTrackNumber>,
         saveRequest: TrackNumberSaveRequest,
-    ): IntId<TrackLayoutTrackNumber> {
+    ): LayoutDaoResponse<TrackLayoutTrackNumber> {
         val original = dao.getOrThrow(branch.draft, id)
         val draftSaveResponse =
             saveDraftInternal(
@@ -78,7 +78,7 @@ class LayoutTrackNumberService(
                 ),
             )
         referenceLineService.updateTrackNumberReferenceLine(branch, id, saveRequest.startAddress)
-        return draftSaveResponse.id
+        return draftSaveResponse
     }
 
     @Transactional

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
@@ -218,6 +218,6 @@ constructor(
                     TrackMeter(KmNumber(5555), 5.5, 1),
                 )
             }
-            .map { saveRequest -> trackNumberService.insert(LayoutBranch.main, saveRequest) }
+            .map { saveRequest -> trackNumberService.insert(LayoutBranch.main, saveRequest).id }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
@@ -255,8 +255,7 @@ constructor(
     private fun alignmentExists(id: IntId<LayoutAlignment>): Boolean {
         val sql = "select exists(select 1 from layout.alignment where id = :id) as exists"
         val params = mapOf("id" to id.intValue)
-        return jdbc.queryForObject(sql, params) { rs, _ -> rs.getBoolean("exists") }
-            ?: throw IllegalStateException("Exists-check failed")
+        return jdbc.queryForObject(sql, params) { rs, _ -> rs.getBoolean("exists") } ?: error { "Exists-check failed" }
     }
 
     private fun createAndPublishTrackNumber() =
@@ -266,15 +265,17 @@ constructor(
         }
 
     private fun createTrackNumber() =
-        trackNumberService.insert(
-            LayoutBranch.main,
-            TrackNumberSaveRequest(
-                number = testDBService.getUnusedTrackNumber(),
-                description = FreeText(trackNumberDescription),
-                state = LayoutState.IN_USE,
-                startAddress = TrackMeter.ZERO,
-            ),
-        )
+        trackNumberService
+            .insert(
+                LayoutBranch.main,
+                TrackNumberSaveRequest(
+                    number = testDBService.getUnusedTrackNumber(),
+                    description = FreeText(trackNumberDescription),
+                    state = LayoutState.IN_USE,
+                    startAddress = TrackMeter.ZERO,
+                ),
+            )
+            .id
 
     private fun address(seed: Int = 0) = TrackMeter(KmNumber(seed), seed * 100)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -23,6 +23,7 @@ import fi.fta.geoviite.infra.geometry.MetaDataName
 import fi.fta.geoviite.infra.getSomeNullableValue
 import fi.fta.geoviite.infra.linking.FittedSwitchJointMatch
 import fi.fta.geoviite.infra.linking.SuggestedSwitchJointMatchType
+import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.linking.fixSegmentStarts
 import fi.fta.geoviite.infra.map.AlignmentHeader
 import fi.fta.geoviite.infra.map.MapAlignmentSource
@@ -252,6 +253,19 @@ fun trackNumber(
         state = state,
         externalId = externalId,
         contextData = contextData,
+    )
+
+fun trackNumberSaveRequest(
+    number: TrackNumber = TrackNumber("100"),
+    description: String = "Test Track number $number",
+    state: LayoutState = LayoutState.IN_USE,
+    startAddress: TrackMeter = TrackMeter.ZERO,
+) =
+    TrackNumberSaveRequest(
+        number = number,
+        description = FreeText(description),
+        state = state,
+        startAddress = startAddress,
     )
 
 fun referenceLineAndAlignment(


### PR DESCRIPTION
Ongelman sai toistumaan stepeillä:

1. Luo suunnitelma ja julkaise siellä joku käsite (esim uusi ratanumero tai km-pylväs)
2. Vie suunnitelmassa luotu olio varsinaisen paikannuspohjan draftiin (älä julkaise vielä)
3. Tee suunnitelmassa uusi julkaisematon muutos kyseiseen käsitteeseen
4. Julkaise varsinaisen paikannuspohjan draft-versio

Tämän jälkeen alkaa lentämään virheitä kun palaa tarkastelemaan suunnitelmaa. Tämä johtui siitä että suunnitelma-draft viittasi edelleen viralliseen suunnitelmaolioon vaikka se olikin prosessin myötä siirtynyt viralliseksi main-puolen olioksi (viite väärää kautta).