### PR TITLE
GVT-2751 Disallow deleted-state for new-draft items + unify edit dialogs

### DIFF
--- a/ui/src/tool-panel/km-post/dialog/km-post-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-delete-confirmation-dialog.tsx
@@ -23,15 +23,21 @@ const KmPostDeleteConfirmationDialog: React.FC<KmPostDeleteConfirmationDialogPro
 }: KmPostDeleteConfirmationDialogProps) => {
     const { t } = useTranslation();
 
-    const deleteKmPost = (id: LayoutKmPostId) =>
-        deleteDraftKmPost(layoutContext, id).then(
-            (kmPostId) => {
-                Snackbar.success('km-post-delete-draft-dialog.delete-succeeded');
-                onSave && onSave(kmPostId);
-                onClose();
-            },
-            () => Snackbar.error('km-post-delete-draft-dialog.delete-failed'),
-        );
+    const [isSaving, setIsSaving] = React.useState(false);
+
+    const deleteKmPost = (id: LayoutKmPostId) => {
+        setIsSaving(true);
+        deleteDraftKmPost(layoutContext, id)
+            .then(
+                (kmPostId) => {
+                    Snackbar.success('km-post-delete-draft-dialog.delete-succeeded');
+                    onSave && onSave(kmPostId);
+                    onClose();
+                },
+                () => Snackbar.error('km-post-delete-draft-dialog.delete-failed'),
+            )
+            .finally(() => setIsSaving(false));
+    };
 
     return (
         <Dialog
@@ -40,11 +46,13 @@ const KmPostDeleteConfirmationDialog: React.FC<KmPostDeleteConfirmationDialogPro
             allowClose={false}
             footerContent={
                 <div className={dialogStyles['dialog__footer-content--centered']}>
-                    <Button variant={ButtonVariant.SECONDARY} onClick={onClose}>
+                    <Button variant={ButtonVariant.SECONDARY} disabled={isSaving} onClick={onClose}>
                         {t('button.cancel')}
                     </Button>
                     <Button
                         variant={ButtonVariant.PRIMARY_WARNING}
+                        disabled={isSaving}
+                        isProcessing={isSaving}
                         onClick={() => deleteKmPost(id)}>
                         {t('button.delete')}
                     </Button>

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -95,12 +95,9 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
         gkLocationEnabled: !!props.geometryKmPostGkLocation,
     });
     const stateActions = createDelegatesWithDispatcher(dispatcher, actions);
+    const canSetDeleted = !state.isNewKmPost && state.existingKmPost?.editState !== 'CREATED';
     const kmPostStateOptions = layoutStates
-        .filter(
-            (ls) =>
-                (!state.isNewKmPost && state.existingKmPost?.editState !== 'CREATED') ||
-                ls.value != 'DELETED',
-        )
+        .map((s) => (s.value !== 'DELETED' || canSetDeleted ? s : { ...s, disabled: true }))
         .map((ls) => ({ ...ls, qaId: ls.value }));
 
     const debouncedKmNumber = useDebouncedState(state.kmPost?.kmNumber, 300);

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -96,7 +96,11 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
     });
     const stateActions = createDelegatesWithDispatcher(dispatcher, actions);
     const kmPostStateOptions = layoutStates
-        .filter((ls) => !state.isNewKmPost || ls.value != 'DELETED')
+        .filter(
+            (ls) =>
+                (!state.isNewKmPost && state.existingKmPost?.editState !== 'CREATED') ||
+                ls.value != 'DELETED',
+        )
         .map((ls) => ({ ...ls, qaId: ls.value }));
 
     const debouncedKmNumber = useDebouncedState(state.kmPost?.kmNumber, 300);
@@ -371,10 +375,15 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                         <div className={dialogStyles['dialog__footer-content--centered']}>
                             <Button
                                 variant={ButtonVariant.SECONDARY}
-                                onClick={() => setNonDraftDeleteConfirmationVisible(false)}>
+                                onClick={() => setNonDraftDeleteConfirmationVisible(false)}
+                                disabled={state.isSaving}>
                                 {t('button.cancel')}
                             </Button>
-                            <Button variant={ButtonVariant.PRIMARY_WARNING} onClick={save}>
+                            <Button
+                                disabled={state.isSaving}
+                                isProcessing={state.isSaving}
+                                variant={ButtonVariant.PRIMARY_WARNING}
+                                onClick={save}>
                                 {t('button.delete')}
                             </Button>
                         </div>

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -140,7 +140,12 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     );
 
     const stateOptions = locationTrackStates
