### PR TITLE
GVT-2777: Projektirekisterin rajapinnan päivitys

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClient.kt
@@ -45,7 +45,7 @@ const val MATERIAL_DICTIONARIES_PATH = "$DICTIONARIES_PATH/aineisto/aineisto"
 const val PROJECT_DICTIONARIES_PATH = "$DICTIONARIES_PATH/projekti/projekti"
 const val REDIRECT_PATH = "$METADATA_API_V2_PATH/ohjaa"
 
-const val PROJECT_REGISTRY_V1_PATH = "/projektirekisteri/api/v1"
+const val PROJECT_REGISTRY_V1_PATH = "/projektirekisteri/api/v2"
 const val ASSIGNMENT_PATH = "$PROJECT_REGISTRY_V1_PATH/toimeksianto"
 const val PROJECT_PATH = "$PROJECT_REGISTRY_V1_PATH/projekti"
 const val PROJECT_GROUP_PATH = "$PROJECT_REGISTRY_V1_PATH/projektijoukko"


### PR DESCRIPTION
V1 ja V2 toimivat tarpeeksi samalla tavalla, että versiopäivityksen pystyi vaan tekemään koskematta tyyppeihin