### PR TITLE
GVT-2819 Move geometry change remark calculation out of transaction

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateService.kt
@@ -23,7 +23,6 @@ class PublicationGeometryChangeRemarksUpdateService(
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    @Transactional
     fun processPublication(publicationId: IntId<Publication>) {
         publicationDao.fetchUnprocessedGeometryChangeRemarks(publicationId).forEach(::processOne)
     }
@@ -49,6 +48,7 @@ class PublicationGeometryChangeRemarksUpdateService(
     }
 
     private fun processOne(unprocessedChange: PublicationDao.UnprocessedGeometryChange) {
+        logger.info("Processing publication change remarks for location track ${unprocessedChange.locationTrackId} in publication ${unprocessedChange.publicationId}")
         val geocodingContext = geocodingService.getGeocodingContextAtMoment(
             unprocessedChange.trackNumberId,
             unprocessedChange.publicationTime,


### PR DESCRIPTION
Tämä oli aikoinaan tuotu mukaan transaktioon sillä oletuksella, että olkoonkin, että tämä laskutoimitus on liian raskas tehtäväksi julkaisulokia lukiessa, ei siihen todellisuudessa mene pahimmillaankaan kuin pari sekuntia, joten olkoon vaan samassa syssyssä.

Eipä ollutkaan, vaan kyllä tähän pystyy menemään useampi minuutti, ja osumaan siten transaktioiden aikakatkaisuun. Kokonaisvaltainen ratkaisu varmaan vaatisi heittää koko laskennan sivuun omaan säikeeseensä tjms., koska eipä tätä julkaisulokin lisätietojen laskemista voi oikeastaan pitää asiana, jota käyttäjänkään pitäisi tarvita odottaa, mutta tässä nyt minimiratkaisu sitä varten, että saadaan tuotanto kuntoon.