### PR TITLE
GVT-2786 Redo switch topological connectivity validation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -318,11 +318,9 @@ fun transformSwitchPoint(transformation: SwitchPositionTransformation, point: Po
         transformation.translation
 }
 
-data class SwitchConnectivity(
-    val alignmentJoints: List<List<JointNumber>>,
-    val frontJoint: JointNumber?,
-    val sharedPassThroughJoint: JointNumber?,
-)
+data class LinkableSwitchAlignment(val joints: List<JointNumber>, val originalAlignment: SwitchAlignment)
+
+data class SwitchConnectivity(val alignments: List<LinkableSwitchAlignment>, val frontJoint: JointNumber?)
 
 fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
     when (structure.baseType) {
@@ -333,23 +331,24 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
         SwitchBaseType.UKV,
         SwitchBaseType.KV ->
             SwitchConnectivity(
-                alignmentJoints = structure.alignments.map { it.jointNumbers },
+                alignments = structure.alignments.map { LinkableSwitchAlignment(it.jointNumbers, it) },
                 frontJoint = JointNumber(1),
-                sharedPassThroughJoint = null,
             )
 
         SwitchBaseType.KRV,
         SwitchBaseType.RR,
         SwitchBaseType.SRR ->
             SwitchConnectivity(
-                alignmentJoints =
+                alignments =
                     structure.alignments
                         .filter { it.jointNumbers.size == 3 }
                         .flatMap { alignment ->
                             val joints = alignment.jointNumbers
-                            listOf(listOf(joints[0], joints[1]), listOf(joints[1], joints[2]))
+                            listOf(
+                                LinkableSwitchAlignment(listOf(joints[0], joints[1]), alignment),
+                                LinkableSwitchAlignment(listOf(joints[1], joints[2]), alignment),
+                            )
                         },
                 frontJoint = null,
-                sharedPassThroughJoint = JointNumber(5),
             )
     }

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1467,9 +1467,10 @@
                     "front-joint-not-connected": "Vaihteen {{switch}} etujatkokselta ei jatku raidetta",
                     "front-joint-only-duplicate-connected": "Vaihteen {{switch}} etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
                     "switch-no-alignments-connected": "Raiteen muutoksen myötä vaihteen {{switch}} läpi ei kulje raiteita",
-                    "switch-alignment-not-connected": "Joitakin vaihteen {{switch}} linjoja ei ole liitetty raiteelle: {{locationTracks}}",
+                    "switch-alignment-not-connected": "Joitakin vaihteen {{switch}} linjoja ei ole liitetty raiteelle: {{alignments}}",
                     "switch-alignment-only-connected-to-duplicate": "Joitakin vaihteen {{switch}} linjoja on liitetty ainoastaan duplikaatiksi merkityille raiteille: {{locationTracks}}",
-                    "multiple-tracks-through-joint": "Joistain vaihteen {{switch}} pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}"
+                    "switch-alignment-partially-connected": "Jotkin vaihteen {{switch}} linjoista on liitetty raiteelle vain yhdellä vaihdepisteellä: {{locationTracks}}",
+                    "switch-alignment-multiply-connected": "Jotkin vaihteen {{switch}} linjoista on liitetty useammalle kuin yhdelle raiteelle: {{locationTracks}}"
                 },
                 "duplicate-name-official": "Sijaintiraiteen nimi {{locationTrack}} on jo käytössä toisella ratanumeron {{trackNumber}} sijaintiraiteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta sijaintiraidetta nimellä {{locationTrack}} ratanumerolla {{trackNumber}}",
@@ -1498,9 +1499,10 @@
                     "front-joint-not-connected": "Vaihteen etujatkokselta ei jatku raidetta",
                     "front-joint-only-duplicate-connected": "Vaihteen etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
                     "switch-no-alignments-connected": "Vaihteen läpi ei kulje raiteita",
-                    "switch-alignment-not-connected": "Joitakin vaihteen linjoja ei ole liitetty raiteelle: {{locationTracks}}",
+                    "switch-alignment-not-connected": "Joitakin vaihteen linjoja ei ole liitetty raiteelle: {{alignments}}",
                     "switch-alignment-only-connected-to-duplicate": "Joitakin vaihteen linjoja on liitetty ainoastaan duplikaatiksi merkityille raiteille: {{locationTracks}}",
