### PR TITLE
GVT-2812 Ensure in backend launch that we have a supported postgres version in use

### DIFF
--- a/infra/src/main/resources/db/migration/beforeMigrate.sql
+++ b/infra/src/main/resources/db/migration/beforeMigrate.sql
@@ -1,0 +1,9 @@
+do $$
+  declare
+    min_version float = 16.3;
+    current_version float = current_setting('server_version')::float;
+  begin
+    if current_version < min_version then
+      raise exception 'This version of Geoviite supports PostgreSQL version %+. Current version is %.', min_version, current_version;
+    end if;
+  end $$;


### PR DESCRIPTION
Teen lisäksi dokumentaation tietokannan päivityksestä env-puolelle. Tässä koodipuolelle rajoitin joka varmistaa ennen migraatioiden ajoa että ollaan vähintään halutussa versiossa. BeforeMigrate on siinä mielessä hyvä että tiedostoa voi vain päivitittää ja toisaalta se kuitenkin ajetaan ennen kun lähdetään migroimaan mitään. Ainakin tässä extension update tapauksessa riittää hyvin varmistaa että ollaanhan jo 16-sarjassa ennen kun päivitetään extensiot ja tämä hoitaa sen.