### PR TITLE
GVT-2857 Allow GeocodingContext#referenceLineAddresses to be null

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -390,9 +390,7 @@ data class GeocodingContext(
         return if (TrackMeter.isMetersValid(meters)) TrackMeter(addressPoint.kmNumber, meters) else null
     }
 
-    val referenceLineAddresses by lazy {
-        checkNotNull(getAddressPoints(referenceLineGeometry)) { "Can't resolve reference line addresses" }
-    }
+    val referenceLineAddresses by lazy { getAddressPoints(referenceLineGeometry) }
 
     fun getPartialAddressRange(
         sourceAlignment: LayoutAlignment,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.error.NoSuchEntityException
+import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingContextCreateResult
 import fi.fta.geoviite.infra.geocoding.GeocodingService
@@ -120,7 +121,9 @@ class LayoutTrackNumberService(
         trackNumberId: IntId<TrackLayoutTrackNumber>,
     ): List<TrackLayoutKmLengthDetails>? {
         return geocodingService.getGeocodingContextCreateResult(layoutContext, trackNumberId)?.let { contextResult ->
-            extractTrackKmLengths(contextResult.geocodingContext, contextResult)
+            contextResult.geocodingContext.referenceLineAddresses?.startPoint?.let { startPoint ->
+                extractTrackKmLengths(contextResult.geocodingContext, contextResult, startPoint)
+            }
         }
     }
 
@@ -300,11 +303,11 @@ private fun getLocationByPrecision(kmPost: TrackLayoutKmLengthDetails, precision
 private fun extractTrackKmLengths(
     context: GeocodingContext,
     contextResult: GeocodingContextCreateResult,
+    startPoint: AddressPoint,
 ): List<TrackLayoutKmLengthDetails> {
     val distances = getKmPostDistances(context, contextResult.validKmPosts)
     val referenceLineLength = context.referenceLineGeometry.length
     val trackNumber = context.trackNumber
-    val startPoint = context.referenceLineAddresses.startPoint
 
     // First km post is usually on another reference line, and therefore it has to be generated here
     return listOf(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -817,6 +817,19 @@ class GeocodingTest {
         assertNull(result.geocodingContext.getProjectionLine(TrackMeter(KmNumber(0), 100)))
     }
 
+    @Test
+    fun `referenceLineAddresses is null if the end address would have invalid meters`() {
+        val referenceLineAlignment = LayoutAlignment(listOf(segment(Point(0.0, 0.0), Point(15000.0, 0.0))))
+        val result =
+            GeocodingContext.create(
+                trackNumber = TrackNumber("001"),
+                startAddress = TrackMeter(KmNumber(10), 100),
+                referenceLineGeometry = referenceLineAlignment,
+                kmPosts = listOf(),
+            )
+        assertNull(result.geocodingContext.referenceLineAddresses)
+    }
+
     private fun assertProjectionLinesMatch(result: List<ProjectionLine>, vararg expected: Pair<TrackMeter, Line>) {
         assertEquals(
             expected.size,


### PR DESCRIPTION
referenceLineAddresses:n haku räjähtää, jos loppuosoitteen metri olisi liian iso. On räjähtänyt jo pitkään, mutta nyt tämän tilan saa huomattavasti helpommin aikaan asettamalla km-pisteen sijainnin käsin.

Ratkaistaan jatkamalla historian kehitystä siihen suuntaan, että osittainkin toimiva geokoodauskonteksti on hyvä: Julkaisuvalidointi osaa kyllä näistä valittaa. Kaikki paitsi yksi kutsuja sattuivat olemaan jo valmiiksi sellaisessa muodossa, etteivät vaatineet ainuttakaan koodimuutosta, koska kontekstin itsensä muodostaminenhan on voinut jo pitempään epäonnistua. 