### PR TITLE
GVT-2761 & GVT-2766 & GVT-2784: Kilometripylvään GK-sijainnin parannuksia ja rekisterisivun poisto (part 1)

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -301,7 +301,6 @@
     "app-bar": {
         "frontpage": "Etusivu",
         "track-layout": "Kartta",
-        "register": "Rekisteri",
         "infra-model": "InfraModel",
         "components": "Components",
         "localization": "Localization",
@@ -1792,8 +1791,9 @@
             "source-from-geometry": "Linkitetty geometriasta",
             "source-from-layout": "Konvertoitu paikannuspohjasta",
             "source-manual": "Operaattorin asettama",
+            "source-none": "-",
             "location-in-layout": "Sijainti paikannuspohjassa (TM35FIN)",
-            "location-not-defined": "Sijaintia ei ole määritelty"
+            "out-of-bounds": "Sijainti ei ole laskettavissa"
         }
     },
     "km-post-delete-dialog": {

--- a/ui/src/app-bar/app-bar.tsx
+++ b/ui/src/app-bar/app-bar.tsx
@@ -29,7 +29,6 @@ const links: Link[] = [
         type: 'prod',
         qaId: 'track-layout-link',
     },
-    { link: '/registry', name: 'app-bar.register', type: 'test' },
     {
         link: '/infra-model',
         name: 'app-bar.infra-model',

--- a/ui/src/geoviite-design-lib/form-layout/form-layout.scss
+++ b/ui/src/geoviite-design-lib/form-layout/form-layout.scss
@@ -10,6 +10,10 @@
         grid-template-columns: 1fr 1fr;
         grid-gap: 24px;
     }
+
+    &--error-at-bottom {
+        padding-bottom: 0;
+    }
 }
 
 .form-layout__glass {

--- a/ui/src/geoviite-design-lib/form-layout/form-layout.tsx
+++ b/ui/src/geoviite-design-lib/form-layout/form-layout.tsx
@@ -6,6 +6,7 @@ export type FormLayoutProps = {
     children?: React.ReactNode;
     dualColumn?: boolean;
     isProcessing?: boolean;
+    errorAtBottom?: boolean;
 };
 
 export type FormLayoutColumnProps = {
@@ -17,6 +18,7 @@ export const FormLayout: React.FC<FormLayoutProps> = (props: FormLayoutProps) =>
         styles['form-layout'],
         props.isProcessing && styles['form-layout--is-processing'],
         props.dualColumn && styles['form-layout--double-column'],
+        props.errorAtBottom && styles['form-layout--error-at-bottom'],
     );
 
     return (

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -614,6 +614,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                 <KmPostEditDialogContainer
                     onClose={() => setShowAddKmPostDialog(false)}
                     onSave={handleKmPostSave}
+                    role={'CREATE'}
                 />
             )}
 

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
@@ -129,11 +129,20 @@ export const KmPostEditDialogGkLocationSection: React.FC<
             : parseGk(kmPost.gkSrid, kmPost.gkLocationX, kmPost.gkLocationY);
     const layoutLocation = gkLocation ? transformGkToLayout(gkLocation) : undefined;
     const gkLocationEnabled = state.gkLocationEnabled;
+    const fieldsEnabled = role !== 'LINKING' && gkLocationEnabled;
+    const gkLocationEntered = geometryKmPostGkLocation !== undefined || layoutLocation != undefined;
 
     const coordinateSystems = useCoordinateSystems(GK_FIN_COORDINATE_SYSTEMS.map(([srid]) => srid));
 
-    const gkLocationEntered = geometryKmPostGkLocation !== undefined || layoutLocation != undefined;
-    const fieldsEnabled = role !== 'LINKING' && gkLocationEnabled;
+    const layoutLocationString = () => {
+        if (gkLocationEnabled && layoutLocation) {
+            return formatToTM35FINString(layoutLocation);
+        } else if (gkLocationEnabled && gkLocation && !layoutLocation) {
+            return t('km-post-dialog.gk-location.out-of-bounds');
+        } else {
+            return '-';
+        }
+    };
 
     return (
         <>
@@ -256,15 +265,7 @@ export const KmPostEditDialogGkLocationSection: React.FC<
             <FieldLayout
                 label={t('km-post-dialog.gk-location.location-in-layout')}
                 disabled={!fieldsEnabled}
-                value={
-                    gkLocationEnabled
-                        ? layoutLocation === undefined
-                            ? gkLocation
-                                ? t('km-post-dialog.gk-location.out-of-bounds')
-                                : '-'
-                            : formatToTM35FINString(layoutLocation)
-                        : '-'
-                }
+                value={layoutLocationString()}
             />
         </>
     );

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.scss
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.scss
@@ -1,5 +1,10 @@
 @use 'vayla-design-lib' as vayla-design;
 
