### PR TITLE
GVT-2825 Optimize forward geocoding in VKM

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
@@ -39,7 +39,10 @@ data class KmNumber @JsonCreator(mode = DISABLED) constructor(val number: Int, v
         extension?.let(extensionSanitizer::assertSanitized)
     }
 
-    override fun compareTo(other: KmNumber): Int = stringValue.compareTo(other.stringValue)
+    override fun compareTo(other: KmNumber): Int {
+        val kmComparison = number - other.number
+        return if (kmComparison != 0) kmComparison else compareValues(extension, other.extension)
+    }
 
     fun isPrimary(): Boolean = extension?.let { it == "A" } ?: true
 }
@@ -223,7 +226,8 @@ fun formatTrackMeter(kmNumber: KmNumber, meters: BigDecimal): String =
     "$kmNumber$TRACK_METER_SEPARATOR${getMetersFormat(meters.scale()).format(meters)}"
 
 fun compare(trackMeter1: ITrackMeter, trackMeter2: ITrackMeter): Int {
-    return compareValuesBy(trackMeter1, trackMeter2, { tm -> tm.kmNumber }, { tm -> tm.meters })
+    val kmNumberComparison = trackMeter1.kmNumber.compareTo(trackMeter2.kmNumber)
+    return if (kmNumberComparison != 0) kmNumberComparison else compareValues(trackMeter1.meters, trackMeter2.meters)
 }
 
 fun compare(trackMeter1: ITrackMeter, trackMeter2: ITrackMeter, decimals: Int): Int {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Either.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Either.kt
@@ -46,7 +46,7 @@ fun <T, LeftValue, RightValue, Result> processPartitioned(
     processLefts: (lefts: List<LeftValue>) -> List<Result>,
     processRights: (rights: List<RightValue>) -> List<Result>,
 ): List<Result> {
-    val extractedSidesLeft = mutableListOf<Boolean>()
+    val extractedSidesLeft: MutableList<Boolean> = ArrayList(values.size)
     val lefts = mutableListOf<LeftValue>()
     val rights = mutableListOf<RightValue>()
     values.forEach { value ->
@@ -68,7 +68,7 @@ fun <T, LeftValue, RightValue, Result> processPartitioned(
         "expected ${lefts.size} results from processLefts, but got ${leftResults.size}"
     }
     assert(rights.size == rightResults.size) {
-        "expected ${rights.size} results from processLefts, but got ${rightResults.size}"
+        "expected ${rights.size} results from processRights, but got ${rightResults.size}"
     }
     var leftIndex = 0
     var rightIndex = 0
@@ -82,8 +82,19 @@ fun <T, LeftValue, RightValue, Result> processPartitioned(
  * on the Rights. process must return a list of the same length as it was passed in, and if it logically maps its inputs
  * to outputs element by element in the order they were passed in, so does this function.
  */
-fun <T, ValidInput, ErrorOrProcessedResult> processValidated(
+fun <T, ValidInput, ErrorOrProcessedResult> processRights(
     values: List<T>,
     extractSide: (value: T) -> Either<ErrorOrProcessedResult, ValidInput>,
     process: (input: List<ValidInput>) -> List<ErrorOrProcessedResult>,
 ): List<ErrorOrProcessedResult> = processPartitioned(values, extractSide, { it }, process)
+
+fun <T, ProcessableInput, Result> processNonNulls(
+    values: List<T>,
+    extractProcessable: (value: T) -> ProcessableInput?,
+    process: (input: List<ProcessableInput>) -> List<Result>,
+): List<Result?> =
+    processRights(
+        values,
+        { value -> extractProcessable(value).let { if (it == null) Left(null) else Right(it) } },
+        process,
+    )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -452,6 +452,13 @@ class GeocodingTest {
                 TrackMeter(2, "0.1") to Point(5.1, 5.1),
                 TrackMeter(2, "3.12") to Point(8.12, 8.12),
             )
+            .also { addressesAndLocations ->
+                context.getTrackLocations(trackAlignment, addressesAndLocations.map { it.first }).zip(
+                    addressesAndLocations
+                ) { addressPoint, addressAndLocation ->
+                    assertAddressPoint(addressPoint, addressAndLocation.first, addressAndLocation.second)
+                }
+            }
             .forEach { (address, location) ->
                 assertAddressPoint(context.getTrackLocation(trackAlignment, address), address, location)
             }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -48,7 +48,6 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 import fi.fta.geoviite.infra.tracklayout.GeometrySource.GENERATED
 import fi.fta.geoviite.infra.tracklayout.GeometrySource.PLAN
-import fi.fta.geoviite.infra.util.FreeText
 import java.time.LocalDate
 import kotlin.math.ceil
 import kotlin.random.Random
@@ -439,6 +438,7 @@ fun locationTrack(
     duplicateOf: IntId<LocationTrack>? = null,
     ownerId: IntId<LocationTrackOwner> = IntId(1),
     contextData: LayoutContextData<LocationTrack> = createMainContext(id, null, draft),
+    descriptionSuffix: DescriptionSuffixType = DescriptionSuffixType.NONE,
 ) =
     locationTrack(
         trackNumberId = trackNumberId,
@@ -455,6 +455,7 @@ fun locationTrack(
         topologyEndSwitch = topologyEndSwitch,
         duplicateOf = duplicateOf,
         ownerId = ownerId,
+        descriptionSuffix = descriptionSuffix,
     )
 
 fun locationTrack(
@@ -472,11 +473,12 @@ fun locationTrack(
     topologyEndSwitch: TopologyLocationTrackSwitch? = null,
     duplicateOf: IntId<LocationTrack>? = null,
     ownerId: IntId<LocationTrackOwner> = IntId(1),
+    descriptionSuffix: DescriptionSuffixType = DescriptionSuffixType.NONE,
 ) =
     LocationTrack(
         name = AlignmentName(name),
         descriptionBase = LocationTrackDescriptionBase(description),
-        descriptionSuffix = DescriptionSuffixType.NONE,
+        descriptionSuffix = descriptionSuffix,
         type = type,
         state = state,
         externalId = externalId,


### PR DESCRIPTION
Konseptuaalisesti varsin yksinkertaista juttua, kaikki geokoodaukseen liittyvät asiat nyt vaan ryhmitellään niin, että asiat, joita tarvitsee tehdä vain kerran, tehdään vain kerran:

- validoinnin osana tehtävät ratanumerohaut tehdään vain kerran per eri ratanumeron nimi, muut osat rinnakkaistetaan
- pyynnöt ryhmitellään ratanumeroittain
- raiteelle suodatetaan pyynnöittäin, mitkä pyynnöt osuvat nimen/tyypin mukaan tälle raiteelle, ja haetaan osoitteet vain niille
- raiteelle osuvat geokoodauspyynnöt tehdään massana; raiteen alku- ja loppupisteen käänteinen geokoodaus on itse asiassa yksi kalleimmista kohdista koko haussa, eli on iso voitto tehdä ne vain kerran per pyyntöön liittyvä raide (ja jos niitä voisi tulevaisuudessa kakuttaa, se olisi vielä parempi)

Geokoodauksen itsensä laskentaan en lopulta koskenut, koska se on aika vaikeaa.

Mukana myös pari mikro-optimointia profiileissa isoimpina näkyviin kohtiin.

Rinnakkaistukset ratanumeroiden ja sijaintiraiteiden tasolla on arvoltaan ehkä vähän fifti-fifti, mutta kyllä niillä saa näppärästi nopeampia vastauksia takaisin näissä lokaaleissa testeissä, joissa tehdään geokoodauksia hillittömän pitkälle ratanumerolle, jolla on kymmeniä raiteita.