### PR TITLE
GVT-2814: Add toggle for all publication item details in publication log

### DIFF
--- a/ui/src/publication/table/publication-table-row.tsx
+++ b/ui/src/publication/table/publication-table-row.tsx
@@ -12,6 +12,8 @@ import { first } from 'utils/array-utils';
 
 type PublicationTableRowProps = {
     propChanges: PublicationChange[];
+    detailsVisible: boolean;
+    detailsVisibleToggle: () => void;
 } & PublicationTableItem;
 
 export const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
@@ -25,11 +27,13 @@ export const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
     message,
     ratkoPushTime,
     propChanges,
+    detailsVisible,
+    detailsVisibleToggle,
 }) => {
     const { t } = useTranslation();
     const messageRows = message.split('\n');
     const [messageExpanded, setMessageExpanded] = React.useState(false);
-    const [detailsVisible, setDetailsVisible] = React.useState<boolean>(false);
+    // const [detailsVisible, setDetailsVisible] = React.useState<boolean>(false);
     const contentClassNames = createClassName(
         styles['publication-table__message-content'],
         messageExpanded
@@ -46,13 +50,15 @@ export const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
         detailsVisible && styles['publication-table__row-details--borderless'],
     );
 
+    console.log(detailsVisible);
+
     return (
         <React.Fragment>
             <tr className={rowClassNames}>
                 <td className={styles['publication-table__accordion-column']}>
                     <AccordionToggle
                         open={detailsVisible}
-                        onToggle={() => setDetailsVisible(!detailsVisible)}
+                        onToggle={() => detailsVisibleToggle()}
                     />
                 </td>
                 <td>{name}</td>

--- a/ui/src/publication/table/publication-table.tsx
+++ b/ui/src/publication/table/publication-table.tsx
@@ -10,6 +10,8 @@ import {
     PublicationDetailsTableSortInformation,
 } from './publication-table-utils';
 import { getSortDirectionIcon } from 'utils/table-utils';
+import { AccordionToggle } from 'vayla-design-lib/accordion-toggle/accordion-toggle';
+import { useState } from 'react';
 
 export type PublicationTableProps = {
     items: PublicationTableItem[];
@@ -47,12 +49,36 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
         </Th>
     );
 
+    const [itemDetailsVisible, setItemDetailsVisible] = useState<PublicationTableItem['id'][]>([]);
+
+    const publicationItemDetailsVisibilityToggle = (id: PublicationTableItem['id']) => {
+        if (!itemDetailsVisible.includes(id)) {
+            setItemDetailsVisible([...itemDetailsVisible, id]);
+        } else {
+            setItemDetailsVisible(itemDetailsVisible.filter((existingId) => existingId !== id));
+        }
+    };
+
+    const anyPublicationItemDetailsVisible = itemDetailsVisible.length > 0;
+    const toggleVisibilityOfAllDetails = () => {
+        if (anyPublicationItemDetailsVisible) {
+            setItemDetailsVisible([]);
+        } else {
+            setItemDetailsVisible(items.map((item) => item.id));
+        }
+    };
+
     return (
         <div className={styles['publication-table']}>
             <Table wide isLoading={isLoading}>
                 <thead className={styles['publication-table__table-header']}>
                     <tr>
-                        <Th />
+                        <Th>
+                            <AccordionToggle
+                                open={anyPublicationItemDetailsVisible}
+                                onToggle={() => toggleVisibilityOfAllDetails()}
+                            />
+                        </Th>
                         {sortableTableHeader(
                             PublicationDetailsTableSortField.NAME,
                             'publication-table.name',
@@ -101,6 +127,10 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
                             changedKmNumbers={entry.changedKmNumbers}
                             message={entry.message}
                             propChanges={entry.propChanges}
+                            detailsVisible={itemDetailsVisible.includes(entry.id)}
+                            detailsVisibleToggle={() =>
+                                publicationItemDetailsVisibilityToggle(entry.id)
+                            }
                         />
                     ))}
                 </tbody>


### PR DESCRIPTION
Julkaisulokissa piti kliksutella aikaisemmin aikas paljon jos halusi saada näkyviin paljon tietoa kerralla. Nyt riittää yksi painallus kaikkien tarkempien tietojen avaamiseen ja jos sattuu olemaan esim. pari auki, niin tuosta napista klikkaamalla saa suljettua avattuna olevat.