### PR TITLE
GVT-2815 & GVT-2749: Dropdown-parannuksia ja `stopPropagation()`-poistoja

### DIFF
--- a/ui/src/infra-model/list/infra-model-search-result-row.tsx
+++ b/ui/src/infra-model/list/infra-model-search-result-row.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { GeometryPlanHeader, GeometryPlanId } from 'geometry/geometry-model';
+import { formatDateFull, formatDateShort } from 'utils/date-utils';
+import { inframodelDownloadUri } from 'infra-model/infra-model-api';
+import PlanPhase from 'geoviite-design-lib/geometry-plan/plan-phase';
+import DecisionPhase from 'geoviite-design-lib/geometry-plan/plan-decision-phase';
+import { PrivilegeRequired } from 'user/privilege-required';
+import { DOWNLOAD_GEOMETRY, EDIT_GEOMETRY_FILE } from 'user/user-model';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { GeometryPlanLinkingSummary } from 'geometry/geometry-api';
+
+type InfraModelSearchResultRowProps = {
+    plan: GeometryPlanHeader;
+    linkingSummaries: Map<GeometryPlanId, GeometryPlanLinkingSummary | undefined>;
+    setConfirmDownloadPlan: (planId: GeometryPlanHeader | undefined) => void;
+    setConfirmHidePlan: (planId: GeometryPlanHeader | undefined) => void;
+    onSelectPlan: (planId: GeometryPlanId) => void;
+};
+
+export const InfraModelSearchResultRow: React.FC<InfraModelSearchResultRowProps> = ({
+    plan,
+    linkingSummaries,
+    setConfirmDownloadPlan,
+    setConfirmHidePlan,
+    onSelectPlan,
+}) => {
+    const { t } = useTranslation();
+
+    const downloadButtonRef = React.useRef<HTMLButtonElement>(null);
+    const hideButtonRef = React.useRef<HTMLButtonElement>(null);
+
+    function linkingSummaryDate(planId: GeometryPlanId) {
+        const linkingSummary = linkingSummaries.get(planId);
+        return linkingSummary?.linkedAt == undefined ? '' : formatDateFull(linkingSummary.linkedAt);
+    }
+
+    const linkingSummaryUsers = (planId: GeometryPlanId) =>
+        linkingSummaries.get(planId)?.linkedByUsers.join(', ') ?? '';
+
+    const isCurrentlyLinked = (planId: GeometryPlanId) =>
+        linkingSummaries.get(planId)?.currentlyLinked;
+
+    const downloadPlan = (plan: GeometryPlanHeader) => {
+        if (plan.source === 'PAIKANNUSPALVELU') {
+            setConfirmDownloadPlan(plan);
+        } else {
+            location.href = inframodelDownloadUri(plan.id);
+        }
+    };
+
+    const targetWithinButton = (target: EventTarget) =>
+        downloadButtonRef.current?.contains(target as HTMLElement) ||
+        hideButtonRef.current?.contains(target as HTMLElement);
+
+    return (
+        <tr
+            key={plan.id}
+            className="infra-model-list-search-result__plan"
+            onClick={(e) => {
+                if (!targetWithinButton(e.target)) {
+                    onSelectPlan(plan.id);
+                }
+            }}>
+            <td>
+                {plan.project.name}
+                {plan.source == 'PAIKANNUSPALVELU' && (
+                    <div className="infra-model-list-search-result__plan-paikannuspalvelu">
+                        {t('enum.plan-source.PAIKANNUSPALVELU')}
+                    </div>
+                )}
+            </td>
+            <td>{plan.fileName}</td>
+            <td>{plan.trackNumber}</td>
+            <td>{plan.kmNumberRange?.min?.padStart(3, '0') || ''}</td>
+            <td>{plan.kmNumberRange?.max?.padStart(3, '0') || ''}</td>
+            <td>
+                <PlanPhase phase={plan.planPhase} />
+            </td>
+            <td>
+                <DecisionPhase decision={plan.decisionPhase} />
+            </td>
+            <td>{plan.planTime && formatDateShort(plan.planTime)}</td>
+            <td>{plan.uploadTime && formatDateFull(plan.uploadTime)}</td>
+            <td>{linkingSummaryDate(plan.id)}</td>
+            <td>{linkingSummaryUsers(plan.id)}</td>
+            <td>
+                <PrivilegeRequired privilege={DOWNLOAD_GEOMETRY}>
+                    <Button
+                        title={t('im-form.download-file')}
+                        onClick={() => downloadPlan(plan)}
+                        variant={ButtonVariant.GHOST}
+                        size={ButtonSize.SMALL}
+                        icon={Icons.Download}
+                        ref={downloadButtonRef}
+                    />
+                </PrivilegeRequired>
+            </td>
+            <td>
+                <PrivilegeRequired privilege={EDIT_GEOMETRY_FILE}>
+                    <Button
+                        title={
+                            isCurrentlyLinked(plan.id)
+                                ? t('im-form.cannot-hide-file')
+                                : t('im-form.hide-file')
+                        }
+                        onClick={() => setConfirmHidePlan(plan)}
+                        disabled={isCurrentlyLinked(plan.id) ?? true}
+                        variant={ButtonVariant.GHOST}
+                        size={ButtonSize.SMALL}
+                        icon={Icons.Delete}
+                        ref={hideButtonRef}
+                    />
+                </PrivilegeRequired>
+            </td>
+            <td>
+                {plan.message ? (
+                    <span title={plan.message}>
+                        <Icons.Info size={IconSize.SMALL} />
+                    </span>
+                ) : (
+                    <React.Fragment />
+                )}
+            </td>
+        </tr>
+    );
+};

