### PR TITLE
GVT-2821: Handle stale frontend version during backend update

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -207,6 +207,14 @@ class DuplicateDesignNameException(name: String, cause: Throwable? = null) :
         localizedMessageParams = localizationParams("name" to name),
     )
 
+class InvalidUiVersionException(cause: Throwable? = null) :
+    ClientException(
+        status = BAD_REQUEST,
+        message = "Invalid request: version mismatch",
+        cause = cause,
+        localizedMessageKey = "error.bad-request.invalid-version",
+    )
+
 class ExtApiExceptionV1(
     message: String,
     cause: Throwable? = null,

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -91,7 +91,8 @@
             "invalid-path": "Virhe: pyynnön polku oli virheellinen ({{method}})",
             "missing-parameter": "Virhe: pyynnöstä puuttuu vaadittu parametri ({{param}})",
             "invalid-body": "Virhe: pyynnön sisältöä ei voitu lukea",
-            "conversion-failed": "Virhe: Pyynnössä oli virheellinen arvo {{name}}"
+            "conversion-failed": "Virhe: Pyynnössä oli virheellinen arvo {{name}}",
+            "invalid-version": "Virhe: Käyttöliittymän versio ei vastaa palvelimen versiota"
         },
         "deleting": {
             "generic": "Poistamisessa tapahtui virhe",

--- a/ui/src/common/common-slice.ts
+++ b/ui/src/common/common-slice.ts
@@ -39,14 +39,18 @@ export const initialChangeTimes: ChangeTimes = {
     layoutDesign: initialChangeTime,
 };
 
+export type VersionStatus = 'loading' | 'reload' | 'ok';
+
 export type CommonState = {
     version: string | undefined;
+    versionStatus: VersionStatus;
     changeTimes: ChangeTimes;
     user: User | undefined;
 };
 
-export const initialCommonState = {
+export const initialCommonState: CommonState = {
     version: undefined,
+    versionStatus: 'loading',
     changeTimes: initialChangeTimes,
     user: undefined,
 };
@@ -66,6 +70,12 @@ const commonSlice = createSlice({
     reducers: {
         setVersion: (state: CommonState, { payload: version }: PayloadAction<string>): void => {
             state.version = version;
+        },
+        setVersionStatus: (
+            state: CommonState,
+            { payload: versionStatus }: PayloadAction<VersionStatus>,
+        ): void => {
+            state.versionStatus = versionStatus;
         },
         setChangeTimes: function (
             { changeTimes }: CommonState,

--- a/ui/src/main/main.tsx
+++ b/ui/src/main/main.tsx
@@ -100,11 +100,10 @@ export const MainContainer: React.FC = () => {
     const mapDelegates = createDelegates(trackLayoutActionCreators);
 
     const layoutMode = useTrackLayoutAppSelector((state) => state.layoutMode);
-    const versionInStore = useCommonDataAppSelector((state) => state.version);
+    const commonAppData = useCommonDataAppSelector((state) => state);
+    const versionInStore = commonAppData.version;
+    const versionStatus = commonAppData.versionStatus;
     const versionFromBackend = getEnvironmentInfo()?.releaseVersion;
-    const [versionStatus, setVersionStatus] = React.useState<'loading' | 'reload' | 'ok'>(
-        'loading',
-    );
     const delegates = React.useMemo(() => createDelegates(commonActionCreators), []);
 
     React.useEffect(() => {
@@ -119,7 +118,7 @@ export const MainContainer: React.FC = () => {
 
     React.useEffect(() => {
         if (typeof versionFromBackend == 'string') {
-            setVersionStatus(
+            delegates.setVersionStatus(
                 !versionInStore || versionInStore === versionFromBackend ? 'ok' : 'reload',
             );
 


### PR DESCRIPTION
Periaate: Välitetään frontilta `x-geoviite-ui-version`-header kaikissa rajapintapyynnöissä, ja bäkkäri tarkistaa tämän headerin pehmeästi `RequestFilter`'n aikana: Jos kyseistä headeriä ei ole tai se on tyhjä, ei varsinaista tarkistusta tehdä. Jos taas header on epätyhjä, niin bäkkäri tekee vertauksen omaan versioonsa ja heittää poikkeusta tarvittaessa.

Problematiikkaa aiheuttaa:
* Frontti tekee pyyntöjä ennen kuin se tietää ensimmäisen bäkkärin version, jolla käyttöliittymä on ollut aktiivinen. Meillä ei sinänsä ole "ui-bundlen versiota" (pitäisikö olla?), niin sitä ei voi välittää. Tässä siis ainakin yksi syy pehmeään tarkistukseen. Toki tuon voisi synkata, ettei esim. /environment-polkuun tehtäisi versiotarkistusta, ja kaikki muut pyynnöt olisivat nk. hard-faileja. Kaikkihan meidän rajapintapyynnöt käyttävät samoja sisäisiä fetch-kutsuja ennen pitkää.
* Jos nk. hard-failin tekee (versioheaderin pakko mätsätä tai et saa mitään), niin se aiheuttaa lisäikävyyksiä, ettei sillon esimerkiksi pystyisi avaamaan GET-pyyntöä uudessa välilehdessä, joka ei välitä custom-headeriä automaattisesti. (Eli mielummin soft-fail mikä nytkin toteuteltu)
* Rakenneprobleema: Miten välittää tieto bäkkäriltä päätyneestä versiotarkistuksen epäonnistumisesta rajapintakutsussa yleisellä tasolla, että "päivitä sivu"-dialogi näytetään käyttäjälle, muttei tarkistuksia tarvitse tehdä hyvin monessa paikassa. Tällä pullarilla tuolla päätyy redux-store tavaraa fetch-api-filuun, joka ei vaikuta rakenteen puolesta ollenkaan mielekkäältä. Erityisesti jos tähän on jotain parempia ehdotuksia niin vaihdellaan.