### PR TITLE
GVT-2826: Escape new lines in publication log csv export

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -78,7 +78,7 @@ fun asCsvFile(items: List<PublicationTableItem>, timeZone: ZoneId, translation: 
                 "publication-table.operation" to { formatOperation(translation, it.operation) },
                 "publication-table.publication-time" to { formatInstant(it.publicationTime, timeZone) },
                 "publication-table.publication-user" to { "${it.publicationUser}" },
-                "publication-table.message" to { it.message },
+                "publication-table.message" to { it.message.escapeNewLines() },
                 "publication-table.pushed-to-ratko" to
                     {
                         it.ratkoPushTime?.let { pushTime -> formatInstant(pushTime, timeZone) } ?: translation.t("no")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/FreeText.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/FreeText.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
 
+private const val NEW_LINE_CHARACTER = "\n"
+
 data class FreeText @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
     Comparable<FreeText>, CharSequence by value {
 
@@ -30,7 +32,9 @@ data class FreeTextWithNewLines private constructor(private val value: String) :
     Comparable<FreeTextWithNewLines>, CharSequence by value {
 
     companion object {
-        const val ALLOWED_CHARACTERS = FreeText.ALLOWED_CHARACTERS + "\n"
+        const val ALLOWED_CHARACTERS = FreeText.ALLOWED_CHARACTERS + NEW_LINE_CHARACTER
+        const val ESCAPED_NEW_LINE = "\\n"
+
         val sanitizer = StringSanitizer(FreeTextWithNewLines::class, ALLOWED_CHARACTERS)
 
         @JvmStatic @JsonCreator fun of(value: String) = FreeTextWithNewLines(normalizeLinebreaksToUnixFormat(value))
@@ -45,4 +49,8 @@ data class FreeTextWithNewLines private constructor(private val value: String) :
     override fun compareTo(other: FreeTextWithNewLines): Int = value.compareTo(other.value)
 
     operator fun plus(addition: String) = FreeTextWithNewLines("$value$addition")
+
+    fun escapeNewLines(): FreeText {
+        return FreeText(UnsafeString(value.replace(NEW_LINE_CHARACTER, ESCAPED_NEW_LINE)))
+    }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/SanitizedStringTest.kt
@@ -59,6 +59,12 @@ class SanitizedStringTest {
     }
 
     @Test
+    fun `Escaping new lines from FreeTextWithNewLines produces escaped output`() {
+        val escapedNewLines = FreeTextWithNewLines.of("\nSome\n\nthing \n").escapeNewLines()
+        assertEquals("\\nSome\\n\\nthing \\n", escapedNewLines.toString())
+    }
+
+    @Test
     fun `StringSanitizer allows only legal characters`() {
         val legalCharacters = "ABCFÖ1-3_"
         val legalLength = 1..10


### PR DESCRIPTION
Previously the exported csv had new lines in unexpected places, making the csv more difficult to use.