### PR TITLE
General: Disable gradle config cache for now

### DIFF
--- a/infra/gradle.properties
+++ b/infra/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx1g -Dkotlin.daemon.jvm.options=-Xmx1g
 org.gradle.parallel=true
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 org.gradle.caching=true
 selenium.version=4.18.0


### PR DESCRIPTION
Näyttäisi toistaiseksi aiheuttavan enemmän problematiikkaa kuin hyötyä