-        .filter((ls) => !state.isNewLocationTrack || ls.value != 'DELETED')
+        .filter(
+            (ls) =>
+                (!state.isNewLocationTrack &&
+                    state.existingLocationTrack?.editState !== 'CREATED') ||
+                ls.value != 'DELETED',
+        )
         .map((ls) => ({ ...ls, qaId: ls.value }));
 
     const typeOptions = locationTrackTypes.map((ls) => ({ ...ls, qaId: ls.value }));
@@ -715,10 +720,15 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                         <div className={dialogStyles['dialog__footer-content--centered']}>
                             <Button
                                 onClick={() => setNonDraftDeleteConfirmationVisible(false)}
-                                variant={ButtonVariant.SECONDARY}>
+                                variant={ButtonVariant.SECONDARY}
+                                disabled={state.isSaving}>
                                 {t('button.cancel')}
                             </Button>
-                            <Button variant={ButtonVariant.PRIMARY_WARNING} onClick={save}>
+                            <Button
+                                disabled={state.isSaving}
+                                isProcessing={state.isSaving}
+                                variant={ButtonVariant.PRIMARY_WARNING}
+                                onClick={save}>
                                 {t('button.delete')}
                             </Button>
                         </div>

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -139,13 +139,10 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         props.changeTimes,
     );
 
+    const canSetDeleted =
+        !state.isNewLocationTrack && state.existingLocationTrack?.editState !== 'CREATED';
     const stateOptions = locationTrackStates
-        .filter(
-            (ls) =>
-                (!state.isNewLocationTrack &&
-                    state.existingLocationTrack?.editState !== 'CREATED') ||
-                ls.value != 'DELETED',
-        )
+        .map((s) => (s.value !== 'DELETED' || canSetDeleted ? s : { ...s, disabled: true }))
         .map((ls) => ({ ...ls, qaId: ls.value }));
 
     const typeOptions = locationTrackTypes.map((ls) => ({ ...ls, qaId: ls.value }));

