### PR TITLE
GVT-2865 Part 1: KM-pylvään sijainnin vahvistus käyttäytyy oudosti manuaalisessa asetuksessa

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
@@ -12,7 +12,6 @@ import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.TrackNumberDescription
 import fi.fta.geoviite.infra.error.LinkingFailureException
 import fi.fta.geoviite.infra.geography.CoordinateTransformationException
-import fi.fta.geoviite.infra.geography.GeometryPoint
 import fi.fta.geoviite.infra.geography.isGkFinSrid
 import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
@@ -28,7 +27,6 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.DescriptionSuffixType
-import fi.fta.geoviite.infra.tracklayout.KmPostGkLocationSource
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutState
@@ -39,6 +37,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import fi.fta.geoviite.infra.tracklayout.TopologicalConnectivityType
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitchJoint
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
@@ -168,13 +167,11 @@ data class TrackLayoutKmPostSaveRequest(
     val kmNumber: KmNumber,
     val state: LayoutState,
     val trackNumberId: IntId<TrackLayoutTrackNumber>,
-    val gkLocationConfirmed: Boolean,
-    val gkLocationSource: KmPostGkLocationSource?,
-    val gkLocation: GeometryPoint?,
+    val gkLocation: TrackLayoutKmPostGkLocation?,
     val sourceId: IntId<GeometryKmPost>?,
 ) {
     init {
-        gkLocation?.let { location ->
+        gkLocation?.let { (location) ->
             try {
                 if (!isGkFinSrid(location.srid)) {
                     throw LinkingFailureException(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingService.kt
@@ -29,6 +29,7 @@ import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPostGkLocation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
 
@@ -245,10 +246,13 @@ constructor(
             coordinateTransformationService.getTransformationToGkFin(kmPostSrid).transform(geometryKmPost.location)
         val modifiedLayoutKmPost =
             layoutKmPost.copy(
-                gkLocation = newGkLocation,
-                gkLocationSource = KmPostGkLocationSource.FROM_GEOMETRY,
+                gkLocation =
+                    TrackLayoutKmPostGkLocation(
+                        location = newGkLocation,
+                        source = KmPostGkLocationSource.FROM_GEOMETRY,
+                        confirmed = true,
+                    ),
                 sourceId = geometryKmPost.id,
-                gkLocationConfirmed = true,
             )
 
         return layoutKmPostService.saveDraft(branch, modifiedLayoutKmPost)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -29,8 +29,6 @@ class LayoutKmPostService(
                 trackNumberId = request.trackNumberId,
                 sourceId = null,
                 gkLocation = request.gkLocation,
-                gkLocationSource = request.gkLocationSource,
-                gkLocationConfirmed = request.gkLocationConfirmed,
                 contextData = LayoutContextData.newDraft(branch),
             )
         return saveDraftInternal(branch, kmPost).id
@@ -47,8 +45,6 @@ class LayoutKmPostService(
                 .copy(
                     kmNumber = kmPost.kmNumber,
                     state = kmPost.state,
-                    gkLocationConfirmed = kmPost.gkLocationConfirmed,
-                    gkLocationSource = kmPost.gkLocationSource,
                     gkLocation = kmPost.gkLocation,
                     sourceId = kmPost.sourceId,
                 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -234,8 +234,8 @@ private fun asCsvFile(
                     {
                         if (isGeneratedRow(it)) {
                             ""
-                        } else if (precision == KmLengthsLocationPrecision.PRECISE_LOCATION) {
-                            translation.t(gkLocationConfirmedTranslationKey(it.gkLocation?.confirmed))
+                        } else if (precision == KmLengthsLocationPrecision.PRECISE_LOCATION && it.gkLocation != null) {
+                            translation.t(gkLocationConfirmedTranslationKey(it.gkLocation.confirmed))
                         } else {
                             translation.t("$KM_LENGTHS_CSV_TRANSLATION_PREFIX.not-confirmed")
                         }
@@ -288,9 +288,9 @@ private fun locationSourceTranslationKey(
             ?.let(::LocalizationKey)
 }
 
-private fun gkLocationConfirmedTranslationKey(confirmed: Boolean?): LocalizationKey =
+private fun gkLocationConfirmedTranslationKey(confirmed: Boolean): LocalizationKey =
     when {
-        confirmed == true -> "$KM_LENGTHS_CSV_TRANSLATION_PREFIX.confirmed"
+        confirmed -> "$KM_LENGTHS_CSV_TRANSLATION_PREFIX.confirmed"
         else -> "$KM_LENGTHS_CSV_TRANSLATION_PREFIX.not-confirmed"
     }.let(::LocalizationKey)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -90,9 +90,12 @@ fun toTrackLayoutKmPosts(
                 state = getLayoutStateOrDefault(kmPost.state),
                 sourceId = kmPost.id,
                 trackNumberId = trackNumberId,
-                gkLocation = planToGkTransformation.transform(kmPost.location),
-                gkLocationSource = KmPostGkLocationSource.FROM_GEOMETRY,
-                gkLocationConfirmed = true,
+                gkLocation =
+                    TrackLayoutKmPostGkLocation(
+                        location = planToGkTransformation.transform(kmPost.location),
+                        source = KmPostGkLocationSource.FROM_GEOMETRY,
+                        confirmed = true,
+                    ),
                 contextData = LayoutContextData.newDraft(LayoutBranch.main),
             )
         } else {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -392,11 +392,15 @@ enum class KmPostGkLocationSource {
     MANUAL,
 }
 
+data class TrackLayoutKmPostGkLocation(
+    val location: GeometryPoint,
+    val source: KmPostGkLocationSource,
+    val confirmed: Boolean,
+)
+
 data class TrackLayoutKmPost(
     val kmNumber: KmNumber,
-    val gkLocation: GeometryPoint?,
-    val gkLocationSource: KmPostGkLocationSource?,
-    val gkLocationConfirmed: Boolean,
+    val gkLocation: TrackLayoutKmPostGkLocation?,
     val state: LayoutState,
     val trackNumberId: IntId<TrackLayoutTrackNumber>?,
     val sourceId: DomainId<GeometryKmPost>?,
@@ -405,7 +409,8 @@ data class TrackLayoutKmPost(
     @JsonIgnore val exists = !state.isRemoved()
 
     val layoutLocation =
-        if (gkLocation == null) null else transformNonKKJCoordinate(gkLocation.srid, LAYOUT_SRID, gkLocation.toPoint())
+        if (gkLocation == null) null
+        else transformNonKKJCoordinate(gkLocation.location.srid, LAYOUT_SRID, gkLocation.location.toPoint())
 
     fun getAsIntegral(): IntegralTrackLayoutKmPost? =
         if (state != LayoutState.IN_USE || layoutLocation == null || trackNumberId == null) null
@@ -437,9 +442,7 @@ data class TrackLayoutKmLengthDetails(
     val endM: BigDecimal,
     val layoutGeometrySource: GeometrySource,
     val layoutLocation: Point?,
-    val gkLocation: GeometryPoint?,
-    val gkLocationSource: KmPostGkLocationSource?,
-    val gkLocationConfirmed: Boolean,
+    val gkLocation: TrackLayoutKmPostGkLocation?,
     val gkLocationLinkedFromGeometry: Boolean,
 ) {
     val length = endM - startM

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCacheIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCacheIT.kt
@@ -39,9 +39,9 @@ class PlanLayoutCacheIT @Autowired constructor(private val planlayoutCache: Plan
         val layout = planlayoutCache.transformToLayoutPlan(plan).first!!
         val kmPost = layout.kmPosts[0]
         val gkLocation = kmPost.gkLocation!!
-        assertEquals(25505351.859, gkLocation.x, 0.001)
-        assertEquals(6695054.460, gkLocation.y, 0.001)
-        assertEquals(FIN_GK25_SRID, gkLocation.srid)
+        assertEquals(25505351.859, gkLocation.location.x, 0.001)
+        assertEquals(6695054.460, gkLocation.location.y, 0.001)
+        assertEquals(FIN_GK25_SRID, gkLocation.location.srid)
     }
 
     @Test
@@ -74,8 +74,8 @@ class PlanLayoutCacheIT @Autowired constructor(private val planlayoutCache: Plan
         val layout = planlayoutCache.transformToLayoutPlan(plan).first!!
         val kmPost = layout.kmPosts[0]
         val gkLocation = kmPost.gkLocation!!
-        assertEquals(25505351.859, gkLocation.x, 0.001)
-        assertEquals(6695054.460, gkLocation.y, 0.001)
-        assertEquals(FIN_GK25_SRID, gkLocation.srid)
+        assertEquals(25505351.859, gkLocation.location.x, 0.001)
+        assertEquals(6695054.460, gkLocation.location.y, 0.001)
+        assertEquals(FIN_GK25_SRID, gkLocation.location.srid)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
@@ -756,7 +756,16 @@ constructor(
         return layoutKmPostDao.fetch(
             layoutKmPostDao
                 .update(
-                    kmPost.copy(gkLocation = GeometryPoint(moveFunc(kmPost.gkLocation!!), kmPost.gkLocation!!.srid))
+                    kmPost.copy(
+                        gkLocation =
+                            kmPost.gkLocation?.copy(
+                                location =
+                                    GeometryPoint(
+                                        moveFunc(kmPost.gkLocation!!.location),
+                                        kmPost.gkLocation!!.location.srid,
+                                    )
+                            )
+                    )
                 )
                 .rowVersion
         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -221,10 +221,10 @@ constructor(
         assertNotEquals(officialKmPost, draftKmPost)
 
         assertEquals(geometryKmPostId, draftKmPost.sourceId)
-        assertEquals(true, draftKmPost.gkLocationConfirmed)
-        assertEquals(KmPostGkLocationSource.FROM_GEOMETRY, draftKmPost.gkLocationSource)
-        assertEquals(geometryKmPost.location, draftKmPost.gkLocation?.toPoint())
-        assertEquals(fetchedPlan.units.coordinateSystemSrid, draftKmPost.gkLocation?.srid)
+        assertEquals(true, draftKmPost.gkLocation?.confirmed)
+        assertEquals(KmPostGkLocationSource.FROM_GEOMETRY, draftKmPost.gkLocation?.source)
+        assertEquals(geometryKmPost.location, draftKmPost.gkLocation?.location?.toPoint())
+        assertEquals(fetchedPlan.units.coordinateSystemSrid, draftKmPost.gkLocation?.location?.srid)
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1678,8 +1678,6 @@ constructor(
                         LayoutState.IN_USE,
                         trackNumberId,
                         gkLocation = null,
-                        gkLocationSource = null,
-                        gkLocationConfirmed = false,
                         sourceId = null,
                     ),
                 ),
@@ -1700,8 +1698,6 @@ constructor(
                         LayoutState.NOT_IN_USE,
                         trackNumber2Id,
                         gkLocation = null,
-                        gkLocationSource = null,
-                        gkLocationConfirmed = false,
                         sourceId = null,
                     ),
                 ),
@@ -1770,8 +1766,6 @@ constructor(
                 LayoutState.IN_USE,
                 mainOfficialContext.createLayoutTrackNumber().id,
                 gkLocation = null,
-                gkLocationSource = null,
-                gkLocationConfirmed = false,
                 sourceId = null,
             )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -166,8 +166,6 @@ constructor(
                 state = LayoutState.IN_USE,
                 trackNumberId = trackNumberId,
                 gkLocation = null,
-                gkLocationSource = null,
-                gkLocationConfirmed = false,
                 sourceId = null,
             )
         val kmPostId = kmPostService.insertKmPost(LayoutBranch.main, kmPost)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -144,8 +144,6 @@ constructor(
                 layoutGeometrySource = GeometrySource.GENERATED,
                 layoutLocation = Point(0.0, 0.0),
                 gkLocation = null,
-                gkLocationConfirmed = false,
-                gkLocationSource = null,
                 gkLocationLinkedFromGeometry = false,
             ),
             kmLengths.first(),
@@ -161,13 +159,15 @@ constructor(
                 layoutGeometrySource = GeometrySource.IMPORTED,
                 layoutLocation = kmPostLocation1,
                 gkLocation = null,
-                gkLocationConfirmed = false,
-                gkLocationSource = null,
                 gkLocationLinkedFromGeometry = false,
             ),
             kmLengths[1].copy(gkLocation = null),
         )
-        assertApproximatelyEquals(transformFromLayoutToGKCoordinate(kmPostLocation1!!), kmLengths[1].gkLocation!!, 0.01)
+        assertApproximatelyEquals(
+            transformFromLayoutToGKCoordinate(kmPostLocation1!!),
+            kmLengths[1].gkLocation!!.location,
+            0.01,
+        )
 
         val kmPostLocation2 = kmPostDao.fetch(kmPostVersions[1]).layoutLocation
         assertEquals(
@@ -179,13 +179,15 @@ constructor(
                 layoutGeometrySource = GeometrySource.IMPORTED,
                 layoutLocation = kmPostLocation2,
                 gkLocation = null,
-                gkLocationConfirmed = false,
-                gkLocationSource = null,
                 gkLocationLinkedFromGeometry = false,
             ),
             kmLengths[2].copy(gkLocation = null),
         )
-        assertApproximatelyEquals(transformFromLayoutToGKCoordinate(kmPostLocation2!!), kmLengths[2].gkLocation!!, 0.01)
+        assertApproximatelyEquals(
+            transformFromLayoutToGKCoordinate(kmPostLocation2!!),
+            kmLengths[2].gkLocation!!.location,
+            0.01,
+        )
     }
 
     @Test
@@ -242,8 +244,6 @@ constructor(
                 layoutGeometrySource = GeometrySource.GENERATED,
                 layoutLocation = Point(0.0, 0.0),
                 gkLocation = null,
-                gkLocationConfirmed = false,
-                gkLocationSource = null,
                 gkLocationLinkedFromGeometry = false,
             ),
             kmLengths.first(),
@@ -259,15 +259,13 @@ constructor(
                 layoutGeometrySource = GeometrySource.IMPORTED,
                 layoutLocation = kmPostLocation,
                 gkLocation = null,
-                gkLocationConfirmed = false,
-                gkLocationSource = null,
                 gkLocationLinkedFromGeometry = false,
             ),
             kmLengths.last().copy(gkLocation = null),
         )
         assertApproximatelyEquals(
             transformFromLayoutToGKCoordinate(kmPostLocation!!),
-            kmLengths.last().gkLocation!!,
+            kmLengths.last().gkLocation!!.location,
             0.01,
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.math.lineLength
 
 fun moveKmPostLocation(kmPost: TrackLayoutKmPost, layoutLocation: Point, kmPostService: LayoutKmPostService) {
     val gkPoint = transformFromLayoutToGKCoordinate(layoutLocation)
-    kmPostService.saveDraft(LayoutBranch.main, kmPost.copy(gkLocation = gkPoint))
+    kmPostService.saveDraft(LayoutBranch.main, kmPost.copy(gkLocation = kmPost.gkLocation?.copy(location = gkPoint)))
 }
 
 fun moveLocationTrackGeometryPointsAndUpdate(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -999,7 +999,7 @@ fun kmPost(
     draft: Boolean = false,
     state: LayoutState = LayoutState.IN_USE,
     gkLocationConfirmed: Boolean = false,
-    gkLocationSource: KmPostGkLocationSource? = null,
+    gkLocationSource: KmPostGkLocationSource = KmPostGkLocationSource.MANUAL,
     sourceId: IntId<GeometryKmPost>? = null,
     contextData: LayoutContextData<TrackLayoutKmPost> = createMainContext(null, null, draft),
 ): TrackLayoutKmPost {
@@ -1011,11 +1011,16 @@ fun kmPost(
         sourceId = sourceId,
         contextData = contextData,
         gkLocation =
-            if (gkLocation == null && roughLayoutLocation != null) {
-                transformFromLayoutToGKCoordinate(roughLayoutLocation)
-            } else gkLocation,
-        gkLocationConfirmed = gkLocationConfirmed,
-        gkLocationSource = gkLocationSource,
+            if (gkLocation != null || roughLayoutLocation != null)
+                TrackLayoutKmPostGkLocation(
+                    location =
+                        if (gkLocation == null && roughLayoutLocation != null) {
+                            transformFromLayoutToGKCoordinate(roughLayoutLocation)
+                        } else gkLocation!!,
+                    confirmed = gkLocationConfirmed,
+                    source = gkLocationSource,
+                )
+            else null,
     )
 }
 

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-table-item.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-table-item.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import { Precision, roundToPrecision } from 'utils/rounding';
 import styles from '../data-product-table.scss';
-import { GeometrySource, GkLocationSource, LAYOUT_SRID } from 'track-layout/track-layout-model';
+import {
+    GeometrySource,
+    LAYOUT_SRID,
+    LayoutKmPostGkLocation,
+} from 'track-layout/track-layout-model';
 import { useTranslation } from 'react-i18next';
 import { CoordinateSystem } from 'common/common-model';
-import { GeometryPoint, Point } from 'model/geometry';
+import { Point } from 'model/geometry';
 import CoordinateSystemView from 'geoviite-design-lib/coordinate-system/coordinate-system-view';
 import { useCoordinateSystem } from 'track-layout/track-layout-react-utils';
 import { KmLengthsLocationPrecision } from 'data-products/data-products-slice';
@@ -18,9 +22,7 @@ export type KilometerLengthsTableItemProps = {
     coordinateSystem: CoordinateSystem;
     layoutLocation: Point | undefined;
     layoutGeometrySource: GeometrySource;
-    gkLocation: GeometryPoint | undefined;
-    gkLocationSource: GkLocationSource | undefined;
-    gkLocationConfirmed: boolean;
+    gkLocation: LayoutKmPostGkLocation | undefined;
     locationPrecision: KmLengthsLocationPrecision;
     linkedFromGeometry: boolean;
 };
@@ -34,13 +36,11 @@ export const KilometerLengthTableItem: React.FC<KilometerLengthsTableItemProps> 
     layoutLocation,
     layoutGeometrySource,
     gkLocation,
-    gkLocationConfirmed,
-    gkLocationSource,
     locationPrecision,
     linkedFromGeometry,
 }) => {
     const { t } = useTranslation();
-    const kmPostCoordinateSystem = useCoordinateSystem(gkLocation?.srid);
+    const kmPostCoordinateSystem = useCoordinateSystem(gkLocation?.location?.srid);
     const layoutCoordinateSystem = useCoordinateSystem(LAYOUT_SRID);
 
     const hasLayoutLocation = layoutLocation !== undefined;
@@ -48,7 +48,7 @@ export const KilometerLengthTableItem: React.FC<KilometerLengthsTableItemProps> 
     const showingPreciseLocation = locationPrecision === 'PRECISE_LOCATION';
     const generatedRow = layoutGeometrySource === 'GENERATED';
 
-    const location = showingPreciseLocation ? gkLocation : layoutLocation;
+    const location = showingPreciseLocation ? gkLocation?.location : layoutLocation;
     const coordinateSystem = showingPreciseLocation
         ? kmPostCoordinateSystem
         : layoutCoordinateSystem;
@@ -56,7 +56,7 @@ export const KilometerLengthTableItem: React.FC<KilometerLengthsTableItemProps> 
     let locationSourceString = '';
     if (!generatedRow) {
         const gkLocationSourceString = hasGkLocation
-            ? t(`enum.gk-location-source.${gkLocationSource}`)
+            ? t(`enum.gk-location-source.${gkLocation.source}`)
             : '';
         const layoutLocationSourceString = linkedFromGeometry
             ? t('data-products.km-lengths.table.from-geometry')
@@ -69,7 +69,7 @@ export const KilometerLengthTableItem: React.FC<KilometerLengthsTableItemProps> 
 
     let locationPrecisionString = '';
     if (!generatedRow) {
-        const gkLocationConfirmationString = gkLocationConfirmed
+        const gkLocationConfirmationString = gkLocation?.confirmed
             ? t('data-products.km-lengths.table.confirmed')
             : t('data-products.km-lengths.table.not-confirmed');
         const layoutLocationConfirmationString = t('data-products.km-lengths.table.not-confirmed');
@@ -110,7 +110,7 @@ export const KilometerLengthTableItem: React.FC<KilometerLengthsTableItemProps> 
                         layoutGeometrySource == 'IMPORTED' &&
                         t('data-products.km-lengths.table.imported-warning')}
                     {showingPreciseLocation &&
-                        gkLocationSource === 'FROM_LAYOUT' &&
+                        gkLocation?.source === 'FROM_LAYOUT' &&
                         t('data-products.km-lengths.table.imported-warning')}
 
                     {hasLayoutLocation &&

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-table.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-table.tsx
@@ -75,8 +75,6 @@ const KilometerLengthsTable = ({
                                     layoutLocation={item.layoutLocation}
                                     layoutGeometrySource={item.layoutGeometrySource}
                                     gkLocation={item.gkLocation}
-                                    gkLocationSource={item.gkLocationSource}
-                                    gkLocationConfirmed={item.gkLocationConfirmed}
                                     linkedFromGeometry={item.gkLocationLinkedFromGeometry}
                                 />
                             </React.Fragment>

--- a/ui/src/geoviite-design-lib/demo/examples/badge-examples.tsx
+++ b/ui/src/geoviite-design-lib/demo/examples/badge-examples.tsx
@@ -46,7 +46,7 @@ const kmPost: LayoutKmPost = {
     layoutLocation: { x: 0, y: 0 },
     state: 'IN_USE' as LayoutState,
     trackNumberId: brand(''),
-    gkLocationConfirmed: false,
+    gkLocation: undefined,
 };
 const layoutSwitch: LayoutSwitch = {
     ...layoutAssetFields,

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -1,6 +1,6 @@
 import {
     AlignmentPoint,
-    GkLocationSource,
+    LayoutKmPostGkLocation,
     LayoutKmPostId,
     LayoutState,
     LayoutStateCategory,
@@ -22,7 +22,7 @@ import {
     GeometryPlanId,
     GeometrySwitchId,
 } from 'geometry/geometry-model';
-import { GeometryPoint, Point } from 'model/geometry';
+import { Point } from 'model/geometry';
 import {
     JointNumber,
     KmNumber,
@@ -173,13 +173,11 @@ export type KmPostGkFields = {
     gkSrid: Srid | undefined;
     gkLocationX: string;
     gkLocationY: string;
-    gkLocationConfirmed?: boolean;
+    gkLocationConfirmed: boolean;
 };
 
 export type KmPostSaveRequest = KmPostSimpleFields & {
-    gkLocation: GeometryPoint | undefined;
-    gkLocationSource: GkLocationSource | undefined;
-    gkLocationConfirmed: boolean | undefined;
+    gkLocation: LayoutKmPostGkLocation | undefined;
     sourceId: GeometryKmPostId | undefined;
 };
 

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
@@ -137,7 +137,6 @@ export const KmPostEditDialogGkLocationSection: React.FC<
     updateProp,
     hasErrors,
     getVisibleErrorsByProp,
-    geometryKmPostGkLocation,
     editType,
     geometryPlanSrid,
 }) => {
@@ -149,7 +148,6 @@ export const KmPostEditDialogGkLocationSection: React.FC<
     const layoutLocation = gkLocation ? transformGkToLayout(gkLocation) : undefined;
     const gkLocationEnabled = state.gkLocationEnabled;
     const fieldsEnabled = !isLinking && gkLocationEnabled;
-    const gkLocationEntered = geometryKmPostGkLocation !== undefined || layoutLocation != undefined;
 
     const coordinateSystems = useCoordinateSystems(GK_FIN_COORDINATE_SYSTEMS.map(([srid]) => srid));
     const isFromNonGkPlan =
@@ -266,19 +264,13 @@ export const KmPostEditDialogGkLocationSection: React.FC<
                 value={
                     <div className={styles['km-post-edit-dialog__confirmed']}>
                         <Radio
-                            checked={
-                                (state.kmPost.gkLocationConfirmed === true || !gkLocationEntered) &&
-                                gkLocationEnabled
-                            }
+                            checked={gkLocationEnabled && state.kmPost.gkLocationConfirmed}
                             onChange={() => updateProp('gkLocationConfirmed', true)}
                             disabled={!fieldsEnabled}>
                             {t('km-post-dialog.gk-location.confirmed')}
                         </Radio>
                         <Radio
-                            checked={
-                                (state.kmPost.gkLocationConfirmed === false && gkLocationEntered) ||
-                                !gkLocationEnabled
-                            }
+                            checked={!gkLocationEnabled || !state.kmPost.gkLocationConfirmed}
                             onChange={() => updateProp('gkLocationConfirmed', false)}
                             disabled={!fieldsEnabled}>
                             {t('km-post-dialog.gk-location.not-confirmed')}

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -275,7 +275,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                     onClose={() => setShowAddDialog(false)}
                     onSave={handleKmPostSave}
                     prefilledTrackNumberId={geometryKmPost.trackNumberId}
-                    geometryKmPostGkLocation={geometryKmPost.gkLocation}
+                    geometryKmPostGkLocation={geometryKmPost.gkLocation?.location}
                     editType={'LINKING'}
                     geometryPlanSrid={geometryPlan?.units?.coordinateSystemSrid}
                 />

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -130,7 +130,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     );
     const geometryPlanCrs = useCoordinateSystem(geometryPlan?.units?.coordinateSystemSrid);
 
-    const gkCoordinateSystem = useCoordinateSystem(kmPost.gkLocation?.srid);
+    const gkCoordinateSystem = useCoordinateSystem(kmPost.gkLocation?.location?.srid);
 
     const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
 
@@ -251,7 +251,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                         }
                         value={
                             updatedKmPost?.gkLocation
-                                ? formatToGkFinString(updatedKmPost.gkLocation)
+                                ? formatToGkFinString(updatedKmPost.gkLocation.location)
                                 : '-'
                         }
                     />
@@ -259,14 +259,14 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                         qaId="km-post-gk-coordinates-confirmed"
                         label={t(`tool-panel.km-post.layout.gk-coordinates.confirmed-title`)}
                         value={t(
-                            `tool-panel.km-post.layout.gk-coordinates.${updatedKmPost?.gkLocationConfirmed ? '' : 'not-'}confirmed`,
+                            `tool-panel.km-post.layout.gk-coordinates.${updatedKmPost?.gkLocation?.confirmed ? '' : 'not-'}confirmed`,
                         )}
                     />
                     <InfoboxField
                         qaId="km-post-gk-coordinates-source"
                         label={t('tool-panel.km-post.layout.gk-coordinates.source')}
                         value={
-                            updatedKmPost?.gkLocationSource === 'FROM_GEOMETRY' ? (
+                            updatedKmPost?.gkLocation?.source === 'FROM_GEOMETRY' ? (
                                 <span>
                                     {t(
                                         'tool-panel.km-post.layout.gk-coordinates.source-from-geometry',
@@ -289,9 +289,9 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                                         {geometryPlan?.fileName}
                                     </Link>
                                 </span>
-                            ) : updatedKmPost?.gkLocationSource === 'FROM_LAYOUT' ? (
+                            ) : updatedKmPost?.gkLocation?.source === 'FROM_LAYOUT' ? (
                                 t('tool-panel.km-post.layout.gk-coordinates.source-from-layout')
-                            ) : updatedKmPost?.gkLocationSource === 'MANUAL' ? (
+                            ) : updatedKmPost?.gkLocation?.source === 'MANUAL' ? (
                                 t('tool-panel.km-post.layout.gk-coordinates.source-manual')
                             ) : (
                                 '-'
@@ -363,7 +363,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                     kmPostId={kmPost.id}
                     onClose={closeEditDialog}
                     onSave={handleKmPostSave}
-                    geometryKmPostGkLocation={kmPost.gkLocation}
+                    geometryKmPostGkLocation={kmPost.gkLocation?.location}
                     editType={'MODIFY'}
                 />
             )}

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -279,15 +279,19 @@ export type LayoutSwitchJoint = {
     locationAccuracy: LocationAccuracy;
 };
 
+export type LayoutKmPostGkLocation = {
+    location: GeometryPoint;
+    source: GkLocationSource;
+    confirmed: boolean;
+};
+
 export type LayoutKmPostId = Brand<string, 'LayoutKmPostId'>;
 
 export type LayoutKmPost = {
     id: LayoutKmPostId;
     kmNumber: KmNumber;
     layoutLocation?: Point;
-    gkLocation?: GeometryPoint;
-    gkLocationSource?: GkLocationSource;
-    gkLocationConfirmed: boolean;
+    gkLocation: LayoutKmPostGkLocation | undefined;
     state: LayoutState;
     trackNumberId: LayoutTrackNumberId;
     sourceId?: GeometryKmPostId;
@@ -304,9 +308,7 @@ export type LayoutKmLengthDetails = {
     coordinateSystem: CoordinateSystem;
     layoutGeometrySource: GeometrySource;
     layoutLocation?: Point;
-    gkLocation?: GeometryPoint;
-    gkLocationSource?: GkLocationSource;
-    gkLocationConfirmed: boolean;
+    gkLocation: LayoutKmPostGkLocation | undefined;
     gkLocationLinkedFromGeometry: boolean;
 };
 


### PR DESCRIPTION
Täällä korjauksia pääasiassa kilometripylvään muokkausdialogin "Sijainti vahvistettu" -radionappeihin. Aiemmin radionapit elivät hieman omaa elämäänsä, ja niistä saattoi mm. kadota arvo kokonaan joissain tietyissä tilanteissa. Nyt näytetään aina joku arvo (käytännössä jos arvo löytyy kannasta näytetään se, muuten defaultataan "Ei vahvistettu":un.)

Tuo paljastikin sitten taas kaninkolon GK-sijainneista ja kilometripylväiden tietotyypeistä - aiempi flätti rakenne jossa kaikki GK-kentät olivat vain fieldeinä itse kilometripylväällä on nyt korvattu erillisellä alitietotyypillä, joka kuvastaa kilometripylvään GK-sijaintia.