### PR TITLE
GVT-2711 Make pre-caching more configurable + pre-cache geocoding contexts

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
@@ -2,7 +2,6 @@ package fi.fta.geoviite.infra.configuration
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
-import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -13,6 +12,7 @@ import org.springframework.cache.caffeine.CaffeineCacheManager
 import org.springframework.cache.support.NoOpCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.time.Duration
 
 const val CACHE_GEOMETRY_PLAN = "geometry-plan"
 const val CACHE_GEOMETRY_SWITCH = "geometry-switch"
@@ -57,7 +57,7 @@ constructor(@Value("\${geoviite.cache.enabled}") private val cacheEnabled: Boole
             manager.registerCustomCache(CACHE_FEATURE_TYPES, cache(1, staticDataCacheDuration))
             manager.registerCustomCache(CACHE_KKJ_TM35FIN_TRIANGULATION_NETWORK, cache(2, staticDataCacheDuration))
 
-            manager.registerCustomCache(CACHE_GEOCODING_CONTEXTS, cache(500, layoutCacheDuration))
+            manager.registerCustomCache(CACHE_GEOCODING_CONTEXTS, cache(1000, layoutCacheDuration))
 
             manager.registerCustomCache(CACHE_GEOMETRY_PLAN, cache(100, planCacheDuration))
             manager.registerCustomCache(CACHE_GEOMETRY_SWITCH, cache(10000, planCacheDuration))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadScheduler.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadScheduler.kt
@@ -1,6 +1,9 @@
 package fi.fta.geoviite.infra.configuration
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -11,7 +14,14 @@ import org.springframework.stereotype.Component
     havingValue = "true",
     matchIfMissing = false,
 )
