### PR TITLE
GVT-2840 (part 2): Fix broken E2E, rename header to heading

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
@@ -63,16 +63,16 @@ constructor(
                 ),
             )
 
-        val testDateBeforeAnyTestPublications = Instant.parse("2022-01-01T12:34:00Z")
+        val testDateBeforeAnyTestPublications = Instant.parse("2023-01-01T12:34:00Z")
 
         val testPublicationDates =
             listOf(
-                Instant.parse("2023-01-01T12:34:00Z"),
-                Instant.parse("2023-06-01T00:00:00Z"),
-                Instant.parse("2024-01-01T00:00:00Z"),
+                Instant.parse("2023-01-02T12:34:00Z"),
+                Instant.parse("2023-02-15T00:00:00Z"),
+                Instant.parse("2023-03-01T00:00:00Z"),
             )
 
-        val testDateAfterAllTestPublications = Instant.parse("2025-01-01T00:00:00Z")
+        val testDateAfterAllTestPublications = Instant.parse("2023-04-01T00:00:00Z")
 
         publicationRequests
             .map { publicationRequest -> testPublish(publicationRequest) }

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -73,7 +73,7 @@ type PublicationLogTableHeaderProps = {
     publicationAmount: number;
 };
 
-const PublicationLogTableHeader: React.FC<PublicationLogTableHeaderProps> = ({
+const PublicationLogTableHeading: React.FC<PublicationLogTableHeaderProps> = ({
     isLoading,
     isTruncated,
     publicationAmount,
@@ -297,7 +297,7 @@ const PublicationLog: React.FC = () => {
                 </div>
                 <div className={styles['publication-log__count-header']}>
                     {isStoredSearchRangeValid ? (
-                        <PublicationLogTableHeader
+                        <PublicationLogTableHeading
                             isLoading={isLoading}
                             isTruncated={isTruncated}
                             publicationAmount={pagedPublications?.items?.length || 0}


### PR DESCRIPTION
The searchable date range was restricted to 180 days and the previous E2E test was using ranges longer than 180 days.