### PR TITLE
GVT-2758 (Take 2) Split validation: produce comparable start/end points for source track segment

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -32,12 +32,12 @@ import fi.fta.geoviite.infra.tracklayout.LAYOUT_M_DELTA
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.SegmentPoint
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.math.PI
 import kotlin.math.abs
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 data class AddressPoint(val point: AlignmentPoint, val address: TrackMeter) {
     fun isSame(other: AddressPoint) = address.isSame(other.address) && point.isSame(other.point)
@@ -64,13 +64,16 @@ data class AlignmentAddresses(
 
     @get:JsonIgnore
     val integerPrecisionPoints: List<AddressPoint> by lazy {
-        // midPoints are even anyhow, so just transform start/end
+        // midPoints are even anyhow, so just drop zero decimals from start/end
         val start =
             startPoint.withIntegerPrecision()?.takeIf { s ->
                 midPoints.isEmpty() || s.address < midPoints.first().address
             }
         val end =
-            endPoint.withIntegerPrecision()?.takeIf { e -> midPoints.isEmpty() || e.address > midPoints.last().address }
+            endPoint.withIntegerPrecision()?.takeIf { e ->
+                (start == null || e.address > start.address) &&
+                    (midPoints.isEmpty() || e.address > midPoints.last().address)
+            }
         listOfNotNull(start) + midPoints + listOfNotNull(end)
     }
 }
@@ -356,6 +359,25 @@ data class GeocodingContext(
 
     val referenceLineAddresses by lazy {
         checkNotNull(getAddressPoints(referenceLineGeometry)) { "Can't resolve reference line addresses" }
+    }
+
+    fun getPartialAddressRange(
+        sourceAlignment: LayoutAlignment,
+        segmentIndices: IntRange,
+    ): Pair<AddressPoint, AddressPoint>? {
+        assert(segmentIndices.first >= 0 && segmentIndices.last <= sourceAlignment.segments.lastIndex) {
+            "Segment indices out of bounds: indices=$segmentIndices segments=${sourceAlignment.segments.size}"
+        }
+        val startSegment = sourceAlignment.segments[segmentIndices.first]
+        val endSegment = sourceAlignment.segments[segmentIndices.last]
+        val sourceStart = startSegment.segmentStart.toAlignmentPoint(0.0).let(::toAddressPoint)?.first
+        val endSegmentStart = endSegment.startM - startSegment.startM
+        val sourceEnd = endSegment.segmentEnd.toAlignmentPoint(endSegmentStart).let(::toAddressPoint)?.first
+        return if (sourceStart != null && sourceEnd != null) {
+            sourceStart to sourceEnd
+        } else {
+            null
+        }
     }
 
     private fun toAddressPoint(point: AlignmentPoint, decimals: Int = DEFAULT_TRACK_METER_DECIMALS) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -38,9 +38,9 @@ import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.topologicalConnectivityTypeOf
 import fi.fta.geoviite.infra.util.produceIf
-import java.time.Instant
 import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 
 @GeoviiteService
 class SplitService(
@@ -331,9 +331,6 @@ class SplitService(
             } else {
                 null
             }
-        println(
-            "addressRange=$sourceAddressPointRange sourceAddresses=(${sourceAddresses?.firstOrNull()}..${sourceAddresses?.last()}) targetAddresses=(${targetAddresses?.firstOrNull()}..${targetAddresses?.last()})"
-        )
 
         return sourceAddresses to targetAddresses
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -80,28 +80,21 @@ internal fun validateTargetGeometry(
     return if (targetPoints == null || sourcePoints == null) {
         LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.no-geometry")
     } else {
-        targetPoints
-            .withIndex()
-            .firstNotNullOfOrNull { (targetIndex, targetPoint) ->
-                val sourcePoint = sourcePoints.getOrNull(targetIndex)
-                if (sourcePoint?.address != targetPoint.address) {
-                    LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.trackmeters-changed")
-                } else if (operation != SplitTargetOperation.TRANSFER && !targetPoint.point.isSame(sourcePoint.point)) {
-                    LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.geometry-changed")
-                } else if (
-                    operation == SplitTargetOperation.TRANSFER &&
-                        lineLength(targetPoint.point, sourcePoint.point) > MAX_SPLIT_POINT_OFFSET
-                ) {
-                    LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.transfer-geometry-changed")
-                } else {
-                    null
-                }
+        targetPoints.withIndex().firstNotNullOfOrNull { (targetIndex, targetPoint) ->
+            val sourcePoint = sourcePoints.getOrNull(targetIndex)
+            if (sourcePoint?.address != targetPoint.address) {
+                LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.trackmeters-changed")
+            } else if (operation != SplitTargetOperation.TRANSFER && !targetPoint.point.isSame(sourcePoint.point)) {
+                LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.geometry-changed")
+            } else if (
+                operation == SplitTargetOperation.TRANSFER &&
+                    lineLength(targetPoint.point, sourcePoint.point) > MAX_SPLIT_POINT_OFFSET
+            ) {
+                LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.transfer-geometry-changed")
+            } else {
+                null
             }
-            ?.also { error ->
-                println(
-                    "error=$error targetPoints=(${targetPoints.take(3)}..${targetPoints.takeLast(3)}) sourcePoints=(${sourcePoints.take(3)}..${sourcePoints.takeLast(3)})"
-                )
-            }
+        }
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -80,21 +80,28 @@ internal fun validateTargetGeometry(
     return if (targetPoints == null || sourcePoints == null) {
         LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.no-geometry")
     } else {
-        targetPoints.withIndex().firstNotNullOfOrNull { (targetIndex, targetPoint) ->
-            val sourcePoint = sourcePoints.getOrNull(targetIndex)
-            if (sourcePoint?.address != targetPoint.address) {
-                LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.trackmeters-changed")
-            } else if (operation != SplitTargetOperation.TRANSFER && !targetPoint.point.isSame(sourcePoint.point)) {
-                LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.geometry-changed")
-            } else if (
-                operation == SplitTargetOperation.TRANSFER &&
-                    lineLength(targetPoint.point, sourcePoint.point) > MAX_SPLIT_POINT_OFFSET
-            ) {
-                LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.transfer-geometry-changed")
-            } else {
-                null
+        targetPoints
+            .withIndex()
+            .firstNotNullOfOrNull { (targetIndex, targetPoint) ->
+                val sourcePoint = sourcePoints.getOrNull(targetIndex)
+                if (sourcePoint?.address != targetPoint.address) {
+                    LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.trackmeters-changed")
+                } else if (operation != SplitTargetOperation.TRANSFER && !targetPoint.point.isSame(sourcePoint.point)) {
+                    LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.geometry-changed")
+                } else if (
+                    operation == SplitTargetOperation.TRANSFER &&
+                        lineLength(targetPoint.point, sourcePoint.point) > MAX_SPLIT_POINT_OFFSET
+                ) {
+                    LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.transfer-geometry-changed")
+                } else {
+                    null
+                }
             }
-        }
+            ?.also { error ->
+                println(
+                    "error=$error targetPoints=(${targetPoints.take(3)}..${targetPoints.takeLast(3)}) sourcePoints=(${sourcePoints.take(3)}..${sourcePoints.takeLast(3)})"
+                )
+            }
     }
 }
 


### PR DESCRIPTION
Lisäfiksi false positive geometriavirheisiin split-validoinnissa. Tämänkin jälkeen löytyy vielä hassuja, joita pitää vähän tutkia lisää, mutta näyttäisi että ne liittyy transfer-caseihin, joten niissä voi olla oikeita ongelmia