--- a/ui/src/tool-panel/location-track/location-track-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/location-track/location-track-delete-confirmation-dialog.tsx
@@ -20,15 +20,20 @@ const LocationTrackDeleteConfirmationDialog: React.FC<
 > = ({ layoutContext, id, onSave, onClose }: LocationTrackDeleteConfirmationDialogProps) => {
     const { t } = useTranslation();
 
+    const [isSaving, setIsSaving] = React.useState(false);
+
     const deleteDraftLocationTrack = (id: LocationTrackId) => {
-        deleteLocationTrack(layoutContext, id).then(
-            (locationTrackId) => {
-                Snackbar.success('tool-panel.location-track.delete-dialog.delete-succeeded');
-                onSave && onSave(locationTrackId);
-                onClose();
-            },
-            () => Snackbar.error('tool-panel.location-track.delete-dialog.delete-failed'),
-        );
+        setIsSaving(true);
+        deleteLocationTrack(layoutContext, id)
+            .then(
+                (locationTrackId) => {
+                    Snackbar.success('tool-panel.location-track.delete-dialog.delete-succeeded');
+                    onSave && onSave(locationTrackId);
+                    onClose();
+                },
+                () => Snackbar.error('tool-panel.location-track.delete-dialog.delete-failed'),
+            )
+            .finally(() => setIsSaving(false));
     };
 
     return (
@@ -38,10 +43,12 @@ const LocationTrackDeleteConfirmationDialog: React.FC<
             allowClose={false}
             footerContent={
                 <div className={dialogStyles['dialog__footer-content--centered']}>
-                    <Button variant={ButtonVariant.SECONDARY} onClick={onClose}>
+                    <Button disabled={isSaving} variant={ButtonVariant.SECONDARY} onClick={onClose}>
                         {t('button.cancel')}
                     </Button>
                     <Button
+                        disabled={isSaving}
+                        isProcessing={isSaving}
                         variant={ButtonVariant.PRIMARY_WARNING}
                         onClick={() => deleteDraftLocationTrack(id)}>
                         {t('button.delete')}

--- a/ui/src/tool-panel/switch/dialog/switch-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-delete-confirmation-dialog.tsx
@@ -22,14 +22,20 @@ const SwitchDeleteConfirmationDialog: React.FC<SwitchDeleteConfirmationDialogPro
     onClose,
 }) => {
     const { t } = useTranslation();
+
+    const [isSaving, setIsSaving] = React.useState(false);
+
     const deleteSwitch = () => {
-        deleteDraftSwitch(layoutContext, switchId).then((id) => {
-            if (id) {
-                Snackbar.success('switch-delete-dialog.success');
-                onSave(id);
-                onClose();
-            }
-        });
+        setIsSaving(true);
+        deleteDraftSwitch(layoutContext, switchId)
+            .then((id) => {
+                if (id) {
+                    Snackbar.success('switch-delete-dialog.success');
+                    onSave(id);
+                    onClose();
+                }
+            })
+            .finally(() => setIsSaving(false));
     };
 
     return (
@@ -39,10 +45,14 @@ const SwitchDeleteConfirmationDialog: React.FC<SwitchDeleteConfirmationDialogPro
             allowClose={false}
             footerContent={
                 <div className={dialogStyles['dialog__footer-content--centered']}>
-                    <Button variant={ButtonVariant.SECONDARY} onClick={onClose}>
+                    <Button disabled={isSaving} variant={ButtonVariant.SECONDARY} onClick={onClose}>
                         {t('button.cancel')}
                     </Button>
-                    <Button variant={ButtonVariant.PRIMARY_WARNING} onClick={deleteSwitch}>
+                    <Button
+                        disabled={isSaving}
+                        isProcessing={isSaving}
+                        variant={ButtonVariant.PRIMARY_WARNING}
+                        onClick={deleteSwitch}>
                         {t('button.delete')}
                     </Button>
                 </div>

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -116,12 +116,9 @@ export const SwitchEditDialog = ({
     const switchStructureChanged =
         isExistingSwitch && switchStructureId != existingSwitch?.switchStructureId;
 
+    const canSetDeleted = isExistingSwitch && existingSwitch?.editState !== 'CREATED';
     const stateCategoryOptions = layoutStateCategories
-        .filter(
-            (sc) =>
-                (isExistingSwitch && existingSwitch?.editState !== 'CREATED') ||
-                sc.value != 'NOT_EXISTING',
-        )
+        .map((s) => (s.value !== 'NOT_EXISTING' || canSetDeleted ? s : { ...s, disabled: true }))
         .map((sc) => ({ ...sc, qaId: sc.value }));
 
     const conflictingSwitch = useLoader(async () => {

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -477,7 +477,37 @@ export const SwitchEditDialog = ({
                     </p>
                 </Dialog>
             )}
-            {showDeleteOfficialConfirmDialog && (
+            {showDeleteOfficialConfirmDialog && existingSwitch?.editState === 'CREATED' && (
+                <Dialog
+                    title={t('switch-dialog.confirmation-save-as-deleted-new')}
+                    variant={DialogVariant.DARK}
+                    allowClose={false}
+                    footerContent={
+                        <div className={dialogStyles['dialog__footer-content--centered']}>
+                            <Button
+                                onClick={() => setShowDeleteOfficialConfirmDialog(false)}
+                                variant={ButtonVariant.SECONDARY}
+                                disabled={isSaving}>
+                                {t('button.cancel')}
+                            </Button>
+                            {isSaving ? (
+                                <Spinner />
+                            ) : (
+                                <Button variant={ButtonVariant.PRIMARY_WARNING} onClick={save}>
+                                    {t('button.delete')}
+                                </Button>
+                            )}
+                        </div>
+                    }>
+                    <p>{t('switch-dialog.deleted-state-warning-new')}</p>
+                    <div>
+                        <div className={'dialog__text'}>
+                            {t('switch-dialog.confirm-switch-save-deleted-new')}
+                        </div>
+                    </div>
+                </Dialog>
+            )}
+            {showDeleteOfficialConfirmDialog && existingSwitch?.editState !== 'CREATED' && (
                 <Dialog
                     title={t('switch-dialog.confirmation-delete-title')}
                     variant={DialogVariant.DARK}

--- a/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-delete-confirmation-dialog.tsx
@@ -27,21 +27,27 @@ const TrackNumberDeleteConfirmationDialog: React.FC<TrackNumberDeleteConfirmatio
 }: TrackNumberDeleteConfirmationDialogProps) => {
     const { t } = useTranslation();
 
+    const [isSaving, setIsSaving] = React.useState(false);
+
     const deleteDraftLocationTrack = () => {
+        setIsSaving(true);
         revertPublicationCandidates(
             layoutContext.branch,
             changesBeingReverted.changeIncludingDependencies,
-        ).then((result) => {
-            result
-                .map(() => {
-                    Snackbar.success('tool-panel.track-number.delete-dialog.delete-succeeded');
-                    onSave && onSave(brand(changesBeingReverted.requestedRevertChange.source.id));
-                    onClose();
-                })
-                .mapErr(() => {
-                    Snackbar.error('tool-panel.track-number.delete-dialog.delete-failed');
-                });
-        });
+        )
+            .then((result) => {
+                result
+                    .map(() => {
+                        Snackbar.success('tool-panel.track-number.delete-dialog.delete-succeeded');
+                        onSave &&
+                            onSave(brand(changesBeingReverted.requestedRevertChange.source.id));
+                        onClose();
+                    })
+                    .mapErr(() => {
+                        Snackbar.error('tool-panel.track-number.delete-dialog.delete-failed');
+                    });
+            })
+            .finally(() => setIsSaving(false));
     };
 
     return (
@@ -51,10 +57,12 @@ const TrackNumberDeleteConfirmationDialog: React.FC<TrackNumberDeleteConfirmatio
             allowClose={false}
             footerContent={
                 <div className={dialogStyles['dialog__footer-content--centered']}>
-                    <Button variant={ButtonVariant.SECONDARY} onClick={onClose}>
+                    <Button disabled={isSaving} variant={ButtonVariant.SECONDARY} onClick={onClose}>
                         {t('button.cancel')}
                     </Button>
                     <Button
+                        disabled={isSaving}
+                        isProcessing={isSaving}
                         variant={ButtonVariant.PRIMARY_WARNING}
                         onClick={deleteDraftLocationTrack}>
                         {t('button.delete')}

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -121,12 +121,9 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
     const [nonDraftDeleteConfirmationVisible, setNonDraftDeleteConfirmationVisible] =
         React.useState<boolean>(false);
 
+    const canSetDeleted = inEditTrackNumber !== undefined && !isNewDraft;
     const trackNumberStateOptions = layoutStates
-        .map((s) =>
-            s.value !== 'DELETED' || (inEditTrackNumber !== undefined && !isNewDraft)
-                ? s
-                : { ...s, disabled: true },
-        )
+        .map((s) => (s.value !== 'DELETED' || canSetDeleted ? s : { ...s, disabled: true }))
         .map((s) => ({ ...s, qaId: s.value }));
 
     const confirmNewDraftDelete = () => {

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -123,7 +123,9 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
 
     const trackNumberStateOptions = layoutStates
         .map((s) =>
-            s.value !== 'DELETED' || inEditTrackNumber !== undefined ? s : { ...s, disabled: true },
+            s.value !== 'DELETED' || (inEditTrackNumber !== undefined && !isNewDraft)
+                ? s
+                : { ...s, disabled: true },
         )
         .map((s) => ({ ...s, qaId: s.value }));
 
@@ -372,10 +374,13 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
                         <div className={dialogStyles['dialog__footer-content--centered']}>
                             <Button
                                 onClick={() => setNonDraftDeleteConfirmationVisible(false)}
-                                variant={ButtonVariant.SECONDARY}>
+                                variant={ButtonVariant.SECONDARY}
+                                disabled={saveInProgress}>
                                 {t('button.cancel')}
                             </Button>
                             <Button
+                                disabled={saveInProgress}
+                                isProcessing={saveInProgress}
                                 variant={ButtonVariant.PRIMARY_WARNING}
                                 onClick={saveTrackNumber}>
                                 {t('button.delete')}


### PR DESCRIPTION
Tiketin kuvauksesta poiketen, puhuttiin Karin kanssa ja päätettiin vain disabloida deleted-tilan asetus new-draft olioilta sen sijaan että toteutettaisi kolmas erilainen delete-confirm dialogi. Samalla yhtenäistetty noita dialogeja toimimaan samalla tavoin eri tyyppien välillä. Muutokset itsessään näyttää pitkälti samoilta kaikissa.