### PR TITLE
GVT-2804 Optimize coordinate->track address mass conversions

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
@@ -11,6 +11,8 @@ import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.error.ExtApiExceptionV1
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.logging.apiResult
+import fi.fta.geoviite.infra.util.Either
+import fi.fta.geoviite.infra.util.processValidated
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -49,7 +51,9 @@ class FrameConverterControllerV1 @Autowired constructor(private val frameConvert
 
         val queryParams = FrameConverterQueryParamsV1(coordinateSystem, featureGeometry, featureBasic, featureDetails)
 
-        return GeoJsonFeatureCollection(features = processRequest(request, queryParams))
+        return GeoJsonFeatureCollection(
+            features = processTrackAddressToCoordinateRequests(listOf(request), queryParams).flatten()
+        )
     }
 
     @DisableDefaultGeoviiteLogging
@@ -64,7 +68,7 @@ class FrameConverterControllerV1 @Autowired constructor(private val frameConvert
         logRequestAmount("trackAddressToCoordinateRequestBatch", requests)
 
         val queryParams = FrameConverterQueryParamsV1(coordinateSystem, featureGeometry, featureBasic, featureDetails)
-        val features = requests.flatMap { request -> processRequest(request, queryParams) }
+        val features = processTrackAddressToCoordinateRequests(requests, queryParams).flatten()
 
         logFeatureAmount("trackAddressToCoordinateRequestBatch", features)
         return GeoJsonFeatureCollection(features = features)
@@ -96,7 +100,9 @@ class FrameConverterControllerV1 @Autowired constructor(private val frameConvert
 
         val queryParams = FrameConverterQueryParamsV1(coordinateSystem, featureGeometry, featureBasic, featureDetails)
 
-        return GeoJsonFeatureCollection(features = processRequest(request, queryParams))
+        return GeoJsonFeatureCollection(
+            features = processCoordinateToTrackAddressRequests(listOf(request), queryParams).flatten()
+        )
     }
 
     @DisableDefaultGeoviiteLogging
@@ -111,51 +117,58 @@ class FrameConverterControllerV1 @Autowired constructor(private val frameConvert
         logRequestAmount("coordinateToTrackAddressRequestBatch", requests)
 
         val queryParams = FrameConverterQueryParamsV1(coordinateSystem, featureGeometry, featureBasic, featureDetails)
-        val features = requests.flatMap { request -> processRequest(request, queryParams) }
+        val features = processCoordinateToTrackAddressRequests(requests, queryParams).flatten()
 
         logFeatureAmount("coordinateToTrackAddressRequestBatch", features)
+
         return GeoJsonFeatureCollection(features = features)
     }
 
-    private fun processRequest(
-        request: FrameConverterRequestV1,
+    private fun processCoordinateToTrackAddressRequests(
+        requests: List<FrameConverterRequestV1>,
         params: FrameConverterQueryParamsV1,
-    ): List<GeoJsonFeature> {
-        return when (request) {
-            is CoordinateToTrackAddressRequestV1 ->
-                processRequestHelper(
-                    request,
-                    params,
-                    frameConverterServiceV1::validateCoordinateToTrackAddressRequest,
-                    frameConverterServiceV1::coordinateToTrackAddress,
-                )
+    ): List<List<GeoJsonFeature>> =
+        processRequests(
+            assertRequestType(requests),
+            params,
+            frameConverterServiceV1::validateCoordinateToTrackAddressRequest,
+            frameConverterServiceV1::coordinatesToTrackAddresses,
+        )
 
-            is TrackAddressToCoordinateRequestV1 ->
-                processRequestHelper(
-                    request,
-                    params,
-                    frameConverterServiceV1::validateTrackAddressToCoordinateRequest,
-                    frameConverterServiceV1::trackAddressToCoordinate,
-                )
+    private fun processTrackAddressToCoordinateRequests(
+        requests: List<FrameConverterRequestV1>,
+        params: FrameConverterQueryParamsV1,
+    ): List<List<GeoJsonFeature>> {
+        return processRequests(
+            assertRequestType(requests),
+            params,
+            frameConverterServiceV1::validateTrackAddressToCoordinateRequest,
+            frameConverterServiceV1::trackAddressesToCoordinates,
+        )
+    }
 
-            else ->
-                throw ExtApiExceptionV1(
-                    message = "Unsupported request type",
-                    error = FrameConverterErrorV1.UnsupportedRequestType,
-                )
+    private inline fun <reified Request : FrameConverterRequestV1> assertRequestType(requests: List<*>): List<Request> {
+        if (requests.any { it !is Request }) {
+            throw ExtApiExceptionV1(
+                message = "Unsupported request type",
+                error = FrameConverterErrorV1.UnsupportedRequestType,
+            )
         }
+        @Suppress("UNCHECKED_CAST")
+        return requests as List<Request>
     }
 
-    private inline fun <T, V> processRequestHelper(
-        request: T,
+    private fun <Request : FrameConverterRequestV1, ValidRequest> processRequests(
+        requests: List<Request>,
         params: FrameConverterQueryParamsV1,
-        validate: (T, FrameConverterQueryParamsV1) -> Pair<V?, List<GeoJsonFeatureErrorResponseV1>>,
-        process: (LayoutContext, V, FrameConverterQueryParamsV1) -> List<GeoJsonFeature>,
-    ): List<GeoJsonFeature> {
-        val (validatedRequest, errorResponse) = validate(request, params)
-
-        return validatedRequest?.let { req -> process(MainLayoutContext.official, req, params) } ?: errorResponse
-    }
+        validate: (Request, FrameConverterQueryParamsV1) -> Either<List<GeoJsonFeatureErrorResponseV1>, ValidRequest>,
+        process: (LayoutContext, List<ValidRequest>, FrameConverterQueryParamsV1) -> List<List<GeoJsonFeature>>,
+    ): List<List<GeoJsonFeature>> =
+        processValidated(
+            requests,
+            { request -> validate(request, params) },
+            { validRequests -> process(MainLayoutContext.official, validRequests, params) },
+        )
 
     private fun logRequestAmount(method: String, requests: List<FrameConverterRequestV1>) {
         logger.apiCall(method, listOf("requestAmount" to requests.size))

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
@@ -12,6 +12,7 @@ import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.error.InputValidationException
 import fi.fta.geoviite.infra.geocoding.AddressAndM
 import fi.fta.geoviite.infra.geocoding.AddressPoint
+import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.geography.CoordinateTransformationException
 import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
@@ -24,10 +25,16 @@ import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
+import fi.fta.geoviite.infra.util.Either
+import fi.fta.geoviite.infra.util.FreeText
+import fi.fta.geoviite.infra.util.Left
+import fi.fta.geoviite.infra.util.Right
 import fi.fta.geoviite.infra.util.alsoIfNull
+import fi.fta.geoviite.infra.util.processValidated
 import fi.fta.geoviite.infra.util.produceIf
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -47,73 +54,98 @@ constructor(
     private val trackNumberService: LayoutTrackNumberService,
     private val geocodingService: GeocodingService,
     private val locationTrackService: LocationTrackService,
+    private val locationTrackDao: LocationTrackDao,
     localizationService: LocalizationService,
 ) {
+
     val translation = localizationService.getLocalization(LocalizationLanguage.FI)
 
-    fun coordinateToTrackAddress(
+    fun coordinatesToTrackAddresses(
         layoutContext: LayoutContext,
-        request: ValidCoordinateToTrackAddressRequestV1,
+        requests: List<ValidCoordinateToTrackAddressRequestV1>,
         params: FrameConverterQueryParamsV1,
-    ): List<GeoJsonFeature> {
-        val searchPointInLayoutCoordinates =
-            when (request.searchCoordinate.srid) {
-                LAYOUT_SRID -> request.searchCoordinate
-                else ->
-                    try {
-                        transformNonKKJCoordinate(request.searchCoordinate.srid, LAYOUT_SRID, request.searchCoordinate)
-                    } catch (ex: CoordinateTransformationException) {
-                        return createErrorResponse(
-                            request.identifier,
-                            FrameConverterErrorV1.InputCoordinateTransformationFailed,
-                        )
-                    }
-            }
+    ): List<List<GeoJsonFeature>> =
+        processValidated(
+            requests,
+            { request -> getSearchPointInLayoutCoordinates(request).mapRight { point -> request to point } },
+            { requestsWithPoints -> coordinatesWithPointsToTrackAddresses(layoutContext, requestsWithPoints, params) },
+        )
 
-        val nearbyLocationTracks =
-            locationTrackService.listAroundWithAlignments(
-                layoutContext = layoutContext,
-                point = searchPointInLayoutCoordinates,
-                maxDistance = request.searchRadius,
-            )
+    private fun coordinatesWithPointsToTrackAddresses(
+        layoutContext: LayoutContext,
+        requestsWithPoints: List<Pair<ValidCoordinateToTrackAddressRequestV1, IPoint>>,
+        params: FrameConverterQueryParamsV1,
+    ): List<List<GeoJsonFeature>> {
+        val locationTrackVersions =
+            locationTrackDao.fetchVersionsForFrameConverterSearch(layoutContext, requestsWithPoints)
+        val tracksWithAlignments = locationTrackVersions.map { it?.let(locationTrackService::getWithAlignment) }
 
-        val trackNumbers = request.trackNumberName?.let { trackNumberService.mapById(layoutContext) } ?: emptyMap()
+        val geocodingContexts =
+            tracksWithAlignments
+                .mapNotNull { it?.first?.trackNumberId }
+                .distinct()
+                .associateWith { geocodingService.getGeocodingContext(layoutContext, it) }
 
-        val filteredLocationTracks =
-            nearbyLocationTracks
-                .filter { (locationTrack, _) -> filterByLocationTrackName(request.locationTrackName, locationTrack) }
-                .filter { (locationTrack, _) -> filterByLocationTrackType(request.locationTrackType, locationTrack) }
-                .filter { (locationTrack, _) ->
-                    filterByTrackNumber(trackNumbers, request.trackNumberName, locationTrack)
+        val trackDescriptions = getTrackDescriptions(params, tracksWithAlignments.mapNotNull { it?.first })
+
+        return tracksWithAlignments
+            .mapIndexed { index, trackAndAlignment ->
+                val (request, searchPoint) = requestsWithPoints[index]
+                if (trackAndAlignment == null)
+                    createErrorResponse(request.identifier, FrameConverterErrorV1.FeaturesNotFound)
+                else {
+                    val (track, alignment) = trackAndAlignment
+                    calculateCoordinateToTrackAddressResponse(
+                        searchPoint,
+                        request,
+                        track,
+                        alignment,
+                        trackDescriptions?.get(track.id),
+                        params,
+                        geocodingContexts,
+                    )
                 }
+            }
+            .toList()
+    }
 
+    private fun calculateCoordinateToTrackAddressResponse(
+        searchPoint: IPoint,
+        request: ValidCoordinateToTrackAddressRequestV1,
+        track: LocationTrack,
+        alignment: LayoutAlignment,
+        trackDescription: FreeText?,
+        params: FrameConverterQueryParamsV1,
+        geocodingContexts: Map<IntId<TrackLayoutTrackNumber>, GeocodingContext?>,
+    ): List<GeoJsonFeature> {
         val nearestMatch =
-            findNearestLocationTrack(searchPointInLayoutCoordinates, filteredLocationTracks)
+            findNearestMatch(searchPoint, track, alignment)
                 ?: return createErrorResponse(request.identifier, FrameConverterErrorV1.FeaturesNotFound)
 
         val (trackNumber, geocodedAddress) =
-            geocodingService
-                .getGeocodingContext(
-                    layoutContext = layoutContext,
-                    trackNumberId = nearestMatch.locationTrack.trackNumberId,
-                )
-                .let { geocodingContext ->
-                    geocodingContext?.trackNumber to geocodingContext?.getAddressAndM(searchPointInLayoutCoordinates)
-                }
+            geocodingContexts[track.trackNumberId].let { geocodingContext ->
+                geocodingContext?.trackNumber to geocodingContext?.getAddressAndM(searchPoint)
+            }
 
         return if (trackNumber == null || geocodedAddress == null) {
             createErrorResponse(request.identifier, FrameConverterErrorV1.AddressGeocodingFailed)
         } else {
             createCoordinateToTrackAddressResponse(
-                layoutContext,
                 request,
                 params,
                 nearestMatch,
                 trackNumber,
                 geocodedAddress,
+                trackDescription,
             )
         }
     }
+
+    fun trackAddressesToCoordinates(
+        layoutContext: LayoutContext,
+        requests: List<ValidTrackAddressToCoordinateRequestV1>,
+        params: FrameConverterQueryParamsV1,
+    ) = requests.map { request -> trackAddressToCoordinate(layoutContext, request, params) }
 
     fun trackAddressToCoordinate(
         layoutContext: LayoutContext,
@@ -140,14 +172,16 @@ constructor(
                 }
                 .filter { (_, addressPoint) -> addressPoint != null }
 
+        val trackDescriptions = getTrackDescriptions(params, tracksAndAlignments.map { (track) -> track })
+
         return tracksAndMatchingAddressPoints
             .map { (locationTrack, addressPoint) ->
                 createTrackAddressToCoordinateResponse(
-                    layoutContext,
                     request,
                     params,
                     locationTrack,
                     requireNotNull(addressPoint),
+                    trackDescriptions?.get(locationTrack.id),
                 )
             }
             .ifEmpty { createErrorResponse(request.identifier, FrameConverterErrorV1.FeaturesNotFound) }
@@ -156,7 +190,7 @@ constructor(
     fun validateCoordinateToTrackAddressRequest(
         request: CoordinateToTrackAddressRequestV1,
         params: FrameConverterQueryParamsV1,
-    ): Pair<ValidCoordinateToTrackAddressRequestV1?, List<GeoJsonFeatureErrorResponseV1>> {
+    ): Either<List<GeoJsonFeatureErrorResponseV1>, ValidCoordinateToTrackAddressRequestV1> {
         val allowedSearchRadiusRange = 1.0..1000.0
 
         val errors =
@@ -193,8 +227,8 @@ constructor(
             }
 
         val nonNullErrors = errors.filterNotNull()
-        return if (nonNullErrors.isEmpty()) {
-            val validRequest =
+        return if (nonNullErrors.isEmpty())
+            Right(
                 ValidCoordinateToTrackAddressRequestV1(
                     identifier = request.identifier,
                     searchCoordinate =
@@ -210,19 +244,14 @@ constructor(
                     locationTrackName = locationTrackNameOrNull,
                     locationTrackType = mappedLocationTrackTypeOrNull,
                 )
-
-            validRequest to emptyList()
-        } else {
-            val errorResponse = createErrorResponse(identifier = request.identifier, errors = nonNullErrors)
-
-            null to errorResponse
-        }
+            )
+        else Left(createErrorResponse(identifier = request.identifier, errors = nonNullErrors))
     }
 
     fun validateTrackAddressToCoordinateRequest(
         request: TrackAddressToCoordinateRequestV1,
         params: FrameConverterQueryParamsV1,
-    ): Pair<ValidTrackAddressToCoordinateRequestV1?, List<GeoJsonFeatureErrorResponseV1>> {
+    ): Either<List<GeoJsonFeatureErrorResponseV1>, ValidTrackAddressToCoordinateRequestV1> {
         val errors =
             mutableListOf(
                 produceIf(request.trackNumberName == null) { FrameConverterErrorV1.MissingTrackNumber },
@@ -268,8 +297,8 @@ constructor(
             }
 
         val nonNullErrors = errors.filterNotNull()
-        return if (nonNullErrors.isEmpty()) {
-            val validRequest =
+        return if (nonNullErrors.isEmpty())
+            Right(
                 ValidTrackAddressToCoordinateRequestV1(
                     identifier = request.identifier,
                     trackNumber = requireNotNull(layoutTrackNumberOrNull),
@@ -277,12 +306,8 @@ constructor(
                     locationTrackName = locationTrackNameOrNull,
                     locationTrackType = mappedLocationTrackTypeOrNull,
                 )
-
-            validRequest to emptyList()
-        } else {
-            val errorResponse = createErrorResponse(identifier = request.identifier, errors = nonNullErrors)
-            null to errorResponse
-        }
+            )
+        else Left(createErrorResponse(identifier = request.identifier, errors = nonNullErrors))
     }
 
     fun createErrorResponse(
@@ -307,12 +332,12 @@ constructor(
     }
 
     private fun createCoordinateToTrackAddressResponse(
-        layoutContext: LayoutContext,
         request: ValidCoordinateToTrackAddressRequestV1,
         params: FrameConverterQueryParamsV1,
         nearestMatch: NearestLocationTrackPointMatch,
         trackNumber: TrackNumber,
         geocodedAddress: AddressAndM,
+        locationTrackDescription: FreeText?,
     ): List<CoordinateToTrackAddressResponseV1> {
         val featureGeometry = createFeatureGeometry(params, nearestMatch.closestPointOnTrack)
 
@@ -325,11 +350,10 @@ constructor(
 
         val conversionDetails =
             createDetailedFeatureMatchOrNull(
-                params,
-                layoutContext,
                 nearestMatch.locationTrack,
                 trackNumber,
                 geocodedAddress.address,
+                locationTrackDescription,
             )
 
         return listOf(
@@ -346,11 +370,11 @@ constructor(
     }
 
     private fun createTrackAddressToCoordinateResponse(
-        layoutContext: LayoutContext,
         request: ValidTrackAddressToCoordinateRequestV1,
         params: FrameConverterQueryParamsV1,
         locationTrack: LocationTrack,
         addressPoint: AddressPoint,
+        locationTrackDescription: FreeText?,
     ): TrackAddressToCoordinateResponseV1 {
         val featureGeometry = createFeatureGeometry(params, addressPoint.point)
 
@@ -363,11 +387,10 @@ constructor(
 
         val conversionDetails =
             createDetailedFeatureMatchOrNull(
-                params,
-                layoutContext,
                 locationTrack,
                 request.trackNumber.number,
                 addressPoint.address,
+                locationTrackDescription,
             )
 
         return TrackAddressToCoordinateResponseV1(
@@ -382,20 +405,12 @@ constructor(
     }
 
     private fun createDetailedFeatureMatchOrNull(
-        params: FrameConverterQueryParamsV1,
-        layoutContext: LayoutContext,
         locationTrack: LocationTrack,
         trackNumber: TrackNumber,
         trackMeter: TrackMeter,
+        locationTrackDescription: FreeText?,
     ): FeatureMatchDetailsV1? {
-        return if (params.featureDetails) {
-            val locationTrackDescription =
-                locationTrackService.getFullDescription(
-                    layoutContext = layoutContext,
-                    locationTrack = locationTrack,
-                    LocalizationLanguage.FI,
-                )
-
+        return if (locationTrackDescription != null) {
             val (trackMeterIntegers, trackMeterDecimals) = splitBigDecimal(trackMeter.meters)
             val translatedLocationTrackType = translateLocationTrackType(locationTrack).lowercase()
 
@@ -412,29 +427,50 @@ constructor(
             null
         }
     }
+
+    private fun getSearchPointInLayoutCoordinates(
+        request: ValidCoordinateToTrackAddressRequestV1
+    ): Either<List<GeoJsonFeatureErrorResponseV1>, IPoint> =
+        try {
+            Right(
+                when (request.searchCoordinate.srid) {
+                    LAYOUT_SRID -> request.searchCoordinate
+                    else ->
+                        transformNonKKJCoordinate(request.searchCoordinate.srid, LAYOUT_SRID, request.searchCoordinate)
+                }
+            )
+        } catch (ex: CoordinateTransformationException) {
+            Left(createErrorResponse(request.identifier, FrameConverterErrorV1.InputCoordinateTransformationFailed))
+        }
+
+    private fun getTrackDescriptions(params: FrameConverterQueryParamsV1, locationTracks: List<LocationTrack>) =
+        if (params.featureDetails)
+            locationTracks
+                .distinctBy { it.id }
+                .associate { locationTrack ->
+                    locationTrack.id to
+                        locationTrackService.getFullDescription(
+                            MainLayoutContext.official,
+                            locationTrack,
+                            LocalizationLanguage.FI,
+                        )
+                }
+        else null
 }
 
-private fun findNearestLocationTrack(
+private fun findNearestMatch(
     searchPoint: IPoint,
-    locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
-): NearestLocationTrackPointMatch? {
-    return locationTracks
-        .map { (locationTrack, alignment) ->
-            val closestPointOnTrack = alignment.getClosestPoint(searchPoint)?.first
-
-            closestPointOnTrack?.let {
-                NearestLocationTrackPointMatch(
-                    locationTrack,
-                    alignment,
-                    closestPointOnTrack,
-                    distanceToClosestPoint = lineLength(searchPoint, closestPointOnTrack),
-                )
-            }
-        }
-        .minByOrNull { locationTrackPointMatch ->
-            locationTrackPointMatch?.distanceToClosestPoint ?: Double.POSITIVE_INFINITY
-        }
-}
+    locationTrack: LocationTrack,
+    alignment: LayoutAlignment,
+): NearestLocationTrackPointMatch? =
+    alignment.getClosestPoint(searchPoint)?.first?.let { closestPointOnTrack ->
+        NearestLocationTrackPointMatch(
+            locationTrack,
+            alignment,
+            closestPointOnTrack,
+            distanceToClosestPoint = lineLength(searchPoint, closestPointOnTrack),
+        )
+    }
 
 private fun createFeatureGeometry(params: FrameConverterQueryParamsV1, point: AlignmentPoint): GeoJsonGeometryPoint {
     return if (params.featureGeometry) {
@@ -469,18 +505,6 @@ private fun filterByLocationTrackType(locationTrackType: LocationTrackType?, loc
         true
     } else {
         locationTrackType == locationTrack.type
-    }
-}
-
-private fun filterByTrackNumber(
-    trackNumbers: Map<IntId<TrackLayoutTrackNumber>, TrackLayoutTrackNumber>,
-    requestTrackNumber: TrackNumber?,
-    locationTrack: LocationTrack,
-): Boolean {
-    return if (requestTrackNumber == null) {
-        true
-    } else {
-        requestTrackNumber == trackNumbers[locationTrack.trackNumberId]?.number
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Either.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Either.kt
@@ -1,0 +1,89 @@
+package fi.fta.geoviite.infra.util
+
+sealed class Either<out L, out R> {
+
+    abstract fun <T> fold(processLeft: (left: L) -> T, processRight: (right: R) -> T): T
+
+    abstract fun <LR, RR> map(processLeft: (left: L) -> LR, processRight: (right: R) -> RR): Either<LR, RR>
+
+    abstract fun <LR> mapLeft(processLeft: (left: L) -> LR): Either<LR, R>
+
+    abstract fun <RR> mapRight(processRight: (right: R) -> RR): Either<L, RR>
+}
+
+data class Left<L>(val value: L) : Either<L, Nothing>() {
+
+    override fun <T> fold(processLeft: (left: L) -> T, processRight: (right: Nothing) -> T): T = processLeft(value)
+
+    override fun <LR, RR> map(processLeft: (left: L) -> LR, processRight: (right: Nothing) -> RR): Either<LR, RR> =
+        Left(processLeft(value))
+
+    override fun <LR> mapLeft(processLeft: (left: L) -> LR): Either<LR, Nothing> = Left(processLeft(value))
+
+    override fun <RR> mapRight(processRight: (right: Nothing) -> RR): Either<L, RR> = this
+}
+
+data class Right<R>(val value: R) : Either<Nothing, R>() {
+
+    override fun <T> fold(processLeft: (left: Nothing) -> T, processRight: (right: R) -> T): T = processRight(value)
+
+    override fun <LR, RR> map(processLeft: (left: Nothing) -> LR, processRight: (right: R) -> RR): Either<LR, RR> =
+        Right(processRight(value))
+
+    override fun <LR> mapLeft(processLeft: (left: Nothing) -> LR): Either<LR, R> = this
+
+    override fun <RR> mapRight(processRight: (right: R) -> RR): Either<Nothing, RR> = Right(processRight(value))
+}
+
+/**
+ * Process a list of values partitioned into two lists. processLefts and processRights must both return a list of the
+ * same length as they're passed in: If they logically map their inputs to outputs element by element in the order they
+ * were passed in, then so does this function.
+ */
+fun <T, LeftValue, RightValue, Result> processPartitioned(
+    values: List<T>,
+    extractSide: (value: T) -> Either<LeftValue, RightValue>,
+    processLefts: (lefts: List<LeftValue>) -> List<Result>,
+    processRights: (rights: List<RightValue>) -> List<Result>,
+): List<Result> {
+    val extractedSidesLeft = mutableListOf<Boolean>()
+    val lefts = mutableListOf<LeftValue>()
+    val rights = mutableListOf<RightValue>()
+    values.forEach { value ->
+        extractSide(value)
+            .fold(
+                {
+                    lefts.add(it)
+                    extractedSidesLeft.add(true)
+                },
+                {
+                    rights.add(it)
+                    extractedSidesLeft.add(false)
+                },
+            )
+    }
+    val leftResults = processLefts(lefts)
+    val rightResults = processRights(rights)
+    assert(lefts.size == leftResults.size) {
+        "expected ${lefts.size} results from processLefts, but got ${leftResults.size}"
+    }
+    assert(rights.size == rightResults.size) {
+        "expected ${rights.size} results from processLefts, but got ${rightResults.size}"
+    }
+    var leftIndex = 0
+    var rightIndex = 0
+    return extractedSidesLeft.map { sideIsLeft ->
+        if (sideIsLeft) leftResults[leftIndex++] else rightResults[rightIndex++]
+    }
+}
+
+/**
+ * Call extractSide to partition the values into Left and Right ones, then return the Lefts as is, while calling process
+ * on the Rights. process must return a list of the same length as it was passed in, and if it logically maps its inputs
+ * to outputs element by element in the order they were passed in, so does this function.
+ */
+fun <T, ValidInput, ErrorOrProcessedResult> processValidated(
+    values: List<T>,
+    extractSide: (value: T) -> Either<ErrorOrProcessedResult, ValidInput>,
+    process: (input: List<ValidInput>) -> List<ErrorOrProcessedResult>,
+): List<ErrorOrProcessedResult> = processPartitioned(values, extractSide, { it }, process)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/EitherTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/EitherTest.kt
@@ -1,0 +1,19 @@
+package fi.fta.geoviite.infra.util
+
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class EitherTest {
+    @Test
+    fun `processPartitioned retains original order`() {
+        assertEquals(
+            listOf(1, 3, 3, 5, 5, 7),
+            processPartitioned(
+                (0..5).toList(),
+                { n -> if (n % 2 == 0) Left(n) else Right(n) },
+                { ns -> ns.map { n -> n + 1 } },
+                { ns -> ns.map { n -> n + 2 } },
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Kolme oleellista muutosta:

- FrameConverterServicessä on montakin paikkaa missä saattoi joko mennä kaikki hyvin tai sitten tulla virhettä, ja molemmista halutaan jonkinlaisen käsittelyn jälkeen palautusarvoon tieto; ja osassa vielä niin, että hyvin menneet tapaukset halutaan käsitellä massana. Nämä sopivat luonnostaan Either-tyypin muottiin sen verran hyvin, että ajattelin että tehdään nyt lopulta sellainen. Mutta ehkä pitäisi käyttää kirjastoa eikä omaa, jotta käytetään standardimpeja käsitteitä?
- Koko raideosuman haku tehdään nyt kannassa massana. Periaatteessa postgissillä saisi tehtyä nekin käsittelyt, että palauttaa sen lähimmän pisteenkin, mutta päädyin siihen, että tehdään se Kotlinissa, koska se on siellä halpaa tehdä uusiksi (sitä ei juuri profiileissa näy), ja näin vastaukset ei sitten niin helpolla muutu, jos tulevaisuudessa toteutuksesta siirretään lisää Kotlinin puolelle.
- Geokoodauskontekstien ja raiteiden koko nimien haut tehdään nyt vain eri ratanumeroille ja raiteille, ei monta kertaa samoille.