+.km-post-edit-dialog__location-header-container {
+    display: flex;
+    gap: 12px;
+}
+
 .km-post-edit-dialog__location {
     display: flex;
     gap: 12px;
@@ -22,4 +27,12 @@
 .km-post-edit-dialog__confirmed {
     display: flex;
     gap: 4px;
+}
+
+.km-post-edit-dialog__message-box {
+    margin-left: -25px;
+    margin-right: -25px;
+
+    min-height: 60px;
+    align-content: end;
 }

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -87,7 +87,10 @@ export const KmPostEditDialogContainer: React.FC<KmPostEditDialogContainerProps>
 
 export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostEditDialogProps) => {
     const { t } = useTranslation();
-    const [state, dispatcher] = React.useReducer(reducer, initialKmPostEditState);
+    const [state, dispatcher] = React.useReducer(reducer, {
+        ...initialKmPostEditState,
+        gkLocationEnabled: !!props.geometryKmPostGkLocation,
+    });
     const stateActions = createDelegatesWithDispatcher(dispatcher, actions);
     const kmPostStateOptions = layoutStates
         .filter((ls) => !state.isNewKmPost || ls.value != 'DELETED')
@@ -111,9 +114,6 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
             getKmPost(props.kmPostId, draftLayoutContext(props.layoutContext))
                 .then((kmPost) => {
                     if (kmPost) {
-                        stateActions.setGkLocationEnabled(
-                            props.role !== 'CREATE' && !!kmPost.gkLocation,
-                        );
                         stateActions.onKmPostLoaded(kmPost);
                         firstInputRef.current?.focus();
                     } else {

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
+import { Dialog, DialogVariant, DialogWidth } from 'geoviite-design-lib/dialog/dialog';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { FormLayout, FormLayoutColumn } from 'geoviite-design-lib/form-layout/form-layout';
@@ -41,12 +41,15 @@ import { useTrackLayoutAppSelector } from 'store/hooks';
 import { KmPostEditDialogGkLocationSection } from 'tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section';
 import { GeometryPoint } from 'model/geometry';
 
+export type KmPostEditDialogRole = 'MODIFY' | 'CREATE' | 'LINKING';
+
 type KmPostEditDialogContainerProps = {
     kmPostId?: LayoutKmPostId;
     onClose: () => void;
     onSave?: (kmPostId: LayoutKmPostId) => void;
     prefilledTrackNumberId?: LayoutTrackNumberId;
     geometryKmPostGkLocation?: GeometryPoint;
+    role: KmPostEditDialogRole;
 };
 
 type KmPostEditDialogProps = {
@@ -57,6 +60,8 @@ type KmPostEditDialogProps = {
     prefilledTrackNumberId?: LayoutTrackNumberId;
     onEditKmPost: (id?: LayoutKmPostId) => void;
     geometryKmPostGkLocation?: GeometryPoint;
+    geometryKmPostLocation?: GeometryPoint;
+    role: KmPostEditDialogRole;
 };
 
 export const KmPostEditDialogContainer: React.FC<KmPostEditDialogContainerProps> = (
@@ -75,6 +80,7 @@ export const KmPostEditDialogContainer: React.FC<KmPostEditDialogContainerProps>
             onEditKmPost={setEditKmPostId}
             prefilledTrackNumberId={props.prefilledTrackNumberId}
             geometryKmPostGkLocation={props.geometryKmPostGkLocation}
+            role={props.role}
         />
     );
 };
@@ -105,6 +111,9 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
             getKmPost(props.kmPostId, draftLayoutContext(props.layoutContext))
                 .then((kmPost) => {
                     if (kmPost) {
+                        stateActions.setGkLocationEnabled(
+                            props.role !== 'CREATE' && !!kmPost.gkLocation,
+                        );
                         stateActions.onKmPostLoaded(kmPost);
                         firstInputRef.current?.focus();
                     } else {
@@ -228,26 +237,24 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                         : t('km-post-dialog.title-edit')
                 }
                 onClose={close}
+                width={DialogWidth.TWO_COLUMNS}
                 footerContent={
                     <React.Fragment>
                         {state.existingKmPost?.editState === 'CREATED' && !state.isNewKmPost && (
-                            <Button
-                                onClick={() =>
-                                    props.kmPostId
-                                        ? setDraftDeleteConfirmationVisible(true)
-                                        : undefined
-                                }
-                                icon={Icons.Delete}
-                                variant={ButtonVariant.WARNING}>
-                                {t('button.delete-draft')}
-                            </Button>
+                            <div className={dialogStyles['dialog__footer-content--left-aligned']}>
+                                <Button
+                                    onClick={() =>
+                                        props.kmPostId
+                                            ? setDraftDeleteConfirmationVisible(true)
+                                            : undefined
+                                    }
+                                    icon={Icons.Delete}
+                                    variant={ButtonVariant.WARNING}>
+                                    {t('button.delete-draft')}
+                                </Button>
+                            </div>
                         )}
-                        <div
-                            className={
-                                state.existingKmPost?.editState === 'CREATED'
-                                    ? dialogStyles['dialog__footer-content--right-aligned']
-                                    : dialogStyles['dialog__footer-content--centered']
-                            }>
+                        <div className={dialogStyles['dialog__footer-content--centered']}>
                             <Button
                                 variant={ButtonVariant.SECONDARY}
                                 disabled={state.isSaving}
@@ -272,7 +279,7 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                         </div>
                     </React.Fragment>
                 }>
-                <FormLayout>
+                <FormLayout dualColumn>
                     <FormLayoutColumn>
                         <Heading size={HeadingSize.SUB}>
                             {t('km-post-dialog.general-title')}
@@ -337,6 +344,8 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                             }
                             errors={getVisibleErrorsByProp('state')}
                         />
+                    </FormLayoutColumn>
+                    <FormLayoutColumn>
                         <KmPostEditDialogGkLocationSection
                             getVisibleErrorsByProp={getVisibleErrorsByProp}
                             hasErrors={hasErrors}
@@ -344,6 +353,7 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                             stateActions={stateActions}
                             updateProp={updateProp}
                             geometryKmPostGkLocation={props.geometryKmPostGkLocation}
+                            role={props.role}
                         />
                     </FormLayoutColumn>
                 </FormLayout>

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -271,6 +271,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                     onSave={handleKmPostSave}
                     prefilledTrackNumberId={geometryKmPost.trackNumberId}
                     geometryKmPostGkLocation={geometryKmPost.gkLocation}
+                    role={'LINKING'}
                 />
             )}
         </React.Fragment>

--- a/ui/src/tool-panel/km-post/km-post-infobox.scss
+++ b/ui/src/tool-panel/km-post/km-post-infobox.scss
@@ -1,0 +1,3 @@
+.km-post-infobox__plan-link {
+    overflow-wrap: anywhere;
+}

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -34,6 +34,7 @@ import { Link } from 'vayla-design-lib/link/link';
 import { createDelegates } from 'store/store-utils';
 import { getGeometryPlan } from 'geometry/geometry-api';
 import CoordinateSystemView from 'geoviite-design-lib/coordinate-system/coordinate-system-view';
+import styles from './km-post-infobox.scss';
 
 type KmPostInfoboxProps = {
     layoutContext: LayoutContext;
@@ -226,6 +227,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                                         'tool-panel.km-post.layout.gk-coordinates.source-from-geometry',
                                     )}{' '}
                                     <Link
+                                        className={styles['km-post-infobox__plan-link']}
                                         onClick={() => {
                                             if (infoboxExtras?.sourceGeometryPlanId) {
                                                 delegates.onSelect({
@@ -316,6 +318,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                     kmPostId={kmPost.id}
                     onClose={closeEditDialog}
                     onSave={handleKmPostSave}
+                    role={'MODIFY'}
                 />
             )}
         </React.Fragment>

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -318,6 +318,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                     kmPostId={kmPost.id}
                     onClose={closeEditDialog}
                     onSave={handleKmPostSave}
+                    geometryKmPostGkLocation={kmPost.gkLocation}
                     role={'MODIFY'}
                 />
             )}

--- a/ui/src/vayla-design-lib/dropdown/dropdown.scss
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.scss
@@ -80,16 +80,20 @@ $dropdown-border-error: 2px;
 .dropdown--disabled {
     .dropdown__header {
         @include dropdown-shadow($color: colors.$color-white-darker, $width: 1px, $has-icon: false);
-        color: colors.$color-black-lighter;
+        color: colors.$color-white-darker;
         cursor: default;
     }
 
     .dropdown__icon {
-        fill: colors.$color-black-lighter;
+        fill: colors.$color-white-darker;
     }
 
     .dropdown__input {
         background: colors.$color-white-default;
+
+        &:disabled {
+            color: colors.$color-black-lighter;
+        }
     }
 }
 

--- a/ui/src/vayla-design-lib/field-layout/field-layout.scss
+++ b/ui/src/vayla-design-lib/field-layout/field-layout.scss
@@ -7,10 +7,18 @@
     margin-bottom: 10px;
 }
 
+.field-layout__value--disabled {
+    color: colors.$color-black-lighter;
+}
+
 .field-layout__label {
     @include typography.typography-caption-strong;
     color: colors.$color-black-light;
     padding: 3px 0;
+
+    &--disabled {
+        color: colors.$color-black-lighter;
+    }
 }
 
 .field-layout--has-error .field-layout__label {

--- a/ui/src/vayla-design-lib/field-layout/field-layout.tsx
+++ b/ui/src/vayla-design-lib/field-layout/field-layout.tsx
@@ -8,6 +8,7 @@ export type FieldLayoutProps = {
     help?: React.ReactNode;
     warnings?: string[];
     errors?: string[];
+    disabled?: boolean;
     children?: React.ReactNode;
 };
 
@@ -17,10 +18,18 @@ export const FieldLayout: React.FC<FieldLayoutProps> = (props: FieldLayoutProps)
         props.errors?.length && styles['field-layout--has-error'],
     );
 
+    const labelClassName = createClassName(
+        styles['field-layout__label'],
+        props.disabled && styles['field-layout__label--disabled'],
+    );
+    const valueClassName = createClassName(
+        props.disabled && styles['field-layout__value--disabled'],
+    );
+
     return (
         <div className={className}>
-            <div className={styles['field-layout__label']}>{props.label}</div>
-            <div className="field-layout__value">{props.value}</div>
+            <div className={labelClassName}>{props.label}</div>
+            <div className={valueClassName}>{props.value}</div>
             <div className={styles['field-layout__help']}>{props.help}</div>
             {props.errors && (
                 <div className={styles['field-layout__errors']}>

--- a/ui/src/vayla-design-lib/radio/radio.scss
+++ b/ui/src/vayla-design-lib/radio/radio.scss
@@ -61,6 +61,10 @@
 .radio__label-text {
     @include typography.typography-body;
     margin-left: 8px;
+
+    &--disabled {
+        color: colors.$color-black-lighter;
+    }
 }
 
 // Hover state

--- a/ui/src/vayla-design-lib/radio/radio.tsx
+++ b/ui/src/vayla-design-lib/radio/radio.tsx
@@ -14,13 +14,18 @@ export const Radio: React.FC<RadioProps> = ({ children, qaId, ...props }: RadioP
         props.disabled && styles['radio--disabled'],
         touched && styles['radio--touched'],
     );
+    const childrenClassName = createClassName(
+        styles['radio__label-text'],
+        props.disabled && styles['radio__label-text--disabled'],
+    );
+
     return (
         <label qa-id={qaId} className={className} onClick={() => setTouched(true)}>
             <input {...props} type="radio" className={styles.radio__input} />
             <span className={styles.radio__visualization}>
                 <span className={styles['radio__checked-marker']} />
             </span>
-            {children && <span className={styles['radio__label-text']}>{children}</span>}
+            {children && <span className={childrenClassName}>{children}</span>}
         </label>
     );
 };


### PR DESCRIPTION
Tämän pullarin pääjuttuna oli tehdä kilometripylvään GK-sijainnista optionaalisesti pakollinen (GVT-2766). Siihen liittyen täällä tehty:
* Muutettu kilometripylvään muokkausdialogi kaksipalstaiseksi, josta oikea puoli sisältää GK-sijainnin
* Mahdollistettu GK-sijainnin "kytkeminen" päälle/pois. Kun sijainti on kytketty päälle, GK-sijainnin kentät ovat pakollisia
* Mahdollistettu GK-sijainnin nollaaminen kytkemällä sijainti pois päältä KM-pylväälle, jolla sellainen on jo asetettu
* Lisätty GK-sijainnin esitäyttö sunnitelman datasta linkitettäessä
* Tehty valmistelevia töitä kilometripylvään GK-kaistan automaattiseen korjaamiseen liittyen. Loput tästä tulevat omalla tiketillään myöhemmin kun selviää tehdäänkö sitä vai ei, ja jos tehdään, niin missä muodossa. Samoin paremmat virheiden näyttämiset esim. GK-sijainnista jolle ei voi laskea TM35FIN-sijaintia tulee myöhemmin.

Noiden lisäksi täällä tehty pari pienempien tikettien hommaa:
* Kilometripylvään infoboksissa aiemmin overflowanneet suunnitelmat rivittyvät nyt (GVT-2761)
* Poistettu rekisterisivu (GVT-2784)