-                    "multiple-tracks-through-joint": "Joistain vaihteen pisteistä menee läpi enemmän kuin yksi raide: {{locationTracks}}",
+                    "switch-alignment-partially-connected": "Jotkin vaihteen linjoista on liitetty raiteelle vain yhdellä vaihdepisteellä: {{locationTracks}}",
+                    "switch-alignment-multiply-connected": "Jotkin vaihteen linjoista on liitetty useammalle kuin yhdelle raiteelle: {{locationTracks}}",
                     "relinking-failed": "Vaihteen {{switch}} uudelleenlinkitys epäonnistui"
                 }
             },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -1011,7 +1011,10 @@ constructor(
                                     LocalizationKey(
                                         "validation.layout.switch.track-linkage.switch-alignment-only-connected-to-duplicate"
                                     ),
-                                params = LocalizationParams(mapOf("locationTracks" to "1-3", "switch" to "ok but val")),
+                                params =
+                                    LocalizationParams(
+                                        mapOf("locationTracks" to "1-3 (bad branching track)", "switch" to "ok but val")
+                                    ),
                             )
                         ),
                 ),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -2582,11 +2582,11 @@ constructor(
         return validationResult.locationTracks.find { lt -> lt.id == locationTrackId }!!
     }
 
-    private fun switchAlignmentNotConnectedTrackValidationError(locationTrackNames: String, switchName: String) =
+    private fun switchAlignmentNotConnectedTrackValidationError(alignments: String, switchName: String) =
         LayoutValidationIssue(
             LayoutValidationIssueType.WARNING,
             "validation.layout.location-track.switch-linkage.switch-alignment-not-connected",
-            mapOf("locationTracks" to locationTrackNames, "switch" to switchName),
+            mapOf("alignments" to alignments, "switch" to switchName),
         )
 
     private fun switchNotPublishedError(switchName: String) =
@@ -2812,12 +2812,8 @@ constructor(
             switchValidation,
             LayoutValidationIssue(
                 LayoutValidationIssueType.WARNING,
-                "validation.layout.switch.track-linkage.multiple-tracks-through-joint",
-                mapOf(
-                    "locationTracks" to
-                        "3 (${locationTrack2.name}, ${locationTrack3.name}), 4 (${locationTrack2.name}, ${locationTrack3.name})",
-                    "switch" to "TV123",
-                ),
+                "validation.layout.switch.track-linkage.switch-alignment-multiply-connected",
+                mapOf("locationTracks" to "4-5-3 (${locationTrack2.name}, ${locationTrack3.name})", "switch" to "TV123"),
             ),
         )
     }
@@ -3790,7 +3786,7 @@ constructor(
             errorsWhenDeletingStraightTrack.any { error ->
                 error.localizationKey ==
                     LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
-                    error.params.get("locationTracks") == "1-5-2" &&
+                    error.params.get("alignments") == "1-5-2" &&
                     error.params.get("switch") == "TV123"
             }
         )
@@ -3815,7 +3811,7 @@ constructor(
             errorsWhenDeletingBranchingTrack.any { error ->
                 error.localizationKey ==
                     LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
-                    error.params.get("locationTracks") == "1-3" &&
+                    error.params.get("alignments") == "1-3" &&
                     error.params.get("switch") == "TV123"
             }
         )
