### PR TITLE
GVT-2809 (part 2): Use react-router Link

### DIFF
--- a/ui/src/common/navigate.ts
+++ b/ui/src/common/navigate.ts
@@ -16,10 +16,6 @@ export const appPath = {
     'inframodel-rejected': '/infra-model/rejected',
 } as const;
 
-export const appHref = (path: string): string => {
-    return `/#${path}`;
-};
-
 export type AppNavigateFunction = <K extends keyof typeof appPath>(
     key: K,
     ...args: (typeof appPath)[K] extends (...args: unknown[]) => string

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -7,21 +7,19 @@ import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { Spinner, SpinnerSize } from 'vayla-design-lib/spinner/spinner';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { createClassName } from 'vayla-design-lib/utils';
-import { Link } from 'vayla-design-lib/link/link';
 import { formatDateFull } from 'utils/date-utils';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
-import { appHref, AppNavigateFunction, appPath } from 'common/navigate';
 import { Menu, menuOption, MenuSelectOption } from 'vayla-design-lib/menu/menu';
 import { SplitDetailsDialog } from 'publication/split/split-details-dialog';
 import { putBulkTransferState } from 'publication/split/split-api';
 import { success } from 'geoviite-design-lib/snackbar/snackbar';
 import { getChangeTimes, updateSplitChangeTime } from 'common/change-time-api';
 import { useLayoutDesign } from 'track-layout/track-layout-react-utils';
+import { Link } from 'react-router-dom';
 
 type PublicationListRowProps = {
     publication: PublicationDetails;
     setSelectedPublicationId: (id: string) => void;
-    navigate: AppNavigateFunction;
 };
 
 const publicationStateIcon: React.FC<PublicationDetails> = (publication) => {
@@ -69,11 +67,7 @@ const bulkTransferStateIcon = (bulkTransferState: BulkTransferState | undefined)
     }
 };
 
-export const PublicationListRow: React.FC<PublicationListRowProps> = ({
-    publication,
-    setSelectedPublicationId,
-    navigate,
-}) => {
+export const PublicationListRow: React.FC<PublicationListRowProps> = ({ publication }) => {
     const { t } = useTranslation();
 
     const design = useLayoutDesign(getChangeTimes().layoutDesign, publication.layoutBranch)?.name;
@@ -130,14 +124,7 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({
                         {(() => {
                             const text = formatDateFull(publication.publicationTime);
                             return publication.layoutBranch === 'MAIN' ? (
-                                <Link
-                                    onClick={() => {
-                                        setSelectedPublicationId(publication.id);
-                                        navigate('publication-view', publication.id);
-                                    }}
-                                    href={appHref(appPath['publication-view'](publication.id))}>
-                                    {text}
-                                </Link>
+                                <Link to={`/publications/${publication.id}`}>{text}</Link>
                             ) : (
                                 text
                             );

--- a/ui/src/publication/card/publication-list.scss
+++ b/ui/src/publication/card/publication-list.scss
@@ -13,6 +13,8 @@
 
     a {
         text-decoration: none;
+        cursor: pointer;
+        color: vayla-design.$color-blue-dark;
     }
 
     > div {

--- a/ui/src/publication/card/publication-list.tsx
+++ b/ui/src/publication/card/publication-list.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { PublicationDetails } from 'publication/publication-model';
 import { PublicationListRow } from 'publication/card/publication-list-row';
-import { useAppNavigate } from 'common/navigate';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 
@@ -10,8 +9,6 @@ type PublicationListProps = {
 };
 
 export const PublicationList: React.FC<PublicationListProps> = ({ publications }) => {
-    const navigate = useAppNavigate();
-
     const trackLayoutActionDelegates = React.useMemo(
         () => createDelegates(trackLayoutActionCreators),
         [],
@@ -23,7 +20,6 @@ export const PublicationList: React.FC<PublicationListProps> = ({ publications }
                 <PublicationListRow
                     key={publication.id}
                     publication={publication}
-                    navigate={navigate}
                     setSelectedPublicationId={trackLayoutActionDelegates.setSelectedPublicationId}
                 />
             ))}


### PR DESCRIPTION
Tuo aiempi toimintalogiikkahan ei ollut edes tarpeellinen, lähti myös lisää turhuuksia veks näin uusilla silmillä

Unohdinkin jo että tein aiemmin [GVT-2346](https://extranet.vayla.fi/jira/browse/GVT-2346) (meillä on kaksi eri Link-komponenttia samalla nimellä..)

Korjailee siis pilvessä refresh-bugin.