### PR TITLE
GVT-2864 Pair up all tracks in pairsOf()

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
@@ -503,7 +503,8 @@ private fun getClosestPointAsIntersection(
         }
 }
 
-private fun <T> pairsOf(things: List<T>): List<Pair<T, T>> = things.windowed(2).map { p -> p[0] to p[1] }
+private fun <T> pairsOf(things: List<T>): List<Pair<T, T>> =
+    things.flatMapIndexed { index, t1 -> things.drop(index + 1).map { t2 -> t1 to t2 } }
 
 private fun findTrackIntersectionsForGridPoints(
     trackAlignments: List<IAlignment>,


### PR DESCRIPTION
Koodin puolesta hyvin selkeä (ja aika hölmö) regressio, jonka käytännön vaikutus kylläkin on todella pieni. Tässä siis haetaan vaihdelinkitykseen tulevista raiteista (joita haetaan vain kahden metrin säteeltä) pareja joilta hakea risteyskohtia: Jos jossain kohdassa risteää kolme tai ehkä neljä raidegeometriaa, ja geometriat on läheskään oikein, niin aikalailla riippumatta siitä, missä järjestyksessä raiteet satuttiin tälle funktiolle passaamaan, niistä kyllä löytyy jokin pari, jolla on järkevä risteyskohta. (Risteyskohdaksi kelpaa mikä tahansa kohta, jossa raiteet ovat enintään puolen metrin päässä toisistaan)

Mutta koska tämä bugi ei ole vielä mennyt tuotantoon, tuodaan nyt hotfix-haaraan ihan jotta vaihdelinkityksen toiminta pysyy vakaana huonompilaatuistenkin geometrioiden kanssa.