### PR TITLE
General: Remove unnecessary and empty integration test file

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/MixedRequestIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/MixedRequestIT.kt
@@ -1,7 +1,0 @@
-package fi.fta.geoviite.api.frameconverter.v1
-
-class MixedRequestIT {
-    // TODO Create tests for cases where multiple different types of requests are sent at the same
-    // time
-    // At least: All requests that succeed, all requests that fail, and only some that fail
-}


### PR DESCRIPTION
Mixed frameconverter requests are no longer supported, so these tests won't have to be created.