### PR TITLE
General: Optimize VKM reverse geocoding + implement GVT-2834

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
@@ -20,10 +20,10 @@ import fi.fta.geoviite.infra.localization.LocalizationLanguage
 import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
-import fi.fta.geoviite.infra.tracklayout.CacheHit
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackCacheHit
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackSpatialCache
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
@@ -37,9 +37,9 @@ import fi.fta.geoviite.infra.util.all
 import fi.fta.geoviite.infra.util.alsoIfNull
 import fi.fta.geoviite.infra.util.processValidated
 import fi.fta.geoviite.infra.util.produceIf
+import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.math.RoundingMode
-import org.springframework.beans.factory.annotation.Autowired
 
 @GeoviiteService
 class FrameConverterServiceV1
@@ -73,9 +73,9 @@ constructor(
         val trackNumbers = trackNumberService.mapById(layoutContext)
         val spatialCache = locationTrackSpatialCache.get(layoutContext)
         val closestTracks =
-            requestsWithPoints.map { r ->
-                spatialCache.getClosest(r.second, r.first.searchRadius).find { (track, _) ->
-                    filterByRequest(track, trackNumbers, r.first)
+            requestsWithPoints.map { (request, point) ->
+                spatialCache.getClosest(point, request.searchRadius).find { (track, _) ->
+                    filterByRequest(track, trackNumbers, request)
                 }
             }
 
@@ -125,7 +125,7 @@ constructor(
     private fun calculateCoordinateToTrackAddressResponse(
         searchPoint: IPoint,
         request: ValidCoordinateToTrackAddressRequestV1,
-        closestTrack: CacheHit,
+        closestTrack: LocationTrackCacheHit,
         trackDescription: FreeText?,
         params: FrameConverterQueryParamsV1,
         geocodingContexts: Map<IntId<TrackLayoutTrackNumber>, GeocodingContext?>,
@@ -341,7 +341,7 @@ constructor(
     private fun createCoordinateToTrackAddressResponse(
         request: ValidCoordinateToTrackAddressRequestV1,
         params: FrameConverterQueryParamsV1,
-        closestTrack: CacheHit,
+        closestTrack: LocationTrackCacheHit,
         trackNumber: TrackNumber,
         geocodedAddress: AddressAndM,
         locationTrackDescription: FreeText?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadService.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackSpatialCache
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import java.time.Duration
 import java.time.Instant
@@ -30,6 +31,7 @@ class CachePreloadService(
     private val geometryDao: GeometryDao,
     private val geocodingCacheService: GeocodingCacheService,
     private val geocodingDao: GeocodingDao,
+    private val locationTrackSpatialCache: LocationTrackSpatialCache,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -56,6 +58,12 @@ class CachePreloadService(
                     .mapNotNull(geocodingCacheService::getGeocodingContext)
             contexts.parallelStream().forEach(GeocodingContext::preload)
             contexts.size
+        }
+    }
+
+    fun loadLocationTrackSpatialCache() {
+        refreshCache("LocationTrack.Spatial.MAIN_OFFICIAL") {
+            locationTrackSpatialCache.get(MainLayoutContext.official).size
         }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackSpatialCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackSpatialCache.kt
@@ -1,0 +1,128 @@
+package fi.fta.geoviite.infra.tracklayout
+
+import com.github.davidmoten.rtree2.RTree
+import com.github.davidmoten.rtree2.geometry.Geometries
+import com.github.davidmoten.rtree2.geometry.Rectangle
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.math.IPoint
+import fi.fta.geoviite.infra.math.lineLength
+import java.util.concurrent.ConcurrentHashMap
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class LocationTrackSpatialCache
+@Autowired
+constructor(
+    private val locationTrackService: LocationTrackService,
+    private val locationTrackDao: LocationTrackDao,
+    private val alignmentDao: LayoutAlignmentDao,
+) {
+    private val caches: ConcurrentHashMap<LayoutContext, ContextCache> = ConcurrentHashMap()
+
+    fun get(context: LayoutContext): ContextCache {
+        val all = locationTrackService.list(context).associateBy { it.id as IntId }
+        return caches.compute(context) { _, cache -> refresh(cache ?: newCache(), all) }
+            ?: error("Cache should have been created")
+    }
+
+    private fun newCache(): ContextCache = ContextCache(locationTrackDao::fetch, alignmentDao::fetch)
+
+    private fun refresh(cache: ContextCache, newTracks: Map<IntId<LocationTrack>, LocationTrack>): ContextCache {
+        val (staleTracks, currentTracks) =
+            cache.items
+                .asSequence()
+                .partition { (id, track) -> newTracks[id]?.alignmentVersion != track.alignmentVersion }
+                .let { (stale, current) ->
+                    stale.associate { it.key to it.value } to current.associate { it.key to it.value }
+                }
+
+        // Remove all stale items (tracks that have been removed or updated)
+        var newNet =
+            staleTracks
+                .flatMap { (_, entry) -> entry.segmentData }
+                .fold(cache.network) { net, (segment, rect) -> net.delete(segment, rect) }
+
+        // Add all new items (tracks that have been added or updated)
+        fun addEntry(track: LocationTrack) =
+            createEntry(track, alignmentDao.fetch(track.getAlignmentVersionOrThrow())).also { entry ->
+                newNet = entry.segmentData.fold(newNet) { net, (segment, rect) -> net.add(segment, rect) }
+            }
+
+        val newItems = newTracks.map { (id, track) -> id to (currentTracks[id] ?: addEntry(track)) }
+
+        return ContextCache(locationTrackDao::fetch, alignmentDao::fetch, newNet, newItems.toMap())
+    }
+}
+
+data class SpatialCacheSegment(
+    val locationTrackVersion: LayoutRowVersion<LocationTrack>,
+    val alignmentVersion: RowVersion<LayoutAlignment>,
+    val segment: LayoutSegment,
+)
+
+data class SpatialCacheEntry(
+    val alignmentVersion: RowVersion<LayoutAlignment>,
+    val segmentData: List<Pair<SpatialCacheSegment, Rectangle>>,
+)
+
+data class CacheHit(
+    val track: LocationTrack,
+    val alignment: LayoutAlignment,
+    val closestPoint: AlignmentPoint,
+    val distance: Double,
+)
+
+private val cacheHitComparator =
+    compareBy<CacheHit>(
+        { it.distance }, // Primary sort by distance
+        { if (it.track.duplicateOf == null) 0 else 1 }, // Favor non-duplicates as tie-breaker
+        { it.track.version?.rowId?.intValue }, // Stable ordering by row ID
+    )
+
+data class ContextCache(
+    private val getTrack: (LayoutRowVersion<LocationTrack>) -> LocationTrack,
+    private val getAlignment: (RowVersion<LayoutAlignment>) -> LayoutAlignment,
+    val network: RTree<SpatialCacheSegment, Rectangle> = RTree.star().create(),
+    val items: Map<IntId<LocationTrack>, SpatialCacheEntry> = emptyMap(),
+) {
+    val size: Int
+        get() = items.size
+
+    fun getClosest(location: IPoint, thresholdMeters: Double = 100.0): List<CacheHit> =
+        network
+            .search(Geometries.point(location.x, location.y), thresholdMeters)
+            .mapNotNull { entry -> createHit(entry.value(), location, thresholdMeters) }
+            .sortedWith(cacheHitComparator)
+            .distinctBy { it.track.id }
+
+    private fun createHit(segment: SpatialCacheSegment, location: IPoint, thresholdMeters: Double): CacheHit? {
+        val closestPointM = segment.segment.getClosestPointM(location).first
+        val closestPoint = segment.segment.seekPointAtM(closestPointM).point
+        val distance = lineLength(location, closestPoint)
+        return if (distance < thresholdMeters) {
+            CacheHit(
+                getTrack(segment.locationTrackVersion),
+                getAlignment(segment.alignmentVersion),
+                closestPoint,
+                distance,
+            )
+        } else {
+            null
+        }
+    }
+}
+
+private fun createEntry(track: LocationTrack, alignment: LayoutAlignment): SpatialCacheEntry {
+    val alignmentVersion = track.getAlignmentVersionOrThrow()
+    val segmentData =
+        alignment.segments.map { segment ->
+            val bbox = segment.boundingBox!!
+            val entry = SpatialCacheSegment(track.version!!, alignmentVersion, segment)
+            val rect = Geometries.rectangle(bbox.x.min, bbox.y.min, bbox.x.max, bbox.y.max)
+            entry to rect
+        }
+    return SpatialCacheEntry(alignmentVersion, segmentData)
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Functional.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Functional.kt
@@ -8,3 +8,5 @@ inline fun <T> T?.alsoIfNull(action: () -> Unit): T? {
     if (this == null) action()
     return this
 }
+
+fun all(vararg conditions: () -> Boolean): Boolean = conditions.all { it() }


### PR DESCRIPTION
Pääjuttu: muistinvarainen spatiaalinen (r-puu) cache sijaintiraiteiden haulle vkm:ään.
Samalla toteutett GVT-2834 ko. haun osalta, eli käsitellään vain IN_USE tilaisia raiteita. Tuon tiketin koko kuvaus on vähän laajempi joten loput tulee perästä.