### PR TITLE
GVT-2795 Fix branch confusions in switch link change query

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -708,14 +708,17 @@ class PublicationDao(
                 and not exists(
                   select *
                   from publication.switch psw
+                    join publication.publication psw_publication on psw.publication_id = psw_publication.id
                   where psw.switch_id = switch_version.id
+                    and psw_publication.design_id is not distinct from publication.design_id
                     and direct_change
                     and (psw.switch_version = switch_version.version and psw.publication_id > plt.publication_id
                       or psw.switch_version > switch_version.version and psw.publication_id <= plt.publication_id))
-                and (:publicationId::integer is null or :publicationId = publication.id)
+                and case when :publicationId::integer is not null
+                      then :publicationId = publication.id
+                      else :design_id is not distinct from publication.design_id end
                 and (:from::timestamptz is null or :from <= publication_time)
                 and (:to::timestamptz is null or :to >= publication_time)
-                and (case when :publicationId::integer is not null then :design_id is not distinct from publication.design_id end)
         """
                 .trimIndent()
 


### PR DESCRIPTION
Alussa löytyi yksi bugi, sille testejä kirjoittaessa toinen:
- Logiikka sille, että haetaan muutoksia joko julkaisu-id:llä tai design-id:llä, oli väärinpäin, ja siksi julkaisulokista katosi vaihdelinkkimuutokset kokonaan
- Vaihteiden design-julkaisut saattoivat rynniä mainin vaihdejulkaisujen päälle ja hämmentää hakua

Haku ei edelleenkään kokonaisuutena yritäkään tukea millään lailla design-puolen julkaisulokien tekoa, mutta jätin nyt siitä huolimatta tuon vaihteiden design-julkaisujen erottelun rakenteen ainakin alustavasti sellaiseksi, että se toimii (ehkä, ei lainkaan testattu) yhdenmukaisesti eri suuntiin.