### PR TITLE
GVT-2824: GK-kaistan automaattinen valinta KM-pylvään linkityksessä ja linkityksen purku muutettaessa sijaintia käsin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationService.kt
@@ -43,15 +43,17 @@ constructor(private val kkjTm35FinTriangulationDao: KkjTm35finTriangulationDao) 
         getTransformation(sourceSrid, targetSrid).transform(point)
 
     fun getTransformationToGkFin(sourceSrid: Srid): ToGkFinTransformation {
-        if (isGkFinSrid(sourceSrid)) {
-            return ToGkFinTransformation { point: Point -> GeometryPoint(point, sourceSrid) }
-        }
         val toLayout = getTransformation(sourceSrid, LAYOUT_SRID)
         return ToGkFinTransformation { point: Point ->
             val layoutCoord = toLayout.transform(point)
             val etrs89Coord = transformNonKKJCoordinate(LAYOUT_SRID, ETRS89_SRID, layoutCoord)
             val gkSrid = getFinnishGKCoordinateProjectionByLongitude(etrs89Coord.x)
-            GeometryPoint(transformNonKKJCoordinate(LAYOUT_SRID, gkSrid, layoutCoord), gkSrid)
+
+            if (gkSrid == sourceSrid) {
+                GeometryPoint(point, sourceSrid)
+            } else {
+                GeometryPoint(transformNonKKJCoordinate(LAYOUT_SRID, gkSrid, layoutCoord), gkSrid)
+            }
         }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
@@ -171,6 +171,7 @@ data class TrackLayoutKmPostSaveRequest(
     val gkLocationConfirmed: Boolean,
     val gkLocationSource: KmPostGkLocationSource?,
     val gkLocation: GeometryPoint?,
+    val sourceId: IntId<GeometryKmPost>?,
 ) {
     init {
         gkLocation?.let { location ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -50,6 +50,7 @@ class LayoutKmPostService(
                     gkLocationConfirmed = kmPost.gkLocationConfirmed,
                     gkLocationSource = kmPost.gkLocationSource,
                     gkLocation = kmPost.gkLocation,
+                    sourceId = kmPost.sourceId,
                 )
         return saveDraftInternal(branch, trackLayoutKmPost).id
     }

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1798,8 +1798,7 @@
             "location-in-layout": "Sijainti paikannuspohjassa (TM35FIN)",
             "out-of-bounds": "Sijainti ei ole laskettavissa",
             "location-converted": "Sijainti muunnettu koordinaatistosta {{originalCrs}}",
-            "original-crs": "Alkuperäinen koordinaatisto {{originalCrs}}",
-            "original-location": "Sijainti alkuperäisessä koordinaatistossa {{originalE}} E {{originalN}} N"
+            "original-crs": "Alkuperäinen koordinaatisto {{originalCrs}}"
         }
     },
     "km-post-delete-dialog": {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -486,7 +486,8 @@
                 "change-info-heading": "Lokitiedot",
                 "no-kilometer-length": "Pituutta ei voida laskea",
                 "negative-kilometer-length": "Virheellinen sijainti",
-                "no-location": "Ei sijaintia"
+                "no-location": "Ei sijaintia",
+                "plan-crs": "Lähdekoordinaatisto"
             },
             "geometry": {
                 "general-title": "Raidegeometria: Tasakilometripiste",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1795,7 +1795,10 @@
             "source-manual": "Operaattorin asettama",
             "source-none": "-",
             "location-in-layout": "Sijainti paikannuspohjassa (TM35FIN)",
-            "out-of-bounds": "Sijainti ei ole laskettavissa"
+            "out-of-bounds": "Sijainti ei ole laskettavissa",
+            "location-converted": "Sijainti muunnettu koordinaatistosta {{originalCrs}}",
+            "original-crs": "Alkuperäinen koordinaatisto {{originalCrs}}",
+            "original-location": "Sijainti alkuperäisessä koordinaatistossa {{originalE}} E {{originalN}} N"
         }
     },
     "km-post-delete-dialog": {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1678,6 +1678,7 @@ constructor(
                         gkLocation = null,
                         gkLocationSource = null,
                         gkLocationConfirmed = false,
+                        sourceId = null,
                     ),
                 ),
             )