--- a/ui/src/infra-model/list/infra-model-search-result.tsx
+++ b/ui/src/infra-model/list/infra-model-search-result.tsx
@@ -3,8 +3,6 @@ import { useEffect, useState } from 'react';
 import { InfraModelListState } from 'infra-model/list/infra-model-list-store';
 import './infra-model-list.module.scss';
 import { useTranslation } from 'react-i18next';
-import { formatDateFull, formatDateShort } from 'utils/date-utils';
-
 import {
     GeometryPlanHeader,
     GeometryPlanId,
@@ -12,17 +10,13 @@ import {
     GeometrySortBy,
     GeometrySortOrder,
 } from 'geometry/geometry-model';
-import { IconComponent, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { IconComponent, Icons } from 'vayla-design-lib/icon/Icon';
 import { Table, Th } from 'vayla-design-lib/table/table';
-import DecisionPhase from 'geoviite-design-lib/geometry-plan/plan-decision-phase';
-import PlanPhase from 'geoviite-design-lib/geometry-plan/plan-phase';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
-import { inframodelDownloadUri } from 'infra-model/infra-model-api';
 import { GeometryPlanLinkingSummary, getGeometryPlanLinkingSummaries } from 'geometry/geometry-api';
 import { ConfirmHideInfraModel } from './confirm-hide-infra-model-dialog';
 import { ConfirmDownloadUnreliableInfraModelDialog } from './confirm-download-unreliable-infra-model-dialog';
-import { PrivilegeRequired } from 'user/privilege-required';
-import { DOWNLOAD_GEOMETRY, EDIT_GEOMETRY_FILE } from 'user/user-model';
+import { InfraModelSearchResultRow } from 'infra-model/list/infra-model-search-result-row';
 
 export type InfraModelSearchResultProps = Pick<
     InfraModelListState,
@@ -114,28 +108,10 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
             : Icons.Descending;
     }
 
-    function linkingSummaryDate(planId: GeometryPlanId) {
-        const linkingSummary = linkingSummaries.get(planId);
-        return linkingSummary?.linkedAt == undefined ? '' : formatDateFull(linkingSummary.linkedAt);
-    }
-
-    const linkingSummaryUsers = (planId: GeometryPlanId) =>
-        linkingSummaries.get(planId)?.linkedByUsers.join(', ') ?? '';
-
-    const isCurrentlyLinked = (planId: GeometryPlanId) =>
-        linkingSummaries.get(planId)?.currentlyLinked;
-
-    const downloadPlan = (plan: GeometryPlanHeader) => {
-        if (plan.source === 'PAIKANNUSPALVELU') {
-            setConfirmDownloadPlan(plan);
-        } else {
-            location.href = inframodelDownloadUri(plan.id);
-        }
-    };
-
     const { t } = useTranslation();
     const firstItem = props.page * props.pageSize + (props.plans.length > 0 ? 1 : 0);
     const lastItem = props.page * props.pageSize + props.plans.length;
+
     return (
         <div className="infra-model-list-search-result">
             <div className="infra-model-list-search-result__status-row">
@@ -290,69 +266,14 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                     <tbody id="infra-model-list-search-result__table-body">
                         {props.plans.map((plan) => {
                             return (
-                                <tr
+                                <InfraModelSearchResultRow
+                                    setConfirmHidePlan={setConfirmHidePlan}
+                                    setConfirmDownloadPlan={setConfirmDownloadPlan}
+                                    onSelectPlan={props.onSelectPlan}
+                                    linkingSummaries={linkingSummaries}
+                                    plan={plan}
                                     key={plan.id}
-                                    className="infra-model-list-search-result__plan"
-                                    onClick={() => props.onSelectPlan(plan.id)}>
-                                    <td>
-                                        {plan.project.name}
-                                        {plan.source == 'PAIKANNUSPALVELU' && (
-                                            <div className="infra-model-list-search-result__plan-paikannuspalvelu">
-                                                {t('enum.plan-source.PAIKANNUSPALVELU')}
-                                            </div>
-                                        )}
-                                    </td>
-                                    <td>{plan.fileName}</td>
-                                    <td>{plan.trackNumber}</td>
-                                    <td>{plan.kmNumberRange?.min?.padStart(3, '0') || ''}</td>
-                                    <td>{plan.kmNumberRange?.max?.padStart(3, '0') || ''}</td>
-                                    <td>
-                                        <PlanPhase phase={plan.planPhase} />
-                                    </td>
-                                    <td>
-                                        <DecisionPhase decision={plan.decisionPhase} />
-                                    </td>
-                                    <td>{plan.planTime && formatDateShort(plan.planTime)}</td>
-                                    <td>{plan.uploadTime && formatDateFull(plan.uploadTime)}</td>
-                                    <td>{linkingSummaryDate(plan.id)}</td>
-                                    <td>{linkingSummaryUsers(plan.id)}</td>
-                                    <td onClick={(e) => e.stopPropagation()}>
-                                        <PrivilegeRequired privilege={DOWNLOAD_GEOMETRY}>
-                                            <Button
-                                                title={t('im-form.download-file')}
-                                                onClick={() => downloadPlan(plan)}
-                                                variant={ButtonVariant.GHOST}
-                                                size={ButtonSize.SMALL}
-                                                icon={Icons.Download}
-                                            />
-                                        </PrivilegeRequired>
-                                    </td>
-                                    <td onClick={(e) => e.stopPropagation()}>
-                                        <PrivilegeRequired privilege={EDIT_GEOMETRY_FILE}>
-                                            <Button
-                                                title={
-                                                    isCurrentlyLinked(plan.id)
-                                                        ? t('im-form.cannot-hide-file')
-                                                        : t('im-form.hide-file')
-                                                }
-                                                onClick={() => setConfirmHidePlan(plan)}
-                                                disabled={isCurrentlyLinked(plan.id) ?? true}
-                                                variant={ButtonVariant.GHOST}
-                                                size={ButtonSize.SMALL}
-                                                icon={Icons.Delete}
-                                            />
-                                        </PrivilegeRequired>
-                                    </td>
-                                    <td>
-                                        {plan.message ? (
-                                            <span title={plan.message}>
-                                                <Icons.Info size={IconSize.SMALL} />
-                                            </span>
-                                        ) : (
-                                            <React.Fragment />
-                                        )}
-                                    </td>
-                                </tr>
+                                />
                             );
                         })}
                     </tbody>

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -224,6 +224,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
     const [savingWorkspace, setSavingWorkspace] = React.useState(false);
     const menuRef = React.useRef(null);
     const designIdSelectorRef = React.useRef(null);
+    const designIdButtonRef = React.useRef(null);
 
     const [currentDesign, designLoadStatus] = useLoaderWithStatus(
         () => designId && getLayoutDesign(getChangeTimes().layoutDesign, designId),
@@ -471,8 +472,8 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                                                 iconPosition={ButtonIconPosition.END}
                                                 disabled={!!splittingState}
                                                 inheritTypography={true}
-                                                onClick={(e) => {
-                                                    e.stopPropagation(); // otherwise layout selection gets the click
+                                                ref={designIdButtonRef}
+                                                onClick={() => {
                                                     switchToDesign();
                                                     setDesignIdSelectorOpened(
                                                         !designIdSelectorOpened,
@@ -521,7 +522,10 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                                     <div ref={designIdSelectorRef}>
                                         <CloseableModal
                                             positionRef={designIdSelectorRef}
-                                            onClickOutside={() => setDesignIdSelectorOpened(false)}
+                                            openingRef={designIdButtonRef}
+                                            onClickOutside={() => {
+                                                setDesignIdSelectorOpened(false);
+                                            }}
                                             className={styles['tool-bar__design-id-selector-popup']}
                                             offsetX={0}
                                             offsetY={0}>

--- a/ui/src/tool-bar/workspace-selection.tsx
+++ b/ui/src/tool-bar/workspace-selection.tsx
@@ -71,28 +71,30 @@ export const DesignSelection: React.FC<DesignSelectionProps> = ({ designId, onDe
 
     return (
         <React.Fragment>
-            <Dropdown
-                inputRef={selectWorkspaceDropdownRef}
-                placeholder={t('tool-bar.search-design')}
-                filter={nameIncludes}
-                displaySelectedName={false}
-                openOverride={true}
-                popupMode={DropdownPopupMode.Inline}
-                onAddClick={canAddDesigns ? onAddClick : undefined}
-                onChange={(designId) => designId && onDesignSelected(designId)}
-                options={
-                    designs
-                        ?.map((design) => ({
-                            value: design.id,
-                            name: design.name,
-                            qaId: `workspace-${design.id}`,
-                        }))
-                        .toSorted((a, b) => a.name.localeCompare(b.name)) ?? []
-                }
-                value={designId}
-                qaId={'workspace-selection'}
-                customIcon={Icons.Search}
-            />
+            {!showCreateWorkspaceDialog && (
+                <Dropdown
+                    inputRef={selectWorkspaceDropdownRef}
+                    placeholder={t('tool-bar.search-design')}
+                    filter={nameIncludes}
+                    displaySelectedName={false}
+                    openOverride={true}
+                    popupMode={DropdownPopupMode.Inline}
+                    onAddClick={canAddDesigns ? onAddClick : undefined}
+                    onChange={(designId) => designId && onDesignSelected(designId)}
+                    options={
+                        designs
+                            ?.map((design) => ({
+                                value: design.id,
+                                name: design.name,
+                                qaId: `workspace-${design.id}`,
+                            }))
+                            .toSorted((a, b) => a.name.localeCompare(b.name)) ?? []
+                    }
+                    value={designId}
+                    qaId={'workspace-selection'}
+                    customIcon={Icons.Search}
+                />
+            )}
 
             {showCreateWorkspaceDialog && (
                 <WorkspaceDialog

--- a/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
+++ b/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
@@ -6,6 +6,7 @@ export type OpenTowards = 'LEFT' | 'RIGHT';
 
 type CloseableModalProps = {
     positionRef: React.MutableRefObject<HTMLElement | null>;
+    openingRef?: React.RefObject<HTMLElement | SVGSVGElement | null>;
     onClickOutside: () => void;
     offsetX?: number;
     offsetY?: number;
@@ -31,6 +32,7 @@ type ModalSize = {
 
 export const CloseableModal: React.FC<CloseableModalProps> = ({
     positionRef,
+    openingRef,
     onClickOutside,
     children,
     className,
@@ -48,7 +50,11 @@ export const CloseableModal: React.FC<CloseableModalProps> = ({
 
     React.useEffect(() => {
         function clickHandler(event: MouseEvent) {
-            if (positionRef.current && !positionRef.current.contains(event.target as HTMLElement)) {
+            if (
+                positionRef.current &&
+                !positionRef.current.contains(event.target as HTMLElement) &&
+                (!openingRef?.current || !openingRef.current?.contains(event.target as HTMLElement))
+            ) {
                 onClickOutside();
             }
         }

--- a/ui/src/vayla-design-lib/datepicker/datepicker.tsx
+++ b/ui/src/vayla-design-lib/datepicker/datepicker.tsx
@@ -159,9 +159,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, .
             />
             {open && (
                 <CloseableModal
-                    onClickOutside={() => {
-                        undefined;
-                    }}
+                    onClickOutside={() => undefined}
                     offsetY={ref.current?.getBoundingClientRect().height ?? 0}
                     positionRef={ref}
                     openingRef={iconRef}
@@ -174,6 +172,9 @@ export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, .
                             onChange(date ?? undefined, 'PICKER');
                         }}
                         onChangeRaw={() => setOpen(false)}
+                        onClickOutside={() => {
+                            setOpen(false);
+                        }}
                         minDate={props.minDate}
                         maxDate={props.maxDate}
                         calendarStartDay={1}

--- a/ui/src/vayla-design-lib/datepicker/datepicker.tsx
+++ b/ui/src/vayla-design-lib/datepicker/datepicker.tsx
@@ -28,7 +28,6 @@ type DatePickerInputProps = {
     wide: boolean | undefined;
     minDate?: Date;
     maxDate?: Date;
-    iconRef: React.RefObject<SVGSVGElement>;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>;
 
 const DATE_FORMAT = 'dd.MM.yyyy';
@@ -80,14 +79,12 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, DatePickerInputProps>
 
         return (
             <TextField
-                Icon={(iconProps) => (
-                    <Icons.SetDate
-                        {...iconProps}
-                        onClick={() => localRef.current?.focus()}
-                        ref={props.iconRef}
-                    />
-                )}
+                Icon={(iconProps) => <Icons.SetDate {...iconProps} />}
                 iconPosition={TextInputIconPosition.RIGHT}
+                onClickIcon={() => {
+                    localRef.current?.focus();
+                    openDatePicker();
+                }}
                 wide={wide}
                 value={value}
                 onFocusCapture={openDatePicker}
@@ -158,12 +155,13 @@ export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, .
                 setDate={(date) => onChange(date, 'TEXT')}
                 wide={wide}
                 ref={ref}
-                iconRef={iconRef}
                 {...props}
             />
             {open && (
                 <CloseableModal
-                    onClickOutside={() => setOpen(false)}
+                    onClickOutside={() => {
+                        undefined;
+                    }}
                     offsetY={ref.current?.getBoundingClientRect().height ?? 0}
                     positionRef={ref}
                     openingRef={iconRef}
@@ -176,7 +174,6 @@ export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, .
                             onChange(date ?? undefined, 'PICKER');
                         }}
                         onChangeRaw={() => setOpen(false)}
-                        onClickOutside={() => setOpen(false)}
                         minDate={props.minDate}
                         maxDate={props.maxDate}
                         calendarStartDay={1}

--- a/ui/src/vayla-design-lib/datepicker/datepicker.tsx
+++ b/ui/src/vayla-design-lib/datepicker/datepicker.tsx
@@ -28,6 +28,7 @@ type DatePickerInputProps = {
     wide: boolean | undefined;
     minDate?: Date;
     maxDate?: Date;
+    iconRef: React.RefObject<SVGSVGElement>;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>;
 
 const DATE_FORMAT = 'dd.MM.yyyy';
@@ -82,10 +83,8 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, DatePickerInputProps>
                 Icon={(iconProps) => (
                     <Icons.SetDate
                         {...iconProps}
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            localRef.current?.focus();
-                        }}
+                        onClick={() => localRef.current?.focus()}
+                        ref={props.iconRef}
                     />
                 )}
                 iconPosition={TextInputIconPosition.RIGHT}
@@ -148,6 +147,7 @@ function getHeaderElement({
 export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, ...props }) => {
     const [open, setOpen] = React.useState(false);
     const ref = React.useRef<HTMLInputElement>(null);
+    const iconRef = React.useRef<SVGSVGElement>(null);
     const className = createClassName(styles['datepicker'], wide && styles['datepicker--wide']);
 
     return (
@@ -158,6 +158,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, .
                 setDate={(date) => onChange(date, 'TEXT')}
                 wide={wide}
                 ref={ref}
+                iconRef={iconRef}
                 {...props}
             />
             {open && (
@@ -165,6 +166,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, .
                     onClickOutside={() => setOpen(false)}
                     offsetY={ref.current?.getBoundingClientRect().height ?? 0}
                     positionRef={ref}
+                    openingRef={iconRef}
                     className={styles['datepicker__popup-container']}>
                     <ReactDatePicker
                         renderCustomHeader={getHeaderElement}

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -410,7 +410,9 @@ export const Dropdown = function <TItemValue>({
                             variant={ButtonVariant.GHOST}
                             icon={props.onAddClickIcon ?? Icons.Append}
                             wide
-                            onClick={props.onAddClick}>
+                            onClick={() => {
+                                props.onAddClick && props.onAddClick();
+                            }}>
                             {props.onAddClickTitle ?? t('dropdown.add-new')}
                         </Button>
                     </div>
@@ -428,9 +430,8 @@ export const Dropdown = function <TItemValue>({
             <div
                 className={styles['dropdown__header']}
                 role="button"
-                onClick={(e) => {
+                onClick={() => {
                     if (!props.disabled) {
-                        e.stopPropagation();
                         focusInput();
                         openOrOverridden ? setOpen(false) : openListAndFocusSelectedItem();
                     }

--- a/ui/src/vayla-design-lib/icon/Icon.tsx
+++ b/ui/src/vayla-design-lib/icon/Icon.tsx
@@ -145,6 +145,7 @@ export type IconProps = {
     size?: IconSize;
     rotation?: IconRotation;
     color?: IconColor;
+    ref?: React.RefObject<SVGSVGElement>;
 } & Pick<React.HTMLProps<HTMLOrSVGElement>, 'onClick'>;
 
 export type IconComponent = React.FC<IconProps>;

--- a/ui/src/vayla-design-lib/text-field/text-field.tsx
+++ b/ui/src/vayla-design-lib/text-field/text-field.tsx
@@ -34,6 +34,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             wide,
             attachLeft,
             attachRight,
+            onClickIcon,
             ...props
         }: TextFieldProps,
         forwardedRef,
@@ -57,7 +58,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             <div className={className}>
                 <div className="text-field__input">
                     {Icon && (
-                        <div className={styles['text-field__icon']} onClick={props.onClickIcon}>
+                        <div className={styles['text-field__icon']} onClick={onClickIcon}>
                             <Icon size={IconSize.SMALL} color={IconColor.INHERIT} />
                         </div>
                     )}

--- a/ui/src/vayla-design-lib/text-field/text-field.tsx
+++ b/ui/src/vayla-design-lib/text-field/text-field.tsx
@@ -21,6 +21,7 @@ export type TextFieldProps = {
     wide?: boolean;
     attachLeft?: boolean;
     attachRight?: boolean;
+    onClickIcon?: () => void;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
@@ -56,7 +57,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             <div className={className}>
                 <div className="text-field__input">
                     {Icon && (
-                        <div className={styles['text-field__icon']}>
+                        <div className={styles['text-field__icon']} onClick={props.onClickIcon}>
                             <Icon size={IconSize.SMALL} color={IconColor.INHERIT} />
                         </div>
                     )}


### PR DESCRIPTION
Täällä pääasiassa pyritty poistamaan frontilta klikkieventtien `stopPropagation()`-kutsuja, jotta klikit toimisivat niinkuin niiden olettaisi toimivan. Ihan kaikkia en saanut poistettua, mutta suurimman osan. Lisäksi korjattu työtilan valinta -dropdownin jääminen näkyviin uuden työtilan luontidialogin ollessa näkyvissä.