### PR TITLE
General: Optimize validating track relinking

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -239,7 +239,7 @@ data class LayoutAlignment(
     override val id: DomainId<LayoutAlignment> = StringId(),
     val dataType: DataType = DataType.TEMP,
 ) : IAlignment {
-    override val boundingBox: BoundingBox? = boundingBoxCombining(segments.mapNotNull { s -> s.boundingBox })
+    override val boundingBox: BoundingBox? by lazy { boundingBoxCombining(segments.mapNotNull { s -> s.boundingBox }) }
 
     init {
         segments.forEachIndexed { index, segment ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -211,24 +211,13 @@ fun <T> compareByDistanceNullsFirst(itemAndDistance1: Pair<T, Double?>, itemAndD
     }
 }
 
-private fun <T> mapCopyOnWrite(originalList: List<T>, f: (v: T) -> T): List<T> {
-    var changed = false
-    val newList =
-        originalList.map { entry ->
-            val newEntry = f(entry)
-            if (newEntry !== entry) changed = true
-            newEntry
-        }
-    return if (changed) newList else originalList
-}
-
 fun clearLinksToSwitch(
     locationTrack: LocationTrack,
     alignment: LayoutAlignment,
     layoutSwitchId: IntId<TrackLayoutSwitch>,
 ): Pair<LocationTrack, LayoutAlignment> {
     val newSegments =
-        mapCopyOnWrite(alignment.segments) { segment ->
+        alignment.segments.map { segment ->
             if (segment.switchId == layoutSwitchId) segment.withoutSwitch() else segment
         }
     val newAlignment = alignment.withSegments(newSegments)


### PR DESCRIPTION
Pientä profilerin nokasta löytyneiden asioiden nysväysoptimointia pitkän raiteen tehtävälistan lataukseen, ei funktionaalisia muutoksia. Eikä meidän 16-ytimisillä tehokoneilla kyllä juuri perffimuutoksiakaan, koska vaikka nämä jutut nielivät itse asiassa aika paljon prosessoriaikaa, rinnakkaistus peittää vaikutuksen.

mapCopyOnWrite oli tarpeeton jäänne aiemmasta raiteiden vaihteiden uudelleenlinkityksen optimoinnista, joka oli sittemmin korvattu eri toteutuksella.