@@ -3908,7 +3904,7 @@ constructor(
             locationTrackDeletionErrors.any { error ->
                 error.localizationKey ==
                     LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
-                    error.params.get("locationTracks") == "1-5-2" &&
+                    error.params.get("alignments") == "1-5-2" &&
                     error.params.get("switch") == "TV123"
             }
         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
@@ -1,0 +1,352 @@
+package fi.fta.geoviite.infra.publication
+
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackState
+import fi.fta.geoviite.infra.tracklayout.TopologyLocationTrackSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitchJoint
+import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.switch
+import fi.fta.geoviite.infra.tracklayout.switchStructureRR54_4x1_9
+import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class SwitchTopologicalConnectivityTest {
+
+    @Test
+    fun `minimal OK switch topological connectivity is OK`() {
+        val (switch, link) = switchAndLink()
+        val tracks = listOf(track("through track", null, link(1, 5), link(5, 2)), track("branching track", link(1, 3)))
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureYV60_300_1_9(), tracks, null)
+        assertEquals(listOf(), issues)
+    }
+
+    @Test
+    fun `track from front joint is allowed to be only topologically connected`() {
+        val (switch, link) = switchAndLink()
+        val tracks =
+            listOf(
+                track("through track", link(1, 5), link(5, 2)),
+                track("branching track", link(1, 3)),
+                track("topo track", topologyLinks = link(1, null)),
+            )
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureYV60_300_1_9(), tracks, null)
+        assertEquals(listOf(), issues)
+    }
+
+    @Test
+    fun `the only track from the front joint must not be duplicate`() {
+        val (switch, link) = switchAndLink()
+        val tracks =
+            listOf(
+                track("through track", link(1, 5), link(5, 2)),
+                track("branching track", link(1, 3)),
+                track("topo track", isDuplicate = true, topologyLinks = link(1, null)),
+            )
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureYV60_300_1_9(), tracks, null)
+        assertEquals(
+            listOf("validation.layout.switch.track-linkage.front-joint-only-duplicate-connected"),
+            issues.map { it.localizationKey.toString() },
+        )
+    }
+
+    @Test
+    fun `head-to-head YV switches with branching tracks topologically linked to opposing sides are okay`() {
+        val (switchA, linkA) = switchAndLink()
+        val (switchB, linkB) = switchAndLink()
+        val tracks =
+            listOf(
+                track("through track", linkA(2, 5), linkA(5, 1), linkB(1, 5), linkB(5, 2)),
+                track("branching A", linkA(3, 1), topologyLinks = linkB(null, 1)),
+                track("branching B", linkB(1, 3), topologyLinks = linkA(1, null)),
+            )
+        val issuesA = validateSwitchTopologicalConnectivity(switchA, switchStructureYV60_300_1_9(), tracks, null)
+        assertEquals(emptyList(), issuesA)
+        val issuesB = validateSwitchTopologicalConnectivity(switchB, switchStructureYV60_300_1_9(), tracks, null)
+        assertEquals(emptyList(), issuesB)
+    }
+
+    @Test
+    fun `one missing alignment causes a warning`() {
+        val (switch, link) = switchAndLink()
+        val tracks = listOf(track("through track", null, link(1, 5), link(5, 2)))
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureYV60_300_1_9(), tracks, null)
+        assertEquals(
+            listOf("validation.layout.switch.track-linkage.switch-alignment-not-connected"),
+            issues.map { it.localizationKey.toString() },
+        )
+    }
+
+    @Test
+    fun `one duplicate-only alignment causes a warning`() {
+        val (switch, link) = switchAndLink()
+        val tracks =
+            listOf(
+                track("through track", null, link(1, 5), link(5, 2)),
+                track("branching track", link(1, 3), isDuplicate = true),
+            )
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureYV60_300_1_9(), tracks, null)
+        assertEquals(
+            listOf("validation.layout.switch.track-linkage.switch-alignment-only-connected-to-duplicate"),
+            issues.map { it.localizationKey.toString() },
+        )
+    }
+
+    @Test
+    fun `one multiply linked alignment causes a warning`() {
+        val (switch, link) = switchAndLink()
+        val tracks =
+            listOf(
+                track("through track", null, link(1, 5), link(5, 2)),
+                track("branching track", link(1, 3)),
+                track("also branching track", link(1, 3)),
+            )
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureYV60_300_1_9(), tracks, null)
+        assertEquals(
+            listOf("validation.layout.switch.track-linkage.switch-alignment-multiply-connected"),
+            issues.map { it.localizationKey.toString() },
+        )
+    }
+
+    @Test
+    fun `some connected tracks must be present`() {
+        val (switch) = switchAndLink()
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureYV60_300_1_9(), listOf(), null)
+        assertContains(
+            issues,
+            LayoutValidationIssue(
+                LayoutValidationIssueType.ERROR,
+                "validation.layout.switch.track-linkage.switch-no-alignments-connected",
+                mapOf("switch" to switch.name.toString()),
+            ),
+        )
+    }
+
+    @Test
+    fun `through track is not responsible for missing branching track`() {
+        val (switch, link) = switchAndLink()
+        val throughTrack = track("through track", null, link(1, 5), link(5, 2))
+        val issues =
+            validateSwitchTopologicalConnectivity(
+                switch,
+                switchStructureYV60_300_1_9(),
+                listOf(throughTrack),
+                throughTrack.first,
+            )
+        assertEquals(listOf(), issues)
+    }
+
+    @Test
+    fun `rail crossing is OK with layout alignments connected to full or split switch alignments`() {
+        val (switch, link) = switchAndLink(switchStructureRR54_4x1_9())
+        val tracks =
+            listOf(
+                track("track 152", link(1, 5), link(5, 2)),
+                track("track 45", link(4, 5)),
+                track("track 53", link(5, 3)),
+            )
+
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureRR54_4x1_9(), tracks, null)
+        assertEquals(emptyList(), issues)
+    }
+
+    @Test
+    fun `track through rail crossing is not responsible for missing links on other switch alignments`() {
+        val (switch, link) = switchAndLink(switchStructureRR54_4x1_9())
+        val track152 = track("track 152", link(1, 5), link(5, 2))
+
+        val issues =
+            validateSwitchTopologicalConnectivity(switch, switchStructureRR54_4x1_9(), listOf(track152), track152.first)
+        assertEquals(emptyList(), issues)
+    }
+
+    @Test
+    fun `track partially through rail crossing is responsible for non-full link on its switch alignment`() {
+        val (switch, link) = switchAndLink(switchStructureRR54_4x1_9())
+        val track53 = track("track 53", link(5, 3))
+        val tracks = listOf(track("track 152", link(1, 5), link(5, 2)), track53)
+
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureRR54_4x1_9(), tracks, track53.first)
+        assertEquals(
+            listOf("validation.layout.location-track.switch-linkage.switch-alignment-not-connected"),
+            issues.map { it.localizationKey.toString() },
+        )
+    }
+
+    @Test
+    fun `degenerate single-joint links cause a warning`() {
+        val (switch, link) = switchAndLink()
+        val oneTrack = track("one track", null, link(1, null))
+        val anotherTrack = track("another track", link(1, null))
+        val issues =
+            validateSwitchTopologicalConnectivity(
+                switch,
+                switchStructureYV60_300_1_9(),
+                listOf(oneTrack, anotherTrack),
+                null,
+            )
+        assertEquals(
+            setOf(
+                "validation.layout.switch.track-linkage.switch-alignment-partially-connected",
+                "validation.layout.switch.track-linkage.switch-alignment-multiply-connected",
+            ),
+            issues.map { it.localizationKey.toString() }.toSet(),
+        )
+    }
+
+    @Test
+    fun `track linked to a split alignment is not responsible for missing links on a different switch alignment`() {
+        val (switch, link) = switchAndLink(switchStructureRR54_4x1_9())
+        val track15 = track("track 15", link(1, 5))
+        val track52 = track("track 52", link(5, 2))
+        val track45 = track("track 45", link(4, 5))
+        // missing track link on 5-3
+        val tracks = listOf(track15, track52, track45)
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureRR54_4x1_9(), tracks, track15.first)
+        assertEquals(listOf(), issues)
+    }
+
+    @Test
+    fun `rail crossing alignments can be linked end to end`() {
+        val (switch, link) = switchAndLink(switchStructureRR54_4x1_9())
+        val track12 = track("track 12", link(1, 2))
+        val track43 = track("track 43", link(4, 3))
+        val tracks = listOf(track12, track43)
+        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureRR54_4x1_9(), tracks, null)
+        assertEquals(listOf(), issues)
+    }
+
+    @Test
+    fun `deleted alignments do not exist`() {
+        val (switch, link) = switchAndLink()
+        val throughTrack = track("through track", null, link(1, 2))
+        val branchingTrack = track("branching track", link(1, 3), isDeleted = true)
+        val issues =
+            validateSwitchTopologicalConnectivity(
+                switch,
+                switchStructureYV60_300_1_9(),
+                listOf(throughTrack, branchingTrack),
+                null,
+            )
+        assertEquals(
+            listOf("validation.layout.switch.track-linkage.switch-alignment-not-connected"),
+            issues.map { it.localizationKey.toString() },
+        )
+    }
+
+    @Test
+    fun `switches can be abandoned by deletion`() {
+        val (switch, link) = switchAndLink()
+        val throughTrack = track("through track", null, link(1, 2), isDeleted = true)
+        val branchingTrack = track("branching track", link(1, 3), isDeleted = true)
+        val issues =
+            validateSwitchTopologicalConnectivity(
+                switch,
+                switchStructureYV60_300_1_9(),
+                listOf(throughTrack, branchingTrack),
+                null,
+            )
+        assertEquals(
+            setOf(
+                "validation.layout.switch.track-linkage.front-joint-not-connected",
+                "validation.layout.switch.track-linkage.switch-no-alignments-connected",
+            ),
+            issues.map { it.localizationKey.toString() }.toSet(),
+        )
+    }
+
+    @Test
+    fun `a switch with topological connections is not abandoned`() {
+        val (switch, link) = switchAndLink()
+        val topoTrack = track("topo track", null, topologyLinks = link(1, null))
+        val issues =
+            validateSwitchTopologicalConnectivity(switch, switchStructureYV60_300_1_9(), listOf(topoTrack), null)
+        assertEquals(
+            setOf("validation.layout.switch.track-linkage.switch-alignment-not-connected"),
+            issues.map { it.localizationKey.toString() }.toSet(),
+        )
+    }
+
+    // might be a segment's start and/or end joint, might be a track's topology start or end link
+    private data class SwitchLinkPair(
+        val switchId: IntId<TrackLayoutSwitch>,
+        val startJointNumber: JointNumber?,
+        val endJointNumber: JointNumber?,
+    )
+
+    private fun interface MakeSwitchLinkPair {
+
+        operator fun invoke(start: Int?, end: Int?): SwitchLinkPair
+    }
+
+    private fun switchLink(switchId: IntId<TrackLayoutSwitch>) = MakeSwitchLinkPair { startJoint, endJoint ->
+        SwitchLinkPair(
+            switchId,
+            startJointNumber = startJoint?.let(::JointNumber),
+            endJointNumber = endJoint?.let(::JointNumber),
+        )
+    }
+
+    private var idCounter: Int = 0
+
+    private fun track(
+        name: String,
+        vararg switchLinks: SwitchLinkPair?,
+        isDuplicate: Boolean = false,
+        isDeleted: Boolean = false,
+        topologyLinks: SwitchLinkPair? = null,
+    ): Pair<LocationTrack, LayoutAlignment> {
+        val locationTrack =
+            locationTrack(
+                IntId(1),
+                id = IntId(idCounter++),
+                name = name,
+                duplicateOf = if (isDuplicate) IntId(12345) else null,
+                state = if (isDeleted) LocationTrackState.DELETED else LocationTrackState.IN_USE,
+                topologyStartSwitch =
+                    topologyLinks?.let { t ->
+                        t.startJointNumber?.let { jointNumber -> TopologyLocationTrackSwitch(t.switchId, jointNumber) }
+                    },
+                topologyEndSwitch =
+                    topologyLinks?.let { t ->
+                        t.endJointNumber?.let { jointNumber -> TopologyLocationTrackSwitch(t.switchId, jointNumber) }
+                    },
+            )
+        val alignment =
+            alignment(
+                switchLinks.mapIndexed { index, link ->
+                    segment(
+                        Point(0.0, index.toDouble()),
+                        Point(0.0, index.toDouble() + 1.0),
+                        switchId = link?.switchId,
+                        startJointNumber = link?.startJointNumber,
+                        endJointNumber = link?.endJointNumber,
+                    )
+                }
+            )
+        return locationTrack to alignment
+    }
+
+    private fun switchAndLink(
+        switchStructure: SwitchStructure = switchStructureYV60_300_1_9()
+    ): Pair<TrackLayoutSwitch, MakeSwitchLinkPair> {
+        val switchId: IntId<TrackLayoutSwitch> = IntId(idCounter++)
+        val switch =
+            switch(
+                id = switchId,
+                structureId = switchStructure.id as IntId,
+                joints = switchStructure.joints.map { j -> TrackLayoutSwitchJoint(j.number, j.location, null) },
+            )
+        val link = switchLink(switchId)
+        return switch to link
+    }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -90,6 +90,40 @@ fun switchStructureYV60_300_1_9(): SwitchStructure {
     )
 }
 
