### PR TITLE
GVT-2729: Improve workspace selector

### DIFF
--- a/ui/src/tool-bar/workspace-selection.tsx
+++ b/ui/src/tool-bar/workspace-selection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Dropdown, DropdownPopupMode } from 'vayla-design-lib/dropdown/dropdown';
+import { Dropdown, DropdownPopupMode, nameIncludes } from 'vayla-design-lib/dropdown/dropdown';
 import { useLoaderWithStatus } from 'utils/react-utils';
 import {
     getLayoutDesigns,
@@ -74,17 +74,20 @@ export const DesignSelection: React.FC<DesignSelectionProps> = ({ designId, onDe
             <Dropdown
                 inputRef={selectWorkspaceDropdownRef}
                 placeholder={t('tool-bar.search-design')}
+                filter={nameIncludes}
                 displaySelectedName={false}
                 openOverride={true}
                 popupMode={DropdownPopupMode.Inline}
                 onAddClick={canAddDesigns ? onAddClick : undefined}
                 onChange={(designId) => designId && onDesignSelected(designId)}
                 options={
-                    designs?.map((design) => ({
-                        value: design.id,
-                        name: design.name,
-                        qaId: `workspace-${design.id}`,
-                    })) ?? []
+                    designs
+                        ?.map((design) => ({
+                            value: design.id,
+                            name: design.name,
+                            qaId: `workspace-${design.id}`,
+                        }))
+                        .toSorted((a, b) => a.name.localeCompare(b.name)) ?? []
                 }
                 value={designId}
                 qaId={'workspace-selection'}

--- a/ui/src/vayla-design-lib/dropdown/dropdown.scss
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.scss
@@ -166,6 +166,7 @@ $dropdown-border-error: 2px;
 
 .dropdown__list-container--inline {
     zoom: 1;
+    max-height: 306px;
 }
 
 .dropdown--wide-list {

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -90,6 +90,10 @@ function nameStartsWith<TItemValue>(option: Item<TItemValue>, searchTerm: string
     return option.name.toUpperCase().startsWith(searchTerm.toUpperCase());
 }
 
+export function nameIncludes<TItemValue>(option: Item<TItemValue>, searchTerm: string) {
+    return option.name.toUpperCase().includes(searchTerm.toUpperCase());
+}
+
 export const Dropdown = function <TItemValue>({
     size = DropdownSize.MEDIUM,
     filter = nameStartsWith,


### PR DESCRIPTION
* Add vertical display limit css
* Add alphabetical sorting
* Search now checks the entire string for substring matches instead of from the beginning of the string values (workspace names).