### PR TITLE
GVT-2852 Optimize and separate out track switch relinking validation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
@@ -16,6 +16,7 @@ import fi.fta.geoviite.infra.geometry.GeometrySwitch
 import fi.fta.geoviite.infra.linking.switches.SamplingGridPoints
 import fi.fta.geoviite.infra.linking.switches.SuggestedSwitchesAtGridPoints
 import fi.fta.geoviite.infra.linking.switches.SwitchLinkingService
+import fi.fta.geoviite.infra.linking.switches.SwitchTrackRelinkingValidationService
 import fi.fta.geoviite.infra.linking.switches.matchSamplingGridToQueryPoints
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
@@ -39,7 +40,11 @@ import org.springframework.web.bind.annotation.RequestParam
 @GeoviiteController("/linking")
 class LinkingController
 @Autowired
-constructor(private val linkingService: LinkingService, private val switchLinkingService: SwitchLinkingService) {
+constructor(
+    private val linkingService: LinkingService,
+    private val switchLinkingService: SwitchLinkingService,
+    private val switchTrackRelinkingValidationService: SwitchTrackRelinkingValidationService,
+) {
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
     @PostMapping("/{$LAYOUT_BRANCH}/reference-lines/geometry")
@@ -192,7 +197,7 @@ constructor(private val linkingService: LinkingService, private val switchLinkin
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable("id") id: IntId<LocationTrack>,
     ): List<SwitchRelinkingValidationResult> {
-        return switchLinkingService.validateRelinkingTrack(branch, id)
+        return switchTrackRelinkingValidationService.validateRelinkingTrack(branch, id)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchTrackRelinkingValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchTrackRelinkingValidationService.kt
@@ -1,0 +1,249 @@
+package fi.fta.geoviite.infra.linking.switches
+
+import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.geocoding.GeocodingContext
+import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.linking.SuggestedSwitch
+import fi.fta.geoviite.infra.linking.SwitchRelinkingSuggestion
+import fi.fta.geoviite.infra.linking.SwitchRelinkingValidationResult
+import fi.fta.geoviite.infra.localization.localizationParams
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.publication.LayoutValidationIssue
+import fi.fta.geoviite.infra.publication.LayoutValidationIssueType
+import fi.fta.geoviite.infra.publication.VALIDATION_SWITCH
+import fi.fta.geoviite.infra.publication.validateSwitchLocationTrackLinkStructure
+import fi.fta.geoviite.infra.publication.validateWithParams
+import fi.fta.geoviite.infra.split.VALIDATION_SPLIT
+import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.SwitchPlacingRequest
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.asDraft
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+
+@GeoviiteService
+class SwitchTrackRelinkingValidationService
+@Autowired
+constructor(
+    private val switchService: LayoutSwitchService,
+    private val locationTrackService: LocationTrackService,
+    private val switchLinkingService: SwitchLinkingService,
+    private val switchLibraryService: SwitchLibraryService,
+    private val geocodingService: GeocodingService,
+) {
+
+    @Transactional(readOnly = true)
+    fun validateRelinkingTrack(
+        branch: LayoutBranch,
+        trackId: IntId<LocationTrack>,
+    ): List<SwitchRelinkingValidationResult> {
+        val (track, alignment) = locationTrackService.getWithAlignmentOrThrow(branch.draft, trackId)
+        val switchIds = switchLinkingService.collectAllSwitchesOnTrackAndNearby(branch, track, alignment)
+        val originalSwitches = getOriginalSwitches(branch, switchIds)
+        val switchStructures = originalSwitches.map { switchLibraryService.getSwitchStructure(it.switchStructureId) }
+        val originalLocations = getOriginalLocations(originalSwitches, switchStructures)
+
+        val switchPlacingRequests = currentSwitchLocationsAsSwitchPlacingRequests(switchIds, originalLocations)
+        val switchSuggestions = collectSwitchSuggestionsAtPoints(branch, switchPlacingRequests)
+        val changedLocationTracks =
+            collectLocationTrackChangesFromSwitchSuggestions(branch, switchSuggestions, switchPlacingRequests)
+
+        val geocodingContext =
+            geocodingService.getGeocodingContext(branch.draft, track.trackNumberId)
+                ?: return switchIds.zip(originalSwitches) { switchId, originalSwitch ->
+                    failRelinkingValidationFor(switchId, originalSwitch)
+                }
+
+        return switchIds.mapIndexed { index, switchId ->
+            validateChangeFromSwitchRelinking(
+                track,
+                geocodingContext,
+                switchId,
+                switchSuggestions[index],
+                originalSwitches[index],
+                switchLibraryService.getSwitchStructure(originalSwitches[index].switchStructureId),
+                changedLocationTracks[index],
+            )
+        }
+    }
+
+    private fun getOriginalSwitches(branch: LayoutBranch, switchIds: List<IntId<TrackLayoutSwitch>>) =
+        switchService.getMany(branch.draft, switchIds).also { foundSwitches ->
+            require(switchIds.size == foundSwitches.size) {
+                val notFoundSwitches = switchIds.filterNot { id -> foundSwitches.any { found -> found.id == id } }
+                "did not find switches with IDs $notFoundSwitches"
+            }
+        }
+
+    private fun collectSwitchSuggestionsAtPoints(
+        branch: LayoutBranch,
+        switchPlacingRequests: List<SwitchPlacingRequest>,
+    ): List<SuggestedSwitchWithOriginallyLinkedTracks?> =
+        switchLinkingService.getSuggestedSwitchesWithOriginallyLinkedTracks(branch, switchPlacingRequests).map {
+            pointAssociation ->
+            pointAssociation.keys().firstOrNull()
+        }
+
+    private fun collectLocationTrackChangesFromSwitchSuggestions(
+        branch: LayoutBranch,
+        switchSuggestions: List<SuggestedSwitchWithOriginallyLinkedTracks?>,
+        switchPlacingRequests: List<SwitchPlacingRequest>,
+    ): List<List<Pair<LocationTrack, LayoutAlignment>>> =
+        lookupTracksForSuggestedSwitchValidation(branch, switchSuggestions.map { it?.suggestedSwitch })
+            .mapIndexed { index, tracks -> index to tracks }
+            .parallelStream()
+            .map { (index, originalTracks) ->
+                switchSuggestions[index]?.let { suggestion ->
+                    withChangesFromLinkingSwitch(
+                        suggestion.suggestedSwitch,
+                        switchPlacingRequests[index].layoutSwitchId,
+                        originalTracks,
+                    )
+                }
+            }
+            .toList()
+
+    private fun lookupTracksForSuggestedSwitchValidation(
+        branch: LayoutBranch,
+        suggestedSwitches: List<SuggestedSwitch?>,
+    ): List<Map<IntId<LocationTrack>, Pair<LocationTrack, LayoutAlignment>>> {
+        val changedTracksIds =
+            suggestedSwitches.asSequence().mapNotNull { it?.trackLinks?.keys }.flatten().distinct().toList()
+        val tracks =
+            locationTrackService.getManyWithAlignments(branch.draft, changedTracksIds).associateBy { it.first.id }
+        return suggestedSwitches.map { suggestedSwitch ->
+            suggestedSwitch?.trackLinks?.keys?.associateWith { id -> tracks.getValue(id) } ?: mapOf()
+        }
+    }
+}
+
+// some validation logic depends on draftness state, so we need to pre-draft tracks for online
+// validation
+private fun draft(tracks: List<Pair<LocationTrack, LayoutAlignment>>) =
+    tracks.map { (track, alignment) -> asDraft(track.branch, track) to alignment }
+
+private fun currentSwitchLocationsAsSwitchPlacingRequests(
+    switchIds: List<IntId<TrackLayoutSwitch>>,
+    locations: List<Point>,
+) = locations.zip(switchIds) { location, switchId -> SwitchPlacingRequest(SamplingGridPoints(location), switchId) }
+
+private fun validateChangeFromSwitchRelinking(
+    track: LocationTrack,
+    geocodingContext: GeocodingContext,
+    switchId: IntId<TrackLayoutSwitch>,
+    suggestedSwitchWithOriginallyLinkedTracks: SuggestedSwitchWithOriginallyLinkedTracks?,
+    originalSwitch: TrackLayoutSwitch,
+    switchStructure: SwitchStructure,
+    changedTracks: List<Pair<LocationTrack, LayoutAlignment>>,
+): SwitchRelinkingValidationResult {
+    return if (suggestedSwitchWithOriginallyLinkedTracks == null) failRelinkingValidationFor(switchId, originalSwitch)
+    else {
+        val suggestedSwitch = suggestedSwitchWithOriginallyLinkedTracks.suggestedSwitch
+        val validationResults =
+            validateForSplit(
+                suggestedSwitch,
+                originalSwitch,
+                switchStructure,
+                track,
+                changedTracks,
+                suggestedSwitchWithOriginallyLinkedTracks.originallyLinkedTracks.keys.toList(),
+            )
+        val presentationJointLocation = getSuggestedLocation(switchId, suggestedSwitch, switchStructure)
+        val address =
+            requireNotNull(geocodingContext.getAddress(presentationJointLocation)) {
+                "Could not geocode relinked location for switch $switchId on track $track"
+            }
+        SwitchRelinkingValidationResult(
+            switchId,
+            SwitchRelinkingSuggestion(presentationJointLocation, address.first),
+            validationResults,
+        )
+    }
+}
+
+private fun validateForSplit(
+    suggestedSwitch: SuggestedSwitch,
+    originalSwitch: TrackLayoutSwitch,
+    switchStructure: SwitchStructure,
+    track: LocationTrack,
+    changedTracksFromSwitchSuggestion: List<Pair<LocationTrack, LayoutAlignment>>,
+    currentSwitchLocationTrackConnections: List<IntId<LocationTrack>>,
+): List<LayoutValidationIssue> {
+    val createdSwitch = createModifiedLayoutSwitchLinking(suggestedSwitch, originalSwitch)
+
+    val originTrackLinkErrors =
+        validateRelinkingRetainsLocationTrackConnections(
+            suggestedSwitch,
+            track,
+            originalSwitch.name,
+            currentSwitchLocationTrackConnections,
+        )
+    val publicationValidationErrorsMapped =
+        validateSwitchLocationTrackLinkStructure(
+                createdSwitch,
+                switchStructure,
+                draft(changedTracksFromSwitchSuggestion),
+            )
+            .map { error ->
+                // Structure based issues aren't critical for splitting/relinking -> turn them
+                // into warnings
+                LayoutValidationIssue(LayoutValidationIssueType.WARNING, error.localizationKey, error.params)
+            }
+
+    return publicationValidationErrorsMapped + originTrackLinkErrors
+}
+
+private fun validateRelinkingRetainsLocationTrackConnections(
+    suggestedSwitch: SuggestedSwitch,
+    track: LocationTrack,
+    switchName: SwitchName,
+    currentConnections: List<IntId<LocationTrack>>,
+): List<LayoutValidationIssue> {
+    val suggestedConnections = suggestedSwitch.trackLinks.filter { link -> link.value.isLinked() }.keys
+
+    return listOfNotNull(
+        validateWithParams(suggestedConnections.containsAll(currentConnections), LayoutValidationIssueType.ERROR) {
+            "$VALIDATION_SPLIT.track-links-missing-after-relinking" to
+                localizationParams("switchName" to switchName, "sourceName" to track.name)
+        }
+    )
+}
+
+private fun failRelinkingValidationFor(switchId: IntId<TrackLayoutSwitch>, originalSwitch: TrackLayoutSwitch) =
+    SwitchRelinkingValidationResult(
+        switchId,
+        null,
+        listOf(
+            LayoutValidationIssue(
+                LayoutValidationIssueType.ERROR,
+                "$VALIDATION_SWITCH.track-linkage.relinking-failed",
+                mapOf("switch" to originalSwitch.name),
+            )
+        ),
+    )
+
+private fun getOriginalLocations(originalSwitches: List<TrackLayoutSwitch>, switchStructures: List<SwitchStructure>) =
+    originalSwitches.zip(switchStructures) { switch, structure ->
+        checkNotNull(switch.getJoint(structure.presentationJointNumber)) {
+                "expected switch ${switch.id} to have a location"
+            }
+            .location
+    }
+
+private fun getSuggestedLocation(
+    switchId: IntId<TrackLayoutSwitch>,
+    suggestedSwitch: SuggestedSwitch,
+    switchStructure: SwitchStructure,
+) =
+    checkNotNull(suggestedSwitch.joints.find { joint -> joint.number == switchStructure.presentationJointNumber }) {
+            "expected suggested switch for switch $switchId to have location"
+        }
+        .location

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -602,8 +602,11 @@ class LayoutSwitchDao(
                 join layout.segment_geometry on segment_version.geometry_id = segment_geometry.id
                 join layout.switch_joint on
                   postgis.st_contains(postgis.st_expand(segment_geometry.bounding_box, :dist), switch_joint.location)
-                  and postgis.st_distance(segment_geometry.geometry, switch_joint.location) < :dist
-                join layout.switch_in_layout_context('DRAFT', :design_id) switch on switch_joint.switch_id = switch.row_id
+                  and postgis.st_dwithin(segment_geometry.geometry, switch_joint.location, :dist)
+                join (select *
+                      from layout.switch,
+                        layout.switch_is_in_layout_context('DRAFT', :design_id, switch))
+                         switch on switch_joint.switch_id = switch.id
               where segment_version.alignment_id = :alignmentId
                 and segment_version.alignment_version = :alignmentVersion
                 and switch.state_category != 'NOT_EXISTING';

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/SwitchLinkingServiceIT.kt
@@ -19,6 +19,7 @@ import fi.fta.geoviite.infra.geometry.GeometrySwitch
 import fi.fta.geoviite.infra.geometry.plan
 import fi.fta.geoviite.infra.geometry.testFile
 import fi.fta.geoviite.infra.linking.switches.SwitchLinkingService
+import fi.fta.geoviite.infra.linking.switches.SwitchTrackRelinkingValidationService
 import fi.fta.geoviite.infra.linking.switches.matchFittedSwitchToTracks
 import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.localization.LocalizationParams
@@ -70,6 +71,7 @@ class SwitchLinkingServiceIT
 @Autowired
 constructor(
     private val switchLinkingService: SwitchLinkingService,
+    private val switchTrackRelinkingValidationService: SwitchTrackRelinkingValidationService,
     private val switchDao: LayoutSwitchDao,
     private val locationTrackService: LocationTrackService,
     private val geometryDao: GeometryDao,
@@ -993,7 +995,8 @@ constructor(
             locationTrack(trackNumberId, name = "bad branching track", duplicateOf = throughTrack.id, draft = true),
             alignment(shiftTrack(templateBranchingTrackSegments, null, shift1)),
         )
-        val validationResult = switchLinkingService.validateRelinkingTrack(LayoutBranch.main, throughTrack.id)
+        val validationResult =
+            switchTrackRelinkingValidationService.validateRelinkingTrack(LayoutBranch.main, throughTrack.id)
         assertEqualsRounded(
             listOf(
                 SwitchRelinkingValidationResult(
@@ -1067,7 +1070,7 @@ constructor(
         )
         val okSwitch = switchDao.insert(shiftSwitch(templateSwitch, "ok", Point(10.0, 0.0)))
 
-        val validationResult = switchLinkingService.validateRelinkingTrack(LayoutBranch.main, track152)
+        val validationResult = switchTrackRelinkingValidationService.validateRelinkingTrack(LayoutBranch.main, track152)
         val relinkingResult = switchLinkingService.relinkTrack(LayoutBranch.main, track152)
         assertEquals(
             listOf(
@@ -1142,7 +1145,8 @@ constructor(
                     segment(Point(5.0, 0.0), basePoint),
                 ),
             )
-        val validationResult = switchLinkingService.validateRelinkingTrack(LayoutBranch.main, topoTrack.id)
+        val validationResult =
+            switchTrackRelinkingValidationService.validateRelinkingTrack(LayoutBranch.main, topoTrack.id)
         assertEqualsRounded(
             listOf(
                 SwitchRelinkingValidationResult(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/BoundingBoxTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/BoundingBoxTest.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.math
 
+import kotlin.math.sqrt
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -113,5 +114,56 @@ class BoundingBoxTest {
         assertEquals(Point(15.0, 25.0), bbox.min)
         assertEquals(Point(25.0, 35.0), bbox.max)
         assertEquals(Point(20.0, 30.0), bbox.center)
+    }
+
+    @Test
+    fun minimumDistance() {
+        // Inclusion, symmetrically: Always 0, because this is a minimum distance between entire
+        // bounding boxes, not their perimeters
+        assertEquals(
+            0.0,
+            BoundingBox(Point(0.0, 0.0), Point(10.0, 10.0))
+                .minimumDistance(BoundingBox(Point(1.0, 1.0), Point(9.0, 9.0))),
+        )
+        assertEquals(
+            0.0,
+            BoundingBox(Point(1.0, 1.0), Point(9.0, 9.0))
+                .minimumDistance(BoundingBox(Point(0.0, 0.0), Point(10.0, 10.0))),
+        )
+
+        // axial distance
+        assertEquals(
+            1.0,
+            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0)).minimumDistance(BoundingBox(Point(2.0, 0.0), Point(3.0, 1.0))),
+        )
+        assertEquals(
+            1.0,
+            BoundingBox(Point(0.0, 11.0), Point(10.0, 20.0))
+                .minimumDistance(BoundingBox(Point(0.0, 0.0), Point(10.0, 10.0))),
+        )
+
+        // diagonal distance
+        assertEquals(
+            sqrt(2.0),
+            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0))
+                .minimumDistance(BoundingBox(Point(2.0, 2.0), Point(3.0, 3.0))),
+            0.00001,
+        )
+
+        // intersection
+        assertEquals(
+            0.0,
+            BoundingBox(Point(0.0, 0.0), Point(3.0, 3.0)).minimumDistance(BoundingBox(Point(1.0, 1.0), Point(5.0, 2.0))),
+        )
+
+        // touch axially or diagonally
+        assertEquals(
+            0.0,
+            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0)).minimumDistance(BoundingBox(Point(1.0, 0.0), Point(2.0, 1.0))),
+        )
+        assertEquals(
+            0.0,
+            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0)).minimumDistance(BoundingBox(Point(1.0, 1.0), Point(2.0, 2.0))),
+        )
     }
 }


### PR DESCRIPTION
Isohko(?) määrä muuttunutta koodia, mutta testattu ajamalla tämä validaatio kaikille paikannuspohjan raiteille ja toteamalla, että tulos on bitilleen sama.

Isoimmat muutosteemat:
- Koko validaatio siirtyi omaan tiedostoonsa, SwitchLinkingService kun tuntuu olevan sen verran iso kokonaisuus että se poikii näitä lapsukaisia. Koodi on suurelta osin kokonaan uutta, toimintaperiaatteet kylläkin korkealla tasolla samat kuin ennen.
- Vaihdelinkityksen raiteiden sijaintihaut tehdään nyt spatial cachesta
- Linkityksessä useita optimointeja, osa yleiskäyttöisiä (raiteiden risteyskohtien etsimisen nopeutus boundingboxeilla pönkittämällä), osa mikro-optimointeja juuri pitkän raiteen tehtävälistan laskemiseen