### PR TITLE
GVT-2800: Add unit test for frame converter example request deserialization

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterExamplesTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterExamplesTest.kt
@@ -1,0 +1,30 @@
+package fi.fta.geoviite.api.frameconverter.v1
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.core.io.ClassPathResource
+
+class FrameConverterExamplesTest {
+    private val objectMapper = jacksonObjectMapper()
+
+    @Test
+    fun `Example JSON request files should be deserializable`() {
+        val exampleJsonDirectory = "static/frameconverter/examples"
+
+        val tests =
+            mapOf(
+                CoordinateToTrackAddressRequestV1::class to "example-request-coordinate-to-track-address.json",
+                TrackAddressToCoordinateRequestV1::class to "example-request-track-address-to-coordinate.json",
+            )
+
+        tests.forEach { (clazz, filename) ->
+            assertDoesNotThrow {
+                val jsonString = ClassPathResource("$exampleJsonDirectory/$filename").file
+                val typeReference = objectMapper.typeFactory.constructCollectionType(List::class.java, clazz.java)
+
+                objectMapper.readValue(jsonString, typeReference)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Responseille vastaavan testin tekeminen meneekin hankalammaksi, koska nykyrakenteella noita vastaustyyppejä ei oikein ole mietitty deserialisointia ajatellen. Jackson ei nimittäin osaa tehdä mitään hyödyllistä ilman että tekee käytännössä koko deserialisointilogiikan itse 😄

Also VKM:n vastaukset on GeoJsonia jossa ei ole sitä diskriminaattorikenttää -- jos joku koodaa jotain yleisempää vastauskäsittelijää kuin käsittely-per-pyyntö, niin törmää siihen diskriminointiärsyttävyyteen (eli "arvaa mikä properties-kenttä-kombinaatio milläkin vastaustyypillä on uniikki"). Meillä voisi siis olla siellä properties-kentässä jokin "type/kind/vastaava"-kenttä kertomassa, että minkälaisesta muunnostuloksesta on kysymys käyttäjäkoodarin ergonomian parantamiseksi. Silloin myös näiden response-esimerkkien deserialisoiminen olisi helpompaa täällä testissäkin, kun voisi tehdä tuon kentän perusteella suoran mäppäyksen minkälaiseen GeoJson-vastaukseen mikäkin esimerkki-json pitäisi yrittää deserialisoida