@@ -1699,6 +1700,7 @@ constructor(
                         gkLocation = null,
                         gkLocationSource = null,
                         gkLocationConfirmed = false,
+                        sourceId = null,
                     ),
                 ),
             )
@@ -1768,6 +1770,7 @@ constructor(
                 gkLocation = null,
                 gkLocationSource = null,
                 gkLocationConfirmed = false,
+                sourceId = null,
             )
 
         val kmPost =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -168,6 +168,7 @@ constructor(
                 gkLocation = null,
                 gkLocationSource = null,
                 gkLocationConfirmed = false,
+                sourceId = null,
             )
         val kmPostId = kmPostService.insertKmPost(LayoutBranch.main, kmPost)
 

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -173,6 +173,7 @@ export type KmPostSimpleFields = {
 export type KmPostSaveRequest = KmPostSimpleFields & {
     gkLocation: GeometryPoint | undefined;
     gkLocationSource: GkLocationSource | undefined;
+    sourceId: GeometryKmPostId | undefined;
 };
 
 export type KmPostEditFields = KmPostSimpleFields & {

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
@@ -28,13 +28,15 @@ import proj4 from 'proj4';
 
 // GK-FIN coordinate systems currently only used for the live display of layout coordinates when editing km post
 // positions manually
-const GK_FIN_COORDINATE_SYSTEMS: [Srid, string][] = [...Array(12)].map((_, meridianIndex) => {
-    const meridian = 19 + meridianIndex;
-    const falseNorthing = meridian * 1e6 + 0.5e6;
-    const srid = `EPSG:${3873 + meridianIndex}`;
-    const projection = `+proj=tmerc +lat_0=0 +lon_0=${meridian} +k=1 +x_0=${falseNorthing} +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs`;
-    return [srid, projection];
-});
+export const GK_FIN_COORDINATE_SYSTEMS: [Srid, string][] = [...Array(12)].map(
+    (_, meridianIndex) => {
+        const meridian = 19 + meridianIndex;
+        const falseNorthing = meridian * 1e6 + 0.5e6;
+        const srid = `EPSG:${3873 + meridianIndex}`;
+        const projection = `+proj=tmerc +lat_0=0 +lon_0=${meridian} +k=1 +x_0=${falseNorthing} +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs`;
+        return [srid, projection];
+    },
+);
 
 type KmPostEditDialogGkLocationSectionProps = {
     state: KmPostEditState;

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
@@ -15,7 +15,6 @@ import { KmPostEditFields } from 'linking/linking-model';
 import { useCoordinateSystem, useCoordinateSystems } from 'track-layout/track-layout-react-utils';
 import { GkLocationSource, LAYOUT_SRID } from 'track-layout/track-layout-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
-import proj4 from 'proj4';
 import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
 import { GeometryPoint, Point } from 'model/geometry';
 import styles from 'tool-panel/km-post/dialog/km-post-edit-dialog.scss';
@@ -23,6 +22,9 @@ import { Srid } from 'common/common-model';
 import { parseFloatOrUndefined } from 'utils/string-utils';
 import { KmPostEditDialogRole } from 'tool-panel/km-post/dialog/km-post-edit-dialog';
 import { Switch } from 'vayla-design-lib/switch/switch';
+import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { createClassName } from 'vayla-design-lib/utils';
+import proj4 from 'proj4';
 
 // GK-FIN coordinate systems currently only used for the live display of layout coordinates when editing km post
 // positions manually
@@ -45,6 +47,7 @@ type KmPostEditDialogGkLocationSectionProps = {
     getVisibleErrorsByProp: (prop: keyof KmPostEditFields) => string[];
     geometryKmPostGkLocation?: GeometryPoint;
     role: KmPostEditDialogRole;
+    geometryPlanSrid?: Srid;
 };
 
 function gkLocationSourceI18nKey(source: GkLocationSource) {
@@ -109,6 +112,46 @@ const gkLocationSourceTranslationKey = (
     }
 };
 
+const TransformedFromNonGkWarning: React.FC<{ originalSrid: Srid }> = ({ originalSrid }) => {
+    const { t } = useTranslation();
+
+    const originalCoordinateSystem = useCoordinateSystem(originalSrid);
+
+    const className = createClassName(
+        styles['km-post-edit-dialog__crs-transform-notice'],
+        styles['km-post-edit-dialog__crs-transform-notice--warning'],
+    );
+
+    return (
+        <span className={className}>
+            {t('km-post-dialog.gk-location.location-converted', {
+                originalCrs: originalCoordinateSystem
+                    ? formatWithSrid(originalCoordinateSystem)
+                    : '',
+            })}
+            <Icons.StatusError size={IconSize.SMALL} color={IconColor.INHERIT} />
+        </span>
+    );
+};
+
+const TransformedGkWarning: React.FC<{ originalSrid: Srid }> = ({ originalSrid }) => {
+    const { t } = useTranslation();
+
+    const originalCoordinateSystem = useCoordinateSystem(originalSrid);
+
+    return (
+        <span className={styles['km-post-edit-dialog__crs-transform-notice']}>
+            {t('km-post-dialog.gk-location.location-converted', {
+                originalCrs: originalCoordinateSystem
+                    ? formatWithSrid(originalCoordinateSystem)
+                    : '',
+            })}
+
+            <Icons.Info size={IconSize.SMALL} color={IconColor.INHERIT} />
+        </span>
+    );
+};
+
 export const KmPostEditDialogGkLocationSection: React.FC<
     KmPostEditDialogGkLocationSectionProps
 > = ({
@@ -119,20 +162,26 @@ export const KmPostEditDialogGkLocationSection: React.FC<
     getVisibleErrorsByProp,
     geometryKmPostGkLocation,
     role,
+    geometryPlanSrid,
 }) => {
     const { t } = useTranslation();
+    const isLinking = role === 'LINKING';
 
     const kmPost = state.kmPost;
-    const gkLocation =
-        role === 'LINKING'
-            ? geometryKmPostGkLocation
-            : parseGk(kmPost.gkSrid, kmPost.gkLocationX, kmPost.gkLocationY);
+    const gkLocation = parseGk(kmPost.gkSrid, kmPost.gkLocationX, kmPost.gkLocationY);
     const layoutLocation = gkLocation ? transformGkToLayout(gkLocation) : undefined;
     const gkLocationEnabled = state.gkLocationEnabled;
-    const fieldsEnabled = role !== 'LINKING' && gkLocationEnabled;
+    const fieldsEnabled = !isLinking && gkLocationEnabled;
     const gkLocationEntered = geometryKmPostGkLocation !== undefined || layoutLocation != undefined;
 
     const coordinateSystems = useCoordinateSystems(GK_FIN_COORDINATE_SYSTEMS.map(([srid]) => srid));
+    const isFromNonGkPlan =
+        geometryPlanSrid !== undefined &&
+        !GK_FIN_COORDINATE_SYSTEMS.find(([srid]) => srid === geometryPlanSrid);
+    const isFromDifferentGk =
+        geometryPlanSrid !== undefined &&
+        geometryPlanSrid !== state.kmPost.gkSrid &&
+        !!GK_FIN_COORDINATE_SYSTEMS.find(([srid]) => srid === geometryPlanSrid);
 
     const layoutLocationString = () => {
         if (gkLocationEnabled && layoutLocation) {
@@ -182,12 +231,21 @@ export const KmPostEditDialogGkLocationSection: React.FC<
             <FieldLayout
                 label={`${t('km-post-dialog.gk-location.location-field')} *`}
                 disabled={!fieldsEnabled}
+                help={
+                    isLinking && isFromNonGkPlan ? (
+                        <TransformedFromNonGkWarning originalSrid={geometryPlanSrid} />
+                    ) : isLinking && isFromDifferentGk ? (
+                        <TransformedGkWarning originalSrid={geometryPlanSrid} />
+                    ) : (
+                        <React.Fragment />
+                    )
+                }
                 value={
                     <div className={styles['km-post-edit-dialog__location']}>
                         <div className={styles['km-post-edit-dialog__location-axis']}>
                             <TextField
                                 qa-id="km-post-gk-location-n"
-                                value={gkLocationEnabled ? state.kmPost?.gkLocationY : ''}
+                                value={gkLocationEnabled ? state.kmPost.gkLocationY : ''}
                                 onChange={(e) => updateProp('gkLocationY', e.target.value)}
                                 disabled={!fieldsEnabled}
                                 onBlur={() => {
@@ -204,7 +262,7 @@ export const KmPostEditDialogGkLocationSection: React.FC<
                         <div className={styles['km-post-edit-dialog__location-axis']}>
                             <TextField
                                 qa-id="km-post-gk-location-e"
-                                value={gkLocationEnabled ? state.kmPost?.gkLocationX : ''}
+                                value={gkLocationEnabled ? state.kmPost.gkLocationX : ''}
                                 disabled={!fieldsEnabled}
                                 onChange={(e) => updateProp('gkLocationX', e.target.value)}
                                 onBlur={() => {

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.scss
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.scss
@@ -36,3 +36,17 @@
     min-height: 60px;
     align-content: end;
 }
+
+.km-post-edit-dialog__crs-transform-notice {
+    display: inline-flex;
+    align-items: center;
+
+    > .icon {
+        margin-left: 6px;
+    }
+
+    &--warning {
+        color: vayla-design.$color-lemon-dark;
+        fill: vayla-design.$color-lemon-dark;
+    }
+}

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -36,7 +36,7 @@ import {
     getSaveDisabledReasons,
     useTrackNumbersIncludingDeleted,
 } from 'track-layout/track-layout-react-utils';
-import { draftLayoutContext, LayoutContext } from 'common/common-model';
+import { draftLayoutContext, LayoutContext, Srid } from 'common/common-model';
 import { useTrackLayoutAppSelector } from 'store/hooks';
 import { KmPostEditDialogGkLocationSection } from 'tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section';
 import { GeometryPoint } from 'model/geometry';
@@ -50,6 +50,7 @@ type KmPostEditDialogContainerProps = {
     prefilledTrackNumberId?: LayoutTrackNumberId;
     geometryKmPostGkLocation?: GeometryPoint;
     role: KmPostEditDialogRole;
+    geometryPlanSrid?: Srid;
 };
 
 type KmPostEditDialogProps = {
@@ -62,6 +63,7 @@ type KmPostEditDialogProps = {
     geometryKmPostGkLocation?: GeometryPoint;
     geometryKmPostLocation?: GeometryPoint;
     role: KmPostEditDialogRole;
+    geometryPlanSrid?: Srid;
 };
 
 export const KmPostEditDialogContainer: React.FC<KmPostEditDialogContainerProps> = (
@@ -81,6 +83,7 @@ export const KmPostEditDialogContainer: React.FC<KmPostEditDialogContainerProps>
             prefilledTrackNumberId={props.prefilledTrackNumberId}
             geometryKmPostGkLocation={props.geometryKmPostGkLocation}
             role={props.role}
+            geometryPlanSrid={props.geometryPlanSrid}
         />
     );
 };
@@ -354,6 +357,7 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                             updateProp={updateProp}
                             geometryKmPostGkLocation={props.geometryKmPostGkLocation}
                             role={props.role}
+                            geometryPlanSrid={props.geometryPlanSrid}
                         />
                     </FormLayoutColumn>
                 </FormLayout>

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
@@ -33,7 +33,7 @@ export const initialKmPostEditState: KmPostEditState = {
     isNewKmPost: false,
     existingKmPost: undefined,
     geometryKmPostLocation: undefined,
-    gkLocationEnabled: true,
+    gkLocationEnabled: false,
     kmPost: {
         kmNumber: '',
         gkLocationX: '',
@@ -206,6 +206,7 @@ const kmPostEditSlice = createSlice({
                     ? { gkLocationX: '', gkLocationY: '', gkSrid: undefined }
                     : saveGkPointToEditingGkPoint(existingKmPost.gkLocation)),
             };
+            state.gkLocationEnabled = existingKmPost.gkLocation !== undefined;
             state.validationIssues = validateLinkingKmPost(state);
         },
         onUpdateProp: function <TKey extends keyof KmPostEditFields>(

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
@@ -369,6 +369,10 @@ export function kmPostSaveRequest(state: KmPostEditState): KmPostSaveRequest {
         gkLocation: state.gkLocationEnabled ? editingGkPointToSavePoint(state) : undefined,
         gkLocationSource: state.gkLocationEnabled ? gkLocationSource(state) : undefined,
         gkLocationConfirmed: state.gkLocationEnabled ? state.kmPost.gkLocationConfirmed : false,
+        sourceId:
+            gkLocationSource(state) === 'FROM_GEOMETRY'
+                ? state.existingKmPost?.sourceId
+                : undefined,
     };
 }
 

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -22,7 +22,11 @@ import { TextField, TextFieldVariant } from 'vayla-design-lib/text-field/text-fi
 import { KmPostEditDialogContainer } from 'tool-panel/km-post/dialog/km-post-edit-dialog';
 import { filterNotEmpty } from 'utils/array-utils';
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
-import { refereshKmPostSelection, useTrackNumbers } from 'track-layout/track-layout-react-utils';
+import {
+    refereshKmPostSelection,
+    usePlanHeader,
+    useTrackNumbers,
+} from 'track-layout/track-layout-react-utils';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
 
@@ -63,6 +67,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
         () => (planId ? getPlanLinkStatus(planId, layoutContext) : undefined),
         [planId, kmPostChangeTime, layoutContext],
     );
+    const geometryPlan = usePlanHeader(planId);
 
     const linkedLayoutKmPosts = useLoader(() => {
         if (!planStatus) return undefined;
@@ -272,6 +277,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                     prefilledTrackNumberId={geometryKmPost.trackNumberId}
                     geometryKmPostGkLocation={geometryKmPost.gkLocation}
                     role={'LINKING'}
+                    geometryPlanSrid={geometryPlan?.units?.coordinateSystemSrid}
                 />
             )}
         </React.Fragment>

--- a/ui/src/tool-panel/km-post/km-post-infobox.scss
+++ b/ui/src/tool-panel/km-post/km-post-infobox.scss
@@ -1,3 +1,19 @@
+@use 'vayla-design-lib' as vayla-design;
+
 .km-post-infobox__plan-link {
     overflow-wrap: anywhere;
+}
+
+.km-post-infobox__crs {
+    display: inline-flex;
+    align-items: center;
+
+    .icon {
+        margin-left: 6px;
+    }
+
+    &--warning .icon {
+        color: vayla-design.$color-lemon-dark;
+        fill: vayla-design.$color-lemon-dark;
+    }
 }


### PR DESCRIPTION
Täällä käytännössä toteutettu GK-kaistan automaattinen valinta linkitettäessä ja linkityksen purkaminen jos kilometripylvään sijaintia välppää käsin. Härmäisemmät UI-ongelmat, kuten paikannuspohjan sijainnin virheellisyyden näyttäminen GK:sta muuntamisen jälkeen jätetty myöhemmäksi, sillä ne vaativat oman mietintänsä. 