### PR TITLE
GVT-2853 Encourage switches to maintain their original links

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -147,7 +147,7 @@ constructor(
             .parallelStream()
             .map { (index, request) ->
                 findBestSwitchFitForAllPointsInSamplingGrid(
-                    request.points,
+                    request,
                     switchStructures[index],
                     alignmentsNearRequests[index],
                 )
@@ -285,7 +285,7 @@ constructor(
                         .toList()
 
                 val fittedSwitch =
-                    createFittedSwitchByPoint(presentationJointLocation, switchStructure, nearbyTracksForFit)
+                    createFittedSwitchByPoint(switchId, presentationJointLocation, switchStructure, nearbyTracksForFit)
                 if (fittedSwitch == null) {
                     TrackSwitchRelinkingResult(switchId, TrackSwitchRelinkingResultType.NOT_AUTOMATICALLY_LINKABLE)
                 } else {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -1494,7 +1494,7 @@ constructor(
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
 
         // left side is slightly squished on the y axis compared to the right side, to make the
-        // arrangement realistically slightly symmetric
+        // arrangement realistically slightly asymmetric
         val leftSwitchJoints =
             switchStructure.joints.map { joint ->
                 TrackLayoutSwitchJoint(joint.number, Point(-joint.location.x, -joint.location.y * 0.99), null)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingTest.kt
@@ -702,7 +702,12 @@ class SwitchLinkingTest {
         val nearbyPoint = Point(10.0, -1.0)
 
         val suggestedSwitch =
-            createFittedSwitchByPoint(nearbyPoint, switchStructure, listOf(locationTrack152, locationTrack13))
+            createFittedSwitchByPoint(
+                IntId(1234),
+                nearbyPoint,
+                switchStructure,
+                listOf(locationTrack152, locationTrack13),
+            )
 
         assertNotNull(suggestedSwitch)
     }


### PR DESCRIPTION
Päittäin linkitetyt YV-vaihteet ovat tähän asti uudelleenlinkityksessä saattaneet heitellä ärsyttävästi puolelle tai toiselle. Mahdollisena lääkkeenä ehdotettiin ohjata niitä vaihteen pisteytyksessä pysymään kiinni samoilla raiteilla kuin millä olivat jo aiemmin.

Ratkaisu vaikuttaisi ainakin minun testailun perusteella toimivan, tosin ärsyttävästi niin, että jostain syystä linkitys ei muutu ainoastaan näillä päittäin linkitetyillä tapauksilla, vaan monissa kohdin mikrometrien verran muillakin vaihteilla. Mutta sellaista kohtaa en löytänyt, jossa olisi mitään näkyvän kokoista muutosta muualla kuin siellä, missä pitikin olla.