### PR TITLE
GVT-2768 part 2: adjust design row references when implementing an updated (non-new) design row

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -30,11 +30,11 @@ import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.requireOne
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.Timestamp
+import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Timestamp
-import java.time.Instant
 
 data class LayoutDaoResponse<T>(val id: IntId<T>, val rowVersion: LayoutRowVersion<T>)
 
@@ -366,7 +366,7 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
         """
                 .trimIndent()
         jdbcTemplate.setUser()
-        val params = mapOf("official_row_id" to officialRowId.intValue, "design_row_id" to officialRowId.intValue)
+        val params = mapOf("official_row_id" to officialRowId.intValue, "design_row_id" to designRowId.intValue)
         return jdbcTemplate
             .query<LayoutDaoResponse<T>>(sql, params) { rs, _ ->
                 rs.getDaoResponse("official_id", "row_id", "row_version")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
@@ -108,11 +108,9 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
                 require(r.id == draft.id) { "Publication response ID doesn't match object: id=${draft.id} updated=$r" }
             }
         val publishedRowId = publicationResponse.rowVersion.rowId
-        println("publishedRowId: $publishedRowId")
         // If draft row-id changed, the data was updated to the official row -> delete the
         // now-redundant draft row
         if (draftVersion.rowId != publishedRowId) {
-            println("deleting draft: ${draftVersion.rowId}")
             dao.deleteRow(draftVersion.rowId)
         }
 
@@ -120,11 +118,9 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
         draft.contextData.designRowId
             ?.takeIf { draft.branch == LayoutBranch.main }
             ?.let { designRowId ->
-                println("updating design draft references: $designRowId -> $publishedRowId")
                 // Update potential draft-design references to point to the new main row
                 dao.updateImplementedDesignDraftReferences(designRowId, publishedRowId)
                 // If the design row didn't become the main-row, it's redundant
-                println("deleting design official: $designRowId")
                 if (designRowId != publishedRowId) dao.deleteRow(designRowId)
             }
 


### PR DESCRIPTION
Eli tulipa mieen tästä edellisestä bugista (https://github.com/finnishtransportagency/geoviite/pull/1422) toinen variantti: jos design-rivi on tuotu jo main-puolella olevan rivin pohjalta tilanne muuttuu hiukan. Nyt design-rivi ei muutu officialiksi vaan se poistuu ja tiedot kopioidaan main-riville. Design-draft rivi täytyy silti päivittää, mutta se pitää tehdä ennen design-officialin poistoa koska muuten poistosta aiheutuu reference-error. 

Korjauksena riittää siis pyöräyttää komentojen järjestys toisin päin, mutta samalla lisätty IT-testi tällekin caselle.