### PR TITLE
GVT-2706 Draw split alignments exactly up to split point

### DIFF
--- a/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
@@ -106,15 +106,12 @@ function interpolateWithPrecedingPointOnAlignment(
     index: number,
     alignmentM: number,
 ): AlignmentPoint[] {
-    return index <= 0 || index >= points.length
+    const preceding = points[index - 1];
+    const here = points[index];
+    // check vs points being too close to avoid bad precision in interpolation
+    return preceding === undefined || here === undefined || here.m - preceding.m < 0.0001
         ? []
-        : [
-              linearlyInterpolateAlignmentPoint(
-                  expectDefined(points[index - 1]),
-                  expectDefined(points[index]),
-                  alignmentM,
-              ),
-          ];
+        : [linearlyInterpolateAlignmentPoint(preceding, here, alignmentM)];
 }
 
 function linearlyInterpolateAlignmentPoint(

--- a/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
@@ -16,6 +16,8 @@ import { Stroke, Style } from 'ol/style';
 import { filterNotEmpty, first, last } from 'utils/array-utils';
 import { LayoutContext } from 'common/common-model';
 import { expectDefined } from 'utils/type-utils';
+import { AlignmentPoint } from 'track-layout/track-layout-model';
+import { interpolate } from 'utils/math-utils';
 
 const splittingLocationTrackStyle = new Style({
     stroke: new Stroke({
@@ -72,9 +74,13 @@ function splitToParts(
             index + 1 < allSplits.length
                 ? expectDefined(allSplits[index + 1]).distance
                 : endOfAlignment;
-        const pointsForSplit = alignment.points.filter(
-            (point) => point.m >= start && point.m <= end,
-        );
+        const startIndex = alignment.points.findIndex((point) => point.m >= start);
+        const firstIndexPastEnd = findFirstIndexAfterM(alignment.points, end);
+        const pointsForSplit = [
+            ...interpolateWithPrecedingPointOnAlignment(alignment.points, startIndex, start),
+            ...alignment.points.slice(startIndex, firstIndexPastEnd),
+            ...interpolateWithPrecedingPointOnAlignment(alignment.points, firstIndexPastEnd, end),
+        ];
         const alignmentPart = {
             ...alignment,
             points: pointsForSplit,
@@ -88,6 +94,40 @@ function splitToParts(
             alignmentStyle(splittingEnabled, splitIsFocused),
         );
     });
+}
+
+function findFirstIndexAfterM(points: AlignmentPoint[], m: number): number {
+    const index = points.findIndex((point) => point.m > m);
+    return index === -1 ? points.length : index;
+}
+
+function interpolateWithPrecedingPointOnAlignment(
+    points: AlignmentPoint[],
+    index: number,
+    alignmentM: number,
+): AlignmentPoint[] {
+    return index <= 0 || index >= points.length
+        ? []
+        : [
+              linearlyInterpolateAlignmentPoint(
+                  expectDefined(points[index - 1]),
+                  expectDefined(points[index]),
+                  alignmentM,
+              ),
+          ];
+}
+
+function linearlyInterpolateAlignmentPoint(
+    start: AlignmentPoint,
+    end: AlignmentPoint,
+    alignmentM: number,
+): AlignmentPoint {
+    const portion = (alignmentM - start.m) / (end.m - start.m);
+    return {
+        x: interpolate(start.x, end.x, portion),
+        y: interpolate(start.y, end.y, portion),
+        m: alignmentM,
+    };
 }
 
 export function createLocationTrackSplitAlignmentLayer(


### PR DESCRIPTION
Splitin ei tarvitse osua segmenttipisteelle, joten alignmenttien piirtymistä ei pysty saamaan osumaan tarkkaan splittikohtiin asti pelkällä pisteiden suodatuksella. Päätepisteet pitää siis interpoloida.