-class CachePreloadScheduler @Autowired constructor(private val cachePreloadService: CachePreloadService) {
+class CachePreloadScheduler
+@Autowired
+constructor(
+    @Value("\${geoviite.cache.tasks.preload.geocoding-contexts}") private val preloadGeocodingContexts: Boolean,
+    @Value("\${geoviite.cache.tasks.preload.plan-headers}") private val preloadPlanHeaders: Boolean,
+    private val cachePreloadService: CachePreloadService,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     companion object {
         const val CONFIG_INITIAL_DELAY = "\${geoviite.cache.tasks.preload.initial-delay}"
@@ -19,17 +29,17 @@ class CachePreloadScheduler @Autowired constructor(private val cachePreloadServi
     }
 
     @Scheduled(initialDelayString = CONFIG_INITIAL_DELAY, fixedDelayString = CONFIG_INTERVAL)
-    private fun scheduleLayoutAssetReload() {
-        cachePreloadService.loadLayoutCache()
-    }
-
-    @Scheduled(initialDelayString = CONFIG_INITIAL_DELAY, fixedDelayString = CONFIG_INTERVAL)
-    private fun schedulePlanHeaderReload() {
-        cachePreloadService.loadPlanHeaderCache()
-    }
-
-    @Scheduled(initialDelayString = CONFIG_INITIAL_DELAY, fixedDelayString = CONFIG_INTERVAL)
-    private fun scheduleAlignmentReload() {
-        cachePreloadService.loadAlignmentCache()
+    private fun scheduleReload() {
+        val startTime = System.currentTimeMillis()
+        logger.info("Preloading caches: geocodingContexts=$preloadGeocodingContexts planHeaders=$preloadPlanHeaders")
+        listOf(
+                { cachePreloadService.loadAlignmentCache() },
+                { cachePreloadService.loadLayoutCache() },
+                { if (preloadPlanHeaders) cachePreloadService.loadPlanHeaderCache() },
+            )
+            .parallelStream()
+            .forEach { preload -> preload() }
+        if (preloadGeocodingContexts) cachePreloadService.loadGeocodingContextCache()
+        logger.info("Preloading caches done: duration=${System.currentTimeMillis() - startTime}ms")
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadService.kt
@@ -1,8 +1,19 @@
 package fi.fta.geoviite.infra.configuration
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.common.MainLayoutContext
+import fi.fta.geoviite.infra.geocoding.GeocodingCacheService
+import fi.fta.geoviite.infra.geocoding.GeocodingContext
+import fi.fta.geoviite.infra.geocoding.GeocodingDao
 import fi.fta.geoviite.infra.geometry.GeometryDao
-import fi.fta.geoviite.infra.tracklayout.*
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutAsset
+import fi.fta.geoviite.infra.tracklayout.LayoutAssetDao
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import java.time.Duration
 import java.time.Instant
 import org.slf4j.Logger
@@ -17,6 +28,8 @@ class CachePreloadService(
     private val locationTrackDao: LocationTrackDao,
     private val alignmentDao: LayoutAlignmentDao,
     private val geometryDao: GeometryDao,
+    private val geocodingCacheService: GeocodingCacheService,
+    private val geocodingDao: GeocodingDao,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -35,13 +48,26 @@ class CachePreloadService(
         refreshCache("Alignment", alignmentDao::preloadAlignmentCache)
     }
 
+    fun loadGeocodingContextCache() {
+        refreshCache("GeocodingContext") {
+            val contexts =
+                geocodingDao
+                    .listLayoutGeocodingContextCacheKeys(MainLayoutContext.official)
+                    .mapNotNull(geocodingCacheService::getGeocodingContext)
+            contexts.parallelStream().forEach(GeocodingContext::preload)
+            contexts.size
+        }
+    }
+
     private fun <T : LayoutAsset<T>> refreshCache(dao: LayoutAssetDao<T>) =
         refreshCache(dao.table.name, dao::preloadCache)
 
-    private fun refreshCache(name: String, refresh: () -> Unit) {
+    private fun refreshCache(name: String, refresh: () -> Int) {
         logger.info("Refreshing cache: name=$name")
         val start = Instant.now()
-        refresh()
-        logger.info("Cache refreshed: name=$name duration=${Duration.between(start, Instant.now()).toMillis()}ms")
+        val rowCount = refresh()
+        logger.info(
+            "Cache refreshed: name=$name rows=$rowCount duration=${Duration.between(start, Instant.now()).toMillis()}ms"
+        )
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -32,12 +32,12 @@ import fi.fta.geoviite.infra.tracklayout.LAYOUT_M_DELTA
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.SegmentPoint
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.math.PI
 import kotlin.math.abs
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 data class AddressPoint(val point: AlignmentPoint, val address: TrackMeter) {
     fun isSame(other: AddressPoint) = address.isSame(other.address) && point.isSame(other.point)
@@ -191,6 +191,15 @@ data class GeocodingContext(
             val projectionLine = polyLineEdges.last().crossSectionAt(referenceLineGeometry.length)
             ProjectionLine(address, projectionLine, referenceLineGeometry.length)
         }
+    }
+
+    fun preload() {
+        // Preload the lazy properties
+        polyLineEdges
+        startProjection
+        endProjection
+        projectionLines
+        allKms
     }
 
     fun getProjectionLine(address: TrackMeter): ProjectionLine? {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -672,7 +672,7 @@ constructor(
         } ?: throw IllegalStateException("Failed to get generated ID for new alignment")
     }
 
-    fun preloadHeaderCache() {
+    fun preloadHeaderCache(): Int {
         val sql =
             """
           select 
@@ -721,6 +721,7 @@ constructor(
                 .associateBy(GeometryPlanHeader::version)
         logger.daoAccess(FETCH, GeometryPlanHeader::class, headers.keys)
         headerCache.putAll(headers)
+        return headers.size
     }
 
     fun getPlanHeader(planId: IntId<GeometryPlan>) = getPlanHeader(fetchPlanVersion(planId))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -78,7 +78,7 @@ class LayoutAlignmentDao(
             .also { alignment -> logger.daoAccess(AccessType.FETCH, LayoutAlignment::class, alignment.id) }
     }
 
-    fun preloadAlignmentCache() {
+    fun preloadAlignmentCache(): Int {
         val sql =
             """
           select 
@@ -104,7 +104,7 @@ class LayoutAlignmentDao(
         data class AlignmentData(val version: RowVersion<LayoutAlignment>)
 
         val dataTriple =
-            jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
+            jdbcTemplate.query(sql) { rs, _ ->
                 val alignmentData = AlignmentData(version = rs.getRowVersion("alignment_id", "alignment_version"))
                 val segmentData =
                     SegmentData(
@@ -131,6 +131,7 @@ class LayoutAlignmentDao(
                 .collect(Collectors.toList())
                 .associate { it }
         alignmentsCache.putAll(alignments)
+        return alignments.size
     }
 
     @Transactional
@@ -739,7 +740,7 @@ class LayoutAlignmentDao(
         } else mapOf()
     }
 
-    fun preloadSegmentGeometries() {
+    fun preloadSegmentGeometries(): Int {
         val sql =
             """
           select 
@@ -763,7 +764,7 @@ class LayoutAlignmentDao(
                 .trimIndent()
 
         val rowResults =
-            jdbcTemplate.query(sql, mapOf<String, Any>()) { rs, _ ->
+            jdbcTemplate.query(sql) { rs, _ ->
                 GeometryRowResult(
                     id = rs.getIntId("id"),
                     wktString = rs.getString("geometry_wkt"),
@@ -773,6 +774,7 @@ class LayoutAlignmentDao(
                 )
             }
         segmentGeometryCache.putAll(parseGeometries(rowResults))
+        return rowResults.size
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -116,7 +116,7 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
 
     protected abstract fun fetchInternal(version: LayoutRowVersion<T>): T
 
-    abstract fun preloadCache()
+    abstract fun preloadCache(): Int
 
     private val allCandidateVersionsSql =
         """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -22,11 +22,11 @@ import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
 import fi.fta.geoviite.infra.util.toDbId
-import java.sql.ResultSet
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.sql.ResultSet
 
 const val KM_POST_CACHE_SIZE = 10000L
 
@@ -189,7 +189,7 @@ class LayoutKmPostDao(
         }
     }
 
-    override fun preloadCache() {
+    override fun preloadCache(): Int {
         val sql =
             """
             select 
@@ -212,12 +212,10 @@ class LayoutKmPostDao(
         """
                 .trimIndent()
 
-        val posts =
-            jdbcTemplate
-                .query(sql, mapOf<String, Any>()) { rs, _ -> getLayoutKmPost(rs) }
-                .associateBy(TrackLayoutKmPost::version)
+        val posts = jdbcTemplate.query(sql) { rs, _ -> getLayoutKmPost(rs) }.associateBy(TrackLayoutKmPost::version)
         logger.daoAccess(AccessType.FETCH, TrackLayoutKmPost::class, posts.keys)
         cache.putAll(posts)
+        return posts.size
     }
 
     private fun getLayoutKmPost(rs: ResultSet): TrackLayoutKmPost =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -356,7 +356,7 @@ class LayoutSwitchDao(
         }
     }
 
-    override fun preloadCache() {
+    override fun preloadCache(): Int {
         val sql =
             """
             select 
@@ -385,12 +385,10 @@ class LayoutSwitchDao(
         """
                 .trimIndent()
 
-        val switches =
-            jdbcTemplate
-                .query(sql, mapOf<String, Any>()) { rs, _ -> getLayoutSwitch(rs) }
-                .associateBy(TrackLayoutSwitch::version)
+        val switches = jdbcTemplate.query(sql) { rs, _ -> getLayoutSwitch(rs) }.associateBy(TrackLayoutSwitch::version)
         logger.daoAccess(FETCH, TrackLayoutSwitch::class, switches.keys)
         cache.putAll(switches)
+        return switches.size
     }
 
     private fun getLayoutSwitch(rs: ResultSet): TrackLayoutSwitch {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -97,7 +97,7 @@ class LayoutTrackNumberDao(
         }
     }
 
-    override fun preloadCache() {
+    override fun preloadCache(): Int {
         val sql =
             """
             -- Draft vs Official reference line might duplicate the row, but results will be the same. Just pick one.
@@ -119,11 +119,10 @@ class LayoutTrackNumberDao(
         """
                 .trimIndent()
         val trackNumbers =
-            jdbcTemplate
-                .query(sql, mapOf<String, Any>()) { rs, _ -> getLayoutTrackNumber(rs) }
-                .associateBy(TrackLayoutTrackNumber::version)
+            jdbcTemplate.query(sql) { rs, _ -> getLayoutTrackNumber(rs) }.associateBy(TrackLayoutTrackNumber::version)
         logger.daoAccess(AccessType.FETCH, TrackLayoutTrackNumber::class, trackNumbers.keys)
         cache.putAll(trackNumbers)
+        return trackNumbers.size
     }
 
     private fun getLayoutTrackNumber(rs: ResultSet): TrackLayoutTrackNumber =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -156,7 +156,7 @@ class LocationTrackDao(
         }
     }
 
-    override fun preloadCache() {
+    override fun preloadCache(): Int {
         val sql =
             """
             select 
@@ -198,12 +198,10 @@ class LocationTrackDao(
         """
                 .trimIndent()
 
-        val tracks =
-            jdbcTemplate
-                .query(sql, mapOf<String, Any>()) { rs, _ -> getLocationTrack(rs) }
-                .associateBy(LocationTrack::version)
+        val tracks = jdbcTemplate.query(sql) { rs, _ -> getLocationTrack(rs) }.associateBy(LocationTrack::version)
         logger.daoAccess(AccessType.FETCH, LocationTrack::class, tracks.keys)
         cache.putAll(tracks)
+        return tracks.size
     }
 
     private fun getLocationTrack(rs: ResultSet): LocationTrack =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -15,11 +15,11 @@ import fi.fta.geoviite.infra.util.getRowVersion
 import fi.fta.geoviite.infra.util.getTrackMeter
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
-import java.sql.ResultSet
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.sql.ResultSet
 
 const val REFERENCE_LINE_CACHE_SIZE = 1000L
 
@@ -66,7 +66,7 @@ class ReferenceLineDao(
         }
     }
 
-    override fun preloadCache() {
+    override fun preloadCache(): Int {
         val sql =
             """
             select
@@ -89,11 +89,10 @@ class ReferenceLineDao(
                 .trimIndent()
 
         val referenceLines =
-            jdbcTemplate
-                .query(sql, mapOf<String, Any>()) { rs, _ -> getReferenceLine(rs) }
-                .associateBy(ReferenceLine::version)
+            jdbcTemplate.query(sql) { rs, _ -> getReferenceLine(rs) }.associateBy(ReferenceLine::version)
         logger.daoAccess(AccessType.FETCH, ReferenceLine::class, referenceLines.keys)
         cache.putAll(referenceLines)
+        return referenceLines.size
     }
 
     private fun getReferenceLine(rs: ResultSet): ReferenceLine =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/NamedParameterJdbcTemplateExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/NamedParameterJdbcTemplateExternal.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.authorization.UserName
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import java.sql.ResultSet
 import org.springframework.jdbc.core.ParameterizedPreparedStatementSetter
+import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 
 inline fun <reified T> NamedParameterJdbcTemplate.queryNotNull(
@@ -48,3 +49,6 @@ fun <T> NamedParameterJdbcTemplate.batchUpdate(
     items: List<T>,
     paramSetter: ParameterizedPreparedStatementSetter<T>,
 ): Array<IntArray> = jdbcTemplate.batchUpdate(sql, items, items.size, paramSetter)
+
+fun <T> NamedParameterJdbcTemplate.query(sql: String, rowMapper: RowMapper<T>) =
+    query(sql, emptyMap<String, Any>(), rowMapper)

--- a/infra/src/main/resources/application-ext-api.yml
+++ b/infra/src/main/resources/application-ext-api.yml
@@ -7,6 +7,8 @@ geoviite:
     tasks:
       preload:
         enabled: true
+        geocoding-contexts: true
+        plan-headers: false
 
   data:
     import: false

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -53,6 +53,8 @@ geoviite:
     enabled: true
     tasks:
       preload:
+        geocoding-contexts: false
+        plan-headers: true
         enabled: true
         initial-delay: PT1S
         interval: PT45M


### PR DESCRIPTION
Testailin samalla myös vain official-main cachetusta jne, mutta ei niissä ole järkeä sillä konffaus lisää monimutkaisuutta ja hyöty jää olemattomaksi koska valtaosa datast on joka tapauksessa official-main. Tässä siis vain vähän lisää konfiguroitavuutta siihen mitä kakkuja esilämmitetään (planHeaders, geocodingContexts), tuo geokoodauskontekstien esilämmitys yleensä ottaen ja vähän detaljimpaa logitusta preloadista.