+fun switchStructureRR54_4x1_9() =
+    SwitchStructure(
+        id = IntId(133),
+        type = SwitchType("RR54-4x1:9"),
+        presentationJointNumber = JointNumber(5),
+        joints =
+            listOf(
+                SwitchJoint(JointNumber(1), Point(-5.075, -1.142)),
+                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchJoint(JointNumber(2), Point(5.075, 1.142)),
+                SwitchJoint(JointNumber(4), Point(-5.075, 1.142)),
+                SwitchJoint(JointNumber(3), Point(5.075, -1.142)),
+            ),
+        alignments =
+            listOf(
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(IndexedId(3, 1), Point(-5.075, -1.142), Point(0.0, 0.0)),
+                            SwitchElementLine(IndexedId(3, 2), Point(0.0, 0.0), Point(5.075, 1.142)),
+                        ),
+                ),
+                SwitchAlignment(
+                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                    elements =
+                        listOf(
+                            SwitchElementLine(IndexedId(4, 1), Point(-5.075, 1.142), Point(0.0, 0.0)),
+                            SwitchElementLine(IndexedId(4, 2), Point(0.0, 0.0), Point(-5.075, 1.142)),
+                        ),
+                ),
+            ),
+    )
+
 fun switchAndMatchingAlignments(
     trackNumberId: IntId<TrackLayoutTrackNumber>,
     structure: SwitchStructure,


### PR DESCRIPTION
Hieman koomisen iso muutos siihen nähden, että varsinainen alkuperäinen ongelma oli regressio siinä, miten validaatio käsittelee vanhoja Ratko-peräisiä yhdellä pisteellä linkitettyjä vaihteita; mutta regression syy oli puuttuvat testit, ja testejä kirjoittaessa tuli sitten löydettyä kaikenlaista parannettavaa ja selkeytettävää.

Funktionaaliset muutokset:
- Validaatio tunnistaa nyt yhdellä pisteellä linkitetyt vaihteet omana tapauksenaan, josta antaa varoituksen
- Ylimääräisten linkityksien validointi menee nyt vaihdelinjoittain koottuna, alkuperäinen muoto (missä ylimääräiset linkitykset oli listattu vaihdepisteittäin) oli vähän liikaa noisea
- Pelkästään topologialinkeillä, ei lainkaan segmenttilinkeillä kiinni oleva vaihde aiheuttaa nyt vain varoituksen (näitä on paikannuspohjassa 24, eli eivät ole yleisiä, mutta olivat kuitenkin oma tapauksensa, missä validointi luuli raiteen muutoksen irrottaneen vaihteen, vaikka mitään muutosta ei edes ollut)
- Vain duplikaattiraiteille linkitetyillä linjoilla näkyy nyt validaatioviestissä mukana kyseisten raiteiden nimet
- Raidetta validoitaessa raideristeyksen kohdalla tarkistetaan tarkemmin, mistä linkistä tämä raide voi olla vastuussa (esim. jos vaihteelta puuttuu linjat 1-5 ja 4-5, linjalle 5-2 linkitetty raide voi olla niistä vastuussa linjasta 1-5, koska voihan olla, että ongelman syy oli, että sen geometria on pätkäisty liian lyhyeksi; mutta ei linjasta 4-5, koska raide ei voi meillä tehdä sellaista mutkaa raideristeyksen läpi)